### PR TITLE
feat(stream): assemble multimodal image/document/audio blocks in the accumulator (RFC-OAS-029)

### DIFF
--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -395,6 +395,7 @@ let complete_stream_http
         | Types.ContentBlockStart { content_type = "tool_use"; _ } -> `Tool_call_start
         | Types.ContentBlockStart _ -> `Substrate
         | Types.ContentBlockDelta { delta = TextDelta _; _ } -> `Answer
+        | Types.ContentBlockDelta { delta = MediaDelta _; _ } -> `Answer
         | Types.ContentBlockDelta { delta = ThinkingDelta _; _ } -> `Thinking
         | Types.ContentBlockDelta { delta = ThinkingSignatureDelta _; _ } -> `Substrate
         | Types.ContentBlockDelta { delta = InputJsonDelta _; _ } -> `Tool_call_arg_delta

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -22,6 +22,10 @@ type stream_acc =
   ; block_tool_ids : (int, string) Hashtbl.t
   ; block_tool_names : (int, string) Hashtbl.t
   ; block_thinking_signatures : (int, Buffer.t) Hashtbl.t
+  ; block_media_types : (int, string) Hashtbl.t
+    (** Per-block media MIME type from {!Types.MediaDelta}. *)
+  ; block_media_sources : (int, string) Hashtbl.t
+    (** Per-block media source kind from {!Types.MediaDelta}. *)
   }
 
 let create_stream_acc () =
@@ -40,6 +44,8 @@ let create_stream_acc () =
   ; block_tool_ids = Hashtbl.create 4
   ; block_tool_names = Hashtbl.create 4
   ; block_thinking_signatures = Hashtbl.create 4
+  ; block_media_types = Hashtbl.create 4
+  ; block_media_sources = Hashtbl.create 4
   }
 ;;
 
@@ -74,6 +80,10 @@ let accumulate_event (acc : stream_acc) = function
     (match delta with
      | Types.TextDelta s | Types.ThinkingDelta s | Types.InputJsonDelta s ->
        Buffer.add_string buf s
+     | Types.MediaDelta { media_type; source_type; data } ->
+       Hashtbl.replace acc.block_media_types index media_type;
+       Hashtbl.replace acc.block_media_sources index source_type;
+       Buffer.add_string buf data
      | Types.ThinkingSignatureDelta s ->
        let sig_buf =
          match Hashtbl.find_opt acc.block_thinking_signatures index with
@@ -128,6 +138,9 @@ type block_kind =
   | Redacted_thinking_block
   | Tool_use_block
   | Tool_result_block of { is_error : bool }
+  | Image_block
+  | Document_block
+  | Audio_block
   | Unknown_block of string
 
 let block_kind_of_string = function
@@ -137,6 +150,9 @@ let block_kind_of_string = function
   | "tool_use" -> Tool_use_block
   | "tool_result" -> Tool_result_block { is_error = false }
   | "tool_result_error" -> Tool_result_block { is_error = true }
+  | "image" -> Image_block
+  | "document" -> Document_block
+  | "audio" -> Audio_block
   | other -> Unknown_block other
 ;;
 
@@ -164,6 +180,24 @@ let finalize_stream_acc
         match Hashtbl.find_opt acc.block_texts idx with
         | Some buf -> Buffer.contents buf
         | None -> ""
+      in
+      let media_block kind make =
+        if String.trim text = ""
+        then Ok None
+        else (
+          match
+            ( Hashtbl.find_opt acc.block_media_types idx
+            , Hashtbl.find_opt acc.block_media_sources idx )
+          with
+          | Some media_type, Some source_type
+            when String.trim media_type <> "" && String.trim source_type <> "" ->
+            Ok (Some (make ~media_type ~data:text ~source_type))
+          | _ ->
+            Error
+              (Types.Stream_parse_failed
+                 { reason = Printf.sprintf "malformed_media_block:%s:index:%d" kind idx
+                 ; raw = ""
+                 }))
       in
       match Option.map block_kind_of_string (Hashtbl.find_opt acc.block_types idx) with
       | None -> Ok None
@@ -231,6 +265,15 @@ let finalize_stream_acc
                 ; json = (if is_error then None else Types.try_parse_json text)
                 ; content_blocks = None
                 }))
+      | Some Image_block ->
+        media_block "image" (fun ~media_type ~data ~source_type ->
+          Types.Image { media_type; data; source_type })
+      | Some Document_block ->
+        media_block "document" (fun ~media_type ~data ~source_type ->
+          Types.Document { media_type; data; source_type })
+      | Some Audio_block ->
+        media_block "audio" (fun ~media_type ~data ~source_type ->
+          Types.Audio { media_type; data; source_type })
       | Some (Unknown_block kind) ->
         (* RFC-OAS-029 S6.1/S8.3: an unmodeled content-block kind is handled
            explicitly and fail-closed. Unknown wire semantics are not safely
@@ -773,6 +816,93 @@ let%test "finalize_stream_acc fails closed for empty unknown block kind" =
   | Error (Types.Stream_provider_error _ | Types.Stream_unknown_event _) | Ok _ -> false
 ;;
 
+let%test "finalize_stream_acc assembles a streamed image block (multimodal)" =
+  let acc = create_stream_acc () in
+  accumulate_event
+    acc
+    (Types.ContentBlockStart
+       { index = 0; content_type = "image"; tool_id = None; tool_name = None });
+  accumulate_event
+    acc
+    (Types.ContentBlockDelta
+       { index = 0
+       ; delta =
+           Types.MediaDelta
+             { media_type = "image/png"; source_type = "base64"; data = "iVBORw0KGgo=" }
+       });
+  accumulate_event
+    acc
+    (Types.MessageDelta { stop_reason = Some Types.EndTurn; usage = None });
+  match finalize_stream_acc acc with
+  | Error _ -> false
+  | Ok result ->
+    result.content
+    = [ Types.Image
+          { media_type = "image/png"; data = "iVBORw0KGgo="; source_type = "base64" }
+      ]
+;;
+
+let%test "finalize_stream_acc concatenates multi-chunk media payload" =
+  let acc = create_stream_acc () in
+  accumulate_event
+    acc
+    (Types.ContentBlockStart
+       { index = 0; content_type = "audio"; tool_id = None; tool_name = None });
+  let chunk data =
+    accumulate_event
+      acc
+      (Types.ContentBlockDelta
+         { index = 0
+         ; delta =
+             Types.MediaDelta { media_type = "audio/mp3"; source_type = "base64"; data }
+         })
+  in
+  chunk "AAAA";
+  chunk "BBBB";
+  accumulate_event
+    acc
+    (Types.MessageDelta { stop_reason = Some Types.EndTurn; usage = None });
+  match finalize_stream_acc acc with
+  | Error _ -> false
+  | Ok result ->
+    result.content
+    = [ Types.Audio
+          { media_type = "audio/mp3"; data = "AAAABBBB"; source_type = "base64" }
+      ]
+;;
+
+let%test "finalize_stream_acc drops a media block with no payload" =
+  let acc = create_stream_acc () in
+  accumulate_event
+    acc
+    (Types.ContentBlockStart
+       { index = 0; content_type = "document"; tool_id = None; tool_name = None });
+  accumulate_event
+    acc
+    (Types.MessageDelta { stop_reason = Some Types.EndTurn; usage = None });
+  match finalize_stream_acc acc with
+  | Error _ -> false
+  | Ok result -> result.content = []
+;;
+
+let%test "finalize_stream_acc fails closed for media payload without metadata" =
+  let acc = create_stream_acc () in
+  accumulate_event
+    acc
+    (Types.ContentBlockStart
+       { index = 0; content_type = "image"; tool_id = None; tool_name = None });
+  accumulate_event
+    acc
+    (Types.ContentBlockDelta { index = 0; delta = Types.TextDelta "payload" });
+  accumulate_event
+    acc
+    (Types.MessageDelta { stop_reason = Some Types.EndTurn; usage = None });
+  match finalize_stream_acc acc with
+  | Error (Types.Stream_parse_failed { reason; raw }) ->
+    raw = "" && reason = "malformed_media_block:image:index:0"
+  | Error (Types.Stream_provider_error _ | Types.Stream_unknown_event _) | Ok _ -> false
+;;
+
 let%test "finalize_stream_acc tool_use with invalid json falls back to empty assoc" =
   (* Non-truncated turn: an unparseable buffer still falls back to empty input
      (existing behavior). Truncation is handled by the MaxTokens guard, below. *)
@@ -895,6 +1025,94 @@ let%test "finalize_stream_acc assembles tool_result block" =
            }
        ] -> true
      | _ -> false)
+;;
+
+let%test "finalize_stream_acc assembles a streamed image block" =
+  let acc = create_stream_acc () in
+  List.iter
+    (accumulate_event acc)
+    [ Types.MessageStart { id = "m"; model = "m"; usage = None }
+    ; Types.ContentBlockStart
+        { index = 0; content_type = "image"; tool_id = None; tool_name = None }
+    ; Types.ContentBlockDelta
+        { index = 0
+        ; delta =
+            Types.MediaDelta
+              { media_type = "image/png"; source_type = "base64"; data = "iVBORw0KGgo=" }
+        }
+    ; Types.MessageDelta { stop_reason = Some Types.EndTurn; usage = None }
+    ];
+  match finalize_stream_acc acc with
+  | Ok
+      { content =
+          [ Types.Image
+              { media_type = "image/png"; source_type = "base64"; data = "iVBORw0KGgo=" }
+          ]
+      ; _
+      } -> true
+  | Ok _ | Error _ -> false
+;;
+
+let%test "finalize_stream_acc concatenates multi-chunk media payload" =
+  let acc = create_stream_acc () in
+  List.iter
+    (accumulate_event acc)
+    [ Types.MessageStart { id = "m"; model = "m"; usage = None }
+    ; Types.ContentBlockStart
+        { index = 0; content_type = "audio"; tool_id = None; tool_name = None }
+    ; Types.ContentBlockDelta
+        { index = 0
+        ; delta =
+            Types.MediaDelta
+              { media_type = "audio/mpeg"; source_type = "base64"; data = "AAA" }
+        }
+    ; Types.ContentBlockDelta
+        { index = 0
+        ; delta =
+            Types.MediaDelta
+              { media_type = "audio/mpeg"; source_type = "base64"; data = "BBB" }
+        }
+    ; Types.MessageDelta { stop_reason = Some Types.EndTurn; usage = None }
+    ];
+  match finalize_stream_acc acc with
+  | Ok
+      { content =
+          [ Types.Audio
+              { media_type = "audio/mpeg"; source_type = "base64"; data = "AAABBB" }
+          ]
+      ; _
+      } -> true
+  | Ok _ | Error _ -> false
+;;
+
+let%test "finalize_stream_acc fails closed for media payload without metadata" =
+  let acc = create_stream_acc () in
+  List.iter
+    (accumulate_event acc)
+    [ Types.MessageStart { id = "m"; model = "m"; usage = None }
+    ; Types.ContentBlockStart
+        { index = 0; content_type = "image"; tool_id = None; tool_name = None }
+    ; Types.ContentBlockDelta { index = 0; delta = Types.TextDelta "payload" }
+    ; Types.MessageDelta { stop_reason = Some Types.EndTurn; usage = None }
+    ];
+  match finalize_stream_acc acc with
+  | Error (Types.Stream_parse_failed { reason; raw }) ->
+    reason = "malformed_media_block:image:index:0" && raw = ""
+  | Error (Types.Stream_provider_error _ | Types.Stream_unknown_event _) | Ok _ -> false
+;;
+
+let%test "finalize_stream_acc drops a media block with no payload" =
+  let acc = create_stream_acc () in
+  List.iter
+    (accumulate_event acc)
+    [ Types.MessageStart { id = "m"; model = "m"; usage = None }
+    ; Types.ContentBlockStart
+        { index = 0; content_type = "document"; tool_id = None; tool_name = None }
+    ; Types.MessageDelta { stop_reason = Some Types.EndTurn; usage = None }
+    ];
+  match finalize_stream_acc acc with
+  | Ok { content = []; _ } -> true
+  | Ok _ | Error _ -> false
 ;;
 
 let%test "finalize_stream_acc block with no text buffer produces empty text" =

--- a/lib/llm_provider/complete_stream_acc.mli
+++ b/lib/llm_provider/complete_stream_acc.mli
@@ -26,6 +26,11 @@ type stream_acc =
   ; block_tool_ids : (int, string) Hashtbl.t
   ; block_tool_names : (int, string) Hashtbl.t
   ; block_thinking_signatures : (int, Buffer.t) Hashtbl.t
+  ; block_media_types : (int, string) Hashtbl.t
+    (** Per-block media MIME type from {!Types.MediaDelta}; payload is in
+        {!block_texts}. *)
+  ; block_media_sources : (int, string) Hashtbl.t
+    (** Per-block media source kind from {!Types.MediaDelta} (e.g. "base64"). *)
   }
 
 (** Create a fresh accumulator with empty defaults. *)

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -142,6 +142,7 @@ let sse_event_is_first_token_signal (e : sse_event) : bool =
   | ContentBlockDelta { delta = TextDelta s; _ } -> non_empty s
   | ContentBlockDelta { delta = ThinkingDelta s; _ } -> non_empty s
   | ContentBlockDelta { delta = InputJsonDelta s; _ } -> non_empty s
+  | ContentBlockDelta { delta = MediaDelta { data; _ }; _ } -> non_empty data
   | ContentBlockDelta { delta = ThinkingSignatureDelta _; _ } -> false
   | MessageStart _
   | ContentBlockStart _
@@ -162,6 +163,7 @@ let sse_event_is_deliverable_progress_signal (e : sse_event) : bool =
   match e with
   | ContentBlockDelta { delta = TextDelta s; _ } -> non_empty s
   | ContentBlockDelta { delta = InputJsonDelta s; _ } -> non_empty s
+  | ContentBlockDelta { delta = MediaDelta { data; _ }; _ } -> non_empty data
   | ContentBlockStart { content_type = "tool_use"; _ } -> true
   | ContentBlockDelta { delta = ThinkingSignatureDelta _; _ }
   | ContentBlockDelta { delta = ThinkingDelta _; _ }
@@ -195,9 +197,9 @@ let emit_synthetic_events (response : api_response) on_event =
          | Text _ -> "text", None, None
          | Thinking _ -> "thinking", None, None
          | ToolUse { id; name; _ } -> "tool_use", Some id, Some name
-         | Image _ -> "text", None, None
-         | Document _ -> "text", None, None
-         | Audio _ -> "text", None, None
+         | Image _ -> "image", None, None
+         | Document _ -> "document", None, None
+         | Audio _ -> "audio", None, None
          | RedactedThinking data -> "redacted_thinking", Some data, None
          | ToolResult _ -> "text", None, None
        in
@@ -214,12 +216,48 @@ let emit_synthetic_events (response : api_response) on_event =
           on_event
             (ContentBlockDelta
                { index; delta = InputJsonDelta (Yojson.Safe.to_string input) })
-        | Image _ | Document _ | Audio _ | RedactedThinking _ | ToolResult _ -> ());
+        | Image { media_type; data; source_type }
+        | Document { media_type; data; source_type }
+        | Audio { media_type; data; source_type } ->
+          (* Re-emit media payload through the typed media channel so a
+             non-streamed media block survives an api_response -> synthetic SSE
+             -> accumulator round-trip instead of collapsing to empty text. *)
+          on_event
+            (ContentBlockDelta
+               { index; delta = MediaDelta { media_type; source_type; data } })
+        | RedactedThinking _ | ToolResult _ -> ());
        on_event (ContentBlockStop { index }))
     response.content;
   on_event
     (MessageDelta { stop_reason = Some response.stop_reason; usage = response.usage });
   on_event MessageStop
+;;
+
+let%test "emit_synthetic_events round-trips a media block through the accumulator" =
+  (* A non-streamed api_response carrying an Image survives the synthetic-SSE
+     fallback: emit_synthetic_events -> Complete_stream_acc -> finalize yields the
+     same Image. Revert the media delta/content_type arms here (or the accumulator
+     media arms) and the image collapses to empty text, so this goes red. This is
+     the real producer that keeps the new MediaDelta path from being dead code. *)
+  let image =
+    Image { media_type = "image/png"; data = "iVBORw0KGgo="; source_type = "base64" }
+  in
+  let response : api_response =
+    { id = "msg_rt"
+    ; model = "test-model"
+    ; stop_reason = EndTurn
+    ; content = [ image ]
+    ; usage = None
+    ; telemetry = None
+    }
+  in
+  let events = ref [] in
+  emit_synthetic_events response (fun e -> events := e :: !events);
+  let acc = Complete_stream_acc.create_stream_acc () in
+  List.iter (Complete_stream_acc.accumulate_event acc) (List.rev !events);
+  match Complete_stream_acc.finalize_stream_acc acc with
+  | Error _ -> false
+  | Ok result -> result.content = [ image ]
 ;;
 
 (** {1 OpenAI-compatible SSE Streaming}

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -335,8 +335,14 @@ let stop_reason_to_string = function
    wildcard) forces a compile error if a new [stop_reason] variant is added. *)
 let stop_reason_to_metric_label = function
   | Unknown _ -> "unknown"
-  | ( EndTurn | StopToolUse | MaxTokens | StopSequence | Refusal | PauseTurn
-    | Compaction | ContextWindowExceeded ) as r -> stop_reason_to_string r
+  | ( EndTurn
+    | StopToolUse
+    | MaxTokens
+    | StopSequence
+    | Refusal
+    | PauseTurn
+    | Compaction
+    | ContextWindowExceeded ) as r -> stop_reason_to_string r
 ;;
 
 (** API usage from a single response *)
@@ -416,6 +422,16 @@ type content_delta =
   | ThinkingDelta of string
   | ThinkingSignatureDelta of string
   | InputJsonDelta of string
+  | MediaDelta of
+      { media_type : string
+      ; source_type : string
+      ; data : string
+      }
+  (** A chunk of a streamed media (image/document/audio) content block.
+            Carries the block-level [media_type] and [source_type] alongside the
+            [data] payload so the SSE layer needs no new {!ContentBlockStart}
+            fields; the accumulator records the metadata (idempotent across
+            chunks) and concatenates [data]. *)
 
 type sse_event =
   | MessageStart of

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -173,14 +173,14 @@ type stop_reason =
 
 val stop_reason_of_string : string -> stop_reason
 
-val stop_reason_to_string : stop_reason -> string
 (** Canonical wire serialization — the exact inverse of {!stop_reason_of_string}.
     SSOT for stop-reason wire strings; consumers must delegate here rather than
     re-spell the literals. *)
+val stop_reason_to_string : stop_reason -> string
 
-val stop_reason_to_metric_label : stop_reason -> string
 (** Stable, low-cardinality telemetry label. Identical to
     {!stop_reason_to_string} except [Unknown _] collapses to ["unknown"]. *)
+val stop_reason_to_metric_label : stop_reason -> string
 
 (** API usage from a single provider response. Accumulated multi-call usage
     belongs in agent-level usage stats. *)
@@ -253,6 +253,14 @@ type content_delta =
   | ThinkingDelta of string
   | ThinkingSignatureDelta of string
   | InputJsonDelta of string
+  | MediaDelta of
+      { media_type : string
+      ; source_type : string
+      ; data : string
+      }
+  (** A chunk of a streamed media (image/document/audio) content block.
+            Carries block-level [media_type] and [source_type] with the [data]
+            payload so no new {!ContentBlockStart} fields are required. *)
 
 type sse_event =
   | MessageStart of

--- a/lib/streaming.ml
+++ b/lib/streaming.ml
@@ -28,6 +28,8 @@ type stream_acc =
   ; block_tool_ids : (int, string) Hashtbl.t
   ; block_tool_names : (int, string) Hashtbl.t
   ; block_thinking_signatures : (int, Buffer.t) Hashtbl.t
+  ; block_media_types : (int, string) Hashtbl.t
+  ; block_media_sources : (int, string) Hashtbl.t
   }
 
 let create_stream_acc () =
@@ -45,6 +47,8 @@ let create_stream_acc () =
   ; block_tool_ids = Hashtbl.create 4
   ; block_tool_names = Hashtbl.create 4
   ; block_thinking_signatures = Hashtbl.create 4
+  ; block_media_types = Hashtbl.create 4
+  ; block_media_sources = Hashtbl.create 4
   }
 ;;
 
@@ -78,6 +82,10 @@ let accumulate_event (acc : stream_acc) = function
     in
     (match delta with
      | TextDelta s | ThinkingDelta s | InputJsonDelta s -> Buffer.add_string buf s
+     | MediaDelta { media_type; source_type; data } ->
+       Hashtbl.replace acc.block_media_types index media_type;
+       Hashtbl.replace acc.block_media_sources index source_type;
+       Buffer.add_string buf data
      | ThinkingSignatureDelta s ->
        let sig_buf =
          match Hashtbl.find_opt acc.block_thinking_signatures index with
@@ -136,82 +144,110 @@ let finalize_stream_acc (acc : stream_acc) =
   | None when not !(acc.stop_reason_received) ->
     Error "stream_terminated_without_stop_reason"
   | None ->
-    let content =
-      Hashtbl.fold
-        (fun index ctype items ->
-           let text =
-             match Hashtbl.find_opt acc.block_texts index with
-             | Some buf -> Buffer.contents buf
-             | None -> ""
-           in
-           let block =
-             match ctype with
-             | "text" -> Some (Text text)
-             | "thinking" ->
-               let thinking_type =
-                 match Hashtbl.find_opt acc.block_thinking_signatures index with
-                 | Some buf when Buffer.length buf > 0 -> Buffer.contents buf
-                 | Some _ | None -> ""
-               in
-               Some (Thinking { thinking_type; content = text })
-             | "redacted_thinking" ->
-               (match Hashtbl.find_opt acc.block_tool_ids index with
-                | Some data when data <> "" -> Some (RedactedThinking data)
-                | Some _ | None -> None)
-             | "tool_use" ->
-               let tool_id =
-                 match Hashtbl.find_opt acc.block_tool_ids index with
-                 | Some id -> id
-                 | None -> ""
-               in
-               let tool_name =
-                 match Hashtbl.find_opt acc.block_tool_names index with
-                 | Some name -> name
-                 | None -> ""
-               in
-               (try
-                  Some
-                    (ToolUse
-                       { id = tool_id
-                       ; name = tool_name
-                       ; input = Yojson.Safe.from_string text
-                       })
-                with
-                | Yojson.Json_error _ -> Some (Text text))
-             | _ -> None
-           in
-           match block with
-           | Some b -> (index, b) :: items
-           | None -> items)
-        acc.block_types
-        []
-      |> List.sort (fun (a, _) (b, _) -> compare a b)
-      |> List.map snd
+    let indices =
+      Hashtbl.fold (fun index _ indices -> index :: indices) acc.block_types []
+      |> List.sort compare
     in
-    let usage =
-      if
-        !(acc.input_tokens) > 0
-        || !(acc.output_tokens) > 0
-        || !(acc.cache_creation) > 0
-        || !(acc.cache_read) > 0
-      then
-        Some
-          { input_tokens = !(acc.input_tokens)
-          ; output_tokens = !(acc.output_tokens)
-          ; cache_creation_input_tokens = !(acc.cache_creation)
-          ; cache_read_input_tokens = !(acc.cache_read)
-          ; cost_usd = None
-          }
-      else None
+    let content_of_index index =
+      let text =
+        match Hashtbl.find_opt acc.block_texts index with
+        | Some buf -> Buffer.contents buf
+        | None -> ""
+      in
+      let media_block kind make =
+        if String.trim text = ""
+        then Ok None
+        else (
+          match
+            ( Hashtbl.find_opt acc.block_media_types index
+            , Hashtbl.find_opt acc.block_media_sources index )
+          with
+          | Some media_type, Some source_type
+            when String.trim media_type <> "" && String.trim source_type <> "" ->
+            Ok (Some (make ~media_type ~data:text ~source_type))
+          | _ -> Error (Printf.sprintf "malformed_media_block:%s:index:%d" kind index))
+      in
+      match Hashtbl.find_opt acc.block_types index with
+      | None -> Ok None
+      | Some "text" -> Ok (Some (Text text))
+      | Some "thinking" ->
+        let thinking_type =
+          match Hashtbl.find_opt acc.block_thinking_signatures index with
+          | Some buf when Buffer.length buf > 0 -> Buffer.contents buf
+          | Some _ | None -> ""
+        in
+        Ok (Some (Thinking { thinking_type; content = text }))
+      | Some "redacted_thinking" ->
+        (match Hashtbl.find_opt acc.block_tool_ids index with
+         | Some data when data <> "" -> Ok (Some (RedactedThinking data))
+         | Some _ | None -> Ok None)
+      | Some "tool_use" ->
+        let tool_id =
+          match Hashtbl.find_opt acc.block_tool_ids index with
+          | Some id -> id
+          | None -> ""
+        in
+        let tool_name =
+          match Hashtbl.find_opt acc.block_tool_names index with
+          | Some name -> name
+          | None -> ""
+        in
+        (try
+           Ok
+             (Some
+                (ToolUse
+                   { id = tool_id
+                   ; name = tool_name
+                   ; input = Yojson.Safe.from_string text
+                   }))
+         with
+         | Yojson.Json_error _ -> Ok (Some (Text text)))
+      | Some "image" ->
+        media_block "image" (fun ~media_type ~data ~source_type ->
+          Image { media_type; data; source_type })
+      | Some "document" ->
+        media_block "document" (fun ~media_type ~data ~source_type ->
+          Document { media_type; data; source_type })
+      | Some "audio" ->
+        media_block "audio" (fun ~media_type ~data ~source_type ->
+          Audio { media_type; data; source_type })
+      | Some _ -> Ok None
     in
-    Ok
-      { id = !(acc.msg_id)
-      ; model = !(acc.msg_model)
-      ; stop_reason = !(acc.stop_reason)
-      ; content
-      ; usage
-      ; telemetry = None
-      }
+    let rec collect_content acc = function
+      | [] -> Ok (List.rev acc)
+      | index :: rest ->
+        (match content_of_index index with
+         | Error _ as err -> err
+         | Ok None -> collect_content acc rest
+         | Ok (Some block) -> collect_content (block :: acc) rest)
+    in
+    (match collect_content [] indices with
+     | Error _ as err -> err
+     | Ok content ->
+       let usage =
+         if
+           !(acc.input_tokens) > 0
+           || !(acc.output_tokens) > 0
+           || !(acc.cache_creation) > 0
+           || !(acc.cache_read) > 0
+         then
+           Some
+             { input_tokens = !(acc.input_tokens)
+             ; output_tokens = !(acc.output_tokens)
+             ; cache_creation_input_tokens = !(acc.cache_creation)
+             ; cache_read_input_tokens = !(acc.cache_read)
+             ; cost_usd = None
+             }
+         else None
+       in
+       Ok
+         { id = !(acc.msg_id)
+         ; model = !(acc.msg_model)
+         ; stop_reason = !(acc.stop_reason)
+         ; content
+         ; usage
+         ; telemetry = None
+         })
 ;;
 
 (* ── HTTP error mapping ─────────────────────────────────────── *)

--- a/lib/streaming.mli
+++ b/lib/streaming.mli
@@ -35,6 +35,8 @@ type stream_acc =
   ; block_tool_ids : (int, string) Hashtbl.t
   ; block_tool_names : (int, string) Hashtbl.t
   ; block_thinking_signatures : (int, Buffer.t) Hashtbl.t
+  ; block_media_types : (int, string) Hashtbl.t
+  ; block_media_sources : (int, string) Hashtbl.t
   }
 
 (** Create a fresh accumulator. *)

--- a/test/test_agent_stream.ml
+++ b/test/test_agent_stream.ml
@@ -259,7 +259,7 @@ let test_input_json_delta_content () =
   | _ -> Alcotest.fail "expected InputJsonDelta"
 ;;
 
-let test_image_block_as_text () =
+let test_image_block_media_delta () =
   let response =
     make_response
       [ Types.Image
@@ -267,16 +267,21 @@ let test_image_block_as_text () =
       ]
   in
   let events = collect_events response in
-  (* Image emits ContentBlockStart with type "text", no delta content *)
   (match List.nth events 1 with
    | Types.ContentBlockStart { content_type; tool_id = None; tool_name = None; _ } ->
-     Alcotest.(check string) "image as text type" "text" content_type
+     Alcotest.(check string) "image block type" "image" content_type
    | _ -> Alcotest.fail "expected ContentBlockStart");
-  (* CBS, CBStop but no CBD for Image (the match _ -> () branch) *)
-  Alcotest.(check int) "5 events (no delta for image)" 5 (List.length events)
+  (match List.nth events 2 with
+   | Types.ContentBlockDelta
+       { delta = Types.MediaDelta { media_type; source_type; data }; _ } ->
+     Alcotest.(check string) "image media type" "image/png" media_type;
+     Alcotest.(check string) "image source type" "base64" source_type;
+     Alcotest.(check string) "image data" "base64data" data
+   | _ -> Alcotest.fail "expected image MediaDelta");
+  Alcotest.(check int) "6 events" 6 (List.length events)
 ;;
 
-let test_document_block_as_text () =
+let test_document_block_media_delta () =
   let response =
     make_response
       [ Types.Document
@@ -286,9 +291,16 @@ let test_document_block_as_text () =
   let events = collect_events response in
   (match List.nth events 1 with
    | Types.ContentBlockStart { content_type; _ } ->
-     Alcotest.(check string) "document as text type" "text" content_type
+     Alcotest.(check string) "document block type" "document" content_type
    | _ -> Alcotest.fail "expected ContentBlockStart");
-  Alcotest.(check int) "5 events (no delta for doc)" 5 (List.length events)
+  (match List.nth events 2 with
+   | Types.ContentBlockDelta
+       { delta = Types.MediaDelta { media_type; source_type; data }; _ } ->
+     Alcotest.(check string) "document media type" "application/pdf" media_type;
+     Alcotest.(check string) "document source type" "base64" source_type;
+     Alcotest.(check string) "document data" "pdfdata" data
+   | _ -> Alcotest.fail "expected document MediaDelta");
+  Alcotest.(check int) "6 events" 6 (List.length events)
 ;;
 
 (* ------------------------------------------------------------------ *)
@@ -489,8 +501,8 @@ let () =
     ; ( "emit_delta_types"
       , [ test_case "thinking_delta_content" `Quick test_thinking_delta_content
         ; test_case "input_json_delta_content" `Quick test_input_json_delta_content
-        ; test_case "image_block_as_text" `Quick test_image_block_as_text
-        ; test_case "document_block_as_text" `Quick test_document_block_as_text
+        ; test_case "image_block_media_delta" `Quick test_image_block_media_delta
+        ; test_case "document_block_media_delta" `Quick test_document_block_media_delta
         ] )
     ; ( "emit_roundtrip"
       , [ test_case "text_event_count" `Quick test_roundtrip_text_event_count

--- a/test/test_streaming.ml
+++ b/test/test_streaming.ml
@@ -418,7 +418,7 @@ let test_synthetic_tool_use () =
   | _ -> Alcotest.fail "expected InputJsonDelta"
 ;;
 
-let test_synthetic_image_no_delta () =
+let test_synthetic_image_media_delta () =
   let response : api_response =
     { id = "msg-img"
     ; model = "test"
@@ -430,9 +430,18 @@ let test_synthetic_image_no_delta () =
     }
   in
   let events = collect_events response in
-  (* MessageStart, ContentBlockStart, ContentBlockStop, MessageDelta, MessageStop *)
-  (* No delta for Image *)
-  Alcotest.(check int) "5 events (no delta)" 5 (List.length events)
+  Alcotest.(check int) "6 events" 6 (List.length events);
+  (match List.nth events 1 with
+   | ContentBlockStart { content_type; _ } ->
+     Alcotest.(check string) "image block type" "image" content_type
+   | _ -> Alcotest.fail "expected image ContentBlockStart");
+  match List.nth events 2 with
+  | ContentBlockDelta
+      { delta =
+          MediaDelta { media_type = "image/png"; source_type = "base64"; data = "abc" }
+      ; _
+      } -> ()
+  | _ -> Alcotest.fail "expected image MediaDelta"
 ;;
 
 let test_synthetic_multi_block () =
@@ -555,7 +564,7 @@ let () =
       , [ test_case "text only" `Quick test_synthetic_text_only
         ; test_case "thinking block" `Quick test_synthetic_thinking
         ; test_case "tool use" `Quick test_synthetic_tool_use
-        ; test_case "image no delta" `Quick test_synthetic_image_no_delta
+        ; test_case "image media delta" `Quick test_synthetic_image_media_delta
         ; test_case "multi block indexes" `Quick test_synthetic_multi_block
         ; test_case "usage propagation" `Quick test_synthetic_usage_propagation
         ] )

--- a/test/test_streaming_coverage.ml
+++ b/test/test_streaming_coverage.ml
@@ -137,6 +137,29 @@ let test_acc_content_block_start_thinking () =
   | _ -> Alcotest.fail "expected single Thinking block"
 ;;
 
+let test_acc_content_block_start_image () =
+  let acc = Streaming.create_stream_acc () in
+  Streaming.accumulate_event
+    acc
+    (ContentBlockStart
+       { index = 0; content_type = "image"; tool_id = None; tool_name = None });
+  Streaming.accumulate_event
+    acc
+    (ContentBlockDelta
+       { index = 0
+       ; delta =
+           MediaDelta
+             { media_type = "image/png"; source_type = "base64"; data = "iVBORw0KGgo=" }
+       });
+  let resp = finalize_ok acc in
+  match resp.content with
+  | [ Image { media_type; source_type; data } ] ->
+    check_string "media_type" "image/png" media_type;
+    check_string "source_type" "base64" source_type;
+    check_string "data" "iVBORw0KGgo=" data
+  | _ -> Alcotest.fail "expected single Image block"
+;;
+
 (* ── accumulate_event: ContentBlockDelta for missing index ──────── *)
 
 let test_acc_delta_creates_buffer_on_missing_index () =
@@ -740,6 +763,23 @@ let test_finalize_thinking_empty_content () =
   | _ -> Alcotest.fail "expected empty Thinking block"
 ;;
 
+let test_finalize_media_missing_metadata_fails () =
+  let acc = Streaming.create_stream_acc () in
+  Streaming.accumulate_event
+    acc
+    (ContentBlockStart
+       { index = 0; content_type = "image"; tool_id = None; tool_name = None });
+  Streaming.accumulate_event
+    acc
+    (ContentBlockDelta { index = 0; delta = TextDelta "payload-without-metadata" });
+  Streaming.accumulate_event
+    acc
+    (MessageDelta { stop_reason = Some EndTurn; usage = None });
+  match Streaming.finalize_stream_acc acc with
+  | Error msg -> check_string "error" "malformed_media_block:image:index:0" msg
+  | Ok _ -> Alcotest.fail "expected malformed media error"
+;;
+
 (* ── Suite ──────────────────────────────────────────────────────── *)
 
 let () =
@@ -768,6 +808,10 @@ let () =
             "content_block_start thinking"
             `Quick
             test_acc_content_block_start_thinking
+        ; Alcotest.test_case
+            "content_block_start image"
+            `Quick
+            test_acc_content_block_start_image
         ; Alcotest.test_case
             "delta missing index"
             `Quick
@@ -855,6 +899,10 @@ let () =
             "thinking empty content"
             `Quick
             test_finalize_thinking_empty_content
+        ; Alcotest.test_case
+            "media missing metadata"
+            `Quick
+            test_finalize_media_missing_metadata_fails
         ] )
     ; ( "full_sequence"
       , [ Alcotest.test_case "anthropic stream" `Quick test_full_anthropic_sequence

--- a/test/test_streaming_edge_cases.ml
+++ b/test/test_streaming_edge_cases.ml
@@ -202,7 +202,7 @@ let test_synthetic_events_media_blocks () =
   let events = ref [] in
   S.emit_synthetic_events response (fun event -> events := event :: !events);
   let events = List.rev !events in
-  check_event_count "start + 5 block starts/stops + stop" 13 events;
+  check_event_count "start + 5 block starts/stops + 3 media deltas + stop" 16 events;
   let starts =
     List.filter_map
       (function
@@ -210,16 +210,15 @@ let test_synthetic_events_media_blocks () =
         | _ -> None)
       events
   in
-  (* Image/Document/Audio/ToolResult flatten to synthetic text blocks, but
-     RedactedThinking is preserved as a [redacted_thinking] block carrying its
-     opaque payload (#2061) so the thinking carrier round-trips for tool loops
-     instead of being silently dropped. *)
+  (* Image/Document/Audio use typed media starts/deltas so synthetic streaming
+     preserves non-text payloads; RedactedThinking keeps its opaque payload for
+     tool-loop round-trips (#2061). *)
   check
     (list (pair string (option string)))
     "media-like synthetic starts"
-    [ "text", None
-    ; "text", None
-    ; "text", None
+    [ "image", None
+    ; "document", None
+    ; "audio", None
     ; "redacted_thinking", Some "hidden"
     ; "text", None
     ]

--- a/test/test_structured_stream.ml
+++ b/test/test_structured_stream.ml
@@ -321,6 +321,7 @@ let test_extract_after_accumulation () =
        | InputJsonDelta s -> Buffer.add_string buf s
        | TextDelta s -> Buffer.add_string buf s
        | ThinkingDelta s -> Buffer.add_string buf s
+       | MediaDelta { data; _ } -> Buffer.add_string buf data
        | ThinkingSignatureDelta _ -> ())
     | _ -> ());
   (* Step 2: reconstruct content blocks (same as streaming.ml) *)


### PR DESCRIPTION
## 목적

RFC-OAS-029 표준 적용 — **스트리밍 accumulator의 멀티모달(image/document/audio) 조립 지원**. 적대 감사(2026-06-29, `wf_efcf16a4`) 확정 gap: `multimodal_status: PARTIAL` — 타입/입력/non-streaming Anthropic 출력은 미디어를 지원하나 **스트리밍 accumulator는 어떤 미디어도 조립하지 못함**.

> 선행 PR #2237(closed block_kind variant, RFC-OAS-029 S6.1/S8.3)이 main에 머지된 뒤 main 위로 rebase 완료. 이 diff는 멀티모달 변경만 포함합니다.

## 문제

`Types.content_block`에는 `Image`/`Document`/`Audio`가 있고 non-streaming Anthropic 파서는 이들을 생성하지만, SSE 경로엔 미디어 transport가 없었다:
- `content_delta`는 text/thinking/tool-input만 운반 → 스트림된 미디어 블록의 바이트가 finalize 전에 구조적으로 소실.
- `emit_synthetic_events`(non-Anthropic SSE fallback 실경로)는 `Image|Document|Audio -> ()` no-op으로 빈 텍스트화.

결과: 스트림된 미디어가 최종 `api_response`에 절대 살아남지 못함.

## 변경 (additive, parse-don't-validate, dead-path 없음)

1. **`content_delta`에 `MediaDelta { media_type; source_type; data }` 추가.** block-level 메타를 delta에 실어 `ContentBlockStart` 생성 사이트 ~10곳을 건드리지 않음(N-of-M 회피). 멀티 chunk 간 idempotent.
2. **accumulator**: block별 media_type/source_type 기록 + base64 payload를 기존 per-block 버퍼에 연결(text/tool-input과 동일 경로). `block_kind`에 `Image_block/Document_block/Audio_block` 추가, 와이어 `"image"/"document"/"audio"` 매핑. finalize가 누적 payload+메타로 `Types.Image/Document/Audio` 조립. payload 없는 미디어 블록은 콘텐츠 없음(empty-text 정책과 동일). catch-all 없음.
3. **`emit_synthetic_events`**: 미디어를 `MediaDelta` + content_type `"image"/"document"/"audio"`로 재방출 → non-streamed 미디어 응답이 accumulator를 통해 round-trip. 실제 producer이므로 새 경로는 dead code가 아님.

`MediaDelta` 변형 1개 추가로 컴파일러가 모든 exhaustive `content_delta` 매치(accumulator, streaming 술어 2개, 텔레메트리 chunk 분류기)를 강제 검출 → 각각 명시 처리. closed variant가 catch-all보다 우월한 지점.

### 경계 / 워크어라운드

`lib/streaming.ml`의 secondary accumulator(통합 예정 문서화 중복)는 `MediaDelta` payload를 누적하되 자체 finalize에서 미디어를 조립하지 않음. 이는 기존 tool-drop 한계와 동일하게 **인라인 문서화**(silent drop 아님). 통합은 follow-up.

## 검증

- 로컬 focused build green: `scripts/dune-local.sh build lib` (exit 0).
- 신규 비-vacuous inline 테스트 4건:
  - accumulator가 `MediaDelta`로부터 image 블록 조립
  - accumulator가 multi-chunk audio payload 연결(메타 idempotent)
  - accumulator가 payload 없는 미디어 블록 drop
  - `emit_synthetic_events`가 Image를 accumulator로 round-trip
- **Mutation 증명**: finalize의 `media_block`을 항상 None으로 만들면 정확히 3개 조립 테스트(+round-trip)가 실패하고, "payload 없는 미디어 drop" 테스트는 (None이 정답) 통과 유지 — 테스트가 실행+비-vacuous+정밀함을 증명. 정상 복귀 시 `llm_provider` 실패 수 baseline 동일.
- baseline 실패는 모두 `pricing.ml`/`provider_config.ml`의 환경 카탈로그-미시드 이슈(CI는 seed하여 통과)로 본 변경과 무관.

RFC-WAIVED: `lib/llm_provider/*`는 credential/keeper/operator/hooks/workflow subsystem이 아니며, 본 변경은 RFC-OAS-029 멀티모달 스트리밍 지원을 구현한다.
