### PR TITLE
fix(provider): use provider-qualified model capabilities

### DIFF
--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -162,7 +162,12 @@ let effective_tool_choice_json
   | Some Types.None_ when is_glm -> None
   | Some (Types.Auto | Types.Any) when is_glm ->
     Some (tool_choice_to_openai_json Types.Auto)
-  | Some (Types.Tool _) when is_glm -> None
+  | Some (Types.Tool name) when is_glm ->
+    invalid_arg
+      (Printf.sprintf
+         "build_openai_body: Z.AI GLM does not support named forced tool_choice %S; use \
+          auto/any or remove tool_choice"
+         name)
   | Some Types.Auto when capabilities.supports_tool_choice ->
     Some (tool_choice_to_openai_json Types.Auto)
   | Some choice when capabilities.supports_tool_choice ->

--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -69,7 +69,7 @@ let%test "tool_choice_to_openai_json Tool name" =
   && result |> member "function" |> member "name" |> to_string = "my_tool"
 ;;
 
-let%test "glm passes named tool_choice through (no coerce)" =
+let%test "glm rejects named forced tool_choice" =
   let cfg =
     Provider_config.make
       ~kind:Provider_config.Glm
@@ -78,12 +78,12 @@ let%test "glm passes named tool_choice through (no coerce)" =
       ~tool_choice:(Tool "calculator")
       ()
   in
-  effective_tool_choice cfg
-  = Some
-      (`Assoc
-          [ "type", `String "function"
-          ; "function", `Assoc [ "name", `String "calculator" ]
-          ])
+  match effective_tool_choice cfg with
+  | exception Invalid_argument msg ->
+    String.starts_with
+      ~prefix:"Backend_openai_request.build_request: Z.AI GLM does not support"
+      msg
+  | _ -> false
 ;;
 
 let%test "glm passes tool_choice any through (no coerce)" =
@@ -1114,7 +1114,7 @@ let%test "build_request omits tool_choice when tool_choice=None" =
   json_object_missing_key "tool_choice" json
 ;;
 
-let%test "glm build_request drops tool_choice when unsupported" =
+let%test "glm build_request rejects unsupported forced tool_choice" =
   let config =
     Provider_config.make
       ~kind:Provider_config.Glm
@@ -1123,10 +1123,11 @@ let%test "glm build_request drops tool_choice when unsupported" =
       ~tool_choice:(Tool "calc")
       ()
   in
-  let body = build_request ~config ~messages:[] () in
-  let json = Yojson.Safe.from_string body in
-  match json with
-  | `Assoc fields -> not (List.exists (fun (k, _) -> k = "tool_choice") fields)
+  match build_request ~config ~messages:[] () with
+  | exception Invalid_argument msg ->
+    String.starts_with
+      ~prefix:"Backend_openai_request.build_request: Z.AI GLM does not support"
+      msg
   | _ -> false
 ;;
 

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -62,10 +62,16 @@ let add_sampling_field dialect (config : Provider_config.t) field value body =
 (* ── Request building ──────────────────────────────────── *)
 
 let effective_tool_choice (config : Provider_config.t) =
-  match config.tool_choice with
-  | Some None_ -> None
-  | Some choice -> Some (Backend_openai_serialize.tool_choice_to_openai_json choice)
-  | None -> None
+  match config.kind, config.tool_choice with
+  | Glm, Some (Tool name) ->
+    invalid_arg
+      (Printf.sprintf
+         "Backend_openai_request.build_request: Z.AI GLM does not support named forced \
+          tool_choice %S; use auto/any or remove tool_choice"
+         name)
+  | _, Some None_ -> None
+  | _, Some choice -> Some (Backend_openai_serialize.tool_choice_to_openai_json choice)
+  | _, None -> None
 ;;
 
 let effective_tools (config : Provider_config.t) tools =

--- a/lib/provider_runtime_binding.ml
+++ b/lib/provider_runtime_binding.ml
@@ -380,7 +380,7 @@ let registry_capabilities_for_provider_config (cfg : PConfig.t) =
 let capabilities_for_provider_config (cfg : PConfig.t) =
   let caps = registry_capabilities_for_provider_config cfg in
   let caps =
-    match Llm_provider.Capabilities.for_model_id cfg.model_id with
+    match PConfig.capabilities_for_config_model cfg with
     | Some model_caps -> model_caps
     | None -> caps
   in

--- a/models.toml
+++ b/models.toml
@@ -1750,6 +1750,34 @@ supports_native_streaming = true
 supports_top_k = true
 supports_min_p = true
 
+[[models]]
+id_prefix = "runpod_mtp/qwen36-35b-a3b-mtp"
+base = "openai_chat"
+max_context_tokens = 131072
+supports_tools = true
+supports_tool_choice = true
+supports_parallel_tool_calls = true
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "chat_template_kwargs"
+preserve_thinking_control_format = "chat_template_kwargs_preserve_thinking"
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "qwen36-35b-a3b-mtp"
+base = "openai_chat"
+max_context_tokens = 131072
+supports_tools = true
+supports_tool_choice = true
+supports_parallel_tool_calls = true
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "chat_template_kwargs"
+preserve_thinking_control_format = "chat_template_kwargs_preserve_thinking"
+supports_native_streaming = true
+
 # Llama Models
 [[models]]
 id_prefix = "llama-4"

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -763,7 +763,7 @@ let test_build_openai_body_omits_provider_m_only_fields_for_generic_compat () =
   check bool "tools preserved" true (List.mem_assoc "tools" assoc)
 ;;
 
-let test_build_openai_body_uses_glm_thinking_and_drops_forced_tool_choice () =
+let test_build_openai_body_rejects_glm_forced_tool_choice () =
   let provider_config =
     { Provider.provider =
         Provider.OpenAICompat
@@ -795,47 +795,26 @@ let test_build_openai_body_uses_glm_thinking_and_drops_forced_tool_choice () =
       ; "input_schema", `Assoc [ "type", `String "object" ]
       ]
   in
-  let json =
-    Api.build_openai_body
-      ~provider_config
-      ~config:state
-      ~messages:[]
-      ~tools:[ tool_json ]
-      ()
-    |> Yojson.Safe.from_string
-  in
-  let open Yojson.Safe.Util in
-  let thinking = json |> member "thinking" in
-  check string "thinking enabled" "enabled" (thinking |> member "type" |> to_string);
-  check
-    bool
-    "clear_thinking default true"
-    true
-    (thinking |> member "clear_thinking" |> to_bool);
-  check
-    bool
-    "glm forced tool_choice omitted"
-    false
-    (List.mem_assoc "tool_choice" (to_assoc json))
+  check_raises
+    "glm rejects named forced tool_choice"
+    (Invalid_argument
+       "build_openai_body: Z.AI GLM does not support named forced tool_choice \
+        \"calculator\"; use auto/any or remove tool_choice")
+    (fun () ->
+       ignore
+         (Api.build_openai_body
+            ~provider_config
+            ~config:state
+            ~messages:[]
+            ~tools:[ tool_json ]
+            ()))
 ;;
 
-let test_build_openai_body_uses_bare_glm_thinking_and_drops_forced_tool_choice () =
-  let provider_config =
-    { Provider.provider =
-        Provider.OpenAICompat
-          { base_url = Llm_provider.Zai_catalog.general_base_url
-          ; auth_header = None
-          ; path = "/chat/completions"
-          ; static_token = None
-          }
-    ; model_id = "glm-5"
-    ; api_key_env = ""
-    }
-  in
+let test_build_openai_body_rejects_bare_glm_forced_tool_choice () =
   let state =
     { Types.config =
         { Types.default_config with
-          model = provider_config.model_id
+          model = "glm-5"
         ; enable_thinking = Some true
         ; tool_choice = Some (Types.Tool "calculator")
         }
@@ -851,28 +830,13 @@ let test_build_openai_body_uses_bare_glm_thinking_and_drops_forced_tool_choice (
       ; "input_schema", `Assoc [ "type", `String "object" ]
       ]
   in
-  let json =
-    Api.build_openai_body
-      ~provider_config
-      ~config:state
-      ~messages:[]
-      ~tools:[ tool_json ]
-      ()
-    |> Yojson.Safe.from_string
-  in
-  let open Yojson.Safe.Util in
-  let thinking = json |> member "thinking" in
-  check string "thinking enabled" "enabled" (thinking |> member "type" |> to_string);
-  check
-    bool
-    "clear_thinking default true"
-    true
-    (thinking |> member "clear_thinking" |> to_bool);
-  check
-    bool
-    "bare glm forced tool_choice omitted"
-    false
-    (List.mem_assoc "tool_choice" (to_assoc json))
+  check_raises
+    "bare glm rejects named forced tool_choice"
+    (Invalid_argument
+       "build_openai_body: Z.AI GLM does not support named forced tool_choice \
+        \"calculator\"; use auto/any or remove tool_choice")
+    (fun () ->
+       ignore (Api.build_openai_body ~config:state ~messages:[] ~tools:[ tool_json ] ()))
 ;;
 
 let test_build_openai_body_glm_preserves_reasoning_content () =
@@ -911,7 +875,7 @@ let test_build_openai_body_glm_preserves_reasoning_content () =
           model = provider_config.model_id
         ; enable_thinking = Some true
         ; preserve_thinking = Some true
-        ; tool_choice = Some (Types.Tool "calculator")
+        ; tool_choice = Some Types.Auto
         }
     ; messages = []
     ; turn_count = 0
@@ -931,10 +895,10 @@ let test_build_openai_body_glm_preserves_reasoning_content () =
     "I should call the calculator."
     (assistant |> member "reasoning_content" |> to_string);
   check
-    bool
-    "forced tool_choice omitted"
-    false
-    (List.mem_assoc "tool_choice" (to_assoc json))
+    string
+    "auto tool_choice preserved"
+    "auto"
+    (json |> member "tool_choice" |> to_string)
 ;;
 
 let test_build_openai_body_does_not_treat_non_zai_glm_as_glm () =
@@ -1858,13 +1822,13 @@ let () =
             `Quick
             test_build_openai_body_omits_provider_m_only_fields_for_generic_compat
         ; test_case
-            "glm thinking + unsupported forced tool choice"
+            "glm rejects unsupported forced tool choice"
             `Quick
-            test_build_openai_body_uses_glm_thinking_and_drops_forced_tool_choice
+            test_build_openai_body_rejects_glm_forced_tool_choice
         ; test_case
-            "bare glm thinking + unsupported forced tool choice"
+            "bare glm rejects unsupported forced tool choice"
             `Quick
-            test_build_openai_body_uses_bare_glm_thinking_and_drops_forced_tool_choice
+            test_build_openai_body_rejects_bare_glm_forced_tool_choice
         ; test_case
             "glm preserved reasoning replay"
             `Quick

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -629,7 +629,7 @@ let test_kimi_direct_tool_result_uses_text_blocks () =
     (block |> member "content" |> to_string)
 ;;
 
-let test_glm_preserved_reasoning_replay_and_drops_unsupported_tool_choice () =
+let test_glm_preserved_reasoning_replay_and_preserves_auto_tool_choice () =
   let config =
     PC.make
       ~kind:Glm
@@ -638,7 +638,7 @@ let test_glm_preserved_reasoning_replay_and_drops_unsupported_tool_choice () =
       ~enable_thinking:true
       ~clear_thinking:false
       ~tool_stream:true
-      ~tool_choice:(Tool "calculator")
+      ~tool_choice:Auto
       ()
   in
   let messages =
@@ -676,12 +676,10 @@ let test_glm_preserved_reasoning_replay_and_drops_unsupported_tool_choice () =
   let json = Yojson.Safe.from_string body in
   let open Yojson.Safe.Util in
   let assistant = json |> member "messages" |> index 0 in
-  Alcotest.(check bool)
-    "glm unsupported tool_choice dropped"
-    true
-    (match json with
-     | `Assoc fields -> not (List.mem_assoc "tool_choice" fields)
-     | _ -> false);
+  Alcotest.(check string)
+    "glm auto tool_choice preserved"
+    "auto"
+    (json |> member "tool_choice" |> to_string);
   Alcotest.(check string)
     "assistant content remains text channel"
     ""
@@ -1218,7 +1216,7 @@ let () =
         ; test_case
             "glm preserved reasoning replay"
             `Quick
-            test_glm_preserved_reasoning_replay_and_drops_unsupported_tool_choice
+            test_glm_preserved_reasoning_replay_and_preserves_auto_tool_choice
         ] )
     ; ( "gemini_build_request"
       , [ test_case "with json schema" `Quick test_gemini_with_json_schema ] )

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -639,6 +639,7 @@ let test_glm_preserved_reasoning_replay_and_preserves_auto_tool_choice () =
       ~clear_thinking:false
       ~tool_stream:true
       ~tool_choice:Auto
+      ~supports_tool_choice_override:true
       ()
   in
   let messages =
@@ -696,6 +697,24 @@ let test_glm_preserved_reasoning_replay_and_preserves_auto_tool_choice () =
     "tool_stream enabled"
     true
     (json |> member "tool_stream" |> to_bool)
+;;
+
+let test_glm_rejects_named_forced_tool_choice () =
+  let config =
+    PC.make
+      ~kind:Glm
+      ~model_id:"glm-5.1"
+      ~base_url:"https://api.z.ai/api/coding/paas/v4"
+      ~enable_thinking:true
+      ~tool_choice:(Tool "calculator")
+      ()
+  in
+  Alcotest.check_raises
+    "glm rejects named forced tool_choice"
+    (Invalid_argument
+       "Backend_openai_request.build_request: Z.AI GLM does not support named forced \
+        tool_choice \"calculator\"; use auto/any or remove tool_choice")
+    (fun () -> ignore (BGlm.build_request ~stream:true ~config ~messages:[] ()))
 ;;
 
 (* ── Provider_config.make ────────────────────────────── *)
@@ -1217,6 +1236,10 @@ let () =
             "glm preserved reasoning replay"
             `Quick
             test_glm_preserved_reasoning_replay_and_preserves_auto_tool_choice
+        ; test_case
+            "glm rejects named forced tool_choice"
+            `Quick
+            test_glm_rejects_named_forced_tool_choice
         ] )
     ; ( "gemini_build_request"
       , [ test_case "with json schema" `Quick test_gemini_with_json_schema ] )

--- a/test/test_provider_runtime_binding.ml
+++ b/test/test_provider_runtime_binding.ml
@@ -21,6 +21,23 @@ let with_provider_catalog json f =
     Fun.protect ~finally:Llm_provider.Provider_catalog.clear_global f
 ;;
 
+let with_model_catalog toml f =
+  let path = Filename.temp_file "oas-provider-runtime-binding-models" ".toml" in
+  let oc = open_out path in
+  Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () -> output_string oc toml);
+  Fun.protect
+    ~finally:(fun () ->
+      Llm_provider.Model_catalog.clear_global ();
+      try Sys.remove path with
+      | Sys_error _ -> ())
+    (fun () ->
+       match Llm_provider.Model_catalog.load_file path with
+       | Error msg -> Alcotest.fail msg
+       | Ok catalog ->
+         Llm_provider.Model_catalog.set_global catalog;
+         f ())
+;;
+
 let catalog_json =
   {|
 {
@@ -182,6 +199,51 @@ let test_capabilities_for_provider_config_honors_override () =
     in
     let caps = Provider_runtime_binding.capabilities_for_provider_config cfg in
     Alcotest.(check bool) "override disables tool choice" false caps.supports_tool_choice)
+;;
+
+let test_capabilities_for_provider_config_uses_provider_qualified_model_catalog () =
+  with_model_catalog
+    {|
+[[models]]
+id_prefix = "kimi-k2.6"
+base = "kimi"
+supports_tools = true
+supports_tool_choice = true
+thinking_control_format = "none"
+
+[[models]]
+id_prefix = "ollama_cloud/kimi-k2.6"
+base = "ollama_cloud"
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "reasoning_effort"
+reasoning_replay = "preserve_always"
+|}
+    (fun () ->
+       let cfg =
+         Llm_provider.Provider_config.make
+           ~kind:Llm_provider.Provider_config.OpenAI_compat
+           ~model_id:"kimi-k2.6"
+           ~base_url:"https://ollama.com/v1"
+           ~request_path:"/chat/completions"
+           ()
+       in
+       let caps = Provider_runtime_binding.capabilities_for_provider_config cfg in
+       Alcotest.(check bool)
+         "ollama cloud row disables forced tool_choice"
+         false
+         caps.supports_tool_choice;
+       Alcotest.(check bool)
+         "ollama cloud row uses reasoning_effort"
+         true
+         (caps.thinking_control_format = Llm_provider.Capabilities.Reasoning_effort);
+       Alcotest.(check bool)
+         "ollama cloud row preserves reasoning replay"
+         true
+         (caps.reasoning_replay_override = Llm_provider.Capabilities.Force_preserve_always))
 ;;
 
 let test_all_includes_catalog_entry_once () =
@@ -356,6 +418,10 @@ let () =
             "capabilities honor tool_choice override"
             `Quick
             test_capabilities_for_provider_config_honors_override
+        ; Alcotest.test_case
+            "provider-qualified model catalog capabilities"
+            `Quick
+            test_capabilities_for_provider_config_uses_provider_qualified_model_catalog
         ; Alcotest.test_case
             "all includes catalog once"
             `Quick


### PR DESCRIPTION
## Summary
- use provider-qualified model catalog lookup when deriving provider runtime binding capabilities
- add exact qwen36 MTP catalog rows used by MASC runtimes
- fail closed for unsupported GLM named forced tool_choice instead of silently dropping it
- update provider-complete GLM reasoning replay coverage to use supported auto tool_choice

## Verification
- opam exec -- ocamlformat --check lib/api_openai.ml lib/llm_provider/backend_openai.ml lib/llm_provider/backend_openai_request.ml test/test_api.ml test/test_provider_complete.ml lib/provider_runtime_binding.ml test/test_provider_runtime_binding.ml
- git diff --check

## Notes
- Follow-up after merged jeong-sik/oas#2244; opened on a new branch as requested.