### PR TITLE
feat(types): expose summarize_blocks and total_tokens canonical projections

### DIFF
--- a/lib/llm_provider/response_shape.ml
+++ b/lib/llm_provider/response_shape.ml
@@ -51,7 +51,7 @@ let dedupe_keep_order values =
   loop [] [] values
 ;;
 
-let summarize (response : Types.api_response) =
+let summarize_blocks (content : Types.content_block list) =
   let shape =
     List.fold_left
       (fun shape -> function
@@ -82,10 +82,12 @@ let summarize (response : Types.api_response) =
          | Types.Audio _ ->
            { (add_kind "audio" shape) with audio_count = shape.audio_count + 1 })
       empty
-      response.content
+      content
   in
   { shape with content_kinds = List.rev shape.content_kinds |> dedupe_keep_order }
 ;;
+
+let summarize (response : Types.api_response) = summarize_blocks response.content
 
 let has_deliverable_content shape = shape.text_chars > 0 || shape.tool_use_count > 0
 

--- a/lib/llm_provider/response_shape.mli
+++ b/lib/llm_provider/response_shape.mli
@@ -27,6 +27,12 @@ type content_shape =
   | Mixed_without_deliverable_content
   | Has_deliverable_content
 
+(** [summarize_blocks blocks] computes the redacted shape counts over a bare
+    content-block list, independent of any response envelope. This is the core
+    of {!summarize}: [summarize r = summarize_blocks r.content]. Counts only
+    (lengths/counts; never the underlying text/thinking/tool payloads). *)
+val summarize_blocks : Types.content_block list -> t
+
 val summarize : Types.api_response -> t
 val content_shape : Types.api_response -> t -> content_shape
 val content_shape_to_string : content_shape -> string

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -635,3 +635,4 @@ let zero_api_usage =
 ;;
 
 let usage_of_response (resp : api_response) = resp.usage
+let total_tokens (usage : api_usage) = usage.input_tokens + usage.output_tokens

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -419,3 +419,7 @@ val zero_api_usage : api_usage
 (** Extract usage from a response, preserving [None] when the provider did not
     report usage. *)
 val usage_of_response : api_response -> api_usage option
+
+(** Billable token total: [input_tokens + output_tokens]. Cache tokens are
+    excluded — this counts the metered request/response pair, not full context. *)
+val total_tokens : api_usage -> int

--- a/test/dune
+++ b/test/dune
@@ -475,6 +475,11 @@
  (libraries agent_sdk llm_provider alcotest))
 
 (test
+ (name test_canonical_projections)
+ (modules test_canonical_projections)
+ (libraries agent_sdk llm_provider alcotest))
+
+(test
  (name test_telemetry_event)
  (modules test_telemetry_event)
  (libraries agent_sdk llm_provider alcotest eio_main))

--- a/test/test_canonical_projections.ml
+++ b/test/test_canonical_projections.ml
@@ -1,0 +1,65 @@
+(** Tests for the canonical type projections exposed on OAS ADTs:
+    - [Response_shape.summarize_blocks] (the content-block-list core of
+      [summarize]).
+    - [Types.total_tokens] (billable token pair on [api_usage]). *)
+
+open Alcotest
+open Llm_provider
+
+let mk_image () =
+  Types.Image { media_type = "image/png"; data = "AAAA"; source_type = "base64" }
+;;
+
+(* summarize_blocks folds a bare content_block list into the redacted shape. *)
+let test_summarize_blocks_counts () =
+  let blocks =
+    [ Types.Text "hello"
+    ; Types.Thinking { thinking_type = "thinking"; content = "abcde" }
+    ; Types.RedactedThinking "opaque"
+    ; Types.Text "   " (* whitespace-only: trimmed to 0 chars *)
+    ; mk_image ()
+    ]
+  in
+  let t = Response_shape.summarize_blocks blocks in
+  check int "text_blocks" 2 t.Response_shape.text_blocks;
+  check int "text_chars (whitespace trimmed)" 5 t.Response_shape.text_chars;
+  check int "thinking_blocks" 1 t.Response_shape.thinking_blocks;
+  check int "thinking_chars" 5 t.Response_shape.thinking_chars;
+  check int "redacted_thinking_blocks" 1 t.Response_shape.redacted_thinking_blocks;
+  check int "image_count" 1 t.Response_shape.image_count;
+  check int "distinct content_kinds" 4 (List.length t.Response_shape.content_kinds)
+;;
+
+(* The empty list yields all-zero counts. *)
+let test_summarize_blocks_empty () =
+  let t = Response_shape.summarize_blocks [] in
+  check int "text_blocks" 0 t.Response_shape.text_blocks;
+  check int "thinking_blocks" 0 t.Response_shape.thinking_blocks;
+  check int "tool_use_count" 0 t.Response_shape.tool_use_count;
+  check int "content_kinds" 0 (List.length t.Response_shape.content_kinds)
+;;
+
+(* total_tokens sums the billable pair and excludes cache tokens. *)
+let test_total_tokens () =
+  let u =
+    { Types.input_tokens = 10
+    ; output_tokens = 5
+    ; cache_creation_input_tokens = 100
+    ; cache_read_input_tokens = 200
+    ; cost_usd = Some 0.01
+    }
+  in
+  check int "input + output, cache excluded" 15 (Types.total_tokens u);
+  check int "zero usage totals zero" 0 (Types.total_tokens Types.zero_api_usage)
+;;
+
+let () =
+  run
+    "canonical_projections"
+    [ ( "response_shape"
+      , [ test_case "summarize_blocks counts" `Quick test_summarize_blocks_counts
+        ; test_case "summarize_blocks empty" `Quick test_summarize_blocks_empty
+        ] )
+    ; "usage", [ test_case "total_tokens" `Quick test_total_tokens ]
+    ]
+;;


### PR DESCRIPTION
## 목적
Canonical Projection SSOT 이니셔티브(PR #2240 stop_reason에 이어)의 batch-1. OAS ADT의 정식 projection을 타입 옆에 노출해, OAS 내부·downstream(MASC 포함)이 재구현하던 중복을 제거할 발판을 만듭니다. 둘 다 **additive / byte-identical** 입니다.

## 변경
- `Response_shape.summarize_blocks : content_block list -> t` — `summarize`의 content-block core 추출. `summarize r = summarize_blocks r.content` (현재 `summarize`가 `response.content`만 읽음을 검증 후 추출 → **byte-identical**). thinking-block 등 shape 카운팅을 OAS fold 재사용으로 통일 가능.
- `Types.total_tokens : api_usage -> int` — billable input+output (cache 토큰 제외).

## 안전성
- `summarize`는 한 줄 delegate로만 변경, 출력 불변. 기존 `test_types` response_shape 그룹 **55 PASS 무회귀**로 증명.
- adversarial 검증(독립 skeptic) 통과: F2 5개 반증 모두 실패, F12 shadowing만(harmless).

## 테스트
`test_canonical_projections`: summarize_blocks 카운트/empty, total_tokens(cache 제외 + zero). 3 PASS.

## 경계 / 후속
OAS는 MASC를 모릅니다(불변). 이 projection들은 downstream(MASC `summarize_thinking_blocks`, `total_tokens`×2)이 향후 `Agent_sdk.*`에 위임해 자기 복제본을 삭제할 수 있게 합니다(MASC-side 삭제는 OAS 릴리즈 후, 별도 작업). 설계/로드맵: `docs/design/2026-06-29-canonical-projection-ssot.md`.

WORKAROUND-WAIVED: string 분류기/N-of-M/cap-cooldown 아님. 타입 옆에 정식 projection을 추가하는 SSOT 강화(중복 제거 방향).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
