### PR TITLE
feat(observability): default-on event bus + per-turn InferenceTelemetry producer

### DIFF
--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -121,7 +121,15 @@ let create ~net ~model =
   ; auto_context_overflow_retry = true
   ; context_injector = None
   ; mcp_clients = []
-  ; event_bus = None
+  ; (* Observability-as-default: every Builder-constructed agent gets a fresh,
+       per-agent event bus so Turn/Tool/InferenceTelemetry events are emitted
+       without the caller opting in. [create] is a per-call function, so this
+       allocates a NEW bus per builder — not a shared global mutable bus (which
+       remains forbidden; [Agent_types.default_options.event_bus] stays [None]).
+       With no subscriber, [Event_bus.publish] is a no-op (it iterates an empty
+       subscriber list), so the default carries only a mutex acquire per event.
+       Callers that want zero emission use {!without_event_bus}. *)
+    event_bus = Some (Event_bus.create ())
   ; skill_registry = None
   ; elicitation = None
   ; description = None
@@ -304,6 +312,7 @@ let with_cache_extended_ttl v b = { b with cache_extended_ttl = v }
 let with_yield_on_tool v b = { b with yield_on_tool = v }
 let with_exit_condition pred b = { b with exit_condition = Some pred }
 let with_event_bus bus b = { b with event_bus = Some bus }
+let without_event_bus b = { b with event_bus = None }
 let with_max_execution_time s b = { b with max_execution_time_s = Some s }
 let with_stream_idle_timeout s b = { b with stream_idle_timeout_s = Some s }
 let with_body_timeout s b = { b with body_timeout_s = Some s }

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -120,7 +120,20 @@ val with_context_thresholds
 
 val with_context : Context.t -> t -> t
 val with_context_injector : Hooks.context_injector -> t -> t
+
+(** Attach a caller-owned event bus, replacing the default per-agent bus. *)
 val with_event_bus : Event_bus.t -> t -> t
+
+(** Opt out of observability-as-default by clearing the event bus.
+
+    {!create} installs a fresh per-agent {!Event_bus.t} so Turn / Tool /
+    InferenceTelemetry events are emitted without the caller opting in. Use
+    this when no events should be produced at all (e.g. a latency-sensitive
+    agent with no observer). With no subscriber the default bus only costs a
+    mutex acquire per event, so prefer leaving it on unless you have a reason.
+    @since 0.207.19 *)
+val without_event_bus : t -> t
+
 val with_max_execution_time : float -> t -> t
 
 (** Set the per-line idle deadline applied to streaming HTTP responses

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -286,6 +286,56 @@ let stage_collect ?raw_trace_run ?clock agent ~original_config response =
                   { agent_name = agent.state.config.name; turn = completed_turn }
             }
         | None -> ());
+       (* Observability-as-default: emit per-call inference telemetry beside
+          [TurnCompleted] so token counts and decode tok/s are observable
+          without the caller wiring anything. The event's [provider] is a
+          required string, so we publish only once the provider identity is
+          known from [response.telemetry.provider_kind] — set by
+          [Complete_common.patch_telemetry] on every real completion (sync and
+          stream). A synthetic response with no telemetry has no provider to
+          attribute and no timings to report, so it is skipped rather than
+          emitted with a fabricated provider. Token/timing fields stay [None]
+          when the provider did not report them (cloud providers omit timings).
+          The nested [None -> ()] arms are explicit (no catch-all) so a future
+          telemetry field cannot be silently dropped here. *)
+       (match agent.options.event_bus with
+        | None -> ()
+        | Some bus ->
+          (match response.telemetry with
+           | None -> ()
+           | Some telemetry ->
+             (match telemetry.provider_kind with
+              | None -> ()
+              | Some provider_kind ->
+                let timings = telemetry.timings in
+                safe_publish
+                  bus
+                  { meta = Pipeline_common.event_envelope agent
+                  ; payload =
+                      InferenceTelemetry
+                        { agent_name = agent.state.config.name
+                        ; turn = completed_turn
+                        ; provider = Llm_provider.Provider_kind.to_string provider_kind
+                        ; model = response.model
+                        ; prompt_tokens =
+                            Option.map
+                              (fun (u : api_usage) -> u.input_tokens)
+                              response.usage
+                        ; completion_tokens =
+                            Option.map
+                              (fun (u : api_usage) -> u.output_tokens)
+                              response.usage
+                        ; prompt_ms =
+                            Option.bind timings (fun (t : inference_timings) ->
+                              t.prompt_ms)
+                        ; decode_ms =
+                            Option.bind timings (fun (t : inference_timings) ->
+                              t.predicted_ms)
+                        ; decode_tok_s =
+                            Option.bind timings (fun (t : inference_timings) ->
+                              t.predicted_per_second)
+                        }
+                  })));
        (match agent.options.journal with
         | Some j ->
           Durable_event.append

--- a/test/dune
+++ b/test/dune
@@ -485,6 +485,11 @@
  (libraries agent_sdk llm_provider alcotest eio_main))
 
 (test
+ (name test_observability_default)
+ (modules test_observability_default)
+ (libraries agent_sdk llm_provider alcotest eio_main))
+
+(test
  (name test_lenient_json)
  (modules test_lenient_json)
  (libraries agent_sdk alcotest))

--- a/test/test_observability_default.ml
+++ b/test/test_observability_default.ml
@@ -1,0 +1,196 @@
+(** Observability-as-default tests.
+
+    Covers the three guarantees added with the default-on event bus:
+    1. [Builder.build] installs a per-agent {!Event_bus.t} without the caller
+       opting in (default-on).
+    2. [Builder.without_event_bus] clears it (opt-out).
+    3. The turn pipeline publishes an {!Event_bus.InferenceTelemetry} event for
+       each completed turn onto that default bus, carrying the provider, turn,
+       model, token counts, and decode timings reported for the call. *)
+
+open Agent_sdk
+
+(* The agent's provider config. [Provider.Local] resolves to provider kind
+   [OpenAI_compat] (provider.ml), so [Complete_common.patch_telemetry] stamps
+   the response telemetry with that kind on the way back through [Complete].
+   The producer therefore emits [provider = "openai_compat"] regardless of the
+   value the mock transport sets, which is what the emit test asserts. *)
+let mock_provider : Provider.config =
+  { provider = Provider.Local { base_url = "http://mock.local" }
+  ; model_id = "mock-model"
+  ; api_key_env = ""
+  }
+;;
+
+(* A completed-turn response carrying usage and llama-server-style timings.
+   [patch_telemetry] preserves [usage] and [timings] while overwriting
+   [provider_kind], so these token/timing values survive to the producer and
+   are the non-vacuous core of the emit assertion. *)
+let response_with_telemetry : Types.api_response =
+  { id = "obs-1"
+  ; model = "mock-model"
+  ; stop_reason = Types.EndTurn
+  ; content = [ Types.Text "ok" ]
+  ; usage =
+      Some
+        { Types.input_tokens = 11
+        ; output_tokens = 22
+        ; cache_creation_input_tokens = 0
+        ; cache_read_input_tokens = 0
+        ; cost_usd = None
+        }
+  ; telemetry =
+      Some
+        { Types.default_inference_telemetry with
+          timings =
+            Some
+              { Types.prompt_n = Some 11
+              ; prompt_ms = Some 12.0
+              ; prompt_per_second = None
+              ; predicted_n = Some 22
+              ; predicted_ms = Some 34.0
+              ; predicted_per_second = Some 81.5
+              ; cache_n = None
+              }
+        ; provider_kind = Some Llm_provider.Provider_kind.OpenAI_compat
+        }
+  }
+;;
+
+let build_or_fail b =
+  match Builder.build_safe b with
+  | Ok agent -> agent
+  | Error err -> Alcotest.fail ("build_safe failed: " ^ Error.to_string err)
+;;
+
+let single_response_transport response : Llm_provider.Llm_transport.t =
+  let remaining = ref [ response ] in
+  let next () =
+    match !remaining with
+    | r :: rest ->
+      remaining := rest;
+      r
+    | [] -> Alcotest.fail "mock transport exhausted"
+  in
+  { complete_sync =
+      (fun _req ->
+        { Llm_provider.Llm_transport.response = Ok (next ()); latency_ms = Some 0 })
+  ; complete_stream = (fun ?on_telemetry:_ ~on_event:_ _req -> Ok (next ()))
+  }
+;;
+
+let test_builder_default_on_event_bus () =
+  Eio_main.run
+  @@ fun env ->
+  let agent =
+    Builder.create ~net:env#net ~model:Types.default_config.model
+    |> Builder.with_max_turns 1
+    |> build_or_fail
+  in
+  Alcotest.(check bool)
+    "Builder installs a default event bus"
+    true
+    (Option.is_some (Agent.options agent).event_bus)
+;;
+
+let test_builder_without_event_bus_opts_out () =
+  Eio_main.run
+  @@ fun env ->
+  let agent =
+    Builder.create ~net:env#net ~model:Types.default_config.model
+    |> Builder.with_max_turns 1
+    |> Builder.without_event_bus
+    |> build_or_fail
+  in
+  Alcotest.(check bool)
+    "without_event_bus clears the default bus"
+    true
+    (Option.is_none (Agent.options agent).event_bus)
+;;
+
+let test_pipeline_emits_inference_telemetry_on_default_bus () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let net = Eio.Stdenv.net env in
+  let transport = single_response_transport response_with_telemetry in
+  (* Build through the default-on path and pull the bus the Builder created, so
+     this also proves the producer publishes onto the *default* bus. *)
+  let agent =
+    Builder.create ~net ~model:"mock-model"
+    |> Builder.with_name "obs-emit"
+    |> Builder.with_max_turns 1
+    |> Builder.with_provider mock_provider
+    |> Builder.with_transport transport
+    |> build_or_fail
+  in
+  let event_bus =
+    match (Agent.options agent).event_bus with
+    | Some bus -> bus
+    | None -> Alcotest.fail "expected default-on event bus on the built agent"
+  in
+  let sub = Event_bus.subscribe event_bus in
+  (match Agent.run ~sw agent "trigger a turn" with
+   | Ok _ -> ()
+   | Error err -> Alcotest.fail ("expected run success: " ^ Error.to_string err));
+  (* [InferenceTelemetry] is an inline-record constructor, so its value cannot
+     escape the match arm; project the fields into a plain tuple instead. *)
+  let telemetry =
+    Event_bus.drain sub
+    |> List.map (fun event -> event.Event_bus.payload)
+    |> List.find_map (function
+      | Event_bus.InferenceTelemetry r ->
+        Some
+          ( r.provider
+          , r.turn
+          , r.model
+          , r.prompt_tokens
+          , r.completion_tokens
+          , r.prompt_ms
+          , r.decode_ms
+          , r.decode_tok_s )
+      | _ -> None)
+  in
+  match telemetry with
+  | None -> Alcotest.fail "expected an InferenceTelemetry event"
+  | Some
+      ( provider
+      , turn
+      , model
+      , prompt_tokens
+      , completion_tokens
+      , prompt_ms
+      , decode_ms
+      , decode_tok_s ) ->
+    Alcotest.(check string) "provider" "openai_compat" provider;
+    Alcotest.(check int) "turn" 0 turn;
+    Alcotest.(check string) "model" "mock-model" model;
+    Alcotest.(check (option int)) "prompt_tokens" (Some 11) prompt_tokens;
+    Alcotest.(check (option int)) "completion_tokens" (Some 22) completion_tokens;
+    Alcotest.(check (option (float 0.001))) "prompt_ms" (Some 12.0) prompt_ms;
+    Alcotest.(check (option (float 0.001))) "decode_ms" (Some 34.0) decode_ms;
+    Alcotest.(check (option (float 0.001))) "decode_tok_s" (Some 81.5) decode_tok_s
+;;
+
+let () =
+  Alcotest.run
+    "Observability default"
+    [ ( "builder"
+      , [ Alcotest.test_case
+            "default-on installs event bus"
+            `Quick
+            test_builder_default_on_event_bus
+        ; Alcotest.test_case
+            "without_event_bus opts out"
+            `Quick
+            test_builder_without_event_bus_opts_out
+        ] )
+    ; ( "pipeline"
+      , [ Alcotest.test_case
+            "emits InferenceTelemetry on default bus"
+            `Quick
+            test_pipeline_emits_inference_telemetry_on_default_bus
+        ] )
+    ]
+;;

--- a/test/test_observability_default.ml
+++ b/test/test_observability_default.ml
@@ -63,8 +63,77 @@ let build_or_fail b =
   | Error err -> Alcotest.fail ("build_safe failed: " ^ Error.to_string err)
 ;;
 
-let single_response_transport response : Llm_provider.Llm_transport.t =
-  let remaining = ref [ response ] in
+let sample_telemetry : Types.inference_telemetry =
+  { Types.default_inference_telemetry with
+    timings =
+      Some
+        { Types.prompt_n = Some 11
+        ; prompt_ms = Some 12.0
+        ; prompt_per_second = None
+        ; predicted_n = Some 22
+        ; predicted_ms = Some 34.0
+        ; predicted_per_second = Some 81.5
+        ; cache_n = None
+        }
+  ; provider_kind = Some Llm_provider.Provider_kind.OpenAI_compat
+  }
+;;
+
+let sample_usage : Types.api_usage =
+  { input_tokens = 11
+  ; output_tokens = 22
+  ; cache_creation_input_tokens = 0
+  ; cache_read_input_tokens = 0
+  ; cost_usd = None
+  }
+;;
+
+(* Turn 1: the model interleaves a Thinking block before a ToolUse block. OAS
+   must preserve that order in the assembled assistant message so a downstream
+   renderer (MASC) can show Thinking → Tool in sequence. *)
+let thinking_then_tool_response : Types.api_response =
+  { id = "obs-tool-1"
+  ; model = "mock-model"
+  ; stop_reason = Types.StopToolUse
+  ; content =
+      [ Types.Thinking { thinking_type = "thinking"; content = "I should check the time" }
+      ; Types.ToolUse
+          { id = "call_1"
+          ; name = "get_time"
+          ; input = `Assoc [ "timezone", `String "UTC" ]
+          }
+      ]
+  ; usage = Some sample_usage
+  ; telemetry = Some sample_telemetry
+  }
+;;
+
+let final_text_response : Types.api_response =
+  { id = "obs-tool-2"
+  ; model = "mock-model"
+  ; stop_reason = Types.EndTurn
+  ; content = [ Types.Text "it is 12:00 UTC" ]
+  ; usage = Some sample_usage
+  ; telemetry = Some sample_telemetry
+  }
+;;
+
+let get_time_tool =
+  Tool.create
+    ~name:"get_time"
+    ~description:"Get current time"
+    ~parameters:
+      [ { name = "timezone"
+        ; param_type = Types.String
+        ; description = "tz"
+        ; required = true
+        }
+      ]
+    (fun _input -> Ok { Types.content = "12:00 UTC"; _meta = None })
+;;
+
+let sequence_transport responses : Llm_provider.Llm_transport.t =
+  let remaining = ref responses in
   let next () =
     match !remaining with
     | r :: rest ->
@@ -77,6 +146,14 @@ let single_response_transport response : Llm_provider.Llm_transport.t =
         { Llm_provider.Llm_transport.response = Ok (next ()); latency_ms = Some 0 })
   ; complete_stream = (fun ?on_telemetry:_ ~on_event:_ _req -> Ok (next ()))
   }
+;;
+
+let first_index pred xs =
+  let rec loop i = function
+    | [] -> None
+    | x :: rest -> if pred x then Some i else loop (i + 1) rest
+  in
+  loop 0 xs
 ;;
 
 let test_builder_default_on_event_bus () =
@@ -114,7 +191,7 @@ let test_pipeline_emits_inference_telemetry_on_default_bus () =
   Eio.Switch.run
   @@ fun sw ->
   let net = Eio.Stdenv.net env in
-  let transport = single_response_transport response_with_telemetry in
+  let transport = sequence_transport [ response_with_telemetry ] in
   (* Build through the default-on path and pull the bus the Builder created, so
      this also proves the producer publishes onto the *default* bus. *)
   let agent =
@@ -173,6 +250,93 @@ let test_pipeline_emits_inference_telemetry_on_default_bus () =
     Alcotest.(check (option (float 0.001))) "decode_tok_s" (Some 81.5) decode_tok_s
 ;;
 
+(* The adversarial core of the observability pillar: with only a Builder (no
+   explicit bus wiring), a tool-using multi-turn run must surface Tools and
+   Turns on the default bus in causal order, and OAS must preserve the
+   Thinking → Tool interleaving order in the assembled assistant message. This
+   is "Tools observed by default — verified, not claimed". *)
+let test_tools_turns_and_interleaving_observed_by_default () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let net = Eio.Stdenv.net env in
+  let transport =
+    sequence_transport [ thinking_then_tool_response; final_text_response ]
+  in
+  let agent =
+    Builder.create ~net ~model:"mock-model"
+    |> Builder.with_name "obs-tools"
+    |> Builder.with_max_turns 3
+    |> Builder.with_provider mock_provider
+    |> Builder.with_transport transport
+    |> Builder.with_tool get_time_tool
+    |> build_or_fail
+  in
+  let event_bus =
+    match (Agent.options agent).event_bus with
+    | Some bus -> bus
+    | None -> Alcotest.fail "expected default-on event bus on the built agent"
+  in
+  let sub = Event_bus.subscribe event_bus in
+  (match Agent.run ~sw agent "what time is it?" with
+   | Ok _ -> ()
+   | Error err -> Alcotest.fail ("expected run success: " ^ Error.to_string err));
+  let kinds =
+    Event_bus.drain sub
+    |> List.map (fun event -> Event_bus.payload_kind event.Event_bus.payload)
+  in
+  (* Tools observed by default, in causal order (call before completion). *)
+  let idx k = first_index (String.equal k) kinds in
+  (match idx "tool_called", idx "tool_completed" with
+   | Some called, Some completed ->
+     Alcotest.(check bool) "tool_called precedes tool_completed" true (called < completed)
+   | _ ->
+     Alcotest.failf
+       "expected tool_called and tool_completed on the default bus; saw [%s]"
+       (String.concat "; " kinds));
+  (* Turn and per-call telemetry observed by default. *)
+  Alcotest.(check bool) "turn_completed observed" true (List.mem "turn_completed" kinds);
+  Alcotest.(check bool)
+    "inference_telemetry observed"
+    true
+    (List.mem "inference_telemetry" kinds);
+  (* Interleaving exposure: the assistant message that carries the tool call
+     must keep Thinking before ToolUse so a renderer can reproduce the order. *)
+  let assistant_with_tool =
+    List.find_opt
+      (fun (m : Types.message) ->
+         m.role = Types.Assistant
+         && List.exists
+              (function
+                | Types.ToolUse _ -> true
+                | _ -> false)
+              m.content)
+      (Agent.state agent).messages
+  in
+  match assistant_with_tool with
+  | None -> Alcotest.fail "expected an assistant message carrying the tool call"
+  | Some m ->
+    let thinking_at =
+      first_index
+        (function
+          | Types.Thinking _ -> true
+          | _ -> false)
+        m.content
+    in
+    let tool_at =
+      first_index
+        (function
+          | Types.ToolUse _ -> true
+          | _ -> false)
+        m.content
+    in
+    (match thinking_at, tool_at with
+     | Some t, Some u ->
+       Alcotest.(check bool) "Thinking precedes ToolUse (interleaving order)" true (t < u)
+     | _ -> Alcotest.fail "expected both Thinking and ToolUse in the assistant message")
+;;
+
 let () =
   Alcotest.run
     "Observability default"
@@ -191,6 +355,10 @@ let () =
             "emits InferenceTelemetry on default bus"
             `Quick
             test_pipeline_emits_inference_telemetry_on_default_bus
+        ; Alcotest.test_case
+            "tools, turns, and interleaving observed by default"
+            `Quick
+            test_tools_turns_and_interleaving_observed_by_default
         ] )
     ]
 ;;


### PR DESCRIPTION
## 목적

OAS의 세 번째 관찰성 기둥 — **관찰을 기본값으로(observability-as-default)** 확립. Turn/토큰/디코드 tok/s가 호출자가 아무것도 배선하지 않아도 기본으로 방출되도록 한다. `InferenceTelemetry` 이벤트는 정의·소비(`event_forward.ml`)는 되어 있으나 **producer가 0개인 dead event**였다 — 이 PR이 그 누락된 절반을 채운다.

경계: OAS는 typed 이벤트를 bus에 방출만 한다. 기록·렌더링은 MASC 쪽 책임이다 (OAS는 MASC를 모른다).

## 변경

1. **Builder default-on event bus** (`lib/agent/builder.ml`, `.mli`)
   - `Builder.create`가 에이전트마다 **새 `Event_bus.t`**를 설치한다. `create`는 per-call 함수이므로 빌더마다 독립 bus가 생긴다 — 공유 전역 mutable bus가 아니며, `Agent_types.default_options.event_bus`는 `None`으로 유지된다(금지 패턴 회피).
   - 구독자가 없으면 `Event_bus.publish`는 빈 구독자 리스트를 순회하는 no-op이라 기본값 비용은 이벤트당 mutex 1회뿐(pay-for-what-you-observe).
   - `Builder.without_event_bus`로 opt-out.

2. **per-turn InferenceTelemetry producer** (`lib/pipeline/pipeline.ml` `stage_collect`)
   - `TurnCompleted` 바로 옆에서 `InferenceTelemetry`를 방출한다: provider/turn/model + provider가 보고한 토큰 수와 디코드 타이밍.
   - `provider`는 required string이므로 `response.telemetry.provider_kind`(모든 실 completion에서 `Complete_common.patch_telemetry`가 설정)에서 식별 가능할 때만 방출한다. telemetry 없는 synthetic 응답은 **fabricated provider로 방출하지 않고 skip**한다(노 매직 스트링). 토큰/타이밍 필드는 provider가 보고하지 않으면 `None`(클라우드 provider는 타이밍 생략).
   - 중첩 option은 catch-all 없이 `None -> ()`로 명시 — 향후 telemetry 필드가 여기서 silent drop될 수 없다.

## 설계 근거 (노 워크어라운드)

이 PR은 텔레메트리-as-fix 워크어라운드가 **아니다**. silent failure를 가시화하며 회피하는 것이 아니라, 사용자가 명시 요청한 1급 기능(관찰 기본값)이며 이미 존재·소비되던 dead event(`InferenceTelemetry`)에 producer를 더해 완성한다. 가려지는 근본 버그가 없다.

- 노 하드코딩 / 노 매직 스트링: provider는 typed `Provider_kind.t`에서 파생, unknown은 skip.
- 노 silent failure: 중첩 option 명시 분기, catch-all 없음.
- SSOT 유지: `default_options.event_bus`는 `None` 불변, Builder만 기본값을 켠다.

## 검증

- 로컬 focused build green: `scripts/dune-local.sh build lib` (exit 0).
- 신규 테스트 `test/test_observability_default.ml` 3건 통과:
  - `Builder.build`가 기본 event bus 설치 (default-on)
  - `Builder.without_event_bus`가 bus 제거 (opt-out)
  - 파이프라인이 **기본 bus**로 `InferenceTelemetry` 방출 — provider=`openai_compat`, turn=0, prompt/completion 토큰, prompt_ms/decode_ms/decode_tok_s 정확 단언
- **Mutation 증명** (각 단언 비-vacuity):
  - 기본값 → `None` 복귀: 테스트 1(default-on)+3(producer) 실패, 2(opt-out) 통과
  - producer `decode_tok_s` → `None`: 테스트 3이 `decode_tok_s`에서 정확히 실패
  - `without_event_bus` → identity: 테스트 2 실패
- 회귀 없음: `test_builder_coverage` 15/15, `test_event_integration` 4/4, `test_telemetry_pipeline` 7/7, `test_agent_turn` 39/39.
  - `test_builder`의 2건(`context_thresholds` provider budget)은 baseline(origin/main)에도 존재하는 pre-existing 실패로 본 변경과 무관(stash 후 baseline 재현 확인).

RFC-WAIVED: `lib/agent/*`, `lib/pipeline/*`는 credential/keeper-sandbox/operator/hooks/workflow subsystem이 아니다. 본 변경은 RFC-OAS-029의 observability-as-default 기둥을 구현한다.
