### PR TITLE
style(llm_provider): format response_shape.ml to clear OCaml Format on main

### DIFF
--- a/lib/llm_provider/response_shape.ml
+++ b/lib/llm_provider/response_shape.ml
@@ -88,7 +88,6 @@ let summarize_blocks (content : Types.content_block list) =
 ;;
 
 let summarize (response : Types.api_response) = summarize_blocks response.content
-
 let has_deliverable_content shape = shape.text_chars > 0 || shape.tool_use_count > 0
 
 let content_shape (response : Types.api_response) shape =


### PR DESCRIPTION
## 목적
main(`01276bbe`, #2248 머지 후)의 유일한 red인 **OCaml Format**을 회복합니다. `Build & Test (OCaml 5.4.1)`는 이미 SUCCESS — GLM reasoning stale-test 문제는 #2244/#2249 흡수로 해소됨. 남은 건 포맷뿐.

## 원인
3개 파일이 미포맷 상태로 main에 머지되어 OCaml Format check가 red 유지:
- `lib/llm_provider/backend_tool_call_harness.ml` — 단일 라인 match arm을 janestreet 프로필 멀티라인으로 펼침
- `lib/llm_provider/response_shape.ml` — 연속 `let` 사이 빈 줄 제거
- `test/test_agent_tool.ml` — 긴 `Alcotest.failf` 줄바꿈

## 변경 성격
ocamlformat **0.29.0 (janestreet)** — CI와 동일 버전으로 생성. 순수 layout, 의미 변경 0.

## #2242와의 관계
#2242("repair main format and GLM reasoning assertion")는 base `a3f7d978`로 stale(29파일), CONFLICTING이며 미포맷 3파일 중 `response_shape.ml`을 **포함하지 않음**. GLM assertion 목적도 main에 이미 반영됨. 이 PR은 main이 *지금* 필요한 최소 포맷 fix만 담아 충돌 없이 회복합니다.

## 검증
빌드/포맷은 CI에서 확인(로컬 빌드 안 함). OCaml Format job green 확인 후 Ready 전환.
