### PR TITLE
fix(ci): restore oas main green (OCaml Format 3 files + drop keeper term)

### DIFF
--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -79,7 +79,7 @@ let%test "glm rejects named forced tool_choice" =
       ()
   in
   match effective_tool_choice cfg with
- | exception Invalid_argument msg ->
+  | exception Invalid_argument msg ->
     String.starts_with
       ~prefix:"Backend_openai_request.effective_tool_choice: glm model"
       msg
@@ -1124,7 +1124,7 @@ let%test "glm build_request rejects unsupported forced tool_choice" =
       ()
   in
   match build_request ~config ~messages:[] () with
- | exception Invalid_argument msg ->
+  | exception Invalid_argument msg ->
     String.starts_with
       ~prefix:"Backend_openai_request.effective_tool_choice: glm model"
       msg

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -64,8 +64,7 @@ let add_sampling_field dialect (config : Provider_config.t) field value body =
 let effective_tool_choice (config : Provider_config.t) =
   match Provider_config.validate_tool_choice_request config with
   | Error reason ->
-    invalid_arg
-      (Printf.sprintf "Backend_openai_request.effective_tool_choice: %s" reason)
+    invalid_arg (Printf.sprintf "Backend_openai_request.effective_tool_choice: %s" reason)
   | Ok () ->
     (match config.tool_choice with
      | Some None_ -> None

--- a/lib/llm_provider/provider_config.mli
+++ b/lib/llm_provider/provider_config.mli
@@ -414,7 +414,7 @@ val validate_cli_sampling_params : t -> (unit, string) result
 (** Validate provider-specific [tool_choice] constraints before request-body
     construction. This catches unsupported runtime/provider contracts at the
     typed config boundary instead of letting serializers raise exceptions after
-    a keeper turn has started. *)
+    a turn has started. *)
 type tool_choice_request_rejection =
   | Unsupported_named_tool_choice of
       { provider_kind : provider_kind
@@ -423,10 +423,7 @@ type tool_choice_request_rejection =
       }
 
 val tool_choice_request_rejection_to_message : tool_choice_request_rejection -> string
-
-val validate_tool_choice_request_typed
-  :  t
-  -> (unit, tool_choice_request_rejection) result
+val validate_tool_choice_request_typed : t -> (unit, tool_choice_request_rejection) result
 
 val validate_tool_choice_request_with_capabilities
   :  provider_kind:provider_kind


### PR DESCRIPTION
## 목적
머지 wave(09:06–09:11Z, 6 PR) 직후 oas main(`39a7d139`)에 들어온 **두 신규 회귀**를 회복합니다.

## 회귀 1: OCaml Format red (신규 3파일)
- `lib/llm_provider/backend_openai_request.ml`, `backend_openai.ml`, `provider_config.mli`이 미포맷 상태로 머지됨.
- ocamlformat 0.29.0 (janestreet, CI와 동일)로 포맷. 순수 layout, 의미 변경 0.

## 회귀 2: SDK Independence Gate red
- `provider_config.mli`의 doc 코멘트에 coordinator 용어 **"keeper"**("after a keeper turn has started")가 포함 → strict `\bkeeper\b`(lib/) 매칭.
- SDK-중립 "after a turn has started"로 리워드(동작 변경 없음). 이 용어는 #2254에서 유입.
- `scripts/check-sdk-independence.sh` 로컬 PASS 확인.

## 근본 원인 (반복 패턴, 2번째 발생)
이번이 oas main OCaml Format **2번째** 회복입니다(직전 #2253: response_shape 등 3파일). 매번 PR이 미포맷/coordinator-term 상태로 머지됩니다. call-site 반복 fix는 비용만 누적 — CLAUDE.md "2번째 fix→근본 수정 강제".

**근본 해결 권고**:
- **OCaml Format을 main branch protection의 required check로** 승격 → 미포맷 PR 머지 차단.
- **SDK Independence Gate를 PR-level required check로** (현재 main에서만 잡혀 #2254 PR에서 "keeper"를 못 막음).
- #22673(masc Draft Auto-Merge Guard 포팅)과 같은 main-protection 작업의 oas 대응이 필요.

## 검증
빌드/포맷/SDK 체크는 CI에서 확인. 회복 후 Ready.
