### PR TITLE
fix(ci): scope legacy-stage lint to OCaml sources

### DIFF
--- a/scripts/lint-legacy-pipeline-stages.sh
+++ b/scripts/lint-legacy-pipeline-stages.sh
@@ -28,11 +28,18 @@ for path in "${legacy_files[@]}"; do
   fi
 done
 
+# Scope the scan to OCaml sources only. A legacy *module* reference
+# (Stage_execute.foo / open Stage_execute) can only exist in .ml/.mli; once the
+# files above are gone such a reference is an unbound-module compile error that
+# Build & Test catches. Scanning docs/README matched prose that merely describes
+# the pipeline (e.g. an audit doc saying "Stage_execute takes a Nonempty.t"),
+# producing false positives that blocked legitimate documentation. The nonexistent
+# `bin` path also emitted a spurious "No such file or directory" each run.
 pattern='\bStage_(input|parse|route|collect|execute|output)\b'
 if command -v rg >/dev/null 2>&1; then
-  matches="$(rg --no-heading -n -- "$pattern" lib test docs bin README.md || true)"
+  matches="$(rg --no-heading -n -g '*.ml' -g '*.mli' -- "$pattern" lib test || true)"
 else
-  matches="$(grep -RnE -- "$pattern" lib test docs bin README.md 2>/dev/null || true)"
+  matches="$(grep -RnE --include='*.ml' --include='*.mli' -- "$pattern" lib test 2>/dev/null || true)"
 fi
 
 if [ -n "$matches" ]; then


### PR DESCRIPTION
## 문제

`scripts/lint-legacy-pipeline-stages.sh`(Boundary Lint Core→CDAL job)가 string-match 오탐으로 정당한 문서 PR을 차단합니다.

- #2256(`docs/audits/oas-ttrm-adversarial-verdict-20260629.md`)이 아키텍처를 서술하며 "`Stage_execute` takes a `Nonempty.t`"를 인용 → 린트가 "레거시 모듈 재도입"으로 오탐, `exit 1`.
- 스캔 대상에 존재하지 않는 `bin` 경로가 포함돼 매 실행 `rg: bin: No such file or directory` 노이즈.

## 근본 원인

OCaml 모듈 참조(`Stage_execute.foo`, `open Stage_execute`)는 `.ml`/`.mli`에만 존재할 수 있습니다. 마크다운은 모듈을 재도입하지 못합니다. 또한 레거시 파일이 없으면(스크립트 1차 검사) `.ml`에 남은 참조는 unbound-module **컴파일 에러**로 Build & Test가 잡습니다. 따라서 `docs`/`README` 스캔은 구조적으로 거짓양성만 만듭니다.

## 변경

스캔 대상을 `lib`/`test`의 `.ml`/`.mli`로 한정. 파일 존재 검사와 컴파일러가 권위 가드로 유지됩니다. 왜 docs를 제외하는지 주석으로 명시(재추가 방지).

```diff
- rg --no-heading -n -- "$pattern" lib test docs bin README.md
+ rg --no-heading -n -g '*.ml' -g '*.mli' -- "$pattern" lib test
```

## 검증 (로컬, bash 스크립트라 빌드 무관)

- 수정 후 `bash scripts/lint-legacy-pipeline-stages.sh` → `legacy pipeline stage lint passed` (exit 0).
- 음성 테스트: 임시 `lib/fake.ml`에 `Stage_execute.run` → **잡힘**. 임시 `docs/note.md`의 동일 산문 → **무시**. 가드 보존 확인.
- 최종 CI는 GitHub Actions에서 확인.

## 영향 / 관계

- 이 수정 후 #2256 rebase 시 Boundary Lint green 예상.
- `scripts/` 변경 — credential/identity/operator/sandbox/hooks/workflow subsystem 비대상.

RFC-WAIVED: CI 린트 스크립트 스코프 수정. credential/identity/operator/sandbox/hooks/workflow-docs subsystem 미해당 (pr-rfc-check 대상 외).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
