### PR TITLE
fix(streaming): fail closed on malformed streamed tool arguments

### DIFF
--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -245,11 +245,27 @@ let finalize_stream_acc
           | Some s -> s
           | None -> ""
         in
-        let input =
-          try Yojson.Safe.from_string text with
-          | Yojson.Json_error _ -> `Assoc []
-        in
-        Ok (Some (Types.ToolUse { id; name; input }))
+        (* Tool arguments must parse. An empty argument buffer is the
+           legitimate "no arguments" case and becomes the empty object; a
+           non-empty buffer that fails to parse is a malformed tool call —
+           fail closed with a typed [Stream_parse_failed] rather than coercing
+           to [`Assoc []], which would silently dispatch the tool with empty
+           arguments (RFC-OAS-029 S8: no silent permissive default). Mirrors
+           the [Unknown_block] fail-closed arm and the typed-absence policy of
+           the sibling [Tool_result_block] branch (which carries [json = None]
+           rather than fabricating an object). *)
+        if String.trim text = ""
+        then Ok (Some (Types.ToolUse { id; name; input = `Assoc [] }))
+        else (
+          match Yojson.Safe.from_string text with
+          | input -> Ok (Some (Types.ToolUse { id; name; input }))
+          | exception Yojson.Json_error reason ->
+            Error
+              (Types.Stream_parse_failed
+                 { reason =
+                     Printf.sprintf "malformed_tool_use_arguments:index:%d:%s" idx reason
+                 ; raw = ""
+                 }))
       | Some (Tool_result_block { is_error }) ->
         let tool_use_id =
           match Hashtbl.find_opt acc.block_tool_ids idx with

--- a/test/test_streaming_openai.ml
+++ b/test/test_streaming_openai.ml
@@ -841,6 +841,97 @@ let test_responses_stream_incomplete_content_filter_drops_tool () =
          response.content)
 ;;
 
+(* ── tool-argument fail-closed (canonical accumulator) ───────────────────────
+   The canonical [Complete_stream_acc] finalize path must not silently coerce a
+   malformed tool-argument buffer to empty arguments. A non-empty buffer that
+   fails to parse is a malformed tool call and surfaces a typed
+   [Stream_parse_failed]; an empty buffer is the legitimate no-arguments case
+   and yields [`Assoc []]. (RFC-OAS-029 S8: no silent permissive default.) *)
+let malformed_tool_args_tag = "malformed_tool_use_arguments"
+
+let test_stream_tool_args_malformed_fails_closed () =
+  let module Acc = Llm_provider.Complete_stream_acc in
+  let acc = Acc.create_stream_acc () in
+  List.iter
+    (Acc.accumulate_event acc)
+    [ MessageStart { id = "m"; model = "m"; usage = None }
+    ; ContentBlockStart
+        { index = 0
+        ; content_type = "tool_use"
+        ; tool_id = Some "tu_bad"
+        ; tool_name = Some "get_weather"
+        }
+    ; ContentBlockDelta { index = 0; delta = InputJsonDelta "not json{" }
+    ; MessageDelta { stop_reason = Some StopToolUse; usage = None }
+    ];
+  match Acc.finalize_stream_acc acc with
+  | Ok _ -> Alcotest.fail "expected Error: malformed tool arguments must fail closed"
+  | Error (Stream_parse_failed { reason; _ }) ->
+    Alcotest.(check bool)
+      "reason identifies malformed tool arguments"
+      true
+      (String.starts_with ~prefix:malformed_tool_args_tag reason)
+  | Error _ -> Alcotest.fail "expected Stream_parse_failed, got a different stream_error"
+;;
+
+let test_stream_tool_args_empty_is_no_args () =
+  let module Acc = Llm_provider.Complete_stream_acc in
+  let acc = Acc.create_stream_acc () in
+  List.iter
+    (Acc.accumulate_event acc)
+    [ MessageStart { id = "m"; model = "m"; usage = None }
+    ; ContentBlockStart
+        { index = 0
+        ; content_type = "tool_use"
+        ; tool_id = Some "tu_empty"
+        ; tool_name = Some "now"
+        }
+      (* no InputJsonDelta: the argument buffer stays empty *)
+    ; MessageDelta { stop_reason = Some StopToolUse; usage = None }
+    ];
+  match Acc.finalize_stream_acc acc with
+  | Error _ ->
+    Alcotest.fail "expected Ok: empty arguments are the legitimate no-args case"
+  | Ok response ->
+    (match response.content with
+     | [ ToolUse { id; name; input } ] ->
+       Alcotest.(check string) "tool id preserved" "tu_empty" id;
+       Alcotest.(check string) "tool name preserved" "now" name;
+       Alcotest.(check string)
+         "empty args -> empty object"
+         "{}"
+         (Yojson.Safe.to_string input)
+     | _ -> Alcotest.fail "expected a single ToolUse block")
+;;
+
+let test_stream_tool_args_valid_parsed () =
+  let module Acc = Llm_provider.Complete_stream_acc in
+  let acc = Acc.create_stream_acc () in
+  List.iter
+    (Acc.accumulate_event acc)
+    [ MessageStart { id = "m"; model = "m"; usage = None }
+    ; ContentBlockStart
+        { index = 0
+        ; content_type = "tool_use"
+        ; tool_id = Some "tu_ok"
+        ; tool_name = Some "get_weather"
+        }
+    ; ContentBlockDelta { index = 0; delta = InputJsonDelta "{\"city\":" }
+    ; ContentBlockDelta { index = 0; delta = InputJsonDelta "\"Paris\"}" }
+    ; MessageDelta { stop_reason = Some StopToolUse; usage = None }
+    ];
+  match Acc.finalize_stream_acc acc with
+  | Error _ -> Alcotest.fail "expected Ok for valid tool arguments"
+  | Ok response ->
+    (match response.content with
+     | [ ToolUse { input; _ } ] ->
+       Alcotest.(check string)
+         "parsed args preserved verbatim"
+         {|{"city":"Paris"}|}
+         (Yojson.Safe.to_string input)
+     | _ -> Alcotest.fail "expected a single ToolUse block")
+;;
+
 let () =
   let open Alcotest in
   run
@@ -902,6 +993,20 @@ let () =
             "incomplete content_filter drops tool (#2073)"
             `Quick
             test_responses_stream_incomplete_content_filter_drops_tool
+        ] )
+    ; ( "tool_args_failclosed"
+      , [ test_case
+            "malformed args -> typed Stream_parse_failed"
+            `Quick
+            test_stream_tool_args_malformed_fails_closed
+        ; test_case
+            "empty args -> empty object (no-args)"
+            `Quick
+            test_stream_tool_args_empty_is_no_args
+        ; test_case
+            "valid args -> parsed verbatim"
+            `Quick
+            test_stream_tool_args_valid_parsed
         ] )
     ]
 ;;


### PR DESCRIPTION
## 목적

스트리밍 도구 인자(tool arguments)가 파싱에 실패할 때, canonical accumulator(`Complete_stream_acc.finalize_stream_acc`)가 조용히 `{}`(빈 인자)로 강등해 도구를 잘못된 빈 인자로 디스패치하던 silent failure를 제거한다.

## 변경

- `lib/llm_provider/complete_stream_acc.ml` — `Tool_use_block` arm:
  - 빈 버퍼 → 정당한 no-arguments 호출, `` `Assoc [] `` 유지 (회귀 없음)
  - 비어있지 않은 파싱 실패 버퍼 → typed `Stream_parse_failed { reason = "malformed_tool_use_arguments:index:..." }` 로 fail-closed
  - 기존 `Unknown_block` fail-closed arm 및 sibling `Tool_result`(`json = None`) typed-absence 정책과 일관
- `test/test_streaming_openai.ml` — canonical accumulator 대상 3개 테스트 추가:
  - malformed → `Error (Stream_parse_failed _)`
  - empty → `{}` (no-args)
  - valid → 파싱값 보존
  - mutation 검증: coercion으로 되돌리면 malformed 테스트만 실패(non-vacuous 증명)

## 근거

RFC-OAS-029 §8 (no silent permissive default), CLAUDE.md "Unknown → Permissive Default" 안티패턴. 적대적 리뷰 verdict(`docs/audits/oas-ttrm-adversarial-verdict-20260629.md`, PR #2256)에서 식별한 canonical-path P0 해소.

이것은 silent permissive default를 typed fail-closed로 교체하는 parse-don't-validate 근본 수정이다. 진단 신호 추가나 증상 억제가 아니다.

## 검증

- `scripts/dune-local.sh build lib test/test_streaming_openai.exe` → exit 0 (origin/main 0.207.22 rebase 후 재확인)
- `test_streaming_openai` 31 tests green (기존 28 + 신규 3)
- `test_stream_accumulator` 27 tests green (보조 경로 무영향)
- mutation 검증 완료 (coercion 복원 시 malformed 테스트만 실패 후 fix 복원)

## 알려진 후속 (Issue Discovery)

보조 accumulator(`lib/streaming.ml:195-204`, `create_message_stream` = examples + e2e 표면)도 malformed tool args를 조용히 `Text` 블록으로 강등한다. 이는 해당 파일 주석에 이미 기록된 duplicate accumulator 이슈의 일부이며, 근본 해결은 두 accumulator를 `Complete_stream_acc`로 통합하는 것이다. 본 PR에서 병렬 패치하면 N-of-M 패치 안티패턴이 되므로 통합 RFC 후속으로 남긴다.

RFC-WAIVED: `lib/llm_provider/complete_stream_acc.ml` 은 credential/identity/operator/sandbox/dashboard-credential/hooks/workflow 게이트 subsystem 이 아니다. silent failure 제거는 기존 typed error 정책(`Unknown_block`/`Tool_result`)을 따르는 국소 변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
