### PR TITLE
style(llm_provider): clear OCaml Format on main (post-merge cleanup)

### DIFF
--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -4,7 +4,6 @@
     Request building remains here due to agent_config/agent_state/Provider coupling. *)
 
 open Types
-
 module PConfig = Llm_provider.Provider_config
 
 (* Re-export pure functions from llm_provider *)
@@ -165,11 +164,11 @@ let tool_choice_validation_context ?provider_config (config : agent_state) =
     let caps = capabilities_for_request ?provider_config config in
     Ok (PConfig.Anthropic, model_id, llm_capabilities_of_provider_capabilities caps)
   | Some
-      ({ provider =
-           (Provider.Local { base_url } | Provider.OpenAICompat { base_url; _ })
+      ({ provider = Provider.Local { base_url } | Provider.OpenAICompat { base_url; _ }
        ; model_id
        ; _
-       } : Provider.config) ->
+       } :
+        Provider.config) ->
     let provider_kind = provider_config_kind_for_openai_compat ~base_url ~model_id in
     let caps =
       match provider_kind with
@@ -183,20 +182,14 @@ let tool_choice_validation_context ?provider_config (config : agent_state) =
       | PConfig.Gemini
       | PConfig.DashScope -> Llm_provider.Capabilities.default_capabilities
     in
-    Ok
-      ( provider_kind
-      , model_id
-      , caps )
+    Ok (provider_kind, model_id, caps)
   | None ->
     let model_id = model_to_string config.config.model in
     if Llm_provider.Zai_catalog.is_glm_model_id model_id
     then Ok (PConfig.Glm, model_id, Llm_provider.Capabilities.glm_capabilities)
     else (
       let caps = capabilities_for_request config in
-      Ok
-        ( PConfig.OpenAI_compat
-        , model_id
-        , llm_capabilities_of_provider_capabilities caps ))
+      Ok (PConfig.OpenAI_compat, model_id, llm_capabilities_of_provider_capabilities caps))
 ;;
 
 let validate_tool_choice_request ?provider_config (config : agent_state) =

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -393,8 +393,8 @@ type tool_choice_request_rejection =
 let tool_choice_request_rejection_to_message = function
   | Unsupported_named_tool_choice { provider_kind; model_id; tool_name } ->
     Printf.sprintf
-      "%s model %S does not support named forced tool_choice %S; use auto/any or \
-       remove tool_choice"
+      "%s model %S does not support named forced tool_choice %S; use auto/any or remove \
+       tool_choice"
       (string_of_provider_kind provider_kind)
       model_id
       tool_name
@@ -413,20 +413,23 @@ let tool_choice_capabilities_for_config (config : t) =
   match config.supports_tool_choice_override with
   | Some supports_tool_choice ->
     { caps with
-      Capabilities.supports_tool_choice = supports_tool_choice
+      Capabilities.supports_tool_choice
     ; supports_named_tool_choice = supports_tool_choice
     }
   | None -> caps
 ;;
 
-let validate_tool_choice_request_with_capabilities ~provider_kind ~model_id ~tool_choice caps =
+let validate_tool_choice_request_with_capabilities
+      ~provider_kind
+      ~model_id
+      ~tool_choice
+      caps
+  =
   match tool_choice with
   | Some (Types.Tool tool_name)
     when caps.Capabilities.supports_tool_choice
          && not caps.Capabilities.supports_named_tool_choice ->
-    Error
-      (Unsupported_named_tool_choice
-         { provider_kind; model_id; tool_name })
+    Error (Unsupported_named_tool_choice { provider_kind; model_id; tool_name })
   | Some (Types.Tool _) -> Ok ()
   | Some (Types.Auto | Types.Any | Types.None_) | None -> Ok ()
 ;;
@@ -441,7 +444,8 @@ let validate_tool_choice_request_typed (config : t) =
 ;;
 
 let validate_tool_choice_request config =
-  Result.map_error tool_choice_request_rejection_to_message
+  Result.map_error
+    tool_choice_request_rejection_to_message
     (validate_tool_choice_request_typed config)
 ;;
 

--- a/lib/provider_runtime_binding.ml
+++ b/lib/provider_runtime_binding.ml
@@ -387,10 +387,7 @@ let capabilities_for_provider_config (cfg : PConfig.t) =
   in
   match cfg.supports_tool_choice_override with
   | Some supports_tool_choice ->
-    { caps with
-      supports_tool_choice
-    ; supports_named_tool_choice = supports_tool_choice
-    }
+    { caps with supports_tool_choice; supports_named_tool_choice = supports_tool_choice }
   | None -> caps
 ;;
 


### PR DESCRIPTION
## 목적

oas `main`(500f0b30e)의 **OCaml Format** 게이트가 빨간 상태를 회복합니다. 직전 머지 웨이브(#2254 forced tool_choice, #2258 ollama think dialect 등)에서 손으로 작성한 OCaml이 `ocamlformat 0.29.0` 기준 미포맷으로 들어왔고, OCaml Format 게이트는 PR이 아니라 `main` push에서만 실행되므로 머지 후 main에서만 빨갛게 드러났습니다.

## 변경

`ocamlformat -i`로 3개 파일을 포맷합니다. **포맷 전용 — 의미 변화 없음.**

- `lib/llm_provider/provider_config.ml` — 긴 에러 문자열 break 위치, 함수 인자 wrapping 정규화
- `lib/provider_runtime_binding.ml` — record update 한 줄 압축
- `lib/api_openai.ml` — provider or-pattern / tuple 압축, 빈 줄 제거

## 검증

- `ocamlformat --check` 3파일 모두 통과 (로컬, 결정론적 포맷 진단)
- line-anchored `| _ ->` wildcard 개수 변화 없음 → `hardening-ratchet` baseline 무영향 (baseline 변경 없음)
- 빌드/테스트는 CI에서 확인

## 근본 원인 (반복 패턴)

OCaml Format 게이트가 PR-level required check가 아니라 `main` push 트리거라, 매 머지 웨이브마다 main이 다시 빨개지고 사후 청소 PR이 반복 필요합니다. 근본 해결은 OCaml Format(및 SDK Independence Gate)을 PR-level required check로 승격하는 것입니다 (masc #22673 Draft Auto-Merge Guard port와 동일 패턴). 이번 PR은 즉시 회복용이며, 게이트 승격은 별도 인프라 작업으로 분리합니다.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>