### PR TITLE
fix(streaming): correct inline test for fail-closed tool arguments (main red)

### DIFF
--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -919,14 +919,32 @@ let%test "finalize_stream_acc fails closed for media payload without metadata" =
   | Error (Types.Stream_provider_error _ | Types.Stream_unknown_event _) | Ok _ -> false
 ;;
 
-let%test "finalize_stream_acc tool_use with invalid json falls back to empty assoc" =
-  (* Non-truncated turn: an unparseable buffer still falls back to empty input
-     (existing behavior). Truncation is handled by the MaxTokens guard, below. *)
+let%test "finalize_stream_acc fails closed on malformed tool_use arguments" =
+  (* Non-truncated turn: a non-empty argument buffer that fails to parse is a
+     malformed tool call and surfaces a typed [Stream_parse_failed] rather than
+     silently coercing to empty arguments (RFC-OAS-029 S8: no silent permissive
+     default). Truncation is handled by the MaxTokens guard, below. *)
   let acc = create_stream_acc () in
   Hashtbl.replace acc.block_types 0 "tool_use";
   let buf = Buffer.create 16 in
   Buffer.add_string buf "not valid json";
   Hashtbl.replace acc.block_texts 0 buf;
+  match
+    acc.stop_reason_received := true;
+    finalize_stream_acc acc
+  with
+  | Error (Types.Stream_parse_failed { reason; raw }) ->
+    raw = "" && String.starts_with ~prefix:"malformed_tool_use_arguments:index:0" reason
+  | Error (Types.Stream_provider_error _ | Types.Stream_unknown_event _) | Ok _ -> false
+;;
+
+let%test "finalize_stream_acc keeps empty tool_use arguments as empty object" =
+  (* An empty argument buffer is the legitimate no-arguments call and must
+     remain [`Assoc []] (not be treated as malformed). *)
+  let acc = create_stream_acc () in
+  Hashtbl.replace acc.block_types 0 "tool_use";
+  Hashtbl.replace acc.block_tool_ids 0 "tool-id-1";
+  Hashtbl.replace acc.block_tool_names 0 "now";
   match
     acc.stop_reason_received := true;
     finalize_stream_acc acc


### PR DESCRIPTION
## 목적

main의 `Build & Test` (required check)를 green으로 회복한다.

PR #2261이 `finalize_stream_acc`의 fail-closed fix를 머지했으나, 같은 파일의 **co-located 인라인 테스트**가 옛 silent-coercion 동작("invalid json falls back to empty assoc")을 그대로 단언하고 있어 main의 `complete_stream_acc` 인라인 파티션이 red 상태다.

## 원인

`test/test_streaming_openai.ml`의 out-of-line 테스트(malformed/empty/valid)는 #2261에 포함됐지만, `lib/llm_provider/complete_stream_acc.ml` 내부의 `let%test "...falls back to empty assoc"`가 함께 갱신되지 않았다. focused build(`dune build lib`)는 인라인 테스트를 실행하지 않아 #2261 작업 중 이 단언 갱신이 누락됐다.

근본 교훈: lib 소스 내부 `let%test` 변경 시 컴파일만으로는 부족하고 `dune runtest`로 인라인 파티션까지 실행해 확인해야 한다.

## 변경

- `lib/llm_provider/complete_stream_acc.ml` 인라인 테스트:
  - `"...falls back to empty assoc"` → `"fails closed on malformed tool_use arguments"` 로 정정 (non-empty malformed → typed `Stream_parse_failed`, sibling media-block 인라인 테스트와 동일 스타일)
  - companion 추가: `"keeps empty tool_use arguments as empty object"` (empty 버퍼 → `` `Assoc [] `` no-args 보존)

## 검증

- `scripts/dune-local.sh build lib` → exit 0
- `complete_stream_acc` 인라인 파티션 단독 실행 → 전부 통과 (exit 0)
- 로컬 `backend_openai`/`provider_config` 인라인 실패는 로컬 capability-manifest 환경 노이즈로 CI와 무관 (#2261 CI 로그에서 해당 파티션 통과 확인됨).

RFC-WAIVED: `lib/llm_provider/complete_stream_acc.ml` 은 credential/identity/operator/sandbox/dashboard-credential/hooks/workflow 게이트 subsystem 이 아니다. 인라인 테스트 단언을 #2261이 머지한 fail-closed 동작과 일치시키는 국소 수정이며, 워크어라운드가 아니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
