### PR TITLE
test(streaming): assert malformed tool args fail closed

### DIFF
--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -919,9 +919,11 @@ let%test "finalize_stream_acc fails closed for media payload without metadata" =
   | Error (Types.Stream_provider_error _ | Types.Stream_unknown_event _) | Ok _ -> false
 ;;
 
-let%test "finalize_stream_acc tool_use with invalid json falls back to empty assoc" =
-  (* Non-truncated turn: an unparseable buffer still falls back to empty input
-     (existing behavior). Truncation is handled by the MaxTokens guard, below. *)
+let%test "finalize_stream_acc tool_use with invalid json fails closed" =
+  (* Non-truncated turn: an unparseable non-empty argument buffer is malformed
+     provider output. It must not be coerced to empty input, which would silently
+     dispatch the tool with fabricated arguments. Truncation is handled by the
+     MaxTokens guard, below. *)
   let acc = create_stream_acc () in
   Hashtbl.replace acc.block_types 0 "tool_use";
   let buf = Buffer.create 16 in
@@ -931,11 +933,9 @@ let%test "finalize_stream_acc tool_use with invalid json falls back to empty ass
     acc.stop_reason_received := true;
     finalize_stream_acc acc
   with
-  | Error _ -> false
-  | Ok result ->
-    (match result.content with
-     | [ Types.ToolUse { input = `Assoc []; _ } ] -> true
-     | _ -> false)
+  | Error (Types.Stream_parse_failed { reason; raw }) ->
+    raw = "" && String.starts_with ~prefix:"malformed_tool_use_arguments:index:0:" reason
+  | Error (Types.Stream_provider_error _ | Types.Stream_unknown_event _) | Ok _ -> false
 ;;
 
 let%test "finalize_stream_acc drops tool_use on truncated turn (MaxTokens)" =


### PR DESCRIPTION
Fixes stale inline-test expectation blocking OAS main CI run 28362616126. No runtime logic changed; the test now asserts fail-closed behavior for non-empty malformed tool_use JSON instead of permissive empty-assoc coercion. Local evidence: git diff --check; ocamlformat --check lib/llm_provider/complete_stream_acc.ml; scripts/dune-local.sh build lib/llm_provider/.llm_provider.inline-tests/inline-test-runner.exe; _build/default/lib/llm_provider/.llm_provider.inline-tests/inline-test-runner.exe inline-test-runner llm_provider -partition complete_stream_acc.ml -source-tree-root . -diff-cmd -.