### PR TITLE
test(streaming): align stale inline test with fail-closed tool_use json (main red P0)

### DIFF
--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -919,9 +919,13 @@ let%test "finalize_stream_acc fails closed for media payload without metadata" =
   | Error (Types.Stream_provider_error _ | Types.Stream_unknown_event _) | Ok _ -> false
 ;;
 
-let%test "finalize_stream_acc tool_use with invalid json falls back to empty assoc" =
-  (* Non-truncated turn: an unparseable buffer still falls back to empty input
-     (existing behavior). Truncation is handled by the MaxTokens guard, below. *)
+let%test "finalize_stream_acc tool_use with invalid json fails closed (Stream_parse_failed)" =
+  (* Non-truncated turn: a non-empty buffer that fails to parse is a malformed
+     tool call and must fail closed with a typed [Stream_parse_failed] rather
+     than coercing to [`Assoc []], which would silently dispatch the tool with
+     empty arguments (RFC-OAS-029 S8: no silent permissive default — see the
+     finalize tool_use branch above). The empty-buffer "no arguments" case and
+     MaxTokens truncation are covered by sibling tests. *)
   let acc = create_stream_acc () in
   Hashtbl.replace acc.block_types 0 "tool_use";
   let buf = Buffer.create 16 in
@@ -931,11 +935,10 @@ let%test "finalize_stream_acc tool_use with invalid json falls back to empty ass
     acc.stop_reason_received := true;
     finalize_stream_acc acc
   with
-  | Error _ -> false
-  | Ok result ->
-    (match result.content with
-     | [ Types.ToolUse { input = `Assoc []; _ } ] -> true
-     | _ -> false)
+  | Error (Types.Stream_parse_failed { reason; raw }) ->
+    raw = ""
+    && String.starts_with ~prefix:"malformed_tool_use_arguments:index:0:" reason
+  | Error (Types.Stream_provider_error _ | Types.Stream_unknown_event _) | Ok _ -> false
 ;;
 
 let%test "finalize_stream_acc drops tool_use on truncated turn (MaxTokens)" =


### PR DESCRIPTION
## P0 — oas main red 회복 (stale inline test)

main CI(Build & Test)가 `lib/llm_provider/complete_stream_acc.ml:922` inline test에서 실패하고 있습니다:

```
File "lib/llm_provider/complete_stream_acc.ml", line 922:
  finalize_stream_acc tool_use with invalid json falls back to empty assoc is false.
FAILED 1 / 49 tests
```

merge-ref에 main을 포함하는 **모든 open PR(#2256/#2260/#2232)의 Build가 동일 실패** → 머지 전면 차단.

## 근본 원인

#2261(`fix(streaming): fail closed on malformed streamed tool arguments`)이 `finalize_stream_acc`의 동작을 변경:

- **이전**: tool_use 버퍼가 파싱 실패 → `try ... with Json_error _ -> `Assoc []` (빈 객체로 coerce, silent)
- **현재 (fail-closed)**: 비어있지 않은 unparseable 버퍼 → `Error (Stream_parse_failed { reason = "malformed_tool_use_arguments:index:%d:%s"; raw = "" })` (RFC-OAS-029 S8: no silent permissive default)

#2261은 `test/test_streaming_openai.ml`(+105)에 새 커버리지를 추가했으나, **같은 파일의 co-located inline test(line 922)가 옛 "empty assoc fallback"을 단언한 채 남아** main을 red로 만들었습니다.

행동 변경(silent → fail-closed)은 **옳습니다** — malformed tool call을 빈 인자로 조용히 dispatch하는 건 사용자 기준 "노 Silent Failure" 위반. 따라서 코드는 그대로 두고 **stale 테스트를 새 동작에 맞게 갱신**합니다.

## 변경

- 테스트 이름/주석을 fail-closed 의미로 갱신, RFC-OAS-029 S8 근거 명시.
- 단언을 `Error (Stream_parse_failed { reason; raw })`로 변경, sibling media-block 테스트와 동일한 **exhaustive 에러 match**(catch-all `_` 없음) 사용.
- `reason`은 Yojson 버전 의존 suffix 대신 **안정 prefix** `"malformed_tool_use_arguments:index:0:"`만 단언(`String.starts_with`, 코드베이스 기존 용례 test_code_snippet_eval.ml / test_streaming_coverage.ml과 동일).

## 검증

- 변경부가 `types.mli:340`/`types.ml:499`의 실제 `Stream_parse_failed { reason; raw }` 변형과 일치, `String.starts_with`는 oas 테스트 기존 사용 API.
- worktree 로컬 빌드는 main repo로 진입할 수 있어 거짓 green 위험 → 최종 검증은 CI Build & Test green으로 확인.

RFC-WAIVED: test-only 변경(`lib/llm_provider/complete_stream_acc.ml`의 inline test). credential/identity/operator/sandbox/hooks/workflow-docs subsystem 미해당. production 로직 무변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
