### PR TITLE
feat(multimodal): close media source kinds

### DIFF
--- a/lib/agent_tool.ml
+++ b/lib/agent_tool.ml
@@ -83,21 +83,21 @@ let content_block_to_json = function
       [ "type", `String "image"
       ; "media_type", `String media_type
       ; "data", `String data
-      ; "source_type", `String source_type
+      ; "source_type", `String (Types.media_source_kind_to_string source_type)
       ]
   | Document { media_type; data; source_type } ->
     `Assoc
       [ "type", `String "document"
       ; "media_type", `String media_type
       ; "data", `String data
-      ; "source_type", `String source_type
+      ; "source_type", `String (Types.media_source_kind_to_string source_type)
       ]
   | Audio { media_type; data; source_type } ->
     `Assoc
       [ "type", `String "audio"
       ; "media_type", `String media_type
       ; "data", `String data
-      ; "source_type", `String source_type
+      ; "source_type", `String (Types.media_source_kind_to_string source_type)
       ]
 ;;
 

--- a/lib/llm_provider/api_common.ml
+++ b/lib/llm_provider/api_common.ml
@@ -98,7 +98,7 @@ let rec content_block_to_json_with
       [ "type", `String "image"
       ; ( "source"
         , `Assoc
-            [ "type", `String source_type
+            [ "type", `String (media_source_kind_to_string source_type)
             ; "media_type", `String media_type
             ; "data", `String data
             ] )
@@ -108,7 +108,7 @@ let rec content_block_to_json_with
       [ "type", `String "document"
       ; ( "source"
         , `Assoc
-            [ "type", `String source_type
+            [ "type", `String (media_source_kind_to_string source_type)
             ; "media_type", `String media_type
             ; "data", `String data
             ] )
@@ -118,7 +118,7 @@ let rec content_block_to_json_with
       [ "type", `String "audio"
       ; ( "source"
         , `Assoc
-            [ "type", `String source_type
+            [ "type", `String (media_source_kind_to_string source_type)
             ; "media_type", `String media_type
             ; "data", `String data
             ] )
@@ -163,22 +163,43 @@ let rec content_block_of_json json =
     Some (ToolResult { tool_use_id; content; is_error; json; content_blocks })
   | Some "image" ->
     let source = json |> member "source" in
-    let source_type = source |> member "type" |> to_string in
-    let media_type = source |> member "media_type" |> to_string in
-    let data = source |> member "data" |> to_string in
-    Some (Image { media_type; data; source_type })
+    (match
+       source
+       |> member "type"
+       |> to_string_option
+       |> fun source_type -> Option.bind source_type media_source_kind_of_string
+     with
+     | Some source_type ->
+       let media_type = source |> member "media_type" |> to_string in
+       let data = source |> member "data" |> to_string in
+       Some (Image { media_type; data; source_type })
+     | None -> None)
   | Some "document" ->
     let source = json |> member "source" in
-    let source_type = source |> member "type" |> to_string in
-    let media_type = source |> member "media_type" |> to_string in
-    let data = source |> member "data" |> to_string in
-    Some (Document { media_type; data; source_type })
+    (match
+       source
+       |> member "type"
+       |> to_string_option
+       |> fun source_type -> Option.bind source_type media_source_kind_of_string
+     with
+     | Some source_type ->
+       let media_type = source |> member "media_type" |> to_string in
+       let data = source |> member "data" |> to_string in
+       Some (Document { media_type; data; source_type })
+     | None -> None)
   | Some "audio" ->
     let source = json |> member "source" in
-    let source_type = source |> member "type" |> to_string in
-    let media_type = source |> member "media_type" |> to_string in
-    let data = source |> member "data" |> to_string in
-    Some (Audio { media_type; data; source_type })
+    (match
+       source
+       |> member "type"
+       |> to_string_option
+       |> fun source_type -> Option.bind source_type media_source_kind_of_string
+     with
+     | Some source_type ->
+       let media_type = source |> member "media_type" |> to_string in
+       let data = source |> member "data" |> to_string in
+       Some (Audio { media_type; data; source_type })
+     | None -> None)
   | _ -> None
 ;;
 

--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -491,7 +491,7 @@ let%test "openai_messages_of_message user with image" =
   let msg =
     { role = User
     ; content =
-        [ Image { media_type = "image/png"; data = "abc123"; source_type = "base64" }
+        [ Image { media_type = "image/png"; data = "abc123"; source_type = Types.Base64 }
         ; Text "describe this"
         ]
     ; name = None
@@ -508,7 +508,7 @@ let%test "openai_messages_of_message user with document" =
     { role = User
     ; content =
         [ Document
-            { media_type = "application/pdf"; data = "abc"; source_type = "base64" }
+            { media_type = "application/pdf"; data = "abc"; source_type = Types.Base64 }
         ]
     ; name = None
     ; tool_call_id = None
@@ -523,7 +523,9 @@ let%test "openai_messages_of_message user with audio" =
   let msg =
     { role = User
     ; content =
-        [ Audio { media_type = "audio/wav"; data = "audiodata"; source_type = "base64" } ]
+        [ Audio
+            { media_type = "audio/wav"; data = "audiodata"; source_type = Types.Base64 }
+        ]
     ; name = None
     ; tool_call_id = None
     ; metadata = []
@@ -1024,7 +1026,7 @@ let%test "usage_of_openai_json prompt_tokens_details null" =
 
 let%test "openai_content_parts_of_blocks image block" =
   let blocks =
-    [ Image { media_type = "image/png"; data = "abc"; source_type = "base64" } ]
+    [ Image { media_type = "image/png"; data = "abc"; source_type = Types.Base64 } ]
   in
   let result = openai_content_parts_of_blocks blocks in
   List.length result = 1
@@ -1032,7 +1034,9 @@ let%test "openai_content_parts_of_blocks image block" =
 
 let%test "openai_content_parts_of_blocks document block" =
   let blocks =
-    [ Document { media_type = "application/pdf"; data = "abc"; source_type = "base64" } ]
+    [ Document
+        { media_type = "application/pdf"; data = "abc"; source_type = Types.Base64 }
+    ]
   in
   let result = openai_content_parts_of_blocks blocks in
   List.length result = 1
@@ -1040,7 +1044,7 @@ let%test "openai_content_parts_of_blocks document block" =
 
 let%test "openai_content_parts_of_blocks audio block" =
   let blocks =
-    [ Audio { media_type = "audio/wav"; data = "abc"; source_type = "base64" } ]
+    [ Audio { media_type = "audio/wav"; data = "abc"; source_type = Types.Base64 } ]
   in
   let result = openai_content_parts_of_blocks blocks in
   List.length result = 1

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -24,7 +24,7 @@ type stream_acc =
   ; block_thinking_signatures : (int, Buffer.t) Hashtbl.t
   ; block_media_types : (int, string) Hashtbl.t
     (** Per-block media MIME type from {!Types.MediaDelta}. *)
-  ; block_media_sources : (int, string) Hashtbl.t
+  ; block_media_sources : (int, Types.media_source_kind) Hashtbl.t
     (** Per-block media source kind from {!Types.MediaDelta}. *)
   }
 
@@ -189,8 +189,7 @@ let finalize_stream_acc
             ( Hashtbl.find_opt acc.block_media_types idx
             , Hashtbl.find_opt acc.block_media_sources idx )
           with
-          | Some media_type, Some source_type
-            when String.trim media_type <> "" && String.trim source_type <> "" ->
+          | Some media_type, Some source_type when String.trim media_type <> "" ->
             Ok (Some (make ~media_type ~data:text ~source_type))
           | _ ->
             Error
@@ -844,7 +843,10 @@ let%test "finalize_stream_acc assembles a streamed image block (multimodal)" =
        { index = 0
        ; delta =
            Types.MediaDelta
-             { media_type = "image/png"; source_type = "base64"; data = "iVBORw0KGgo=" }
+             { media_type = "image/png"
+             ; source_type = Types.Base64
+             ; data = "iVBORw0KGgo="
+             }
        });
   accumulate_event
     acc
@@ -854,7 +856,7 @@ let%test "finalize_stream_acc assembles a streamed image block (multimodal)" =
   | Ok result ->
     result.content
     = [ Types.Image
-          { media_type = "image/png"; data = "iVBORw0KGgo="; source_type = "base64" }
+          { media_type = "image/png"; data = "iVBORw0KGgo="; source_type = Types.Base64 }
       ]
 ;;
 
@@ -870,7 +872,8 @@ let%test "finalize_stream_acc concatenates multi-chunk media payload" =
       (Types.ContentBlockDelta
          { index = 0
          ; delta =
-             Types.MediaDelta { media_type = "audio/mp3"; source_type = "base64"; data }
+             Types.MediaDelta
+               { media_type = "audio/mp3"; source_type = Types.Base64; data }
          })
   in
   chunk "AAAA";
@@ -883,7 +886,7 @@ let%test "finalize_stream_acc concatenates multi-chunk media payload" =
   | Ok result ->
     result.content
     = [ Types.Audio
-          { media_type = "audio/mp3"; data = "AAAABBBB"; source_type = "base64" }
+          { media_type = "audio/mp3"; data = "AAAABBBB"; source_type = Types.Base64 }
       ]
 ;;
 
@@ -1072,7 +1075,10 @@ let%test "finalize_stream_acc assembles a streamed image block" =
         { index = 0
         ; delta =
             Types.MediaDelta
-              { media_type = "image/png"; source_type = "base64"; data = "iVBORw0KGgo=" }
+              { media_type = "image/png"
+              ; source_type = Types.Base64
+              ; data = "iVBORw0KGgo="
+              }
         }
     ; Types.MessageDelta { stop_reason = Some Types.EndTurn; usage = None }
     ];
@@ -1080,7 +1086,10 @@ let%test "finalize_stream_acc assembles a streamed image block" =
   | Ok
       { content =
           [ Types.Image
-              { media_type = "image/png"; source_type = "base64"; data = "iVBORw0KGgo=" }
+              { media_type = "image/png"
+              ; source_type = Types.Base64
+              ; data = "iVBORw0KGgo="
+              }
           ]
       ; _
       } -> true
@@ -1098,13 +1107,13 @@ let%test "finalize_stream_acc concatenates multi-chunk media payload" =
         { index = 0
         ; delta =
             Types.MediaDelta
-              { media_type = "audio/mpeg"; source_type = "base64"; data = "AAA" }
+              { media_type = "audio/mpeg"; source_type = Types.Base64; data = "AAA" }
         }
     ; Types.ContentBlockDelta
         { index = 0
         ; delta =
             Types.MediaDelta
-              { media_type = "audio/mpeg"; source_type = "base64"; data = "BBB" }
+              { media_type = "audio/mpeg"; source_type = Types.Base64; data = "BBB" }
         }
     ; Types.MessageDelta { stop_reason = Some Types.EndTurn; usage = None }
     ];
@@ -1112,7 +1121,7 @@ let%test "finalize_stream_acc concatenates multi-chunk media payload" =
   | Ok
       { content =
           [ Types.Audio
-              { media_type = "audio/mpeg"; source_type = "base64"; data = "AAABBB" }
+              { media_type = "audio/mpeg"; source_type = Types.Base64; data = "AAABBB" }
           ]
       ; _
       } -> true

--- a/lib/llm_provider/complete_stream_acc.mli
+++ b/lib/llm_provider/complete_stream_acc.mli
@@ -29,8 +29,8 @@ type stream_acc =
   ; block_media_types : (int, string) Hashtbl.t
     (** Per-block media MIME type from {!Types.MediaDelta}; payload is in
         {!block_texts}. *)
-  ; block_media_sources : (int, string) Hashtbl.t
-    (** Per-block media source kind from {!Types.MediaDelta} (e.g. "base64"). *)
+  ; block_media_sources : (int, Types.media_source_kind) Hashtbl.t
+    (** Per-block media source kind from {!Types.MediaDelta}. *)
   }
 
 (** Create a fresh accumulator with empty defaults. *)

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -240,7 +240,7 @@ let%test "emit_synthetic_events round-trips a media block through the accumulato
      media arms) and the image collapses to empty text, so this goes red. This is
      the real producer that keeps the new MediaDelta path from being dead code. *)
   let image =
-    Image { media_type = "image/png"; data = "iVBORw0KGgo="; source_type = "base64" }
+    Image { media_type = "image/png"; data = "iVBORw0KGgo="; source_type = Types.Base64 }
   in
   let response : api_response =
     { id = "msg_rt"

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -221,6 +221,18 @@ let response_format_to_json = function
 
 (** {1 Content Types} *)
 
+(** Closed set of supported media source encodings. *)
+type media_source_kind = Base64 [@@deriving show]
+
+let media_source_kind_to_string = function
+  | Base64 -> "base64"
+;;
+
+let media_source_kind_of_string = function
+  | "base64" -> Some Base64
+  | _ -> None
+;;
+
 (** Content block types -- inline records for clarity *)
 type content_block =
   | Text of string
@@ -250,17 +262,17 @@ type content_block =
   | Image of
       { media_type : string
       ; data : string
-      ; source_type : string
+      ; source_type : media_source_kind
       }
   | Document of
       { media_type : string
       ; data : string
-      ; source_type : string
+      ; source_type : media_source_kind
       }
   | Audio of
       { media_type : string
       ; data : string
-      ; source_type : string
+      ; source_type : media_source_kind
       }
 [@@deriving show]
 
@@ -424,7 +436,7 @@ type content_delta =
   | InputJsonDelta of string
   | MediaDelta of
       { media_type : string
-      ; source_type : string
+      ; source_type : media_source_kind
       ; data : string
       }
   (** A chunk of a streamed media (image/document/audio) content block.
@@ -519,17 +531,17 @@ let make_message ?name ?tool_call_id ?(metadata = []) ~role content =
 let text_block text = Text text
 
 (** Create a base64-backed image content block by default. *)
-let image_block ?(source_type = "base64") ~media_type ~data () =
+let image_block ?(source_type = Base64) ~media_type ~data () =
   Image { media_type; data; source_type }
 ;;
 
 (** Create a base64-backed document content block by default. *)
-let document_block ?(source_type = "base64") ~media_type ~data () =
+let document_block ?(source_type = Base64) ~media_type ~data () =
   Document { media_type; data; source_type }
 ;;
 
 (** Create a base64-backed audio content block by default. *)
-let audio_block ?(source_type = "base64") ~media_type ~data () =
+let audio_block ?(source_type = Base64) ~media_type ~data () =
   Audio { media_type; data; source_type }
 ;;
 

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -106,6 +106,14 @@ val response_format_of_json_mode : bool -> response_format
 
 (** {1 Content Types} *)
 
+(** Closed set of supported media source encodings. The public wire value stays
+    ["base64"], but internal content blocks no longer carry arbitrary source
+    strings. *)
+type media_source_kind = Base64 [@@deriving show]
+
+val media_source_kind_to_string : media_source_kind -> string
+val media_source_kind_of_string : string -> media_source_kind option
+
 type content_block =
   | Text of string
   | Thinking of
@@ -131,17 +139,17 @@ type content_block =
   | Image of
       { media_type : string
       ; data : string
-      ; source_type : string
+      ; source_type : media_source_kind
       }
   | Document of
       { media_type : string
       ; data : string
-      ; source_type : string
+      ; source_type : media_source_kind
       }
   | Audio of
       { media_type : string
       ; data : string
-      ; source_type : string
+      ; source_type : media_source_kind
       }
 [@@deriving show]
 
@@ -255,7 +263,7 @@ type content_delta =
   | InputJsonDelta of string
   | MediaDelta of
       { media_type : string
-      ; source_type : string
+      ; source_type : media_source_kind
       ; data : string
       }
   (** A chunk of a streamed media (image/document/audio) content block.
@@ -359,21 +367,21 @@ val make_message
 val text_block : string -> content_block
 
 val image_block
-  :  ?source_type:string
+  :  ?source_type:media_source_kind
   -> media_type:string
   -> data:string
   -> unit
   -> content_block
 
 val document_block
-  :  ?source_type:string
+  :  ?source_type:media_source_kind
   -> media_type:string
   -> data:string
   -> unit
   -> content_block
 
 val audio_block
-  :  ?source_type:string
+  :  ?source_type:media_source_kind
   -> media_type:string
   -> data:string
   -> unit

--- a/lib/streaming.ml
+++ b/lib/streaming.ml
@@ -29,7 +29,7 @@ type stream_acc =
   ; block_tool_names : (int, string) Hashtbl.t
   ; block_thinking_signatures : (int, Buffer.t) Hashtbl.t
   ; block_media_types : (int, string) Hashtbl.t
-  ; block_media_sources : (int, string) Hashtbl.t
+  ; block_media_sources : (int, media_source_kind) Hashtbl.t
   }
 
 let create_stream_acc () =
@@ -162,8 +162,7 @@ let finalize_stream_acc (acc : stream_acc) =
             ( Hashtbl.find_opt acc.block_media_types index
             , Hashtbl.find_opt acc.block_media_sources index )
           with
-          | Some media_type, Some source_type
-            when String.trim media_type <> "" && String.trim source_type <> "" ->
+          | Some media_type, Some source_type when String.trim media_type <> "" ->
             Ok (Some (make ~media_type ~data:text ~source_type))
           | _ -> Error (Printf.sprintf "malformed_media_block:%s:index:%d" kind index))
       in

--- a/lib/streaming.mli
+++ b/lib/streaming.mli
@@ -36,7 +36,7 @@ type stream_acc =
   ; block_tool_names : (int, string) Hashtbl.t
   ; block_thinking_signatures : (int, Buffer.t) Hashtbl.t
   ; block_media_types : (int, string) Hashtbl.t
-  ; block_media_sources : (int, string) Hashtbl.t
+  ; block_media_sources : (int, Types.media_source_kind) Hashtbl.t
   }
 
 (** Create a fresh accumulator. *)

--- a/test/test_agent_stream.ml
+++ b/test/test_agent_stream.ml
@@ -263,7 +263,7 @@ let test_image_block_media_delta () =
   let response =
     make_response
       [ Types.Image
-          { media_type = "image/png"; data = "base64data"; source_type = "base64" }
+          { media_type = "image/png"; data = "base64data"; source_type = Types.Base64 }
       ]
   in
   let events = collect_events response in
@@ -275,7 +275,10 @@ let test_image_block_media_delta () =
    | Types.ContentBlockDelta
        { delta = Types.MediaDelta { media_type; source_type; data }; _ } ->
      Alcotest.(check string) "image media type" "image/png" media_type;
-     Alcotest.(check string) "image source type" "base64" source_type;
+     Alcotest.(check string)
+       "image source type"
+       "base64"
+       (Types.media_source_kind_to_string source_type);
      Alcotest.(check string) "image data" "base64data" data
    | _ -> Alcotest.fail "expected image MediaDelta");
   Alcotest.(check int) "6 events" 6 (List.length events)
@@ -285,7 +288,7 @@ let test_document_block_media_delta () =
   let response =
     make_response
       [ Types.Document
-          { media_type = "application/pdf"; data = "pdfdata"; source_type = "base64" }
+          { media_type = "application/pdf"; data = "pdfdata"; source_type = Types.Base64 }
       ]
   in
   let events = collect_events response in
@@ -297,7 +300,10 @@ let test_document_block_media_delta () =
    | Types.ContentBlockDelta
        { delta = Types.MediaDelta { media_type; source_type; data }; _ } ->
      Alcotest.(check string) "document media type" "application/pdf" media_type;
-     Alcotest.(check string) "document source type" "base64" source_type;
+     Alcotest.(check string)
+       "document source type"
+       "base64"
+       (Types.media_source_kind_to_string source_type);
      Alcotest.(check string) "document data" "pdfdata" data
    | _ -> Alcotest.fail "expected document MediaDelta");
   Alcotest.(check int) "6 events" 6 (List.length events)

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -102,7 +102,7 @@ let test_tool_result_error_round_trip () =
 
 let test_image_round_trip () =
   let block =
-    Types.Image { media_type = "image/png"; data = "abc"; source_type = "base64" }
+    Types.Image { media_type = "image/png"; data = "abc"; source_type = Types.Base64 }
   in
   let json = Api.content_block_to_json block in
   match Api.content_block_of_json json with
@@ -113,7 +113,7 @@ let test_image_round_trip () =
 let test_document_round_trip () =
   let block =
     Types.Document
-      { media_type = "application/pdf"; data = "pdf"; source_type = "base64" }
+      { media_type = "application/pdf"; data = "pdf"; source_type = Types.Base64 }
   in
   let json = Api.content_block_to_json block in
   match Api.content_block_of_json json with
@@ -1637,7 +1637,7 @@ let test_openai_messages_with_image () =
     ; content =
         [ Types.Text "describe this"
         ; Types.Image
-            { media_type = "image/png"; data = "abc123"; source_type = "base64" }
+            { media_type = "image/png"; data = "abc123"; source_type = Types.Base64 }
         ]
     ; name = None
     ; tool_call_id = None
@@ -1703,7 +1703,7 @@ let test_text_blocks_to_string () =
         ; json = None
         ; content_blocks = None
         }
-    ; Types.Image { media_type = "image/png"; data = ""; source_type = "base64" }
+    ; Types.Image { media_type = "image/png"; data = ""; source_type = Types.Base64 }
     ; Types.Text "world"
     ]
   in

--- a/test/test_backend_gemini.ml
+++ b/test/test_backend_gemini.ml
@@ -644,7 +644,10 @@ let test_contents_multimodal () =
       ; content =
           [ Text "Describe this image:"
           ; Image
-              { media_type = "image/png"; data = "base64data"; source_type = "base64" }
+              { media_type = "image/png"
+              ; data = "base64data"
+              ; source_type = Types.Base64
+              }
           ]
       ; name = None
       ; tool_call_id = None

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -138,9 +138,10 @@ let test_content_parts_cover_modalities () =
   let parts =
     Serialize.openai_content_parts_of_blocks
       [ Text "hello"
-      ; Image { media_type = "image/png"; data = "img"; source_type = "base64" }
-      ; Document { media_type = "application/pdf"; data = "doc"; source_type = "base64" }
-      ; Audio { media_type = "wav"; data = "aud"; source_type = "base64" }
+      ; Image { media_type = "image/png"; data = "img"; source_type = Types.Base64 }
+      ; Document
+          { media_type = "application/pdf"; data = "doc"; source_type = Types.Base64 }
+      ; Audio { media_type = "wav"; data = "aud"; source_type = Types.Base64 }
       ; Thinking { thinking_type = "reasoning"; content = "hidden" }
       ; RedactedThinking "redacted"
       ; ToolUse { id = "tc"; name = "tool"; input = `Assoc [] }
@@ -233,7 +234,7 @@ let test_wire_adjacency_nudged_tool_turn () =
 let test_user_multimodal_preserve_and_visual_first () =
   let content =
     [ Text "caption"
-    ; Image { media_type = "image/jpeg"; data = "jpeg"; source_type = "base64" }
+    ; Image { media_type = "image/jpeg"; data = "jpeg"; source_type = Types.Base64 }
     ]
   in
   let openai = Serialize.openai_messages_of_message (msg User content) |> only "openai" in
@@ -262,7 +263,7 @@ let test_ollama_native_multimodal_variants () =
     Serialize.ollama_messages_of_message
       (msg
          User
-         [ Image { media_type = "image/png"; data = "png1"; source_type = "base64" } ])
+         [ Image { media_type = "image/png"; data = "png1"; source_type = Types.Base64 } ])
     |> only "ollama"
   in
   check_string "image-only content empty" "" (member "content" image_only |> to_string);
@@ -275,7 +276,7 @@ let test_ollama_native_multimodal_variants () =
       (msg
          User
          [ Document
-             { media_type = "application/pdf"; data = "pdf1"; source_type = "base64" }
+             { media_type = "application/pdf"; data = "pdf1"; source_type = Types.Base64 }
          ])
     |> only "ollama"
   in
@@ -288,7 +289,7 @@ let test_ollama_native_multimodal_variants () =
     Serialize.ollama_messages_of_message
       (msg
          User
-         [ Audio { media_type = "audio/wav"; data = "wav1"; source_type = "base64" } ])
+         [ Audio { media_type = "audio/wav"; data = "wav1"; source_type = Types.Base64 } ])
   in
   check_int "audio-only produces no ollama messages" 0 (List.length audio_msgs);
   (* Mixed text + image + document preserves text in content and both payloads in images. *)
@@ -297,9 +298,9 @@ let test_ollama_native_multimodal_variants () =
       (msg
          User
          [ Text "describe these"
-         ; Image { media_type = "image/png"; data = "png2"; source_type = "base64" }
+         ; Image { media_type = "image/png"; data = "png2"; source_type = Types.Base64 }
          ; Document
-             { media_type = "application/pdf"; data = "pdf2"; source_type = "base64" }
+             { media_type = "application/pdf"; data = "pdf2"; source_type = Types.Base64 }
          ])
     |> only "ollama"
   in
@@ -647,9 +648,9 @@ let ignored_blocks : content_block list =
       ; json = None
       ; content_blocks = None
       }
-  ; Image { media_type = "image/png"; data = "img"; source_type = "base64" }
-  ; Document { media_type = "application/pdf"; data = "doc"; source_type = "base64" }
-  ; Audio { media_type = "wav"; data = "aud"; source_type = "base64" }
+  ; Image { media_type = "image/png"; data = "img"; source_type = Types.Base64 }
+  ; Document { media_type = "application/pdf"; data = "doc"; source_type = Types.Base64 }
+  ; Audio { media_type = "wav"; data = "aud"; source_type = Types.Base64 }
   ]
 ;;
 
@@ -685,9 +686,10 @@ let test_serializer_ignored_block_variants () =
     [ Thinking { thinking_type = "reasoning"; content = "   " }
     ; RedactedThinking "hidden"
     ; ToolUse { id = "local-call"; name = "local"; input = `Null }
-    ; Image { media_type = "image/png"; data = "img"; source_type = "base64" }
-    ; Document { media_type = "application/pdf"; data = "doc"; source_type = "base64" }
-    ; Audio { media_type = "wav"; data = "aud"; source_type = "base64" }
+    ; Image { media_type = "image/png"; data = "img"; source_type = Types.Base64 }
+    ; Document
+        { media_type = "application/pdf"; data = "doc"; source_type = Types.Base64 }
+    ; Audio { media_type = "wav"; data = "aud"; source_type = Types.Base64 }
     ]
   in
   let tool_fallback =
@@ -731,10 +733,10 @@ let test_strip_helpers_cover_non_tool_variants () =
               ; json = None
               ; content_blocks = None
               }
-          ; Image { media_type = "image/png"; data = "img"; source_type = "base64" }
+          ; Image { media_type = "image/png"; data = "img"; source_type = Types.Base64 }
           ; Document
-              { media_type = "application/pdf"; data = "doc"; source_type = "base64" }
-          ; Audio { media_type = "wav"; data = "aud"; source_type = "base64" }
+              { media_type = "application/pdf"; data = "doc"; source_type = Types.Base64 }
+          ; Audio { media_type = "wav"; data = "aud"; source_type = Types.Base64 }
           ]
       ]
   in

--- a/test/test_backend_tool_call_harness.ml
+++ b/test/test_backend_tool_call_harness.ml
@@ -135,9 +135,9 @@ let test_validate_response_flags_unknown_tool_and_stop_reason () =
           ; json = None
           ; content_blocks = None
           }
-      ; T.Image { media_type = "image/png"; data = "abc"; source_type = "base64" }
-      ; T.Document { media_type = "text/plain"; data = "doc"; source_type = "base64" }
-      ; T.Audio { media_type = "audio/wav"; data = "audio"; source_type = "base64" }
+      ; T.Image { media_type = "image/png"; data = "abc"; source_type = T.Base64 }
+      ; T.Document { media_type = "text/plain"; data = "doc"; source_type = T.Base64 }
+      ; T.Audio { media_type = "audio/wav"; data = "audio"; source_type = T.Base64 }
       ]
   in
   let result = H.validate_response ~declared_tools:[ "read_file" ] response in

--- a/test/test_canonical_projections.ml
+++ b/test/test_canonical_projections.ml
@@ -7,7 +7,7 @@ open Alcotest
 open Llm_provider
 
 let mk_image () =
-  Types.Image { media_type = "image/png"; data = "AAAA"; source_type = "base64" }
+  Types.Image { media_type = "image/png"; data = "AAAA"; source_type = Types.Base64 }
 ;;
 
 (* summarize_blocks folds a bare content_block list into the redacted shape. *)

--- a/test/test_canonical_tool.ml
+++ b/test/test_canonical_tool.ml
@@ -64,10 +64,10 @@ let test_result_none_for_non_toolresult () =
     ; Types.Thinking { thinking_type = "thinking"; content = "..." }
     ; Types.RedactedThinking "redacted"
     ; Types.ToolUse { id = "call_x"; name = "t"; input = `Null }
-    ; Types.Image { media_type = "image/png"; data = "AAAA"; source_type = "base64" }
+    ; Types.Image { media_type = "image/png"; data = "AAAA"; source_type = Types.Base64 }
     ; Types.Document
-        { media_type = "application/pdf"; data = "JVBE"; source_type = "base64" }
-    ; Types.Audio { media_type = "audio/wav"; data = "UklG"; source_type = "base64" }
+        { media_type = "application/pdf"; data = "JVBE"; source_type = Types.Base64 }
+    ; Types.Audio { media_type = "audio/wav"; data = "UklG"; source_type = Types.Base64 }
     ]
   in
   List.iter

--- a/test/test_context_reducer.ml
+++ b/test/test_context_reducer.ml
@@ -168,7 +168,8 @@ let test_token_budget_image_doc () =
     [ Types.
         { role = User
         ; content =
-            [ Image { media_type = "image/png"; data = large_img; source_type = "base64" }
+            [ Image
+                { media_type = "image/png"; data = large_img; source_type = Types.Base64 }
             ]
         ; name = None
         ; tool_call_id = None
@@ -181,7 +182,7 @@ let test_token_budget_image_doc () =
             [ Document
                 { media_type = "application/pdf"
                 ; data = large_doc
-                ; source_type = "base64"
+                ; source_type = Types.Base64
                 }
             ]
         ; name = None
@@ -249,7 +250,7 @@ let test_estimate_image () =
     Types.
       { role = User
       ; content =
-          [ Image { media_type = "image/png"; data = "x"; source_type = "base64" } ]
+          [ Image { media_type = "image/png"; data = "x"; source_type = Types.Base64 } ]
       ; name = None
       ; tool_call_id = None
       ; metadata = []
@@ -265,7 +266,7 @@ let test_estimate_image () =
           [ Image
               { media_type = "image/png"
               ; data = String.make 100_000 'A'
-              ; source_type = "base64"
+              ; source_type = Types.Base64
               }
           ]
       ; name = None
@@ -284,7 +285,7 @@ let test_estimate_document () =
       { role = User
       ; content =
           [ Document
-              { media_type = "application/pdf"; data = "x"; source_type = "base64" }
+              { media_type = "application/pdf"; data = "x"; source_type = Types.Base64 }
           ]
       ; name = None
       ; tool_call_id = None
@@ -300,7 +301,7 @@ let test_estimate_document () =
           [ Document
               { media_type = "application/pdf"
               ; data = String.make 200_000 'A'
-              ; source_type = "base64"
+              ; source_type = Types.Base64
               }
           ]
       ; name = None
@@ -321,7 +322,7 @@ let test_estimate_audio () =
           [ Audio
               { media_type = "audio/wav"
               ; data = String.make 50_000 'A'
-              ; source_type = "base64"
+              ; source_type = Types.Base64
               }
           ]
       ; name = None

--- a/test/test_llm_cache.ml
+++ b/test/test_llm_cache.ml
@@ -231,7 +231,7 @@ let test_roundtrip_tool_result_error () =
 let test_roundtrip_tool_result_content_blocks () =
   let blocks =
     [ Text "preview"
-    ; Image { media_type = "image/png"; data = "abc"; source_type = "base64" }
+    ; Image { media_type = "image/png"; data = "abc"; source_type = Base64 }
     ]
   in
   let resp =
@@ -388,13 +388,13 @@ let test_roundtrip_redacted_thinking () =
 let test_roundtrip_binary_block () =
   let resp =
     simple_response
-      [ Image { media_type = "image/png"; data = "base64data"; source_type = "base64" } ]
+      [ Image { media_type = "image/png"; data = "base64data"; source_type = Base64 } ]
   in
   let json = Cache.response_to_json resp in
   match Cache.response_of_json json with
   | Some r ->
     (match r.content with
-     | [ Image { media_type = "image/png"; data = "base64data"; source_type = "base64" } ]
+     | [ Image { media_type = "image/png"; data = "base64data"; source_type = Base64 } ]
        -> ()
      | _ -> Alcotest.fail "expected image block to roundtrip")
   | None -> Alcotest.fail "roundtrip failed"
@@ -418,7 +418,7 @@ let test_roundtrip_document_block () =
   let resp =
     simple_response
       [ Document
-          { media_type = "application/pdf"; data = "pdf-data"; source_type = "base64" }
+          { media_type = "application/pdf"; data = "pdf-data"; source_type = Base64 }
       ]
   in
   let json = Cache.response_to_json resp in
@@ -426,7 +426,7 @@ let test_roundtrip_document_block () =
   | Some r ->
     (match r.content with
      | [ Document
-           { media_type = "application/pdf"; data = "pdf-data"; source_type = "base64" }
+           { media_type = "application/pdf"; data = "pdf-data"; source_type = Base64 }
        ] -> ()
      | _ -> Alcotest.fail "expected document block to roundtrip")
   | None -> Alcotest.fail "roundtrip failed"
@@ -435,13 +435,13 @@ let test_roundtrip_document_block () =
 let test_roundtrip_audio_block () =
   let resp =
     simple_response
-      [ Audio { media_type = "audio/mp3"; data = "audio-data"; source_type = "base64" } ]
+      [ Audio { media_type = "audio/mp3"; data = "audio-data"; source_type = Base64 } ]
   in
   let json = Cache.response_to_json resp in
   match Cache.response_of_json json with
   | Some r ->
     (match r.content with
-     | [ Audio { media_type = "audio/mp3"; data = "audio-data"; source_type = "base64" } ]
+     | [ Audio { media_type = "audio/mp3"; data = "audio-data"; source_type = Base64 } ]
        -> ()
      | _ -> Alcotest.fail "expected audio block to roundtrip")
   | None -> Alcotest.fail "roundtrip failed"

--- a/test/test_llm_provider_cov.ml
+++ b/test/test_llm_provider_cov.ml
@@ -366,7 +366,7 @@ let test_content_block_to_json_tool_result () =
 let test_content_block_to_json_image () =
   let json =
     Api_common.content_block_to_json
-      (Image { media_type = "image/png"; data = "abc"; source_type = "base64" })
+      (Image { media_type = "image/png"; data = "abc"; source_type = Types.Base64 })
   in
   let open Yojson.Safe.Util in
   Alcotest.(check string) "type" "image" (json |> member "type" |> to_string);
@@ -380,7 +380,8 @@ let test_content_block_to_json_image () =
 let test_content_block_to_json_document () =
   let json =
     Api_common.content_block_to_json
-      (Document { media_type = "application/pdf"; data = "pdf"; source_type = "base64" })
+      (Document
+         { media_type = "application/pdf"; data = "pdf"; source_type = Types.Base64 })
   in
   let open Yojson.Safe.Util in
   Alcotest.(check string) "type" "document" (json |> member "type" |> to_string)
@@ -389,7 +390,7 @@ let test_content_block_to_json_document () =
 let test_content_block_to_json_audio () =
   let json =
     Api_common.content_block_to_json
-      (Audio { media_type = "audio/wav"; data = "wav"; source_type = "base64" })
+      (Audio { media_type = "audio/wav"; data = "wav"; source_type = Types.Base64 })
   in
   let open Yojson.Safe.Util in
   Alcotest.(check string) "type" "audio" (json |> member "type" |> to_string)
@@ -477,7 +478,8 @@ let test_content_block_of_json_image () =
       ]
   in
   match Api_common.content_block_of_json json with
-  | Some (Image { media_type = "image/png"; data = "abc"; source_type = "base64" }) -> ()
+  | Some (Image { media_type = "image/png"; data = "abc"; source_type = Types.Base64 }) ->
+    ()
   | _ -> Alcotest.fail "image roundtrip"
 ;;
 

--- a/test/test_modality.ml
+++ b/test/test_modality.ml
@@ -19,15 +19,16 @@ let kinds bs = List.map block_kind bs
 let mk_text s = Types.Text s
 
 let mk_image () =
-  Types.Image { media_type = "image/png"; data = "AAAA"; source_type = "base64" }
+  Types.Image { media_type = "image/png"; data = "AAAA"; source_type = Types.Base64 }
 ;;
 
 let mk_audio () =
-  Types.Audio { media_type = "audio/mp3"; data = "BBBB"; source_type = "base64" }
+  Types.Audio { media_type = "audio/mp3"; data = "BBBB"; source_type = Types.Base64 }
 ;;
 
 let mk_document () =
-  Types.Document { media_type = "application/pdf"; data = "CCCC"; source_type = "base64" }
+  Types.Document
+    { media_type = "application/pdf"; data = "CCCC"; source_type = Types.Base64 }
 ;;
 
 let test_preserve_input_order () =

--- a/test/test_multimodal.ml
+++ b/test/test_multimodal.ml
@@ -20,7 +20,7 @@ let test_image_round_trip () =
       { media_type = "image/png"
       ; data =
           "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
-      ; source_type = "base64"
+      ; source_type = Types.Base64
       }
   in
   let json = Api.content_block_to_json img in
@@ -38,7 +38,7 @@ let test_document_round_trip () =
     Types.Document
       { media_type = "application/pdf"
       ; data = "JVBERi0xLjQKMSAwIG9iago8PAovVHlwZSAvQ2F0YWxvZwo+Pg=="
-      ; source_type = "base64"
+      ; source_type = Types.Base64
       }
   in
   let json = Api.content_block_to_json doc in
@@ -67,7 +67,10 @@ let test_image_parse_nested_source () =
   | Some (Types.Image { media_type; data; source_type }) ->
     Alcotest.(check string) "media_type" "image/jpeg" media_type;
     Alcotest.(check string) "data" "abc123" data;
-    Alcotest.(check string) "source_type" "base64" source_type
+    Alcotest.(check string)
+      "source_type"
+      "base64"
+      (Types.media_source_kind_to_string source_type)
   | Some _ -> Alcotest.fail "expected Image variant"
   | None -> Alcotest.fail "content_block_of_json returned None"
 ;;
@@ -92,7 +95,10 @@ let test_document_parse_nested_source () =
   | Some (Types.Document { media_type; data; source_type }) ->
     Alcotest.(check string) "media_type" "application/pdf" media_type;
     Alcotest.(check string) "data" "pdf_data_here" data;
-    Alcotest.(check string) "source_type" "base64" source_type
+    Alcotest.(check string)
+      "source_type"
+      "base64"
+      (Types.media_source_kind_to_string source_type)
   | Some _ -> Alcotest.fail "expected Document variant"
   | None -> Alcotest.fail "content_block_of_json returned None"
 ;;
@@ -117,6 +123,23 @@ let test_malformed_document_missing_source () =
   | Some _ -> Alcotest.fail "expected None or exception for malformed Document"
 ;;
 
+let test_unknown_media_source_kind_fails_closed () =
+  let json =
+    `Assoc
+      [ "type", `String "image"
+      ; ( "source"
+        , `Assoc
+            [ "type", `String "url"
+            ; "media_type", `String "image/png"
+            ; "data", `String "https://example.invalid/image.png"
+            ] )
+      ]
+  in
+  match Api.content_block_of_json json with
+  | None -> ()
+  | Some _ -> Alcotest.fail "unsupported media source kind must not parse"
+;;
+
 (* ------------------------------------------------------------------ *)
 (* Mixed content: Text + Image + Document                               *)
 (* ------------------------------------------------------------------ *)
@@ -125,9 +148,9 @@ let test_mixed_content_serialization () =
   let blocks =
     [ Types.Text "Here is an image:"
     ; Types.Image
-        { media_type = "image/png"; data = "base64data"; source_type = "base64" }
+        { media_type = "image/png"; data = "base64data"; source_type = Types.Base64 }
     ; Types.Document
-        { media_type = "application/pdf"; data = "pdfdata"; source_type = "base64" }
+        { media_type = "application/pdf"; data = "pdfdata"; source_type = Types.Base64 }
     ]
   in
   let json_list = List.map Api.content_block_to_json blocks in
@@ -149,9 +172,9 @@ let test_multimodal_constructors () =
   Alcotest.(check string) "role" "user" (Types.role_to_string msg.role);
   Alcotest.(check int) "blocks" 4 (List.length msg.content);
   match image, document, audio with
-  | ( Types.Image { source_type = "base64"; media_type = "image/png"; _ }
-    , Types.Document { source_type = "base64"; media_type = "application/pdf"; _ }
-    , Types.Audio { source_type = "base64"; media_type = "audio/wav"; _ } ) -> ()
+  | ( Types.Image { source_type = Types.Base64; media_type = "image/png"; _ }
+    , Types.Document { source_type = Types.Base64; media_type = "application/pdf"; _ }
+    , Types.Audio { source_type = Types.Base64; media_type = "audio/wav"; _ } ) -> ()
   | _ -> Alcotest.fail "unexpected multimodal constructor shape"
 ;;
 
@@ -226,7 +249,8 @@ let test_agent_run_with_handoffs_blocks_rejects_internal_blocks () =
 
 let test_image_json_structure () =
   let img =
-    Types.Image { media_type = "image/webp"; data = "webpdata"; source_type = "base64" }
+    Types.Image
+      { media_type = "image/webp"; data = "webpdata"; source_type = Types.Base64 }
   in
   let json = Api.content_block_to_json img in
   let open Yojson.Safe.Util in
@@ -243,7 +267,7 @@ let test_image_json_structure () =
 let test_document_json_structure () =
   let doc =
     Types.Document
-      { media_type = "text/plain"; data = "textdata"; source_type = "base64" }
+      { media_type = "text/plain"; data = "textdata"; source_type = Types.Base64 }
   in
   let json = Api.content_block_to_json doc in
   let open Yojson.Safe.Util in
@@ -286,7 +310,8 @@ let test_tool_result_content_blocks_serialize () =
       ; content_blocks =
           Some
             [ Types.Text "hi"
-            ; Types.Image { media_type = "image/png"; data = "d"; source_type = "base64" }
+            ; Types.Image
+                { media_type = "image/png"; data = "d"; source_type = Types.Base64 }
             ]
       }
   in
@@ -331,6 +356,10 @@ let () =
             "document missing source"
             `Quick
             test_malformed_document_missing_source
+        ; Alcotest.test_case
+            "unknown media source kind fail-closed"
+            `Quick
+            test_unknown_media_source_kind_fails_closed
         ] )
     ; ( "mixed"
       , [ Alcotest.test_case

--- a/test/test_multimodal.ml
+++ b/test/test_multimodal.ml
@@ -123,21 +123,42 @@ let test_malformed_document_missing_source () =
   | Some _ -> Alcotest.fail "expected None or exception for malformed Document"
 ;;
 
-let test_unknown_media_source_kind_fails_closed () =
+let check_unknown_media_source_kind_fails_closed ~block_type ~media_type ~data =
   let json =
     `Assoc
-      [ "type", `String "image"
+      [ "type", `String block_type
       ; ( "source"
         , `Assoc
             [ "type", `String "url"
-            ; "media_type", `String "image/png"
-            ; "data", `String "https://example.invalid/image.png"
+            ; "media_type", `String media_type
+            ; "data", `String data
             ] )
       ]
   in
   match Api.content_block_of_json json with
   | None -> ()
-  | Some _ -> Alcotest.fail "unsupported media source kind must not parse"
+  | Some _ -> Alcotest.failf "unsupported %s media source kind must not parse" block_type
+;;
+
+let test_unknown_image_source_kind_fails_closed () =
+  check_unknown_media_source_kind_fails_closed
+    ~block_type:"image"
+    ~media_type:"image/png"
+    ~data:"https://example.invalid/image.png"
+;;
+
+let test_unknown_document_source_kind_fails_closed () =
+  check_unknown_media_source_kind_fails_closed
+    ~block_type:"document"
+    ~media_type:"application/pdf"
+    ~data:"https://example.invalid/document.pdf"
+;;
+
+let test_unknown_audio_source_kind_fails_closed () =
+  check_unknown_media_source_kind_fails_closed
+    ~block_type:"audio"
+    ~media_type:"audio/wav"
+    ~data:"https://example.invalid/audio.wav"
 ;;
 
 (* ------------------------------------------------------------------ *)
@@ -357,9 +378,17 @@ let () =
             `Quick
             test_malformed_document_missing_source
         ; Alcotest.test_case
-            "unknown media source kind fail-closed"
+            "unknown image source kind fail-closed"
             `Quick
-            test_unknown_media_source_kind_fails_closed
+            test_unknown_image_source_kind_fails_closed
+        ; Alcotest.test_case
+            "unknown document source kind fail-closed"
+            `Quick
+            test_unknown_document_source_kind_fails_closed
+        ; Alcotest.test_case
+            "unknown audio source kind fail-closed"
+            `Quick
+            test_unknown_audio_source_kind_fails_closed
         ] )
     ; ( "mixed"
       , [ Alcotest.test_case

--- a/test/test_progressive_tools.ml
+++ b/test/test_progressive_tools.ml
@@ -183,7 +183,8 @@ let test_retrieval_hook_extracts_last_user_message () =
     [ { role = Types.User
       ; content =
           [ Types.Text "first"
-          ; Types.Image { media_type = "image/png"; data = ""; source_type = "base64" }
+          ; Types.Image
+              { media_type = "image/png"; data = ""; source_type = Types.Base64 }
           ]
       ; name = None
       ; tool_call_id = None

--- a/test/test_property_advanced.ml
+++ b/test/test_property_advanced.ml
@@ -240,24 +240,13 @@ let test_cost_scales_with_tokens =
 
 (* ── Provider Resolve Properties ──────────────────────────────── *)
 
-let rec find_repo_root dir =
-  if Sys.file_exists (Filename.concat dir "dune-project")
-  then dir
-  else (
-    let parent = Filename.dirname dir in
-    if String.equal parent dir then dir else find_repo_root parent)
-;;
-
-let repo_model_catalog =
-  lazy
-    (let path = Filename.concat (find_repo_root (Sys.getcwd ())) "models.toml" in
-     Llm_provider.Model_catalog.load_file path)
-;;
-
 let with_repo_model_catalog f =
-  match Lazy.force repo_model_catalog with
-  | Error _ -> false
-  | Ok catalog ->
+  match Llm_provider.Model_catalog.global () with
+  | None ->
+    Alcotest.fail
+      "OAS_MODEL_CATALOG did not load the repository models.toml for capability \
+       property tests"
+  | Some catalog ->
     Llm_provider.Model_catalog.set_global catalog;
     Fun.protect ~finally:Llm_provider.Model_catalog.clear_global f
 ;;
@@ -284,7 +273,7 @@ let test_capabilities_provider_m_reasoning =
        ~print:(fun s -> s)
        (QCheck.Gen.oneof
           [ QCheck.Gen.return "dashscope-3.5-35b"
-          ; QCheck.Gen.return "qwen3.6:27b-coding-nvfp4"
+          ; QCheck.Gen.return "dashscope_3.6:27b-coding-nvfp4"
           ; QCheck.Gen.return "DashScope_3.6-35B-A3B-UD-Q4_K_XL.gguf"
           ]))
     (fun model_id ->

--- a/test/test_property_advanced.ml
+++ b/test/test_property_advanced.ml
@@ -240,7 +240,19 @@ let test_cost_scales_with_tokens =
 
 (* ── Provider Resolve Properties ──────────────────────────────── *)
 
-let repo_model_catalog = lazy (Llm_provider.Model_catalog.load_file "models.toml")
+let rec find_repo_root dir =
+  if Sys.file_exists (Filename.concat dir "dune-project")
+  then dir
+  else (
+    let parent = Filename.dirname dir in
+    if String.equal parent dir then dir else find_repo_root parent)
+;;
+
+let repo_model_catalog =
+  lazy
+    (let path = Filename.concat (find_repo_root (Sys.getcwd ())) "models.toml" in
+     Llm_provider.Model_catalog.load_file path)
+;;
 
 let with_repo_model_catalog f =
   match Lazy.force repo_model_catalog with

--- a/test/test_property_advanced.ml
+++ b/test/test_property_advanced.ml
@@ -33,16 +33,14 @@ let content_block_gen =
         QCheck.Gen.string_printable
         QCheck.Gen.string_printable
         QCheck.Gen.bool
-    ; QCheck.Gen.map3
-        (fun mt d st -> Image { media_type = mt; data = d; source_type = st })
+    ; QCheck.Gen.map2
+        (fun mt d -> Image { media_type = mt; data = d; source_type = Base64 })
         (QCheck.Gen.return "image/png")
         QCheck.Gen.string_printable
-        (QCheck.Gen.return "base64")
-    ; QCheck.Gen.map3
-        (fun mt d st -> Document { media_type = mt; data = d; source_type = st })
+    ; QCheck.Gen.map2
+        (fun mt d -> Document { media_type = mt; data = d; source_type = Base64 })
         (QCheck.Gen.return "application/pdf")
         QCheck.Gen.string_printable
-        (QCheck.Gen.return "base64")
     ]
 ;;
 
@@ -242,6 +240,16 @@ let test_cost_scales_with_tokens =
 
 (* ── Provider Resolve Properties ──────────────────────────────── *)
 
+let repo_model_catalog = lazy (Llm_provider.Model_catalog.load_file "models.toml")
+
+let with_repo_model_catalog f =
+  match Lazy.force repo_model_catalog with
+  | Error _ -> false
+  | Ok catalog ->
+    Llm_provider.Model_catalog.set_global catalog;
+    Fun.protect ~finally:Llm_provider.Model_catalog.clear_global f
+;;
+
 let test_local_provider_resolve_always_succeeds =
   QCheck.Test.make
     ~count:100
@@ -268,18 +276,19 @@ let test_capabilities_provider_m_reasoning =
           ; QCheck.Gen.return "DashScope_3.6-35B-A3B-UD-Q4_K_XL.gguf"
           ]))
     (fun model_id ->
-       let caps =
-         Provider.capabilities_for_model
-           ~provider:
-             (Provider.OpenAICompat
-                { base_url = "x"
-                ; auth_header = None
-                ; path = "/v1/chat/completions"
-                ; static_token = None
-                })
-           ~model_id
-       in
-       caps.supports_reasoning)
+       with_repo_model_catalog (fun () ->
+         let caps =
+           Provider.capabilities_for_model
+             ~provider:
+               (Provider.OpenAICompat
+                  { base_url = "x"
+                  ; auth_header = None
+                  ; path = "/v1/chat/completions"
+                  ; static_token = None
+                  })
+             ~model_id
+         in
+         caps.supports_reasoning))
 ;;
 
 (* ── Context Reducer Properties ──────────────────────────────── *)

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -350,7 +350,7 @@ let test_ollama_native_multimodal_request_body () =
     [ { role = User
       ; content =
           [ Text "What is in this image?"
-          ; Image { media_type = "image/png"; data = "base64img"; source_type = "base64" }
+          ; Image { media_type = "image/png"; data = "base64img"; source_type = Base64 }
           ]
       ; name = None
       ; tool_call_id = None

--- a/test/test_streaming.ml
+++ b/test/test_streaming.ml
@@ -423,8 +423,7 @@ let test_synthetic_image_media_delta () =
     { id = "msg-img"
     ; model = "test"
     ; stop_reason = EndTurn
-    ; content =
-        [ Image { media_type = "image/png"; data = "abc"; source_type = "base64" } ]
+    ; content = [ Image { media_type = "image/png"; data = "abc"; source_type = Base64 } ]
     ; usage = None
     ; telemetry = None
     }
@@ -438,7 +437,7 @@ let test_synthetic_image_media_delta () =
   match List.nth events 2 with
   | ContentBlockDelta
       { delta =
-          MediaDelta { media_type = "image/png"; source_type = "base64"; data = "abc" }
+          MediaDelta { media_type = "image/png"; source_type = Base64; data = "abc" }
       ; _
       } -> ()
   | _ -> Alcotest.fail "expected image MediaDelta"

--- a/test/test_streaming_coverage.ml
+++ b/test/test_streaming_coverage.ml
@@ -149,13 +149,16 @@ let test_acc_content_block_start_image () =
        { index = 0
        ; delta =
            MediaDelta
-             { media_type = "image/png"; source_type = "base64"; data = "iVBORw0KGgo=" }
+             { media_type = "image/png"
+             ; source_type = Types.Base64
+             ; data = "iVBORw0KGgo="
+             }
        });
   let resp = finalize_ok acc in
   match resp.content with
   | [ Image { media_type; source_type; data } ] ->
     check_string "media_type" "image/png" media_type;
-    check_string "source_type" "base64" source_type;
+    check_string "source_type" "base64" (Types.media_source_kind_to_string source_type);
     check_string "data" "iVBORw0KGgo=" data
   | _ -> Alcotest.fail "expected single Image block"
 ;;

--- a/test/test_streaming_edge_cases.ml
+++ b/test/test_streaming_edge_cases.ml
@@ -184,10 +184,9 @@ let test_synthetic_events_media_blocks () =
     ; usage = Some (usage ())
     ; telemetry = None
     ; content =
-        [ Image { media_type = "image/png"; data = "aW1n"; source_type = "base64" }
-        ; Document
-            { media_type = "application/pdf"; data = "ZG9j"; source_type = "base64" }
-        ; Audio { media_type = "wav"; data = "YXVkaW8="; source_type = "base64" }
+        [ Image { media_type = "image/png"; data = "aW1n"; source_type = Base64 }
+        ; Document { media_type = "application/pdf"; data = "ZG9j"; source_type = Base64 }
+        ; Audio { media_type = "wav"; data = "YXVkaW8="; source_type = Base64 }
         ; RedactedThinking "hidden"
         ; ToolResult
             { tool_use_id = "call-1"

--- a/test/test_structured_coverage.ml
+++ b/test/test_structured_coverage.ml
@@ -171,7 +171,7 @@ let test_text_extractor_parse_returns_none () =
 let test_extract_ignores_image () =
   let input_json = `Assoc [ "name", `String "Alice"; "age", `Int 30 ] in
   let content =
-    [ Image { media_type = "image/png"; data = "abc"; source_type = "base64" }
+    [ Image { media_type = "image/png"; data = "abc"; source_type = Types.Base64 }
     ; ToolUse { id = "tu_img"; name = "extract_person"; input = input_json }
     ]
   in
@@ -187,7 +187,7 @@ let test_extract_ignores_image () =
 let test_extract_ignores_document () =
   let input_json = `Assoc [ "name", `String "Bob"; "age", `Int 25 ] in
   let content =
-    [ Document { media_type = "application/pdf"; data = "x"; source_type = "base64" }
+    [ Document { media_type = "application/pdf"; data = "x"; source_type = Types.Base64 }
     ; ToolUse { id = "tu_doc"; name = "extract_person"; input = input_json }
     ]
   in
@@ -316,7 +316,7 @@ let test_schema_all_optional () =
 let test_extract_ignores_audio () =
   let input_json = `Assoc [ "name", `String "Dan"; "age", `Int 35 ] in
   let content =
-    [ Audio { media_type = "audio/mp3"; data = "bin"; source_type = "base64" }
+    [ Audio { media_type = "audio/mp3"; data = "bin"; source_type = Types.Base64 }
     ; ToolUse { id = "tu_aud"; name = "extract_person"; input = input_json }
     ]
   in
@@ -353,7 +353,7 @@ let test_extract_mixed_blocks () =
         ; json = None
         ; content_blocks = None
         }
-    ; Image { media_type = "image/png"; data = "img"; source_type = "base64" }
+    ; Image { media_type = "image/png"; data = "img"; source_type = Types.Base64 }
     ; ToolUse { id = "tu_mix"; name = "wrong_tool"; input = `Null }
     ; ToolUse { id = "tu_right"; name = "extract_person"; input = input_json }
     ]

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -332,9 +332,9 @@ let test_show_content_block_variants () =
         ; json = None
         ; content_blocks = None
         }
-    ; Types.Image { media_type = "image/png"; data = "abc"; source_type = "base64" }
+    ; Types.Image { media_type = "image/png"; data = "abc"; source_type = Types.Base64 }
     ; Types.Document
-        { media_type = "application/pdf"; data = "pdf"; source_type = "base64" }
+        { media_type = "application/pdf"; data = "pdf"; source_type = Types.Base64 }
     ]
   in
   List.iter
@@ -925,7 +925,7 @@ let test_validate_tool_result_shape () =
 
 let test_show_audio_block () =
   let block =
-    Types.Audio { media_type = "audio/wav"; data = "data"; source_type = "base64" }
+    Types.Audio { media_type = "audio/wav"; data = "data"; source_type = Types.Base64 }
   in
   let s = Types.show_content_block block in
   Alcotest.(check bool) "show non-empty" true (String.length s > 0)


### PR DESCRIPTION
## Summary
- replace free-form multimodal source_type strings with a closed media_source_kind type
- keep wire JSON compatible by serializing Base64 as "base64"
- fail closed when content_block_of_json sees an unsupported media source kind
- make DashScope/Qwen capability property tests load the repo model catalog explicitly instead of depending on ambient env state

## Validation
- scripts/dune-local.sh build @check
- scripts/dune-local.sh build @fmt
- scripts/dune-local.sh exec ./test/test_multimodal.exe
- scripts/dune-local.sh exec ./test/test_streaming.exe
- scripts/dune-local.sh exec ./test/test_streaming_coverage.exe
- scripts/dune-local.sh exec ./test/test_backend_openai_codec.exe
- scripts/dune-local.sh exec ./test/test_llm_cache.exe
- scripts/dune-local.sh exec ./test/test_property_advanced.exe