### PR TITLE
fix(tool-use): gate strict text recovery by provider

### DIFF
--- a/docs/rfc/RFC-OAS-029-tools-thinking-reasoning-multiturn-standard.md
+++ b/docs/rfc/RFC-OAS-029-tools-thinking-reasoning-multiturn-standard.md
@@ -29,7 +29,7 @@ OAS의 Tools / Thinking / Reasoning / Multi-turn 처리는 **코어는 견고하
 ### 1.2 Where it rots (위반의 형태)
 - **이미 drift한 2중/3중 builder.** OpenAI-compat thinking-request body가 `lib/api_openai.ml`과 `lib/llm_provider/backend_openai_request.ml`에 각각 재구현돼 *실질적으로 갈라짐* (`clear_thinking`이 agent_sdk 경로에선 하드코딩 `true`, 다른 경로에선 config-driven). N-of-M workaround 시그니처가 물질화된 사례 — `#2228`이 preserve 축을 *양쪽 모두*에 추가(41+40줄)했지 통합하지 않았다.
 - **typed kind로 1회 승격하지 않고 런타임에 재유도되는 string 분류기.** GLM-ness가 `String.starts_with ~prefix:"glm-"`로 모듈마다 재평가되어 serializer를 분기하고, typed `replay_policy`를 우회한다(GLM은 `No_replay`로 resolve되어 죽은 값).
-- **typed 레이어가 제거한 휴리스틱을 다시 들여오는 lenient/repair shell.** `tool_use_recovery.ml`이 자유 텍스트에서 JSON tool call을 긁어내고 `Lenient_json` bracket/keyword completion 후 실행한다 (repair-on-read + JSON 휴리스틱).
+- **typed 레이어가 제거한 휴리스틱을 다시 들여오는 lenient/repair shell.** Historical: `tool_use_recovery.ml` used to scrape JSON tool calls from free text and run `Lenient_json` bracket/keyword completion before execution. Current remediation keeps only a strict, provider-telemetry-gated fallback for GLM/Ollama-family responses and leaves ambiguous or repair-needed JSON as `Text`.
 - **closed sum이 가능한 자리의 string 판별 + silent `_ -> None` drop.** historical stream finalizer drift는 `content_type` raw-string match + catch-all drop이었다. Current branch ancestry already adds `block_kind`, `Unknown_block`, and typed SSE parse/unknown-event errors, so remaining D3 work must be policy-specific rather than a wholesale redo.
 - **같은 사실의 두 번째 SSOT.** 중복 stream accumulator(`lib/streaming.ml`, 자체 WORKAROUND 라벨, RFC/removal target 없음)가 reconcile + partial-tool-drop fix를 결여.
 - **doc/typed surface가 배포 모델에 뒤처짐.** GLM이 Kimi `No_thinking_control`로 오모델링; MiniMax M2/M3 catalog rows exist but replay/tool-choice facts are under-sourced; Claude `tool_choice`-forcing-400 미모델, audit-reported `thinking.display` gap(공식 source refresh 필요), `Reasoning_effort` enum에 stale `Minimal`, `none` 누락.
@@ -88,7 +88,7 @@ OAS의 Tools / Thinking / Reasoning / Multi-turn 처리는 **코어는 견고하
 - **S10.1 (정직한 계약).** "Pure"로 문서화된 모듈은 pure여야 한다; 효과(wall-clock, mutable global)는 경계로 옮기거나 `.mli`에 문서화. recovered id는 결정론적(block index + content hash) 또는 주입된 generator로 유도.
 - **S10.2 (데이터 손실은 관측되되, 관측이 fix는 아니다).** block을 drop하면 `repair_dangling_tool_calls`가 synthesized block에 태그하듯 태그한다. counter/log는 typed fix와 함께하는 *alarm*으로만 허용, fix 자체로는 금지(telemetry-as-fix = reject 시그니처).
 
-## 3. Evidence — confirmed/historical violations (22 findings: 19 open, 3 resolved in current branch ancestry, 16 refuted/boundary-acceptable)
+## 3. Evidence — confirmed/historical violations (22 findings: 18 open, 4 resolved in current branch ancestry, 16 refuted/boundary-acceptable)
 
 | Sev | ID | Principle | File:line | Standard |
 |---|---|---|---|---|
@@ -101,7 +101,7 @@ OAS의 Tools / Thinking / Reasoning / Multi-turn 처리는 **코어는 견고하
 | P2 | D4-provider-preset-stale-numeric-limits | hardcode | capabilities.ml:223-255; provider_registry.ml:408; builder.ml:256 | S9.1 |
 | P2 | D2-streaming-reasoning-dialect-dead-and-field-guess | ssot | reasoning_dialect.ml:39-42; streaming.ml:331-335; backend_openai_parse.ml:208-298 | S6.3 |
 | P2 | D4-duplicate-stream-accumulator-missing-reconcile | ssot | streaming.ml:16-215 | S6.2 |
-| P2 | D-TOOLS-1-recovery-text-scrape-heuristic | heuristic | tool_use_recovery.ml:32-237 | S4.2 |
+| P2 | D-TOOLS-1-recovery-text-scrape-heuristic | historical heuristic, now strict provider-gated fallback | tool_use_recovery.ml:32-237; pipeline.ml:31-39,1124-1134 | S4.2 |
 | P2 | D-TOOLS-6-agent_tool-untyped-silent-prompt-fallback | silent_failure | agent_tool.ml:149-161 | S4.3 |
 | P2 | D-TOOLS-9-harness-unknown-schema-type-permissive | silent_failure | backend_tool_call_harness.ml:52-68 | S8.1 |
 | P2 | D6-source-type-ignored-non-anthropic | string_match/silent | backend_openai_serialize.ml:60-82; backend_gemini.ml:161-174; backend_openai_responses.ml:121-137 | S7.1 |
@@ -115,10 +115,10 @@ OAS의 Tools / Thinking / Reasoning / Multi-turn 처리는 **코어는 견고하
 | P3 | D7-anthropic-prefix-list-literal-duplicates | hardcode | capabilities.ml:189-217 | S1.2 |
 | P3 | D8-manifest-cannot-override-catalog-precedence | ssot | capabilities.ml:826-839 | S9.3 |
 
-Status note: `D-TOOLS-6`, `D-TOOLS-9`, and `D-TOOLS-8` are historical
-confirmed violations but are already fixed in the current branch ancestry.
-They are retained here as evidence for S4.3/S8.1/S10.1, not as open backlog
-items.
+Status note: `D-TOOLS-1`, `D-TOOLS-6`, `D-TOOLS-9`, and `D-TOOLS-8` are
+historical confirmed violations but are already fixed in the current branch
+ancestry. They are retained here as evidence for S4.2/S4.3/S8.1/S10.1, not as
+open backlog items.
 
 ### 3b. Doc-currency drifts (official 2026-06-29 docs vs OAS)
 
@@ -177,12 +177,12 @@ RFC 컬럼: **RFC** = dialect/capability *type shape* 변경 또는 N-of-M resha
 ### 미뤄도 안전 (latent, 현재 배포 모델 트리거 없음) — typed cleanup으로 batch
 - `D2-budget-to-effort-triplicated`, `D5-anthropic-thinkmode-hardcoded-prefix-table`, `D4-provider-preset-stale-numeric-limits` (SSOT/hardcode 부채; 현재 값이 일치해 active break 없음 — catalog-field RFC로 fold).
 - **Partially closed before this RFC update (do not redo wholesale)**: `D3-finalize` already has the `block_kind` conversion, explicit `Unknown_block` handling, and typed `SSEUnknownEventType`/parse-error propagation in `Complete_stream_acc`; keep only the residual policy/test work listed above.
-- **Closed before this RFC update (do not redo)**: `D-TOOLS-6`(agent_tool typed delegation), `D-TOOLS-9`(harness unknown schema type fail-closed), and `D-TOOLS-8`(deterministic recovery id) are historical violations already fixed in the current branch ancestry. They remain evidence for the standard, not open backlog.
+- **Closed before this RFC update (do not redo)**: `D-TOOLS-1`(strict provider-gated recovery; no `Lenient_json` repair), `D-TOOLS-6`(agent_tool typed delegation), `D-TOOLS-9`(harness unknown schema type fail-closed), and `D-TOOLS-8`(deterministic recovery id) are historical violations already fixed in the current branch ancestry. They remain evidence for the standard, not open backlog.
 - **Direct, RFC 불필요, 저위험 (언제든)**: `D4-test-only-normalize-effort-wrapper` should be narrowed to any truly dead wrapper only; keep `Reasoning_dialect.normalize_effort_value`, which is a live backend dependency required by S2.2. Also: `D7-anthropic-prefix-list-literal-duplicates`(dedupe), `D4-budget-magic-defaults-silent`, `D8-manifest-precedence` 문서/테스트, Kimi visibility 사실.
 - `D7-gemini-family-leaks-second-string-match`(P3) + Gemini `supports_medium`/`thoughtSignature` strictness: 단일 Gemini variant reshape로 fold.
 
 ### Backlog 자체의 가드레일
-여러 "root fix"는 그 workaround twin으로 구현하면 안 된다. `D3-tool-pair-silent-drop`은 append-time 불변식 또는 drop된 id 반환으로 고친다 — drop counter 아님(telemetry-as-fix = reject). `D-TOOLS-1`은 typed provider parse 경로로 고친다 — lenient repair 강화 아님.
+여러 "root fix"는 그 workaround twin으로 구현하면 안 된다. `D3-tool-pair-silent-drop`은 append-time 불변식 또는 drop된 id 반환으로 고친다 — drop counter 아님(telemetry-as-fix = reject). `D-TOOLS-1`은 typed provider telemetry gate + strict JSON parse로 닫힌 상태를 유지한다 — lenient repair 재도입 금지.
 
 ## 6. Boundary note (OAS ↔ MASC)
 

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -28,6 +28,16 @@ let hook_failed_sdk_error ~hook_name ~stage ~detail =
    cancellation); the thin wrapper keeps this module's log label. *)
 let safe_publish bus event = Pipeline_common.safe_publish ~log:_log bus event
 
+let should_recover_text_tool_use (response : Types.api_response) =
+  match response.telemetry with
+  | Some
+      { provider_kind =
+          Some (Llm_provider.Provider_kind.Glm | Llm_provider.Provider_kind.Ollama)
+      ; _
+      } -> true
+  | Some _ | None -> false
+;;
+
 (* ── Context compaction watermark ───────────────────── *)
 
 (** Default ratio at which proactive compaction fires (0.9 = 90% of context).
@@ -1111,14 +1121,18 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
        update_state agent (fun s -> { s with config = original_config });
        Error e
      | Ok raw_response ->
-       (* Stage 3.4: Lenient tool-use recovery.
-       Some providers (Glm, smaller Ollama models) return tool-call
-       intent as text content instead of a ToolUse content block.
-       Promote recoverable Text blocks to ToolUse before contract
-       validation so the pipeline proceeds normally.
-       Ref: Samchon harness Layer 1 (dev.to/samchon, DashScope 2025). *)
-       let valid_tool_names = Pipeline_stage_prepare.turn_ready_tool_names prep in
-       let response = Tool_use_recovery.recover_response ~valid_tool_names raw_response in
+       (* Stage 3.4: Strict provider-gated tool-use recovery.
+       GLM and Ollama-family responses may return tool-call intent as text
+       content instead of a ToolUse content block. Only typed provider telemetry
+       can enable this fallback; unknown or unrelated providers fail closed and
+       keep Text unchanged. *)
+       let response =
+         if should_recover_text_tool_use raw_response
+         then (
+           let valid_tool_names = Pipeline_stage_prepare.turn_ready_tool_names prep in
+           Tool_use_recovery.recover_response ~valid_tool_names raw_response)
+         else raw_response
+       in
        (* RFC-OAS-025 Option A: forced-tool-use enforcement removed.
           [tool_choice] is enforced server-side by the provider, so the SDK no
           longer validates the response against a completion contract nor retries

--- a/lib/tool_use_recovery.ml
+++ b/lib/tool_use_recovery.ml
@@ -1,4 +1,4 @@
-(** Tool use recovery — extract ToolUse blocks from text content when the
+(** Tool use recovery — strictly extract ToolUse blocks from text content when the
     provider returns a tool-call intent as text instead of a proper
     ToolUse block.
 
@@ -13,10 +13,10 @@
     returns either the original response (unchanged) or a response with
     Text blocks promoted to ToolUse blocks.
 
-    Reference: Samchon function calling harness, Layer 1 "Lenient parse"
-    (dev.to/samchon, DashScope Meetup 2025). Delegates JSON normalization to
-    {!Llm_provider.Lenient_json} (markdown fence strip, double-stringify
-    unwrap, trailing comma cleanup, bracket completion).
+    This fallback deliberately does not repair malformed JSON. It may strip a
+    Markdown code fence wrapper, but promotion requires exactly one balanced
+    JSON object that parses with {!Yojson.Safe.from_string}. Ambiguous text or
+    repair-needed JSON remains Text.
 
     @since 0.136.0 *)
 
@@ -26,66 +26,85 @@ let _log = Log.create ~module_name:"tool_use_recovery" ()
 
 (* ── JSON candidate location ─────────────────────────────── *)
 
+(** Strip a Markdown code fence wrapper without changing the wrapped JSON. *)
+let strip_markdown_fence (s : string) =
+  let trimmed = String.trim s in
+  let fence = "```" in
+  let fence_len = String.length fence in
+  if String.length trimmed < fence_len || String.sub trimmed 0 fence_len <> fence
+  then trimmed
+  else (
+    let lines = String.split_on_char '\n' trimmed in
+    match lines with
+    | _opening :: rest ->
+      (match List.rev rest with
+       | closing :: body_rev when String.trim closing = fence ->
+         String.trim (String.concat "\n" (List.rev body_rev))
+       | _ -> trimmed)
+    | _ -> trimmed)
+;;
+
 (** Find the first balanced top-level JSON object in a string by
     scanning for '{' and tracking depth while respecting string
     literals. Returns [Some (start, length)] or [None]. *)
-let find_json_object (s : string) : (int * int) option =
+let find_json_objects (s : string) : (int * int) list =
   let len = String.length s in
   let rec find_start i =
     if i >= len then None else if s.[i] = '{' then Some i else find_start (i + 1)
   in
-  match find_start 0 with
-  | None -> None
-  | Some start ->
-    let depth = ref 0 in
-    let in_string = ref false in
-    let escaped = ref false in
-    let end_idx = ref (-1) in
-    let i = ref start in
-    while !end_idx = -1 && !i < len do
-      let c = s.[!i] in
-      if !escaped
-      then escaped := false
-      else if c = '\\' && !in_string
-      then escaped := true
-      else if c = '"'
-      then in_string := not !in_string
-      else if not !in_string
-      then
-        if c = '{'
-        then incr depth
-        else if c = '}'
-        then (
-          decr depth;
-          if !depth = 0 then end_idx := !i);
-      incr i
-    done;
-    if !end_idx >= 0 then Some (start, !end_idx - start + 1) else None
+  let rec loop i acc =
+    match find_start i with
+    | None -> List.rev acc
+    | Some start ->
+      let depth = ref 0 in
+      let in_string = ref false in
+      let escaped = ref false in
+      let end_idx = ref (-1) in
+      let i = ref start in
+      while !end_idx = -1 && !i < len do
+        let c = s.[!i] in
+        if !escaped
+        then escaped := false
+        else if c = '\\' && !in_string
+        then escaped := true
+        else if c = '"'
+        then in_string := not !in_string
+        else if not !in_string
+        then
+          if c = '{'
+          then incr depth
+          else if c = '}'
+          then (
+            decr depth;
+            if !depth = 0 then end_idx := !i);
+        incr i
+      done;
+      if !end_idx >= 0
+      then loop (!end_idx + 1) ((start, !end_idx - start + 1) :: acc)
+      else List.rev acc
+  in
+  loop 0 []
 ;;
 
-(** Try to parse a JSON object from a string using {!Lenient_json.parse}
-    after locating a balanced object. Returns [None] only when no
-    object can be located at all (Lenient_json never raises). *)
+let find_json_object (s : string) : (int * int) option =
+  match find_json_objects s with
+  | first :: _ -> Some first
+  | [] -> None
+;;
+
+(** Try to parse a JSON object from a string using strict JSON parsing after
+    locating exactly one balanced object. Returns [None] when no object can be
+    located, when more than one candidate exists, or when parsing fails. *)
 let try_parse_json_object (s : string) : Yojson.Safe.t option =
-  (* Lenient_json handles markdown fences, double-stringify, trailing
-     commas, and unclosed brackets. We still locate the first balanced
-     object first, because content blocks may wrap JSON in surrounding
-     prose ("I will call: {...}"). *)
-  let stripped = Llm_provider.Lenient_json.strip_markdown_fence s in
-  match find_json_object stripped with
-  | None ->
-    (* Fall back to lenient_json on the whole input — handles cases
-       where the stream is the JSON itself, possibly truncated. *)
-    let parsed = Llm_provider.Lenient_json.parse stripped in
-    (match parsed with
-     | `Assoc [ ("raw", `String _) ] -> None (* Sentinel for parse failure *)
-     | other -> Some other)
-  | Some (start, length) ->
+  let stripped = strip_markdown_fence s in
+  match find_json_objects stripped with
+  | [ (start, length) ] ->
     let candidate = String.sub stripped start length in
-    let parsed = Llm_provider.Lenient_json.parse candidate in
-    (match parsed with
-     | `Assoc [ ("raw", `String _) ] -> None
-     | other -> Some other)
+    (match Yojson.Safe.from_string candidate with
+     | `Assoc _ as parsed -> Some parsed
+     | _ -> None
+     | exception Yojson.Json_error _ -> None)
+  | [] | _ :: _ :: _ -> None
 ;;
 
 (* ── Tool call shape matching ────────────────────────────── *)
@@ -116,11 +135,10 @@ let rec extract_name_and_input (json : Yojson.Safe.t) : (string * Yojson.Safe.t)
          | None ->
            (match List.assoc_opt "arguments" fields with
             | Some (`String s) ->
-              (* Double-stringified: arguments is a JSON-encoded string *)
-              let inner = Llm_provider.Lenient_json.parse s in
-              (match inner with
-               | `Assoc [ ("raw", `String _) ] -> Some (`String s)
-               | other -> Some other)
+              (* Double-stringified: arguments is a strict JSON-encoded string. *)
+              (match Yojson.Safe.from_string s with
+               | parsed -> Some parsed
+               | exception Yojson.Json_error _ -> None)
             | Some v -> Some v
             | None ->
               (match List.assoc_opt "parameters" fields with

--- a/lib/tool_use_recovery.mli
+++ b/lib/tool_use_recovery.mli
@@ -1,8 +1,9 @@
-(** Tool use recovery — extract ToolUse blocks from Text content when a
+(** Tool use recovery — strictly extract ToolUse blocks from Text content when a
     provider emits tool-call intent as text instead of a proper ToolUse
     block.
 
-    Delegates JSON normalization to {!Llm_provider.Lenient_json}.
+    This fallback only promotes an exact, unambiguous JSON object. It may strip
+    a Markdown code fence wrapper, but it does not repair malformed JSON.
 
     @since 0.136.0 *)
 
@@ -13,9 +14,9 @@ open Types
     or [None]. Exposed for testing. *)
 val find_json_object : string -> (int * int) option
 
-(** Try to parse a JSON object from a string. Strips markdown fences,
-    locates the first balanced object, and runs {!Lenient_json.parse}
-    for transform-based recovery. Returns [None] if no JSON found. *)
+(** Try to parse a JSON object from a string. Strips Markdown fences, requires
+    exactly one balanced object, and parses it strictly. Returns [None] when the
+    text has no object, multiple object candidates, or malformed JSON. *)
 val try_parse_json_object : string -> Yojson.Safe.t option
 
 (** Match a JSON value against known tool-call shapes and extract

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -204,13 +204,13 @@ let test_agent_turn_idle_detection () =
   Alcotest.(check int) "consecutive 1" 1 idle_result2.new_state.consecutive_idle_turns
 ;;
 
-let pipeline_response stop_reason : Types.api_response =
+let pipeline_response ?telemetry stop_reason : Types.api_response =
   { id = "pipeline-reset-test"
   ; model = "mock-model"
   ; stop_reason
   ; content = [ Text "done" ]
   ; usage = None
-  ; telemetry = None
+  ; telemetry
   }
 ;;
 
@@ -257,6 +257,41 @@ let make_pipeline_test_agent ~net ~response =
   agent
 ;;
 
+let tool_recovery_response () =
+  { (pipeline_response EndTurn) with
+    id = "pipeline-tool-recovery-test"
+  ; content = [ Text "{\"name\":\"my_tool\",\"input\":{\"x\":1}}" ]
+  }
+;;
+
+let make_tool_recovery_test_agent ~net ~(provider : Provider.config) =
+  let tool =
+    Tool.create ~name:"my_tool" ~description:"test" ~parameters:[] (fun _ ->
+      Ok { Types.content = "ok"; _meta = None })
+  in
+  let response = tool_recovery_response () in
+  let transport = transport_returning response in
+  let options =
+    { Internal_agent.default_options with
+      transport = Some transport
+    ; provider = Some provider
+    ; guardrails = Guardrails.permissive
+    }
+  in
+  let agent =
+    Internal_agent.create
+      ~net
+      ~tools:[ tool ]
+      ~config:{ Types.default_config with name = "pipeline-tool-recovery-test" }
+      ~options
+      ()
+  in
+  Internal_agent.set_state
+    agent
+    { (Internal_agent.state agent) with messages = [ Types.user_msg "hello" ] };
+  agent
+;;
+
 let assert_pipeline_idle_reset agent =
   let last_tool_calls, consecutive_idle_turns = idle_state_snapshot agent in
   Alcotest.(check bool) "last tool calls reset" true (Option.is_none last_tool_calls);
@@ -296,6 +331,46 @@ let test_pipeline_output_resets_idle_on_unknown () =
    | Error err -> Alcotest.failf "unexpected run error: %s" (Error.to_string err)
    | Ok _ -> Alcotest.fail "expected unrecognized stop reason");
   assert_pipeline_idle_reset agent
+;;
+
+let test_pipeline_tool_recovery_allows_glm_provider () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let net = Eio.Stdenv.net env in
+  let provider : Provider.config =
+    { provider = Provider.Custom_registered { name = "glm" }
+    ; model_id = "glm-5"
+    ; api_key_env = "ZAI_API_KEY"
+    }
+  in
+  let agent = make_tool_recovery_test_agent ~net ~provider in
+  match Internal_pipeline.run_turn ~sw ~api_strategy:Internal_pipeline.Sync agent with
+  | Ok Internal_pipeline.ToolsExecuted -> ()
+  | Ok (Internal_pipeline.Complete _) ->
+    Alcotest.fail "expected tool recovery to execute a tool"
+  | Ok Internal_pipeline.IdleSkipped -> Alcotest.fail "expected ToolsExecuted"
+  | Error err -> Alcotest.failf "unexpected run error: %s" (Error.to_string err)
+;;
+
+let test_pipeline_tool_recovery_rejects_openai_compat_provider () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let net = Eio.Stdenv.net env in
+  let provider = Provider.local_llm () in
+  let agent = make_tool_recovery_test_agent ~net ~provider in
+  match Internal_pipeline.run_turn ~sw ~api_strategy:Internal_pipeline.Sync agent with
+  | Ok (Internal_pipeline.Complete response) ->
+    (match response.content with
+     | [ Text _ ] -> ()
+     | _ -> Alcotest.fail "expected text to remain unpromoted")
+  | Ok Internal_pipeline.ToolsExecuted ->
+    Alcotest.fail "expected OpenAI-compatible text tool intent to fail closed"
+  | Ok Internal_pipeline.IdleSkipped -> Alcotest.fail "expected Complete"
+  | Error err -> Alcotest.failf "unexpected run error: %s" (Error.to_string err)
 ;;
 
 (* ── Provider_mock: additional coverage ─────────────────── *)
@@ -1108,6 +1183,14 @@ let () =
             "output resets idle on unknown"
             `Quick
             test_pipeline_output_resets_idle_on_unknown
+        ; Alcotest.test_case
+            "tool recovery allows glm"
+            `Quick
+            test_pipeline_tool_recovery_allows_glm_provider
+        ; Alcotest.test_case
+            "tool recovery rejects openai compat"
+            `Quick
+            test_pipeline_tool_recovery_rejects_openai_compat_provider
         ; Alcotest.test_case "extra system context" `Quick test_prepare_turn_extra_context
         ; Alcotest.test_case
             "tool filter override"

--- a/test/test_tool_use_recovery.ml
+++ b/test/test_tool_use_recovery.ml
@@ -1,4 +1,4 @@
-(** Tests for Tool_use_recovery — lenient extraction of ToolUse blocks
+(** Tests for Tool_use_recovery — strict extraction of ToolUse blocks
     from Text content. *)
 
 open Alcotest
@@ -88,6 +88,15 @@ let test_extract_double_stringified () =
   | None -> fail "expected extraction"
 ;;
 
+let test_extract_rejects_invalid_arguments_string () =
+  let json = `Assoc [ "name", `String "tool"; "arguments", `String "{\"x\": tru" ] in
+  check
+    (option (pair string string))
+    "invalid arguments string rejected"
+    None
+    (Option.map (fun (n, _) -> n, "") (TUR.extract_name_and_input json))
+;;
+
 let test_extract_tool_calls_wrapper () =
   let json =
     `Assoc
@@ -162,6 +171,32 @@ let test_recover_plain_text_preserved () =
   | _ -> fail "expected Text preserved"
 ;;
 
+let test_recover_rejects_repair_needed_json () =
+  let response =
+    make_response ~content:[ Text "{\"name\":\"my_tool\",\"input\":{\"x\":1}" ] ()
+  in
+  let recovered = TUR.recover_response ~valid_tool_names:[ "my_tool" ] response in
+  match recovered.content with
+  | [ Text _ ] -> ()
+  | _ -> fail "expected malformed JSON to remain Text"
+;;
+
+let test_recover_rejects_ambiguous_json_candidates () =
+  let response =
+    make_response
+      ~content:
+        [ Text
+            ("{\"name\":\"my_tool\",\"input\":{}}"
+             ^ " {\"name\":\"my_tool\",\"input\":{\"second\":true}}")
+        ]
+      ()
+  in
+  let recovered = TUR.recover_response ~valid_tool_names:[ "my_tool" ] response in
+  match recovered.content with
+  | [ Text _ ] -> ()
+  | _ -> fail "expected ambiguous JSON candidates to remain Text"
+;;
+
 let test_recovered_id_is_deterministic () =
   (* RFC-OAS-029 S10.1: recovered ids derive from block index + content hash,
      not wall-clock, so the same response recovers to the same id every run
@@ -204,6 +239,10 @@ let () =
       , [ test_case "anthropic style" `Quick test_extract_anthropic_style
         ; test_case "openai arguments object" `Quick test_extract_openai_arguments_object
         ; test_case "double stringified" `Quick test_extract_double_stringified
+        ; test_case
+            "invalid arguments string rejected"
+            `Quick
+            test_extract_rejects_invalid_arguments_string
         ; test_case "tool_calls wrapper" `Quick test_extract_tool_calls_wrapper
         ; test_case "no shape" `Quick test_extract_none
         ] )
@@ -216,6 +255,14 @@ let () =
             test_recover_noop_when_tool_use_present
         ; test_case "noop when no tools" `Quick test_recover_noop_when_no_tools
         ; test_case "plain text preserved" `Quick test_recover_plain_text_preserved
+        ; test_case
+            "repair-needed json preserved"
+            `Quick
+            test_recover_rejects_repair_needed_json
+        ; test_case
+            "ambiguous json candidates preserved"
+            `Quick
+            test_recover_rejects_ambiguous_json_candidates
         ; test_case "recovered id deterministic" `Quick test_recovered_id_is_deterministic
         ] )
     ]


### PR DESCRIPTION
## Summary
- remove Lenient_json repair from Tool_use_recovery and require exactly one strict JSON object
- gate text-to-ToolUse recovery in the pipeline by typed provider telemetry (GLM/Ollama only)
- update RFC-OAS-029 S4 status for D-TOOLS-1 and add regression coverage for strict parsing and provider gating

## Verification
- scripts/dune-local.sh build @fmt
- scripts/dune-local.sh build @check
- scripts/dune-local.sh exec ./test/test_tool_use_recovery.exe
- scripts/dune-local.sh exec ./test/test_pipeline.exe