### PR TITLE
style(test): clear OCaml Format on main (test_property_advanced, post-#2269)

### DIFF
--- a/test/test_property_advanced.ml
+++ b/test/test_property_advanced.ml
@@ -244,8 +244,8 @@ let with_repo_model_catalog f =
   match Llm_provider.Model_catalog.global () with
   | None ->
     Alcotest.fail
-      "OAS_MODEL_CATALOG did not load the repository models.toml for capability \
-       property tests"
+      "OAS_MODEL_CATALOG did not load the repository models.toml for capability property \
+       tests"
   | Some catalog ->
     Llm_provider.Model_catalog.set_global catalog;
     Fun.protect ~finally:Llm_provider.Model_catalog.clear_global f


### PR DESCRIPTION
## 목적

oas `main`(`8e345ed5`)의 **OCaml Format** 게이트를 green으로 회복합니다.

## 변경

`ocamlformat -i test/test_property_advanced.ml` — **포맷 전용**(긴 에러 문자열의 줄바꿈 위치 정규화, 2줄). 의미 변화 없음, `| _ ->` wildcard 변화 없음 → `hardening-ratchet` 무영향.

## 근본 원인 (반복 3회차 — 구조적 해결 필요)

미포맷 코드는 `#2269`(`test(property): locate model catalog from sandbox cwd`)에서 유입됐습니다. `#2269`는 PR CI를 통과했는데, **OCaml Format 게이트가 PR이 아니라 `main` push에서만 실행**되기 때문입니다. 따라서 머지 후에야 main에서 red로 드러납니다.

이 패턴은 반복되고 있습니다(이전: `#2257`, `#2264`, 이번 `#2269` 후속). 청소 PR로는 막을 수 없는 구조적 문제이므로, **근본 해결을 강하게 권합니다**:

- **OCaml Format을 PR-level required check로 승격** (현재 main-push-only → `pull_request` 트리거 추가 + branch protection required). masc `#22673`(Draft Auto-Merge Guard 포팅)과 동일한 "게이트를 PR 시점으로 당기기" 패턴입니다.
- 이렇게 하면 미포맷 PR이 머지 전 차단되어 main이 red가 되는 경로 자체가 닫힙니다.

## 검증

- `ocamlformat --check test/test_property_advanced.ml` 통과(로컬, 결정론적 포맷 진단).
- 빌드/테스트는 CI에서 확인.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>