### PR TITLE
fix(tool-harness): treat reconciled Unknown stop as non-tool consistent (main Build & Test green-restore)

### DIFF
--- a/lib/llm_provider/backend_tool_call_harness.ml
+++ b/lib/llm_provider/backend_tool_call_harness.ml
@@ -276,7 +276,13 @@ let stop_reason_matches_tool_calls ~has_tool_calls = function
   | PauseTurn
   | Compaction
   | ContextWindowExceeded -> not has_tool_calls
-  | Unknown _ -> false
+  (* A reconciled-fail-closed stop (e.g. [Unknown "tool_calls"] from
+     Stop_reason_wire.reconcile when the wire claimed tool_use but no
+     ToolUse block exists) carries no executable tool, so it is consistent
+     exactly when there are no tool calls — same rule as the non-tool family.
+     This is not a permissive default: [Unknown] with tool calls present
+     still flags as a mismatch. *)
+  | Unknown _ -> not has_tool_calls
 ;;
 
 let is_dropped_content_block = function


### PR DESCRIPTION
## 목적

`main`(`8e345ed5`)의 **Build & Test (OCaml 5.4.1)** red 를 회복합니다. (OCaml Format red 는 별개로 #2273 이 처리)

실패 테스트: `test_anthropic_tool_use_stop_without_tool_block_fails_closed` (test_backend_tool_call_harness.ml:313) — "validation sees non-tool stop, Expected: `true`". #2232 / #2272 의 Build & Test 실패도 전부 이 main 상속분입니다.

## 근본 원인 (#2271 producer/consumer 불일치)

#2271 (`fix(agent): remove built-in consumer tool aliases`) 이:
1. `Backend_anthropic.parse_response` 를 `Stop_reason_wire.reconcile ~has_tool_blocks` 로 통과시켜, `stop_reason=tool_use` 인데 ToolUse 블록이 없으면 `Unknown "tool_calls"` 로 fail-closed demote (**producer**).
2. demote 된 응답을 validator 가 `stop_reason_correct = true` 로 인정하길 기대하는 테스트 추가.

그러나 **consumer** `stop_reason_matches_tool_calls` 는 `5d51dfa`(2026-06-16, demote 경로 신설 이전) 이래 `Unknown _ -> false` 로 모든 Unknown 을 무조건 불일치 처리합니다. #2271 이 이 함수를 갱신하지 않아 어긋남 → main red.

## 변경 (1 라인 + 회귀 방지 주석)

```ocaml
- | Unknown _ -> false
+ | Unknown _ -> not has_tool_calls
```

EndTurn 계열과 동일 규칙: reconciled-fail-closed stop 은 실행 가능한 tool 이 없으므로 tool call 이 없을 때 정확히 일치(true). **permissive default 아님** — `Unknown` + tool call 존재는 여전히 mismatch(false)로 flag. 이로써 #2271 PR body 의 invariant("StopToolUse 는 executable ToolUse block 을 가져야 한다")를 validator 에 일관 적용합니다.

## 검증 (영향 범위)

- `stop_reason_correct` 를 Unknown stop 으로 보는 테스트는 test_backend_tool_call_harness.ml:313 **하나뿐**(나머지 단언 41/89/144/273/291 은 다른 stop_reason, 무영향).
- `stop_reason_matches_tool_calls` 호출처는 harness 내부 `validate_response` / `validate_response_with_schemas` 2곳뿐(외부 caller 없음).
- repo 전역에 `Unknown + no-tools` 에 `stop_reason_correct=false` 를 기대하는 테스트 없음.
- `ocamlformat --check` PASS (0.29.0). `| _ ->` wildcard 변화 없음 → `hardening-ratchet` 무영향.
- 빌드/테스트는 CI 에서 확인.

## 워크어라운드 아님

이 변경은 워크어라운드를 *추가*하지 않습니다 — 기존 exhaustive match arm 하나를 EndTurn 계열과 일관되게 *정정*해 producer/consumer 불일치를 제거합니다. catch-all(`| _ ->`) 추가 없음, string 분류기 추가 없음, telemetry-as-fix 없음.

## 대안

"demote 된 Unknown 은 항상 의심스럽다"가 의도라면 harness 대신 테스트 line 313 을 `false` 로 뒤집어야 합니다. 다만 #2271 PR body 의 invariant 서술상 harness 수정이 작성자 의도에 부합한다고 판단했습니다. 작성자가 후자를 원하면 close 하셔도 됩니다.

Closes #2275

🤖 Generated with [Claude Code](https://claude.com/claude-code)