### PR TITLE
fix(streaming): use canonical stream accumulator

### DIFF
--- a/lib/streaming.ml
+++ b/lib/streaming.ml
@@ -89,6 +89,9 @@ let create_message_stream
   match resolve_result with
   | Error e -> Error e
   | Ok (provider_cfg, base_url, api_key) ->
+    let reasoning_visibility =
+      Api_openai.reasoning_visibility_of_request ~provider_config:provider_cfg config
+    in
     (match Provider.request_kind provider_cfg.provider with
      | Provider.Anthropic_messages ->
        let headers =
@@ -128,7 +131,7 @@ let create_message_stream
                    accumulate_event acc evt))
              ();
            if !(acc.stop_reason_received) then on_event MessageStop;
-           finalize_stream_acc acc)
+           finalize_stream_acc ~reasoning_visibility acc)
          ()
        |> map_stream_finalize_result
      | Provider.Openai_chat_completions ->
@@ -215,7 +218,7 @@ let create_message_stream
                         evs))
                 ();
               if !(acc.stop_reason_received) then on_event MessageStop;
-              finalize_stream_acc acc)
+              finalize_stream_acc ~reasoning_visibility acc)
             ()
           |> map_stream_finalize_result)
      | Provider.Custom _ ->

--- a/lib/streaming.ml
+++ b/lib/streaming.ml
@@ -13,16 +13,17 @@ let emit_synthetic_events = Llm_provider.Streaming.emit_synthetic_events
 
 (* ── Shared streaming accumulation ──────────────────────────── *)
 
-type stream_acc =
-  { msg_id : string ref
-  ; msg_model : string ref
+type stream_acc = Llm_provider.Complete_stream_acc.stream_acc =
+  { id : string ref
+  ; model : string ref
   ; input_tokens : int ref
   ; output_tokens : int ref
   ; cache_creation : int ref
   ; cache_read : int ref
   ; stop_reason : stop_reason ref
   ; stop_reason_received : bool ref
-  ; sse_error : string option ref
+  ; terminal_incomplete : bool ref
+  ; sse_error : stream_error option ref
   ; block_texts : (int, Buffer.t) Hashtbl.t
   ; block_types : (int, string) Hashtbl.t
   ; block_tool_ids : (int, string) Hashtbl.t
@@ -32,226 +33,20 @@ type stream_acc =
   ; block_media_sources : (int, media_source_kind) Hashtbl.t
   }
 
-let create_stream_acc () =
-  { msg_id = ref ""
-  ; msg_model = ref ""
-  ; input_tokens = ref 0
-  ; output_tokens = ref 0
-  ; cache_creation = ref 0
-  ; cache_read = ref 0
-  ; stop_reason = ref EndTurn
-  ; stop_reason_received = ref false
-  ; sse_error = ref None
-  ; block_texts = Hashtbl.create 4
-  ; block_types = Hashtbl.create 4
-  ; block_tool_ids = Hashtbl.create 4
-  ; block_tool_names = Hashtbl.create 4
-  ; block_thinking_signatures = Hashtbl.create 4
-  ; block_media_types = Hashtbl.create 4
-  ; block_media_sources = Hashtbl.create 4
-  }
-;;
-
-let accumulate_event (acc : stream_acc) = function
-  | MessageStart { id; model; usage } ->
-    acc.msg_id := id;
-    acc.msg_model := model;
-    (match usage with
-     | Some u ->
-       acc.input_tokens := u.input_tokens;
-       acc.cache_creation := u.cache_creation_input_tokens;
-       acc.cache_read := u.cache_read_input_tokens
-     | None -> ())
-  | ContentBlockStart { index; content_type; tool_id; tool_name } ->
-    Hashtbl.replace acc.block_types index content_type;
-    Hashtbl.replace acc.block_texts index (Buffer.create 64);
-    (match tool_id with
-     | Some id -> Hashtbl.replace acc.block_tool_ids index id
-     | None -> ());
-    (match tool_name with
-     | Some n -> Hashtbl.replace acc.block_tool_names index n
-     | None -> ())
-  | ContentBlockDelta { index; delta } ->
-    let buf =
-      match Hashtbl.find_opt acc.block_texts index with
-      | Some b -> b
-      | None ->
-        let b = Buffer.create 64 in
-        Hashtbl.replace acc.block_texts index b;
-        b
-    in
-    (match delta with
-     | TextDelta s | ThinkingDelta s | InputJsonDelta s -> Buffer.add_string buf s
-     | MediaDelta { media_type; source_type; data } ->
-       Hashtbl.replace acc.block_media_types index media_type;
-       Hashtbl.replace acc.block_media_sources index source_type;
-       Buffer.add_string buf data
-     | ThinkingSignatureDelta s ->
-       let sig_buf =
-         match Hashtbl.find_opt acc.block_thinking_signatures index with
-         | Some b -> b
-         | None ->
-           let b = Buffer.create 256 in
-           Hashtbl.replace acc.block_thinking_signatures index b;
-           b
-       in
-       Buffer.add_string sig_buf s)
-  | MessageDelta { stop_reason = sr; usage } ->
-    (match sr with
-     | Some r ->
-       acc.stop_reason := r;
-       acc.stop_reason_received := true
-     | None -> ());
-    (match usage with
-     | Some u ->
-       acc.output_tokens := u.output_tokens;
-       if u.cache_creation_input_tokens > 0
-       then acc.cache_creation := u.cache_creation_input_tokens;
-       if u.cache_read_input_tokens > 0 then acc.cache_read := u.cache_read_input_tokens
-     | None -> ())
-  (* WORKAROUND: this secondary streaming surface ([create_message_stream] via
-     [provider_intf], used by examples + e2e) keeps its own string [sse_error]
-     carrier and still collapses to [NetworkError {Unknown}] at finalize. The
-     typed-carrier fix landed on the primary completion path
-     ([Complete.complete_stream] / [Complete_stream_acc]). Root fix: unify this
-     duplicate accumulator onto [Complete_stream_acc] (follow-on). Here we only
-     destructure the enriched [SSEError] payload to keep compiling. *)
-  | SSEError { message; _ } -> acc.sse_error := Some message
-  | SSEParseFailed { raw; reason } ->
-    let preview =
-      if String.length raw > 200 then String.sub raw 0 200 ^ "...(truncated)" else raw
-    in
-    acc.sse_error
-    := Some (Printf.sprintf "sse_parse_failed: %s | chunk: %s" reason preview)
-  | SSEUnknownEventType { event_type; raw } ->
-    let preview =
-      if String.length raw > 200 then String.sub raw 0 200 ^ "...(truncated)" else raw
-    in
-    acc.sse_error
-    := Some (Printf.sprintf "sse_unknown_event_type: %s | chunk: %s" event_type preview)
-  | MessageStop -> acc.stop_reason_received := true
-  (* StreamIncomplete drives the partial-tool drop on the primary
-     [Complete_stream_acc] path; this secondary accumulator (see WORKAROUND
-     above) does not assemble/drop tool blocks here, so it is a no-op pending the
-     same unification. *)
-  | StreamIncomplete _ -> ()
-  | Ping | ContentBlockStop _ | Connected | Timeout _ -> ()
-;;
-
-let finalize_stream_acc (acc : stream_acc) =
-  match !(acc.sse_error) with
-  | Some msg -> Error msg
-  | None when not !(acc.stop_reason_received) ->
-    Error "stream_terminated_without_stop_reason"
-  | None ->
-    let indices =
-      Hashtbl.fold (fun index _ indices -> index :: indices) acc.block_types []
-      |> List.sort compare
-    in
-    let content_of_index index =
-      let text =
-        match Hashtbl.find_opt acc.block_texts index with
-        | Some buf -> Buffer.contents buf
-        | None -> ""
-      in
-      let media_block kind make =
-        if String.trim text = ""
-        then Ok None
-        else (
-          match
-            ( Hashtbl.find_opt acc.block_media_types index
-            , Hashtbl.find_opt acc.block_media_sources index )
-          with
-          | Some media_type, Some source_type when String.trim media_type <> "" ->
-            Ok (Some (make ~media_type ~data:text ~source_type))
-          | _ -> Error (Printf.sprintf "malformed_media_block:%s:index:%d" kind index))
-      in
-      match Hashtbl.find_opt acc.block_types index with
-      | None -> Ok None
-      | Some "text" -> Ok (Some (Text text))
-      | Some "thinking" ->
-        let thinking_type =
-          match Hashtbl.find_opt acc.block_thinking_signatures index with
-          | Some buf when Buffer.length buf > 0 -> Buffer.contents buf
-          | Some _ | None -> ""
-        in
-        Ok (Some (Thinking { thinking_type; content = text }))
-      | Some "redacted_thinking" ->
-        (match Hashtbl.find_opt acc.block_tool_ids index with
-         | Some data when data <> "" -> Ok (Some (RedactedThinking data))
-         | Some _ | None -> Ok None)
-      | Some "tool_use" ->
-        let tool_id =
-          match Hashtbl.find_opt acc.block_tool_ids index with
-          | Some id -> id
-          | None -> ""
-        in
-        let tool_name =
-          match Hashtbl.find_opt acc.block_tool_names index with
-          | Some name -> name
-          | None -> ""
-        in
-        (try
-           Ok
-             (Some
-                (ToolUse
-                   { id = tool_id
-                   ; name = tool_name
-                   ; input = Yojson.Safe.from_string text
-                   }))
-         with
-         | Yojson.Json_error _ -> Ok (Some (Text text)))
-      | Some "image" ->
-        media_block "image" (fun ~media_type ~data ~source_type ->
-          Image { media_type; data; source_type })
-      | Some "document" ->
-        media_block "document" (fun ~media_type ~data ~source_type ->
-          Document { media_type; data; source_type })
-      | Some "audio" ->
-        media_block "audio" (fun ~media_type ~data ~source_type ->
-          Audio { media_type; data; source_type })
-      | Some _ -> Ok None
-    in
-    let rec collect_content acc = function
-      | [] -> Ok (List.rev acc)
-      | index :: rest ->
-        (match content_of_index index with
-         | Error _ as err -> err
-         | Ok None -> collect_content acc rest
-         | Ok (Some block) -> collect_content (block :: acc) rest)
-    in
-    (match collect_content [] indices with
-     | Error _ as err -> err
-     | Ok content ->
-       let usage =
-         if
-           !(acc.input_tokens) > 0
-           || !(acc.output_tokens) > 0
-           || !(acc.cache_creation) > 0
-           || !(acc.cache_read) > 0
-         then
-           Some
-             { input_tokens = !(acc.input_tokens)
-             ; output_tokens = !(acc.output_tokens)
-             ; cache_creation_input_tokens = !(acc.cache_creation)
-             ; cache_read_input_tokens = !(acc.cache_read)
-             ; cost_usd = None
-             }
-         else None
-       in
-       Ok
-         { id = !(acc.msg_id)
-         ; model = !(acc.msg_model)
-         ; stop_reason = !(acc.stop_reason)
-         ; content
-         ; usage
-         ; telemetry = None
-         })
-;;
+let create_stream_acc = Llm_provider.Complete_stream_acc.create_stream_acc
+let accumulate_event = Llm_provider.Complete_stream_acc.accumulate_event
+let finalize_stream_acc = Llm_provider.Complete_stream_acc.finalize_stream_acc
 
 (* ── HTTP error mapping ─────────────────────────────────────── *)
 
 let map_http_error = Http_error_sdk.of_http_error
+
+let map_stream_finalize_result = function
+  | Error e -> Error (map_http_error e)
+  | Ok (Ok resp) -> Ok (Llm_provider.Pricing.annotate_response_cost resp)
+  | Ok (Error serr) ->
+    Error (map_http_error (Llm_provider.Complete_stream.http_error_of_stream_error serr))
+;;
 
 (** Streaming variant of create_message.
     Supports Anthropic (native SSE) and OpenAI-compatible (SSE).
@@ -305,50 +100,37 @@ let create_message_stream
        let body_assoc = Api.build_body_assoc ~config ~messages ?tools ~stream:true () in
        let body = Yojson.Safe.to_string (`Assoc body_assoc) in
        let url = base_url ^ "/v1/messages" in
-       (match
-          Llm_provider.Http_client.with_post_stream
-            ?clock
-            ~net
-            ~url
-            ~headers
-            ~body
-            ~f:(fun reader ->
-              let acc = create_stream_acc () in
-              Llm_provider.Http_client.read_sse
-                ?clock
-                ?idle_timeout
-                ~reader
-                ~on_data:(fun ~event_type data ->
-                  if data <> "[DONE]"
-                  then (
-                    match parse_sse_event event_type data with
-                    | None ->
-                      let evt =
-                        SSEParseFailed
-                          { raw = data; reason = "anthropic_sse_chunk_parse_failure" }
-                      in
-                      on_event evt;
-                      accumulate_event acc evt
-                    | Some evt ->
-                      on_event evt;
-                      accumulate_event acc evt))
-                ();
-              if !(acc.stop_reason_received) then on_event MessageStop;
-              finalize_stream_acc acc)
-            ()
-        with
-        | Error e -> Error (map_http_error e)
-        | Ok (Ok resp) -> Ok (Llm_provider.Pricing.annotate_response_cost resp)
-        | Ok (Error msg) ->
-          Error
-            (Error.Provider
-               (Llm_provider.Error.of_http_error
-                  (Llm_provider.Http_client.ProviderFailure
-                     { kind =
-                         Llm_provider.Http_client.Provider_parse_error
-                           { parser = Some "sse_stream_accumulator" }
-                     ; message = Printf.sprintf "SSE stream error: %s" msg
-                     }))))
+       Llm_provider.Http_client.with_post_stream
+         ?clock
+         ~net
+         ~url
+         ~headers
+         ~body
+         ~f:(fun reader ->
+           let acc = create_stream_acc () in
+           Llm_provider.Http_client.read_sse
+             ?clock
+             ?idle_timeout
+             ~reader
+             ~on_data:(fun ~event_type data ->
+               if data <> "[DONE]"
+               then (
+                 match parse_sse_event event_type data with
+                 | None ->
+                   let evt =
+                     SSEParseFailed
+                       { raw = data; reason = "anthropic_sse_chunk_parse_failure" }
+                   in
+                   on_event evt;
+                   accumulate_event acc evt
+                 | Some evt ->
+                   on_event evt;
+                   accumulate_event acc evt))
+             ();
+           if !(acc.stop_reason_received) then on_event MessageStop;
+           finalize_stream_acc acc)
+         ()
+       |> map_stream_finalize_result
      | Provider.Openai_chat_completions ->
        (* OpenAI-compatible SSE streaming. *)
        let openai_compat_kind = Llm_provider.Provider_config.OpenAI_compat in
@@ -384,71 +166,58 @@ let create_message_stream
             |> Llm_provider.Http_client.inject_stream_and_options
           in
           let url = base_url ^ stream_path in
-          (match
-             Llm_provider.Http_client.with_post_stream
-               ?clock
-               ~net
-               ~url
-               ~headers
-               ~body
-               ~f:(fun reader ->
-                 let acc = create_stream_acc () in
-                 let oai_state = Llm_provider.Streaming.create_openai_stream_state () in
-                 let msg_started = ref false in
-                 Llm_provider.Http_client.read_sse
-                   ?clock
-                   ?idle_timeout
-                   ~reader
-                   ~on_data:(fun ~event_type:_ data ->
-                     if data = "[DONE]"
-                     then ()
-                     else (
-                       match Llm_provider.Streaming.parse_openai_sse_chunk data with
-                       | None ->
-                         let evt =
-                           SSEParseFailed
-                             { raw = data; reason = "openai_sse_chunk_parse_failure" }
-                         in
-                         on_event evt;
-                         accumulate_event acc evt
-                       | Some chunk ->
-                         if not !msg_started
-                         then (
-                           msg_started := true;
-                           let evt =
-                             MessageStart
-                               { id = chunk.chunk_id
-                               ; model = chunk.chunk_model
-                               ; usage = None
-                               }
-                           in
+          Llm_provider.Http_client.with_post_stream
+            ?clock
+            ~net
+            ~url
+            ~headers
+            ~body
+            ~f:(fun reader ->
+              let acc = create_stream_acc () in
+              let oai_state = Llm_provider.Streaming.create_openai_stream_state () in
+              let msg_started = ref false in
+              Llm_provider.Http_client.read_sse
+                ?clock
+                ?idle_timeout
+                ~reader
+                ~on_data:(fun ~event_type:_ data ->
+                  if data = "[DONE]"
+                  then ()
+                  else (
+                    match Llm_provider.Streaming.parse_openai_sse_chunk data with
+                    | None ->
+                      let evt =
+                        SSEParseFailed
+                          { raw = data; reason = "openai_sse_chunk_parse_failure" }
+                      in
+                      on_event evt;
+                      accumulate_event acc evt
+                    | Some chunk ->
+                      if not !msg_started
+                      then (
+                        msg_started := true;
+                        let evt =
+                          MessageStart
+                            { id = chunk.chunk_id
+                            ; model = chunk.chunk_model
+                            ; usage = None
+                            }
+                        in
+                        on_event evt;
+                        accumulate_event acc evt);
+                      let evs, _tel =
+                        Llm_provider.Streaming.openai_chunk_to_events oai_state chunk
+                      in
+                      List.iter
+                        (fun evt ->
                            on_event evt;
-                           accumulate_event acc evt);
-                         let evs, _tel =
-                           Llm_provider.Streaming.openai_chunk_to_events oai_state chunk
-                         in
-                         List.iter
-                           (fun evt ->
-                              on_event evt;
-                              accumulate_event acc evt)
-                           evs))
-                   ();
-                 if !(acc.stop_reason_received) then on_event MessageStop;
-                 finalize_stream_acc acc)
-               ()
-           with
-           | Error e -> Error (map_http_error e)
-           | Ok (Ok resp) -> Ok (Llm_provider.Pricing.annotate_response_cost resp)
-           | Ok (Error msg) ->
-             Error
-               (Error.Provider
-                  (Llm_provider.Error.of_http_error
-                     (Llm_provider.Http_client.ProviderFailure
-                        { kind =
-                            Llm_provider.Http_client.Provider_parse_error
-                              { parser = Some "sse_stream_accumulator" }
-                        ; message = Printf.sprintf "SSE stream error: %s" msg
-                        })))))
+                           accumulate_event acc evt)
+                        evs))
+                ();
+              if !(acc.stop_reason_received) then on_event MessageStop;
+              finalize_stream_acc acc)
+            ()
+          |> map_stream_finalize_result)
      | Provider.Custom _ ->
        (* Sync fallback: non-streaming call + synthetic events *)
        (match

--- a/lib/streaming.mli
+++ b/lib/streaming.mli
@@ -21,15 +21,16 @@ val emit_synthetic_events : Types.api_response -> (Types.sse_event -> unit) -> u
 (** Mutable accumulator for building an {!Types.api_response} from
     a sequence of SSE events. *)
 type stream_acc =
-  { msg_id : string ref
-  ; msg_model : string ref
+  { id : string ref
+  ; model : string ref
   ; input_tokens : int ref
   ; output_tokens : int ref
   ; cache_creation : int ref
   ; cache_read : int ref
   ; stop_reason : Types.stop_reason ref
   ; stop_reason_received : bool ref
-  ; sse_error : string option ref
+  ; terminal_incomplete : bool ref
+  ; sse_error : Types.stream_error option ref
   ; block_texts : (int, Buffer.t) Hashtbl.t
   ; block_types : (int, string) Hashtbl.t
   ; block_tool_ids : (int, string) Hashtbl.t
@@ -46,8 +47,12 @@ val create_stream_acc : unit -> stream_acc
 val accumulate_event : stream_acc -> Types.sse_event -> unit
 
 (** Finalize the accumulator into a complete API response.
-    Returns [Error msg] if an SSE error was recorded during the stream. *)
-val finalize_stream_acc : stream_acc -> (Types.api_response, string) result
+    Returns [Error stream_error] if an SSE error or fail-closed stream parse
+    error was recorded during the stream. *)
+val finalize_stream_acc
+  :  ?reasoning_visibility:Llm_provider.Reasoning_dialect.reasoning_visibility
+  -> stream_acc
+  -> (Types.api_response, Types.stream_error) result
 
 (** {1 HTTP Error Mapping} *)
 

--- a/test/test_property_advanced.ml
+++ b/test/test_property_advanced.ml
@@ -244,8 +244,8 @@ let with_repo_model_catalog f =
   match Llm_provider.Model_catalog.global () with
   | None ->
     Alcotest.fail
-      "OAS_MODEL_CATALOG did not load the repository models.toml for capability \
-       property tests"
+      "OAS_MODEL_CATALOG did not load the repository models.toml for capability property \
+       tests"
   | Some catalog ->
     Llm_provider.Model_catalog.set_global catalog;
     Fun.protect ~finally:Llm_provider.Model_catalog.clear_global f

--- a/test/test_stream_accumulator.ml
+++ b/test/test_stream_accumulator.ml
@@ -286,6 +286,40 @@ let test_finalize_thinking_block () =
      | _ -> Alcotest.fail "expected Thinking")
 ;;
 
+let test_finalize_visible_text_promotes_reasoning_only () =
+  let acc = Streaming.create_stream_acc () in
+  acc_events
+    acc
+    [ MessageStart { id = "m"; model = "m"; usage = None }
+    ; ContentBlockStart
+        { index = 0; content_type = "thinking"; tool_id = None; tool_name = None }
+    ; ContentBlockDelta { index = 0; delta = ThinkingDelta "final answer is 42" }
+    ; MessageDelta { stop_reason = Some EndTurn; usage = None }
+    ];
+  match
+    Streaming.finalize_stream_acc
+      ~reasoning_visibility:Llm_provider.Reasoning_dialect.Visible_text
+      acc
+  with
+  | Error err -> fail_unexpected_stream_error err
+  | Ok resp ->
+    let has_promoted_text =
+      List.exists
+        (function
+          | Text "final answer is 42" -> true
+          | Text _
+          | Thinking _
+          | RedactedThinking _
+          | ToolUse _
+          | ToolResult _
+          | Image _
+          | Document _
+          | Audio _ -> false)
+        resp.content
+    in
+    Alcotest.(check bool) "visible text promoted" true has_promoted_text
+;;
+
 let test_finalize_thinking_signature_block () =
   let acc = Streaming.create_stream_acc () in
   acc_events
@@ -523,6 +557,10 @@ let () =
     ; ( "finalize"
       , [ Alcotest.test_case "text response" `Quick test_finalize_text_response
         ; Alcotest.test_case "thinking block" `Quick test_finalize_thinking_block
+        ; Alcotest.test_case
+            "visible_text promotes reasoning-only"
+            `Quick
+            test_finalize_visible_text_promotes_reasoning_only
         ; Alcotest.test_case
             "thinking signature block"
             `Quick

--- a/test/test_stream_accumulator.ml
+++ b/test/test_stream_accumulator.ml
@@ -17,12 +17,31 @@ let make_usage ?(cache_create = 0) ?(cache_read = 0) inp out =
 
 let acc_events acc events = List.iter (Streaming.accumulate_event acc) events
 
+let stream_error_to_string = function
+  | Stream_provider_error { message; _ } -> message
+  | Stream_parse_failed { reason; _ } -> reason
+  | Stream_unknown_event { event_type; _ } -> "unknown_event:" ^ event_type
+;;
+
+let fail_unexpected_stream_error err =
+  Alcotest.fail ("unexpected error: " ^ stream_error_to_string err)
+;;
+
+let check_zero_usage = function
+  | Some u ->
+    Alcotest.(check int) "input" 0 u.input_tokens;
+    Alcotest.(check int) "output" 0 u.output_tokens;
+    Alcotest.(check int) "cache_creation" 0 u.cache_creation_input_tokens;
+    Alcotest.(check int) "cache_read" 0 u.cache_read_input_tokens
+  | None -> Alcotest.fail "expected zero usage"
+;;
+
 (* ── create_stream_acc ────────────────────────────────────── *)
 
 let test_create_initial_state () =
   let acc = Streaming.create_stream_acc () in
-  Alcotest.(check string) "msg_id empty" "" !(acc.msg_id);
-  Alcotest.(check string) "msg_model empty" "" !(acc.msg_model);
+  Alcotest.(check string) "msg_id empty" "" !(acc.id);
+  Alcotest.(check string) "msg_model empty" "" !(acc.model);
   Alcotest.(check int) "input_tokens 0" 0 !(acc.input_tokens);
   Alcotest.(check int) "output_tokens 0" 0 !(acc.output_tokens);
   Alcotest.(check int) "cache_creation 0" 0 !(acc.cache_creation);
@@ -38,8 +57,8 @@ let test_accumulate_message_start () =
       { id = "msg_123"; model = "claude-sonnet-4"; usage = Some (make_usage 100 0) }
   in
   Streaming.accumulate_event acc evt;
-  Alcotest.(check string) "id set" "msg_123" !(acc.msg_id);
-  Alcotest.(check string) "model set" "claude-sonnet-4" !(acc.msg_model);
+  Alcotest.(check string) "id set" "msg_123" !(acc.id);
+  Alcotest.(check string) "model set" "claude-sonnet-4" !(acc.model);
   Alcotest.(check int) "input_tokens" 100 !(acc.input_tokens)
 ;;
 
@@ -48,7 +67,7 @@ let test_accumulate_message_start_no_usage () =
   Streaming.accumulate_event
     acc
     (MessageStart { id = "m1"; model = "test"; usage = None });
-  Alcotest.(check string) "id" "m1" !(acc.msg_id);
+  Alcotest.(check string) "id" "m1" !(acc.id);
   Alcotest.(check int) "input stays 0" 0 !(acc.input_tokens)
 ;;
 
@@ -214,7 +233,7 @@ let test_accumulate_ignores_ping () =
   Streaming.accumulate_event
     acc
     (SSEError { message = "oops"; error_type = None; raw = "oops" });
-  Alcotest.(check string) "state unchanged" "" !(acc.msg_id)
+  Alcotest.(check string) "state unchanged" "" !(acc.id)
 ;;
 
 (* ── finalize_stream_acc ──────────────────────────────────── *)
@@ -230,7 +249,7 @@ let test_finalize_text_response () =
     ; MessageDelta { stop_reason = Some EndTurn; usage = Some (make_usage 0 50) }
     ];
   match Streaming.finalize_stream_acc acc with
-  | Error msg -> Alcotest.fail ("unexpected error: " ^ msg)
+  | Error err -> fail_unexpected_stream_error err
   | Ok resp ->
     Alcotest.(check string) "id" "msg_f" resp.id;
     Alcotest.(check string) "model" "test" resp.model;
@@ -259,7 +278,7 @@ let test_finalize_thinking_block () =
     ; MessageDelta { stop_reason = Some EndTurn; usage = None }
     ];
   match Streaming.finalize_stream_acc acc with
-  | Error msg -> Alcotest.fail ("unexpected error: " ^ msg)
+  | Error err -> fail_unexpected_stream_error err
   | Ok resp ->
     (match List.hd resp.content with
      | Thinking { content; _ } ->
@@ -279,7 +298,7 @@ let test_finalize_thinking_signature_block () =
     ; MessageDelta { stop_reason = Some EndTurn; usage = None }
     ];
   match Streaming.finalize_stream_acc acc with
-  | Error msg -> Alcotest.fail ("unexpected error: " ^ msg)
+  | Error err -> fail_unexpected_stream_error err
   | Ok resp ->
     (match List.hd resp.content with
      | Thinking { thinking_type; content } ->
@@ -302,7 +321,7 @@ let test_finalize_redacted_thinking_block () =
     ; MessageDelta { stop_reason = Some StopToolUse; usage = None }
     ];
   match Streaming.finalize_stream_acc acc with
-  | Error msg -> Alcotest.fail ("unexpected error: " ^ msg)
+  | Error err -> fail_unexpected_stream_error err
   | Ok resp ->
     (match List.hd resp.content with
      | RedactedThinking data -> Alcotest.(check string) "data" "opaque_data" data
@@ -324,7 +343,7 @@ let test_finalize_tool_use () =
     ; MessageDelta { stop_reason = Some StopToolUse; usage = None }
     ];
   match Streaming.finalize_stream_acc acc with
-  | Error msg -> Alcotest.fail ("unexpected error: " ^ msg)
+  | Error err -> fail_unexpected_stream_error err
   | Ok resp ->
     (match List.hd resp.content with
      | ToolUse { id; name; input } ->
@@ -349,11 +368,14 @@ let test_finalize_tool_use_invalid_json () =
     ; MessageDelta { stop_reason = Some EndTurn; usage = None }
     ];
   match Streaming.finalize_stream_acc acc with
-  | Error msg -> Alcotest.fail ("unexpected error: " ^ msg)
-  | Ok resp ->
-    (match List.hd resp.content with
-     | Text s -> Alcotest.(check string) "fallback to text" "not json{" s
-     | _ -> Alcotest.fail "expected Text fallback for invalid JSON")
+  | Error (Stream_parse_failed { reason; raw }) ->
+    Alcotest.(check string) "raw omitted" "" raw;
+    Alcotest.(check bool)
+      "malformed tool args"
+      true
+      (String.starts_with ~prefix:"malformed_tool_use_arguments:index:0" reason)
+  | Error err -> fail_unexpected_stream_error err
+  | Ok _ -> Alcotest.fail "expected malformed tool_use arguments to fail closed"
 ;;
 
 let test_finalize_multi_block_ordering () =
@@ -370,7 +392,7 @@ let test_finalize_multi_block_ordering () =
     ; MessageDelta { stop_reason = Some EndTurn; usage = None }
     ];
   match Streaming.finalize_stream_acc acc with
-  | Error msg -> Alcotest.fail ("unexpected error: " ^ msg)
+  | Error err -> fail_unexpected_stream_error err
   | Ok resp ->
     Alcotest.(check int) "2 blocks" 2 (List.length resp.content);
     (match resp.content with
@@ -389,11 +411,11 @@ let test_finalize_no_usage () =
     ; MessageDelta { stop_reason = Some EndTurn; usage = None }
     ];
   match Streaming.finalize_stream_acc acc with
-  | Error msg -> Alcotest.fail ("unexpected error: " ^ msg)
-  | Ok resp -> Alcotest.(check bool) "no usage" true (Option.is_none resp.usage)
+  | Error err -> fail_unexpected_stream_error err
+  | Ok resp -> check_zero_usage resp.usage
 ;;
 
-let test_finalize_unknown_block_type_skipped () =
+let test_finalize_unknown_block_type_fails_closed () =
   let acc = Streaming.create_stream_acc () in
   acc_events
     acc
@@ -404,8 +426,14 @@ let test_finalize_unknown_block_type_skipped () =
     ; MessageDelta { stop_reason = Some EndTurn; usage = None }
     ];
   match Streaming.finalize_stream_acc acc with
-  | Error msg -> Alcotest.fail ("unexpected error: " ^ msg)
-  | Ok resp -> Alcotest.(check int) "unknown type skipped" 0 (List.length resp.content)
+  | Error (Stream_parse_failed { reason; raw }) ->
+    Alcotest.(check string)
+      "reason"
+      "unsupported_content_block_kind:future_type:index:0"
+      reason;
+    Alcotest.(check string) "raw omitted" "" raw
+  | Error err -> fail_unexpected_stream_error err
+  | Ok _ -> Alcotest.fail "expected unknown content block kind to fail closed"
 ;;
 
 (* ── map_http_error ───────────────────────────────────────── *)
@@ -514,9 +542,9 @@ let () =
             test_finalize_multi_block_ordering
         ; Alcotest.test_case "no usage" `Quick test_finalize_no_usage
         ; Alcotest.test_case
-            "unknown type skipped"
+            "unknown type fails closed"
             `Quick
-            test_finalize_unknown_block_type_skipped
+            test_finalize_unknown_block_type_fails_closed
         ] )
     ; ( "map_http_error"
       , [ Alcotest.test_case "http error" `Quick test_map_http_error_http

--- a/test/test_streaming_cov.ml
+++ b/test/test_streaming_cov.ml
@@ -11,6 +11,25 @@
 
 open Agent_sdk
 
+let stream_error_to_string = function
+  | Types.Stream_provider_error { message; _ } -> message
+  | Types.Stream_parse_failed { reason; _ } -> reason
+  | Types.Stream_unknown_event { event_type; _ } -> "unknown_event:" ^ event_type
+;;
+
+let fail_unexpected_stream_error err =
+  Alcotest.fail ("unexpected SSE error: " ^ stream_error_to_string err)
+;;
+
+let check_zero_usage = function
+  | Some (u : Types.api_usage) ->
+    Alcotest.(check int) "input" 0 u.input_tokens;
+    Alcotest.(check int) "output" 0 u.output_tokens;
+    Alcotest.(check int) "cache_creation" 0 u.cache_creation_input_tokens;
+    Alcotest.(check int) "cache_read" 0 u.cache_read_input_tokens
+  | None -> Alcotest.fail "expected zero usage"
+;;
+
 (** Unwrap finalize result or fail the test. *)
 let finalize_ok acc =
   if not !(acc.Streaming.stop_reason_received)
@@ -20,15 +39,15 @@ let finalize_ok acc =
       (Types.MessageDelta { stop_reason = Some Types.EndTurn; usage = None });
   match Streaming.finalize_stream_acc acc with
   | Ok resp -> resp
-  | Error msg -> Alcotest.fail ("unexpected SSE error: " ^ msg)
+  | Error err -> fail_unexpected_stream_error err
 ;;
 
 (* ── stream_acc creation ──────────────────────────────────── *)
 
 let test_create_stream_acc () =
   let acc = Streaming.create_stream_acc () in
-  Alcotest.(check string) "empty id" "" !(acc.msg_id);
-  Alcotest.(check string) "empty model" "" !(acc.msg_model);
+  Alcotest.(check string) "empty id" "" !(acc.id);
+  Alcotest.(check string) "empty model" "" !(acc.model);
   Alcotest.(check int) "zero input" 0 !(acc.input_tokens);
   Alcotest.(check int) "zero output" 0 !(acc.output_tokens)
 ;;
@@ -48,8 +67,8 @@ let test_accumulate_message_start () =
   Streaming.accumulate_event
     acc
     (Types.MessageStart { id = "msg_1"; model = "claude-3"; usage = Some usage });
-  Alcotest.(check string) "id" "msg_1" !(acc.msg_id);
-  Alcotest.(check string) "model" "claude-3" !(acc.msg_model);
+  Alcotest.(check string) "id" "msg_1" !(acc.id);
+  Alcotest.(check string) "model" "claude-3" !(acc.model);
   Alcotest.(check int) "input tokens" 10 !(acc.input_tokens);
   Alcotest.(check int) "cache creation" 2 !(acc.cache_creation);
   Alcotest.(check int) "cache read" 3 !(acc.cache_read)
@@ -60,7 +79,7 @@ let test_accumulate_message_start_no_usage () =
   Streaming.accumulate_event
     acc
     (Types.MessageStart { id = "msg_2"; model = "gpt-4"; usage = None });
-  Alcotest.(check string) "id" "msg_2" !(acc.msg_id);
+  Alcotest.(check string) "id" "msg_2" !(acc.id);
   Alcotest.(check int) "input still 0" 0 !(acc.input_tokens)
 ;;
 
@@ -184,7 +203,7 @@ let test_accumulate_other_events () =
   Streaming.accumulate_event
     acc
     (Types.SSEError { message = "test error"; error_type = None; raw = "test error" });
-  Alcotest.(check string) "id unchanged" "" !(acc.msg_id)
+  Alcotest.(check string) "id unchanged" "" !(acc.id)
 ;;
 
 (* ── finalize_stream_acc ──────────────────────────────────── *)
@@ -291,7 +310,7 @@ let test_finalize_with_usage () =
 let test_finalize_no_usage () =
   let acc = Streaming.create_stream_acc () in
   let resp = finalize_ok acc in
-  Alcotest.(check bool) "no usage" true (resp.usage = None)
+  check_zero_usage resp.usage
 ;;
 
 let test_finalize_unknown_content_type () =
@@ -303,8 +322,18 @@ let test_finalize_unknown_content_type () =
   Streaming.accumulate_event
     acc
     (Types.ContentBlockDelta { index = 0; delta = Types.TextDelta "data" });
-  let resp = finalize_ok acc in
-  Alcotest.(check int) "unknown skipped" 0 (List.length resp.content)
+  Streaming.accumulate_event
+    acc
+    (Types.MessageDelta { stop_reason = Some Types.EndTurn; usage = None });
+  match Streaming.finalize_stream_acc acc with
+  | Error (Types.Stream_parse_failed { reason; raw }) ->
+    Alcotest.(check string)
+      "reason"
+      "unsupported_content_block_kind:unknown_type:index:0"
+      reason;
+    Alcotest.(check string) "raw omitted" "" raw
+  | Error err -> fail_unexpected_stream_error err
+  | Ok _ -> Alcotest.fail "expected unknown content type to fail closed"
 ;;
 
 let test_finalize_invalid_tool_json () =
@@ -320,11 +349,18 @@ let test_finalize_invalid_tool_json () =
   Streaming.accumulate_event
     acc
     (Types.ContentBlockDelta { index = 0; delta = Types.InputJsonDelta "not json{" });
-  let resp = finalize_ok acc in
-  (* Invalid JSON falls back to Text *)
-  match resp.content with
-  | [ Types.Text _ ] -> ()
-  | _ -> Alcotest.fail "expected Text fallback for invalid JSON"
+  Streaming.accumulate_event
+    acc
+    (Types.MessageDelta { stop_reason = Some Types.EndTurn; usage = None });
+  match Streaming.finalize_stream_acc acc with
+  | Error (Types.Stream_parse_failed { reason; raw }) ->
+    Alcotest.(check string) "raw omitted" "" raw;
+    Alcotest.(check bool)
+      "malformed tool args"
+      true
+      (String.starts_with ~prefix:"malformed_tool_use_arguments:index:0" reason)
+  | Error err -> fail_unexpected_stream_error err
+  | Ok _ -> Alcotest.fail "expected invalid tool JSON to fail closed"
 ;;
 
 let test_finalize_multiple_blocks () =

--- a/test/test_streaming_coverage.ml
+++ b/test/test_streaming_coverage.ml
@@ -14,6 +14,25 @@ let check_string = Alcotest.(check string)
 let check_int = Alcotest.(check int)
 let check_bool = Alcotest.(check bool)
 
+let stream_error_to_string = function
+  | Stream_provider_error { message; _ } -> message
+  | Stream_parse_failed { reason; _ } -> reason
+  | Stream_unknown_event { event_type; _ } -> "unknown_event:" ^ event_type
+;;
+
+let fail_unexpected_stream_error err =
+  Alcotest.fail ("unexpected SSE error: " ^ stream_error_to_string err)
+;;
+
+let check_zero_usage = function
+  | Some u ->
+    check_int "input" 0 u.input_tokens;
+    check_int "output" 0 u.output_tokens;
+    check_int "cache_creation" 0 u.cache_creation_input_tokens;
+    check_int "cache_read" 0 u.cache_read_input_tokens
+  | None -> Alcotest.fail "expected zero usage"
+;;
+
 (** Unwrap finalize result or fail the test. *)
 let finalize_ok acc =
   if not !(acc.Streaming.stop_reason_received)
@@ -23,7 +42,7 @@ let finalize_ok acc =
       (MessageDelta { stop_reason = Some EndTurn; usage = None });
   match Streaming.finalize_stream_acc acc with
   | Ok resp -> resp
-  | Error msg -> Alcotest.fail ("unexpected SSE error: " ^ msg)
+  | Error err -> fail_unexpected_stream_error err
 ;;
 
 (* ── create_stream_acc + finalize empty ─────────────────────────── *)
@@ -34,9 +53,7 @@ let test_empty_acc_finalize () =
   check_string "empty id" "" resp.id;
   check_string "empty model" "" resp.model;
   Alcotest.(check int) "no content" 0 (List.length resp.content);
-  match resp.usage with
-  | None -> ()
-  | Some _ -> Alcotest.fail "expected no usage for empty acc"
+  check_zero_usage resp.usage
 ;;
 
 (* ── accumulate_event: MessageStart ─────────────────────────────── *)
@@ -73,9 +90,7 @@ let test_acc_message_start_no_usage () =
     (MessageStart { id = "msg_2"; model = "test"; usage = None });
   let resp = finalize_ok acc in
   check_string "id" "msg_2" resp.id;
-  match resp.usage with
-  | None -> ()
-  | Some _ -> Alcotest.fail "expected no usage"
+  check_zero_usage resp.usage
 ;;
 
 (* ── accumulate_event: ContentBlockStart ────────────────────────── *)
@@ -186,10 +201,15 @@ let test_acc_message_delta_stop_reason () =
   Streaming.accumulate_event
     acc
     (MessageDelta { stop_reason = Some StopToolUse; usage = None });
+  check_bool "stop reason received" true !(acc.Streaming.stop_reason_received);
+  (match !(acc.Streaming.stop_reason) with
+   | StopToolUse -> ()
+   | _ -> Alcotest.fail "expected accumulated StopToolUse");
   let resp = finalize_ok acc in
+  (* Finalization reconciles a tool-stop with no tool blocks to Unknown. *)
   match resp.stop_reason with
-  | StopToolUse -> ()
-  | _ -> Alcotest.fail "expected StopToolUse"
+  | Unknown "tool_calls" -> ()
+  | _ -> Alcotest.fail "expected reconciled Unknown tool_calls"
 ;;
 
 let test_acc_message_delta_none_stop_reason () =
@@ -251,9 +271,7 @@ let test_acc_message_delta_none_usage () =
     acc
     (MessageDelta { stop_reason = Some EndTurn; usage = None });
   let resp = finalize_ok acc in
-  match resp.usage with
-  | None -> ()
-  | Some _ -> Alcotest.fail "expected no usage"
+  check_zero_usage resp.usage
 ;;
 
 (* ── accumulate_event: ignored events ───────────────────────────── *)
@@ -279,7 +297,10 @@ let test_acc_sse_error_propagated () =
     acc
     (SSEError { message = "overloaded"; error_type = None; raw = "overloaded" });
   match Streaming.finalize_stream_acc acc with
-  | Error msg -> check_string "error msg" "overloaded" msg
+  | Error (Stream_provider_error { message; raw; _ }) ->
+    check_string "error msg" "overloaded" message;
+    check_string "raw" "overloaded" raw
+  | Error err -> fail_unexpected_stream_error err
   | Ok _ -> Alcotest.fail "expected Error from SSEError"
 ;;
 
@@ -288,9 +309,10 @@ let test_acc_parse_failed_truncates_raw_chunk () =
   let raw = String.make 240 'x' in
   Streaming.accumulate_event acc (SSEParseFailed { raw; reason = "bad-json" });
   match Streaming.finalize_stream_acc acc with
-  | Error msg ->
-    check_bool "has prefix" true (String.starts_with ~prefix:"sse_parse_failed:" msg);
-    check_bool "truncated" true (String.contains msg '.')
+  | Error (Stream_parse_failed { reason; raw = got_raw }) ->
+    check_string "reason" "bad-json" reason;
+    check_int "raw preserved" 240 (String.length got_raw)
+  | Error err -> fail_unexpected_stream_error err
   | Ok _ -> Alcotest.fail "expected parse failure"
 ;;
 
@@ -301,12 +323,10 @@ let test_acc_unknown_event_truncates_raw_chunk () =
     acc
     (SSEUnknownEventType { event_type = "future.event"; raw });
   match Streaming.finalize_stream_acc acc with
-  | Error msg ->
-    check_bool
-      "has prefix"
-      true
-      (String.starts_with ~prefix:"sse_unknown_event_type: future.event" msg);
-    check_bool "truncated" true (String.contains msg '.')
+  | Error (Stream_unknown_event { event_type; raw = got_raw }) ->
+    check_string "event_type" "future.event" event_type;
+    check_int "raw preserved" 240 (String.length got_raw)
+  | Error err -> fail_unexpected_stream_error err
   | Ok _ -> Alcotest.fail "expected unknown event failure"
 ;;
 
@@ -356,7 +376,7 @@ let test_finalize_multi_block_ordered () =
   | _ -> Alcotest.fail "expected 3 text blocks in order"
 ;;
 
-(* ── finalize: tool_use with invalid JSON falls back to Text ────── *)
+(* ── finalize: tool_use with invalid JSON fails closed ─────────── *)
 
 let test_finalize_tool_use_invalid_json () =
   let acc = Streaming.create_stream_acc () in
@@ -371,11 +391,18 @@ let test_finalize_tool_use_invalid_json () =
   Streaming.accumulate_event
     acc
     (ContentBlockDelta { index = 0; delta = InputJsonDelta "not valid json{{{" });
-  let resp = finalize_ok acc in
-  (* Invalid JSON in tool_use should fall back to Text *)
-  match resp.content with
-  | [ Text s ] -> check_bool "contains raw text" true (String.length s > 0)
-  | _ -> Alcotest.fail "expected Text fallback for invalid tool_use JSON"
+  Streaming.accumulate_event
+    acc
+    (MessageDelta { stop_reason = Some EndTurn; usage = None });
+  match Streaming.finalize_stream_acc acc with
+  | Error (Stream_parse_failed { reason; raw }) ->
+    check_string "raw omitted" "" raw;
+    check_bool
+      "malformed tool args"
+      true
+      (String.starts_with ~prefix:"malformed_tool_use_arguments:index:0" reason)
+  | Error err -> fail_unexpected_stream_error err
+  | Ok _ -> Alcotest.fail "expected invalid tool_use JSON to fail closed"
 ;;
 
 (* ── finalize: tool_use with missing tool_id/tool_name ──────────── *)
@@ -412,7 +439,7 @@ let test_finalize_text_block_no_delta () =
   | _ -> Alcotest.fail "expected empty Text block"
 ;;
 
-(* ── finalize: unknown content_type is skipped ──────────────────── *)
+(* ── finalize: unknown content_type fails closed ────────────────── *)
 
 let test_finalize_unknown_content_type () =
   let acc = Streaming.create_stream_acc () in
@@ -423,8 +450,15 @@ let test_finalize_unknown_content_type () =
   Streaming.accumulate_event
     acc
     (ContentBlockDelta { index = 0; delta = TextDelta "ignored" });
-  let resp = finalize_ok acc in
-  check_int "unknown type skipped" 0 (List.length resp.content)
+  Streaming.accumulate_event
+    acc
+    (MessageDelta { stop_reason = Some EndTurn; usage = None });
+  match Streaming.finalize_stream_acc acc with
+  | Error (Stream_parse_failed { reason; raw }) ->
+    check_string "reason" "unsupported_content_block_kind:unknown_future:index:0" reason;
+    check_string "raw omitted" "" raw
+  | Error err -> fail_unexpected_stream_error err
+  | Ok _ -> Alcotest.fail "expected unknown content type to fail closed"
 ;;
 
 let test_finalize_registered_type_without_buffer () =
@@ -440,11 +474,8 @@ let test_finalize_registered_type_without_buffer () =
 
 let test_finalize_usage_all_zero () =
   let acc = Streaming.create_stream_acc () in
-  (* No usage-carrying events -> usage should be None *)
   let resp = finalize_ok acc in
-  match resp.usage with
-  | None -> ()
-  | Some _ -> Alcotest.fail "expected None usage when all zero"
+  check_zero_usage resp.usage
 ;;
 
 let test_finalize_usage_only_cache_creation () =
@@ -707,8 +738,8 @@ let test_acc_message_delta_cache_update_nonzero () =
   | Some u ->
     check_int "input" 50 u.input_tokens;
     check_int "output" 100 u.output_tokens;
-    check_int "cache_creation updated" 20 u.cache_creation_input_tokens;
-    check_int "cache_read updated" 15 u.cache_read_input_tokens
+    check_int "cache_creation added" 30 u.cache_creation_input_tokens;
+    check_int "cache_read added" 20 u.cache_read_input_tokens
   | None -> Alcotest.fail "expected usage"
 ;;
 
@@ -779,7 +810,10 @@ let test_finalize_media_missing_metadata_fails () =
     acc
     (MessageDelta { stop_reason = Some EndTurn; usage = None });
   match Streaming.finalize_stream_acc acc with
-  | Error msg -> check_string "error" "malformed_media_block:image:index:0" msg
+  | Error (Stream_parse_failed { reason; raw }) ->
+    check_string "error" "malformed_media_block:image:index:0" reason;
+    check_string "raw omitted" "" raw
+  | Error err -> fail_unexpected_stream_error err
   | Ok _ -> Alcotest.fail "expected malformed media error"
 ;;
 


### PR DESCRIPTION
## Summary

- Replace the duplicate Agent_sdk.Streaming accumulator with the canonical Llm_provider.Complete_stream_acc implementation.
- Preserve typed stream failures through the streaming SDK surface instead of collapsing them to string parse errors.
- Update accumulator coverage for canonical behavior: fail-closed unknown block/tool JSON handling, typed stream errors, additive usage/cache accounting, and zero usage records.
- Apply the ocamlformat-only fix needed for `@fmt`.

## Verification

- `scripts/dune-local.sh exec ./test/test_stream_accumulator.exe`
- `scripts/dune-local.sh exec ./test/test_streaming_cov.exe`
- `scripts/dune-local.sh exec ./test/test_streaming_coverage.exe`
- `scripts/dune-local.sh exec ./test/test_streaming.exe`
- `scripts/dune-local.sh exec ./test/test_streaming_openai.exe`
- `scripts/dune-local.sh exec ./test/test_streaming_edge_cases.exe`
- `scripts/dune-local.sh exec ./test/test_streaming_cut_cleanup.exe`
- `env OAS_MODEL_CATALOG=/Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/oas-s6-streaming-acc-ssot-20260629/models.toml scripts/dune-local.sh exec ./test/test_provider_complete.exe`
- `scripts/dune-local.sh build @fmt`
