### PR TITLE
fix(streaming): treat OpenAI-compat [DONE] sentinel as a clean stream close

### DIFF
--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -254,8 +254,8 @@ let%test "truncated stream (no terminal stop_reason) finalizes Error, not phanto
    wire). The helper now emits [MessageStop], so the stream finalizes [Ok] with
    the default [EndTurn]. *)
 let%test
-    "clean stream finalizes Ok: OpenAI-compat [DONE] without finish_reason \
-     defaults EndTurn (covers GLM/Kimi/DashScope)"
+    "clean stream finalizes Ok: OpenAI-compat [DONE] without finish_reason defaults \
+     EndTurn (covers GLM/Kimi/DashScope)"
   =
   let acc = Complete_stream_acc.create_stream_acc () in
   let st = Streaming.create_openai_stream_state ~provider:"openai" ~model:"m" () in
@@ -277,7 +277,8 @@ let%test
    a stop_reason was received). Guards against the helper turning every
    OpenAI-compat completion into EndTurn. *)
 let%test
-    "clean stream finalizes Ok: OpenAI-compat finish_reason:length then [DONE] keeps MaxTokens"
+    "clean stream finalizes Ok: OpenAI-compat finish_reason:length then [DONE] keeps \
+     MaxTokens"
   =
   let acc = Complete_stream_acc.create_stream_acc () in
   let st = Streaming.create_openai_stream_state ~provider:"openai" ~model:"m" () in

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -244,6 +244,69 @@ let%test "truncated stream (no terminal stop_reason) finalizes Error, not phanto
   | Ok _ -> false
 ;;
 
+(* GAP 1: an OpenAI-compatible stream whose only completion signal is the
+   [data: [DONE]] sentinel (every content chunk carries [finish_reason: null]).
+   The sentinel parses to [None], so before the terminal-events helper it
+   produced no event and [finalize_stream_acc] rejected the stream as a phantom
+   truncation -- surfacing "SSE parse failed:
+   stream_terminated_without_stop_reason" to the caller. This is the exact shape
+   the keeper's default provider hit (https://ollama.com/v1, OpenAI-compat
+   wire). The helper now emits [MessageStop], so the stream finalizes [Ok] with
+   the default [EndTurn]. *)
+let%test
+    "clean stream finalizes Ok: OpenAI-compat [DONE] without finish_reason \
+     defaults EndTurn (covers GLM/Kimi/DashScope)"
+  =
+  let acc = Complete_stream_acc.create_stream_acc () in
+  let st = Streaming.create_openai_stream_state ~provider:"openai" ~model:"m" () in
+  (match
+     Streaming.parse_openai_sse_chunk
+       {|{"choices":[{"delta":{"content":"hi"},"finish_reason":null}]}|}
+   with
+   | Some chunk -> accumulate_events acc (fst (Streaming.openai_chunk_to_events st chunk))
+   | None -> ());
+  accumulate_events acc (Streaming.openai_compat_terminal_events "[DONE]");
+  match Complete_stream_acc.finalize_stream_acc acc with
+  | Ok resp -> resp.stop_reason = Types.EndTurn
+  | Error _ -> false
+;;
+
+(* The [DONE] sentinel must not overwrite a real stop_reason that already
+   arrived: a [finish_reason: "length"] chunk followed by [data: [DONE]] keeps
+   MaxTokens (the sentinel only sets [done_sentinel_seen], which is ignored once
+   a stop_reason was received). Guards against the helper turning every
+   OpenAI-compat completion into EndTurn. *)
+let%test
+    "clean stream finalizes Ok: OpenAI-compat finish_reason:length then [DONE] keeps MaxTokens"
+  =
+  let acc = Complete_stream_acc.create_stream_acc () in
+  let st = Streaming.create_openai_stream_state ~provider:"openai" ~model:"m" () in
+  (match
+     Streaming.parse_openai_sse_chunk
+       {|{"choices":[{"delta":{"content":"hi"},"finish_reason":"length"}]}|}
+   with
+   | Some chunk -> accumulate_events acc (fst (Streaming.openai_chunk_to_events st chunk))
+   | None -> ());
+  accumulate_events acc (Streaming.openai_compat_terminal_events "[DONE]");
+  match Complete_stream_acc.finalize_stream_acc acc with
+  | Ok resp -> resp.stop_reason = Types.MaxTokens
+  | Error _ -> false
+;;
+
+(* A provider error object routed through the same helper still finalizes Error,
+   never an [Ok] / a [MessageStop]: the helper's non-[DONE] branch surfaces a
+   typed SSEError so the consumer routes it through error classification. *)
+let%test "OpenAI-compat error object via terminal-events helper finalizes Error" =
+  let acc = Complete_stream_acc.create_stream_acc () in
+  accumulate_events
+    acc
+    (Streaming.openai_compat_terminal_events
+       {|{"error":{"type":"rate_limit_exceeded","message":"slow down"}}|});
+  match Complete_stream_acc.finalize_stream_acc acc with
+  | Error _ -> true
+  | Ok _ -> false
+;;
+
 let complete_stream_http
       ~sw:_
       ~net
@@ -682,12 +745,11 @@ let complete_stream_http
                                 (* A [None] from the chunk parser is the [DONE]
                                    sentinel, a usage-only/empty chunk, OR a
                                    provider error object ([{"error": ...}]) that
-                                   has no [choices]. Surface the last as a typed
-                                   [SSEError] so the stream finalizes as [Error]
-                                   instead of a phantom completion. *)
-                                (match Streaming.openai_compat_error_event data with
-                                 | Some evt -> [ evt ], None
-                                 | None -> [], None))
+                                   has no [choices]. The helper maps [DONE] to a
+                                   [MessageStop] (clean close -> no phantom
+                                   completion) and an error object to a typed
+                                   [SSEError]; everything else yields no events. *)
+                                Streaming.openai_compat_terminal_events data, None)
                            | Provider_config.Gemini ->
                              (match Streaming.parse_gemini_sse_chunk data with
                               | Some chunk ->
@@ -704,9 +766,10 @@ let complete_stream_http
                               | Some chunk ->
                                 Streaming.openai_chunk_to_events (get_state ()) chunk
                               | None ->
-                                (match Streaming.openai_compat_error_event data with
-                                 | Some evt -> [ evt ], None
-                                 | None -> [], None))
+                                (* Same [None] cases as the OpenAI-compatible
+                                   branch: [DONE] -> [MessageStop], error object
+                                   -> [SSEError], else no events. *)
+                                Streaming.openai_compat_terminal_events data, None)
                            | Provider_config.Ollama ->
                              [], None (* unreachable: handled above *)
                          in

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -15,6 +15,11 @@ type stream_acc =
   ; cache_read : int ref
   ; stop_reason : Types.stop_reason ref
   ; stop_reason_received : bool ref
+  ; done_sentinel_seen : bool ref
+    (** Set on {!Types.MessageStop}: an explicit terminal sentinel was seen
+        ([data: [DONE]] for OpenAI-compatible streams, [message_stop] for
+        Anthropic). Lets the finalizer tell a clean completion-without-stop_reason
+        apart from a truncated stream. *)
   ; terminal_incomplete : bool ref
   ; sse_error : Types.stream_error option ref
   ; block_texts : (int, Buffer.t) Hashtbl.t
@@ -37,6 +42,7 @@ let create_stream_acc () =
   ; cache_read = ref 0
   ; stop_reason = ref Types.EndTurn
   ; stop_reason_received = ref false
+  ; done_sentinel_seen = ref false
   ; terminal_incomplete = ref false
   ; sse_error = ref None
   ; block_texts = Hashtbl.create 4
@@ -122,7 +128,14 @@ let accumulate_event (acc : stream_acc) = function
   | Types.SSEUnknownEventType { event_type; raw } ->
     acc.sse_error := Some (Types.Stream_unknown_event { event_type; raw })
   | Types.StreamIncomplete _ -> acc.terminal_incomplete := true
-  | Types.MessageStop | Types.Ping | Types.Connected | Types.Timeout _ -> ()
+  | Types.MessageStop ->
+    (* Explicit terminal sentinel from the provider ([data: [DONE]] for
+       OpenAI-compatible streams, [message_stop] for Anthropic). It carries no
+       stop_reason, but its presence proves the stream closed cleanly rather than
+       being truncated, so the finalizer may default a missing stop_reason to
+       EndTurn instead of failing closed. *)
+    acc.done_sentinel_seen := true
+  | Types.Ping | Types.Connected | Types.Timeout _ -> ()
 ;;
 
 (* Closed set of streamed content-block kinds. The wire [content_type] string
@@ -162,12 +175,20 @@ let finalize_stream_acc
   =
   match !(acc.sse_error) with
   | Some serr -> Error serr
-  | None when not !(acc.stop_reason_received) ->
-    (* Stream ended without a terminal MessageDelta carrying a stop_reason.
-       This happens when the connection drops mid-stream (End_of_file in
-       sse_parser) or the provider sends no stop_reason.  Without this
-       check the default EndTurn would make a truncated stream look like
-       a successful completion (phantom completion). *)
+  | None when (not !(acc.stop_reason_received)) && not !(acc.done_sentinel_seen) ->
+    (* Stream ended without a terminal stop_reason AND without an explicit
+       terminal sentinel. This is a truncated stream: the connection dropped
+       mid-stream (End_of_file in sse_parser) before any [data: [DONE]] /
+       message_stop arrived. Without this check the default EndTurn would make a
+       truncated stream look like a successful completion (phantom completion).
+
+       When a sentinel WAS seen ([done_sentinel_seen] is true) the stream closed
+       cleanly, so we fall through to the success arm below even if no
+       stop_reason was reported -- some OpenAI-compatible providers send
+       [data: [DONE]] with every prior chunk carrying [finish_reason: null], and
+       [acc.stop_reason] already defaults to EndTurn. This mirrors the
+       Ollama-native ([done: true]) and Responses-API terminal defaults; only a
+       sentinel-less close is rejected. *)
     Error
       (Types.Stream_parse_failed
          { reason = "stream_terminated_without_stop_reason"; raw = "" })

--- a/lib/llm_provider/complete_stream_acc.mli
+++ b/lib/llm_provider/complete_stream_acc.mli
@@ -19,6 +19,13 @@ type stream_acc =
   ; cache_read : int ref
   ; stop_reason : Types.stop_reason ref
   ; stop_reason_received : bool ref
+  ; done_sentinel_seen : bool ref
+    (** Set when a {!Types.MessageStop} is observed: the provider sent an
+        explicit terminal sentinel (e.g. the OpenAI-compatible [data: [DONE]]
+        line or an Anthropic [message_stop]). Distinguishes a stream that
+        completed without a [finish_reason]/[stop_reason] from one truncated by
+        a dropped connection; {!finalize_stream_acc} uses it to default
+        {!stop_reason} (EndTurn) instead of rejecting a phantom completion. *)
   ; terminal_incomplete : bool ref
   ; sse_error : Types.stream_error option ref
   ; block_texts : (int, Buffer.t) Hashtbl.t

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -303,10 +303,17 @@ let chunk_has_non_empty_delta (c : openai_chunk) : bool =
   || c.delta_tool_calls <> []
 ;;
 
+(* OpenAI-compatible / GLM / DashScope / Kimi streams terminate with this
+   literal SSE payload (the bare token after [data: ]), not a JSON object. SSOT
+   for the sentinel shared by the chunk parser, the terminal-event helper, and
+   the Responses-API trailer. *)
+let openai_done_sentinel = "[DONE]"
+
 (** Parse a single Openai SSE data payload into an {!openai_chunk}.
-    Returns [None] for the "[DONE]" sentinel or unparseable data. *)
+    Returns [None] for the {!openai_done_sentinel} ("[DONE]") or unparseable
+    data. *)
 let parse_openai_sse_chunk data_str : openai_chunk option =
-  if data_str = "[DONE]"
+  if String.equal data_str openai_done_sentinel
   then None
   else
     let open Yojson.Safe.Util in
@@ -443,6 +450,27 @@ let openai_compat_error_event data_str : sse_event option =
         | `String s -> Some (SSEError { message = s; error_type = None; raw = data_str })
         | _non_error_object -> None)
      | _non_object_payload -> None)
+;;
+
+(** Terminal events for an OpenAI-compatible SSE payload that
+    {!parse_openai_sse_chunk} returned [None] for. The explicit
+    {!openai_done_sentinel} ("[DONE]") becomes a single [MessageStop]: the
+    accumulator records a clean stream close and may default a missing
+    [stop_reason] to [EndTurn] rather than rejecting a phantom completion (some
+    providers send [data: [DONE]] with every prior chunk carrying
+    [finish_reason: null]). A provider error object becomes a typed [SSEError]
+    (see {!openai_compat_error_event}); any other [None] payload
+    (empty/usage-only/malformed) yields no events. A stream truncated WITHOUT a
+    [DONE] sentinel never reaches here, so it still finalizes as [Error].
+
+    @since 0.207.25 *)
+let openai_compat_terminal_events data_str : sse_event list =
+  if String.equal data_str openai_done_sentinel
+  then [ MessageStop ]
+  else (
+    match openai_compat_error_event data_str with
+    | Some evt -> [ evt ]
+    | None -> [])
 ;;
 
 (** Mutable state for converting Openai flat deltas to block-based events. *)
@@ -792,7 +820,10 @@ let responses_emit_redacted_reasoning_outputs state emit response =
 let responses_sse_to_events (state : openai_stream_state) event_type data_str
   : sse_event list * Telemetry_event.t option
   =
-  if String.equal data_str "[DONE]"
+  (* The Responses API delivers its terminal status via a [response.completed]
+     event before this trailing sentinel, so [DONE] needs no synthesized
+     terminal here -- the accumulator already has a stop_reason. *)
+  if String.equal data_str openai_done_sentinel
   then [], None
   else (
     match Yojson.Safe.from_string data_str with

--- a/lib/llm_provider/streaming.mli
+++ b/lib/llm_provider/streaming.mli
@@ -101,6 +101,17 @@ val parse_openai_sse_chunk : string -> openai_chunk option
     @since 0.205.0 *)
 val openai_compat_error_event : string -> sse_event option
 
+(** Terminal events for an OpenAI-compatible SSE payload that
+    {!parse_openai_sse_chunk} returned [None] for. The explicit [data: [DONE]]
+    sentinel becomes a single [MessageStop] so the accumulator records a clean
+    stream close (and may default a missing [stop_reason] to [EndTurn] instead
+    of rejecting a phantom completion); a provider error object becomes a typed
+    [SSEError]; any other [None] payload yields no events. A stream truncated
+    without a [DONE] sentinel never reaches here and still finalizes as [Error].
+
+    @since 0.207.25 *)
+val openai_compat_terminal_events : string -> sse_event list
+
 (** RFC-OAS-020: [true] when the chunk carries either a non-empty
     [delta_content] or a non-empty [delta_reasoning] or any
     [delta_tool_calls] — that is, the consumer would surface a


### PR DESCRIPTION
## 무엇을

OpenAI 호환 스트림이 `data: [DONE]` 센티넬만으로 종료될 때(모든 content chunk가 `finish_reason: null`) `finalize_stream_acc`가 정상 완료를 truncation으로 오판해 거부하던 문제를 고칩니다.

호출자에게는 다음 에러로 노출되었습니다:

```
Keeper request failed: Parse error: sse: SSE parse failed: stream_terminated_without_stop_reason
```

keeper의 기본 provider(`https://ollama.com/v1`, OpenAI 호환 wire)가 정확히 이 경로를 탑니다.

## 근본 원인

`parse_openai_sse_chunk`는 `[DONE]` 센티넬을 `None`으로 반환합니다. dispatch의 `None` 브랜치는 error object만 처리하고 `[DONE]`에 대해서는 아무 이벤트도 방출하지 않았습니다. 그 결과 accumulator는 terminal `stop_reason`을 한 번도 보지 못했고, `finalize_stream_acc`의 phantom-completion guard가 스트림을 truncation으로 간주해 `Error`를 반환했습니다.

provider 비대칭이 본질입니다: Ollama-native(`done: true`)와 Responses API(`response.completed`)는 terminal 기본값을 갖지만, OpenAI 호환/GLM/Gemini chunk 경로는 갖지 않았습니다.

## 변경

wire 센티넬을 추론하지 않고 **typed terminal 이벤트로 모델링**합니다 (parse, don't validate):

- **`streaming.ml`**: `[DONE]` 리터럴을 `openai_done_sentinel` SSOT 상수로 추출(기존엔 chunk parser와 Responses trailer 2곳에 중복). `openai_compat_terminal_events` 헬퍼 추가 — `[DONE]` → 단일 `MessageStop`, error object → typed `SSEError`, 그 외 `None` payload → 무이벤트.
- **`complete_stream.ml`**: OpenAI 호환 / DashScope / Kimi 와 GLM dispatch의 `None` 브랜치를 이 헬퍼로 라우팅.
- **`complete_stream_acc.{ml,mli}`**: `done_sentinel_seen` 필드 추가, `MessageStop`에서 set. phantom-completion guard 조건을 `stop_reason 미수신 AND 센티넬 미관측`으로 좁힘. `[DONE]` 정상 종료는 `EndTurn` 기본값으로 완료, `[DONE]` 없는 소켓 종료는 그대로 fail-closed.

Responses API 경로는 불변입니다 — terminal을 `response.completed` 이벤트로 전달하므로 trailing `[DONE]`은 no-op 유지.

## 안전 속성

- `[DONE]` 정상 종료 → `Ok` (EndTurn 기본값)
- `[DONE]` 없는 소켓/`End_of_file` 종료 → `Error` (truncation, 기존 동작 유지)
- 실제 `finish_reason`(예: `length` → `MaxTokens`)이 먼저 오면 센티넬이 그 값을 덮지 않음

즉, "센티넬 없는 종료는 truncation"이라는 안전 속성을 보존하면서 정상 케이스만 통과시킵니다. Unknown → Permissive Default 안티패턴을 피합니다.

## 테스트

`complete_stream.ml` 내 co-located 인라인 `let%test` (`dune runtest`로 실행):

- `[DONE]` without finish_reason → `Ok` (EndTurn). **이 fix 이전에는 실패했을 회귀 가드.**
- `finish_reason: "length"` then `[DONE]` → `Ok` (MaxTokens 보존).
- error object를 헬퍼로 통과 → `Error`.
- 기존 truncated-stream-without-`[DONE]` 가드 → `Error` (유지).

## 로컬 검증

- `dune build lib/llm_provider/` PASS (exit 0).
- `dune runtest lib/llm_provider/`: 내 변경 파일(`complete_stream.ml` 등) 실패 0건. 잔존 실패 21건은 전부 `pricing.ml`/`discovery.ml`/`provider_config.ml`의 로컬 env 의존 실패(`OAS_PRICING_OVERRIDES` + `/Users/dancer/me/.masc/config/capability-manifest.json` + local llama-server probe)로, main 단독에서도 재현되며 본 변경과 무관합니다.

## 경계

OAS는 MASC를 참조하지 않습니다(MASC→OAS 단방향). 본 변경은 `lib/llm_provider/`에만 한정되며 MASC 의존이 없습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
