### PR TITLE
fix(thinking): centralize OpenAI request controls

### DIFF
--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -56,35 +56,6 @@ let is_glm_request ?provider_config (config : agent_state) =
   | None -> Llm_provider.Zai_catalog.is_glm_model_id (model_to_string config.config.model)
 ;;
 
-let bool_field name = function
-  | Some value -> [ name, `Bool value ]
-  | None -> []
-;;
-
-let chat_template_kwargs_fields dialect (config : agent_state) =
-  bool_field "enable_thinking" config.config.enable_thinking
-  @ bool_field
-      "preserve_thinking"
-      (Llm_provider.Reasoning_dialect.chat_template_kwargs_preserve_field
-         dialect
-         ~preserve_thinking:config.config.preserve_thinking)
-;;
-
-let thinking_object_only_fields dialect (config : agent_state) =
-  let control =
-    Llm_provider.Reasoning_dialect.thinking_object_only_control
-      dialect
-      ~enable_thinking:config.config.enable_thinking
-      ~preserve_thinking:config.config.preserve_thinking
-  in
-  let fields =
-    match control.enabled with
-    | Some enabled -> [ "type", `String (if enabled then "enabled" else "disabled") ]
-    | None -> []
-  in
-  if control.keep_all then fields @ [ "keep", `String "all" ] else fields
-;;
-
 let llm_capabilities_of_provider_capabilities (caps : Provider.capabilities)
   : Llm_provider.Capabilities.capabilities
   =
@@ -190,6 +161,72 @@ let tool_choice_validation_context ?provider_config (config : agent_state) =
     else (
       let caps = capabilities_for_request config in
       Ok (PConfig.OpenAI_compat, model_id, llm_capabilities_of_provider_capabilities caps))
+;;
+
+let provider_config_for_thinking_fields ?provider_config ~model_id (config : agent_state) =
+  let cfg = config.config in
+  let kind, base_url, request_path, model_id =
+    match provider_config with
+    | Some
+        ({ Provider.provider = Provider.Custom_registered { name }; model_id; _ } :
+          Provider.config) ->
+      let registry = Llm_provider.Provider_registry.default () in
+      (match Llm_provider.Provider_registry.find registry name with
+       | Some entry ->
+         ( entry.defaults.kind
+         , entry.defaults.base_url
+         , entry.defaults.request_path
+         , model_id )
+       | None ->
+         (match Provider.find_provider name with
+          | Some impl ->
+            let kind = provider_config_kind_of_request_kind impl.Provider.request_kind in
+            kind, "", impl.Provider.request_path, model_id
+          | None ->
+            ( PConfig.OpenAI_compat
+            , ""
+            , PConfig.request_path_default_for_kind PConfig.OpenAI_compat
+            , model_id )))
+    | Some ({ provider = Provider.Anthropic; model_id; _ } : Provider.config) ->
+      ( PConfig.Anthropic
+      , ""
+      , PConfig.request_path_default_for_kind PConfig.Anthropic
+      , model_id )
+    | Some ({ provider = Provider.Local { base_url }; model_id; _ } : Provider.config) ->
+      let kind = provider_config_kind_for_openai_compat ~base_url ~model_id in
+      kind, base_url, PConfig.request_path_default_for_kind kind, model_id
+    | Some
+        ({ provider = Provider.OpenAICompat { base_url; path; _ }; model_id; _ } :
+          Provider.config) ->
+      let kind = provider_config_kind_for_openai_compat ~base_url ~model_id in
+      kind, base_url, path, model_id
+    | None ->
+      let kind =
+        if Llm_provider.Zai_catalog.is_glm_model_id model_id
+        then PConfig.Glm
+        else PConfig.OpenAI_compat
+      in
+      kind, "", PConfig.request_path_default_for_kind kind, model_id
+  in
+  PConfig.make
+    ~kind
+    ~model_id
+    ~base_url
+    ~request_path
+    ?max_tokens:cfg.max_tokens
+    ?temperature:cfg.temperature
+    ?top_p:cfg.top_p
+    ?top_k:cfg.top_k
+    ?min_p:cfg.min_p
+    ?system_prompt:cfg.system_prompt
+    ?enable_thinking:cfg.enable_thinking
+    ?preserve_thinking:cfg.preserve_thinking
+    ?thinking_budget:cfg.thinking_budget
+    ?tool_choice:cfg.tool_choice
+    ~disable_parallel_tool_use:cfg.disable_parallel_tool_use
+    ~response_format:cfg.response_format
+    ~cache_system_prompt:cfg.cache_system_prompt
+    ()
 ;;
 
 let validate_tool_choice_request ?provider_config (config : agent_state) =
@@ -327,84 +364,12 @@ let build_openai_body_unchecked ?provider_config ~config ~messages ?tools ?slot_
       body_assoc
   in
   let body_assoc =
-    if not capabilities.supports_reasoning
-    then body_assoc
-    else (
-      match capabilities.thinking_control_format with
-      | Llm_provider.Capabilities.Chat_template_kwargs ->
-        (match chat_template_kwargs_fields dialect config with
-         | [] -> body_assoc
-         | fields -> ("chat_template_kwargs", `Assoc fields) :: body_assoc)
-      | Llm_provider.Capabilities.Chat_template_token -> body_assoc
-      | Llm_provider.Capabilities.Ollama_think -> body_assoc
-      | Llm_provider.Capabilities.Enable_thinking ->
-        let body_assoc =
-          match config.config.enable_thinking with
-          | Some enabled -> ("enable_thinking", `Bool enabled) :: body_assoc
-          | None -> body_assoc
-        in
-        let body_assoc =
-          match
-            Llm_provider.Reasoning_dialect.top_level_preserve_field
-              dialect
-              ~preserve_thinking:config.config.preserve_thinking
-          with
-          | Some preserve -> ("preserve_thinking", `Bool preserve) :: body_assoc
-          | None -> body_assoc
-        in
-        (match config.config.enable_thinking, config.config.thinking_budget with
-         | Some true, Some budget -> ("thinking_budget", `Int budget) :: body_assoc
-         | _ -> body_assoc)
-      | Llm_provider.Capabilities.Reasoning_effort ->
-        (match
-           Llm_provider.Provider_config.reasoning_effort_request_value_typed
-             ~enable_thinking:config.config.enable_thinking
-             ~thinking_budget:config.config.thinking_budget
-         with
-         | Some effort ->
-           (match
-              Llm_provider.Reasoning_dialect.normalize_effort_value dialect effort
-            with
-            | Some normalized -> ("reasoning_effort", `String normalized) :: body_assoc
-            | None -> body_assoc)
-         | None -> body_assoc)
-      | Llm_provider.Capabilities.Thinking_object ->
-        (match config.config.enable_thinking with
-         | Some true ->
-           let body_assoc =
-             match
-               Llm_provider.Provider_config.reasoning_effort_request_value_typed
-                 ~enable_thinking:config.config.enable_thinking
-                 ~thinking_budget:config.config.thinking_budget
-             with
-             | Some effort ->
-               (match
-                  Llm_provider.Reasoning_dialect.normalize_effort_value dialect effort
-                with
-                | Some normalized ->
-                  ("reasoning_effort", `String normalized) :: body_assoc
-                | None -> body_assoc)
-             | None -> body_assoc
-           in
-           ("thinking", `Assoc [ "type", `String "enabled" ]) :: body_assoc
-         | Some false -> ("thinking", `Assoc [ "type", `String "disabled" ]) :: body_assoc
-         | None -> body_assoc)
-      | Llm_provider.Capabilities.Thinking_object_only ->
-        (match thinking_object_only_fields dialect config with
-         | [] -> body_assoc
-         | fields -> ("thinking", `Assoc fields) :: body_assoc)
-      | Llm_provider.Capabilities.No_thinking_control
-        when is_glm_request ?provider_config config ->
-        (match config.config.enable_thinking with
-         | Some enabled ->
-           let thinking =
-             if enabled
-             then `Assoc [ "type", `String "enabled"; "clear_thinking", `Bool true ]
-             else `Assoc [ "type", `String "disabled" ]
-           in
-           ("thinking", thinking) :: body_assoc
-         | None -> body_assoc)
-      | Llm_provider.Capabilities.No_thinking_control -> body_assoc)
+    Llm_provider.Backend_openai_request.thinking_request_fields
+      ~is_glm_request:(is_glm_request ?provider_config config)
+      ~capabilities:(llm_capabilities_of_provider_capabilities capabilities)
+      dialect
+      (provider_config_for_thinking_fields ?provider_config ~model_id:model_str config)
+    @ body_assoc
   in
   let body_assoc =
     match tools_to_send with

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -135,35 +135,6 @@ let capabilities_of_config (config : Provider_config.t) =
         | Provider_config.DashScope -> Capabilities.dashscope_capabilities))
 ;;
 
-let bool_field name = function
-  | Some value -> [ name, `Bool value ]
-  | None -> []
-;;
-
-let chat_template_kwargs_fields dialect (config : Provider_config.t) =
-  bool_field "enable_thinking" config.enable_thinking
-  @ bool_field
-      "preserve_thinking"
-      (Reasoning_dialect.chat_template_kwargs_preserve_field
-         dialect
-         ~preserve_thinking:config.preserve_thinking)
-;;
-
-let thinking_object_only_fields dialect (config : Provider_config.t) =
-  let control =
-    Reasoning_dialect.thinking_object_only_control
-      dialect
-      ~enable_thinking:config.enable_thinking
-      ~preserve_thinking:config.preserve_thinking
-  in
-  let fields =
-    match control.enabled with
-    | Some enabled -> [ "type", `String (if enabled then "enabled" else "disabled") ]
-    | None -> []
-  in
-  if control.keep_all then fields @ [ "keep", `String "all" ] else fields
-;;
-
 (* Resolution delegated to [Provider_config.glm_clear_thinking] (SSOT) so the
    request-body clear_thinking field below and the reasoning-replay gate cannot
    diverge. *)
@@ -186,6 +157,105 @@ let normalized_reasoning_effort dialect (config : Provider_config.t) =
   with
   | Some effort -> Reasoning_dialect.normalize_effort_value dialect effort
   | None -> None
+;;
+
+let thinking_request_fields
+      ~is_glm_request
+      ~capabilities
+      dialect
+      (config : Provider_config.t)
+  =
+  let bool_field name = function
+    | Some value -> [ name, `Bool value ]
+    | None -> []
+  in
+  if not capabilities.Capabilities.supports_reasoning
+  then []
+  else (
+    match capabilities.thinking_control_format with
+    | Chat_template_kwargs ->
+      let fields =
+        bool_field "enable_thinking" config.enable_thinking
+        @ bool_field
+            "preserve_thinking"
+            (Reasoning_dialect.chat_template_kwargs_preserve_field
+               dialect
+               ~preserve_thinking:config.preserve_thinking)
+      in
+      (match fields with
+       | [] -> []
+       | fields -> [ "chat_template_kwargs", `Assoc fields ])
+    | Chat_template_token -> []
+    | Ollama_think -> []
+    | Enable_thinking ->
+      let enable_fields =
+        match config.enable_thinking with
+        | Some enabled -> [ "enable_thinking", `Bool enabled ]
+        | None -> []
+      in
+      let preserve_fields =
+        match
+          Reasoning_dialect.top_level_preserve_field
+            dialect
+            ~preserve_thinking:config.preserve_thinking
+        with
+        | Some preserve -> [ "preserve_thinking", `Bool preserve ]
+        | None -> []
+      in
+      let budget_fields =
+        match config.enable_thinking, config.thinking_budget with
+        | Some true, Some budget -> [ "thinking_budget", `Int budget ]
+        | _ -> []
+      in
+      budget_fields @ preserve_fields @ enable_fields
+    | Reasoning_effort ->
+      (match normalized_reasoning_effort dialect config with
+       | Some normalized -> [ "reasoning_effort", `String normalized ]
+       | None -> [])
+    | Thinking_object ->
+      (match config.enable_thinking with
+       | Some true ->
+         let effort_fields =
+           match normalized_reasoning_effort dialect config with
+           | Some normalized -> [ "reasoning_effort", `String normalized ]
+           | None -> []
+         in
+         ("thinking", `Assoc [ "type", `String "enabled" ]) :: effort_fields
+       | Some false -> [ "thinking", `Assoc [ "type", `String "disabled" ] ]
+       | None -> [])
+    | Thinking_object_only ->
+      let control =
+        Reasoning_dialect.thinking_object_only_control
+          dialect
+          ~enable_thinking:config.enable_thinking
+          ~preserve_thinking:config.preserve_thinking
+      in
+      let fields =
+        match control.enabled with
+        | Some enabled -> [ "type", `String (if enabled then "enabled" else "disabled") ]
+        | None -> []
+      in
+      let fields =
+        if control.keep_all then fields @ [ "keep", `String "all" ] else fields
+      in
+      (match fields with
+       | [] -> []
+       | fields -> [ "thinking", `Assoc fields ])
+    | No_thinking_control when is_glm_request ->
+      (match config.enable_thinking with
+       | Some enabled ->
+         let thinking =
+           if enabled
+           then
+             `Assoc
+               [ "type", `String "enabled"
+               ; "clear_thinking", `Bool (glm_clear_thinking_of_config config)
+               ]
+           else `Assoc [ "type", `String "disabled" ]
+         in
+         [ "thinking", thinking ]
+       | None -> [])
+    | No_thinking_control -> [])
 ;;
 
 (** Build Openai Chat Completions request body from {!Provider_config.t}.
@@ -306,65 +376,12 @@ let build_request_assoc
     | None -> body
   in
   let body =
-    match caps.thinking_control_format with
-    | Chat_template_kwargs ->
-      (match chat_template_kwargs_fields dialect config with
-       | [] -> body
-       | fields -> ("chat_template_kwargs", `Assoc fields) :: body)
-    | Chat_template_token -> body
-    | Ollama_think -> body
-    | Enable_thinking ->
-      let body =
-        match config.enable_thinking with
-        | Some enabled -> ("enable_thinking", `Bool enabled) :: body
-        | None -> body
-      in
-      let body =
-        match
-          Reasoning_dialect.top_level_preserve_field
-            dialect
-            ~preserve_thinking:config.preserve_thinking
-        with
-        | Some preserve -> ("preserve_thinking", `Bool preserve) :: body
-        | None -> body
-      in
-      (match config.enable_thinking, config.thinking_budget with
-       | Some true, Some budget -> ("thinking_budget", `Int budget) :: body
-       | _ -> body)
-    | Reasoning_effort ->
-      (match normalized_reasoning_effort dialect config with
-       | Some normalized -> ("reasoning_effort", `String normalized) :: body
-       | None -> body)
-    | Thinking_object ->
-      (match config.enable_thinking with
-       | Some true ->
-         let body =
-           match normalized_reasoning_effort dialect config with
-           | Some normalized -> ("reasoning_effort", `String normalized) :: body
-           | None -> body
-         in
-         ("thinking", `Assoc [ "type", `String "enabled" ]) :: body
-       | Some false -> ("thinking", `Assoc [ "type", `String "disabled" ]) :: body
-       | None -> body)
-    | Thinking_object_only ->
-      (match thinking_object_only_fields dialect config with
-       | [] -> body
-       | fields -> ("thinking", `Assoc fields) :: body)
-    | No_thinking_control when is_zai_glm_request config ->
-      (match config.enable_thinking with
-       | Some enabled ->
-         let thinking =
-           if enabled
-           then
-             `Assoc
-               [ "type", `String "enabled"
-               ; "clear_thinking", `Bool (glm_clear_thinking_of_config config)
-               ]
-           else `Assoc [ "type", `String "disabled" ]
-         in
-         ("thinking", thinking) :: body
-       | None -> body)
-    | No_thinking_control -> body
+    thinking_request_fields
+      ~is_glm_request:(is_zai_glm_request config)
+      ~capabilities:caps
+      dialect
+      config
+    @ body
   in
   let supports_tool_choice =
     match config.supports_tool_choice_override with

--- a/lib/llm_provider/backend_openai_request.mli
+++ b/lib/llm_provider/backend_openai_request.mli
@@ -21,6 +21,13 @@ val normalized_reasoning_effort
   -> Provider_config.t
   -> string option
 
+val thinking_request_fields
+  :  is_glm_request:bool
+  -> capabilities:Capabilities.capabilities
+  -> Reasoning_dialect.t
+  -> Provider_config.t
+  -> (string * Yojson.Safe.t) list
+
 (** [build_request_assoc] is {!build_request} before the final
     [Yojson.Safe.to_string]; sibling backends (e.g. {!Backend_glm}) mutate the
     Assoc directly instead of parsing the serialized string back. *)

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -22,6 +22,27 @@ let contains_substring ~sub text =
   if sub_len = 0 then true else loop 0
 ;;
 
+let rec find_repo_root dir =
+  if Sys.file_exists (Filename.concat dir "dune-project")
+  then dir
+  else (
+    let parent = Filename.dirname dir in
+    if String.equal parent dir
+    then fail "could not locate dune-project"
+    else find_repo_root parent)
+;;
+
+let source_path path =
+  if Filename.is_relative path
+  then (
+    match Sys.getenv_opt "DUNE_SOURCEROOT" with
+    | Some root -> Filename.concat root path
+    | None -> Filename.concat (find_repo_root (Sys.getcwd ())) path)
+  else path
+;;
+
+let read_source path = In_channel.with_open_text (source_path path) In_channel.input_all
+
 (* Helper: compare content_block via show string *)
 let check_block msg expected actual =
   check string msg (Types.show_content_block expected) (Types.show_content_block actual)
@@ -910,7 +931,12 @@ let test_build_openai_body_glm_preserves_reasoning_content () =
     string
     "auto tool_choice preserved"
     "auto"
-    (json |> member "tool_choice" |> to_string)
+    (json |> member "tool_choice" |> to_string);
+  check
+    bool
+    "preserved GLM request clears no thinking"
+    false
+    (json |> member "thinking" |> member "clear_thinking" |> to_bool)
 ;;
 
 let test_build_openai_body_does_not_treat_non_zai_glm_as_glm () =
@@ -965,6 +991,23 @@ let test_build_openai_body_does_not_treat_non_zai_glm_as_glm () =
   match json |> member "tool_choice" with
   | `Assoc _ -> ()
   | _ -> fail "non-zai glm tool_choice should preserve named function form"
+;;
+
+let test_openai_api_uses_backend_thinking_builder_ssot () =
+  let api_source = read_source "lib/api_openai.ml" in
+  [ "chat_template_kwargs"
+  ; "reasoning_effort"
+  ; "thinking_budget"
+  ; "clear_thinking"
+  ; "enable_thinking"
+  ; "preserve_thinking"
+  ]
+  |> List.iter (fun field ->
+    check
+      bool
+      (field ^ " not duplicated in api_openai.ml")
+      false
+      (contains_substring ~sub:("\"" ^ field ^ "\"") api_source))
 ;;
 
 let test_build_openai_body_glm_tool_choice_none_omits_tools () =
@@ -1849,6 +1892,10 @@ let () =
             "non-zai glm avoids glm path"
             `Quick
             test_build_openai_body_does_not_treat_non_zai_glm_as_glm
+        ; test_case
+            "api thinking builder ssot"
+            `Quick
+            test_openai_api_uses_backend_thinking_builder_ssot
         ; test_case
             "glm none tool_choice omits tools"
             `Quick


### PR DESCRIPTION
## Summary
- centralize OpenAI-compatible thinking request fields in Backend_openai_request.thinking_request_fields
- route Api.build_openai_body through the same typed builder instead of duplicating wire-field assembly
- pin ZAI GLM preserved-thinking requests so clear_thinking follows Provider_config.glm_clear_thinking and stays aligned with reasoning replay
- add an API source gate that rejects reintroduced thinking wire-field literals in api_openai.ml

## Verification
- scripts/dune-local.sh build @fmt
- env OAS_MODEL_CATALOG=$PWD/models.toml scripts/dune-local.sh exec ./test/test_api.exe
- env OAS_MODEL_CATALOG=$PWD/models.toml scripts/dune-local.sh exec ./test/test_provider_complete.exe
- env OAS_MODEL_CATALOG=$PWD/models.toml scripts/dune-local.sh exec ./test/test_thinking_control_dialects.exe

Note: test_api is catalog-dependent for DashScope/Qwen/DeepSeek cases; without OAS_MODEL_CATALOG=models.toml those existing cases fail before this change.