### PR TITLE
fix(multimodal): close media source kinds

### DIFF
--- a/lib/llm_provider/backend_gemini.ml
+++ b/lib/llm_provider/backend_gemini.ml
@@ -153,26 +153,34 @@ let build_tool_id_to_name (messages : message list) : (string, string) Hashtbl.t
 
 (* ── Content block -> Gemini part ───────────────────── *)
 
+let unsupported_media_source ~block source_type =
+  invalid_arg
+    (Printf.sprintf
+       "gemini does not support %s media source kind %s"
+       block
+       (Types.media_source_kind_to_string source_type))
+;;
+
+let inline_data_part ~block ~media_type ~data = function
+  | Base64 ->
+    Some
+      (`Assoc
+          [ "inlineData", `Assoc [ "mimeType", `String media_type; "data", `String data ]
+          ])
+  | (Url | File_id) as source_type -> unsupported_media_source ~block source_type
+;;
+
 let part_of_content_block id_to_name tool_signatures = function
   | Text s -> Some (`Assoc [ "text", `String (Utf8_sanitize.sanitize s) ])
   | Thinking { content; _ } ->
     Some
       (`Assoc [ "thought", `Bool true; "text", `String (Utf8_sanitize.sanitize content) ])
-  | Image { media_type; data; _ } ->
-    Some
-      (`Assoc
-          [ "inlineData", `Assoc [ "mimeType", `String media_type; "data", `String data ]
-          ])
-  | Audio { media_type; data; _ } ->
-    Some
-      (`Assoc
-          [ "inlineData", `Assoc [ "mimeType", `String media_type; "data", `String data ]
-          ])
-  | Document { media_type; data; _ } ->
-    Some
-      (`Assoc
-          [ "inlineData", `Assoc [ "mimeType", `String media_type; "data", `String data ]
-          ])
+  | Image { media_type; data; source_type } ->
+    inline_data_part ~block:"image" ~media_type ~data source_type
+  | Audio { media_type; data; source_type } ->
+    inline_data_part ~block:"audio" ~media_type ~data source_type
+  | Document { media_type; data; source_type } ->
+    inline_data_part ~block:"document" ~media_type ~data source_type
   | ToolUse { id; name; input } ->
     let fields = [ "functionCall", `Assoc [ "name", `String name; "args", input ] ] in
     let fields =

--- a/lib/llm_provider/backend_openai_responses.ml
+++ b/lib/llm_provider/backend_openai_responses.ml
@@ -114,23 +114,36 @@ let content_string_of_tool_result ~content ~content_blocks =
   | None -> Utf8_sanitize.sanitize content
 ;;
 
+let unsupported_media_source ~block source_type =
+  invalid_arg
+    (Printf.sprintf
+       "openai_responses does not support %s media source kind %s"
+       block
+       (Types.media_source_kind_to_string source_type))
+;;
+
+let base64_data_url ~block ~media_type ~data = function
+  | Base64 -> Printf.sprintf "data:%s;base64,%s" media_type data
+  | (Url | File_id) as source_type -> unsupported_media_source ~block source_type
+;;
+
+let base64_audio_data ~block ~data = function
+  | Base64 -> data
+  | (Url | File_id) as source_type -> unsupported_media_source ~block source_type
+;;
+
 let input_content_part_of_block = function
   | Text s ->
     Some
       (`Assoc [ "type", `String "input_text"; "text", `String (Utf8_sanitize.sanitize s) ])
-  | Image { media_type; data; source_type = _ } ->
-    Some
-      (`Assoc
-          [ "type", `String "input_image"
-          ; "image_url", `String (Printf.sprintf "data:%s;base64,%s" media_type data)
-          ])
-  | Document { media_type; data; source_type = _ } ->
-    Some
-      (`Assoc
-          [ "type", `String "input_file"
-          ; "file_data", `String (Printf.sprintf "data:%s;base64,%s" media_type data)
-          ])
-  | Audio { media_type; data; source_type = _ } ->
+  | Image { media_type; data; source_type } ->
+    let image_url = base64_data_url ~block:"image" ~media_type ~data source_type in
+    Some (`Assoc [ "type", `String "input_image"; "image_url", `String image_url ])
+  | Document { media_type; data; source_type } ->
+    let file_data = base64_data_url ~block:"document" ~media_type ~data source_type in
+    Some (`Assoc [ "type", `String "input_file"; "file_data", `String file_data ])
+  | Audio { media_type; data; source_type } ->
+    let data = base64_audio_data ~block:"audio" ~data source_type in
     Some
       (`Assoc
           [ "type", `String "input_audio"

--- a/lib/llm_provider/backend_openai_serialize.ml
+++ b/lib/llm_provider/backend_openai_serialize.ml
@@ -7,6 +7,25 @@
 
 open Types
 
+let unsupported_media_source ~backend ~block source_type =
+  invalid_arg
+    (Printf.sprintf
+       "%s does not support %s media source kind %s"
+       backend
+       block
+       (Types.media_source_kind_to_string source_type))
+;;
+
+let base64_data_url ~backend ~block ~media_type ~data = function
+  | Base64 -> Printf.sprintf "data:%s;base64,%s" media_type data
+  | (Url | File_id) as source_type -> unsupported_media_source ~backend ~block source_type
+;;
+
+let base64_audio_data ~backend ~block ~data = function
+  | Base64 -> data
+  | (Url | File_id) as source_type -> unsupported_media_source ~backend ~block source_type
+;;
+
 let tool_calls_to_openai_json blocks =
   blocks
   |> List.filter_map (function
@@ -57,25 +76,34 @@ let openai_content_parts_of_blocks blocks =
   |> List.filter_map (function
     | Text s ->
       Some (`Assoc [ "type", `String "text"; "text", `String (Utf8_sanitize.sanitize s) ])
-    | Image { media_type; data; source_type = _ } ->
+    | Image { media_type; data; source_type } ->
+      let url =
+        base64_data_url
+          ~backend:"openai_chat"
+          ~block:"image"
+          ~media_type
+          ~data
+          source_type
+      in
       Some
         (`Assoc
-            [ "type", `String "image_url"
-            ; ( "image_url"
-              , `Assoc
-                  [ "url", `String (Printf.sprintf "data:%s;base64,%s" media_type data) ]
-              )
-            ])
-    | Document { media_type; data; source_type = _ } ->
+            [ "type", `String "image_url"; "image_url", `Assoc [ "url", `String url ] ])
+    | Document { media_type; data; source_type } ->
+      let url =
+        base64_data_url
+          ~backend:"openai_chat"
+          ~block:"document"
+          ~media_type
+          ~data
+          source_type
+      in
       Some
         (`Assoc
-            [ "type", `String "image_url"
-            ; ( "image_url"
-              , `Assoc
-                  [ "url", `String (Printf.sprintf "data:%s;base64,%s" media_type data) ]
-              )
-            ])
-    | Audio { media_type; data; source_type = _ } ->
+            [ "type", `String "image_url"; "image_url", `Assoc [ "url", `String url ] ])
+    | Audio { media_type; data; source_type } ->
+      let data =
+        base64_audio_data ~backend:"openai_chat" ~block:"audio" ~data source_type
+      in
       Some
         (`Assoc
             [ "type", `String "input_audio"
@@ -275,11 +303,16 @@ let ollama_native_user_message ~modality_priority content : Yojson.Safe.t option
       (fun (texts, images) block ->
          match block with
          | Text s -> Utf8_sanitize.sanitize s :: texts, images
-         | Image { data; _ } | Document { data; _ } ->
+         | Image { data; source_type = Base64; _ }
+         | Document { data; source_type = Base64; _ } ->
            (* Ollama native /api/chat accepts base64 image payloads in the
               images field. Document blocks are forwarded the same way so
               vision models can attempt to process them as pages. *)
            texts, data :: images
+         | Image { source_type; _ } ->
+           unsupported_media_source ~backend:"ollama_native" ~block:"image" source_type
+         | Document { source_type; _ } ->
+           unsupported_media_source ~backend:"ollama_native" ~block:"document" source_type
          | Audio _ ->
            (* Ollama native /api/chat does not support audio input. *)
            texts, images

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -221,15 +221,24 @@ let response_format_to_json = function
 
 (** {1 Content Types} *)
 
-(** Closed set of supported media source encodings. *)
-type media_source_kind = Base64 [@@deriving show]
+(** Closed set of supported media source carriers. *)
+type media_source_kind =
+  | Base64
+  | Url
+  | File_id
+[@@deriving show]
 
 let media_source_kind_to_string = function
   | Base64 -> "base64"
+  | Url -> "url"
+  | File_id -> "file_id"
 ;;
 
-let media_source_kind_of_string = function
+let media_source_kind_of_string raw =
+  match String.lowercase_ascii (String.trim raw) with
   | "base64" -> Some Base64
+  | "url" -> Some Url
+  | "file_id" -> Some File_id
   | _ -> None
 ;;
 

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -106,10 +106,13 @@ val response_format_of_json_mode : bool -> response_format
 
 (** {1 Content Types} *)
 
-(** Closed set of supported media source encodings. The public wire value stays
-    ["base64"], but internal content blocks no longer carry arbitrary source
-    strings. *)
-type media_source_kind = Base64 [@@deriving show]
+(** Closed set of supported media source carriers. Unsupported provider/source
+    combinations must fail closed instead of reinterpreting [data] as base64. *)
+type media_source_kind =
+  | Base64
+  | Url
+  | File_id
+[@@deriving show]
 
 val media_source_kind_to_string : media_source_kind -> string
 val media_source_kind_of_string : string -> media_source_kind option

--- a/lib/streaming.ml
+++ b/lib/streaming.ml
@@ -22,6 +22,7 @@ type stream_acc = Llm_provider.Complete_stream_acc.stream_acc =
   ; cache_read : int ref
   ; stop_reason : stop_reason ref
   ; stop_reason_received : bool ref
+  ; done_sentinel_seen : bool ref
   ; terminal_incomplete : bool ref
   ; sse_error : stream_error option ref
   ; block_texts : (int, Buffer.t) Hashtbl.t

--- a/lib/streaming.mli
+++ b/lib/streaming.mli
@@ -29,6 +29,7 @@ type stream_acc =
   ; cache_read : int ref
   ; stop_reason : Types.stop_reason ref
   ; stop_reason_received : bool ref
+  ; done_sentinel_seen : bool ref
   ; terminal_incomplete : bool ref
   ; sse_error : Types.stream_error option ref
   ; block_texts : (int, Buffer.t) Hashtbl.t

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -26,6 +26,12 @@ let as_list label = function
       (Printf.sprintf "expected %s list, got %s" label (Yojson.Safe.to_string json))
 ;;
 
+let expect_invalid_arg label f =
+  match f () with
+  | exception Invalid_argument _ -> ()
+  | _ -> Alcotest.fail (label ^ " should fail closed with Invalid_argument")
+;;
+
 let member key json = Yojson.Safe.Util.member key json
 let to_string json = Yojson.Safe.Util.to_string json
 let to_int json = Yojson.Safe.Util.to_int json
@@ -168,6 +174,51 @@ let test_content_parts_cover_modalities () =
     "audio format"
     "wav"
     (member "input_audio" audio |> member "format" |> to_string)
+;;
+
+let test_non_base64_media_source_fails_closed () =
+  expect_invalid_arg "openai chat image url" (fun () ->
+    Serialize.openai_content_parts_of_blocks
+      [ Image
+          { media_type = "image/png"
+          ; data = "https://example.invalid/image.png"
+          ; source_type = Types.Url
+          }
+      ]
+    |> ignore);
+  expect_invalid_arg "ollama image url" (fun () ->
+    Serialize.ollama_messages_of_message
+      (msg
+         User
+         [ Image
+             { media_type = "image/png"
+             ; data = "https://example.invalid/image.png"
+             ; source_type = Types.Url
+             }
+         ])
+    |> ignore);
+  let config =
+    Provider_config.make
+      ~kind:Provider_config.OpenAI_compat
+      ~model_id:"gpt-test"
+      ~base_url:""
+      ()
+  in
+  expect_invalid_arg "responses document file_id" (fun () ->
+    Responses.build_request
+      ~config
+      ~messages:
+        [ msg
+            User
+            [ Document
+                { media_type = "application/pdf"
+                ; data = "file_abc123"
+                ; source_type = Types.File_id
+                }
+            ]
+        ]
+      ()
+    |> ignore)
 ;;
 
 let test_openai_user_messages_text_tool_and_empty () =
@@ -1411,6 +1462,10 @@ let () =
             "openai user text/tool/empty"
             `Quick
             test_openai_user_messages_text_tool_and_empty
+        ; Alcotest.test_case
+            "non-base64 media source fail-closed"
+            `Quick
+            test_non_base64_media_source_fails_closed
         ; Alcotest.test_case
             "wire adjacency: nudged tool turn"
             `Quick

--- a/test/test_multimodal.ml
+++ b/test/test_multimodal.ml
@@ -47,6 +47,34 @@ let test_document_round_trip () =
   | None -> Alcotest.fail "content_block_of_json returned None for Document"
 ;;
 
+let test_image_url_round_trip () =
+  let img =
+    Types.Image
+      { media_type = "image/png"
+      ; data = "https://example.invalid/image.png"
+      ; source_type = Types.Url
+      }
+  in
+  let json = Api.content_block_to_json img in
+  match Api.content_block_of_json json with
+  | Some parsed -> check_block "image url round-trip" img parsed
+  | None -> Alcotest.fail "content_block_of_json returned None for URL Image"
+;;
+
+let test_document_file_id_round_trip () =
+  let doc =
+    Types.Document
+      { media_type = "application/pdf"
+      ; data = "file_abc123"
+      ; source_type = Types.File_id
+      }
+  in
+  let json = Api.content_block_to_json doc in
+  match Api.content_block_of_json json with
+  | Some parsed -> check_block "document file_id round-trip" doc parsed
+  | None -> Alcotest.fail "content_block_of_json returned None for file_id Document"
+;;
+
 (* ------------------------------------------------------------------ *)
 (* Parsing: Image with nested source                                    *)
 (* ------------------------------------------------------------------ *)
@@ -129,7 +157,7 @@ let check_unknown_media_source_kind_fails_closed ~block_type ~media_type ~data =
       [ "type", `String block_type
       ; ( "source"
         , `Assoc
-            [ "type", `String "url"
+            [ "type", `String "unknown_source"
             ; "media_type", `String media_type
             ; "data", `String data
             ] )
@@ -360,6 +388,11 @@ let () =
     [ ( "round_trip"
       , [ Alcotest.test_case "image base64 round-trip" `Quick test_image_round_trip
         ; Alcotest.test_case "document pdf round-trip" `Quick test_document_round_trip
+        ; Alcotest.test_case "image url round-trip" `Quick test_image_url_round_trip
+        ; Alcotest.test_case
+            "document file_id round-trip"
+            `Quick
+            test_document_file_id_round_trip
         ] )
     ; ( "parsing"
       , [ Alcotest.test_case "image nested source" `Quick test_image_parse_nested_source


### PR DESCRIPTION
## Summary

- change multimodal media source kind from a single base64 tag into a closed `Base64 | Url | File_id` sum
- parse and round-trip `base64`, `url`, and `file_id` explicitly while rejecting unknown source kinds
- fail closed in provider serializers when a known but unsupported non-base64 source reaches OpenAI Chat, OpenAI Responses, Ollama native, or Gemini inline media paths
- keep the streaming manifest alias compatible with the current accumulator `done_sentinel_seen` field from main

## Verification

- `scripts/dune-local.sh build @fmt`
- `scripts/dune-local.sh exec ./test/test_multimodal.exe`
- `env OAS_MODEL_CATALOG=$PWD/models.toml scripts/dune-local.sh exec ./test/test_backend_openai_codec.exe`
- `scripts/dune-local.sh exec ./test/test_backend_gemini.exe`
- `scripts/dune-local.sh exec ./test/test_streaming.exe`
- `git diff --check origin/main...HEAD`
- `rg -n 'source_type\\s*=\\s*_' lib test -g '*.ml' -g '*.mli'`