### PR TITLE
fix(streaming): drop coordinator term from complete_stream comment (SDK Independence Gate red)

### DIFF
--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -250,8 +250,9 @@ let%test "truncated stream (no terminal stop_reason) finalizes Error, not phanto
    produced no event and [finalize_stream_acc] rejected the stream as a phantom
    truncation -- surfacing "SSE parse failed:
    stream_terminated_without_stop_reason" to the caller. This is the exact shape
-   the keeper's default provider hit (https://ollama.com/v1, OpenAI-compat
-   wire). The helper now emits [MessageStop], so the stream finalizes [Ok] with
+   a downstream consumer's default provider hits (https://ollama.com/v1,
+   OpenAI-compat wire). The helper now emits [MessageStop], so the stream
+   finalizes [Ok] with
    the default [EndTurn]. *)
 let%test
     "clean stream finalizes Ok: OpenAI-compat [DONE] without finish_reason defaults \


### PR DESCRIPTION
## 문제

oas main이 `SDK Independence Gate`로 green→red 회귀. 이전 main(#2279)은 green이었으나 #2281 머지 후 fail.

```
FAIL [strict]: coordinator-specific term matched pattern: \bkeeper\b
lib/llm_provider/complete_stream.ml:253: the keeper's default provider hit (...)
```

`scripts/check-sdk-independence.sh`(strict tier)는 OAS SDK 소스(`lib/`, `bin/`, `README.md`)에 coordinator 계층 어휘(`\bkeeper\b`, `keeper_` 등)가 등장하면 빌드를 실패시킨다. OAS는 독립 SDK라 MASC 계층 개념인 `keeper`를 주석에조차 두지 않는 게 게이트의 취지. #2281이 GAP 1 설명 주석에 "the keeper's default provider hit"를 추가하면서 위반했고, PR head에서 이미 이 게이트가 fail이었으나 머지되어 main을 회귀시킴.

## 수정

주석의 "the keeper's default provider" → "a downstream consumer's default provider"로 reword.

- "downstream consumer"는 CLAUDE.md Provider Routing이 명시한 OAS 상위 계층 정식 용어("Cross-provider failover ... are the responsibility of downstream consumers").
- semantic 변화 0: GAP 1 설명, `https://ollama.com/v1` OpenAI-compat wire 참조 모두 보존.
- `boundary-allow` escape hatch 대신 reword를 택함 — escape hatch는 용어가 불가피할 때용이고, 여기선 단순 예시 언급이라 reword가 게이트 취지(SDK 독립)에 부합. escape hatch를 쓰면 coordinator 어휘를 SDK에 정식으로 들이는 셈.

## 검증 (로컬 lint/format, 빌드는 CI)

- `bash scripts/check-sdk-independence.sh` → `OK: SDK independence check passed`
- `ocamlformat --check lib/llm_provider/complete_stream.ml` → clean
- Build & Test는 CI에서 확인.

## 연계

- #2281 (머지됨, 회귀 유발) / #2279 (직전 green main)
