### PR TITLE
fix(streaming): restore sdk-independent stream mirror

### DIFF
--- a/lib/streaming.ml
+++ b/lib/streaming.ml
@@ -22,6 +22,7 @@ type stream_acc = Llm_provider.Complete_stream_acc.stream_acc =
   ; cache_read : int ref
   ; stop_reason : stop_reason ref
   ; stop_reason_received : bool ref
+  ; done_sentinel_seen : bool ref
   ; terminal_incomplete : bool ref
   ; sse_error : stream_error option ref
   ; block_texts : (int, Buffer.t) Hashtbl.t

--- a/lib/streaming.mli
+++ b/lib/streaming.mli
@@ -29,6 +29,7 @@ type stream_acc =
   ; cache_read : int ref
   ; stop_reason : Types.stop_reason ref
   ; stop_reason_received : bool ref
+  ; done_sentinel_seen : bool ref
   ; terminal_incomplete : bool ref
   ; sse_error : Types.stream_error option ref
   ; block_texts : (int, Buffer.t) Hashtbl.t


### PR DESCRIPTION
## Summary

- Follow-up after #2281 merged into main with Build/Lint red.
- Mirror `done_sentinel_seen` into the public `Agent_sdk.Streaming.stream_acc` record re-export so it matches the canonical `Complete_stream_acc.stream_acc` type.
- Keep #2284's SDK-independence comment cleanup on main; this PR only fixes the public type mirror compile failure.

## Validation

- `bash scripts/check-sdk-independence.sh`
- `opam exec -- ocamlformat --check lib/streaming.ml lib/streaming.mli`
- `git diff --check`

No runtime behavior changes; this restores the public stream accumulator mirror to the canonical type.
