### PR TITLE
fix streaming accumulator re-export

### DIFF
--- a/lib/streaming.ml
+++ b/lib/streaming.ml
@@ -22,6 +22,7 @@ type stream_acc = Llm_provider.Complete_stream_acc.stream_acc =
   ; cache_read : int ref
   ; stop_reason : stop_reason ref
   ; stop_reason_received : bool ref
+  ; done_sentinel_seen : bool ref
   ; terminal_incomplete : bool ref
   ; sse_error : stream_error option ref
   ; block_texts : (int, Buffer.t) Hashtbl.t

--- a/lib/streaming.mli
+++ b/lib/streaming.mli
@@ -29,6 +29,7 @@ type stream_acc =
   ; cache_read : int ref
   ; stop_reason : Types.stop_reason ref
   ; stop_reason_received : bool ref
+  ; done_sentinel_seen : bool ref
   ; terminal_incomplete : bool ref
   ; sse_error : Types.stream_error option ref
   ; block_texts : (int, Buffer.t) Hashtbl.t


### PR DESCRIPTION
## Summary
- Add the new done_sentinel_seen accumulator field to the top-level Streaming.stream_acc re-export
- Restore consistency with Llm_provider.Complete_stream_acc.stream_acc after the OpenAI-compatible [DONE] sentinel handling change

## Verification
- ocamlformat --check lib/streaming.ml lib/streaming.mli
- git diff --check
- scripts/dune-local.sh build @install