### PR TITLE
fix(streaming): restore main build — mirror done_sentinel_seen in stream_acc re-export

### DIFF
--- a/lib/streaming.ml
+++ b/lib/streaming.ml
@@ -13,6 +13,10 @@ let emit_synthetic_events = Llm_provider.Streaming.emit_synthetic_events
 
 (* ── Shared streaming accumulation ──────────────────────────── *)
 
+(* Manifest re-export of the canonical accumulator. This field list MUST mirror
+   {!Llm_provider.Complete_stream_acc.stream_acc} exactly -- the [= { ... }]
+   equation fails to compile if a field is added to the canonical type and not
+   here (SSOT lives in complete_stream_acc.ml/.mli). *)
 type stream_acc = Llm_provider.Complete_stream_acc.stream_acc =
   { id : string ref
   ; model : string ref
@@ -22,6 +26,7 @@ type stream_acc = Llm_provider.Complete_stream_acc.stream_acc =
   ; cache_read : int ref
   ; stop_reason : stop_reason ref
   ; stop_reason_received : bool ref
+  ; done_sentinel_seen : bool ref
   ; terminal_incomplete : bool ref
   ; sse_error : stream_error option ref
   ; block_texts : (int, Buffer.t) Hashtbl.t

--- a/lib/streaming.mli
+++ b/lib/streaming.mli
@@ -29,6 +29,7 @@ type stream_acc =
   ; cache_read : int ref
   ; stop_reason : Types.stop_reason ref
   ; stop_reason_received : bool ref
+  ; done_sentinel_seen : bool ref
   ; terminal_incomplete : bool ref
   ; sse_error : Types.stream_error option ref
   ; block_texts : (int, Buffer.t) Hashtbl.t


### PR DESCRIPTION
## 🚨 main 빌드 복구 (fix-forward)

main(`f70c006c7`)이 컴파일되지 않습니다. `lib/streaming.ml`이 다음 에러로 실패:

```
File "lib/streaming.ml", lines 16-34:
type stream_acc = Llm_provider.Complete_stream_acc.stream_acc = { id; ... }
Error: This variant or record definition does not match that of type
       Llm_provider.Complete_stream_acc.stream_acc
       An extra field, done_sentinel_seen, is provided in the original definition.
```

## 원인 (각각 green, 결합 red)

| PR | 변경 | base |
|----|------|------|
| #2279 (`3d886a1f4`) | `lib/streaming.ml`에 `type stream_acc = Complete_stream_acc.stream_acc = { 명시적 필드 }` manifest 재export 추가 | `done_sentinel_seen` 추가 이전 |
| #2281 (`fd2563124`) | `Complete_stream_acc.stream_acc`에 `done_sentinel_seen : bool ref` 추가 | #2279 이전 |

두 PR이 서로 다른 base에서 각각 CI green이었으나, main에서 결합되니 `lib/streaming.ml`의 manifest type-equation(`= { ... }`)이 canonical 타입과 필드가 달라 컴파일 깨짐. squash merge가 post-#2279 main에 대해 #2281을 재검증하지 않은 통합 사고.

## 변경

`done_sentinel_seen : bool ref`를 manifest 재export에 미러링:

- `lib/streaming.ml`: 재선언에 필드 추가 + SSOT 동기화 의무를 명시하는 주석 추가
- `lib/streaming.mli`: 계약의 record 선언에 동일 필드 추가

`stop_reason_received` 바로 뒤(canonical 순서 일치)에 배치.

## 검증

- `dune build --root . @check` PASS (이전: `lib/streaming.ml`에서 실패)
- 동작 변경 없음 — 순수 타입 정합성 복구 (필드는 #2281에서 이미 추가된 것을 재export 미러에 반영)

## 근본 개선 (이 PR 범위 아님 — 별도 제안)

`lib/streaming.ml`/`.mli`가 canonical record를 **명시적 필드로 재선언**하는 구조가 이 사고의 근본 fragility입니다. canonical 타입에 필드를 추가할 때마다 두 mirror를 수동 동기화해야 합니다. plain alias(`type stream_acc = Llm_provider.Complete_stream_acc.stream_acc`, 필드 목록 제거)로 바꾸면 중복이 사라지지만, `.mli` 계약 표면 변경 + 내부 2개 필드 접근(`acc.stop_reason_received`)의 라벨 scope 처리가 필요해 main-red 핫픽스 범위를 벗어납니다. 후속 RFC/PR로 분리 권장.

## 경계

`lib/streaming.{ml,mli}`만 변경, 동작·MASC 참조 없음.

Follow-up to #2279 + #2281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
