### PR TITLE
fix(provider-catalog): carry reasoning replay override

### DIFF
--- a/lib/llm_provider/provider_catalog.ml
+++ b/lib/llm_provider/provider_catalog.ml
@@ -256,6 +256,19 @@ let parse_reasoning_visibility = function
             other))
 ;;
 
+let parse_reasoning_replay = function
+  | None -> Ok None
+  | Some raw ->
+    (match Capability_vocab.reasoning_replay_override_of_string raw with
+     | Some policy -> Ok (Some policy)
+     | None ->
+       Error
+         (Printf.sprintf
+            "unknown reasoning_replay %S (canonical: %s)"
+            (String.lowercase_ascii (String.trim raw))
+            (String.concat ", " Capability_vocab.reasoning_replay_values)))
+;;
+
 let parse_assistant_tool_content_format = function
   | None -> Ok None
   | Some raw ->
@@ -321,6 +334,9 @@ let parse_capabilities provider_json =
   in
   let* reasoning_visibility =
     parse_reasoning_visibility (member_string "reasoning_visibility" cap_json)
+  in
+  let* reasoning_replay =
+    parse_reasoning_replay (member_string "reasoning_replay" cap_json)
   in
   let* assistant_tool_content_format =
     parse_assistant_tool_content_format
@@ -532,6 +548,12 @@ let parse_capabilities provider_json =
     | None -> caps
     | Some reasoning_visibility_override ->
       { caps with Capabilities.reasoning_visibility_override }
+  in
+  let caps =
+    match reasoning_replay with
+    | None -> caps
+    | Some reasoning_replay_override ->
+      { caps with Capabilities.reasoning_replay_override }
   in
   let caps =
     match member_supported_models cap_json with

--- a/lib/streaming.ml
+++ b/lib/streaming.ml
@@ -22,6 +22,7 @@ type stream_acc = Llm_provider.Complete_stream_acc.stream_acc =
   ; cache_read : int ref
   ; stop_reason : stop_reason ref
   ; stop_reason_received : bool ref
+  ; done_sentinel_seen : bool ref
   ; terminal_incomplete : bool ref
   ; sse_error : stream_error option ref
   ; block_texts : (int, Buffer.t) Hashtbl.t

--- a/lib/streaming.mli
+++ b/lib/streaming.mli
@@ -29,6 +29,7 @@ type stream_acc =
   ; cache_read : int ref
   ; stop_reason : Types.stop_reason ref
   ; stop_reason_received : bool ref
+  ; done_sentinel_seen : bool ref
   ; terminal_incomplete : bool ref
   ; sse_error : Types.stream_error option ref
   ; block_texts : (int, Buffer.t) Hashtbl.t

--- a/test/test_provider_catalog_coverage.ml
+++ b/test/test_provider_catalog_coverage.ml
@@ -74,6 +74,7 @@ let test_full_entry_parses_auth_transport_and_capabilities () =
               "supports_code_execution": true,
               "emits_usage_tokens": true,
               "thinking_control_format": "chat_template_kwargs",
+              "reasoning_replay": "preserve_always",
               "supported_models": [" rich-model ", "", 3, "rich-fast"]
             }
           },
@@ -136,6 +137,11 @@ let test_full_entry_parses_auth_transport_and_capabilities () =
     "thinking format"
     true
     (caps.thinking_control_format = Capabilities.Chat_template_kwargs);
+  check
+    bool
+    "reasoning replay"
+    true
+    (caps.reasoning_replay_override = Capabilities.Force_preserve_always);
   check
     (option (list string))
     "supported models"
@@ -360,7 +366,11 @@ let test_removed_catalog_aliases_are_rejected () =
   assert_reject
     "thinking alias rejected"
     {|{"schema_version":1,"providers":[{"id":"p","capabilities":{"thinking_control_format":"thinking-object"}}]}|}
-    "unknown thinking_control_format"
+    "unknown thinking_control_format";
+  assert_reject
+    "reasoning replay alias rejected"
+    {|{"schema_version":1,"providers":[{"id":"p","capabilities":{"reasoning_replay":"preserve-allways"}}]}|}
+    "unknown reasoning_replay"
 ;;
 
 let test_non_list_providers_is_empty_catalog () =


### PR DESCRIPTION
## Summary

- parse provider catalog `capabilities.reasoning_replay` with the shared `Capability_vocab` vocabulary
- carry the parsed value into `Capabilities.reasoning_replay_override` so external provider rows can declare replay policy instead of silently inheriting the base
- reject unknown provider catalog `reasoning_replay` values with the same fail-closed behavior used by model catalog / capability manifest
- keep the public streaming accumulator mirror aligned with `Complete_stream_acc.done_sentinel_seen` so current main compiles before the separate stream mirror PR lands

## OAS Matrix Impact

- S3: extends typed reasoning replay SSOT from model catalog/manifest into provider catalog overlays
- S8: adds fail-closed handling for unknown provider catalog replay dialect values
- S9: reduces provider catalog vs capability record precedence drift by carrying the declared capability into the actual capability record

## Verification

- `scripts/dune-local.sh build @fmt`
- `scripts/dune-local.sh exec ./test/test_provider_catalog_coverage.exe`
- `env OAS_MODEL_CATALOG=$PWD/models.toml scripts/dune-local.sh exec ./test/test_provider_runtime_binding.exe`
- `env OAS_MODEL_CATALOG=$PWD/models.toml scripts/dune-local.sh exec ./test/test_thinking_control_dialects.exe`
- `scripts/dune-local.sh exec ./test/test_streaming.exe`
- `env OAS_MODEL_CATALOG=$PWD/models.toml scripts/dune-local.sh exec ./test/test_capabilities.exe`
- `git diff --check origin/main...HEAD`