### PR TITLE
test(api): lock GLM clear_thinking=true side after thinking builder SSOT (#2282 follow-up)

### DIFF
--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -939,6 +939,57 @@ let test_build_openai_body_glm_preserves_reasoning_content () =
     (json |> member "thinking" |> member "clear_thinking" |> to_bool)
 ;;
 
+(* Complement of [test_build_openai_body_glm_preserves_reasoning_content]: that
+   test locks the [clear_thinking = false] (preserve) side of the GLM SSOT
+   ([Provider_config.glm_clear_thinking_value]). This locks the [true]
+   (non-preserve) side via the api_openai.ml builder. Before #2282 consolidated
+   the two thinking builders, api_openai.ml hardcoded [clear_thinking = true]
+   here while backend_openai_request.ml derived it from the config; the
+   consolidation made api_openai.ml respect the config, so both sides of the SSOT
+   now need a regression guard through the api builder. With [preserve_thinking =
+   Some false] the SSOT yields [not false = true]. *)
+let test_build_openai_body_glm_clears_thinking_when_not_preserving () =
+  let provider_config =
+    { Provider.provider =
+        Provider.OpenAICompat
+          { base_url = Llm_provider.Zai_catalog.general_base_url
+          ; auth_header = None
+          ; path = "/chat/completions"
+          ; static_token = None
+          }
+    ; model_id = "glm-5"
+    ; api_key_env = ""
+    }
+  in
+  let state =
+    { Types.config =
+        { Types.default_config with
+          model = provider_config.model_id
+        ; enable_thinking = Some true
+        ; preserve_thinking = Some false
+        }
+    ; messages = []
+    ; turn_count = 0
+    ; usage = Types.empty_usage
+    }
+  in
+  let json =
+    Api.build_openai_body ~provider_config ~config:state ~messages:[] ()
+    |> Yojson.Safe.from_string
+  in
+  let open Yojson.Safe.Util in
+  check
+    string
+    "GLM thinking enabled"
+    "enabled"
+    (json |> member "thinking" |> member "type" |> to_string);
+  check
+    bool
+    "non-preserving GLM request clears thinking"
+    true
+    (json |> member "thinking" |> member "clear_thinking" |> to_bool)
+;;
+
 let test_build_openai_body_does_not_treat_non_zai_glm_as_glm () =
   let provider_config =
     { Provider.provider =
@@ -1888,6 +1939,10 @@ let () =
             "glm preserved reasoning replay"
             `Quick
             test_build_openai_body_glm_preserves_reasoning_content
+        ; test_case
+            "glm clears thinking when not preserving"
+            `Quick
+            test_build_openai_body_glm_clears_thinking_when_not_preserving
         ; test_case
             "non-zai glm avoids glm path"
             `Quick


### PR DESCRIPTION
## 무엇을

#2282(`fix(thinking): centralize openai request controls`)의 적대 검증에서 발견한 **테스트 갭**을 닫습니다. 프로덕션 코드 변경 없음 — 테스트 1건 추가.

## 배경 (왜 이게 갭인가)

#2282는 `api_openai.ml`과 `backend_openai_request.ml`에 중복돼 있던 thinking-control 빌더를 `Backend_openai_request.thinking_request_fields` 하나로 통합했습니다. 그 과정에서 **숨은 divergence가 교정**되었습니다:

- 통합 전 `api_openai.ml`은 GLM `clear_thinking`을 **하드코딩 `true`**로 보냈습니다.
- `backend_openai_request.ml`은 `Provider_config.glm_clear_thinking`(SSOT)에서 유도했습니다.
- 통합이 backend 버전을 채택해, 이제 `api_openai.ml`도 config를 따릅니다 (= GLM enabled-thinking 요청의 wire 페이로드가 바뀌는 동작 변경).

SSOT 의미 (`provider_config.ml`):

```
glm_clear_thinking_value ~clear_thinking ~preserve_thinking =
  | Some clear -> clear
  | None -> (match preserve_thinking with Some p -> not p | None -> true)
```

#2282가 추가/수정한 테스트(`test_build_openai_body_glm_preserves_reasoning_content`)는 `preserve_thinking = Some true → clear_thinking = false` **한쪽만** 잠급니다. 통합으로 api 빌더의 동작이 바뀐 `clear_thinking = true`(non-preserve) 쪽은 회귀 가드가 없었습니다.

## 변경

`test_build_openai_body_glm_clears_thinking_when_not_preserving` 추가 (`test/test_api.ml`):

- GLM(zai) provider + `enable_thinking = Some true; preserve_thinking = Some false`
- `Api.build_openai_body`를 통과시켜 `thinking.type = "enabled"` 와 `thinking.clear_thinking = true` 단언
- `preserve_thinking`을 명시적으로 `Some false`로 둬 `default_config` 기본값에 의존하지 않음 (`not false = true` 결정론적)

이로써 GLM `clear_thinking` SSOT의 **양쪽(true/false)** 이 api 빌더 경로를 통해 잠깁니다.

## 검증

CI 동등 환경(`OAS_MODEL_CATALOG=models.toml`)에서 `test/test_api.exe` 실행:

```
[OK] build_body_assoc 24 glm preserved reasoning   (기존)
[OK] build_body_assoc 25 glm clears thinking        (신규)
Test Successful. 78 tests run.
```

> 참고: 로컬 shell에 `OAS_CAPABILITY_MANIFEST` override가 있고 `OAS_MODEL_CATALOG`가 없으면 이 GLM/qwen/deepseek `build_body_assoc` 테스트들이 **기존 #24 포함 함께** 실패합니다 — 문서화된 capability-catalog 로컬 env 이슈이며 테스트 로직과 무관합니다. CI는 `OAS_MODEL_CATALOG`를 주입하므로 영향 없습니다.

## 현재 main 상태 주의

작성 시점 main이 별도 이슈로 build red입니다 (`lib/streaming.ml`의 `stream_acc` 재export가 #2281의 `done_sentinel_seen` 누락 — #2279+#2281 결합). 운영자 PR #2285/#2288이 이를 수정합니다. **본 PR의 CI Build red는 그 main-red 상속이며 본 변경과 무관**합니다. main green 후 rebase하면 CI green입니다.

## 경계

`test/`만 변경, 프로덕션 코드·MASC 참조 없음.

Follow-up to #2282.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
