### PR TITLE
fix(provider-catalog): fail closed on enum field type drift

### DIFF
--- a/lib/llm_provider/provider_catalog.ml
+++ b/lib/llm_provider/provider_catalog.ml
@@ -93,6 +93,14 @@ let member_string_default key ~default json =
   | None -> default
 ;;
 
+let member_string_strict key json =
+  match member key json with
+  | `String s -> Ok (Some s)
+  | `Null -> Ok None
+  | actual ->
+    Error (Printf.sprintf "field %S expected string, got %s" key (json_kind actual))
+;;
+
 let member_bool key json =
   match member key json with
   | `Bool b -> Some b
@@ -326,21 +334,24 @@ let parse_capabilities provider_json =
   in
   let* base = capability_base provider_json in
   let* thinking_control_format =
-    parse_thinking_control_format (member_string "thinking_control_format" cap_json)
+    let* raw = member_string_strict "thinking_control_format" cap_json in
+    parse_thinking_control_format raw
   in
   let* preserve_thinking_control_format =
-    parse_preserve_thinking_control_format
-      (member_string "preserve_thinking_control_format" cap_json)
+    let* raw = member_string_strict "preserve_thinking_control_format" cap_json in
+    parse_preserve_thinking_control_format raw
   in
   let* reasoning_visibility =
-    parse_reasoning_visibility (member_string "reasoning_visibility" cap_json)
+    let* raw = member_string_strict "reasoning_visibility" cap_json in
+    parse_reasoning_visibility raw
   in
   let* reasoning_replay =
-    parse_reasoning_replay (member_string "reasoning_replay" cap_json)
+    let* raw = member_string_strict "reasoning_replay" cap_json in
+    parse_reasoning_replay raw
   in
   let* assistant_tool_content_format =
-    parse_assistant_tool_content_format
-      (member_string "assistant_tool_content_format" cap_json)
+    let* raw = member_string_strict "assistant_tool_content_format" cap_json in
+    parse_assistant_tool_content_format raw
   in
   let caps =
     base

--- a/test/test_provider_catalog_coverage.ml
+++ b/test/test_provider_catalog_coverage.ml
@@ -370,7 +370,11 @@ let test_removed_catalog_aliases_are_rejected () =
   assert_reject
     "reasoning replay alias rejected"
     {|{"schema_version":1,"providers":[{"id":"p","capabilities":{"reasoning_replay":"preserve-allways"}}]}|}
-    "unknown reasoning_replay"
+    "unknown reasoning_replay";
+  assert_reject
+    "reasoning replay type rejected"
+    {|{"schema_version":1,"providers":[{"id":"p","capabilities":{"reasoning_replay":true}}]}|}
+    "expected string"
 ;;
 
 let test_non_list_providers_is_empty_catalog () =


### PR DESCRIPTION
## Summary

- add strict string decoding for provider catalog capability enum/dialect fields
- fail closed when fields like `thinking_control_format`, `preserve_thinking_control_format`, `reasoning_visibility`, `reasoning_replay`, or `assistant_tool_content_format` are present with the wrong JSON type
- keep existing bool/int capability fallback behavior unchanged; this PR only covers operator-facing enum policy fields where silently dropping the value changes dialect semantics

## OAS Matrix Impact

- S8: expands unknown/wrong input fail-closed behavior from unknown enum values to wrong-typed enum fields in provider catalog overlays
- S9: prevents provider catalog capability policy from silently disappearing when a catalog row has schema/type drift
- S3: protects reasoning replay policy declarations from type drift after #2290 added provider catalog replay support

## Verification

- `scripts/dune-local.sh build @fmt`
- `scripts/dune-local.sh exec ./test/test_provider_catalog_coverage.exe`
- `env OAS_MODEL_CATALOG=$PWD/models.toml scripts/dune-local.sh exec ./test/test_provider_runtime_binding.exe`
- `env OAS_MODEL_CATALOG=$PWD/models.toml scripts/dune-local.sh exec ./test/test_thinking_control_dialects.exe`
- `env OAS_MODEL_CATALOG=$PWD/models.toml scripts/dune-local.sh exec ./test/test_capabilities.exe`
- `git diff --check origin/main...HEAD`