### PR TITLE
fix(catalog): fail closed on policy string drift

### DIFF
--- a/lib/llm_provider/capability_manifest.ml
+++ b/lib/llm_provider/capability_manifest.ml
@@ -138,34 +138,6 @@ let canonical_choice key ~allowed json =
            (String.concat ", " allowed))
 ;;
 
-let thinking_control_format_values =
-  [ "none"
-  ; "thinking_object"
-  ; "thinking_object_only"
-  ; "chat_template_kwargs"
-  ; "chat_template_token"
-  ; "reasoning_effort"
-  ; "enable_thinking"
-  ]
-;;
-
-let preserve_thinking_control_format_values =
-  [ "none"
-  ; "thinking_object_keep_all"
-  ; "chat_template_kwargs_preserve_thinking"
-  ; "top_level_preserve_thinking"
-  ; "always_preserved"
-  ]
-;;
-
-let assistant_tool_content_format_values =
-  Capability_vocab.assistant_tool_content_format_values
-;;
-
-let reasoning_visibility_values =
-  [ "default"; "provider_hidden"; "hidden"; "visible_channel"; "visible_text" ]
-;;
-
 let known_manifest_keys = [ "_comment"; "schema_version"; "models" ]
 
 let known_entry_keys =
@@ -231,13 +203,13 @@ let parse_entry json =
   let* thinking_control_format =
     canonical_choice
       "thinking_control_format"
-      ~allowed:thinking_control_format_values
+      ~allowed:Capability_vocab.thinking_control_format_values
       json
   in
   let* preserve_thinking_control_format =
     canonical_choice
       "preserve_thinking_control_format"
-      ~allowed:preserve_thinking_control_format_values
+      ~allowed:Capability_vocab.preserve_thinking_control_format_values
       json
   in
   let* reasoning_replay =
@@ -247,12 +219,15 @@ let parse_entry json =
       json
   in
   let* reasoning_visibility =
-    canonical_choice "reasoning_visibility" ~allowed:reasoning_visibility_values json
+    canonical_choice
+      "reasoning_visibility"
+      ~allowed:Capability_vocab.reasoning_visibility_values
+      json
   in
   let* assistant_tool_content_format =
     canonical_choice
       "assistant_tool_content_format"
-      ~allowed:assistant_tool_content_format_values
+      ~allowed:Capability_vocab.assistant_tool_content_format_values
       json
   in
   Ok

--- a/lib/llm_provider/capability_manifest.ml
+++ b/lib/llm_provider/capability_manifest.ml
@@ -112,16 +112,18 @@ let member_int key json =
     None
 ;;
 
-let member_string_opt key json =
+let member_string_closed key json =
   match Yojson.Safe.Util.member key json with
-  | `String s -> Some s
+  | `String s -> Ok (Some s)
+  | `Null -> Ok None
   | actual ->
-    warn_type_mismatch key ~expected:"string" actual;
-    None
+    Error (Printf.sprintf "entry field %S expected string, got %s" key (json_kind actual))
 ;;
 
 let canonical_choice key ~allowed json =
-  match member_string_opt key json with
+  let open Result_syntax in
+  let* value = member_string_closed key json in
+  match value with
   | None -> Ok None
   | Some raw ->
     let normalized = String.lowercase_ascii (String.trim raw) in
@@ -158,6 +160,10 @@ let preserve_thinking_control_format_values =
 
 let assistant_tool_content_format_values =
   Capability_vocab.assistant_tool_content_format_values
+;;
+
+let reasoning_visibility_values =
+  [ "default"; "provider_hidden"; "hidden"; "visible_channel"; "visible_text" ]
 ;;
 
 let known_manifest_keys = [ "_comment"; "schema_version"; "models" ]
@@ -216,10 +222,12 @@ let parse_entry json =
   let open Result_syntax in
   let* () = reject_unknown_keys ~scope:"entry" ~known:known_entry_keys json in
   let* id_prefix =
-    match member_string_opt "id_prefix" json with
-    | None -> Error "entry missing required \"id_prefix\" field"
-    | Some id_prefix -> Ok id_prefix
+    match member_string_closed "id_prefix" json with
+    | Error _ as error -> error
+    | Ok None -> Error "entry missing required \"id_prefix\" field"
+    | Ok (Some id_prefix) -> Ok id_prefix
   in
+  let* base_label = member_string_closed "base" json in
   let* thinking_control_format =
     canonical_choice
       "thinking_control_format"
@@ -238,6 +246,9 @@ let parse_entry json =
       ~allowed:Capability_vocab.reasoning_replay_values
       json
   in
+  let* reasoning_visibility =
+    canonical_choice "reasoning_visibility" ~allowed:reasoning_visibility_values json
+  in
   let* assistant_tool_content_format =
     canonical_choice
       "assistant_tool_content_format"
@@ -246,7 +257,7 @@ let parse_entry json =
   in
   Ok
     { id_prefix
-    ; base_label = member_string_opt "base" json
+    ; base_label
     ; max_context_tokens = member_int "max_context_tokens" json
     ; max_output_tokens = member_int "max_output_tokens" json
     ; supports_tools = member_bool "supports_tools" json
@@ -274,7 +285,7 @@ let parse_entry json =
     ; supports_code_execution = member_bool "supports_code_execution" json
     ; thinking_control_format
     ; preserve_thinking_control_format
-    ; reasoning_visibility = member_string_opt "reasoning_visibility" json
+    ; reasoning_visibility
     ; reasoning_replay
     }
 ;;

--- a/lib/llm_provider/capability_vocab.ml
+++ b/lib/llm_provider/capability_vocab.ml
@@ -17,6 +17,40 @@ type assistant_tool_content_format =
 
 let normalize raw = String.lowercase_ascii (String.trim raw)
 
+let thinking_control_format_values =
+  [ "none"
+  ; "thinking_object"
+  ; "thinking_object_only"
+  ; "chat_template_kwargs"
+  ; "chat_template_token"
+  ; "ollama_think"
+  ; "reasoning_effort"
+  ; "enable_thinking"
+  ]
+;;
+
+let preserve_thinking_control_format_values =
+  [ "none"
+  ; "thinking_object_keep_all"
+  ; "chat_template_kwargs_preserve_thinking"
+  ; "top_level_preserve_thinking"
+  ; "always_preserved"
+  ]
+;;
+
+let reasoning_visibility_values =
+  [ "default"; "provider_hidden"; "hidden"; "visible_channel"; "visible_text" ]
+;;
+
+let modality_priority_values =
+  [ "preserve_input_order"
+  ; "preserve-input-order"
+  ; "preserve"
+  ; "visual_first"
+  ; "visual-first"
+  ]
+;;
+
 let reasoning_replay_table =
   [ "default", Default_reasoning_replay
   ; "no_replay", Force_no_replay

--- a/lib/llm_provider/model_catalog.ml
+++ b/lib/llm_provider/model_catalog.ml
@@ -74,40 +74,6 @@ let canonical_string_opt ~entry_id key ~allowed toml =
            (String.concat ", " allowed))
 ;;
 
-let thinking_control_format_values =
-  [ "none"
-  ; "thinking_object"
-  ; "thinking_object_only"
-  ; "chat_template_kwargs"
-  ; "chat_template_token"
-  ; "ollama_think"
-  ; "reasoning_effort"
-  ; "enable_thinking"
-  ]
-;;
-
-let preserve_thinking_control_format_values =
-  [ "none"
-  ; "thinking_object_keep_all"
-  ; "chat_template_kwargs_preserve_thinking"
-  ; "top_level_preserve_thinking"
-  ; "always_preserved"
-  ]
-;;
-
-let reasoning_visibility_values =
-  [ "default"; "provider_hidden"; "hidden"; "visible_channel"; "visible_text" ]
-;;
-
-let modality_priority_values =
-  [ "preserve_input_order"
-  ; "preserve-input-order"
-  ; "preserve"
-  ; "visual_first"
-  ; "visual-first"
-  ]
-;;
-
 let find_bool_opt toml path =
   match Otoml.find_opt toml Otoml.get_boolean path with
   | Some b -> Some b
@@ -156,28 +122,28 @@ let parse_entry entry_toml =
          canonical_string_opt
            ~entry_id:id_prefix
            "modality_priority"
-           ~allowed:modality_priority_values
+           ~allowed:Capability_vocab.modality_priority_values
            entry_toml
        in
        let thinking_control_format_result =
          canonical_string_opt
            ~entry_id:id_prefix
            "thinking_control_format"
-           ~allowed:thinking_control_format_values
+           ~allowed:Capability_vocab.thinking_control_format_values
            entry_toml
        in
        let preserve_thinking_control_format_result =
          canonical_string_opt
            ~entry_id:id_prefix
            "preserve_thinking_control_format"
-           ~allowed:preserve_thinking_control_format_values
+           ~allowed:Capability_vocab.preserve_thinking_control_format_values
            entry_toml
        in
        let reasoning_visibility_result =
          canonical_string_opt
            ~entry_id:id_prefix
            "reasoning_visibility"
-           ~allowed:reasoning_visibility_values
+           ~allowed:Capability_vocab.reasoning_visibility_values
            entry_toml
        in
        (match

--- a/lib/llm_provider/model_catalog.ml
+++ b/lib/llm_provider/model_catalog.ml
@@ -48,10 +48,19 @@ let find_string_opt toml path =
   | exception Otoml.Type_error _ -> None
 ;;
 
-let canonical_string_opt ~entry_id key ~allowed toml =
-  match find_string_opt toml [ key ] with
+let find_string_field ~entry_id key toml =
+  match Otoml.find_opt toml Otoml.get_string [ key ] with
+  | Some s -> Ok (Some s)
   | None -> Ok None
-  | Some raw ->
+  | exception Otoml.Type_error _ ->
+    Error (Printf.sprintf "model entry %S field %S expected string" entry_id key)
+;;
+
+let canonical_string_opt ~entry_id key ~allowed toml =
+  match find_string_field ~entry_id key toml with
+  | Error _ as e -> e
+  | Ok None -> Ok None
+  | Ok (Some raw) ->
     let normalized = String.lowercase_ascii (String.trim raw) in
     if List.mem normalized allowed
     then Ok (Some raw)
@@ -63,6 +72,40 @@ let canonical_string_opt ~entry_id key ~allowed toml =
            key
            normalized
            (String.concat ", " allowed))
+;;
+
+let thinking_control_format_values =
+  [ "none"
+  ; "thinking_object"
+  ; "thinking_object_only"
+  ; "chat_template_kwargs"
+  ; "chat_template_token"
+  ; "ollama_think"
+  ; "reasoning_effort"
+  ; "enable_thinking"
+  ]
+;;
+
+let preserve_thinking_control_format_values =
+  [ "none"
+  ; "thinking_object_keep_all"
+  ; "chat_template_kwargs_preserve_thinking"
+  ; "top_level_preserve_thinking"
+  ; "always_preserved"
+  ]
+;;
+
+let reasoning_visibility_values =
+  [ "default"; "provider_hidden"; "hidden"; "visible_channel"; "visible_text" ]
+;;
+
+let modality_priority_values =
+  [ "preserve_input_order"
+  ; "preserve-input-order"
+  ; "preserve"
+  ; "visual_first"
+  ; "visual-first"
+  ]
 ;;
 
 let find_bool_opt toml path =
@@ -108,56 +151,103 @@ let parse_entry entry_toml =
     (match reasoning_replay_result, assistant_tool_content_format_result with
      | (Error _ as e), _ | _, (Error _ as e) -> e
      | Ok reasoning_replay, Ok assistant_tool_content_format ->
-       Ok
-         { id_prefix
-         ; base_label = find_string_opt entry_toml [ "base" ]
-         ; max_context_tokens = find_int_opt entry_toml [ "max_context_tokens" ]
-         ; max_output_tokens = find_int_opt entry_toml [ "max_output_tokens" ]
-         ; supports_tools = find_bool_opt entry_toml [ "supports_tools" ]
-         ; supports_tool_choice = find_bool_opt entry_toml [ "supports_tool_choice" ]
-         ; supports_named_tool_choice =
-             find_bool_opt entry_toml [ "supports_named_tool_choice" ]
-         ; supports_parallel_tool_calls =
-             find_bool_opt entry_toml [ "supports_parallel_tool_calls" ]
-         ; assistant_tool_content_format
-         ; supports_reasoning = find_bool_opt entry_toml [ "supports_reasoning" ]
-         ; supports_extended_thinking =
-             find_bool_opt entry_toml [ "supports_extended_thinking" ]
-         ; supports_reasoning_budget =
-             find_bool_opt entry_toml [ "supports_reasoning_budget" ]
-         ; supports_response_format_json =
-             find_bool_opt entry_toml [ "supports_response_format_json" ]
-         ; supports_structured_output =
-             find_bool_opt entry_toml [ "supports_structured_output" ]
-         ; supports_multimodal_inputs =
-             find_bool_opt entry_toml [ "supports_multimodal_inputs" ]
-         ; supports_image_input = find_bool_opt entry_toml [ "supports_image_input" ]
-         ; supports_audio_input = find_bool_opt entry_toml [ "supports_audio_input" ]
-         ; supports_video_input = find_bool_opt entry_toml [ "supports_video_input" ]
-         ; modality_priority = find_string_opt entry_toml [ "modality_priority" ]
-         ; supports_native_streaming =
-             find_bool_opt entry_toml [ "supports_native_streaming" ]
-         ; supports_system_prompt = find_bool_opt entry_toml [ "supports_system_prompt" ]
-         ; supports_caching = find_bool_opt entry_toml [ "supports_caching" ]
-         ; supports_prompt_caching =
-             find_bool_opt entry_toml [ "supports_prompt_caching" ]
-         ; supports_top_k = find_bool_opt entry_toml [ "supports_top_k" ]
-         ; supports_min_p = find_bool_opt entry_toml [ "supports_min_p" ]
-         ; supports_seed = find_bool_opt entry_toml [ "supports_seed" ]
-         ; supports_computer_use = find_bool_opt entry_toml [ "supports_computer_use" ]
-         ; supports_code_execution =
-             find_bool_opt entry_toml [ "supports_code_execution" ]
-         ; thinking_control_format =
-             find_string_opt entry_toml [ "thinking_control_format" ]
-         ; preserve_thinking_control_format =
-             find_string_opt entry_toml [ "preserve_thinking_control_format" ]
-         ; reasoning_visibility = find_string_opt entry_toml [ "reasoning_visibility" ]
-         ; reasoning_replay
-         ; input_per_million = find_float_opt entry_toml [ "input_per_million" ]
-         ; output_per_million = find_float_opt entry_toml [ "output_per_million" ]
-         ; cache_write_multiplier = find_float_opt entry_toml [ "cache_write_multiplier" ]
-         ; cache_read_multiplier = find_float_opt entry_toml [ "cache_read_multiplier" ]
-         })
+       let base_label_result = find_string_field ~entry_id:id_prefix "base" entry_toml in
+       let modality_priority_result =
+         canonical_string_opt
+           ~entry_id:id_prefix
+           "modality_priority"
+           ~allowed:modality_priority_values
+           entry_toml
+       in
+       let thinking_control_format_result =
+         canonical_string_opt
+           ~entry_id:id_prefix
+           "thinking_control_format"
+           ~allowed:thinking_control_format_values
+           entry_toml
+       in
+       let preserve_thinking_control_format_result =
+         canonical_string_opt
+           ~entry_id:id_prefix
+           "preserve_thinking_control_format"
+           ~allowed:preserve_thinking_control_format_values
+           entry_toml
+       in
+       let reasoning_visibility_result =
+         canonical_string_opt
+           ~entry_id:id_prefix
+           "reasoning_visibility"
+           ~allowed:reasoning_visibility_values
+           entry_toml
+       in
+       (match
+          ( base_label_result
+          , modality_priority_result
+          , thinking_control_format_result
+          , preserve_thinking_control_format_result
+          , reasoning_visibility_result )
+        with
+        | (Error _ as e), _, _, _, _
+        | _, (Error _ as e), _, _, _
+        | _, _, (Error _ as e), _, _
+        | _, _, _, (Error _ as e), _
+        | _, _, _, _, (Error _ as e) -> e
+        | ( Ok base_label
+          , Ok modality_priority
+          , Ok thinking_control_format
+          , Ok preserve_thinking_control_format
+          , Ok reasoning_visibility ) ->
+          Ok
+            { id_prefix
+            ; base_label
+            ; max_context_tokens = find_int_opt entry_toml [ "max_context_tokens" ]
+            ; max_output_tokens = find_int_opt entry_toml [ "max_output_tokens" ]
+            ; supports_tools = find_bool_opt entry_toml [ "supports_tools" ]
+            ; supports_tool_choice = find_bool_opt entry_toml [ "supports_tool_choice" ]
+            ; supports_named_tool_choice =
+                find_bool_opt entry_toml [ "supports_named_tool_choice" ]
+            ; supports_parallel_tool_calls =
+                find_bool_opt entry_toml [ "supports_parallel_tool_calls" ]
+            ; assistant_tool_content_format
+            ; supports_reasoning = find_bool_opt entry_toml [ "supports_reasoning" ]
+            ; supports_extended_thinking =
+                find_bool_opt entry_toml [ "supports_extended_thinking" ]
+            ; supports_reasoning_budget =
+                find_bool_opt entry_toml [ "supports_reasoning_budget" ]
+            ; supports_response_format_json =
+                find_bool_opt entry_toml [ "supports_response_format_json" ]
+            ; supports_structured_output =
+                find_bool_opt entry_toml [ "supports_structured_output" ]
+            ; supports_multimodal_inputs =
+                find_bool_opt entry_toml [ "supports_multimodal_inputs" ]
+            ; supports_image_input = find_bool_opt entry_toml [ "supports_image_input" ]
+            ; supports_audio_input = find_bool_opt entry_toml [ "supports_audio_input" ]
+            ; supports_video_input = find_bool_opt entry_toml [ "supports_video_input" ]
+            ; modality_priority
+            ; supports_native_streaming =
+                find_bool_opt entry_toml [ "supports_native_streaming" ]
+            ; supports_system_prompt =
+                find_bool_opt entry_toml [ "supports_system_prompt" ]
+            ; supports_caching = find_bool_opt entry_toml [ "supports_caching" ]
+            ; supports_prompt_caching =
+                find_bool_opt entry_toml [ "supports_prompt_caching" ]
+            ; supports_top_k = find_bool_opt entry_toml [ "supports_top_k" ]
+            ; supports_min_p = find_bool_opt entry_toml [ "supports_min_p" ]
+            ; supports_seed = find_bool_opt entry_toml [ "supports_seed" ]
+            ; supports_computer_use = find_bool_opt entry_toml [ "supports_computer_use" ]
+            ; supports_code_execution =
+                find_bool_opt entry_toml [ "supports_code_execution" ]
+            ; thinking_control_format
+            ; preserve_thinking_control_format
+            ; reasoning_visibility
+            ; reasoning_replay
+            ; input_per_million = find_float_opt entry_toml [ "input_per_million" ]
+            ; output_per_million = find_float_opt entry_toml [ "output_per_million" ]
+            ; cache_write_multiplier =
+                find_float_opt entry_toml [ "cache_write_multiplier" ]
+            ; cache_read_multiplier =
+                find_float_opt entry_toml [ "cache_read_multiplier" ]
+            }))
 ;;
 
 let load_file path =

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -976,6 +976,65 @@ reasoning_replay = "preserve-allways"
        | Ok _ -> Alcotest.fail "unknown model catalog reasoning_replay should reject")
 ;;
 
+let test_model_catalog_rejects_wrong_type_policy_string () =
+  with_temp_model_catalog
+    {|
+[[models]]
+id_prefix = "bad-policy-type"
+reasoning_replay = true
+|}
+    (fun path ->
+       match Model_catalog.load_file path with
+       | Error msg ->
+         check_contains "mentions field" msg "reasoning_replay";
+         check_contains "mentions expected type" msg "expected string"
+       | Ok _ -> Alcotest.fail "wrong-type model catalog reasoning_replay should reject")
+;;
+
+let test_model_catalog_rejects_unknown_policy_strings () =
+  let cases =
+    [ "thinking_control_format", "mind_palace"
+    ; "preserve_thinking_control_format", "memory_palace"
+    ; "reasoning_visibility", "visible_ether"
+    ; "modality_priority", "image_only"
+    ]
+  in
+  List.iter
+    (fun (field, value) ->
+       with_temp_model_catalog
+         (Printf.sprintf
+            {|
+[[models]]
+id_prefix = "bad-%s"
+%s = "%s"
+|}
+            field
+            field
+            value)
+         (fun path ->
+            match Model_catalog.load_file path with
+            | Error msg ->
+              check_contains (field ^ " mentions field") msg field;
+              check_contains (field ^ " mentions value") msg value
+            | Ok _ -> Alcotest.failf "unknown model catalog %s should reject" field))
+    cases
+;;
+
+let test_model_catalog_rejects_wrong_type_base_label () =
+  with_temp_model_catalog
+    {|
+[[models]]
+id_prefix = "bad-base-type"
+base = 17
+|}
+    (fun path ->
+       match Model_catalog.load_file path with
+       | Error msg ->
+         check_contains "mentions base" msg "base";
+         check_contains "mentions expected type" msg "expected string"
+       | Ok _ -> Alcotest.fail "wrong-type model catalog base should reject")
+;;
+
 (* ── DashScope preset ────────────────────────────────── *)
 
 let test_dashscope_capabilities () =
@@ -1224,6 +1283,18 @@ let () =
             "model catalog rejects unknown reasoning_replay"
             `Quick
             test_model_catalog_rejects_unknown_reasoning_replay
+        ; test_case
+            "model catalog rejects wrong-type policy string"
+            `Quick
+            test_model_catalog_rejects_wrong_type_policy_string
+        ; test_case
+            "model catalog rejects unknown policy strings"
+            `Quick
+            test_model_catalog_rejects_unknown_policy_strings
+        ; test_case
+            "model catalog rejects wrong-type base"
+            `Quick
+            test_model_catalog_rejects_wrong_type_base_label
         ] )
     ; ( "prefix_ordering"
       , [ test_case

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -798,11 +798,11 @@ let test_apply_manifest_entry_all_none_uses_base () =
   check bool "caching matches base" base.supports_caching caps.supports_caching
 ;;
 
-let test_manifest_wrong_type_fields_warn_and_ignore () =
+let test_manifest_wrong_type_feature_fields_warn_and_ignore () =
   let warnings = ref [] in
   let json =
     Yojson.Safe.from_string
-      {|{"schema_version":1,"models":[{"id_prefix":"typed","base":17,"max_context_tokens":"131072","supports_tools":"yes"}]}|}
+      {|{"schema_version":1,"models":[{"id_prefix":"typed","max_context_tokens":"131072","supports_tools":"yes"}]}|}
   in
   let manifest =
     Diag.with_sink
@@ -815,7 +815,6 @@ let test_manifest_wrong_type_fields_warn_and_ignore () =
     | Ok _ -> Alcotest.fail "expected one manifest entry"
     | Error msg -> Alcotest.failf "unexpected parse error: %s" msg
   in
-  check (option string) "wrong-type base ignored" None entry.base_label;
   check (option int) "wrong-type int ignored" None entry.max_context_tokens;
   check (option bool) "wrong-type bool ignored" None entry.supports_tools;
   let has_warning field expected =
@@ -827,9 +826,32 @@ let test_manifest_wrong_type_fields_warn_and_ignore () =
          && string_contains_sub msg (Printf.sprintf "expected %s" expected))
       !warnings
   in
-  check bool "warned for base" true (has_warning "base" "string");
   check bool "warned for max_context_tokens" true (has_warning "max_context_tokens" "int");
   check bool "warned for supports_tools" true (has_warning "supports_tools" "bool")
+;;
+
+let test_manifest_rejects_wrong_type_base () =
+  let json =
+    Yojson.Safe.from_string
+      {|{"schema_version":1,"models":[{"id_prefix":"bad-base","base":17}]}|}
+  in
+  match Capability_manifest.of_json json with
+  | Error msg ->
+    check_contains "mentions field" msg "base";
+    check_contains "mentions expected type" msg "expected string"
+  | Ok _ -> Alcotest.fail "wrong-type base should reject"
+;;
+
+let test_manifest_rejects_wrong_type_policy_string () =
+  let json =
+    Yojson.Safe.from_string
+      {|{"schema_version":1,"models":[{"id_prefix":"bad-policy","thinking_control_format":false}]}|}
+  in
+  match Capability_manifest.of_json json with
+  | Error msg ->
+    check_contains "mentions field" msg "thinking_control_format";
+    check_contains "mentions expected type" msg "expected string"
+  | Ok _ -> Alcotest.fail "wrong-type thinking_control_format should reject"
 ;;
 
 let test_manifest_rejects_unknown_preserve_thinking_control_format () =
@@ -852,6 +874,18 @@ let test_manifest_rejects_unknown_reasoning_replay () =
     check_contains "mentions field" msg "reasoning_replay";
     check_contains "mentions value" msg "preserve-allways"
   | Ok _ -> Alcotest.fail "unknown reasoning_replay should reject"
+;;
+
+let test_manifest_rejects_unknown_reasoning_visibility () =
+  let json =
+    Yojson.Safe.from_string
+      {|{"schema_version":1,"models":[{"id_prefix":"bad-visibility","reasoning_visibility":"translucent"}]}|}
+  in
+  match Capability_manifest.of_json json with
+  | Error msg ->
+    check_contains "mentions field" msg "reasoning_visibility";
+    check_contains "mentions value" msg "translucent"
+  | Ok _ -> Alcotest.fail "unknown reasoning_visibility should reject"
 ;;
 
 let test_manifest_intlit_in_range_accepted () =
@@ -1248,9 +1282,14 @@ let () =
             `Quick
             test_apply_manifest_entry_all_none_uses_base
         ; test_case
-            "wrong-type fields warn and ignore"
+            "wrong-type feature fields warn and ignore"
             `Quick
-            test_manifest_wrong_type_fields_warn_and_ignore
+            test_manifest_wrong_type_feature_fields_warn_and_ignore
+        ; test_case "wrong-type base rejects" `Quick test_manifest_rejects_wrong_type_base
+        ; test_case
+            "wrong-type policy string rejects"
+            `Quick
+            test_manifest_rejects_wrong_type_policy_string
         ; test_case
             "unknown preserve_thinking_control_format rejects"
             `Quick
@@ -1259,6 +1298,10 @@ let () =
             "unknown reasoning_replay rejects"
             `Quick
             test_manifest_rejects_unknown_reasoning_replay
+        ; test_case
+            "unknown reasoning_visibility rejects"
+            `Quick
+            test_manifest_rejects_unknown_reasoning_visibility
         ; test_case
             "intlit in range accepted"
             `Quick

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -854,6 +854,22 @@ let test_manifest_rejects_wrong_type_policy_string () =
   | Ok _ -> Alcotest.fail "wrong-type thinking_control_format should reject"
 ;;
 
+let test_manifest_accepts_ollama_think_policy_string () =
+  let json =
+    Yojson.Safe.from_string
+      {|{"schema_version":1,"models":[{"id_prefix":"ollama-manifest","thinking_control_format":"ollama_think"}]}|}
+  in
+  match Capability_manifest.of_json json with
+  | Ok [ entry ] ->
+    let caps = Capabilities.apply_manifest_entry entry in
+    check_thinking_control
+      "manifest ollama_think"
+      Capabilities.Ollama_think
+      caps.thinking_control_format
+  | Ok _ -> Alcotest.fail "expected one manifest entry"
+  | Error msg -> Alcotest.failf "unexpected parse error: %s" msg
+;;
+
 let test_manifest_rejects_unknown_preserve_thinking_control_format () =
   let json =
     Yojson.Safe.from_string
@@ -1290,6 +1306,10 @@ let () =
             "wrong-type policy string rejects"
             `Quick
             test_manifest_rejects_wrong_type_policy_string
+        ; test_case
+            "ollama_think policy string accepted"
+            `Quick
+            test_manifest_accepts_ollama_think_policy_string
         ; test_case
             "unknown preserve_thinking_control_format rejects"
             `Quick


### PR DESCRIPTION
## Summary
- reject wrong TOML types and unknown canonical values for model catalog policy/base strings
- reject wrong JSON types for capability manifest base and policy strings
- validate manifest `reasoning_visibility` values at parse time instead of silently falling back to the base capabilities
- move shared policy value lists into `Capability_vocab` so model catalog and capability manifest use the same canonical vocabulary
- keep existing manifest bool/int feature-flag compatibility as warn-and-ignore

## OAS matrix impact
- S8/S9: catalog and manifest policy inputs now fail closed instead of silently drifting to defaults
- S3: reasoning visibility/replay overrides are parse-time checked across catalog/manifest inputs
- S7: model catalog multimodal ordering policy (`modality_priority`) is canonicalized before capability application

## Verification
- `scripts/dune-local.sh build @fmt`
- `env OAS_MODEL_CATALOG=$PWD/models.toml scripts/dune-local.sh exec ./test/test_capabilities.exe`
- `env OAS_MODEL_CATALOG=$PWD/models.toml scripts/dune-local.sh exec ./test/test_provider_runtime_binding.exe`
- `env OAS_MODEL_CATALOG=$PWD/models.toml scripts/dune-local.sh exec ./test/test_thinking_control_dialects.exe`
- `git diff --check origin/main...HEAD`