### PR TITLE
fix(tool-choice): fail closed on unsupported forced any

### DIFF
--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -1077,6 +1077,7 @@ let%test "build_request includes tool_choice for model with supports_tool_choice
       ~model_id:"gpt"
       ~base_url:"http://localhost"
       ~tool_choice:Any
+      ~supports_tool_choice_override:true
       ()
   in
   let body = build_request ~config ~messages:[] () in
@@ -1091,7 +1092,7 @@ let json_object_missing_key key json =
   | exception Yojson.Safe.Util.Type_error _ -> false
 ;;
 
-let%test "build_request omits tool_choice for unknown model without override" =
+let%test "build_request rejects forced tool_choice for unknown model without override" =
   let config =
     Provider_config.make
       ~kind:OpenAI_compat
@@ -1100,9 +1101,12 @@ let%test "build_request omits tool_choice for unknown model without override" =
       ~tool_choice:Any
       ()
   in
-  let body = build_request ~config ~messages:[] () in
-  let json = Yojson.Safe.from_string body in
-  json_object_missing_key "tool_choice" json
+  match build_request ~config ~messages:[] () with
+  | exception Invalid_argument msg ->
+    String.starts_with
+      ~prefix:"Backend_openai_request.effective_tool_choice: openai_compat model"
+      msg
+  | _ -> false
 ;;
 
 let%test "build_request omits tool_choice when tool_choice=None" =
@@ -1218,7 +1222,7 @@ let%test "build_request prefers output_schema over json_object mode" =
   body |> member "response_format" |> member "type" |> to_string = "json_schema"
 ;;
 
-let%test "supports_tool_choice_override=Some false drops tool_choice on unknown model" =
+let%test "supports_tool_choice_override=Some false rejects forced tool_choice" =
   (* Unknown model_id defaults to supports_tool_choice=false. Override false
      keeps the fail-closed behavior explicit. *)
   let config =
@@ -1230,10 +1234,11 @@ let%test "supports_tool_choice_override=Some false drops tool_choice on unknown 
       ~supports_tool_choice_override:false
       ()
   in
-  let body = build_request ~config ~messages:[] () in
-  let json = Yojson.Safe.from_string body in
-  match json with
-  | `Assoc fields -> not (List.exists (fun (k, _) -> k = "tool_choice") fields)
+  match build_request ~config ~messages:[] () with
+  | exception Invalid_argument msg ->
+    String.starts_with
+      ~prefix:"Backend_openai_request.effective_tool_choice: openai_compat model"
+      msg
   | _ -> false
 ;;
 

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -384,6 +384,11 @@ let is_zai_glm_config (config : t) =
 ;;
 
 type tool_choice_request_rejection =
+  | Unsupported_forced_tool_choice of
+      { provider_kind : provider_kind
+      ; model_id : string
+      ; requested : Types.tool_choice
+      }
   | Unsupported_named_tool_choice of
       { provider_kind : provider_kind
       ; model_id : string
@@ -391,6 +396,12 @@ type tool_choice_request_rejection =
       }
 
 let tool_choice_request_rejection_to_message = function
+  | Unsupported_forced_tool_choice { provider_kind; model_id; requested } ->
+    Printf.sprintf
+      "%s model %S does not support forced tool_choice %S; use auto or remove tool_choice"
+      (string_of_provider_kind provider_kind)
+      model_id
+      (Types.show_tool_choice requested)
   | Unsupported_named_tool_choice { provider_kind; model_id; tool_name } ->
     Printf.sprintf
       "%s model %S does not support named forced tool_choice %S; use auto/any or remove \
@@ -426,6 +437,10 @@ let validate_tool_choice_request_with_capabilities
       caps
   =
   match tool_choice with
+  | Some (Types.Any as requested) when not caps.Capabilities.supports_tool_choice ->
+    Error (Unsupported_forced_tool_choice { provider_kind; model_id; requested })
+  | Some (Types.Tool _ as requested) when not caps.Capabilities.supports_tool_choice ->
+    Error (Unsupported_forced_tool_choice { provider_kind; model_id; requested })
   | Some (Types.Tool tool_name) when not caps.Capabilities.supports_named_tool_choice ->
     Error (Unsupported_named_tool_choice { provider_kind; model_id; tool_name })
   | Some (Types.Tool _) -> Ok ()

--- a/lib/llm_provider/provider_config.mli
+++ b/lib/llm_provider/provider_config.mli
@@ -417,6 +417,11 @@ val validate_cli_sampling_params : t -> (unit, string) result
     typed config boundary instead of letting serializers raise exceptions after
     a turn has started. *)
 type tool_choice_request_rejection =
+  | Unsupported_forced_tool_choice of
+      { provider_kind : provider_kind
+      ; model_id : string
+      ; requested : Types.tool_choice
+      }
   | Unsupported_named_tool_choice of
       { provider_kind : provider_kind
       ; model_id : string

--- a/test/test_provider_runtime_binding.ml
+++ b/test/test_provider_runtime_binding.ml
@@ -269,6 +269,27 @@ let expect_named_tool_choice_rejected label cfg =
   | Error (Llm_provider.Provider_config.Unsupported_named_tool_choice { tool_name; _ }) ->
     Alcotest.(check string) (label ^ " tool") "calc" tool_name
   | Ok () -> Alcotest.failf "%s unexpectedly accepted named forced tool_choice" label
+  | Error rejection ->
+    Alcotest.failf
+      "%s expected named forced tool_choice rejection, got: %s"
+      label
+      (Llm_provider.Provider_config.tool_choice_request_rejection_to_message rejection)
+;;
+
+let expect_forced_tool_choice_rejected label expected cfg =
+  match Llm_provider.Provider_config.validate_tool_choice_request_typed cfg with
+  | Error (Llm_provider.Provider_config.Unsupported_forced_tool_choice { requested; _ })
+    ->
+    Alcotest.(check string)
+      (label ^ " requested")
+      (Types.show_tool_choice expected)
+      (Types.show_tool_choice requested)
+  | Ok () -> Alcotest.failf "%s unexpectedly accepted forced tool_choice" label
+  | Error rejection ->
+    Alcotest.failf
+      "%s expected forced tool_choice rejection, got: %s"
+      label
+      (Llm_provider.Provider_config.tool_choice_request_rejection_to_message rejection)
 ;;
 
 let request_tool_choice_field cfg =
@@ -390,7 +411,10 @@ supports_named_tool_choice = false
            ~tool_choice:named
            ()
        in
-       expect_named_tool_choice_rejected "ollama cloud minimax named" hosted_minimax_named;
+       expect_forced_tool_choice_rejected
+         "ollama cloud minimax named"
+         named
+         hosted_minimax_named;
        let hosted_minimax_any =
          Llm_provider.Provider_config.make
            ~kind:Llm_provider.Provider_config.OpenAI_compat
@@ -400,8 +424,10 @@ supports_named_tool_choice = false
            ~tool_choice:Types.Any
            ()
        in
-       expect_tool_choice_ok "ollama cloud minimax any" hosted_minimax_any;
-       expect_no_tool_choice_field "ollama cloud minimax any" hosted_minimax_any)
+       expect_forced_tool_choice_rejected
+         "ollama cloud minimax any"
+         Types.Any
+         hosted_minimax_any)
 ;;
 
 let test_all_includes_catalog_entry_once () =

--- a/test/test_snapshot_provider_serialization.ml
+++ b/test/test_snapshot_provider_serialization.ml
@@ -127,7 +127,6 @@ let openai_no_parallel_capability_cfg =
     ~api_key:"test-key"
     ~max_tokens:1024
     ~temperature:0.7
-    ~tool_choice:Any
     ~disable_parallel_tool_use:false
     ()
 ;;


### PR DESCRIPTION
## Summary
- fail closed when `tool_choice=Any` or `tool_choice=Tool _` is requested for a capability row with `supports_tool_choice=false`
- keep the named-tool rejection separate for providers that support required tool choice but not named forcing
- update OpenAI-compatible request tests and hosted Ollama Cloud invariants so unsupported forced tool use is rejected instead of silently dropped

## OAS impact
- S5 forced tool-use typed constraints: closes the silent downgrade path where `Any` could be accepted and then omitted for unsupported transports/models.

## Verification
- `scripts/dune-local.sh build @fmt`
- `env OAS_MODEL_CATALOG=$PWD/models.toml scripts/dune-local.sh exec ./test/test_provider_runtime_binding.exe`
- `env -u OAS_CAPABILITY_MANIFEST -u OAS_PRICING_OVERRIDES -u OAS_PRICING_FILE OAS_MODEL_CATALOG=$PWD/models.toml scripts/dune-local.sh runtest lib/llm_provider`
- `git diff --check origin/main...HEAD`
