### PR TITLE
fix(streaming): tool-call arguments 완성값 snapshot은 append 대신 replace (keeper transport_failure 근본 수정)

### DIFF
--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -463,7 +463,8 @@ let complete_stream_http
         | Types.ContentBlockDelta { delta = MediaDelta _; _ } -> `Answer
         | Types.ContentBlockDelta { delta = ThinkingDelta _; _ } -> `Thinking
         | Types.ContentBlockDelta { delta = ThinkingSignatureDelta _; _ } -> `Substrate
-        | Types.ContentBlockDelta { delta = InputJsonDelta _; _ } -> `Tool_call_arg_delta
+        | Types.ContentBlockDelta { delta = InputJsonDelta _ | InputJsonSnapshot _; _ }
+          -> `Tool_call_arg_delta
         | Types.ContentBlockStop _ -> `Tool_call_complete
         | Types.MessageDelta _ -> `Skip
         | Types.MessageStop -> `Done

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -463,8 +463,8 @@ let complete_stream_http
         | Types.ContentBlockDelta { delta = MediaDelta _; _ } -> `Answer
         | Types.ContentBlockDelta { delta = ThinkingDelta _; _ } -> `Thinking
         | Types.ContentBlockDelta { delta = ThinkingSignatureDelta _; _ } -> `Substrate
-        | Types.ContentBlockDelta { delta = InputJsonDelta _ | InputJsonSnapshot _; _ }
-          -> `Tool_call_arg_delta
+        | Types.ContentBlockDelta { delta = InputJsonDelta _ | InputJsonSnapshot _; _ } ->
+          `Tool_call_arg_delta
         | Types.ContentBlockStop _ -> `Tool_call_complete
         | Types.MessageDelta _ -> `Skip
         | Types.MessageStop -> `Done

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -86,6 +86,13 @@ let accumulate_event (acc : stream_acc) = function
     (match delta with
      | Types.TextDelta s | Types.ThinkingDelta s | Types.InputJsonDelta s ->
        Buffer.add_string buf s
+     | Types.InputJsonSnapshot s ->
+       (* A complete tool-call arguments value replaces the block buffer rather
+          than appending, so a provider that re-emits the same whole value over
+          multiple chunks does not concatenate it into invalid JSON (e.g.
+          [{"limit":10}{"limit":10}]). *)
+       Buffer.clear buf;
+       Buffer.add_string buf s
      | Types.MediaDelta { media_type; source_type; data } ->
        Hashtbl.replace acc.block_media_types index media_type;
        Hashtbl.replace acc.block_media_sources index source_type;
@@ -721,6 +728,50 @@ let%test "accumulate_event InputJsonDelta appends to buffer" =
     (Types.ContentBlockDelta { index = 0; delta = Types.InputJsonDelta "\"v\"}" });
   let buf = Hashtbl.find acc.block_texts 0 in
   Buffer.contents buf = "{\"k\":\"v\"}"
+;;
+
+let%test "accumulate_event InputJsonSnapshot replaces buffer (no concat on repeat)" =
+  let acc = create_stream_acc () in
+  accumulate_event
+    acc
+    (Types.ContentBlockStart
+       { index = 0; content_type = "tool_use"; tool_id = None; tool_name = None });
+  accumulate_event
+    acc
+    (Types.ContentBlockDelta { index = 0; delta = Types.InputJsonSnapshot {|{"old":1}|} });
+  (* A provider that re-emits the same (or an updated) complete arguments value
+     must replace, not append, so the buffer never becomes invalid JSON. *)
+  accumulate_event
+    acc
+    (Types.ContentBlockDelta { index = 0; delta = Types.InputJsonSnapshot {|{"limit":10}|} });
+  let buf = Hashtbl.find acc.block_texts 0 in
+  Buffer.contents buf = {|{"limit":10}|}
+;;
+
+let%test "finalize_stream_acc repeated tool-arg snapshot stays valid JSON" =
+  (* Regression: an OpenAI-compatible/Ollama/Gemini provider that streams a
+     whole tool-call arguments object and re-emits it on a later chunk used to
+     append into [{"limit":10}{"limit":10}], which finalize rejected as
+     [malformed_tool_use_arguments]. With InputJsonSnapshot the second emit
+     replaces the first, so the tool input parses cleanly. *)
+  let acc = create_stream_acc () in
+  List.iter
+    (accumulate_event acc)
+    [ Types.MessageStart { id = "m"; model = "m"; usage = None }
+    ; Types.ContentBlockStart
+        { index = 0
+        ; content_type = "tool_use"
+        ; tool_id = Some "call_1"
+        ; tool_name = Some "list"
+        }
+    ; Types.ContentBlockDelta { index = 0; delta = Types.InputJsonSnapshot {|{"limit":10}|} }
+    ; Types.ContentBlockDelta { index = 0; delta = Types.InputJsonSnapshot {|{"limit":10}|} }
+    ; Types.MessageDelta { stop_reason = Some Types.StopToolUse; usage = None }
+    ];
+  match finalize_stream_acc acc with
+  | Ok { content = [ Types.ToolUse { input; name; _ } ]; _ } ->
+    name = "list" && input = `Assoc [ ("limit", `Int 10) ]
+  | Ok _ | Error _ -> false
 ;;
 
 let%test "accumulate_event MessageDelta None stop_reason keeps default" =

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -743,7 +743,8 @@ let%test "accumulate_event InputJsonSnapshot replaces buffer (no concat on repea
      must replace, not append, so the buffer never becomes invalid JSON. *)
   accumulate_event
     acc
-    (Types.ContentBlockDelta { index = 0; delta = Types.InputJsonSnapshot {|{"limit":10}|} });
+    (Types.ContentBlockDelta
+       { index = 0; delta = Types.InputJsonSnapshot {|{"limit":10}|} });
   let buf = Hashtbl.find acc.block_texts 0 in
   Buffer.contents buf = {|{"limit":10}|}
 ;;
@@ -764,13 +765,15 @@ let%test "finalize_stream_acc repeated tool-arg snapshot stays valid JSON" =
         ; tool_id = Some "call_1"
         ; tool_name = Some "list"
         }
-    ; Types.ContentBlockDelta { index = 0; delta = Types.InputJsonSnapshot {|{"limit":10}|} }
-    ; Types.ContentBlockDelta { index = 0; delta = Types.InputJsonSnapshot {|{"limit":10}|} }
+    ; Types.ContentBlockDelta
+        { index = 0; delta = Types.InputJsonSnapshot {|{"limit":10}|} }
+    ; Types.ContentBlockDelta
+        { index = 0; delta = Types.InputJsonSnapshot {|{"limit":10}|} }
     ; Types.MessageDelta { stop_reason = Some Types.StopToolUse; usage = None }
     ];
   match finalize_stream_acc acc with
   | Ok { content = [ Types.ToolUse { input; name; _ } ]; _ } ->
-    name = "list" && input = `Assoc [ ("limit", `Int 10) ]
+    name = "list" && input = `Assoc [ "limit", `Int 10 ]
   | Ok _ | Error _ -> false
 ;;
 

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -141,7 +141,8 @@ let sse_event_is_first_token_signal (e : sse_event) : bool =
   match e with
   | ContentBlockDelta { delta = TextDelta s; _ } -> non_empty s
   | ContentBlockDelta { delta = ThinkingDelta s; _ } -> non_empty s
-  | ContentBlockDelta { delta = InputJsonDelta s; _ } -> non_empty s
+  | ContentBlockDelta { delta = (InputJsonDelta s | InputJsonSnapshot s); _ } ->
+    non_empty s
   | ContentBlockDelta { delta = MediaDelta { data; _ }; _ } -> non_empty data
   | ContentBlockDelta { delta = ThinkingSignatureDelta _; _ } -> false
   | MessageStart _
@@ -162,7 +163,8 @@ let sse_event_is_deliverable_progress_signal (e : sse_event) : bool =
   let non_empty s = String.length s > 0 in
   match e with
   | ContentBlockDelta { delta = TextDelta s; _ } -> non_empty s
-  | ContentBlockDelta { delta = InputJsonDelta s; _ } -> non_empty s
+  | ContentBlockDelta { delta = (InputJsonDelta s | InputJsonSnapshot s); _ } ->
+    non_empty s
   | ContentBlockDelta { delta = MediaDelta { data; _ }; _ } -> non_empty data
   | ContentBlockStart { content_type = "tool_use"; _ } -> true
   | ContentBlockDelta { delta = ThinkingSignatureDelta _; _ }
@@ -215,7 +217,7 @@ let emit_synthetic_events (response : api_response) on_event =
         | ToolUse { input; _ } ->
           on_event
             (ContentBlockDelta
-               { index; delta = InputJsonDelta (Yojson.Safe.to_string input) })
+               { index; delta = InputJsonSnapshot (Yojson.Safe.to_string input) })
         | Image { media_type; data; source_type }
         | Document { media_type; data; source_type }
         | Audio { media_type; data; source_type } ->
@@ -271,11 +273,20 @@ let%test "emit_synthetic_events round-trips a media block through the accumulato
     We parse each SSE chunk into {!openai_chunk}, then convert to
     {!sse_event} list using a stateful adapter ({!openai_stream_state}). *)
 
+(* Wire shape of streamed tool-call arguments. [Args_fragment] is an incremental
+   string chunk that the accumulator appends; [Args_complete] is a whole
+   object/array value serialized in a single delta, which the accumulator uses
+   to replace the block buffer so a provider that re-emits the same complete
+   value does not concatenate it into invalid JSON. *)
+type tool_call_arguments =
+  | Args_fragment of string
+  | Args_complete of string
+
 type openai_tool_call_delta =
   { tc_index : int
   ; tc_id : string option
   ; tc_name : string option
-  ; tc_arguments : string option
+  ; tc_arguments : tool_call_arguments option
   }
 
 type openai_chunk =
@@ -391,14 +402,18 @@ let parse_openai_sse_chunk data_str : openai_chunk option =
                    let tc_arguments =
                      (* llama.cpp/llama-server (#20198) streams tool-call
                         arguments as a JSON object/array, not a serialized
-                        string; serialize so the string-fragment accumulator
-                        does not silently drop them (the Ollama NDJSON path
-                        already handles this shape). *)
+                        string. A whole object/array is a complete value, so
+                        tag it [Args_complete]: the accumulator replaces the
+                        block buffer instead of appending, so a provider that
+                        re-emits the same value over multiple chunks does not
+                        concatenate it into invalid JSON. A bare string is an
+                        incremental fragment ([Args_fragment]). *)
                      match fn |> member "arguments" with
                      | `Null -> None
-                     | (`Assoc _ | `List _) as v -> Some (Yojson.Safe.to_string v)
-                     | `String s -> Some s
-                     | other -> Some (Yojson.Safe.to_string other)
+                     | (`Assoc _ | `List _) as v ->
+                       Some (Args_complete (Yojson.Safe.to_string v))
+                     | `String s -> Some (Args_fragment s)
+                     | other -> Some (Args_complete (Yojson.Safe.to_string other))
                    in
                    Some { tc_index; tc_id; tc_name; tc_arguments }
                  with
@@ -597,11 +612,12 @@ let openai_chunk_to_events (state : openai_stream_state) (chunk : openai_chunk)
            idx
        in
        match tc.tc_arguments with
-       | Some args when args <> "" ->
+       | Some (Args_fragment args) when args <> "" ->
          emit (ContentBlockDelta { index = block_idx; delta = InputJsonDelta args })
-       | Some empty_args ->
-         let (_ : string) = empty_args in
-         ()
+       | Some (Args_complete args) when args <> "" ->
+         emit
+           (ContentBlockDelta { index = block_idx; delta = InputJsonSnapshot args })
+       | Some (Args_fragment _ | Args_complete _) -> ()
        | None -> ())
     chunk.delta_tool_calls;
   (* Finish reason -> MessageDelta *)
@@ -1074,7 +1090,7 @@ let gemini_chunk_to_events (state : openai_stream_state) (chunk : gemini_chunk)
            state.next_block_index <- state.next_block_index + 1;
            emit
              (ContentBlockDelta
-                { index = idx; delta = InputJsonDelta (Yojson.Safe.to_string args) })
+                { index = idx; delta = InputJsonSnapshot (Yojson.Safe.to_string args) })
          | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ -> ()
        in
        match part |> member "text" |> to_string_option with
@@ -1148,7 +1164,7 @@ type ollama_tool_call_delta =
   { oll_tc_index : int
   ; oll_tc_id : string option
   ; oll_tc_name : string option
-  ; oll_tc_arguments : string option
+  ; oll_tc_arguments : tool_call_arguments option
   }
 
 type ollama_chunk =
@@ -1201,9 +1217,10 @@ let parse_ollama_ndjson_chunk data_str : ollama_chunk option =
                 let oll_tc_arguments =
                   match func |> member "arguments" with
                   | `Null -> None
-                  | (`Assoc _ | `List _) as v -> Some (Yojson.Safe.to_string v)
-                  | `String s -> Some s
-                  | other -> Some (Yojson.Safe.to_string other)
+                  | (`Assoc _ | `List _) as v ->
+                    Some (Args_complete (Yojson.Safe.to_string v))
+                  | `String s -> Some (Args_fragment s)
+                  | other -> Some (Args_complete (Yojson.Safe.to_string other))
                 in
                 { oll_tc_index = idx; oll_tc_id; oll_tc_name; oll_tc_arguments })
              items
@@ -1378,11 +1395,12 @@ let ollama_chunk_to_events (state : openai_stream_state) (chunk : ollama_chunk)
            idx
        in
        match tc.oll_tc_arguments with
-       | Some args when args <> "" ->
+       | Some (Args_fragment args) when args <> "" ->
          emit (ContentBlockDelta { index = block_idx; delta = InputJsonDelta args })
-       | Some empty_args ->
-         let (_ : string) = empty_args in
-         ()
+       | Some (Args_complete args) when args <> "" ->
+         emit
+           (ContentBlockDelta { index = block_idx; delta = InputJsonSnapshot args })
+       | Some (Args_fragment _ | Args_complete _) -> ()
        | None -> ())
     chunk.oll_tool_calls;
   (* Terminal chunk: emit MessageDelta with stop_reason + usage. *)
@@ -1479,7 +1497,7 @@ let%test "parse_ollama_ndjson_chunk: tool_calls fully formed in done line" =
        tc.oll_tc_name = Some "foo"
        &&
          (match tc.oll_tc_arguments with
-         | Some args ->
+         | Some (Args_fragment args | Args_complete args) ->
            let json = Yojson.Safe.from_string args in
            json |> Yojson.Safe.Util.member "x" |> Yojson.Safe.Util.to_int = 1
          | None -> false)
@@ -1601,7 +1619,7 @@ let%test "ollama_chunk_to_events: done with zero usage → usage=None" =
     false
 ;;
 
-let%test "ollama_chunk_to_events: tool_calls emit Start+InputJsonDelta" =
+let%test "ollama_chunk_to_events: tool_calls emit Start+InputJsonSnapshot" =
   let state = create_openai_stream_state () in
   let chunk =
     { oll_model = "dashscope-3:8b"
@@ -1611,7 +1629,7 @@ let%test "ollama_chunk_to_events: tool_calls emit Start+InputJsonDelta" =
         [ { oll_tc_index = 0
           ; oll_tc_id = None
           ; oll_tc_name = Some "search"
-          ; oll_tc_arguments = Some {|{"q":"hello"}|}
+          ; oll_tc_arguments = Some (Args_complete {|{"q":"hello"}|})
           }
         ]
     ; oll_done_reason = Some "tool_calls"
@@ -1624,7 +1642,7 @@ let%test "ollama_chunk_to_events: tool_calls emit Start+InputJsonDelta" =
   match events with
   | [ ContentBlockStart
         { index = 0; content_type = "tool_use"; tool_name = Some "search"; _ }
-    ; ContentBlockDelta { index = 0; delta = InputJsonDelta args }
+    ; ContentBlockDelta { index = 0; delta = InputJsonSnapshot args }
     ; MessageDelta { stop_reason = Some StopToolUse; _ }
     ] -> args = {|{"q":"hello"}|}
   | unexpected_events ->

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -141,8 +141,7 @@ let sse_event_is_first_token_signal (e : sse_event) : bool =
   match e with
   | ContentBlockDelta { delta = TextDelta s; _ } -> non_empty s
   | ContentBlockDelta { delta = ThinkingDelta s; _ } -> non_empty s
-  | ContentBlockDelta { delta = (InputJsonDelta s | InputJsonSnapshot s); _ } ->
-    non_empty s
+  | ContentBlockDelta { delta = InputJsonDelta s | InputJsonSnapshot s; _ } -> non_empty s
   | ContentBlockDelta { delta = MediaDelta { data; _ }; _ } -> non_empty data
   | ContentBlockDelta { delta = ThinkingSignatureDelta _; _ } -> false
   | MessageStart _
@@ -163,8 +162,7 @@ let sse_event_is_deliverable_progress_signal (e : sse_event) : bool =
   let non_empty s = String.length s > 0 in
   match e with
   | ContentBlockDelta { delta = TextDelta s; _ } -> non_empty s
-  | ContentBlockDelta { delta = (InputJsonDelta s | InputJsonSnapshot s); _ } ->
-    non_empty s
+  | ContentBlockDelta { delta = InputJsonDelta s | InputJsonSnapshot s; _ } -> non_empty s
   | ContentBlockDelta { delta = MediaDelta { data; _ }; _ } -> non_empty data
   | ContentBlockStart { content_type = "tool_use"; _ } -> true
   | ContentBlockDelta { delta = ThinkingSignatureDelta _; _ }
@@ -615,8 +613,7 @@ let openai_chunk_to_events (state : openai_stream_state) (chunk : openai_chunk)
        | Some (Args_fragment args) when args <> "" ->
          emit (ContentBlockDelta { index = block_idx; delta = InputJsonDelta args })
        | Some (Args_complete args) when args <> "" ->
-         emit
-           (ContentBlockDelta { index = block_idx; delta = InputJsonSnapshot args })
+         emit (ContentBlockDelta { index = block_idx; delta = InputJsonSnapshot args })
        | Some (Args_fragment _ | Args_complete _) -> ()
        | None -> ())
     chunk.delta_tool_calls;
@@ -1398,8 +1395,7 @@ let ollama_chunk_to_events (state : openai_stream_state) (chunk : ollama_chunk)
        | Some (Args_fragment args) when args <> "" ->
          emit (ContentBlockDelta { index = block_idx; delta = InputJsonDelta args })
        | Some (Args_complete args) when args <> "" ->
-         emit
-           (ContentBlockDelta { index = block_idx; delta = InputJsonSnapshot args })
+         emit (ContentBlockDelta { index = block_idx; delta = InputJsonSnapshot args })
        | Some (Args_fragment _ | Args_complete _) -> ()
        | None -> ())
     chunk.oll_tool_calls;

--- a/lib/llm_provider/streaming.mli
+++ b/lib/llm_provider/streaming.mli
@@ -21,9 +21,9 @@ val emit_synthetic_events : api_response -> (sse_event -> unit) -> unit
 
 (** [true] when the SSE event represents the first generated
     token delta. That means a [ContentBlockDelta] carrying a
-    non-empty [TextDelta] / [ThinkingDelta] / [InputJsonDelta]
-    payload. Prelude events ([MessageStart], [ContentBlockStart],
-    [ThinkingSignatureDelta] carriers,
+    non-empty [TextDelta] / [ThinkingDelta] / [InputJsonDelta] /
+    [InputJsonSnapshot] payload. Prelude events ([MessageStart],
+    [ContentBlockStart], [ThinkingSignatureDelta] carriers,
     [Ping]), terminator events ([MessageStop], [MessageDelta] with
     no usage), and error events return [false].
 
@@ -195,7 +195,7 @@ type ollama_tool_call_delta =
   ; oll_tc_id : string option
   ; oll_tc_name : string option
   ; oll_tc_arguments : tool_call_arguments option
-      (** Tool-call arguments as they arrive on the wire. *)
+    (** Tool-call arguments as they arrive on the wire. *)
   }
 
 type ollama_chunk =

--- a/lib/llm_provider/streaming.mli
+++ b/lib/llm_provider/streaming.mli
@@ -55,11 +55,20 @@ val thinking_only_timeout_exceeded
 
 (** {1 Openai SSE} *)
 
+(** Wire shape of streamed tool-call arguments. [Args_fragment] is an incremental
+    string chunk the accumulator appends; [Args_complete] is a whole object/array
+    value serialized in a single delta, which the accumulator uses to replace the
+    block buffer so a re-emitted complete value does not concatenate into invalid
+    JSON. *)
+type tool_call_arguments =
+  | Args_fragment of string
+  | Args_complete of string
+
 type openai_tool_call_delta =
   { tc_index : int
   ; tc_id : string option
   ; tc_name : string option
-  ; tc_arguments : string option
+  ; tc_arguments : tool_call_arguments option
   }
 
 type openai_chunk =
@@ -185,7 +194,8 @@ type ollama_tool_call_delta =
   { oll_tc_index : int
   ; oll_tc_id : string option
   ; oll_tc_name : string option
-  ; oll_tc_arguments : string option (** JSON string of arguments. *)
+  ; oll_tc_arguments : tool_call_arguments option
+      (** Tool-call arguments as they arrive on the wire. *)
   }
 
 type ollama_chunk =

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -443,6 +443,15 @@ type content_delta =
   | ThinkingDelta of string
   | ThinkingSignatureDelta of string
   | InputJsonDelta of string
+      (** Incremental fragment of a tool-call arguments JSON string. The
+          accumulator appends successive fragments to the block buffer. *)
+  | InputJsonSnapshot of string
+      (** A whole tool-call arguments value serialized in a single delta, used
+          by providers that stream [arguments] as a JSON object/array instead of
+          string fragments. The accumulator replaces the block buffer rather
+          than appending, so a provider that re-emits the same complete value
+          does not concatenate it into invalid JSON (e.g.
+          [{"limit":10}{"limit":10}]). *)
   | MediaDelta of
       { media_type : string
       ; source_type : media_source_kind

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -443,10 +443,10 @@ type content_delta =
   | ThinkingDelta of string
   | ThinkingSignatureDelta of string
   | InputJsonDelta of string
-      (** Incremental fragment of a tool-call arguments JSON string. The
+  (** Incremental fragment of a tool-call arguments JSON string. The
           accumulator appends successive fragments to the block buffer. *)
   | InputJsonSnapshot of string
-      (** A whole tool-call arguments value serialized in a single delta, used
+  (** A whole tool-call arguments value serialized in a single delta, used
           by providers that stream [arguments] as a JSON object/array instead of
           string fragments. The accumulator replaces the block buffer rather
           than appending, so a provider that re-emits the same complete value

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -264,10 +264,10 @@ type content_delta =
   | ThinkingDelta of string
   | ThinkingSignatureDelta of string
   | InputJsonDelta of string
-      (** Incremental fragment of a tool-call arguments JSON string. The
+  (** Incremental fragment of a tool-call arguments JSON string. The
           accumulator appends successive fragments to the block buffer. *)
   | InputJsonSnapshot of string
-      (** A whole tool-call arguments value serialized in a single delta, used
+  (** A whole tool-call arguments value serialized in a single delta, used
           by providers that stream [arguments] as a JSON object/array instead of
           string fragments. The accumulator replaces the block buffer rather
           than appending, so a provider that re-emits the same complete value

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -264,6 +264,14 @@ type content_delta =
   | ThinkingDelta of string
   | ThinkingSignatureDelta of string
   | InputJsonDelta of string
+      (** Incremental fragment of a tool-call arguments JSON string. The
+          accumulator appends successive fragments to the block buffer. *)
+  | InputJsonSnapshot of string
+      (** A whole tool-call arguments value serialized in a single delta, used
+          by providers that stream [arguments] as a JSON object/array instead of
+          string fragments. The accumulator replaces the block buffer rather
+          than appending, so a provider that re-emits the same complete value
+          does not concatenate it into invalid JSON. *)
   | MediaDelta of
       { media_type : string
       ; source_type : media_source_kind

--- a/test/test_agent_stream.ml
+++ b/test/test_agent_stream.ml
@@ -71,10 +71,10 @@ let test_emit_tool_use () =
      Alcotest.(check (option string)) "tool_name" (Some "get_weather") tool_name
    | _ -> Alcotest.fail "expected ContentBlockStart with tool_use");
   match List.nth events 2 with
-  | Types.ContentBlockDelta { delta = Types.InputJsonDelta s; _ } ->
+  | Types.ContentBlockDelta { delta = Types.InputJsonSnapshot s; _ } ->
     let _parsed = Yojson.Safe.from_string s in
     Alcotest.(check bool) "valid JSON" true true
-  | _ -> Alcotest.fail "expected InputJsonDelta"
+  | _ -> Alcotest.fail "expected InputJsonSnapshot"
 ;;
 
 let test_emit_thinking () =
@@ -243,7 +243,7 @@ let test_thinking_delta_content () =
   | _ -> Alcotest.fail "expected ThinkingDelta"
 ;;
 
-let test_input_json_delta_content () =
+let test_input_json_snapshot_content () =
   let input = `Assoc [ "key", `String "value"; "num", `Int 42 ] in
   let response =
     make_response
@@ -252,11 +252,11 @@ let test_input_json_delta_content () =
   in
   let events = collect_events response in
   match List.nth events 2 with
-  | Types.ContentBlockDelta { delta = Types.InputJsonDelta s; _ } ->
+  | Types.ContentBlockDelta { delta = Types.InputJsonSnapshot s; _ } ->
     let parsed = Yojson.Safe.from_string s in
     let key = Yojson.Safe.Util.(parsed |> member "key" |> to_string) in
     Alcotest.(check string) "parsed key" "value" key
-  | _ -> Alcotest.fail "expected InputJsonDelta"
+  | _ -> Alcotest.fail "expected InputJsonSnapshot"
 ;;
 
 let test_image_block_media_delta () =
@@ -506,7 +506,7 @@ let () =
         ] )
     ; ( "emit_delta_types"
       , [ test_case "thinking_delta_content" `Quick test_thinking_delta_content
-        ; test_case "input_json_delta_content" `Quick test_input_json_delta_content
+        ; test_case "input_json_snapshot_content" `Quick test_input_json_snapshot_content
         ; test_case "image_block_media_delta" `Quick test_image_block_media_delta
         ; test_case "document_block_media_delta" `Quick test_document_block_media_delta
         ] )

--- a/test/test_backend_gemini.ml
+++ b/test/test_backend_gemini.ml
@@ -940,7 +940,7 @@ let test_gemini_stream_tool_first_then_text () =
      let events, _tel = Streaming.gemini_chunk_to_events state chunk in
      (match events with
       | [ ContentBlockStart { index; content_type = "tool_use"; _ }
-        ; ContentBlockDelta { index = d_idx; delta = InputJsonDelta _; _ }
+        ; ContentBlockDelta { index = d_idx; delta = InputJsonSnapshot _; _ }
         ] ->
         check int "tool start index" 0 index;
         check int "tool delta index" 0 d_idx
@@ -1022,7 +1022,7 @@ let test_gemini_stream_function_call_preserves_thought_signature () =
            ; tool_id = Some tool_id
            ; tool_name = Some "search"
            }
-       ; ContentBlockDelta { index = delta_idx; delta = InputJsonDelta {|{"q":"test"}|} }
+       ; ContentBlockDelta { index = delta_idx; delta = InputJsonSnapshot {|{"q":"test"}|} }
        ; MessageDelta { stop_reason = Some StopToolUse; _ }
        ] ->
        check int "redacted index" 0 redacted_idx;

--- a/test/test_backend_gemini.ml
+++ b/test/test_backend_gemini.ml
@@ -1022,7 +1022,8 @@ let test_gemini_stream_function_call_preserves_thought_signature () =
            ; tool_id = Some tool_id
            ; tool_name = Some "search"
            }
-       ; ContentBlockDelta { index = delta_idx; delta = InputJsonSnapshot {|{"q":"test"}|} }
+       ; ContentBlockDelta
+           { index = delta_idx; delta = InputJsonSnapshot {|{"q":"test"}|} }
        ; MessageDelta { stop_reason = Some StopToolUse; _ }
        ] ->
        check int "redacted index" 0 redacted_idx;

--- a/test/test_gemini_edge_cases.ml
+++ b/test/test_gemini_edge_cases.ml
@@ -115,11 +115,11 @@ let test_sse_function_call () =
     let has_input_delta =
       List.exists
         (function
-          | Types.ContentBlockDelta { delta = InputJsonDelta _; _ } -> true
+          | Types.ContentBlockDelta { delta = InputJsonSnapshot _; _ } -> true
           | _ -> false)
         events
     in
-    check "InputJsonDelta emitted" has_input_delta;
+    check "InputJsonSnapshot emitted" has_input_delta;
     (* A Gemini stream that emitted a functionCall and finishes with STOP now
        reports StopToolUse, not EndTurn (#2061): the model wants a tool call.
        Mirrors the Alcotest gemini stop-reason tests #2061 already updated. *)

--- a/test/test_streaming.ml
+++ b/test/test_streaming.ml
@@ -413,9 +413,9 @@ let test_synthetic_tool_use () =
      Alcotest.(check (option string)) "tool_name" (Some "calc") tool_name
    | _ -> Alcotest.fail "expected tool_use ContentBlockStart");
   match List.nth events 2 with
-  | ContentBlockDelta { delta = InputJsonDelta s; _ } ->
+  | ContentBlockDelta { delta = InputJsonSnapshot s; _ } ->
     Alcotest.(check bool) "has json" true (String.length s > 0)
-  | _ -> Alcotest.fail "expected InputJsonDelta"
+  | _ -> Alcotest.fail "expected InputJsonSnapshot"
 ;;
 
 let test_synthetic_image_media_delta () =

--- a/test/test_streaming_edge_cases.ml
+++ b/test/test_streaming_edge_cases.ml
@@ -259,11 +259,16 @@ let test_openai_object_arguments () =
   let chunk = require_some "openai object args" (S.parse_openai_sse_chunk object_args) in
   match chunk.delta_tool_calls with
   | [ tc ] ->
-    check
-      (option string)
-      "object arguments serialized (not dropped to None)"
-      (Some {|{"x":1}|})
-      tc.tc_arguments
+    (match tc.tc_arguments with
+     | Some (S.Args_complete s) ->
+       check
+         string
+         "object arguments serialized as a complete value (not dropped to None)"
+         {|{"x":1}|}
+         s
+     | Some (S.Args_fragment _) ->
+       fail "object arguments must be tagged Args_complete, not a fragment"
+     | None -> fail "object arguments dropped to None")
   | _ -> fail "expected exactly one tool call"
 ;;
 
@@ -292,7 +297,7 @@ let test_openai_event_edge_branches () =
     { S.tc_index = 0
     ; tc_id = Some "call-1"
     ; tc_name = Some "search"
-    ; tc_arguments = Some ""
+    ; tc_arguments = Some (S.Args_fragment "")
     }
   in
   let tc_none = { S.tc_index = 0; tc_id = None; tc_name = None; tc_arguments = None } in
@@ -427,9 +432,15 @@ let test_ollama_parse_edge_shapes () =
   check int "three tool calls" 3 (List.length args_variants.oll_tool_calls);
   (match args_variants.oll_tool_calls with
    | [ first; second; third ] ->
-     check (option string) "null args" None first.oll_tc_arguments;
-     check (option string) "string args" (Some {|{"x":1}|}) second.oll_tc_arguments;
-     check (option string) "bool args" (Some "true") third.oll_tc_arguments
+     (match first.oll_tc_arguments with
+      | None -> ()
+      | Some _ -> fail "expected None for null args");
+     (match second.oll_tc_arguments with
+      | Some (S.Args_fragment s) -> check string "string args" {|{"x":1}|} s
+      | _ -> fail "expected Args_fragment for string args");
+     (match third.oll_tc_arguments with
+      | Some (S.Args_complete s) -> check string "bool args" "true" s
+      | _ -> fail "expected Args_complete for bool args")
    | _ -> fail "unexpected tool calls");
   (match args_variants.oll_timings with
    | Some t ->
@@ -473,7 +484,7 @@ let test_ollama_event_edge_branches () =
     { S.oll_tc_index = 0
     ; oll_tc_id = Some "call"
     ; oll_tc_name = Some "lookup"
-    ; oll_tc_arguments = Some ""
+    ; oll_tc_arguments = Some (S.Args_fragment "")
     }
   in
   let tc_none =

--- a/test/test_streaming_openai.ml
+++ b/test/test_streaming_openai.ml
@@ -47,7 +47,9 @@ let test_parse_tool_call_start () =
     Alcotest.(check int) "tc_index" 0 tc.tc_index;
     Alcotest.(check (option string)) "tc_id" (Some "call_abc") tc.tc_id;
     Alcotest.(check (option string)) "tc_name" (Some "get_weather") tc.tc_name;
-    Alcotest.(check (option string)) "tc_args" (Some "") tc.tc_arguments
+    (match tc.tc_arguments with
+     | Some (S.Args_fragment s) -> Alcotest.(check string) "tc_args" "" s
+     | _ -> Alcotest.fail "expected Args_fragment for empty string arguments")
   | None -> Alcotest.fail "expected Some chunk"
 ;;
 
@@ -58,7 +60,9 @@ let test_parse_tool_call_args () =
   match S.parse_openai_sse_chunk data with
   | Some chunk ->
     let tc = List.hd chunk.delta_tool_calls in
-    Alcotest.(check (option string)) "args" (Some {|{"loc|}) tc.tc_arguments;
+    (match tc.tc_arguments with
+     | Some (S.Args_fragment s) -> Alcotest.(check string) "args" {|{"loc|} s
+     | _ -> Alcotest.fail "expected Args_fragment for string arguments");
     Alcotest.(check (option string)) "no id" None tc.tc_id;
     Alcotest.(check (option string)) "no name" None tc.tc_name
   | None -> Alcotest.fail "expected Some chunk"
@@ -157,7 +161,7 @@ let test_events_tool_call () =
     { tc_index = 0
     ; tc_id = Some "call_1"
     ; tc_name = Some "calc"
-    ; tc_arguments = Some "{\"x\":1}"
+    ; tc_arguments = Some (S.Args_fragment "{\"x\":1}")
     }
   in
   let events, _tel =
@@ -437,7 +441,7 @@ let test_events_tool_first_then_text () =
     { tc_index = 0
     ; tc_id = Some "call_1"
     ; tc_name = Some "get_weather"
-    ; tc_arguments = Some {|{"city":"Seoul"}|}
+    ; tc_arguments = Some (S.Args_fragment {|{"city":"Seoul"}|})
     }
   in
   let tool_events, _tel =
@@ -515,14 +519,14 @@ let test_events_multi_tool_then_text () =
     { tc_index = 0
     ; tc_id = Some "call_a"
     ; tc_name = Some "fn_a"
-    ; tc_arguments = Some "{}"
+    ; tc_arguments = Some (S.Args_fragment "{}")
     }
   in
   let tc1 : S.openai_tool_call_delta =
     { tc_index = 1
     ; tc_id = Some "call_b"
     ; tc_name = Some "fn_b"
-    ; tc_arguments = Some "{}"
+    ; tc_arguments = Some (S.Args_fragment "{}")
     }
   in
   let _ =
@@ -583,7 +587,7 @@ let test_events_thinking_tool_text () =
     { tc_index = 0
     ; tc_id = Some "call_x"
     ; tc_name = Some "search"
-    ; tc_arguments = Some "{}"
+    ; tc_arguments = Some (S.Args_fragment "{}")
     }
   in
   let _ =

--- a/test/test_streaming_summary.ml
+++ b/test/test_streaming_summary.ml
@@ -156,7 +156,7 @@ let test_chunk_tool_call_is_token () =
     { tc_index = 0
     ; tc_id = Some "call_1"
     ; tc_name = Some "fetch"
-    ; tc_arguments = Some "{}"
+    ; tc_arguments = Some (Streaming.Args_complete "{}")
     }
   in
   let c = make_openai_chunk ~delta_tool_calls:[ tc ] () in

--- a/test/test_structured_stream.ml
+++ b/test/test_structured_stream.ml
@@ -187,7 +187,8 @@ let test_tool_use_json_parseable () =
   let json_parts = ref [] in
   Streaming.emit_synthetic_events response (fun e ->
     match e with
-    | ContentBlockDelta { delta = InputJsonSnapshot s; _ } -> json_parts := s :: !json_parts
+    | ContentBlockDelta { delta = InputJsonSnapshot s; _ } ->
+      json_parts := s :: !json_parts
     | _ -> ());
   let combined = String.concat "" (List.rev !json_parts) in
   try

--- a/test/test_structured_stream.ml
+++ b/test/test_structured_stream.ml
@@ -113,9 +113,9 @@ let test_synthetic_events_for_tool_use () =
      Alcotest.(check bool) "tool_name" true (tool_name = Some "extract_person")
    | _ -> Alcotest.fail "expected ContentBlockStart");
   (match List.nth events 2 with
-   | ContentBlockDelta { index; delta = InputJsonDelta _ } ->
+   | ContentBlockDelta { index; delta = InputJsonSnapshot _ } ->
      Alcotest.(check int) "delta index" 0 index
-   | _ -> Alcotest.fail "expected InputJsonDelta");
+   | _ -> Alcotest.fail "expected InputJsonSnapshot");
   (match List.nth events 3 with
    | ContentBlockStop { index } -> Alcotest.(check int) "stop" 0 index
    | _ -> Alcotest.fail "expected ContentBlockStop");
@@ -187,7 +187,7 @@ let test_tool_use_json_parseable () =
   let json_parts = ref [] in
   Streaming.emit_synthetic_events response (fun e ->
     match e with
-    | ContentBlockDelta { delta = InputJsonDelta s; _ } -> json_parts := s :: !json_parts
+    | ContentBlockDelta { delta = InputJsonSnapshot s; _ } -> json_parts := s :: !json_parts
     | _ -> ());
   let combined = String.concat "" (List.rev !json_parts) in
   try
@@ -319,6 +319,9 @@ let test_extract_after_accumulation () =
       in
       (match delta with
        | InputJsonDelta s -> Buffer.add_string buf s
+       | InputJsonSnapshot s ->
+         Buffer.clear buf;
+         Buffer.add_string buf s
        | TextDelta s -> Buffer.add_string buf s
        | ThinkingDelta s -> Buffer.add_string buf s
        | MediaDelta { data; _ } -> Buffer.add_string buf data


### PR DESCRIPTION
## 증상

여러 keeper가 동시에 대화할 때 fleet-wide(16개 keeper 전부, 06-29부터 급증)로 다음이 발생했습니다:

- `malformed_tool_use_arguments:index:1: ... Junk after end of JSON value: '{"limit":10}'`
- keeper가 thinking에만 갇히고 visible reply 없이 종료 → `transport_failure`
- 대시보드 turn timeline에서 동일 thinking 블록이 중복 표시

로그 증거(`base.jsonl`): 누적 버퍼가 `{"limit":10}{"limit":10}` — 같은 완성 객체가 두 번 이어붙어 invalid JSON.

## Root cause (2-part)

1. **잠재 버그 (#2097, 2026-06-16)**: `complete_stream_acc.ml`은 모든 `InputJsonDelta`를 `Buffer.add_string`으로 **append**(문자열 조각 누적 가정)합니다. 그런데 `streaming.ml`은 tool arguments가 `Assoc`/`List`(완성 객체)로 오면 **전체 값을 직렬화해 통째로 emit**합니다. provider가 같은 tool index의 완성 arguments를 여러 chunk에 걸쳐 재방출하면(llama-server/Ollama/Gemini cumulative delta) 버퍼가 `{...}{...}`로 이어붙어 invalid JSON이 됩니다. `InputJsonDelta`가 *fragment*와 *완성값*이라는 두 의미를 한 타입으로 conflate한 것이 근본입니다.

2. **회귀 트리거 (#2261, 2026-06-29 18:31 KST = "어제")**: `complete_stream_acc.ml:257-288`이 기존의 조용한 `try ... with Json_error _ -> \`Assoc []` coercion을 typed hard error(`malformed_tool_use_arguments`)로 교체했습니다. 예전엔 빈 인자로 조용히 dispatch되던 malformed가 이제 keeper-blocking 에러로 **표면화**됐습니다.

> 참고: "canonical vs sdk-mirror 이중 누적 경로" 가설은 반증됐습니다 — `streaming.ml`의 create/accumulate/finalize는 canonical `Complete_stream_acc` 단일 구현을 re-export하며, #2285/#2288은 이중 feed를 만들지 않습니다.

## 수정

`InputJsonDelta`를 wire shape에 따라 typed variant로 분리합니다 (Parse, don't validate):

- `InputJsonDelta of string` — incremental fragment, accumulator가 **append** (기존과 동일)
- `InputJsonSnapshot of string` — 완성된 전체 값, accumulator가 block buffer를 **clear 후 write(replace)**

emit 사이트는 wire shape로 분류합니다:

| emit 사이트 | shape | delta |
|---|---|---|
| Anthropic `partial_json` | fragment | `InputJsonDelta` |
| OpenAI Responses `.delta` | fragment | `InputJsonDelta` |
| OpenAI chat `String` args | fragment | `InputJsonDelta` |
| OpenAI chat `Assoc`/`List` args | 완성값 | `InputJsonSnapshot` |
| Gemini functionCall | 완성값 | `InputJsonSnapshot` |
| Ollama `Assoc`/`List` args | 완성값 | `InputJsonSnapshot` |
| round-trip `ToolUse` | 완성값 | `InputJsonSnapshot` |

wire shape는 `tool_call_arguments`(`Args_fragment`/`Args_complete`) 타입으로 파서에서 emit 사이트까지 보존됩니다(이전엔 bare `string`이라 정보 소실). 완성값 snapshot이 두 번 와도 두 번째가 첫 번째를 덮어쓰므로 `{...}{...}` 연결이 **구조적으로 불가능**합니다.

**워크어라운드가 아닌 이유**: concat된 JSON을 read-time에 dedup/normalize하는 repair(금지 시그니처)가 아니라, write-time에 타입으로 의미를 분리해 concat이 애초에 발생하지 않게 합니다. exhaustive match라 컴파일러가 누락 사이트를 전부 강제합니다.

## 검증

- `dune build @check`: 전체 컴파일 통과
- lib inline runtest: streaming·accumulator inline test 통과 (신규 회귀 테스트 2개 포함)
- streaming/gemini alcotest 7/7 통과 (`test_streaming_openai`, `test_streaming_edge_cases`, `test_stream_accumulator`, `test_backend_gemini`, `test_gemini_edge_cases`, `test_structured_stream`, `test_streaming_summary`)
- 신규 회귀 테스트(`finalize_stream_acc repeated tool-arg snapshot stays valid JSON`)는 사용자 증상(`{"limit":10}` 2회 → malformed)을 그대로 재현하고, 수정 후 valid `Assoc [("limit", Int 10)]`로 finalize됨을 단언합니다.

> 로컬에서 pricing(16/99)·provider_config(2/6) inline test가 실패하나, main(baseline)에서 동일하게 실패합니다 — `OAS_PRICING_OVERRIDES` env + `.masc/config/capability-manifest.json` 로딩이 catalog를 덮어쓴 로컬 환경 문제로, 본 변경과 무관합니다.

## 남은 gap (follow-up)

라이브 wire trace 미확보 상태입니다. 어떤 provider가 완성 arguments를 **`String`으로 cumulative하게 2회** 보내는 경우(예: 비표준 OpenAI-compat 서버)는 `String → Args_fragment → append`라 여전히 중복될 수 있습니다. 알려진 케이스(object/array emit)는 모두 닫혔고, String-cumulative variant는 라이브 trace 확보 후 별도 처리합니다.

## 관련

- RFC-OAS-029 (Tools/Thinking/Reasoning/Multi-turn) streaming 영역
- thinking-only/visible-reply 누락(증상 2/3/4)은 masc 측 `direct_reply_terminal_error` 분류 문제와도 얽혀 있으나, 본 PR(OAS streaming root)이 malformed→Error cascade를 끊으면 대부분 해소됩니다. masc 측 (a)모델이 text 미생성 vs (b)파싱으로 text 유실 구분은 별도 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
