### PR TITLE
fix(reasoning): centralize budget effort thresholds

### DIFF
--- a/lib/llm_provider/backend_anthropic.ml
+++ b/lib/llm_provider/backend_anthropic.ml
@@ -60,11 +60,18 @@ let parse_response json =
   }
 ;;
 
-let effort_of_budget = function
-  | n when n <= 2_048 -> "low"
-  | n when n <= 8_192 -> "medium"
-  | n when n <= 32_768 -> "high"
-  | _ -> "max"
+let adaptive_effort_dialect =
+  { Reasoning_dialect.default with effort_alias_policy = Reasoning_dialect.Xhigh_as_max }
+;;
+
+let effort_of_budget budget =
+  let effort =
+    match Reasoning_effort.of_budget_with_xhigh budget with
+    | Some effort -> effort
+    | None -> Reasoning_effort.Low
+  in
+  Reasoning_dialect.normalize_effort_value adaptive_effort_dialect effort
+  |> Option.value ~default:"low"
 ;;
 
 let effort_for_config mode (config : Provider_config.t) =

--- a/lib/llm_provider/backend_gemini.ml
+++ b/lib/llm_provider/backend_gemini.ml
@@ -44,9 +44,13 @@ let warn_parallel_disable_unsupported ~model_id =
 
 let thinking_level_of_budget ~supports_minimal = function
   | Some n when n <= 0 -> if supports_minimal then "minimal" else "low"
-  | Some n when n <= 2_048 -> "low"
-  | Some n when n <= 8_192 -> "medium"
-  | Some _ | None -> "high"
+  | Some n ->
+    (match Reasoning_effort.of_budget n with
+     | Some effort ->
+       Reasoning_dialect.normalize_effort_value Reasoning_dialect.default effort
+       |> Option.value ~default:"high"
+     | None -> "high")
+  | None -> "high"
 ;;
 
 let thinking_config_of_config (config : Provider_config.t) =

--- a/lib/llm_provider/reasoning_dialect.ml
+++ b/lib/llm_provider/reasoning_dialect.ml
@@ -20,6 +20,7 @@ type toggle_wire =
 type effort_alias_policy =
   | Preserve_effort
   | Deepseek_high_or_max
+  | Xhigh_as_max
 
 type sampling_policy =
   | Sampling_supported
@@ -286,6 +287,9 @@ let normalize_effort_value dialect effort =
     Some "high"
   | Deepseek_high_or_max, Reasoning_effort.XHigh -> Some "max"
   | Deepseek_high_or_max, Reasoning_effort.Minimal -> None
+  | Xhigh_as_max, Reasoning_effort.XHigh -> Some "max"
+  | Xhigh_as_max, Reasoning_effort.Minimal -> None
+  | Xhigh_as_max, effort -> Some (Reasoning_effort.to_string effort)
   | Preserve_effort, effort -> Some (Reasoning_effort.to_string effort)
 ;;
 

--- a/lib/llm_provider/reasoning_dialect.mli
+++ b/lib/llm_provider/reasoning_dialect.mli
@@ -30,6 +30,7 @@ type toggle_wire =
 type effort_alias_policy =
   | Preserve_effort
   | Deepseek_high_or_max
+  | Xhigh_as_max
 
 type sampling_policy =
   | Sampling_supported

--- a/lib/llm_provider/reasoning_effort.ml
+++ b/lib/llm_provider/reasoning_effort.ml
@@ -25,10 +25,19 @@ let of_string value =
 let values_for_log = String.concat "/" (List.map to_string all)
 let low_budget_max_tokens = 2048
 let medium_budget_max_tokens = 8192
+let high_budget_max_tokens = 32768
 
 let of_budget = function
   | n when n <= 0 -> None
   | n when n <= low_budget_max_tokens -> Some Low
   | n when n <= medium_budget_max_tokens -> Some Medium
   | _ -> Some High
+;;
+
+let of_budget_with_xhigh = function
+  | n when n <= 0 -> None
+  | n when n <= low_budget_max_tokens -> Some Low
+  | n when n <= medium_budget_max_tokens -> Some Medium
+  | n when n <= high_budget_max_tokens -> Some High
+  | _ -> Some XHigh
 ;;

--- a/lib/llm_provider/reasoning_effort.mli
+++ b/lib/llm_provider/reasoning_effort.mli
@@ -18,4 +18,8 @@ val of_string : string -> t option
 val values_for_log : string
 val low_budget_max_tokens : int
 val medium_budget_max_tokens : int
+val high_budget_max_tokens : int
 val of_budget : int -> t option
+
+(** Budget mapping for providers that expose the top effort tier separately. *)
+val of_budget_with_xhigh : int -> t option

--- a/test/test_backend_gemini.ml
+++ b/test/test_backend_gemini.ml
@@ -121,7 +121,11 @@ let test_thinking_disabled_uses_budget_zero () =
 
 let test_gemini3_uses_thinking_level () =
   let config =
-    gemini_config ~model_id:"gemini-3.5-flash" ~enable_thinking:true ~budget:1024 ()
+    gemini_config
+      ~model_id:"gemini-3.5-flash"
+      ~enable_thinking:true
+      ~budget:Reasoning_effort.low_budget_max_tokens
+      ()
   in
   let body =
     Backend_gemini.build_request ~config ~messages:[ Types.user_msg "Think." ] ()

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -531,6 +531,29 @@ let test_reasoning_effort_of_thinking_config () =
     (Some (Reasoning_effort.medium_budget_max_tokens + 1))
 ;;
 
+let test_reasoning_effort_top_tier_budget_mapping () =
+  let check_effort label expected budget =
+    Alcotest.(check (option string))
+      label
+      (Some expected)
+      (reasoning_effort_option_to_string (Reasoning_effort.of_budget_with_xhigh budget))
+  in
+  check_effort "low top-tier mapping" "low" Reasoning_effort.low_budget_max_tokens;
+  check_effort
+    "medium top-tier mapping"
+    "medium"
+    Reasoning_effort.medium_budget_max_tokens;
+  check_effort "high top-tier mapping" "high" Reasoning_effort.high_budget_max_tokens;
+  check_effort
+    "xhigh top-tier mapping"
+    "xhigh"
+    (Reasoning_effort.high_budget_max_tokens + 1);
+  Alcotest.(check (option string))
+    "non-positive budget omits effort"
+    None
+    (reasoning_effort_option_to_string (Reasoning_effort.of_budget_with_xhigh 0))
+;;
+
 let test_reasoning_effort_typed_roundtrip () =
   let cases =
     [ Provider_config.Minimal, "minimal"
@@ -1197,6 +1220,10 @@ let () =
             "thinking effort thresholds"
             `Quick
             test_reasoning_effort_of_thinking_config
+        ; Alcotest.test_case
+            "thinking effort top-tier thresholds"
+            `Quick
+            test_reasoning_effort_top_tier_budget_mapping
         ; Alcotest.test_case
             "reasoning effort by config"
             `Quick

--- a/test/test_thinking_control_dialects.ml
+++ b/test/test_thinking_control_dialects.ml
@@ -653,7 +653,10 @@ let test_anthropic_manual_model_uses_budget_tokens () =
 
 let test_anthropic_opus48_uses_adaptive_effort () =
   let config =
-    anthropic_config ~enable_thinking:true ~thinking_budget:4096 "claude-opus-4-8"
+    anthropic_config
+      ~enable_thinking:true
+      ~thinking_budget:(RE.low_budget_max_tokens + 1)
+      "claude-opus-4-8"
   in
   let json = BAN.build_request ~config ~messages:[ user_msg "hi" ] () |> json_of_body in
   let thinking = json |> member "thinking" in
@@ -670,7 +673,7 @@ let test_anthropic_agent_llm_alias_uses_adaptive_effort () =
   let config =
     anthropic_config
       ~enable_thinking:true
-      ~thinking_budget:4096
+      ~thinking_budget:(RE.low_budget_max_tokens + 1)
       "claude-sonnet-4-6-20250514"
   in
   let json = BAN.build_request ~config ~messages:[ user_msg "hi" ] () |> json_of_body in
@@ -703,7 +706,7 @@ let test_anthropic_output_config_merges_format_and_effort () =
   let config =
     anthropic_config
       ~enable_thinking:true
-      ~thinking_budget:50_000
+      ~thinking_budget:(RE.high_budget_max_tokens + 1)
       ~output_schema:schema
       "claude-opus-4-8"
   in


### PR DESCRIPTION
## Summary
- move top-tier budget effort mapping into Reasoning_effort instead of re-hardcoding thresholds in Anthropic/Gemini backends
- route Anthropic adaptive max aliasing through Reasoning_dialect
- update regression tests to use Reasoning_effort threshold constants

## Verification
- ocamlformat --check lib/llm_provider/reasoning_effort.mli lib/llm_provider/reasoning_effort.ml lib/llm_provider/reasoning_dialect.mli lib/llm_provider/reasoning_dialect.ml lib/llm_provider/backend_anthropic.ml lib/llm_provider/backend_gemini.ml test/test_provider_config.ml test/test_thinking_control_dialects.ml test/test_backend_gemini.ml
- git diff --check
- rg -n '2_048|8_192|32_768|2048|8192|32768' lib/llm_provider/backend_anthropic.ml lib/llm_provider/backend_gemini.ml lib/llm_provider/reasoning_effort.ml lib/llm_provider/reasoning_effort.mli test/test_backend_gemini.ml test/test_thinking_control_dialects.ml test/test_provider_config.ml
- env -u OAS_CAPABILITY_MANIFEST -u OAS_PRICING_FILE -u OAS_PRICING_OVERRIDES scripts/dune-local.sh build test/test_provider_config.exe test/test_backend_gemini.exe test/test_thinking_control_dialects.exe
- env -u OAS_CAPABILITY_MANIFEST -u OAS_PRICING_FILE -u OAS_PRICING_OVERRIDES scripts/dune-local.sh exec ./test/test_provider_config.exe -- test --compact locality 7-12
- scripts/dune-local.sh exec ./test/test_backend_gemini.exe
- env -u OAS_CAPABILITY_MANIFEST -u OAS_PRICING_FILE -u OAS_PRICING_OVERRIDES scripts/dune-local.sh exec ./test/test_thinking_control_dialects.exe -- test --compact native 2-6

## Notes
- I also tried scripts/dune-local.sh build @lib/llm_provider/runtest test/test_provider_config.exe test/test_backend_gemini.exe test/test_thinking_control_dialects.exe. The focused build compiled, but the llm_provider inline test target is currently polluted by ambient /Users/dancer/me/.masc capability/pricing overrides and fails unrelated catalog/capability assertions.