### PR TITLE
fix(capabilities): Kimi는 named forced tool_choice 거부 (auto-only API)

### DIFF
--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -298,7 +298,20 @@ let kimi_capabilities =
   ; max_output_tokens = Some 32_768
   ; supports_tools = true
   ; supports_tool_choice = true
-  ; supports_named_tool_choice = true
+  ; (* Kimi's chat API documents [tools] but not [tool_choice] in any request
+     schema (platform.kimi.ai/docs/api/chat covers KimiK27Code/K26/K25/MoonshotV1
+     request bodies; none expose tool_choice), and tool_choice=required is
+     unsupported — developers prompt the model to force a tool instead. Plain
+     [auto] passes through the OpenAI-compatible endpoint so [supports_tool_choice]
+     stays true, but a forced *named* tool_choice has no faithful wire
+     representation. OAS therefore treats Kimi like GLM: tools supported, named
+     forced tool_choice rejected with a typed [Unsupported_named_tool_choice]
+     rather than serialized into a request the model cannot honor. This is the
+     conservative declaration-over-probing default (same rationale as the Ollama
+     profile); a deployment that verified native named support can still override
+     per-entry via the model catalog. Ref checked 2026-06-30:
+     platform.kimi.ai/docs/api/chat, platform.kimi.ai/docs/api/tool-use. *)
+    supports_named_tool_choice = false
   ; supports_parallel_tool_calls = true
   ; supports_reasoning = true
   ; supports_extended_thinking = true

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -1104,6 +1104,22 @@ let test_dashscope_capabilities () =
   check bool "has min_p" true c.supports_min_p
 ;;
 
+(* ── Kimi tool_choice preset ─────────────────────────── *)
+
+let test_kimi_tool_choice_capabilities () =
+  let c = Capabilities.kimi_capabilities in
+  (* Kimi's chat API documents [tools] but not [tool_choice] in any request
+     schema, and tool_choice=required is unsupported (developers prompt the model
+     to force a tool). Plain [auto] passes through the OpenAI-compatible endpoint
+     so [supports_tool_choice] stays true, but a forced named tool_choice has no
+     faithful wire representation — Kimi mirrors GLM: tools supported, named
+     forced tool_choice rejected (typed) rather than serialized. Ref checked
+     2026-06-30: platform.kimi.ai/docs/api/chat, platform.kimi.ai/docs/api/tool-use. *)
+  check bool "has tools" true c.supports_tools;
+  check bool "accepts auto tool_choice" true c.supports_tool_choice;
+  check bool "rejects named forced tool_choice" false c.supports_named_tool_choice
+;;
+
 let test_openai_compat_reasoning_records_have_explicit_control () =
   let cases =
     [ "openai_chat_extended", Some Capabilities.openai_compat_chat_extended_capabilities
@@ -1222,6 +1238,7 @@ let () =
         ; test_case "openai" `Quick test_openai_capabilities
         ; test_case "openai extended" `Quick test_openai_extended
         ; test_case "dashscope" `Quick test_dashscope_capabilities
+        ; test_case "kimi tool_choice" `Quick test_kimi_tool_choice_capabilities
         ; test_case
             "openai compat reasoning records have explicit control"
             `Quick


### PR DESCRIPTION
## 무엇을

`kimi_capabilities`의 `supports_named_tool_choice`를 `true` → `false`로 수정합니다.

## 왜 (공식 문서 대조, 2026-06-30 확인)

각 모델별 thinking/tools 구현이 2026년 6월 말 공식 문서와 일치하는지 sweep하던 중 발견했습니다.

- **Kimi chat API는 `tool_choice`를 어떤 request 스키마에도 문서화하지 않습니다** — `platform.kimi.ai/docs/api/chat`의 `KimiK27CodeChatRequest`/`KimiK26ChatRequest`/`KimiK25ChatRequest`/`MoonshotV1ChatRequest` 본문에 `tools`만 있고 `tool_choice`는 없습니다.
- **`tool_choice=required` 미지원** — 공식 가이드는 도구 강제가 필요하면 프롬프트로 유도하라고 안내합니다.
- 따라서 forced **named** tool_choice(`{"type":"function","function":{"name":...}}`)는 faithful한 wire 표현이 없습니다. 반면 plain `auto`는 OpenAI-호환 엔드포인트로 통과하므로 `supports_tool_choice`는 `true`로 유지합니다.

## 동작 변화

`validate_tool_choice_request_with_capabilities`(`provider_config.ml:429`)는 `supports_named_tool_choice = false`일 때 named forced tool_choice를 typed `Unsupported_named_tool_choice` 에러로 거부합니다. 이 수정 전에는 Kimi에 named forced tool_choice를 **그대로 직렬화·전송**했고, Kimi는 이를 400 또는 silent-ignore했습니다. 수정 후에는 모델이 honor할 수 없는 요청을 보내는 대신 호출자가 타입 에러를 받습니다 (노 Silent Failure).

## 일관성 / 선례

동일한 "auto만 지원" 제약을 가진 **GLM은 이미 `supports_named_tool_choice = false`**로 인코딩돼 있습니다(`capabilities.ml`, Z.AI docs 2026-04-21 확인 주석). Kimi만 `true`로 비대칭이었습니다. 이 PR은 Kimi를 GLM과 동일하게 맞춥니다.

이는 OAS의 기존 설계 철학(Ollama 프로파일 주석의 "declaration-over-probing, conservative default")과도 정렬합니다 — native named 지원을 검증한 배포는 model catalog에서 per-entry override로 선언할 수 있습니다(base를 깨지 않음).

## 라이브 영향 범위

- **라이브 keeper 경로는 latent**: MASC keeper는 `sanitize_runtime_mcp_external_tool_choice`로 forced tool_choice를 `Auto`로 다운그레이드하므로 named forced를 Kimi에 보내지 않습니다. 이 수정은 주로 keeper 외 inline-tools 경로 및 향후 forced-named 사용에 대한 fail-closed 하드닝입니다.
- catalog row가 `supports_named_tool_choice`를 명시하지 않으면 base를 상속(`base.n && supports_tool_choice`)하므로, 이 base 수정이 SSOT-level 올바른 위치입니다.

## 범위에서 제외 (의도적)

- `tool_choice=required`(`Any`) 게이팅은 별도 관심사입니다. 현 main은 `Any`를 항상 통과시키고, GLM도 `supports_tool_choice = true`로 동일하게 둡니다. `Any`/required fail-closed는 `#2295`(forced-tool-choice fail-closed) 영역이며 이 PR과 중복되지 않습니다.
- 다른 모델(minimax는 이미 `named=false`, deepseek/qwen/gemma)은 후속 tick에서 동일 sweep으로 다룹니다.

## 검증

- `test/test_capabilities.ml`에 `test_kimi_tool_choice_capabilities` 추가: `supports_tools=true`, `supports_tool_choice=true`(auto), `supports_named_tool_choice=false`(named 거부) 단정. presets 그룹에 등록.
- 빌드/테스트는 CI에서 확인합니다 (로컬 focused 빌드 정책).

RFC-WAIVED: capabilities.ml은 RFC-gated subsystem(credential/keeper_sandbox/operator_control/dashboard-credential/hooks/workflow/repo_manager)이 아닙니다. 단일 모델 capability 플래그를 공식 문서에 맞추는 surgical correctness 수정입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
