### PR TITLE
fix(catalog): DeepSeek V4는 named forced tool_choice 거부 (thinking-mode 400)

### DIFF
--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -1229,7 +1229,11 @@ let deepseek_v4_test_entry id_prefix : Model_catalog.model_entry =
   ; max_output_tokens = Some 384_000
   ; supports_tools = Some true
   ; supports_tool_choice = Some true
-  ; supports_named_tool_choice = Some true
+  ; (* DeepSeek V4 thinking mode (the default for these thinking_object rows)
+       400s on forced tool_choice — both required and named function choice.
+       Mirrors the models.toml entries. Ref 2026-06-30: deepseek-ai/DeepSeek-V3
+       issue #1376, api-docs.deepseek.com/guides/function_calling. *)
+    supports_named_tool_choice = Some false
   ; supports_reasoning = Some true
   ; supports_extended_thinking = Some true
   ; thinking_control_format = Some "thinking_object"

--- a/models.toml
+++ b/models.toml
@@ -209,6 +209,14 @@ cache_write_multiplier = 1.0
 cache_read_multiplier = 1.0
 
 # DeepSeek Models
+# DeepSeek V4 (pro/flash) rejects forced tool_choice in thinking mode — the
+# default for these rows (thinking_control_format = thinking_object). Both
+# tool_choice="required" and a named function tool_choice return HTTP 400.
+# Ref checked 2026-06-30: api-docs.deepseek.com/guides/function_calling and
+# deepseek-ai/DeepSeek-V3 issue #1376. supports_named_tool_choice=false makes OAS
+# reject a named forced tool_choice (typed Unsupported_named_tool_choice) instead
+# of serializing a request the model 400s on. Plain auto still works, so
+# supports_tool_choice stays true (mirrors the Kimi/GLM profiles).
 [[models]]
 id_prefix = "deepseek-v4-pro"
 base = "openai_chat"
@@ -216,6 +224,7 @@ max_context_tokens = 1000000
 max_output_tokens = 384000
 supports_tools = true
 supports_tool_choice = true
+supports_named_tool_choice = false
 supports_reasoning = true
 supports_extended_thinking = true
 supports_reasoning_budget = true
@@ -236,6 +245,7 @@ max_context_tokens = 1000000
 max_output_tokens = 384000
 supports_tools = true
 supports_tool_choice = true
+supports_named_tool_choice = false
 supports_reasoning = true
 supports_extended_thinking = true
 supports_reasoning_budget = true
@@ -256,6 +266,7 @@ max_context_tokens = 1000000
 max_output_tokens = 384000
 supports_tools = true
 supports_tool_choice = true
+supports_named_tool_choice = false
 supports_reasoning = true
 supports_extended_thinking = true
 supports_reasoning_budget = true
@@ -276,6 +287,7 @@ max_context_tokens = 1000000
 max_output_tokens = 384000
 supports_tools = true
 supports_tool_choice = true
+supports_named_tool_choice = false
 supports_reasoning = true
 supports_extended_thinking = true
 supports_reasoning_budget = true

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -366,6 +366,9 @@ let test_lookup_deepseek_v4_flash () =
     check (option int) "context 1M" (Some 1_000_000) c.max_context_tokens;
     check (option int) "output 384K" (Some 384_000) c.max_output_tokens;
     check bool "tools" true c.supports_tools;
+    (* thinking mode (default) 400s on forced tool_choice; auto stays valid *)
+    check bool "accepts auto tool_choice" true c.supports_tool_choice;
+    check bool "rejects named forced tool_choice" false c.supports_named_tool_choice;
     check bool "reasoning" true c.supports_reasoning;
     check_thinking_control
       "uses thinking object"
@@ -381,6 +384,9 @@ let test_lookup_deepseek_v4_pro () =
     check (option int) "context 1M" (Some 1_000_000) c.max_context_tokens;
     check (option int) "output 384K" (Some 384_000) c.max_output_tokens;
     check bool "tools" true c.supports_tools;
+    (* thinking mode (default) 400s on forced tool_choice; auto stays valid *)
+    check bool "accepts auto tool_choice" true c.supports_tool_choice;
+    check bool "rejects named forced tool_choice" false c.supports_named_tool_choice;
     check bool "reasoning" true c.supports_reasoning;
     check_thinking_control
       "uses thinking object"


### PR DESCRIPTION
## 무엇을

`models.toml`의 DeepSeek V4 catalog 행 4개(`deepseek-v4-pro`, `deepseek-ai/deepseek-v4-pro`, `deepseek-v4-flash`, `deepseek-ai/deepseek-v4-flash`)에 `supports_named_tool_choice = false`를 명시합니다.

## 왜 (공식 문서 대조, 2026-06-30 확인)

per-model 공식 문서 sweep(#2298 Kimi에 이은 2번째 모델)에서 발견했습니다.

- **DeepSeek V4(pro/flash)는 thinking 모드에서 forced tool_choice를 HTTP 400으로 거부합니다** — `tool_choice="required"`와 named function tool_choice(`{"type":"function","function":{"name":...}}`) 둘 다. 그리고 thinking 모드가 이 모델들의 **기본값**입니다(해당 행의 `thinking_control_format = "thinking_object"`).
- 근거: `api-docs.deepseek.com/guides/function_calling` + `deepseek-ai/DeepSeek-V3` issue **#1376** ("DeepSeek V4 rejects tool_choice='required' and specific function tool_choice — breaks structured output in all agent frameworks").
- function calling 자체는 모든 thinking 모드에서 지원되므로 plain `auto`는 동작합니다 → `supports_tool_choice`는 `true` 유지.

## 문제

DeepSeek V4 행은 `base = "openai_chat"`이고 `supports_named_tool_choice`를 명시하지 않아 base(`openai_compat_chat`)의 **`true`를 상속**했습니다. 그 결과 OAS는 DeepSeek V4에 named forced tool_choice를 보낼 수 있다고 선언했지만, 실제로는 HTTP 400입니다. Kimi(#2298)보다 심각합니다 — silent-ignore가 아니라 hard 400 에러.

## 동작 변화

`validate_tool_choice_request_with_capabilities`(`provider_config.ml:429`)가 `supports_named_tool_choice = false`일 때 named forced tool_choice를 typed `Unsupported_named_tool_choice`로 거부합니다. 모델이 400을 반환할 요청을 직렬화하는 대신 호출자가 타입 에러를 받습니다 (노 Silent Failure).

## 일관성 / 선례

GLM·Kimi(#2298) 프로파일과 동일한 패턴입니다: tools 지원, auto 통과(`supports_tool_choice=true`), named forced 거부(`supports_named_tool_choice=false`).

`for_model_id`는 in-code fallback 없이 `Model_catalog.global()`(= 주입된 `models.toml`)만 사용하므로(capabilities.ml:964-966), `models.toml`이 SSOT입니다. catalog 행에 명시하는 것이 올바른 수정 위치입니다.

## 라이브 영향 범위

- **라이브 keeper 경로는 latent**: MASC keeper sanitizer가 forced tool_choice를 `Auto`로 다운그레이드하므로 named forced를 DeepSeek에 보내지 않습니다. 이 수정은 keeper 외 inline-tools 경로 및 structured-output 강제 경로에 대한 fail-closed 하드닝입니다.

## 범위에서 제외 (의도적)

- `tool_choice="required"`(`Any`) 게이팅은 별도 관심사입니다(현 main은 `Any` 항상 통과, GLM/Kimi도 동일). = `#2295`(forced fail-closed) 영역.
- **Gemma/Qwen은 변경하지 않습니다**: 공식 문서에서 named tool_choice 거부의 명확한 근거를 찾지 못했습니다(Qwen은 Hermes-style tool use 지원 가능성, Gemma는 serving-stack 의존). 증거 불충분 → deferred. 추측으로 false 처리하지 않습니다.

## 검증

- `test/test_capabilities.ml`의 `test_lookup_deepseek_v4_flash`/`_pro`에 `supports_tool_choice=true`(auto) + `supports_named_tool_choice=false`(named 거부) 단정 추가. 이 테스트는 `for_model_id`로 주입된 `models.toml`을 해석합니다.
- `deepseek_v4_test_entry` fixture(explicit-catalog 테스트용 스냅샷)도 `models.toml`을 미러링하도록 `Some false`로 갱신.
- 빌드/테스트는 CI에서 확인합니다.

RFC-WAIVED: `models.toml` catalog 데이터 + capabilities 테스트는 RFC-gated subsystem(credential/keeper_sandbox/operator_control/dashboard-credential/hooks/workflow/repo_manager)이 아닙니다. 공식 문서에 맞추는 per-model capability correctness 수정입니다.

관련: #2298 (Kimi 동일 발견 클래스, named tool_choice doc-conformance sweep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
