### PR TITLE
refactor(types): split conflated Thinking.thinking_type into signature option

### DIFF
--- a/lib/agent_tool.ml
+++ b/lib/agent_tool.ml
@@ -55,10 +55,10 @@ let api_usage_to_json = function
 
 let content_block_to_json = function
   | Text text -> `Assoc [ "type", `String "text"; "text", `String text ]
-  | Thinking { thinking_type; content } ->
+  | Thinking { content; signature } ->
     `Assoc
       [ "type", `String "thinking"
-      ; "thinking_type", `String thinking_type
+      ; "signature", (match signature with Some s -> `String s | None -> `Null)
       ; "content", `String content
       ]
   | RedactedThinking value ->

--- a/lib/context_reducer.ml
+++ b/lib/context_reducer.ml
@@ -618,7 +618,7 @@ let%test "estimate_block_tokens Text uses CJK-aware estimation" =
 let%test "estimate_block_tokens Thinking uses CJK-aware estimation" =
   let block =
     Thinking
-      { thinking_type = "thinking"
+      { signature = None
       ; content =
           "\xEB\xB6\x84\xEC\x84\x9D \xEC\xA4\x91\xEC\x9E\x85\xEB\x8B\x88\xEB\x8B\xA4"
       }

--- a/lib/llm_provider/api_common.ml
+++ b/lib/llm_provider/api_common.ml
@@ -54,12 +54,26 @@ let rec content_block_to_json_with
   = function
   | Text s ->
     `Assoc [ "type", `String "text"; "text", `String (Utf8_sanitize.sanitize s) ]
-  | Thinking { thinking_type; content } ->
-    `Assoc
-      [ "type", `String "thinking"
-      ; "signature", `String thinking_type
-      ; "thinking", `String (Utf8_sanitize.sanitize content)
-      ]
+  | Thinking { content; signature } ->
+    (* Anthropic verifies [signature] against the exact thinking text, so a
+       signed block is serialized byte-exact (no sanitize); unsigned provider
+       reasoning is sanitized defensively. A block without a signature omits the
+       field rather than emitting a fabricated one. *)
+    let thinking_text =
+      match signature with
+      | Some _ -> content
+      | None -> Utf8_sanitize.sanitize content
+    in
+    let fields =
+      match signature with
+      | Some s ->
+        [ "type", `String "thinking"
+        ; "signature", `String s
+        ; "thinking", `String thinking_text
+        ]
+      | None -> [ "type", `String "thinking"; "thinking", `String thinking_text ]
+    in
+    `Assoc fields
   | RedactedThinking data ->
     `Assoc [ "type", `String "redacted_thinking"; "data", `String data ]
   | ToolUse { id; name; input } ->
@@ -136,9 +150,9 @@ let rec content_block_of_json json =
     let text = json |> member "text" |> to_string in
     Some (Text text)
   | Some "thinking" ->
-    let thinking_type = json |> member "signature" |> to_string in
+    let signature = json |> member "signature" |> to_string_option in
     let content = json |> member "thinking" |> to_string in
-    Some (Thinking { thinking_type; content })
+    Some (Thinking { content; signature })
   | Some "redacted_thinking" ->
     let data = json |> member "data" |> to_string in
     Some (RedactedThinking data)

--- a/lib/llm_provider/backend_gemini.ml
+++ b/lib/llm_provider/backend_gemini.ml
@@ -437,7 +437,7 @@ let parse_response json =
            | `String s ->
              let is_thought = Cli_common_json.member_bool "thought" part in
              if is_thought
-             then [ Thinking { thinking_type = "thinking"; content = s } ]
+             then [ Thinking { signature = None; content = s } ]
              else [ Text s ]
            | _ ->
              (match part |> member "functionCall" with

--- a/lib/llm_provider/backend_glm.ml
+++ b/lib/llm_provider/backend_glm.ml
@@ -222,7 +222,7 @@ let extract_reasoning_content_json (resp : api_response) (json : Yojson.Safe.t)
          (match resp.content with
           | Thinking { content; _ } :: _ when String.equal content r -> resp
           | _ ->
-            let thinking_block = Thinking { thinking_type = "thinking"; content = r } in
+            let thinking_block = Thinking { signature = None; content = r } in
             { resp with content = thinking_block :: resp.content })
        | Some _ | None -> resp)
     | `List [] | `Assoc _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null ->

--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -269,7 +269,7 @@ let parse_ollama_response json_str =
         let thinking =
           match message |> member "thinking" with
           | `String s when not (Api_common.string_is_blank s) ->
-            [ Thinking { thinking_type = "thinking"; content = s } ]
+            [ Thinking { signature = None; content = s } ]
           | _ -> []
         in
         txt, tools, thinking

--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -222,7 +222,7 @@ let%test "tool_calls_to_openai_json empty for no tool_use" =
 let%test "openai_content_parts_of_blocks filters text and image" =
   let blocks =
     [ Text "hello"
-    ; Thinking { thinking_type = "reasoning"; content = "..." }
+    ; Thinking { signature = None; content = "..." }
     ; ToolUse { id = "tc1"; name = "fn"; input = `Null }
     ]
   in
@@ -554,7 +554,7 @@ let%test "openai_messages_of_message assistant excludes reasoning from content" 
   let msg =
     { role = Assistant
     ; content =
-        [ Thinking { thinking_type = "reasoning"; content = "hidden chain of thought" }
+        [ Thinking { signature = None; content = "hidden chain of thought" }
         ; Text "final answer"
         ]
     ; name = None
@@ -573,7 +573,7 @@ let%test "glm_messages_of_message preserves reasoning_content separately" =
   let msg =
     { role = Assistant
     ; content =
-        [ Thinking { thinking_type = "reasoning"; content = "step one" }
+        [ Thinking { signature = None; content = "step one" }
         ; ToolUse { id = "tc1"; name = "calc"; input = `Assoc [ "expr", `String "2+2" ] }
         ]
     ; name = None
@@ -1151,7 +1151,7 @@ let%test
   let messages =
     [ { role = Assistant
       ; content =
-          [ Thinking { thinking_type = "reasoning"; content = "use calculator" }
+          [ Thinking { signature = None; content = "use calculator" }
           ; ToolUse
               { id = "call_1"; name = "calc"; input = `Assoc [ "expr", `String "2+2" ] }
           ]
@@ -1535,7 +1535,7 @@ let%test "strip_thinking_blocks removes Thinking from all messages" =
       }
     ; { role = Assistant
       ; content =
-          [ Text "hi"; Thinking { thinking_type = "reasoning"; content = "step 1" } ]
+          [ Text "hi"; Thinking { signature = None; content = "step 1" } ]
       ; name = None
       ; tool_call_id = None
       ; metadata = []

--- a/lib/llm_provider/backend_openai_parse.ml
+++ b/lib/llm_provider/backend_openai_parse.ml
@@ -299,7 +299,7 @@ let parse_openai_response_result_json
     in
     let thinking_blocks =
       match reasoning_text with
-      | Some s -> [ Thinking { thinking_type = "reasoning"; content = s } ]
+      | Some s -> [ Thinking { signature = None; content = s } ]
       | None -> []
     in
     let stop_reason =

--- a/lib/llm_provider/backend_openai_responses.ml
+++ b/lib/llm_provider/backend_openai_responses.ml
@@ -418,9 +418,9 @@ let content_blocks_of_reasoning_item item =
        in
        if Api_common.string_is_blank content
        then []
-       else [ Thinking { thinking_type = "reasoning_summary"; content } ]
+       else [ Thinking { signature = None; content } ]
      | Some (`String text) when not (Api_common.string_is_blank text) ->
-       [ Thinking { thinking_type = "reasoning_summary"; content = text } ]
+       [ Thinking { signature = None; content = text } ]
      | Some (`String _)
      | Some (`Assoc _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null)
      | None -> [])

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -223,12 +223,12 @@ let finalize_stream_acc
       | None -> Ok None
       | Some Text_block -> Ok (Some (Types.Text text))
       | Some Thinking_block ->
-        let thinking_type =
+        let signature =
           match Hashtbl.find_opt acc.block_thinking_signatures idx with
-          | Some buf when Buffer.length buf > 0 -> Buffer.contents buf
-          | Some _ | None -> "thinking"
+          | Some buf when Buffer.length buf > 0 -> Some (Buffer.contents buf)
+          | Some _ | None -> None
         in
-        Ok (Some (Types.Thinking { thinking_type; content = text }))
+        Ok (Some (Types.Thinking { content = text; signature }))
       | Some Redacted_thinking_block ->
         (match Hashtbl.find_opt acc.block_tool_ids idx with
          | Some data when data <> "" -> Ok (Some (Types.RedactedThinking data))
@@ -539,7 +539,7 @@ let%test "finalize_stream_acc assembles thinking block" =
   | Error _ -> false
   | Ok result ->
     (match result.content with
-     | [ Types.Thinking { thinking_type = "thinking"; content = "reasoning..." } ] -> true
+     | [ Types.Thinking { content = "reasoning..."; signature = None } ] -> true
      | _ -> false)
 ;;
 
@@ -684,8 +684,8 @@ let%test "finalize_stream_acc preserves omitted thinking signature" =
     ; Types.MessageDelta { stop_reason = Some Types.EndTurn; usage = None }
     ];
   match finalize_stream_acc acc with
-  | Ok { content = [ Types.Thinking { thinking_type; content } ]; _ } ->
-    thinking_type = "sig_opaque" && content = ""
+  | Ok { content = [ Types.Thinking { content; signature } ]; _ } ->
+    signature = Some "sig_opaque" && content = ""
   | Ok _ | Error _ -> false
 ;;
 

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -206,12 +206,12 @@ let emit_synthetic_events (response : api_response) on_event =
        on_event (ContentBlockStart { index; content_type; tool_id; tool_name });
        (match block with
         | Text s -> on_event (ContentBlockDelta { index; delta = TextDelta s })
-        | Thinking { thinking_type; content } ->
+        | Thinking { content; signature } ->
           on_event (ContentBlockDelta { index; delta = ThinkingDelta content });
-          if thinking_type <> ""
-          then
-            on_event
-              (ContentBlockDelta { index; delta = ThinkingSignatureDelta thinking_type })
+          (match signature with
+           | Some s ->
+             on_event (ContentBlockDelta { index; delta = ThinkingSignatureDelta s })
+           | None -> ())
         | ToolUse { input; _ } ->
           on_event
             (ContentBlockDelta

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -246,8 +246,15 @@ let media_source_kind_of_string raw =
 type content_block =
   | Text of string
   | Thinking of
-      { thinking_type : string
-      ; content : string
+      { content : string
+      ; signature : string option
+        (** [Some s]: Anthropic cryptographic signature, replayed byte-exact on
+            tool turns (never sanitized or re-encoded). [None]: provider
+            reasoning that carries no verification signature
+            (OpenAI-compatible / Gemini / GLM / Ollama). Replaces the former
+            [thinking_type : string], which conflated this signature with a
+            free-form provider label ("reasoning" / "thinking" /
+            "reasoning_summary") that no consumer read. *)
       }
   | RedactedThinking of string
   | ToolUse of

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -120,8 +120,11 @@ val media_source_kind_of_string : string -> media_source_kind option
 type content_block =
   | Text of string
   | Thinking of
-      { thinking_type : string
-      ; content : string
+      { content : string
+      ; signature : string option
+        (** [Some s]: Anthropic cryptographic signature, replayed byte-exact on
+            tool turns. [None]: provider reasoning without a verification
+            signature (OpenAI-compatible / Gemini / GLM / Ollama). *)
       }
   | RedactedThinking of string
   | ToolUse of

--- a/lib/provider_mock.ml
+++ b/lib/provider_mock.ml
@@ -115,7 +115,7 @@ let thinking_response
   { id
   ; model
   ; stop_reason = EndTurn
-  ; content = [ Thinking { thinking_type = "thinking"; content = thinking }; Text text ]
+  ; content = [ Thinking { signature = None; content = thinking }; Text text ]
   ; usage =
       Some
         { input_tokens

--- a/test/test_agent_stream.ml
+++ b/test/test_agent_stream.ml
@@ -79,7 +79,7 @@ let test_emit_tool_use () =
 
 let test_emit_thinking () =
   let response =
-    make_response [ Types.Thinking { thinking_type = "sig"; content = "I think..." } ]
+    make_response [ Types.Thinking { signature = Some "sig"; content = "I think..." } ]
   in
   let events = collect_events response in
   Alcotest.(check int) "7 events" 7 (List.length events);
@@ -234,7 +234,7 @@ let test_text_delta_content () =
 let test_thinking_delta_content () =
   let response =
     make_response
-      [ Types.Thinking { thinking_type = "sig123"; content = "deep thought" } ]
+      [ Types.Thinking { signature = Some "sig123"; content = "deep thought" } ]
   in
   let events = collect_events response in
   match List.nth events 2 with
@@ -345,7 +345,7 @@ let test_roundtrip_mixed_block_count () =
   let response =
     make_response
       [ Types.Text "intro"
-      ; Types.Thinking { thinking_type = "sig"; content = "hmm" }
+      ; Types.Thinking { signature = Some "sig"; content = "hmm" }
       ; Types.Text "conclusion"
       ]
   in

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -62,7 +62,7 @@ let test_text_round_trip () =
 
 let test_thinking_round_trip () =
   let block =
-    Types.Thinking { thinking_type = "sig123"; content = "I think therefore I am" }
+    Types.Thinking { signature = Some "sig123"; content = "I think therefore I am" }
   in
   let json = Api.content_block_to_json block in
   match Api.content_block_of_json json with
@@ -572,7 +572,7 @@ let test_build_openai_body_qwen_preserve_replays_reasoning () =
   let messages =
     [ { Types.role = Types.Assistant
       ; content =
-          [ Types.Thinking { thinking_type = "reasoning"; content = "keep this" }
+          [ Types.Thinking { signature = None; content = "keep this" }
           ; Types.Text "answer"
           ]
       ; name = None
@@ -612,7 +612,7 @@ let test_build_openai_body_kimi_latest_replays_reasoning () =
   let messages =
     [ { Types.role = Types.Assistant
       ; content =
-          [ Types.Thinking { thinking_type = "reasoning"; content = "keep latest" }
+          [ Types.Thinking { signature = None; content = "keep latest" }
           ; Types.Text "answer"
           ]
       ; name = None
@@ -684,12 +684,12 @@ let test_build_openai_body_deepseek_replays_tool_reasoning_only () =
   let assistant_content tool =
     if tool
     then
-      [ Types.Thinking { thinking_type = "reasoning"; content = "call the tool" }
+      [ Types.Thinking { signature = None; content = "call the tool" }
       ; Types.ToolUse
           { id = "call_1"; name = "calculator"; input = `Assoc [ "expr", `String "2+2" ] }
       ]
     else
-      [ Types.Thinking { thinking_type = "reasoning"; content = "plain thought" }
+      [ Types.Thinking { signature = None; content = "plain thought" }
       ; Types.Text "answer"
       ]
   in
@@ -889,7 +889,7 @@ let test_build_openai_body_glm_preserves_reasoning_content () =
     [ { Types.role = Types.Assistant
       ; content =
           [ Types.Thinking
-              { thinking_type = "reasoning"; content = "I should call the calculator." }
+              { signature = None; content = "I should call the calculator." }
           ; Types.ToolUse
               { id = "call_1"
               ; name = "calculator"
@@ -1227,8 +1227,8 @@ let test_parse_openai_response_reasoning_content () =
   | Ok resp ->
     check int "2 content blocks" 2 (List.length resp.content);
     (match resp.content with
-     | [ Types.Thinking { thinking_type; content }; Types.Text text ] ->
-       check string "thinking_type" "reasoning" thinking_type;
+     | [ Types.Thinking { signature; content }; Types.Text text ] ->
+       check bool "thinking unsigned" true (signature = None);
        check
          string
          "thinking content"
@@ -1787,7 +1787,7 @@ let test_openai_error_returns_result () =
 let test_text_blocks_to_string () =
   let blocks =
     [ Types.Text "hello"
-    ; Types.Thinking { thinking_type = "s"; content = "hmm" }
+    ; Types.Thinking { signature = Some "s"; content = "hmm" }
     ; Types.RedactedThinking "r"
     ; Types.ToolUse { id = "t"; name = "n"; input = `Null }
     ; Types.ToolResult

--- a/test/test_approval.ml
+++ b/test/test_approval.ml
@@ -351,7 +351,7 @@ let test_non_tool_use_blocks_filtered () =
       ~hooks
       [ Text "some assistant text"
       ; ToolUse { id = "t1"; name = "safe"; input = `String "data" }
-      ; Thinking { thinking_type = "thinking"; content = "reasoning" }
+      ; Thinking { signature = None; content = "reasoning" }
       ; ToolUse { id = "t2"; name = "safe"; input = `String "more" }
       ]
   in
@@ -373,7 +373,7 @@ let test_only_non_tool_use_blocks () =
   let results =
     run_execute
       ~hooks
-      [ Text "just text"; Thinking { thinking_type = "thinking"; content = "thoughts" } ]
+      [ Text "just text"; Thinking { signature = None; content = "thoughts" } ]
   in
   check int "empty results" 0 (List.length results)
 ;;

--- a/test/test_backend_gemini.ml
+++ b/test/test_backend_gemini.ml
@@ -825,7 +825,7 @@ let test_thinking_part_roundtrip () =
   let messages =
     [ { Types.role = Assistant
       ; content =
-          [ Thinking { thinking_type = "thinking"; content = "Let me consider..." }
+          [ Thinking { signature = None; content = "Let me consider..." }
           ; Text "The answer is 42."
           ]
       ; name = None

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -148,7 +148,7 @@ let test_content_parts_cover_modalities () =
       ; Document
           { media_type = "application/pdf"; data = "doc"; source_type = Types.Base64 }
       ; Audio { media_type = "wav"; data = "aud"; source_type = Types.Base64 }
-      ; Thinking { thinking_type = "reasoning"; content = "hidden" }
+      ; Thinking { signature = None; content = "hidden" }
       ; RedactedThinking "redacted"
       ; ToolUse { id = "tc"; name = "tool"; input = `Assoc [] }
       ]
@@ -250,7 +250,7 @@ let test_openai_user_messages_text_tool_and_empty () =
   check_string "user content" "first\nsecond" (member "content" user_json |> to_string);
   let empty_user =
     Serialize.openai_messages_of_message
-      (msg User [ Thinking { thinking_type = ""; content = "x" } ])
+      (msg User [ Thinking { signature = None; content = "x" } ])
   in
   check_int "empty user drops message" 0 (List.length empty_user)
 ;;
@@ -387,7 +387,7 @@ let test_assistant_tool_calls_openai_ollama_and_glm () =
   let replay_assistant =
     msg
       Assistant
-      [ Thinking { thinking_type = "reasoning"; content = "because" }
+      [ Thinking { signature = None; content = "because" }
       ; ToolUse { id = "call-2"; name = "lookup"; input = `Assoc [ "q", `String "y" ] }
       ]
   in
@@ -431,7 +431,7 @@ let test_assistant_tool_calls_openai_ollama_and_glm () =
     Serialize.glm_messages_of_message
       (msg
          Assistant
-         [ Text "answer"; Thinking { thinking_type = "reasoning"; content = "because" } ])
+         [ Text "answer"; Thinking { signature = None; content = "because" } ])
     |> only "glm"
   in
   check_string "glm content" "answer" (member "content" glm |> to_string);
@@ -612,7 +612,7 @@ let test_strip_thinking_blocks () =
   let messages =
     [ msg
         Assistant
-        [ Thinking { thinking_type = "reasoning"; content = "x" }; Text "visible" ]
+        [ Thinking { signature = None; content = "x" }; Text "visible" ]
     ; msg User [ Text "same" ]
     ]
   in
@@ -690,7 +690,7 @@ let test_tool_choice_and_tool_schema_conversion () =
 ;;
 
 let ignored_blocks : content_block list =
-  [ Thinking { thinking_type = "reasoning"; content = "   " }
+  [ Thinking { signature = None; content = "   " }
   ; RedactedThinking "hidden"
   ; ToolResult
       { tool_use_id = "call-x"
@@ -734,7 +734,7 @@ let test_serializer_ignored_block_variants () =
     true
     (member "reasoning_content" glm = `Null);
   let tool_fallback_blocks =
-    [ Thinking { thinking_type = "reasoning"; content = "   " }
+    [ Thinking { signature = None; content = "   " }
     ; RedactedThinking "hidden"
     ; ToolUse { id = "local-call"; name = "local"; input = `Null }
     ; Image { media_type = "image/png"; data = "img"; source_type = Types.Base64 }
@@ -1116,8 +1116,8 @@ let test_responses_parse_reasoning_and_function_call () =
     check_string "model" "gpt-5.5" response.model;
     check_bool "stop tool use" true (response.stop_reason = StopToolUse);
     (match response.content with
-     | [ Thinking { thinking_type; content }; ToolUse { id; name; input } ] ->
-       check_string "thinking type" "reasoning_summary" thinking_type;
+     | [ Thinking { signature; content }; ToolUse { id; name; input } ] ->
+       check_bool "thinking unsigned" true (signature = None);
        check_string "thinking content" "Need current weather before answering." content;
        check_string "tool call_id" "call_weather" id;
        check_string "tool name" "get_weather" name;
@@ -1317,7 +1317,7 @@ let test_responses_build_request_round_trips_tool_result_items () =
         [ msg User [ Text "weather?" ]
         ; msg
             Assistant
-            [ Thinking { thinking_type = "reasoning_summary"; content = "Need a tool." }
+            [ Thinking { signature = None; content = "Need a tool." }
             ; ToolUse
                 { id = "call_weather"
                 ; name = "get_weather"

--- a/test/test_backend_tool_call_harness.ml
+++ b/test/test_backend_tool_call_harness.ml
@@ -126,7 +126,7 @@ let test_validate_response_flags_unknown_tool_and_stop_reason () =
     mk_response
       ~stop_reason:T.EndTurn
       [ T.ToolUse { id = "call-2"; name = "undeclared"; input = `Assoc [] }
-      ; T.Thinking { thinking_type = "visible"; content = "reason" }
+      ; T.Thinking { signature = None; content = "reason" }
       ; T.RedactedThinking "redacted"
       ; T.ToolResult
           { tool_use_id = "call-2"

--- a/test/test_budget_strategy.ml
+++ b/test/test_budget_strategy.ml
@@ -197,7 +197,7 @@ let test_reduce_aggressive_drops_thinking () =
     [ user_msg "turn1"
     ; { Types.role = Assistant
       ; content =
-          [ Types.Thinking { thinking_type = "thinking"; content = "long thought" }
+          [ Types.Thinking { signature = None; content = "long thought" }
           ; Types.Text "answer"
           ]
       ; name = None

--- a/test/test_bug_hunt.ml
+++ b/test/test_bug_hunt.ml
@@ -38,7 +38,7 @@ let asst_msg text =
 let thinking_only_msg content =
   Types.
     { role = Assistant
-    ; content = [ Thinking { thinking_type = "thinking"; content } ]
+    ; content = [ Thinking { signature = None; content } ]
     ; name = None
     ; tool_call_id = None
     ; metadata = []

--- a/test/test_canonical_projections.ml
+++ b/test/test_canonical_projections.ml
@@ -14,7 +14,7 @@ let mk_image () =
 let test_summarize_blocks_counts () =
   let blocks =
     [ Types.Text "hello"
-    ; Types.Thinking { thinking_type = "thinking"; content = "abcde" }
+    ; Types.Thinking { signature = None; content = "abcde" }
     ; Types.RedactedThinking "opaque"
     ; Types.Text "   " (* whitespace-only: trimmed to 0 chars *)
     ; mk_image ()

--- a/test/test_canonical_tool.ml
+++ b/test/test_canonical_tool.ml
@@ -61,7 +61,7 @@ let test_result_preserves_is_error () =
 let test_result_none_for_non_toolresult () =
   let cases =
     [ Types.Text "hi"
-    ; Types.Thinking { thinking_type = "thinking"; content = "..." }
+    ; Types.Thinking { signature = None; content = "..." }
     ; Types.RedactedThinking "redacted"
     ; Types.ToolUse { id = "call_x"; name = "t"; input = `Null }
     ; Types.Image { media_type = "image/png"; data = "AAAA"; source_type = Types.Base64 }

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -1263,9 +1263,9 @@ let test_complete_stream_preserves_thinking_signature () =
     | Ok resp ->
       check bool "stop tool use" true (resp.stop_reason = Types.StopToolUse);
       (match resp.content with
-       | [ Types.Thinking { thinking_type; content }; Types.ToolUse { id; name; input } ]
+       | [ Types.Thinking { signature; content }; Types.ToolUse { id; name; input } ]
          ->
-         check string "thinking signature" "sig_opaque" thinking_type;
+         check bool "thinking signature" true (signature = Some "sig_opaque");
          check string "thinking content" "Need a lookup." content;
          check string "tool id" "tu_1" id;
          check string "tool name" "lookup" name;

--- a/test/test_context_reducer.ml
+++ b/test/test_context_reducer.ml
@@ -721,7 +721,7 @@ let test_drop_thinking_removes () =
     [ Types.
         { role = Assistant
         ; content =
-            [ Thinking { thinking_type = ""; content = "internal reasoning" }
+            [ Thinking { signature = None; content = "internal reasoning" }
             ; Text "answer"
             ]
         ; name = None
@@ -753,7 +753,7 @@ let test_drop_thinking_preserves_recent () =
     ; Types.
         { role = Assistant
         ; content =
-            [ Thinking { thinking_type = ""; content = "recent thinking" }
+            [ Thinking { signature = None; content = "recent thinking" }
             ; Text "answer"
             ]
         ; name = None
@@ -782,7 +782,7 @@ let test_drop_thinking_preserves_tool_use_thinking () =
     ; Types.
         { role = Assistant
         ; content =
-            [ Thinking { thinking_type = "thinking"; content = "pick tool" }
+            [ Thinking { signature = None; content = "pick tool" }
             ; RedactedThinking "encrypted"
             ; ToolUse { id = "t1"; name = "search"; input = `Assoc [] }
             ]
@@ -824,7 +824,7 @@ let test_compose () =
     [ Types.
         { role = Assistant
         ; content =
-            [ Thinking { thinking_type = ""; content = "old thinking" }
+            [ Thinking { signature = None; content = "old thinking" }
             ; Text "old answer"
             ]
         ; name = None

--- a/test/test_defaults_unit.ml
+++ b/test/test_defaults_unit.ml
@@ -126,7 +126,7 @@ let () =
               [ mk Types.User [ Text "first question" ]
               ; mk
                   Types.Assistant
-                  [ Thinking { thinking_type = "thinking"; content = "let me think" }
+                  [ Thinking { signature = None; content = "let me think" }
                   ; Text "first answer"
                   ]
               ; mk Types.User [ Text "second question" ]

--- a/test/test_http_client.ml
+++ b/test/test_http_client.ml
@@ -348,7 +348,7 @@ let test_api_common_text_blocks_to_string () =
       [ Text "hello"
       ; ToolUse { id = "t1"; name = "fn"; input = `Null }
       ; Text "world"
-      ; Thinking { thinking_type = "sig"; content = "thought" }
+      ; Thinking { signature = Some "sig"; content = "thought" }
       ]
   in
   let result = Api_common.text_blocks_to_string blocks in

--- a/test/test_llm_cache.ml
+++ b/test/test_llm_cache.ml
@@ -146,7 +146,7 @@ let test_roundtrip_text () =
 let test_roundtrip_thinking () =
   let resp =
     simple_response
-      [ Thinking { thinking_type = "thinking"; content = "let me think..." }
+      [ Thinking { signature = None; content = "let me think..." }
       ; Text "answer"
       ]
   in
@@ -403,7 +403,7 @@ let test_roundtrip_binary_block () =
 let test_roundtrip_mixed_content () =
   let resp =
     simple_response
-      [ Thinking { thinking_type = "thinking"; content = "hmm" }
+      [ Thinking { signature = None; content = "hmm" }
       ; Text "answer"
       ; ToolUse { id = "tu_1"; name = "calc"; input = `Int 42 }
       ]

--- a/test/test_llm_provider_cov.ml
+++ b/test/test_llm_provider_cov.ml
@@ -277,7 +277,7 @@ let test_string_is_blank () =
 let test_text_blocks_to_string () =
   let blocks : Types.content_block list =
     [ Text "hello"
-    ; Thinking { thinking_type = "t"; content = "reason" }
+    ; Thinking { signature = Some "t"; content = "reason" }
     ; ToolUse { id = "t1"; name = "tool"; input = `Null }
     ; Text "world"
     ]
@@ -321,7 +321,7 @@ let test_content_block_to_json_text () =
 let test_content_block_to_json_thinking () =
   let json =
     Api_common.content_block_to_json
-      (Thinking { thinking_type = "sig123"; content = "reason" })
+      (Thinking { signature = Some "sig123"; content = "reason" })
   in
   let open Yojson.Safe.Util in
   Alcotest.(check string) "type" "thinking" (json |> member "type" |> to_string);
@@ -413,7 +413,7 @@ let test_content_block_of_json_thinking () =
       ]
   in
   match Api_common.content_block_of_json json with
-  | Some (Thinking { thinking_type = "sig"; content = "reason" }) -> ()
+  | Some (Thinking { signature = Some "sig"; content = "reason" }) -> ()
   | _ -> Alcotest.fail "thinking roundtrip"
 ;;
 

--- a/test/test_observability_default.ml
+++ b/test/test_observability_default.ml
@@ -96,7 +96,7 @@ let thinking_then_tool_response : Types.api_response =
   ; model = "mock-model"
   ; stop_reason = Types.StopToolUse
   ; content =
-      [ Types.Thinking { thinking_type = "thinking"; content = "I should check the time" }
+      [ Types.Thinking { signature = None; content = "I should check the time" }
       ; Types.ToolUse
           { id = "call_1"
           ; name = "get_time"

--- a/test/test_pipeline_deep.ml
+++ b/test/test_pipeline_deep.ml
@@ -18,7 +18,7 @@ let test_reasoning_multiple_messages () =
   let messages : Types.message list =
     [ { role = Assistant
       ; content =
-          [ Types.Thinking { thinking_type = "thinking"; content = "First thought" }
+          [ Types.Thinking { signature = None; content = "First thought" }
           ; Types.Text "response 1"
           ]
       ; name = None
@@ -34,7 +34,7 @@ let test_reasoning_multiple_messages () =
     ; { role = Assistant
       ; content =
           [ Types.Thinking
-              { thinking_type = "thinking"
+              { signature = None
               ; content = "Second thought, I'm not sure about this"
               }
           ; Types.Text "response 2"
@@ -79,7 +79,7 @@ let test_reasoning_no_tool_rationale_inference () =
     [ { role = Assistant
       ; content =
           [ Types.Thinking
-              { thinking_type = "thinking"
+              { signature = None
               ; content = "I should use the search function to find info"
               }
           ; Types.Text "Searching now"
@@ -112,7 +112,7 @@ let test_reasoning_no_uncertainty_marker_inference () =
          [ { role = Assistant
            ; content =
                [ Types.Thinking
-                   { thinking_type = "thinking"; content = "Analysis: " ^ marker }
+                   { signature = None; content = "Analysis: " ^ marker }
                ]
            ; name = None
            ; tool_call_id = None
@@ -134,7 +134,7 @@ let test_reasoning_no_uncertainty () =
     [ { role = Assistant
       ; content =
           [ Types.Thinking
-              { thinking_type = "thinking"; content = "The answer is clearly 42" }
+              { signature = None; content = "The answer is clearly 42" }
           ]
       ; name = None
       ; tool_call_id = None

--- a/test/test_property_advanced.ml
+++ b/test/test_property_advanced.ml
@@ -12,7 +12,7 @@ let content_block_gen =
   QCheck.Gen.oneof
     [ QCheck.Gen.map (fun s -> Text s) QCheck.Gen.string_printable
     ; QCheck.Gen.map2
-        (fun t c -> Thinking { thinking_type = t; content = c })
+        (fun t c -> Thinking { signature = Some t; content = c })
         QCheck.Gen.string_printable
         QCheck.Gen.string_printable
     ; QCheck.Gen.map (fun s -> RedactedThinking s) QCheck.Gen.string_printable

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -579,7 +579,7 @@ let test_kimi_direct_tool_result_uses_text_blocks () =
     [ { role = Assistant
       ; content =
           [ Thinking
-              { thinking_type = "sig_1"; content = "I should call the calculator." }
+              { signature = Some "sig_1"; content = "I should call the calculator." }
           ; ToolUse
               { id = "tool_1"
               ; name = "calculator"
@@ -646,7 +646,7 @@ let test_glm_preserved_reasoning_replay_and_preserves_auto_tool_choice () =
     [ { role = Assistant
       ; content =
           [ Thinking
-              { thinking_type = "reasoning"; content = "I need the calculator result." }
+              { signature = None; content = "I need the calculator result." }
           ; ToolUse
               { id = "call_1"
               ; name = "calculator"
@@ -850,7 +850,7 @@ let response_with_thinking =
   { id = "resp-thinking"
   ; model = "auto"
   ; stop_reason = EndTurn
-  ; content = [ Thinking { thinking_type = "thinking"; content = "reasoning" } ]
+  ; content = [ Thinking { signature = None; content = "reasoning" } ]
   ; usage
   ; telemetry = None
   }

--- a/test/test_snapshot_provider_serialization.ml
+++ b/test/test_snapshot_provider_serialization.ml
@@ -399,7 +399,7 @@ let zai_glm_messages_with_reasoning =
   ; msg
       Assistant
       [ Text "answer"
-      ; Thinking { thinking_type = "reasoning"; content = "chain of thought" }
+      ; Thinking { signature = None; content = "chain of thought" }
       ]
   ]
 ;;

--- a/test/test_stream_accumulator.ml
+++ b/test/test_stream_accumulator.ml
@@ -335,8 +335,8 @@ let test_finalize_thinking_signature_block () =
   | Error err -> fail_unexpected_stream_error err
   | Ok resp ->
     (match List.hd resp.content with
-     | Thinking { thinking_type; content } ->
-       Alcotest.(check string) "signature" "sig_opaque" thinking_type;
+     | Thinking { signature; content } ->
+       Alcotest.(check bool) "signature" true (signature = Some "sig_opaque");
        Alcotest.(check string) "omitted thinking text" "" content
      | _ -> Alcotest.fail "expected Thinking")
 ;;

--- a/test/test_streaming.ml
+++ b/test/test_streaming.ml
@@ -383,7 +383,7 @@ let test_synthetic_thinking () =
     { id = "msg-t"
     ; model = "test"
     ; stop_reason = EndTurn
-    ; content = [ Thinking { thinking_type = "sig"; content = "I think..." } ]
+    ; content = [ Thinking { signature = Some "sig"; content = "I think..." } ]
     ; usage = None
     ; telemetry = None
     }
@@ -449,7 +449,7 @@ let test_synthetic_multi_block () =
     ; model = "test"
     ; stop_reason = EndTurn
     ; content =
-        [ Thinking { thinking_type = "s"; content = "hmm" }
+        [ Thinking { signature = Some "s"; content = "hmm" }
         ; Text "answer"
         ; ToolUse { id = "tu2"; name = "read"; input = `Assoc [] }
         ]

--- a/test/test_structured.ml
+++ b/test/test_structured.ml
@@ -175,7 +175,7 @@ let test_schema_optional_params () =
 let test_extract_with_thinking_blocks () =
   let input_json = `Assoc [ "name", `String "Bob"; "age", `Int 25 ] in
   let content =
-    [ Types.Thinking { thinking_type = "sig"; content = "some thinking..." }
+    [ Types.Thinking { signature = Some "sig"; content = "some thinking..." }
     ; Text "preamble"
     ; ToolUse { id = "tu_t"; name = "extract_person"; input = input_json }
     ]

--- a/test/test_structured_coverage.ml
+++ b/test/test_structured_coverage.ml
@@ -113,7 +113,7 @@ let test_json_extractor_skips_non_text () =
   in
   let resp =
     make_response
-      [ Thinking { thinking_type = "s"; content = "thinking" }
+      [ Thinking { signature = Some "s"; content = "thinking" }
       ; ToolUse { id = "tu"; name = "tool"; input = `Null }
       ; Text {|{"v": 99}|}
       ]
@@ -138,7 +138,7 @@ let test_text_extractor_only_non_text () =
   let resp =
     make_response
       [ ToolUse { id = "t"; name = "n"; input = `Null }
-      ; Thinking { thinking_type = "s"; content = "x" }
+      ; Thinking { signature = Some "s"; content = "x" }
       ]
   in
   match extract resp with
@@ -345,7 +345,7 @@ let test_extract_mixed_blocks () =
   let input_json = `Assoc [ "name", `String "Eve"; "age", `Int 50 ] in
   let content =
     [ Text "preamble"
-    ; Thinking { thinking_type = "s"; content = "reasoning" }
+    ; Thinking { signature = Some "s"; content = "reasoning" }
     ; ToolResult
         { tool_use_id = "old"
         ; content = "old result"

--- a/test/test_succession.ml
+++ b/test/test_succession.ml
@@ -245,7 +245,7 @@ let test_normalize_strips_thinking () =
   let msgs =
     [ { Types.role = Types.Assistant
       ; content =
-          [ Types.Thinking { thinking_type = "thinking"; content = "hmm" }
+          [ Types.Thinking { signature = None; content = "hmm" }
           ; Types.Text "answer"
           ]
       ; name = None

--- a/test/test_thinking_control_dialects.ml
+++ b/test/test_thinking_control_dialects.ml
@@ -401,11 +401,11 @@ let assistant_with_reasoning ?(tool = false) () =
   let content =
     if tool
     then
-      [ Thinking { thinking_type = "reasoning"; content = "use calculator" }
+      [ Thinking { signature = None; content = "use calculator" }
       ; ToolUse { id = "call_1"; name = "calc"; input = `Assoc [ "expr", `String "2+2" ] }
       ]
     else
-      [ Thinking { thinking_type = "reasoning"; content = "plain thought" }
+      [ Thinking { signature = None; content = "plain thought" }
       ; Text "answer"
       ]
   in

--- a/test/test_turn_params.ml
+++ b/test/test_turn_params.ml
@@ -41,7 +41,7 @@ let test_reasoning_with_thinking () =
     [ { role = Assistant
       ; content =
           [ Types.Thinking
-              { thinking_type = "thinking"; content = "I'm not sure about this approach" }
+              { signature = None; content = "I'm not sure about this approach" }
           ; Types.Text "Here is my answer"
           ]
       ; name = None
@@ -60,7 +60,7 @@ let test_reasoning_tool_rationale () =
     [ { role = Assistant
       ; content =
           [ Types.Thinking
-              { thinking_type = "thinking"
+              { signature = None
               ; content = "I should use the search tool to find information"
               }
           ; Types.Text "Let me search for that"

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -322,7 +322,7 @@ let test_tool_choice_of_json_error_non_object () =
 let test_show_content_block_variants () =
   let blocks =
     [ Types.Text "hello"
-    ; Types.Thinking { thinking_type = "sig"; content = "hmm" }
+    ; Types.Thinking { signature = Some "sig"; content = "hmm" }
     ; Types.RedactedThinking "redacted"
     ; Types.ToolUse { id = "tu1"; name = "read"; input = `Null }
     ; Types.ToolResult
@@ -738,7 +738,7 @@ let test_text_of_content_text_only () =
 let test_text_of_content_mixed () =
   let content =
     [ Types.Text "start"
-    ; Types.Thinking { thinking_type = "sig"; content = "hmm" }
+    ; Types.Thinking { signature = Some "sig"; content = "hmm" }
     ; Types.ToolUse { id = "tu1"; name = "search"; input = `Null }
     ; Types.Text "end"
     ]
@@ -801,7 +801,7 @@ let test_text_of_response_and_usage_helpers () =
             ; json = None
             ; content_blocks = None
             }
-        ; Types.Thinking { thinking_type = "sig"; content = "hidden" }
+        ; Types.Thinking { signature = Some "sig"; content = "hidden" }
         ]
     ; usage = Some usage
     ; telemetry = None
@@ -964,7 +964,7 @@ let summary_contains ~needle response =
 let test_response_shape_thinking_only_is_not_deliverable () =
   let response =
     response
-      ~content:[ Types.Thinking { thinking_type = "reasoning"; content = "hidden" } ]
+      ~content:[ Types.Thinking { signature = None; content = "hidden" } ]
       ()
   in
   let shape = Response_shape.summarize response in
@@ -1027,7 +1027,7 @@ let test_response_shape_thinking_plus_text_is_deliverable () =
   let response =
     response
       ~content:
-        [ Types.Thinking { thinking_type = "reasoning"; content = "hidden" }
+        [ Types.Thinking { signature = None; content = "hidden" }
         ; Types.Text " final answer "
         ]
       ()
@@ -1051,7 +1051,7 @@ let test_response_shape_thinking_plus_tool_use_is_deliverable () =
   let response =
     response
       ~content:
-        [ Types.Thinking { thinking_type = "reasoning"; content = "hidden" }
+        [ Types.Thinking { signature = None; content = "hidden" }
         ; Types.ToolUse { id = "tool-1"; name = "search"; input = `Assoc [] }
         ]
       ()


### PR DESCRIPTION
## 무엇을

`content_block`의 `Thinking { thinking_type : string; content }` 필드를 `Thinking { content; signature : string option }`으로 교체합니다.

## 왜 (적대적 발견, 2026-06-30)

`thinking_type : string`이 **두 비호환 개념을 주석 없이 오버로드**하고 있었습니다:

- **(A) Anthropic 암호서명** (opaque, tool 턴에 byte-exact 무수정 replay 필수) — `api_common.ml`이 wire `"signature"`로 직렬화/파싱, streaming `ThinkingSignatureDelta`, accumulator `block_thinking_signatures`.
- **(B) provider reasoning 라벨** ("reasoning" / "thinking" / "reasoning_summary") — OpenAI-compat·Gemini·GLM·Ollama 백엔드가 자유 문자열로 부착. **어떤 consumer도 이 값을 behavioral하게 읽지 않음** (전수 확인: 0 match).

이 오버로드는 다음을 유발했습니다:
- **illegal state representable**: 라벨이 Anthropic 서명 자리에 직렬화 (`"signature":"reasoning"`) → cross-provider replay 시 위조 서명.
- **string-match 게이트**: `streaming.ml`의 `if thinking_type <> ""`가 서명 방출을 문자열 공백 검사로 게이팅.
- **가짜 서명 방출**: synthetic SSE round-trip이 비-Anthropic 라벨("reasoning")을 `ThinkingSignatureDelta`로 실어, MASC가 9바이트 "서명"을 기록.
- **서명된 content sanitize**: `Utf8_sanitize.sanitize`가 Anthropic 서명 검증 대상 thinking 텍스트를 수정할 수 있는 latent 위험.

## 변경

`signature : string option`:
- `Some s`: Anthropic 서명. 직렬화 시 byte-exact (sanitize 안 함), `"signature"` 키 emit.
- `None`: 서명 없는 provider reasoning. `"signature"` 키 생략, content는 방어적으로 sanitize.

효과:
- **label-as-signature unrepresentable** (타입 레벨). 라벨 string은 제거 — 아무도 안 읽었고, streaming에선 빈 문자열/non-streaming에선 라벨로 inconsistent했음.
- `streaming.ml`: `match signature with Some s -> emit | None -> ()` (string-match 게이트 제거).
- accumulator: 서명 바이트 없으면 `None` (가짜 "thinking" 기본값 제거).
- Anthropic thinking content byte-exact 직렬화 → 서명 검증 불일치 불가.

## Downstream 안전성 (MASC 교차 확인)

- MASC는 thinking 블록을 `Agent_sdk.Types.Thinking _` (필드 무시)로 소비 — `worker_oas.ml`, `fusion_oas.ml`, `runtime_agent.ml`, `keeper_agent_prompt_metrics.ml`. **필드 변경 무영향**.
- MASC `keeper_chat_oas_stream_bridge.ml`은 `ThinkingSignatureDelta`를 `Oas_thinking_signature_delta { signature_bytes }`(바이트 수만)로 변환, discord/slack 표시 채널은 `_ ->`로 무시. 비-Anthropic의 가짜 서명 방출 제거는 **개선** (가짜 byte count 사라짐).
- MASC `keeper_context_core_message_json.ml` 주석도 "signature=canonical carrier, thinking=historical wire"로 본 방향과 정렬.
- `thinking_type` JSON 키를 읽는 MASC 코드 0건.

## 검증

- lib/ 전 construction·serialize·parse·streaming·accumulator 사이트 마이그레이션, `Thinking { content; _ }` 매치(sandbox_runner/hooks/context_reducer_estimate/response_shape)는 `_`가 새 필드 흡수해 무변경.
- test/ 32파일: 라벨→`None`, 서명 placeholder→`Some`, 패턴매치 바인딩+assertion 5곳 수작업(`signature = Some/None` bool 검사).
- 빌드/테스트는 CI에서 확인 (로컬 focused 정책). snapshot 테스트는 None 블록의 signature 키 생략으로 재생성이 필요할 수 있음 — CI 결과로 확인.

## 범위

`lib/llm_provider/types.ml` content_block 표현 + 직렬화. tool_choice/capabilities (#2232 영역)와 직교 — 충돌 없음.

RFC-WAIVED: `lib/llm_provider/types.ml` content-block 표현은 RFC-gated subsystem(credential/keeper_sandbox/operator_control/dashboard-credential/hooks/workflow/repo_manager)이 아닙니다. parse-don't-validate 타입 하드닝(string conflation → typed option)입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
