### PR TITLE
fix(llm_provider): validate UTF-8 via Stdlib decoder, not byte-length

### DIFF
--- a/lib/llm_provider/utf8_sanitize.ml
+++ b/lib/llm_provider/utf8_sanitize.ml
@@ -1,72 +1,38 @@
-(** Replace invalid UTF-8 bytes with U+FFFD replacement character
-    and disallowed control characters with spaces.
-    Valid UTF-8 with no control chars is passed through unchanged.  O(n).
+(** Replace invalid UTF-8 sequences with the U+FFFD replacement character and
+    disallowed control characters with spaces. Valid UTF-8 with no control
+    chars is passed through unchanged. O(n).
 
-    Control characters (0x00-0x1F except LF/CR/TAB, plus DEL 0x7F)
-    break LLM prompt formatting. Replacing them at the SDK level
-    prevents consumers from needing their own sanitize pass.
+    Validity is decided by the OCaml Stdlib UTF-8 decoder
+    ([String.is_valid_utf_8] / [String.get_utf_8_uchar]), so overlong
+    encodings, UTF-16 surrogates (U+D800..U+DFFF), and code points above
+    U+10FFFF are rejected per the Unicode standard. A hand-rolled byte-length
+    check cannot reject those classes (e.g. the overlong [0xC0 0x80] has a
+    structurally well-formed lead byte and continuation), which is why this
+    delegates to the Stdlib decoder — the same primitive [Tool_index] already
+    uses.
 
-    @since 0.138.0 — control character sanitization added *)
+    Control characters (0x00-0x1F except LF/CR/TAB, plus DEL 0x7F) break LLM
+    prompt formatting. Replacing them at the SDK level prevents consumers from
+    needing their own sanitize pass.
+
+    @since 0.138.0 — control character sanitization added
+    @since 0.139.0 — UTF-8 validation delegated to the Stdlib decoder *)
 
 let replacement = "\xEF\xBF\xBD" (* U+FFFD *)
 
 (** True for ASCII control characters that break prompt formatting.
-    LF (0x0A), CR (0x0D), TAB (0x09) are kept — prompts rely on them. *)
+    LF (0x0A), CR (0x0D), TAB (0x09) are kept — prompts rely on them.
+    All disallowed control characters are single-byte ASCII (< 0x80). *)
 let is_disallowed_control byte =
   (byte < 0x20 && byte <> 0x0A && byte <> 0x0D && byte <> 0x09) || byte = 0x7F
 ;;
 
-(** Expected byte length of a UTF-8 sequence given its lead byte.
-    Returns 0 for invalid lead bytes (0x80..0xBF, 0xF8+). *)
-let expected_seq_len byte =
-  if byte < 0x80
-  then 1
-  else if byte < 0xC0
-  then 0 (* continuation byte as lead *)
-  else if byte < 0xE0
-  then 2
-  else if byte < 0xF0
-  then 3
-  else if byte < 0xF8
-  then 4
-  else 0 (* 0xF8+ is invalid *)
-;;
-
-(** Check whether [s.[i+1] .. s.[i+n-1]] are all continuation bytes (0x80..0xBF). *)
-let continuations_valid s i n =
-  let len = String.length s in
-  if i + n > len
-  then false
-  else (
-    let rec loop j =
-      if j >= n
-      then true
-      else (
-        let b = Char.code (String.unsafe_get s (i + j)) in
-        b >= 0x80 && b < 0xC0 && loop (j + 1))
-    in
-    loop 1)
-;;
-
-(** Fast-path: scan the string and return [true] if it is already
-    valid UTF-8 with no disallowed control characters. *)
+(** Fast-path: already valid UTF-8 with no disallowed control characters.
+    Disallowed control characters are all single-byte ASCII, so a byte scan
+    settles that half without decoding. *)
 let is_clean s =
-  let len = String.length s in
-  let rec check i =
-    if i >= len
-    then true
-    else (
-      let byte = Char.code (String.unsafe_get s i) in
-      let n = expected_seq_len byte in
-      if n = 0
-      then false (* invalid lead *)
-      else if n = 1
-      then if is_disallowed_control byte then false else check (i + 1)
-      else if not (continuations_valid s i n)
-      then false
-      else check (i + n))
-  in
-  check 0
+  String.is_valid_utf_8 s
+  && not (String.exists (fun c -> is_disallowed_control (Char.code c)) s)
 ;;
 
 let sanitize s =
@@ -75,37 +41,29 @@ let sanitize s =
   else (
     let len = String.length s in
     let buf = Buffer.create len in
-    let rec loop i =
-      if i >= len
-      then Buffer.contents buf
-      else (
-        let byte = Char.code (String.unsafe_get s i) in
-        let n = expected_seq_len byte in
-        if n = 0
-        then (
-          (* invalid lead byte *)
-          Buffer.add_string buf replacement;
-          loop (i + 1))
-        else if n = 1
-        then (
-          (* ASCII — replace disallowed control chars with space *)
-          if is_disallowed_control byte
-          then Buffer.add_char buf ' '
-          else Buffer.add_char buf (String.unsafe_get s i);
-          loop (i + 1))
-        else if not (continuations_valid s i n)
-        then (
-          (* truncated or bad continuation *)
-          Buffer.add_string buf replacement;
-          loop (i + 1))
-        else (
-          Buffer.add_string buf (String.sub s i n);
-          loop (i + n)))
-    in
-    loop 0)
+    let i = ref 0 in
+    while !i < len do
+      let dec = String.get_utf_8_uchar s !i in
+      (if Uchar.utf_decode_is_valid dec
+       then (
+         let u = Uchar.utf_decode_uchar dec in
+         let code = Uchar.to_int u in
+         if code < 0x80 && is_disallowed_control code
+         then Buffer.add_char buf ' '
+         else Buffer.add_utf_8_uchar buf u)
+       else
+         (* Malformed: the decoder reports a U+FFFD decode spanning the maximal
+            invalid subpart; emit one replacement for it. *)
+         Buffer.add_string buf replacement);
+      i := !i + Uchar.utf_decode_length dec
+    done;
+    Buffer.contents buf)
 ;;
 
 (* === Inline tests === *)
+
+(** Every sanitized output is, by construction, valid UTF-8. *)
+let is_valid out = String.is_valid_utf_8 out
 
 let%test "ascii only unchanged" =
   let s = "Hello, world 123" in
@@ -124,58 +82,87 @@ let%test "valid utf8 emoji unchanged" =
   sanitize s == s
 ;;
 
-let%test "truncated 2-byte replaced" =
-  let s = "abc\xC3" in
-  (* C3 expects one continuation *)
-  sanitize s = "abc" ^ replacement
-;;
-
-let%test "truncated 3-byte replaced" =
-  let s = "x\xE2\x80" in
-  (* E2 expects two continuations, only one *)
-  sanitize s = "x" ^ replacement ^ replacement
-;;
-
-let%test "truncated 4-byte replaced" =
-  let s = "\xF0\x9F\x98" in
-  (* F0 expects three continuations, only two *)
-  sanitize s = replacement ^ replacement ^ replacement
-;;
-
-let%test "invalid continuation byte" =
-  let s = "a\xC3\x00b" in
-  (* C3 followed by 0x00 instead of 0x80..0xBF *)
-  sanitize s = "a" ^ replacement ^ " b" (* NUL → space *)
-;;
-
-let%test "bare continuation byte" =
-  let s = "\x80\x81" in
-  sanitize s = replacement ^ replacement
-;;
-
-let%test "mixed valid and invalid" =
-  let s = "ok\xC3\xA9\xFF\xE2\x9C\x93" in
-  (* "okU+00E9" + 0xFF + U+2713 *)
-  sanitize s = "ok\xC3\xA9" ^ replacement ^ "\xE2\x9C\x93"
-;;
-
 let%test "empty string" =
   let s = "" in
   sanitize s == s
 ;;
 
-let%test "0xF8+ lead byte invalid" =
-  let s = "\xF8\x80\x80\x80" in
-  sanitize s = replacement ^ replacement ^ replacement ^ replacement
+let%test "LF CR TAB preserved" =
+  let s = "a\nb\rc\td" in
+  sanitize s == s (* physical equality: no allocation *)
+;;
+
+(* Malformed sequences: assert the invariant (output is valid UTF-8 and the
+   valid neighbours survive) rather than an exact replacement-character count,
+   which follows the Stdlib decoder's maximal-subpart substitution. *)
+
+let%test "truncated 2-byte replaced" =
+  let out = sanitize "abc\xC3" in
+  is_valid out && String.length out > 3 && String.sub out 0 3 = "abc"
+;;
+
+let%test "truncated 3-byte replaced" =
+  let out = sanitize "x\xE2\x80" in
+  is_valid out && out.[0] = 'x' && out <> "x\xE2\x80"
+;;
+
+let%test "truncated 4-byte replaced" =
+  let out = sanitize "\xF0\x9F\x98" in
+  is_valid out && out <> "" && out <> "\xF0\x9F\x98"
+;;
+
+let%test "invalid continuation byte" =
+  (* C3 followed by 0x00 (not a continuation); NUL becomes a space. *)
+  let out = sanitize "a\xC3\x00b" in
+  is_valid out
+  && out.[0] = 'a'
+  && String.length out >= 3
+  && out.[String.length out - 1] = 'b'
+;;
+
+let%test "bare continuation bytes replaced" =
+  let out = sanitize "\x80\x81" in
+  is_valid out && out = replacement ^ replacement
+;;
+
+let%test "0xFF invalid byte replaced" =
+  let out = sanitize "ok\xFF" in
+  is_valid out && out = "ok" ^ replacement
+;;
+
+let%test "0xF8 lead byte invalid" =
+  let out = sanitize "\xF8\x80\x80\x80" in
+  is_valid out && out <> "\xF8\x80\x80\x80" && String.length out > 0
+;;
+
+let%test "mixed valid and invalid" =
+  (* "ok" + U+00E9 (C3 A9) + 0xFF (isolated invalid) + U+2713 (E2 9C 93). *)
+  let out = sanitize "ok\xC3\xA9\xFF\xE2\x9C\x93" in
+  is_valid out && out = "ok\xC3\xA9" ^ replacement ^ "\xE2\x9C\x93"
+;;
+
+(* Classes a byte-length check cannot reject but the Stdlib decoder does. *)
+
+let%test "overlong encoding rejected" =
+  (* 0xC0 0x80 is an overlong encoding of U+0000; structurally well-formed. *)
+  let out = sanitize "\xC0\x80" in
+  is_valid out && out <> "\xC0\x80"
+;;
+
+let%test "surrogate rejected" =
+  (* 0xED 0xA0 0x80 encodes U+D800, a UTF-16 surrogate forbidden in UTF-8. *)
+  let out = sanitize "\xED\xA0\x80" in
+  is_valid out && out <> "\xED\xA0\x80"
+;;
+
+let%test "out of range code point rejected" =
+  (* 0xF4 0x90 0x80 0x80 encodes U+110000, above the U+10FFFF maximum. *)
+  let out = sanitize "\xF4\x90\x80\x80" in
+  is_valid out && out <> "\xF4\x90\x80\x80"
 ;;
 
 let%test "NUL replaced with space" = sanitize "ab\x00cd" = "ab cd"
 let%test "BEL replaced with space" = sanitize "x\x07y" = "x y"
 let%test "DEL replaced with space" = sanitize "a\x7Fb" = "a b"
-
-let%test "LF CR TAB preserved" =
-  let s = "a\nb\rc\td" in
-  sanitize s == s (* physical equality: no allocation *)
-;;
 
 let%test "mixed control chars" = sanitize "\x01hello\x00\nworld\x1F" = " hello \nworld "

--- a/lib/llm_provider/utf8_sanitize.mli
+++ b/lib/llm_provider/utf8_sanitize.mli
@@ -8,12 +8,17 @@
     reject the resulting JSON with parse errors.  Control characters
     (0x00-0x1F except LF/CR/TAB, plus DEL) break prompt formatting.
 
+    Validity follows the Unicode standard via the OCaml Stdlib UTF-8
+    decoder, so overlong encodings, UTF-16 surrogates, and code points
+    above U+10FFFF are rejected (a byte-length check alone cannot).
+
     Valid UTF-8 with no control chars is passed through unchanged.
     The function runs in O(n) with a fast-path that avoids allocation
     when the input is already clean.
 
     @stability Internal
     @since 0.93.1
-    @since 0.138.0 — control character sanitization *)
+    @since 0.138.0 — control character sanitization
+    @since 0.139.0 — UTF-8 validation delegated to the Stdlib decoder *)
 
 val sanitize : string -> string


### PR DESCRIPTION
## 무엇을

`Utf8_sanitize`의 손수 짠 UTF-8 검증(`expected_seq_len` / `continuations_valid`)을 OCaml Stdlib UTF-8 디코더(`String.is_valid_utf_8` / `String.get_utf_8_uchar`)로 교체합니다. 공개 API(`val sanitize : string -> string`)는 불변 — 순수 내부 정합성 개선입니다.

## 왜 (적대적 발견, 2026-06-30)

손수 짠 검증은 **바이트 구조만** 검사하고 디코드된 **코드포인트**는 검사하지 않아, Unicode 표준상 불법인 3개 클래스를 valid로 통과시켰습니다:

- **Overlong encoding** — `0xC0 0x80`(U+0000의 overlong). lead 바이트와 continuation이 구조적으로 멀쩡해 `expected_seq_len`/`continuations_valid`를 통과.
- **UTF-16 surrogate** — `0xED 0xA0 0x80`(U+D800). UTF-8에서 금지된 surrogate 영역이지만 3바이트 구조는 valid.
- **범위 초과** — `0xF4 0x90 0x80 0x80`(U+110000 > U+10FFFF 최대값). 4바이트 구조는 valid.

`expected_seq_len`은 lead 바이트 범위로 길이만 추정하고 `continuations_valid`는 continuation 바이트가 `0x80..0xBF`인지만 봅니다. 둘 다 코드포인트 값을 모르므로 위 세 클래스를 거를 수 없습니다. 이런 시퀀스가 그대로 wire에 실리면 일부 provider(Glm/BigModel)가 JSON parse 에러로 거부합니다 — `.mli`가 명시한 본래 방지 대상이 sanitize를 통과하는 모순.

## 변경

`sanitize`를 Stdlib 디코더 기반으로 재작성:

- `is_clean`: `String.is_valid_utf_8 s && not (String.exists is_disallowed_control s)`. 첫 절이 Unicode 표준 유효성을, 둘째 절이 제어문자(모두 단일바이트 ASCII)를 본다. clean이면 입력을 물리적으로 그대로 반환(무할당 fast-path 유지).
- 그 외: `String.get_utf_8_uchar`로 한 시퀀스씩 디코드. `Uchar.utf_decode_is_valid`면 코드포인트를 `Buffer.add_utf_8_uchar`로 재방출(제어문자는 공백), 불법이면 `replacement`(U+FFFD) 1개를 방출하고 `Uchar.utf_decode_length`만큼 전진. 디코더의 maximal-subpart 치환을 그대로 사용.

이건 이 레포의 확립된 패턴과 일치합니다 — `tool_index.ml`이 이미 `String.get_utf_8_uchar`를 사용합니다. `Utf8_sanitize`만 Stdlib UTF-8을 재구현한 outlier였습니다.

## 검증

인라인 테스트:
- 기존 정확-개수 단언(잘린 2/3/4바이트, 0xF8 시퀀스, invalid continuation) → **불변식 단언**으로 전환: `String.is_valid_utf_8 (sanitize s)` + valid 이웃 바이트 보존. per-byte 방식과 Stdlib maximal-subpart의 U+FFFD 개수가 다를 수 있으므로 개수가 아닌 "출력은 항상 valid UTF-8" 불변식을 검증.
- **신규 테스트 3종**(이번 fix로 거부됨): overlong / surrogate / out-of-range 각각 `is_valid out && out <> 원본`.
- 확신 가능한 정확 단언 유지: valid passthrough(물리적 동일), 단일 invalid 바이트(0xFF, bare 0x80), 제어문자→공백(NUL/BEL/DEL/mixed), valid 사이 격리된 0xFF.

호출부 영향: `Utf8_sanitize.sanitize` 사용처 ~30곳 전부 `string -> string` 시그니처 그대로 — call-site 변경 0. 제거한 내부 함수는 `.mli` 미노출이라 외부 참조 0.

빌드/테스트는 CI에서 확인(로컬 focused 정책).

## 범위

`lib/llm_provider/utf8_sanitize.{ml,mli}` 2파일. 검증 로직만 교체, 제어문자 처리·fast-path·U+FFFD 치환 동작은 보존.

RFC-WAIVED: `lib/llm_provider/utf8_sanitize.ml`은 SDK 내부 문자열 sanitize helper로 RFC-gated subsystem(credential/keeper_sandbox/operator_control/dashboard-credential/hooks/workflow/repo_manager)이 아닙니다. 재구현 → Stdlib 위임의 정합성 하드닝입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
