### PR TITLE
refactor(capabilities): replace hand-rolled starts_with with stdlib String.starts_with

### DIFF
--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -1015,11 +1015,6 @@ let for_model_id model_id =
      | None -> for_model_id_catalog model_id)
 ;;
 
-let starts_with ~prefix s =
-  String.length s >= String.length prefix
-  && String.sub s 0 (String.length prefix) = prefix
-;;
-
 let for_provider_model_id_catalog ~(provider_label : string) ~(model_id : string) =
   let provider_label = String.lowercase_ascii (String.trim provider_label) in
   let model_id = String.trim model_id in
@@ -1035,7 +1030,7 @@ let for_provider_model_id_catalog ~(provider_label : string) ~(model_id : string
          | Some entry
            when List.exists
                   (fun prefix ->
-                     starts_with
+                     String.starts_with
                        ~prefix
                        (String.lowercase_ascii (String.trim entry.id_prefix)))
                   qualified_prefixes -> Some (apply_catalog_entry entry)

--- a/lib/llm_provider/capability_manifest.ml
+++ b/lib/llm_provider/capability_manifest.ml
@@ -334,8 +334,7 @@ let lookup (t : t) model_id =
   List.find_opt
     (fun entry ->
        let prefix = String.lowercase_ascii entry.id_prefix in
-       String.length m >= String.length prefix
-       && String.sub m 0 (String.length prefix) = prefix)
+       String.starts_with ~prefix m)
     t
 ;;
 

--- a/lib/llm_provider/model_catalog.ml
+++ b/lib/llm_provider/model_catalog.ml
@@ -270,8 +270,7 @@ let lookup t model_id =
   List.find_opt
     (fun entry ->
        let prefix = String.lowercase_ascii entry.id_prefix in
-       String.length m >= String.length prefix
-       && String.sub m 0 (String.length prefix) = prefix)
+       String.starts_with ~prefix m)
     sorted_t
 ;;
 

--- a/lib/llm_provider/zai_catalog.ml
+++ b/lib/llm_provider/zai_catalog.ml
@@ -116,10 +116,7 @@ let resolve_glm_coding_alias ~default_model model_id =
 
 let general_concurrency_for_model model_id =
   let m = String.lowercase_ascii model_id in
-  let starts_with prefix =
-    String.length m >= String.length prefix
-    && String.sub m 0 (String.length prefix) = prefix
-  in
+  let starts_with prefix = String.starts_with ~prefix m in
   if starts_with "glm-4-plus"
   then 20
   else if starts_with "glm-4-32b-0414-128k"


### PR DESCRIPTION
## 배경

`lib/llm_provider`의 4개 모듈이 다음 동일 술어를 손수 구현하고 있습니다:

```ocaml
String.length s >= String.length prefix
&& String.sub s 0 (String.length prefix) = prefix
```

이는 Stdlib `String.starts_with ~prefix s`(OCaml 4.13+)를 그대로 재구현한 것이며, stdlib 버전과 달리 `String.sub`로 부분 문자열을 **할당**합니다. 게다가 같은 파일들(`capabilities.ml`, `zai_catalog.ml`)이 이미 다른 곳에서 `String.starts_with`를 직접 호출하고 있어 내부 불일치 상태입니다.

`capabilities.mli`의 주석도 이 dispatch가 "used to live as scattered `String.starts_with` calls"라고 기록하고 있어, 코드베이스가 이미 stdlib 위임 + typed dispatch 방향으로 정리 중임을 보여줍니다. 본 변경은 그 방향과 정렬되어 남은 hand-rolled 사본을 제거합니다.

## 변경

| 파일 | 변경 |
|------|------|
| `capabilities.ml` | top-level `starts_with` 헬퍼 삭제(단일 call site를 `String.starts_with`로 교체) |
| `zai_catalog.ml` | 로컬 클로저 본체를 `String.starts_with ~prefix m`로 위임 |
| `capability_manifest.ml` | `List.find_opt` prefix 람다에서 `String.starts_with ~prefix m` 인라인 |
| `model_catalog.ml` | 동일하게 인라인 |

4개 사이트를 한 PR로 전수 교체했습니다(N-of-M 분할 회피).

## 정당성

- **동작 보존**: `String.starts_with ~prefix s`는 `length 체크 + String.sub 비교`와 의미상 동일합니다(stdlib 공식 정의).
- **할당 제거**: stdlib `String.starts_with`는 부분 문자열을 만들지 않습니다.
- **재구현 제거**: 사용자/프로젝트 기준 "이미 있는 라이브러리를 재구현한 코드 제거".
- **공개 API 불변**: 삭제한 `capabilities.ml`의 `starts_with`는 `.mli`에 노출되지 않으며 cross-module 사용처가 없습니다(레포 전수 확인).

## 검증

- diff: 4 files, +4/-14. 잔여 `String.sub ... = prefix` 재구현 0건(레포 grep 확인).
- 빌드/테스트는 CI에서 확인합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
