### PR TITLE
fix(streaming): surface unknown content_block_delta type as SSEParseFailed (no silent empty TextDelta)

### DIFF
--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -62,19 +62,45 @@ let parse_sse_event event_type data_str =
       let index = json |> member "index" |> to_int in
       let delta_json = json |> member "delta" in
       let delta_type = delta_json |> member "type" |> to_string in
-      let delta =
-        match delta_type with
-        | "text_delta" -> TextDelta (delta_json |> member "text" |> to_string)
-        | "thinking_delta" -> ThinkingDelta (delta_json |> member "thinking" |> to_string)
-        | "signature_delta" ->
-          ThinkingSignatureDelta (delta_json |> member "signature" |> to_string)
-        | "input_json_delta" ->
-          InputJsonDelta (delta_json |> member "partial_json" |> to_string)
-        | unknown_delta_type ->
-          let (_ : string) = unknown_delta_type in
-          TextDelta ""
-      in
-      Some (ContentBlockDelta { index; delta })
+      (match delta_type with
+       | "text_delta" ->
+         Some
+           (ContentBlockDelta
+              { index; delta = TextDelta (delta_json |> member "text" |> to_string) })
+       | "thinking_delta" ->
+         Some
+           (ContentBlockDelta
+              { index
+              ; delta = ThinkingDelta (delta_json |> member "thinking" |> to_string)
+              })
+       | "signature_delta" ->
+         Some
+           (ContentBlockDelta
+              { index
+              ; delta =
+                  ThinkingSignatureDelta (delta_json |> member "signature" |> to_string)
+              })
+       | "input_json_delta" ->
+         Some
+           (ContentBlockDelta
+              { index
+              ; delta =
+                  InputJsonDelta (delta_json |> member "partial_json" |> to_string)
+              })
+       | unknown_delta_type ->
+         (* An unrecognized content_block_delta subtype is content we cannot
+            represent as a typed delta. Mirror the unknown-event-type contract
+            ([SSEUnknownEventType] at the event level): surface a typed
+            [SSEParseFailed] so [accumulate_event] marks [sse_error] and
+            [finalize_stream_acc] yields [Error _], letting the caller route to
+            another provider. The previous branch coerced this to [TextDelta ""],
+            silently dropping the provider's output and finalizing a phantom
+            completion (the exact silent-drop the event-level fix already closed). *)
+         Some
+           (SSEParseFailed
+              { raw = data_str
+              ; reason = "unknown content_block_delta type: " ^ unknown_delta_type
+              }))
     | "content_block_stop" ->
       let index = json |> member "index" |> to_int in
       Some (ContentBlockStop { index })
@@ -1709,6 +1735,29 @@ let%test
   match parse_sse_event None raw with
   | Some (SSEUnknownEventType { event_type = ""; _ }) -> true
   | Some (SSEParseFailed _) -> true
+  | unexpected_event ->
+    let (_ : sse_event option) = unexpected_event in
+    false
+;;
+
+let%test
+    "parse_sse_event: unknown content_block_delta type yields SSEParseFailed (not \
+     silent empty TextDelta)"
+  =
+  (* Same silent-drop class as the unknown-event-type case, one level deeper:
+     a recognized [content_block_delta] event carrying an unrecognized inner
+     [delta.type]. The previous implementation coerced it to [TextDelta ""],
+     fabricating empty text and silently discarding the provider's output, so
+     the accumulator finalized a phantom completion. The contract is that the
+     parser surfaces a typed failure the accumulator marks as [sse_error]. *)
+  let raw =
+    "{\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"citations_delta\",\"citation\":{}}}"
+  in
+  match parse_sse_event None raw with
+  | Some (SSEParseFailed { raw = r; reason }) ->
+    (* raw is carried verbatim; reason names the offending subtype verbatim so
+       operators can diagnose which delta the provider sent. *)
+    r = raw && reason = "unknown content_block_delta type: citations_delta"
   | unexpected_event ->
     let (_ : sse_event option) = unexpected_event in
     false


### PR DESCRIPTION
## 배경

`parse_sse_event`(streaming.ml)는 `content_block_delta` 이벤트의 내부 `delta.type`이 알려지지 않은 값일 때 다음과 같이 빈 텍스트로 강제 변환했습니다:

```ocaml
| unknown_delta_type ->
  let (_ : string) = unknown_delta_type in
  TextDelta ""   (* provider 출력을 조용히 버림 *)
```

이는 provider가 보낸 내용을 빈 `TextDelta`로 날조하고 **silently drop**합니다. accumulator는 이를 정상 chunk로 간주해 phantom completion(데이터가 빠진 응답을 성공으로 처리)을 finalize합니다.

이 silent-drop 클래스는 이미 **이벤트 레벨에서 닫힌 계약**입니다. 동일 모듈이 unknown 이벤트 타입과 JSON parse 실패에 대해 `SSEUnknownEventType` / `SSEParseFailed`를 surface하도록 고쳐졌고(테스트 주석 streaming.ml:1672-1679이 정확히 이 의도를 기록), `complete_stream_acc.ml:818-822`이 그 계약을 명문화합니다:

> SSEParseFailed and SSEUnknownEventType replace the previous silent [None] discard in [parse_sse_event]. They MUST mark [sse_error] so that [finalize_stream_acc] yields [Error _] and the caller can route to another provider instead of presenting a phantom completion.

하지만 **delta 레벨(한 단계 더 깊은 곳)만 silent 갭으로 남아** 있었습니다. 이벤트는 알려진(`content_block_delta`) 타입인데 내부 delta 서브타입만 미지인 경우입니다.

## 변경

unknown delta 서브타입을 `delta` 생산에서 `sse_event option` 생산으로 끌어올려, 동일 계약대로 typed 실패를 surface합니다:

```ocaml
| unknown_delta_type ->
  Some
    (SSEParseFailed
       { raw = data_str
       ; reason = "unknown content_block_delta type: " ^ unknown_delta_type
       })
```

배선은 변경 없이 그대로 작동합니다:
- `complete_stream_acc.ml:133-134`: `SSEParseFailed {raw; reason}` → `acc.sse_error := Some (Stream_parse_failed {reason; raw})`
- `finalize_stream_acc`(:183/:812)가 `sse_error`를 보고 `Error _` 반환 → caller가 다른 provider로 라우팅

## 정당성 (로직/흐름/계약 중심)

- **Silent Failure 제거**: 빈 `TextDelta ""` 날조 → typed `SSEParseFailed`. CLAUDE.md "Unknown → Permissive Default(조용한 허용)" 안티패턴 #2 해소.
- **SSOT 계약 일치**: 모듈이 이미 정의·테스트한 unknown-SSE-입력 처리 계약을 delta 레벨로 확장. 새 variant 추가 없음(`SSEUnknownEventType`/`SSEParseFailed` 모두 행동상 동일하게 `sse_error` mark → fail-closed → 라우팅, "차이 없는 구분" 회피). `reason` free-form 필드가 진단 정보를 담음.
- **실 트래픽 영향 0**: 알려진 Anthropic delta 4종(text/thinking/signature/input_json) 전부 처리되고 OAS는 citations를 지원하지 않으므로, 이 분기는 **진짜 미지의 프로토콜 확장**에서만 발동. 그 경우 silently drop보다 fail-closed-and-route가 안전.
- **regression 테스트**: unknown delta type이 `SSEParseFailed`를 내고 `raw`/`reason`을 verbatim 운반함을 고정(기존 unknown-event 테스트 그룹과 대칭).

## 검증

- diff: 1 file (`lib/llm_provider/streaming.ml`), +62/-13. 잔여 `TextDelta ""` coercion 0건(주석 2건만 — 제거된 동작 문서화).
- 빌드/테스트는 CI에서 확인합니다(로컬은 fresh worktree라 `_build` 없음).

## 워크어라운드 게이트 self-check

해당 없음(reject 사유 0):
- telemetry-as-fix 아님 — silent failure를 *visible*하게 만드는 게 아니라 *fix*(fail-closed + 라우팅).
- string 분류기 추가 아님 — coercion 제거. `reason`은 진단 텍스트지 분류 로직 아님.
- N-of-M 아님 — 단일 사이트.
- catch-all 추가 아님 — silent catch-all(`unknown -> TextDelta ""`)을 typed 실패로 **교체**.
- cap/cooldown/dedup/repair 아님.

RFC 게이트 비대상(credential/identity/operator/sandbox/hooks/workflow 무관, `lib/llm_provider` 스트리밍 파서).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
