### PR TITLE
feat(types): expose visible answer text projection

### DIFF
--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -676,6 +676,30 @@ let text_of_message (msg : message) = text_of_content msg.content
 (** Extract text from an api_response. *)
 let text_of_response (resp : api_response) = text_of_content resp.content
 
+(** Extract end-user-visible assistant text from content blocks.
+    This is intentionally narrower than [text_of_content]: tool results are
+    model-visible execution payloads, and Thinking blocks are provider reasoning
+    payloads. Neither belongs in an answer-text projection. *)
+let visible_text_of_content content =
+  content
+  |> List.filter_map (function
+    | Text s -> Some s
+    | Thinking _
+    | RedactedThinking _
+    | ToolUse _
+    | ToolResult _
+    | Image _
+    | Document _
+    | Audio _ -> None)
+  |> String.concat "\n"
+;;
+
+(** Extract end-user-visible assistant text from a message. *)
+let visible_text_of_message (msg : message) = visible_text_of_content msg.content
+
+(** Extract end-user-visible assistant text from an api_response. *)
+let visible_text_of_response (resp : api_response) = visible_text_of_content resp.content
+
 (** {1 Usage Helpers} *)
 
 let zero_api_usage =

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -439,6 +439,17 @@ val text_of_content : content_block list -> string
 val text_of_message : message -> string
 val text_of_response : api_response -> string
 
+(** End-user-visible assistant text projection.
+
+    Unlike {!text_of_content}, these helpers only include [Text] blocks. They
+    intentionally exclude [Thinking], [RedactedThinking], [ToolUse],
+    [ToolResult], and media blocks so downstream answer surfaces do not leak
+    reasoning or execution payloads. *)
+val visible_text_of_content : content_block list -> string
+
+val visible_text_of_message : message -> string
+val visible_text_of_response : api_response -> string
+
 (** {1 Usage Helpers}
 
     @since 0.78.0 *)

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -763,6 +763,33 @@ let test_text_of_content_tool_result () =
     (Types.text_of_content content)
 ;;
 
+let test_visible_text_of_content_excludes_non_answer_blocks () =
+  let content =
+    [ Types.Text "answer"
+    ; Types.Thinking { signature = Some "sig"; content = "private reasoning" }
+    ; Types.RedactedThinking "opaque"
+    ; Types.ToolUse { id = "tu1"; name = "search"; input = `Assoc [] }
+    ; Types.ToolResult
+        { tool_use_id = "tu1"
+        ; content = "tool payload"
+        ; is_error = false
+        ; json = Some (`Assoc [ "ok", `Bool true ])
+        ; content_blocks = Some [ Types.Text "structured tool payload" ]
+        }
+    ; Types.Image { media_type = "image/png"; data = "bytes"; source_type = Types.Base64 }
+    ; Types.Document
+        { media_type = "application/pdf"; data = "doc"; source_type = Types.Base64 }
+    ; Types.Audio
+        { media_type = "audio/mpeg"; data = "audio"; source_type = Types.Base64 }
+    ; Types.Text "tail"
+    ]
+  in
+  Alcotest.(check string)
+    "visible text"
+    "answer\ntail"
+    (Types.visible_text_of_content content)
+;;
+
 let test_text_of_content_empty () =
   Alcotest.(check string) "empty" "" (Types.text_of_content [])
 ;;
@@ -811,6 +838,10 @@ let test_text_of_response_and_usage_helpers () =
     "response text"
     "hello\ntool text"
     (Types.text_of_response response);
+  Alcotest.(check string)
+    "visible response text excludes tool result and thinking"
+    "hello"
+    (Types.visible_text_of_response response);
   Alcotest.(check (option int))
     "usage"
     (Some 1)
@@ -963,9 +994,7 @@ let summary_contains ~needle response =
 
 let test_response_shape_thinking_only_is_not_deliverable () =
   let response =
-    response
-      ~content:[ Types.Thinking { signature = None; content = "hidden" } ]
-      ()
+    response ~content:[ Types.Thinking { signature = None; content = "hidden" } ] ()
   in
   let shape = Response_shape.summarize response in
   Alcotest.(check bool)
@@ -1215,6 +1244,10 @@ let () =
       , [ Alcotest.test_case "text only" `Quick test_text_of_content_text_only
         ; Alcotest.test_case "mixed" `Quick test_text_of_content_mixed
         ; Alcotest.test_case "tool result" `Quick test_text_of_content_tool_result
+        ; Alcotest.test_case
+            "visible text excludes non-answer blocks"
+            `Quick
+            test_visible_text_of_content_excludes_non_answer_blocks
         ; Alcotest.test_case "empty" `Quick test_text_of_content_empty
         ; Alcotest.test_case "text_of_message" `Quick test_text_of_message
         ; Alcotest.test_case


### PR DESCRIPTION
## Summary
- Add Types.visible_text_of_content/message/response for end-user-visible answer text.
- Keep existing Types.text_of_content semantics intact, including ToolResult.content.
- Cover Thinking, RedactedThinking, ToolUse, ToolResult, and media exclusion in test_types.

## Why
MASC has several answer-surface paths that need Text-only output. Existing OAS helpers are intentionally different: Types.text_of_response includes ToolResult.content, and Api.text_blocks_to_string includes Thinking. This helper gives downstream consumers a typed OAS-owned projection without leaking reasoning or execution payloads.

## Verification
- ocamlformat --check lib/llm_provider/types.ml lib/llm_provider/types.mli test/test_types.ml
- scripts/dune-local.sh build test/test_types.exe
- ./_build/default/test/test_types.exe
- git diff --check

Note: scripts/dune-local.sh build @fmt currently reports existing main formatting drift in unrelated files; touched-file ocamlformat check passes.