### PR TITLE
fix(glm): route thinking fields through shared builder

### DIFF
--- a/lib/llm_provider/backend_glm.ml
+++ b/lib/llm_provider/backend_glm.ml
@@ -1,7 +1,7 @@
 (** ZhipuAI Glm native backend.
 
     Openai wire format with Glm-specific extensions:
-    - [thinking] parameter: [{"type":"enabled","clear_thinking":true}]
+    - thinking control parameter with type=enabled and clear_thinking=true
     - [reasoning_content] in response message and streaming delta
     - String error codes (e.g., ["1305"])
     - Temperature range 0-1 (not 0-2)
@@ -89,15 +89,6 @@ exception Glm_api_error of glm_error
 
 (* ── Request building ────────────────────────────── *)
 
-let clear_thinking_of_config (config : Provider_config.t) =
-  match config.clear_thinking with
-  | Some clear -> clear
-  | None ->
-    (match config.preserve_thinking with
-     | Some preserve -> not preserve
-     | None -> true)
-;;
-
 let without_field name fields =
   List.filter (fun (key, _) -> not (String.equal key name)) fields
 ;;
@@ -135,27 +126,12 @@ let build_request
   in
   match base_assoc with
   | `Assoc fields ->
-    (* [thinking] single-owner normalization. The shared request builder's
-       ZAI/GLM branch may already have emitted a [thinking] field (it fires for
-       api.z.ai base URLs); strip it so Backend_glm is the authoritative owner
-       and the key is never duplicated for [kind:Glm] (mirrors the response-path
-       dedup at [extract_reasoning_content]). Bare GLM via [kind:OpenAI_compat]
-       does not pass through here and is covered by that shared branch instead.
-       The capability-driven unification of both emitters via
-       [Glm_enable_thinking] is deferred to the RFC-OAS-023 axis reshape, which
-       needs model-based [capabilities_of_config] resolution. *)
-    let fields = without_field "thinking" fields in
+    (* GLM thinking-control fields are emitted by the shared
+       [Reasoning_dialect.request_control_fields] path inside the OpenAI
+       request builder. Keep Backend_glm limited to GLM-only post-processing
+       that is not a thinking builder: Z.AI's [tool_choice=auto] normalization
+       and [tool_stream]. *)
     let fields = normalize_tool_choice_fields ~tool_choice:config.tool_choice fields in
-    let fields =
-      match config.enable_thinking with
-      | Some true ->
-        let clear_thinking = clear_thinking_of_config config in
-        ( "thinking"
-        , `Assoc [ "type", `String "enabled"; "clear_thinking", `Bool clear_thinking ] )
-        :: fields
-      | Some false -> ("thinking", `Assoc [ "type", `String "disabled" ]) :: fields
-      | None -> fields
-    in
     let fields =
       (* GLM streams tool-call arguments incrementally only when both
          [stream] and [tool_stream] are set; [config.tool_stream] defaults
@@ -378,12 +354,10 @@ let%test "build_request maps preserve_thinking to GLM clear_thinking=false" =
 ;;
 
 let%test "build_request emits exactly one thinking key for ZAI GLM (RFC-OAS-023)" =
-  (* Regression guard for the duplicate-[thinking]-key bug: before the fix,
-     both Backend_glm.build_request (overlay) and the shared OpenAI-compat
-     builder (No_thinking_control + is_zai_glm workaround) emitted a [thinking]
-     field, producing a duplicate JSON key. The fix routes GLM thinking through
-     the single [Glm_enable_thinking] capability path. Yojson [member] is blind
-     to duplicates, so count the keys directly on the assoc list. *)
+  (* Regression guard for the duplicate-[thinking]-key bug: GLM thinking now
+     comes from the shared OpenAI-compatible request builder. Backend_glm must
+     not add a second key. Yojson [member] is blind to duplicates, so count the
+     keys directly on the assoc list. *)
   let config =
     Provider_config.make
       ~kind:Glm

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -141,11 +141,7 @@ let capabilities_of_config (config : Provider_config.t) =
    request-body clear_thinking field below and the reasoning-replay gate cannot
    diverge. *)
 let glm_clear_thinking_of_config = Provider_config.glm_clear_thinking
-
-let is_zai_glm_request (config : Provider_config.t) =
-  Zai_catalog.is_zai_base_url config.base_url
-  && Zai_catalog.is_glm_model_id config.model_id
-;;
+let is_zai_glm_request = Provider_config.is_zai_glm_config
 
 let zai_glm_preserve_thinking_request (config : Provider_config.t) =
   is_zai_glm_request config && Provider_config.glm_should_replay_reasoning config

--- a/test/test_backend_glm_coverage.ml
+++ b/test/test_backend_glm_coverage.ml
@@ -7,45 +7,18 @@ let member key json = Yojson.Safe.Util.member key json
 let to_bool json = Yojson.Safe.Util.to_bool json
 let to_string json = Yojson.Safe.Util.to_string json
 
-let contains_substring ~sub text =
-  let sub_len = String.length sub in
-  let text_len = String.length text in
-  let rec loop i =
-    i + sub_len <= text_len && (String.sub text i sub_len = sub || loop (i + 1))
-  in
-  sub_len = 0 || loop 0
+let assoc_fields label = function
+  | `Assoc fields -> fields
+  | json ->
+    fail (Printf.sprintf "expected %s object, got %s" label (Yojson.Safe.to_string json))
 ;;
 
-let source_path path =
-  let rec find_up dir remaining =
-    let candidate = Filename.concat dir path in
-    if Sys.file_exists candidate
-    then Some candidate
-    else if remaining = 0
-    then None
-    else (
-      let parent = Filename.dirname dir in
-      if String.equal parent dir then None else find_up parent (remaining - 1))
-  in
-  match find_up (Sys.getcwd ()) 12 with
-  | Some candidate -> candidate
-  | None -> path
-;;
-
-let read_source path = In_channel.with_open_text (source_path path) In_channel.input_all
-
-let source_before_inline_tests source =
-  source
-  |> String.split_on_char '\n'
+let field_count key json =
+  json
+  |> assoc_fields "request body"
   |> List.fold_left
-       (fun (keep, lines) line ->
-          if (not keep) || String.equal line "[@@@coverage off]"
-          then false, lines
-          else true, line :: lines)
-       (true, [])
-  |> snd
-  |> List.rev
-  |> String.concat "\n"
+       (fun count (field, _) -> if String.equal field key then count + 1 else count)
+       0
 ;;
 
 let glm_config ?enable_thinking ?clear_thinking ?(tool_stream = false) () =
@@ -139,6 +112,7 @@ let test_build_request_thinking_modes_and_tool_stream () =
       ()
     |> Yojson.Safe.from_string
   in
+  check int "thinking enabled field count" 1 (field_count "thinking" enabled);
   check
     string
     "thinking enabled"
@@ -157,6 +131,7 @@ let test_build_request_thinking_modes_and_tool_stream () =
       ()
     |> Yojson.Safe.from_string
   in
+  check int "thinking disabled field count" 1 (field_count "thinking" disabled);
   check
     string
     "thinking disabled"
@@ -170,20 +145,8 @@ let test_build_request_thinking_modes_and_tool_stream () =
   let passthrough =
     K.build_request ~config:(glm_config ()) ~messages () |> Yojson.Safe.from_string
   in
+  check int "thinking omitted field count" 0 (field_count "thinking" passthrough);
   check bool "thinking omitted" true (passthrough |> member "thinking" = `Null)
-;;
-
-let test_backend_glm_delegates_thinking_builder_to_shared_request_builder () =
-  let source =
-    read_source "lib/llm_provider/backend_glm.ml" |> source_before_inline_tests
-  in
-  [ "clear_thinking"; "chat_template_kwargs"; "reasoning_effort"; "enable_thinking" ]
-  |> List.iter (fun field ->
-    check
-      bool
-      (field ^ " not emitted directly in backend_glm.ml")
-      false
-      (contains_substring ~sub:("\"" ^ field ^ "\"") source))
 ;;
 
 let test_parse_response_extracts_reasoning_and_usage () =
@@ -281,10 +244,6 @@ let () =
             "thinking modes and tool_stream"
             `Quick
             test_build_request_thinking_modes_and_tool_stream
-        ; test_case
-            "thinking builder delegated"
-            `Quick
-            test_backend_glm_delegates_thinking_builder_to_shared_request_builder
         ] )
     ; ( "response"
       , [ test_case

--- a/test/test_backend_glm_coverage.ml
+++ b/test/test_backend_glm_coverage.ml
@@ -7,6 +7,47 @@ let member key json = Yojson.Safe.Util.member key json
 let to_bool json = Yojson.Safe.Util.to_bool json
 let to_string json = Yojson.Safe.Util.to_string json
 
+let contains_substring ~sub text =
+  let sub_len = String.length sub in
+  let text_len = String.length text in
+  let rec loop i =
+    i + sub_len <= text_len && (String.sub text i sub_len = sub || loop (i + 1))
+  in
+  sub_len = 0 || loop 0
+;;
+
+let source_path path =
+  let rec find_up dir remaining =
+    let candidate = Filename.concat dir path in
+    if Sys.file_exists candidate
+    then Some candidate
+    else if remaining = 0
+    then None
+    else (
+      let parent = Filename.dirname dir in
+      if String.equal parent dir then None else find_up parent (remaining - 1))
+  in
+  match find_up (Sys.getcwd ()) 12 with
+  | Some candidate -> candidate
+  | None -> path
+;;
+
+let read_source path = In_channel.with_open_text (source_path path) In_channel.input_all
+
+let source_before_inline_tests source =
+  source
+  |> String.split_on_char '\n'
+  |> List.fold_left
+       (fun (keep, lines) line ->
+          if (not keep) || String.equal line "[@@@coverage off]"
+          then false, lines
+          else true, line :: lines)
+       (true, [])
+  |> snd
+  |> List.rev
+  |> String.concat "\n"
+;;
+
 let glm_config ?enable_thinking ?clear_thinking ?(tool_stream = false) () =
   PC.make
     ~kind:PC.Glm
@@ -132,6 +173,19 @@ let test_build_request_thinking_modes_and_tool_stream () =
   check bool "thinking omitted" true (passthrough |> member "thinking" = `Null)
 ;;
 
+let test_backend_glm_delegates_thinking_builder_to_shared_request_builder () =
+  let source =
+    read_source "lib/llm_provider/backend_glm.ml" |> source_before_inline_tests
+  in
+  [ "clear_thinking"; "chat_template_kwargs"; "reasoning_effort"; "enable_thinking" ]
+  |> List.iter (fun field ->
+    check
+      bool
+      (field ^ " not emitted directly in backend_glm.ml")
+      false
+      (contains_substring ~sub:("\"" ^ field ^ "\"") source))
+;;
+
 let test_parse_response_extracts_reasoning_and_usage () =
   let resp = K.parse_response (response_json ()) in
   check string "id" "chatcmpl-provider-k" resp.id;
@@ -227,6 +281,10 @@ let () =
             "thinking modes and tool_stream"
             `Quick
             test_build_request_thinking_modes_and_tool_stream
+        ; test_case
+            "thinking builder delegated"
+            `Quick
+            test_backend_glm_delegates_thinking_builder_to_shared_request_builder
         ] )
     ; ( "response"
       , [ test_case


### PR DESCRIPTION
## Summary
- Route native GLM detection in the OpenAI-compatible request builder through the typed Provider_config.is_zai_glm_config predicate, so kind=Glm and ZAI OpenAI-compatible GLM use the same canonical thinking-field path.
- Remove Backend_glm's duplicate manual thinking object emitter; Backend_glm now only keeps GLM-specific post-processing for tool_choice normalization and tool_stream.
- Add a regression guard that fails if Backend_glm starts emitting thinking-control wire fields directly before its inline tests section.

## Verification
- git diff --check
- Dune build/test: intentionally left to GitHub CI per maintainer workflow.

## RFC-OAS-029
Closes part of S2.1/S9.2 by reducing GLM thinking field construction to the shared Reasoning_dialect.request_control_fields path instead of a second backend-local builder.