### PR TITLE
fix(main): restore CI — drop retired visibility ref + format drift (#2232 fallout)

### DIFF
--- a/lib/agent_tool.ml
+++ b/lib/agent_tool.ml
@@ -58,7 +58,10 @@ let content_block_to_json = function
   | Thinking { content; signature } ->
     `Assoc
       [ "type", `String "thinking"
-      ; "signature", (match signature with Some s -> `String s | None -> `Null)
+      ; ( "signature"
+        , match signature with
+          | Some s -> `String s
+          | None -> `Null )
       ; "content", `String content
       ]
   | RedactedThinking value ->

--- a/lib/llm_provider/utf8_sanitize.ml
+++ b/lib/llm_provider/utf8_sanitize.ml
@@ -44,17 +44,17 @@ let sanitize s =
     let i = ref 0 in
     while !i < len do
       let dec = String.get_utf_8_uchar s !i in
-      (if Uchar.utf_decode_is_valid dec
-       then (
-         let u = Uchar.utf_decode_uchar dec in
-         let code = Uchar.to_int u in
-         if code < 0x80 && is_disallowed_control code
-         then Buffer.add_char buf ' '
-         else Buffer.add_utf_8_uchar buf u)
-       else
-         (* Malformed: the decoder reports a U+FFFD decode spanning the maximal
+      if Uchar.utf_decode_is_valid dec
+      then (
+        let u = Uchar.utf_decode_uchar dec in
+        let code = Uchar.to_int u in
+        if code < 0x80 && is_disallowed_control code
+        then Buffer.add_char buf ' '
+        else Buffer.add_utf_8_uchar buf u)
+      else
+        (* Malformed: the decoder reports a U+FFFD decode spanning the maximal
             invalid subpart; emit one replacement for it. *)
-         Buffer.add_string buf replacement);
+        Buffer.add_string buf replacement;
       i := !i + Uchar.utf_decode_length dec
     done;
     Buffer.contents buf)
@@ -164,5 +164,4 @@ let%test "out of range code point rejected" =
 let%test "NUL replaced with space" = sanitize "ab\x00cd" = "ab cd"
 let%test "BEL replaced with space" = sanitize "x\x07y" = "x y"
 let%test "DEL replaced with space" = sanitize "a\x7Fb" = "a b"
-
 let%test "mixed control chars" = sanitize "\x01hello\x00\nworld\x1F" = " hello \nworld "

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -888,8 +888,7 @@ let test_build_openai_body_glm_preserves_reasoning_content () =
   let messages =
     [ { Types.role = Types.Assistant
       ; content =
-          [ Types.Thinking
-              { signature = None; content = "I should call the calculator." }
+          [ Types.Thinking { signature = None; content = "I should call the calculator." }
           ; Types.ToolUse
               { id = "call_1"
               ; name = "calculator"

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -1263,8 +1263,7 @@ let test_complete_stream_preserves_thinking_signature () =
     | Ok resp ->
       check bool "stop tool use" true (resp.stop_reason = Types.StopToolUse);
       (match resp.content with
-       | [ Types.Thinking { signature; content }; Types.ToolUse { id; name; input } ]
-         ->
+       | [ Types.Thinking { signature; content }; Types.ToolUse { id; name; input } ] ->
          check bool "thinking signature" true (signature = Some "sig_opaque");
          check string "thinking content" "Need a lookup." content;
          check string "tool id" "tu_1" id;

--- a/test/test_context_reducer.ml
+++ b/test/test_context_reducer.ml
@@ -753,9 +753,7 @@ let test_drop_thinking_preserves_recent () =
     ; Types.
         { role = Assistant
         ; content =
-            [ Thinking { signature = None; content = "recent thinking" }
-            ; Text "answer"
-            ]
+            [ Thinking { signature = None; content = "recent thinking" }; Text "answer" ]
         ; name = None
         ; tool_call_id = None
         ; metadata = []
@@ -824,9 +822,7 @@ let test_compose () =
     [ Types.
         { role = Assistant
         ; content =
-            [ Thinking { signature = None; content = "old thinking" }
-            ; Text "old answer"
-            ]
+            [ Thinking { signature = None; content = "old thinking" }; Text "old answer" ]
         ; name = None
         ; tool_call_id = None
         ; metadata = []

--- a/test/test_llm_cache.ml
+++ b/test/test_llm_cache.ml
@@ -146,9 +146,7 @@ let test_roundtrip_text () =
 let test_roundtrip_thinking () =
   let resp =
     simple_response
-      [ Thinking { signature = None; content = "let me think..." }
-      ; Text "answer"
-      ]
+      [ Thinking { signature = None; content = "let me think..." }; Text "answer" ]
   in
   let json = Cache.response_to_json resp in
   match Cache.response_of_json json with

--- a/test/test_pipeline_deep.ml
+++ b/test/test_pipeline_deep.ml
@@ -34,9 +34,7 @@ let test_reasoning_multiple_messages () =
     ; { role = Assistant
       ; content =
           [ Types.Thinking
-              { signature = None
-              ; content = "Second thought, I'm not sure about this"
-              }
+              { signature = None; content = "Second thought, I'm not sure about this" }
           ; Types.Text "response 2"
           ]
       ; name = None
@@ -111,9 +109,7 @@ let test_reasoning_no_uncertainty_marker_inference () =
        let messages : Types.message list =
          [ { role = Assistant
            ; content =
-               [ Types.Thinking
-                   { signature = None; content = "Analysis: " ^ marker }
-               ]
+               [ Types.Thinking { signature = None; content = "Analysis: " ^ marker } ]
            ; name = None
            ; tool_call_id = None
            ; metadata = []
@@ -133,9 +129,7 @@ let test_reasoning_no_uncertainty () =
   let messages : Types.message list =
     [ { role = Assistant
       ; content =
-          [ Types.Thinking
-              { signature = None; content = "The answer is clearly 42" }
-          ]
+          [ Types.Thinking { signature = None; content = "The answer is clearly 42" } ]
       ; name = None
       ; tool_call_id = None
       ; metadata = []

--- a/test/test_provider_agnostic_reasoning_replay.ml
+++ b/test/test_provider_agnostic_reasoning_replay.ml
@@ -95,8 +95,7 @@ let test_reasoning_never_in_content_any_provider () =
     (fun (name, caps) ->
        let dialect = RD.of_capabilities caps in
        let shapes =
-         [ ( "reasoning_only"
-           , [ Thinking { content = reasoning_marker; signature = None } ] )
+         [ "reasoning_only", [ Thinking { content = reasoning_marker; signature = None } ]
          ; ( "reasoning_then_answer"
            , [ Thinking { content = reasoning_marker; signature = None }
              ; Text answer_text
@@ -161,9 +160,7 @@ let test_replay_matches_should_replay_reasoning_any_provider () =
        let plain_msg =
          msg
            Assistant
-           [ Thinking { content = reasoning_marker; signature = None }
-           ; Text answer_text
-           ]
+           [ Thinking { content = reasoning_marker; signature = None }; Text answer_text ]
        in
        let expect_plain =
          RD.should_replay_reasoning dialect ~assistant_had_tool_call:false
@@ -192,9 +189,7 @@ let test_reasoning_only_replay_does_not_accumulate () =
     (fun (name, caps) ->
        let dialect = RD.of_capabilities caps in
        let reasoning_only =
-         msg
-           Assistant
-           [ Thinking { content = reasoning_marker; signature = None } ]
+         msg Assistant [ Thinking { content = reasoning_marker; signature = None } ]
        in
        for round = 1 to 5 do
          let j = serialized_assistant dialect reasoning_only in

--- a/test/test_succession.ml
+++ b/test/test_succession.ml
@@ -245,9 +245,7 @@ let test_normalize_strips_thinking () =
   let msgs =
     [ { Types.role = Types.Assistant
       ; content =
-          [ Types.Thinking { signature = None; content = "hmm" }
-          ; Types.Text "answer"
-          ]
+          [ Types.Thinking { signature = None; content = "hmm" }; Types.Text "answer" ]
       ; name = None
       ; tool_call_id = None
       ; metadata = []

--- a/test/test_thinking_control_dialects.ml
+++ b/test/test_thinking_control_dialects.ml
@@ -228,11 +228,9 @@ let test_mimo_v25_uses_thinking_object_and_json_schema () =
     "toggle wire"
     "thinking_object_only"
     (RD.toggle_wire_to_string dialect.toggle_wire);
-  check
-    string
-    "visibility"
-    "side_channel:reasoning_content"
-    (RD.visibility_to_string dialect.visibility);
+  (* reasoning_visibility vocab was retired (#2304, #2236 CoT loop fix);
+     "side_channel:reasoning_content" is now governed by reasoning_replay
+     policy, exercised in test_provider_agnostic_reasoning_replay. *)
   let thinking = json |> member "thinking" in
   check string "thinking type" "disabled" (thinking |> member "type" |> to_string);
   check_member_absent "chat_template_kwargs" json;


### PR DESCRIPTION
## Why
oas main CI is red since the #2232 merge (run 28417389801, 03:04Z): **Build & Test**, **OCaml Format**, and **Release Tag Drift** all fail. This blocks the 0.208.1 release and every downstream PR.

## Root cause
- **Build**: `test/test_thinking_control_dialects.ml:235` referenced `RD.visibility_to_string dialect.visibility`. #2304 retired the `reasoning_visibility` vocab (the `visibility` field and `visibility_to_string`). #2232 re-introduced the stale reference from a pre-#2304 base → `Unbound value RD.visibility_to_string` → Build failure. (Radius collision: two PRs in the same reasoning area diverged.)
- **OCaml Format**: 9 files drifted — draft PRs skip the Format check, so post-merge main `dune build @fmt` is red.
- **Release Tag Drift**: `v0.207.28` is in CHANGELOG but has no git tag (handled separately).

## Fix
- Drop the obsolete visibility check. `side_channel:reasoning_content` is now governed by the `reasoning_replay` policy, exercised in `test_provider_agnostic_reasoning_replay` (the #2236 anti-parrot harness).
- `ocamlformat -i` the 9 drifted files: `lib/agent_tool.ml`, `lib/llm_provider/utf8_sanitize.ml`, `test/test_api.ml`, `test/test_complete_http.ml`, `test/test_context_reducer.ml`, `test/test_llm_cache.ml`, `test/test_pipeline_deep.ml`, `test/test_provider_agnostic_reasoning_replay.ml`, `test/test_succession.ml`.

## Validation
CI on this PR (Build & Test + OCaml Format must both turn green). Local `ocamlformat -i` applied; no behavior change beyond dropping the obsolete assertion and formatting.

## P0–P3
- **P0**: main CI red — fixed (Build + Format).
- **P1**: none.
- **P2**: Release Tag Drift `v0.207.28` — separate tag push, not in this PR.
- **P3**: Format check should run on draft PRs too (systemic guard), so draft skips stop reddening main on merge. Out of scope here.

## Mergeability
Shippable once CI green. main recovery is time-critical (0.208.1 release + downstream PRs blocked).

Co-Authored-By: Claude <noreply@anthropic.com>
