### PR TITLE
fix: harden thinking capability fallbacks

### DIFF
--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -47,18 +47,7 @@ type model_spec =
   ; capabilities : capabilities
   }
 
-(** Check if a model needs extended OpenAI capabilities
-    (reasoning, top_k, min_p). Currently triggers on dashscope family models. *)
-let needs_extended_capabilities model_id =
-  let normalized = String.lowercase_ascii (String.trim model_id) in
-  Util.string_contains ~needle:"dashscope" normalized
-;;
-
-let default_openai_compat_capabilities model_id =
-  if needs_extended_capabilities model_id
-  then openai_compat_chat_extended_capabilities
-  else openai_compat_chat_capabilities
-;;
+let default_openai_compat_capabilities () = openai_compat_chat_capabilities
 
 let uses_native_glm_capabilities ~base_url ~model_id =
   Llm_provider.Zai_catalog.is_zai_base_url base_url
@@ -289,11 +278,11 @@ let capabilities_for_model ~(provider : provider) ~(model_id : string) =
     if
       Llm_provider.Zai_catalog.is_glm_model_id model_id
       && not (uses_native_glm_capabilities ~base_url ~model_id)
-    then default_openai_compat_capabilities model_id
+    then default_openai_compat_capabilities ()
     else (
       match Llm_provider.Capabilities.for_model_id model_id with
       | Some caps -> caps
-      | None -> default_openai_compat_capabilities model_id)
+      | None -> default_openai_compat_capabilities ())
   | Custom_registered { name } ->
     (match find_provider name with
      | Some impl -> impl.capabilities

--- a/test/dune
+++ b/test/dune
@@ -439,6 +439,7 @@
   test_tool_op
   test_tool_set)
  (libraries agent_sdk alcotest qcheck-core qcheck-alcotest)
+ (deps ../models.toml)
  (action
   (run %{test})))
 

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -37,6 +37,32 @@ let with_provider_catalog json f =
     Fun.protect ~finally:Llm_provider.Provider_catalog.clear_global f
 ;;
 
+let install_repo_model_catalog () =
+  let candidates = [ "models.toml"; "../models.toml"; "../../models.toml" ] in
+  match List.find_opt Sys.file_exists candidates with
+  | None -> Alcotest.fail "models.toml not found for provider tests"
+  | Some path ->
+    (match Llm_provider.Model_catalog.load_file path with
+     | Error msg -> Alcotest.fail (Printf.sprintf "models.toml should parse: %s" msg)
+     | Ok catalog -> Llm_provider.Model_catalog.set_global catalog)
+;;
+
+let with_empty_capability_sources f =
+  let original_catalog = Llm_provider.Model_catalog.global () in
+  let original_manifest = Llm_provider.Capability_manifest.global () in
+  Llm_provider.Model_catalog.set_global [];
+  Llm_provider.Capability_manifest.set_global [];
+  Fun.protect
+    ~finally:(fun () ->
+      (match original_catalog with
+       | Some catalog -> Llm_provider.Model_catalog.set_global catalog
+       | None -> Llm_provider.Model_catalog.clear_global ());
+      match original_manifest with
+      | Some manifest -> Llm_provider.Capability_manifest.set_global manifest
+      | None -> Llm_provider.Capability_manifest.clear_global ())
+    f
+;;
+
 let test_missing_env_var () =
   (* Anthropic provider checks env var; nonexistent key -> Error *)
   let cfg : Provider.config =
@@ -360,6 +386,24 @@ let test_extended_openai_capabilities () =
   Alcotest.(check bool) "supports reasoning" true capabilities.supports_reasoning;
   Alcotest.(check bool) "supports top_k" true capabilities.supports_top_k;
   Alcotest.(check bool) "supports min_p" true capabilities.supports_min_p
+;;
+
+let test_raw_openai_compat_does_not_infer_dashscope_from_model_id () =
+  with_empty_capability_sources (fun () ->
+    let capabilities =
+      Provider.capabilities_for_model
+        ~provider:
+          (Provider.OpenAICompat
+             { base_url = "https://compat.example.invalid/v1"
+             ; auth_header = None
+             ; path = "/chat/completions"
+             ; static_token = None
+             })
+        ~model_id:"dashscope-compatible-unknown"
+    in
+    Alcotest.(check bool) "supports reasoning" false capabilities.supports_reasoning;
+    Alcotest.(check bool) "supports top_k" false capabilities.supports_top_k;
+    Alcotest.(check bool) "supports min_p" false capabilities.supports_min_p)
 ;;
 
 let test_anthropic_capabilities_consults_for_model_id () =
@@ -1017,6 +1061,7 @@ let test_provider_config_of_agent_custom_registered_unknown_name () =
 ;;
 
 let () =
+  install_repo_model_catalog ();
   Alcotest.run
     "Provider"
     [ ( "resolve"
@@ -1073,6 +1118,10 @@ let () =
             "extended openai capabilities"
             `Quick
             test_extended_openai_capabilities
+        ; Alcotest.test_case
+            "raw openai_compat does not infer dashscope"
+            `Quick
+            test_raw_openai_compat_does_not_infer_dashscope_from_model_id
         ; Alcotest.test_case
             "anthropic consults for_model_id (#824)"
             `Quick

--- a/test/test_thinking_control_dialects.ml
+++ b/test/test_thinking_control_dialects.ml
@@ -11,6 +11,7 @@ module BOL = Llm_provider.Backend_ollama
 module BAN = Llm_provider.Backend_anthropic
 module CAP = Llm_provider.Capabilities
 module CM = Llm_provider.Capability_manifest
+module MC = Llm_provider.Model_catalog
 module RD = Llm_provider.Reasoning_dialect
 module RE = Llm_provider.Reasoning_effort
 open Alcotest
@@ -25,7 +26,24 @@ let with_manifest json f =
   | Error msg -> fail ("manifest parse failed: " ^ msg)
   | Ok manifest ->
     CM.set_global manifest;
-    Fun.protect ~finally:CM.clear_global f
+    Fun.protect ~finally:(fun () -> CM.set_global []) f
+;;
+
+let without_ambient_manifest f =
+  CM.set_global [];
+  let candidates = [ "models.toml"; "../models.toml" ] in
+  match List.find_opt Sys.file_exists candidates with
+  | None -> fail "models.toml not found for thinking-control dialect tests"
+  | Some path ->
+    (match MC.load_file path with
+     | Error msg -> fail ("failed to load " ^ path ^ ": " ^ msg)
+     | Ok catalog ->
+       MC.set_global catalog;
+       Fun.protect
+         ~finally:(fun () ->
+           MC.clear_global ();
+           CM.clear_global ())
+         f)
 ;;
 
 let check_member_absent name json =
@@ -761,133 +779,134 @@ let test_gemini_reasoning_dialect_uses_thinking_config () =
 ;;
 
 let () =
-  run
-    "thinking_control_dialects"
-    [ ( "openai_compat"
-      , [ test_case
-            "qwen uses chat_template_kwargs"
-            `Quick
-            test_qwen_openai_compat_uses_chat_template_kwargs
-        ; test_case
-            "qwen3.6 self-hosted uses chat_template_kwargs"
-            `Quick
-            test_qwen36_self_hosted_openai_compat_uses_chat_template_kwargs
-        ; test_case
-            "qwen3.6 reasoning dialect uses chat_template_kwargs"
-            `Quick
-            test_qwen36_reasoning_dialect_uses_chat_template_kwargs
-        ; test_case
-            "qwen3.6 reasoning dialect without preserve drops reasoning"
-            `Quick
-            test_qwen36_reasoning_dialect_without_preserve_drops_reasoning
-        ; test_case
-            "qwen3.6 dashscope uses top-level enable_thinking"
-            `Quick
-            test_qwen36_dashscope_uses_top_level_enable_thinking
-        ; test_case
-            "qwen3.6 dashscope dialect reports enable_thinking"
-            `Quick
-            test_qwen36_dashscope_dialect_reports_enable_thinking
-        ; test_case
-            "mimo v2.5 uses thinking object and json_schema"
-            `Quick
-            test_mimo_v25_uses_thinking_object_and_json_schema
-        ; test_case
-            "openai reasoning dialect uses reasoning_effort"
-            `Quick
-            test_openai_reasoning_dialect_uses_reasoning_effort
-        ; test_case
-            "openai reasoning request uses reasoning_effort"
-            `Quick
-            test_openai_reasoning_request_uses_reasoning_effort
-        ; test_case
-            "deepseek uses thinking object"
-            `Quick
-            test_deepseek_openai_compat_uses_thinking_object
-        ; test_case
-            "deepseek reasoning dialect semantics"
-            `Quick
-            test_deepseek_reasoning_dialect_semantics
-        ; test_case
-            "deepseek suppresses ignored sampling in thinking mode"
-            `Quick
-            test_deepseek_sampling_suppressed_in_thinking_mode
-        ; test_case
-            "deepseek disabled thinking keeps sampling"
-            `Quick
-            test_deepseek_disabled_thinking_keeps_sampling
-        ; test_case
-            "deepseek replays reasoning only for tool call turns"
-            `Quick
-            test_deepseek_replays_reasoning_only_for_tool_call_turns
-        ; test_case
-            "qwen preserve replays reasoning_content"
-            `Quick
-            test_qwen_preserve_replays_reasoning_content
-        ; test_case
-            "thinking_object_keep_all axis uses thinking keep all"
-            `Quick
-            test_thinking_object_keep_all_axis_uses_keep_all
-        ; test_case
-            "thinking_object_keep_all axis replays reasoning"
-            `Quick
-            test_thinking_object_keep_all_axis_replays_reasoning
-        ; test_case
-            "kimi latest always-preserved omits thinking param"
-            `Quick
-            test_kimi_latest_always_preserved_omits_thinking_param
-        ] )
-    ; ( "ollama"
-      , [ test_case
-            "qwen uses native think bool"
-            `Quick
-            test_ollama_qwen_uses_native_think_bool
-        ; test_case
-            "cloud GLM uses native think not ZAI thinking"
-            `Quick
-            test_ollama_cloud_glm_uses_native_think_not_zai_thinking
-        ; test_case
-            "gemma4 enabled uses chat template token"
-            `Quick
-            test_ollama_gemma4_enabled_uses_chat_template_token
-        ; test_case
-            "gemma4 disabled uses native think false"
-            `Quick
-            test_ollama_gemma4_disabled_uses_native_think_false
-        ; test_case
-            "gemma4 reasoning dialect uses template parser"
-            `Quick
-            test_gemma4_reasoning_dialect_uses_template_parser
-        ] )
-    ; ( "native"
-      , [ test_case
-            "anthropic reasoning dialect preserves thinking"
-            `Quick
-            test_anthropic_reasoning_dialect_preserves_thinking
-        ; test_case
-            "anthropic manual model uses budget_tokens"
-            `Quick
-            test_anthropic_manual_model_uses_budget_tokens
-        ; test_case
-            "anthropic opus 4.8 uses adaptive effort"
-            `Quick
-            test_anthropic_opus48_uses_adaptive_effort
-        ; test_case
-            "anthropic claude alias uses adaptive effort"
-            `Quick
-            test_anthropic_agent_llm_alias_uses_adaptive_effort
-        ; test_case
-            "anthropic sonnet 4.6 defaults to adaptive"
-            `Quick
-            test_anthropic_sonnet46_defaults_to_adaptive
-        ; test_case
-            "anthropic output_config merges format and effort"
-            `Quick
-            test_anthropic_output_config_merges_format_and_effort
-        ; test_case
-            "gemini reasoning dialect uses thinking config"
-            `Quick
-            test_gemini_reasoning_dialect_uses_thinking_config
-        ] )
-    ]
+  without_ambient_manifest (fun () ->
+    run
+      "thinking_control_dialects"
+      [ ( "openai_compat"
+        , [ test_case
+              "qwen uses chat_template_kwargs"
+              `Quick
+              test_qwen_openai_compat_uses_chat_template_kwargs
+          ; test_case
+              "qwen3.6 self-hosted uses chat_template_kwargs"
+              `Quick
+              test_qwen36_self_hosted_openai_compat_uses_chat_template_kwargs
+          ; test_case
+              "qwen3.6 reasoning dialect uses chat_template_kwargs"
+              `Quick
+              test_qwen36_reasoning_dialect_uses_chat_template_kwargs
+          ; test_case
+              "qwen3.6 reasoning dialect without preserve drops reasoning"
+              `Quick
+              test_qwen36_reasoning_dialect_without_preserve_drops_reasoning
+          ; test_case
+              "qwen3.6 dashscope uses top-level enable_thinking"
+              `Quick
+              test_qwen36_dashscope_uses_top_level_enable_thinking
+          ; test_case
+              "qwen3.6 dashscope dialect reports enable_thinking"
+              `Quick
+              test_qwen36_dashscope_dialect_reports_enable_thinking
+          ; test_case
+              "mimo v2.5 uses thinking object and json_schema"
+              `Quick
+              test_mimo_v25_uses_thinking_object_and_json_schema
+          ; test_case
+              "openai reasoning dialect uses reasoning_effort"
+              `Quick
+              test_openai_reasoning_dialect_uses_reasoning_effort
+          ; test_case
+              "openai reasoning request uses reasoning_effort"
+              `Quick
+              test_openai_reasoning_request_uses_reasoning_effort
+          ; test_case
+              "deepseek uses thinking object"
+              `Quick
+              test_deepseek_openai_compat_uses_thinking_object
+          ; test_case
+              "deepseek reasoning dialect semantics"
+              `Quick
+              test_deepseek_reasoning_dialect_semantics
+          ; test_case
+              "deepseek suppresses ignored sampling in thinking mode"
+              `Quick
+              test_deepseek_sampling_suppressed_in_thinking_mode
+          ; test_case
+              "deepseek disabled thinking keeps sampling"
+              `Quick
+              test_deepseek_disabled_thinking_keeps_sampling
+          ; test_case
+              "deepseek replays reasoning only for tool call turns"
+              `Quick
+              test_deepseek_replays_reasoning_only_for_tool_call_turns
+          ; test_case
+              "qwen preserve replays reasoning_content"
+              `Quick
+              test_qwen_preserve_replays_reasoning_content
+          ; test_case
+              "thinking_object_keep_all axis uses thinking keep all"
+              `Quick
+              test_thinking_object_keep_all_axis_uses_keep_all
+          ; test_case
+              "thinking_object_keep_all axis replays reasoning"
+              `Quick
+              test_thinking_object_keep_all_axis_replays_reasoning
+          ; test_case
+              "kimi latest always-preserved omits thinking param"
+              `Quick
+              test_kimi_latest_always_preserved_omits_thinking_param
+          ] )
+      ; ( "ollama"
+        , [ test_case
+              "qwen uses native think bool"
+              `Quick
+              test_ollama_qwen_uses_native_think_bool
+          ; test_case
+              "cloud GLM uses native think not ZAI thinking"
+              `Quick
+              test_ollama_cloud_glm_uses_native_think_not_zai_thinking
+          ; test_case
+              "gemma4 enabled uses chat template token"
+              `Quick
+              test_ollama_gemma4_enabled_uses_chat_template_token
+          ; test_case
+              "gemma4 disabled uses native think false"
+              `Quick
+              test_ollama_gemma4_disabled_uses_native_think_false
+          ; test_case
+              "gemma4 reasoning dialect uses template parser"
+              `Quick
+              test_gemma4_reasoning_dialect_uses_template_parser
+          ] )
+      ; ( "native"
+        , [ test_case
+              "anthropic reasoning dialect preserves thinking"
+              `Quick
+              test_anthropic_reasoning_dialect_preserves_thinking
+          ; test_case
+              "anthropic manual model uses budget_tokens"
+              `Quick
+              test_anthropic_manual_model_uses_budget_tokens
+          ; test_case
+              "anthropic opus 4.8 uses adaptive effort"
+              `Quick
+              test_anthropic_opus48_uses_adaptive_effort
+          ; test_case
+              "anthropic claude alias uses adaptive effort"
+              `Quick
+              test_anthropic_agent_llm_alias_uses_adaptive_effort
+          ; test_case
+              "anthropic sonnet 4.6 defaults to adaptive"
+              `Quick
+              test_anthropic_sonnet46_defaults_to_adaptive
+          ; test_case
+              "anthropic output_config merges format and effort"
+              `Quick
+              test_anthropic_output_config_merges_format_and_effort
+          ; test_case
+              "gemini reasoning dialect uses thinking config"
+              `Quick
+              test_gemini_reasoning_dialect_uses_thinking_config
+          ] )
+      ])
 ;;


### PR DESCRIPTION
## Summary
- remove raw OpenAI-compatible DashScope capability inference from model-id substrings
- keep DashScope support on explicit catalog/provider-kind paths and add a negative regression for unknown raw compat endpoints
- make provider and thinking-control tests load/clear model capability sources explicitly
- apply ocamlformat drift needed for the previously failing format target

## Validation
- `scripts/dune-local.sh exec test/test_provider.exe`
- `scripts/dune-local.sh exec test/test_thinking_control_dialects.exe`
- `env OAS_MODEL_CATALOG=models.toml scripts/dune-local.sh exec test/test_property_advanced.exe`
- `scripts/dune-local.sh build @fmt`
- `git diff --check`

## Notes
- PR #2232 is already merged, but its check set still shows release tag drift for `v0.207.28`; that release metadata issue is tracked on #2035 with a fresh comment.