### PR TITLE
fix(streaming): read reasoning deltas from dialect

### DIFF
--- a/lib/llm_provider/backend_glm.ml
+++ b/lib/llm_provider/backend_glm.ml
@@ -268,7 +268,11 @@ let parse_response body =
 (** Parse Glm SSE chunk.  Glm uses Openai SSE format but adds
     [delta.reasoning_content] for thinking. We parse this as
     [delta_reasoning] in the openai_chunk type. *)
-let parse_stream_chunk = Streaming.parse_openai_sse_chunk
+let parse_stream_chunk data =
+  Streaming.parse_openai_sse_chunk
+    ~streaming_reasoning:(Reasoning_dialect.Delta_field "reasoning_content")
+    data
+;;
 
 (* ── Inline tests ────────────────────────────────── *)
 

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -550,6 +550,9 @@ let complete_stream_http
             let body_logic () =
               let acc = Complete_stream_acc.create_stream_acc () in
               let openai_state = ref None in
+              let streaming_reasoning =
+                (Reasoning_dialect.for_provider_config config).streaming
+              in
               (* RFC-OAS-019: first_chunk_seen / chunk_counter / last_chunk_t
                  hoisted out of body_logic so publish_summary on
                  exception paths sees consistent state. *)
@@ -741,7 +744,11 @@ let complete_stream_http
                            | Provider_config.OpenAI_compat
                            | Provider_config.DashScope
                            | Provider_config.Kimi ->
-                             (match Streaming.parse_openai_sse_chunk data with
+                             (match
+                                Streaming.parse_openai_sse_chunk
+                                  ~streaming_reasoning
+                                  data
+                              with
                               | Some chunk ->
                                 Streaming.openai_chunk_to_events (get_state ()) chunk
                               | None ->

--- a/lib/llm_provider/reasoning_dialect.ml
+++ b/lib/llm_provider/reasoning_dialect.ml
@@ -72,7 +72,11 @@ let base_of_capabilities (caps : Capabilities.capabilities) =
   | No_thinking_control ->
     let dialect = { default with preserve_wire } in
     (match preserve_wire with
-     | Always_preserved_thinking -> { dialect with replay_policy = Preserve_always }
+     | Always_preserved_thinking ->
+       { dialect with
+         replay_policy = Preserve_always
+       ; streaming = Delta_field "reasoning_content"
+       }
      | No_preserve_thinking_control
      | Thinking_object_keep_all
      | Chat_template_kwargs_preserve_thinking

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -322,7 +322,7 @@ let openai_done_sentinel = "[DONE]"
 (** Parse a single Openai SSE data payload into an {!openai_chunk}.
     Returns [None] for the {!openai_done_sentinel} ("[DONE]") or unparseable
     data. *)
-let parse_openai_sse_chunk data_str : openai_chunk option =
+let parse_openai_sse_chunk ?streaming_reasoning data_str : openai_chunk option =
   if String.equal data_str openai_done_sentinel
   then None
   else
@@ -383,10 +383,21 @@ let parse_openai_sse_chunk data_str : openai_chunk option =
       | choice :: _ ->
         let delta = choice |> member "delta" in
         let delta_content = delta |> member "content" |> to_string_option in
-        let delta_reasoning =
-          match delta |> member "reasoning_content" |> to_string_option with
+        let non_blank_delta_field field =
+          match delta |> member field |> to_string_option with
           | Some s when String.trim s <> "" -> Some s
-          | Some _ | None -> delta |> member "reasoning" |> to_string_option
+          | Some _ | None -> None
+        in
+        let delta_reasoning =
+          match streaming_reasoning with
+          | Some (Reasoning_dialect.Delta_field field) -> non_blank_delta_field field
+          | Some
+              (Reasoning_dialect.No_streaming_reasoning | Reasoning_dialect.Template_parser)
+            -> None
+          | None ->
+            (match non_blank_delta_field "reasoning_content" with
+             | Some _ as reasoning -> reasoning
+             | None -> delta |> member "reasoning" |> to_string_option)
         in
         let delta_tool_calls =
           match delta |> member "tool_calls" with

--- a/lib/llm_provider/streaming.mli
+++ b/lib/llm_provider/streaming.mli
@@ -98,7 +98,10 @@ type openai_stream_state =
   ; model : string
   }
 
-val parse_openai_sse_chunk : string -> openai_chunk option
+val parse_openai_sse_chunk
+  :  ?streaming_reasoning:Reasoning_dialect.streaming_reasoning
+  -> string
+  -> openai_chunk option
 
 (** Surface an OpenAI-compatible mid-stream error object
     ([{"error": {"type"; "message"; ...}}]) as a typed [SSEError]. Call this

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -322,6 +322,15 @@ let test_lookup_kimi_k2_native_cloud_suffix () =
       "native latest Kimi always preserves reasoning"
       true
       (native.preserve_thinking_control_format = Capabilities.Always_preserved_thinking);
+    let native_kimi_dialect = Reasoning_dialect.of_capabilities native in
+    (match native_kimi_dialect.streaming with
+     | Reasoning_dialect.Delta_field "reasoning_content" -> ()
+     | Reasoning_dialect.Delta_field field ->
+       fail ("native latest Kimi reasoning delta field drifted: " ^ field)
+     | Reasoning_dialect.No_streaming_reasoning ->
+       fail "native latest Kimi reasoning stream field was dropped"
+     | Reasoning_dialect.Template_parser ->
+       fail "native latest Kimi should not use template parser streaming");
     check_preserve_order "native Kimi latest" native;
     check bool "native Kimi code execution" true native.supports_code_execution;
     (match Capabilities.for_model_id "kimi-k2" with

--- a/test/test_streaming_openai.ml
+++ b/test/test_streaming_openai.ml
@@ -2,6 +2,7 @@
 
 open Llm_provider.Types
 module S = Llm_provider.Streaming
+module RD = Llm_provider.Reasoning_dialect
 
 (* ── parse_openai_sse_chunk ─────────────────────────────── *)
 
@@ -318,6 +319,33 @@ let test_parse_blank_reasoning_content_falls_back () =
       "blank falls back"
       (Some "actual thinking")
       chunk.delta_reasoning
+  | None -> Alcotest.fail "expected Some chunk"
+;;
+
+let test_parse_reasoning_uses_dialect_delta_field () =
+  let data =
+    {|{"id":"c-dialect","model":"dialect","choices":[{"index":0,"delta":{"reasoning_content":"wrong","reasoning":"selected"},"finish_reason":null}]}|}
+  in
+  match
+    S.parse_openai_sse_chunk ~streaming_reasoning:(RD.Delta_field "reasoning") data
+  with
+  | Some chunk ->
+    Alcotest.(check (option string))
+      "dialect-selected reasoning"
+      (Some "selected")
+      chunk.delta_reasoning
+  | None -> Alcotest.fail "expected Some chunk"
+;;
+
+let test_parse_reasoning_respects_no_streaming_dialect () =
+  let data =
+    {|{"id":"c-none","model":"dialect","choices":[{"index":0,"delta":{"reasoning_content":"hidden"},"finish_reason":null}]}|}
+  in
+  match
+    S.parse_openai_sse_chunk ~streaming_reasoning:RD.No_streaming_reasoning data
+  with
+  | Some chunk ->
+    Alcotest.(check (option string)) "no reasoning" None chunk.delta_reasoning
   | None -> Alcotest.fail "expected Some chunk"
 ;;
 
@@ -1068,6 +1096,14 @@ let () =
             "blank reasoning_content falls back"
             `Quick
             test_parse_blank_reasoning_content_falls_back
+        ; test_case
+            "reasoning dialect field"
+            `Quick
+            test_parse_reasoning_uses_dialect_delta_field
+        ; test_case
+            "no streaming reasoning dialect"
+            `Quick
+            test_parse_reasoning_respects_no_streaming_dialect
         ] )
     ; ( "openai_chunk_to_events"
       , [ test_case "text first chunk" `Quick test_events_text_first_chunk


### PR DESCRIPTION
## Summary
- thread OpenAI-compatible stream reasoning parsing through Reasoning_dialect.streaming
- make always-preserved Kimi-style dialects declare reasoning_content as their stream side-channel
- add parser and capability regressions for dialect-selected/no-streaming behavior

## Validation
- git diff --check
- CI is the Dune build/test authority for this branch