### PR TITLE
fix(streaming): preserve malformed tool-arg buffer for keeper-log diagnosis

### DIFF
--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -29,15 +29,21 @@ let record_streaming_metrics (metrics : Metrics.t) = function
   | Context_window_usage _ -> ()
 ;;
 
-(* Bound the offending payload echoed into a parse-failure message so a large
-   tool-argument buffer cannot bloat the keeper log. [%S] at the call site
+(* Scrub-then-bound the offending payload echoed into a parse-failure message.
+   Tool arguments can carry credentials (Bearer tokens, API keys, URL userinfo),
+   so the buffer passes through the [Secret_redactor] SSOT -- the same boundary
+   [complete_common] already applies to provider error bodies -- before it
+   reaches the operator-facing message. Redaction runs first so truncation
+   cannot split a token past the redactor and leak a partial; the bound then
+   keeps a large buffer from bloating the keeper log. [%S] at the call site
    escapes embedded quotes/newlines. *)
 let max_parse_error_raw_excerpt = 256
 
 let parse_error_raw_excerpt raw =
-  if String.length raw <= max_parse_error_raw_excerpt
-  then raw
-  else String.sub raw 0 max_parse_error_raw_excerpt ^ "...(truncated)"
+  let redacted = Secret_redactor.redact_string raw in
+  if String.length redacted <= max_parse_error_raw_excerpt
+  then redacted
+  else String.sub redacted 0 max_parse_error_raw_excerpt ^ "...(truncated)"
 ;;
 
 (* Internal: HTTP-specific streaming implementation. *)
@@ -173,6 +179,21 @@ let%test "parse failure raw excerpt is bounded" =
   match http_error_of_stream_error (Types.Stream_parse_failed { reason; raw }) with
   | Http_client.ProviderFailure { message; _ } ->
     String.length message < String.length raw
+  | _ -> false
+;;
+
+let%test "parse failure redacts secret tokens in the echoed raw buffer" =
+  (* Tool arguments can carry credentials; the operator-visible message must
+     scrub them through the [Secret_redactor] SSOT rather than echo the token
+     verbatim. A [ghp_]-prefixed token is redacted to [[REDACTED]] (see
+     [Secret_redactor]'s own tests), so the rendered message must equal the
+     redacted form -- which definitionally no longer contains the token. *)
+  let reason = "malformed_tool_use_arguments:index:0:bad" in
+  let raw = {|{"auth":"ghp_xxxxxxxxxxxx"}{}|} in
+  match http_error_of_stream_error (Types.Stream_parse_failed { reason; raw }) with
+  | Http_client.ProviderFailure { message; _ } ->
+    message
+    = Printf.sprintf "SSE parse failed: %s raw=%S" reason {|{"auth":"[REDACTED]"}{}|}
   | _ -> false
 ;;
 

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -29,6 +29,17 @@ let record_streaming_metrics (metrics : Metrics.t) = function
   | Context_window_usage _ -> ()
 ;;
 
+(* Bound the offending payload echoed into a parse-failure message so a large
+   tool-argument buffer cannot bloat the keeper log. [%S] at the call site
+   escapes embedded quotes/newlines. *)
+let max_parse_error_raw_excerpt = 256
+
+let parse_error_raw_excerpt raw =
+  if String.length raw <= max_parse_error_raw_excerpt
+  then raw
+  else String.sub raw 0 max_parse_error_raw_excerpt ^ "...(truncated)"
+;;
+
 (* Internal: HTTP-specific streaming implementation. *)
 (* Converge a stream-finalize error onto the same typed carrier the
    non-streaming path produces. A provider-reported error with a recognized
@@ -48,10 +59,20 @@ let http_error_of_stream_error (serr : Types.stream_error) : Http_client.http_er
                }
          ; message = Printf.sprintf "SSE stream error: %s" message
          })
-  | Types.Stream_parse_failed { reason; _ } ->
+  | Types.Stream_parse_failed { reason; raw } ->
     Http_client.ProviderFailure
       { kind = Http_client.Provider_parse_error { parser = Some "sse" }
-      ; message = Printf.sprintf "SSE parse failed: %s" reason
+      ; message =
+          (match raw with
+           | "" -> Printf.sprintf "SSE parse failed: %s" reason
+           | raw ->
+             (* Echo the offending buffer (bounded) so a rare, provider-specific
+                malformed wire is diagnosable from the keeper log instead of
+                discarded at the carrier boundary. *)
+             Printf.sprintf
+               "SSE parse failed: %s raw=%S"
+               reason
+               (parse_error_raw_excerpt raw))
       }
   | Types.Stream_unknown_event { event_type; _ } ->
     Http_client.ProviderFailure
@@ -130,6 +151,29 @@ let maps_to_sse_parse_failure stream_error =
 
 let%test "stream parse failure stays provider parse failure" =
   maps_to_sse_parse_failure (Types.Stream_parse_failed { reason = "bad json"; raw = "x" })
+;;
+
+let%test "parse failure echoes the offending raw buffer for diagnosis" =
+  (* The malformed tool-arg buffer must reach the keeper-visible message so a
+     rare, provider-specific malformed wire is debuggable instead of discarded
+     at the carrier boundary. *)
+  let reason = "malformed_tool_use_arguments:index:1:bad" in
+  let raw = {|{"location":"Tokyo"}{}|} in
+  match http_error_of_stream_error (Types.Stream_parse_failed { reason; raw }) with
+  | Http_client.ProviderFailure { message; _ } ->
+    message = Printf.sprintf "SSE parse failed: %s raw=%S" reason raw
+  | _ -> false
+;;
+
+let%test "parse failure raw excerpt is bounded" =
+  (* A large argument buffer must not bloat the log line: the echoed excerpt is
+     bounded well below the full buffer length. *)
+  let reason = "malformed_tool_use_arguments:index:0:bad" in
+  let raw = String.make 1000 'x' in
+  match http_error_of_stream_error (Types.Stream_parse_failed { reason; raw }) with
+  | Http_client.ProviderFailure { message; _ } ->
+    String.length message < String.length raw
+  | _ -> false
 ;;
 
 let%test "stream unknown event stays provider parse failure" =

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -284,11 +284,21 @@ let finalize_stream_acc (acc : stream_acc) =
           match Yojson.Safe.from_string text with
           | input -> Ok (Some (Types.ToolUse { id; name; input }))
           | exception Yojson.Json_error reason ->
+            (* Preserve the offending accumulated buffer in [raw] so the rare,
+               provider-specific malformed tool-arg wire is diagnosable from the
+               keeper log (the [Complete_stream] renderer bounds it to 256 bytes).
+               [raw] reaches operator-facing logs only, never replayed into
+               conversation history. It may hold model-generated tool-argument
+               values, so it carries the same sensitivity as any logged request
+               payload -- not a new exposure surface, but not leak-free either.
+               The deliberately-empty [Unknown_block] arm below stays empty
+               because an unrecognized block payload has neither this bound nor a
+               known shape. *)
             Error
               (Types.Stream_parse_failed
                  { reason =
                      Printf.sprintf "malformed_tool_use_arguments:index:%d:%s" idx reason
-                 ; raw = ""
+                 ; raw = text
                  }))
       | Some (Tool_result_block { is_error }) ->
         let tool_use_id =
@@ -1013,7 +1023,10 @@ let%test "finalize_stream_acc fails closed on malformed tool_use arguments" =
     finalize_stream_acc acc
   with
   | Error (Types.Stream_parse_failed { reason; raw }) ->
-    raw = "" && String.starts_with ~prefix:"malformed_tool_use_arguments:index:0" reason
+    (* [raw] now preserves the offending buffer so the malformed wire is
+       diagnosable from the keeper log instead of being discarded. *)
+    raw = "not valid json"
+    && String.starts_with ~prefix:"malformed_tool_use_arguments:index:0" reason
   | Error (Types.Stream_provider_error _ | Types.Stream_unknown_event _) | Ok _ -> false
 ;;
 

--- a/test/test_stream_accumulator.ml
+++ b/test/test_stream_accumulator.ml
@@ -369,7 +369,9 @@ let test_finalize_tool_use_invalid_json () =
     ];
   match Streaming.finalize_stream_acc acc with
   | Error (Stream_parse_failed { reason; raw }) ->
-    Alcotest.(check string) "raw omitted" "" raw;
+    (* The offending tool-arg buffer is preserved in [raw] for keeper-log
+       diagnosis (the Unknown_block/media arms still omit it). *)
+    Alcotest.(check string) "raw preserved" "not json{" raw;
     Alcotest.(check bool)
       "malformed tool args"
       true

--- a/test/test_streaming_cov.ml
+++ b/test/test_streaming_cov.ml
@@ -354,7 +354,9 @@ let test_finalize_invalid_tool_json () =
     (Types.MessageDelta { stop_reason = Some Types.EndTurn; usage = None });
   match Streaming.finalize_stream_acc acc with
   | Error (Types.Stream_parse_failed { reason; raw }) ->
-    Alcotest.(check string) "raw omitted" "" raw;
+    (* The offending tool-arg buffer is preserved in [raw] for keeper-log
+       diagnosis (the Unknown_block/media arms still omit it). *)
+    Alcotest.(check string) "raw preserved" "not json{" raw;
     Alcotest.(check bool)
       "malformed tool args"
       true

--- a/test/test_streaming_coverage.ml
+++ b/test/test_streaming_coverage.ml
@@ -396,7 +396,9 @@ let test_finalize_tool_use_invalid_json () =
     (MessageDelta { stop_reason = Some EndTurn; usage = None });
   match Streaming.finalize_stream_acc acc with
   | Error (Stream_parse_failed { reason; raw }) ->
-    check_string "raw omitted" "" raw;
+    (* The offending tool-arg buffer is preserved in [raw] for keeper-log
+       diagnosis (the Unknown_block/media arms still omit it). *)
+    check_string "raw preserved" "not valid json{{{" raw;
     check_bool
       "malformed tool args"
       true


### PR DESCRIPTION
## 목적

스트리밍 도구 인자(tool arguments)가 파싱에 실패할 때(`malformed_tool_use_arguments`), 키퍼 로그에 실패 *사유*만 남고 **실제 offending 버퍼는 폐기되어** 근본 원인을 진단할 수 없는 관측성 공백을 메운다.

## 배경

라이브 fleet에서 `ollama_cloud.minimax-m3` 키퍼가 다음으로 turn-terminal:

```
malformed_tool_use_arguments:index:1:Line 1, bytes 45-47: Junk after end of JSON value: '{}'
```

- 이 fail-closed 자체는 정상이다 — PR #2261이 도입한 안전망(빈 `{}`로 silent 강등하지 않고 typed reject)이 작동한 것이다. #2296이 object-snapshot append→replace를 이미 고쳤다.
- 그러나 `ollama_cloud.minimax-m3`를 tool과 함께 **15회 재현**(작은/큰 args, multi-tool, thinking 활성)한 결과 매번 단일 청크 + object arguments로 정상 처리되었다. production malformed wire는 on-demand 재현되지 않는 **희귀** 케이스다.
- 실제 wire를 잡으려면 다음 발생 시점의 **offending 버퍼를 보존**해야 하는데, 현재는 두 지점에서 폐기된다:
  - `complete_stream_acc.ml` tool-arg arm: `Stream_parse_failed { raw = "" }` — 버퍼(`text`)를 안 담음
  - `complete_stream.ml:51` 렌더: `Stream_parse_failed { reason; _ }` — `raw`를 무시

## 변경

- `lib/llm_provider/complete_stream_acc.ml` — malformed tool-arg arm: `raw = ""` → `raw = text`. offending 누적 버퍼를 typed error에 보존.
  - **scope**: tool-arg arm만 변경. `Unknown_block` arm의 `raw = ""`는 미지 블록 내용 누출 방지를 위한 **의도된** 빈값(주석 명시)이고, `stream_terminated_without_stop_reason`은 per-buffer raw가 없다. 일괄 변경이 아닌 arm별 rationale 존중(N-of-M 아님).
- `lib/llm_provider/complete_stream.ml` — `Stream_parse_failed` 렌더에 bounded raw 노출: `"SSE parse failed: %s raw=%S"`. `parse_error_raw_excerpt`(256자 상한 + `...(truncated)`)로 큰 버퍼가 로그를 비대화하지 않게 절단. `%S`가 따옴표/개행 escape.
- 테스트:
  - 기존 inline 테스트(`raw = ""` 박제) → `raw = "not valid json"`(보존 단언)로 갱신
  - 신규 inline 2개: ① offending raw가 carrier 메시지에 정확히 echo됨 ② 1000자 버퍼가 절단되어 메시지가 버퍼보다 짧음

## 근거 / 비-안티패턴

- `raw` 필드는 원래 offending payload 운반용이다(`Stream_provider_error`는 이미 raw를 HTTP body로 사용). tool-arg arm만 이를 버리던 관측성 공백 복원.
- **telemetry-as-fix 아님**: malformed 처리(typed fail-closed)는 #2261이 이미 올바르게 한다. 본 변경은 그 fail-closed가 *왜* 발생했는지 진단 가능하게 만드는 관측성 복원이지, 데이터 손실을 가시화만 하고 두는 패턴이 아니다.
- `raw`는 operator-facing 로그에만 가고 conversation history로 replay되지 않는다. 다만 model-generated tool-argument 값(사용자 파생 데이터 가능)을 담을 수 있으므로, **"누출 위험 없음"이 아니라** 기존에 로깅되는 request payload와 동일한 민감도를 가진다 — 새 노출 표면을 만들지 않되 leak-free도 아니다. 256자 bound + history 미반영으로 노출 범위를 제한한다. (Unknown_block arm은 미지 페이로드라 bound도 shape도 없어 `raw=""` 유지.)

## 검증

- `scripts/dune-local.sh build test/test_stream_accumulator.exe` → exit 0 (post-#2232 main `9e7794f9b` / 0.208.1 기준)
- `dune runtest lib/llm_provider` inline 테스트 green (갱신 1 + 신규 2 포함)
- `test_stream_accumulator` green (보조 경로 무영향)

## 후속

이 PR은 진단 instrument이다. 배포 후 다음 `malformed_tool_use_arguments` 발생 시 키퍼 로그의 `raw=...`로 minimax 실제 wire를 확보하면, append-concat(provider별 tool-arg 관습 미스매치)인지 모델/게이트웨이 측 malformed인지 확정해 근본 fix(필요 시 provider-keyed tool-arg dialect)를 진행한다.

RFC-WAIVED: `lib/llm_provider/complete_stream*.ml`은 credential/identity/operator/sandbox/dashboard-credential/hooks/workflow 게이트 subsystem이 아니다. typed error의 기존 `raw` 운반 의미를 tool-arg arm에서 복원하는 국소 관측성 변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
