### PR TITLE
[codex] Add canonical tool call projection

### DIFF
--- a/lib/llm_provider/canonical_tool.ml
+++ b/lib/llm_provider/canonical_tool.ml
@@ -1,21 +1,43 @@
-(** Canonical tool-result projection (RFC-OAS-024, WP8 Increment 1).
+(** Canonical tool projections (RFC-OAS-024, WP8 Increments 1-2).
 
-    Increment 1 ships only the {e result} projection — the one piece wired into
-    a live consumer (the turn pipeline, see [Pipeline_stage_prepare]). The call
-    projection ([provider_tool_call] / [tool_calls_of_response]) and the
-    reasoning-link types are deferred to Increment 2, where a per-provider parse
-    path will consume them; shipping them now would be a fan-in==0 surface
-    (RFC-OAS-024 §7).
+    Increment 1 shipped the {e result} projection. Increment 2 adds the call
+    projection plus structural reasoning adjacency for consumers that need to
+    render or execute interleaved Thinking -> ToolUse responses.
 
-    Pure, total function over [Types.content_block]. It is {b not} a second
+    Pure, total projections over [Types.content_block]. This is {b not} a second
     in-memory SSOT: [content_block] remains the canonical representation and the
     projected value is derived from it at the provider boundary. Depends only on
-    [{Types; Yojson}] and references no execution, policy, or coordinator
-    concept (RFC-OAS-024 §1).
+    provider-boundary types and references no execution, policy, or coordinator
+    concept (RFC-OAS-024 §1). Reasoning adjacency is purely structural: only
+    contiguous reasoning blocks immediately before a ToolUse are linked.
 
     Lane A (Keystone K): no [id_origin]. [call_id] is the block's id verbatim,
     already the native wire id or a synthesized id depending on the provider
     parse path; ids are neither re-synthesized nor re-classified here. *)
+
+type provider_reasoning_kind =
+  | Visible_thinking
+  | Redacted_thinking
+
+type provider_reasoning_block =
+  { order_index : int
+  ; kind : provider_reasoning_kind
+  ; content : string
+  ; signature : string option
+  }
+
+type adjacent_reasoning =
+  | No_adjacent_reasoning
+  | Adjacent_reasoning of provider_reasoning_block list
+
+type provider_tool_call =
+  { call_id : string
+  ; name : string
+  ; input : Yojson.Safe.t
+  ; order_index : int
+  ; provider_kind : Provider_kind.t option
+  ; adjacent_reasoning : adjacent_reasoning
+  }
 
 type provider_tool_result =
   { call_id : string (** Correlates with the originating tool call. *)
@@ -27,6 +49,78 @@ type provider_tool_result =
         fresh parse, and not [provider_config.output_schema] (RFC-OAS-024 D7). *)
   ; is_error : bool
   }
+
+let provider_kind_of_response (response : Types.api_response) =
+  match response.telemetry with
+  | Some telemetry -> telemetry.provider_kind
+  | None -> None
+;;
+
+let reasoning_of_block ~order_index (block : Types.content_block) =
+  match block with
+  | Types.Thinking { content; signature } ->
+    Some { order_index; kind = Visible_thinking; content; signature }
+  | Types.RedactedThinking content ->
+    Some { order_index; kind = Redacted_thinking; content; signature = None }
+  | Types.Text _
+  | Types.ToolUse _
+  | Types.ToolResult _
+  | Types.Image _
+  | Types.Document _
+  | Types.Audio _ -> None
+;;
+
+type scan_state =
+  { order_index : int
+  ; provider_kind : Provider_kind.t option
+  ; pending_reasoning_rev : provider_reasoning_block list
+  ; tool_calls_rev : provider_tool_call list
+  }
+
+let adjacent_reasoning_of_pending = function
+  | [] -> No_adjacent_reasoning
+  | pending_reasoning_rev -> Adjacent_reasoning (List.rev pending_reasoning_rev)
+;;
+
+let scan_tool_call state (block : Types.content_block) =
+  match block with
+  | Types.ToolUse { id; name; input } ->
+    let tool_call =
+      { call_id = id
+      ; name
+      ; input
+      ; order_index = state.order_index
+      ; provider_kind = state.provider_kind
+      ; adjacent_reasoning = adjacent_reasoning_of_pending state.pending_reasoning_rev
+      }
+    in
+    { state with
+      order_index = state.order_index + 1
+    ; pending_reasoning_rev = []
+    ; tool_calls_rev = tool_call :: state.tool_calls_rev
+    }
+  | Types.Thinking _ | Types.RedactedThinking _ ->
+    let pending_reasoning_rev =
+      match reasoning_of_block ~order_index:state.order_index block with
+      | Some reasoning -> reasoning :: state.pending_reasoning_rev
+      | None -> state.pending_reasoning_rev
+    in
+    { state with order_index = state.order_index + 1; pending_reasoning_rev }
+  | Types.Text _ | Types.ToolResult _ | Types.Image _ | Types.Document _ | Types.Audio _
+    -> { state with order_index = state.order_index + 1; pending_reasoning_rev = [] }
+;;
+
+let tool_calls_of_response (response : Types.api_response) : provider_tool_call list =
+  let initial =
+    { order_index = 0
+    ; provider_kind = provider_kind_of_response response
+    ; pending_reasoning_rev = []
+    ; tool_calls_rev = []
+    }
+  in
+  let final_state = List.fold_left scan_tool_call initial response.content in
+  List.rev final_state.tool_calls_rev
+;;
 
 let tool_result_of_block (block : Types.content_block) : provider_tool_result option =
   match block with

--- a/lib/llm_provider/canonical_tool.mli
+++ b/lib/llm_provider/canonical_tool.mli
@@ -1,24 +1,70 @@
-(** Canonical tool-result projection (RFC-OAS-024, WP8 — Increment 1).
+(** Canonical tool projections (RFC-OAS-024, WP8 — Increments 1-2).
 
-    A typed read-projection of the tool-{e result} dimension of
-    {!Types.content_block}. It is {b not} a second in-memory SSOT:
+    Typed read-projections of the tool-call/tool-result dimensions of
+    {!Types.content_block}. These are {b not} a second in-memory SSOT:
     [content_block] remains the canonical representation and every value here is
     derived from it at the provider boundary.
 
-    Scope (RFC-OAS-024 §7): Increment 1 ships only [tool_result_of_block], which
-    is wired into the live turn pipeline. The call projection
-    ([provider_tool_call] / [tool_calls_of_response]) and the reasoning-link
-    types are deferred to Increment 2, where a per-provider parse path consumes
-    them — shipping them ahead of a consumer would be a fan-in==0 surface. The
-    Keystone (K: [id_origin]) and module-merge (M) sign-offs in RFC-OAS-024 §0
-    gate that call-projection increment, not this result-only slice.
+    Scope (RFC-OAS-024 §7): Increment 1 shipped [tool_result_of_block].
+    Increment 2 adds [provider_tool_call] and [tool_calls_of_response] as a
+    structural projection for downstream renderers/executors. Reasoning is only
+    linked when it is immediately adjacent in the canonical content order; this
+    module never infers semantic ownership across Text/media/result boundaries.
 
     Boundary (RFC-OAS-024 §1): OAS-owned provider canonicalization only. Depends
-    solely on [{Types; Yojson}] and references no execution, policy, or
+    solely on provider-boundary types and references no execution, policy, or
     coordinator concept. The downstream consumer is named only as an unnamed
     external role.
 
     @stability Evolving *)
+
+(** Reasoning block kind preserved from the canonical content block. *)
+type provider_reasoning_kind =
+  | Visible_thinking
+  | Redacted_thinking
+
+(** A provider reasoning block observed in a response.
+
+    [order_index] is the zero-based position in {!Types.api_response.content}.
+    [content] is the provider payload verbatim; for {!Redacted_thinking} it is
+    opaque redacted data, not display text. [signature] is present only for
+    signed visible thinking blocks. *)
+type provider_reasoning_block =
+  { order_index : int
+  ; kind : provider_reasoning_kind
+  ; content : string
+  ; signature : string option
+  }
+
+(** Reasoning blocks immediately adjacent to a tool call.
+
+    [Adjacent_reasoning blocks] means the blocks are contiguous immediately
+    before the [ToolUse] in canonical content order. It does {b not} mean OAS
+    inferred provider intent. *)
+type adjacent_reasoning =
+  | No_adjacent_reasoning
+  | Adjacent_reasoning of provider_reasoning_block list
+
+(** A single tool call projected at the provider boundary.
+
+    [call_id], [name], and [input] are mirrors of [ToolUse]. [order_index] is
+    the zero-based position in the response content list. [provider_kind] is
+    copied from response telemetry when present; it is never guessed. *)
+type provider_tool_call =
+  { call_id : string
+  ; name : string
+  ; input : Yojson.Safe.t
+  ; order_index : int
+  ; provider_kind : Provider_kind.t option
+  ; adjacent_reasoning : adjacent_reasoning
+  }
+
+(** Project tool calls from a response while preserving response order.
+
+    The projection is pure and total. Non-[ToolUse] blocks are ignored as tool
+    calls but still affect adjacency: any non-reasoning block clears pending
+    adjacent reasoning. *)
+val tool_calls_of_response : Types.api_response -> provider_tool_call list
 
 (** A single tool result projected at the provider boundary. Lane A: [call_id]
     is the originating tool-use id verbatim (native or synthesized upstream),

--- a/test/test_canonical_tool.ml
+++ b/test/test_canonical_tool.ml
@@ -1,15 +1,166 @@
-(** Tests for {!Llm_provider.Canonical_tool} — RFC-OAS-024 WP8 Increment 1.
+(** Tests for {!Llm_provider.Canonical_tool} — RFC-OAS-024 WP8 Increments 1-2.
 
-    Covers the result projection (round-trip fidelity, is_error, totality). The
-    call projection and reasoning types are deferred to Increment 2 (no live
-    consumer yet), so they are not implemented or tested here. The {e wiring} of
+    Covers result projection (round-trip fidelity, is_error, totality) and the
+    structural call projection used by downstream consumers that need to render
+    interleaved Thinking -> ToolUse responses. The {e wiring} of
     [tool_result_of_block] into the turn pipeline is covered by the inline tests
     on [Pipeline_stage_prepare.last_tool_results_from]. *)
 
 module Ct = Llm_provider.Canonical_tool
+module PK = Llm_provider.Provider_kind
 module Types = Llm_provider.Types
 
 let json_eq = Alcotest.testable Yojson.Safe.pp Yojson.Safe.equal
+
+let response ?provider_kind content : Types.api_response =
+  let telemetry =
+    match provider_kind with
+    | Some provider_kind ->
+      Some { Types.default_inference_telemetry with provider_kind = Some provider_kind }
+    | None -> None
+  in
+  { id = "resp_1"
+  ; model = "model"
+  ; stop_reason = Types.StopToolUse
+  ; content
+  ; usage = None
+  ; telemetry
+  }
+;;
+
+let one_tool_call resp =
+  match Ct.tool_calls_of_response resp with
+  | [ call ] -> call
+  | calls -> Alcotest.failf "expected one tool call, got %d" (List.length calls)
+;;
+
+let check_provider_kind label expected actual =
+  match expected, actual with
+  | None, None -> ()
+  | Some PK.Ollama, Some PK.Ollama -> ()
+  | Some PK.Anthropic, Some PK.Anthropic -> ()
+  | Some PK.Kimi, Some PK.Kimi -> ()
+  | Some PK.OpenAI_compat, Some PK.OpenAI_compat -> ()
+  | Some PK.Gemini, Some PK.Gemini -> ()
+  | Some PK.Glm, Some PK.Glm -> ()
+  | Some PK.DashScope, Some PK.DashScope -> ()
+  | _ -> Alcotest.failf "%s provider kind mismatch" label
+;;
+
+let check_no_adjacent_reasoning label = function
+  | Ct.No_adjacent_reasoning -> ()
+  | Ct.Adjacent_reasoning blocks ->
+    Alcotest.failf
+      "%s expected no adjacent reasoning, got %d blocks"
+      label
+      (List.length blocks)
+;;
+
+let check_visible_reasoning
+      label
+      expected_order
+      expected_content
+      expected_signature
+      (block : Ct.provider_reasoning_block)
+  =
+  Alcotest.(check int) (label ^ " order") expected_order block.Ct.order_index;
+  (match block.Ct.kind with
+   | Ct.Visible_thinking -> ()
+   | Ct.Redacted_thinking -> Alcotest.failf "%s expected visible thinking" label);
+  Alcotest.(check string) (label ^ " content") expected_content block.Ct.content;
+  Alcotest.(check (option string))
+    (label ^ " signature")
+    expected_signature
+    block.Ct.signature
+;;
+
+let check_redacted_reasoning
+      label
+      expected_order
+      expected_content
+      (block : Ct.provider_reasoning_block)
+  =
+  Alcotest.(check int) (label ^ " order") expected_order block.Ct.order_index;
+  (match block.Ct.kind with
+   | Ct.Redacted_thinking -> ()
+   | Ct.Visible_thinking -> Alcotest.failf "%s expected redacted thinking" label);
+  Alcotest.(check string) (label ^ " content") expected_content block.Ct.content;
+  Alcotest.(check (option string)) (label ^ " signature") None block.Ct.signature
+;;
+
+let test_tool_call_projection_preserves_fields_and_adjacent_reasoning () =
+  let input = `Assoc [ "city", `String "Seoul" ] in
+  let resp =
+    response
+      ~provider_kind:PK.Ollama
+      [ Types.Text "visible preface"
+      ; Types.Thinking { signature = Some "sig_1"; content = "call weather" }
+      ; Types.ToolUse { id = "call_weather"; name = "get_weather"; input }
+      ]
+  in
+  let call = one_tool_call resp in
+  Alcotest.(check string) "call_id" "call_weather" call.Ct.call_id;
+  Alcotest.(check string) "name" "get_weather" call.Ct.name;
+  Alcotest.check json_eq "input" input call.Ct.input;
+  Alcotest.(check int) "order_index" 2 call.Ct.order_index;
+  check_provider_kind "call" (Some PK.Ollama) call.Ct.provider_kind;
+  match call.Ct.adjacent_reasoning with
+  | Ct.Adjacent_reasoning [ block ] ->
+    check_visible_reasoning "adjacent reasoning" 1 "call weather" (Some "sig_1") block
+  | Ct.Adjacent_reasoning blocks ->
+    Alcotest.failf "expected one adjacent reasoning block, got %d" (List.length blocks)
+  | Ct.No_adjacent_reasoning -> Alcotest.fail "expected adjacent reasoning"
+;;
+
+let test_tool_calls_keep_interleaved_reasoning_groups () =
+  let resp =
+    response
+      [ Types.Thinking { signature = None; content = "first plan" }
+      ; Types.ToolUse { id = "call_1"; name = "lookup"; input = `Assoc [] }
+      ; Types.Thinking { signature = None; content = "second plan" }
+      ; Types.RedactedThinking "opaque_blob"
+      ; Types.ToolUse
+          { id = "call_2"; name = "search"; input = `Assoc [ "q", `String "x" ] }
+      ; Types.ToolUse { id = "call_3"; name = "summarize"; input = `Assoc [] }
+      ]
+  in
+  match Ct.tool_calls_of_response resp with
+  | [ first; second; third ] ->
+    Alcotest.(check string) "first id" "call_1" first.Ct.call_id;
+    Alcotest.(check int) "first order" 1 first.Ct.order_index;
+    (match first.Ct.adjacent_reasoning with
+     | Ct.Adjacent_reasoning [ block ] ->
+       check_visible_reasoning "first reasoning" 0 "first plan" None block
+     | _ -> Alcotest.fail "first call should have one adjacent reasoning block");
+    Alcotest.(check string) "second id" "call_2" second.Ct.call_id;
+    Alcotest.(check int) "second order" 4 second.Ct.order_index;
+    (match second.Ct.adjacent_reasoning with
+     | Ct.Adjacent_reasoning [ visible; redacted ] ->
+       check_visible_reasoning "second visible reasoning" 2 "second plan" None visible;
+       check_redacted_reasoning "second redacted reasoning" 3 "opaque_blob" redacted
+     | Ct.Adjacent_reasoning blocks ->
+       Alcotest.failf
+         "second call expected two adjacent reasoning blocks, got %d"
+         (List.length blocks)
+     | Ct.No_adjacent_reasoning -> Alcotest.fail "second call should have reasoning");
+    Alcotest.(check string) "third id" "call_3" third.Ct.call_id;
+    Alcotest.(check int) "third order" 5 third.Ct.order_index;
+    check_no_adjacent_reasoning "third call" third.Ct.adjacent_reasoning
+  | calls -> Alcotest.failf "expected three tool calls, got %d" (List.length calls)
+;;
+
+let test_text_breaks_reasoning_adjacency () =
+  let resp =
+    response
+      [ Types.Thinking { signature = None; content = "not adjacent" }
+      ; Types.Text "visible answer fragment"
+      ; Types.ToolUse { id = "call_late"; name = "late_tool"; input = `Null }
+      ]
+  in
+  let call = one_tool_call resp in
+  Alcotest.(check int) "order_index" 2 call.Ct.order_index;
+  check_no_adjacent_reasoning "text break" call.Ct.adjacent_reasoning
+;;
 
 let test_result_roundtrip_preserves_fields () =
   let json = `Assoc [ "rows", `Int 3 ] in
@@ -82,7 +233,21 @@ let test_result_none_for_non_toolresult () =
 let () =
   Alcotest.run
     "canonical_tool"
-    [ ( "tool_result_of_block"
+    [ ( "tool_calls_of_response"
+      , [ Alcotest.test_case
+            "preserves call fields and adjacent reasoning"
+            `Quick
+            test_tool_call_projection_preserves_fields_and_adjacent_reasoning
+        ; Alcotest.test_case
+            "keeps interleaved reasoning groups"
+            `Quick
+            test_tool_calls_keep_interleaved_reasoning_groups
+        ; Alcotest.test_case
+            "text breaks reasoning adjacency"
+            `Quick
+            test_text_breaks_reasoning_adjacency
+        ] )
+    ; ( "tool_result_of_block"
       , [ Alcotest.test_case
             "roundtrip preserves fields"
             `Quick


### PR DESCRIPTION
## What changed

This PR adds the RFC-OAS-024 Increment 2 read-projection for provider tool calls in `Llm_provider.Canonical_tool`.

- Adds `provider_tool_call` with verbatim `call_id`, `name`, `input`, `order_index`, and optional `provider_kind` copied from response telemetry.
- Adds `provider_reasoning_block` and `adjacent_reasoning` so downstream consumers can render or inspect interleaved Thinking -> ToolUse responses without parsing raw blocks themselves.
- Keeps `Types.content_block` as the canonical SSOT: every projection is derived from response content and no ids or provider metadata are synthesized.
- Treats reasoning linkage as structural only: reasoning is attached only when contiguous immediately before a `ToolUse`; Text/media/result boundaries clear adjacency rather than guessing semantic ownership.
- Adds focused regression coverage for field preservation, multi-turn-style interleaved reasoning groups, consecutive tools, and Text breaking adjacency.

## Why

MASC can already consume raw content blocks, but OAS needs to expose provider-boundary typed surfaces for tool-call grouping/interleaving so consumers do not reimplement provider parsing or make heuristic assumptions. This is the next incremental slice after failing closed on malformed Responses output items.

## Validation

GitHub CI is the validation gate for this PR per operator instruction. Local Dune was intentionally not run.