### PR TITLE
fix(provider): classify OpenAI-compatible provider identity

### DIFF
--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -1212,6 +1212,7 @@ let%test "for_model_id glm-4.5-flash has GLM-4.5 thinking limits" =
 let test_catalog_entry id_prefix : Model_catalog.model_entry =
   { id_prefix
   ; base_label = None
+  ; provider_name = None
   ; max_context_tokens = None
   ; max_output_tokens = None
   ; supports_tools = None

--- a/lib/llm_provider/model_catalog.ml
+++ b/lib/llm_provider/model_catalog.ml
@@ -3,6 +3,7 @@
 type model_entry =
   { id_prefix : string
   ; base_label : string option
+  ; provider_name : string option
   ; max_context_tokens : int option
   ; max_output_tokens : int option
   ; supports_tools : bool option
@@ -55,6 +56,17 @@ let find_string_field ~entry_id key toml =
   | None -> Ok None
   | exception Otoml.Type_error _ ->
     Error (Printf.sprintf "model entry %S field %S expected string" entry_id key)
+;;
+
+let non_empty_string_field ~entry_id key toml =
+  match find_string_field ~entry_id key toml with
+  | Error _ as e -> e
+  | Ok None -> Ok None
+  | Ok (Some raw) ->
+    let value = String.lowercase_ascii (String.trim raw) in
+    if value = ""
+    then Error (Printf.sprintf "model entry %S field %S must not be empty" entry_id key)
+    else Ok (Some value)
 ;;
 
 let canonical_string_opt ~entry_id key ~allowed toml =
@@ -162,6 +174,9 @@ let parse_entry entry_toml =
        , Ok assistant_tool_content_format
        , Ok accepted_reasoning_efforts ) ->
        let base_label_result = find_string_field ~entry_id:id_prefix "base" entry_toml in
+       let provider_name_result =
+         non_empty_string_field ~entry_id:id_prefix "provider_name" entry_toml
+       in
        let modality_priority_result =
          canonical_string_opt
            ~entry_id:id_prefix
@@ -185,21 +200,25 @@ let parse_entry entry_toml =
        in
        (match
           ( base_label_result
+          , provider_name_result
           , modality_priority_result
           , thinking_control_format_result
           , preserve_thinking_control_format_result )
         with
-        | (Error _ as e), _, _, _
-        | _, (Error _ as e), _, _
-        | _, _, (Error _ as e), _
-        | _, _, _, (Error _ as e) -> e
+        | (Error _ as e), _, _, _, _
+        | _, (Error _ as e), _, _, _
+        | _, _, (Error _ as e), _, _
+        | _, _, _, (Error _ as e), _
+        | _, _, _, _, (Error _ as e) -> e
         | ( Ok base_label
+          , Ok provider_name
           , Ok modality_priority
           , Ok thinking_control_format
           , Ok preserve_thinking_control_format ) ->
           Ok
             { id_prefix
             ; base_label
+            ; provider_name
             ; max_context_tokens = find_int_opt entry_toml [ "max_context_tokens" ]
             ; max_output_tokens = find_int_opt entry_toml [ "max_output_tokens" ]
             ; supports_tools = find_bool_opt entry_toml [ "supports_tools" ]
@@ -308,6 +327,12 @@ let lookup t model_id =
        let prefix = String.lowercase_ascii entry.id_prefix in
        String.starts_with ~prefix m)
     sorted_t
+;;
+
+let provider_name_for_model_id t model_id =
+  match lookup t model_id with
+  | Some { provider_name = Some provider_name; _ } -> Some provider_name
+  | Some _ | None -> None
 ;;
 
 type env_cache =

--- a/lib/llm_provider/model_catalog.mli
+++ b/lib/llm_provider/model_catalog.mli
@@ -6,6 +6,10 @@
 type model_entry =
   { id_prefix : string
   ; base_label : string option
+    (** Registry provider identity for OpenAI-compatible model families whose
+        wire kind alone would otherwise collapse to [openai_compat]. This is
+        not a capability preset; [base_label] remains the capability base. *)
+  ; provider_name : string option
   ; max_context_tokens : int option
   ; max_output_tokens : int option
   ; supports_tools : bool option
@@ -48,6 +52,11 @@ type t = model_entry list
 val load_file : string -> (t, string) result
 val load_runtime_file : string -> t option
 val lookup : t -> string -> model_entry option
+
+(** Return the catalog-declared provider identity for the longest matching
+    [id_prefix], if that entry declares one. *)
+val provider_name_for_model_id : t -> string -> string option
+
 val global : unit -> t option
 val preload_global : unit -> unit
 val set_global : t -> unit

--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -364,6 +364,38 @@ let siliconflow_defaults =
   }
 ;;
 
+let xai_defaults =
+  { kind = OpenAI_compat
+  ; base_url = env_or_default "XAI_BASE_URL" "https://api.x.ai/v1"
+  ; api_key_env = "XAI_API_KEY"
+  ; request_path = "/chat/completions"
+  }
+;;
+
+let mistral_defaults =
+  { kind = OpenAI_compat
+  ; base_url = env_or_default "MISTRAL_BASE_URL" "https://api.mistral.ai/v1"
+  ; api_key_env = "MISTRAL_API_KEY"
+  ; request_path = "/chat/completions"
+  }
+;;
+
+let cohere_defaults =
+  { kind = OpenAI_compat
+  ; base_url = env_or_default "COHERE_BASE_URL" "https://api.cohere.com/compatibility/v1"
+  ; api_key_env = "COHERE_API_KEY"
+  ; request_path = "/chat/completions"
+  }
+;;
+
+let mimo_defaults =
+  { kind = OpenAI_compat
+  ; base_url = env_or_default "MIMO_BASE_URL" "https://token-plan-sgp.xiaomimimo.com/v1"
+  ; api_key_env = "MIMO_API_KEY"
+  ; request_path = "/chat/completions"
+  }
+;;
+
 let normalize_url value =
   let trimmed = String.trim value in
   if trimmed = ""
@@ -445,6 +477,26 @@ let default () =
     siliconflow_defaults
     ~max_context:128_000
     Capabilities.openai_compat_chat_capabilities;
+  reg
+    "xai"
+    xai_defaults
+    ~max_context:1_000_000
+    Capabilities.openai_compat_chat_extended_capabilities;
+  reg
+    "mistral"
+    mistral_defaults
+    ~max_context:260_000
+    Capabilities.openai_compat_chat_extended_capabilities;
+  reg
+    "cohere"
+    cohere_defaults
+    ~max_context:256_000
+    Capabilities.openai_compat_chat_capabilities;
+  reg
+    "mimo"
+    mimo_defaults
+    ~max_context:128_000
+    Capabilities.openai_compat_chat_capabilities;
   register
     t
     { name = "ollama"
@@ -460,6 +512,12 @@ let default () =
     Capabilities.ollama_cloud_capabilities;
   overlay_provider_catalog t;
   t
+;;
+
+let provider_name_of_catalog_model_id model_id =
+  match Model_catalog.global () with
+  | None -> None
+  | Some catalog -> Model_catalog.provider_name_for_model_id catalog model_id
 ;;
 
 let provider_name_of_config (config : Provider_config.t) =
@@ -491,5 +549,8 @@ let provider_name_of_config (config : Provider_config.t) =
           && String.equal (String.trim entry.defaults.request_path) request_path)
       with
       | Some entry -> entry.name
-      | None -> "openai_compat")
+      | None ->
+        (match provider_name_of_catalog_model_id config.model_id with
+         | Some provider_name -> provider_name
+         | None -> "openai_compat"))
 ;;

--- a/lib/llm_provider/provider_registry.mli
+++ b/lib/llm_provider/provider_registry.mli
@@ -70,8 +70,11 @@ val default : unit -> t
     Unlike [Provider_config.string_of_provider_kind], this keeps
     registry-level distinctions that share a wire kind but differ by
     endpoint (for example [glm] vs [glm-coding], or
-    [openai_compat] vs [openrouter]). Falls back to a stable kind-derived label when the
-    config does not match a known registry entry exactly. *)
+    [openai_compat] vs [openrouter]). For unmatched OpenAI-compatible
+    endpoints, the model catalog may still classify provider identity via
+    [Model_catalog.model_entry.provider_name] (for example xAI, Mistral,
+    Cohere, or MiMo). Falls back to a stable kind-derived label when neither
+    endpoint nor catalog classification matches. *)
 val provider_name_of_config : Provider_config.t -> string
 
 (** Initial fallback endpoint snapshot. This is intentionally not parsed from

--- a/models.toml
+++ b/models.toml
@@ -1648,6 +1648,7 @@ output_per_million = 0.0
 [[models]]
 id_prefix = "xai/grok-4.3"
 base = "openai_chat_extended"
+provider_name = "xai"
 max_context_tokens = 1000000
 supports_tools = true
 supports_tool_choice = true
@@ -1664,6 +1665,7 @@ supports_caching = true
 [[models]]
 id_prefix = "grok-4.3"
 base = "openai_chat_extended"
+provider_name = "xai"
 max_context_tokens = 1000000
 supports_tools = true
 supports_tool_choice = true
@@ -1680,6 +1682,7 @@ supports_caching = true
 [[models]]
 id_prefix = "grok-latest"
 base = "openai_chat_extended"
+provider_name = "xai"
 max_context_tokens = 1000000
 supports_tools = true
 supports_tool_choice = true
@@ -1697,6 +1700,7 @@ supports_caching = true
 [[models]]
 id_prefix = "mistral-large"
 base = "openai_chat"
+provider_name = "mistral"
 max_context_tokens = 260000
 supports_tools = true
 supports_tool_choice = true
@@ -1707,6 +1711,7 @@ supports_native_streaming = true
 [[models]]
 id_prefix = "mistral-small"
 base = "openai_chat_extended"
+provider_name = "mistral"
 max_context_tokens = 256000
 supports_tools = true
 supports_tool_choice = true
@@ -1722,6 +1727,7 @@ supports_native_streaming = true
 [[models]]
 id_prefix = "command-r-plus"
 base = "openai_chat"
+provider_name = "cohere"
 max_context_tokens = 256000
 max_output_tokens = 32000
 supports_tools = true
@@ -1878,6 +1884,7 @@ supports_native_streaming = true
 [[models]]
 id_prefix = "mimo-v2.5"
 base = "openai_chat"
+provider_name = "mimo"
 supports_reasoning = true
 # Live MiMo V2.5 OpenAI-compatible smoke, checked 2026-06-29: responses carry
 # reasoning in the `reasoning_content` side-channel, accept tool calls, stream

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -1627,6 +1627,21 @@ base = 17
        | Ok _ -> Alcotest.fail "wrong-type model catalog base should reject")
 ;;
 
+let test_model_catalog_rejects_empty_provider_name () =
+  with_temp_model_catalog
+    {|
+[[models]]
+id_prefix = "bad-provider-name"
+provider_name = "   "
+|}
+    (fun path ->
+       match Model_catalog.load_file path with
+       | Error msg ->
+         check_contains "mentions provider_name" msg "provider_name";
+         check_contains "mentions empty" msg "must not be empty"
+       | Ok _ -> Alcotest.fail "empty model catalog provider_name should reject")
+;;
+
 let test_model_catalog_rejects_unknown_accepted_reasoning_effort () =
   with_temp_model_catalog
     {|
@@ -1957,6 +1972,10 @@ let () =
             "model catalog rejects wrong-type base"
             `Quick
             test_model_catalog_rejects_wrong_type_base_label
+        ; test_case
+            "model catalog rejects empty provider_name"
+            `Quick
+            test_model_catalog_rejects_empty_provider_name
         ; test_case
             "model catalog rejects unknown accepted reasoning effort"
             `Quick

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -897,6 +897,24 @@ let test_structured_output_name_of_schema () =
 
 (* ── provider_name_of_config ─────────────────────────── *)
 
+let with_repository_model_catalog f =
+  let previous_catalog = Model_catalog.global () in
+  let restore () =
+    match previous_catalog with
+    | Some catalog -> Model_catalog.set_global catalog
+    | None -> Model_catalog.clear_global ()
+  in
+  let candidates = [ "models.toml"; "../models.toml" ] in
+  match List.find_opt Sys.file_exists candidates with
+  | None -> Alcotest.fail "models.toml not found for provider_name tests"
+  | Some path ->
+    (match Model_catalog.load_file path with
+     | Error msg -> Alcotest.failf "failed to load %s: %s" path msg
+     | Ok catalog ->
+       Model_catalog.set_global catalog;
+       Fun.protect f ~finally:restore)
+;;
+
 let test_provider_name_of_config_glm_general () =
   let cfg =
     Provider_config.make
@@ -958,6 +976,47 @@ let test_provider_name_of_config_unmatched_openai_compat () =
     "unmatched openai compat"
     "openai_compat"
     (Provider_registry.provider_name_of_config cfg)
+;;
+
+let check_provider_name_from_catalog_model ~label ~model_id ~expected =
+  with_repository_model_catalog (fun () ->
+    let cfg =
+      Provider_config.make
+        ~kind:OpenAI_compat
+        ~model_id
+        ~base_url:"https://unlisted.example/v1"
+        ~request_path:"/chat/completions"
+        ()
+    in
+    check_string label expected (Provider_registry.provider_name_of_config cfg))
+;;
+
+let test_provider_name_of_config_xai_model_catalog () =
+  check_provider_name_from_catalog_model
+    ~label:"xai model catalog provider"
+    ~model_id:"grok-4.3"
+    ~expected:"xai"
+;;
+
+let test_provider_name_of_config_mistral_model_catalog () =
+  check_provider_name_from_catalog_model
+    ~label:"mistral model catalog provider"
+    ~model_id:"mistral-large"
+    ~expected:"mistral"
+;;
+
+let test_provider_name_of_config_cohere_model_catalog () =
+  check_provider_name_from_catalog_model
+    ~label:"cohere model catalog provider"
+    ~model_id:"command-r-plus"
+    ~expected:"cohere"
+;;
+
+let test_provider_name_of_config_mimo_model_catalog () =
+  check_provider_name_from_catalog_model
+    ~label:"mimo model catalog provider"
+    ~model_id:"mimo-v2.5-pro"
+    ~expected:"mimo"
 ;;
 
 (* ── provider_kind_of_string ─────────────────────────── *)
@@ -1460,6 +1519,22 @@ let () =
             "unmatched openai_compat"
             `Quick
             test_provider_name_of_config_unmatched_openai_compat
+        ; Alcotest.test_case
+            "xai model catalog"
+            `Quick
+            test_provider_name_of_config_xai_model_catalog
+        ; Alcotest.test_case
+            "mistral model catalog"
+            `Quick
+            test_provider_name_of_config_mistral_model_catalog
+        ; Alcotest.test_case
+            "cohere model catalog"
+            `Quick
+            test_provider_name_of_config_cohere_model_catalog
+        ; Alcotest.test_case
+            "mimo model catalog"
+            `Quick
+            test_provider_name_of_config_mimo_model_catalog
         ] )
     ; ( "kind_of_string"
       , [ Alcotest.test_case "roundtrip all variants" `Quick test_kind_roundtrip

--- a/test/test_provider_registry.ml
+++ b/test/test_provider_registry.ml
@@ -215,10 +215,10 @@ let test_find_capable_composite () =
 
 (* ── Default registry ───────────────────────────────── *)
 
-let test_default_has_14 () =
+let test_default_has_18 () =
   let reg = Provider_registry.default () in
   let all = Provider_registry.all reg in
-  check int "14 known providers" 14 (List.length all);
+  check int "18 known providers" 18 (List.length all);
   check bool "llama exists" true (Option.is_some (Provider_registry.find reg "nous"));
   check bool "ollama exists" true (Option.is_some (Provider_registry.find reg "ollama"));
   check
@@ -256,7 +256,11 @@ let test_default_has_14 () =
     bool
     "siliconflow exists"
     true
-    (Option.is_some (Provider_registry.find reg "siliconflow"))
+    (Option.is_some (Provider_registry.find reg "siliconflow"));
+  check bool "xai exists" true (Option.is_some (Provider_registry.find reg "xai"));
+  check bool "mistral exists" true (Option.is_some (Provider_registry.find reg "mistral"));
+  check bool "cohere exists" true (Option.is_some (Provider_registry.find reg "cohere"));
+  check bool "mimo exists" true (Option.is_some (Provider_registry.find reg "mimo"))
 ;;
 
 let test_default_capabilities () =
@@ -1074,7 +1078,7 @@ let () =
         ; test_case "requires_any" `Quick test_requires_any
         ] )
     ; ( "default"
-      , [ test_case "has 14 providers" `Quick test_default_has_14
+      , [ test_case "has 18 providers" `Quick test_default_has_18
         ; test_case "correct capabilities" `Quick test_default_capabilities
         ; test_case "ollama_cloud entry" `Quick test_default_ollama_cloud_entry
         ; test_case "deepseek entry" `Quick test_default_deepseek_entry


### PR DESCRIPTION
## Summary
- add catalog-level provider_name for OpenAI-compatible model families whose wire kind remains openai_compat
- register xAI, Mistral, Cohere, and MiMo provider identities in the default provider registry
- route provider_name_of_config through endpoint matching first, then catalog model-prefix identity, then openai_compat fallback

## Verification
- ocamlformat --check lib/llm_provider/model_catalog.ml lib/llm_provider/model_catalog.mli lib/llm_provider/provider_registry.ml lib/llm_provider/provider_registry.mli lib/llm_provider/capabilities.ml test/test_provider_config.ml test/test_provider_registry.ml test/test_capabilities.ml
- git diff --check origin/main...HEAD

Local dune not run per operator instruction; GitHub CI is the build/test authority.