### PR TITLE
fix(test): include model catalog in sandboxed provider suites

### DIFF
--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -745,9 +745,7 @@ let complete_stream_http
                            | Provider_config.DashScope
                            | Provider_config.Kimi ->
                              (match
-                                Streaming.parse_openai_sse_chunk
-                                  ~streaming_reasoning
-                                  data
+                                Streaming.parse_openai_sse_chunk ~streaming_reasoning data
                               with
                               | Some chunk ->
                                 Streaming.openai_chunk_to_events (get_state ()) chunk

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -392,8 +392,8 @@ let parse_openai_sse_chunk ?streaming_reasoning data_str : openai_chunk option =
           match streaming_reasoning with
           | Some (Reasoning_dialect.Delta_field field) -> non_blank_delta_field field
           | Some
-              (Reasoning_dialect.No_streaming_reasoning | Reasoning_dialect.Template_parser)
-            -> None
+              ( Reasoning_dialect.No_streaming_reasoning
+              | Reasoning_dialect.Template_parser ) -> None
           | None ->
             (match non_blank_delta_field "reasoning_content" with
              | Some _ as reasoning -> reasoning

--- a/test/dune
+++ b/test/dune
@@ -417,7 +417,7 @@
   test_v024_fixes
   test_vcs_graph_snapshot)
  (libraries agent_sdk agent_sdk.llm_provider alcotest eio_main)
- (deps ../docs/example-capability-manifest.json)
+ (deps ../docs/example-capability-manifest.json ../models.toml)
  (action
   (run %{test})))
 

--- a/test/test_property_advanced.ml
+++ b/test/test_property_advanced.ml
@@ -242,13 +242,19 @@ let test_cost_scales_with_tokens =
 
 let with_repo_model_catalog f =
   match Llm_provider.Model_catalog.global () with
-  | None ->
-    Alcotest.fail
-      "OAS_MODEL_CATALOG did not load the repository models.toml for capability property \
-       tests"
   | Some catalog ->
     Llm_provider.Model_catalog.set_global catalog;
     Fun.protect ~finally:Llm_provider.Model_catalog.clear_global f
+  | None ->
+    let candidates = [ "models.toml"; "../models.toml"; "../../models.toml" ] in
+    (match List.find_opt Sys.file_exists candidates with
+     | None -> Alcotest.fail "models.toml not found for capability property tests"
+     | Some path ->
+       (match Llm_provider.Model_catalog.load_file path with
+        | Error msg -> Alcotest.fail (Printf.sprintf "models.toml should parse: %s" msg)
+        | Ok catalog ->
+          Llm_provider.Model_catalog.set_global catalog;
+          Fun.protect ~finally:Llm_provider.Model_catalog.clear_global f))
 ;;
 
 let test_local_provider_resolve_always_succeeds =

--- a/test/test_streaming_openai.ml
+++ b/test/test_streaming_openai.ml
@@ -341,9 +341,7 @@ let test_parse_reasoning_respects_no_streaming_dialect () =
   let data =
     {|{"id":"c-none","model":"dialect","choices":[{"index":0,"delta":{"reasoning_content":"hidden"},"finish_reason":null}]}|}
   in
-  match
-    S.parse_openai_sse_chunk ~streaming_reasoning:RD.No_streaming_reasoning data
-  with
+  match S.parse_openai_sse_chunk ~streaming_reasoning:RD.No_streaming_reasoning data with
   | Some chunk ->
     Alcotest.(check (option string)) "no reasoning" None chunk.delta_reasoning
   | None -> Alcotest.fail "expected Some chunk"


### PR DESCRIPTION
## Summary
- add models.toml to the sandbox deps for the large provider/test suite so test_provider and test_thinking_control_dialects can load the catalog under dune runtest
- make test_property_advanced load the repository models.toml when no global catalog is already present
- apply ocamlformat output required by current main after #2314

## CI failure evidence
- #2313 post-merge PR run 28421794263 failed in Build & Test / Test
- job 84216248672 reported: ASSERT models.toml not found for thinking-control dialect tests
- same job reported: ASSERT models.toml not found for provider tests

## Local validation
- scripts/dune-local.sh exec test/test_property_advanced.exe
- scripts/dune-local.sh exec test/test_provider.exe
- scripts/dune-local.sh exec test/test_thinking_control_dialects.exe
- scripts/dune-local.sh exec test/test_streaming_openai.exe
- scripts/dune-local.sh build @fmt
- git diff --check