### PR TITLE
fix(test): prefer OAS_MODEL_CATALOG in provider suites

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -216,6 +216,7 @@
   test_v024_fixes
   test_vcs_graph_snapshot)
  (modules
+  model_catalog_test_support
   test_metrics_aggregating
   test_modality
   test_capabilities

--- a/test/model_catalog_test_support.ml
+++ b/test/model_catalog_test_support.ml
@@ -1,0 +1,31 @@
+let dune_model_catalog_path () =
+  let executable_dir = Filename.dirname Sys.executable_name in
+  if executable_dir = "." || executable_dir = ""
+  then None
+  else Some (Filename.concat (Filename.dirname executable_dir) "models.toml")
+;;
+
+let repository_model_catalog_path ~suite =
+  match Sys.getenv_opt "OAS_MODEL_CATALOG" with
+  | Some path when path <> "" -> path
+  | Some _ | None ->
+    (match dune_model_catalog_path () with
+     | Some path -> path
+     | None ->
+       Alcotest.failf
+         "models.toml path unavailable for %s tests; set OAS_MODEL_CATALOG or run the \
+          suite through Dune"
+         suite)
+;;
+
+let load_repo_model_catalog ~suite =
+  let path = repository_model_catalog_path ~suite in
+  match Llm_provider.Model_catalog.load_file path with
+  | Ok catalog -> catalog
+  | Error msg ->
+    Alcotest.failf "models.toml should parse for %s tests (%s): %s" suite path msg
+;;
+
+let install_repo_model_catalog ~suite =
+  Llm_provider.Model_catalog.set_global (load_repo_model_catalog ~suite)
+;;

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -38,21 +38,7 @@ let with_provider_catalog json f =
 ;;
 
 let install_repo_model_catalog () =
-  let candidates =
-    List.filter_map
-      (fun x -> x)
-      [ Sys.getenv_opt "OAS_MODEL_CATALOG"
-      ; Some "models.toml"
-      ; Some "../models.toml"
-      ; Some "../../models.toml"
-      ]
-  in
-  match List.find_opt Sys.file_exists candidates with
-  | None -> Alcotest.fail "models.toml not found for provider tests"
-  | Some path ->
-    (match Llm_provider.Model_catalog.load_file path with
-     | Error msg -> Alcotest.fail (Printf.sprintf "models.toml should parse: %s" msg)
-     | Ok catalog -> Llm_provider.Model_catalog.set_global catalog)
+  Model_catalog_test_support.install_repo_model_catalog ~suite:"provider"
 ;;
 
 let with_empty_capability_sources f =

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -38,7 +38,15 @@ let with_provider_catalog json f =
 ;;
 
 let install_repo_model_catalog () =
-  let candidates = [ "models.toml"; "../models.toml"; "../../models.toml" ] in
+  let candidates =
+    List.filter_map
+      (fun x -> x)
+      [ Sys.getenv_opt "OAS_MODEL_CATALOG"
+      ; Some "models.toml"
+      ; Some "../models.toml"
+      ; Some "../../models.toml"
+      ]
+  in
   match List.find_opt Sys.file_exists candidates with
   | None -> Alcotest.fail "models.toml not found for provider tests"
   | Some path ->

--- a/test/test_thinking_control_dialects.ml
+++ b/test/test_thinking_control_dialects.ml
@@ -37,7 +37,15 @@ let with_manifest json f =
 ;;
 
 let load_repository_catalog () =
-  let candidates = [ "models.toml"; "../models.toml" ] in
+  let candidates =
+    List.filter_map
+      (fun x -> x)
+      [ Sys.getenv_opt "OAS_MODEL_CATALOG"
+      ; Some "models.toml"
+      ; Some "../models.toml"
+      ; Some "../../models.toml"
+      ]
+  in
   match List.find_opt Sys.file_exists candidates with
   | None -> fail "models.toml not found for thinking-control dialect tests"
   | Some path ->

--- a/test/test_thinking_control_dialects.ml
+++ b/test/test_thinking_control_dialects.ml
@@ -36,27 +36,13 @@ let with_manifest json f =
     Fun.protect ~finally:(fun () -> CM.set_global []) f
 ;;
 
-let load_repository_catalog () =
-  let candidates =
-    List.filter_map
-      (fun x -> x)
-      [ Sys.getenv_opt "OAS_MODEL_CATALOG"
-      ; Some "models.toml"
-      ; Some "../models.toml"
-      ; Some "../../models.toml"
-      ]
-  in
-  match List.find_opt Sys.file_exists candidates with
-  | None -> fail "models.toml not found for thinking-control dialect tests"
-  | Some path ->
-    (match MC.load_file path with
-     | Error msg -> fail ("failed to load " ^ path ^ ": " ^ msg)
-     | Ok catalog -> catalog)
+let install_repository_catalog () =
+  Model_catalog_test_support.install_repo_model_catalog ~suite:"thinking-control dialect"
 ;;
 
 let without_ambient_manifest f =
   CM.set_global [];
-  MC.set_global (load_repository_catalog ());
+  install_repository_catalog ();
   Fun.protect
     ~finally:(fun () ->
       MC.clear_global ();
@@ -79,7 +65,7 @@ let with_catalog_toml contents f =
        | Error msg -> fail ("custom catalog parse failed: " ^ msg)
        | Ok catalog ->
          MC.set_global catalog;
-         Fun.protect ~finally:(fun () -> MC.set_global (load_repository_catalog ())) f)
+         Fun.protect ~finally:install_repository_catalog f)
 ;;
 
 let check_member_absent name json =


### PR DESCRIPTION
## Summary
- prefer the CI-provided OAS_MODEL_CATALOG absolute path when provider/thinking-control tests load models.toml
- keep relative fallbacks for local/manual runs

## Verification
- ocamlformat --check test/test_provider.ml test/test_thinking_control_dialects.ml
- git diff --check origin/main...HEAD

Local dune not run per operator instruction; GitHub CI is the build/test authority.