### PR TITLE
ci: run Lint + OCaml Format (+ version/transport) on draft PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,9 @@ jobs:
 
   lint:
     name: Lint
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+    # Run on drafts: catching drift at draft time prevents main from going
+    # red after a draft merge (#2311, #2319 were post-merge format/lint fixes
+    # a draft-time check would have caught).
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -227,7 +229,9 @@ jobs:
 
   ocamlformat:
     name: OCaml Format
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+    # Run on drafts: catching drift at draft time prevents main from going
+    # red after a draft merge (#2311, #2319 were post-merge format/lint fixes
+    # a draft-time check would have caught).
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -249,7 +253,9 @@ jobs:
 
   version-check:
     name: Version Consistency
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+    # Run on drafts: catching drift at draft time prevents main from going
+    # red after a draft merge (#2311, #2319 were post-merge format/lint fixes
+    # a draft-time check would have caught).
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -277,7 +283,9 @@ jobs:
 
   transport-drift:
     name: Transport Drift Gate
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+    # Run on drafts: catching drift at draft time prevents main from going
+    # red after a draft merge (#2311, #2319 were post-merge format/lint fixes
+    # a draft-time check would have caught).
     runs-on: ubuntu-latest
     timeout-minutes: 5
 


### PR DESCRIPTION
## Why
oas main went red twice in one session from the same systemic cause:
- #2311 fixed post-merge OCaml Format drift (9 files) after #2232 was merged from a draft.
- #2319 fixed post-#2314 OCaml Format drift (3 files) + a test dep.

Both were **draft PRs whose format/lint violations were invisible until main**, because the `lint`, `ocamlformat`, `version-check`, and `transport-drift` jobs all gated on `github.event.pull_request.draft == false`. This is the recurring "draft Format skip → merge → main red" trap.

## Fix
Remove the `draft == false` gate from those jobs so they run on draft PRs too. Drift now fails the PR before merge, not main after. The `pull_request` trigger already includes `converted_to_draft` (`ci.yml:8`), so converting to draft re-runs the checks.

## Note on CI self-validation
This PR changes the workflow itself, so PR CI runs under the **old** workflow (Format/Lint still skip drafts here). Validation is structural: the edited YAML is syntactically valid and the gates are removed. Effect is observable on the **next** draft PR after merge.

## P0–P3
- **P0**: systemic main-red cause removed (root fix, not another post-merge patch).
- **P1**: none.
- **P2**: none.
- **P3**: CI minutes increase (drafts now run Lint/Format/Version/Transport). Tradeoff is bounded (these jobs are fast, 5–15 min) and main stability is worth it. If cost matters, scope to Format/Lint only.

## Mergeability
Shippable. Root-cause fix for the repeated main-red pattern. CI cost tradeoff noted in P3.

Co-Authored-By: Claude <noreply@anthropic.com>
