### PR TITLE
fix(streaming): remove coordinator term from provider comments

### DIFF
--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -35,8 +35,8 @@ let record_streaming_metrics (metrics : Metrics.t) = function
    [complete_common] already applies to provider error bodies -- before it
    reaches the operator-facing message. Redaction runs first so truncation
    cannot split a token past the redactor and leak a partial; the bound then
-   keeps a large buffer from bloating the keeper log. [%S] at the call site
-   escapes embedded quotes/newlines. *)
+   keeps a large buffer from bloating the operator-facing diagnostic log. [%S] at
+   the call site escapes embedded quotes/newlines. *)
 let max_parse_error_raw_excerpt = 256
 
 let parse_error_raw_excerpt raw =
@@ -73,8 +73,8 @@ let http_error_of_stream_error (serr : Types.stream_error) : Http_client.http_er
            | "" -> Printf.sprintf "SSE parse failed: %s" reason
            | raw ->
              (* Echo the offending buffer (bounded) so a rare, provider-specific
-                malformed wire is diagnosable from the keeper log instead of
-                discarded at the carrier boundary. *)
+                malformed wire is diagnosable from the operator-facing
+                diagnostic log instead of discarded at the carrier boundary. *)
              Printf.sprintf
                "SSE parse failed: %s raw=%S"
                reason
@@ -160,7 +160,7 @@ let%test "stream parse failure stays provider parse failure" =
 ;;
 
 let%test "parse failure echoes the offending raw buffer for diagnosis" =
-  (* The malformed tool-arg buffer must reach the keeper-visible message so a
+  (* The malformed tool-arg buffer must reach the operator-facing message so a
      rare, provider-specific malformed wire is debuggable instead of discarded
      at the carrier boundary. *)
   let reason = "malformed_tool_use_arguments:index:1:bad" in

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -286,7 +286,8 @@ let finalize_stream_acc (acc : stream_acc) =
           | exception Yojson.Json_error reason ->
             (* Preserve the offending accumulated buffer in [raw] so the rare,
                provider-specific malformed tool-arg wire is diagnosable from the
-               keeper log (the [Complete_stream] renderer bounds it to 256 bytes).
+               operator-facing diagnostic log (the [Complete_stream] renderer
+               bounds it to 256 bytes).
                [raw] reaches operator-facing logs only, never replayed into
                conversation history. It may hold model-generated tool-argument
                values, so it carries the same sensitivity as any logged request
@@ -1024,7 +1025,8 @@ let%test "finalize_stream_acc fails closed on malformed tool_use arguments" =
   with
   | Error (Types.Stream_parse_failed { reason; raw }) ->
     (* [raw] now preserves the offending buffer so the malformed wire is
-       diagnosable from the keeper log instead of being discarded. *)
+       diagnosable from the operator-facing diagnostic log instead of being
+       discarded. *)
     raw = "not valid json"
     && String.starts_with ~prefix:"malformed_tool_use_arguments:index:0" reason
   | Error (Types.Stream_provider_error _ | Types.Stream_unknown_event _) | Ok _ -> false


### PR DESCRIPTION
## Summary
- remove coordinator-specific `keeper` wording from OAS provider streaming comments
- keep the existing operator-facing diagnostic-log contract intact

## Why
Latest main CI run `28422667523` failed `SDK Independence Gate` because strict boundary scan matched `keeper` in `lib/llm_provider/complete_stream.ml` and `lib/llm_provider/complete_stream_acc.ml`.

This is a boundary terminology fix only; no runtime behavior changes.

## Verification
- `ocamlformat -i lib/llm_provider/complete_stream.ml lib/llm_provider/complete_stream_acc.ml`
- `rg -n \bkeeper\b lib/llm_provider` -> no matches
- `git diff --check`
- `scripts/check-sdk-independence.sh` -> passed

Local Dune not run per operator instruction; GitHub CI is the build/test authority.