### PR TITLE
fix(responses): centralize stop reason status mapping

### DIFF
--- a/lib/llm_provider/backend_openai_responses.ml
+++ b/lib/llm_provider/backend_openai_responses.ml
@@ -516,39 +516,26 @@ let telemetry_of_response_json json =
     None
 ;;
 
+let response_status json = opt_bind (json_assoc_opt "status" json) json_string_opt
+
+let response_incomplete_reason json =
+  match json_assoc_opt "incomplete_details" json with
+  | Some details -> opt_bind (json_assoc_opt "reason" details) json_string_opt
+  | None -> None
+;;
+
+let response_failed_message json =
+  match json_assoc_opt "error" json with
+  | Some error -> opt_bind (json_assoc_opt "message" error) json_string_opt
+  | None -> None
+;;
+
 let stop_reason_of_response_json ~has_tool_calls json =
-  let status =
-    opt_bind (json_assoc_opt "status" json) json_string_opt |> Option.value ~default:""
-  in
-  (* A terminal [incomplete]/[failed] response status wins over tool-use
-     detection: a Responses result can carry a [function_call] item while the
-     generation was actually cut off (status="incomplete", e.g. max output
-     tokens). Returning [StopToolUse] there would execute partial/invalid tool
-     arguments instead of surfacing MaxTokens/an incomplete response. So we
-     match the cut-off statuses first, then fall back to tool-use, then the
-     normal completion path. (Codex P2, #2048.) *)
-  match String.lowercase_ascii status with
-  | "incomplete" ->
-    let reason =
-      match json_assoc_opt "incomplete_details" json with
-      | Some details ->
-        opt_bind (json_assoc_opt "reason" details) json_string_opt
-        |> Option.value ~default:"incomplete"
-      | None -> "incomplete"
-    in
-    if String.equal reason "max_output_tokens" then MaxTokens else Unknown reason
-  | "failed" ->
-    (match
-       match json_assoc_opt "error" json with
-       | Some error -> json_assoc_opt "message" error
-       | None -> None
-     with
-     | Some (`String message) -> Unknown message
-     | Some (`Assoc _ | `List _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null) | None
-       -> Unknown status)
-  | _ when has_tool_calls -> StopToolUse
-  | "completed" | "" -> EndTurn
-  | other -> Unknown other
+  Responses_stop_reason.of_status
+    ~status:(response_status json)
+    ~incomplete_reason:(response_incomplete_reason json)
+    ~failed_message:(response_failed_message json)
+    ~has_tool_calls
 ;;
 
 let parse_response_result json_str =

--- a/lib/llm_provider/responses_stop_reason.ml
+++ b/lib/llm_provider/responses_stop_reason.ml
@@ -1,0 +1,65 @@
+(** OpenAI Responses terminal status -> stop_reason SSOT. *)
+
+let normalized_status status =
+  status |> Option.value ~default:"" |> String.lowercase_ascii
+;;
+
+let incomplete_stop_reason incomplete_reason =
+  match incomplete_reason with
+  | Some "max_output_tokens" -> Types.MaxTokens
+  | Some reason -> Types.Unknown reason
+  | None -> Types.Unknown "incomplete"
+;;
+
+let failed_stop_reason failed_message =
+  match failed_message with
+  | Some message -> Types.Unknown message
+  | None -> Types.Unknown "failed"
+;;
+
+let of_status ~status ~incomplete_reason ~failed_message ~has_tool_calls =
+  match normalized_status status with
+  | "incomplete" -> incomplete_stop_reason incomplete_reason
+  | "failed" -> failed_stop_reason failed_message
+  | _ when has_tool_calls -> Types.StopToolUse
+  | "completed" | "" -> Types.EndTurn
+  | other -> Types.Unknown other
+;;
+
+[@@@coverage off]
+
+let%test "incomplete max output tokens wins over tool calls" =
+  of_status
+    ~status:(Some "incomplete")
+    ~incomplete_reason:(Some "max_output_tokens")
+    ~failed_message:None
+    ~has_tool_calls:true
+  = Types.MaxTokens
+;;
+
+let%test "failed message wins over tool calls" =
+  of_status
+    ~status:(Some "failed")
+    ~incomplete_reason:None
+    ~failed_message:(Some "quota exhausted")
+    ~has_tool_calls:true
+  = Types.Unknown "quota exhausted"
+;;
+
+let%test "completed with tool calls is tool use" =
+  of_status
+    ~status:(Some "completed")
+    ~incomplete_reason:None
+    ~failed_message:None
+    ~has_tool_calls:true
+  = Types.StopToolUse
+;;
+
+let%test "unknown status without tools is preserved" =
+  of_status
+    ~status:(Some "queued")
+    ~incomplete_reason:None
+    ~failed_message:None
+    ~has_tool_calls:false
+  = Types.Unknown "queued"
+;;

--- a/lib/llm_provider/responses_stop_reason.mli
+++ b/lib/llm_provider/responses_stop_reason.mli
@@ -1,0 +1,14 @@
+(** Single source of truth for OpenAI Responses terminal status ->
+    {!Types.stop_reason} mapping.
+
+    Responses exposes terminal state through [status] plus optional
+    [incomplete_details.reason] / [error.message]. Both the non-streaming
+    Responses parser and the Responses SSE terminal event handler must use this
+    module so cut-off or failed responses win over partial tool-call items. *)
+
+val of_status
+  :  status:string option
+  -> incomplete_reason:string option
+  -> failed_message:string option
+  -> has_tool_calls:bool
+  -> Types.stop_reason

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -719,33 +719,30 @@ let responses_output_has_function_call response =
   | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _ -> false
 ;;
 
-let responses_incomplete_reason response =
+let responses_incomplete_reason_opt response =
   let open Yojson.Safe.Util in
   match response |> member "incomplete_details" with
-  | `Assoc _ as details ->
-    responses_member_string_opt "reason" details |> Option.value ~default:"incomplete"
-  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ -> "incomplete"
+  | `Assoc _ as details -> responses_member_string_opt "reason" details
+  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ -> None
+;;
+
+let responses_incomplete_reason response =
+  responses_incomplete_reason_opt response |> Option.value ~default:"incomplete"
+;;
+
+let responses_failed_message response =
+  let open Yojson.Safe.Util in
+  match response |> member "error" with
+  | `Assoc _ as err -> responses_member_string_opt "message" err
+  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ -> None
 ;;
 
 let responses_stop_reason_of_response response =
-  (* A cut-off generation ([status="incomplete"]/[status="failed"]) can still
-     carry a partial [function_call] item. The terminal status must win over
-     tool-call detection, otherwise the stream finalizes as [StopToolUse] and the
-     agent executes truncated arguments. Mirrors
-     [Backend_openai_responses.stop_reason_of_response_json] for the non-stream
-     path (Codex P2, #2073 streaming follow-up). [response.failed] events route
-     through [SSEError] before reaching here, but the status is handled for
-     symmetry. *)
-  match responses_member_string_opt "status" response with
-  | Some "incomplete" ->
-    if String.equal (responses_incomplete_reason response) "max_output_tokens"
-    then MaxTokens
-    else Unknown (responses_incomplete_reason response)
-  | Some "failed" -> Unknown "failed"
-  | Some "completed" | None ->
-    if responses_output_has_function_call response then StopToolUse else EndTurn
-  | Some other ->
-    if responses_output_has_function_call response then StopToolUse else Unknown other
+  Responses_stop_reason.of_status
+    ~status:(responses_member_string_opt "status" response)
+    ~incomplete_reason:(responses_incomplete_reason_opt response)
+    ~failed_message:(responses_failed_message response)
+    ~has_tool_calls:(responses_output_has_function_call response)
 ;;
 
 let responses_error_message json =

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -1483,6 +1483,36 @@ let test_responses_incomplete_status_wins_over_function_call () =
          response.content)
 ;;
 
+let test_responses_stop_reason_ssot_status_table () =
+  check_bool
+    "failed message wins over tool calls"
+    true
+    (Responses_stop_reason.of_status
+       ~status:(Some "failed")
+       ~incomplete_reason:None
+       ~failed_message:(Some "quota exhausted")
+       ~has_tool_calls:true
+     = Unknown "quota exhausted");
+  check_bool
+    "completed with tool calls is tool use"
+    true
+    (Responses_stop_reason.of_status
+       ~status:(Some "completed")
+       ~incomplete_reason:None
+       ~failed_message:None
+       ~has_tool_calls:true
+     = StopToolUse);
+  check_bool
+    "unknown status without tools is preserved"
+    true
+    (Responses_stop_reason.of_status
+       ~status:(Some "queued")
+       ~incomplete_reason:None
+       ~failed_message:None
+       ~has_tool_calls:false
+     = Unknown "queued")
+;;
+
 let test_responses_preserves_encrypted_reasoning_item_for_replay () =
   let encrypted_reasoning_item =
     `Assoc
@@ -2033,6 +2063,10 @@ let () =
             "incomplete status wins over function_call (#2048)"
             `Quick
             test_responses_incomplete_status_wins_over_function_call
+        ; Alcotest.test_case
+            "stop reason status table SSOT"
+            `Quick
+            test_responses_stop_reason_ssot_status_table
         ; Alcotest.test_case
             "preserve encrypted reasoning item for replay"
             `Quick


### PR DESCRIPTION
## Summary
- centralize OpenAI Responses terminal status to stop_reason mapping in `Responses_stop_reason`
- route both non-streaming and streaming Responses paths through the same status table
- keep terminal status/incomplete/failed precedence ahead of partial tool calls, and align streaming failed-message handling with non-streaming

## Validation
- `ocamlformat --check test/test_backend_openai_codec.ml lib/llm_provider/responses_stop_reason.ml lib/llm_provider/responses_stop_reason.mli lib/llm_provider/backend_openai_responses.ml lib/llm_provider/streaming.ml`
- `git diff --check`
- `scripts/dune-local.sh build @install test/test_backend_openai_codec.exe test/test_streaming.exe`
- `./_build/default/test/test_backend_openai_codec.exe`
- `./_build/default/test/test_streaming.exe`

## Non-gating local note
- Earlier local `scripts/dune-local.sh runtest lib/llm_provider` failed outside this patch radius because this machine loads existing capability/pricing manifest overrides from `/Users/dancer/me/.masc/config/capability-manifest.json`; the focused parser/streaming build and tests above pass.
