### PR TITLE
fix(context): preserve thinking skips summarization

### DIFF
--- a/lib/context_reducer.ml
+++ b/lib/context_reducer.ml
@@ -203,7 +203,7 @@ let compose strategies =
 let custom f = { strategy = Custom f }
 
 let rec strategy_preserving_thinking = function
-  | Drop_thinking -> None
+  | Drop_thinking | Summarize_old _ -> None
   | Compose strategies ->
     (match List.filter_map strategy_preserving_thinking strategies with
      | [] -> None
@@ -225,7 +225,6 @@ let rec strategy_preserving_thinking = function
     | Merge_contiguous
     | Keep_first_and_last _
     | Prune_by_role _
-    | Summarize_old _
     | Clear_tool_results _
     | Stub_tool_results _
     | Cap_message_tokens _

--- a/lib/context_reducer.mli
+++ b/lib/context_reducer.mli
@@ -190,10 +190,12 @@ val relocate_tool_results : state:Content_replacement_state.t -> keep_recent:int
 val compose : t list -> t
 val custom : (message list -> message list) -> t
 
-(** Return an equivalent reducer with implicit [Drop_thinking] steps removed.
-    This is used when the agent/provider config explicitly requests historical
-    thinking preservation; callers keep the same repair/windowing policy without
-    silently deleting reasoning blocks from retained messages. *)
+(** Return an equivalent reducer with implicit reasoning-erasing steps removed.
+    This drops [Drop_thinking] and [Summarize_old] because the latter rewrites
+    older turns into a text summary and cannot structurally preserve reasoning
+    blocks. This is used when the agent/provider config explicitly requests
+    historical thinking preservation; callers keep the same repair/windowing
+    policy without silently deleting reasoning blocks from retained messages. *)
 val preserve_thinking : t -> t
 
 val importance_scored

--- a/test/test_context_reducer.ml
+++ b/test/test_context_reducer.ml
@@ -814,6 +814,71 @@ let test_drop_thinking_preserves_tool_use_thinking () =
     Alcotest.(check bool) "redacted thinking preserved beside tool_use" true has_redacted
 ;;
 
+let test_preserve_thinking_removes_summarize_old () =
+  let msgs =
+    [ user_msg "turn1"
+    ; Types.
+        { role = Assistant
+        ; content =
+            [ Thinking { signature = None; content = "old reasoning" }
+            ; Text "old answer"
+            ]
+        ; name = None
+        ; tool_call_id = None
+        ; metadata = []
+        }
+    ; user_msg "turn2"
+    ; asst_msg "new answer"
+    ]
+  in
+  let reducer =
+    Context_reducer.compose
+      [ Context_reducer.summarize_old ~keep_recent:1 ~summarizer:(fun _ ->
+          "summary erased reasoning")
+      ; Context_reducer.drop_thinking
+      ; Context_reducer.merge_contiguous
+      ]
+    |> Context_reducer.preserve_thinking
+  in
+  let result = Context_reducer.reduce reducer msgs in
+  let has_old_reasoning =
+    List.exists
+      (fun (msg : Types.message) ->
+         List.exists
+           (function
+             | Types.Thinking { content = "old reasoning"; _ } -> true
+             | Types.Thinking _
+             | Types.Text _
+             | Types.RedactedThinking _
+             | Types.ToolUse _
+             | Types.ToolResult _
+             | Types.Image _
+             | Types.Document _
+             | Types.Audio _ -> false)
+           msg.content)
+      result
+  in
+  let has_summary =
+    List.exists
+      (fun (msg : Types.message) ->
+         List.exists
+           (function
+             | Types.Text "summary erased reasoning" -> true
+             | Types.Text _
+             | Types.Thinking _
+             | Types.RedactedThinking _
+             | Types.ToolUse _
+             | Types.ToolResult _
+             | Types.Image _
+             | Types.Document _
+             | Types.Audio _ -> false)
+           msg.content)
+      result
+  in
+  Alcotest.(check bool) "old reasoning retained" true has_old_reasoning;
+  Alcotest.(check bool) "summarizer omitted" false has_summary
+;;
+
 (* --- compose --- *)
 
 let test_compose () =
@@ -1608,6 +1673,10 @@ let () =
             "preserves tool-use thinking"
             `Quick
             test_drop_thinking_preserves_tool_use_thinking
+        ; Alcotest.test_case
+            "preserve_thinking removes summarize_old"
+            `Quick
+            test_preserve_thinking_removes_summarize_old
         ] )
     ; "compose", [ Alcotest.test_case "compose strategies" `Quick test_compose ]
     ; ( "keep_first_and_last"


### PR DESCRIPTION
## Summary
- make `Context_reducer.preserve_thinking` remove `Summarize_old` as well as `Drop_thinking`
- document that summarization cannot structurally preserve reasoning blocks
- add a regression test that an old `Thinking` block is retained and the summarizer is not invoked under preserve mode

## Why
`preserve_thinking=true` already prevents budget compaction from using `Summarize_old`, but the generic context-reducer wrapper only removed `Drop_thinking`. A custom reducer containing `Summarize_old` could still rewrite historical reasoning into plain text, violating the provider/agent preserve-thinking contract.

## Verification
- `ocamlformat --check lib/context_reducer.ml lib/context_reducer.mli test/test_context_reducer.ml`
- `git diff --check`

Local Dune not run per operator instruction; GitHub CI is the build/test authority.