### PR TITLE
test(capabilities): pin config capability source

### DIFF
--- a/lib/llm_provider/complete_common.ml
+++ b/lib/llm_provider/complete_common.ml
@@ -125,6 +125,35 @@ let%test "model capability thinking drift remains high-confidence warning" =
   && info_observations = []
 ;;
 
+let%test "capability source is model when catalog resolves config model" =
+  let config =
+    Provider_config.make
+      ~kind:OpenAI_compat
+      ~model_id:"grok-latest"
+      ~base_url:"https://api.x.ai/v1"
+      ()
+  in
+  match resolve_capabilities_for_config config with
+  | _, Model_capability -> true
+  | _, Provider_default_capability -> false
+;;
+
+let%test "capability source is provider default when model is unknown" =
+  let config =
+    Provider_config.make
+      ~kind:OpenAI_compat
+      ~model_id:"not-in-model-catalog-xyz"
+      ~base_url:"https://example.invalid/v1"
+      ()
+  in
+  match resolve_capabilities_for_config config with
+  | caps, Provider_default_capability ->
+    caps.supports_tools = Capabilities.openai_compat_chat_capabilities.supports_tools
+    && caps.thinking_control_format
+       = Capabilities.openai_compat_chat_capabilities.thinking_control_format
+  | _, Model_capability -> false
+;;
+
 type latency_counter =
   | Unknown_latency
   | Monotonic_latency of Mtime_clock.counter


### PR DESCRIPTION
## Summary
- pin `resolve_capabilities_for_config` source classification for catalog-backed models
- pin provider-default fallback classification for unknown OpenAI-compatible models
- keep capability drift telemetry source selection covered without adding new runtime behavior

## Validation
- `ocamlformat --check lib/llm_provider/complete_common.ml`
- `git diff --check`
- Per operator instruction, no local Dune run; GitHub CI is the build/test gate.
