### PR TITLE
fix(streaming): preserve+redact malformed tool-arg buffer for diagnosis (supersedes #2315)

### DIFF
--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -35,7 +35,7 @@ let record_streaming_metrics (metrics : Metrics.t) = function
    [complete_common] already applies to provider error bodies -- before it
    reaches the operator-facing message. Redaction runs first so truncation
    cannot split a token past the redactor and leak a partial; the bound then
-   keeps a large buffer from bloating the keeper log. [%S] at the call site
+   keeps a large buffer from bloating the operator log. [%S] at the call site
    escapes embedded quotes/newlines. *)
 let max_parse_error_raw_excerpt = 256
 
@@ -73,7 +73,7 @@ let http_error_of_stream_error (serr : Types.stream_error) : Http_client.http_er
            | "" -> Printf.sprintf "SSE parse failed: %s" reason
            | raw ->
              (* Echo the offending buffer (bounded) so a rare, provider-specific
-                malformed wire is diagnosable from the keeper log instead of
+                malformed wire is diagnosable from the operator log instead of
                 discarded at the carrier boundary. *)
              Printf.sprintf
                "SSE parse failed: %s raw=%S"
@@ -160,7 +160,7 @@ let%test "stream parse failure stays provider parse failure" =
 ;;
 
 let%test "parse failure echoes the offending raw buffer for diagnosis" =
-  (* The malformed tool-arg buffer must reach the keeper-visible message so a
+  (* The malformed tool-arg buffer must reach the operator-visible message so a
      rare, provider-specific malformed wire is debuggable instead of discarded
      at the carrier boundary. *)
   let reason = "malformed_tool_use_arguments:index:1:bad" in
@@ -810,9 +810,7 @@ let complete_stream_http
                            | Provider_config.DashScope
                            | Provider_config.Kimi ->
                              (match
-                                Streaming.parse_openai_sse_chunk
-                                  ~streaming_reasoning
-                                  data
+                                Streaming.parse_openai_sse_chunk ~streaming_reasoning data
                               with
                               | Some chunk ->
                                 Streaming.openai_chunk_to_events (get_state ()) chunk

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -29,15 +29,21 @@ let record_streaming_metrics (metrics : Metrics.t) = function
   | Context_window_usage _ -> ()
 ;;
 
-(* Bound the offending payload echoed into a parse-failure message so a large
-   tool-argument buffer cannot bloat the keeper log. [%S] at the call site
+(* Scrub-then-bound the offending payload echoed into a parse-failure message.
+   Tool arguments can carry credentials (Bearer tokens, API keys, URL userinfo),
+   so the buffer passes through the [Secret_redactor] SSOT -- the same boundary
+   [complete_common] already applies to provider error bodies -- before it
+   reaches the operator-facing message. Redaction runs first so truncation
+   cannot split a token past the redactor and leak a partial; the bound then
+   keeps a large buffer from bloating the keeper log. [%S] at the call site
    escapes embedded quotes/newlines. *)
 let max_parse_error_raw_excerpt = 256
 
 let parse_error_raw_excerpt raw =
-  if String.length raw <= max_parse_error_raw_excerpt
-  then raw
-  else String.sub raw 0 max_parse_error_raw_excerpt ^ "...(truncated)"
+  let redacted = Secret_redactor.redact_string raw in
+  if String.length redacted <= max_parse_error_raw_excerpt
+  then redacted
+  else String.sub redacted 0 max_parse_error_raw_excerpt ^ "...(truncated)"
 ;;
 
 (* Internal: HTTP-specific streaming implementation. *)
@@ -173,6 +179,21 @@ let%test "parse failure raw excerpt is bounded" =
   match http_error_of_stream_error (Types.Stream_parse_failed { reason; raw }) with
   | Http_client.ProviderFailure { message; _ } ->
     String.length message < String.length raw
+  | _ -> false
+;;
+
+let%test "parse failure redacts secret tokens in the echoed raw buffer" =
+  (* Tool arguments can carry credentials; the operator-visible message must
+     scrub them through the [Secret_redactor] SSOT rather than echo the token
+     verbatim. A [ghp_]-prefixed token is redacted to [[REDACTED]] (see
+     [Secret_redactor]'s own tests), so the rendered message must equal the
+     redacted form -- which definitionally no longer contains the token. *)
+  let reason = "malformed_tool_use_arguments:index:0:bad" in
+  let raw = {|{"auth":"ghp_xxxxxxxxxxxx"}{}|} in
+  match http_error_of_stream_error (Types.Stream_parse_failed { reason; raw }) with
+  | Http_client.ProviderFailure { message; _ } ->
+    message
+    = Printf.sprintf "SSE parse failed: %s raw=%S" reason {|{"auth":"[REDACTED]"}{}|}
   | _ -> false
 ;;
 

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -29,6 +29,17 @@ let record_streaming_metrics (metrics : Metrics.t) = function
   | Context_window_usage _ -> ()
 ;;
 
+(* Bound the offending payload echoed into a parse-failure message so a large
+   tool-argument buffer cannot bloat the keeper log. [%S] at the call site
+   escapes embedded quotes/newlines. *)
+let max_parse_error_raw_excerpt = 256
+
+let parse_error_raw_excerpt raw =
+  if String.length raw <= max_parse_error_raw_excerpt
+  then raw
+  else String.sub raw 0 max_parse_error_raw_excerpt ^ "...(truncated)"
+;;
+
 (* Internal: HTTP-specific streaming implementation. *)
 (* Converge a stream-finalize error onto the same typed carrier the
    non-streaming path produces. A provider-reported error with a recognized
@@ -48,10 +59,20 @@ let http_error_of_stream_error (serr : Types.stream_error) : Http_client.http_er
                }
          ; message = Printf.sprintf "SSE stream error: %s" message
          })
-  | Types.Stream_parse_failed { reason; _ } ->
+  | Types.Stream_parse_failed { reason; raw } ->
     Http_client.ProviderFailure
       { kind = Http_client.Provider_parse_error { parser = Some "sse" }
-      ; message = Printf.sprintf "SSE parse failed: %s" reason
+      ; message =
+          (match raw with
+           | "" -> Printf.sprintf "SSE parse failed: %s" reason
+           | raw ->
+             (* Echo the offending buffer (bounded) so a rare, provider-specific
+                malformed wire is diagnosable from the keeper log instead of
+                discarded at the carrier boundary. *)
+             Printf.sprintf
+               "SSE parse failed: %s raw=%S"
+               reason
+               (parse_error_raw_excerpt raw))
       }
   | Types.Stream_unknown_event { event_type; _ } ->
     Http_client.ProviderFailure
@@ -130,6 +151,29 @@ let maps_to_sse_parse_failure stream_error =
 
 let%test "stream parse failure stays provider parse failure" =
   maps_to_sse_parse_failure (Types.Stream_parse_failed { reason = "bad json"; raw = "x" })
+;;
+
+let%test "parse failure echoes the offending raw buffer for diagnosis" =
+  (* The malformed tool-arg buffer must reach the keeper-visible message so a
+     rare, provider-specific malformed wire is debuggable instead of discarded
+     at the carrier boundary. *)
+  let reason = "malformed_tool_use_arguments:index:1:bad" in
+  let raw = {|{"location":"Tokyo"}{}|} in
+  match http_error_of_stream_error (Types.Stream_parse_failed { reason; raw }) with
+  | Http_client.ProviderFailure { message; _ } ->
+    message = Printf.sprintf "SSE parse failed: %s raw=%S" reason raw
+  | _ -> false
+;;
+
+let%test "parse failure raw excerpt is bounded" =
+  (* A large argument buffer must not bloat the log line: the echoed excerpt is
+     bounded well below the full buffer length. *)
+  let reason = "malformed_tool_use_arguments:index:0:bad" in
+  let raw = String.make 1000 'x' in
+  match http_error_of_stream_error (Types.Stream_parse_failed { reason; raw }) with
+  | Http_client.ProviderFailure { message; _ } ->
+    String.length message < String.length raw
+  | _ -> false
 ;;
 
 let%test "stream unknown event stays provider parse failure" =

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -286,7 +286,7 @@ let finalize_stream_acc (acc : stream_acc) =
           | exception Yojson.Json_error reason ->
             (* Preserve the offending accumulated buffer in [raw] so the rare,
                provider-specific malformed tool-arg wire is diagnosable from the
-               keeper log (the [Complete_stream] renderer bounds it to 256 bytes).
+               operator log (the [Complete_stream] renderer bounds it to 256 bytes).
                [raw] reaches operator-facing logs only, never replayed into
                conversation history. It may hold model-generated tool-argument
                values, so it carries the same sensitivity as any logged request
@@ -1024,7 +1024,7 @@ let%test "finalize_stream_acc fails closed on malformed tool_use arguments" =
   with
   | Error (Types.Stream_parse_failed { reason; raw }) ->
     (* [raw] now preserves the offending buffer so the malformed wire is
-       diagnosable from the keeper log instead of being discarded. *)
+       diagnosable from the operator log instead of being discarded. *)
     raw = "not valid json"
     && String.starts_with ~prefix:"malformed_tool_use_arguments:index:0" reason
   | Error (Types.Stream_provider_error _ | Types.Stream_unknown_event _) | Ok _ -> false

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -284,11 +284,21 @@ let finalize_stream_acc (acc : stream_acc) =
           match Yojson.Safe.from_string text with
           | input -> Ok (Some (Types.ToolUse { id; name; input }))
           | exception Yojson.Json_error reason ->
+            (* Preserve the offending accumulated buffer in [raw] so the rare,
+               provider-specific malformed tool-arg wire is diagnosable from the
+               keeper log (the [Complete_stream] renderer bounds it to 256 bytes).
+               [raw] reaches operator-facing logs only, never replayed into
+               conversation history. It may hold model-generated tool-argument
+               values, so it carries the same sensitivity as any logged request
+               payload -- not a new exposure surface, but not leak-free either.
+               The deliberately-empty [Unknown_block] arm below stays empty
+               because an unrecognized block payload has neither this bound nor a
+               known shape. *)
             Error
               (Types.Stream_parse_failed
                  { reason =
                      Printf.sprintf "malformed_tool_use_arguments:index:%d:%s" idx reason
-                 ; raw = ""
+                 ; raw = text
                  }))
       | Some (Tool_result_block { is_error }) ->
         let tool_use_id =
@@ -1013,7 +1023,10 @@ let%test "finalize_stream_acc fails closed on malformed tool_use arguments" =
     finalize_stream_acc acc
   with
   | Error (Types.Stream_parse_failed { reason; raw }) ->
-    raw = "" && String.starts_with ~prefix:"malformed_tool_use_arguments:index:0" reason
+    (* [raw] now preserves the offending buffer so the malformed wire is
+       diagnosable from the keeper log instead of being discarded. *)
+    raw = "not valid json"
+    && String.starts_with ~prefix:"malformed_tool_use_arguments:index:0" reason
   | Error (Types.Stream_provider_error _ | Types.Stream_unknown_event _) | Ok _ -> false
 ;;
 

--- a/test/test_stream_accumulator.ml
+++ b/test/test_stream_accumulator.ml
@@ -369,7 +369,9 @@ let test_finalize_tool_use_invalid_json () =
     ];
   match Streaming.finalize_stream_acc acc with
   | Error (Stream_parse_failed { reason; raw }) ->
-    Alcotest.(check string) "raw omitted" "" raw;
+    (* The offending tool-arg buffer is preserved in [raw] for keeper-log
+       diagnosis (the Unknown_block/media arms still omit it). *)
+    Alcotest.(check string) "raw preserved" "not json{" raw;
     Alcotest.(check bool)
       "malformed tool args"
       true

--- a/test/test_stream_accumulator.ml
+++ b/test/test_stream_accumulator.ml
@@ -369,7 +369,7 @@ let test_finalize_tool_use_invalid_json () =
     ];
   match Streaming.finalize_stream_acc acc with
   | Error (Stream_parse_failed { reason; raw }) ->
-    (* The offending tool-arg buffer is preserved in [raw] for keeper-log
+    (* The offending tool-arg buffer is preserved in [raw] for operator-log
        diagnosis (the Unknown_block/media arms still omit it). *)
     Alcotest.(check string) "raw preserved" "not json{" raw;
     Alcotest.(check bool)

--- a/test/test_streaming_cov.ml
+++ b/test/test_streaming_cov.ml
@@ -354,7 +354,7 @@ let test_finalize_invalid_tool_json () =
     (Types.MessageDelta { stop_reason = Some Types.EndTurn; usage = None });
   match Streaming.finalize_stream_acc acc with
   | Error (Types.Stream_parse_failed { reason; raw }) ->
-    (* The offending tool-arg buffer is preserved in [raw] for keeper-log
+    (* The offending tool-arg buffer is preserved in [raw] for operator-log
        diagnosis (the Unknown_block/media arms still omit it). *)
     Alcotest.(check string) "raw preserved" "not json{" raw;
     Alcotest.(check bool)

--- a/test/test_streaming_cov.ml
+++ b/test/test_streaming_cov.ml
@@ -354,7 +354,9 @@ let test_finalize_invalid_tool_json () =
     (Types.MessageDelta { stop_reason = Some Types.EndTurn; usage = None });
   match Streaming.finalize_stream_acc acc with
   | Error (Types.Stream_parse_failed { reason; raw }) ->
-    Alcotest.(check string) "raw omitted" "" raw;
+    (* The offending tool-arg buffer is preserved in [raw] for keeper-log
+       diagnosis (the Unknown_block/media arms still omit it). *)
+    Alcotest.(check string) "raw preserved" "not json{" raw;
     Alcotest.(check bool)
       "malformed tool args"
       true

--- a/test/test_streaming_coverage.ml
+++ b/test/test_streaming_coverage.ml
@@ -396,7 +396,7 @@ let test_finalize_tool_use_invalid_json () =
     (MessageDelta { stop_reason = Some EndTurn; usage = None });
   match Streaming.finalize_stream_acc acc with
   | Error (Stream_parse_failed { reason; raw }) ->
-    (* The offending tool-arg buffer is preserved in [raw] for keeper-log
+    (* The offending tool-arg buffer is preserved in [raw] for operator-log
        diagnosis (the Unknown_block/media arms still omit it). *)
     check_string "raw preserved" "not valid json{{{" raw;
     check_bool

--- a/test/test_streaming_coverage.ml
+++ b/test/test_streaming_coverage.ml
@@ -396,7 +396,9 @@ let test_finalize_tool_use_invalid_json () =
     (MessageDelta { stop_reason = Some EndTurn; usage = None });
   match Streaming.finalize_stream_acc acc with
   | Error (Stream_parse_failed { reason; raw }) ->
-    check_string "raw omitted" "" raw;
+    (* The offending tool-arg buffer is preserved in [raw] for keeper-log
+       diagnosis (the Unknown_block/media arms still omit it). *)
+    check_string "raw preserved" "not valid json{{{" raw;
     check_bool
       "malformed tool args"
       true


### PR DESCRIPTION
## 목적

스트리밍 도구 인자(tool arguments) 파싱 실패(`malformed_tool_use_arguments`) 시, 실패 *사유*만 남고 **실제 offending 버퍼가 폐기되어** 근본 원인을 진단할 수 없던 관측성 공백을 메운다. 보존하는 버퍼는 secret-redaction 경계를 통과시켜 안전하게 노출한다.

> #2315를 대체한다. #2315는 동일 브랜치에 대한 병렬 force-push race로 un-rebased 상태에 머물러 3개 required 게이트(Build&Test/OCaml Format/SDK Independence)를 모두 실패했다. 본 PR은 그 모든 수정 + 최신 main(#2313/#2314) rebase를 담은 검증본이다.

## 배경

라이브 fleet에서 `ollama_cloud.minimax-m3`가 다음으로 turn-terminal:

```
malformed_tool_use_arguments:index:1:Line 1, bytes 45-47: Junk after end of JSON value: '{}'
```

- fail-closed 자체는 정상(#2261이 빈 `{}` silent 강등 대신 typed reject 도입, #2296이 object-snapshot replace 수정).
- `minimax-m3`를 tool과 함께 **15회 재현**했으나 매번 단일 청크 + object args로 정상 처리 — production malformed wire는 on-demand 재현 안 되는 희귀 케이스다. 실제 wire를 잡으려면 다음 발생 시 **offending 버퍼 보존**이 필요한데, 현재 두 지점에서 폐기된다(`complete_stream_acc.ml` tool-arg arm `raw=""`, `complete_stream.ml` 렌더가 `raw` 무시).

## 변경

- `complete_stream_acc.ml` — malformed tool-arg arm: `raw = ""` → `raw = text`. offending 버퍼 보존. scope: tool-arg arm만. `Unknown_block`(미지 블록 누출 방지)·media·stream_terminated arm은 `raw=""` 유지(arm별 rationale, N-of-M 아님).
- `complete_stream.ml` — `Stream_parse_failed` 렌더가 raw를 **secret-redaction 후 bounded** 노출:
  - **redact → truncate 순서**. `Secret_redactor.redact_string`(기존 SSOT, `complete_common.ml:454`가 provider error body에 이미 적용)으로 Bearer/API key/URL userinfo/PEM 등을 `[REDACTED]` 처리한 뒤 256자 절단. redact를 먼저 해야 truncation 경계로 토큰이 쪼개져 새지 않는다. `%S`가 따옴표/개행 escape.
- 테스트:
  - 기존 fail-closed 테스트(inline + `test/` alcotest 3개) → raw 보존 단언으로 갱신(mutation-proof). 다른 arm 4개 alcotest는 `raw=""` 유지.
  - 신규 inline 3개: ① raw echo 정확성 ② 큰 버퍼 절단 ③ **`ghp_` 토큰이 `[REDACTED]`로 스크럽**되어 carrier 메시지에 평문 토큰이 안 남음.
- 용어: 진단 주석에 coordinator 용어(`keeper`) 대신 provider-agnostic `operator` 사용 — SDK는 coordinator를 참조하지 않는다(SDK Independence Gate).

## 근거 / 비-안티패턴

- **telemetry-as-fix 아님**: malformed 처리(typed fail-closed)는 #2261이 이미 올바르게 한다. 본 변경은 그 실패가 *왜* 발생했는지 진단 가능하게 하는 관측성 복원 + secret-safe 노출이지, 데이터 손실을 가시화만 하는 패턴이 아니다.
- `raw`는 operator-facing 로그에만 가고 conversation history로 replay되지 않는다. model-generated tool-arg 값(사용자 파생 가능)을 담을 수 있으나, redaction SSOT + 256자 bound + history 미반영으로 노출을 제한한다 — 새 노출 표면을 만들지 않는다.

## 검증 (로컬, post-#2314 rebase)

- `scripts/dune-local.sh build` + `dune runtest lib/llm_provider` → green (갱신/신규 inline 테스트 포함)
- `test/` alcotest 4개 exe(`test_stream_accumulator`/`test_streaming_coverage`/`test_streaming_cov`/`test_streaming_openai`) → 전부 `Test Successful`
- `scripts/check-sdk-independence.sh` → **PASS**
- `ocamlformat --check` 5개 변경 파일 → **CLEAN**

## 후속

진단 instrument이다. 배포 후 다음 `malformed_tool_use_arguments` 발생 시 로그의 (redacted) `raw=...`로 minimax 실제 wire를 확보하면 append-concat인지 모델/게이트웨이 측 malformed인지 확정해 근본 fix(필요 시 provider-keyed tool-arg dialect)를 진행한다.

RFC-WAIVED: `lib/llm_provider/complete_stream*.ml`은 credential/identity/operator-control/sandbox/dashboard-credential/hooks/workflow 게이트 subsystem이 아니다. typed error의 기존 `raw` 운반 의미를 tool-arg arm에서 복원하고, 노출을 기존 redaction SSOT로 통과시키는 국소 관측성 변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
