### PR TITLE
[codex] replay OpenAI Responses assistant phase metadata

### DIFF
--- a/lib/llm_provider/backend_openai_responses.ml
+++ b/lib/llm_provider/backend_openai_responses.ml
@@ -51,6 +51,29 @@ let assoc_remove keys fields =
   List.filter (fun (key, _) -> not (List.mem key keys)) fields
 ;;
 
+let response_phase_metadata_key = "openai.responses.phase"
+
+let response_phase_of_metadata metadata =
+  match List.assoc_opt response_phase_metadata_key metadata with
+  | None -> None
+  | Some (`String raw) ->
+    let phase = String.trim raw in
+    (match phase with
+     | "" -> None
+     | "commentary" | "final_answer" -> Some phase
+     | _ ->
+       invalid_arg
+         (Printf.sprintf
+            "Backend_openai_responses.phase: unsupported %s=%S"
+            response_phase_metadata_key
+            raw))
+  | Some (`Assoc _ | `List _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null) ->
+    invalid_arg
+      (Printf.sprintf
+         "Backend_openai_responses.phase: %s must be a string"
+         response_phase_metadata_key)
+;;
+
 let responses_raw_reasoning_item_of_redacted data =
   try
     match Yojson.Safe.from_string data with
@@ -168,6 +191,12 @@ let output_text_content_part text =
   `Assoc [ "type", `String "output_text"; "text", `String (Utf8_sanitize.sanitize text) ]
 ;;
 
+let with_response_phase phase fields =
+  match phase with
+  | Some phase -> ("phase", `String phase) :: fields
+  | None -> fields
+;;
+
 let message_item ~role content_blocks =
   match List.filter_map input_content_part_of_block content_blocks with
   | [] ->
@@ -180,7 +209,7 @@ let message_item ~role content_blocks =
   | parts -> [ `Assoc [ "role", `String role; "content", `List parts ] ]
 ;;
 
-let assistant_output_item_of_block = function
+let assistant_output_item_of_block ?phase = function
   | Thinking { content; _ } when not (Api_common.string_is_blank content) ->
     Some
       (`Assoc
@@ -192,10 +221,12 @@ let assistant_output_item_of_block = function
   | Text s when not (Api_common.string_is_blank s) ->
     Some
       (`Assoc
-          [ "type", `String "message"
-          ; "role", `String "assistant"
-          ; "content", `List [ output_text_content_part s ]
-          ])
+          (with_response_phase
+             phase
+             [ "type", `String "message"
+             ; "role", `String "assistant"
+             ; "content", `List [ output_text_content_part s ]
+             ]))
   | RedactedThinking data -> responses_raw_reasoning_item_of_redacted data
   | ToolUse { id; name; input } ->
     Some
@@ -249,7 +280,9 @@ let input_items_of_message (msg : message) =
         msg.content
     in
     tool_results @ message_item ~role:"user" non_tool_content
-  | Assistant -> List.filter_map assistant_output_item_of_block msg.content
+  | Assistant ->
+    let phase = response_phase_of_metadata msg.metadata in
+    List.filter_map (assistant_output_item_of_block ?phase) msg.content
   | Tool -> tool_result_items msg.content
 ;;
 

--- a/lib/llm_provider/backend_openai_responses.ml
+++ b/lib/llm_provider/backend_openai_responses.ml
@@ -53,20 +53,30 @@ let assoc_remove keys fields =
 
 let response_phase_metadata_key = "openai.responses.phase"
 
+type response_phase =
+  | Commentary
+  | Final_answer
+
+let response_phase_to_wire = function
+  | Commentary -> "commentary"
+  | Final_answer -> "final_answer"
+;;
+
+let response_phase_metadata phase =
+  response_phase_metadata_key, `String (response_phase_to_wire phase)
+;;
+
 let response_phase_of_metadata metadata =
   match List.assoc_opt response_phase_metadata_key metadata with
   | None -> None
+  | Some (`String "commentary") -> Some Commentary
+  | Some (`String "final_answer") -> Some Final_answer
   | Some (`String raw) ->
-    let phase = String.trim raw in
-    (match phase with
-     | "" -> None
-     | "commentary" | "final_answer" -> Some phase
-     | _ ->
-       invalid_arg
-         (Printf.sprintf
-            "Backend_openai_responses.phase: unsupported %s=%S"
-            response_phase_metadata_key
-            raw))
+    invalid_arg
+      (Printf.sprintf
+         "Backend_openai_responses.phase: unsupported %s=%S"
+         response_phase_metadata_key
+         raw)
   | Some (`Assoc _ | `List _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null) ->
     invalid_arg
       (Printf.sprintf
@@ -193,7 +203,7 @@ let output_text_content_part text =
 
 let with_response_phase phase fields =
   match phase with
-  | Some phase -> ("phase", `String phase) :: fields
+  | Some phase -> ("phase", `String (response_phase_to_wire phase)) :: fields
   | None -> fields
 ;;
 

--- a/lib/llm_provider/backend_openai_responses.mli
+++ b/lib/llm_provider/backend_openai_responses.mli
@@ -5,6 +5,11 @@
     while Chat Completions uses [choices[].message]. Mixing the two wire
     contracts is what breaks reasoning/tool round trips. *)
 
+(** Message metadata key used to replay OpenAI Responses assistant
+    ["phase"] values on stateless manual replay. Accepted values are
+    ["commentary"] and ["final_answer"]. *)
+val response_phase_metadata_key : string
+
 val responses_tool_json : Yojson.Safe.t -> Yojson.Safe.t
 
 val build_request

--- a/lib/llm_provider/backend_openai_responses.mli
+++ b/lib/llm_provider/backend_openai_responses.mli
@@ -10,6 +10,11 @@
     ["commentary"] and ["final_answer"]. *)
 val response_phase_metadata_key : string
 
+type response_phase =
+  | Commentary
+  | Final_answer
+
+val response_phase_metadata : response_phase -> string * Yojson.Safe.t
 val responses_tool_json : Yojson.Safe.t -> Yojson.Safe.t
 
 val build_request

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -3,6 +3,7 @@
 module PC = Llm_provider.Provider_config
 module BA = Llm_provider.Backend_anthropic
 module BO = Llm_provider.Backend_openai
+module BOR = Llm_provider.Backend_openai_responses
 module BGlm = Llm_provider.Backend_glm
 module BOL = Llm_provider.Backend_ollama
 module BGemini = Llm_provider.Backend_gemini
@@ -441,6 +442,67 @@ let test_openai_with_tools () =
   let open Yojson.Safe.Util in
   let tools = json |> member "tools" |> to_list in
   Alcotest.(check int) "1 tool" 1 (List.length tools)
+;;
+
+let openai_responses_config () =
+  PC.make
+    ~kind:OpenAI_compat
+    ~model_id:"gpt-5.5"
+    ~base_url:"https://api.openai.com/v1"
+    ~request_path:"/v1/responses"
+    ()
+;;
+
+let test_openai_responses_replays_assistant_phase_metadata () =
+  let config = openai_responses_config () in
+  let messages =
+    [ { role = User
+      ; content = [ Text "continue" ]
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = [ BOR.response_phase_metadata_key, `String "final_answer" ]
+      }
+    ; { role = Assistant
+      ; content = [ Text "I will check." ]
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = [ BOR.response_phase_metadata_key, `String "commentary" ]
+      }
+    ]
+  in
+  let body = BOR.build_request ~config ~messages () in
+  let json = Yojson.Safe.from_string body in
+  let open Yojson.Safe.Util in
+  let input = json |> member "input" |> to_list in
+  let user_item = List.nth input 0 in
+  let assistant_item = List.nth input 1 in
+  Alcotest.(check bool) "user phase omitted" true (user_item |> member "phase" = `Null);
+  Alcotest.(check string)
+    "assistant type"
+    "message"
+    (assistant_item |> member "type" |> to_string);
+  Alcotest.(check string)
+    "assistant phase"
+    "commentary"
+    (assistant_item |> member "phase" |> to_string)
+;;
+
+let test_openai_responses_rejects_unknown_assistant_phase () =
+  let config = openai_responses_config () in
+  let messages =
+    [ { role = Assistant
+      ; content = [ Text "drafting" ]
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = [ BOR.response_phase_metadata_key, `String "analysis" ]
+      }
+    ]
+  in
+  Alcotest.check_raises
+    "unknown Responses phase rejected"
+    (Invalid_argument
+       "Backend_openai_responses.phase: unsupported openai.responses.phase=\"analysis\"")
+    (fun () -> ignore (BOR.build_request ~config ~messages ()))
 ;;
 
 let test_openai_stream_flag () =
@@ -1413,6 +1475,14 @@ let () =
             test_kimi_direct_tool_result_uses_text_blocks
         ; test_case "stream flag" `Quick test_openai_stream_flag
         ; test_case "with json schema" `Quick test_openai_with_json_schema
+        ; test_case
+            "Responses assistant phase metadata"
+            `Quick
+            test_openai_responses_replays_assistant_phase_metadata
+        ; test_case
+            "Responses unknown phase rejected"
+            `Quick
+            test_openai_responses_rejects_unknown_assistant_phase
         ; test_case "ollama output schema" `Quick test_ollama_output_schema
         ; test_case
             "ollama gemma4 thinking uses template token"

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -460,13 +460,13 @@ let test_openai_responses_replays_assistant_phase_metadata () =
       ; content = [ Text "continue" ]
       ; name = None
       ; tool_call_id = None
-      ; metadata = [ BOR.response_phase_metadata_key, `String "final_answer" ]
+      ; metadata = [ BOR.response_phase_metadata BOR.Final_answer ]
       }
     ; { role = Assistant
       ; content = [ Text "I will check." ]
       ; name = None
       ; tool_call_id = None
-      ; metadata = [ BOR.response_phase_metadata_key, `String "commentary" ]
+      ; metadata = [ BOR.response_phase_metadata BOR.Commentary ]
       }
     ]
   in
@@ -487,22 +487,58 @@ let test_openai_responses_replays_assistant_phase_metadata () =
     (assistant_item |> member "phase" |> to_string)
 ;;
 
-let test_openai_responses_rejects_unknown_assistant_phase () =
+let unsupported_openai_responses_phase_message phase =
+  Printf.sprintf
+    "Backend_openai_responses.phase: unsupported %s=%S"
+    BOR.response_phase_metadata_key
+    phase
+;;
+
+let check_openai_responses_phase_metadata_rejected ~name ~metadata ~message =
   let config = openai_responses_config () in
   let messages =
     [ { role = Assistant
       ; content = [ Text "drafting" ]
       ; name = None
       ; tool_call_id = None
-      ; metadata = [ BOR.response_phase_metadata_key, `String "analysis" ]
+      ; metadata = [ metadata ]
       }
     ]
   in
-  Alcotest.check_raises
-    "unknown Responses phase rejected"
-    (Invalid_argument
-       "Backend_openai_responses.phase: unsupported openai.responses.phase=\"analysis\"")
-    (fun () -> ignore (BOR.build_request ~config ~messages ()))
+  Alcotest.check_raises name (Invalid_argument message) (fun () ->
+    ignore (BOR.build_request ~config ~messages ()))
+;;
+
+let check_openai_responses_phase_rejected ~name ~phase =
+  check_openai_responses_phase_metadata_rejected
+    ~name
+    ~metadata:(BOR.response_phase_metadata_key, `String phase)
+    ~message:(unsupported_openai_responses_phase_message phase)
+;;
+
+let test_openai_responses_rejects_unknown_assistant_phase () =
+  check_openai_responses_phase_rejected
+    ~name:"unknown Responses phase rejected"
+    ~phase:"analysis"
+;;
+
+let test_openai_responses_rejects_padded_assistant_phase () =
+  check_openai_responses_phase_rejected
+    ~name:"padded Responses phase rejected"
+    ~phase:" commentary "
+;;
+
+let test_openai_responses_rejects_blank_assistant_phase () =
+  check_openai_responses_phase_rejected
+    ~name:"blank Responses phase rejected"
+    ~phase:"   "
+;;
+
+let test_openai_responses_rejects_non_string_assistant_phase () =
+  check_openai_responses_phase_metadata_rejected
+    ~name:"non-string Responses phase rejected"
+    ~metadata:(BOR.response_phase_metadata_key, `Int 1)
+    ~message:"Backend_openai_responses.phase: openai.responses.phase must be a string"
 ;;
 
 let test_openai_stream_flag () =
@@ -1483,6 +1519,18 @@ let () =
             "Responses unknown phase rejected"
             `Quick
             test_openai_responses_rejects_unknown_assistant_phase
+        ; test_case
+            "Responses padded phase rejected"
+            `Quick
+            test_openai_responses_rejects_padded_assistant_phase
+        ; test_case
+            "Responses blank phase rejected"
+            `Quick
+            test_openai_responses_rejects_blank_assistant_phase
+        ; test_case
+            "Responses non-string phase rejected"
+            `Quick
+            test_openai_responses_rejects_non_string_assistant_phase
         ; test_case "ollama output schema" `Quick test_ollama_output_schema
         ; test_case
             "ollama gemma4 thinking uses template token"


### PR DESCRIPTION
## Summary

- Add `Backend_openai_responses.response_phase_metadata_key` for OpenAI Responses assistant `phase` replay.
- Emit `phase` only on assistant `message` input items during stateless Responses replay.
- Reject unsupported or non-string phase metadata before sending a provider request.

## Why

RFC-OAS-029 tracks the OpenAI Responses residual where `phase: "commentary" | "final_answer"` needs explicit modeling for manual replay. This keeps the provider-native dialect in OAS instead of inventing an internal CoT state machine.

[근거] OpenAI Developer Docs, Responses/reasoning `phase` guidance, 확인일시 2026-06-30 KST, 신뢰도 High: assistant `phase` is used on Responses assistant messages and should be preserved unchanged when replaying assistant history manually.

## Validation

- `scripts/dune-local.sh build @fmt`
- `env DUNE_CACHE=disabled scripts/dune-local.sh build test/test_provider_complete.exe`
- `env DUNE_CACHE=disabled scripts/dune-local.sh exec test/test_provider_complete.exe` (49 tests)
- `git diff --check`

Refs jeong-sik/masc#27924.
