### PR TITLE
refactor(response_shape): delegate stop_reason serialization to Types SSOT

### DIFF
--- a/lib/llm_provider/response_shape.ml
+++ b/lib/llm_provider/response_shape.ml
@@ -146,6 +146,11 @@ let ended_without_deliverable_content response =
   response.Types.stop_reason = Types.EndTurn && not (has_deliverable_content shape)
 ;;
 
+let stop_reason_diagnostic_string = function
+  | Types.Unknown raw -> Printf.sprintf "unknown(%S)" raw
+  | stop_reason -> Types.stop_reason_to_string stop_reason
+;;
+
 let diagnostic_summary response =
   let shape = summarize response in
   let content_kinds =
@@ -158,7 +163,7 @@ let diagnostic_summary response =
      tool_use_count=%d tool_result_count=%d thinking_blocks=%d thinking_chars=%d \
      redacted_thinking_blocks=%d image_count=%d document_count=%d audio_count=%d"
     (content_shape_to_string (content_shape response shape))
-    (Types.stop_reason_to_string response.stop_reason)
+    (stop_reason_diagnostic_string response.stop_reason)
     shape.text_chars
     (List.length response.content)
     content_kinds

--- a/lib/llm_provider/response_shape.ml
+++ b/lib/llm_provider/response_shape.ml
@@ -141,18 +141,6 @@ let content_shape_to_string = function
   | Has_deliverable_content -> "has_deliverable_content"
 ;;
 
-let stop_reason_to_string = function
-  | Types.EndTurn -> "end_turn"
-  | Types.StopToolUse -> "tool_use"
-  | Types.MaxTokens -> "max_tokens"
-  | Types.StopSequence -> "stop_sequence"
-  | Types.Refusal -> "refusal"
-  | Types.PauseTurn -> "pause_turn"
-  | Types.Compaction -> "compaction"
-  | Types.ContextWindowExceeded -> "context_window_exceeded"
-  | Types.Unknown raw -> Printf.sprintf "unknown(%S)" raw
-;;
-
 let ended_without_deliverable_content response =
   let shape = summarize response in
   response.Types.stop_reason = Types.EndTurn && not (has_deliverable_content shape)
@@ -170,7 +158,7 @@ let diagnostic_summary response =
      tool_use_count=%d tool_result_count=%d thinking_blocks=%d thinking_chars=%d \
      redacted_thinking_blocks=%d image_count=%d document_count=%d audio_count=%d"
     (content_shape_to_string (content_shape response shape))
-    (stop_reason_to_string response.stop_reason)
+    (Types.stop_reason_to_string response.stop_reason)
     shape.text_chars
     (List.length response.content)
     content_kinds

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -1052,6 +1052,21 @@ let test_response_shape_empty_end_turn_is_not_deliverable () =
     (summary_contains ~needle:"content_kinds=[none]" response)
 ;;
 
+let test_response_shape_unknown_stop_reason_is_escaped_in_diagnostics () =
+  let response = response ~stop_reason:(Types.Unknown "provider\nmessage") () in
+  let summary = Response_shape.diagnostic_summary response in
+  Alcotest.(check bool)
+    "escapes unknown stop reason"
+    true
+    (summary_contains ~needle:"stop_reason=unknown(\"provider\\nmessage\")" response);
+  Alcotest.(check bool) "keeps summary single-line" false (String.contains summary '\n');
+  let empty = response ~stop_reason:(Types.Unknown "") () in
+  Alcotest.(check bool)
+    "empty unknown remains visible"
+    true
+    (summary_contains ~needle:"stop_reason=unknown(\"\")" empty)
+;;
+
 let test_response_shape_thinking_plus_text_is_deliverable () =
   let response =
     response
@@ -1135,6 +1150,10 @@ let () =
             "empty end_turn is not deliverable"
             `Quick
             test_response_shape_empty_end_turn_is_not_deliverable
+        ; Alcotest.test_case
+            "unknown stop reason is escaped in diagnostics"
+            `Quick
+            test_response_shape_unknown_stop_reason_is_escaped_in_diagnostics
         ; Alcotest.test_case
             "thinking plus text is deliverable"
             `Quick


### PR DESCRIPTION
## Why

`Response_shape.stop_reason_to_string` re-spelled the `stop_reason` wire mapping that `Types.stop_reason_to_string` already owns as SSOT. `types.ml` documents this explicitly:

> *"SSOT for stop-reason wire strings — callers must delegate here instead of re-spelling the literals, which previously drifted across modules (e.g. 'tool_use' vs 'stop_tool_use')."*

The two copies had **already diverged**:

| variant | `Response_shape` | `Types` (SSOT) |
|---|---|---|
| `ContextWindowExceeded` | `"context_window_exceeded"` | `"model_context_window_exceeded"` |
| `Unknown raw` | `"unknown(%S)" raw` | `raw` (raw token) |

So this is not a benign duplicate — it is active drift. `diagnostic_summary` was reporting `"context_window_exceeded"` while the actual wire/model token is `"model_context_window_exceeded"`, exactly the drift class the SSOT was created to prevent.

Surfaced as confirmed in the provider SSOT audit (variant-fragmentation dimension; line accuracy verified against `types.ml:346` and `response_shape.ml:144`).

## Fix

- Remove `Response_shape.stop_reason_to_string` (not exposed in `response_shape.mli`; only caller was `diagnostic_summary`).
- `diagnostic_summary` now calls `Types.stop_reason_to_string` directly.

Net effect: the diagnostic now shows the correct wire token (`model_context_window_exceeded`) and raw `Unknown` token, and a future `stop_reason` variant addition can no longer leave `response_shape` behind — the compiler points every site at the one SSOT match.

## P0–P3

- **P0**: none (diagnostic-only path, no wire emission).
- **P1**: drift corrected — `diagnostic_summary` now reports the canonical wire token for `ContextWindowExceeded` instead of a divergent literal.
- **P2**: SSOT duplicate removed; the local match that could silently diverge is gone.
- **P3**: `Unknown raw` in diagnostics changes from `"unknown(raw)"` to the bare raw token (SSOT behavior). Acceptable — the surrounding diagnostic line already identifies the field.

## Mergeability

Small surgical fix, one file. No API change (function was private). The `test_stop_reason_ssot` suite already pins `Types.stop_reason_to_string` round-trip behavior.

## Scope note

Part of the provider SSOT audit follow-up (18 confirmed violations). Larger clusters (`thinking_control_format` variant relocation, `stop_reason_wire` per-backend mapping consolidation) are tracked separately and not bundled here.

Co-Authored-By: Claude <noreply@anthropic.com>
