### PR TITLE
refactor(llm_provider): replace catch-all arms with exhaustive variant enums

### DIFF
--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -123,7 +123,12 @@ let response_format_of_config (config : Provider_config.t) =
 let capabilities_of_config (config : Provider_config.t) =
   match config.kind with
   | Provider_config.DashScope -> Capabilities.dashscope_capabilities
-  | _ ->
+  | Provider_config.Anthropic
+  | Provider_config.Kimi
+  | Provider_config.OpenAI_compat
+  | Provider_config.Ollama
+  | Provider_config.Glm
+  | Provider_config.Gemini ->
     (match Provider_config.capabilities_for_config_model config with
      | Some caps -> caps
      | None ->

--- a/lib/llm_provider/backend_openai_serialize.ml
+++ b/lib/llm_provider/backend_openai_serialize.ml
@@ -346,7 +346,7 @@ let ollama_messages_of_message ?(model_id = "") msg =
     (match user_msg with
      | None -> tool_msgs
      | Some m -> tool_msgs @ [ m ])
-  | _ ->
+  | System | Assistant | Tool ->
     messages_of_message_with
       ~tool_calls_fn:tool_calls_to_ollama_json
       ~modality_priority

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -36,7 +36,7 @@ let request_path_default_for_kind = function
     phase only, not total stream duration. *)
 let default_connect_timeout_s = function
   | Ollama -> 600.0
-  | _ -> 60.0
+  | Anthropic | Kimi | OpenAI_compat | Gemini | Glm | DashScope -> 60.0
 ;;
 
 (** Default inter-chunk idle timeout (seconds) for a provider kind. For
@@ -45,7 +45,7 @@ let default_connect_timeout_s = function
     default. Cloud providers keep 60s as a generation-stall detector. *)
 let default_stream_idle_timeout_s = function
   | Ollama -> 600.0
-  | _ -> 60.0
+  | Anthropic | Kimi | OpenAI_compat | Gemini | Glm | DashScope -> 60.0
 ;;
 
 (** [output_schema] derived from [response_format] when no explicit


### PR DESCRIPTION
## Why

Four match arms on **closed variant types** used `_ ->` catch-alls that silently absorbed constructors the OCaml compiler should have flagged at compile time. Adding a new variant to `provider_kind` or `role` would compile cleanly and silently inherit a default at these sites — no review triggered.

Surfaced as confirmed in the provider SSOT audit (catch-all-fsm dimension).

## Fix

Replace each catch-all with an explicit enumeration of the remaining constructors. **No runtime behavior change** — the new arms route exactly the constructors the catch-all already absorbed. The only effect is that the exhaustiveness checker now forces a deliberate decision when a future variant is added.

| file | scrutinee | change |
|---|---|---|
| `provider_config.ml:37-48` | `provider_kind` (7) | `default_connect_timeout_s` / `default_stream_idle_timeout_s`: `\| _ -> 60.0` → explicit 6 cloud kinds |
| `backend_openai_request.ml:126` | `provider_kind` (7) | `capabilities_of_config` outer dispatch: `\| _ ->` → explicit 6 non-DashScope kinds (inner fallback match unchanged) |
| `backend_openai_serialize.ml:349` | `Types.role` (4) | `ollama_messages_of_message`: `\| _ ->` → explicit `System \| Assistant \| Tool` |

### Note on `capabilities_of_config`

The outer dispatch's `| _ ->` becomes an explicit 6-kind or-pattern. The inner fallback match (lines 130-137) still enumerates all 7 kinds including `DashScope` — this is required because OCaml does not propagate the outer arm's refinement into the nested `match`, so removing the inner `DashScope` arm would be a non-exhaustive error. The inner `DashScope` arm remains unreachable (the outer arm short-circuits DashScope) but harmless, exactly as before.

## P0–P3

- **P0**: none.
- **P1**: none.
- **P2**: `capabilities_of_config` and `default_stream_idle_timeout_s` — exhaustiveness discipline on the dispatch a new provider kind would silently ride.
- **P3**: `default_connect_timeout_s`, `ollama_messages_of_message` role match — same class, lower blast radius.

## Mergeability

Zero runtime behavior change (identical routing). Pure compile-time safety. Aligns these sites with the exhaustive-match discipline already used by `max_turns_hard_cap`, `default_attempt_timeout_s` (same file), and every other `provider_kind` match in the codebase (e.g. `complete_sync.ml`, `complete_stream.ml`, `complete_sampling.ml`).

## Scope note

Part of the provider SSOT audit follow-up. Semantic fixes (`provider_registry` `max_context` drift where hardcoded 262_144 shadows the capability-verified 256_000/128_000, and `provider.ml:335` documented dual fallback) are intentionally **not** bundled here — they change resolved values and belong in a separate PR. The `thinking_control_format` variant relocation is tracked as a separate RFC.

Co-Authored-By: Claude <noreply@anthropic.com>
