### PR TITLE
fix(capabilities): reject padded exact thinking tokens

### DIFF
--- a/docs/capability-manifest.md
+++ b/docs/capability-manifest.md
@@ -102,7 +102,7 @@ for the full JSON Schema (draft-07).
 | `supports_computer_use` | bool | from base | Computer-use tools. |
 | `supports_code_execution` | bool | from base | Server-side code sandbox. |
 | `thinking_control_format` | string | from base | Thinking enable/depth wire control. Accepted values: `none`, `thinking_object`, `thinking_object_only`, `chat_template_kwargs`, `chat_template_token`, `ollama_think`, `reasoning_effort`, `enable_thinking`. |
-| `thinking_control_token` | string | absent | Exact chat-template token used when `thinking_control_format = "chat_template_token"`. |
+| `thinking_control_token` | string | absent | Exact chat-template token used when `thinking_control_format = "chat_template_token"`; blank values and leading/trailing whitespace are rejected. |
 | `preserve_thinking_control_format` | string | from base | Historical reasoning replay/preserve wire control. Accepted values: `none`, `thinking_object_keep_all`, `chat_template_kwargs_preserve_thinking`, `top_level_preserve_thinking`, `always_preserved`. |
 | `reasoning_replay` | string | `default` | Optional multi-turn reasoning replay override. Accepted values: `default`, `no_replay`, `drop_without_tool`, `preserve_always`. |
 

--- a/docs/schemas/capability-manifest-v1.json
+++ b/docs/schemas/capability-manifest-v1.json
@@ -175,8 +175,9 @@
         },
         "thinking_control_token": {
           "type": "string",
-          "description": "Exact chat-template token to inject when thinking_control_format is chat_template_token.",
+          "description": "Exact chat-template token to inject when thinking_control_format is chat_template_token. Leading or trailing whitespace is rejected.",
           "minLength": 1,
+          "pattern": "^\\S(?:[\\s\\S]*\\S)?$",
           "examples": ["<|think|>"]
         },
         "preserve_thinking_control_format": {

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -1153,7 +1153,7 @@ let for_provider_model_id ~(provider_label : string) ~(model_id : string) =
 ;;
 
 let exact_token = function
-  | Some raw when String.trim raw = "" -> None
+  | Some raw when String.trim raw = "" || raw <> String.trim raw -> None
   | Some raw -> Some raw
   | None -> None
 ;;
@@ -1675,26 +1675,46 @@ let%test "for_model_id_catalog empty catalog returns None" =
     Option.is_none (for_model_id_catalog "qwen3-32b"))
 ;;
 
-let%test "thinking_control_token catalog runtime override blank-only token is absent" =
+let%test "thinking_control_token catalog runtime override rejects blank or padded token" =
   Model_catalog.set_global
     [ { (test_catalog_entry "programmatic-blank-catalog-token") with
         thinking_control_token = Some " \t "
       }
+    ; { (test_catalog_entry "programmatic-padded-catalog-token") with
+        thinking_control_token = Some " <|think|> "
+      }
+    ; { (test_catalog_entry "programmatic-exact-catalog-token") with
+        thinking_control_token = Some "<|think|>"
+      }
     ];
   Fun.protect ~finally:Model_catalog.clear_global (fun () ->
     Option.is_none
-      (thinking_control_token_for_model_id "programmatic-blank-catalog-token"))
+      (thinking_control_token_for_model_id "programmatic-blank-catalog-token")
+    && Option.is_none
+         (thinking_control_token_for_model_id "programmatic-padded-catalog-token")
+    && thinking_control_token_for_model_id "programmatic-exact-catalog-token"
+       = Some "<|think|>")
 ;;
 
-let%test "thinking_control_token manifest runtime override blank-only token is absent" =
+let%test "thinking_control_token manifest runtime override rejects blank or padded token" =
   Capability_manifest.set_global
     [ { (test_manifest_entry "programmatic-blank-manifest-token") with
         thinking_control_token = Some " \t "
       }
+    ; { (test_manifest_entry "programmatic-padded-manifest-token") with
+        thinking_control_token = Some " <|think|> "
+      }
+    ; { (test_manifest_entry "programmatic-exact-manifest-token") with
+        thinking_control_token = Some "<|think|>"
+      }
     ];
   Fun.protect ~finally:Capability_manifest.clear_global (fun () ->
     Option.is_none
-      (thinking_control_token_for_model_id "programmatic-blank-manifest-token"))
+      (thinking_control_token_for_model_id "programmatic-blank-manifest-token")
+    && Option.is_none
+         (thinking_control_token_for_model_id "programmatic-padded-manifest-token")
+    && thinking_control_token_for_model_id "programmatic-exact-manifest-token"
+       = Some "<|think|>")
 ;;
 
 (* --- emits_usage_tokens / capabilities_for_provider_label --- *)

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -1153,9 +1153,8 @@ let for_provider_model_id ~(provider_label : string) ~(model_id : string) =
 ;;
 
 let exact_token = function
-  | Some raw ->
-    let value = String.trim raw in
-    if value = "" then None else Some value
+  | Some "" -> None
+  | Some raw -> Some raw
   | None -> None
 ;;
 

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -1153,7 +1153,7 @@ let for_provider_model_id ~(provider_label : string) ~(model_id : string) =
 ;;
 
 let exact_token = function
-  | Some "" -> None
+  | Some raw when String.trim raw = "" -> None
   | Some raw -> Some raw
   | None -> None
 ;;
@@ -1377,6 +1377,43 @@ let test_catalog_entry id_prefix : Model_catalog.model_entry =
   ; output_per_million = None
   ; cache_write_multiplier = None
   ; cache_read_multiplier = None
+  }
+;;
+
+let test_manifest_entry id_prefix : Capability_manifest.entry =
+  { id_prefix
+  ; base_label = None
+  ; max_context_tokens = None
+  ; max_output_tokens = None
+  ; supports_tools = None
+  ; supports_tool_choice = None
+  ; supports_required_tool_choice = None
+  ; supports_named_tool_choice = None
+  ; supports_parallel_tool_calls = None
+  ; assistant_tool_content_format = None
+  ; supports_reasoning = None
+  ; supports_extended_thinking = None
+  ; supports_reasoning_budget = None
+  ; accepted_reasoning_efforts = None
+  ; supports_response_format_json = None
+  ; supports_structured_output = None
+  ; supports_multimodal_inputs = None
+  ; supports_image_input = None
+  ; supports_audio_input = None
+  ; supports_video_input = None
+  ; supports_native_streaming = None
+  ; supports_system_prompt = None
+  ; supports_caching = None
+  ; supports_prompt_caching = None
+  ; supports_top_k = None
+  ; supports_min_p = None
+  ; supports_seed = None
+  ; supports_computer_use = None
+  ; supports_code_execution = None
+  ; thinking_control_format = None
+  ; thinking_control_token = None
+  ; preserve_thinking_control_format = None
+  ; reasoning_replay = None
   }
 ;;
 
@@ -1636,6 +1673,28 @@ let%test "for_model_id_catalog empty catalog returns None" =
   Model_catalog.set_global [];
   Fun.protect ~finally:Model_catalog.clear_global (fun () ->
     Option.is_none (for_model_id_catalog "qwen3-32b"))
+;;
+
+let%test "thinking_control_token catalog runtime override blank-only token is absent" =
+  Model_catalog.set_global
+    [ { (test_catalog_entry "programmatic-blank-catalog-token") with
+        thinking_control_token = Some " \t "
+      }
+    ];
+  Fun.protect ~finally:Model_catalog.clear_global (fun () ->
+    Option.is_none
+      (thinking_control_token_for_model_id "programmatic-blank-catalog-token"))
+;;
+
+let%test "thinking_control_token manifest runtime override blank-only token is absent" =
+  Capability_manifest.set_global
+    [ { (test_manifest_entry "programmatic-blank-manifest-token") with
+        thinking_control_token = Some " \t "
+      }
+    ];
+  Fun.protect ~finally:Capability_manifest.clear_global (fun () ->
+    Option.is_none
+      (thinking_control_token_for_model_id "programmatic-blank-manifest-token"))
 ;;
 
 (* --- emits_usage_tokens / capabilities_for_provider_label --- *)

--- a/lib/llm_provider/capability_manifest.ml
+++ b/lib/llm_provider/capability_manifest.ml
@@ -133,10 +133,14 @@ let non_empty_member_string key json =
   match value with
   | None -> Ok None
   | Some raw ->
-    let value = String.trim raw in
-    if value = ""
+    let trimmed = String.trim raw in
+    if trimmed = ""
     then Error (Printf.sprintf "entry field %S must not be empty" key)
-    else Ok (Some value)
+    else if raw <> trimmed
+    then
+      Error
+        (Printf.sprintf "entry field %S must not have leading or trailing whitespace" key)
+    else Ok (Some raw)
 ;;
 
 let member_string_list key json =

--- a/lib/llm_provider/model_catalog.ml
+++ b/lib/llm_provider/model_catalog.ml
@@ -75,10 +75,17 @@ let exact_non_empty_string_field ~entry_id key toml =
   | Error _ as e -> e
   | Ok None -> Ok None
   | Ok (Some raw) ->
-    let value = String.trim raw in
-    if value = ""
+    let trimmed = String.trim raw in
+    if trimmed = ""
     then Error (Printf.sprintf "model entry %S field %S must not be empty" entry_id key)
-    else Ok (Some value)
+    else if raw <> trimmed
+    then
+      Error
+        (Printf.sprintf
+           "model entry %S field %S must not have leading or trailing whitespace"
+           entry_id
+           key)
+    else Ok (Some raw)
 ;;
 
 let canonical_string_opt ~entry_id key ~allowed toml =

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -1406,6 +1406,18 @@ let test_manifest_rejects_blank_thinking_control_token () =
   | Ok _ -> Alcotest.fail "blank thinking_control_token should reject"
 ;;
 
+let test_manifest_rejects_padded_thinking_control_token () =
+  let json =
+    Yojson.Safe.from_string
+      {|{"schema_version":1,"models":[{"id_prefix":"token-model","thinking_control_token":" <|custom_think|> "}]}|}
+  in
+  match Capability_manifest.of_json json with
+  | Error msg ->
+    check_contains "mentions field" msg "thinking_control_token";
+    check_contains "mentions exact rejection" msg "leading or trailing whitespace"
+  | Ok _ -> Alcotest.fail "padded thinking_control_token should reject"
+;;
+
 let test_manifest_rejects_unknown_preserve_thinking_control_format () =
   let json =
     Yojson.Safe.from_string
@@ -1682,6 +1694,21 @@ thinking_control_token = "   "
          check_contains "mentions thinking_control_token" msg "thinking_control_token";
          check_contains "mentions empty" msg "must not be empty"
        | Ok _ -> Alcotest.fail "empty model catalog thinking_control_token should reject")
+;;
+
+let test_model_catalog_rejects_padded_thinking_control_token () =
+  with_temp_model_catalog
+    {|
+[[models]]
+id_prefix = "bad-thinking-token"
+thinking_control_token = " <|custom_think|> "
+|}
+    (fun path ->
+       match Model_catalog.load_file path with
+       | Error msg ->
+         check_contains "mentions thinking_control_token" msg "thinking_control_token";
+         check_contains "mentions exact" msg "leading or trailing whitespace"
+       | Ok _ -> Alcotest.fail "padded model catalog thinking_control_token should reject")
 ;;
 
 let test_model_catalog_rejects_unknown_accepted_reasoning_effort () =
@@ -1967,6 +1994,10 @@ let () =
             `Quick
             test_manifest_rejects_blank_thinking_control_token
         ; test_case
+            "padded thinking_control_token rejects"
+            `Quick
+            test_manifest_rejects_padded_thinking_control_token
+        ; test_case
             "unknown preserve_thinking_control_format rejects"
             `Quick
             test_manifest_rejects_unknown_preserve_thinking_control_format
@@ -2030,6 +2061,10 @@ let () =
             "model catalog rejects empty thinking_control_token"
             `Quick
             test_model_catalog_rejects_empty_thinking_control_token
+        ; test_case
+            "model catalog rejects padded thinking_control_token"
+            `Quick
+            test_model_catalog_rejects_padded_thinking_control_token
         ; test_case
             "model catalog rejects unknown accepted reasoning effort"
             `Quick


### PR DESCRIPTION
## Summary

- fix the post-#2332 exact-token gap where `thinking_control_token` was silently `String.trim`-normalized
- reject padded exact token values in both model catalog TOML and capability manifest JSON
- preserve the raw exact token during capability lookup instead of trimming it again

## Evidence

- `git diff --check`
- `ocamlformat --check lib/llm_provider/model_catalog.ml lib/llm_provider/capability_manifest.ml lib/llm_provider/capabilities.ml test/test_capabilities.ml`

## Notes

- This is a follow-up to the adversarial review on #2332.
- Per workflow, local Dune build was not run; GitHub CI is the build authority.
