### PR TITLE
[codex] Model MiniMax M3 adaptive thinking dialect

### DIFF
--- a/docs/capability-manifest.md
+++ b/docs/capability-manifest.md
@@ -101,7 +101,7 @@ for the full JSON Schema (draft-07).
 | `supports_seed` | bool | from base | Deterministic seed. |
 | `supports_computer_use` | bool | from base | Computer-use tools. |
 | `supports_code_execution` | bool | from base | Server-side code sandbox. |
-| `thinking_control_format` | string | from base | Thinking enable/depth wire control. Accepted values: `none`, `thinking_object`, `thinking_object_only`, `chat_template_kwargs`, `chat_template_token`, `ollama_think`, `reasoning_effort`, `enable_thinking`. |
+| `thinking_control_format` | string | from base | Thinking enable/depth wire control. Accepted values: `none`, `thinking_object`, `thinking_object_adaptive`, `thinking_object_only`, `chat_template_kwargs`, `chat_template_token`, `ollama_think`, `reasoning_effort`, `enable_thinking`. |
 | `thinking_control_token` | string | absent | Exact chat-template token used when `thinking_control_format = "chat_template_token"`; blank values and leading/trailing whitespace are rejected. |
 | `preserve_thinking_control_format` | string | from base | Historical reasoning replay/preserve wire control. Accepted values: `none`, `thinking_object_keep_all`, `chat_template_kwargs_preserve_thinking`, `top_level_preserve_thinking`, `always_preserved`. |
 | `reasoning_replay` | string | `default` | Optional multi-turn reasoning replay override. Accepted values: `default`, `no_replay`, `drop_without_tool`, `preserve_always`. |

--- a/docs/capability-manifest.md
+++ b/docs/capability-manifest.md
@@ -104,6 +104,7 @@ for the full JSON Schema (draft-07).
 | `thinking_control_format` | string | from base | Thinking enable/depth wire control. Accepted values: `none`, `thinking_object`, `thinking_object_adaptive`, `thinking_object_only`, `chat_template_kwargs`, `chat_template_token`, `ollama_think`, `reasoning_effort`, `enable_thinking`. |
 | `thinking_control_token` | string | absent | Exact chat-template token used when `thinking_control_format = "chat_template_token"`; blank values and leading/trailing whitespace are rejected. |
 | `preserve_thinking_control_format` | string | from base | Historical reasoning replay/preserve wire control. Accepted values: `none`, `thinking_object_keep_all`, `chat_template_kwargs_preserve_thinking`, `top_level_preserve_thinking`, `always_preserved`. |
+| `reasoning_output_format` | string | from base | Request-side reasoning output split control. Accepted values: `none`, `split_reasoning_fields`. |
 | `reasoning_replay` | string | `default` | Optional multi-turn reasoning replay override. Accepted values: `default`, `no_replay`, `drop_without_tool`, `preserve_always`. |
 
 Unknown fields and unknown enum values are rejected. Additive schema changes

--- a/docs/design/provider-reasoning-dialects.md
+++ b/docs/design/provider-reasoning-dialects.md
@@ -20,7 +20,7 @@ accepting no request-time thinking parameter.
 | Thinking control format | Preserve control format | Dialect meaning | Replay policy |
 | --- | --- | --- | --- |
 | `Thinking_object` | `No_preserve_thinking_control` | DeepSeek-style top-level `thinking` object, optional `reasoning_effort`, side-channel `reasoning_content` | Drop reasoning between plain user turns, preserve reasoning after assistant tool calls |
-| `Thinking_object_adaptive` | `No_preserve_thinking_control` + `reasoning_replay="preserve_always"` when documented | MiniMax-style top-level `thinking` object with `type:"adaptive"` / `type:"disabled"`, no effort/depth field | Replay policy is explicit catalog data; MiniMax-M3 requires complete assistant replay |
+| `Thinking_object_adaptive` | `No_preserve_thinking_control` + `reasoning_output_format="split_reasoning_fields"` / `reasoning_replay="preserve_always"` when documented | MiniMax-style top-level `thinking` object with `type:"adaptive"` / `type:"disabled"` plus `reasoning_split=true` for side-channel output, no effort/depth field | Replay policy is explicit catalog data; MiniMax-M3 requires complete assistant replay |
 | `Thinking_object_only` | `Thinking_object_keep_all` | Top-level `thinking` object without effort plus `thinking.keep="all"` when requested | Preserve historical `reasoning_content` when `preserve_thinking=true` |
 | `Chat_template_kwargs` | `Chat_template_kwargs_preserve_thinking` | Self-hosted chat-template kwargs such as Qwen `enable_thinking` / `preserve_thinking` | Preserve historical reasoning only when requested |
 | `Enable_thinking` | `Top_level_preserve_thinking` | DashScope-style top-level `enable_thinking` plus separate `preserve_thinking` | Preserve historical reasoning only when requested |

--- a/docs/design/provider-reasoning-dialects.md
+++ b/docs/design/provider-reasoning-dialects.md
@@ -20,6 +20,7 @@ accepting no request-time thinking parameter.
 | Thinking control format | Preserve control format | Dialect meaning | Replay policy |
 | --- | --- | --- | --- |
 | `Thinking_object` | `No_preserve_thinking_control` | DeepSeek-style top-level `thinking` object, optional `reasoning_effort`, side-channel `reasoning_content` | Drop reasoning between plain user turns, preserve reasoning after assistant tool calls |
+| `Thinking_object_adaptive` | `No_preserve_thinking_control` + `reasoning_replay="preserve_always"` when documented | MiniMax-style top-level `thinking` object with `type:"adaptive"` / `type:"disabled"`, no effort/depth field | Replay policy is explicit catalog data; MiniMax-M3 requires complete assistant replay |
 | `Thinking_object_only` | `Thinking_object_keep_all` | Top-level `thinking` object without effort plus `thinking.keep="all"` when requested | Preserve historical `reasoning_content` when `preserve_thinking=true` |
 | `Chat_template_kwargs` | `Chat_template_kwargs_preserve_thinking` | Self-hosted chat-template kwargs such as Qwen `enable_thinking` / `preserve_thinking` | Preserve historical reasoning only when requested |
 | `Enable_thinking` | `Top_level_preserve_thinking` | DashScope-style top-level `enable_thinking` plus separate `preserve_thinking` | Preserve historical reasoning only when requested |

--- a/docs/provider-catalog.md
+++ b/docs/provider-catalog.md
@@ -187,6 +187,11 @@ Accepted `preserve_thinking_control_format` values are:
 - `top_level_preserve_thinking`
 - `always_preserved` (historical reasoning must be replayed; no request field)
 
+Accepted `reasoning_output_format` values are:
+
+- `none`
+- `split_reasoning_fields` (emit provider split control such as `reasoning_split=true`)
+
 Accepted `assistant_tool_content_format` values are:
 
 - `null` (`content: null` for assistant tool-call messages with no visible text)

--- a/docs/provider-catalog.md
+++ b/docs/provider-catalog.md
@@ -171,6 +171,7 @@ Accepted `thinking_control_format` values are:
 
 - `none`
 - `thinking_object` (top-level `thinking` object plus `reasoning_effort`)
+- `thinking_object_adaptive` (top-level `thinking` object with `type: "adaptive"` / `type: "disabled"`)
 - `thinking_object_only` (top-level `thinking` object only)
 - `chat_template_kwargs`
 - `chat_template_token` (inject the catalog/manifest `thinking_control_token` into the chat template)

--- a/docs/rfc/RFC-OAS-029-tools-thinking-reasoning-multiturn-standard.md
+++ b/docs/rfc/RFC-OAS-029-tools-thinking-reasoning-multiturn-standard.md
@@ -188,7 +188,7 @@ RFC 컬럼: **RFC** = dialect/capability *type shape* 변경 또는 N-of-M resha
 
 경계는 대체로 올바르다: MASC는 `Llm_provider.Capabilities`를 typed로 직접 소비하고(`runtime_wire_overlay.ml: agent_capabilities_of_llm_capabilities`가 OAS variant를 verbatim 통과) model 이름 string-match로 reasoning을 결정하지 않는다. OAS는 MASC를 모른다.
 
-단 하나의 경계 부채(MASC측, 정보용): `masc lib/runtime/runtime_schema.ml`이 자체 `thinking_control_format`를 **재선언(5/7 variant, `Thinking_object_only`/`Enable_thinking` 누락)** 한다. parse는 unknown에서 fail-closed(silent 아님)지만, OAS에 8번째 variant가 추가돼도 MASC 컴파일이 깨지지 않아 drift 무방비다. 게다가 그 필드는 wire 경로에서 읽히지 않아 운영자 TOML 설정이 inert no-op(의도-침묵)이다. **P2 SSOT 부채(데이터 경로는 안전).** 해결: 필드 삭제(OAS catalog가 단일 SSOT) 또는 OAS variant 집합에 대한 exhaustive drift 테스트. 이는 OAS 변경이 아니라 MASC 후속 작업이며, 본 RFC의 S9.1을 경계 너머로 확장한 사례로 기록한다. Tracking issue: [jeong-sik/masc#22654](https://github.com/jeong-sik/masc/issues/22654).
+단 하나의 경계 부채(MASC측, 정보용): `masc lib/runtime/runtime_schema.ml`이 자체 `thinking_control_format`를 **재선언(5/9 variant, `Thinking_object_adaptive`/`Thinking_object_only`/`Enable_thinking`/`Ollama_think` 누락)** 한다. parse는 unknown에서 fail-closed(silent 아님)지만, OAS에 새 variant가 추가돼도 MASC 컴파일이 깨지지 않아 drift 무방비다. 게다가 그 필드는 wire 경로에서 읽히지 않아 운영자 TOML 설정이 inert no-op(의도-침묵)이다. **P2 SSOT 부채(데이터 경로는 안전).** 해결: 필드 삭제(OAS catalog가 단일 SSOT) 또는 OAS variant 집합에 대한 exhaustive drift 테스트. 이는 OAS 변경이 아니라 MASC 후속 작업이며, 본 RFC의 S9.1을 경계 너머로 확장한 사례로 기록한다. Tracking issue: [jeong-sik/masc#22654](https://github.com/jeong-sik/masc/issues/22654).
 
 ## 7. Relationships
 - **RFC-OAS-023** (capability axis reshape) — GLM/MiniMax dialect 작업과 model×transport two-record가 여기 land. 본 RFC는 그 작업이 만족해야 할 표준을 정의한다.

--- a/docs/schemas/capability-manifest-v1.json
+++ b/docs/schemas/capability-manifest-v1.json
@@ -165,6 +165,7 @@
           "enum": [
             "none",
             "thinking_object",
+            "thinking_object_adaptive",
             "thinking_object_only",
             "chat_template_kwargs",
             "chat_template_token",

--- a/docs/schemas/capability-manifest-v1.json
+++ b/docs/schemas/capability-manifest-v1.json
@@ -192,6 +192,11 @@
             "always_preserved"
           ]
         },
+        "reasoning_output_format": {
+          "type": "string",
+          "description": "Provider/model request-side reasoning output split control.",
+          "enum": ["none", "split_reasoning_fields"]
+        },
         "reasoning_replay": {
           "type": "string",
           "description": "Optional override for multi-turn reasoning replay policy.",

--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -134,7 +134,8 @@ let trace_prompt_of_blocks blocks =
           (Printf.sprintf "[document:%s data_chars=%d]" media_type (String.length data))
       | Audio { media_type; data; _ } ->
         Some (Printf.sprintf "[audio:%s data_chars=%d]" media_type (String.length data))
-      | Thinking _ | RedactedThinking _ | ToolUse _ | ToolResult _ -> None)
+      | Thinking _ | ReasoningDetails _ | RedactedThinking _ | ToolUse _ | ToolResult _ ->
+        None)
   in
   match String.concat "\n" parts with
   | "" -> "[multimodal input]"
@@ -147,6 +148,7 @@ let validate_user_input_blocks blocks =
       (function
         | Text _ | Image _ | Document _ | Audio _ -> None
         | Thinking _ -> Some "Thinking"
+        | ReasoningDetails _ -> Some "ReasoningDetails"
         | RedactedThinking _ -> Some "RedactedThinking"
         | ToolUse _ -> Some "ToolUse"
         | ToolResult _ -> Some "ToolResult")

--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -925,6 +925,7 @@ let execute_tools
          | ToolUse { id; name; input } -> Some (id, name, input)
          | Text _
          | Thinking _
+         | ReasoningDetails _
          | RedactedThinking _
          | ToolResult _
          | Image _

--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -31,6 +31,7 @@ let compute_fingerprints ?(normalize_tool_call = identity_tool_call_normalizer) 
          Some { fp_name; fp_input = Yojson.Safe.to_string fp_input }
        | Text _
        | Thinking _
+       | ReasoningDetails _
        | RedactedThinking _
        | ToolResult _
        | Image _
@@ -95,6 +96,7 @@ let extract_last_user_text (messages : message list) : string =
                match block with
                | Text s -> Some s
                | Thinking _
+               | ReasoningDetails _
                | RedactedThinking _
                | ToolUse _
                | ToolResult _
@@ -363,6 +365,7 @@ let resolve_turn_params ~hooks ~messages ~max_turns ~turn ~invoke_hook =
                     else Some (Ok { content; _meta = None } : tool_result)
                   | Text _
                   | Thinking _
+                  | ReasoningDetails _
                   | RedactedThinking _
                   | ToolUse _
                   | Image _
@@ -462,6 +465,7 @@ let apply_context_injection ~context ~messages ~injector ~tool_uses ~results =
               [ S ("tool", name); S ("error", Printexc.to_string exn) ])
        | Text _
        | Thinking _
+       | ReasoningDetails _
        | RedactedThinking _
        | ToolResult _
        | Image _
@@ -779,6 +783,7 @@ let single_tool_result = function
   | []
   | [ Text _ ]
   | [ Thinking _ ]
+  | [ ReasoningDetails _ ]
   | [ RedactedThinking _ ]
   | [ ToolUse _ ]
   | [ Image _ ]

--- a/lib/agent_tool.ml
+++ b/lib/agent_tool.ml
@@ -64,6 +64,18 @@ let content_block_to_json = function
           | None -> `Null )
       ; "content", `String content
       ]
+  | ReasoningDetails { reasoning_content; details } ->
+    let fields =
+      [ ( "details"
+        , `List (List.map (fun (detail : reasoning_detail) -> detail.raw) details) )
+      ]
+    in
+    let fields =
+      match reasoning_content with
+      | Some content -> ("reasoning_content", `String content) :: fields
+      | None -> fields
+    in
+    `Assoc (("type", `String "reasoning_details") :: fields)
   | RedactedThinking value ->
     `Assoc [ "type", `String "redacted_thinking"; "content", `String value ]
   | ToolUse { id; name; input } ->

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -326,6 +326,7 @@ let%test "content_block_of_json text block" =
   | Some
       ( Types.Text _
       | Types.Thinking _
+      | Types.ReasoningDetails _
       | Types.RedactedThinking _
       | Types.Image _
       | Types.Document _
@@ -407,6 +408,7 @@ let%test "content_block_of_json tool_use block" =
   | Some
       ( Types.Text _
       | Types.Thinking _
+      | Types.ReasoningDetails _
       | Types.RedactedThinking _
       | Types.Image _
       | Types.Document _
@@ -429,6 +431,7 @@ let%test "content_block_of_json tool_result" =
   | Some
       ( Types.Text _
       | Types.Thinking _
+      | Types.ReasoningDetails _
       | Types.RedactedThinking _
       | Types.Image _
       | Types.Document _

--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -303,6 +303,7 @@ let build_openai_body_unchecked ?provider_config ~config ~messages ?tools ?slot_
                ~preserve_thinking:config.config.preserve_thinking)
         | Llm_provider.Capabilities.No_thinking_control
         | Llm_provider.Capabilities.Thinking_object
+        | Llm_provider.Capabilities.Thinking_object_adaptive
         | Llm_provider.Capabilities.Thinking_object_only
         | Llm_provider.Capabilities.Chat_template_kwargs
         | Llm_provider.Capabilities.Chat_template_token

--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -75,6 +75,7 @@ let llm_capabilities_of_provider_capabilities (caps : Provider.capabilities)
   ; accepted_reasoning_efforts = caps.accepted_reasoning_efforts
   ; thinking_control_format = caps.thinking_control_format
   ; preserve_thinking_control_format = caps.preserve_thinking_control_format
+  ; reasoning_output_format = caps.reasoning_output_format
   ; reasoning_replay_override = caps.reasoning_replay_override
   ; supports_response_format_json = caps.supports_response_format_json
   ; supports_structured_output = caps.supports_structured_output

--- a/lib/base/hooks.ml
+++ b/lib/base/hooks.ml
@@ -76,6 +76,14 @@ let extract_reasoning (messages : message list) : reasoning_summary =
          List.filter_map
            (function
              | Thinking { content; _ } -> Some content
+             | ReasoningDetails { reasoning_content = Some content; _ } -> Some content
+             | ReasoningDetails { reasoning_content = None; details } ->
+               let content =
+                 details
+                 |> List.filter_map (fun (detail : reasoning_detail) -> detail.text)
+                 |> String.concat ""
+               in
+               if content = "" then None else Some content
              | Text _
              | RedactedThinking _
              | ToolUse _

--- a/lib/context_reducer_apply.ml
+++ b/lib/context_reducer_apply.ml
@@ -90,6 +90,7 @@ let tool_use_ids (msg : message) =
       | ToolUse { id; _ } -> Some id
       | Text _
       | Thinking _
+      | ReasoningDetails _
       | RedactedThinking _
       | ToolResult _
       | Image _
@@ -104,6 +105,7 @@ let tool_result_ids (msg : message) =
       | ToolResult { tool_use_id; _ } -> Some tool_use_id
       | Text _
       | Thinking _
+      | ReasoningDetails _
       | RedactedThinking _
       | ToolUse _
       | Image _
@@ -190,6 +192,7 @@ let apply_repair_orphaned_tool_results messages =
             keep
           | Text _
           | Thinking _
+          | ReasoningDetails _
           | RedactedThinking _
           | ToolUse _
           | Image _
@@ -248,6 +251,7 @@ let apply_merge_contiguous messages =
                           | ToolResult _ -> true
                           | Text _
                           | Thinking _
+                          | ReasoningDetails _
                           | RedactedThinking _
                           | ToolUse _
                           | Image _
@@ -261,6 +265,7 @@ let apply_merge_contiguous messages =
                          | ToolResult _ -> true
                          | Text _
                          | Thinking _
+                         | ReasoningDetails _
                          | RedactedThinking _
                          | ToolUse _
                          | Image _
@@ -285,7 +290,7 @@ let apply_drop_thinking messages =
            List.filter
              (fun (block : content_block) ->
                 match block with
-                | Thinking _ | RedactedThinking _ -> false
+                | Thinking _ | ReasoningDetails _ | RedactedThinking _ -> false
                 | Text _ | ToolUse _ | ToolResult _ | Image _ | Document _ | Audio _ ->
                   true)
              msg.content
@@ -304,6 +309,7 @@ let apply_prune_by_role ~drop_roles messages =
                 | ToolResult _ -> true
                 | Text _
                 | Thinking _
+                | ReasoningDetails _
                 | RedactedThinking _
                 | ToolUse _
                 | Image _
@@ -317,6 +323,7 @@ let apply_prune_by_role ~drop_roles messages =
                | ToolUse _ -> true
                | Text _
                | Thinking _
+               | ReasoningDetails _
                | RedactedThinking _
                | ToolResult _
                | Image _
@@ -454,8 +461,13 @@ let apply_cap_message_tokens ?cache ~max_tokens ~keep_recent messages =
       let is_pair_block (block : content_block) =
         match block with
         | ToolUse _ | ToolResult _ -> true
-        | Text _ | Thinking _ | RedactedThinking _ | Image _ | Document _ | Audio _ ->
-          false
+        | Text _
+        | Thinking _
+        | ReasoningDetails _
+        | RedactedThinking _
+        | Image _
+        | Document _
+        | Audio _ -> false
       in
       let cap_message (msg : message) =
         let msg_tokens = estimate_message_tokens ?cache msg in

--- a/lib/context_reducer_estimate.ml
+++ b/lib/context_reducer_estimate.ml
@@ -20,6 +20,13 @@ let estimate_block_tokens ?cache block =
     match block with
     | Text s -> estimate_char_tokens s
     | Thinking { content; _ } -> estimate_char_tokens content
+    | ReasoningDetails { reasoning_content = Some content; _ } ->
+      estimate_char_tokens content
+    | ReasoningDetails { reasoning_content = None; details } ->
+      details
+      |> List.filter_map (fun (detail : reasoning_detail) -> detail.text)
+      |> String.concat ""
+      |> estimate_char_tokens
     | RedactedThinking _ -> 50
     | ToolUse { name; input; _ } ->
       let input_str = Yojson.Safe.to_string input in

--- a/lib/context_reducer_turns.ml
+++ b/lib/context_reducer_turns.ml
@@ -7,6 +7,7 @@ let has_tool_result_message (msg : message) =
        | ToolResult _ -> true
        | Text _
        | Thinking _
+       | ReasoningDetails _
        | RedactedThinking _
        | ToolUse _
        | Image _

--- a/lib/harness_runner.ml
+++ b/lib/harness_runner.ml
@@ -20,6 +20,7 @@ let case_failure ?detail ?response_text ?metrics ?raw_trace_path (case_ : Harnes
 let response_text_block = function
   | Types.Text text -> Some text
   | Types.Thinking _
+  | Types.ReasoningDetails _
   | Types.RedactedThinking _
   | Types.ToolUse _
   | Types.ToolResult _

--- a/lib/llm_provider/api_common.ml
+++ b/lib/llm_provider/api_common.ml
@@ -37,42 +37,13 @@ let text_blocks_to_string blocks =
   |> List.filter_map (function
     | Text s -> Some (Utf8_sanitize.sanitize s)
     | Thinking { content = s; _ } -> Some (Utf8_sanitize.sanitize s)
+    | ReasoningDetails _ -> None
     | RedactedThinking _ -> None
     | ToolUse _ | ToolResult _ | Image _ | Document _ | Audio _ -> None)
   |> String.concat "\n"
 ;;
 
 let json_of_string_or_raw s = Lenient_json.parse s
-let openai_chat_reasoning_details_carrier_type = "openai_chat.reasoning_details.v1"
-
-let openai_chat_reasoning_details_to_redacted details =
-  RedactedThinking
-    (Yojson.Safe.to_string
-       (`Assoc
-           [ "type", `String openai_chat_reasoning_details_carrier_type
-           ; "reasoning_details", `List details
-           ]))
-;;
-
-let openai_chat_reasoning_details_of_redacted data =
-  try
-    match Yojson.Safe.from_string data with
-    | `Assoc fields ->
-      (match List.assoc_opt "type" fields, List.assoc_opt "reasoning_details" fields with
-       | Some (`String carrier_type), Some (`List details)
-         when String.equal carrier_type openai_chat_reasoning_details_carrier_type ->
-         Some details
-       | _ -> None)
-    | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> None
-  with
-  | Yojson.Json_error _ -> None
-;;
-
-let is_openai_chat_reasoning_details_redacted data =
-  match openai_chat_reasoning_details_of_redacted data with
-  | Some _ -> true
-  | None -> false
-;;
 
 type tool_result_content_style =
   | Tool_result_content_string
@@ -104,6 +75,19 @@ let rec content_block_to_json_with
       | None -> [ "type", `String "thinking"; "thinking", `String thinking_text ]
     in
     `Assoc fields
+  | ReasoningDetails { reasoning_content; details } ->
+    let fields =
+      [ ( "details"
+        , `List (List.map (fun (detail : reasoning_detail) -> detail.raw) details) )
+      ]
+    in
+    let fields =
+      match reasoning_content with
+      | Some content ->
+        ("reasoning_content", `String (Utf8_sanitize.sanitize content)) :: fields
+      | None -> fields
+    in
+    `Assoc (("type", `String "reasoning_details") :: fields)
   | RedactedThinking data ->
     `Assoc [ "type", `String "redacted_thinking"; "data", `String data ]
   | ToolUse { id; name; input } ->
@@ -202,6 +186,22 @@ let required_string_field ~block_type ~field json =
   | None -> Error (Missing_content_block_field { block_type; field })
 ;;
 
+let reasoning_detail_of_json json =
+  let open Yojson.Safe.Util in
+  match json with
+  | `Assoc _ ->
+    let text =
+      match json |> member "text" |> to_string_option with
+      | Some text when not (string_is_blank text) -> Some text
+      | Some _ | None -> None
+    in
+    Ok { raw = json; text }
+  | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null ->
+    Error
+      (Missing_content_block_field
+         { block_type = "reasoning_details"; field = "details[]" })
+;;
+
 let parse_media_block ~block_type ~make json =
   let open Yojson.Safe.Util in
   let source = json |> member "source" in
@@ -230,6 +230,21 @@ let rec content_block_of_json_result json =
     Result.map
       (fun content -> Thinking { content; signature })
       (required_string_field ~block_type:"thinking" ~field:"thinking" json)
+  | Some "reasoning_details" ->
+    let ( let* ) = Result.bind in
+    let details_json = json |> member "details" in
+    let details =
+      match details_json with
+      | `List details -> details
+      | _ -> []
+    in
+    let* details = result_all (List.map reasoning_detail_of_json details) in
+    let reasoning_content =
+      match json |> member "reasoning_content" |> to_string_option with
+      | Some content when not (string_is_blank content) -> Some content
+      | Some _ | None -> None
+    in
+    Ok (ReasoningDetails { reasoning_content; details })
   | Some "redacted_thinking" ->
     Result.map
       (fun data -> RedactedThinking data)
@@ -301,6 +316,7 @@ let message_has_tool_result (msg : message) =
       | ToolResult _ -> true
       | Text _
       | Thinking _
+      | ReasoningDetails _
       | RedactedThinking _
       | ToolUse _
       | Image _

--- a/lib/llm_provider/api_common.ml
+++ b/lib/llm_provider/api_common.ml
@@ -236,8 +236,7 @@ let rec content_block_of_json_result json =
     let* details =
       match details_json with
       | `List details -> Ok details
-      | `Null -> Ok []
-      | `Assoc _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ ->
+      | `Assoc _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null ->
         Error
           (Missing_content_block_field
              { block_type = "reasoning_details"; field = "details" })

--- a/lib/llm_provider/api_common.ml
+++ b/lib/llm_provider/api_common.ml
@@ -233,10 +233,14 @@ let rec content_block_of_json_result json =
   | Some "reasoning_details" ->
     let ( let* ) = Result.bind in
     let details_json = json |> member "details" in
-    let details =
+    let* details =
       match details_json with
-      | `List details -> details
-      | _ -> []
+      | `List details -> Ok details
+      | `Null -> Ok []
+      | `Assoc _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ ->
+        Error
+          (Missing_content_block_field
+             { block_type = "reasoning_details"; field = "details" })
     in
     let* details = result_all (List.map reasoning_detail_of_json details) in
     let reasoning_content =

--- a/lib/llm_provider/api_common.ml
+++ b/lib/llm_provider/api_common.ml
@@ -43,6 +43,36 @@ let text_blocks_to_string blocks =
 ;;
 
 let json_of_string_or_raw s = Lenient_json.parse s
+let openai_chat_reasoning_details_carrier_type = "openai_chat.reasoning_details.v1"
+
+let openai_chat_reasoning_details_to_redacted details =
+  RedactedThinking
+    (Yojson.Safe.to_string
+       (`Assoc
+           [ "type", `String openai_chat_reasoning_details_carrier_type
+           ; "reasoning_details", `List details
+           ]))
+;;
+
+let openai_chat_reasoning_details_of_redacted data =
+  try
+    match Yojson.Safe.from_string data with
+    | `Assoc fields ->
+      (match List.assoc_opt "type" fields, List.assoc_opt "reasoning_details" fields with
+       | Some (`String carrier_type), Some (`List details)
+         when String.equal carrier_type openai_chat_reasoning_details_carrier_type ->
+         Some details
+       | _ -> None)
+    | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> None
+  with
+  | Yojson.Json_error _ -> None
+;;
+
+let is_openai_chat_reasoning_details_redacted data =
+  match openai_chat_reasoning_details_of_redacted data with
+  | Some _ -> true
+  | None -> false
+;;
 
 type tool_result_content_style =
   | Tool_result_content_string

--- a/lib/llm_provider/api_common.mli
+++ b/lib/llm_provider/api_common.mli
@@ -17,15 +17,6 @@ val string_is_blank : string -> bool
 val text_blocks_to_string : Types.content_block list -> string
 val json_of_string_or_raw : string -> Yojson.Safe.t
 
-(** Opaque OpenAI-compatible Chat replay carrier for providers that require
-    structured [reasoning_details] to be returned in assistant history. The
-    carrier is stored as {!Types.RedactedThinking} so visible text projections
-    never treat it as assistant answer text. *)
-val openai_chat_reasoning_details_to_redacted : Yojson.Safe.t list -> Types.content_block
-
-val openai_chat_reasoning_details_of_redacted : string -> Yojson.Safe.t list option
-val is_openai_chat_reasoning_details_redacted : string -> bool
-
 (** {2 Content block JSON conversion} *)
 
 val content_block_to_json : Types.content_block -> Yojson.Safe.t

--- a/lib/llm_provider/api_common.mli
+++ b/lib/llm_provider/api_common.mli
@@ -17,6 +17,15 @@ val string_is_blank : string -> bool
 val text_blocks_to_string : Types.content_block list -> string
 val json_of_string_or_raw : string -> Yojson.Safe.t
 
+(** Opaque OpenAI-compatible Chat replay carrier for providers that require
+    structured [reasoning_details] to be returned in assistant history. The
+    carrier is stored as {!Types.RedactedThinking} so visible text projections
+    never treat it as assistant answer text. *)
+val openai_chat_reasoning_details_to_redacted : Yojson.Safe.t list -> Types.content_block
+
+val openai_chat_reasoning_details_of_redacted : string -> Yojson.Safe.t list option
+val is_openai_chat_reasoning_details_redacted : string -> bool
+
 (** {2 Content block JSON conversion} *)
 
 val content_block_to_json : Types.content_block -> Yojson.Safe.t

--- a/lib/llm_provider/backend_anthropic.ml
+++ b/lib/llm_provider/backend_anthropic.ml
@@ -53,6 +53,7 @@ let parse_response json =
         | ToolUse _ -> true
         | Text _
         | Thinking _
+        | ReasoningDetails _
         | RedactedThinking _
         | ToolResult _
         | Image _

--- a/lib/llm_provider/backend_gemini.ml
+++ b/lib/llm_provider/backend_gemini.ml
@@ -134,8 +134,14 @@ let gemini_tool_signatures_of_blocks blocks =
         (match gemini_thought_signature_of_redacted data with
          | Some (tool_use_id, signature) -> Hashtbl.replace tbl tool_use_id signature
          | None -> ())
-      | Text _ | Thinking _ | ToolUse _ | ToolResult _ | Image _ | Document _ | Audio _ ->
-        ())
+      | Text _
+      | Thinking _
+      | ReasoningDetails _
+      | ToolUse _
+      | ToolResult _
+      | Image _
+      | Document _
+      | Audio _ -> ())
     blocks;
   tbl
 ;;
@@ -180,6 +186,7 @@ let part_of_content_block id_to_name tool_signatures = function
   | Thinking { content; _ } ->
     Some
       (`Assoc [ "thought", `Bool true; "text", `String (Utf8_sanitize.sanitize content) ])
+  | ReasoningDetails _ -> None
   | Image { media_type; data; source_type } ->
     inline_data_part ~block:"image" ~media_type ~data source_type
   | Audio { media_type; data; source_type } ->
@@ -478,6 +485,7 @@ let parse_response json =
            | ToolUse _ -> true
            | Text _
            | Thinking _
+           | ReasoningDetails _
            | RedactedThinking _
            | ToolResult _
            | Image _

--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -971,6 +971,7 @@ let%test "parse_openai_response_result with reasoning_content" =
          match block with
          | Thinking _ -> true
          | Text _
+         | ReasoningDetails _
          | RedactedThinking _
          | ToolUse _
          | ToolResult _
@@ -1576,6 +1577,7 @@ let%test "strip_thinking_blocks removes Thinking from all messages" =
                match block with
                | Thinking _ -> true
                | Text _
+               | ReasoningDetails _
                | RedactedThinking _
                | ToolUse _
                | ToolResult _

--- a/lib/llm_provider/backend_openai_parse.ml
+++ b/lib/llm_provider/backend_openai_parse.ml
@@ -47,6 +47,20 @@ let reasoning_texts_of_details details =
   List.filter_map (fun (detail : reasoning_detail) -> detail.text) details
 ;;
 
+let reasoning_texts_of_block = function
+  | Thinking { content; _ } -> [ content ]
+  | ReasoningDetails { reasoning_content = Some content; _ } -> [ content ]
+  | ReasoningDetails { reasoning_content = None; details } ->
+    reasoning_texts_of_details details
+  | Text _
+  | RedactedThinking _
+  | ToolUse _
+  | ToolResult _
+  | Image _
+  | Document _
+  | Audio _ -> []
+;;
+
 let reasoning_content_blocks_of_message msg =
   let open Yojson.Safe.Util in
   let reasoning_content = non_blank_json_string (msg |> member "reasoning_content") in
@@ -293,14 +307,9 @@ let telemetry_of_openai_json json =
         let texts =
           if msg = `Null
           then []
-          else (
-            match reasoning_content_blocks_of_message msg with
-            | [ Thinking { content; _ } ] -> [ content ]
-            | [ ReasoningDetails { reasoning_content; details } ] ->
-              (match reasoning_content with
-               | Some content -> [ content ]
-               | None -> reasoning_texts_of_details details)
-            | _ -> [])
+          else
+            reasoning_content_blocks_of_message msg
+            |> List.concat_map reasoning_texts_of_block
         in
         match texts with
         | [] -> None

--- a/lib/llm_provider/backend_openai_parse.ml
+++ b/lib/llm_provider/backend_openai_parse.ml
@@ -27,20 +27,37 @@ let non_blank_json_string = function
     None
 ;;
 
-let reasoning_detail_of_json = function
+let assoc_field_opt name = function
+  | `Assoc fields -> List.assoc_opt name fields
+  | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> None
+;;
+
+let reasoning_detail_of_json ~index = function
   | `Assoc fields as raw ->
     let text =
       match List.assoc_opt "text" fields with
       | Some text -> non_blank_json_string text
       | None -> None
     in
-    Some { raw; text }
-  | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> None
+    Ok { raw; text }
+  | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null ->
+    Error (Printf.sprintf "malformed_reasoning_details:index:%d:not_object" index)
 ;;
 
-let reasoning_details_of_json = function
-  | `List details -> List.filter_map reasoning_detail_of_json details
-  | `Assoc _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> []
+let reasoning_details_of_message msg =
+  match assoc_field_opt "reasoning_details" msg with
+  | None -> Ok None
+  | Some (`List details) ->
+    let rec loop index acc = function
+      | [] -> Ok (Some (List.rev acc))
+      | detail :: rest ->
+        (match reasoning_detail_of_json ~index detail with
+         | Ok parsed -> loop (index + 1) (parsed :: acc) rest
+         | Error _ as error -> error)
+    in
+    loop 0 [] details
+  | Some (`Assoc _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null) ->
+    Error "malformed_reasoning_details:not_list"
 ;;
 
 let reasoning_texts_of_details details =
@@ -61,18 +78,19 @@ let reasoning_texts_of_block = function
   | Audio _ -> []
 ;;
 
-let reasoning_content_blocks_of_message msg =
+let reasoning_content_blocks_of_message_result msg =
   let open Yojson.Safe.Util in
   let reasoning_content = non_blank_json_string (msg |> member "reasoning_content") in
-  match reasoning_details_of_json (msg |> member "reasoning_details") with
-  | _ :: _ as details -> [ ReasoningDetails { reasoning_content; details } ]
-  | [] ->
+  let* reasoning_details = reasoning_details_of_message msg in
+  match reasoning_details with
+  | Some details -> Ok [ ReasoningDetails { reasoning_content; details } ]
+  | None ->
     (match reasoning_content with
-     | Some content -> [ Thinking { signature = None; content } ]
+     | Some content -> Ok [ Thinking { signature = None; content } ]
      | None ->
        (match non_blank_json_string (msg |> member "reasoning") with
-        | Some content -> [ Thinking { signature = None; content } ]
-        | None -> []))
+        | Some content -> Ok [ Thinking { signature = None; content } ]
+        | None -> Ok []))
 ;;
 
 let text_of_openai_content_block = function
@@ -307,9 +325,10 @@ let telemetry_of_openai_json json =
         let texts =
           if msg = `Null
           then []
-          else
-            reasoning_content_blocks_of_message msg
-            |> List.concat_map reasoning_texts_of_block
+          else (
+            match reasoning_content_blocks_of_message_result msg with
+            | Ok blocks -> List.concat_map reasoning_texts_of_block blocks
+            | Error (_msg : string) -> [])
         in
         match texts with
         | [] -> None
@@ -370,7 +389,7 @@ let parse_openai_response_result_json (raw_json : Yojson.Safe.t) =
        MiniMax split reasoning stays as [ReasoningDetails] so the original
        provider message shape can be replayed without overloading visible or
        redacted thinking channels. Other reasoning text stays [Thinking]. *)
-    let thinking_blocks = reasoning_content_blocks_of_message msg in
+    let* thinking_blocks = reasoning_content_blocks_of_message_result msg in
     let stop_reason =
       (* SSOT: Stop_reason_wire owns the wire finish-reason -> stop_reason table
          and the StopToolUse => has-tool-block invariant (previously duplicated

--- a/lib/llm_provider/backend_openai_parse.ml
+++ b/lib/llm_provider/backend_openai_parse.ml
@@ -27,37 +27,37 @@ let non_blank_json_string = function
     None
 ;;
 
-let reasoning_detail_text = function
-  | `Assoc fields ->
-    (match List.assoc_opt "text" fields with
-     | Some text -> non_blank_json_string text
-     | None -> None)
+let reasoning_detail_of_json = function
+  | `Assoc fields as raw ->
+    let text =
+      match List.assoc_opt "text" fields with
+      | Some text -> non_blank_json_string text
+      | None -> None
+    in
+    Some { raw; text }
   | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> None
 ;;
 
-let reasoning_detail_texts = function
-  | `List details -> List.filter_map reasoning_detail_text details
+let reasoning_details_of_json = function
+  | `List details -> List.filter_map reasoning_detail_of_json details
   | `Assoc _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> []
 ;;
 
-let reasoning_details_of_message msg =
-  let open Yojson.Safe.Util in
-  match msg |> member "reasoning_details" with
-  | `List (_ :: _ as details) -> Some details
-  | `List [] | `Assoc _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null ->
-    None
+let reasoning_texts_of_details details =
+  List.filter_map (fun (detail : reasoning_detail) -> detail.text) details
 ;;
 
-let reasoning_texts_of_message msg =
+let reasoning_content_blocks_of_message msg =
   let open Yojson.Safe.Util in
-  match non_blank_json_string (msg |> member "reasoning_content") with
-  | Some text -> [ text ]
-  | None ->
-    (match reasoning_detail_texts (msg |> member "reasoning_details") with
-     | _ :: _ as texts -> texts
-     | [] ->
+  let reasoning_content = non_blank_json_string (msg |> member "reasoning_content") in
+  match reasoning_details_of_json (msg |> member "reasoning_details") with
+  | _ :: _ as details -> [ ReasoningDetails { reasoning_content; details } ]
+  | [] ->
+    (match reasoning_content with
+     | Some content -> [ Thinking { signature = None; content } ]
+     | None ->
        (match non_blank_json_string (msg |> member "reasoning") with
-        | Some text -> [ text ]
+        | Some content -> [ Thinking { signature = None; content } ]
         | None -> []))
 ;;
 
@@ -290,7 +290,19 @@ let telemetry_of_openai_json json =
         | `Assoc _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> `Null
       in
       let reasoning_text =
-        match if msg = `Null then [] else reasoning_texts_of_message msg with
+        let texts =
+          if msg = `Null
+          then []
+          else (
+            match reasoning_content_blocks_of_message msg with
+            | [ Thinking { content; _ } ] -> [ content ]
+            | [ ReasoningDetails { reasoning_content; details } ] ->
+              (match reasoning_content with
+               | Some content -> [ content ]
+               | None -> reasoning_texts_of_details details)
+            | _ -> [])
+        in
+        match texts with
         | [] -> None
         | texts -> Some (String.concat "" texts)
       in
@@ -346,20 +358,10 @@ let parse_openai_response_result_json (raw_json : Yojson.Safe.t) =
     let* tool_blocks = parse_tool_calls_field (msg |> member "tool_calls") in
     (* Ollama uses "reasoning"; OpenAI-compatible providers commonly use
        "reasoning_content"; MiniMax split mode may return "reasoning_details".
-       The extracted text becomes [Thinking] blocks below and stays typed as
-       reasoning end-to-end (see the content-assembly comment). The raw
-       MiniMax details are also kept as an opaque replay carrier so
-       reasoning-split histories can be sent back without inventing a local CoT
-       representation. *)
-    let reasoning_detail_blocks =
-      match reasoning_details_of_message msg with
-      | Some details -> [ Api_common.openai_chat_reasoning_details_to_redacted details ]
-      | None -> []
-    in
-    let reasoning_texts = reasoning_texts_of_message msg in
-    let thinking_blocks =
-      List.map (fun content -> Thinking { signature = None; content }) reasoning_texts
-    in
+       MiniMax split reasoning stays as [ReasoningDetails] so the original
+       provider message shape can be replayed without overloading visible or
+       redacted thinking channels. Other reasoning text stays [Thinking]. *)
+    let thinking_blocks = reasoning_content_blocks_of_message msg in
     let stop_reason =
       (* SSOT: Stop_reason_wire owns the wire finish-reason -> stop_reason table
          and the StopToolUse => has-tool-block invariant (previously duplicated
@@ -385,7 +387,7 @@ let parse_openai_response_result_json (raw_json : Yojson.Safe.t) =
               projection concern (see [Api_common.text_blocks_to_string] and the
               runtime text extractors), not a parse-time mutation that also
               pollutes replay. *)
-           reasoning_detail_blocks @ thinking_blocks @ text_blocks @ tool_blocks)
+           thinking_blocks @ text_blocks @ tool_blocks)
       ; usage = usage_of_openai_json json
       ; telemetry = telemetry_of_openai_json json
       }

--- a/lib/llm_provider/backend_openai_parse.ml
+++ b/lib/llm_provider/backend_openai_parse.ml
@@ -27,6 +27,32 @@ let non_blank_json_string = function
     None
 ;;
 
+let reasoning_detail_text = function
+  | `Assoc fields ->
+    (match List.assoc_opt "text" fields with
+     | Some text -> non_blank_json_string text
+     | None -> None)
+  | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> None
+;;
+
+let reasoning_detail_texts = function
+  | `List details -> List.filter_map reasoning_detail_text details
+  | `Assoc _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> []
+;;
+
+let reasoning_texts_of_message msg =
+  let open Yojson.Safe.Util in
+  match non_blank_json_string (msg |> member "reasoning_content") with
+  | Some text -> [ text ]
+  | None ->
+    (match reasoning_detail_texts (msg |> member "reasoning_details") with
+     | _ :: _ as texts -> texts
+     | [] ->
+       (match non_blank_json_string (msg |> member "reasoning") with
+        | Some text -> [ text ]
+        | None -> []))
+;;
+
 let text_of_openai_content_block = function
   | `String s -> Some s
   | `Assoc fields ->
@@ -256,12 +282,9 @@ let telemetry_of_openai_json json =
         | `Assoc _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> `Null
       in
       let reasoning_text =
-        if msg = `Null
-        then None
-        else (
-          match non_blank_json_string (msg |> member "reasoning_content") with
-          | Some _ as text -> text
-          | None -> non_blank_json_string (msg |> member "reasoning"))
+        match if msg = `Null then [] else reasoning_texts_of_message msg with
+        | [] -> None
+        | texts -> Some (String.concat "" texts)
       in
       (match reasoning_text with
        | Some s ->
@@ -313,19 +336,13 @@ let parse_openai_response_result_json (raw_json : Yojson.Safe.t) =
         | Yojson.Json_error _ -> text_content)
     in
     let* tool_blocks = parse_tool_calls_field (msg |> member "tool_calls") in
-    (* Ollama uses "reasoning" field; Openai/Deepseek use "reasoning_content".
-       Check both, preferring reasoning_content. The extracted reasoning becomes a
-       [Thinking] block below and stays typed as reasoning end-to-end (see the
-       content-assembly comment). *)
-    let reasoning_text =
-      match non_blank_json_string (msg |> member "reasoning_content") with
-      | Some _ as text -> text
-      | None -> non_blank_json_string (msg |> member "reasoning")
-    in
+    (* Ollama uses "reasoning"; OpenAI-compatible providers commonly use
+       "reasoning_content"; MiniMax split mode may return "reasoning_details".
+       The extracted reasoning becomes [Thinking] blocks below and stays typed
+       as reasoning end-to-end (see the content-assembly comment). *)
+    let reasoning_texts = reasoning_texts_of_message msg in
     let thinking_blocks =
-      match reasoning_text with
-      | Some s -> [ Thinking { signature = None; content = s } ]
-      | None -> []
+      List.map (fun content -> Thinking { signature = None; content }) reasoning_texts
     in
     let stop_reason =
       (* SSOT: Stop_reason_wire owns the wire finish-reason -> stop_reason table

--- a/lib/llm_provider/backend_openai_parse.ml
+++ b/lib/llm_provider/backend_openai_parse.ml
@@ -40,6 +40,14 @@ let reasoning_detail_texts = function
   | `Assoc _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> []
 ;;
 
+let reasoning_details_of_message msg =
+  let open Yojson.Safe.Util in
+  match msg |> member "reasoning_details" with
+  | `List (_ :: _ as details) -> Some details
+  | `List [] | `Assoc _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null ->
+    None
+;;
+
 let reasoning_texts_of_message msg =
   let open Yojson.Safe.Util in
   match non_blank_json_string (msg |> member "reasoning_content") with
@@ -338,8 +346,16 @@ let parse_openai_response_result_json (raw_json : Yojson.Safe.t) =
     let* tool_blocks = parse_tool_calls_field (msg |> member "tool_calls") in
     (* Ollama uses "reasoning"; OpenAI-compatible providers commonly use
        "reasoning_content"; MiniMax split mode may return "reasoning_details".
-       The extracted reasoning becomes [Thinking] blocks below and stays typed
-       as reasoning end-to-end (see the content-assembly comment). *)
+       The extracted text becomes [Thinking] blocks below and stays typed as
+       reasoning end-to-end (see the content-assembly comment). The raw
+       MiniMax details are also kept as an opaque replay carrier so
+       reasoning-split histories can be sent back without inventing a local CoT
+       representation. *)
+    let reasoning_detail_blocks =
+      match reasoning_details_of_message msg with
+      | Some details -> [ Api_common.openai_chat_reasoning_details_to_redacted details ]
+      | None -> []
+    in
     let reasoning_texts = reasoning_texts_of_message msg in
     let thinking_blocks =
       List.map (fun content -> Thinking { signature = None; content }) reasoning_texts
@@ -369,7 +385,7 @@ let parse_openai_response_result_json (raw_json : Yojson.Safe.t) =
               projection concern (see [Api_common.text_blocks_to_string] and the
               runtime text extractors), not a parse-time mutation that also
               pollutes replay. *)
-           thinking_blocks @ text_blocks @ tool_blocks)
+           reasoning_detail_blocks @ thinking_blocks @ text_blocks @ tool_blocks)
       ; usage = usage_of_openai_json json
       ; telemetry = telemetry_of_openai_json json
       }

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -276,6 +276,7 @@ let build_request_assoc
         Some (glm_clear_thinking_of_config config)
       | No_thinking_control
       | Thinking_object
+      | Thinking_object_adaptive
       | Thinking_object_only
       | Chat_template_kwargs
       | Chat_template_token

--- a/lib/llm_provider/backend_openai_responses.ml
+++ b/lib/llm_provider/backend_openai_responses.ml
@@ -103,8 +103,14 @@ let message_has_responses_raw_reasoning (msg : message) =
     (function
       | RedactedThinking data ->
         Option.is_some (responses_raw_reasoning_item_of_redacted data)
-      | Text _ | Thinking _ | ToolUse _ | ToolResult _ | Image _ | Document _ | Audio _ ->
-        false)
+      | Text _
+      | Thinking _
+      | ReasoningDetails _
+      | ToolUse _
+      | ToolResult _
+      | Image _
+      | Document _
+      | Audio _ -> false)
     msg.content
 ;;
 
@@ -194,7 +200,8 @@ let input_content_part_of_block = function
           [ "type", `String "input_audio"
           ; "input_audio", `Assoc [ "data", `String data; "format", `String media_type ]
           ])
-  | Thinking _ | RedactedThinking _ | ToolUse _ | ToolResult _ -> None
+  | Thinking _ | ReasoningDetails _ | RedactedThinking _ | ToolUse _ | ToolResult _ ->
+    None
 ;;
 
 let output_text_content_part text =
@@ -228,6 +235,7 @@ let assistant_output_item_of_block ?phase = function
             , `List [ `Assoc [ "type", `String "summary_text"; "text", `String content ] ]
             )
           ])
+  | ReasoningDetails _ -> None
   | Text s when not (Api_common.string_is_blank s) ->
     Some
       (`Assoc
@@ -264,6 +272,7 @@ let tool_result_items blocks =
       Some (function_call_output_item ~tool_use_id ~content ~content_blocks)
     | Text _
     | Thinking _
+    | ReasoningDetails _
     | RedactedThinking _
     | ToolUse _
     | Image _
@@ -282,6 +291,7 @@ let input_items_of_message (msg : message) =
           | ToolResult _ -> false
           | Text _
           | Thinking _
+          | ReasoningDetails _
           | RedactedThinking _
           | ToolUse _
           | Image _
@@ -645,6 +655,7 @@ let parse_response_result json_str =
             | ToolUse _ -> true
             | Text _
             | Thinking _
+            | ReasoningDetails _
             | RedactedThinking _
             | ToolResult _
             | Image _

--- a/lib/llm_provider/backend_openai_serialize.ml
+++ b/lib/llm_provider/backend_openai_serialize.ml
@@ -42,6 +42,7 @@ let tool_calls_to_openai_json blocks =
             ])
     | Text _
     | Thinking _
+    | ReasoningDetails _
     | RedactedThinking _
     | ToolResult _
     | Image _
@@ -64,6 +65,7 @@ let tool_calls_to_ollama_json blocks =
             ])
     | Text _
     | Thinking _
+    | ReasoningDetails _
     | RedactedThinking _
     | ToolResult _
     | Image _
@@ -109,7 +111,8 @@ let openai_content_parts_of_blocks blocks =
             [ "type", `String "input_audio"
             ; "input_audio", `Assoc [ "data", `String data; "format", `String media_type ]
             ])
-    | Thinking _ | RedactedThinking _ | ToolUse _ | ToolResult _ -> None)
+    | Thinking _ | ReasoningDetails _ | RedactedThinking _ | ToolUse _ | ToolResult _ ->
+      None)
 ;;
 
 let assistant_text_content_of_blocks blocks =
@@ -117,6 +120,7 @@ let assistant_text_content_of_blocks blocks =
   |> List.filter_map (function
     | Text s -> Some (Utf8_sanitize.sanitize s)
     | Thinking _
+    | ReasoningDetails _
     | RedactedThinking _
     | ToolUse _
     | ToolResult _
@@ -132,6 +136,17 @@ let assistant_reasoning_content_of_blocks blocks =
     | Thinking { content; _ } when not (Api_common.string_is_blank content) ->
       Some (Utf8_sanitize.sanitize content)
     | Thinking _ -> None
+    | ReasoningDetails { reasoning_content = Some content; _ }
+      when not (Api_common.string_is_blank content) ->
+      Some (Utf8_sanitize.sanitize content)
+    | ReasoningDetails { reasoning_content = None; details } ->
+      let text =
+        details
+        |> List.filter_map (fun (detail : reasoning_detail) -> detail.text)
+        |> String.concat ""
+      in
+      if Api_common.string_is_blank text then None else Some (Utf8_sanitize.sanitize text)
+    | ReasoningDetails { reasoning_content = Some _; _ } -> None
     | Text _
     | RedactedThinking _
     | ToolUse _
@@ -143,11 +158,23 @@ let assistant_reasoning_content_of_blocks blocks =
 ;;
 
 let assistant_reasoning_details_of_blocks blocks =
-  blocks
-  |> List.find_map (function
-    | RedactedThinking data -> Api_common.openai_chat_reasoning_details_of_redacted data
-    | Text _ | Thinking _ | ToolUse _ | ToolResult _ | Image _ | Document _ | Audio _ ->
-      None)
+  let details =
+    blocks
+    |> List.concat_map (function
+      | ReasoningDetails { details; _ } ->
+        List.map (fun (detail : reasoning_detail) -> detail.raw) details
+      | Text _
+      | Thinking _
+      | RedactedThinking _
+      | ToolUse _
+      | ToolResult _
+      | Image _
+      | Document _
+      | Audio _ -> [])
+  in
+  match details with
+  | [] -> None
+  | _ :: _ -> Some details
 ;;
 
 let openai_tool_message_of_result ~tool_use_id ~content ~content_blocks =
@@ -173,6 +200,7 @@ let openai_tool_messages_of_blocks blocks =
       Some (openai_tool_message_of_result ~tool_use_id ~content ~content_blocks)
     | Text _
     | Thinking _
+    | ReasoningDetails _
     | RedactedThinking _
     | ToolUse _
     | Image _
@@ -183,7 +211,7 @@ let openai_tool_messages_of_blocks blocks =
 let messages_of_message_with
       ?(tool_calls_fn = tool_calls_to_openai_json)
       ?(include_reasoning_content = false)
-      ?(reasoning_output_wire = Reasoning_dialect.No_output_control)
+      ?(include_reasoning_details = false)
       ?(assistant_tool_content_format = Capability_vocab.Assistant_tool_content_null)
       ?(modality_priority = Modality.Preserve_input_order)
       (msg : message)
@@ -202,7 +230,12 @@ let messages_of_message_with
       List.exists
         (function
           | Image _ | Document _ | Audio _ -> true
-          | Text _ | Thinking _ | RedactedThinking _ | ToolUse _ | ToolResult _ -> false)
+          | Text _
+          | Thinking _
+          | ReasoningDetails _
+          | RedactedThinking _
+          | ToolUse _
+          | ToolResult _ -> false)
         msg.content
     in
     let user_msgs =
@@ -228,12 +261,8 @@ let messages_of_message_with
       else ""
     in
     let reasoning_details =
-      if include_reasoning_content
-      then (
-        match reasoning_output_wire with
-        | Reasoning_dialect.Reasoning_split ->
-          assistant_reasoning_details_of_blocks msg.content
-        | Reasoning_dialect.No_output_control -> None)
+      if include_reasoning_details
+      then assistant_reasoning_details_of_blocks msg.content
       else None
     in
     let tool_calls = tool_calls_fn msg.content in
@@ -303,10 +332,17 @@ let dialect_messages_of_message
       dialect
       ~assistant_had_tool_call:(tool_calls <> [])
   in
+  let include_reasoning_details =
+    include_reasoning_content
+    &&
+    match dialect.Reasoning_dialect.output_wire with
+    | Reasoning_dialect.Reasoning_split -> true
+    | Reasoning_dialect.No_output_control -> false
+  in
   messages_of_message_with
     ~tool_calls_fn:(fun _ -> tool_calls)
     ~include_reasoning_content
-    ~reasoning_output_wire:dialect.Reasoning_dialect.output_wire
+    ~include_reasoning_details
     ~assistant_tool_content_format
     msg
 ;;
@@ -346,7 +382,8 @@ let ollama_native_user_message ~modality_priority content : Yojson.Safe.t option
            unsupported_media_source ~backend:"ollama_native" ~block:"document" source_type
          | Audio { source_type; _ } ->
            unsupported_media_source ~backend:"ollama_native" ~block:"audio" source_type
-         | Thinking _ | RedactedThinking _ | ToolUse _ | ToolResult _ -> texts, images)
+         | Thinking _ | ReasoningDetails _ | RedactedThinking _ | ToolUse _ | ToolResult _
+           -> texts, images)
       ([], [])
       ordered_content
   in
@@ -414,7 +451,7 @@ let strip_thinking_blocks (messages : message list) : message list =
        let filtered =
          List.filter
            (function
-             | Thinking _ -> false
+             | Thinking _ | ReasoningDetails _ -> false
              | Text _
              | RedactedThinking _
              | ToolUse _

--- a/lib/llm_provider/backend_openai_serialize.ml
+++ b/lib/llm_provider/backend_openai_serialize.ml
@@ -142,6 +142,14 @@ let assistant_reasoning_content_of_blocks blocks =
   |> String.concat ""
 ;;
 
+let assistant_reasoning_details_of_blocks blocks =
+  blocks
+  |> List.find_map (function
+    | RedactedThinking data -> Api_common.openai_chat_reasoning_details_of_redacted data
+    | Text _ | Thinking _ | ToolUse _ | ToolResult _ | Image _ | Document _ | Audio _ ->
+      None)
+;;
+
 let openai_tool_message_of_result ~tool_use_id ~content ~content_blocks =
   let content_str =
     match content_blocks with
@@ -175,6 +183,7 @@ let openai_tool_messages_of_blocks blocks =
 let messages_of_message_with
       ?(tool_calls_fn = tool_calls_to_openai_json)
       ?(include_reasoning_content = false)
+      ?(reasoning_output_wire = Reasoning_dialect.No_output_control)
       ?(assistant_tool_content_format = Capability_vocab.Assistant_tool_content_null)
       ?(modality_priority = Modality.Preserve_input_order)
       (msg : message)
@@ -218,6 +227,15 @@ let messages_of_message_with
       then assistant_reasoning_content_of_blocks msg.content
       else ""
     in
+    let reasoning_details =
+      if include_reasoning_content
+      then (
+        match reasoning_output_wire with
+        | Reasoning_dialect.Reasoning_split ->
+          assistant_reasoning_details_of_blocks msg.content
+        | Reasoning_dialect.No_output_control -> None)
+      else None
+    in
     let tool_calls = tool_calls_fn msg.content in
     let assistant_content =
       if Api_common.string_is_blank text_content && tool_calls <> []
@@ -229,7 +247,19 @@ let messages_of_message_with
     in
     let fields = [ "role", `String "assistant"; "content", assistant_content ] in
     let fields =
-      if include_reasoning_content && not (Api_common.string_is_blank reasoning_content)
+      match reasoning_details with
+      | Some details -> ("reasoning_details", `List details) :: fields
+      | None
+        when include_reasoning_content
+             && not (Api_common.string_is_blank reasoning_content) ->
+        ("reasoning_content", `String reasoning_content) :: fields
+      | None -> fields
+    in
+    let fields =
+      if
+        include_reasoning_content
+        && reasoning_details <> None
+        && not (Api_common.string_is_blank reasoning_content)
       then ("reasoning_content", `String reasoning_content) :: fields
       else fields
     in
@@ -276,6 +306,7 @@ let dialect_messages_of_message
   messages_of_message_with
     ~tool_calls_fn:(fun _ -> tool_calls)
     ~include_reasoning_content
+    ~reasoning_output_wire:dialect.Reasoning_dialect.output_wire
     ~assistant_tool_content_format
     msg
 ;;

--- a/lib/llm_provider/backend_tool_call_harness.ml
+++ b/lib/llm_provider/backend_tool_call_harness.ml
@@ -168,6 +168,7 @@ let tool_call_check_of_content = function
     Some { name; arguments_valid = true; violations = [] }
   | Text _
   | Thinking _
+  | ReasoningDetails _
   | RedactedThinking _
   | ToolResult _
   | Image _
@@ -260,6 +261,7 @@ let schema_tool_call_check schema_lookup = function
     Some { name; arguments_valid = violations = []; violations }
   | Text _
   | Thinking _
+  | ReasoningDetails _
   | RedactedThinking _
   | ToolResult _
   | Image _
@@ -284,6 +286,7 @@ let is_dropped_content_block = function
   | Text s when String.trim s = "" -> true
   | Text _
   | Thinking _
+  | ReasoningDetails _
   | RedactedThinking _
   | ToolUse _
   | ToolResult _

--- a/lib/llm_provider/canonical_tool.ml
+++ b/lib/llm_provider/canonical_tool.ml
@@ -60,8 +60,18 @@ let reasoning_of_block ~order_index (block : Types.content_block) =
   match block with
   | Types.Thinking { content; signature } ->
     Some { order_index; kind = Visible_thinking; content; signature }
-  | Types.RedactedThinking content
-    when Api_common.is_openai_chat_reasoning_details_redacted content -> None
+  | Types.ReasoningDetails { reasoning_content; details } ->
+    let content =
+      match reasoning_content with
+      | Some content -> content
+      | None ->
+        details
+        |> List.filter_map (fun (detail : Types.reasoning_detail) -> detail.text)
+        |> String.concat ""
+    in
+    if String.trim content = ""
+    then None
+    else Some { order_index; kind = Visible_thinking; content; signature = None }
   | Types.RedactedThinking content ->
     Some { order_index; kind = Redacted_thinking; content; signature = None }
   | Types.Text _
@@ -101,7 +111,7 @@ let scan_tool_call state (block : Types.content_block) =
     ; pending_reasoning_rev = []
     ; tool_calls_rev = tool_call :: state.tool_calls_rev
     }
-  | Types.Thinking _ | Types.RedactedThinking _ ->
+  | Types.Thinking _ | Types.ReasoningDetails _ | Types.RedactedThinking _ ->
     let pending_reasoning_rev =
       match reasoning_of_block ~order_index:state.order_index block with
       | Some reasoning -> reasoning :: state.pending_reasoning_rev
@@ -136,6 +146,7 @@ let tool_result_of_block (block : Types.content_block) : provider_tool_result op
       }
   | Types.Text _
   | Types.Thinking _
+  | Types.ReasoningDetails _
   | Types.RedactedThinking _
   | Types.ToolUse _
   | Types.Image _

--- a/lib/llm_provider/canonical_tool.ml
+++ b/lib/llm_provider/canonical_tool.ml
@@ -60,6 +60,8 @@ let reasoning_of_block ~order_index (block : Types.content_block) =
   match block with
   | Types.Thinking { content; signature } ->
     Some { order_index; kind = Visible_thinking; content; signature }
+  | Types.RedactedThinking content
+    when Api_common.is_openai_chat_reasoning_details_redacted content -> None
   | Types.RedactedThinking content ->
     Some { order_index; kind = Redacted_thinking; content; signature = None }
   | Types.Text _

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -69,6 +69,10 @@ type assistant_tool_content_format = Capability_vocab.assistant_tool_content_for
   | Assistant_tool_content_null
   | Assistant_tool_content_empty_string
 
+type reasoning_output_format = Capability_vocab.reasoning_output_format =
+  | No_reasoning_output_format
+  | Split_reasoning_fields
+
 type capabilities =
   { (* ── Numeric limits ────────────────────────────────── *)
     max_context_tokens : int option (** Model's context window. None = unknown. *)
@@ -106,6 +110,11 @@ type capabilities =
         This is intentionally separate from [thinking_control_format]: some
         models use [thinking.keep], some have no request toggle but require
         replay, and Qwen-style chat templates use a nested boolean. *)
+  ; reasoning_output_format : reasoning_output_format
+    (** Request-side control for where provider reasoning is returned. Some
+        OpenAI-compatible providers require an explicit split switch before
+        returning reasoning in side-channel fields instead of embedding it in
+        visible [content]. *)
   ; reasoning_replay_override : reasoning_replay_override
     (** Optional override for the multi-turn reasoning replay policy. Defaults to
         the policy implied by [thinking_control_format]; catalog entries set this
@@ -171,6 +180,7 @@ let default_capabilities =
   ; accepted_reasoning_efforts = None
   ; thinking_control_format = No_thinking_control
   ; preserve_thinking_control_format = No_preserve_thinking_control
+  ; reasoning_output_format = No_reasoning_output_format
   ; reasoning_replay_override = Default_reasoning_replay
   ; supports_response_format_json = false
   ; supports_structured_output = false
@@ -724,6 +734,10 @@ let assistant_tool_content_format_of_catalog_string raw =
   Capability_vocab.assistant_tool_content_format_of_string raw
 ;;
 
+let reasoning_output_format_of_catalog_string raw =
+  Capability_vocab.reasoning_output_format_of_string raw
+;;
+
 let modality_priority_of_catalog_string raw =
   match String.lowercase_ascii (String.trim raw) with
   | "preserve_input_order" | "preserve-input-order" | "preserve" ->
@@ -869,6 +883,15 @@ let apply_manifest_entry (entry : Capability_manifest.entry) : capabilities =
             warn_unknown_capability_value ~field:"preserve_thinking_control_format" s;
             base.preserve_thinking_control_format)
        | None -> base.preserve_thinking_control_format)
+  ; reasoning_output_format =
+      (match entry.reasoning_output_format with
+       | Some s ->
+         (match reasoning_output_format_of_catalog_string s with
+          | Some format -> format
+          | None ->
+            warn_unknown_capability_value ~field:"reasoning_output_format" s;
+            base.reasoning_output_format)
+       | None -> base.reasoning_output_format)
   ; reasoning_replay_override =
       (match entry.reasoning_replay with
        | Some s ->
@@ -1062,6 +1085,15 @@ let apply_catalog_entry (entry : Model_catalog.model_entry) : capabilities =
             warn_unknown_capability_value ~field:"preserve_thinking_control_format" s;
             base.preserve_thinking_control_format)
        | None -> base.preserve_thinking_control_format)
+  ; reasoning_output_format =
+      (match entry.reasoning_output_format with
+       | Some s ->
+         (match reasoning_output_format_of_catalog_string s with
+          | Some format -> format
+          | None ->
+            warn_unknown_capability_value ~field:"reasoning_output_format" s;
+            base.reasoning_output_format)
+       | None -> base.reasoning_output_format)
   ; reasoning_replay_override =
       (match entry.reasoning_replay with
        | Some s ->
@@ -1375,6 +1407,7 @@ let test_catalog_entry id_prefix : Model_catalog.model_entry =
   ; thinking_control_format = None
   ; thinking_control_token = None
   ; preserve_thinking_control_format = None
+  ; reasoning_output_format = None
   ; reasoning_replay = None
   ; input_per_million = None
   ; output_per_million = None
@@ -2033,6 +2066,7 @@ let%test "capabilities_for_provider_label: aliases resolve to identical capabili
       && ca.thinking_control_format = cb.thinking_control_format
       && ca.accepted_reasoning_efforts = cb.accepted_reasoning_efforts
       && ca.preserve_thinking_control_format = cb.preserve_thinking_control_format
+      && ca.reasoning_output_format = cb.reasoning_output_format
       && ca.assistant_tool_content_format = cb.assistant_tool_content_format
       && ca.reasoning_replay_override = cb.reasoning_replay_override
     | _ -> false

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -2031,7 +2031,7 @@ let detect_drift (caps : capabilities) (resp : Types.api_response)
     (fun (block : Types.content_block) ->
        match block with
        | ToolUse _ -> has_tool_use := true
-       | Thinking _ | RedactedThinking _ -> has_thinking := true
+       | Thinking _ | ReasoningDetails _ | RedactedThinking _ -> has_thinking := true
        | Text _ | ToolResult _ | Image _ | Document _ | Audio _ ->
          (* No capability-drift signal: these blocks are valid against any
            capability set the response declares. *)

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -1449,6 +1449,7 @@ let test_manifest_entry id_prefix : Capability_manifest.entry =
   ; thinking_control_format = None
   ; thinking_control_token = None
   ; preserve_thinking_control_format = None
+  ; reasoning_output_format = None
   ; reasoning_replay = None
   }
 ;;

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -15,6 +15,8 @@
 type thinking_control_format =
   | No_thinking_control (** No thinking control supported *)
   | Thinking_object (** Top-level [thinking] object plus optional [reasoning_effort]. *)
+  | Thinking_object_adaptive
+  (** Top-level [thinking] object whose enabled value is [adaptive]. *)
   | Thinking_object_only
   (** Kimi K2.5-style: top-level [thinking] object without [reasoning_effort]. *)
   | Chat_template_kwargs
@@ -682,6 +684,7 @@ let thinking_control_format_of_manifest_string raw =
   match String.lowercase_ascii (String.trim raw) with
   | "none" -> Some No_thinking_control
   | "thinking_object" -> Some Thinking_object
+  | "thinking_object_adaptive" -> Some Thinking_object_adaptive
   | "thinking_object_only" -> Some Thinking_object_only
   | "chat_template_kwargs" -> Some Chat_template_kwargs
   | "chat_template_token" -> Some Chat_template_token

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -9,6 +9,8 @@
 type thinking_control_format =
   | No_thinking_control (** No thinking control supported *)
   | Thinking_object (** Top-level [thinking] object plus optional [reasoning_effort]. *)
+  | Thinking_object_adaptive
+  (** Top-level [thinking] object whose enabled value is [adaptive]. *)
   | Thinking_object_only
   (** Kimi-style: top-level [thinking] object without [reasoning_effort]. *)
   | Chat_template_kwargs

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -55,6 +55,10 @@ type assistant_tool_content_format = Capability_vocab.assistant_tool_content_for
   | Assistant_tool_content_null
   | Assistant_tool_content_empty_string
 
+type reasoning_output_format = Capability_vocab.reasoning_output_format =
+  | No_reasoning_output_format
+  | Split_reasoning_fields
+
 type capabilities =
   { (* Numeric limits *)
     max_context_tokens : int option
@@ -79,6 +83,7 @@ type capabilities =
         serialization. *)
   ; thinking_control_format : thinking_control_format
   ; preserve_thinking_control_format : preserve_thinking_control_format
+  ; reasoning_output_format : reasoning_output_format
   ; reasoning_replay_override : reasoning_replay_override
   ; (* Output format *)
     supports_response_format_json : bool

--- a/lib/llm_provider/capability_manifest.ml
+++ b/lib/llm_provider/capability_manifest.ml
@@ -36,8 +36,8 @@ type entry =
   ; supports_code_execution : bool option
   ; thinking_control_format : string option
     (** Canonical thinking-wire format the model uses (none / thinking_object /
-        thinking_object_only / chat_template_kwargs / chat_template_token /
-        reasoning_effort / enable_thinking). Parsed + applied in
+        thinking_object_adaptive / thinking_object_only / chat_template_kwargs /
+        chat_template_token / reasoning_effort / enable_thinking). Parsed + applied in
         {!Capabilities.apply_manifest_entry}. Without this field a manifest
         entry silently dropped the model's thinking knob (RFC-OAS-023). *)
   ; thinking_control_token : string option

--- a/lib/llm_provider/capability_manifest.ml
+++ b/lib/llm_provider/capability_manifest.ml
@@ -49,6 +49,10 @@ type entry =
         thinking_object_keep_all / chat_template_kwargs_preserve_thinking /
         top_level_preserve_thinking / always_preserved). Parsed + applied in
         {!Capabilities.apply_manifest_entry}. *)
+  ; reasoning_output_format : string option
+    (** Canonical request-side reasoning output split control (none /
+        split_reasoning_fields). Parsed + applied in
+        {!Capabilities.apply_manifest_entry}. *)
   ; reasoning_replay : string option
     (** Optional multi-turn reasoning replay policy override (default / no_replay
         / drop_without_tool / preserve_always); applied in
@@ -245,6 +249,7 @@ let known_entry_keys =
   ; "thinking_control_format"
   ; "thinking_control_token"
   ; "preserve_thinking_control_format"
+  ; "reasoning_output_format"
   ; "reasoning_replay"
   ]
 ;;
@@ -284,6 +289,12 @@ let parse_entry json =
     canonical_choice
       "preserve_thinking_control_format"
       ~allowed:Capability_vocab.preserve_thinking_control_format_values
+      json
+  in
+  let* reasoning_output_format =
+    canonical_choice
+      "reasoning_output_format"
+      ~allowed:Capability_vocab.reasoning_output_format_values
       json
   in
   let* reasoning_replay =
@@ -337,6 +348,7 @@ let parse_entry json =
     ; thinking_control_format
     ; thinking_control_token
     ; preserve_thinking_control_format
+    ; reasoning_output_format
     ; reasoning_replay
     }
 ;;

--- a/lib/llm_provider/capability_manifest.mli
+++ b/lib/llm_provider/capability_manifest.mli
@@ -91,6 +91,9 @@ type entry =
         thinking_object_keep_all / chat_template_kwargs_preserve_thinking /
         top_level_preserve_thinking / always_preserved); applied in
         {!Capabilities.apply_manifest_entry}. *)
+  ; reasoning_output_format : string option
+    (** Canonical request-side reasoning output split control (none /
+        split_reasoning_fields); applied in {!Capabilities.apply_manifest_entry}. *)
   ; reasoning_replay : string option
     (** Optional multi-turn reasoning replay policy override (default /
         no_replay / drop_without_tool / preserve_always). *)

--- a/lib/llm_provider/capability_manifest.mli
+++ b/lib/llm_provider/capability_manifest.mli
@@ -80,8 +80,8 @@ type entry =
   ; supports_code_execution : bool option
   ; thinking_control_format : string option
     (** Canonical thinking-wire format (none / thinking_object /
-        thinking_object_only / chat_template_kwargs / chat_template_token /
-        reasoning_effort / enable_thinking); applied in
+        thinking_object_adaptive / thinking_object_only / chat_template_kwargs /
+        chat_template_token / reasoning_effort / enable_thinking); applied in
         {!Capabilities.apply_manifest_entry}. *)
   ; thinking_control_token : string option
     (** Exact chat-template token used when [thinking_control_format] is

--- a/lib/llm_provider/capability_vocab.ml
+++ b/lib/llm_provider/capability_vocab.ml
@@ -20,6 +20,7 @@ let normalize raw = String.lowercase_ascii (String.trim raw)
 let thinking_control_format_values =
   [ "none"
   ; "thinking_object"
+  ; "thinking_object_adaptive"
   ; "thinking_object_only"
   ; "chat_template_kwargs"
   ; "chat_template_token"

--- a/lib/llm_provider/capability_vocab.ml
+++ b/lib/llm_provider/capability_vocab.ml
@@ -15,6 +15,10 @@ type assistant_tool_content_format =
   | Assistant_tool_content_null
   | Assistant_tool_content_empty_string
 
+type reasoning_output_format =
+  | No_reasoning_output_format
+  | Split_reasoning_fields
+
 let normalize raw = String.lowercase_ascii (String.trim raw)
 
 let thinking_control_format_values =
@@ -79,4 +83,16 @@ let assistant_tool_content_format_of_string raw =
   match normalize raw with
   | "" -> Some Assistant_tool_content_null
   | normalized -> List.assoc_opt normalized assistant_tool_content_format_table
+;;
+
+let reasoning_output_format_table =
+  [ "none", No_reasoning_output_format; "split_reasoning_fields", Split_reasoning_fields ]
+;;
+
+let reasoning_output_format_values = List.map fst reasoning_output_format_table
+
+let reasoning_output_format_of_string raw =
+  match normalize raw with
+  | "" -> Some No_reasoning_output_format
+  | normalized -> List.assoc_opt normalized reasoning_output_format_table
 ;;

--- a/lib/llm_provider/complete_common.ml
+++ b/lib/llm_provider/complete_common.ml
@@ -288,6 +288,7 @@ let tool_use_count (content : Types.content_block list) =
        | Types.ToolUse _ -> acc + 1
        | Text _
        | Thinking _
+       | ReasoningDetails _
        | RedactedThinking _
        | ToolResult _
        | Image _

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -362,6 +362,7 @@ let finalize_stream_acc (acc : stream_acc) =
              | Types.ToolUse _ -> true
              | Types.Text _
              | Types.Thinking _
+             | Types.ReasoningDetails _
              | Types.RedactedThinking _
              | Types.ToolResult _
              | Types.Image _

--- a/lib/llm_provider/modality.ml
+++ b/lib/llm_provider/modality.ml
@@ -10,7 +10,12 @@ let reorder priority (blocks : content_block list) : content_block list =
   | Visual_first ->
     let is_visual = function
       | Image _ | Audio _ | Document _ -> true
-      | Text _ | Thinking _ | RedactedThinking _ | ToolUse _ | ToolResult _ -> false
+      | Text _
+      | Thinking _
+      | ReasoningDetails _
+      | RedactedThinking _
+      | ToolUse _
+      | ToolResult _ -> false
     in
     let visuals, others = List.partition is_visual blocks in
     visuals @ others

--- a/lib/llm_provider/model_catalog.ml
+++ b/lib/llm_provider/model_catalog.ml
@@ -35,6 +35,7 @@ type model_entry =
   ; thinking_control_format : string option
   ; thinking_control_token : string option
   ; preserve_thinking_control_format : string option
+  ; reasoning_output_format : string option
   ; reasoning_replay : string option
   ; input_per_million : float option
   ; output_per_million : float option
@@ -217,6 +218,13 @@ let parse_entry entry_toml =
            ~allowed:Capability_vocab.preserve_thinking_control_format_values
            entry_toml
        in
+       let reasoning_output_format_result =
+         canonical_string_opt
+           ~entry_id:id_prefix
+           "reasoning_output_format"
+           ~allowed:Capability_vocab.reasoning_output_format_values
+           entry_toml
+       in
        let thinking_control_token_result =
          exact_non_empty_string_field
            ~entry_id:id_prefix
@@ -229,19 +237,22 @@ let parse_entry entry_toml =
           , modality_priority_result
           , thinking_control_format_result
           , preserve_thinking_control_format_result
+          , reasoning_output_format_result
           , thinking_control_token_result )
         with
-        | (Error _ as e), _, _, _, _, _
-        | _, (Error _ as e), _, _, _, _
-        | _, _, (Error _ as e), _, _, _
-        | _, _, _, (Error _ as e), _, _
-        | _, _, _, _, (Error _ as e), _
-        | _, _, _, _, _, (Error _ as e) -> e
+        | (Error _ as e), _, _, _, _, _, _
+        | _, (Error _ as e), _, _, _, _, _
+        | _, _, (Error _ as e), _, _, _, _
+        | _, _, _, (Error _ as e), _, _, _
+        | _, _, _, _, (Error _ as e), _, _
+        | _, _, _, _, _, (Error _ as e), _
+        | _, _, _, _, _, _, (Error _ as e) -> e
         | ( Ok base_label
           , Ok provider_name
           , Ok modality_priority
           , Ok thinking_control_format
           , Ok preserve_thinking_control_format
+          , Ok reasoning_output_format
           , Ok thinking_control_token ) ->
           Ok
             { id_prefix
@@ -290,6 +301,7 @@ let parse_entry entry_toml =
             ; thinking_control_format
             ; thinking_control_token
             ; preserve_thinking_control_format
+            ; reasoning_output_format
             ; reasoning_replay
             ; input_per_million = find_float_opt entry_toml [ "input_per_million" ]
             ; output_per_million = find_float_opt entry_toml [ "output_per_million" ]

--- a/lib/llm_provider/model_catalog.mli
+++ b/lib/llm_provider/model_catalog.mli
@@ -41,6 +41,7 @@ type model_entry =
   ; thinking_control_format : string option
   ; thinking_control_token : string option
   ; preserve_thinking_control_format : string option
+  ; reasoning_output_format : string option
   ; reasoning_replay : string option
   ; input_per_million : float option
   ; output_per_million : float option

--- a/lib/llm_provider/provider_catalog.ml
+++ b/lib/llm_provider/provider_catalog.ml
@@ -274,6 +274,19 @@ let parse_assistant_tool_content_format = function
             (String.concat ", " Capability_vocab.assistant_tool_content_format_values)))
 ;;
 
+let parse_reasoning_output_format = function
+  | None -> Ok None
+  | Some raw ->
+    (match Capability_vocab.reasoning_output_format_of_string raw with
+     | Some format -> Ok (Some format)
+     | None ->
+       Error
+         (Printf.sprintf
+            "unknown reasoning_output_format %S (canonical: %s)"
+            (String.lowercase_ascii (String.trim raw))
+            (String.concat ", " Capability_vocab.reasoning_output_format_values)))
+;;
+
 let member_supported_models json = member_string_list "supported_models" json
 
 let capability_base json =
@@ -332,6 +345,10 @@ let parse_capabilities provider_json =
   let* assistant_tool_content_format =
     let* raw = member_string_strict "assistant_tool_content_format" cap_json in
     parse_assistant_tool_content_format raw
+  in
+  let* reasoning_output_format =
+    let* raw = member_string_strict "reasoning_output_format" cap_json in
+    parse_reasoning_output_format raw
   in
   let caps =
     base
@@ -413,6 +430,10 @@ let parse_capabilities provider_json =
     (match assistant_tool_content_format with
      | Some assistant_tool_content_format ->
        { caps with Capabilities.assistant_tool_content_format }
+     | None -> caps)
+    |> fun caps ->
+    (match reasoning_output_format with
+     | Some reasoning_output_format -> { caps with Capabilities.reasoning_output_format }
      | None -> caps)
     |> fun caps ->
     override_bool

--- a/lib/llm_provider/provider_catalog.ml
+++ b/lib/llm_provider/provider_catalog.ml
@@ -211,6 +211,7 @@ let parse_thinking_control_format = function
      | "" -> Ok None
      | "none" -> Ok (Some Capabilities.No_thinking_control)
      | "thinking_object" -> Ok (Some Capabilities.Thinking_object)
+     | "thinking_object_adaptive" -> Ok (Some Capabilities.Thinking_object_adaptive)
      | "thinking_object_only" -> Ok (Some Capabilities.Thinking_object_only)
      | "chat_template_kwargs" -> Ok (Some Capabilities.Chat_template_kwargs)
      | "chat_template_token" -> Ok (Some Capabilities.Chat_template_token)
@@ -221,8 +222,8 @@ let parse_thinking_control_format = function
        Error
          (Printf.sprintf
             "unknown thinking_control_format %S (canonical: none, thinking_object, \
-             thinking_object_only, chat_template_kwargs, chat_template_token, \
-             ollama_think, reasoning_effort, enable_thinking)"
+             thinking_object_adaptive, thinking_object_only, chat_template_kwargs, \
+             chat_template_token, ollama_think, reasoning_effort, enable_thinking)"
             other))
 ;;
 

--- a/lib/llm_provider/reasoning_dialect.ml
+++ b/lib/llm_provider/reasoning_dialect.ml
@@ -8,6 +8,7 @@ type toggle_default =
 type toggle_wire =
   | No_toggle
   | Thinking_object of { includes_reasoning_effort : bool }
+  | Thinking_object_adaptive
   | Thinking_object_only
   | Chat_template_kwargs
   | Chat_template_token
@@ -88,6 +89,13 @@ let base_of_capabilities (caps : Capabilities.capabilities) =
     ; effort_alias_policy = Deepseek_high_or_max
     ; sampling_policy = Ignored_when_thinking deepseek_ignored_sampling_params
     ; replay_policy = Drop_without_tool_preserve_with_tool
+    ; streaming = Delta_field "reasoning_content"
+    }
+  | Thinking_object_adaptive ->
+    { default with
+      toggle_default = Enabled
+    ; toggle_wire = Thinking_object_adaptive
+    ; preserve_wire
     ; streaming = Delta_field "reasoning_content"
     }
   | Thinking_object_only ->
@@ -270,6 +278,11 @@ let request_control_fields
        ("thinking", `Assoc [ "type", `String "enabled" ]) :: normalized_effort_field ()
      | Some false -> [ "thinking", `Assoc [ "type", `String "disabled" ] ]
      | None -> [])
+  | Thinking_object_adaptive ->
+    (match enable_thinking with
+     | Some true -> [ "thinking", `Assoc [ "type", `String "adaptive" ] ]
+     | Some false -> [ "thinking", `Assoc [ "type", `String "disabled" ] ]
+     | None -> [])
   | Thinking_object_only ->
     let control =
       thinking_object_only_control dialect ~enable_thinking ~preserve_thinking
@@ -359,6 +372,7 @@ let sampling_params_ignored_for_format
   = function
   | Capabilities.Thinking_object -> deepseek_ignored_sampling_params
   | Capabilities.No_thinking_control
+  | Capabilities.Thinking_object_adaptive
   | Capabilities.Thinking_object_only
   | Capabilities.Chat_template_kwargs
   | Capabilities.Chat_template_token
@@ -393,6 +407,7 @@ let toggle_wire_to_string = function
   | No_toggle -> "no_toggle"
   | Thinking_object { includes_reasoning_effort = true } -> "thinking_object"
   | Thinking_object { includes_reasoning_effort = false } -> "thinking_object_no_effort"
+  | Thinking_object_adaptive -> "thinking_object_adaptive"
   | Thinking_object_only -> "thinking_object_only"
   | Chat_template_kwargs -> "chat_template_kwargs"
   | Chat_template_token -> "chat_template_token"

--- a/lib/llm_provider/reasoning_dialect.ml
+++ b/lib/llm_provider/reasoning_dialect.ml
@@ -37,6 +37,10 @@ type streaming_reasoning =
   | Delta_field of string
   | Template_parser
 
+type output_wire =
+  | No_output_control
+  | Reasoning_split
+
 type thinking_object_only_control =
   { enabled : bool option
   ; keep_all : bool
@@ -50,6 +54,7 @@ type t =
   ; sampling_policy : sampling_policy
   ; replay_policy : replay_policy
   ; streaming : streaming_reasoning
+  ; output_wire : output_wire
   }
 
 let default =
@@ -60,6 +65,7 @@ let default =
   ; sampling_policy = Sampling_supported
   ; replay_policy = No_replay
   ; streaming = No_streaming_reasoning
+  ; output_wire = No_output_control
   }
 ;;
 
@@ -69,9 +75,14 @@ let deepseek_ignored_sampling_params =
 
 let base_of_capabilities (caps : Capabilities.capabilities) =
   let preserve_wire = caps.preserve_thinking_control_format in
+  let output_wire =
+    match caps.reasoning_output_format with
+    | No_reasoning_output_format -> No_output_control
+    | Split_reasoning_fields -> Reasoning_split
+  in
   match caps.thinking_control_format with
   | No_thinking_control ->
-    let dialect = { default with preserve_wire } in
+    let dialect = { default with preserve_wire; output_wire } in
     (match preserve_wire with
      | Always_preserved_thinking ->
        { dialect with
@@ -90,6 +101,7 @@ let base_of_capabilities (caps : Capabilities.capabilities) =
     ; sampling_policy = Ignored_when_thinking deepseek_ignored_sampling_params
     ; replay_policy = Drop_without_tool_preserve_with_tool
     ; streaming = Delta_field "reasoning_content"
+    ; output_wire
     }
   | Thinking_object_adaptive ->
     { default with
@@ -97,6 +109,7 @@ let base_of_capabilities (caps : Capabilities.capabilities) =
     ; toggle_wire = Thinking_object_adaptive
     ; preserve_wire
     ; streaming = Delta_field "reasoning_content"
+    ; output_wire
     }
   | Thinking_object_only ->
     { default with
@@ -104,36 +117,42 @@ let base_of_capabilities (caps : Capabilities.capabilities) =
     ; toggle_wire = Thinking_object_only
     ; preserve_wire
     ; streaming = Delta_field "reasoning_content"
+    ; output_wire
     }
   | Chat_template_kwargs ->
     { default with
       toggle_wire = Chat_template_kwargs
     ; preserve_wire
     ; streaming = Template_parser
+    ; output_wire
     }
   | Chat_template_token ->
     { default with
       toggle_wire = Chat_template_token
     ; preserve_wire
     ; streaming = Template_parser
+    ; output_wire
     }
   | Ollama_think ->
     { default with
       toggle_wire = Ollama_think
     ; preserve_wire
     ; streaming = Delta_field "thinking"
+    ; output_wire
     }
   | Reasoning_effort ->
     { default with
       toggle_wire = Reasoning_effort
     ; preserve_wire
     ; streaming = Delta_field "reasoning"
+    ; output_wire
     }
   | Enable_thinking ->
     { default with
       toggle_wire = Enable_thinking
     ; preserve_wire
     ; streaming = Delta_field "reasoning_content"
+    ; output_wire
     }
 ;;
 
@@ -220,6 +239,12 @@ let bool_field name = function
   | None -> []
 ;;
 
+let reasoning_output_fields dialect ~enable_thinking =
+  match dialect.output_wire, thinking_enabled ~enable_thinking with
+  | Reasoning_split, true -> [ "reasoning_split", `Bool true ]
+  | Reasoning_split, false | No_output_control, _ -> []
+;;
+
 let normalize_effort_value dialect effort =
   match dialect.effort_alias_policy, (effort : Reasoning_effort.t) with
   | ( Deepseek_high_or_max
@@ -239,6 +264,7 @@ let request_control_fields
       ?zai_glm_clear_thinking
       ()
   =
+  let output_fields = reasoning_output_fields dialect ~enable_thinking in
   let normalized_effort_field () =
     match reasoning_effort with
     | Some effort ->
@@ -249,15 +275,17 @@ let request_control_fields
   in
   match dialect.toggle_wire with
   | Chat_template_kwargs ->
-    (match
-       bool_field "enable_thinking" enable_thinking
-       @ bool_field
-           "preserve_thinking"
-           (chat_template_kwargs_preserve_field dialect ~preserve_thinking)
-     with
-     | [] -> []
-     | fields -> [ "chat_template_kwargs", `Assoc fields ])
-  | Chat_template_token | Ollama_think -> []
+    output_fields
+    @
+      (match
+         bool_field "enable_thinking" enable_thinking
+         @ bool_field
+             "preserve_thinking"
+             (chat_template_kwargs_preserve_field dialect ~preserve_thinking)
+       with
+      | [] -> []
+      | fields -> [ "chat_template_kwargs", `Assoc fields ])
+  | Chat_template_token | Ollama_think -> output_fields
   | Enable_thinking ->
     let fields =
       bool_field "enable_thinking" enable_thinking
@@ -270,19 +298,23 @@ let request_control_fields
       | Some true, Some budget -> ("thinking_budget", `Int budget) :: fields
       | _ -> fields
     in
-    fields
-  | Reasoning_effort -> normalized_effort_field ()
+    output_fields @ fields
+  | Reasoning_effort -> output_fields @ normalized_effort_field ()
   | Thinking_object _ ->
-    (match enable_thinking with
-     | Some true ->
-       ("thinking", `Assoc [ "type", `String "enabled" ]) :: normalized_effort_field ()
-     | Some false -> [ "thinking", `Assoc [ "type", `String "disabled" ] ]
-     | None -> [])
+    output_fields
+    @
+      (match enable_thinking with
+      | Some true ->
+        ("thinking", `Assoc [ "type", `String "enabled" ]) :: normalized_effort_field ()
+      | Some false -> [ "thinking", `Assoc [ "type", `String "disabled" ] ]
+      | None -> [])
   | Thinking_object_adaptive ->
-    (match enable_thinking with
-     | Some true -> [ "thinking", `Assoc [ "type", `String "adaptive" ] ]
-     | Some false -> [ "thinking", `Assoc [ "type", `String "disabled" ] ]
-     | None -> [])
+    output_fields
+    @
+      (match enable_thinking with
+      | Some true -> [ "thinking", `Assoc [ "type", `String "adaptive" ] ]
+      | Some false -> [ "thinking", `Assoc [ "type", `String "disabled" ] ]
+      | None -> [])
   | Thinking_object_only ->
     let control =
       thinking_object_only_control dialect ~enable_thinking ~preserve_thinking
@@ -295,18 +327,22 @@ let request_control_fields
     let fields =
       if control.keep_all then fields @ [ "keep", `String "all" ] else fields
     in
-    (match fields with
-     | [] -> []
-     | fields -> [ "thinking", `Assoc fields ])
+    output_fields
+    @
+      (match fields with
+      | [] -> []
+      | fields -> [ "thinking", `Assoc fields ])
   | No_toggle ->
-    (match zai_glm_clear_thinking, enable_thinking with
-     | Some clear_thinking, Some true ->
-       [ ( "thinking"
-         , `Assoc [ "type", `String "enabled"; "clear_thinking", `Bool clear_thinking ] )
-       ]
-     | Some _, Some false -> [ "thinking", `Assoc [ "type", `String "disabled" ] ]
-     | Some _, None | None, _ -> [])
-  | Anthropic_thinking | Gemini_thinking_config -> []
+    output_fields
+    @
+      (match zai_glm_clear_thinking, enable_thinking with
+      | Some clear_thinking, Some true ->
+        [ ( "thinking"
+          , `Assoc [ "type", `String "enabled"; "clear_thinking", `Bool clear_thinking ] )
+        ]
+      | Some _, Some false -> [ "thinking", `Assoc [ "type", `String "disabled" ] ]
+      | Some _, None | None, _ -> [])
+  | Anthropic_thinking | Gemini_thinking_config -> output_fields
 ;;
 
 let provider_capabilities_of_kind kind = Capabilities.capabilities_of_kind kind

--- a/lib/llm_provider/reasoning_dialect.mli
+++ b/lib/llm_provider/reasoning_dialect.mli
@@ -47,6 +47,10 @@ type streaming_reasoning =
   | Delta_field of string
   | Template_parser
 
+type output_wire =
+  | No_output_control
+  | Reasoning_split
+
 type thinking_object_only_control =
   { enabled : bool option
   ; keep_all : bool
@@ -60,6 +64,7 @@ type t =
   ; sampling_policy : sampling_policy
   ; replay_policy : replay_policy
   ; streaming : streaming_reasoning
+  ; output_wire : output_wire
   }
 
 val default : t

--- a/lib/llm_provider/reasoning_dialect.mli
+++ b/lib/llm_provider/reasoning_dialect.mli
@@ -18,6 +18,7 @@ type toggle_default =
 type toggle_wire =
   | No_toggle
   | Thinking_object of { includes_reasoning_effort : bool }
+  | Thinking_object_adaptive
   | Thinking_object_only
   | Chat_template_kwargs
   | Chat_template_token

--- a/lib/llm_provider/response_shape.ml
+++ b/lib/llm_provider/response_shape.ml
@@ -52,6 +52,15 @@ let dedupe_keep_order values =
 ;;
 
 let summarize_blocks (content : Types.content_block list) =
+  let reasoning_details_chars reasoning_content details =
+    match reasoning_content with
+    | Some content -> String.length content
+    | None ->
+      details
+      |> List.filter_map (fun (detail : Types.reasoning_detail) -> detail.text)
+      |> String.concat ""
+      |> String.length
+  in
   let shape =
     List.fold_left
       (fun shape -> function
@@ -64,6 +73,12 @@ let summarize_blocks (content : Types.content_block list) =
            { (add_kind "thinking" shape) with
              thinking_blocks = shape.thinking_blocks + 1
            ; thinking_chars = shape.thinking_chars + String.length content
+           }
+         | Types.ReasoningDetails { reasoning_content; details } ->
+           { (add_kind "reasoning_details" shape) with
+             thinking_blocks = shape.thinking_blocks + 1
+           ; thinking_chars =
+               shape.thinking_chars + reasoning_details_chars reasoning_content details
            }
          | Types.RedactedThinking _ ->
            { (add_kind "redacted_thinking" shape) with

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -197,6 +197,7 @@ let emit_synthetic_events (response : api_response) on_event =
          match block with
          | Text _ -> "text", None, None
          | Thinking _ -> "thinking", None, None
+         | ReasoningDetails _ -> "thinking", None, None
          | ToolUse { id; name; _ } -> "tool_use", Some id, Some name
          | Image _ -> "image", None, None
          | Document _ -> "document", None, None
@@ -213,6 +214,17 @@ let emit_synthetic_events (response : api_response) on_event =
            | Some s ->
              on_event (ContentBlockDelta { index; delta = ThinkingSignatureDelta s })
            | None -> ())
+        | ReasoningDetails { reasoning_content; details } ->
+          let content =
+            match reasoning_content with
+            | Some content -> content
+            | None ->
+              details
+              |> List.filter_map (fun (detail : reasoning_detail) -> detail.text)
+              |> String.concat ""
+          in
+          if content <> ""
+          then on_event (ContentBlockDelta { index; delta = ThinkingDelta content })
         | ToolUse { input; _ } ->
           on_event
             (ContentBlockDelta

--- a/lib/llm_provider/tool_message_pairs.ml
+++ b/lib/llm_provider/tool_message_pairs.ml
@@ -6,6 +6,7 @@ let tool_use_ids (msg : message) =
       | ToolUse { id; _ } -> Some id
       | Text _
       | Thinking _
+      | ReasoningDetails _
       | RedactedThinking _
       | ToolResult _
       | Image _
@@ -20,6 +21,7 @@ let tool_uses (msg : message) =
       | ToolUse { id; name; _ } -> Some (id, name)
       | Text _
       | Thinking _
+      | ReasoningDetails _
       | RedactedThinking _
       | ToolResult _
       | Image _
@@ -34,6 +36,7 @@ let tool_result_ids (msg : message) =
       | ToolResult { tool_use_id; _ } -> Some tool_use_id
       | Text _
       | Thinking _
+      | ReasoningDetails _
       | RedactedThinking _
       | ToolUse _
       | Image _
@@ -66,6 +69,7 @@ let strip_orphaned_tool_results (messages : message list) : message list =
             keep
           | Text _
           | Thinking _
+          | ReasoningDetails _
           | RedactedThinking _
           | ToolUse _
           | Image _

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -242,6 +242,12 @@ let media_source_kind_of_string raw =
   | _ -> None
 ;;
 
+type reasoning_detail =
+  { raw : Yojson.Safe.t
+  ; text : string option
+  }
+[@@deriving show]
+
 (** Content block types -- inline records for clarity *)
 type content_block =
   | Text of string
@@ -255,6 +261,10 @@ type content_block =
             [thinking_type : string], which conflated this signature with a
             free-form provider label ("reasoning" / "thinking" /
             "reasoning_summary") that no consumer read. *)
+      }
+  | ReasoningDetails of
+      { reasoning_content : string option
+      ; details : reasoning_detail list
       }
   | RedactedThinking of string
   | ToolUse of
@@ -685,6 +695,7 @@ let visible_text_of_content content =
   |> List.filter_map (function
     | Text s -> Some s
     | Thinking _
+    | ReasoningDetails _
     | RedactedThinking _
     | ToolUse _
     | ToolResult _

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -117,6 +117,12 @@ type media_source_kind =
 val media_source_kind_to_string : media_source_kind -> string
 val media_source_kind_of_string : string -> media_source_kind option
 
+type reasoning_detail =
+  { raw : Yojson.Safe.t
+  ; text : string option
+  }
+[@@deriving show]
+
 type content_block =
   | Text of string
   | Thinking of
@@ -125,6 +131,10 @@ type content_block =
         (** [Some s]: Anthropic cryptographic signature, replayed byte-exact on
             tool turns. [None]: provider reasoning without a verification
             signature (OpenAI-compatible / Gemini / GLM / Ollama). *)
+      }
+  | ReasoningDetails of
+      { reasoning_content : string option
+      ; details : reasoning_detail list
       }
   | RedactedThinking of string
   | ToolUse of

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -446,6 +446,7 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses_nonempty 
                 | ToolUse { name; _ } -> Some name
                 | Text _
                 | Thinking _
+                | ReasoningDetails _
                 | RedactedThinking _
                 | ToolResult _
                 | Image _
@@ -627,6 +628,7 @@ let stage_output ?raw_trace_run agent ~effective_guardrails response =
                 | ToolUse _ -> true
                 | Text _
                 | Thinking _
+                | ReasoningDetails _
                 | RedactedThinking _
                 | ToolResult _
                 | Image _

--- a/lib/provider.mli
+++ b/lib/provider.mli
@@ -56,6 +56,7 @@ type modality =
 type thinking_control_format = Llm_provider.Capabilities.thinking_control_format =
   | No_thinking_control
   | Thinking_object
+  | Thinking_object_adaptive (** @since 0.207.33 *)
   | Thinking_object_only (** @since 0.196.11 *)
   | Chat_template_kwargs
   | Chat_template_token

--- a/lib/provider.mli
+++ b/lib/provider.mli
@@ -83,6 +83,10 @@ type assistant_tool_content_format =
   | Assistant_tool_content_null
   | Assistant_tool_content_empty_string
 
+type reasoning_output_format = Llm_provider.Capabilities.reasoning_output_format =
+  | No_reasoning_output_format
+  | Split_reasoning_fields
+
 type capabilities =
   { max_context_tokens : int option
   ; max_output_tokens : int option
@@ -100,6 +104,7 @@ type capabilities =
   ; accepted_reasoning_efforts : Llm_provider.Reasoning_effort.t list option
   ; thinking_control_format : thinking_control_format
   ; preserve_thinking_control_format : preserve_thinking_control_format
+  ; reasoning_output_format : reasoning_output_format
   ; reasoning_replay_override : reasoning_replay_override
   ; supports_response_format_json : bool
   ; supports_structured_output : bool

--- a/lib/provider_runtime_binding.ml
+++ b/lib/provider_runtime_binding.ml
@@ -90,6 +90,7 @@ let public_capabilities (caps : Llm_provider.Capabilities.capabilities)
   ; accepted_reasoning_efforts = caps.accepted_reasoning_efforts
   ; thinking_control_format = caps.thinking_control_format
   ; preserve_thinking_control_format = caps.preserve_thinking_control_format
+  ; reasoning_output_format = caps.reasoning_output_format
   ; reasoning_replay_override = caps.reasoning_replay_override
   ; supports_response_format_json = caps.supports_response_format_json
   ; supports_structured_output = caps.supports_structured_output

--- a/lib/raw_trace.ml
+++ b/lib/raw_trace.ml
@@ -527,6 +527,7 @@ let record_assistant_block active ~block_index block =
     match block with
     | Text _ -> "text"
     | Thinking _ -> "thinking"
+    | ReasoningDetails _ -> "reasoning_details"
     | RedactedThinking _ -> "redacted_thinking"
     | ToolUse _ -> "tool_use"
     | ToolResult _ -> "tool_result"

--- a/lib/runtime_server.ml
+++ b/lib/runtime_server.ml
@@ -21,6 +21,7 @@ let extract_text (resp : Types.api_response) =
   |> List.filter_map (function
     | Types.Text s -> Some s
     | Types.Thinking _
+    | Types.ReasoningDetails _
     | Types.RedactedThinking _
     | Types.ToolUse _
     | Types.ToolResult _

--- a/lib/structured.ml
+++ b/lib/structured.ml
@@ -32,6 +32,7 @@ let schema_to_json_schema (s : _ schema) : Yojson.Safe.t =
 let text_block = function
   | Text s -> Some s
   | Thinking _
+  | ReasoningDetails _
   | RedactedThinking _
   | Image _
   | Document _
@@ -49,6 +50,7 @@ let extract_tool_input ~(schema : _ schema) (content : content_block list) =
         | ToolUse { name; input; _ } when name = schema.name -> Some input
         | Text _
         | Thinking _
+        | ReasoningDetails _
         | RedactedThinking _
         | Image _
         | Document _

--- a/lib/tool_use_recovery.ml
+++ b/lib/tool_use_recovery.ml
@@ -231,6 +231,7 @@ let recover_response ~(valid_tool_names : string list) (response : api_response)
            | ToolUse _ -> true
            | Text _
            | Thinking _
+           | ReasoningDetails _
            | RedactedThinking _
            | ToolResult _
            | Image _

--- a/models.toml
+++ b/models.toml
@@ -315,7 +315,9 @@ cache_write_multiplier = 1.0
 cache_read_multiplier = 0.02
 
 # MiniMax Models
-# Source: ollama-cloud /api/show 2026-06-17 caps=[completion,tools,thinking,vision].
+# Source: official MiniMax docs checked 2026-06-30:
+# - https://platform.minimaxi.com/docs/api-reference/text-chat-openai.md
+# - https://platform.minimaxi.com/docs/guides/text-m3-function-call.md
 # minimax-m3 is the memory-os librarian runtime (runtime.toml [runtime].librarian).
 # Without this entry it resolved to provider_default (OpenAI_compat) whose
 # thinking_control_format = No_thinking_control, so the librarian's
@@ -323,22 +325,27 @@ cache_read_multiplier = 0.02
 # polluted/emptied the JSON-mode body (librarian "empty response" / "invalid episode
 # JSON"). This entry supersedes the inert MASC runtime.toml [models.minimax-m3.capabilities]
 # block (#21521), which OAS for_model_id never reads.
-# thinking_control_format mirrors the sibling ollama-cloud deepseek-v4 entries
-# ("thinking_object" -> request emits {"thinking":{"type":"disabled"}}); verify against
-# a live ollama-cloud probe if minimax uses a different disable dialect.
+# MiniMax-M3 Chat uses thinking.type adaptive|disabled. The Chat schema documents
+# tools but no tool_choice or response_format field, and its interleaved-thinking
+# guide requires replaying the complete assistant message including reasoning_details
+# or embedded <think> content.
 # Pricing intentionally omitted (float option): minimax-m3 rates not yet confirmed.
 [[models]]
 id_prefix = "minimax-m3"
 base = "openai_chat"
 max_context_tokens = 524288
 supports_tools = true
-supports_tool_choice = true
+supports_tool_choice = false
+supports_required_tool_choice = false
+supports_named_tool_choice = false
 supports_reasoning = true
 supports_extended_thinking = true
-supports_reasoning_budget = true
-thinking_control_format = "thinking_object"
-supports_response_format_json = true
-supports_structured_output = true
+supports_reasoning_budget = false
+thinking_control_format = "thinking_object_adaptive"
+reasoning_replay = "preserve_always"
+supports_response_format_json = false
+supports_structured_output = false
+supports_multimodal_inputs = true
 supports_image_input = true
 supports_native_streaming = true
 

--- a/models.toml
+++ b/models.toml
@@ -325,9 +325,10 @@ cache_read_multiplier = 0.02
 # polluted/emptied the JSON-mode body (librarian "empty response" / "invalid episode
 # JSON"). This entry supersedes the inert MASC runtime.toml [models.minimax-m3.capabilities]
 # block (#21521), which OAS for_model_id never reads.
-# MiniMax-M3 Chat uses thinking.type adaptive|disabled. The Chat schema documents
-# tools but no tool_choice or response_format field, and its interleaved-thinking
-# guide requires replaying the complete assistant message including reasoning_details
+# MiniMax-M3 Chat uses thinking.type adaptive|disabled plus reasoning_split=true
+# to expose thinking outside visible content. The Chat schema documents tools but
+# no tool_choice or response_format field, and its interleaved-thinking guide
+# requires replaying the complete assistant message including reasoning_details
 # or embedded <think> content.
 # Pricing intentionally omitted (float option): minimax-m3 rates not yet confirmed.
 [[models]]
@@ -342,6 +343,7 @@ supports_reasoning = true
 supports_extended_thinking = true
 supports_reasoning_budget = false
 thinking_control_format = "thinking_object_adaptive"
+reasoning_output_format = "split_reasoning_fields"
 reasoning_replay = "preserve_always"
 supports_response_format_json = false
 supports_structured_output = false

--- a/test/test_agent_turn.ml
+++ b/test/test_agent_turn.ml
@@ -266,6 +266,7 @@ let test_prepare_messages_preserve_thinking_keeps_default_reducer_thinking () =
           | Types.ToolResult _
           | Types.Image _
           | Types.Document _
+          | Types.ReasoningDetails _
           | Types.Audio _ -> false)
         content
     in

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -646,6 +646,19 @@ let deepseek_provider_config : Provider.config =
   }
 ;;
 
+let minimax_m3_provider_config : Provider.config =
+  { Provider.provider =
+      Provider.OpenAICompat
+        { base_url = "https://api.minimaxi.com/v1"
+        ; auth_header = None
+        ; path = "/chat/completions"
+        ; static_token = None
+        }
+  ; model_id = "minimax-m3"
+  ; api_key_env = "MINIMAX_API_KEY"
+  }
+;;
+
 let test_build_openai_body_deepseek_uses_dialect_controls () =
   let state =
     { Types.config =
@@ -678,6 +691,47 @@ let test_build_openai_body_deepseek_uses_dialect_controls () =
   check string "low maps high" "high" (json |> member "reasoning_effort" |> to_string);
   check bool "temperature omitted" true (json |> member "temperature" = `Null);
   check bool "top_p omitted" true (json |> member "top_p" = `Null)
+;;
+
+let test_build_openai_body_minimax_uses_public_projection_dialect_controls () =
+  let state =
+    make_state
+      ~model:minimax_m3_provider_config.model_id
+      ~enable_thinking:true
+      ~tool_choice:Types.Auto
+      ()
+  in
+  let tool_json =
+    `Assoc
+      [ "name", `String "calculator"
+      ; "description", `String "math"
+      ; "input_schema", `Assoc [ "type", `String "object" ]
+      ]
+  in
+  let json =
+    Api.build_openai_body
+      ~provider_config:minimax_m3_provider_config
+      ~config:state
+      ~messages:[]
+      ~tools:[ tool_json ]
+      ()
+    |> Yojson.Safe.from_string
+  in
+  let open Yojson.Safe.Util in
+  check
+    string
+    "thinking adaptive"
+    "adaptive"
+    (json |> member "thinking" |> member "type" |> to_string);
+  check bool "reasoning split enabled" true (json |> member "reasoning_split" |> to_bool);
+  check bool "tools preserved" false (member_absent json "tools");
+  check bool "tool_choice omitted" true (member_absent json "tool_choice");
+  check bool "reasoning_effort omitted" true (member_absent json "reasoning_effort");
+  check
+    bool
+    "chat_template_kwargs omitted"
+    true
+    (member_absent json "chat_template_kwargs")
 ;;
 
 let test_build_openai_body_deepseek_replays_tool_reasoning_only () =
@@ -1918,6 +1972,10 @@ let () =
             "deepseek dialect controls"
             `Quick
             test_build_openai_body_deepseek_uses_dialect_controls
+        ; test_case
+            "minimax public projection dialect controls"
+            `Quick
+            test_build_openai_body_minimax_uses_public_projection_dialect_controls
         ; test_case
             "deepseek tool reasoning replay"
             `Quick

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -149,6 +149,20 @@ let test_unknown_type_returns_none () =
   | Some _ -> fail "expected None for unknown type"
 ;;
 
+let test_reasoning_details_requires_details_list () =
+  let cases =
+    [ `Assoc [ "type", `String "reasoning_details" ]
+    ; `Assoc [ "type", `String "reasoning_details"; "details", `Null ]
+    ]
+  in
+  List.iter
+    (fun json ->
+       match Api.content_block_of_json json with
+       | None -> ()
+       | Some _ -> fail "expected malformed reasoning_details to fail closed")
+    cases
+;;
+
 let test_kimi_message_to_json_tool_result_uses_text_blocks () =
   let msg =
     { Types.role = Tool
@@ -1911,6 +1925,10 @@ let () =
         ; test_case "image" `Quick test_image_round_trip
         ; test_case "document" `Quick test_document_round_trip
         ; test_case "unknown type" `Quick test_unknown_type_returns_none
+        ; test_case
+            "reasoning_details requires details"
+            `Quick
+            test_reasoning_details_requires_details_list
         ] )
     ; ( "build_body_assoc"
       , [ test_case "basic" `Quick test_build_body_basic

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -330,6 +330,51 @@ let test_parse_reasoning_details_and_tool_calls_coexist () =
      | _ -> false)
 ;;
 
+let test_parse_reasoning_details_rejects_malformed () =
+  let expect_error label expected_prefix reasoning_details =
+    let json =
+      response_json
+        ~content:(`String "")
+        ~finish_reason:"tool_calls"
+        ~message_fields:
+          [ "reasoning_content", `String "use weather tool"
+          ; "reasoning_details", reasoning_details
+          ; ( "tool_calls"
+            , `List
+                [ `Assoc
+                    [ "id", `String "call-1"
+                    ; "type", `String "function"
+                    ; ( "function"
+                      , `Assoc
+                          [ "name", `String "get_weather"
+                          ; "arguments", `String {|{"location":"San Francisco, US"}|}
+                          ] )
+                    ]
+                ] )
+          ]
+        ()
+    in
+    match Parse.parse_openai_response_result (Yojson.Safe.to_string json) with
+    | Error msg -> check_bool label true (String.starts_with ~prefix:expected_prefix msg)
+    | Ok _ -> Alcotest.fail (label ^ " should fail closed")
+  in
+  expect_error
+    "non-list reasoning_details"
+    "malformed_reasoning_details:not_list"
+    (`Assoc [ "text", `String "bad shape" ]);
+  expect_error
+    "non-object reasoning detail"
+    "malformed_reasoning_details:index:1:not_object"
+    (`List
+        [ `Assoc
+            [ "type", `String "reasoning.text"
+            ; "id", `String "reasoning-text-1"
+            ; "text", `String "valid"
+            ]
+        ; `String "bad detail"
+        ])
+;;
+
 let test_reasoning_only_stays_thinking_and_never_reinjected_on_replay () =
   (* End-to-end #2236 regression guard. Provider-agnostic: it exercises the
      Types<->serialize boundary every OpenAI-compatible family (DeepSeek, Kimi,
@@ -2276,6 +2321,10 @@ let () =
             "reasoning_details and tool_calls coexist"
             `Quick
             test_parse_reasoning_details_and_tool_calls_coexist
+        ; Alcotest.test_case
+            "reasoning_details rejects malformed"
+            `Quick
+            test_parse_reasoning_details_rejects_malformed
         ; Alcotest.test_case
             "reasoning-only stays Thinking and is never re-injected on replay"
             `Quick

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -262,7 +262,27 @@ let test_parse_reasoning_details_and_tool_calls_coexist () =
   check_bool "blank reasoning_details text ignored" true (List.length response.content = 2);
   check_bool "reasoning_details does not leak as visible text" false has_visible_text;
   check_bool "tool_calls -> ToolUse" true has_tool;
-  check_bool "stop_reason is StopToolUse" true (response.stop_reason = StopToolUse)
+  check_bool "stop_reason is StopToolUse" true (response.stop_reason = StopToolUse);
+  let minimax_dialect =
+    match Capabilities.for_model_id "minimax-m3" with
+    | Some caps -> Reasoning_dialect.of_capabilities caps
+    | None -> Alcotest.fail "minimax-m3 capabilities missing"
+  in
+  let replay =
+    Serialize.dialect_messages_of_message minimax_dialect (msg Assistant response.content)
+    |> only "assistant replay"
+  in
+  check_string
+    "reasoning_details text replays as reasoning_content"
+    "use weather tool"
+    (member "reasoning_content" replay |> to_string);
+  check_bool
+    "reasoning_details text still absent from visible content on replay"
+    true
+    (match member "content" replay with
+     | `Null -> true
+     | `String s -> Api_common.string_is_blank s
+     | _ -> false)
 ;;
 
 let test_reasoning_only_stays_thinking_and_never_reinjected_on_replay () =

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -197,14 +197,15 @@ let test_parse_reasoning_content_and_tool_calls_coexist () =
 
 let test_parse_reasoning_details_and_tool_calls_coexist () =
   (* MiniMax-M3 reasoning_split mode documents structured reasoning_details on
-     tool-call turns. If reasoning_content is absent, the detail text must still
-     stay typed as Thinking rather than leaking through assistant content. *)
+     tool-call turns. Preserve that message shape for replay rather than
+     flattening it into generic reasoning_content text. *)
   let json =
     response_json
       ~content:(`String "")
       ~finish_reason:"tool_calls"
       ~message_fields:
-        [ ( "reasoning_details"
+        [ "reasoning_content", `String "use weather tool"
+        ; ( "reasoning_details"
           , `List
               [ `Assoc
                   [ "type", `String "reasoning.text"
@@ -237,14 +238,6 @@ let test_parse_reasoning_details_and_tool_calls_coexist () =
       ()
   in
   let response = parse_ok json in
-  let raw_details =
-    List.filter_map
-      (function
-        | RedactedThinking data ->
-          Api_common.openai_chat_reasoning_details_of_redacted data
-        | _ -> None)
-      response.content
-  in
   let has_visible_text =
     List.exists
       (function
@@ -252,12 +245,18 @@ let test_parse_reasoning_details_and_tool_calls_coexist () =
         | _ -> false)
       response.content
   in
-  let has_thinking =
+  let has_flat_thinking =
     List.exists
       (function
-        | Thinking { content; _ } -> content = "use weather tool"
+        | Thinking _ -> true
         | _ -> false)
       response.content
+  in
+  let reasoning_content, details =
+    match response.content with
+    | ReasoningDetails { reasoning_content; details } :: ToolUse { name; _ } :: _
+      when name = "get_weather" -> reasoning_content, details
+    | _ -> Alcotest.fail "expected [ReasoningDetails; ToolUse]"
   in
   let has_tool =
     List.exists
@@ -266,16 +265,21 @@ let test_parse_reasoning_details_and_tool_calls_coexist () =
         | _ -> false)
       response.content
   in
-  check_bool "reasoning_details.text -> Thinking" true has_thinking;
-  check_int "raw reasoning_details carrier count" 1 (List.length raw_details);
-  check_int
-    "raw reasoning_details entries preserved"
-    2
-    (match raw_details with
-     | [ details ] -> List.length details
-     | _ -> 0);
-  check_bool "blank reasoning_details text ignored" true (List.length response.content = 3);
+  Alcotest.(check (option string))
+    "reasoning_content preserved"
+    (Some "use weather tool")
+    reasoning_content;
+  check_bool "reasoning_details block count" true (List.length details = 2);
+  check_string
+    "reasoning_details raw id preserved"
+    "reasoning-text-1"
+    (member "id" (List.hd details).raw |> to_string);
+  check_string
+    "reasoning_details text captured"
+    "use weather tool"
+    (Option.value ~default:"" (List.hd details).text);
   check_bool "reasoning_details does not leak as visible text" false has_visible_text;
+  check_bool "reasoning_details are not flattened to Thinking" false has_flat_thinking;
   check_bool "tool_calls -> ToolUse" true has_tool;
   check_bool "stop_reason is StopToolUse" true (response.stop_reason = StopToolUse);
   let projected_calls = Canonical_tool.tool_calls_of_response response in
@@ -288,9 +292,10 @@ let test_parse_reasoning_details_and_tool_calls_coexist () =
      ] -> check_string "adjacent reasoning text" "use weather tool" content
    | _ -> Alcotest.fail "expected one visible adjacent reasoning block");
   let minimax_dialect =
-    match Capabilities.for_model_id "minimax-m3" with
-    | Some caps -> Reasoning_dialect.of_capabilities caps
-    | None -> Alcotest.fail "minimax-m3 capabilities missing"
+    { Reasoning_dialect.default with
+      replay_policy = Preserve_always
+    ; output_wire = Reasoning_split
+    }
   in
   let replay =
     Serialize.dialect_messages_of_message minimax_dialect (msg Assistant response.content)
@@ -299,13 +304,23 @@ let test_parse_reasoning_details_and_tool_calls_coexist () =
   let replay_details = member "reasoning_details" replay |> as_list "reasoning_details" in
   check_int "replay preserves reasoning_details entries" 2 (List.length replay_details);
   check_string
-    "replay preserves reasoning_details text"
-    "use weather tool"
-    (List.nth replay_details 0 |> member "text" |> to_string);
-  check_string
-    "reasoning_details text replays as reasoning_content"
+    "reasoning_content preserved on replay"
     "use weather tool"
     (member "reasoning_content" replay |> to_string);
+  let first_detail = List.hd replay_details in
+  check_string
+    "reasoning_details replay id"
+    "reasoning-text-1"
+    (member "id" first_detail |> to_string);
+  check_string
+    "reasoning_details replay format"
+    "MiniMax-response-v1"
+    (member "format" first_detail |> to_string);
+  check_int "reasoning_details replay index" 0 (member "index" first_detail |> to_int);
+  check_string
+    "reasoning_details replay text"
+    "use weather tool"
+    (member "text" first_detail |> to_string);
   check_bool
     "reasoning_details text still absent from visible content on replay"
     true

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -237,6 +237,14 @@ let test_parse_reasoning_details_and_tool_calls_coexist () =
       ()
   in
   let response = parse_ok json in
+  let raw_details =
+    List.filter_map
+      (function
+        | RedactedThinking data ->
+          Api_common.openai_chat_reasoning_details_of_redacted data
+        | _ -> None)
+      response.content
+  in
   let has_visible_text =
     List.exists
       (function
@@ -259,10 +267,26 @@ let test_parse_reasoning_details_and_tool_calls_coexist () =
       response.content
   in
   check_bool "reasoning_details.text -> Thinking" true has_thinking;
-  check_bool "blank reasoning_details text ignored" true (List.length response.content = 2);
+  check_int "raw reasoning_details carrier count" 1 (List.length raw_details);
+  check_int
+    "raw reasoning_details entries preserved"
+    2
+    (match raw_details with
+     | [ details ] -> List.length details
+     | _ -> 0);
+  check_bool "blank reasoning_details text ignored" true (List.length response.content = 3);
   check_bool "reasoning_details does not leak as visible text" false has_visible_text;
   check_bool "tool_calls -> ToolUse" true has_tool;
   check_bool "stop_reason is StopToolUse" true (response.stop_reason = StopToolUse);
+  let projected_calls = Canonical_tool.tool_calls_of_response response in
+  (match projected_calls with
+   | [ { Canonical_tool.adjacent_reasoning =
+           Canonical_tool.Adjacent_reasoning
+             [ { Canonical_tool.kind = Canonical_tool.Visible_thinking; content; _ } ]
+       ; _
+       }
+     ] -> check_string "adjacent reasoning text" "use weather tool" content
+   | _ -> Alcotest.fail "expected one visible adjacent reasoning block");
   let minimax_dialect =
     match Capabilities.for_model_id "minimax-m3" with
     | Some caps -> Reasoning_dialect.of_capabilities caps
@@ -272,6 +296,12 @@ let test_parse_reasoning_details_and_tool_calls_coexist () =
     Serialize.dialect_messages_of_message minimax_dialect (msg Assistant response.content)
     |> only "assistant replay"
   in
+  let replay_details = member "reasoning_details" replay |> as_list "reasoning_details" in
+  check_int "replay preserves reasoning_details entries" 2 (List.length replay_details);
+  check_string
+    "replay preserves reasoning_details text"
+    "use weather tool"
+    (List.nth replay_details 0 |> member "text" |> to_string);
   check_string
     "reasoning_details text replays as reasoning_content"
     "use weather tool"

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -195,6 +195,76 @@ let test_parse_reasoning_content_and_tool_calls_coexist () =
   check_bool "stop_reason is StopToolUse" true (response.stop_reason = StopToolUse)
 ;;
 
+let test_parse_reasoning_details_and_tool_calls_coexist () =
+  (* MiniMax-M3 reasoning_split mode documents structured reasoning_details on
+     tool-call turns. If reasoning_content is absent, the detail text must still
+     stay typed as Thinking rather than leaking through assistant content. *)
+  let json =
+    response_json
+      ~content:(`String "")
+      ~finish_reason:"tool_calls"
+      ~message_fields:
+        [ ( "reasoning_details"
+          , `List
+              [ `Assoc
+                  [ "type", `String "reasoning.text"
+                  ; "id", `String "reasoning-text-1"
+                  ; "format", `String "MiniMax-response-v1"
+                  ; "index", `Int 0
+                  ; "text", `String "use weather tool"
+                  ]
+              ; `Assoc
+                  [ "type", `String "reasoning.text"
+                  ; "id", `String "reasoning-text-2"
+                  ; "format", `String "MiniMax-response-v1"
+                  ; "index", `Int 1
+                  ; "text", `String "  "
+                  ]
+              ] )
+        ; ( "tool_calls"
+          , `List
+              [ `Assoc
+                  [ "id", `String "call-1"
+                  ; "type", `String "function"
+                  ; ( "function"
+                    , `Assoc
+                        [ "name", `String "get_weather"
+                        ; "arguments", `String {|{"location":"San Francisco, US"}|}
+                        ] )
+                  ]
+              ] )
+        ]
+      ()
+  in
+  let response = parse_ok json in
+  let has_visible_text =
+    List.exists
+      (function
+        | Text s -> not (Api_common.string_is_blank s)
+        | _ -> false)
+      response.content
+  in
+  let has_thinking =
+    List.exists
+      (function
+        | Thinking { content; _ } -> content = "use weather tool"
+        | _ -> false)
+      response.content
+  in
+  let has_tool =
+    List.exists
+      (function
+        | ToolUse { name; _ } -> name = "get_weather"
+        | _ -> false)
+      response.content
+  in
+  check_bool "reasoning_details.text -> Thinking" true has_thinking;
+  check_bool "blank reasoning_details text ignored" true (List.length response.content = 2);
+  check_bool "reasoning_details does not leak as visible text" false has_visible_text;
+  check_bool "tool_calls -> ToolUse" true has_tool;
+  check_bool "stop_reason is StopToolUse" true (response.stop_reason = StopToolUse)
+;;
+
 let test_reasoning_only_stays_thinking_and_never_reinjected_on_replay () =
   (* End-to-end #2236 regression guard. Provider-agnostic: it exercises the
      Types<->serialize boundary every OpenAI-compatible family (DeepSeek, Kimi,
@@ -2137,6 +2207,10 @@ let () =
             "reasoning_content and tool_calls coexist"
             `Quick
             test_parse_reasoning_content_and_tool_calls_coexist
+        ; Alcotest.test_case
+            "reasoning_details and tool_calls coexist"
+            `Quick
+            test_parse_reasoning_details_and_tool_calls_coexist
         ; Alcotest.test_case
             "reasoning-only stays Thinking and is never re-injected on replay"
             `Quick

--- a/test/test_budget_strategy.ml
+++ b/test/test_budget_strategy.ml
@@ -285,6 +285,7 @@ let test_reduce_preserve_thinking_keeps_old_thinking () =
            (function
              | Types.Thinking { content = "long thought"; _ } -> true
              | Types.Thinking _
+             | Types.ReasoningDetails _
              | Types.Text _
              | Types.RedactedThinking _
              | Types.ToolUse _

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -467,6 +467,43 @@ let test_lookup_deepseek_v4_pro () =
   | None -> fail "should match deepseek-v4-pro"
 ;;
 
+let test_lookup_minimax_m3_official_chat_dialect () =
+  match Capabilities.for_model_id "minimax-m3" with
+  | Some c ->
+    check bool "has tools" true c.supports_tools;
+    check bool "omits explicit Chat tool_choice" false c.supports_tool_choice;
+    check bool "rejects required forced tool_choice" false c.supports_required_tool_choice;
+    check bool "rejects named forced tool_choice" false c.supports_named_tool_choice;
+    check bool "reasoning" true c.supports_reasoning;
+    check bool "extended thinking" true c.supports_extended_thinking;
+    check bool "no reasoning depth budget" false c.supports_reasoning_budget;
+    check_thinking_control
+      "uses MiniMax adaptive thinking object"
+      Capabilities.Thinking_object_adaptive
+      c.thinking_control_format;
+    check bool "no Chat response_format json" false c.supports_response_format_json;
+    check bool "no Chat structured output" false c.supports_structured_output;
+    check bool "multimodal" true c.supports_multimodal_inputs;
+    check bool "image input" true c.supports_image_input;
+    check
+      bool
+      "complete assistant replay"
+      true
+      (c.reasoning_replay_override = Capabilities.Force_preserve_always);
+    let dialect = Reasoning_dialect.of_capabilities c in
+    check
+      string
+      "toggle wire"
+      "thinking_object_adaptive"
+      (Reasoning_dialect.toggle_wire_to_string dialect.toggle_wire);
+    check
+      string
+      "replay policy"
+      "preserve_always"
+      (Reasoning_dialect.replay_policy_to_string dialect.replay_policy)
+  | None -> fail "should match minimax-m3"
+;;
+
 let test_lookup_grok () =
   match Capabilities.for_model_id "grok-4.3" with
   | Some c ->
@@ -790,6 +827,7 @@ let test_ollama_cloud_provider_qualified_preserves_shared_bare_family () =
 type structured_contract =
   | Response_format_json_schema
   | Native_structured_output
+  | No_structured_output
 
 type replay_contract =
   | Replay_not_required
@@ -860,15 +898,31 @@ let check_frontier_model
          true
          c.supports_extended_thinking);
     check bool (label ^ " supports native streaming") true c.supports_native_streaming;
-    check bool (label ^ " supports structured output") true c.supports_structured_output;
     (match structured_contract with
      | Response_format_json_schema ->
+       check
+         bool
+         (label ^ " supports structured output")
+         true
+         c.supports_structured_output;
        check
          bool
          (label ^ " supports response_format/json_schema")
          true
          c.supports_response_format_json
-     | Native_structured_output -> ());
+     | Native_structured_output ->
+       check
+         bool
+         (label ^ " supports structured output")
+         true
+         c.supports_structured_output
+     | No_structured_output ->
+       check bool (label ^ " no structured output") false c.supports_structured_output;
+       check
+         bool
+         (label ^ " no response_format/json_schema")
+         false
+         c.supports_response_format_json);
     let dialect = frontier_dialect route model_id c in
     (match replay_contract with
      | Replay_not_required ->
@@ -989,8 +1043,8 @@ let test_frontier_grouped_tool_thinking_structured_models () =
       , Direct_model
       , "minimax-m3"
       , Extended_thinking
-      , Response_format_json_schema
-      , Replay_tool_turn_only
+      , No_structured_output
+      , Replay_every_turn
       , Delta_stream "reasoning_content" )
     ; ( "OpenAI GPT-5.5"
       , Direct_model
@@ -1416,6 +1470,22 @@ let test_manifest_rejects_padded_thinking_control_token () =
     check_contains "mentions field" msg "thinking_control_token";
     check_contains "mentions exact rejection" msg "leading or trailing whitespace"
   | Ok _ -> Alcotest.fail "padded thinking_control_token should reject"
+;;
+
+let test_manifest_accepts_thinking_object_adaptive_policy_string () =
+  let json =
+    Yojson.Safe.from_string
+      {|{"schema_version":1,"models":[{"id_prefix":"adaptive-manifest","thinking_control_format":"thinking_object_adaptive"}]}|}
+  in
+  match Capability_manifest.of_json json with
+  | Ok [ entry ] ->
+    let caps = Capabilities.apply_manifest_entry entry in
+    check_thinking_control
+      "manifest thinking_object_adaptive"
+      Capabilities.Thinking_object_adaptive
+      caps.thinking_control_format
+  | Ok _ -> Alcotest.fail "expected one manifest entry"
+  | Error msg -> Alcotest.failf "unexpected parse error: %s" msg
 ;;
 
 let test_manifest_rejects_unknown_preserve_thinking_control_format () =
@@ -1918,6 +1988,10 @@ let () =
         ; test_case "dashscope runpod name" `Quick test_lookup_provider_m_runpod_name
         ; test_case "deepseek v4 flash" `Quick test_lookup_deepseek_v4_flash
         ; test_case "deepseek v4 pro" `Quick test_lookup_deepseek_v4_pro
+        ; test_case
+            "minimax m3 official chat dialect"
+            `Quick
+            test_lookup_minimax_m3_official_chat_dialect
         ; test_case "grok 4.3 1M context" `Quick test_lookup_grok
         ; test_case "glm-5 text only" `Quick test_lookup_glm5_text_only
         ; test_case "glm-5v vision" `Quick test_lookup_glm5v_vision
@@ -1997,6 +2071,10 @@ let () =
             "padded thinking_control_token rejects"
             `Quick
             test_manifest_rejects_padded_thinking_control_token
+        ; test_case
+            "thinking_object_adaptive policy string accepted"
+            `Quick
+            test_manifest_accepts_thinking_object_adaptive_policy_string
         ; test_case
             "unknown preserve_thinking_control_format rejects"
             `Quick

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -481,6 +481,11 @@ let test_lookup_minimax_m3_official_chat_dialect () =
       "uses MiniMax adaptive thinking object"
       Capabilities.Thinking_object_adaptive
       c.thinking_control_format;
+    check
+      bool
+      "uses split reasoning fields"
+      true
+      (c.reasoning_output_format = Capabilities.Split_reasoning_fields);
     check bool "no Chat response_format json" false c.supports_response_format_json;
     check bool "no Chat structured output" false c.supports_structured_output;
     check bool "multimodal" true c.supports_multimodal_inputs;
@@ -500,7 +505,12 @@ let test_lookup_minimax_m3_official_chat_dialect () =
       string
       "replay policy"
       "preserve_always"
-      (Reasoning_dialect.replay_policy_to_string dialect.replay_policy)
+      (Reasoning_dialect.replay_policy_to_string dialect.replay_policy);
+    check
+      bool
+      "dialect emits reasoning split"
+      true
+      (dialect.output_wire = Reasoning_dialect.Reasoning_split)
   | None -> fail "should match minimax-m3"
 ;;
 
@@ -1488,6 +1498,23 @@ let test_manifest_accepts_thinking_object_adaptive_policy_string () =
   | Error msg -> Alcotest.failf "unexpected parse error: %s" msg
 ;;
 
+let test_manifest_accepts_reasoning_output_format () =
+  let json =
+    Yojson.Safe.from_string
+      {|{"schema_version":1,"models":[{"id_prefix":"split-manifest","reasoning_output_format":"split_reasoning_fields"}]}|}
+  in
+  match Capability_manifest.of_json json with
+  | Ok [ entry ] ->
+    let caps = Capabilities.apply_manifest_entry entry in
+    check
+      bool
+      "manifest split_reasoning_fields"
+      true
+      (caps.reasoning_output_format = Capabilities.Split_reasoning_fields)
+  | Ok _ -> Alcotest.fail "expected one manifest entry"
+  | Error msg -> Alcotest.failf "unexpected parse error: %s" msg
+;;
+
 let test_manifest_rejects_unknown_preserve_thinking_control_format () =
   let json =
     Yojson.Safe.from_string
@@ -1496,6 +1523,18 @@ let test_manifest_rejects_unknown_preserve_thinking_control_format () =
   match Capability_manifest.of_json json with
   | Error msg -> check_contains "mentions field" msg "preserve_thinking_control_format"
   | Ok _ -> Alcotest.fail "unknown preserve_thinking_control_format should reject"
+;;
+
+let test_manifest_rejects_unknown_reasoning_output_format () =
+  let json =
+    Yojson.Safe.from_string
+      {|{"schema_version":1,"models":[{"id_prefix":"bad-output","reasoning_output_format":"split_thoughts"}]}|}
+  in
+  match Capability_manifest.of_json json with
+  | Error msg ->
+    check_contains "mentions field" msg "reasoning_output_format";
+    check_contains "mentions value" msg "split_thoughts"
+  | Ok _ -> Alcotest.fail "unknown reasoning_output_format should reject"
 ;;
 
 let test_manifest_rejects_unknown_reasoning_replay () =
@@ -1697,6 +1736,7 @@ let test_model_catalog_rejects_unknown_policy_strings () =
   let cases =
     [ "thinking_control_format", "mind_palace"
     ; "preserve_thinking_control_format", "memory_palace"
+    ; "reasoning_output_format", "split_thoughts"
     ; "modality_priority", "image_only"
     ]
   in
@@ -2076,9 +2116,17 @@ let () =
             `Quick
             test_manifest_accepts_thinking_object_adaptive_policy_string
         ; test_case
+            "reasoning_output_format accepted"
+            `Quick
+            test_manifest_accepts_reasoning_output_format
+        ; test_case
             "unknown preserve_thinking_control_format rejects"
             `Quick
             test_manifest_rejects_unknown_preserve_thinking_control_format
+        ; test_case
+            "unknown reasoning_output_format rejects"
+            `Quick
+            test_manifest_rejects_unknown_reasoning_output_format
         ; test_case
             "unknown reasoning_replay rejects"
             `Quick

--- a/test/test_context_reducer.ml
+++ b/test/test_context_reducer.ml
@@ -848,6 +848,7 @@ let test_preserve_thinking_removes_summarize_old () =
            (function
              | Types.Thinking { content = "old reasoning"; _ } -> true
              | Types.Thinking _
+             | Types.ReasoningDetails _
              | Types.Text _
              | Types.RedactedThinking _
              | Types.ToolUse _
@@ -866,6 +867,7 @@ let test_preserve_thinking_removes_summarize_old () =
              | Types.Text "summary erased reasoning" -> true
              | Types.Text _
              | Types.Thinking _
+             | Types.ReasoningDetails _
              | Types.RedactedThinking _
              | Types.ToolUse _
              | Types.ToolResult _

--- a/test/test_modality.ml
+++ b/test/test_modality.ml
@@ -10,6 +10,7 @@ let block_kind = function
   | Types.Audio _ -> "Audio"
   | Types.Document _ -> "Document"
   | Types.Thinking _ -> "Thinking"
+  | Types.ReasoningDetails _ -> "ReasoningDetails"
   | Types.RedactedThinking _ -> "RedactedThinking"
   | Types.ToolUse _ -> "ToolUse"
   | Types.ToolResult _ -> "ToolResult"

--- a/test/test_provider_runtime_binding.ml
+++ b/test/test_provider_runtime_binding.ml
@@ -373,9 +373,9 @@ supports_named_tool_choice = false
 id_prefix = "minimax-m3"
 base = "openai_chat"
 supports_tools = true
-supports_tool_choice = true
-supports_required_tool_choice = true
-supports_named_tool_choice = true
+supports_tool_choice = false
+supports_required_tool_choice = false
+supports_named_tool_choice = false
 
 [[models]]
 id_prefix = "ollama_cloud/minimax-m3"
@@ -404,8 +404,17 @@ supports_named_tool_choice = false
            ~tool_choice:named
            ()
        in
-       expect_tool_choice_ok "minimax named" minimax;
-       expect_named_tool_choice_serialized "minimax named" minimax;
+       expect_named_tool_choice_rejected "minimax named" minimax;
+       let minimax_auto =
+         Llm_provider.Provider_config.make
+           ~kind:Llm_provider.Provider_config.OpenAI_compat
+           ~model_id:"minimax-m3"
+           ~base_url:"https://api.minimax.chat/v1"
+           ~tool_choice:Types.Auto
+           ()
+       in
+       expect_tool_choice_ok "minimax auto" minimax_auto;
+       expect_no_tool_choice_field "minimax auto" minimax_auto;
        let glm =
          Llm_provider.Provider_config.make
            ~kind:Llm_provider.Provider_config.Glm

--- a/test/test_thinking_control_dialects.ml
+++ b/test/test_thinking_control_dialects.ml
@@ -373,6 +373,55 @@ let test_deepseek_openai_compat_uses_thinking_object () =
   check_member_absent "think" json
 ;;
 
+let test_minimax_m3_openai_compat_uses_adaptive_thinking_object () =
+  let enabled_config = openai_compat_config ~enable_thinking:true "minimax-m3" in
+  let enabled_json =
+    BOR.build_request ~config:enabled_config ~messages:[ user_msg "hi" ] ()
+    |> json_of_body
+  in
+  check
+    string
+    "enabled thinking type"
+    "adaptive"
+    (enabled_json |> member "thinking" |> member "type" |> to_string);
+  check_member_absent "reasoning_effort" enabled_json;
+  check_member_absent "chat_template_kwargs" enabled_json;
+  let disabled_config = openai_compat_config ~enable_thinking:false "minimax-m3" in
+  let disabled_json =
+    BOR.build_request ~config:disabled_config ~messages:[ user_msg "hi" ] ()
+    |> json_of_body
+  in
+  check
+    string
+    "disabled thinking type"
+    "disabled"
+    (disabled_json |> member "thinking" |> member "type" |> to_string);
+  let auto_tool_choice_config =
+    PC.make
+      ~kind:OpenAI_compat
+      ~model_id:"minimax-m3"
+      ~base_url:"https://api.minimaxi.com/v1"
+      ~tool_choice:Auto
+      ()
+  in
+  let auto_tool_choice_json =
+    BOR.build_request ~config:auto_tool_choice_config ~messages:[ user_msg "hi" ] ()
+    |> json_of_body
+  in
+  check_member_absent "tool_choice" auto_tool_choice_json;
+  let dialect = RD.for_provider_config enabled_config in
+  check
+    string
+    "toggle wire"
+    "thinking_object_adaptive"
+    (RD.toggle_wire_to_string dialect.toggle_wire);
+  check
+    string
+    "replay policy"
+    "preserve_always"
+    (RD.replay_policy_to_string dialect.replay_policy)
+;;
+
 let test_deepseek_reasoning_dialect_semantics () =
   let config =
     PC.make
@@ -914,6 +963,10 @@ let () =
               "deepseek uses thinking object"
               `Quick
               test_deepseek_openai_compat_uses_thinking_object
+          ; test_case
+              "minimax m3 uses adaptive thinking object"
+              `Quick
+              test_minimax_m3_openai_compat_uses_adaptive_thinking_object
           ; test_case
               "deepseek reasoning dialect semantics"
               `Quick

--- a/test/test_thinking_control_dialects.ml
+++ b/test/test_thinking_control_dialects.ml
@@ -384,8 +384,23 @@ let test_minimax_m3_openai_compat_uses_adaptive_thinking_object () =
     "enabled thinking type"
     "adaptive"
     (enabled_json |> member "thinking" |> member "type" |> to_string);
+  check
+    bool
+    "enabled reasoning split"
+    true
+    (enabled_json |> member "reasoning_split" |> to_bool);
   check_member_absent "reasoning_effort" enabled_json;
   check_member_absent "chat_template_kwargs" enabled_json;
+  let default_config = openai_compat_config "minimax-m3" in
+  let default_json =
+    BOR.build_request ~config:default_config ~messages:[ user_msg "hi" ] ()
+    |> json_of_body
+  in
+  check
+    bool
+    "default reasoning split"
+    true
+    (default_json |> member "reasoning_split" |> to_bool);
   let disabled_config = openai_compat_config ~enable_thinking:false "minimax-m3" in
   let disabled_json =
     BOR.build_request ~config:disabled_config ~messages:[ user_msg "hi" ] ()
@@ -396,6 +411,7 @@ let test_minimax_m3_openai_compat_uses_adaptive_thinking_object () =
     "disabled thinking type"
     "disabled"
     (disabled_json |> member "thinking" |> member "type" |> to_string);
+  check_member_absent "reasoning_split" disabled_json;
   let auto_tool_choice_config =
     PC.make
       ~kind:OpenAI_compat


### PR DESCRIPTION
## Summary
- Add `thinking_object_adaptive` as a typed OpenAI-compatible thinking dialect for MiniMax-style `thinking.type = adaptive|disabled`.
- Add `reasoning_output_format = split_reasoning_fields` and typed `reasoning_split=true` request emission for MiniMax Chat while thinking is active.
- Preserve MiniMax `reasoning_details` as canonical `Thinking` plus an opaque native replay carrier, so tool-turn history can replay the provider-native split field without promoting reasoning into answer text.
- Reclassify the direct `minimax-m3` Chat catalog row: tools yes, explicit Chat `tool_choice` no, no reasoning depth budget, preserve-always assistant replay, and no unsupported Chat `response_format`/structured-output claim.
- Update manifest/catalog vocabulary, docs/schema, request-body tests, parser/serializer tests, capability lookup tests, and runtime-binding tool_choice regressions.

Refs jeong-sik/masc#27924.

## Evidence
[근거] MiniMax OpenAI Chat docs: https://platform.minimaxi.com/docs/api-reference/text-chat-openai.md ; checked 2026-06-30 KST; confidence High. The Chat schema documents MiniMax-M3 `thinking.type` as `disabled|adaptive`, documents `reasoning_split`, `reasoning_content`, `reasoning_details`, and `tools`, and does not expose Chat `tool_choice` or `response_format` fields.
[근거] MiniMax M3 tool/interleaved-thinking guide: https://platform.minimaxi.com/docs/guides/text-m3-function-call.md ; checked 2026-06-30 KST; confidence High. The guide requires preserving the complete assistant response, including `reasoning_details` or embedded `<think>` content, in message history.
[근거] MiniMax Responses docs: https://platform.minimaxi.com/docs/api-reference/responses-create.md ; checked 2026-06-30 KST; confidence Medium for endpoint split. The Responses endpoint has its own `tool_choice none|auto` and `reasoning.effort` shape; this PR intentionally models only the existing direct Chat catalog row (`base = "openai_chat"`).

## Validation
- `git diff --check`
- `scripts/dune-local.sh build @fmt`
- `env DUNE_CACHE=disabled scripts/dune-local.sh build test/test_api.exe test/test_backend_openai_codec.exe test/test_capabilities.exe test/test_thinking_control_dialects.exe test/test_provider_runtime_binding.exe`
- `env OAS_MODEL_CATALOG=models.toml OAS_CAPABILITY_MANIFEST= ./_build/default/test/test_api.exe`
- `env OAS_MODEL_CATALOG=models.toml OAS_CAPABILITY_MANIFEST= ./_build/default/test/test_backend_openai_codec.exe`
- `env OAS_MODEL_CATALOG=models.toml OAS_CAPABILITY_MANIFEST= ./_build/default/test/test_capabilities.exe`
- `env OAS_MODEL_CATALOG=models.toml OAS_CAPABILITY_MANIFEST= ./_build/default/test/test_thinking_control_dialects.exe`
- `env OAS_MODEL_CATALOG=models.toml OAS_CAPABILITY_MANIFEST= ./_build/default/test/test_provider_runtime_binding.exe`
