### PR TITLE
fix(test): avoid response helper shadowing

### DIFF
--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -1053,18 +1053,20 @@ let test_response_shape_empty_end_turn_is_not_deliverable () =
 ;;
 
 let test_response_shape_unknown_stop_reason_is_escaped_in_diagnostics () =
-  let response = response ~stop_reason:(Types.Unknown "provider\nmessage") () in
-  let summary = Response_shape.diagnostic_summary response in
+  let newline_response = response ~stop_reason:(Types.Unknown "provider\nmessage") () in
+  let summary = Response_shape.diagnostic_summary newline_response in
   Alcotest.(check bool)
     "escapes unknown stop reason"
     true
-    (summary_contains ~needle:"stop_reason=unknown(\"provider\\nmessage\")" response);
+    (summary_contains
+       ~needle:"stop_reason=unknown(\"provider\\nmessage\")"
+       newline_response);
   Alcotest.(check bool) "keeps summary single-line" false (String.contains summary '\n');
-  let empty = response ~stop_reason:(Types.Unknown "") () in
+  let empty_response = response ~stop_reason:(Types.Unknown "") () in
   Alcotest.(check bool)
     "empty unknown remains visible"
     true
-    (summary_contains ~needle:"stop_reason=unknown(\"\")" empty)
+    (summary_contains ~needle:"stop_reason=unknown(\"\")" empty_response)
 ;;
 
 let test_response_shape_thinking_plus_text_is_deliverable () =


### PR DESCRIPTION
## Summary
- Fixes the main Build & Test failure introduced by the response_shape diagnostic regression test.
- Renames the local test value so it no longer shadows the `response` helper before the empty-Unknown case.

## Verification
- `ocamlformat --check test/test_types.ml`
- `git diff --check`
- Full Dune/build verification is left to GitHub CI per workflow instruction.