### PR TITLE
test(types): avoid response helper shadowing

### DIFF
--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -1053,12 +1053,14 @@ let test_response_shape_empty_end_turn_is_not_deliverable () =
 ;;
 
 let test_response_shape_unknown_stop_reason_is_escaped_in_diagnostics () =
-  let response = response ~stop_reason:(Types.Unknown "provider\nmessage") () in
-  let summary = Response_shape.diagnostic_summary response in
+  let unknown_response = response ~stop_reason:(Types.Unknown "provider\nmessage") () in
+  let summary = Response_shape.diagnostic_summary unknown_response in
   Alcotest.(check bool)
     "escapes unknown stop reason"
     true
-    (summary_contains ~needle:"stop_reason=unknown(\"provider\\nmessage\")" response);
+    (summary_contains
+       ~needle:"stop_reason=unknown(\"provider\\nmessage\")"
+       unknown_response);
   Alcotest.(check bool) "keeps summary single-line" false (String.contains summary '\n');
   let empty = response ~stop_reason:(Types.Unknown "") () in
   Alcotest.(check bool)


### PR DESCRIPTION
## Summary
- Fix OAS `main` Build & Test failure from `test/test_types.ml`.
- Rename the local `response` value in the unknown-stop-reason diagnostic test so it does not shadow the `response` helper before the second helper call.

## Evidence
- Failing main CI: `a09c4cdbe8828cfe828315ac28af6f1a973863d7` Build & Test fails at `test/test_types.ml:1063` with `Types.api_response is not a function`.
- `git diff --check`
- `ocamlformat --check test/test_types.ml`

## Not run
- `scripts/dune-local.sh build test/test_types.exe` was started, but stopped while waiting on `/tmp/me-dune-local.lock` held by another worktree build. CI is the build authority for this fix.
