### PR TITLE
fix(judge): fail closed on invalid structured output

### DIFF
--- a/lib/judge/judge.ml
+++ b/lib/judge/judge.ml
@@ -62,95 +62,109 @@ let risk_of_score score =
 (* ── JSON parsing helpers ───────────────────────────────── *)
 
 let risk_level_of_string = function
-  | "low" -> Low
-  | "medium" -> Medium
-  | "high" -> High
-  | "critical" -> Critical
-  | _ -> Low (* conservative default *)
+  | "low" -> Ok Low
+  | "medium" -> Ok Medium
+  | "high" -> Ok High
+  | "critical" -> Ok Critical
+  | value -> Error (Printf.sprintf "unsupported risk level: %S" value)
 ;;
 
-let clamp_01 v = Float.max 0.0 (Float.min 1.0 v)
+let parse_unit_float ~field value =
+  match value with
+  | `Float v ->
+    if Float.is_nan v || v < 0.0 || v > 1.0
+    then Error (Printf.sprintf "%s must be a number between 0.0 and 1.0" field)
+    else Ok v
+  | `Int v ->
+    let v = float_of_int v in
+    if v < 0.0 || v > 1.0
+    then Error (Printf.sprintf "%s must be a number between 0.0 and 1.0" field)
+    else Ok v
+  | _ -> Error (Printf.sprintf "%s must be a number" field)
+;;
 
-(** Extract the first JSON object from a string that may contain
-    markdown fencing or surrounding prose. *)
-let extract_json_substring text =
-  match String.index_opt text '{' with
-  | None -> None
-  | Some start ->
-    let len = String.length text in
-    let depth = ref 0 in
-    let in_string = ref false in
-    let escape = ref false in
-    let found = ref None in
-    let i = ref start in
-    while !i < len && Option.is_none !found do
-      let c = text.[!i] in
-      if !escape
-      then escape := false
-      else if c = '\\' && !in_string
-      then escape := true
-      else if c = '"'
-      then in_string := not !in_string
-      else if not !in_string
-      then
-        if c = '{'
-        then incr depth
-        else if c = '}'
-        then (
-          decr depth;
-          if !depth = 0 then found := Some (String.sub text start (!i - start + 1)));
-      incr i
-    done;
-    !found
+let required_member name fields =
+  match List.assoc_opt name fields with
+  | Some value -> Ok value
+  | None -> Error (Printf.sprintf "missing required field: %s" name)
+;;
+
+let parse_required_string ~field value =
+  match value with
+  | `String value -> Ok value
+  | _ -> Error (Printf.sprintf "%s must be a string" field)
+;;
+
+let parse_evidence = function
+  | None | Some `Null -> Ok []
+  | Some (`List items) ->
+    List.fold_right
+      (fun item acc ->
+         match item, acc with
+         | `String value, Ok values -> Ok (value :: values)
+         | _, Ok _ -> Error "evidence must contain only strings"
+         | _, (Error _ as error) -> error)
+      items
+      (Ok [])
+  | Some _ -> Error "evidence must be an array of strings"
+;;
+
+let parse_recommended_action = function
+  | None | Some `Null -> Ok None
+  | Some (`String value) -> Ok (Some value)
+  | Some _ -> Error "recommended_action must be a string or null"
+;;
+
+let strip_exact_json_fence text =
+  let text = String.trim text in
+  let len = String.length text in
+  if len >= 6 && String.sub text 0 3 = "```"
+  then (
+    let closing = len - 3 in
+    if String.sub text closing 3 <> "```"
+    then Error "JSON fence is not closed at the end of the response"
+    else (
+      let body = String.sub text 3 (closing - 3) in
+      match String.index_opt body '\n' with
+      | None -> Ok (String.trim body)
+      | Some first_newline ->
+        let fence_label = String.sub body 0 first_newline |> String.trim in
+        let payload =
+          String.sub body (first_newline + 1) (String.length body - first_newline - 1)
+          |> String.trim
+        in
+        if fence_label = "" || String.lowercase_ascii fence_label = "json"
+        then Ok payload
+        else Error (Printf.sprintf "unsupported JSON fence label: %S" fence_label)))
+  else Ok text
 ;;
 
 let parse_judgment text =
-  let json_str =
-    match extract_json_substring text with
-    | Some s -> s
-    | None -> text
-  in
+  let ( let* ) = Result.bind in
   try
+    let* json_str = strip_exact_json_fence text in
     let json = Yojson.Safe.from_string json_str in
-    let open Yojson.Safe.Util in
-    let score = clamp_01 (json |> member "score" |> to_float) in
-    let confidence =
-      clamp_01
-        (try json |> member "confidence" |> to_float with
-         | Type_error _ -> 0.5)
+    let* fields =
+      match json with
+      | `Assoc fields -> Ok fields
+      | _ -> Error "judgment response must be a JSON object"
     in
-    let risk =
-      try
-        json
-        |> member "risk"
-        |> to_string
-        |> String.lowercase_ascii
-        |> risk_level_of_string
-      with
-      | Type_error _ -> risk_of_score score
+    let* score_json = required_member "score" fields in
+    let* score = parse_unit_float ~field:"score" score_json in
+    let* confidence =
+      let* confidence_json = required_member "confidence" fields in
+      parse_unit_float ~field:"confidence" confidence_json
     in
-    let summary =
-      try json |> member "summary" |> to_string with
-      | Type_error _ -> "No summary provided"
+    let* risk =
+      let* risk_json = required_member "risk" fields in
+      let* value = parse_required_string ~field:"risk" risk_json in
+      risk_level_of_string (String.lowercase_ascii value)
     in
-    let evidence =
-      try
-        json
-        |> member "evidence"
-        |> to_list
-        |> List.filter_map (fun j ->
-          try Some (to_string j) with
-          | Type_error _ -> None)
-      with
-      | Type_error _ -> []
-    in
-    let recommended_action =
-      try
-        match json |> member "recommended_action" with
-        | `Null -> None
-        | j -> Some (to_string j)
-      with
-      | Type_error _ -> None
+    let* summary_json = required_member "summary" fields in
+    let* summary = parse_required_string ~field:"summary" summary_json in
+    let* evidence = parse_evidence (List.assoc_opt "evidence" fields) in
+    let* recommended_action =
+      parse_recommended_action (List.assoc_opt "recommended_action" fields)
     in
     Ok { score; confidence; risk; summary; evidence; recommended_action }
   with
@@ -221,16 +235,6 @@ let judge ~sw ~net ~provider ~config ~context () =
     else (
       match parse_judgment text with
       | Ok j -> Ok j
-      | Error _parse_err ->
-        (* Fallback: create low-confidence judgment from raw text *)
-        Ok
-          { score = 0.5
-          ; confidence = 0.1
-          ; risk = Medium
-          ; summary =
-              (if String.length text > 200 then String.sub text 0 200 ^ "..." else text)
-          ; evidence = []
-          ; recommended_action =
-              Some "Manual review recommended (structured parse failed)"
-          })
+      | Error parse_err ->
+        Error (Printf.sprintf "Judge LLM returned invalid JSON: %s" parse_err))
 ;;

--- a/lib/judge/judge.mli
+++ b/lib/judge/judge.mli
@@ -68,8 +68,13 @@ val provider_config_for_judge
 val risk_of_score : float -> risk_level
 
 (** Parse LLM output text into a judgment.
-    Expects JSON with at least [score], [confidence], [risk], [summary] fields.
-    Returns [Error msg] on parse failure. *)
+
+    Accepts either an exact JSON object or an exact fenced JSON block. Prose
+    surrounding a JSON object is rejected instead of scraped. [score] and
+    [confidence] must be numbers in [0.0, 1.0], [risk] must be one of
+    [low|medium|high|critical], and [summary] must be a string. [evidence],
+    when present, must contain only strings. Returns [Error msg] on parse or
+    type failure. *)
 val parse_judgment : string -> (judgment, string) result
 
 (** Execute a single judgment against a single provider.
@@ -78,7 +83,8 @@ val parse_judgment : string -> (judgment, string) result
     as the system message and [context] as the user message.  Parses the
     structured JSON response into a {!judgment}.
 
-    If JSON parsing fails, creates a low-confidence judgment from raw text.
+    If JSON parsing fails, returns [Error] rather than fabricating a
+    low-confidence judgment from raw text.
 
     @param provider The LLM provider to evaluate with. Callers that need
                     multi-provider routing should handle that outside OAS. *)

--- a/test/test_judge.ml
+++ b/test/test_judge.ml
@@ -51,18 +51,17 @@ let test_parse_valid_json () =
       j.recommended_action
 ;;
 
-(* ── parse_judgment: minimal JSON ────────────────────────── *)
-
-let test_parse_minimal_json () =
-  let json = {|{"score": 0.2}|} in
+let expect_parse_error label json =
   match Judge.parse_judgment json with
-  | Error e -> Alcotest.fail (Printf.sprintf "Expected Ok, got Error: %s" e)
-  | Ok j ->
-    Alcotest.(check (float 0.001)) "score" 0.2 j.score;
-    (* confidence defaults to 0.5 when missing *)
-    Alcotest.(check (float 0.001)) "confidence" 0.5 j.confidence;
-    (* risk derived from score: 0.2 < 0.3 = Low *)
-    Alcotest.check risk_testable "risk" Judge.Low j.risk
+  | Ok _ -> Alcotest.fail (Printf.sprintf "Expected Error for %s" label)
+  | Error msg -> Alcotest.(check bool) "has error message" true (String.length msg > 0)
+;;
+
+(* ── parse_judgment: missing required fields ─────────────── *)
+
+let test_parse_missing_required_fields () =
+  let json = {|{"score": 0.2}|} in
+  expect_parse_error "missing required fields" json
 ;;
 
 (* ── parse_judgment: malformed JSON returns Error ────────── *)
@@ -89,21 +88,23 @@ let test_parse_json_with_fencing () =
     Alcotest.(check (float 0.001)) "confidence" 0.8 j.confidence
 ;;
 
-(* ── parse_judgment: score clamped to 0-1 ────────────────── *)
+(* ── parse_judgment: score/confidence range ──────────────── *)
 
-let test_parse_clamps_score () =
-  let json = {|{"score": 1.5, "confidence": -0.3}|} in
-  match Judge.parse_judgment json with
-  | Error e -> Alcotest.fail (Printf.sprintf "Expected Ok, got Error: %s" e)
-  | Ok j ->
-    Alcotest.(check (float 0.001)) "score clamped" 1.0 j.score;
-    Alcotest.(check (float 0.001)) "confidence clamped" 0.0 j.confidence
+let test_parse_rejects_out_of_range_score_confidence () =
+  expect_parse_error
+    "score out of range"
+    {|{"score": 1.5, "confidence": 0.3, "risk": "high", "summary": "bad"}|};
+  expect_parse_error
+    "confidence out of range"
+    {|{"score": 0.5, "confidence": -0.3, "risk": "medium", "summary": "bad"}|}
 ;;
 
 (* ── parse_judgment: null recommended_action ─────────────── *)
 
 let test_parse_null_action () =
-  let json = {|{"score": 0.5, "recommended_action": null}|} in
+  let json =
+    {|{"score": 0.5, "confidence": 0.8, "risk": "medium", "summary": "ok", "recommended_action": null}|}
+  in
   match Judge.parse_judgment json with
   | Error e -> Alcotest.fail (Printf.sprintf "Expected Ok, got Error: %s" e)
   | Ok j -> Alcotest.(check (option string)) "null action" None j.recommended_action
@@ -260,21 +261,23 @@ let test_risk_level_roundtrip () =
 
 (* ── parse_judgment: evidence with non-string items ──────── *)
 
-let test_parse_evidence_filters_non_strings () =
-  let json = {|{"score": 0.5, "evidence": ["valid", 42, "also valid", null]}|} in
-  match Judge.parse_judgment json with
-  | Error e -> Alcotest.fail (Printf.sprintf "Expected Ok, got Error: %s" e)
-  | Ok j -> Alcotest.(check int) "evidence filtered" 2 (List.length j.evidence)
+let test_parse_evidence_rejects_non_strings () =
+  let json =
+    {|{"score": 0.5, "confidence": 0.9, "risk": "medium", "summary": "ok", "evidence": ["valid", 42, "also valid", null]}|}
+  in
+  expect_parse_error "non-string evidence" json
 ;;
 
 (* ── parse_judgment: risk string variants ────────────────── *)
 
 let test_parse_risk_string_variants () =
   let cases =
-    [ {|{"score": 0.5, "risk": "LOW"}|}, Judge.Low
-    ; {|{"score": 0.5, "risk": "Medium"}|}, Judge.Medium
-    ; {|{"score": 0.5, "risk": "HIGH"}|}, Judge.High
-    ; {|{"score": 0.5, "risk": "CRITICAL"}|}, Judge.Critical
+    [ {|{"score": 0.5, "confidence": 0.9, "risk": "LOW", "summary": "ok"}|}, Judge.Low
+    ; ( {|{"score": 0.5, "confidence": 0.9, "risk": "Medium", "summary": "ok"}|}
+      , Judge.Medium )
+    ; {|{"score": 0.5, "confidence": 0.9, "risk": "HIGH", "summary": "ok"}|}, Judge.High
+    ; ( {|{"score": 0.5, "confidence": 0.9, "risk": "CRITICAL", "summary": "ok"}|}
+      , Judge.Critical )
     ]
   in
   List.iter
@@ -291,21 +294,33 @@ let test_parse_risk_string_variants () =
     cases
 ;;
 
+let test_parse_unknown_risk_errors () =
+  expect_parse_error
+    "unknown risk"
+    {|{"score": 0.5, "confidence": 0.9, "risk": "unknown", "summary": "ok"}|}
+;;
+
+let test_parse_rejects_prose_wrapped_json () =
+  expect_parse_error
+    "prose-wrapped JSON"
+    {|The result is {"score": 0.5, "confidence": 0.9, "risk": "medium", "summary": "ok"}.|}
+;;
+
 (* ── parse_judgment: score boundary values ───────────────── *)
 
 let test_parse_score_boundaries () =
   (* Exactly at boundary: 0.3 -> Medium *)
-  let json = {|{"score": 0.3}|} in
+  let json = {|{"score": 0.3, "confidence": 0.9, "risk": "medium", "summary": "ok"}|} in
   (match Judge.parse_judgment json with
    | Error e -> Alcotest.fail e
    | Ok j -> Alcotest.check risk_testable "0.3" Judge.Medium j.risk);
   (* Exactly at boundary: 0.6 -> High *)
-  let json = {|{"score": 0.6}|} in
+  let json = {|{"score": 0.6, "confidence": 0.9, "risk": "high", "summary": "ok"}|} in
   (match Judge.parse_judgment json with
    | Error e -> Alcotest.fail e
    | Ok j -> Alcotest.check risk_testable "0.6" Judge.High j.risk);
   (* Exactly at boundary: 0.8 -> Critical *)
-  let json = {|{"score": 0.8}|} in
+  let json = {|{"score": 0.8, "confidence": 0.9, "risk": "critical", "summary": "ok"}|} in
   match Judge.parse_judgment json with
   | Error e -> Alcotest.fail e
   | Ok j -> Alcotest.check risk_testable "0.8" Judge.Critical j.risk
@@ -318,16 +333,27 @@ let () =
     "Judge"
     [ ( "parse_judgment"
       , [ Alcotest.test_case "valid JSON" `Quick test_parse_valid_json
-        ; Alcotest.test_case "minimal JSON" `Quick test_parse_minimal_json
+        ; Alcotest.test_case
+            "missing required fields"
+            `Quick
+            test_parse_missing_required_fields
         ; Alcotest.test_case "malformed JSON" `Quick test_parse_malformed_json
         ; Alcotest.test_case "JSON with fencing" `Quick test_parse_json_with_fencing
-        ; Alcotest.test_case "clamps score/confidence" `Quick test_parse_clamps_score
+        ; Alcotest.test_case
+            "rejects out-of-range score/confidence"
+            `Quick
+            test_parse_rejects_out_of_range_score_confidence
         ; Alcotest.test_case "null action" `Quick test_parse_null_action
         ; Alcotest.test_case
-            "evidence filters non-strings"
+            "evidence rejects non-strings"
             `Quick
-            test_parse_evidence_filters_non_strings
+            test_parse_evidence_rejects_non_strings
         ; Alcotest.test_case "risk string variants" `Quick test_parse_risk_string_variants
+        ; Alcotest.test_case "unknown risk errors" `Quick test_parse_unknown_risk_errors
+        ; Alcotest.test_case
+            "rejects prose-wrapped JSON"
+            `Quick
+            test_parse_rejects_prose_wrapped_json
         ; Alcotest.test_case "score boundaries" `Quick test_parse_score_boundaries
         ] )
     ; "default_config", [ Alcotest.test_case "values" `Quick test_default_config ]


### PR DESCRIPTION
## Summary
- make `Judge.parse_judgment` reject prose-wrapped JSON instead of scraping the first object
- reject unsupported risk labels, out-of-range score/confidence, invalid evidence, and invalid recommended_action types
- return `Error` from `Judge.judge` when structured parsing fails instead of fabricating a low-confidence judgment

## Verification
- `ocamlformat --check lib/judge/judge.ml lib/judge/judge.mli test/test_judge.ml`
- `git diff --check`

Local Dune was intentionally not run; GitHub CI is the build/test authority for this PR.