### PR TITLE
fix(stream-acc): replace InputJsonDelta buffer on whole-value re-emit (malformed {}{})

### DIFF
--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -96,8 +96,7 @@ let accumulate_event (acc : stream_acc) = function
         b
     in
     (match delta with
-     | Types.TextDelta s | Types.ThinkingDelta s ->
-       Buffer.add_string buf s
+     | Types.TextDelta s | Types.ThinkingDelta s -> Buffer.add_string buf s
      | Types.InputJsonDelta s ->
        (* A provider may re-emit a whole tool-call arguments value as an
           InputJsonDelta rather than an InputJsonSnapshot. If the buffer
@@ -108,10 +107,14 @@ let accumulate_event (acc : stream_acc) = function
           into malformed "{}{}" (raw="{}{}", malformed_tool_use_arguments).
           The re-emit vs incremental decision derives from the buffer state,
           not the delta tag (SSOT). *)
-       if String.length s > 0 && s.[0] = '{'
-          && Buffer.length buf > 0
-          && is_complete_json_value (Buffer.contents buf)
-       then (Buffer.clear buf; Buffer.add_string buf s)
+       if
+         String.length s > 0
+         && s.[0] = '{'
+         && Buffer.length buf > 0
+         && is_complete_json_value (Buffer.contents buf)
+       then (
+         Buffer.clear buf;
+         Buffer.add_string buf s)
        else Buffer.add_string buf s
      | Types.InputJsonSnapshot s ->
        (* A complete tool-call arguments value replaces the block buffer rather

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -55,6 +55,18 @@ let create_stream_acc () =
   }
 ;;
 
+(* [true] iff [s] parses as one complete JSON value. Used by the
+   [InputJsonDelta] re-emit guard below: a buffer that already holds a complete
+   value, followed by a delta starting a fresh object, is a provider re-emit
+   (replace) rather than an incremental fragment (concat). Yojson rejects
+   trailing bytes, so ["{}{}"] is [false] here -- exactly the malformed shape
+   we prevent from reaching [finalize]. *)
+let is_complete_json_value s =
+  match Yojson.Safe.from_string s with
+  | _ -> true
+  | exception Yojson.Json_error _ -> false
+;;
+
 let accumulate_event (acc : stream_acc) = function
   | Types.MessageStart { id; model; usage } ->
     acc.id := id;
@@ -84,8 +96,23 @@ let accumulate_event (acc : stream_acc) = function
         b
     in
     (match delta with
-     | Types.TextDelta s | Types.ThinkingDelta s | Types.InputJsonDelta s ->
+     | Types.TextDelta s | Types.ThinkingDelta s ->
        Buffer.add_string buf s
+     | Types.InputJsonDelta s ->
+       (* A provider may re-emit a whole tool-call arguments value as an
+          InputJsonDelta rather than an InputJsonSnapshot. If the buffer
+          already holds a complete JSON value and the incoming delta starts a
+          fresh object, treat it as a re-emit and replace (not concatenate),
+          mirroring the [InputJsonSnapshot] arm below. Without this, an
+          OpenAI-compat/Ollama/Gemini provider that re-emits "{}" concatenates
+          into malformed "{}{}" (raw="{}{}", malformed_tool_use_arguments).
+          The re-emit vs incremental decision derives from the buffer state,
+          not the delta tag (SSOT). *)
+       if String.length s > 0 && s.[0] = '{'
+          && Buffer.length buf > 0
+          && is_complete_json_value (Buffer.contents buf)
+       then (Buffer.clear buf; Buffer.add_string buf s)
+       else Buffer.add_string buf s
      | Types.InputJsonSnapshot s ->
        (* A complete tool-call arguments value replaces the block buffer rather
           than appending, so a provider that re-emits the same whole value over
@@ -786,6 +813,53 @@ let%test "finalize_stream_acc repeated tool-arg snapshot stays valid JSON" =
   match finalize_stream_acc acc with
   | Ok { content = [ Types.ToolUse { input; name; _ } ]; _ } ->
     name = "list" && input = `Assoc [ "limit", `Int 10 ]
+  | Ok _ | Error _ -> false
+;;
+
+let%test "accumulate_event InputJsonDelta replaces buffer on re-emit (no concat)" =
+  (* Regression: an OpenAI-compat/Ollama/Gemini provider that re-emits a whole
+     arguments value as an InputJsonDelta (not InputJsonSnapshot) used to
+     concatenate into "{}{}" or [{"limit":10}{"limit":10}], which finalize
+     rejected as [malformed_tool_use_arguments]. When the buffer already holds
+     a complete JSON value and the incoming delta starts a fresh object, the
+     accumulator now replaces. *)
+  let acc = create_stream_acc () in
+  accumulate_event
+    acc
+    (Types.ContentBlockStart
+       { index = 0; content_type = "tool_use"; tool_id = None; tool_name = None });
+  accumulate_event
+    acc
+    (Types.ContentBlockDelta { index = 0; delta = Types.InputJsonDelta {|{}|} });
+  accumulate_event
+    acc
+    (Types.ContentBlockDelta { index = 0; delta = Types.InputJsonDelta {|{}|} });
+  let buf = Hashtbl.find acc.block_texts 0 in
+  Buffer.contents buf = {|{}|}
+;;
+
+let%test "finalize_stream_acc InputJsonDelta empty-object re-emit stays valid" =
+  (* The live malformed_tool_use_arguments raw="{}{}" regression: a provider
+     re-emits the empty arguments object "{}" as InputJsonDelta. Without the
+     re-emit guard the buffer concatenates into "{}{}" and finalize fails
+     closed. With the guard the second "{}" replaces the first. *)
+  let acc = create_stream_acc () in
+  List.iter
+    (accumulate_event acc)
+    [ Types.MessageStart { id = "m"; model = "m"; usage = None }
+    ; Types.ContentBlockStart
+        { index = 0
+        ; content_type = "tool_use"
+        ; tool_id = Some "call_1"
+        ; tool_name = Some "noop"
+        }
+    ; Types.ContentBlockDelta { index = 0; delta = Types.InputJsonDelta {|{}|} }
+    ; Types.ContentBlockDelta { index = 0; delta = Types.InputJsonDelta {|{}|} }
+    ; Types.MessageDelta { stop_reason = Some Types.StopToolUse; usage = None }
+    ];
+  match finalize_stream_acc acc with
+  | Ok { content = [ Types.ToolUse { input; name; _ } ]; _ } ->
+    name = "noop" && input = `Assoc []
   | Ok _ | Error _ -> false
 ;;
 


### PR DESCRIPTION
## Root cause

A provider (OpenAI-compat/Ollama/Gemini) may re-emit a whole tool-call arguments value as an `InputJsonDelta` rather than an `InputJsonSnapshot`. The accumulator concatenated such deltas unconditionally, so a re-emitted `"{}"` became malformed `"{}{}"`:

```
Keeper request failed: Parse error: sse: SSE parse failed:
malformed_tool_use_arguments:index:2: ... raw="{}{}"
```

Live failure observed on the sangsu keeper (`~/me/.masc`).

## Why the existing fix missed it

`complete_stream_acc.ml` already replaced on re-emit — but only for the `InputJsonSnapshot` arm (line 89-94). The `InputJsonDelta` arm (line 87-88) concatenated unconditionally. The existing regression tests (line 772, 791) covered `InputJsonSnapshot` only. Classic N-of-M gap.

This is also an SSOT violation: the "incremental fragment vs whole value" semantics were hidden in the delta tag, so behavior depended on which tag a provider chose.

## Fix

Add `is_complete_json_value` (parses via `Yojson.Safe.from_string`, which rejects trailing bytes — so `"{}{}"` is `false`). In the `InputJsonDelta` arm, when the incoming delta starts a fresh object (`s.[0] = '{'`) and the buffer already holds a complete JSON value, **replace** (mirror `InputJsonSnapshot`) instead of concatenating. Otherwise concat (normal incremental).

The re-emit vs incremental decision now derives from **buffer state**, not the delta tag (SSOT). Parse-don't-validate: the guard is structural, not a string classifier.

## Tests

Two regression tests added next to the existing `InputJsonSnapshot` pair:
1. `accumulate_event InputJsonDelta replaces buffer on re-emit (no concat)` — `{}` + `{}` delta → buffer is `{}`, not `{}{}`.
2. `finalize_stream_acc InputJsonDelta empty-object re-emit stays valid` — the live `raw="{}{}"` case, end-to-end through finalize.

## P0–P3

- **P0 (보안/데이터 손실)**: 해당 없음.
- **P1 (정확성)**: GOOD — `InputJsonDelta` re-emit이 이제 replace. sangsu `{}{}` 회귀 근본 fix. N-of-M gap 영구 폐쇄.
- **P2 (구조)**: GOOD — semantics가 delta tag → buffer state로 이동 (SSOT). `is_complete_json_value` 헬퍼로 JSON 완성 검사 한 곳. 노 스트링 매치, 노 silent failure.
- **P3 (잔여)**: `is_complete_json_value`가 매 re-emit 후보(s.[0]='{'인 delta)마다 Yojson 파싱. 빈도 낮고 buf 작아 비용 무시 가능. 정상 증분(s[0]≠'{')은 파싱 스킵.

## 워크어라운드 게이트

근본 fix (accumulator semantics 교정). silent recovery(`{}{}`→첫 객체)가 아님 — re-emit을 구조적으로 감지해 replace. telemetry-as-fix / string classifier / N-of-M 패치 아님.

병합 가능성: CI(Build & Test + accumulator 회귀 테스트) green 후 머지.

\# This is not a workaround — root semantics fix.
