### PR TITLE
[codex] Preserve Ollama Cloud OpenAI reasoning stream

### DIFF
--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -76,6 +76,7 @@ let llm_capabilities_of_provider_capabilities (caps : Provider.capabilities)
   ; thinking_control_format = caps.thinking_control_format
   ; preserve_thinking_control_format = caps.preserve_thinking_control_format
   ; reasoning_output_format = caps.reasoning_output_format
+  ; reasoning_streaming_format = caps.reasoning_streaming_format
   ; reasoning_replay_override = caps.reasoning_replay_override
   ; supports_response_format_json = caps.supports_response_format_json
   ; supports_structured_output = caps.supports_structured_output

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -73,6 +73,12 @@ type reasoning_output_format = Capability_vocab.reasoning_output_format =
   | No_reasoning_output_format
   | Split_reasoning_fields
 
+type reasoning_streaming_format = Capability_vocab.reasoning_streaming_format =
+  | Default_reasoning_streaming
+  | No_reasoning_streaming
+  | Delta_reasoning_field of string
+  | Template_reasoning_streaming
+
 type capabilities =
   { (* ── Numeric limits ────────────────────────────────── *)
     max_context_tokens : int option (** Model's context window. None = unknown. *)
@@ -115,6 +121,11 @@ type capabilities =
         OpenAI-compatible providers require an explicit split switch before
         returning reasoning in side-channel fields instead of embedding it in
         visible [content]. *)
+  ; reasoning_streaming_format : reasoning_streaming_format
+    (** Optional streaming side-channel override. [Default_reasoning_streaming]
+        derives the parser field from [thinking_control_format]; catalog entries
+        set a concrete value when the endpoint stream field differs from the
+        request-side thinking control shape. *)
   ; reasoning_replay_override : reasoning_replay_override
     (** Optional override for the multi-turn reasoning replay policy. Defaults to
         the policy implied by [thinking_control_format]; catalog entries set this
@@ -181,6 +192,7 @@ let default_capabilities =
   ; thinking_control_format = No_thinking_control
   ; preserve_thinking_control_format = No_preserve_thinking_control
   ; reasoning_output_format = No_reasoning_output_format
+  ; reasoning_streaming_format = Default_reasoning_streaming
   ; reasoning_replay_override = Default_reasoning_replay
   ; supports_response_format_json = false
   ; supports_structured_output = false
@@ -738,6 +750,10 @@ let reasoning_output_format_of_catalog_string raw =
   Capability_vocab.reasoning_output_format_of_string raw
 ;;
 
+let reasoning_streaming_format_of_catalog_string raw =
+  Capability_vocab.reasoning_streaming_format_of_string raw
+;;
+
 let modality_priority_of_catalog_string raw =
   match String.lowercase_ascii (String.trim raw) with
   | "preserve_input_order" | "preserve-input-order" | "preserve" ->
@@ -892,6 +908,15 @@ let apply_manifest_entry (entry : Capability_manifest.entry) : capabilities =
             warn_unknown_capability_value ~field:"reasoning_output_format" s;
             base.reasoning_output_format)
        | None -> base.reasoning_output_format)
+  ; reasoning_streaming_format =
+      (match entry.reasoning_streaming_format with
+       | Some s ->
+         (match reasoning_streaming_format_of_catalog_string s with
+          | Some format -> format
+          | None ->
+            warn_unknown_capability_value ~field:"reasoning_streaming_format" s;
+            base.reasoning_streaming_format)
+       | None -> base.reasoning_streaming_format)
   ; reasoning_replay_override =
       (match entry.reasoning_replay with
        | Some s ->
@@ -1094,6 +1119,15 @@ let apply_catalog_entry (entry : Model_catalog.model_entry) : capabilities =
             warn_unknown_capability_value ~field:"reasoning_output_format" s;
             base.reasoning_output_format)
        | None -> base.reasoning_output_format)
+  ; reasoning_streaming_format =
+      (match entry.reasoning_streaming_format with
+       | Some s ->
+         (match reasoning_streaming_format_of_catalog_string s with
+          | Some format -> format
+          | None ->
+            warn_unknown_capability_value ~field:"reasoning_streaming_format" s;
+            base.reasoning_streaming_format)
+       | None -> base.reasoning_streaming_format)
   ; reasoning_replay_override =
       (match entry.reasoning_replay with
        | Some s ->
@@ -1408,6 +1442,7 @@ let test_catalog_entry id_prefix : Model_catalog.model_entry =
   ; thinking_control_token = None
   ; preserve_thinking_control_format = None
   ; reasoning_output_format = None
+  ; reasoning_streaming_format = None
   ; reasoning_replay = None
   ; input_per_million = None
   ; output_per_million = None
@@ -1450,6 +1485,7 @@ let test_manifest_entry id_prefix : Capability_manifest.entry =
   ; thinking_control_token = None
   ; preserve_thinking_control_format = None
   ; reasoning_output_format = None
+  ; reasoning_streaming_format = None
   ; reasoning_replay = None
   }
 ;;
@@ -2068,6 +2104,7 @@ let%test "capabilities_for_provider_label: aliases resolve to identical capabili
       && ca.accepted_reasoning_efforts = cb.accepted_reasoning_efforts
       && ca.preserve_thinking_control_format = cb.preserve_thinking_control_format
       && ca.reasoning_output_format = cb.reasoning_output_format
+      && ca.reasoning_streaming_format = cb.reasoning_streaming_format
       && ca.assistant_tool_content_format = cb.assistant_tool_content_format
       && ca.reasoning_replay_override = cb.reasoning_replay_override
     | _ -> false

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -59,6 +59,12 @@ type reasoning_output_format = Capability_vocab.reasoning_output_format =
   | No_reasoning_output_format
   | Split_reasoning_fields
 
+type reasoning_streaming_format = Capability_vocab.reasoning_streaming_format =
+  | Default_reasoning_streaming
+  | No_reasoning_streaming
+  | Delta_reasoning_field of string
+  | Template_reasoning_streaming
+
 type capabilities =
   { (* Numeric limits *)
     max_context_tokens : int option
@@ -84,6 +90,7 @@ type capabilities =
   ; thinking_control_format : thinking_control_format
   ; preserve_thinking_control_format : preserve_thinking_control_format
   ; reasoning_output_format : reasoning_output_format
+  ; reasoning_streaming_format : reasoning_streaming_format
   ; reasoning_replay_override : reasoning_replay_override
   ; (* Output format *)
     supports_response_format_json : bool

--- a/lib/llm_provider/capability_manifest.ml
+++ b/lib/llm_provider/capability_manifest.ml
@@ -53,6 +53,10 @@ type entry =
     (** Canonical request-side reasoning output split control (none /
         split_reasoning_fields). Parsed + applied in
         {!Capabilities.apply_manifest_entry}. *)
+  ; reasoning_streaming_format : string option
+    (** Canonical streaming reasoning side-channel (default / none /
+        template_parser / delta:<field>). Parsed + applied in
+        {!Capabilities.apply_manifest_entry}. *)
   ; reasoning_replay : string option
     (** Optional multi-turn reasoning replay policy override (default / no_replay
         / drop_without_tool / preserve_always); applied in
@@ -213,6 +217,24 @@ let canonical_string_list key ~allowed json =
             (String.concat ", " allowed)))
 ;;
 
+let canonical_reasoning_streaming_format key json =
+  let open Result_syntax in
+  let* value = member_string_closed key json in
+  match value with
+  | None -> Ok None
+  | Some raw ->
+    (match Capability_vocab.reasoning_streaming_format_of_string raw with
+     | Some _ -> Ok (Some raw)
+     | None ->
+       let normalized = String.lowercase_ascii (String.trim raw) in
+       Error
+         (Printf.sprintf
+            "entry field %S has unknown value %S (canonical: %s)"
+            key
+            normalized
+            Capability_vocab.reasoning_streaming_format_syntax))
+;;
+
 let known_manifest_keys = [ "_comment"; "schema_version"; "models" ]
 
 let known_entry_keys =
@@ -250,6 +272,7 @@ let known_entry_keys =
   ; "thinking_control_token"
   ; "preserve_thinking_control_format"
   ; "reasoning_output_format"
+  ; "reasoning_streaming_format"
   ; "reasoning_replay"
   ]
 ;;
@@ -296,6 +319,9 @@ let parse_entry json =
       "reasoning_output_format"
       ~allowed:Capability_vocab.reasoning_output_format_values
       json
+  in
+  let* reasoning_streaming_format =
+    canonical_reasoning_streaming_format "reasoning_streaming_format" json
   in
   let* reasoning_replay =
     canonical_choice
@@ -349,6 +375,7 @@ let parse_entry json =
     ; thinking_control_token
     ; preserve_thinking_control_format
     ; reasoning_output_format
+    ; reasoning_streaming_format
     ; reasoning_replay
     }
 ;;

--- a/lib/llm_provider/capability_manifest.mli
+++ b/lib/llm_provider/capability_manifest.mli
@@ -94,6 +94,10 @@ type entry =
   ; reasoning_output_format : string option
     (** Canonical request-side reasoning output split control (none /
         split_reasoning_fields); applied in {!Capabilities.apply_manifest_entry}. *)
+  ; reasoning_streaming_format : string option
+    (** Canonical streaming reasoning side-channel (default / none /
+        template_parser / delta:<field>); applied in
+        {!Capabilities.apply_manifest_entry}. *)
   ; reasoning_replay : string option
     (** Optional multi-turn reasoning replay policy override (default /
         no_replay / drop_without_tool / preserve_always). *)

--- a/lib/llm_provider/capability_vocab.ml
+++ b/lib/llm_provider/capability_vocab.ml
@@ -19,6 +19,12 @@ type reasoning_output_format =
   | No_reasoning_output_format
   | Split_reasoning_fields
 
+type reasoning_streaming_format =
+  | Default_reasoning_streaming
+  | No_reasoning_streaming
+  | Delta_reasoning_field of string
+  | Template_reasoning_streaming
+
 let normalize raw = String.lowercase_ascii (String.trim raw)
 
 let thinking_control_format_values =
@@ -95,4 +101,31 @@ let reasoning_output_format_of_string raw =
   match normalize raw with
   | "" -> Some No_reasoning_output_format
   | normalized -> List.assoc_opt normalized reasoning_output_format_table
+;;
+
+let reasoning_streaming_format_values =
+  [ "default"; "none"; "template_parser"; "delta:<field>" ]
+;;
+
+let reasoning_streaming_format_syntax =
+  String.concat ", " reasoning_streaming_format_values
+;;
+
+let reasoning_streaming_delta_prefix = "delta:"
+
+let reasoning_streaming_format_of_string raw =
+  match normalize raw with
+  | "" | "default" -> Some Default_reasoning_streaming
+  | "none" -> Some No_reasoning_streaming
+  | "template_parser" -> Some Template_reasoning_streaming
+  | normalized when String.starts_with ~prefix:reasoning_streaming_delta_prefix normalized
+    ->
+    let prefix_len = String.length reasoning_streaming_delta_prefix in
+    let field =
+      String.sub normalized prefix_len (String.length normalized - prefix_len)
+    in
+    if field = "" || String.contains field ' '
+    then None
+    else Some (Delta_reasoning_field field)
+  | _ -> None
 ;;

--- a/lib/llm_provider/model_catalog.ml
+++ b/lib/llm_provider/model_catalog.ml
@@ -36,6 +36,7 @@ type model_entry =
   ; thinking_control_token : string option
   ; preserve_thinking_control_format : string option
   ; reasoning_output_format : string option
+  ; reasoning_streaming_format : string option
   ; reasoning_replay : string option
   ; input_per_million : float option
   ; output_per_million : float option
@@ -158,6 +159,24 @@ let canonical_string_list_opt ~entry_id key ~allowed toml =
             (String.concat ", " allowed)))
 ;;
 
+let reasoning_streaming_format_opt ~entry_id key toml =
+  match find_string_field ~entry_id key toml with
+  | Error _ as e -> e
+  | Ok None -> Ok None
+  | Ok (Some raw) ->
+    (match Capability_vocab.reasoning_streaming_format_of_string raw with
+     | Some _ -> Ok (Some raw)
+     | None ->
+       let normalized = String.lowercase_ascii (String.trim raw) in
+       Error
+         (Printf.sprintf
+            "model entry %S field %S has unknown value %S (canonical: %s)"
+            entry_id
+            key
+            normalized
+            Capability_vocab.reasoning_streaming_format_syntax))
+;;
+
 let parse_entry entry_toml =
   match find_string_opt entry_toml [ "id_prefix" ] with
   | None -> Error "model entry missing required \"id_prefix\" field"
@@ -225,6 +244,12 @@ let parse_entry entry_toml =
            ~allowed:Capability_vocab.reasoning_output_format_values
            entry_toml
        in
+       let reasoning_streaming_format_result =
+         reasoning_streaming_format_opt
+           ~entry_id:id_prefix
+           "reasoning_streaming_format"
+           entry_toml
+       in
        let thinking_control_token_result =
          exact_non_empty_string_field
            ~entry_id:id_prefix
@@ -238,21 +263,24 @@ let parse_entry entry_toml =
           , thinking_control_format_result
           , preserve_thinking_control_format_result
           , reasoning_output_format_result
+          , reasoning_streaming_format_result
           , thinking_control_token_result )
         with
-        | (Error _ as e), _, _, _, _, _, _
-        | _, (Error _ as e), _, _, _, _, _
-        | _, _, (Error _ as e), _, _, _, _
-        | _, _, _, (Error _ as e), _, _, _
-        | _, _, _, _, (Error _ as e), _, _
-        | _, _, _, _, _, (Error _ as e), _
-        | _, _, _, _, _, _, (Error _ as e) -> e
+        | (Error _ as e), _, _, _, _, _, _, _
+        | _, (Error _ as e), _, _, _, _, _, _
+        | _, _, (Error _ as e), _, _, _, _, _
+        | _, _, _, (Error _ as e), _, _, _, _
+        | _, _, _, _, (Error _ as e), _, _, _
+        | _, _, _, _, _, (Error _ as e), _, _
+        | _, _, _, _, _, _, (Error _ as e), _
+        | _, _, _, _, _, _, _, (Error _ as e) -> e
         | ( Ok base_label
           , Ok provider_name
           , Ok modality_priority
           , Ok thinking_control_format
           , Ok preserve_thinking_control_format
           , Ok reasoning_output_format
+          , Ok reasoning_streaming_format
           , Ok thinking_control_token ) ->
           Ok
             { id_prefix
@@ -302,6 +330,7 @@ let parse_entry entry_toml =
             ; thinking_control_token
             ; preserve_thinking_control_format
             ; reasoning_output_format
+            ; reasoning_streaming_format
             ; reasoning_replay
             ; input_per_million = find_float_opt entry_toml [ "input_per_million" ]
             ; output_per_million = find_float_opt entry_toml [ "output_per_million" ]

--- a/lib/llm_provider/model_catalog.mli
+++ b/lib/llm_provider/model_catalog.mli
@@ -42,6 +42,7 @@ type model_entry =
   ; thinking_control_token : string option
   ; preserve_thinking_control_format : string option
   ; reasoning_output_format : string option
+  ; reasoning_streaming_format : string option
   ; reasoning_replay : string option
   ; input_per_million : float option
   ; output_per_million : float option

--- a/lib/llm_provider/provider_catalog.ml
+++ b/lib/llm_provider/provider_catalog.ml
@@ -287,6 +287,19 @@ let parse_reasoning_output_format = function
             (String.concat ", " Capability_vocab.reasoning_output_format_values)))
 ;;
 
+let parse_reasoning_streaming_format = function
+  | None -> Ok None
+  | Some raw ->
+    (match Capability_vocab.reasoning_streaming_format_of_string raw with
+     | Some format -> Ok (Some format)
+     | None ->
+       Error
+         (Printf.sprintf
+            "unknown reasoning_streaming_format %S (canonical: %s)"
+            (String.lowercase_ascii (String.trim raw))
+            Capability_vocab.reasoning_streaming_format_syntax))
+;;
+
 let member_supported_models json = member_string_list "supported_models" json
 
 let capability_base json =
@@ -349,6 +362,10 @@ let parse_capabilities provider_json =
   let* reasoning_output_format =
     let* raw = member_string_strict "reasoning_output_format" cap_json in
     parse_reasoning_output_format raw
+  in
+  let* reasoning_streaming_format =
+    let* raw = member_string_strict "reasoning_streaming_format" cap_json in
+    parse_reasoning_streaming_format raw
   in
   let caps =
     base
@@ -434,6 +451,11 @@ let parse_capabilities provider_json =
     |> fun caps ->
     (match reasoning_output_format with
      | Some reasoning_output_format -> { caps with Capabilities.reasoning_output_format }
+     | None -> caps)
+    |> fun caps ->
+    (match reasoning_streaming_format with
+     | Some reasoning_streaming_format ->
+       { caps with Capabilities.reasoning_streaming_format }
      | None -> caps)
     |> fun caps ->
     override_bool

--- a/lib/llm_provider/reasoning_dialect.ml
+++ b/lib/llm_provider/reasoning_dialect.ml
@@ -347,6 +347,12 @@ let request_control_fields
 
 let provider_capabilities_of_kind kind = Capabilities.capabilities_of_kind kind
 
+let with_endpoint_streaming_override (config : Provider_config.t) dialect =
+  match config.kind, Provider_config.capability_provider_label config with
+  | OpenAI_compat, "ollama_cloud" -> { dialect with streaming = Delta_field "reasoning" }
+  | (Anthropic | Kimi | OpenAI_compat | Ollama | Gemini | Glm | DashScope), _ -> dialect
+;;
+
 let for_provider_config (config : Provider_config.t) =
   match config.kind with
   | Anthropic ->
@@ -366,10 +372,12 @@ let for_provider_config (config : Provider_config.t) =
      | Some caps ->
        of_capabilities caps
        |> with_preserve_thinking ~preserve_thinking:config.preserve_thinking
+       |> with_endpoint_streaming_override config
      | None ->
        let caps = provider_capabilities_of_kind config.kind in
        of_capabilities caps
-       |> with_preserve_thinking ~preserve_thinking:config.preserve_thinking)
+       |> with_preserve_thinking ~preserve_thinking:config.preserve_thinking
+       |> with_endpoint_streaming_override config)
   | DashScope ->
     (* DashScope emits top-level enable_thinking/preserve_thinking regardless of
        the model catalog. Backend_openai_request.capabilities_of_config is

--- a/lib/llm_provider/reasoning_dialect.ml
+++ b/lib/llm_provider/reasoning_dialect.ml
@@ -165,7 +165,17 @@ let apply_replay_override caps dialect =
   | Force_preserve_always -> { dialect with replay_policy = Preserve_always }
 ;;
 
-let of_capabilities caps = base_of_capabilities caps |> apply_replay_override caps
+let apply_streaming_format caps dialect =
+  match caps.Capabilities.reasoning_streaming_format with
+  | Default_reasoning_streaming -> dialect
+  | No_reasoning_streaming -> { dialect with streaming = No_streaming_reasoning }
+  | Delta_reasoning_field field -> { dialect with streaming = Delta_field field }
+  | Template_reasoning_streaming -> { dialect with streaming = Template_parser }
+;;
+
+let of_capabilities caps =
+  base_of_capabilities caps |> apply_streaming_format caps |> apply_replay_override caps
+;;
 
 let with_preserve_thinking ~preserve_thinking dialect =
   match dialect.preserve_wire, preserve_thinking with
@@ -347,12 +357,6 @@ let request_control_fields
 
 let provider_capabilities_of_kind kind = Capabilities.capabilities_of_kind kind
 
-let with_endpoint_streaming_override (config : Provider_config.t) dialect =
-  match config.kind, Provider_config.capability_provider_label config with
-  | OpenAI_compat, "ollama_cloud" -> { dialect with streaming = Delta_field "reasoning" }
-  | (Anthropic | Kimi | OpenAI_compat | Ollama | Gemini | Glm | DashScope), _ -> dialect
-;;
-
 let for_provider_config (config : Provider_config.t) =
   match config.kind with
   | Anthropic ->
@@ -372,12 +376,10 @@ let for_provider_config (config : Provider_config.t) =
      | Some caps ->
        of_capabilities caps
        |> with_preserve_thinking ~preserve_thinking:config.preserve_thinking
-       |> with_endpoint_streaming_override config
      | None ->
        let caps = provider_capabilities_of_kind config.kind in
        of_capabilities caps
-       |> with_preserve_thinking ~preserve_thinking:config.preserve_thinking
-       |> with_endpoint_streaming_override config)
+       |> with_preserve_thinking ~preserve_thinking:config.preserve_thinking)
   | DashScope ->
     (* DashScope emits top-level enable_thinking/preserve_thinking regardless of
        the model catalog. Backend_openai_request.capabilities_of_config is

--- a/lib/provider.mli
+++ b/lib/provider.mli
@@ -87,6 +87,12 @@ type reasoning_output_format = Llm_provider.Capabilities.reasoning_output_format
   | No_reasoning_output_format
   | Split_reasoning_fields
 
+type reasoning_streaming_format = Llm_provider.Capabilities.reasoning_streaming_format =
+  | Default_reasoning_streaming
+  | No_reasoning_streaming
+  | Delta_reasoning_field of string
+  | Template_reasoning_streaming
+
 type capabilities =
   { max_context_tokens : int option
   ; max_output_tokens : int option
@@ -105,6 +111,7 @@ type capabilities =
   ; thinking_control_format : thinking_control_format
   ; preserve_thinking_control_format : preserve_thinking_control_format
   ; reasoning_output_format : reasoning_output_format
+  ; reasoning_streaming_format : reasoning_streaming_format
   ; reasoning_replay_override : reasoning_replay_override
   ; supports_response_format_json : bool
   ; supports_structured_output : bool

--- a/lib/provider_runtime_binding.ml
+++ b/lib/provider_runtime_binding.ml
@@ -91,6 +91,7 @@ let public_capabilities (caps : Llm_provider.Capabilities.capabilities)
   ; thinking_control_format = caps.thinking_control_format
   ; preserve_thinking_control_format = caps.preserve_thinking_control_format
   ; reasoning_output_format = caps.reasoning_output_format
+  ; reasoning_streaming_format = caps.reasoning_streaming_format
   ; reasoning_replay_override = caps.reasoning_replay_override
   ; supports_response_format_json = caps.supports_response_format_json
   ; supports_structured_output = caps.supports_structured_output

--- a/models.toml
+++ b/models.toml
@@ -709,6 +709,7 @@ supports_reasoning = true
 supports_extended_thinking = true
 supports_reasoning_budget = true
 thinking_control_format = "ollama_think"
+reasoning_streaming_format = "delta:reasoning"
 supports_multimodal_inputs = true
 supports_image_input = true
 modality_priority = "visual_first"

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -1125,7 +1125,7 @@ let test_frontier_grouped_tool_thinking_structured_models () =
       , Extended_thinking
       , Response_format_json_schema
       , Replay_not_required
-      , Delta_stream "thinking" )
+      , Delta_stream "reasoning" )
     ; ( "Ollama Cloud Nemotron 3 Ultra"
       , Provider_qualified "ollama_cloud"
       , "nemotron-3-ultra"
@@ -1515,6 +1515,23 @@ let test_manifest_accepts_reasoning_output_format () =
   | Error msg -> Alcotest.failf "unexpected parse error: %s" msg
 ;;
 
+let test_manifest_accepts_reasoning_streaming_format () =
+  let json =
+    Yojson.Safe.from_string
+      {|{"schema_version":1,"models":[{"id_prefix":"stream-manifest","reasoning_streaming_format":"delta:reasoning"}]}|}
+  in
+  match Capability_manifest.of_json json with
+  | Ok [ entry ] ->
+    let caps = Capabilities.apply_manifest_entry entry in
+    check
+      bool
+      "manifest delta reasoning stream"
+      true
+      (caps.reasoning_streaming_format = Capabilities.Delta_reasoning_field "reasoning")
+  | Ok _ -> Alcotest.fail "expected one manifest entry"
+  | Error msg -> Alcotest.failf "unexpected parse error: %s" msg
+;;
+
 let test_manifest_rejects_unknown_preserve_thinking_control_format () =
   let json =
     Yojson.Safe.from_string
@@ -1535,6 +1552,18 @@ let test_manifest_rejects_unknown_reasoning_output_format () =
     check_contains "mentions field" msg "reasoning_output_format";
     check_contains "mentions value" msg "split_thoughts"
   | Ok _ -> Alcotest.fail "unknown reasoning_output_format should reject"
+;;
+
+let test_manifest_rejects_unknown_reasoning_streaming_format () =
+  let json =
+    Yojson.Safe.from_string
+      {|{"schema_version":1,"models":[{"id_prefix":"bad-stream","reasoning_streaming_format":"delta:"}]}|}
+  in
+  match Capability_manifest.of_json json with
+  | Error msg ->
+    check_contains "mentions field" msg "reasoning_streaming_format";
+    check_contains "mentions value" msg "delta:"
+  | Ok _ -> Alcotest.fail "unknown reasoning_streaming_format should reject"
 ;;
 
 let test_manifest_rejects_unknown_reasoning_replay () =
@@ -1737,6 +1766,7 @@ let test_model_catalog_rejects_unknown_policy_strings () =
     [ "thinking_control_format", "mind_palace"
     ; "preserve_thinking_control_format", "memory_palace"
     ; "reasoning_output_format", "split_thoughts"
+    ; "reasoning_streaming_format", "delta:"
     ; "modality_priority", "image_only"
     ]
   in
@@ -2120,6 +2150,10 @@ let () =
             `Quick
             test_manifest_accepts_reasoning_output_format
         ; test_case
+            "reasoning_streaming_format accepted"
+            `Quick
+            test_manifest_accepts_reasoning_streaming_format
+        ; test_case
             "unknown preserve_thinking_control_format rejects"
             `Quick
             test_manifest_rejects_unknown_preserve_thinking_control_format
@@ -2127,6 +2161,10 @@ let () =
             "unknown reasoning_output_format rejects"
             `Quick
             test_manifest_rejects_unknown_reasoning_output_format
+        ; test_case
+            "unknown reasoning_streaming_format rejects"
+            `Quick
+            test_manifest_rejects_unknown_reasoning_streaming_format
         ; test_case
             "unknown reasoning_replay rejects"
             `Quick

--- a/test/test_thinking_control_dialects.ml
+++ b/test/test_thinking_control_dialects.ml
@@ -14,6 +14,7 @@ module CM = Llm_provider.Capability_manifest
 module MC = Llm_provider.Model_catalog
 module RD = Llm_provider.Reasoning_dialect
 module RE = Llm_provider.Reasoning_effort
+module S = Llm_provider.Streaming
 open Alcotest
 open Llm_provider.Types
 open Yojson.Safe.Util
@@ -430,6 +431,54 @@ let test_minimax_m3_openai_compat_uses_adaptive_thinking_object () =
     "replay policy"
     "preserve_always"
     (RD.replay_policy_to_string dialect.replay_policy)
+;;
+
+let test_ollama_cloud_openai_compat_streams_reasoning_delta () =
+  let config =
+    PC.make
+      ~kind:OpenAI_compat
+      ~model_id:"minimax-m3"
+      ~base_url:"https://ollama.com/v1"
+      ()
+  in
+  let dialect = RD.for_provider_config config in
+  (match dialect.streaming with
+   | RD.Delta_field "reasoning" -> ()
+   | RD.Delta_field field ->
+     fail
+       (Printf.sprintf
+          "ollama cloud OpenAI-compatible reasoning delta field drifted: %s"
+          field)
+   | RD.No_streaming_reasoning ->
+     fail "ollama cloud OpenAI-compatible reasoning stream field was dropped"
+   | RD.Template_parser ->
+     fail "ollama cloud OpenAI-compatible should not use template parser streaming");
+  let live_shape =
+    {|{"id":"chatcmpl-ollama-minimax","object":"chat.completion.chunk","created":1782812554,"model":"minimax-m3","system_fingerprint":"fp_ollama","choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":"9.9 is bigger."},"finish_reason":null}]}|}
+  in
+  let chunk =
+    match S.parse_openai_sse_chunk ~streaming_reasoning:dialect.streaming live_shape with
+    | Some chunk -> chunk
+    | None -> fail "expected Ollama Cloud OpenAI-compatible reasoning chunk"
+  in
+  check
+    (option string)
+    "delta.reasoning parsed"
+    (Some "9.9 is bigger.")
+    chunk.delta_reasoning;
+  let events, _telemetry =
+    S.openai_chunk_to_events
+      (S.create_openai_stream_state
+         ~provider:"ollama_cloud_openai"
+         ~model:"minimax-m3"
+         ())
+      chunk
+  in
+  match events with
+  | [ ContentBlockStart { content_type = "thinking"; _ }
+    ; ContentBlockDelta { delta = ThinkingDelta "9.9 is bigger."; _ }
+    ] -> ()
+  | _ -> fail "expected delta.reasoning to emit thinking block events, not visible text"
 ;;
 
 let test_deepseek_reasoning_dialect_semantics () =
@@ -977,6 +1026,10 @@ let () =
               "minimax m3 uses adaptive thinking object"
               `Quick
               test_minimax_m3_openai_compat_uses_adaptive_thinking_object
+          ; test_case
+              "ollama cloud openai-compat streams reasoning delta"
+              `Quick
+              test_ollama_cloud_openai_compat_streams_reasoning_delta
           ; test_case
               "deepseek reasoning dialect semantics"
               `Quick

--- a/test/test_thinking_control_dialects.ml
+++ b/test/test_thinking_control_dialects.ml
@@ -441,6 +441,21 @@ let test_ollama_cloud_openai_compat_streams_reasoning_delta () =
       ~base_url:"https://ollama.com/v1"
       ()
   in
+  let caps =
+    match PC.capabilities_for_config_model config with
+    | Some caps -> caps
+    | None -> fail "expected Ollama Cloud MiniMax-M3 catalog capabilities"
+  in
+  (match caps.CAP.reasoning_streaming_format with
+   | CAP.Delta_reasoning_field "reasoning" -> ()
+   | CAP.Delta_reasoning_field field ->
+     fail (Printf.sprintf "unexpected catalog reasoning stream field: %s" field)
+   | CAP.Default_reasoning_streaming ->
+     fail "catalog reasoning stream override was not applied"
+   | CAP.No_reasoning_streaming ->
+     fail "catalog reasoning stream override disabled streaming"
+   | CAP.Template_reasoning_streaming ->
+     fail "catalog reasoning stream override selected template parser");
   let dialect = RD.for_provider_config config in
   (match dialect.streaming with
    | RD.Delta_field "reasoning" -> ()


### PR DESCRIPTION
## Summary
- Endpoint-qualified Ollama Cloud OpenAI-compatible streams now use `delta.reasoning` for reasoning tokens, based on live `/v1/chat/completions` capture.
- Native Ollama `/api/chat` remains on `message.thinking`; direct MiniMax official Chat remains on the split-field path added in #2339.
- Adds a regression proving `delta.reasoning` is emitted as typed `ThinkingDelta`, not visible `TextDelta`.
- Does not claim `think:false` works on Ollama Cloud MiniMax; live probe showed reasoning still returned.

## Evidence
- [근거] MiniMax Chat docs: https://platform.minimax.io/docs/api-reference/text-chat-openai.md, checked 2026-06-30 KST, confidence High for `thinking` / `reasoning_split` sync fields; Medium for streaming split fields because the documented streaming chunk schema only shows `delta.content`.
- [근거] Ollama Thinking docs: https://docs.ollama.com/capabilities/thinking.md, checked 2026-06-30 KST, confidence High for native `/api/chat` `think` and `message.thinking`.
- [근거] Live Ollama Cloud `/v1/chat/completions` probe on this machine, checked 2026-06-30 KST, confidence High for current `minimax-m3` OpenAI-compatible wire shape: streaming chunks contained `delta.reasoning`; `think:false` and `thinking:{"type":"disabled"}` still returned reasoning, so this PR only preserves typed stream reasoning.

## Validation
- `ocamlformat --check lib/llm_provider/reasoning_dialect.ml test/test_thinking_control_dialects.ml`
- `git diff --check HEAD~1..HEAD`
- `scripts/dune-local.sh build test/test_thinking_control_dialects.exe` was attempted twice but blocked waiting on the shared `/tmp/me-dune-local.lock`; CI is the build authority for this branch.