### PR TITLE
fix(streaming): preserve MiniMax split reasoning details

### DIFF
--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -527,6 +527,7 @@ let complete_stream_http
         | Types.ContentBlockDelta { delta = TextDelta _; _ } -> `Answer
         | Types.ContentBlockDelta { delta = MediaDelta _; _ } -> `Answer
         | Types.ContentBlockDelta { delta = ThinkingDelta _; _ } -> `Thinking
+        | Types.ContentBlockDelta { delta = ReasoningDetailsDelta _; _ } -> `Thinking
         | Types.ContentBlockDelta { delta = ThinkingSignatureDelta _; _ } -> `Substrate
         | Types.ContentBlockDelta { delta = InputJsonDelta _ | InputJsonSnapshot _; _ } ->
           `Tool_call_arg_delta

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -27,6 +27,7 @@ type stream_acc =
   ; block_tool_ids : (int, string) Hashtbl.t
   ; block_tool_names : (int, string) Hashtbl.t
   ; block_thinking_signatures : (int, Buffer.t) Hashtbl.t
+  ; block_reasoning_details : (int, Types.reasoning_detail list ref) Hashtbl.t
   ; block_media_types : (int, string) Hashtbl.t
     (** Per-block media MIME type from {!Types.MediaDelta}. *)
   ; block_media_sources : (int, Types.media_source_kind) Hashtbl.t
@@ -50,6 +51,7 @@ let create_stream_acc () =
   ; block_tool_ids = Hashtbl.create 4
   ; block_tool_names = Hashtbl.create 4
   ; block_thinking_signatures = Hashtbl.create 4
+  ; block_reasoning_details = Hashtbl.create 4
   ; block_media_types = Hashtbl.create 4
   ; block_media_sources = Hashtbl.create 4
   }
@@ -116,6 +118,19 @@ let accumulate_event (acc : stream_acc) = function
          Buffer.clear buf;
          Buffer.add_string buf s)
        else Buffer.add_string buf s
+     | Types.ReasoningDetailsDelta { reasoning_content; details } ->
+       (match reasoning_content with
+        | Some content -> Buffer.add_string buf content
+        | None -> ());
+       let details_ref =
+         match Hashtbl.find_opt acc.block_reasoning_details index with
+         | Some details_ref -> details_ref
+         | None ->
+           let details_ref = ref [] in
+           Hashtbl.replace acc.block_reasoning_details index details_ref;
+           details_ref
+       in
+       details_ref := List.rev_append details !details_ref
      | Types.InputJsonSnapshot s ->
        (* A complete tool-call arguments value replaces the block buffer rather
           than appending, so a provider that re-emits the same whole value over
@@ -185,6 +200,7 @@ let accumulate_event (acc : stream_acc) = function
 type block_kind =
   | Text_block
   | Thinking_block
+  | Reasoning_details_block
   | Redacted_thinking_block
   | Tool_use_block
   | Tool_result_block of { is_error : bool }
@@ -196,6 +212,7 @@ type block_kind =
 let block_kind_of_string = function
   | "text" -> Text_block
   | "thinking" -> Thinking_block
+  | "reasoning_details" -> Reasoning_details_block
   | "redacted_thinking" -> Redacted_thinking_block
   | "tool_use" -> Tool_use_block
   | "tool_result" -> Tool_result_block { is_error = false }
@@ -263,6 +280,17 @@ let finalize_stream_acc (acc : stream_acc) =
           | Some _ | None -> None
         in
         Ok (Some (Types.Thinking { content = text; signature }))
+      | Some Reasoning_details_block ->
+        let details =
+          match Hashtbl.find_opt acc.block_reasoning_details idx with
+          | Some details_ref -> List.rev !details_ref
+          | None -> []
+        in
+        let reasoning_content = if String.trim text = "" then None else Some text in
+        (match reasoning_content, details with
+         | None, [] -> Ok None
+         | Some _, _ | None, _ :: _ ->
+           Ok (Some (Types.ReasoningDetails { reasoning_content; details })))
       | Some Redacted_thinking_block ->
         (match Hashtbl.find_opt acc.block_tool_ids idx with
          | Some data when data <> "" -> Ok (Some (Types.RedactedThinking data))

--- a/lib/llm_provider/complete_stream_acc.mli
+++ b/lib/llm_provider/complete_stream_acc.mli
@@ -33,6 +33,7 @@ type stream_acc =
   ; block_tool_ids : (int, string) Hashtbl.t
   ; block_tool_names : (int, string) Hashtbl.t
   ; block_thinking_signatures : (int, Buffer.t) Hashtbl.t
+  ; block_reasoning_details : (int, Types.reasoning_detail list ref) Hashtbl.t
   ; block_media_types : (int, string) Hashtbl.t
     (** Per-block media MIME type from {!Types.MediaDelta}; payload is in
         {!block_texts}. *)

--- a/lib/llm_provider/reasoning_dialect.ml
+++ b/lib/llm_provider/reasoning_dialect.ml
@@ -35,6 +35,7 @@ type replay_policy =
 type streaming_reasoning =
   | No_streaming_reasoning
   | Delta_field of string
+  | Delta_reasoning_details
   | Template_parser
 
 type output_wire =
@@ -108,7 +109,10 @@ let base_of_capabilities (caps : Capabilities.capabilities) =
       toggle_default = Enabled
     ; toggle_wire = Thinking_object_adaptive
     ; preserve_wire
-    ; streaming = Delta_field "reasoning_content"
+    ; streaming =
+        (match output_wire with
+         | Reasoning_split -> Delta_reasoning_details
+         | No_output_control -> Delta_field "reasoning_content")
     ; output_wire
     }
   | Thinking_object_only ->

--- a/lib/llm_provider/reasoning_dialect.mli
+++ b/lib/llm_provider/reasoning_dialect.mli
@@ -45,6 +45,7 @@ type replay_policy =
 type streaming_reasoning =
   | No_streaming_reasoning
   | Delta_field of string
+  | Delta_reasoning_details
   | Template_parser
 
 type output_wire =

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -142,6 +142,11 @@ let sse_event_is_first_token_signal (e : sse_event) : bool =
   match e with
   | ContentBlockDelta { delta = TextDelta s; _ } -> non_empty s
   | ContentBlockDelta { delta = ThinkingDelta s; _ } -> non_empty s
+  | ContentBlockDelta { delta = ReasoningDetailsDelta { reasoning_content; details }; _ }
+    ->
+    (match reasoning_content with
+     | Some s when non_empty s -> true
+     | Some _ | None -> details <> [])
   | ContentBlockDelta { delta = InputJsonDelta s | InputJsonSnapshot s; _ } -> non_empty s
   | ContentBlockDelta { delta = MediaDelta { data; _ }; _ } -> non_empty data
   | ContentBlockDelta { delta = ThinkingSignatureDelta _; _ } -> false
@@ -168,6 +173,7 @@ let sse_event_is_deliverable_progress_signal (e : sse_event) : bool =
   | ContentBlockStart { content_type = "tool_use"; _ } -> true
   | ContentBlockDelta { delta = ThinkingSignatureDelta _; _ }
   | ContentBlockDelta { delta = ThinkingDelta _; _ }
+  | ContentBlockDelta { delta = ReasoningDetailsDelta _; _ }
   | MessageStart _
   | ContentBlockStart _
   | ContentBlockStop _
@@ -197,7 +203,7 @@ let emit_synthetic_events (response : api_response) on_event =
          match block with
          | Text _ -> "text", None, None
          | Thinking _ -> "thinking", None, None
-         | ReasoningDetails _ -> "thinking", None, None
+         | ReasoningDetails _ -> "reasoning_details", None, None
          | ToolUse { id; name; _ } -> "tool_use", Some id, Some name
          | Image _ -> "image", None, None
          | Document _ -> "document", None, None
@@ -215,16 +221,9 @@ let emit_synthetic_events (response : api_response) on_event =
              on_event (ContentBlockDelta { index; delta = ThinkingSignatureDelta s })
            | None -> ())
         | ReasoningDetails { reasoning_content; details } ->
-          let content =
-            match reasoning_content with
-            | Some content -> content
-            | None ->
-              details
-              |> List.filter_map (fun (detail : reasoning_detail) -> detail.text)
-              |> String.concat ""
-          in
-          if content <> ""
-          then on_event (ContentBlockDelta { index; delta = ThinkingDelta content })
+          on_event
+            (ContentBlockDelta
+               { index; delta = ReasoningDetailsDelta { reasoning_content; details } })
         | ToolUse { input; _ } ->
           on_event
             (ContentBlockDelta
@@ -300,14 +299,26 @@ type openai_tool_call_delta =
   ; tc_arguments : tool_call_arguments option
   }
 
+type openai_reasoning_details_delta =
+  { delta_reasoning_content : string option
+  ; delta_details : reasoning_detail list
+  }
+
+type openai_chunk_parse_error =
+  { reason : string
+  ; raw : string
+  }
+
 type openai_chunk =
   { chunk_id : string
   ; chunk_model : string
   ; delta_content : string option
   ; delta_reasoning : string option
+  ; delta_reasoning_details : openai_reasoning_details_delta option
   ; delta_tool_calls : openai_tool_call_delta list
   ; finish_reason : string option
   ; chunk_usage : api_usage option
+  ; chunk_parse_error : openai_chunk_parse_error option
   }
 
 (* RFC-OAS-020: TTFT classification for OpenAI-compat / Gemini /
@@ -320,8 +331,14 @@ let chunk_has_non_empty_delta (c : openai_chunk) : bool =
     | Some s -> String.length s > 0
     | None -> false
   in
+  let non_empty_reasoning_details = function
+    | Some { delta_reasoning_content; delta_details } ->
+      non_empty_opt delta_reasoning_content || delta_details <> []
+    | None -> false
+  in
   non_empty_opt c.delta_content
   || non_empty_opt c.delta_reasoning
+  || non_empty_reasoning_details c.delta_reasoning_details
   || c.delta_tool_calls <> []
 ;;
 
@@ -330,6 +347,74 @@ let chunk_has_non_empty_delta (c : openai_chunk) : bool =
    for the sentinel shared by the chunk parser, the terminal-event helper, and
    the Responses-API trailer. *)
 let openai_done_sentinel = "[DONE]"
+
+let string_contains_substring ~needle haystack =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  if needle_len = 0
+  then true
+  else if needle_len > haystack_len
+  then false
+  else (
+    let last_start = haystack_len - needle_len in
+    let rec loop i =
+      if i > last_start
+      then false
+      else if String.sub haystack i needle_len = needle
+      then true
+      else loop (i + 1)
+    in
+    loop 0)
+;;
+
+let contains_inline_thinking_tag text =
+  let lower = String.lowercase_ascii text in
+  string_contains_substring ~needle:"<think" lower
+  || string_contains_substring ~needle:"<mm:think" lower
+;;
+
+let assoc_field_opt name = function
+  | `Assoc fields -> List.assoc_opt name fields
+  | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> None
+;;
+
+let non_blank_json_string = function
+  | `String s when String.trim s <> "" -> Ok (Some s)
+  | `String _ -> Ok None
+  | `Null -> Ok None
+  | `Assoc _ | `List _ | `Int _ | `Intlit _ | `Float _ | `Bool _ -> Error "not_string"
+;;
+
+let parse_stream_reasoning_detail ~index = function
+  | `Assoc fields as raw ->
+    let text =
+      match List.assoc_opt "text" fields with
+      | Some (`String s) when String.trim s <> "" -> Some s
+      | Some (`String _)
+      | Some (`Assoc _ | `List _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null)
+      | None -> None
+    in
+    Ok { raw; text }
+  | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null ->
+    Error (Printf.sprintf "malformed_delta_reasoning_details:index:%d:not_object" index)
+;;
+
+let parse_stream_reasoning_details = function
+  | None -> Ok None
+  | Some `Null -> Ok None
+  | Some (`List []) -> Ok None
+  | Some (`List details) ->
+    let rec loop index acc = function
+      | [] -> Ok (Some (List.rev acc))
+      | detail :: rest ->
+        (match parse_stream_reasoning_detail ~index detail with
+         | Ok parsed -> loop (index + 1) (parsed :: acc) rest
+         | Error _ as error -> error)
+    in
+    loop 0 [] details
+  | Some (`Assoc _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _) ->
+    Error "malformed_delta_reasoning_details:not_list"
+;;
 
 (** Parse a single Openai SSE data payload into an {!openai_chunk}.
     Returns [None] for the {!openai_done_sentinel} ("[DONE]") or unparseable
@@ -387,9 +472,11 @@ let parse_openai_sse_chunk ?streaming_reasoning data_str : openai_chunk option =
              ; chunk_model
              ; delta_content = None
              ; delta_reasoning = None
+             ; delta_reasoning_details = None
              ; delta_tool_calls = []
              ; finish_reason = None
              ; chunk_usage
+             ; chunk_parse_error = None
              }
          | None -> None)
       | choice :: _ ->
@@ -400,16 +487,54 @@ let parse_openai_sse_chunk ?streaming_reasoning data_str : openai_chunk option =
           | Some s when String.trim s <> "" -> Some s
           | Some _ | None -> None
         in
-        let delta_reasoning =
+        let delta_reasoning, delta_reasoning_details, chunk_parse_error =
           match streaming_reasoning with
-          | Some (Reasoning_dialect.Delta_field field) -> non_blank_delta_field field
+          | Some Reasoning_dialect.Delta_reasoning_details ->
+            let reasoning_content_result =
+              match assoc_field_opt "reasoning_content" delta with
+              | None -> Ok None
+              | Some value ->
+                (match non_blank_json_string value with
+                 | Ok _ as ok -> ok
+                 | Error _ -> Error "malformed_delta_reasoning_content:not_string")
+            in
+            let details_result =
+              parse_stream_reasoning_details (assoc_field_opt "reasoning_details" delta)
+            in
+            let split_result =
+              match reasoning_content_result, details_result with
+              | Ok reasoning_content, Ok details ->
+                let inline_thinking =
+                  match delta_content with
+                  | Some text -> contains_inline_thinking_tag text
+                  | None -> false
+                in
+                if inline_thinking
+                then Error "inline_thinking_in_split_stream_content"
+                else (
+                  match reasoning_content, details with
+                  | None, None -> Ok None
+                  | Some _, None | _, Some _ ->
+                    Ok
+                      (Some
+                         { delta_reasoning_content = reasoning_content
+                         ; delta_details = Option.value details ~default:[]
+                         }))
+              | Error reason, Ok _ | Ok _, Error reason | Error reason, Error _ ->
+                Error reason
+            in
+            (match split_result with
+             | Ok details -> None, details, None
+             | Error reason -> None, None, Some { reason; raw = data_str })
+          | Some (Reasoning_dialect.Delta_field field) ->
+            non_blank_delta_field field, None, None
           | Some
               ( Reasoning_dialect.No_streaming_reasoning
-              | Reasoning_dialect.Template_parser ) -> None
+              | Reasoning_dialect.Template_parser ) -> None, None, None
           | None ->
             (match non_blank_delta_field "reasoning_content" with
-             | Some _ as reasoning -> reasoning
-             | None -> delta |> member "reasoning" |> to_string_option)
+             | Some _ as reasoning -> reasoning, None, None
+             | None -> delta |> member "reasoning" |> to_string_option, None, None)
         in
         let delta_tool_calls =
           match delta |> member "tool_calls" with
@@ -449,9 +574,11 @@ let parse_openai_sse_chunk ?streaming_reasoning data_str : openai_chunk option =
           ; chunk_model
           ; delta_content
           ; delta_reasoning
+          ; delta_reasoning_details
           ; delta_tool_calls
           ; finish_reason
           ; chunk_usage
+          ; chunk_parse_error
           }
     with
     | Yojson.Safe.Util.Type_error _
@@ -550,102 +677,130 @@ let openai_chunk_to_events (state : openai_stream_state) (chunk : openai_chunk)
   let events = ref [] in
   let emit evt = events := evt :: !events in
   let telemetry_event = ref None in
-  (* Reasoning content delta — emitted before text *)
-  (match chunk.delta_reasoning with
-   | Some text when text <> "" ->
-     (match state.thinking_state with
-      | Not_thinking -> state.thinking_state <- Thinking_started (Unix.gettimeofday ())
-      | Thinking_started _ | Thinking_done ->
-        (* Already started, or model is re-emitting reasoning after a
+  match chunk.chunk_parse_error with
+  | Some { reason; raw } -> [ SSEParseFailed { reason; raw } ], None
+  | None ->
+    (* Reasoning content delta — emitted before text *)
+    (match chunk.delta_reasoning with
+     | Some text when text <> "" ->
+       (match state.thinking_state with
+        | Not_thinking -> state.thinking_state <- Thinking_started (Unix.gettimeofday ())
+        | Thinking_started _ | Thinking_done ->
+          (* Already started, or model is re-emitting reasoning after a
            closure — keep current state. Enumerated explicitly so adding
            a new [thinking_state] variant forces review of how it should
            react to a fresh reasoning chunk. *)
-        ());
-     if not state.thinking_block_started
-     then (
-       state.thinking_block_index <- state.next_block_index;
+          ());
+       if not state.thinking_block_started
+       then (
+         state.thinking_block_index <- state.next_block_index;
+         emit
+           (ContentBlockStart
+              { index = state.next_block_index
+              ; content_type = "thinking"
+              ; tool_id = None
+              ; tool_name = None
+              });
+         state.thinking_block_started <- true;
+         state.next_block_index <- state.next_block_index + 1);
        emit
-         (ContentBlockStart
-            { index = state.next_block_index
-            ; content_type = "thinking"
-            ; tool_id = None
-            ; tool_name = None
-            });
-       state.thinking_block_started <- true;
-       state.next_block_index <- state.next_block_index + 1);
-     emit
-       (ContentBlockDelta
-          { index = state.thinking_block_index; delta = ThinkingDelta text })
-   | Some "" ->
-     (match state.thinking_state with
-      | Thinking_started t0 ->
-        let thinking_duration_ms = (Unix.gettimeofday () -. t0) *. 1000.0 in
-        state.thinking_state <- Thinking_done;
-        telemetry_event
-        := Some
-             (Telemetry_event.Thinking_complete
-                { provider = state.provider; model = state.model; thinking_duration_ms })
-      | Not_thinking | Thinking_done ->
-        (* Empty reasoning chunk while never started, or after a prior
+         (ContentBlockDelta
+            { index = state.thinking_block_index; delta = ThinkingDelta text })
+     | Some "" ->
+       (match state.thinking_state with
+        | Thinking_started t0 ->
+          let thinking_duration_ms = (Unix.gettimeofday () -. t0) *. 1000.0 in
+          state.thinking_state <- Thinking_done;
+          telemetry_event
+          := Some
+               (Telemetry_event.Thinking_complete
+                  { provider = state.provider; model = state.model; thinking_duration_ms })
+        | Not_thinking | Thinking_done ->
+          (* Empty reasoning chunk while never started, or after a prior
            close — no telemetry to emit. Enumerated explicitly so a new
            [thinking_state] variant cannot silently inherit the no-op. *)
-        ())
-   | Some empty_reasoning ->
-     let (_ : string) = empty_reasoning in
-     ()
-   | None -> ());
-  (* Text content delta *)
-  (match chunk.delta_content with
-   | Some text when text <> "" ->
-     if not state.text_block_started
-     then (
-       state.text_block_index <- state.next_block_index;
+          ())
+     | Some empty_reasoning ->
+       let (_ : string) = empty_reasoning in
+       ()
+     | None -> ());
+    (match chunk.delta_reasoning_details with
+     | Some { delta_reasoning_content; delta_details } ->
+       (match state.thinking_state with
+        | Not_thinking -> state.thinking_state <- Thinking_started (Unix.gettimeofday ())
+        | Thinking_started _ | Thinking_done -> ());
+       if not state.thinking_block_started
+       then (
+         state.thinking_block_index <- state.next_block_index;
+         emit
+           (ContentBlockStart
+              { index = state.next_block_index
+              ; content_type = "reasoning_details"
+              ; tool_id = None
+              ; tool_name = None
+              });
+         state.thinking_block_started <- true;
+         state.next_block_index <- state.next_block_index + 1);
        emit
-         (ContentBlockStart
-            { index = state.next_block_index
-            ; content_type = "text"
-            ; tool_id = None
-            ; tool_name = None
-            });
-       state.text_block_started <- true;
-       state.next_block_index <- state.next_block_index + 1);
-     emit (ContentBlockDelta { index = state.text_block_index; delta = TextDelta text })
-   | Some empty_text ->
-     let (_ : string) = empty_text in
-     ()
-   | None -> ());
-  (* Tool call deltas *)
-  List.iter
-    (fun (tc : openai_tool_call_delta) ->
-       let block_idx =
-         match Hashtbl.find_opt state.tool_block_indices tc.tc_index with
-         | Some idx -> idx
-         | None ->
-           let idx = state.next_block_index in
-           Hashtbl.replace state.tool_block_indices tc.tc_index idx;
-           emit
-             (ContentBlockStart
-                { index = idx
-                ; content_type = "tool_use"
-                ; tool_id = tc.tc_id
-                ; tool_name = tc.tc_name
-                });
-           state.next_block_index <- state.next_block_index + 1;
-           idx
-       in
-       match tc.tc_arguments with
-       | Some (Args_fragment args) when args <> "" ->
-         emit (ContentBlockDelta { index = block_idx; delta = InputJsonDelta args })
-       | Some (Args_complete args) when args <> "" ->
-         emit (ContentBlockDelta { index = block_idx; delta = InputJsonSnapshot args })
-       | Some (Args_fragment _ | Args_complete _) -> ()
-       | None -> ())
-    chunk.delta_tool_calls;
-  (* Finish reason -> MessageDelta *)
-  (match chunk.finish_reason with
-   | Some reason ->
-     let stop_reason =
-       (* OpenAI wire vocabulary -> PROVISIONAL stop_reason. The accumulated
+         (ContentBlockDelta
+            { index = state.thinking_block_index
+            ; delta =
+                ReasoningDetailsDelta
+                  { reasoning_content = delta_reasoning_content; details = delta_details }
+            })
+     | None -> ());
+    (* Text content delta *)
+    (match chunk.delta_content with
+     | Some text when text <> "" ->
+       if not state.text_block_started
+       then (
+         state.text_block_index <- state.next_block_index;
+         emit
+           (ContentBlockStart
+              { index = state.next_block_index
+              ; content_type = "text"
+              ; tool_id = None
+              ; tool_name = None
+              });
+         state.text_block_started <- true;
+         state.next_block_index <- state.next_block_index + 1);
+       emit (ContentBlockDelta { index = state.text_block_index; delta = TextDelta text })
+     | Some empty_text ->
+       let (_ : string) = empty_text in
+       ()
+     | None -> ());
+    (* Tool call deltas *)
+    List.iter
+      (fun (tc : openai_tool_call_delta) ->
+         let block_idx =
+           match Hashtbl.find_opt state.tool_block_indices tc.tc_index with
+           | Some idx -> idx
+           | None ->
+             let idx = state.next_block_index in
+             Hashtbl.replace state.tool_block_indices tc.tc_index idx;
+             emit
+               (ContentBlockStart
+                  { index = idx
+                  ; content_type = "tool_use"
+                  ; tool_id = tc.tc_id
+                  ; tool_name = tc.tc_name
+                  });
+             state.next_block_index <- state.next_block_index + 1;
+             idx
+         in
+         match tc.tc_arguments with
+         | Some (Args_fragment args) when args <> "" ->
+           emit (ContentBlockDelta { index = block_idx; delta = InputJsonDelta args })
+         | Some (Args_complete args) when args <> "" ->
+           emit (ContentBlockDelta { index = block_idx; delta = InputJsonSnapshot args })
+         | Some (Args_fragment _ | Args_complete _) -> ()
+         | None -> ())
+      chunk.delta_tool_calls;
+    (* Finish reason -> MessageDelta *)
+    (match chunk.finish_reason with
+     | Some reason ->
+       let stop_reason =
+         (* OpenAI wire vocabulary -> PROVISIONAL stop_reason. The accumulated
           tool-block set is unknown at the chunk boundary (tool arguments arrive
           as deltas before this terminal chunk), so a "tool_calls" finish is
           recorded as a provisional StopToolUse and reconciled against the
@@ -653,20 +808,20 @@ let openai_chunk_to_events (state : openai_stream_state) (chunk : openai_chunk)
           (Stop_reason_wire.reconcile). SSOT: the wire vocabulary lives in
           Stop_reason_wire, not in an unguarded chunk-level match.
           "content_filter" stays Unknown — a moderation cutoff, not a refusal. *)
-       Stop_reason_wire.provisional_of_string reason
-     in
-     emit (MessageDelta { stop_reason = Some stop_reason; usage = chunk.chunk_usage })
-   | None ->
-     (* With stream_options.include_usage the provider sends token totals in a
+         Stop_reason_wire.provisional_of_string reason
+       in
+       emit (MessageDelta { stop_reason = Some stop_reason; usage = chunk.chunk_usage })
+     | None ->
+       (* With stream_options.include_usage the provider sends token totals in a
         separate final chunk that has no finish_reason and an empty choices
         array (hence no content/tool deltas). Emit a MessageDelta carrying only
         the usage so the accumulator records it. The finish_reason branch above
         already forwards usage when a stop arrives in the same chunk, so the two
         paths are mutually exclusive and usage is never emitted twice. *)
-     (match chunk.chunk_usage with
-      | Some _ -> emit (MessageDelta { stop_reason = None; usage = chunk.chunk_usage })
-      | None -> ()));
-  List.rev !events, !telemetry_event
+       (match chunk.chunk_usage with
+        | Some _ -> emit (MessageDelta { stop_reason = None; usage = chunk.chunk_usage })
+        | None -> ()));
+    List.rev !events, !telemetry_event
 ;;
 
 (** {1 OpenAI Responses API SSE Streaming}

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -348,31 +348,6 @@ let chunk_has_non_empty_delta (c : openai_chunk) : bool =
    the Responses-API trailer. *)
 let openai_done_sentinel = "[DONE]"
 
-let string_contains_substring ~needle haystack =
-  let needle_len = String.length needle in
-  let haystack_len = String.length haystack in
-  if needle_len = 0
-  then true
-  else if needle_len > haystack_len
-  then false
-  else (
-    let last_start = haystack_len - needle_len in
-    let rec loop i =
-      if i > last_start
-      then false
-      else if String.sub haystack i needle_len = needle
-      then true
-      else loop (i + 1)
-    in
-    loop 0)
-;;
-
-let contains_inline_thinking_tag text =
-  let lower = String.lowercase_ascii text in
-  string_contains_substring ~needle:"<think" lower
-  || string_contains_substring ~needle:"<mm:think" lower
-;;
-
 let assoc_field_opt name = function
   | `Assoc fields -> List.assoc_opt name fields
   | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> None
@@ -504,22 +479,14 @@ let parse_openai_sse_chunk ?streaming_reasoning data_str : openai_chunk option =
             let split_result =
               match reasoning_content_result, details_result with
               | Ok reasoning_content, Ok details ->
-                let inline_thinking =
-                  match delta_content with
-                  | Some text -> contains_inline_thinking_tag text
-                  | None -> false
-                in
-                if inline_thinking
-                then Error "inline_thinking_in_split_stream_content"
-                else (
-                  match reasoning_content, details with
-                  | None, None -> Ok None
-                  | Some _, None | _, Some _ ->
-                    Ok
-                      (Some
-                         { delta_reasoning_content = reasoning_content
-                         ; delta_details = Option.value details ~default:[]
-                         }))
+                (match reasoning_content, details with
+                 | None, None -> Ok None
+                 | Some _, None | _, Some _ ->
+                   Ok
+                     (Some
+                        { delta_reasoning_content = reasoning_content
+                        ; delta_details = Option.value details ~default:[]
+                        }))
               | Error reason, Ok _ | Ok _, Error reason | Error reason, Error _ ->
                 Error reason
             in

--- a/lib/llm_provider/streaming.mli
+++ b/lib/llm_provider/streaming.mli
@@ -21,11 +21,11 @@ val emit_synthetic_events : api_response -> (sse_event -> unit) -> unit
 
 (** [true] when the SSE event represents the first generated
     token delta. That means a [ContentBlockDelta] carrying a
-    non-empty [TextDelta] / [ThinkingDelta] / [InputJsonDelta] /
-    [InputJsonSnapshot] payload. Prelude events ([MessageStart],
-    [ContentBlockStart], [ThinkingSignatureDelta] carriers,
-    [Ping]), terminator events ([MessageStop], [MessageDelta] with
-    no usage), and error events return [false].
+    non-empty [TextDelta] / [ThinkingDelta] / [ReasoningDetailsDelta] /
+    [InputJsonDelta] / [InputJsonSnapshot] payload. Prelude events
+    ([MessageStart], [ContentBlockStart], [ThinkingSignatureDelta] carriers,
+    [Ping]), terminator events ([MessageStop], [MessageDelta] with no usage),
+    and error events return [false].
 
     @stability Internal *)
 val sse_event_is_first_token_signal : sse_event -> bool
@@ -33,9 +33,9 @@ val sse_event_is_first_token_signal : sse_event -> bool
 (** [true] when the SSE event represents progress that a downstream
     application can act on without exposing model-private reasoning:
     non-empty text, non-empty tool-call JSON, or a tool-use block start.
-    Thinking deltas intentionally return [false]. Complete uses this to
-    distinguish "the model is generating hidden reasoning" from "the
-    stream has produced a deliverable answer/tool signal".
+    Thinking/reasoning details deltas intentionally return [false]. Complete
+    uses this to distinguish "the model is generating hidden reasoning" from
+    "the stream has produced a deliverable answer/tool signal".
 
     @stability Internal
     @since 0.205.12 *)
@@ -71,14 +71,26 @@ type openai_tool_call_delta =
   ; tc_arguments : tool_call_arguments option
   }
 
+type openai_reasoning_details_delta =
+  { delta_reasoning_content : string option
+  ; delta_details : reasoning_detail list
+  }
+
+type openai_chunk_parse_error =
+  { reason : string
+  ; raw : string
+  }
+
 type openai_chunk =
   { chunk_id : string
   ; chunk_model : string
   ; delta_content : string option
   ; delta_reasoning : string option
+  ; delta_reasoning_details : openai_reasoning_details_delta option
   ; delta_tool_calls : openai_tool_call_delta list
   ; finish_reason : string option
   ; chunk_usage : api_usage option
+  ; chunk_parse_error : openai_chunk_parse_error option
   }
 
 type thinking_state =

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -459,6 +459,10 @@ type content_delta =
   | TextDelta of string
   | ThinkingDelta of string
   | ThinkingSignatureDelta of string
+  | ReasoningDetailsDelta of
+      { reasoning_content : string option
+      ; details : reasoning_detail list
+      }
   | InputJsonDelta of string
   (** Incremental fragment of a tool-call arguments JSON string. The
           accumulator appends successive fragments to the block buffer. *)

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -276,6 +276,10 @@ type content_delta =
   | TextDelta of string
   | ThinkingDelta of string
   | ThinkingSignatureDelta of string
+  | ReasoningDetailsDelta of
+      { reasoning_content : string option
+      ; details : reasoning_detail list
+      }
   | InputJsonDelta of string
   (** Incremental fragment of a tool-call arguments JSON string. The
           accumulator appends successive fragments to the block buffer. *)

--- a/lib/streaming.ml
+++ b/lib/streaming.ml
@@ -30,6 +30,7 @@ type stream_acc = Llm_provider.Complete_stream_acc.stream_acc =
   ; block_tool_ids : (int, string) Hashtbl.t
   ; block_tool_names : (int, string) Hashtbl.t
   ; block_thinking_signatures : (int, Buffer.t) Hashtbl.t
+  ; block_reasoning_details : (int, reasoning_detail list ref) Hashtbl.t
   ; block_media_types : (int, string) Hashtbl.t
   ; block_media_sources : (int, media_source_kind) Hashtbl.t
   }

--- a/lib/streaming.mli
+++ b/lib/streaming.mli
@@ -37,6 +37,7 @@ type stream_acc =
   ; block_tool_ids : (int, string) Hashtbl.t
   ; block_tool_names : (int, string) Hashtbl.t
   ; block_thinking_signatures : (int, Buffer.t) Hashtbl.t
+  ; block_reasoning_details : (int, Types.reasoning_detail list ref) Hashtbl.t
   ; block_media_types : (int, string) Hashtbl.t
   ; block_media_sources : (int, Types.media_source_kind) Hashtbl.t
   }

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -327,6 +327,8 @@ let test_lookup_kimi_k2_native_cloud_suffix () =
      | Reasoning_dialect.Delta_field "reasoning_content" -> ()
      | Reasoning_dialect.Delta_field field ->
        fail ("native latest Kimi reasoning delta field drifted: " ^ field)
+     | Reasoning_dialect.Delta_reasoning_details ->
+       fail "native latest Kimi should not use split reasoning_details streaming"
      | Reasoning_dialect.No_streaming_reasoning ->
        fail "native latest Kimi reasoning stream field was dropped"
      | Reasoning_dialect.Template_parser ->
@@ -510,7 +512,12 @@ let test_lookup_minimax_m3_official_chat_dialect () =
       bool
       "dialect emits reasoning split"
       true
-      (dialect.output_wire = Reasoning_dialect.Reasoning_split)
+      (dialect.output_wire = Reasoning_dialect.Reasoning_split);
+    check
+      bool
+      "dialect streams typed reasoning details"
+      true
+      (dialect.streaming = Reasoning_dialect.Delta_reasoning_details)
   | None -> fail "should match minimax-m3"
 ;;
 
@@ -847,7 +854,15 @@ type replay_contract =
 type streaming_contract =
   | Streaming_not_required
   | Delta_stream of string
+  | Delta_reasoning_details_stream
   | Template_stream
+
+let streaming_reasoning_to_string = function
+  | Reasoning_dialect.No_streaming_reasoning -> "no_streaming_reasoning"
+  | Reasoning_dialect.Template_parser -> "template_parser"
+  | Reasoning_dialect.Delta_field actual -> "delta_field:" ^ actual
+  | Reasoning_dialect.Delta_reasoning_details -> "delta_reasoning_details"
+;;
 
 type thinking_contract =
   | Reasoning_only
@@ -1005,19 +1020,19 @@ let check_frontier_model
             "%s expected Delta_field(%s), got %s"
             label
             field
-            (match other with
-             | Reasoning_dialect.No_streaming_reasoning -> "no_streaming_reasoning"
-             | Reasoning_dialect.Template_parser -> "template_parser"
-             | Reasoning_dialect.Delta_field actual -> "delta_field:" ^ actual))
+            (streaming_reasoning_to_string other))
+     | Delta_reasoning_details_stream ->
+       check
+         string
+         (label ^ " reasoning details stream")
+         "delta_reasoning_details"
+         (streaming_reasoning_to_string dialect.streaming)
      | Template_stream ->
        check
          string
          (label ^ " template stream")
          "template_parser"
-         (match dialect.streaming with
-          | Reasoning_dialect.Template_parser -> "template_parser"
-          | Reasoning_dialect.No_streaming_reasoning -> "no_streaming_reasoning"
-          | Reasoning_dialect.Delta_field actual -> "delta_field:" ^ actual))
+         (streaming_reasoning_to_string dialect.streaming))
 ;;
 
 let test_frontier_grouped_tool_thinking_structured_models () =
@@ -1055,7 +1070,7 @@ let test_frontier_grouped_tool_thinking_structured_models () =
       , Extended_thinking
       , No_structured_output
       , Replay_every_turn
-      , Delta_stream "reasoning_content" )
+      , Delta_reasoning_details_stream )
     ; ( "OpenAI GPT-5.5"
       , Direct_model
       , "gpt-5.5"

--- a/test/test_streaming_edge_cases.ml
+++ b/test/test_streaming_edge_cases.ml
@@ -14,9 +14,11 @@ let usage ?(input_tokens = 1) ?(output_tokens = 2) () =
 let openai_chunk
       ?delta_content
       ?delta_reasoning
+      ?delta_reasoning_details
       ?(delta_tool_calls = [])
       ?finish_reason
       ?chunk_usage
+      ?chunk_parse_error
       ()
   : S.openai_chunk
   =
@@ -24,9 +26,11 @@ let openai_chunk
   ; chunk_model = "model-1"
   ; delta_content
   ; delta_reasoning
+  ; delta_reasoning_details
   ; delta_tool_calls
   ; finish_reason
   ; chunk_usage
+  ; chunk_parse_error
   }
 ;;
 

--- a/test/test_streaming_openai.ml
+++ b/test/test_streaming_openai.ml
@@ -3,6 +3,7 @@
 open Llm_provider.Types
 module S = Llm_provider.Streaming
 module RD = Llm_provider.Reasoning_dialect
+module Acc = Llm_provider.Complete_stream_acc
 
 (* ── parse_openai_sse_chunk ─────────────────────────────── *)
 
@@ -105,9 +106,11 @@ let test_events_text_first_chunk () =
     ; chunk_model = "m"
     ; delta_content = Some "Hi"
     ; delta_reasoning = None
+    ; delta_reasoning_details = None
     ; delta_tool_calls = []
     ; finish_reason = None
     ; chunk_usage = None
+    ; chunk_parse_error = None
     }
   in
   let events, _tel = S.openai_chunk_to_events state chunk in
@@ -132,9 +135,11 @@ let test_events_text_subsequent () =
       ; chunk_model = "m"
       ; delta_content = Some "A"
       ; delta_reasoning = None
+      ; delta_reasoning_details = None
       ; delta_tool_calls = []
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_parse_error = None
       }
   in
   (* Second chunk: no ContentBlockStart *)
@@ -145,9 +150,11 @@ let test_events_text_subsequent () =
       ; chunk_model = "m"
       ; delta_content = Some "B"
       ; delta_reasoning = None
+      ; delta_reasoning_details = None
       ; delta_tool_calls = []
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_parse_error = None
       }
   in
   Alcotest.(check int) "1 event" 1 (List.length events);
@@ -172,9 +179,11 @@ let test_events_tool_call () =
       ; chunk_model = "m"
       ; delta_content = None
       ; delta_reasoning = None
+      ; delta_reasoning_details = None
       ; delta_tool_calls = [ tc ]
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_parse_error = None
       }
   in
   Alcotest.(check int) "2 events" 2 (List.length events);
@@ -200,8 +209,10 @@ let test_events_finish_reason () =
       ; delta_content = None
       ; delta_tool_calls = []
       ; delta_reasoning = None
+      ; delta_reasoning_details = None
       ; finish_reason = Some "stop"
       ; chunk_usage = None
+      ; chunk_parse_error = None
       }
   in
   Alcotest.(check int) "1 event" 1 (List.length events);
@@ -220,8 +231,10 @@ let test_events_tool_calls_finish () =
       ; delta_content = None
       ; delta_tool_calls = []
       ; delta_reasoning = None
+      ; delta_reasoning_details = None
       ; finish_reason = Some "tool_calls"
       ; chunk_usage = None
+      ; chunk_parse_error = None
       }
   in
   match List.hd events with
@@ -239,8 +252,10 @@ let test_events_length_finish () =
       ; delta_content = None
       ; delta_tool_calls = []
       ; delta_reasoning = None
+      ; delta_reasoning_details = None
       ; finish_reason = Some "length"
       ; chunk_usage = None
+      ; chunk_parse_error = None
       }
   in
   match List.hd events with
@@ -257,9 +272,11 @@ let test_events_empty_content_ignored () =
       ; chunk_model = "m"
       ; delta_content = Some ""
       ; delta_reasoning = None
+      ; delta_reasoning_details = None
       ; delta_tool_calls = []
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_parse_error = None
       }
   in
   Alcotest.(check int) "0 events" 0 (List.length events)
@@ -347,6 +364,69 @@ let test_parse_reasoning_respects_no_streaming_dialect () =
   | None -> Alcotest.fail "expected Some chunk"
 ;;
 
+let test_parse_minimax_split_reasoning_details () =
+  let data =
+    {|{"id":"c-minimax","model":"minimax-m3","choices":[{"index":0,"delta":{"reasoning_content":"inspect schema","reasoning_details":[{"type":"text","text":"inspect schema"}]},"finish_reason":null}]}|}
+  in
+  match S.parse_openai_sse_chunk ~streaming_reasoning:RD.Delta_reasoning_details data with
+  | Some chunk ->
+    Alcotest.(check (option string)) "no visible content" None chunk.delta_content;
+    Alcotest.(check (option string)) "legacy reasoning unused" None chunk.delta_reasoning;
+    (match chunk.delta_reasoning_details with
+     | Some { delta_reasoning_content; delta_details } ->
+       Alcotest.(check (option string))
+         "reasoning content"
+         (Some "inspect schema")
+         delta_reasoning_content;
+       (match delta_details with
+        | [ detail ] ->
+          Alcotest.(check (option string))
+            "detail text"
+            (Some "inspect schema")
+            detail.text
+        | _ -> Alcotest.fail "expected one reasoning detail")
+     | None -> Alcotest.fail "expected typed reasoning_details delta")
+  | None -> Alcotest.fail "expected Some chunk"
+;;
+
+let expect_split_parse_failed label expected_reason data =
+  match S.parse_openai_sse_chunk ~streaming_reasoning:RD.Delta_reasoning_details data with
+  | Some chunk ->
+    (match chunk.chunk_parse_error with
+     | Some { reason; raw } ->
+       Alcotest.(check string) (label ^ " reason") expected_reason reason;
+       Alcotest.(check string) (label ^ " raw") data raw
+     | None -> Alcotest.fail (label ^ ": expected chunk_parse_error"));
+    let events, _tel = S.openai_chunk_to_events (S.create_openai_stream_state ()) chunk in
+    (match events with
+     | [ SSEParseFailed { reason; raw } ] ->
+       Alcotest.(check string) (label ^ " event reason") expected_reason reason;
+       Alcotest.(check string) (label ^ " event raw") data raw
+     | _ -> Alcotest.fail (label ^ ": expected only SSEParseFailed"))
+  | None -> Alcotest.fail (label ^ ": expected Some chunk")
+;;
+
+let test_parse_minimax_split_malformed_details_fails_closed () =
+  expect_split_parse_failed
+    "non-list details"
+    "malformed_delta_reasoning_details:not_list"
+    {|{"id":"c-minimax","model":"minimax-m3","choices":[{"index":0,"delta":{"reasoning_details":{"text":"bad"}},"finish_reason":null}]}|}
+;;
+
+let test_parse_minimax_split_malformed_detail_item_fails_closed () =
+  expect_split_parse_failed
+    "non-object detail"
+    "malformed_delta_reasoning_details:index:0:not_object"
+    {|{"id":"c-minimax","model":"minimax-m3","choices":[{"index":0,"delta":{"reasoning_details":["bad"]},"finish_reason":null}]}|}
+;;
+
+let test_parse_minimax_split_inline_think_fails_closed () =
+  expect_split_parse_failed
+    "inline thinking"
+    "inline_thinking_in_split_stream_content"
+    {|{"id":"c-minimax","model":"minimax-m3","choices":[{"index":0,"delta":{"content":"<think>hidden</think>visible"},"finish_reason":null}]}|}
+;;
+
 let test_events_reasoning_then_text () =
   let state = S.create_openai_stream_state () in
   let r_events, _tel =
@@ -356,9 +436,11 @@ let test_events_reasoning_then_text () =
       ; chunk_model = "m"
       ; delta_content = None
       ; delta_reasoning = Some "thinking..."
+      ; delta_reasoning_details = None
       ; delta_tool_calls = []
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_parse_error = None
       }
   in
   Alcotest.(check int) "2 events (start+delta)" 2 (List.length r_events);
@@ -377,9 +459,11 @@ let test_events_reasoning_then_text () =
       ; chunk_model = "m"
       ; delta_content = Some "answer"
       ; delta_reasoning = None
+      ; delta_reasoning_details = None
       ; delta_tool_calls = []
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_parse_error = None
       }
   in
   Alcotest.(check int) "2 events (start+delta)" 2 (List.length t_events);
@@ -405,9 +489,11 @@ let test_events_reasoning_delta_index_multi_chunk () =
       ; chunk_model = "m"
       ; delta_content = None
       ; delta_reasoning = Some "step 1"
+      ; delta_reasoning_details = None
       ; delta_tool_calls = []
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_parse_error = None
       }
   in
   Alcotest.(check int) "2 events (start+delta)" 2 (List.length r1);
@@ -428,9 +514,11 @@ let test_events_reasoning_delta_index_multi_chunk () =
       ; chunk_model = "m"
       ; delta_content = None
       ; delta_reasoning = Some "step 2"
+      ; delta_reasoning_details = None
       ; delta_tool_calls = []
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_parse_error = None
       }
   in
   Alcotest.(check int) "1 event (delta only)" 1 (List.length r2);
@@ -447,9 +535,11 @@ let test_events_reasoning_delta_index_multi_chunk () =
       ; chunk_model = "m"
       ; delta_content = Some "answer"
       ; delta_reasoning = None
+      ; delta_reasoning_details = None
       ; delta_tool_calls = []
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_parse_error = None
       }
   in
   match List.nth t_events 1 with
@@ -477,9 +567,11 @@ let test_events_tool_first_then_text () =
       ; chunk_model = "m"
       ; delta_content = None
       ; delta_reasoning = None
+      ; delta_reasoning_details = None
       ; delta_tool_calls = [ tc ]
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_parse_error = None
       }
   in
   Alcotest.(check int) "2 tool events" 2 (List.length tool_events);
@@ -500,9 +592,11 @@ let test_events_tool_first_then_text () =
       ; chunk_model = "m"
       ; delta_content = Some "sunny"
       ; delta_reasoning = None
+      ; delta_reasoning_details = None
       ; delta_tool_calls = []
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_parse_error = None
       }
   in
   Alcotest.(check int) "2 text events" 2 (List.length text_events);
@@ -524,9 +618,11 @@ let test_events_tool_first_then_text () =
       ; chunk_model = "m"
       ; delta_content = Some " today"
       ; delta_reasoning = None
+      ; delta_reasoning_details = None
       ; delta_tool_calls = []
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_parse_error = None
       }
   in
   Alcotest.(check int) "1 event (delta only)" 1 (List.length text2_events);
@@ -562,9 +658,11 @@ let test_events_multi_tool_then_text () =
       ; chunk_model = "m"
       ; delta_content = None
       ; delta_reasoning = None
+      ; delta_reasoning_details = None
       ; delta_tool_calls = [ tc0; tc1 ]
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_parse_error = None
       }
   in
   Alcotest.(check int) "next_block_index after 2 tools" 2 state.next_block_index;
@@ -576,9 +674,11 @@ let test_events_multi_tool_then_text () =
       ; chunk_model = "m"
       ; delta_content = Some "result"
       ; delta_reasoning = None
+      ; delta_reasoning_details = None
       ; delta_tool_calls = []
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_parse_error = None
       }
   in
   (match List.nth text_events 0 with
@@ -602,9 +702,11 @@ let test_events_thinking_tool_text () =
       ; chunk_model = "m"
       ; delta_content = None
       ; delta_reasoning = Some "planning"
+      ; delta_reasoning_details = None
       ; delta_tool_calls = []
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_parse_error = None
       }
   in
   Alcotest.(check int) "next after thinking" 1 state.next_block_index;
@@ -623,9 +725,11 @@ let test_events_thinking_tool_text () =
       ; chunk_model = "m"
       ; delta_content = None
       ; delta_reasoning = None
+      ; delta_reasoning_details = None
       ; delta_tool_calls = [ tc ]
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_parse_error = None
       }
   in
   Alcotest.(check int) "next after tool" 2 state.next_block_index;
@@ -637,9 +741,11 @@ let test_events_thinking_tool_text () =
       ; chunk_model = "m"
       ; delta_content = Some "found it"
       ; delta_reasoning = None
+      ; delta_reasoning_details = None
       ; delta_tool_calls = []
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_parse_error = None
       }
   in
   (match List.nth text_events 0 with
@@ -651,6 +757,55 @@ let test_events_thinking_tool_text () =
     Alcotest.(check int) "text delta index" 2 index;
     Alcotest.(check string) "text" "found it" s
   | _ -> Alcotest.fail "expected TextDelta at index 2"
+;;
+
+let test_events_reasoning_details_accumulates_typed () =
+  let data =
+    {|{"id":"c-minimax","model":"minimax-m3","choices":[{"index":0,"delta":{"reasoning_content":"inspect schema","reasoning_details":[{"type":"text","text":"inspect schema"}]},"finish_reason":null}]}|}
+  in
+  let chunk =
+    match
+      S.parse_openai_sse_chunk ~streaming_reasoning:RD.Delta_reasoning_details data
+    with
+    | Some chunk -> chunk
+    | None -> Alcotest.fail "expected Some chunk"
+  in
+  let events, _tel = S.openai_chunk_to_events (S.create_openai_stream_state ()) chunk in
+  (match events with
+   | [ ContentBlockStart { index = 0; content_type = "reasoning_details"; _ }
+     ; ContentBlockDelta
+         { index = 0
+         ; delta =
+             ReasoningDetailsDelta
+               { reasoning_content = Some "inspect schema"; details = [ detail ] }
+         }
+     ] ->
+     Alcotest.(check (option string))
+       "streamed detail text"
+       (Some "inspect schema")
+       detail.text
+   | _ -> Alcotest.fail "expected reasoning_details start+delta");
+  let acc = Acc.create_stream_acc () in
+  Acc.accumulate_event
+    acc
+    (MessageStart { id = "msg"; model = "minimax-m3"; usage = None });
+  List.iter (Acc.accumulate_event acc) events;
+  Acc.accumulate_event acc (MessageDelta { stop_reason = Some EndTurn; usage = None });
+  match Acc.finalize_stream_acc acc with
+  | Ok { content = [ ReasoningDetails { reasoning_content; details } ]; _ } ->
+    Alcotest.(check (option string))
+      "final reasoning content"
+      (Some "inspect schema")
+      reasoning_content;
+    (match details with
+     | [ detail ] ->
+       Alcotest.(check (option string))
+         "final detail text"
+         (Some "inspect schema")
+         detail.text
+     | _ -> Alcotest.fail "expected one final reasoning detail")
+  | Ok _ -> Alcotest.fail "expected final ReasoningDetails block"
+  | Error _ -> Alcotest.fail "expected successful accumulator finalization"
 ;;
 
 let test_responses_stream_reasoning_tool_and_terminal () =
@@ -1102,6 +1257,22 @@ let () =
             "no streaming reasoning dialect"
             `Quick
             test_parse_reasoning_respects_no_streaming_dialect
+        ; test_case
+            "minimax split reasoning details"
+            `Quick
+            test_parse_minimax_split_reasoning_details
+        ; test_case
+            "minimax split malformed details"
+            `Quick
+            test_parse_minimax_split_malformed_details_fails_closed
+        ; test_case
+            "minimax split malformed detail item"
+            `Quick
+            test_parse_minimax_split_malformed_detail_item_fails_closed
+        ; test_case
+            "minimax split inline thinking fail-closed"
+            `Quick
+            test_parse_minimax_split_inline_think_fails_closed
         ] )
     ; ( "openai_chunk_to_events"
       , [ test_case "text first chunk" `Quick test_events_text_first_chunk
@@ -1119,6 +1290,10 @@ let () =
         ; test_case "tool-first then text (#333)" `Quick test_events_tool_first_then_text
         ; test_case "multi-tool then text (#333)" `Quick test_events_multi_tool_then_text
         ; test_case "thinking + tool + text (#333)" `Quick test_events_thinking_tool_text
+        ; test_case
+            "reasoning details accumulates typed"
+            `Quick
+            test_events_reasoning_details_accumulates_typed
         ] )
     ; ( "responses_sse_to_events"
       , [ test_case

--- a/test/test_streaming_openai.ml
+++ b/test/test_streaming_openai.ml
@@ -420,13 +420,6 @@ let test_parse_minimax_split_malformed_detail_item_fails_closed () =
     {|{"id":"c-minimax","model":"minimax-m3","choices":[{"index":0,"delta":{"reasoning_details":["bad"]},"finish_reason":null}]}|}
 ;;
 
-let test_parse_minimax_split_inline_think_fails_closed () =
-  expect_split_parse_failed
-    "inline thinking"
-    "inline_thinking_in_split_stream_content"
-    {|{"id":"c-minimax","model":"minimax-m3","choices":[{"index":0,"delta":{"content":"<think>hidden</think>visible"},"finish_reason":null}]}|}
-;;
-
 let test_events_reasoning_then_text () =
   let state = S.create_openai_stream_state () in
   let r_events, _tel =
@@ -1269,10 +1262,6 @@ let () =
             "minimax split malformed detail item"
             `Quick
             test_parse_minimax_split_malformed_detail_item_fails_closed
-        ; test_case
-            "minimax split inline thinking fail-closed"
-            `Quick
-            test_parse_minimax_split_inline_think_fails_closed
         ] )
     ; ( "openai_chunk_to_events"
       , [ test_case "text first chunk" `Quick test_events_text_first_chunk

--- a/test/test_streaming_summary.ml
+++ b/test/test_streaming_summary.ml
@@ -114,16 +114,24 @@ let test_terminal_cancelled_roundtrip () =
 module Streaming = Llm_provider.Streaming
 module Types = Llm_provider.Types
 
-let make_openai_chunk ?delta_content ?delta_reasoning ?(delta_tool_calls = []) ()
+let make_openai_chunk
+      ?delta_content
+      ?delta_reasoning
+      ?delta_reasoning_details
+      ?(delta_tool_calls = [])
+      ?chunk_parse_error
+      ()
   : Streaming.openai_chunk
   =
   { chunk_id = "c1"
   ; chunk_model = "m"
   ; delta_content
   ; delta_reasoning
+  ; delta_reasoning_details
   ; delta_tool_calls
   ; finish_reason = None
   ; chunk_usage = None
+  ; chunk_parse_error
   }
 ;;
 
@@ -148,6 +156,34 @@ let test_chunk_only_reasoning_is_token () =
   Alcotest.(check bool)
     "reasoning-only chunk is a token"
     true
+    (Streaming.chunk_has_non_empty_delta c)
+;;
+
+let test_chunk_reasoning_details_is_token () =
+  let detail : Types.reasoning_detail =
+    { raw = `Assoc [ "text", `String "thinking..." ]; text = Some "thinking..." }
+  in
+  let c =
+    make_openai_chunk
+      ~delta_reasoning_details:
+        { delta_reasoning_content = None; delta_details = [ detail ] }
+      ()
+  in
+  Alcotest.(check bool)
+    "reasoning_details chunk is a token"
+    true
+    (Streaming.chunk_has_non_empty_delta c)
+;;
+
+let test_chunk_empty_reasoning_details_is_not_token () =
+  let c =
+    make_openai_chunk
+      ~delta_reasoning_details:{ delta_reasoning_content = None; delta_details = [] }
+      ()
+  in
+  Alcotest.(check bool)
+    "empty reasoning_details chunk is not a token"
+    false
     (Streaming.chunk_has_non_empty_delta c)
 ;;
 
@@ -198,6 +234,27 @@ let test_sse_event_empty_text_delta_is_not_token () =
     (Streaming.sse_event_is_first_token_signal e)
 ;;
 
+let test_sse_event_reasoning_details_is_token_not_deliverable () =
+  let detail : Types.reasoning_detail =
+    { raw = `Assoc [ "text", `String "thinking..." ]; text = Some "thinking..." }
+  in
+  let e =
+    Types.ContentBlockDelta
+      { index = 0
+      ; delta =
+          Types.ReasoningDetailsDelta { reasoning_content = None; details = [ detail ] }
+      }
+  in
+  Alcotest.(check bool)
+    "ReasoningDetailsDelta is a token"
+    true
+    (Streaming.sse_event_is_first_token_signal e);
+  Alcotest.(check bool)
+    "ReasoningDetailsDelta is not deliverable progress"
+    false
+    (Streaming.sse_event_is_deliverable_progress_signal e)
+;;
+
 let test_sse_event_ping_is_not_token () =
   Alcotest.(check bool)
     "Ping is not a token"
@@ -246,6 +303,14 @@ let () =
             `Quick
             test_chunk_only_reasoning_is_token
         ; Alcotest.test_case
+            "chunk_has_non_empty_delta: reasoning details"
+            `Quick
+            test_chunk_reasoning_details_is_token
+        ; Alcotest.test_case
+            "chunk_has_non_empty_delta: empty reasoning details rejected"
+            `Quick
+            test_chunk_empty_reasoning_details_is_not_token
+        ; Alcotest.test_case
             "chunk_has_non_empty_delta: tool call"
             `Quick
             test_chunk_tool_call_is_token
@@ -265,6 +330,10 @@ let () =
             "sse_event_is_first_token_signal: empty TextDelta rejected"
             `Quick
             test_sse_event_empty_text_delta_is_not_token
+        ; Alcotest.test_case
+            "sse_event_is_first_token_signal: ReasoningDetailsDelta hidden"
+            `Quick
+            test_sse_event_reasoning_details_is_token_not_deliverable
         ; Alcotest.test_case
             "sse_event_is_first_token_signal: Ping rejected"
             `Quick

--- a/test/test_structured_stream.ml
+++ b/test/test_structured_stream.ml
@@ -325,6 +325,9 @@ let test_extract_after_accumulation () =
          Buffer.add_string buf s
        | TextDelta s -> Buffer.add_string buf s
        | ThinkingDelta s -> Buffer.add_string buf s
+       | ReasoningDetailsDelta { reasoning_content = Some s; _ } ->
+         Buffer.add_string buf s
+       | ReasoningDetailsDelta { reasoning_content = None; _ } -> ()
        | MediaDelta { data; _ } -> Buffer.add_string buf data
        | ThinkingSignatureDelta _ -> ())
     | _ -> ());


### PR DESCRIPTION
## Summary
- add a typed OpenAI-compatible stream delta for split reasoning_details
- route MiniMax M3 split-reasoning streaming through reasoning_details blocks instead of legacy thinking/text flattening
- fail closed when split-mode chunks contain malformed reasoning_details or inline <think> content
- keep reasoning_details hidden from deliverable-progress classification while preserving TTFT token signaling

## Evidence
- Official MiniMax docs: thinking.type supports adaptive/disabled; reasoning_split separates reasoning_content and reasoning_details
- Follow-up to merged #2339 P2: native MiniMax split stream now has a typed preservation path; Ollama Cloud remains on its separate thinking field route

## Local checks
- ocamlformat --check targeted OCaml files
- git diff --check origin/main...HEAD
- scripts/hardening-ratchet.sh --check

Dune/build verification intentionally left to CI per workflow.