### PR TITLE
[codex] Keep stream accumulator ratchet green

### DIFF
--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -65,7 +65,8 @@ let create_stream_acc () =
    we prevent from reaching [finalize]. *)
 let is_complete_json_value s =
   match Yojson.Safe.from_string s with
-  | _ -> true
+  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _ | `List _ ->
+    true
   | exception Yojson.Json_error _ -> false
 ;;
 


### PR DESCRIPTION
## Summary
- Replaces the wildcard success arm in complete_stream_acc JSON completeness detection with explicit Yojson.Safe constructors.
- Behavior is unchanged: every successfully parsed JSON value still returns true, malformed JSON still returns false.
- Fixes the main branch hardening ratchet regression: wildcard_silent_defaults 252 back to 251.

## Validation
- ocamlformat --check lib/llm_provider/complete_stream_acc.ml
- git diff --check
- scripts/hardening-ratchet.sh --check
- scripts/ci-code-smell-ratchet.sh --check
- scripts/hardening-ratchet.sh --self-test
- scripts/dune-local.sh build test/test_streaming_openai.exe test/test_streaming_summary.exe test/test_streaming_edge_cases.exe test/test_structured_stream.exe
- ./_build/default/test/test_streaming_openai.exe: 39 tests
- ./_build/default/test/test_streaming_summary.exe: 17 tests
- ./_build/default/test/test_streaming_edge_cases.exe: 12 tests
- ./_build/default/test/test_structured_stream.exe: 8 tests