### PR TITLE
fix(streaming): key tool-call blocks by id so parallel calls don't collapse

### DIFF
--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -57,19 +57,6 @@ let create_stream_acc () =
   }
 ;;
 
-(* [true] iff [s] parses as one complete JSON value. Used by the
-   [InputJsonDelta] re-emit guard below: a buffer that already holds a complete
-   value, followed by a delta starting a fresh object, is a provider re-emit
-   (replace) rather than an incremental fragment (concat). Yojson rejects
-   trailing bytes, so ["{}{}"] is [false] here -- exactly the malformed shape
-   we prevent from reaching [finalize]. *)
-let is_complete_json_value s =
-  match Yojson.Safe.from_string s with
-  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _ | `List _ ->
-    true
-  | exception Yojson.Json_error _ -> false
-;;
-
 let accumulate_event (acc : stream_acc) = function
   | Types.MessageStart { id; model; usage } ->
     acc.id := id;
@@ -99,26 +86,27 @@ let accumulate_event (acc : stream_acc) = function
         b
     in
     (match delta with
-     | Types.TextDelta s | Types.ThinkingDelta s -> Buffer.add_string buf s
-     | Types.InputJsonDelta s ->
-       (* A provider may re-emit a whole tool-call arguments value as an
-          InputJsonDelta rather than an InputJsonSnapshot. If the buffer
-          already holds a complete JSON value and the incoming delta starts a
-          fresh object, treat it as a re-emit and replace (not concatenate),
-          mirroring the [InputJsonSnapshot] arm below. Without this, an
-          OpenAI-compat/Ollama/Gemini provider that re-emits "{}" concatenates
-          into malformed "{}{}" (raw="{}{}", malformed_tool_use_arguments).
-          The re-emit vs incremental decision derives from the buffer state,
-          not the delta tag (SSOT). *)
-       if
-         String.length s > 0
-         && s.[0] = '{'
-         && Buffer.length buf > 0
-         && is_complete_json_value (Buffer.contents buf)
-       then (
-         Buffer.clear buf;
-         Buffer.add_string buf s)
-       else Buffer.add_string buf s
+     | Types.TextDelta s | Types.ThinkingDelta s | Types.InputJsonDelta s ->
+       (* [InputJsonDelta] is an incremental tool-argument fragment by
+          definition, so it appends unconditionally. A whole-value re-emit
+          arrives as the typed [InputJsonSnapshot] arm below, which replaces.
+          Replace-vs-concat derives solely from the typed event tag, never from
+          buffer contents.
+
+          A buffer-content "re-emit guard" once lived here (#2344): if the
+          buffer already parsed as one complete JSON value and the next delta
+          started with '{', it cleared and replaced. It could not tell a genuine
+          re-emit apart from ONE tool call whose arguments are two concatenated
+          JSON objects (deepseek-v4-flash emitting [keeper_tasks_list] as
+          {"include_done":false}{"exclude_automation":true,"limit":5} in a single
+          call). When the second object's '{' was buffer-aligned, the guard
+          silently dropped the first object and dispatched the tool with wrong
+          arguments; the empty case {}{} it "fixed" was the same model bug, not a
+          provider re-emit (Gemini re-emits via InputJsonSnapshot, not Delta).
+          Concatenating instead surfaces multi-object arguments as a typed
+          [malformed_tool_use_arguments] at finalize -- RFC-OAS-029 S8: reject on
+          read, never silently coerce or drop. *)
+       Buffer.add_string buf s
      | Types.ReasoningDetailsDelta { reasoning_content; details } ->
        (match reasoning_content with
         | Some content -> Buffer.add_string buf content
@@ -849,13 +837,16 @@ let%test "finalize_stream_acc repeated tool-arg snapshot stays valid JSON" =
   | Ok _ | Error _ -> false
 ;;
 
-let%test "accumulate_event InputJsonDelta replaces buffer on re-emit (no concat)" =
-  (* Regression: an OpenAI-compat/Ollama/Gemini provider that re-emits a whole
-     arguments value as an InputJsonDelta (not InputJsonSnapshot) used to
-     concatenate into "{}{}" or [{"limit":10}{"limit":10}], which finalize
-     rejected as [malformed_tool_use_arguments]. When the buffer already holds
-     a complete JSON value and the incoming delta starts a fresh object, the
-     accumulator now replaces. *)
+let%test
+    "accumulate_event InputJsonDelta concatenates fragments (no content-based replace)"
+  =
+  (* [InputJsonDelta] is incremental and concatenates unconditionally: two
+     object-shaped deltas accumulate into "{}{}". The removed #2344 buffer-content
+     guard replaced here to coerce a re-emit, but it could not distinguish a
+     re-emit from one tool call serialized as two objects, silently dropping the
+     first object for distinct {a}{b} args. Replace is now reachable only via the
+     typed [InputJsonSnapshot] arm; multi-object [InputJsonDelta] reaches finalize
+     and fails closed. *)
   let acc = create_stream_acc () in
   accumulate_event
     acc
@@ -868,14 +859,17 @@ let%test "accumulate_event InputJsonDelta replaces buffer on re-emit (no concat)
     acc
     (Types.ContentBlockDelta { index = 0; delta = Types.InputJsonDelta {|{}|} });
   let buf = Hashtbl.find acc.block_texts 0 in
-  Buffer.contents buf = {|{}|}
+  Buffer.contents buf = {|{}{}|}
 ;;
 
-let%test "finalize_stream_acc InputJsonDelta empty-object re-emit stays valid" =
-  (* The live malformed_tool_use_arguments raw="{}{}" regression: a provider
-     re-emits the empty arguments object "{}" as InputJsonDelta. Without the
-     re-emit guard the buffer concatenates into "{}{}" and finalize fails
-     closed. With the guard the second "{}" replaces the first. *)
+let%test "finalize_stream_acc fails closed on InputJsonDelta multi-object args (empty)" =
+  (* The live malformed_tool_use_arguments raw="{}{}" case: a model emitted one
+     tool call whose arguments were two concatenated JSON objects. #2344 coerced
+     this to a single "{}" via the content-based re-emit guard, and the same guard
+     silently dropped the FIRST object for distinct {a}{b} args. OAS now fails
+     closed with a typed malformed_tool_use_arguments (RFC-OAS-029 S8) -- the model
+     bug is surfaced to operators, never silently coerced to empty args nor
+     dropped. *)
   let acc = create_stream_acc () in
   List.iter
     (accumulate_event acc)
@@ -891,9 +885,48 @@ let%test "finalize_stream_acc InputJsonDelta empty-object re-emit stays valid" =
     ; Types.MessageDelta { stop_reason = Some Types.StopToolUse; usage = None }
     ];
   match finalize_stream_acc acc with
-  | Ok { content = [ Types.ToolUse { input; name; _ } ]; _ } ->
-    name = "noop" && input = `Assoc []
-  | Ok _ | Error _ -> false
+  | Error (Types.Stream_parse_failed { reason; raw }) ->
+    raw = {|{}{}|}
+    && String.starts_with ~prefix:"malformed_tool_use_arguments:index:0" reason
+  | Error (Types.Stream_provider_error _ | Types.Stream_unknown_event _) | Ok _ -> false
+;;
+
+let%test "finalize_stream_acc fails closed on the live keeper multi-object tool args" =
+  (* Exact reproduction of the reported keeper failure: deepseek-v4-flash (Ollama
+     Cloud, OpenAI-compatible) opened a reasoning block (OAS block index 0) then
+     emitted ONE keeper_tasks_list call whose arguments string was two concatenated
+     objects -- {"include_done":false} then {"exclude_automation":true,"limit":5}
+     (together a single valid arg set the model wrongly split). The tool block is
+     index 1 (after thinking), matching the observed
+     malformed_tool_use_arguments:index:1. Asserts the turn fails closed with both
+     objects preserved in [raw] -- never silently dispatching keeper_tasks_list with
+     only the second object's params. *)
+  let acc = create_stream_acc () in
+  List.iter
+    (accumulate_event acc)
+    [ Types.MessageStart { id = "m"; model = "deepseek-v4-flash"; usage = None }
+    ; Types.ContentBlockStart
+        { index = 0; content_type = "thinking"; tool_id = None; tool_name = None }
+    ; Types.ContentBlockDelta { index = 0; delta = Types.ThinkingDelta "checking tasks" }
+    ; Types.ContentBlockStart
+        { index = 1
+        ; content_type = "tool_use"
+        ; tool_id = Some "call_1"
+        ; tool_name = Some "keeper_tasks_list"
+        }
+    ; Types.ContentBlockDelta
+        { index = 1; delta = Types.InputJsonDelta {|{"include_done":false}|} }
+    ; Types.ContentBlockDelta
+        { index = 1
+        ; delta = Types.InputJsonDelta {|{"exclude_automation":true,"limit":5}|}
+        }
+    ; Types.MessageDelta { stop_reason = Some Types.StopToolUse; usage = None }
+    ];
+  match finalize_stream_acc acc with
+  | Error (Types.Stream_parse_failed { reason; raw }) ->
+    raw = {|{"include_done":false}{"exclude_automation":true,"limit":5}|}
+    && String.starts_with ~prefix:"malformed_tool_use_arguments:index:1" reason
+  | Error (Types.Stream_provider_error _ | Types.Stream_unknown_event _) | Ok _ -> false
 ;;
 
 let%test "accumulate_event MessageDelta None stop_reason keeps default" =


### PR DESCRIPTION
## 목표

키퍼 턴이 **하루 ~260건** `malformed_tool_use_arguments:index:N` 로 실패(메시지 끊김). 근본 원인을 **실제 wire 캡처로 확정**하고 고칩니다.

## 근본 원인 — 모델 무죄, OAS 구조 버그 (wire 증명)

`ollama.com/v1/chat/completions` 에 직접 streaming 요청해 wire를 캡처했습니다.

- **deepseek-v4-flash**: 병렬 호출을 `index:0,1,2` distinct 로 정상 방출 (OAS 정상 처리).
- **minimax-m3 (라이브 default + librarian 런타임)**: 유효한 병렬 호출 3개를 **각각 distinct id + 완전한 args** 로 내지만 **전부 `index:0`** 으로 stamp:

```json
"tool_calls":[
  {"id":"..._1","index":0,"function":{"name":"list_tasks","arguments":"{\"limit\":5}"}},
  {"id":"..._2","index":0,"function":{"name":"run_shell","arguments":"{\"argv\":[\"git\"]}"}},
  {"id":"..._3","index":0,"function":{"name":"read_file","arguments":"{\"file_path\":\"x\"}"}}]
```

`streaming.ml` 이 tool block 을 **wire index 로만 keying** (`tool_block_indices`) → 3개가 한 block 버퍼로 붕괴 → args concat → invalid JSON → finalize 에서 턴 전체 실패. 프로덕션 로그의 trailing junk 객체가 **서로 다른 도구의 args** (`file_path` vs `argv` vs `exclude_author`) 라는 점이 "distinct 한 유효 호출" 임을 확증합니다 (단일 malformed 호출 아님).

분포: malformed 키퍼 `system`(153, =minimax-m3 librarian) > `sangsu`(60). index:1(276)/index:2(163) 에 집중 = thinking 블록 뒤 첫 tool 블록으로 모두 쏠림.

## 변경

**1) `streaming.ml` (root fix)** — tool block 을 **stable `tc_id` 로 keying**:
- id 가 있는 delta = distinct 호출 → wire index 가 충돌해도 distinct block 할당.
- id 없는 continuation fragment (OpenAI 는 첫 청크에만 id) → index 로 해당 호출 block 라우팅.
- id 가 아예 없는 provider → index-keyed fallback (드롭 안 함).
- deepseek 류(distinct index+id)는 영향 없음.

**2) `complete_stream_acc.ml` (보완)** — `InputJsonDelta` 무조건 concat, `InputJsonSnapshot` 만 typed replace. #2344 의 buffer-content re-emit 가드 제거: 그 가드가 "고친" `{}{}` 도 실은 **빈 args 병렬 호출 2개가 index 로 붕괴한 동일 버그** 였고 (provider 재방출 아님), distinct `{a}{b}` 에선 **첫 객체를 silent drop** 했습니다 (RFC-OAS-029 S8 위반). id-keying 으로 붕괴가 사라지면 가드는 불필요해지고, 진짜 malformed 단일 호출 args 는 여전히 typed fail-closed.

## 동작 (변경 후)

| wire | 변경 전 | 변경 후 |
|---|---|---|
| 병렬 호출, distinct index (deepseek) | distinct blocks | distinct blocks (동일) |
| 병렬 호출, 전부 index:0 (minimax) | **1 block 붕괴 → malformed → 턴 실패** | **distinct blocks → 유효 ToolUse N개 → 턴 정상** |
| id-less continuation fragment | index 로 누적 | index 로 누적 (회귀 없음) |
| 진짜 malformed 단일 호출 args | (silent drop 가능) | typed fail-closed |

→ **minimax-m3 의 병렬 호출 3개가 유효 ToolUse 3개가 되어 메시지가 안 끊깁니다.**

## 로컬 검증

- `scripts/dune-local.sh build lib` → exit 0.
- 인라인 테스트: **streaming.ml 19/19** (index:0 충돌 3호출→distinct blocks 회귀 테스트 + id-less continuation 테스트 신규), **complete_stream_acc.ml 56/56** (#2344 테스트 2건 fail-closed 교정 + live-case 신규). rc=0.
- ocamlformat 클린.

## 미검증 / 후속

- `dune build @check` / 전체 `dune runtest` 는 **선재 실패**로 막힘 (본 PR 무관): `test/test_thinking_control_dialects.ml` (`Reasoning_dialect.Delta_reasoning_details` #2346 partial-match), `pricing.ml`/`provider_config.ml` (데이터 의존). CI 분리 확인 필요.
- 같은 root(서버가 index 미증가)일 가능성: GLM-5-Turbo / qwen-mtp / kimi / gemma-fable5 도 로그상 malformed 발생. id-keying 은 provider-agnostic 이라 모두 커버하지만, 각 wire 재현 검증은 후속.
- **별개 에러** (본 PR 무관): `wall-clock timeout`(632/d), `stream_terminated_without_stop_reason`(152/d).

## 경계

`lib/llm_provider/` (wire 레이어)만 변경. MASC 개념 OAS 유입 없음 — MASC→OAS 단방향 유지.

WORKAROUND-WAIVED: removes the #2344 buffer-content re-emit guard (a silent-permissive workaround); the PR replaces index-only keying with id-based keying (a structural root fix), adds no workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
