### PR TITLE
refactor(provider): expose Provider.capabilities = Llm_provider.Capabilities.capabilities

### DIFF
--- a/lib/provider.mli
+++ b/lib/provider.mli
@@ -93,7 +93,14 @@ type reasoning_streaming_format = Llm_provider.Capabilities.reasoning_streaming_
   | Delta_reasoning_field of string
   | Template_reasoning_streaming
 
-type capabilities =
+(* Re-export the canonical capabilities record from [Llm_provider.Capabilities]
+   with its type equality exposed, so downstream consumers (e.g. catalog
+   overlays) can pass an [Llm_provider.Capabilities.capabilities] straight into
+   [register_provider] instead of hand-copying all fields. provider.ml already
+   [include]s [Llm_provider.Capabilities]; this only surfaces that identity
+   through the interface. The field list is kept for in-repo documentation and
+   is checked against the source record by the compiler. *)
+type capabilities = Llm_provider.Capabilities.capabilities =
   { max_context_tokens : int option
   ; max_output_tokens : int option
   ; supports_tools : bool

--- a/test/test_provider_intf.ml
+++ b/test/test_provider_intf.ml
@@ -285,6 +285,33 @@ let test_custom_provider_dispatch_uses_registered_impl () =
          | _ -> Alcotest.fail "expected text response"))
 ;;
 
+(* ── capabilities type identity ──────────────────────────── *)
+
+(* Compile-time proof that [Provider.capabilities] is the SAME type as
+   [Llm_provider.Capabilities.capabilities] — provider.mli exposes the type
+   equation. If that equation is dropped, these identity coercions stop
+   compiling, which is exactly what forced downstream consumers (catalog
+   overlays) to hand-copy every field. *)
+let capabilities_as_provider (c : Llm_provider.Capabilities.capabilities)
+  : Provider.capabilities
+  =
+  c
+;;
+
+let capabilities_as_source (c : Provider.capabilities)
+  : Llm_provider.Capabilities.capabilities
+  =
+  c
+;;
+
+let test_capabilities_type_equality () =
+  let c = Provider.default_capabilities in
+  (* Round-trips through both directions with no conversion: the values are
+     physically identical because the two names denote one type. *)
+  let c' = capabilities_as_provider (capabilities_as_source c) in
+  Alcotest.(check bool) "capabilities round-trips by identity" true (c == c')
+;;
+
 (* ── Runner ──────────────────────────────────────────────── *)
 
 let () =
@@ -322,6 +349,12 @@ let () =
             "custom provider dispatch"
             `Quick
             test_custom_provider_dispatch_uses_registered_impl
+        ] )
+    ; ( "capabilities_identity"
+      , [ Alcotest.test_case
+            "Provider.capabilities = Llm_provider.Capabilities.capabilities"
+            `Quick
+            test_capabilities_type_equality
         ] )
     ]
 ;;


### PR DESCRIPTION
## 목표

`Agent_sdk.Provider.capabilities`와 `Llm_provider.Capabilities.capabilities`의 **타입 동일성을 인터페이스에 노출**합니다.

`provider.ml`은 이미 `include Llm_provider.Capabilities`라 내부적으로 `Provider.capabilities`가 그 record와 **같은 타입**입니다(예: `capabilities_for_model`이 `Llm_provider.Capabilities.for_model_id` 결과와 `Provider.default_capabilities`를 한 match에서 반환·컴파일). 그러나 `provider.mli:96`이 같은 record를 **등식 없이 재선언**해 그 동일성을 consumer에게 숨겼습니다. 결과적으로 downstream(예: catalog overlay)이 `Llm_provider.Capabilities.capabilities`(예: `Provider_runtime_binding.capabilities_for_provider_config` 반환)를 `Provider.capabilities`로 바꾸려고 **39필드를 손수 복사**해야 했고, OAS가 capability에 필드를 추가할 때마다 그 수동 복사가 drift됩니다.

## 변경

- `lib/provider.mli`: `type capabilities = { ... }` → `type capabilities = Llm_provider.Capabilities.capabilities = { ... }` (등식 노출). field list·구현 무변경 — 컴파일러가 source record와 대조.
- `test/test_provider_intf.ml`: compile-time identity witness(`Llm_provider.Capabilities.capabilities ↔ Provider.capabilities` 양방향 coercion + round-trip 물리적 동일성). 등식이 제거되면 빌드 실패.

## 영향 / 동기

- consumer가 `capabilities_for_provider_config` 결과를 `register_provider`에 **직접** 전달 가능 → 수동 mirror 제거 가능(drift 근절). 이게 동반 MASC 빌드 깨짐(capability mirror가 `reasoning_output_format`/`reasoning_streaming_format` 신규 필드 누락)의 root이며, 그 수동 복사를 없애려면 이 등식 노출이 선행되어야 합니다.
- 변경은 **더 permissive**(타입 동일성 정보 추가)라 기존 OAS 내부·consumer 무파손. provider.mli의 다른 capability 필드 타입들(`thinking_control_format` 등)은 이미 `= Llm_provider.Capabilities.X` 등식 형태 — 이 PR은 `capabilities` record를 같은 패턴에 맞춥니다.
- 원칙: "OAS는 외부 유저가 간결히 소비하게 해야 함." 등식 노출 한 줄이 consumer의 40필드 변환을 제거.

## 검증

- 로컬 빌드는 machine-wide dune 락(병렬 세션 빌드 점유)으로 미실행 → CI 검증. field-identity는 `provider.mli` ↔ `capabilities.mli` 39필드 정밀 대조 완료(동일 순서/타입).
