### PR TITLE
fix(streaming): emit ContentBlockStop for open blocks on OpenAI-compat finish

### DIFF
--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -635,9 +635,32 @@ let create_openai_stream_state ?(provider = "") ?(model = "") () =
   }
 ;;
 
+(* OpenAI-compatible streams carry no wire [content_block_stop] event (unlike
+   Anthropic, whose stops are parsed straight off the wire). Synthesize one
+   [ContentBlockStop] per block this state opened so the emitted OAS event
+   sequence stays symmetric: every [ContentBlockStart] gets a matching
+   [ContentBlockStop]. The stream accumulator ignores stops, but block-lifecycle
+   consumers depend on them — a stop closes a tool block so the NEXT provider
+   message (a separate stream whose block indices restart at 0) reuses the same
+   index without colliding with a still-open block, and so a tool-call-end is
+   surfaced for that block. Called once on the terminal [finish_reason] chunk;
+   blank/missing-finish chunks never close blocks. *)
+let openai_open_block_stops (state : openai_stream_state) : sse_event list =
+  let indices =
+    (if state.thinking_block_started then [ state.thinking_block_index ] else [])
+    @ (if state.text_block_started then [ state.text_block_index ] else [])
+    @ Hashtbl.fold
+        (fun _tc_index block_index acc -> block_index :: acc)
+        state.tool_block_indices
+        []
+  in
+  indices |> List.sort_uniq compare |> List.map (fun index -> ContentBlockStop { index })
+;;
+
 (** Convert a parsed {!openai_chunk} into {!sse_event} list.
     Synthesizes [ContentBlockStart] events on first occurrence of
-    text content or each new tool_call index. *)
+    text content or each new tool_call index, and a matching
+    [ContentBlockStop] for every open block on the terminal finish chunk. *)
 let openai_chunk_to_events (state : openai_stream_state) (chunk : openai_chunk)
   : sse_event list * Telemetry_event.t option
   =
@@ -777,6 +800,12 @@ let openai_chunk_to_events (state : openai_stream_state) (chunk : openai_chunk)
           "content_filter" stays Unknown — a moderation cutoff, not a refusal. *)
          Stop_reason_wire.provisional_of_string reason
        in
+       (* Close every block this message opened before the terminal MessageDelta,
+          mirroring Anthropic's content_block_stop-then-message_delta ordering.
+          Without this the OpenAI-compat stream leaves tool blocks open and a
+          downstream per-message block-index consumer collides on the next
+          message's reused index. *)
+       List.iter emit (openai_open_block_stops state);
        emit (MessageDelta { stop_reason = Some stop_reason; usage = chunk.chunk_usage })
      | None ->
        (* With stream_options.include_usage the provider sends token totals in a

--- a/test/test_streaming_openai.ml
+++ b/test/test_streaming_openai.ml
@@ -242,6 +242,63 @@ let test_events_tool_calls_finish () =
   | _ -> Alcotest.fail "expected StopToolUse"
 ;;
 
+let test_events_finish_closes_open_tool_block () =
+  (* A tool block opened in an earlier chunk must receive a matching
+     ContentBlockStop on the terminal finish chunk, so a per-message
+     block-index consumer closes it before the next provider message reuses the
+     same index. OpenAI-compat analogue of Anthropic's wire content_block_stop.
+     Regression guard for the keeper-stream [tool_args_without_start]
+     cross-message collision (deepseek-v4-flash via ollama_cloud). *)
+  let state = S.create_openai_stream_state () in
+  let tc : S.openai_tool_call_delta =
+    { tc_index = 0
+    ; tc_id = Some "call_xq02glug"
+    ; tc_name = Some "get_weather"
+    ; tc_arguments = Some (S.Args_fragment {|{"city":"Seoul"}|})
+    }
+  in
+  let _open, _ =
+    S.openai_chunk_to_events
+      state
+      { chunk_id = "c"
+      ; chunk_model = "m"
+      ; delta_content = None
+      ; delta_reasoning = None
+      ; delta_reasoning_details = None
+      ; delta_tool_calls = [ tc ]
+      ; finish_reason = None
+      ; chunk_usage = None
+      ; chunk_parse_error = None
+      }
+  in
+  let events, _tel =
+    S.openai_chunk_to_events
+      state
+      { chunk_id = "c"
+      ; chunk_model = "m"
+      ; delta_content = None
+      ; delta_reasoning = None
+      ; delta_reasoning_details = None
+      ; delta_tool_calls = []
+      ; finish_reason = Some "tool_calls"
+      ; chunk_usage = None
+      ; chunk_parse_error = None
+      }
+  in
+  Alcotest.(check int) "stop + message_delta" 2 (List.length events);
+  let stop_indices =
+    List.filter_map
+      (function
+        | ContentBlockStop { index } -> Some index
+        | _ -> None)
+      events
+  in
+  Alcotest.(check (list int)) "open tool block 0 closed on finish" [ 0 ] stop_indices;
+  match List.rev events with
+  | MessageDelta { stop_reason = Some StopToolUse; _ } :: _ -> ()
+  | _ -> Alcotest.fail "finish chunk must end with MessageDelta after closing blocks"
+;;
+
 let test_events_length_finish () =
   let state = S.create_openai_stream_state () in
   let events, _tel =
@@ -1269,6 +1326,10 @@ let () =
         ; test_case "tool_call" `Quick test_events_tool_call
         ; test_case "finish stop" `Quick test_events_finish_reason
         ; test_case "finish tool_calls" `Quick test_events_tool_calls_finish
+        ; test_case
+            "finish closes open tool block"
+            `Quick
+            test_events_finish_closes_open_tool_block
         ; test_case "finish length" `Quick test_events_length_finish
         ; test_case "empty content ignored" `Quick test_events_empty_content_ignored
         ; test_case "reasoning then text" `Quick test_events_reasoning_then_text


### PR DESCRIPTION
## 문제

대시보드 keeper 채팅에서 `ollama_cloud.deepseek-v4-flash` 사용 시 스트리밍 도중 빨간 글씨로 원시 텍스트가 쏟아지다가, 최종 응답이 다 오면 올바르게 표시되는 현상.

빨간 글씨의 정체:
```
tool_args_without_start | index=N | tool_call_id=call_xxxx | tool argument event arrived after invalid tool block start
```

## 근본 원인 (raw wire 재현으로 확정)

`deepseek-v4-flash`(ollama.com/v1, OpenAI 호환)의 실제 스트림을 직접 재현한 결과, tool_call은 id+name+arguments가 한 청크에 정상 도착하고 이어서 `finish_reason:"tool_calls"` + `[DONE]`이 옵니다. 즉 **단일 응답 내 결함이 아닙니다**.

OpenAI 호환 스트림은 wire에 `content_block_stop`이 없습니다(Anthropic은 wire에서 직접 파싱). 그런데 `openai_chunk_to_events`는 `ContentBlockStart`만 합성하고 **짝이 되는 `ContentBlockStop`을 방출하지 않았습니다**. 결과적으로 OAS가 내보내는 이벤트 시퀀스가 비대칭이 됩니다.

스트림 누산기는 stop을 무시하므로 `finalize`는 무영향이지만, block-lifecycle을 추적하는 소비자는 stop에 의존합니다:
- tool 블록을 닫아, **다음 provider 메시지**(block index가 0부터 재시작하는 별도 스트림)가 같은 index를 재사용해도 아직 열린 블록과 충돌하지 않게 함
- 해당 블록의 tool-call-end를 표면화함

이 stop 부재가 downstream(MASC keeper-stream 브릿지)에서 cross-message index 충돌 → `tool_args_without_start`로 나타납니다. (소비자 측 보강은 별도 PR: masc `fix/keeper-stream-msg-boundary`.)

## 변경

`finish_reason` 종료 청크에서, MessageDelta 직전에 이 메시지가 연 모든 블록(thinking/text/tool)에 대해 `ContentBlockStop`을 합성합니다. Anthropic의 `content_block_stop` → `message_delta` 순서를 따릅니다.

## 검증

- `test/test_streaming_openai.ml`: 40개 통과 (신규 `finish closes open tool block` 포함)
- `test/test_stream_accumulator.ml`: 27개 통과 (누산기는 stop 무시 — finalize 무영향 확인)
- 기존 `finish_reason` 단위 테스트는 fresh state(열린 블록 없음)에서 finish를 보내므로 이벤트 수 변화 없음

## 경계

OAS는 MASC를 모릅니다. 이 수정은 provider-agnostic 프로토콜 대칭성 회복으로, 모든 소비자(외부 사용자 포함)에 이롭습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
