### PR TITLE
test(reasoning): cover split reasoning dialect exhaustively

### DIFF
--- a/test/test_thinking_control_dialects.ml
+++ b/test/test_thinking_control_dialects.ml
@@ -507,6 +507,9 @@ let test_ollama_cloud_openai_compat_streams_reasoning_delta () =
           field)
    | RD.No_streaming_reasoning ->
      fail "ollama cloud OpenAI-compatible reasoning stream field was dropped"
+   | RD.Delta_reasoning_details ->
+     fail
+       "ollama cloud OpenAI-compatible should not use reasoning_details split streaming"
    | RD.Template_parser ->
      fail "ollama cloud OpenAI-compatible should not use template parser streaming");
   let live_shape =


### PR DESCRIPTION
## Summary
- add an explicit Delta_reasoning_details branch to the Ollama Cloud MiniMax streaming dialect assertion
- keep the Ollama Cloud reasoning-field route fail-closed if it drifts to native reasoning_details split streaming
- unblock draft PRs that are failing CI on the same exhaustive-match warning after the split-reasoning dialect landed

## Validation
- ocamlformat --check test/test_thinking_control_dialects.ml
- git diff --check origin/main
- scripts/hardening-ratchet.sh --check

Dune/build intentionally left to GitHub CI.