### PR TITLE
test(reasoning): cover reasoning_details streaming dialect

### DIFF
--- a/test/test_thinking_control_dialects.ml
+++ b/test/test_thinking_control_dialects.ml
@@ -505,6 +505,8 @@ let test_ollama_cloud_openai_compat_streams_reasoning_delta () =
        (Printf.sprintf
           "ollama cloud OpenAI-compatible reasoning delta field drifted: %s"
           field)
+   | RD.Delta_reasoning_details ->
+     fail "ollama cloud OpenAI-compatible should not use reasoning_details streaming"
    | RD.No_streaming_reasoning ->
      fail "ollama cloud OpenAI-compatible reasoning stream field was dropped"
    | RD.Template_parser ->


### PR DESCRIPTION
## Summary
- Close the OCaml 5.4 warning-as-error hole in test_thinking_control_dialects.
- Handle Reasoning_dialect.Delta_reasoning_details explicitly instead of relying on a wildcard.
- Keep the Ollama Cloud OpenAI-compatible contract strict: this path must remain delta.reasoning, not reasoning_details.

## Validation
- ocamlformat --check test/test_thinking_control_dialects.ml
- git diff --check
- Full Dune build/test intentionally left to CI.