### PR TITLE
feat(types): expose reasoning details text projection

### DIFF
--- a/lib/base/hooks.ml
+++ b/lib/base/hooks.ml
@@ -76,13 +76,8 @@ let extract_reasoning (messages : message list) : reasoning_summary =
          List.filter_map
            (function
              | Thinking { content; _ } -> Some content
-             | ReasoningDetails { reasoning_content = Some content; _ } -> Some content
-             | ReasoningDetails { reasoning_content = None; details } ->
-               let content =
-                 details
-                 |> List.filter_map (fun (detail : reasoning_detail) -> detail.text)
-                 |> String.concat ""
-               in
+             | ReasoningDetails { reasoning_content; details } ->
+               let content = reasoning_details_text ~reasoning_content ~details in
                if content = "" then None else Some content
              | Text _
              | RedactedThinking _

--- a/lib/context_reducer_estimate.ml
+++ b/lib/context_reducer_estimate.ml
@@ -20,13 +20,8 @@ let estimate_block_tokens ?cache block =
     match block with
     | Text s -> estimate_char_tokens s
     | Thinking { content; _ } -> estimate_char_tokens content
-    | ReasoningDetails { reasoning_content = Some content; _ } ->
-      estimate_char_tokens content
-    | ReasoningDetails { reasoning_content = None; details } ->
-      details
-      |> List.filter_map (fun (detail : reasoning_detail) -> detail.text)
-      |> String.concat ""
-      |> estimate_char_tokens
+    | ReasoningDetails { reasoning_content; details } ->
+      reasoning_details_text ~reasoning_content ~details |> estimate_char_tokens
     | RedactedThinking _ -> 50
     | ToolUse { name; input; _ } ->
       let input_str = Yojson.Safe.to_string input in

--- a/lib/llm_provider/backend_openai_parse.ml
+++ b/lib/llm_provider/backend_openai_parse.ml
@@ -60,15 +60,11 @@ let reasoning_details_of_message msg =
     Error "malformed_reasoning_details:not_list"
 ;;
 
-let reasoning_texts_of_details details =
-  List.filter_map (fun (detail : reasoning_detail) -> detail.text) details
-;;
-
 let reasoning_texts_of_block = function
   | Thinking { content; _ } -> [ content ]
-  | ReasoningDetails { reasoning_content = Some content; _ } -> [ content ]
-  | ReasoningDetails { reasoning_content = None; details } ->
-    reasoning_texts_of_details details
+  | ReasoningDetails { reasoning_content; details } ->
+    let content = reasoning_details_text ~reasoning_content ~details in
+    if Api_common.string_is_blank content then [] else [ content ]
   | Text _
   | RedactedThinking _
   | ToolUse _

--- a/lib/llm_provider/backend_openai_serialize.ml
+++ b/lib/llm_provider/backend_openai_serialize.ml
@@ -136,17 +136,9 @@ let assistant_reasoning_content_of_blocks blocks =
     | Thinking { content; _ } when not (Api_common.string_is_blank content) ->
       Some (Utf8_sanitize.sanitize content)
     | Thinking _ -> None
-    | ReasoningDetails { reasoning_content = Some content; _ }
-      when not (Api_common.string_is_blank content) ->
-      Some (Utf8_sanitize.sanitize content)
-    | ReasoningDetails { reasoning_content = None; details } ->
-      let text =
-        details
-        |> List.filter_map (fun (detail : reasoning_detail) -> detail.text)
-        |> String.concat ""
-      in
+    | ReasoningDetails { reasoning_content; details } ->
+      let text = reasoning_details_text ~reasoning_content ~details in
       if Api_common.string_is_blank text then None else Some (Utf8_sanitize.sanitize text)
-    | ReasoningDetails { reasoning_content = Some _; _ } -> None
     | Text _
     | RedactedThinking _
     | ToolUse _

--- a/lib/llm_provider/canonical_tool.ml
+++ b/lib/llm_provider/canonical_tool.ml
@@ -61,14 +61,7 @@ let reasoning_of_block ~order_index (block : Types.content_block) =
   | Types.Thinking { content; signature } ->
     Some { order_index; kind = Visible_thinking; content; signature }
   | Types.ReasoningDetails { reasoning_content; details } ->
-    let content =
-      match reasoning_content with
-      | Some content -> content
-      | None ->
-        details
-        |> List.filter_map (fun (detail : Types.reasoning_detail) -> detail.text)
-        |> String.concat ""
-    in
+    let content = Types.reasoning_details_text ~reasoning_content ~details in
     if String.trim content = ""
     then None
     else Some { order_index; kind = Visible_thinking; content; signature = None }

--- a/lib/llm_provider/response_shape.ml
+++ b/lib/llm_provider/response_shape.ml
@@ -52,15 +52,6 @@ let dedupe_keep_order values =
 ;;
 
 let summarize_blocks (content : Types.content_block list) =
-  let reasoning_details_chars reasoning_content details =
-    match reasoning_content with
-    | Some content -> String.length content
-    | None ->
-      details
-      |> List.filter_map (fun (detail : Types.reasoning_detail) -> detail.text)
-      |> String.concat ""
-      |> String.length
-  in
   let shape =
     List.fold_left
       (fun shape -> function
@@ -78,7 +69,8 @@ let summarize_blocks (content : Types.content_block list) =
            { (add_kind "reasoning_details" shape) with
              thinking_blocks = shape.thinking_blocks + 1
            ; thinking_chars =
-               shape.thinking_chars + reasoning_details_chars reasoning_content details
+               shape.thinking_chars
+               + String.length (Types.reasoning_details_text ~reasoning_content ~details)
            }
          | Types.RedactedThinking _ ->
            { (add_kind "redacted_thinking" shape) with

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -302,6 +302,21 @@ type content_block =
       }
 [@@deriving show]
 
+let reasoning_details_text
+      ~(reasoning_content : string option)
+      ~(details : reasoning_detail list)
+  : string
+  =
+  let details_text =
+    details
+    |> List.filter_map (fun (detail : reasoning_detail) -> detail.text)
+    |> String.concat ""
+  in
+  match reasoning_content with
+  | Some content -> if content = "" then details_text else content
+  | None -> details_text
+;;
+
 (** Message metadata: extensible typed key-value pairs attached to a message.
     Keys are caller-defined strings; values are JSON payloads. *)
 type metadata = (string * Yojson.Safe.t) list [@@deriving show]

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -169,6 +169,16 @@ type content_block =
       }
 [@@deriving show]
 
+(** [reasoning_details_text ~reasoning_content ~details] projects provider
+    reasoning details to their textual reasoning channel. Non-empty
+    [reasoning_content] wins; otherwise the function concatenates
+    [details[].text] in order and ignores raw-only detail payloads. It never
+    serializes [raw] as a fallback. *)
+val reasoning_details_text
+  :  reasoning_content:string option
+  -> details:reasoning_detail list
+  -> string
+
 (** Message metadata: extensible typed key-value pairs attached to a message. *)
 type metadata = (string * Yojson.Safe.t) list [@@deriving show]
 

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -790,6 +790,45 @@ let test_visible_text_of_content_excludes_non_answer_blocks () =
     (Types.visible_text_of_content content)
 ;;
 
+let test_reasoning_details_text_prefers_reasoning_content () =
+  let details =
+    [ { Types.raw = `Assoc [ "text", `String "detail" ]; text = Some "detail" } ]
+  in
+  Alcotest.(check string)
+    "reasoning_content wins"
+    "content"
+    (Types.reasoning_details_text ~reasoning_content:(Some "content") ~details)
+;;
+
+let test_reasoning_details_text_projects_detail_text_in_order () =
+  let details =
+    [ { Types.raw = `Assoc [ "text", `String "a" ]; text = Some "a" }
+    ; { Types.raw = `Assoc [ "opaque", `Bool true ]; text = None }
+    ; { Types.raw = `Assoc [ "text", `String "b" ]; text = Some "b" }
+    ]
+  in
+  Alcotest.(check string)
+    "detail text"
+    "ab"
+    (Types.reasoning_details_text ~reasoning_content:None ~details);
+  Alcotest.(check string)
+    "empty reasoning_content falls back"
+    "ab"
+    (Types.reasoning_details_text ~reasoning_content:(Some "") ~details)
+;;
+
+let test_reasoning_details_text_ignores_raw_only_details () =
+  let details =
+    [ { Types.raw = `Assoc [ "opaque", `Bool true ]; text = None }
+    ; { Types.raw = `Assoc [ "encrypted", `String "payload" ]; text = None }
+    ]
+  in
+  Alcotest.(check string)
+    "raw-only details are not serialized"
+    ""
+    (Types.reasoning_details_text ~reasoning_content:None ~details)
+;;
+
 let test_text_of_content_empty () =
   Alcotest.(check string) "empty" "" (Types.text_of_content [])
 ;;
@@ -1269,6 +1308,18 @@ let () =
             "visible text excludes non-answer blocks"
             `Quick
             test_visible_text_of_content_excludes_non_answer_blocks
+        ; Alcotest.test_case
+            "reasoning details text prefers content"
+            `Quick
+            test_reasoning_details_text_prefers_reasoning_content
+        ; Alcotest.test_case
+            "reasoning details text projects details"
+            `Quick
+            test_reasoning_details_text_projects_detail_text_in_order
+        ; Alcotest.test_case
+            "reasoning details text ignores raw-only details"
+            `Quick
+            test_reasoning_details_text_ignores_raw_only_details
         ; Alcotest.test_case "empty" `Quick test_text_of_content_empty
         ; Alcotest.test_case "text_of_message" `Quick test_text_of_message
         ; Alcotest.test_case


### PR DESCRIPTION
Summary:
- add Types.reasoning_details_text as the SSOT projection for ReasoningDetails textual content
- route OpenAI parse/serialize, canonical-tool projection, response-shape sizing, context estimation, and hooks through the helper
- cover content precedence, detail ordering, empty content fallback, and raw-only detail exclusion

Downstream:
- consumed by MASC PR https://github.com/jeong-sik/masc/pull/22832 for details-only Thinking/Tools/Multiturn interleaving

Validation:
- ocamlformat --check touched OCaml files
- git diff --check HEAD~1..HEAD
- scripts/dune-local.sh exec test/test_types.exe