### PR TITLE
test(reasoning): remove duplicate reasoning_details arm

### DIFF
--- a/test/test_thinking_control_dialects.ml
+++ b/test/test_thinking_control_dialects.ml
@@ -509,9 +509,6 @@ let test_ollama_cloud_openai_compat_streams_reasoning_delta () =
      fail "ollama cloud OpenAI-compatible should not use reasoning_details streaming"
    | RD.No_streaming_reasoning ->
      fail "ollama cloud OpenAI-compatible reasoning stream field was dropped"
-   | RD.Delta_reasoning_details ->
-     fail
-       "ollama cloud OpenAI-compatible should not use reasoning_details split streaming"
    | RD.Template_parser ->
      fail "ollama cloud OpenAI-compatible should not use template parser streaming");
   let live_shape =


### PR DESCRIPTION
## Summary
- Remove the duplicate RD.Delta_reasoning_details arm introduced in the Ollama Cloud reasoning stream dialect test.
- Keeps the intended fail-fast coverage while avoiding OCaml warning 11 under -warn-error +a.

## Verification
- scripts/dune-local.sh build test/test_metrics_aggregating.exe