### PR TITLE
Repair reasoning/provider CI regressions

### DIFF
--- a/lib/provider_runtime_binding.ml
+++ b/lib/provider_runtime_binding.ml
@@ -427,6 +427,7 @@ let to_provider_config ?model binding =
     ~model_id
     ~base_url:binding.base_url
     ~supports_structured_output_override:binding.capabilities.supports_structured_output
+    ~model_capabilities_override:binding.capabilities
     ?request_path
     ?max_context
     ()

--- a/test/test_streaming_edge_cases.ml
+++ b/test/test_streaming_edge_cases.ml
@@ -325,9 +325,10 @@ let test_openai_event_edge_branches () =
     S.openai_chunk_to_events tool_state (openai_chunk ~delta_tool_calls:[ tc_none ] ())
   in
   check_event_count "same tool index without args emits nothing" 0 reused_tool_events;
+  let finish_state = S.create_openai_stream_state () in
   let refusal_finish_events, _ =
     S.openai_chunk_to_events
-      tool_state
+      finish_state
       (openai_chunk ~finish_reason:"refusal" ~chunk_usage:(usage ()) ())
   in
   match refusal_finish_events with

--- a/test/test_thinking_control_dialects.ml
+++ b/test/test_thinking_control_dialects.ml
@@ -509,9 +509,6 @@ let test_ollama_cloud_openai_compat_streams_reasoning_delta () =
      fail "ollama cloud OpenAI-compatible should not use reasoning_details streaming"
    | RD.No_streaming_reasoning ->
      fail "ollama cloud OpenAI-compatible reasoning stream field was dropped"
-   | RD.Delta_reasoning_details ->
-     fail
-       "ollama cloud OpenAI-compatible should not use reasoning_details split streaming"
    | RD.Template_parser ->
      fail "ollama cloud OpenAI-compatible should not use template parser streaming");
   let live_shape =


### PR DESCRIPTION
## Summary
- Removes the duplicate `RD.Delta_reasoning_details` branch in the Ollama Cloud OpenAI-compatible reasoning dialect test.
- Projects provider-catalog capabilities into `Provider_runtime_binding.to_provider_config`, matching the declared-endpoint path used elsewhere and avoiding raw model fallback for structured-output validation.
- Isolates the OpenAI SSE refusal finish-reason edge test from a prior open tool-block state so it checks `finish_reason=refusal` mapping directly.

## Evidence
- CI #2359 run `28443050594` failed compiling `test/test_thinking_control_dialects.ml` after the newer reasoning-details constructor landed.
- CI #2365 run `28443877022` then failed deterministically in `test_provider_runtime_binding.exe` and `test_streaming_edge_cases.exe`; both failures were reproduced locally before patching.
- Local: `ocamlformat --check lib/provider_runtime_binding.ml test/test_streaming_edge_cases.ml test/test_thinking_control_dialects.ml`
- Local: `git diff --check`
- Local: `env OAS_MODEL_CATALOG=/Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/oas-reasoning-details-exhaustive-20260630/models.toml OAS_CAPABILITY_MANIFEST= ALCOTEST_QUICK_TESTS=1 ./scripts/dune-local.sh build test/test_provider_runtime_binding.exe test/test_streaming_edge_cases.exe test/test_thinking_control_dialects.exe`
- Local: `env OAS_MODEL_CATALOG=/Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/oas-reasoning-details-exhaustive-20260630/models.toml OAS_CAPABILITY_MANIFEST= ALCOTEST_QUICK_TESTS=1 ./_build/default/test/test_provider_runtime_binding.exe` (16 tests)
- Local: `env OAS_MODEL_CATALOG=/Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/oas-reasoning-details-exhaustive-20260630/models.toml OAS_CAPABILITY_MANIFEST= ALCOTEST_QUICK_TESTS=1 ./_build/default/test/test_streaming_edge_cases.exe` (12 tests)
- Local: `env OAS_MODEL_CATALOG=/Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/oas-reasoning-details-exhaustive-20260630/models.toml OAS_CAPABILITY_MANIFEST= ALCOTEST_QUICK_TESTS=1 ./_build/default/test/test_thinking_control_dialects.exe` (35 tests)
