### PR TITLE
refactor(capabilities): centralize thinking vocabulary parsing

### DIFF
--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -638,6 +638,8 @@ let capabilities_for_provider_label label =
     (match label with
      | "openai_compat_chat_extended" | "openai_chat_extended" ->
        Some openai_compat_chat_extended_capabilities
+     | "xai" | "mistral" -> Some openai_compat_chat_extended_capabilities
+     | "cohere" | "mimo" -> Some openai_compat_chat_capabilities
      | "ollama_cloud" -> Some ollama_cloud_capabilities
      | "nvidia" -> Some provider_l_capabilities
      | _ -> None)
@@ -2073,6 +2075,10 @@ let%test "capabilities_for_provider_label: aliases resolve to identical capabili
   && Option.is_some (resolve "gemini")
   && Option.is_some (resolve "ollama")
   && Option.is_some (resolve "kimi")
+  && Option.is_some (resolve "xai")
+  && Option.is_some (resolve "mistral")
+  && Option.is_some (resolve "cohere")
+  && Option.is_some (resolve "mimo")
   && Option.is_some (resolve "nvidia")
 ;;
 
@@ -2089,6 +2095,10 @@ let%test "capabilities_for_provider_label: all declared labels resolve" =
     ; "ollama"
     ; "glm"
     ; "glm-coding"
+    ; "xai"
+    ; "mistral"
+    ; "cohere"
+    ; "mimo"
     ; "nvidia"
     ; "kimi"
     ]

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -12,46 +12,24 @@
     thinking, so the runtime must know which format to emit.
 
     @since 0.184.0 *)
-type thinking_control_format =
+type thinking_control_format = Capability_vocab.thinking_control_format =
   | No_thinking_control (** No thinking control supported *)
   | Thinking_object (** Top-level [thinking] object plus optional [reasoning_effort]. *)
   | Thinking_object_adaptive
-  (** Top-level [thinking] object whose enabled value is [adaptive]. *)
   | Thinking_object_only
-  (** Kimi K2.5-style: top-level [thinking] object without [reasoning_effort]. *)
   | Chat_template_kwargs
-  (** llama-server/vLLM/SGLang style:
-      [{"chat_template_kwargs":{"enable_thinking":b,"preserve_thinking":b}}] *)
   | Chat_template_token
-  (** Chat-template control token style: inject a model-specific thinking token
-      into the conversation instead of sending a top-level thinking field. *)
   | Ollama_think
-  (** Ollama native [/api/chat] top-level [think] bool or effort level. This is
-      distinct from OpenAI-compatible [reasoning_effort] even when the model
-      family name is shared with a cloud provider such as GLM. *)
   | Reasoning_effort
-  (** Openai-style top-level [reasoning_effort] string field. The typed value
-      set lives in {!Reasoning_effort}; provider-specific aliases are applied
-      by {!Reasoning_dialect.normalize_effort_value}. Disabled reasoning is
-      represented by omitting the field. Ollama's OpenAI-compatible mode uses
-      this shape. *)
   | Enable_thinking
-  (** DashScope-style top-level [enable_thinking] / [preserve_thinking] bools
-      plus optional [thinking_budget]. *)
 
 type preserve_thinking_control_format =
+      Capability_vocab.preserve_thinking_control_format =
   | No_preserve_thinking_control
   | Thinking_object_keep_all
-  (** [thinking.keep = "all"] inside the top-level
-      [thinking] object. *)
   | Chat_template_kwargs_preserve_thinking
-  (** Self-hosted chat-template kwargs [preserve_thinking] flag. *)
   | Top_level_preserve_thinking
-  (** Provider top-level [preserve_thinking] flag, separate from
-      [enable_thinking]. *)
   | Always_preserved_thinking
-  (** Provider always requires historical reasoning replay and has no
-      request-time preserve toggle. *)
 
 (** Optional override for the multi-turn reasoning replay policy. Most providers
     inherit the policy implied by [thinking_control_format]; catalog entries set
@@ -698,36 +676,12 @@ let with_tool_support caps ~supports_tools = { caps with supports_tools }
     when absent or unrecognised.  Each [Some] field in [entry] overrides
     the corresponding field of the base; [None] fields are left unchanged. *)
 
-(* Parse the manifest's [thinking_control_format] string into the typed
-   variant. Mirrors {!Provider_catalog.parse_thinking_control_format}; kept
-   local to avoid a Provider_catalog -> Capabilities dependency cycle. An
-   unrecognised value leaves the base format unchanged (handled by the caller). *)
 let thinking_control_format_of_manifest_string raw =
-  match String.lowercase_ascii (String.trim raw) with
-  | "none" -> Some No_thinking_control
-  | "thinking_object" -> Some Thinking_object
-  | "thinking_object_adaptive" -> Some Thinking_object_adaptive
-  | "thinking_object_only" -> Some Thinking_object_only
-  | "chat_template_kwargs" -> Some Chat_template_kwargs
-  | "chat_template_token" -> Some Chat_template_token
-  | "ollama_think" -> Some Ollama_think
-  | "reasoning_effort" -> Some Reasoning_effort
-  | "enable_thinking" -> Some Enable_thinking
-  | _ -> None
-;;
-
-let preserve_thinking_control_manifest_values =
-  [ "none", No_preserve_thinking_control
-  ; "thinking_object_keep_all", Thinking_object_keep_all
-  ; "chat_template_kwargs_preserve_thinking", Chat_template_kwargs_preserve_thinking
-  ; "top_level_preserve_thinking", Top_level_preserve_thinking
-  ; "always_preserved", Always_preserved_thinking
-  ]
+  Capability_vocab.thinking_control_format_of_string raw
 ;;
 
 let preserve_thinking_control_format_of_manifest_string raw =
-  String.lowercase_ascii (String.trim raw)
-  |> Fun.flip List.assoc_opt preserve_thinking_control_manifest_values
+  Capability_vocab.preserve_thinking_control_format_of_string raw
 ;;
 
 let warn_unknown_capability_value ~field raw =

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -6,44 +6,24 @@
     @stability Internal
     @since 0.93.1 *)
 
-type thinking_control_format =
+type thinking_control_format = Capability_vocab.thinking_control_format =
   | No_thinking_control (** No thinking control supported *)
   | Thinking_object (** Top-level [thinking] object plus optional [reasoning_effort]. *)
   | Thinking_object_adaptive
-  (** Top-level [thinking] object whose enabled value is [adaptive]. *)
   | Thinking_object_only
-  (** Kimi-style: top-level [thinking] object without [reasoning_effort]. *)
   | Chat_template_kwargs
-  (** llama-server/vLLM/SGLang style:
-      [{"chat_template_kwargs":{"enable_thinking":b,"preserve_thinking":b}}] *)
   | Chat_template_token
-  (** Chat-template control token style: the request builder injects a model
-      token such as [<|think|>] into the rendered conversation instead of
-      sending a top-level thinking field. *)
-  | Ollama_think (** Ollama native [/api/chat] top-level [think] bool or effort level. *)
+  | Ollama_think
   | Reasoning_effort
-  (** Openai-style top-level [reasoning_effort] string field. The typed value
-      set lives in {!Reasoning_effort}; provider-specific aliases are applied
-      by {!Reasoning_dialect.normalize_effort_value}. Disabled reasoning is
-      represented by omitting the field. Ollama's OpenAI-compatible mode uses
-      this shape. *)
   | Enable_thinking
-  (** DashScope-style top-level [enable_thinking] / [preserve_thinking] bools
-      plus optional [thinking_budget]. *)
 
 type preserve_thinking_control_format =
+      Capability_vocab.preserve_thinking_control_format =
   | No_preserve_thinking_control
   | Thinking_object_keep_all
-  (** [thinking.keep = "all"] inside the top-level
-      [thinking] object. *)
   | Chat_template_kwargs_preserve_thinking
-  (** Self-hosted chat-template kwargs [preserve_thinking] flag. *)
   | Top_level_preserve_thinking
-  (** Provider top-level [preserve_thinking] flag, separate from
-      [enable_thinking]. *)
   | Always_preserved_thinking
-  (** Provider always requires historical reasoning replay and has no
-      request-time preserve toggle. *)
 
 type reasoning_replay_override = Capability_vocab.reasoning_replay_override =
   | Default_reasoning_replay

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -236,7 +236,8 @@ val for_model_id : string -> capabilities option
 
     Recognized labels (case-insensitive, whitespace trimmed):
     [anthropic] / [claude], [openai_compat] / [openai],
-    [gemini], [ollama], [glm] / [zhipu], [kimi], [dashscope], [nvidia].
+    [gemini], [ollama], [glm] / [zhipu], [kimi], [dashscope],
+    [xai], [mistral], [cohere], [mimo], [nvidia].
 
     Canonical labels and aliases for the closed {!Provider_kind.t} space are
     normalized to a typed kind first, then delegated to {!capabilities_of_kind}.
@@ -257,8 +258,8 @@ val capabilities_for_provider_label : string -> capabilities option
     the kind to a string and re-parsing it. Use this when the caller already
     holds a typed {!Provider_kind.t}; {!capabilities_for_provider_label}
     delegates canonical labels here and only keeps string-only presets (e.g.
-    ["openai_chat_extended"], ["ollama_cloud"], ["nvidia"]) at the label
-    boundary.
+    ["openai_chat_extended"], ["ollama_cloud"], ["xai"], ["mistral"],
+    ["cohere"], ["mimo"], ["nvidia"]) at the label boundary.
 
     @since 0.209.0 *)
 val capabilities_of_kind : Provider_kind.t -> capabilities

--- a/lib/llm_provider/capability_vocab.ml
+++ b/lib/llm_provider/capability_vocab.ml
@@ -5,6 +5,24 @@
     same operator-facing strings, so the canonical wire vocabulary must live in
     a leaf module to avoid duplicate enum tables and dependency cycles. *)
 
+type thinking_control_format =
+  | No_thinking_control
+  | Thinking_object
+  | Thinking_object_adaptive
+  | Thinking_object_only
+  | Chat_template_kwargs
+  | Chat_template_token
+  | Ollama_think
+  | Reasoning_effort
+  | Enable_thinking
+
+type preserve_thinking_control_format =
+  | No_preserve_thinking_control
+  | Thinking_object_keep_all
+  | Chat_template_kwargs_preserve_thinking
+  | Top_level_preserve_thinking
+  | Always_preserved_thinking
+
 type reasoning_replay_override =
   | Default_reasoning_replay
   | Force_no_replay
@@ -27,26 +45,56 @@ type reasoning_streaming_format =
 
 let normalize raw = String.lowercase_ascii (String.trim raw)
 
-let thinking_control_format_values =
-  [ "none"
-  ; "thinking_object"
-  ; "thinking_object_adaptive"
-  ; "thinking_object_only"
-  ; "chat_template_kwargs"
-  ; "chat_template_token"
-  ; "ollama_think"
-  ; "reasoning_effort"
-  ; "enable_thinking"
+let thinking_control_format_table =
+  [ "none", No_thinking_control
+  ; "thinking_object", Thinking_object
+  ; "thinking_object_adaptive", Thinking_object_adaptive
+  ; "thinking_object_only", Thinking_object_only
+  ; "chat_template_kwargs", Chat_template_kwargs
+  ; "chat_template_token", Chat_template_token
+  ; "ollama_think", Ollama_think
+  ; "reasoning_effort", Reasoning_effort
+  ; "enable_thinking", Enable_thinking
+  ]
+;;
+
+let thinking_control_format_values = List.map fst thinking_control_format_table
+
+let thinking_control_format_of_string raw =
+  match normalize raw with
+  | "" -> None
+  | normalized -> List.assoc_opt normalized thinking_control_format_table
+;;
+
+let preserve_thinking_control_format_table =
+  [ "none", No_preserve_thinking_control
+  ; "thinking_object_keep_all", Thinking_object_keep_all
+  ; "chat_template_kwargs_preserve_thinking", Chat_template_kwargs_preserve_thinking
+  ; "top_level_preserve_thinking", Top_level_preserve_thinking
+  ; "always_preserved", Always_preserved_thinking
   ]
 ;;
 
 let preserve_thinking_control_format_values =
-  [ "none"
-  ; "thinking_object_keep_all"
-  ; "chat_template_kwargs_preserve_thinking"
-  ; "top_level_preserve_thinking"
-  ; "always_preserved"
-  ]
+  List.map fst preserve_thinking_control_format_table
+;;
+
+let preserve_thinking_control_format_of_string raw =
+  match normalize raw with
+  | "" -> None
+  | normalized -> List.assoc_opt normalized preserve_thinking_control_format_table
+;;
+
+let%test "thinking_control_format values parse through the canonical table" =
+  List.for_all
+    (fun raw -> Option.is_some (thinking_control_format_of_string raw))
+    thinking_control_format_values
+;;
+
+let%test "preserve_thinking_control_format values parse through the canonical table" =
+  List.for_all
+    (fun raw -> Option.is_some (preserve_thinking_control_format_of_string raw))
+    preserve_thinking_control_format_values
 ;;
 
 let modality_priority_values =

--- a/lib/llm_provider/provider_catalog.ml
+++ b/lib/llm_provider/provider_catalog.ml
@@ -203,49 +203,32 @@ let parse_auth json =
   | _ -> Ok No_auth
 ;;
 
-let parse_thinking_control_format = function
+let parse_optional_capability_value ~field ~canonical parse = function
   | None -> Ok None
   | Some raw ->
-    let trimmed = String.lowercase_ascii (String.trim raw) in
-    (match trimmed with
-     | "" -> Ok None
-     | "none" -> Ok (Some Capabilities.No_thinking_control)
-     | "thinking_object" -> Ok (Some Capabilities.Thinking_object)
-     | "thinking_object_adaptive" -> Ok (Some Capabilities.Thinking_object_adaptive)
-     | "thinking_object_only" -> Ok (Some Capabilities.Thinking_object_only)
-     | "chat_template_kwargs" -> Ok (Some Capabilities.Chat_template_kwargs)
-     | "chat_template_token" -> Ok (Some Capabilities.Chat_template_token)
-     | "ollama_think" -> Ok (Some Capabilities.Ollama_think)
-     | "reasoning_effort" -> Ok (Some Capabilities.Reasoning_effort)
-     | "enable_thinking" -> Ok (Some Capabilities.Enable_thinking)
-     | other ->
-       Error
-         (Printf.sprintf
-            "unknown thinking_control_format %S (canonical: none, thinking_object, \
-             thinking_object_adaptive, thinking_object_only, chat_template_kwargs, \
-             chat_template_token, ollama_think, reasoning_effort, enable_thinking)"
-            other))
+    let normalized = String.lowercase_ascii (String.trim raw) in
+    if String.equal normalized ""
+    then Ok None
+    else (
+      match parse normalized with
+      | Some value -> Ok (Some value)
+      | None ->
+        Error (Printf.sprintf "unknown %s %S (canonical: %s)" field normalized canonical))
 ;;
 
-let parse_preserve_thinking_control_format = function
-  | None -> Ok None
-  | Some raw ->
-    let trimmed = String.lowercase_ascii (String.trim raw) in
-    (match trimmed with
-     | "" -> Ok None
-     | "none" -> Ok (Some Capabilities.No_preserve_thinking_control)
-     | "thinking_object_keep_all" -> Ok (Some Capabilities.Thinking_object_keep_all)
-     | "chat_template_kwargs_preserve_thinking" ->
-       Ok (Some Capabilities.Chat_template_kwargs_preserve_thinking)
-     | "top_level_preserve_thinking" -> Ok (Some Capabilities.Top_level_preserve_thinking)
-     | "always_preserved" -> Ok (Some Capabilities.Always_preserved_thinking)
-     | other ->
-       Error
-         (Printf.sprintf
-            "unknown preserve_thinking_control_format %S (canonical: none, \
-             thinking_object_keep_all, chat_template_kwargs_preserve_thinking, \
-             top_level_preserve_thinking, always_preserved)"
-            other))
+let parse_thinking_control_format =
+  parse_optional_capability_value
+    ~field:"thinking_control_format"
+    ~canonical:(String.concat ", " Capability_vocab.thinking_control_format_values)
+    Capability_vocab.thinking_control_format_of_string
+;;
+
+let parse_preserve_thinking_control_format =
+  parse_optional_capability_value
+    ~field:"preserve_thinking_control_format"
+    ~canonical:
+      (String.concat ", " Capability_vocab.preserve_thinking_control_format_values)
+    Capability_vocab.preserve_thinking_control_format_of_string
 ;;
 
 let parse_reasoning_replay = function

--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -428,6 +428,15 @@ let default () =
       ; is_available = (fun () -> has_api_key defaults.api_key_env)
       }
   in
+  let capabilities_for_registered_label label =
+    match Capabilities.capabilities_for_provider_label label with
+    | Some caps -> caps
+    | None ->
+      invalid_arg
+        (Printf.sprintf
+           "Provider_registry.default: no capabilities for registered provider %S"
+           label)
+  in
   reg
     "nous"
     (llama_defaults ())
@@ -477,26 +486,18 @@ let default () =
     siliconflow_defaults
     ~max_context:128_000
     Capabilities.openai_compat_chat_capabilities;
-  reg
-    "xai"
-    xai_defaults
-    ~max_context:1_000_000
-    Capabilities.openai_compat_chat_extended_capabilities;
+  reg "xai" xai_defaults ~max_context:1_000_000 (capabilities_for_registered_label "xai");
   reg
     "mistral"
     mistral_defaults
     ~max_context:260_000
-    Capabilities.openai_compat_chat_extended_capabilities;
+    (capabilities_for_registered_label "mistral");
   reg
     "cohere"
     cohere_defaults
     ~max_context:256_000
-    Capabilities.openai_compat_chat_capabilities;
-  reg
-    "mimo"
-    mimo_defaults
-    ~max_context:128_000
-    Capabilities.openai_compat_chat_capabilities;
+    (capabilities_for_registered_label "cohere");
+  reg "mimo" mimo_defaults ~max_context:128_000 (capabilities_for_registered_label "mimo");
   register
     t
     { name = "ollama"


### PR DESCRIPTION
## Summary
- move thinking_control_format and preserve_thinking_control_format typed vocabulary/parser into Capability_vocab
- re-export the same typed variants from Capabilities so existing callers keep the same constructor surface
- make provider catalog and capability manifest application use the same parser/table
- add xAI/Mistral/Cohere/MiMo provider labels to the capability classifier and have Provider_registry reuse that classifier for those registered OpenAI-compatible presets
- add inline round-trip guards so vocabulary values and parser entries cannot drift independently

## Verification
- ocamlformat --check lib/llm_provider/capability_vocab.ml lib/llm_provider/capabilities.ml lib/llm_provider/capabilities.mli lib/llm_provider/provider_catalog.ml lib/llm_provider/provider_registry.ml
- git diff --check
- scripts/hardening-ratchet.sh --check
- scripts/ci-code-smell-ratchet.sh

Note: local Dune build/test intentionally not run; CI is the build authority for this branch.