### PR TITLE
Fail closed on unnamed streamed tool calls

### DIFF
--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -1,11 +1,14 @@
 (** Stream accumulator: gather SSE events into a {!Types.api_response}.
 
     Extracts the stream_acc type and its operations from [Complete].
-    Depends only on [Types] -- no provider/backend/transport references.
+    Depends only on [Types] and shared API helpers -- no
+    provider/backend/transport references.
 
     @since 0.79.0 *)
 
 (** Internal: accumulate SSE events into content blocks. *)
+let ( let* ) = Result.bind
+
 type stream_acc =
   { id : string ref
   ; model : string ref
@@ -306,15 +309,15 @@ let finalize_stream_acc (acc : stream_acc) =
                 assembly and never reaches this branch. *)
         Ok None
       | Some Tool_use_block ->
-        let id =
-          match Hashtbl.find_opt acc.block_tool_ids idx with
-          | Some s -> s
-          | None -> ""
-        in
-        let name =
+        let* name =
           match Hashtbl.find_opt acc.block_tool_names idx with
-          | Some s -> s
-          | None -> ""
+          | Some s when not (Api_common.string_is_blank s) -> Ok s
+          | Some _ | None ->
+            Error
+              (Types.Stream_parse_failed
+                 { reason = Printf.sprintf "malformed_tool_use:index:%d:missing_name" idx
+                 ; raw = ""
+                 })
         in
         (* Tool arguments must parse. An empty argument buffer is the
            legitimate "no arguments" case and becomes the empty object; a
@@ -325,13 +328,14 @@ let finalize_stream_acc (acc : stream_acc) =
            the [Unknown_block] fail-closed arm and the typed-absence policy of
            the sibling [Tool_result_block] branch (which carries [json = None]
            rather than fabricating an object). *)
-        if String.trim text = ""
-        then Ok (Some (Types.ToolUse { id; name; input = `Assoc [] }))
-        else (
-          match Yojson.Safe.from_string text with
-          | input -> Ok (Some (Types.ToolUse { id; name; input }))
-          | exception Yojson.Json_error reason ->
-            (* Preserve the offending accumulated buffer in [raw] so the rare,
+        let* input =
+          if String.trim text = ""
+          then Ok (`Assoc [])
+          else (
+            match Yojson.Safe.from_string text with
+            | input -> Ok input
+            | exception Yojson.Json_error reason ->
+              (* Preserve the offending accumulated buffer in [raw] so the rare,
                provider-specific malformed tool-arg wire is diagnosable from the
                operator-facing diagnostic log (the [Complete_stream] renderer
                bounds it to 256 bytes).
@@ -342,12 +346,23 @@ let finalize_stream_acc (acc : stream_acc) =
                The deliberately-empty [Unknown_block] arm below stays empty
                because an unrecognized block payload has neither this bound nor a
                known shape. *)
-            Error
-              (Types.Stream_parse_failed
-                 { reason =
-                     Printf.sprintf "malformed_tool_use_arguments:index:%d:%s" idx reason
-                 ; raw = text
-                 }))
+              Error
+                (Types.Stream_parse_failed
+                   { reason =
+                       Printf.sprintf
+                         "malformed_tool_use_arguments:index:%d:%s"
+                         idx
+                         reason
+                   ; raw = text
+                   }))
+        in
+        let id =
+          match Hashtbl.find_opt acc.block_tool_ids idx with
+          | Some s when not (Api_common.string_is_blank s) -> s
+          | Some _ | None ->
+            Printf.sprintf "%s_%d" (Api_common.synthesize_tool_use_id ~name input) idx
+        in
+        Ok (Some (Types.ToolUse { id; name; input }))
       | Some (Tool_result_block { is_error }) ->
         let tool_use_id =
           match Hashtbl.find_opt acc.block_tool_ids idx with
@@ -1157,6 +1172,8 @@ let%test "finalize_stream_acc fails closed on malformed tool_use arguments" =
      default). Truncation is handled by the MaxTokens guard, below. *)
   let acc = create_stream_acc () in
   Hashtbl.replace acc.block_types 0 "tool_use";
+  Hashtbl.replace acc.block_tool_ids 0 "tool-id-1";
+  Hashtbl.replace acc.block_tool_names 0 "broken_tool";
   let buf = Buffer.create 16 in
   Buffer.add_string buf "not valid json";
   Hashtbl.replace acc.block_texts 0 buf;
@@ -1255,9 +1272,10 @@ let%test "finalize_stream_acc keeps tool_use on StopToolUse (no over-drop)" =
      | _ -> false)
 ;;
 
-let%test "finalize_stream_acc tool_use missing id/name defaults to empty" =
+let%test "finalize_stream_acc tool_use missing name fails closed" =
   let acc = create_stream_acc () in
   Hashtbl.replace acc.block_types 0 "tool_use";
+  Hashtbl.replace acc.block_tool_ids 0 "tool-id-1";
   let buf = Buffer.create 16 in
   Buffer.add_string buf "{}";
   Hashtbl.replace acc.block_texts 0 buf;
@@ -1265,11 +1283,61 @@ let%test "finalize_stream_acc tool_use missing id/name defaults to empty" =
     acc.stop_reason_received := true;
     finalize_stream_acc acc
   with
-  | Error _ -> false
+  | Error (Types.Stream_parse_failed { reason; raw }) ->
+    reason = "malformed_tool_use:index:0:missing_name" && raw = ""
+  | Error err ->
+    let (_ : Types.stream_error) = err in
+    false
+  | Ok result ->
+    let (_ : Types.api_response) = result in
+    false
+;;
+
+let%test "finalize_stream_acc tool_use missing id synthesizes stable id" =
+  let acc = create_stream_acc () in
+  Hashtbl.replace acc.block_types 0 "tool_use";
+  Hashtbl.replace acc.block_tool_names 0 "get_weather";
+  let buf = Buffer.create 16 in
+  Buffer.add_string buf "{}";
+  Hashtbl.replace acc.block_texts 0 buf;
+  match
+    acc.stop_reason_received := true;
+    finalize_stream_acc acc
+  with
+  | Error err ->
+    let (_ : Types.stream_error) = err in
+    false
   | Ok result ->
     (match result.content with
-     | [ Types.ToolUse { id = ""; name = ""; _ } ] -> true
-     | _ -> false)
+     | [ Types.ToolUse { id; name = "get_weather"; input = `Assoc [] } ] ->
+       String.starts_with ~prefix:"call_get_weather_" id
+     | unexpected ->
+       let (_ : Types.content_block list) = unexpected in
+       false)
+;;
+
+let%test "finalize_stream_acc tool_use blank id synthesizes stable id" =
+  let acc = create_stream_acc () in
+  Hashtbl.replace acc.block_types 0 "tool_use";
+  Hashtbl.replace acc.block_tool_ids 0 " ";
+  Hashtbl.replace acc.block_tool_names 0 "get_weather";
+  let buf = Buffer.create 16 in
+  Buffer.add_string buf "{}";
+  Hashtbl.replace acc.block_texts 0 buf;
+  match
+    acc.stop_reason_received := true;
+    finalize_stream_acc acc
+  with
+  | Error err ->
+    let (_ : Types.stream_error) = err in
+    false
+  | Ok result ->
+    (match result.content with
+     | [ Types.ToolUse { id; name = "get_weather"; input = `Assoc [] } ] ->
+       String.starts_with ~prefix:"call_get_weather_" id
+     | unexpected ->
+       let (_ : Types.content_block list) = unexpected in
+       false)
 ;;
 
 let%test "finalize_stream_acc assembles tool_result block" =

--- a/test/test_streaming_coverage.ml
+++ b/test/test_streaming_coverage.ml
@@ -407,23 +407,59 @@ let test_finalize_tool_use_invalid_json () =
   | Ok _ -> Alcotest.fail "expected invalid tool_use JSON to fail closed"
 ;;
 
-(* ── finalize: tool_use with missing tool_id/tool_name ──────────── *)
+(* ── finalize: tool_use metadata boundary ───────────────────────── *)
 
-let test_finalize_tool_use_missing_ids () =
+let test_finalize_tool_use_missing_name () =
   let acc = Streaming.create_stream_acc () in
   Streaming.accumulate_event
     acc
     (ContentBlockStart
-       { index = 0; content_type = "tool_use"; tool_id = None; tool_name = None });
+       { index = 0
+       ; content_type = "tool_use"
+       ; tool_id = Some "tool-id-1"
+       ; tool_name = None
+       });
+  Streaming.accumulate_event
+    acc
+    (ContentBlockDelta { index = 0; delta = InputJsonDelta {|{"ok": true}|} });
+  Streaming.accumulate_event
+    acc
+    (MessageDelta { stop_reason = Some EndTurn; usage = None });
+  match Streaming.finalize_stream_acc acc with
+  | Error (Stream_parse_failed { reason; raw }) ->
+    check_string "missing name reason" "malformed_tool_use:index:0:missing_name" reason;
+    check_string "raw omitted" "" raw
+  | Error err -> fail_unexpected_stream_error err
+  | Ok response ->
+    let (_ : api_response) = response in
+    Alcotest.fail "expected missing tool name to fail closed"
+;;
+
+let test_finalize_tool_use_missing_id_synthesizes () =
+  let acc = Streaming.create_stream_acc () in
+  Streaming.accumulate_event
+    acc
+    (ContentBlockStart
+       { index = 0; content_type = "tool_use"; tool_id = None; tool_name = Some "lookup" });
   Streaming.accumulate_event
     acc
     (ContentBlockDelta { index = 0; delta = InputJsonDelta {|{"ok": true}|} });
   let resp = finalize_ok acc in
   match resp.content with
-  | [ ToolUse { id; name; _ } ] ->
-    check_string "default tool_id" "" id;
-    check_string "default tool_name" "" name
-  | _ -> Alcotest.fail "expected ToolUse with empty defaults"
+  | [ ToolUse { id; name; input } ] ->
+    check_bool "synthetic id prefix" true (String.starts_with ~prefix:"call_lookup_" id);
+    check_string "tool_name" "lookup" name;
+    let input_ok =
+      match input with
+      | `Assoc [ ("ok", `Bool true) ] -> true
+      | unexpected ->
+        let (_ : Yojson.Safe.t) = unexpected in
+        false
+    in
+    check_bool "input ok" true input_ok
+  | unexpected ->
+    let (_ : content_block list) = unexpected in
+    Alcotest.fail "expected ToolUse with synthetic id"
 ;;
 
 (* ── finalize: text block with no delta (empty text) ────────────── *)
@@ -779,7 +815,7 @@ let test_acc_partial_tool_metadata () =
   let resp = finalize_ok acc in
   match resp.content with
   | [ ToolUse { id; name; _ } ] ->
-    check_string "default id" "" id;
+    check_bool "synthetic id" true (String.starts_with ~prefix:"call_partial_" id);
     check_string "partial name" "partial" name
   | _ -> Alcotest.fail "expected ToolUse with partial metadata"
 ;;
@@ -910,9 +946,13 @@ let () =
             `Quick
             test_finalize_tool_use_invalid_json
         ; Alcotest.test_case
-            "tool_use missing ids"
+            "tool_use missing name"
             `Quick
-            test_finalize_tool_use_missing_ids
+            test_finalize_tool_use_missing_name
+        ; Alcotest.test_case
+            "tool_use missing id synthesizes"
+            `Quick
+            test_finalize_tool_use_missing_id_synthesizes
         ; Alcotest.test_case
             "text block no delta"
             `Quick


### PR DESCRIPTION
Summary
- fail closed when a streamed tool_use block reaches finalization without a non-blank tool name
- synthesize a deterministic id for valid streamed tool calls that omit/blank tool_id, matching the existing idless-provider pattern
- update stream accumulator coverage for missing-name failure and missing-id synthesis

Verification
- ocamlformat --check lib/llm_provider/complete_stream_acc.ml test/test_streaming_coverage.ml
- git diff --check
- bash scripts/hardening-ratchet.sh --check
- env OAS_MODEL_CATALOG=$PWD/models.toml OAS_CAPABILITY_MANIFEST= ./scripts/dune-local.sh runtest lib/llm_provider
- env OAS_MODEL_CATALOG=$PWD/models.toml OAS_CAPABILITY_MANIFEST= ./scripts/dune-local.sh exec ./test/test_streaming_coverage.exe
- env OAS_MODEL_CATALOG=$PWD/models.toml OAS_CAPABILITY_MANIFEST= ./scripts/dune-local.sh exec ./test/test_stream_accumulator.exe
- env OAS_MODEL_CATALOG=$PWD/models.toml OAS_CAPABILITY_MANIFEST= ./scripts/dune-local.sh exec ./test/test_streaming_cov.exe
- env OAS_MODEL_CATALOG=$PWD/models.toml OAS_CAPABILITY_MANIFEST= ./scripts/dune-local.sh exec ./test/test_streaming_openai.exe
- env OAS_MODEL_CATALOG=$PWD/models.toml OAS_CAPABILITY_MANIFEST= ./scripts/dune-local.sh exec ./test/test_complete_http.exe
- env OAS_MODEL_CATALOG=$PWD/models.toml OAS_CAPABILITY_MANIFEST= ./scripts/dune-local.sh exec ./test/test_streaming_e2e.exe (skipped: requires LLAMA_LIVE_TEST=1)
