### PR TITLE
fix(provider): stop inferring identity from model id

### DIFF
--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -515,12 +515,6 @@ let default () =
   t
 ;;
 
-let provider_name_of_catalog_model_id model_id =
-  match Model_catalog.global () with
-  | None -> None
-  | Some catalog -> Model_catalog.provider_name_for_model_id catalog model_id
-;;
-
 let provider_name_of_config (config : Provider_config.t) =
   match config.kind with
   | Anthropic -> "claude"
@@ -551,7 +545,9 @@ let provider_name_of_config (config : Provider_config.t) =
       with
       | Some entry -> entry.name
       | None ->
-        (match provider_name_of_catalog_model_id config.model_id with
-         | Some provider_name -> provider_name
-         | None -> "openai_compat"))
+        (* Provider identity must come from the concrete kind or an explicit
+           endpoint registry binding. Catalog provider names describe model
+           provenance/capabilities; using them here would infer transport
+           semantics from a model id on arbitrary compatible gateways. *)
+        "openai_compat")
 ;;

--- a/lib/llm_provider/provider_registry.mli
+++ b/lib/llm_provider/provider_registry.mli
@@ -71,10 +71,10 @@ val default : unit -> t
     registry-level distinctions that share a wire kind but differ by
     endpoint (for example [glm] vs [glm-coding], or
     [openai_compat] vs [openrouter]). For unmatched OpenAI-compatible
-    endpoints, the model catalog may still classify provider identity via
-    [Model_catalog.model_entry.provider_name] (for example xAI, Mistral,
-    Cohere, or MiMo). Falls back to a stable kind-derived label when neither
-    endpoint nor catalog classification matches. *)
+    endpoints, falls back to a stable kind-derived label. Model catalog
+    provider names are intentionally not used as provider identity without
+    an explicit provider kind or endpoint registry binding: request
+    compatibility and provider identity are orthogonal. *)
 val provider_name_of_config : Provider_config.t -> string
 
 (** Initial fallback endpoint snapshot. This is intentionally not parsed from

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -993,7 +993,7 @@ let test_provider_name_of_config_unmatched_openai_compat () =
     (Provider_registry.provider_name_of_config cfg)
 ;;
 
-let check_provider_name_from_catalog_model ~label ~model_id ~expected =
+let check_unmatched_provider_name_ignores_catalog_model ~label ~model_id =
   with_repository_model_catalog (fun () ->
     let cfg =
       Provider_config.make
@@ -1003,35 +1003,74 @@ let check_provider_name_from_catalog_model ~label ~model_id ~expected =
         ~request_path:"/chat/completions"
         ()
     in
-    check_string label expected (Provider_registry.provider_name_of_config cfg))
+    check_string label "openai_compat" (Provider_registry.provider_name_of_config cfg))
 ;;
 
-let test_provider_name_of_config_xai_model_catalog () =
-  check_provider_name_from_catalog_model
-    ~label:"xai model catalog provider"
+let check_provider_name_from_registered_endpoint ~label ~provider ~model_id =
+  match Provider_registry.find (Provider_registry.default ()) provider with
+  | None -> Alcotest.failf "provider %S not registered" provider
+  | Some (entry : Provider_registry.entry) ->
+    let cfg =
+      Provider_config.make
+        ~kind:entry.defaults.kind
+        ~model_id
+        ~base_url:entry.defaults.base_url
+        ~request_path:entry.defaults.request_path
+        ()
+    in
+    check_string label provider (Provider_registry.provider_name_of_config cfg)
+;;
+
+let test_provider_name_of_config_ignores_xai_catalog_model () =
+  check_unmatched_provider_name_ignores_catalog_model
+    ~label:"unmatched endpoint ignores xai catalog provider"
     ~model_id:"grok-4.3"
-    ~expected:"xai"
 ;;
 
-let test_provider_name_of_config_mistral_model_catalog () =
-  check_provider_name_from_catalog_model
-    ~label:"mistral model catalog provider"
+let test_provider_name_of_config_ignores_mistral_catalog_model () =
+  check_unmatched_provider_name_ignores_catalog_model
+    ~label:"unmatched endpoint ignores mistral catalog provider"
     ~model_id:"mistral-large"
-    ~expected:"mistral"
 ;;
 
-let test_provider_name_of_config_cohere_model_catalog () =
-  check_provider_name_from_catalog_model
-    ~label:"cohere model catalog provider"
+let test_provider_name_of_config_ignores_cohere_catalog_model () =
+  check_unmatched_provider_name_ignores_catalog_model
+    ~label:"unmatched endpoint ignores cohere catalog provider"
     ~model_id:"command-r-plus"
-    ~expected:"cohere"
 ;;
 
-let test_provider_name_of_config_mimo_model_catalog () =
-  check_provider_name_from_catalog_model
-    ~label:"mimo model catalog provider"
+let test_provider_name_of_config_ignores_mimo_catalog_model () =
+  check_unmatched_provider_name_ignores_catalog_model
+    ~label:"unmatched endpoint ignores mimo catalog provider"
     ~model_id:"mimo-v2.5-pro"
-    ~expected:"mimo"
+;;
+
+let test_provider_name_of_config_xai_registered_endpoint () =
+  check_provider_name_from_registered_endpoint
+    ~label:"xai registered endpoint"
+    ~provider:"xai"
+    ~model_id:"grok-4.3"
+;;
+
+let test_provider_name_of_config_mistral_registered_endpoint () =
+  check_provider_name_from_registered_endpoint
+    ~label:"mistral registered endpoint"
+    ~provider:"mistral"
+    ~model_id:"mistral-large"
+;;
+
+let test_provider_name_of_config_cohere_registered_endpoint () =
+  check_provider_name_from_registered_endpoint
+    ~label:"cohere registered endpoint"
+    ~provider:"cohere"
+    ~model_id:"command-r-plus"
+;;
+
+let test_provider_name_of_config_mimo_registered_endpoint () =
+  check_provider_name_from_registered_endpoint
+    ~label:"mimo registered endpoint"
+    ~provider:"mimo"
+    ~model_id:"mimo-v2.5-pro"
 ;;
 
 (* ── provider_kind_of_string ─────────────────────────── *)
@@ -1539,21 +1578,37 @@ let () =
             `Quick
             test_provider_name_of_config_unmatched_openai_compat
         ; Alcotest.test_case
-            "xai model catalog"
+            "ignores xai catalog model"
             `Quick
-            test_provider_name_of_config_xai_model_catalog
+            test_provider_name_of_config_ignores_xai_catalog_model
         ; Alcotest.test_case
-            "mistral model catalog"
+            "ignores mistral catalog model"
             `Quick
-            test_provider_name_of_config_mistral_model_catalog
+            test_provider_name_of_config_ignores_mistral_catalog_model
         ; Alcotest.test_case
-            "cohere model catalog"
+            "ignores cohere catalog model"
             `Quick
-            test_provider_name_of_config_cohere_model_catalog
+            test_provider_name_of_config_ignores_cohere_catalog_model
         ; Alcotest.test_case
-            "mimo model catalog"
+            "ignores mimo catalog model"
             `Quick
-            test_provider_name_of_config_mimo_model_catalog
+            test_provider_name_of_config_ignores_mimo_catalog_model
+        ; Alcotest.test_case
+            "xai registered endpoint"
+            `Quick
+            test_provider_name_of_config_xai_registered_endpoint
+        ; Alcotest.test_case
+            "mistral registered endpoint"
+            `Quick
+            test_provider_name_of_config_mistral_registered_endpoint
+        ; Alcotest.test_case
+            "cohere registered endpoint"
+            `Quick
+            test_provider_name_of_config_cohere_registered_endpoint
+        ; Alcotest.test_case
+            "mimo registered endpoint"
+            `Quick
+            test_provider_name_of_config_mimo_registered_endpoint
         ] )
     ; ( "kind_of_string"
       , [ Alcotest.test_case "roundtrip all variants" `Quick test_kind_roundtrip


### PR DESCRIPTION
## Summary

- Remove the model-catalog fallback from `Provider_registry.provider_name_of_config` for unmatched OpenAI-compatible endpoints.
- Keep provider identity tied to concrete provider kind or explicit endpoint registry binding; catalog `provider_name` stays model provenance/capability metadata.
- Extend provider-config tests so catalog model IDs stay `openai_compat` on unmatched endpoints while registered xAI, Mistral, Cohere, and MiMo endpoints still resolve by endpoint binding.

Fixes #2329.

## Verification

- `ocamlformat --check lib/llm_provider/provider_registry.ml lib/llm_provider/provider_registry.mli test/test_provider_config.ml`
- `git diff --check origin/main..HEAD`
- `bash scripts/hardening-ratchet.sh --check`
- `bash scripts/ci-code-smell-ratchet.sh --check`
- `env OAS_MODEL_CATALOG=/Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/oas-provider-identity-no-model-fallback-20260630/models.toml OAS_CAPABILITY_MANIFEST= ./scripts/dune-local.sh exec ./test/test_provider_config.exe`
