### PR TITLE
fix(provider): route RunPod proxy capabilities by endpoint

### DIFF
--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -245,6 +245,11 @@ val for_model_id : string -> capabilities option
     [gemini], [ollama], [glm] / [zhipu], [kimi], [dashscope],
     [xai], [mistral], [cohere], [mimo], [nvidia].
 
+    Provider-qualified catalog namespaces are not automatically provider-level
+    presets. For example ["runpod_mtp"] is resolved only by model catalog lookup
+    against [runpod_mtp/<model>] rows, so raw endpoints cannot inherit a broad
+    RunPod preset by label alone.
+
     Canonical labels and aliases for the closed {!Provider_kind.t} space are
     normalized to a typed kind first, then delegated to {!capabilities_of_kind}.
     String-only presets that are not expressible as a provider kind stay at this
@@ -265,7 +270,8 @@ val capabilities_for_provider_label : string -> capabilities option
     holds a typed {!Provider_kind.t}; {!capabilities_for_provider_label}
     delegates canonical labels here and only keeps string-only presets (e.g.
     ["openai_chat_extended"], ["ollama_cloud"], ["xai"], ["mistral"],
-    ["cohere"], ["mimo"], ["nvidia"]) at the label boundary.
+    ["cohere"], ["mimo"], ["nvidia"]) at the label boundary. Catalog-only
+    namespaces such as ["runpod_mtp"] remain outside this provider-preset API.
 
     @since 0.209.0 *)
 val capabilities_of_kind : Provider_kind.t -> capabilities

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -208,10 +208,23 @@ let base_url_targets_openai base_url =
   | Some host -> String.equal (String.lowercase_ascii host) "api.openai.com"
 ;;
 
+let base_url_targets_runpod_proxy base_url =
+  match Uri.of_string base_url |> Uri.host with
+  | None -> false
+  | Some host ->
+    let host = String.lowercase_ascii (String.trim host) in
+    String.equal host "proxy.runpod.net"
+    || String.ends_with ~suffix:".proxy.runpod.net" host
+;;
+
 let capability_provider_label (config : t) =
   if base_url_targets_ollama_cloud config.base_url
   then "ollama_cloud"
-  else string_of_provider_kind config.kind
+  else (
+    match config.kind with
+    | OpenAI_compat when base_url_targets_runpod_proxy config.base_url -> "runpod_mtp"
+    | Anthropic | Kimi | OpenAI_compat | Ollama | Gemini | Glm | DashScope ->
+      string_of_provider_kind config.kind)
 ;;
 
 let raw_openai_compat_without_builtin_source config provider_label =

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -196,133 +196,21 @@ let show_provider_kind = Provider_kind.show
 let provider_kind_to_yojson = Provider_kind.to_yojson
 let provider_kind_of_yojson = Provider_kind.of_yojson
 
-let base_url_targets_ollama_cloud base_url =
-  let base_url = String.lowercase_ascii (String.trim base_url) in
-  String.starts_with ~prefix:"https://ollama.com" base_url
-  || String.starts_with ~prefix:"http://ollama.com" base_url
-;;
-
-let base_url_targets_openai base_url =
-  match Uri.of_string base_url |> Uri.host with
-  | None -> false
-  | Some host -> String.equal (String.lowercase_ascii host) "api.openai.com"
-;;
-
-let base_url_targets_runpod_proxy base_url =
-  match Uri.of_string base_url |> Uri.host with
-  | None -> false
-  | Some host ->
-    let host = String.lowercase_ascii (String.trim host) in
-    String.equal host "proxy.runpod.net"
-    || String.ends_with ~suffix:".proxy.runpod.net" host
-;;
-
 let capability_provider_label (config : t) =
-  if base_url_targets_ollama_cloud config.base_url
-  then "ollama_cloud"
-  else (
-    match config.kind with
-    | OpenAI_compat when base_url_targets_runpod_proxy config.base_url -> "runpod_mtp"
-    | Anthropic | Kimi | OpenAI_compat | Ollama | Gemini | Glm | DashScope ->
-      string_of_provider_kind config.kind)
+  Provider_endpoint.capability_provider_label ~kind:config.kind ~base_url:config.base_url
 ;;
 
 let raw_openai_compat_without_builtin_source config provider_label =
-  match config.kind, provider_label with
-  | OpenAI_compat, ("openai_compat" | "runpod_mtp") ->
-    not (base_url_targets_openai config.base_url)
-  | (Anthropic | Kimi | OpenAI_compat | Ollama | Gemini | Glm | DashScope), _ -> false
-;;
-
-let capability_requires_endpoint_declaration (caps : Capabilities.capabilities) =
-  let open Capabilities in
-  caps.supports_tools
-  || caps.supports_tool_choice
-  || caps.supports_required_tool_choice
-  || caps.supports_named_tool_choice
-  || caps.supports_parallel_tool_calls
-  || caps.supports_runtime_mcp_tools
-  || caps.supports_runtime_tool_events
-  || (match caps.assistant_tool_content_format with
-      | Assistant_tool_content_null -> false
-      | Assistant_tool_content_empty_string -> true)
-  || caps.supports_reasoning
-  || caps.supports_extended_thinking
-  || caps.supports_reasoning_budget
-  || (match caps.accepted_reasoning_efforts with
-      | Some (_ :: _) -> true
-      | Some [] | None -> false)
-  || (match caps.thinking_control_format with
-      | No_thinking_control -> false
-      | Thinking_object
-      | Thinking_object_adaptive
-      | Thinking_object_only
-      | Chat_template_kwargs
-      | Chat_template_token
-      | Ollama_think
-      | Reasoning_effort
-      | Enable_thinking -> true)
-  || (match caps.preserve_thinking_control_format with
-      | No_preserve_thinking_control -> false
-      | Thinking_object_keep_all
-      | Chat_template_kwargs_preserve_thinking
-      | Top_level_preserve_thinking
-      | Always_preserved_thinking -> true)
-  || (match caps.reasoning_output_format with
-      | No_reasoning_output_format -> false
-      | Split_reasoning_fields -> true)
-  || (match caps.reasoning_streaming_format with
-      | Default_reasoning_streaming | No_reasoning_streaming -> false
-      | Delta_reasoning_field _ | Template_reasoning_streaming -> true)
-  || (match caps.reasoning_replay_override with
-      | Default_reasoning_replay -> false
-      | Force_no_replay
-      | Force_drop_without_tool_preserve_with_tool
-      | Force_preserve_always -> true)
-  || caps.supports_response_format_json
-  || caps.supports_structured_output
-  || caps.supports_multimodal_inputs
-  || caps.supports_image_input
-  || caps.supports_audio_input
-  || caps.supports_video_input
-  || caps.supports_top_k
-  || caps.supports_min_p
-  || caps.supports_seed
-  || caps.supports_seed_with_images
-  || caps.supports_computer_use
-  || caps.supports_code_execution
-;;
-
-let catalog_entry_for_model_id model_id =
-  match Model_catalog.global () with
-  | Some catalog -> Model_catalog.lookup catalog model_id
-  | None -> None
-;;
-
-let normalized_catalog_label = function
-  | Some raw -> Some (String.lowercase_ascii (String.trim raw))
-  | None -> None
-;;
-
-let catalog_entry_requires_endpoint_declaration (entry : Model_catalog.model_entry) =
-  match
-    ( normalized_catalog_label entry.base_label
-    , normalized_catalog_label entry.provider_name )
-  with
-  | Some ("openai_chat" | "openai_chat_extended"), Some _ -> false
-  | Some ("openai_chat" | "openai_chat_extended"), None -> true
-  | Some "glm", _ -> false
-  | Some _, _ -> true
-  | None, Some _ -> false
-  | None, None -> true
+  Provider_endpoint.raw_openai_compat_without_builtin_source
+    ~kind:config.kind
+    ~base_url:config.base_url
+    ~provider_label
 ;;
 
 let raw_openai_compat_requires_endpoint_declaration config caps =
-  capability_requires_endpoint_declaration caps
-  ||
-  match catalog_entry_for_model_id config.model_id with
-  | Some entry -> catalog_entry_requires_endpoint_declaration entry
-  | None -> false
+  Provider_endpoint.raw_openai_compat_requires_endpoint_declaration
+    ~model_id:config.model_id
+    caps
 ;;
 
 let capabilities_for_config_model (config : t) =
@@ -338,7 +226,8 @@ let capabilities_for_config_model (config : t) =
           ~provider_label
           ~model_id:config.model_id
       with
-      | Some caps when capability_requires_endpoint_declaration caps -> None
+      | Some caps when Provider_endpoint.capability_requires_endpoint_declaration caps ->
+        None
       | Some _ as caps -> caps
       | None ->
         (match Capabilities.for_model_id config.model_id with

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -220,14 +220,18 @@ let capabilities_for_config_model (config : t) =
     let provider_label = capability_provider_label config in
     if raw_openai_compat_without_builtin_source config provider_label
     then (
+      (* A provider-qualified catalog hit (e.g. "runpod_mtp/<model>") IS the
+         explicit endpoint declaration this fail-closed policy exists to
+         require - re-applying capability_requires_endpoint_declaration here
+         would reject the exact case it's supposed to admit. The declaration
+         requirement only belongs on the bare/global fallback below, where
+         the catalog entry carries no provider qualification at all. *)
       match
         Capabilities.for_provider_model_id
           ~allow_bare_fallback:false
           ~provider_label
           ~model_id:config.model_id
       with
-      | Some caps when Provider_endpoint.capability_requires_endpoint_declaration caps ->
-        None
       | Some _ as caps -> caps
       | None ->
         (match Capabilities.for_model_id config.model_id with

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -229,7 +229,8 @@ let capability_provider_label (config : t) =
 
 let raw_openai_compat_without_builtin_source config provider_label =
   match config.kind, provider_label with
-  | OpenAI_compat, "openai_compat" -> not (base_url_targets_openai config.base_url)
+  | OpenAI_compat, ("openai_compat" | "runpod_mtp") ->
+    not (base_url_targets_openai config.base_url)
   | (Anthropic | Kimi | OpenAI_compat | Ollama | Gemini | Glm | DashScope), _ -> false
 ;;
 
@@ -337,6 +338,7 @@ let capabilities_for_config_model (config : t) =
           ~provider_label
           ~model_id:config.model_id
       with
+      | Some caps when capability_requires_endpoint_declaration caps -> None
       | Some _ as caps -> caps
       | None ->
         (match Capabilities.for_model_id config.model_id with

--- a/lib/llm_provider/provider_config.mli
+++ b/lib/llm_provider/provider_config.mli
@@ -407,9 +407,19 @@ val reasoning_effort_of_config : t -> string option
 
 (** Capability catalog provider namespace for [config].
 
-    This is usually {!string_of_provider_kind}, except official Ollama Cloud
-    endpoints are scoped as ["ollama_cloud"] even when they use the
-    OpenAI-compatible wire kind. *)
+    This is usually {!string_of_provider_kind}, except endpoint families that
+    publish provider-qualified catalog rows while using the OpenAI-compatible
+    wire kind:
+
+    - official Ollama Cloud endpoints are scoped as ["ollama_cloud"];
+    - RunPod proxy endpoints ([proxy.runpod.net] and subdomains) are scoped as
+      ["runpod_mtp"].
+
+    This namespace is for model capability lookup only. It does not determine
+    provider identity for telemetry/routing; see
+    {!Provider_registry.provider_name_of_config}. ["runpod_mtp"] is
+    intentionally catalog-qualified-only, not a provider-level preset accepted
+    by {!Capabilities.capabilities_for_provider_label}. *)
 val capability_provider_label : t -> string
 
 (** Resolve model capabilities using provider-qualified catalog entries first.

--- a/lib/llm_provider/provider_config.mli
+++ b/lib/llm_provider/provider_config.mli
@@ -419,7 +419,9 @@ val reasoning_effort_of_config : t -> string option
     provider identity for telemetry/routing; see
     {!Provider_registry.provider_name_of_config}. ["runpod_mtp"] is
     intentionally catalog-qualified-only, not a provider-level preset accepted
-    by {!Capabilities.capabilities_for_provider_label}. *)
+    by {!Capabilities.capabilities_for_provider_label}. Raw OpenAI-compatible
+    configs still reject endpoint-declared capabilities unless the endpoint is
+    explicitly declared through model capability overrides. *)
 val capability_provider_label : t -> string
 
 (** Resolve model capabilities using provider-qualified catalog entries first.

--- a/lib/llm_provider/provider_endpoint.ml
+++ b/lib/llm_provider/provider_endpoint.ml
@@ -5,13 +5,14 @@ open Provider_kind
 let base_url_targets_ollama_cloud base_url =
   match Uri.of_string base_url |> Uri.host with
   | None -> false
-  | Some host -> String.equal (String.lowercase_ascii host) "ollama.com"
+  | Some host -> String.equal (String.lowercase_ascii (String.trim host)) "ollama.com"
 ;;
 
 let base_url_targets_openai base_url =
   match Uri.of_string base_url |> Uri.host with
   | None -> false
-  | Some host -> String.equal (String.lowercase_ascii host) "api.openai.com"
+  | Some host ->
+    String.equal (String.lowercase_ascii (String.trim host)) "api.openai.com"
 ;;
 
 let base_url_targets_runpod_proxy base_url =

--- a/lib/llm_provider/provider_endpoint.ml
+++ b/lib/llm_provider/provider_endpoint.ml
@@ -3,9 +3,9 @@
 open Provider_kind
 
 let base_url_targets_ollama_cloud base_url =
-  let base_url = String.lowercase_ascii (String.trim base_url) in
-  String.starts_with ~prefix:"https://ollama.com" base_url
-  || String.starts_with ~prefix:"http://ollama.com" base_url
+  match Uri.of_string base_url |> Uri.host with
+  | None -> false
+  | Some host -> String.equal (String.lowercase_ascii host) "ollama.com"
 ;;
 
 let base_url_targets_openai base_url =

--- a/lib/llm_provider/provider_endpoint.ml
+++ b/lib/llm_provider/provider_endpoint.ml
@@ -1,0 +1,136 @@
+(** Endpoint-scoped provider capability policy. *)
+
+open Provider_kind
+
+let base_url_targets_ollama_cloud base_url =
+  let base_url = String.lowercase_ascii (String.trim base_url) in
+  String.starts_with ~prefix:"https://ollama.com" base_url
+  || String.starts_with ~prefix:"http://ollama.com" base_url
+;;
+
+let base_url_targets_openai base_url =
+  match Uri.of_string base_url |> Uri.host with
+  | None -> false
+  | Some host -> String.equal (String.lowercase_ascii host) "api.openai.com"
+;;
+
+let base_url_targets_runpod_proxy base_url =
+  match Uri.of_string base_url |> Uri.host with
+  | None -> false
+  | Some host ->
+    let host = String.lowercase_ascii (String.trim host) in
+    String.equal host "proxy.runpod.net"
+    || String.ends_with ~suffix:".proxy.runpod.net" host
+;;
+
+let capability_provider_label ~(kind : Provider_kind.t) ~base_url =
+  if base_url_targets_ollama_cloud base_url
+  then "ollama_cloud"
+  else (
+    match kind with
+    | OpenAI_compat when base_url_targets_runpod_proxy base_url -> "runpod_mtp"
+    | Anthropic | Kimi | OpenAI_compat | Ollama | Gemini | Glm | DashScope ->
+      Provider_kind.to_string kind)
+;;
+
+let raw_openai_compat_without_builtin_source
+      ~(kind : Provider_kind.t)
+      ~base_url
+      ~provider_label
+  =
+  match kind, provider_label with
+  | OpenAI_compat, ("openai_compat" | "runpod_mtp") ->
+    not (base_url_targets_openai base_url)
+  | (Anthropic | Kimi | OpenAI_compat | Ollama | Gemini | Glm | DashScope), _ -> false
+;;
+
+let capability_requires_endpoint_declaration (caps : Capabilities.capabilities) =
+  let open Capabilities in
+  caps.supports_tools
+  || caps.supports_tool_choice
+  || caps.supports_required_tool_choice
+  || caps.supports_named_tool_choice
+  || caps.supports_parallel_tool_calls
+  || caps.supports_runtime_mcp_tools
+  || caps.supports_runtime_tool_events
+  || (match caps.assistant_tool_content_format with
+      | Assistant_tool_content_null -> false
+      | Assistant_tool_content_empty_string -> true)
+  || caps.supports_reasoning
+  || caps.supports_extended_thinking
+  || caps.supports_reasoning_budget
+  || (match caps.accepted_reasoning_efforts with
+      | Some (_ :: _) -> true
+      | Some [] | None -> false)
+  || (match caps.thinking_control_format with
+      | No_thinking_control -> false
+      | Thinking_object
+      | Thinking_object_adaptive
+      | Thinking_object_only
+      | Chat_template_kwargs
+      | Chat_template_token
+      | Ollama_think
+      | Reasoning_effort
+      | Enable_thinking -> true)
+  || (match caps.preserve_thinking_control_format with
+      | No_preserve_thinking_control -> false
+      | Thinking_object_keep_all
+      | Chat_template_kwargs_preserve_thinking
+      | Top_level_preserve_thinking
+      | Always_preserved_thinking -> true)
+  || (match caps.reasoning_output_format with
+      | No_reasoning_output_format -> false
+      | Split_reasoning_fields -> true)
+  || (match caps.reasoning_streaming_format with
+      | Default_reasoning_streaming | No_reasoning_streaming -> false
+      | Delta_reasoning_field _ | Template_reasoning_streaming -> true)
+  || (match caps.reasoning_replay_override with
+      | Default_reasoning_replay -> false
+      | Force_no_replay
+      | Force_drop_without_tool_preserve_with_tool
+      | Force_preserve_always -> true)
+  || caps.supports_response_format_json
+  || caps.supports_structured_output
+  || caps.supports_multimodal_inputs
+  || caps.supports_image_input
+  || caps.supports_audio_input
+  || caps.supports_video_input
+  || caps.supports_top_k
+  || caps.supports_min_p
+  || caps.supports_seed
+  || caps.supports_seed_with_images
+  || caps.supports_computer_use
+  || caps.supports_code_execution
+;;
+
+let normalized_catalog_label = function
+  | Some raw -> Some (String.lowercase_ascii (String.trim raw))
+  | None -> None
+;;
+
+let catalog_entry_requires_endpoint_declaration (entry : Model_catalog.model_entry) =
+  match
+    ( normalized_catalog_label entry.base_label
+    , normalized_catalog_label entry.provider_name )
+  with
+  | Some ("openai_chat" | "openai_chat_extended"), Some _ -> false
+  | Some ("openai_chat" | "openai_chat_extended"), None -> true
+  | Some "glm", _ -> false
+  | Some _, _ -> true
+  | None, Some _ -> false
+  | None, None -> true
+;;
+
+let catalog_entry_for_model_id model_id =
+  match Model_catalog.global () with
+  | Some catalog -> Model_catalog.lookup catalog model_id
+  | None -> None
+;;
+
+let raw_openai_compat_requires_endpoint_declaration ~model_id caps =
+  capability_requires_endpoint_declaration caps
+  ||
+  match catalog_entry_for_model_id model_id with
+  | Some entry -> catalog_entry_requires_endpoint_declaration entry
+  | None -> false
+;;

--- a/lib/llm_provider/provider_endpoint.mli
+++ b/lib/llm_provider/provider_endpoint.mli
@@ -1,0 +1,25 @@
+(** Endpoint-scoped provider capability policy.
+
+    This module keeps URL/endpoint classification separate from
+    {!Provider_config.t}, so raw OpenAI-compatible endpoints do not inherit
+    model-family capabilities unless a catalog/endpoint declaration proves the
+    runtime contract. *)
+
+val base_url_targets_ollama_cloud : string -> bool
+val base_url_targets_openai : string -> bool
+val base_url_targets_runpod_proxy : string -> bool
+val capability_provider_label : kind:Provider_kind.t -> base_url:string -> string
+
+val raw_openai_compat_without_builtin_source
+  :  kind:Provider_kind.t
+  -> base_url:string
+  -> provider_label:string
+  -> bool
+
+val capability_requires_endpoint_declaration : Capabilities.capabilities -> bool
+val catalog_entry_requires_endpoint_declaration : Model_catalog.model_entry -> bool
+
+val raw_openai_compat_requires_endpoint_declaration
+  :  model_id:string
+  -> Capabilities.capabilities
+  -> bool

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -626,6 +626,24 @@ let with_model_catalog_toml contents f =
          Fun.protect f ~finally:restore)
 ;;
 
+let with_repository_model_catalog f =
+  let previous_catalog = Model_catalog.global () in
+  let restore () =
+    match previous_catalog with
+    | Some catalog -> Model_catalog.set_global catalog
+    | None -> Model_catalog.clear_global ()
+  in
+  let candidates = [ "models.toml"; "../models.toml" ] in
+  match List.find_opt Sys.file_exists candidates with
+  | None -> Alcotest.fail "models.toml not found"
+  | Some path ->
+    (match Model_catalog.load_file path with
+     | Error msg -> Alcotest.failf "failed to load %s: %s" path msg
+     | Ok catalog ->
+       Model_catalog.set_global catalog;
+       Fun.protect f ~finally:restore)
+;;
+
 let test_openai_compat_raw_tool_capability_requires_endpoint_declaration () =
   with_model_catalog_toml
     {|
@@ -712,27 +730,28 @@ thinking_control_format = "chat_template_kwargs"
    only held because the provider-qualified catalog hit was incorrectly
    discarded by the same guard meant for the bare fallback. *)
 let test_openai_compat_runpod_proxy_label_uses_real_catalog_declaration () =
-  let cfg =
-    Provider_config.make
-      ~kind:OpenAI_compat
-      ~model_id:"qwen36-35b-a3b-mtp"
-      ~base_url:"https://abc123.proxy.runpod.net/v1"
-      ()
-  in
-  Alcotest.(check string)
-    "RunPod proxy capability namespace"
-    "runpod_mtp"
-    (Provider_config.capability_provider_label cfg);
-  match Provider_config.capabilities_for_config_model cfg with
-  | None ->
-    Alcotest.fail
-      "runpod_mtp/qwen36-35b-a3b-mtp is a real models.toml row; it must not be treated \
-       as an undeclared endpoint"
-  | Some caps ->
-    Alcotest.(check bool)
-      "real catalog row's declared thinking dialect is honored"
-      true
-      (caps.thinking_control_format = Capabilities.Chat_template_kwargs)
+  with_repository_model_catalog (fun () ->
+    let cfg =
+      Provider_config.make
+        ~kind:OpenAI_compat
+        ~model_id:"qwen36-35b-a3b-mtp"
+        ~base_url:"https://abc123.proxy.runpod.net/v1"
+        ()
+    in
+    Alcotest.(check string)
+      "RunPod proxy capability namespace"
+      "runpod_mtp"
+      (Provider_config.capability_provider_label cfg);
+    match Provider_config.capabilities_for_config_model cfg with
+    | None ->
+      Alcotest.fail
+        "runpod_mtp/qwen36-35b-a3b-mtp is a real models.toml row; it must not be treated \
+         as an undeclared endpoint"
+    | Some caps ->
+      Alcotest.(check bool)
+        "real catalog row's declared thinking dialect is honored"
+        true
+        (caps.thinking_control_format = Capabilities.Chat_template_kwargs))
 ;;
 
 let test_openai_compat_runpod_proxy_label_uses_declared_catalog_dialect () =
@@ -783,6 +802,29 @@ let test_openai_compat_runpod_proxy_label_is_catalog_only () =
     "RunPod proxy namespace is not a provider preset"
     true
     (Option.is_none (Capabilities.capabilities_for_provider_label "runpod_mtp"))
+;;
+
+let test_ollama_cloud_label_matches_official_host_only () =
+  let cfg host =
+    Provider_config.make ~kind:OpenAI_compat ~model_id:"kimi-k2.6" ~base_url:host ()
+  in
+  Alcotest.(check string)
+    "official host classified as ollama_cloud"
+    "ollama_cloud"
+    (Provider_config.capability_provider_label (cfg "https://ollama.com/v1"));
+  Alcotest.(check bool)
+    "lookalike suffix host is not classified as ollama_cloud"
+    false
+    (String.equal
+       "ollama_cloud"
+       (Provider_config.capability_provider_label
+          (cfg "https://ollama.com.evil.example/v1")));
+  Alcotest.(check bool)
+    "lookalike prefix host is not classified as ollama_cloud"
+    false
+    (String.equal
+       "ollama_cloud"
+       (Provider_config.capability_provider_label (cfg "https://ollama.computer/v1")))
 ;;
 
 let test_validate_responses_request_path_allows_structured_output () =
@@ -1347,24 +1389,6 @@ let test_structured_output_name_of_schema () =
 ;;
 
 (* ── provider_name_of_config ─────────────────────────── *)
-
-let with_repository_model_catalog f =
-  let previous_catalog = Model_catalog.global () in
-  let restore () =
-    match previous_catalog with
-    | Some catalog -> Model_catalog.set_global catalog
-    | None -> Model_catalog.clear_global ()
-  in
-  let candidates = [ "models.toml"; "../models.toml" ] in
-  match List.find_opt Sys.file_exists candidates with
-  | None -> Alcotest.fail "models.toml not found for provider_name tests"
-  | Some path ->
-    (match Model_catalog.load_file path with
-     | Error msg -> Alcotest.failf "failed to load %s: %s" path msg
-     | Ok catalog ->
-       Model_catalog.set_global catalog;
-       Fun.protect f ~finally:restore)
-;;
 
 let test_validate_output_schema_openai_official_catalog () =
   with_repository_model_catalog (fun () ->
@@ -2193,6 +2217,10 @@ let () =
             "runpod proxy label is catalog-only"
             `Quick
             test_openai_compat_runpod_proxy_label_is_catalog_only
+        ; Alcotest.test_case
+            "ollama_cloud label matches official host only"
+            `Quick
+            test_ollama_cloud_label_matches_official_host_only
         ; Alcotest.test_case
             "responses structured path accepted"
             `Quick

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -720,6 +720,38 @@ let test_openai_compat_runpod_proxy_label_stays_raw_fail_closed () =
     (Option.is_none (Provider_config.capabilities_for_config_model cfg))
 ;;
 
+let test_openai_compat_runpod_proxy_label_uses_declared_catalog_dialect () =
+  with_model_catalog_toml
+    {|
+[[models]]
+id_prefix = "runpod_mtp/qwen36-35b-a3b-mtp"
+base = "openai_chat"
+supports_tools = true
+supports_tool_choice = true
+supports_reasoning = true
+supports_extended_thinking = true
+thinking_control_format = "chat_template_kwargs"
+|}
+    (fun () ->
+       let cfg =
+         Provider_config.make
+           ~kind:OpenAI_compat
+           ~model_id:"qwen36-35b-a3b-mtp"
+           ~base_url:"https://abc123.proxy.runpod.net/v1"
+           ()
+       in
+       match Provider_config.capabilities_for_config_model cfg with
+       | None ->
+         Alcotest.fail
+           "provider-qualified runpod_mtp catalog entry IS the endpoint \
+            declaration; it must not be rejected"
+       | Some caps ->
+         Alcotest.(check bool)
+           "provider-qualified catalog hit uses its declared thinking dialect"
+           true
+           (caps.thinking_control_format = Capabilities.Chat_template_kwargs))
+;;
+
 let test_openai_compat_runpod_proxy_label_is_catalog_only () =
   let cfg =
     Provider_config.make
@@ -2138,6 +2170,10 @@ let () =
             "runpod proxy label stays raw fail-closed"
             `Quick
             test_openai_compat_runpod_proxy_label_stays_raw_fail_closed
+        ; Alcotest.test_case
+            "runpod proxy label uses declared catalog dialect"
+            `Quick
+            test_openai_compat_runpod_proxy_label_uses_declared_catalog_dialect
         ; Alcotest.test_case
             "runpod proxy label is catalog-only"
             `Quick

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -702,6 +702,23 @@ thinking_control_format = "chat_template_kwargs"
          (Option.is_none (Provider_config.capabilities_for_config_model cfg)))
 ;;
 
+let test_openai_compat_runpod_proxy_uses_runpod_catalog_label () =
+  let cfg =
+    Provider_config.make
+      ~kind:OpenAI_compat
+      ~model_id:"qwen36-35b-a3b-mtp"
+      ~base_url:"https://abc123.proxy.runpod.net/v1"
+      ()
+  in
+  match Provider_config.capabilities_for_config_model cfg with
+  | None -> Alcotest.fail "expected RunPod proxy model to resolve via runpod_mtp label"
+  | Some caps ->
+    Alcotest.(check bool)
+      "RunPod proxy qwen3.6 uses chat_template_kwargs"
+      true
+      Capabilities.(caps.thinking_control_format = Chat_template_kwargs)
+;;
+
 let test_validate_responses_request_path_allows_structured_output () =
   let cfg =
     Provider_config.make
@@ -2078,6 +2095,10 @@ let () =
             "raw compat dot-qualified provider row requires endpoint declaration"
             `Quick
             test_openai_compat_raw_dot_qualified_provider_row_requires_endpoint_declaration
+        ; Alcotest.test_case
+            "runpod proxy qwen uses runpod catalog label"
+            `Quick
+            test_openai_compat_runpod_proxy_uses_runpod_catalog_label
         ; Alcotest.test_case
             "responses structured path accepted"
             `Quick

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -719,6 +719,24 @@ let test_openai_compat_runpod_proxy_uses_runpod_catalog_label () =
       Capabilities.(caps.thinking_control_format = Chat_template_kwargs)
 ;;
 
+let test_openai_compat_runpod_proxy_label_is_catalog_only () =
+  let cfg =
+    Provider_config.make
+      ~kind:OpenAI_compat
+      ~model_id:"qwen36-35b-a3b-mtp"
+      ~base_url:"https://abc123.proxy.runpod.net/v1"
+      ()
+  in
+  Alcotest.(check string)
+    "RunPod proxy capability namespace"
+    "runpod_mtp"
+    (Provider_config.capability_provider_label cfg);
+  Alcotest.(check bool)
+    "RunPod proxy namespace is not a provider preset"
+    true
+    (Option.is_none (Capabilities.capabilities_for_provider_label "runpod_mtp"))
+;;
+
 let test_validate_responses_request_path_allows_structured_output () =
   let cfg =
     Provider_config.make
@@ -2099,6 +2117,10 @@ let () =
             "runpod proxy qwen uses runpod catalog label"
             `Quick
             test_openai_compat_runpod_proxy_uses_runpod_catalog_label
+        ; Alcotest.test_case
+            "runpod proxy label is catalog-only"
+            `Quick
+            test_openai_compat_runpod_proxy_label_is_catalog_only
         ; Alcotest.test_case
             "responses structured path accepted"
             `Quick

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -702,7 +702,7 @@ thinking_control_format = "chat_template_kwargs"
          (Option.is_none (Provider_config.capabilities_for_config_model cfg)))
 ;;
 
-let test_openai_compat_runpod_proxy_uses_runpod_catalog_label () =
+let test_openai_compat_runpod_proxy_label_stays_raw_fail_closed () =
   let cfg =
     Provider_config.make
       ~kind:OpenAI_compat
@@ -710,13 +710,14 @@ let test_openai_compat_runpod_proxy_uses_runpod_catalog_label () =
       ~base_url:"https://abc123.proxy.runpod.net/v1"
       ()
   in
-  match Provider_config.capabilities_for_config_model cfg with
-  | None -> Alcotest.fail "expected RunPod proxy model to resolve via runpod_mtp label"
-  | Some caps ->
-    Alcotest.(check bool)
-      "RunPod proxy qwen3.6 uses chat_template_kwargs"
-      true
-      Capabilities.(caps.thinking_control_format = Chat_template_kwargs)
+  Alcotest.(check string)
+    "RunPod proxy capability namespace"
+    "runpod_mtp"
+    (Provider_config.capability_provider_label cfg);
+  Alcotest.(check bool)
+    "raw RunPod proxy does not inherit endpoint-declared capabilities"
+    true
+    (Option.is_none (Provider_config.capabilities_for_config_model cfg))
 ;;
 
 let test_openai_compat_runpod_proxy_label_is_catalog_only () =
@@ -2134,9 +2135,9 @@ let () =
             `Quick
             test_openai_compat_raw_dot_qualified_provider_row_requires_endpoint_declaration
         ; Alcotest.test_case
-            "runpod proxy qwen uses runpod catalog label"
+            "runpod proxy label stays raw fail-closed"
             `Quick
-            test_openai_compat_runpod_proxy_uses_runpod_catalog_label
+            test_openai_compat_runpod_proxy_label_stays_raw_fail_closed
         ; Alcotest.test_case
             "runpod proxy label is catalog-only"
             `Quick

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -1515,6 +1515,26 @@ let test_provider_name_of_config_unmatched_openai_compat () =
     (Provider_registry.provider_name_of_config cfg)
 ;;
 
+let test_provider_name_of_config_runpod_proxy_capability_label_not_identity () =
+  with_repository_model_catalog (fun () ->
+    let cfg =
+      Provider_config.make
+        ~kind:OpenAI_compat
+        ~model_id:"qwen36-35b-a3b-mtp"
+        ~base_url:"https://abc123.proxy.runpod.net/v1"
+        ~request_path:"/chat/completions"
+        ()
+    in
+    check_string
+      "runpod proxy provider identity"
+      "openai_compat"
+      (Provider_registry.provider_name_of_config cfg);
+    check_string
+      "runpod proxy capability namespace"
+      "runpod_mtp"
+      (Provider_config.capability_provider_label cfg))
+;;
+
 let check_unmatched_provider_name_ignores_catalog_model ~label ~model_id =
   with_repository_model_catalog (fun () ->
     let cfg =
@@ -2211,6 +2231,10 @@ let () =
             "unmatched openai_compat"
             `Quick
             test_provider_name_of_config_unmatched_openai_compat
+        ; Alcotest.test_case
+            "runpod capability label is not provider identity"
+            `Quick
+            test_provider_name_of_config_runpod_proxy_capability_label_not_identity
         ; Alcotest.test_case
             "ignores xai catalog model"
             `Quick

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -743,8 +743,8 @@ thinking_control_format = "chat_template_kwargs"
        match Provider_config.capabilities_for_config_model cfg with
        | None ->
          Alcotest.fail
-           "provider-qualified runpod_mtp catalog entry IS the endpoint \
-            declaration; it must not be rejected"
+           "provider-qualified runpod_mtp catalog entry IS the endpoint declaration; it \
+            must not be rejected"
        | Some caps ->
          Alcotest.(check bool)
            "provider-qualified catalog hit uses its declared thinking dialect"

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -726,8 +726,8 @@ let test_openai_compat_runpod_proxy_label_uses_real_catalog_declaration () =
   match Provider_config.capabilities_for_config_model cfg with
   | None ->
     Alcotest.fail
-      "runpod_mtp/qwen36-35b-a3b-mtp is a real models.toml row; it must not be \
-       treated as an undeclared endpoint"
+      "runpod_mtp/qwen36-35b-a3b-mtp is a real models.toml row; it must not be treated \
+       as an undeclared endpoint"
   | Some caps ->
     Alcotest.(check bool)
       "real catalog row's declared thinking dialect is honored"

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -702,7 +702,16 @@ thinking_control_format = "chat_template_kwargs"
          (Option.is_none (Provider_config.capabilities_for_config_model cfg)))
 ;;
 
-let test_openai_compat_runpod_proxy_label_stays_raw_fail_closed () =
+(* This model_id/base_url pair resolves to the real "runpod_mtp/qwen36-35b-a3b-mtp"
+   row in the repo's own models.toml (a genuine provider-qualified catalog
+   declaration, not a bare/global fallback), so capabilities_for_config_model
+   is expected to find it - the raw-OpenAI-compat fail-closed policy only
+   withholds capabilities when there is no such explicit declaration.
+   Regression for the bug fixed alongside test_openai_compat_runpod_proxy_
+   label_uses_declared_catalog_dialect: this used to assert None here, which
+   only held because the provider-qualified catalog hit was incorrectly
+   discarded by the same guard meant for the bare fallback. *)
+let test_openai_compat_runpod_proxy_label_uses_real_catalog_declaration () =
   let cfg =
     Provider_config.make
       ~kind:OpenAI_compat
@@ -714,10 +723,16 @@ let test_openai_compat_runpod_proxy_label_stays_raw_fail_closed () =
     "RunPod proxy capability namespace"
     "runpod_mtp"
     (Provider_config.capability_provider_label cfg);
-  Alcotest.(check bool)
-    "raw RunPod proxy does not inherit endpoint-declared capabilities"
-    true
-    (Option.is_none (Provider_config.capabilities_for_config_model cfg))
+  match Provider_config.capabilities_for_config_model cfg with
+  | None ->
+    Alcotest.fail
+      "runpod_mtp/qwen36-35b-a3b-mtp is a real models.toml row; it must not be \
+       treated as an undeclared endpoint"
+  | Some caps ->
+    Alcotest.(check bool)
+      "real catalog row's declared thinking dialect is honored"
+      true
+      (caps.thinking_control_format = Capabilities.Chat_template_kwargs)
 ;;
 
 let test_openai_compat_runpod_proxy_label_uses_declared_catalog_dialect () =
@@ -2167,9 +2182,9 @@ let () =
             `Quick
             test_openai_compat_raw_dot_qualified_provider_row_requires_endpoint_declaration
         ; Alcotest.test_case
-            "runpod proxy label stays raw fail-closed"
+            "runpod proxy label uses real catalog declaration"
             `Quick
-            test_openai_compat_runpod_proxy_label_stays_raw_fail_closed
+            test_openai_compat_runpod_proxy_label_uses_real_catalog_declaration
         ; Alcotest.test_case
             "runpod proxy label uses declared catalog dialect"
             `Quick


### PR DESCRIPTION
## Summary
- recognize `*.proxy.runpod.net` OpenAI-compatible configs as the `runpod_mtp` capability label
- keep raw unknown OpenAI-compatible endpoints on the existing fail-closed path
- add provider_config coverage for RunPod qwen3.6 resolving via the provider-qualified catalog path
- document and test the classifier split: `runpod_mtp` is a catalog namespace, not a provider-level preset

## Verification
- `opam exec -- ocamlformat --check lib/llm_provider/provider_config.ml lib/llm_provider/provider_config.mli lib/llm_provider/capabilities.mli test/test_provider_config.ml`
- `git diff --check`
- `scripts/hardening-ratchet.sh --check`
- `scripts/ci-code-smell-ratchet.sh --check`

Full Dune build/test is left to CI.