### PR TITLE
fix(canonical): omit reasoning payloads from tool projection

### DIFF
--- a/docs/masc-oas-design/RFC-canonical-tool-contract.md
+++ b/docs/masc-oas-design/RFC-canonical-tool-contract.md
@@ -127,7 +127,9 @@ type reasoning_kind =
 
 type reasoning_state =
   { kind : reasoning_kind
-  ; content : string
+  ; signature : string option
+      (** Raw provider reasoning payload is not renderer-facing display data.
+          Replay paths use Types.content_block directly. *)
   ; tokens : int option (** provider가 보고할 때 telemetry에서. *)
   }
 

--- a/lib/llm_provider/canonical_tool.ml
+++ b/lib/llm_provider/canonical_tool.ml
@@ -1,8 +1,9 @@
 (** Canonical tool projections (RFC-OAS-024, WP8 Increments 1-2).
 
     Increment 1 shipped the {e result} projection. Increment 2 adds the call
-    projection plus structural reasoning adjacency for consumers that need to
-    render or execute interleaved Thinking -> ToolUse responses.
+    projection plus structural reasoning-adjacency metadata for consumers that
+    need to render or execute interleaved Thinking -> ToolUse responses without
+    receiving raw provider reasoning payloads.
 
     Pure, total projections over [Types.content_block]. This is {b not} a second
     in-memory SSOT: [content_block] remains the canonical representation and the
@@ -22,7 +23,6 @@ type provider_reasoning_kind =
 type provider_reasoning_block =
   { order_index : int
   ; kind : provider_reasoning_kind
-  ; content : string
   ; signature : string option
   }
 
@@ -58,15 +58,15 @@ let provider_kind_of_response (response : Types.api_response) =
 
 let reasoning_of_block ~order_index (block : Types.content_block) =
   match block with
-  | Types.Thinking { content; signature } ->
-    Some { order_index; kind = Visible_thinking; content; signature }
+  | Types.Thinking { signature; _ } ->
+    Some { order_index; kind = Visible_thinking; signature }
   | Types.ReasoningDetails { reasoning_content; details } ->
     let content = Types.reasoning_details_text ~reasoning_content ~details in
     if String.trim content = ""
     then None
-    else Some { order_index; kind = Visible_thinking; content; signature = None }
-  | Types.RedactedThinking content ->
-    Some { order_index; kind = Redacted_thinking; content; signature = None }
+    else Some { order_index; kind = Visible_thinking; signature = None }
+  | Types.RedactedThinking _ ->
+    Some { order_index; kind = Redacted_thinking; signature = None }
   | Types.Text _
   | Types.ToolUse _
   | Types.ToolResult _

--- a/lib/llm_provider/canonical_tool.mli
+++ b/lib/llm_provider/canonical_tool.mli
@@ -7,9 +7,10 @@
 
     Scope (RFC-OAS-024 §7): Increment 1 shipped [tool_result_of_block].
     Increment 2 adds [provider_tool_call] and [tool_calls_of_response] as a
-    structural projection for downstream renderers/executors. Reasoning is only
-    linked when it is immediately adjacent in the canonical content order; this
-    module never infers semantic ownership across Text/media/result boundaries.
+    structural projection for downstream renderers/executors. Reasoning metadata
+    is only linked when it is immediately adjacent in the canonical content
+    order; this module never infers semantic ownership across Text/media/result
+    boundaries and never exposes raw provider reasoning payloads.
 
     Boundary (RFC-OAS-024 §1): OAS-owned provider canonicalization only. Depends
     solely on provider-boundary types and references no execution, policy, or
@@ -23,16 +24,16 @@ type provider_reasoning_kind =
   | Visible_thinking
   | Redacted_thinking
 
-(** A provider reasoning block observed in a response.
+(** Public metadata for a provider reasoning block observed in a response.
 
     [order_index] is the zero-based position in {!Types.api_response.content}.
-    [content] is the provider payload verbatim; for {!Redacted_thinking} it is
-    opaque redacted data, not display text. [signature] is present only for
-    signed visible thinking blocks. *)
+    Raw provider reasoning payloads are intentionally not exposed by this
+    renderer/executor projection; provider replay paths must use
+    {!Types.content_block} directly. [signature] is present only for signed
+    visible thinking blocks. *)
 type provider_reasoning_block =
   { order_index : int
   ; kind : provider_reasoning_kind
-  ; content : string
   ; signature : string option
   }
 

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -286,10 +286,14 @@ let test_parse_reasoning_details_and_tool_calls_coexist () =
   (match projected_calls with
    | [ { Canonical_tool.adjacent_reasoning =
            Canonical_tool.Adjacent_reasoning
-             [ { Canonical_tool.kind = Canonical_tool.Visible_thinking; content; _ } ]
+             [ { Canonical_tool.kind = Canonical_tool.Visible_thinking
+               ; order_index = 0
+               ; signature = None
+               }
+             ]
        ; _
        }
-     ] -> check_string "adjacent reasoning text" "use weather tool" content
+     ] -> ()
    | _ -> Alcotest.fail "expected one visible adjacent reasoning block");
   let minimax_dialect =
     { Reasoning_dialect.default with

--- a/test/test_canonical_tool.ml
+++ b/test/test_canonical_tool.ml
@@ -59,7 +59,6 @@ let check_no_adjacent_reasoning label = function
 let check_visible_reasoning
       label
       expected_order
-      expected_content
       expected_signature
       (block : Ct.provider_reasoning_block)
   =
@@ -67,25 +66,38 @@ let check_visible_reasoning
   (match block.Ct.kind with
    | Ct.Visible_thinking -> ()
    | Ct.Redacted_thinking -> Alcotest.failf "%s expected visible thinking" label);
-  Alcotest.(check string) (label ^ " content") expected_content block.Ct.content;
   Alcotest.(check (option string))
     (label ^ " signature")
     expected_signature
     block.Ct.signature
 ;;
 
-let check_redacted_reasoning
-      label
-      expected_order
-      expected_content
-      (block : Ct.provider_reasoning_block)
-  =
+let check_redacted_reasoning label expected_order (block : Ct.provider_reasoning_block) =
   Alcotest.(check int) (label ^ " order") expected_order block.Ct.order_index;
   (match block.Ct.kind with
    | Ct.Redacted_thinking -> ()
    | Ct.Visible_thinking -> Alcotest.failf "%s expected redacted thinking" label);
-  Alcotest.(check string) (label ^ " content") expected_content block.Ct.content;
   Alcotest.(check (option string)) (label ^ " signature") None block.Ct.signature
+;;
+
+let metadata_only_copy (block : Ct.provider_reasoning_block) =
+  { Ct.order_index = block.Ct.order_index
+  ; kind = block.Ct.kind
+  ; signature = block.Ct.signature
+  }
+;;
+
+let exposed_reasoning_strings block =
+  let block = metadata_only_copy block in
+  match block.Ct.signature with
+  | Some signature -> [ signature ]
+  | None -> []
+;;
+
+let check_no_exposed_payload label payload block =
+  let exposed = exposed_reasoning_strings block in
+  if List.exists (String.equal payload) exposed
+  then Alcotest.failf "%s leaked reasoning payload %S" label payload
 ;;
 
 let test_tool_call_projection_preserves_fields_and_adjacent_reasoning () =
@@ -106,7 +118,7 @@ let test_tool_call_projection_preserves_fields_and_adjacent_reasoning () =
   check_provider_kind "call" (Some PK.Ollama) call.Ct.provider_kind;
   match call.Ct.adjacent_reasoning with
   | Ct.Adjacent_reasoning [ block ] ->
-    check_visible_reasoning "adjacent reasoning" 1 "call weather" (Some "sig_1") block
+    check_visible_reasoning "adjacent reasoning" 1 (Some "sig_1") block
   | Ct.Adjacent_reasoning blocks ->
     Alcotest.failf "expected one adjacent reasoning block, got %d" (List.length blocks)
   | Ct.No_adjacent_reasoning -> Alcotest.fail "expected adjacent reasoning"
@@ -130,14 +142,14 @@ let test_tool_calls_keep_interleaved_reasoning_groups () =
     Alcotest.(check int) "first order" 1 first.Ct.order_index;
     (match first.Ct.adjacent_reasoning with
      | Ct.Adjacent_reasoning [ block ] ->
-       check_visible_reasoning "first reasoning" 0 "first plan" None block
+       check_visible_reasoning "first reasoning" 0 None block
      | _ -> Alcotest.fail "first call should have one adjacent reasoning block");
     Alcotest.(check string) "second id" "call_2" second.Ct.call_id;
     Alcotest.(check int) "second order" 4 second.Ct.order_index;
     (match second.Ct.adjacent_reasoning with
      | Ct.Adjacent_reasoning [ visible; redacted ] ->
-       check_visible_reasoning "second visible reasoning" 2 "second plan" None visible;
-       check_redacted_reasoning "second redacted reasoning" 3 "opaque_blob" redacted
+       check_visible_reasoning "second visible reasoning" 2 None visible;
+       check_redacted_reasoning "second redacted reasoning" 3 redacted
      | Ct.Adjacent_reasoning blocks ->
        Alcotest.failf
          "second call expected two adjacent reasoning blocks, got %d"
@@ -165,11 +177,7 @@ let test_text_breaks_reasoning_adjacency () =
 let test_tool_call_of_block_preserves_fields_without_inference () =
   let input = `Assoc [ "path", `String "lib/" ] in
   let reasoning =
-    { Ct.order_index = 2
-    ; kind = Ct.Visible_thinking
-    ; content = "inspect tree"
-    ; signature = Some "sig-tool"
-    }
+    { Ct.order_index = 2; kind = Ct.Visible_thinking; signature = Some "sig-tool" }
   in
   let block = Types.ToolUse { id = "call_read"; name = "read"; input } in
   match
@@ -187,16 +195,33 @@ let test_tool_call_of_block_preserves_fields_without_inference () =
     check_provider_kind "block call" (Some PK.Anthropic) call.Ct.provider_kind;
     (match call.Ct.adjacent_reasoning with
      | Ct.Adjacent_reasoning [ block ] ->
-       check_visible_reasoning
-         "block adjacent reasoning"
-         2
-         "inspect tree"
-         (Some "sig-tool")
-         block
+       check_visible_reasoning "block adjacent reasoning" 2 (Some "sig-tool") block
      | Ct.Adjacent_reasoning blocks ->
        Alcotest.failf "expected one adjacent reasoning block, got %d" (List.length blocks)
      | Ct.No_adjacent_reasoning -> Alcotest.fail "expected supplied adjacent reasoning")
   | None -> Alcotest.fail "expected ToolUse projection"
+;;
+
+let test_adjacent_reasoning_projection_omits_payloads () =
+  let visible_payload = "VISIBLE_REASONING_PAYLOAD_DO_NOT_RENDER" in
+  let redacted_payload = "REDACTED_REASONING_PAYLOAD_DO_NOT_RENDER" in
+  let resp =
+    response
+      [ Types.Thinking { signature = Some "payload-sig"; content = visible_payload }
+      ; Types.RedactedThinking redacted_payload
+      ; Types.ToolUse { id = "call_private"; name = "private_tool"; input = `Null }
+      ]
+  in
+  let call = one_tool_call resp in
+  match call.Ct.adjacent_reasoning with
+  | Ct.Adjacent_reasoning [ visible; redacted ] ->
+    check_visible_reasoning "visible metadata" 0 (Some "payload-sig") visible;
+    check_redacted_reasoning "redacted metadata" 1 redacted;
+    check_no_exposed_payload "visible metadata" visible_payload visible;
+    check_no_exposed_payload "redacted metadata" redacted_payload redacted
+  | Ct.Adjacent_reasoning blocks ->
+    Alcotest.failf "expected two adjacent reasoning blocks, got %d" (List.length blocks)
+  | Ct.No_adjacent_reasoning -> Alcotest.fail "expected adjacent reasoning"
 ;;
 
 let test_tool_call_of_block_defaults_to_no_context () =
@@ -323,6 +348,10 @@ let () =
             "text breaks reasoning adjacency"
             `Quick
             test_text_breaks_reasoning_adjacency
+        ; Alcotest.test_case
+            "omits reasoning payloads"
+            `Quick
+            test_adjacent_reasoning_projection_omits_payloads
         ] )
     ; ( "tool_call_of_block"
       , [ Alcotest.test_case


### PR DESCRIPTION
## Summary

- Remove raw provider reasoning payloads from the public `Canonical_tool.provider_reasoning_block` projection.
- Keep adjacent reasoning as renderer/executor-safe metadata: content order, closed kind, and optional provider signature only.
- Leave replay payload authority in `Types.content_block`, and update tests/docs so canonical tool projection no longer surfaces visible or redacted thinking content.

Fixes #2330.

## Verification

- `ocamlformat --check lib/llm_provider/canonical_tool.ml lib/llm_provider/canonical_tool.mli test/test_canonical_tool.ml test/test_backend_openai_codec.ml`
- `git diff --check`
- `bash scripts/hardening-ratchet.sh --check`
- `bash scripts/ci-code-smell-ratchet.sh --check`
- `env OAS_MODEL_CATALOG=/Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/oas-canonical-reasoning-metadata-20260630/models.toml OAS_CAPABILITY_MANIFEST= ./scripts/dune-local.sh exec ./test/test_canonical_tool.exe`
- `env OAS_MODEL_CATALOG=/Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/oas-canonical-reasoning-metadata-20260630/models.toml OAS_CAPABILITY_MANIFEST= ./scripts/dune-local.sh exec ./test/test_backend_openai_codec.exe`
