### PR TITLE
refactor(provider): centralize ZAI GLM thinking field gate

### DIFF
--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -296,22 +296,11 @@ let build_openai_body_unchecked ?provider_config ~config ~messages ?tools ?slot_
     then body_assoc
     else (
       let zai_glm_clear_thinking =
-        match capabilities.thinking_control_format with
-        | Llm_provider.Capabilities.No_thinking_control
-          when is_glm_request ?provider_config config ->
-          Some
-            (Llm_provider.Provider_config.glm_clear_thinking_value
-               ~clear_thinking:None
-               ~preserve_thinking:config.config.preserve_thinking)
-        | Llm_provider.Capabilities.No_thinking_control
-        | Llm_provider.Capabilities.Thinking_object
-        | Llm_provider.Capabilities.Thinking_object_adaptive
-        | Llm_provider.Capabilities.Thinking_object_only
-        | Llm_provider.Capabilities.Chat_template_kwargs
-        | Llm_provider.Capabilities.Chat_template_token
-        | Llm_provider.Capabilities.Ollama_think
-        | Llm_provider.Capabilities.Reasoning_effort
-        | Llm_provider.Capabilities.Enable_thinking -> None
+        Llm_provider.Provider_config.zai_glm_clear_thinking_request_field
+          ~thinking_control_format:capabilities.thinking_control_format
+          ~is_zai_glm:(is_glm_request ?provider_config config)
+          ~clear_thinking:None
+          ~preserve_thinking:config.config.preserve_thinking
       in
       Llm_provider.Reasoning_dialect.request_control_fields
         dialect

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -271,18 +271,11 @@ let build_request_assoc
   in
   let body =
     let zai_glm_clear_thinking =
-      match caps.thinking_control_format with
-      | No_thinking_control when is_zai_glm_request config ->
-        Some (glm_clear_thinking_of_config config)
-      | No_thinking_control
-      | Thinking_object
-      | Thinking_object_adaptive
-      | Thinking_object_only
-      | Chat_template_kwargs
-      | Chat_template_token
-      | Ollama_think
-      | Reasoning_effort
-      | Enable_thinking -> None
+      Provider_config.zai_glm_clear_thinking_request_field
+        ~thinking_control_format:caps.thinking_control_format
+        ~is_zai_glm:(is_zai_glm_request config)
+        ~clear_thinking:config.clear_thinking
+        ~preserve_thinking:config.preserve_thinking
     in
     (match Provider_config.validate_reasoning_effort_request config with
      | Ok () -> ()

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -432,6 +432,26 @@ let glm_clear_thinking (config : t) =
     ~preserve_thinking:config.preserve_thinking
 ;;
 
+let zai_glm_clear_thinking_request_field
+      ~thinking_control_format
+      ~is_zai_glm
+      ~clear_thinking
+      ~preserve_thinking
+  =
+  match thinking_control_format with
+  | Capabilities.No_thinking_control when is_zai_glm ->
+    Some (glm_clear_thinking_value ~clear_thinking ~preserve_thinking)
+  | Capabilities.No_thinking_control
+  | Capabilities.Thinking_object
+  | Capabilities.Thinking_object_adaptive
+  | Capabilities.Thinking_object_only
+  | Capabilities.Chat_template_kwargs
+  | Capabilities.Chat_template_token
+  | Capabilities.Ollama_think
+  | Capabilities.Reasoning_effort
+  | Capabilities.Enable_thinking -> None
+;;
+
 let glm_should_replay_reasoning (config : t) =
   glm_should_replay_reasoning_fields
     ~enable_thinking:config.enable_thinking

--- a/lib/llm_provider/provider_config.mli
+++ b/lib/llm_provider/provider_config.mli
@@ -376,6 +376,17 @@ val glm_clear_thinking_value
 
 val glm_clear_thinking : t -> bool
 
+(** Top-level GLM [thinking.clear_thinking] request-field resolver for
+    OpenAI-compatible ZAI GLM rows that do not expose a normal thinking control
+    capability. Non-GLM rows and rows with an explicit thinking control format
+    omit the compatibility field. *)
+val zai_glm_clear_thinking_request_field
+  :  thinking_control_format:Capabilities.thinking_control_format
+  -> is_zai_glm:bool
+  -> clear_thinking:bool option
+  -> preserve_thinking:bool option
+  -> bool option
+
 (** [true] iff GLM should replay prior-turn [reasoning_content] into request
     history: thinking active AND [clear_thinking] false (Preserved Thinking).
     Under the default [clear_thinking=true] the server discards prior reasoning,

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -833,6 +833,36 @@ let test_validate_reasoning_effort_subset_rejects_unsupported () =
     | Ok () -> Alcotest.fail "high effort should be rejected by accepted subset")
 ;;
 
+let test_zai_glm_clear_thinking_request_field () =
+  let resolve
+        ?(thinking_control_format = Capabilities.No_thinking_control)
+        ?(is_zai_glm = true)
+        ?clear_thinking
+        ?preserve_thinking
+        ()
+    =
+    Provider_config.zai_glm_clear_thinking_request_field
+      ~thinking_control_format
+      ~is_zai_glm
+      ~clear_thinking
+      ~preserve_thinking
+  in
+  Alcotest.(check (option bool)) "default GLM clears" (Some true) (resolve ());
+  Alcotest.(check (option bool))
+    "preserve disables clear"
+    (Some false)
+    (resolve ~preserve_thinking:true ());
+  Alcotest.(check (option bool))
+    "explicit clear wins"
+    (Some true)
+    (resolve ~clear_thinking:true ~preserve_thinking:true ());
+  Alcotest.(check (option bool)) "non-GLM omits" None (resolve ~is_zai_glm:false ());
+  Alcotest.(check (option bool))
+    "typed thinking control omits"
+    None
+    (resolve ~thinking_control_format:Capabilities.Thinking_object ())
+;;
+
 let test_reasoning_effort_of_config () =
   let ollama =
     Provider_config.make
@@ -1521,6 +1551,10 @@ let () =
             "reasoning effort accepted subset"
             `Quick
             test_validate_reasoning_effort_subset_rejects_unsupported
+        ; Alcotest.test_case
+            "zai glm clear_thinking request field"
+            `Quick
+            test_zai_glm_clear_thinking_request_field
         ; Alcotest.test_case
             "structured output names"
             `Quick


### PR DESCRIPTION
## Summary
- add a Provider_config helper that decides when ZAI GLM should emit the compatibility thinking.clear_thinking request field
- route both OpenAI request builders through that helper instead of duplicating the thinking_control_format match
- cover the helper dispatch and clear/preserve precedence in provider config tests

## Verification
- opam exec -- ocamlformat --check lib/llm_provider/provider_config.ml lib/llm_provider/provider_config.mli lib/api_openai.ml lib/llm_provider/backend_openai_request.ml test/test_provider_config.ml
- git diff --check
- scripts/hardening-ratchet.sh --check
- scripts/ci-code-smell-ratchet.sh --check

Note: local Dune was intentionally not run; GitHub CI is the build/test authority for this branch.