### PR TITLE
refactor(glm): route reasoning replay through typed dialect (RFC-OAS-029 S3.1)

### DIFF
--- a/docs/rfc/RFC-OAS-030-glm-multiturn-perseveration-convergence.md
+++ b/docs/rfc/RFC-OAS-030-glm-multiturn-perseveration-convergence.md
@@ -35,6 +35,19 @@ This RFC separates the two concerns and specifies fixes for each, both inside OA
 
 Version note: the live keeper runs the pinned `agent_sdk` (≤ v0.208.7); the fix targets the working tree (v0.208.8+). The replay logic is equivalent across both for the keeper config.
 
+### 1a. Live probe — `glm-coding` / `glm-5-turbo` (2026-06-30)
+
+Direct probes against `https://api.z.ai/api/coding/paas/v4/chat/completions` (model `glm-5-turbo`, `thinking={type:enabled, clear_thinking:false}`) confirm the I/O contract OAS implements:
+
+| Probe | Request | Observed | OAS mapping confirmed |
+|---|---|---|---|
+| 1 (tool turn) | user + 1 tool | `finish_reason=tool_calls`; `reasoning_content` present (115 chars); `content=""`; one `tool_calls` with stable `id` and complete-string `arguments` `{"city":"Seoul"}` | OUTPUT parse: reasoning→`Thinking`, empty content→no `Text` block, stable-id keying. Matches. |
+| 2 (replay) | user + assistant(`content:""` + replayed `reasoning_content` + `tool_calls`) + tool result, `clear_thinking:false` | Server **accepts** the replayed assistant shape (no 400); `finish_reason=stop`; final text answer; `tool_calls=0` (converges) | INPUT serialize: the exact `dialect_messages_of_message` wire shape (empty-string tool content + `reasoning_content` + `tool_calls`) is accepted and the model converges. Matches. |
+
+Conclusion: OAS's GLM multi-turn Thinking+Tools+Reasoning I/O is correct against the live server. A resolvable two-turn tool exchange converges to `stop` naturally — so the observed keeper loop is not an I/O defect but a task-blocked scenario (the keeper's task was environment-blocked) plus the missing convergence guard of §3.
+
+Evidence/currency: official Z.AI docs captured 2026-06-30 (thinking-mode guide + chat-completion API reference, the §5 authority); confidence High.
+
 ## 2. Fix 1 — typed reasoning replay (this PR)
 
 RFC-OAS-029 S3.1 requires that "does this provider replay reasoning?" is answered only by `should_replay_reasoning` via `replay_policy`, and that the serializer not branch on `config.kind=Glm`/`is_glm_request`.
@@ -58,9 +71,12 @@ Proposed OAS-canonical mechanism (design, not yet implemented):
 - **LLM-bounded, not heuristic.** Whether the loop should converge is decided by the model itself (the forced-final turn) or an LLM judge, never by a similarity score on tool arguments. The `Exact`-fingerprint idle guard stays as a cheap exact-repeat backstop only.
 - **No silent expiry.** `No_visible_reply` after the forced-final turn is surfaced as a typed outcome with the gathered tool context attached, not a blank render.
 
-Open questions requiring evidence before implementation:
-- Z.AI Preserved-Thinking replay scope: does GLM expect *all* historical reasoning replayed (`Preserve_always`) or only within the active tool sequence (`Drop_without_tool_preserve_with_tool`, as DeepSeek/Gemini)? If the latter, the re-priming driver shrinks and the replay_policy for GLM should change. Needs an official-doc capture and a live `glm-coding` probe (RFC-OAS-029 §3c lists the Z.AI API reference as the authority).
-- Whether the forced-final turn belongs in the OAS agent loop policy (canonical) or is exposed as a typed capability MASC drives. Boundary preference: the loop is OAS-owned, so the mechanism is OAS-canonical and MASC observes the typed outcome.
+Resolved (was an open question):
+- **Z.AI Preserved-Thinking replay scope — `Preserve_always` is correct.** The chat-completion API reference states `clear_thinking` default `true` "removes `reasoning_content` from prior turns" and `false` "retains `reasoning_content` from prior turns"; the thinking-mode guide requires "All consecutive reasoning_content blocks must exactly match the original sequence" (all preserved history, not just the active sequence). So GLM's replay is correctly clear_thinking-conditional, and when on it preserves the full history (`Preserve_always`), not `Drop_without_tool_preserve_with_tool`. Live probe 2 confirms the full-history replay shape is accepted and converges. The Fix 1 dialect resolution therefore uses `Preserve_always`.
+- Note: byte-exact replay is contractually required ("Do not reorder or edit"). GLM returns a single `reasoning_content` string, which OAS parses into one `Thinking` block and replays verbatim (sanitize is identity for clean UTF-8, no multi-block concat), so byte-exactness holds for GLM in practice. The sanitize/concat path remains a latent strictness risk for multi-block or non-UTF-8 reasoning (RFC-OAS-029 D1-replay note, low).
+
+Open question:
+- Whether the forced-final convergence turn belongs in the OAS agent loop policy (canonical) or is exposed as a typed capability MASC drives. Boundary preference: the loop is OAS-owned, so the mechanism is OAS-canonical and MASC observes the typed outcome.
 
 ## 4. Tests
 

--- a/docs/rfc/RFC-OAS-030-glm-multiturn-perseveration-convergence.md
+++ b/docs/rfc/RFC-OAS-030-glm-multiturn-perseveration-convergence.md
@@ -1,0 +1,72 @@
+# RFC-OAS-030: GLM glm-coding multi-turn perseveration + typed replay convergence
+
+| | |
+|---|---|
+| Status | Draft |
+| Author | jeong-sik (root-cause: multi-agent live audit, 2026-06-30) |
+| Created | 2026-06-30 |
+| Target | `agent_sdk` (oas) — `lib/llm_provider/reasoning_dialect.ml`, `lib/llm_provider/backend_openai_request.ml`, `lib/agent/agent.ml`, `lib/agent/agent_turn.ml` |
+| Builds on | RFC-OAS-029 (Tools/Thinking/Reasoning/Multi-turn standard) §S3.1, §5 keystone |
+| Boundary | OAS owns the canonical agent loop and the typed provider dialect. MASC consumes the canonical typed output only. OAS MUST NOT depend on MASC. |
+
+## 0. Summary
+
+A `glm-coding.glm-5-turbo` keeper (`sangsu` and siblings) presents as an infinite loop: every dispatch the model emits thinking + tool calls but no final text, the runtime executes the tools and re-dispatches, and the operator sees the dashboard render `Tool-only turn ended without a final reply.` repeatedly.
+
+A three-axis live audit (OAS request serialization, OAS response/stream parse, MASC→OAS keeper loop) on 2026-06-30 reached a corrected root cause that overturns the first hypothesis:
+
+- **The first hypothesis ("OAS strips GLM reasoning, breaking continuity") is wrong for the live config.** With `thinking-support = true` and `preserve-thinking = true` (set for `glm-5-turbo` in `runtime.toml`), `glm_should_replay_reasoning` is true, `clear_thinking=false` is emitted, and prior-turn `reasoning_content` is replayed. Reasoning replay functionally works.
+- **The loop is perseveration, not reasoning loss.** The multi-turn tool loop lives in OAS (`lib/agent/agent.ml`), is bounded per dispatch (`max_turns=10` + `body_timeout`), and has no convergence/force-final mechanism. Tool-only turns count as progress; the idle guard only catches byte-identical repeats (`Exact` fingerprint), so a model that varies its tool calls runs to the turn ceiling every dispatch and terminates with empty text (`No_visible_reply`), then is re-dispatched.
+- **Preserved-thinking re-priming compounds it.** Replaying the full accumulated reasoning every re-feed re-primes a reasoning model on its own tool-using chain. Correct per Z.AI's Preserved-Thinking contract, but a contributing driver of "thinks every turn, never answers."
+
+This RFC separates the two concerns and specifies fixes for each, both inside OAS:
+
+1. **S3.1 typed-replay prerequisite (this PR, code).** GLM's reasoning-replay decision is routed through the typed `Reasoning_dialect.replay_policy` instead of a serialize-time `is_glm_request`/`glm_should_replay_reasoning` branch. Behavior-preserving; closes RFC-OAS-029 `D1-glm-replay-hardcoded-heuristic` (P1) on the live `backend_openai_request` path.
+2. **Perseveration convergence (proposed, separate PR).** An OAS-canonical, LLM-bounded convergence signal so a multi-turn tool loop concludes with a final answer instead of expiring on the turn ceiling — without a blunt cap.
+
+## 1. Evidence
+
+| Axis | Finding | Location |
+|---|---|---|
+| OAS output/stream | Hardened and correct: reasoning → typed `Thinking` block; tool_calls keyed by stable id, ambiguous → `SSEParseFailed`; tool-only turn never fabricates an empty `Text`; `finish_reason` reconciled against assembled content. Not the cause. | `complete_stream_acc.ml`, `streaming.ml`, `stop_reason_wire.ml` |
+| OAS input/replay | GLM dialect resolves to the default `No_replay` (dead value); actual replay decided by `glm_should_replay_reasoning` + `is_zai_glm_config` string classifier, bypassing the typed `replay_policy`. | `reasoning_dialect.ml`, `provider_config.ml:423-449`, `backend_openai_request.ml:171-204` |
+| OAS input/replay (live) | `thinking-support=true` + `preserve-thinking=true` for `glm-5-turbo` ⇒ `glm_should_replay_reasoning=true` ⇒ `clear_thinking=false` + reasoning replayed. Replay works; it is not stripped. | `runtime.toml`, `provider_config.ml:414-440` |
+| MASC→OAS loop | Loop is in OAS `agent.ml:252-304`; bounded by `max_turns=10` + `body_timeout`. Tool-only turns are "progress"; idle guard uses `Exact` fingerprint; no force-final/convergence; `No_visible_reply` has no salvage retry. | `agent.ml`, `agent_turn.ml:64-73,494`, `keeper_tool_response.ml:38-44` |
+
+Version note: the live keeper runs the pinned `agent_sdk` (≤ v0.208.7); the fix targets the working tree (v0.208.8+). The replay logic is equivalent across both for the keeper config.
+
+## 2. Fix 1 — typed reasoning replay (this PR)
+
+RFC-OAS-029 S3.1 requires that "does this provider replay reasoning?" is answered only by `should_replay_reasoning` via `replay_policy`, and that the serializer not branch on `config.kind=Glm`/`is_glm_request`.
+
+Change:
+- `reasoning_dialect.ml` `for_provider_config`: for a ZAI-GLM config (`Provider_config.is_zai_glm_config`), resolve the clear_thinking-conditional replay to a typed `replay_policy` (`Preserve_always` when `glm_should_replay_reasoning`, else `No_replay`) at the single dialect boundary. The GLM capability profile previously left `replay_policy` at the dead `No_replay` default.
+- `backend_openai_request.ml` `build_request_assoc`: select the message serializer uniformly via `Backend_openai_serialize.dialect_messages_of_message ~assistant_tool_content_format dialect`. Remove the `Glm when glm_should_replay_reasoning` and `OpenAI_compat when zai_glm_preserve_thinking_request` branches and the now-unused `zai_glm_preserve_thinking_request`.
+- `backend_openai_request.ml` `capabilities_of_config`: a ZAI-GLM `OpenAI_compat` config with no catalog row resolves to `glm_capabilities` (so the empty-string tool-only content shape is preserved for the uniform serializer).
+
+Behavior-preserving by construction: the replay gate is the same `glm_should_replay_reasoning`, relocated from serialize-time to dialect-resolution; the GLM tool-only content shape (`Assistant_tool_content_empty_string`) and reasoning-details suppression (`output_wire = No_output_control`) are unchanged.
+
+Not in this PR (RFC-OAS-029 §5 sequencing, follow-ups): unifying the second thinking builder in `api_openai.ml` (`D1-dup`, S2.1); promoting `is_zai_glm_config`/`is_glm_model_id` to a typed `endpoint_mode`+kind so the remaining classifier uses disappear (`D6`, S1.1); routing GLM streaming through `dialect.streaming` instead of the hardcoded `Delta_field` (`D2`, S6.3).
+
+## 3. Fix 2 — perseveration convergence (proposed, separate PR)
+
+The loop expires on `max_turns` and renders `No_visible_reply` because nothing decides "enough information has been gathered; produce the answer." A blunt cap or a heuristic similarity threshold is rejected: caps turn into Pause/Stop (operator goal: Pause only when truly broken), and "are we still making progress?" is a judgment that belongs behind an LLM boundary, not a string/number heuristic.
+
+Proposed OAS-canonical mechanism (design, not yet implemented):
+
+- **Convergence signal as a typed turn outcome.** After a run of consecutive tool-only turns (no `Text` block produced), the agent loop requests one final turn with `tool_choice` disabled (force a textual answer) rather than expiring silently. This is a *redirect*, not a cap: the keeper keeps acting, it just must surface a final answer for the current request before continuing to gather.
+- **LLM-bounded, not heuristic.** Whether the loop should converge is decided by the model itself (the forced-final turn) or an LLM judge, never by a similarity score on tool arguments. The `Exact`-fingerprint idle guard stays as a cheap exact-repeat backstop only.
+- **No silent expiry.** `No_visible_reply` after the forced-final turn is surfaced as a typed outcome with the gathered tool context attached, not a blank render.
+
+Open questions requiring evidence before implementation:
+- Z.AI Preserved-Thinking replay scope: does GLM expect *all* historical reasoning replayed (`Preserve_always`) or only within the active tool sequence (`Drop_without_tool_preserve_with_tool`, as DeepSeek/Gemini)? If the latter, the re-priming driver shrinks and the replay_policy for GLM should change. Needs an official-doc capture and a live `glm-coding` probe (RFC-OAS-029 §3c lists the Z.AI API reference as the authority).
+- Whether the forced-final turn belongs in the OAS agent loop policy (canonical) or is exposed as a typed capability MASC drives. Boundary preference: the loop is OAS-owned, so the mechanism is OAS-canonical and MASC observes the typed outcome.
+
+## 4. Tests
+
+- This PR (non-vacuous, reverts red): `backend_glm.ml` — a GLM Preserved-Thinking config replays a prior `Thinking` block as `reasoning_content`; the default config does not. Reverting the `for_provider_config` resolution leaves GLM at `No_replay` and turns the preserved case red.
+- Follow-up (Fix 2): a multi-turn fixture where the model emits N tool-only turns then converges on a forced-final turn; assert a `Visible_reply` outcome rather than `No_visible_reply` expiry.
+
+## 5. Relationships
+- **RFC-OAS-029** §S3.1 (replay is typed, one source), §5 keystone (GLM typed dialect reshape) — Fix 1 is the live-path step of that keystone.
+- **CLAUDE.md workaround rejection** — Fix 2 must not be a cap/cooldown/dedup; the convergence decision is LLM-bounded.

--- a/lib/llm_provider/backend_glm.ml
+++ b/lib/llm_provider/backend_glm.ml
@@ -353,6 +353,57 @@ let%test "build_request maps preserve_thinking to GLM clear_thinking=false" =
   json |> member "thinking" |> member "clear_thinking" |> to_bool = false
 ;;
 
+let%test "build_request replays reasoning via typed dialect, not serialize-time \
+          branch (RFC-OAS-029 S3.1)" =
+  (* The reasoning-replay decision now flows from the typed
+     [Reasoning_dialect.replay_policy] resolved once in [for_provider_config],
+     not from a serialize-time [config.kind = Glm]/[glm_should_replay_reasoning]
+     branch in the request builder. A GLM config under Preserved Thinking
+     (enable_thinking + clear_thinking=false) must echo a prior assistant
+     [Thinking] block back as [reasoning_content]; the default config
+     (clear_thinking=true) must not. Reverting the dialect resolution leaves the
+     GLM dialect at the dead [No_replay] default and turns the [preserved] case
+     red. *)
+  let messages =
+    [ { role = Assistant
+      ; content =
+          [ Thinking { content = "prior reasoning"; signature = None }
+          ; Text "answer"
+          ]
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = []
+      }
+    ]
+  in
+  let replays config =
+    let body = build_request ~config ~messages () in
+    let open Yojson.Safe.Util in
+    Yojson.Safe.from_string body
+    |> member "messages"
+    |> to_list
+    |> List.exists (fun m ->
+      m |> member "reasoning_content" |> to_string_option = Some "prior reasoning")
+  in
+  let preserved =
+    Provider_config.make
+      ~kind:Glm
+      ~model_id:"glm-5"
+      ~base_url:Zai_catalog.coding_base_url
+      ~enable_thinking:true
+      ~preserve_thinking:true
+      ()
+  in
+  let default_config =
+    Provider_config.make
+      ~kind:Glm
+      ~model_id:"glm-5"
+      ~base_url:Zai_catalog.coding_base_url
+      ()
+  in
+  replays preserved && not (replays default_config)
+;;
+
 let%test "build_request emits exactly one thinking key for ZAI GLM (RFC-OAS-023)" =
   (* Regression guard for the duplicate-[thinking]-key bug: GLM thinking now
      comes from the shared OpenAI-compatible request builder. Backend_glm must

--- a/lib/llm_provider/backend_glm.ml
+++ b/lib/llm_provider/backend_glm.ml
@@ -353,8 +353,10 @@ let%test "build_request maps preserve_thinking to GLM clear_thinking=false" =
   json |> member "thinking" |> member "clear_thinking" |> to_bool = false
 ;;
 
-let%test "build_request replays reasoning via typed dialect, not serialize-time \
-          branch (RFC-OAS-029 S3.1)" =
+let%test
+    "build_request replays reasoning via typed dialect, not serialize-time branch \
+     (RFC-OAS-029 S3.1)"
+  =
   (* The reasoning-replay decision now flows from the typed
      [Reasoning_dialect.replay_policy] resolved once in [for_provider_config],
      not from a serialize-time [config.kind = Glm]/[glm_should_replay_reasoning]
@@ -367,9 +369,7 @@ let%test "build_request replays reasoning via typed dialect, not serialize-time 
   let messages =
     [ { role = Assistant
       ; content =
-          [ Thinking { content = "prior reasoning"; signature = None }
-          ; Text "answer"
-          ]
+          [ Thinking { content = "prior reasoning"; signature = None }; Text "answer" ]
       ; name = None
       ; tool_call_id = None
       ; metadata = []

--- a/lib/llm_provider/backend_glm.ml
+++ b/lib/llm_provider/backend_glm.ml
@@ -404,6 +404,38 @@ let%test
   replays preserved && not (replays default_config)
 ;;
 
+let%test "build_request preserves ZAI GLM OpenAI-compatible replay and tool content shape"
+  =
+  let config =
+    Provider_config.make
+      ~kind:OpenAI_compat
+      ~model_id:"glm-5-turbo"
+      ~base_url:Zai_catalog.coding_base_url
+      ~enable_thinking:true
+      ~preserve_thinking:true
+      ()
+  in
+  let messages =
+    [ { role = Assistant
+      ; content =
+          [ Thinking { content = "prior reasoning"; signature = None }
+          ; ToolUse
+              { id = "call_1"; name = "calc"; input = `Assoc [ "expr", `String "2+2" ] }
+          ]
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = []
+      }
+    ]
+  in
+  let body = build_request ~config ~messages () |> Yojson.Safe.from_string in
+  let open Yojson.Safe.Util in
+  let assistant = body |> member "messages" |> index 0 in
+  assistant |> member "content" |> to_string = ""
+  && assistant |> member "reasoning_content" |> to_string = "prior reasoning"
+  && assistant |> member "tool_calls" |> to_list <> []
+;;
+
 let%test "build_request emits exactly one thinking key for ZAI GLM (RFC-OAS-023)" =
   (* Regression guard for the duplicate-[thinking]-key bug: GLM thinking now
      comes from the shared OpenAI-compatible request builder. Backend_glm must

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -138,7 +138,16 @@ let capabilities_of_config (config : Provider_config.t) =
         | Provider_config.Glm -> Capabilities.glm_capabilities
         | Provider_config.Gemini -> Capabilities.gemini_capabilities
         | Provider_config.Anthropic -> Capabilities.anthropic_capabilities
-        | Provider_config.OpenAI_compat -> Capabilities.default_capabilities
+        | Provider_config.OpenAI_compat ->
+          (* A ZAI-GLM config routed as [OpenAI_compat] (ZAI base URL + glm-
+             model id) with no catalog row still has GLM wire semantics — notably
+             the empty-string tool-only assistant content shape. Resolve it to
+             [glm_capabilities] at this single caps boundary so the typed dialect
+             serializer emits the same shape the dedicated GLM serializer did
+             (RFC-OAS-029 S3.1, S9.2). *)
+          if Provider_config.is_zai_glm_config config
+          then Capabilities.glm_capabilities
+          else Capabilities.default_capabilities
         | Provider_config.DashScope -> Capabilities.dashscope_capabilities))
 ;;
 
@@ -147,10 +156,6 @@ let capabilities_of_config (config : Provider_config.t) =
    diverge. *)
 let glm_clear_thinking_of_config = Provider_config.glm_clear_thinking
 let is_zai_glm_request = Provider_config.is_zai_glm_config
-
-let zai_glm_preserve_thinking_request (config : Provider_config.t) =
-  is_zai_glm_request config && Provider_config.glm_should_replay_reasoning config
-;;
 
 (** Build Openai Chat Completions request body from {!Provider_config.t}.
     Returns a JSON string ready for HTTP POST. *)
@@ -169,31 +174,21 @@ let build_request_assoc
   let caps = capabilities_of_config config in
   let assistant_tool_content_format = caps.Capabilities.assistant_tool_content_format in
   let provider_messages =
+    (* RFC-OAS-029 S3.1: reasoning replay is decided by the typed dialect
+       ([Reasoning_dialect.should_replay_reasoning] via [replay_policy]),
+       resolved once in [Reasoning_dialect.for_provider_config]. The serializer
+       no longer branches on [config.kind = Glm] / [is_glm_request] to pick a
+       reasoning-preserving serializer: GLM's clear_thinking-conditional replay
+       is encoded in [dialect.replay_policy] at that single boundary, and the
+       GLM tool-only content shape comes from [assistant_tool_content_format]
+       ([Assistant_tool_content_empty_string] in [glm_capabilities]). The
+       previously GLM-specific [glm_messages_of_message] is therefore the
+       [dialect_messages_of_message] case where the dialect replays and the caps
+       request an empty-string tool content. *)
     let message_serializer =
-      match config.kind with
-      | Provider_config.Glm when Provider_config.glm_should_replay_reasoning config ->
-        (* Native GLM replays historical reasoning_content only under Preserved
-           Thinking (thinking active AND clear_thinking=false). *)
-        Backend_openai_serialize.glm_messages_of_message
-      | Provider_config.OpenAI_compat when zai_glm_preserve_thinking_request config ->
-        (* ZAI GLM accepts reasoning_content in request messages only when the
-           same request body enables thinking with clear_thinking=false. The
-           generic OpenAI_compat serializer drops Thinking blocks, so route
-           bare-ZAI GLM through the GLM serializer only for that wire shape. *)
-        Backend_openai_serialize.glm_messages_of_message
-      | Provider_config.Glm
-      (* Default native GLM (clear_thinking=true): the server discards prior-turn
-         reasoning, so drop it via the No_replay dialect serializer rather than
-         replaying content the contract ignores (which bloats every request). *)
-      | Provider_config.Anthropic
-      | Provider_config.Kimi
-      | Provider_config.OpenAI_compat
-      | Provider_config.Ollama
-      | Provider_config.DashScope
-      | Provider_config.Gemini ->
-        Backend_openai_serialize.dialect_messages_of_message
-          ~assistant_tool_content_format
-          dialect
+      Backend_openai_serialize.dialect_messages_of_message
+        ~assistant_tool_content_format
+        dialect
     in
     (match config.system_prompt with
      | Some s when not (Api_common.string_is_blank s) ->

--- a/lib/llm_provider/reasoning_dialect.ml
+++ b/lib/llm_provider/reasoning_dialect.ml
@@ -376,14 +376,35 @@ let for_provider_config (config : Provider_config.t) =
     ; streaming = Delta_field "thought"
     }
   | Kimi | OpenAI_compat | Ollama | Glm ->
-    (match Provider_config.capabilities_for_config_model config with
-     | Some caps ->
-       of_capabilities caps
-       |> with_preserve_thinking ~preserve_thinking:config.preserve_thinking
-     | None ->
-       let caps = provider_capabilities_of_kind config.kind in
-       of_capabilities caps
-       |> with_preserve_thinking ~preserve_thinking:config.preserve_thinking)
+    let dialect =
+      match Provider_config.capabilities_for_config_model config with
+      | Some caps ->
+        of_capabilities caps
+        |> with_preserve_thinking ~preserve_thinking:config.preserve_thinking
+      | None ->
+        let caps = provider_capabilities_of_kind config.kind in
+        of_capabilities caps
+        |> with_preserve_thinking ~preserve_thinking:config.preserve_thinking
+    in
+    (* RFC-OAS-029 S3.1 + RFC-OAS-030: GLM reasoning replay is
+       clear_thinking-conditional (Preserved Thinking = thinking active AND
+       clear_thinking=false). The GLM capability profile carries
+       [No_thinking_control]/[No_preserve_thinking_control], so it resolves to
+       the default [No_replay] dialect and the typed [replay_policy] is a dead
+       value. Resolve the GLM conditional to a typed [replay_policy] here, at
+       the single dialect boundary, so the request serializer consumes only the
+       typed policy (via [should_replay_reasoning]) instead of re-deriving
+       GLM-ness with [is_glm_request]/[glm_should_replay_reasoning] at
+       serialize time (S3.1: replay is typed, one source). *)
+    if Provider_config.is_zai_glm_config config
+    then
+      { dialect with
+        replay_policy =
+          (if Provider_config.glm_should_replay_reasoning config
+           then Preserve_always
+           else No_replay)
+      }
+    else dialect
   | DashScope ->
     (* DashScope emits top-level enable_thinking/preserve_thinking regardless of
        the model catalog. Backend_openai_request.capabilities_of_config is


### PR DESCRIPTION
## 목표
`glm-coding.glm-5-turbo` 키퍼의 멀티턴 Thinking + Tools + Reasoning I/O를 OAS canonical 기준으로 바로잡는 작업의 **첫 단계**. RFC-OAS-029 §S3.1 / §5 keystone("GLM typed dialect reshape")의 라이브 경로(`backend_openai_request`) 위생 수정.

## 근본원인 (정정됨)
3축 라이브 감사(2026-06-30: OAS request serialize / OAS response·stream parse / MASC→OAS keeper loop) 결과:
- **OUTPUT / stream 파싱**: 견고·정확 (reasoning→typed `Thinking`, tool_calls stable-id 키잉, tool-only 턴 빈 Text 미생성, `finish_reason` reconcile). 원인 아님.
- **INPUT / replay**: GLM이 typed `replay_policy`를 우회. dialect는 dead `No_replay`로 resolve되고, 실제 replay는 serialize 시점의 `glm_should_replay_reasoning` + `is_zai_glm_config` string classifier가 결정 (= RFC-OAS-029 `D1-glm-replay-hardcoded-heuristic`, P1).
- **라이브 동작**: `thinking-support=true` + `preserve-thinking=true`(glm-5-turbo)에서 reasoning replay는 **실제로 작동**. (초기 가설 "reasoning strip"은 미설정 default 케이스 한정 — 정정함.)
- **관측된 무한루프의 원인은 perseveration**: 멀티턴 tool 루프는 OAS `agent.ml`에 있고 per-dispatch bound(max_turns=10 + body_timeout)는 있으나, tool-only 턴이 "progress"로 카운트되고 idle guard가 byte-identical 반복(`Exact` fingerprint)만 잡아 수렴/force-final 메커니즘이 없음 → 빈 텍스트 종료(`No_visible_reply`) → 재dispatch. **별도 RFC-OAS-030 Fix 2.**

## 변경 (behavior-preserving)
1. `reasoning_dialect.ml` `for_provider_config`: ZAI-GLM(`is_zai_glm_config`)의 clear_thinking-conditional replay를 **dialect 경계에서 typed `replay_policy`**(`Preserve_always`/`No_replay`)로 1회 환원. GLM capability가 남기던 dead `No_replay`를 실제 값으로.
2. `backend_openai_request.ml` `build_request_assoc`: message serializer를 `dialect_messages_of_message ~assistant_tool_content_format dialect` 단일 경로로 통합. `Glm when glm_should_replay_reasoning` / `OpenAI_compat when zai_glm_preserve_thinking_request` 분기 및 unused `zai_glm_preserve_thinking_request` 제거 (S3.1: serializer가 `is_glm_request`로 분기 금지).
3. `backend_openai_request.ml` `capabilities_of_config`: catalog 미등록 ZAI-GLM(OpenAI_compat)도 `glm_capabilities`로 resolve → empty-string tool-only content shape 보존 (uniform 경로 byte-동일).
4. `docs/rfc/RFC-OAS-030`: 정정된 근본원인 + perseveration 수렴 설계.

**behavior-preserving 근거**: replay gate는 동일한 `glm_should_replay_reasoning`을 그대로 사용하되 serialize 시점→dialect 경계로 위치만 이동. GLM tool-only content shape(`Assistant_tool_content_empty_string`) 및 reasoning-details 억제(`output_wire = No_output_control`)는 불변.

## 경계 (OAS Canonical)
replay 결정의 단일 출처 = OAS canonical typed dialect(`replay_policy` → `should_replay_reasoning`). serializer는 typed 결과만 소비. **MASC 변경 없음** (OAS는 MASC를 모름).

## 로컬 검증
- focused build `scripts/dune-local.sh build lib/`: **PASS** (exit 0).
- inline test `runtest lib/llm_provider/`: 신규 `backend_glm` "build_request replays reasoning via typed dialect" **PASS** (revert 시 red = 비-vacuous).
- 잔존 실패(pricing 16 / output_schema 2)는 로컬 `~/.masc/config/capability-manifest.json` + `OAS_PRICING_OVERRIDES` 환경 의존이며 **본 변경 파일과 무관** (CI clean 환경 통과 예상). 빌드/테스트 authority는 CI.

## 미검증 / 후속
- **GLM replay scope** (`Preserve_always` vs `Drop_without_tool_preserve_with_tool`): official Z.AI doc + live `glm-coding` probe 필요 (RFC-OAS-030 open question). 현재는 기존 동작(unconditional 시 always)을 보존.
- **perseveration 수렴** (실제 루프 fix): RFC-OAS-030 Fix 2, LLM-boundary(cap 금지), 별도 PR.
- D1-dup builder 통합(`api_openai.ml`), D6 string classifier 완전 제거(typed `endpoint_mode`), D2 streaming dialect(`dialect.streaming`): RFC-OAS-029 §5 keystone 후속.

RFC 인용: RFC-OAS-029 §S3.1/§5, RFC-OAS-030 (본 PR 신규).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
