### PR TITLE
feat(structured): expose response JSON extractor

### DIFF
--- a/lib/structured.ml
+++ b/lib/structured.ml
@@ -83,16 +83,21 @@ let parse_schema_text_json schema json =
   | Yojson.Json_error detail -> Error (Error.Serialization (JsonParseError { detail }))
 ;;
 
-(** Extract structured output from the response text JSON. *)
-let extract_text_json ~(schema : _ schema) (response : api_response)
-  : ('a, Error.sdk_error) result
+type response_json_shape =
+  | Any_json
+  | Object_json
+
+let text_json_of_response (response : api_response) =
+  response
+  |> Types.text_of_response
+  |> Llm_provider.Backend_openai.strip_json_markdown_fences
+  |> String.trim
+;;
+
+let extract_response_json ?(shape = Any_json) (response : api_response)
+  : (Yojson.Safe.t, Error.sdk_error) result
   =
-  let text =
-    response
-    |> Types.text_of_response
-    |> Llm_provider.Backend_openai.strip_json_markdown_fences
-    |> String.trim
-  in
+  let text = text_json_of_response response in
   if text = ""
   then
     Error
@@ -104,7 +109,22 @@ let extract_text_json ~(schema : _ schema) (response : api_response)
       parse_json_string text
       |> Result.map_error (fun detail -> Error.Serialization (JsonParseError { detail }))
     in
-    parse_schema_text_json schema json
+    match shape, json with
+    | Any_json, _ -> Ok json
+    | Object_json, `Assoc _ -> Ok json
+    | Object_json, _ ->
+      Error
+        (Error.Serialization
+           (JsonParseError
+              { detail = "structured output response JSON was not an object" }))
+;;
+
+(** Extract structured output from the response text JSON. *)
+let extract_text_json ~(schema : _ schema) (response : api_response)
+  : ('a, Error.sdk_error) result
+  =
+  let* json = extract_response_json response in
+  parse_schema_text_json schema json
 ;;
 
 let sdk_error_of_http_error =
@@ -154,6 +174,11 @@ type 'a extractor = api_response -> ('a, string) result
 
 let schema_extractor (schema : 'a schema) : 'a extractor =
   fun response -> extract_text_json ~schema response |> Result.map_error Error.to_string
+;;
+
+let response_json_extractor ?shape () : Yojson.Safe.t extractor =
+  fun response ->
+  extract_response_json ?shape response |> Result.map_error Error.to_string
 ;;
 
 (* NOTE: keep [json_extractor] / [text_extractor] for callers who parse

--- a/lib/structured.mli
+++ b/lib/structured.mli
@@ -49,6 +49,25 @@ val extract
 
 type 'a extractor = api_response -> ('a, string) result
 
+(** Shape requirement for extracting a provider-native structured-output JSON
+    payload from an API response. *)
+type response_json_shape =
+  | Any_json
+  | Object_json
+
+(** Extract the response text as JSON using the same provider-native
+    structured-output response boundary as {!schema_extractor}. *)
+val extract_response_json
+  :  ?shape:response_json_shape
+  -> api_response
+  -> (Yojson.Safe.t, Error.sdk_error) result
+
+(** Agent-level extractor form of {!extract_response_json}. *)
+val response_json_extractor
+  :  ?shape:response_json_shape
+  -> unit
+  -> Yojson.Safe.t extractor
+
 (** Build an {!extractor} from a typed schema.
 
     This is the Agent-level counterpart to {!extract}: it parses the response

--- a/test/test_structured.ml
+++ b/test/test_structured.ml
@@ -417,6 +417,43 @@ let test_json_extractor_no_text () =
   | Ok _ -> Alcotest.fail "expected error"
 ;;
 
+let test_response_json_extractor_object_success () =
+  let extract = Structured.response_json_extractor ~shape:Structured.Object_json () in
+  let resp = make_response [ Text {|{"value": 42}|} ] in
+  match extract resp with
+  | Ok (`Assoc fields) ->
+    Alcotest.(check bool) "value field present" true (List.mem_assoc "value" fields)
+  | Ok _ -> Alcotest.fail "expected JSON object"
+  | Error e -> Alcotest.fail e
+;;
+
+let test_response_json_extractor_fenced_object () =
+  let extract = Structured.response_json_extractor ~shape:Structured.Object_json () in
+  let resp = make_response [ Text "```json\n{\"ok\":true}\n```" ] in
+  match extract resp with
+  | Ok (`Assoc fields) ->
+    Alcotest.(check bool) "ok field present" true (List.mem_assoc "ok" fields)
+  | Ok _ -> Alcotest.fail "expected JSON object"
+  | Error e -> Alcotest.fail e
+;;
+
+let test_response_json_extractor_any_accepts_array () =
+  let extract = Structured.response_json_extractor () in
+  let resp = make_response [ Text "[1,2,3]" ] in
+  match extract resp with
+  | Ok (`List values) -> Alcotest.(check int) "array length" 3 (List.length values)
+  | Ok _ -> Alcotest.fail "expected JSON array"
+  | Error e -> Alcotest.fail e
+;;
+
+let test_response_json_extractor_object_rejects_array () =
+  let extract = Structured.response_json_extractor ~shape:Structured.Object_json () in
+  let resp = make_response [ Text "[1,2,3]" ] in
+  match extract resp with
+  | Error e -> Alcotest.(check bool) "has error text" true (String.length e > 0)
+  | Ok _ -> Alcotest.fail "expected object shape error"
+;;
+
 let test_text_extractor_success () =
   let extract =
     Structured.text_extractor (fun s ->
@@ -601,6 +638,22 @@ let () =
             `Quick
             test_json_extractor_invalid_json
         ; Alcotest.test_case "json_extractor no text" `Quick test_json_extractor_no_text
+        ; Alcotest.test_case
+            "response_json_extractor object"
+            `Quick
+            test_response_json_extractor_object_success
+        ; Alcotest.test_case
+            "response_json_extractor fenced object"
+            `Quick
+            test_response_json_extractor_fenced_object
+        ; Alcotest.test_case
+            "response_json_extractor any array"
+            `Quick
+            test_response_json_extractor_any_accepts_array
+        ; Alcotest.test_case
+            "response_json_extractor object rejects array"
+            `Quick
+            test_response_json_extractor_object_rejects_array
         ; Alcotest.test_case "text_extractor success" `Quick test_text_extractor_success
         ; Alcotest.test_case "text_extractor none" `Quick test_text_extractor_none
         ; Alcotest.test_case


### PR DESCRIPTION
## Summary
- expose Structured.extract_response_json and response_json_extractor for provider-native structured-output responses
- add a closed response_json_shape axis so object-only consumers can fail closed without ad hoc checks
- reuse the existing schema_extractor text-json boundary, keeping response parsing centralized in OAS

## Verification
- git diff --check
- ocamlformat --check lib/structured.ml lib/structured.mli test/test_structured.ml

Local full dune/test intentionally not run; CI is the build authority for this sequence.