### PR TITLE
refactor(provider): reuse ZAI GLM classifier in validation

### DIFF
--- a/lib/llm_provider/complete_common.ml
+++ b/lib/llm_provider/complete_common.ml
@@ -365,8 +365,7 @@ let thinking_control_disable_unsatisfiable
     let glm_special_case =
       (* backend_openai_request encodes thinking for zai/GLM even under
          No_thinking_control, so that combination IS satisfiable. *)
-      Zai_catalog.is_zai_base_url config.base_url
-      && Zai_catalog.is_glm_model_id config.model_id
+      Provider_config.is_zai_glm_config config
     in
     caps.supports_reasoning
     && caps.thinking_control_format = Capabilities.No_thinking_control


### PR DESCRIPTION
## Summary
- route thinking-control validation's ZAI GLM exception through Provider_config.is_zai_glm_config
- remove one raw base_url + model_id classifier reconstruction from Complete_common
- reduce the hardening ratchet's model_id_string_classifiers_outside_catalog metric by 1

## Verification
- opam exec -- ocamlformat --check lib/llm_provider/complete_common.ml
- git diff --check
- scripts/hardening-ratchet.sh --check
- scripts/ci-code-smell-ratchet.sh --check

Note: local Dune was intentionally not run; GitHub CI is the build/test authority for this branch.