### PR TITLE
refactor(provider): reuse classifier for GLM capabilities

### DIFF
--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -50,8 +50,12 @@ type model_spec =
 let default_openai_compat_capabilities () = openai_compat_chat_capabilities
 
 let uses_native_glm_capabilities ~base_url ~model_id =
-  Llm_provider.Zai_catalog.is_zai_base_url base_url
-  && Llm_provider.Zai_catalog.is_glm_model_id model_id
+  Llm_provider.Provider_config.is_zai_glm_config
+    (Llm_provider.Provider_config.make
+       ~kind:Llm_provider.Provider_config.OpenAI_compat
+       ~model_id
+       ~base_url
+       ())
 ;;
 
 let provider_name = function


### PR DESCRIPTION
## Summary
- route Provider GLM native capability classification through Provider_config.is_zai_glm_config
- keep the non-ZAI GLM OpenAI-compatible fallback behavior unchanged
- reduce direct ZAI base_url + GLM model-id classifier duplication outside the catalog/provider config boundary

## Verification
- opam exec -- ocamlformat --check lib/provider.ml
- git diff --check
- scripts/hardening-ratchet.sh --check
- scripts/ci-code-smell-ratchet.sh --check

Local Dune was intentionally not run; GitHub CI is the build/test authority for this slice.