### PR TITLE
refactor(provider): centralize base64 media source handling

### DIFF
--- a/lib/llm_provider/api_common.ml
+++ b/lib/llm_provider/api_common.ml
@@ -45,6 +45,25 @@ let text_blocks_to_string blocks =
 
 let json_of_string_or_raw s = Lenient_json.parse s
 
+let unsupported_media_source ~backend ~block source_type =
+  invalid_arg
+    (Printf.sprintf
+       "%s does not support %s media source kind %s"
+       backend
+       block
+       (Types.media_source_kind_to_string source_type))
+;;
+
+let base64_media_data_url ~backend ~block ~media_type ~data = function
+  | Base64 -> Printf.sprintf "data:%s;base64,%s" media_type data
+  | (Url | File_id) as source_type -> unsupported_media_source ~backend ~block source_type
+;;
+
+let base64_media_payload ~backend ~block ~data = function
+  | Base64 -> data
+  | (Url | File_id) as source_type -> unsupported_media_source ~backend ~block source_type
+;;
+
 type tool_result_content_style =
   | Tool_result_content_string
   | Tool_result_content_text_blocks

--- a/lib/llm_provider/api_common.mli
+++ b/lib/llm_provider/api_common.mli
@@ -17,6 +17,34 @@ val string_is_blank : string -> bool
 val text_blocks_to_string : Types.content_block list -> string
 val json_of_string_or_raw : string -> Yojson.Safe.t
 
+(** Raise [Invalid_argument] for a media source carrier unsupported by a backend.
+    Backends should use this helper instead of silently reinterpreting [data] as
+    another carrier. *)
+val unsupported_media_source
+  :  backend:string
+  -> block:string
+  -> Types.media_source_kind
+  -> 'a
+
+(** Convert a base64 media block into a data URL. Non-base64 carriers fail
+    closed with {!unsupported_media_source}. *)
+val base64_media_data_url
+  :  backend:string
+  -> block:string
+  -> media_type:string
+  -> data:string
+  -> Types.media_source_kind
+  -> string
+
+(** Return the raw base64 payload for backends whose wire format separates the
+    media type from the base64 data. Non-base64 carriers fail closed. *)
+val base64_media_payload
+  :  backend:string
+  -> block:string
+  -> data:string
+  -> Types.media_source_kind
+  -> string
+
 (** {2 Content block JSON conversion} *)
 
 val content_block_to_json : Types.content_block -> Yojson.Safe.t

--- a/lib/llm_provider/backend_gemini.ml
+++ b/lib/llm_provider/backend_gemini.ml
@@ -164,21 +164,11 @@ let build_tool_id_to_name (messages : message list) : (string, string) Hashtbl.t
 
 (* ── Content block -> Gemini part ───────────────────── *)
 
-let unsupported_media_source ~block source_type =
-  invalid_arg
-    (Printf.sprintf
-       "gemini does not support %s media source kind %s"
-       block
-       (Types.media_source_kind_to_string source_type))
-;;
-
-let inline_data_part ~block ~media_type ~data = function
-  | Base64 ->
-    Some
-      (`Assoc
-          [ "inlineData", `Assoc [ "mimeType", `String media_type; "data", `String data ]
-          ])
-  | (Url | File_id) as source_type -> unsupported_media_source ~block source_type
+let inline_data_part ~block ~media_type ~data source_type =
+  let data = Api_common.base64_media_payload ~backend:"gemini" ~block ~data source_type in
+  Some
+    (`Assoc
+        [ "inlineData", `Assoc [ "mimeType", `String media_type; "data", `String data ] ])
 ;;
 
 let part_of_content_block id_to_name tool_signatures = function

--- a/lib/llm_provider/backend_openai_responses.ml
+++ b/lib/llm_provider/backend_openai_responses.ml
@@ -165,36 +165,38 @@ let content_string_of_tool_result ~content ~content_blocks =
   | None -> Utf8_sanitize.sanitize content
 ;;
 
-let unsupported_media_source ~block source_type =
-  invalid_arg
-    (Printf.sprintf
-       "openai_responses does not support %s media source kind %s"
-       block
-       (Types.media_source_kind_to_string source_type))
-;;
-
-let base64_data_url ~block ~media_type ~data = function
-  | Base64 -> Printf.sprintf "data:%s;base64,%s" media_type data
-  | (Url | File_id) as source_type -> unsupported_media_source ~block source_type
-;;
-
-let base64_audio_data ~block ~data = function
-  | Base64 -> data
-  | (Url | File_id) as source_type -> unsupported_media_source ~block source_type
-;;
-
 let input_content_part_of_block = function
   | Text s ->
     Some
       (`Assoc [ "type", `String "input_text"; "text", `String (Utf8_sanitize.sanitize s) ])
   | Image { media_type; data; source_type } ->
-    let image_url = base64_data_url ~block:"image" ~media_type ~data source_type in
+    let image_url =
+      Api_common.base64_media_data_url
+        ~backend:"openai_responses"
+        ~block:"image"
+        ~media_type
+        ~data
+        source_type
+    in
     Some (`Assoc [ "type", `String "input_image"; "image_url", `String image_url ])
   | Document { media_type; data; source_type } ->
-    let file_data = base64_data_url ~block:"document" ~media_type ~data source_type in
+    let file_data =
+      Api_common.base64_media_data_url
+        ~backend:"openai_responses"
+        ~block:"document"
+        ~media_type
+        ~data
+        source_type
+    in
     Some (`Assoc [ "type", `String "input_file"; "file_data", `String file_data ])
   | Audio { media_type; data; source_type } ->
-    let data = base64_audio_data ~block:"audio" ~data source_type in
+    let data =
+      Api_common.base64_media_payload
+        ~backend:"openai_responses"
+        ~block:"audio"
+        ~data
+        source_type
+    in
     Some
       (`Assoc
           [ "type", `String "input_audio"

--- a/lib/llm_provider/backend_openai_serialize.ml
+++ b/lib/llm_provider/backend_openai_serialize.ml
@@ -7,25 +7,6 @@
 
 open Types
 
-let unsupported_media_source ~backend ~block source_type =
-  invalid_arg
-    (Printf.sprintf
-       "%s does not support %s media source kind %s"
-       backend
-       block
-       (Types.media_source_kind_to_string source_type))
-;;
-
-let base64_data_url ~backend ~block ~media_type ~data = function
-  | Base64 -> Printf.sprintf "data:%s;base64,%s" media_type data
-  | (Url | File_id) as source_type -> unsupported_media_source ~backend ~block source_type
-;;
-
-let base64_audio_data ~backend ~block ~data = function
-  | Base64 -> data
-  | (Url | File_id) as source_type -> unsupported_media_source ~backend ~block source_type
-;;
-
 let tool_calls_to_openai_json blocks =
   blocks
   |> List.filter_map (function
@@ -80,7 +61,7 @@ let openai_content_parts_of_blocks blocks =
       Some (`Assoc [ "type", `String "text"; "text", `String (Utf8_sanitize.sanitize s) ])
     | Image { media_type; data; source_type } ->
       let url =
-        base64_data_url
+        Api_common.base64_media_data_url
           ~backend:"openai_chat"
           ~block:"image"
           ~media_type
@@ -92,7 +73,7 @@ let openai_content_parts_of_blocks blocks =
             [ "type", `String "image_url"; "image_url", `Assoc [ "url", `String url ] ])
     | Document { media_type; data; source_type } ->
       let url =
-        base64_data_url
+        Api_common.base64_media_data_url
           ~backend:"openai_chat"
           ~block:"document"
           ~media_type
@@ -104,7 +85,11 @@ let openai_content_parts_of_blocks blocks =
             [ "type", `String "image_url"; "image_url", `Assoc [ "url", `String url ] ])
     | Audio { media_type; data; source_type } ->
       let data =
-        base64_audio_data ~backend:"openai_chat" ~block:"audio" ~data source_type
+        Api_common.base64_media_payload
+          ~backend:"openai_chat"
+          ~block:"audio"
+          ~data
+          source_type
       in
       Some
         (`Assoc
@@ -369,11 +354,20 @@ let ollama_native_user_message ~modality_priority content : Yojson.Safe.t option
               vision models can attempt to process them as pages. *)
            texts, data :: images
          | Image { source_type; _ } ->
-           unsupported_media_source ~backend:"ollama_native" ~block:"image" source_type
+           Api_common.unsupported_media_source
+             ~backend:"ollama_native"
+             ~block:"image"
+             source_type
          | Document { source_type; _ } ->
-           unsupported_media_source ~backend:"ollama_native" ~block:"document" source_type
+           Api_common.unsupported_media_source
+             ~backend:"ollama_native"
+             ~block:"document"
+             source_type
          | Audio { source_type; _ } ->
-           unsupported_media_source ~backend:"ollama_native" ~block:"audio" source_type
+           Api_common.unsupported_media_source
+             ~backend:"ollama_native"
+             ~block:"audio"
+             source_type
          | Thinking _ | ReasoningDetails _ | RedactedThinking _ | ToolUse _ | ToolResult _
            -> texts, images)
       ([], [])

--- a/test/test_llm_provider_cov.ml
+++ b/test/test_llm_provider_cov.ml
@@ -310,6 +310,47 @@ let test_json_of_string_or_raw_invalid () =
   | _ -> Alcotest.fail "expected raw fallback"
 ;;
 
+let test_base64_media_data_url () =
+  let result =
+    Api_common.base64_media_data_url
+      ~backend:"test_backend"
+      ~block:"image"
+      ~media_type:"image/png"
+      ~data:"abc"
+      Types.Base64
+  in
+  Alcotest.(check string) "data URL" "data:image/png;base64,abc" result
+;;
+
+let test_base64_media_payload () =
+  let result =
+    Api_common.base64_media_payload
+      ~backend:"test_backend"
+      ~block:"audio"
+      ~data:"abc"
+      Types.Base64
+  in
+  Alcotest.(check string) "payload" "abc" result
+;;
+
+let test_base64_media_source_rejects_url () =
+  try
+    ignore
+      (Api_common.base64_media_data_url
+         ~backend:"test_backend"
+         ~block:"image"
+         ~media_type:"image/png"
+         ~data:"https://example.invalid/image.png"
+         Types.Url);
+    Alcotest.fail "expected Url media source to fail closed"
+  with
+  | Invalid_argument message ->
+    Alcotest.(check string)
+      "message"
+      "test_backend does not support image media source kind url"
+      message
+;;
+
 (* content_block_to_json *)
 let test_content_block_to_json_text () =
   let json = Api_common.content_block_to_json (Text "hello") in
@@ -1946,6 +1987,12 @@ let () =
             "json_of_string_or_raw invalid"
             `Quick
             test_json_of_string_or_raw_invalid
+        ; Alcotest.test_case "base64_media_data_url" `Quick test_base64_media_data_url
+        ; Alcotest.test_case "base64_media_payload" `Quick test_base64_media_payload
+        ; Alcotest.test_case
+            "base64_media_source rejects url"
+            `Quick
+            test_base64_media_source_rejects_url
         ] )
     ; ( "api_common.content_block_to_json"
       , [ Alcotest.test_case "text" `Quick test_content_block_to_json_text


### PR DESCRIPTION
## Summary
- add Api_common helpers for base64-only media carriers and unsupported media-source failures
- route OpenAI Chat, OpenAI Responses, Gemini, and Ollama-native media source handling through the shared helper
- add focused coverage that Url media sources fail closed instead of being reinterpreted as base64

## Verification
- opam exec -- ocamlformat --check lib/llm_provider/api_common.mli lib/llm_provider/api_common.ml lib/llm_provider/backend_openai_serialize.ml lib/llm_provider/backend_openai_responses.ml lib/llm_provider/backend_gemini.ml test/test_llm_provider_cov.ml
- git diff --check
- scripts/hardening-ratchet.sh --check
- scripts/ci-code-smell-ratchet.sh --check

Local Dune was intentionally not run; GitHub CI is the build/test authority for this slice.