### PR TITLE
fix(provider): require endpoint declaration for compat dialects

### DIFF
--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -20,8 +20,24 @@ let system_message_json (config : agent_state) : Yojson.Safe.t list =
   | _ -> []
 ;;
 
+let capabilities_for_custom_registered name =
+  match Provider.find_provider name with
+  | Some impl -> Some impl.Provider.capabilities
+  | None ->
+    let registry = Llm_provider.Provider_registry.default () in
+    (match Llm_provider.Provider_registry.find registry name with
+     | Some entry -> Some entry.capabilities
+     | None -> None)
+;;
+
 let capabilities_for_request ?provider_config (config : agent_state) =
   match provider_config with
+  | Some
+      (({ Provider.provider = Provider.Custom_registered { name }; _ } : Provider.config)
+       as cfg) ->
+    (match capabilities_for_custom_registered name with
+     | Some caps -> caps
+     | None -> Provider.capabilities_for_config cfg)
   | Some cfg -> Provider.capabilities_for_config cfg
   | None ->
     Provider.capabilities_for_model

--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -50,6 +50,36 @@ let build_request_assoc = Backend_openai_request.build_request_assoc
 [@@@coverage off]
 (* === Inline tests === *)
 
+let deepseek_v4_capabilities =
+  { Capabilities.openai_compat_chat_capabilities with
+    max_context_tokens = Some 1_000_000
+  ; max_output_tokens = Some 384_000
+  ; supports_tools = true
+  ; supports_tool_choice = true
+  ; supports_required_tool_choice = false
+  ; supports_named_tool_choice = false
+  ; supports_reasoning = true
+  ; supports_extended_thinking = true
+  ; supports_reasoning_budget = true
+  ; thinking_control_format = Capabilities.Thinking_object
+  ; supports_response_format_json = true
+  ; supports_native_streaming = true
+  ; supports_caching = true
+  ; supports_prompt_caching = false
+  }
+;;
+
+let declared_deepseek_config ?enable_thinking ?thinking_budget model_id =
+  Provider_config.make
+    ~kind:OpenAI_compat
+    ~model_id
+    ~base_url:"https://api.deepseek.com"
+    ?enable_thinking
+    ?thinking_budget
+    ~model_capabilities_override:deepseek_v4_capabilities
+    ()
+;;
+
 let%test "tool_choice_to_openai_json Auto" =
   tool_choice_to_openai_json Auto = `String "auto"
 ;;
@@ -1285,47 +1315,29 @@ let%test
 ;;
 
 let%test "build_request serializes thinking object for deepseek-v4-flash" =
-  match Capabilities.for_model_id "deepseek-v4-flash" with
-  | None -> false
-  | Some model_capabilities_override ->
-    let config =
-      Provider_config.make
-        ~kind:OpenAI_compat
-        ~model_id:"deepseek-v4-flash"
-        ~base_url:"https://api.deepseek.com"
-        ~enable_thinking:true
-        ~thinking_budget:2048
-        ~model_capabilities_override
-        ()
-    in
-    let body = build_request ~config ~messages:[] () in
-    let json = Yojson.Safe.from_string body in
-    let open Yojson.Safe.Util in
-    (* thinking_budget 2048 -> typed effort [Low], but the DeepSeek dialect
-       (Deepseek_high_or_max) normalizes low/medium/high -> "high" (see
-       test_thinking_control_dialects.ml "low maps high"). *)
-    json |> member "thinking" |> member "type" |> to_string = "enabled"
-    && json |> member "reasoning_effort" |> to_string = "high"
+  let config =
+    declared_deepseek_config
+      ~enable_thinking:true
+      ~thinking_budget:2048
+      "deepseek-v4-flash"
+  in
+  let body = build_request ~config ~messages:[] () in
+  let json = Yojson.Safe.from_string body in
+  let open Yojson.Safe.Util in
+  (* thinking_budget 2048 -> typed effort [Low], but the DeepSeek dialect
+     (Deepseek_high_or_max) normalizes low/medium/high -> "high" (see
+     test_thinking_control_dialects.ml "low maps high"). *)
+  json |> member "thinking" |> member "type" |> to_string = "enabled"
+  && json |> member "reasoning_effort" |> to_string = "high"
 ;;
 
 let%test "build_request serializes disabled thinking for deepseek-v4-pro" =
-  match Capabilities.for_model_id "deepseek-v4-pro" with
-  | None -> false
-  | Some model_capabilities_override ->
-    let config =
-      Provider_config.make
-        ~kind:OpenAI_compat
-        ~model_id:"deepseek-v4-pro"
-        ~base_url:"https://api.deepseek.com"
-        ~enable_thinking:false
-        ~model_capabilities_override
-        ()
-    in
-    let body = build_request ~config ~messages:[] () in
-    let json = Yojson.Safe.from_string body in
-    let open Yojson.Safe.Util in
-    json |> member "thinking" |> member "type" |> to_string = "disabled"
-    && json |> member "reasoning_effort" = `Null
+  let config = declared_deepseek_config ~enable_thinking:false "deepseek-v4-pro" in
+  let body = build_request ~config ~messages:[] () in
+  let json = Yojson.Safe.from_string body in
+  let open Yojson.Safe.Util in
+  json |> member "thinking" |> member "type" |> to_string = "disabled"
+  && json |> member "reasoning_effort" = `Null
 ;;
 
 let%test "build_request serializes ZAI thinking object for bare GLM compat model" =

--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -1285,39 +1285,47 @@ let%test
 ;;
 
 let%test "build_request serializes thinking object for deepseek-v4-flash" =
-  let config =
-    Provider_config.make
-      ~kind:OpenAI_compat
-      ~model_id:"deepseek-v4-flash"
-      ~base_url:"https://api.deepseek.com"
-      ~enable_thinking:true
-      ~thinking_budget:2048
-      ()
-  in
-  let body = build_request ~config ~messages:[] () in
-  let json = Yojson.Safe.from_string body in
-  let open Yojson.Safe.Util in
-  (* thinking_budget 2048 -> typed effort [Low], but the DeepSeek dialect
-     (Deepseek_high_or_max) normalizes low/medium/high -> "high" (see
-     test_thinking_control_dialects.ml "low maps high"). *)
-  json |> member "thinking" |> member "type" |> to_string = "enabled"
-  && json |> member "reasoning_effort" |> to_string = "high"
+  match Capabilities.for_model_id "deepseek-v4-flash" with
+  | None -> false
+  | Some model_capabilities_override ->
+    let config =
+      Provider_config.make
+        ~kind:OpenAI_compat
+        ~model_id:"deepseek-v4-flash"
+        ~base_url:"https://api.deepseek.com"
+        ~enable_thinking:true
+        ~thinking_budget:2048
+        ~model_capabilities_override
+        ()
+    in
+    let body = build_request ~config ~messages:[] () in
+    let json = Yojson.Safe.from_string body in
+    let open Yojson.Safe.Util in
+    (* thinking_budget 2048 -> typed effort [Low], but the DeepSeek dialect
+       (Deepseek_high_or_max) normalizes low/medium/high -> "high" (see
+       test_thinking_control_dialects.ml "low maps high"). *)
+    json |> member "thinking" |> member "type" |> to_string = "enabled"
+    && json |> member "reasoning_effort" |> to_string = "high"
 ;;
 
 let%test "build_request serializes disabled thinking for deepseek-v4-pro" =
-  let config =
-    Provider_config.make
-      ~kind:OpenAI_compat
-      ~model_id:"deepseek-v4-pro"
-      ~base_url:"https://api.deepseek.com"
-      ~enable_thinking:false
-      ()
-  in
-  let body = build_request ~config ~messages:[] () in
-  let json = Yojson.Safe.from_string body in
-  let open Yojson.Safe.Util in
-  json |> member "thinking" |> member "type" |> to_string = "disabled"
-  && json |> member "reasoning_effort" = `Null
+  match Capabilities.for_model_id "deepseek-v4-pro" with
+  | None -> false
+  | Some model_capabilities_override ->
+    let config =
+      Provider_config.make
+        ~kind:OpenAI_compat
+        ~model_id:"deepseek-v4-pro"
+        ~base_url:"https://api.deepseek.com"
+        ~enable_thinking:false
+        ~model_capabilities_override
+        ()
+    in
+    let body = build_request ~config ~messages:[] () in
+    let json = Yojson.Safe.from_string body in
+    let open Yojson.Safe.Util in
+    json |> member "thinking" |> member "type" |> to_string = "disabled"
+    && json |> member "reasoning_effort" = `Null
 ;;
 
 let%test "build_request serializes ZAI thinking object for bare GLM compat model" =

--- a/lib/llm_provider/complete_common.ml
+++ b/lib/llm_provider/complete_common.ml
@@ -125,7 +125,20 @@ let%test "model capability thinking drift remains high-confidence warning" =
   && info_observations = []
 ;;
 
-let%test "capability source is model when catalog resolves config model" =
+let%test "capability source is model when native catalog resolves config model" =
+  let config =
+    Provider_config.make
+      ~kind:Provider_config.Glm
+      ~model_id:"glm-5"
+      ~base_url:Zai_catalog.general_base_url
+      ()
+  in
+  match resolve_capabilities_for_config config with
+  | _, Model_capability -> true
+  | _, Provider_default_capability -> false
+;;
+
+let%test "capability source is provider default for undeclared raw compat model" =
   let config =
     Provider_config.make
       ~kind:OpenAI_compat
@@ -134,8 +147,11 @@ let%test "capability source is model when catalog resolves config model" =
       ()
   in
   match resolve_capabilities_for_config config with
-  | _, Model_capability -> true
-  | _, Provider_default_capability -> false
+  | caps, Provider_default_capability ->
+    caps.supports_tools = Capabilities.openai_compat_chat_capabilities.supports_tools
+    && caps.thinking_control_format
+       = Capabilities.openai_compat_chat_capabilities.thinking_control_format
+  | _, Model_capability -> false
 ;;
 
 let%test "capability source is provider default when model is unknown" =

--- a/lib/llm_provider/complete_common.ml
+++ b/lib/llm_provider/complete_common.ml
@@ -142,8 +142,8 @@ let%test "capability source is provider default for undeclared raw compat model"
   let config =
     Provider_config.make
       ~kind:OpenAI_compat
-      ~model_id:"grok-latest"
-      ~base_url:"https://api.x.ai/v1"
+      ~model_id:"gpt-4o"
+      ~base_url:"https://unknown-openai-compatible.example/v1"
       ()
   in
   match resolve_capabilities_for_config config with

--- a/lib/llm_provider/complete_sampling.ml
+++ b/lib/llm_provider/complete_sampling.ml
@@ -430,7 +430,7 @@ let%test "apply_sampling_defaults OpenAI_compat Gemini model does not set min_p"
     ; cache_system_prompt = false
     ; supports_tool_choice_override = None
     ; supports_structured_output_override = None
-    ; model_capabilities_override = Capabilities.for_model_id "gemini-2.5-flash"
+    ; model_capabilities_override = Some Capabilities.gemini_capabilities
     ; keep_alive = None
     ; internal_model_rotation_count = None
     ; num_ctx = None

--- a/lib/llm_provider/complete_sampling.ml
+++ b/lib/llm_provider/complete_sampling.ml
@@ -430,7 +430,7 @@ let%test "apply_sampling_defaults OpenAI_compat Gemini model does not set min_p"
     ; cache_system_prompt = false
     ; supports_tool_choice_override = None
     ; supports_structured_output_override = None
-    ; model_capabilities_override = None
+    ; model_capabilities_override = Capabilities.for_model_id "gemini-2.5-flash"
     ; keep_alive = None
     ; internal_model_rotation_count = None
     ; num_ctx = None

--- a/lib/llm_provider/discovery.ml
+++ b/lib/llm_provider/discovery.ml
@@ -257,22 +257,25 @@ let apply_ollama_think_overlay (caps : Capabilities.capabilities)
 ;;
 
 (** Infer capabilities from model info and server props.
-    Priority: model-specific lookup > generic inference > default.
-    When [uses_ollama_think] is [true] the endpoint speaks Ollama native
-    [/api/chat] [think] format, so {!apply_ollama_think_overlay} is layered on
-    top of the model-specific lookup result, or [ollama_capabilities] is used as
-    the fallback base when no lookup match exists. *)
+    Non-Ollama discovery probes generic OpenAI-compatible endpoints, so
+    [/v1/models] names are not enough evidence to import provider-specific
+    thinking/reasoning/tool dialects. When [uses_ollama_think] is [true] the
+    endpoint speaks Ollama native [/api/chat] [think] format, so
+    {!apply_ollama_think_overlay} is layered on top of the model-specific lookup
+    result, or [ollama_capabilities] is used as the fallback base when no lookup
+    match exists. *)
 let infer_capabilities ~uses_ollama_think models props =
-  (* 1. Try model-specific lookup *)
   let from_lookup =
-    List.find_map (fun (m : model_info) -> Capabilities.for_model_id m.id) models
+    if uses_ollama_think
+    then List.find_map (fun (m : model_info) -> Capabilities.for_model_id m.id) models
+    else None
   in
   let base =
     match from_lookup with
     | Some caps ->
       (* Overlay Ollama endpoint flags while keeping model-specific
          context-window and reasoning metadata. *)
-      if uses_ollama_think then apply_ollama_think_overlay caps else caps
+      apply_ollama_think_overlay caps
     | None ->
       if uses_ollama_think
       then
@@ -281,19 +284,9 @@ let infer_capabilities ~uses_ollama_think models props =
            format. Dynamic tool support from /api/show template analysis is
            merged below via props handling in step 3. *)
         Capabilities.ollama_capabilities
-      else (
-        (* 2. Generic inference by model name for non-Ollama endpoints *)
-        let needs_extended =
-          List.exists
-            (fun (m : model_info) ->
-               Retry.contains_case_insensitive ~haystack:m.id ~needle:"dashscope")
-            models
-        in
-        if needs_extended
-        then Capabilities.openai_compat_chat_extended_capabilities
-        else Capabilities.openai_compat_chat_capabilities)
+      else Capabilities.openai_compat_chat_capabilities
   in
-  (* 3. Merge ctx_size from /props into capabilities *)
+  (* Merge endpoint-declared context/tool facts from /props into capabilities. *)
   match props with
   | Some (p : server_props) ->
     let c = Capabilities.with_context_size base ~ctx_size:p.ctx_size in
@@ -1027,12 +1020,14 @@ let%test "contains_case_insensitive exact match" =
 
 (* --- infer_capabilities --- *)
 
-let%test "infer_capabilities dashscope model gets extended" =
+let%test "infer_capabilities non-ollama dashscope name stays generic compat" =
   let models = [ { id = "DashScope_3.5-35B-A3B"; owned_by = "local" } ] in
   let caps = infer_capabilities ~uses_ollama_think:false models None in
-  caps.supports_reasoning = true
-  && caps.supports_top_k = true
-  && caps.supports_min_p = true
+  caps.supports_tools = true
+  && caps.supports_reasoning = false
+  && caps.supports_extended_thinking = false
+  && caps.supports_top_k = false
+  && caps.supports_min_p = false
 ;;
 
 let%test "infer_capabilities unknown model gets basic openai" =
@@ -1041,10 +1036,12 @@ let%test "infer_capabilities unknown model gets basic openai" =
   caps.supports_tools = true && caps.supports_reasoning = false
 ;;
 
-let%test "infer_capabilities known model lookup has priority" =
+let%test "infer_capabilities non-ollama known provider name stays generic compat" =
   let models = [ { id = "claude-opus-4-20260320"; owned_by = "anthropic" } ] in
   let caps = infer_capabilities ~uses_ollama_think:false models None in
-  caps.supports_caching = true && caps.supports_computer_use = true
+  caps.supports_tools = true
+  && caps.supports_computer_use = false
+  && caps.thinking_control_format = Capabilities.No_thinking_control
 ;;
 
 let%test "infer_capabilities merges ctx_size from props" =

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -222,7 +222,17 @@ let raw_openai_compat_without_builtin_source config provider_label =
 
 let capability_requires_endpoint_declaration (caps : Capabilities.capabilities) =
   let open Capabilities in
-  caps.supports_reasoning
+  caps.supports_tools
+  || caps.supports_tool_choice
+  || caps.supports_required_tool_choice
+  || caps.supports_named_tool_choice
+  || caps.supports_parallel_tool_calls
+  || caps.supports_runtime_mcp_tools
+  || caps.supports_runtime_tool_events
+  || (match caps.assistant_tool_content_format with
+      | Assistant_tool_content_null -> false
+      | Assistant_tool_content_empty_string -> true)
+  || caps.supports_reasoning
   || caps.supports_extended_thinking
   || caps.supports_reasoning_budget
   || (match caps.accepted_reasoning_efforts with
@@ -255,8 +265,50 @@ let capability_requires_endpoint_declaration (caps : Capabilities.capabilities) 
       | Force_no_replay
       | Force_drop_without_tool_preserve_with_tool
       | Force_preserve_always -> true)
+  || caps.supports_response_format_json
+  || caps.supports_structured_output
+  || caps.supports_multimodal_inputs
+  || caps.supports_image_input
+  || caps.supports_audio_input
+  || caps.supports_video_input
   || caps.supports_top_k
   || caps.supports_min_p
+  || caps.supports_seed
+  || caps.supports_seed_with_images
+  || caps.supports_computer_use
+  || caps.supports_code_execution
+;;
+
+let catalog_entry_for_model_id model_id =
+  match Model_catalog.global () with
+  | Some catalog -> Model_catalog.lookup catalog model_id
+  | None -> None
+;;
+
+let normalized_catalog_label = function
+  | Some raw -> Some (String.lowercase_ascii (String.trim raw))
+  | None -> None
+;;
+
+let catalog_entry_requires_endpoint_declaration (entry : Model_catalog.model_entry) =
+  match
+    ( normalized_catalog_label entry.base_label
+    , normalized_catalog_label entry.provider_name )
+  with
+  | Some ("openai_chat" | "openai_chat_extended"), Some _ -> false
+  | Some ("openai_chat" | "openai_chat_extended"), None -> true
+  | Some "glm", _ -> false
+  | Some _, _ -> true
+  | None, Some _ -> false
+  | None, None -> true
+;;
+
+let raw_openai_compat_requires_endpoint_declaration config caps =
+  capability_requires_endpoint_declaration caps
+  ||
+  match catalog_entry_for_model_id config.model_id with
+  | Some entry -> catalog_entry_requires_endpoint_declaration entry
+  | None -> false
 ;;
 
 let capabilities_for_config_model (config : t) =
@@ -275,7 +327,8 @@ let capabilities_for_config_model (config : t) =
       | Some _ as caps -> caps
       | None ->
         (match Capabilities.for_model_id config.model_id with
-         | Some caps when capability_requires_endpoint_declaration caps -> None
+         | Some caps when raw_openai_compat_requires_endpoint_declaration config caps ->
+           None
          | other -> other))
     else
       Capabilities.for_provider_model_id

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -221,21 +221,42 @@ let raw_openai_compat_without_builtin_source config provider_label =
 ;;
 
 let capability_requires_endpoint_declaration (caps : Capabilities.capabilities) =
-  match caps.thinking_control_format, caps.preserve_thinking_control_format with
-  | Capabilities.Chat_template_kwargs, _
-  | _, Capabilities.Chat_template_kwargs_preserve_thinking -> true
-  | ( ( Capabilities.No_thinking_control
-      | Capabilities.Thinking_object
-      | Capabilities.Thinking_object_adaptive
-      | Capabilities.Thinking_object_only
-      | Capabilities.Chat_template_token
-      | Capabilities.Ollama_think
-      | Capabilities.Reasoning_effort
-      | Capabilities.Enable_thinking )
-    , ( Capabilities.No_preserve_thinking_control
-      | Capabilities.Thinking_object_keep_all
-      | Capabilities.Top_level_preserve_thinking
-      | Capabilities.Always_preserved_thinking ) ) -> false
+  let open Capabilities in
+  caps.supports_reasoning
+  || caps.supports_extended_thinking
+  || caps.supports_reasoning_budget
+  || (match caps.accepted_reasoning_efforts with
+      | Some (_ :: _) -> true
+      | Some [] | None -> false)
+  || (match caps.thinking_control_format with
+      | No_thinking_control -> false
+      | Thinking_object
+      | Thinking_object_adaptive
+      | Thinking_object_only
+      | Chat_template_kwargs
+      | Chat_template_token
+      | Ollama_think
+      | Reasoning_effort
+      | Enable_thinking -> true)
+  || (match caps.preserve_thinking_control_format with
+      | No_preserve_thinking_control -> false
+      | Thinking_object_keep_all
+      | Chat_template_kwargs_preserve_thinking
+      | Top_level_preserve_thinking
+      | Always_preserved_thinking -> true)
+  || (match caps.reasoning_output_format with
+      | No_reasoning_output_format -> false
+      | Split_reasoning_fields -> true)
+  || (match caps.reasoning_streaming_format with
+      | Default_reasoning_streaming | No_reasoning_streaming -> false
+      | Delta_reasoning_field _ | Template_reasoning_streaming -> true)
+  || (match caps.reasoning_replay_override with
+      | Default_reasoning_replay -> false
+      | Force_no_replay
+      | Force_drop_without_tool_preserve_with_tool
+      | Force_preserve_always -> true)
+  || caps.supports_top_k
+  || caps.supports_min_p
 ;;
 
 let capabilities_for_config_model (config : t) =

--- a/lib/llm_provider/provider_config.mli
+++ b/lib/llm_provider/provider_config.mli
@@ -401,8 +401,10 @@ val reasoning_effort_of_config : t -> string option
     OpenAI-compatible wire kind. *)
 val capability_provider_label : t -> string
 
-(** Resolve model capabilities using provider-qualified catalog entries first,
-    then bare model entries. *)
+(** Resolve model capabilities using provider-qualified catalog entries first.
+    Raw OpenAI-compatible endpoints may use bare catalog entries only for
+    generic model facts; entries that change thinking/reasoning/replay wire
+    semantics require an explicit endpoint capability declaration. *)
 val capabilities_for_config_model : t -> Capabilities.capabilities option
 
 (** Resolve the exact chat-template token for token-based thinking control,

--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -279,8 +279,20 @@ let capabilities_for_model ~(provider : provider) ~(model_id : string) =
       Llm_provider.Zai_catalog.is_glm_model_id model_id
       && not (uses_native_glm_capabilities ~base_url ~model_id)
     then default_openai_compat_capabilities ()
-    else (
+    else if uses_native_glm_capabilities ~base_url ~model_id
+    then (
       match Llm_provider.Capabilities.for_model_id model_id with
+      | Some caps -> caps
+      | None -> default_openai_compat_capabilities ())
+    else (
+      let config =
+        Llm_provider.Provider_config.make
+          ~kind:Llm_provider.Provider_config.OpenAI_compat
+          ~model_id
+          ~base_url
+          ()
+      in
+      match Llm_provider.Provider_config.capabilities_for_config_model config with
       | Some caps -> caps
       | None -> default_openai_compat_capabilities ())
   | Custom_registered { name } ->

--- a/models.toml
+++ b/models.toml
@@ -229,6 +229,7 @@ cache_read_multiplier = 1.0
 [[models]]
 id_prefix = "deepseek-v4-pro"
 base = "openai_chat"
+provider_name = "deepseek"
 max_context_tokens = 1000000
 max_output_tokens = 384000
 supports_tools = true
@@ -251,6 +252,7 @@ cache_read_multiplier = 0.008333333333333333
 [[models]]
 id_prefix = "deepseek-ai/deepseek-v4-pro"
 base = "openai_chat"
+provider_name = "deepseek"
 max_context_tokens = 1000000
 max_output_tokens = 384000
 supports_tools = true
@@ -273,6 +275,7 @@ cache_read_multiplier = 0.008333333333333333
 [[models]]
 id_prefix = "deepseek-v4-flash"
 base = "openai_chat"
+provider_name = "deepseek"
 max_context_tokens = 1000000
 max_output_tokens = 384000
 supports_tools = true
@@ -295,6 +298,7 @@ cache_read_multiplier = 0.02
 [[models]]
 id_prefix = "deepseek-ai/deepseek-v4-flash"
 base = "openai_chat"
+provider_name = "deepseek"
 max_context_tokens = 1000000
 max_output_tokens = 384000
 supports_tools = true
@@ -1584,6 +1588,7 @@ cache_read_multiplier = 0.18333333333333332
 
 [[models]]
 id_prefix = "glm-4-flash"
+provider_name = "glm"
 max_context_tokens = 128000
 max_output_tokens = 4096
 supports_tools = true
@@ -1591,6 +1596,7 @@ supports_native_streaming = true
 
 [[models]]
 id_prefix = "glm-4v"
+provider_name = "glm"
 max_context_tokens = 128000
 max_output_tokens = 4096
 supports_tools = true
@@ -1600,6 +1606,7 @@ supports_native_streaming = true
 
 [[models]]
 id_prefix = "glm-4"
+provider_name = "glm"
 max_context_tokens = 128000
 max_output_tokens = 4096
 supports_tools = true

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -43,6 +43,109 @@ let source_path path =
 
 let read_source path = In_channel.with_open_text (source_path path) In_channel.input_all
 
+let with_provider_catalog json f =
+  let previous = Llm_provider.Provider_catalog.global () in
+  let restore () =
+    match previous with
+    | Some catalog -> Llm_provider.Provider_catalog.set_global catalog
+    | None -> Llm_provider.Provider_catalog.clear_global ()
+  in
+  match Llm_provider.Provider_catalog.of_json (Yojson.Safe.from_string json) with
+  | Error msg -> fail ("provider catalog parse failed: " ^ msg)
+  | Ok catalog ->
+    Llm_provider.Provider_catalog.set_global catalog;
+    Fun.protect ~finally:restore f
+;;
+
+let declared_openai_compat_provider_catalog =
+  {|{
+  "schema_version": 1,
+  "providers": [
+    {
+      "id": "api-deepseek-v4",
+      "kind": "openai_compat",
+      "transport": "http",
+      "base_url": "https://api.deepseek.com",
+      "request_path": "/v1/chat/completions",
+      "auth": {"type": "none"},
+      "capabilities_base": "openai_chat",
+      "capabilities": {
+        "max_context_tokens": 1000000,
+        "max_output_tokens": 384000,
+        "supports_tools": true,
+        "supports_tool_choice": true,
+        "supports_required_tool_choice": false,
+        "supports_named_tool_choice": false,
+        "supports_reasoning": true,
+        "supports_extended_thinking": true,
+        "supports_reasoning_budget": true,
+        "thinking_control_format": "thinking_object",
+        "supports_response_format_json": true,
+        "supports_native_streaming": true,
+        "supports_caching": true,
+        "supports_prompt_caching": false
+      }
+    },
+    {
+      "id": "api-minimax-m3",
+      "kind": "openai_compat",
+      "transport": "http",
+      "base_url": "https://api.minimaxi.com/v1",
+      "request_path": "/chat/completions",
+      "auth": {"type": "none"},
+      "capabilities_base": "openai_chat",
+      "capabilities": {
+        "max_context_tokens": 524288,
+        "supports_tools": true,
+        "supports_tool_choice": false,
+        "supports_required_tool_choice": false,
+        "supports_named_tool_choice": false,
+        "supports_reasoning": true,
+        "supports_extended_thinking": true,
+        "supports_reasoning_budget": false,
+        "thinking_control_format": "thinking_object_adaptive",
+        "reasoning_output_format": "split_reasoning_fields",
+        "reasoning_replay": "preserve_always",
+        "supports_response_format_json": false,
+        "supports_structured_output": false,
+        "supports_multimodal_inputs": true,
+        "supports_image_input": true,
+        "supports_native_streaming": true
+      }
+    },
+    {
+      "id": "api-qwen36",
+      "kind": "openai_compat",
+      "transport": "http",
+      "base_url": "https://declared-qwen.example/v1",
+      "request_path": "/v1/chat/completions",
+      "auth": {"type": "none"},
+      "capabilities_base": "openai_chat",
+      "capabilities": {
+        "max_context_tokens": 131072,
+        "supports_tools": true,
+        "supports_tool_choice": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "supports_extended_thinking": true,
+        "supports_reasoning_budget": true,
+        "thinking_control_format": "chat_template_kwargs",
+        "preserve_thinking_control_format": "chat_template_kwargs_preserve_thinking",
+        "supports_native_streaming": true
+      }
+    }
+  ]
+}|}
+;;
+
+let with_declared_openai_compat_provider_catalog f =
+  with_provider_catalog declared_openai_compat_provider_catalog f
+;;
+
+let declared_provider_config name model_id : Provider.config =
+  { Provider.provider = Provider.Custom_registered { name }; model_id; api_key_env = "" }
+;;
+
 (* Helper: compare content_block via show string *)
 let check_block msg expected actual =
   check string msg (Types.show_content_block expected) (Types.show_content_block actual)
@@ -464,10 +567,13 @@ let test_build_body_sampling_params_omitted_when_none () =
 ;;
 
 let test_build_openai_body_with_provider_m_sampling () =
+  let provider_config =
+    declared_provider_config "dashscope" "dashscope-3.5-35b-a3b-ud-q8-xl"
+  in
   let state =
     { Types.config =
         { Types.default_config with
-          model = "dashscope-3.5-35b-a3b-ud-q8-xl"
+          model = provider_config.model_id
         ; temperature = Some 0.6
         ; top_p = Some 0.95
         ; top_k = Some 20
@@ -480,7 +586,8 @@ let test_build_openai_body_with_provider_m_sampling () =
     }
   in
   let json =
-    Api.build_openai_body ~config:state ~messages:[] () |> Yojson.Safe.from_string
+    Api.build_openai_body ~provider_config ~config:state ~messages:[] ()
+    |> Yojson.Safe.from_string
   in
   let open Yojson.Safe.Util in
   check
@@ -494,123 +601,142 @@ let test_build_openai_body_with_provider_m_sampling () =
     "min_p"
     (Some 0.01)
     (json |> member "min_p" |> to_float_option);
+  check bool "enable_thinking false" false (json |> member "enable_thinking" |> to_bool);
   check
     bool
-    "enable_thinking false"
-    false
-    (json |> member "chat_template_kwargs" |> member "enable_thinking" |> to_bool)
+    "chat_template_kwargs absent"
+    true
+    (member_absent json "chat_template_kwargs")
 ;;
 
 let test_build_openai_body_deepseek_thinking_drops_sampling () =
-  (* Public agent path must drop temperature/top_p for a DeepSeek (Thinking_object)
-     config while thinking is enabled, matching Backend_openai_request.build_request.
-     Thinking defaults on, so no enable_thinking is set here. *)
-  let state =
-    { Types.config =
-        { Types.default_config with
-          model = "deepseek-v4-flash"
-        ; temperature = Some 0.7
-        ; top_p = Some 0.9
-        }
-    ; messages = []
-    ; turn_count = 0
-    ; usage = Types.empty_usage
-    }
-  in
-  let json =
-    Api.build_openai_body ~config:state ~messages:[] () |> Yojson.Safe.from_string
-  in
-  let open Yojson.Safe.Util in
-  check
-    (option (float 0.001))
-    "temperature dropped while thinking"
-    None
-    (json |> member "temperature" |> to_float_option);
-  check
-    (option (float 0.001))
-    "top_p dropped while thinking"
-    None
-    (json |> member "top_p" |> to_float_option)
+  with_declared_openai_compat_provider_catalog (fun () ->
+    (* Declared DeepSeek endpoints drop temperature/top_p while thinking is
+       enabled, matching Backend_openai_request.build_request. Thinking defaults
+       on, so no enable_thinking is set here. *)
+    let provider_config =
+      declared_provider_config "api-deepseek-v4" "deepseek-v4-flash"
+    in
+    let state =
+      { Types.config =
+          { Types.default_config with
+            model = provider_config.model_id
+          ; temperature = Some 0.7
+          ; top_p = Some 0.9
+          }
+      ; messages = []
+      ; turn_count = 0
+      ; usage = Types.empty_usage
+      }
+    in
+    let json =
+      Api.build_openai_body ~provider_config ~config:state ~messages:[] ()
+      |> Yojson.Safe.from_string
+    in
+    let open Yojson.Safe.Util in
+    check
+      (option (float 0.001))
+      "temperature dropped while thinking"
+      None
+      (json |> member "temperature" |> to_float_option);
+    check
+      (option (float 0.001))
+      "top_p dropped while thinking"
+      None
+      (json |> member "top_p" |> to_float_option))
 ;;
 
 let test_build_openai_body_deepseek_disabled_thinking_keeps_sampling () =
-  (* With thinking explicitly disabled the suppression must not fire. *)
-  let state =
-    { Types.config =
-        { Types.default_config with
-          model = "deepseek-v4-flash"
-        ; temperature = Some 0.7
-        ; top_p = Some 0.9
-        ; enable_thinking = Some false
-        }
-    ; messages = []
-    ; turn_count = 0
-    ; usage = Types.empty_usage
-    }
-  in
-  let json =
-    Api.build_openai_body ~config:state ~messages:[] () |> Yojson.Safe.from_string
-  in
-  let open Yojson.Safe.Util in
-  check
-    (option (float 0.001))
-    "temperature kept when thinking disabled"
-    (Some 0.7)
-    (json |> member "temperature" |> to_float_option);
-  check
-    (option (float 0.001))
-    "top_p kept when thinking disabled"
-    (Some 0.9)
-    (json |> member "top_p" |> to_float_option)
+  with_declared_openai_compat_provider_catalog (fun () ->
+    (* With thinking explicitly disabled the suppression must not fire. *)
+    let provider_config =
+      declared_provider_config "api-deepseek-v4" "deepseek-v4-flash"
+    in
+    let state =
+      { Types.config =
+          { Types.default_config with
+            model = provider_config.model_id
+          ; temperature = Some 0.7
+          ; top_p = Some 0.9
+          ; enable_thinking = Some false
+          }
+      ; messages = []
+      ; turn_count = 0
+      ; usage = Types.empty_usage
+      }
+    in
+    let json =
+      Api.build_openai_body ~provider_config ~config:state ~messages:[] ()
+      |> Yojson.Safe.from_string
+    in
+    let open Yojson.Safe.Util in
+    check
+      (option (float 0.001))
+      "temperature kept when thinking disabled"
+      (Some 0.7)
+      (json |> member "temperature" |> to_float_option);
+    check
+      (option (float 0.001))
+      "top_p kept when thinking disabled"
+      (Some 0.9)
+      (json |> member "top_p" |> to_float_option))
 ;;
 
 let test_build_openai_body_with_qwen_preserve_thinking () =
-  let state = make_state ~enable_thinking:true ~preserve_thinking:true () in
-  let state =
-    { state with config = { state.config with model = "qwen36-35b-a3b-mtp" } }
-  in
-  let json =
-    Api.build_openai_body ~config:state ~messages:[] () |> Yojson.Safe.from_string
-  in
-  let open Yojson.Safe.Util in
-  let ctk = json |> member "chat_template_kwargs" in
-  check bool "enable_thinking true" true (ctk |> member "enable_thinking" |> to_bool);
-  check bool "preserve_thinking true" true (ctk |> member "preserve_thinking" |> to_bool)
+  with_declared_openai_compat_provider_catalog (fun () ->
+    let provider_config = declared_provider_config "api-qwen36" "qwen36-35b-a3b-mtp" in
+    let state = make_state ~enable_thinking:true ~preserve_thinking:true () in
+    let state =
+      { state with config = { state.config with model = provider_config.model_id } }
+    in
+    let json =
+      Api.build_openai_body ~provider_config ~config:state ~messages:[] ()
+      |> Yojson.Safe.from_string
+    in
+    let open Yojson.Safe.Util in
+    let ctk = json |> member "chat_template_kwargs" in
+    check bool "enable_thinking true" true (ctk |> member "enable_thinking" |> to_bool);
+    check bool "preserve_thinking true" true (ctk |> member "preserve_thinking" |> to_bool))
 ;;
 
 let test_build_openai_body_qwen_preserve_replays_reasoning () =
-  let state = make_state ~enable_thinking:true ~preserve_thinking:true () in
-  let state =
-    { state with config = { state.config with model = "qwen36-35b-a3b-mtp" } }
-  in
-  let messages =
-    [ { Types.role = Types.Assistant
-      ; content =
-          [ Types.Thinking { signature = None; content = "keep this" }
-          ; Types.Text "answer"
-          ]
-      ; name = None
-      ; tool_call_id = None
-      ; metadata = []
-      }
-    ]
-  in
-  let json =
-    Api.build_openai_body ~config:state ~messages () |> Yojson.Safe.from_string
-  in
-  let open Yojson.Safe.Util in
-  let assistant = json |> member "messages" |> index 1 in
-  check
-    string
-    "reasoning_content replayed"
-    "keep this"
-    (assistant |> member "reasoning_content" |> to_string)
+  with_declared_openai_compat_provider_catalog (fun () ->
+    let provider_config = declared_provider_config "api-qwen36" "qwen36-35b-a3b-mtp" in
+    let state = make_state ~enable_thinking:true ~preserve_thinking:true () in
+    let state =
+      { state with config = { state.config with model = provider_config.model_id } }
+    in
+    let messages =
+      [ { Types.role = Types.Assistant
+        ; content =
+            [ Types.Thinking { signature = None; content = "keep this" }
+            ; Types.Text "answer"
+            ]
+        ; name = None
+        ; tool_call_id = None
+        ; metadata = []
+        }
+      ]
+    in
+    let json =
+      Api.build_openai_body ~provider_config ~config:state ~messages ()
+      |> Yojson.Safe.from_string
+    in
+    let open Yojson.Safe.Util in
+    let assistant = json |> member "messages" |> index 1 in
+    check
+      string
+      "reasoning_content replayed"
+      "keep this"
+      (assistant |> member "reasoning_content" |> to_string))
 ;;
 
 let test_build_openai_body_kimi_latest_omits_thinking_param () =
-  let state = make_state ~model:"kimi-k2.7-code" ~preserve_thinking:true () in
+  let provider_config = declared_provider_config "kimi" "kimi-k2.7-code" in
+  let state = make_state ~model:provider_config.model_id ~preserve_thinking:true () in
   let json =
-    Api.build_openai_body ~config:state ~messages:[] () |> Yojson.Safe.from_string
+    Api.build_openai_body ~provider_config ~config:state ~messages:[] ()
+    |> Yojson.Safe.from_string
   in
   check bool "thinking absent" true (member_absent json "thinking");
   check
@@ -622,7 +748,8 @@ let test_build_openai_body_kimi_latest_omits_thinking_param () =
 ;;
 
 let test_build_openai_body_kimi_latest_replays_reasoning () =
-  let state = make_state ~model:"kimi-k2.7-code" ~preserve_thinking:false () in
+  let provider_config = declared_provider_config "kimi" "kimi-k2.7-code" in
+  let state = make_state ~model:provider_config.model_id ~preserve_thinking:false () in
   let messages =
     [ { Types.role = Types.Assistant
       ; content =
@@ -636,7 +763,8 @@ let test_build_openai_body_kimi_latest_replays_reasoning () =
     ]
   in
   let json =
-    Api.build_openai_body ~config:state ~messages () |> Yojson.Safe.from_string
+    Api.build_openai_body ~provider_config ~config:state ~messages ()
+    |> Yojson.Safe.from_string
   in
   let open Yojson.Safe.Util in
   let assistant = json |> member "messages" |> index 1 in
@@ -648,164 +776,152 @@ let test_build_openai_body_kimi_latest_replays_reasoning () =
 ;;
 
 let deepseek_provider_config : Provider.config =
-  { Provider.provider =
-      Provider.OpenAICompat
-        { base_url = "https://api.deepseek.com"
-        ; auth_header = None
-        ; path = "/v1/chat/completions"
-        ; static_token = None
-        }
-  ; model_id = "deepseek-v4-pro"
-  ; api_key_env = ""
-  }
+  declared_provider_config "api-deepseek-v4" "deepseek-v4-pro"
 ;;
 
 let minimax_m3_provider_config : Provider.config =
-  { Provider.provider =
-      Provider.OpenAICompat
-        { base_url = "https://api.minimaxi.com/v1"
-        ; auth_header = None
-        ; path = "/chat/completions"
-        ; static_token = None
-        }
-  ; model_id = "minimax-m3"
-  ; api_key_env = "MINIMAX_API_KEY"
-  }
+  declared_provider_config "api-minimax-m3" "minimax-m3"
 ;;
 
 let test_build_openai_body_deepseek_uses_dialect_controls () =
-  let state =
-    { Types.config =
-        { Types.default_config with
-          model = deepseek_provider_config.model_id
-        ; enable_thinking = Some true
-        ; thinking_budget = Some 2048
-        ; temperature = Some 0.7
-        ; top_p = Some 0.9
-        }
-    ; messages = []
-    ; turn_count = 0
-    ; usage = Types.empty_usage
-    }
-  in
-  let json =
-    Api.build_openai_body
-      ~provider_config:deepseek_provider_config
-      ~config:state
-      ~messages:[]
-      ()
-    |> Yojson.Safe.from_string
-  in
-  let open Yojson.Safe.Util in
-  check
-    string
-    "thinking enabled"
-    "enabled"
-    (json |> member "thinking" |> member "type" |> to_string);
-  check string "low maps high" "high" (json |> member "reasoning_effort" |> to_string);
-  check bool "temperature omitted" true (json |> member "temperature" = `Null);
-  check bool "top_p omitted" true (json |> member "top_p" = `Null)
+  with_declared_openai_compat_provider_catalog (fun () ->
+    let state =
+      { Types.config =
+          { Types.default_config with
+            model = deepseek_provider_config.model_id
+          ; enable_thinking = Some true
+          ; thinking_budget = Some 2048
+          ; temperature = Some 0.7
+          ; top_p = Some 0.9
+          }
+      ; messages = []
+      ; turn_count = 0
+      ; usage = Types.empty_usage
+      }
+    in
+    let json =
+      Api.build_openai_body
+        ~provider_config:deepseek_provider_config
+        ~config:state
+        ~messages:[]
+        ()
+      |> Yojson.Safe.from_string
+    in
+    let open Yojson.Safe.Util in
+    check
+      string
+      "thinking enabled"
+      "enabled"
+      (json |> member "thinking" |> member "type" |> to_string);
+    check string "low maps high" "high" (json |> member "reasoning_effort" |> to_string);
+    check bool "temperature omitted" true (json |> member "temperature" = `Null);
+    check bool "top_p omitted" true (json |> member "top_p" = `Null))
 ;;
 
 let test_build_openai_body_minimax_uses_public_projection_dialect_controls () =
-  let state =
-    make_state
-      ~model:minimax_m3_provider_config.model_id
-      ~enable_thinking:true
-      ~tool_choice:Types.Auto
-      ()
-  in
-  let tool_json =
-    `Assoc
-      [ "name", `String "calculator"
-      ; "description", `String "math"
-      ; "input_schema", `Assoc [ "type", `String "object" ]
-      ]
-  in
-  let json =
-    Api.build_openai_body
-      ~provider_config:minimax_m3_provider_config
-      ~config:state
-      ~messages:[]
-      ~tools:[ tool_json ]
-      ()
-    |> Yojson.Safe.from_string
-  in
-  let open Yojson.Safe.Util in
-  check
-    string
-    "thinking adaptive"
-    "adaptive"
-    (json |> member "thinking" |> member "type" |> to_string);
-  check bool "reasoning split enabled" true (json |> member "reasoning_split" |> to_bool);
-  check bool "tools preserved" false (member_absent json "tools");
-  check bool "tool_choice omitted" true (member_absent json "tool_choice");
-  check bool "reasoning_effort omitted" true (member_absent json "reasoning_effort");
-  check
-    bool
-    "chat_template_kwargs omitted"
-    true
-    (member_absent json "chat_template_kwargs")
+  with_declared_openai_compat_provider_catalog (fun () ->
+    let state =
+      make_state
+        ~model:minimax_m3_provider_config.model_id
+        ~enable_thinking:true
+        ~tool_choice:Types.Auto
+        ()
+    in
+    let tool_json =
+      `Assoc
+        [ "name", `String "calculator"
+        ; "description", `String "math"
+        ; "input_schema", `Assoc [ "type", `String "object" ]
+        ]
+    in
+    let json =
+      Api.build_openai_body
+        ~provider_config:minimax_m3_provider_config
+        ~config:state
+        ~messages:[]
+        ~tools:[ tool_json ]
+        ()
+      |> Yojson.Safe.from_string
+    in
+    let open Yojson.Safe.Util in
+    check
+      string
+      "thinking adaptive"
+      "adaptive"
+      (json |> member "thinking" |> member "type" |> to_string);
+    check bool "reasoning split enabled" true (json |> member "reasoning_split" |> to_bool);
+    check bool "tools preserved" false (member_absent json "tools");
+    check bool "tool_choice omitted" true (member_absent json "tool_choice");
+    check bool "reasoning_effort omitted" true (member_absent json "reasoning_effort");
+    check
+      bool
+      "chat_template_kwargs omitted"
+      true
+      (member_absent json "chat_template_kwargs"))
 ;;
 
 let test_build_openai_body_deepseek_replays_tool_reasoning_only () =
-  let assistant_content tool =
-    if tool
-    then
-      [ Types.Thinking { signature = None; content = "call the tool" }
-      ; Types.ToolUse
-          { id = "call_1"; name = "calculator"; input = `Assoc [ "expr", `String "2+2" ] }
-      ]
-    else
-      [ Types.Thinking { signature = None; content = "plain thought" }
-      ; Types.Text "answer"
-      ]
-  in
-  let assistant_msg tool =
-    { Types.role = Types.Assistant
-    ; content = assistant_content tool
-    ; name = None
-    ; tool_call_id = None
-    ; metadata = []
-    }
-  in
-  let state =
-    { Types.config =
-        { Types.default_config with model = deepseek_provider_config.model_id }
-    ; messages = []
-    ; turn_count = 0
-    ; usage = Types.empty_usage
-    }
-  in
-  let plain =
-    Api.build_openai_body
-      ~provider_config:deepseek_provider_config
-      ~config:state
-      ~messages:[ assistant_msg false ]
-      ()
-    |> Yojson.Safe.from_string
-  in
-  let tool =
-    Api.build_openai_body
-      ~provider_config:deepseek_provider_config
-      ~config:state
-      ~messages:[ assistant_msg true ]
-      ()
-    |> Yojson.Safe.from_string
-  in
-  let open Yojson.Safe.Util in
-  let plain_assistant = plain |> member "messages" |> index 0 in
-  let tool_assistant = tool |> member "messages" |> index 0 in
-  check
-    bool
-    "plain reasoning omitted"
-    true
-    (plain_assistant |> member "reasoning_content" = `Null);
-  check
-    string
-    "tool reasoning_content"
-    "call the tool"
-    (tool_assistant |> member "reasoning_content" |> to_string)
+  with_declared_openai_compat_provider_catalog (fun () ->
+    let assistant_content tool =
+      if tool
+      then
+        [ Types.Thinking { signature = None; content = "call the tool" }
+        ; Types.ToolUse
+            { id = "call_1"
+            ; name = "calculator"
+            ; input = `Assoc [ "expr", `String "2+2" ]
+            }
+        ]
+      else
+        [ Types.Thinking { signature = None; content = "plain thought" }
+        ; Types.Text "answer"
+        ]
+    in
+    let assistant_msg tool =
+      { Types.role = Types.Assistant
+      ; content = assistant_content tool
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = []
+      }
+    in
+    let state =
+      { Types.config =
+          { Types.default_config with model = deepseek_provider_config.model_id }
+      ; messages = []
+      ; turn_count = 0
+      ; usage = Types.empty_usage
+      }
+    in
+    let plain =
+      Api.build_openai_body
+        ~provider_config:deepseek_provider_config
+        ~config:state
+        ~messages:[ assistant_msg false ]
+        ()
+      |> Yojson.Safe.from_string
+    in
+    let tool =
+      Api.build_openai_body
+        ~provider_config:deepseek_provider_config
+        ~config:state
+        ~messages:[ assistant_msg true ]
+        ()
+      |> Yojson.Safe.from_string
+    in
+    let open Yojson.Safe.Util in
+    let plain_assistant = plain |> member "messages" |> index 0 in
+    let tool_assistant = tool |> member "messages" |> index 0 in
+    check
+      bool
+      "plain reasoning omitted"
+      true
+      (plain_assistant |> member "reasoning_content" = `Null);
+    check
+      string
+      "tool reasoning_content"
+      "call the tool"
+      (tool_assistant |> member "reasoning_content" |> to_string))
 ;;
 
 let test_build_openai_body_omits_provider_m_only_fields_for_generic_compat () =

--- a/test/test_discovery.ml
+++ b/test/test_discovery.ml
@@ -483,8 +483,8 @@ let test_refresh_and_sync_mock_server_updates_indexes () =
          Alcotest.(check int) "idle" 2 slots.idle
        | None -> Alcotest.fail "expected slots");
       Alcotest.(check bool)
-        "dashscope model infers extended reasoning"
-        true
+        "openai-compatible discovery does not infer extended reasoning"
+        false
         status.capabilities.supports_extended_thinking
     | _ -> Alcotest.fail "expected one endpoint status")
 ;;

--- a/test/test_property_advanced.ml
+++ b/test/test_property_advanced.ml
@@ -274,7 +274,28 @@ let test_local_provider_resolve_always_succeeds =
 let test_capabilities_provider_m_reasoning =
   QCheck.Test.make
     ~count:50
-    ~name:"DashScope_3 models get reasoning capability"
+    ~name:"Local DashScope_3 models get reasoning capability"
+    (QCheck.make
+       ~print:(fun s -> s)
+       (QCheck.Gen.oneof
+          [ QCheck.Gen.return "dashscope-3.5-35b"
+          ; QCheck.Gen.return "dashscope_3.6:27b-coding-nvfp4"
+          ; QCheck.Gen.return "DashScope_3.6-35B-A3B-UD-Q4_K_XL.gguf"
+          ]))
+    (fun model_id ->
+       with_repo_model_catalog (fun () ->
+         let caps =
+           Provider.capabilities_for_model
+             ~provider:(Provider.Local { base_url = "http://127.0.0.1:8080" })
+             ~model_id
+         in
+         caps.supports_reasoning))
+;;
+
+let test_raw_openai_compat_dashscope_requires_endpoint_declaration =
+  QCheck.Test.make
+    ~count:50
+    ~name:"Raw OpenAICompat DashScope_3 models require endpoint declaration"
     (QCheck.make
        ~print:(fun s -> s)
        (QCheck.Gen.oneof
@@ -295,7 +316,8 @@ let test_capabilities_provider_m_reasoning =
                   })
              ~model_id
          in
-         caps.supports_reasoning))
+         (not caps.supports_reasoning)
+         && caps.thinking_control_format = Llm_provider.Capabilities.No_thinking_control))
 ;;
 
 (* ── Context Reducer Properties ──────────────────────────────── *)
@@ -397,6 +419,7 @@ let () =
       ; (* Provider resolve *)
         test_local_provider_resolve_always_succeeds
       ; test_capabilities_provider_m_reasoning
+      ; test_raw_openai_compat_dashscope_requires_endpoint_declaration
       ; (* Context reducer *)
         test_context_reducer_never_adds
       ; test_token_budget_reducer_respects_limit

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -365,7 +365,7 @@ let test_validate_inference_contract_rejects_unsupported_modality () =
   | Ok () -> Alcotest.fail "expected unsupported modality validation to fail"
 ;;
 
-let test_extended_openai_capabilities () =
+let test_raw_openai_compat_does_not_infer_extended_capabilities () =
   let capabilities =
     Provider.capabilities_for_model
       ~provider:
@@ -377,9 +377,9 @@ let test_extended_openai_capabilities () =
            })
       ~model_id:"dashscope-3.5-35b-a3b-ud-q8-xl"
   in
-  Alcotest.(check bool) "supports reasoning" true capabilities.supports_reasoning;
-  Alcotest.(check bool) "supports top_k" true capabilities.supports_top_k;
-  Alcotest.(check bool) "supports min_p" true capabilities.supports_min_p
+  Alcotest.(check bool) "supports reasoning" false capabilities.supports_reasoning;
+  Alcotest.(check bool) "supports top_k" false capabilities.supports_top_k;
+  Alcotest.(check bool) "supports min_p" false capabilities.supports_min_p
 ;;
 
 let test_raw_openai_compat_does_not_infer_dashscope_from_model_id () =
@@ -398,6 +398,29 @@ let test_raw_openai_compat_does_not_infer_dashscope_from_model_id () =
     Alcotest.(check bool) "supports reasoning" false capabilities.supports_reasoning;
     Alcotest.(check bool) "supports top_k" false capabilities.supports_top_k;
     Alcotest.(check bool) "supports min_p" false capabilities.supports_min_p)
+;;
+
+let test_raw_openai_compat_does_not_infer_minimax_from_model_id () =
+  let capabilities =
+    Provider.capabilities_for_model
+      ~provider:
+        (Provider.OpenAICompat
+           { base_url = "https://compat.example.invalid/v1"
+           ; auth_header = None
+           ; path = "/chat/completions"
+           ; static_token = None
+           })
+      ~model_id:"minimax-m3"
+  in
+  Alcotest.(check bool) "supports reasoning" false capabilities.supports_reasoning;
+  Alcotest.(check bool)
+    "supports extended thinking"
+    false
+    capabilities.supports_extended_thinking;
+  Alcotest.(check bool)
+    "supports reasoning budget"
+    false
+    capabilities.supports_reasoning_budget
 ;;
 
 let test_anthropic_capabilities_consults_for_model_id () =
@@ -1142,13 +1165,17 @@ let () =
             `Quick
             test_validate_inference_contract_rejects_unsupported_modality
         ; Alcotest.test_case
-            "extended openai capabilities"
+            "raw OpenAI-compatible does not infer extended capabilities"
             `Quick
-            test_extended_openai_capabilities
+            test_raw_openai_compat_does_not_infer_extended_capabilities
         ; Alcotest.test_case
             "raw openai_compat does not infer dashscope"
             `Quick
             test_raw_openai_compat_does_not_infer_dashscope_from_model_id
+        ; Alcotest.test_case
+            "raw openai_compat does not infer minimax"
+            `Quick
+            test_raw_openai_compat_does_not_infer_minimax_from_model_id
         ; Alcotest.test_case
             "anthropic consults for_model_id (#824)"
             `Quick

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -32,6 +32,12 @@ let contains_substring ~sub text =
   if sub_len = 0 then true else loop 0
 ;;
 
+let catalog_capabilities model_id =
+  match Llm_provider.Capabilities.for_model_id model_id with
+  | Some caps -> caps
+  | None -> Alcotest.failf "expected catalog capabilities for %s" model_id
+;;
+
 let with_env name value f =
   let saved = Sys.getenv_opt name in
   (match value with
@@ -1145,7 +1151,8 @@ let test_model_capability_thinking_drift_remains_warn () =
     PC.make
       ~kind:OpenAI_compat
       ~model_id:"glm-4-flash"
-      ~base_url:"https://example.invalid/v1"
+      ~base_url:"https://declared-openai-compat.example/v1"
+      ~model_capabilities_override:(catalog_capabilities "glm-4-flash")
       ()
   in
   let entries = complete_with_captured_diag ~config ~response:response_with_thinking in
@@ -1162,17 +1169,18 @@ let test_model_capability_thinking_drift_remains_warn () =
        entries)
 ;;
 
-let test_bare_glm_model_thinking_uses_model_capability () =
+let test_declared_glm_model_thinking_uses_model_capability () =
   let config =
     PC.make
       ~kind:OpenAI_compat
       ~model_id:"glm-5"
-      ~base_url:"https://api.z.ai/api/coding/paas/v4"
+      ~base_url:"https://declared-zai-openai-compat.example/v1"
+      ~model_capabilities_override:(catalog_capabilities "glm-5")
       ()
   in
   let entries = complete_with_captured_diag ~config ~response:response_with_thinking in
   Alcotest.(check bool)
-    "bare glm-5 thinking does not emit capability drift"
+    "declared glm-5 thinking does not emit capability drift"
     false
     (List.exists
        (fun (_level, ctx, message) ->
@@ -1591,9 +1599,9 @@ let () =
             `Quick
             test_model_capability_thinking_drift_remains_warn
         ; test_case
-            "bare glm thinking uses model capability"
+            "declared glm thinking uses model capability"
             `Quick
-            test_bare_glm_model_thinking_uses_model_capability
+            test_declared_glm_model_thinking_uses_model_capability
         ] )
     ; ( "cost"
       , [ test_case "annotate response cost" `Quick test_annotate_response_cost

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -242,6 +242,7 @@ let test_validate_output_schema_openai_official () =
       ~model_id:"gpt"
       ~base_url:"https://api.openai.com/v1"
       ~output_schema:(`Assoc [ "type", `String "object" ])
+      ~model_capabilities_override:Capabilities.openai_compat_chat_capabilities
       ()
   in
   check_bool
@@ -415,6 +416,8 @@ let test_validate_output_schema_supported_non_openai () =
       ~model_id:"devstral-2:123b"
       ~base_url:"http://localhost:11434"
       ~output_schema:schema
+      ~model_capabilities_override:
+        { Capabilities.ollama_capabilities with supports_structured_output = true }
       ()
   in
   check_bool
@@ -463,6 +466,76 @@ let test_openai_compat_raw_minimax_does_not_inherit_bare_reasoning_dialect () =
     "raw OpenAI-compatible endpoint does not inherit bare reasoning dialect"
     true
     (Option.is_none (Provider_config.capabilities_for_config_model cfg))
+;;
+
+let with_model_catalog_toml contents f =
+  let previous_catalog = Model_catalog.global () in
+  let restore () =
+    match previous_catalog with
+    | Some catalog -> Model_catalog.set_global catalog
+    | None -> Model_catalog.clear_global ()
+  in
+  let path = Filename.temp_file "oas-provider-config-models" ".toml" in
+  Fun.protect
+    ~finally:(fun () ->
+      try Sys.remove path with
+      | Sys_error _ -> ())
+    (fun () ->
+       Out_channel.with_open_text path (fun oc -> output_string oc contents);
+       match Model_catalog.load_file path with
+       | Error msg -> Alcotest.failf "failed to load model catalog: %s" msg
+       | Ok catalog ->
+         Model_catalog.set_global catalog;
+         Fun.protect f ~finally:restore)
+;;
+
+let test_openai_compat_raw_tool_capability_requires_endpoint_declaration () =
+  with_model_catalog_toml
+    {|
+[[models]]
+id_prefix = "raw-tool-only-model"
+base = "openai_chat"
+supports_tools = true
+supports_tool_choice = true
+|}
+    (fun () ->
+       let cfg =
+         Provider_config.make
+           ~kind:OpenAI_compat
+           ~model_id:"raw-tool-only-model"
+           ~base_url:"https://unknown-openai-compatible.example/v1"
+           ()
+       in
+       check_bool
+         "raw OpenAI-compatible endpoint does not inherit bare tool wire capability"
+         true
+         (Option.is_none (Provider_config.capabilities_for_config_model cfg)))
+;;
+
+let test_openai_compat_raw_template_dialect_requires_endpoint_declaration () =
+  with_model_catalog_toml
+    {|
+[[models]]
+id_prefix = "raw-template-model"
+base = "openai_chat"
+supports_tools = true
+supports_tool_choice = true
+supports_reasoning = true
+supports_extended_thinking = true
+thinking_control_format = "chat_template_kwargs"
+|}
+    (fun () ->
+       let cfg =
+         Provider_config.make
+           ~kind:OpenAI_compat
+           ~model_id:"raw-template-model"
+           ~base_url:"https://unknown-openai-compatible.example/v1"
+           ()
+       in
+       check_bool
+         "raw OpenAI-compatible endpoint does not inherit template thinking dialect"
+         true
+         (Option.is_none (Provider_config.capabilities_for_config_model cfg)))
 ;;
 
 let test_validate_responses_request_path_allows_structured_output () =
@@ -533,6 +606,7 @@ let test_validate_anthropic_thinking_rejects_forced_tool_choice () =
       ~base_url:"https://api.anthropic.com"
       ~enable_thinking
       ~tool_choice
+      ~model_capabilities_override:Capabilities.anthropic_capabilities
       ()
   in
   check_bool
@@ -1474,6 +1548,14 @@ let () =
             "raw compat minimax does not inherit reasoning dialect"
             `Quick
             test_openai_compat_raw_minimax_does_not_inherit_bare_reasoning_dialect
+        ; Alcotest.test_case
+            "raw compat tool capability requires endpoint declaration"
+            `Quick
+            test_openai_compat_raw_tool_capability_requires_endpoint_declaration
+        ; Alcotest.test_case
+            "raw compat template dialect requires endpoint declaration"
+            `Quick
+            test_openai_compat_raw_template_dialect_requires_endpoint_declaration
         ; Alcotest.test_case
             "responses structured path accepted"
             `Quick

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -451,6 +451,20 @@ let test_openai_compat_raw_qwen_does_not_inherit_bare_capability () =
     (Option.is_none (Provider_config.capabilities_for_config_model cfg))
 ;;
 
+let test_openai_compat_raw_minimax_does_not_inherit_bare_reasoning_dialect () =
+  let cfg =
+    Provider_config.make
+      ~kind:OpenAI_compat
+      ~model_id:"minimax-m3"
+      ~base_url:"https://unknown-openai-compatible.example/v1"
+      ()
+  in
+  check_bool
+    "raw OpenAI-compatible endpoint does not inherit bare reasoning dialect"
+    true
+    (Option.is_none (Provider_config.capabilities_for_config_model cfg))
+;;
+
 let test_validate_responses_request_path_allows_structured_output () =
   let cfg =
     Provider_config.make
@@ -1456,6 +1470,10 @@ let () =
             "raw compat qwen does not inherit bare capability"
             `Quick
             test_openai_compat_raw_qwen_does_not_inherit_bare_capability
+        ; Alcotest.test_case
+            "raw compat minimax does not inherit reasoning dialect"
+            `Quick
+            test_openai_compat_raw_minimax_does_not_inherit_bare_reasoning_dialect
         ; Alcotest.test_case
             "responses structured path accepted"
             `Quick

--- a/test/test_snapshot_provider_serialization.ml
+++ b/test/test_snapshot_provider_serialization.ml
@@ -119,6 +119,25 @@ let gemini_cfg =
 let glm_cfg = cfg ~kind:Glm ~base_url:"https://open.bigmodel.cn/api/paas/v4"
 let ollama_cfg = cfg ~kind:Ollama ~base_url:"http://127.0.0.1:11434"
 
+let deepseek_v4_capabilities =
+  { Capabilities.openai_compat_chat_capabilities with
+    max_context_tokens = Some 1_000_000
+  ; max_output_tokens = Some 384_000
+  ; supports_tools = true
+  ; supports_tool_choice = true
+  ; supports_required_tool_choice = false
+  ; supports_named_tool_choice = false
+  ; supports_reasoning = true
+  ; supports_extended_thinking = true
+  ; supports_reasoning_budget = true
+  ; thinking_control_format = Capabilities.Thinking_object
+  ; supports_response_format_json = true
+  ; supports_native_streaming = true
+  ; supports_caching = true
+  ; supports_prompt_caching = false
+  }
+;;
+
 let openai_no_parallel_capability_cfg =
   Provider_config.make
     ~kind:OpenAI_compat
@@ -132,18 +151,18 @@ let openai_no_parallel_capability_cfg =
 ;;
 
 (* RFC-OAS-023 fixture. Unlike the shared [cfg] above, this one uses the real
-   provider model id ([deepseek-v4-flash]) and deliberately OMITS
-   [supports_tool_choice_override], so
-   the OpenAI-compat request builder runs the real capability lookup
-   ([Capabilities.for_model_id]) instead of the override. DeepSeek's direct API
-   speaks the OpenAI-compatible Chat Completions wire, so [OpenAI_compat] is
-   the matching kind for this provider-contract fixture. *)
+   provider model id ([deepseek-v4-flash]) and an explicit catalog capability
+   declaration. DeepSeek's direct API speaks the OpenAI-compatible Chat
+   Completions wire, but provider-specific thinking/tool-choice semantics must
+   be declared on raw OpenAI-compatible configs rather than inferred from a bare
+   model id. *)
 let deepseek_cfg ?enable_thinking ?thinking_budget ~tool_choice () =
   Provider_config.make
     ~kind:OpenAI_compat
     ~model_id:"deepseek-v4-flash"
     ~base_url:"https://api.deepseek.com"
     ~api_key:"test-key"
+    ~model_capabilities_override:deepseek_v4_capabilities
     ~max_tokens:1024
     ~temperature:0.7
     ~tool_choice

--- a/test/test_thinking_control_dialects.ml
+++ b/test/test_thinking_control_dialects.ml
@@ -84,6 +84,38 @@ let openai_compat_config ?enable_thinking ?preserve_thinking ?thinking_budget mo
     ()
 ;;
 
+let catalog_capabilities model_id =
+  match CAP.for_model_id model_id with
+  | Some caps -> caps
+  | None -> fail ("expected catalog capabilities for " ^ model_id)
+;;
+
+let declared_catalog_openai_compat_config
+      ?(base_url = "https://declared-openai-compat.example/v1")
+      ?enable_thinking
+      ?preserve_thinking
+      ?thinking_budget
+      ?temperature
+      ?top_p
+      ?tool_choice
+      ?output_schema
+      model_id
+  =
+  PC.make
+    ~kind:OpenAI_compat
+    ~model_id
+    ~base_url
+    ~model_capabilities_override:(catalog_capabilities model_id)
+    ?enable_thinking
+    ?preserve_thinking
+    ?thinking_budget
+    ?temperature
+    ?top_p
+    ?tool_choice
+    ?output_schema
+    ()
+;;
+
 let declared_qwen_openai_compat_capabilities =
   { CAP.openai_compat_chat_capabilities with
     supports_reasoning = true
@@ -295,13 +327,11 @@ let test_mimo_v25_uses_thinking_object_and_json_schema () =
       ]
   in
   let config =
-    PC.make
-      ~kind:OpenAI_compat
-      ~model_id:"mimo-v2.5-pro"
+    declared_catalog_openai_compat_config
       ~base_url:"https://token-plan-sgp.xiaomimimo.com/v1"
       ~enable_thinking:false
       ~output_schema:schema
-      ()
+      "mimo-v2.5-pro"
   in
   let json = BOR.build_request ~config ~messages:[ user_msg "hi" ] () |> json_of_body in
   let dialect = RD.for_provider_config config in
@@ -390,13 +420,11 @@ let test_openai_reasoning_request_uses_reasoning_effort () =
 
 let test_deepseek_openai_compat_uses_thinking_object () =
   let config =
-    PC.make
-      ~kind:OpenAI_compat
-      ~model_id:"deepseek-v4-flash"
+    declared_catalog_openai_compat_config
       ~base_url:"https://api.deepseek.com"
       ~enable_thinking:false
       ~thinking_budget:4096
-      ()
+      "deepseek-v4-flash"
   in
   let json = BOR.build_request ~config ~messages:[ user_msg "hi" ] () |> json_of_body in
   check
@@ -410,7 +438,9 @@ let test_deepseek_openai_compat_uses_thinking_object () =
 ;;
 
 let test_minimax_m3_openai_compat_uses_adaptive_thinking_object () =
-  let enabled_config = openai_compat_config ~enable_thinking:true "minimax-m3" in
+  let enabled_config =
+    declared_catalog_openai_compat_config ~enable_thinking:true "minimax-m3"
+  in
   let enabled_json =
     BOR.build_request ~config:enabled_config ~messages:[ user_msg "hi" ] ()
     |> json_of_body
@@ -427,7 +457,7 @@ let test_minimax_m3_openai_compat_uses_adaptive_thinking_object () =
     (enabled_json |> member "reasoning_split" |> to_bool);
   check_member_absent "reasoning_effort" enabled_json;
   check_member_absent "chat_template_kwargs" enabled_json;
-  let default_config = openai_compat_config "minimax-m3" in
+  let default_config = declared_catalog_openai_compat_config "minimax-m3" in
   let default_json =
     BOR.build_request ~config:default_config ~messages:[ user_msg "hi" ] ()
     |> json_of_body
@@ -437,7 +467,9 @@ let test_minimax_m3_openai_compat_uses_adaptive_thinking_object () =
     "default reasoning split"
     true
     (default_json |> member "reasoning_split" |> to_bool);
-  let disabled_config = openai_compat_config ~enable_thinking:false "minimax-m3" in
+  let disabled_config =
+    declared_catalog_openai_compat_config ~enable_thinking:false "minimax-m3"
+  in
   let disabled_json =
     BOR.build_request ~config:disabled_config ~messages:[ user_msg "hi" ] ()
     |> json_of_body
@@ -449,12 +481,10 @@ let test_minimax_m3_openai_compat_uses_adaptive_thinking_object () =
     (disabled_json |> member "thinking" |> member "type" |> to_string);
   check_member_absent "reasoning_split" disabled_json;
   let auto_tool_choice_config =
-    PC.make
-      ~kind:OpenAI_compat
-      ~model_id:"minimax-m3"
+    declared_catalog_openai_compat_config
       ~base_url:"https://api.minimaxi.com/v1"
       ~tool_choice:Auto
-      ()
+      "minimax-m3"
   in
   let auto_tool_choice_json =
     BOR.build_request ~config:auto_tool_choice_config ~messages:[ user_msg "hi" ] ()
@@ -541,12 +571,10 @@ let test_ollama_cloud_openai_compat_streams_reasoning_delta () =
 
 let test_deepseek_reasoning_dialect_semantics () =
   let config =
-    PC.make
-      ~kind:OpenAI_compat
-      ~model_id:"deepseek-v4-pro"
+    declared_catalog_openai_compat_config
       ~base_url:"https://api.deepseek.com"
       ~enable_thinking:true
-      ()
+      "deepseek-v4-pro"
   in
   let dialect = RD.for_provider_config config in
   check
@@ -604,13 +632,11 @@ let test_deepseek_reasoning_dialect_semantics () =
 
 let test_deepseek_sampling_suppressed_in_thinking_mode () =
   let config =
-    PC.make
-      ~kind:OpenAI_compat
-      ~model_id:"deepseek-v4-flash"
+    declared_catalog_openai_compat_config
       ~base_url:"https://api.deepseek.com"
       ~temperature:0.7
       ~top_p:0.9
-      ()
+      "deepseek-v4-flash"
   in
   let json = BOR.build_request ~config ~messages:[ user_msg "hi" ] () |> json_of_body in
   check_member_absent "temperature" json;
@@ -619,14 +645,12 @@ let test_deepseek_sampling_suppressed_in_thinking_mode () =
 
 let test_deepseek_disabled_thinking_keeps_sampling () =
   let config =
-    PC.make
-      ~kind:OpenAI_compat
-      ~model_id:"deepseek-v4-flash"
+    declared_catalog_openai_compat_config
       ~base_url:"https://api.deepseek.com"
       ~enable_thinking:false
       ~temperature:0.7
       ~top_p:0.9
-      ()
+      "deepseek-v4-flash"
   in
   let json = BOR.build_request ~config ~messages:[ user_msg "hi" ] () |> json_of_body in
   check (float 0.001) "temperature" 0.7 (json |> member "temperature" |> to_float);
@@ -647,11 +671,9 @@ let assistant_with_reasoning ?(tool = false) () =
 
 let test_deepseek_replays_reasoning_only_for_tool_call_turns () =
   let config =
-    PC.make
-      ~kind:OpenAI_compat
-      ~model_id:"deepseek-v4-flash"
+    declared_catalog_openai_compat_config
       ~base_url:"https://api.deepseek.com"
-      ()
+      "deepseek-v4-flash"
   in
   let plain =
     BOR.build_request ~config ~messages:[ assistant_with_reasoning () ] () |> json_of_body
@@ -694,7 +716,9 @@ let keep_all_axis_manifest =
 
 let test_thinking_object_keep_all_axis_uses_keep_all () =
   with_manifest keep_all_axis_manifest (fun () ->
-    let config = openai_compat_config ~preserve_thinking:true "keep-all-axis-test" in
+    let config =
+      declared_catalog_openai_compat_config ~preserve_thinking:true "keep-all-axis-test"
+    in
     let json = BOR.build_request ~config ~messages:[ user_msg "hi" ] () |> json_of_body in
     let thinking = json |> member "thinking" in
     check string "thinking type" "enabled" (thinking |> member "type" |> to_string);
@@ -705,7 +729,9 @@ let test_thinking_object_keep_all_axis_uses_keep_all () =
 
 let test_thinking_object_keep_all_axis_replays_reasoning () =
   with_manifest keep_all_axis_manifest (fun () ->
-    let config = openai_compat_config ~preserve_thinking:true "keep-all-axis-test" in
+    let config =
+      declared_catalog_openai_compat_config ~preserve_thinking:true "keep-all-axis-test"
+    in
     let dialect = RD.for_provider_config config in
     check
       string


### PR DESCRIPTION
## Summary

- Fail closed for raw `OpenAI_compat` configs whose bare catalog match would change thinking/reasoning/replay dialects or non-generic sampling fields.
- Route legacy `Provider.OpenAICompat` capability lookup through `Provider_config.capabilities_for_config_model`, preserving the explicit Z.AI GLM endpoint exception.
- Make `Api_openai` request-body capability resolution honor `Custom_registered` entries from `Provider_registry`, matching the existing validation path.
- Update API/dialect fixtures so provider-specific behavior is declared through provider catalog entries or explicit capability overrides instead of model-id-only inference.

## Verification

- `scripts/dune-local.sh build test/test_provider.exe test/test_provider_config.exe test/test_thinking_control_dialects.exe test/test_provider_runtime_binding.exe test/test_api.exe test/test_capabilities.exe test/test_backend_openai_codec.exe test/test_streaming_openai.exe`
- `env OAS_MODEL_CATALOG=models.toml ./_build/default/test/test_provider.exe`
- `env OAS_MODEL_CATALOG=models.toml ./_build/default/test/test_provider_config.exe`
- `env OAS_MODEL_CATALOG=models.toml ./_build/default/test/test_thinking_control_dialects.exe`
- `env OAS_MODEL_CATALOG=models.toml ./_build/default/test/test_provider_runtime_binding.exe`
- `env OAS_MODEL_CATALOG=models.toml ./_build/default/test/test_api.exe`
- `env OAS_MODEL_CATALOG=models.toml ./_build/default/test/test_capabilities.exe`
- `env OAS_MODEL_CATALOG=models.toml ./_build/default/test/test_backend_openai_codec.exe`
- `env OAS_MODEL_CATALOG=models.toml ./_build/default/test/test_streaming_openai.exe`
- `git diff --check`
- `scripts/ci-code-smell-ratchet.sh --check`
- `scripts/hardening-ratchet.sh --self-test`
- `scripts/hardening-ratchet.sh --check`
