### PR TITLE
refactor(provider): route Anthropic effort aliases through dialect

### DIFF
--- a/lib/llm_provider/backend_anthropic.ml
+++ b/lib/llm_provider/backend_anthropic.ml
@@ -73,15 +73,10 @@ let parse_response json =
   }
 ;;
 
-let effort_of_budget budget =
-  match Reasoning_effort.of_budget budget with
-  | Some Reasoning_effort.None_ -> None
-  | Some Reasoning_effort.Minimal -> None
-  | Some Reasoning_effort.Low -> Some "low"
-  | Some Reasoning_effort.Medium -> Some "medium"
-  | Some Reasoning_effort.High -> Some "high"
-  | Some Reasoning_effort.XHigh -> Some "max"
-  | None -> None
+let effort_of_budget dialect budget =
+  Option.bind
+    (Reasoning_effort.of_budget budget)
+    (Reasoning_dialect.normalize_effort_value dialect)
 ;;
 
 let effort_for_config mode (config : Provider_config.t) =
@@ -92,11 +87,12 @@ let effort_for_config mode (config : Provider_config.t) =
   match config.enable_thinking with
   | Some false | None -> None
   | Some true ->
+    let dialect = Reasoning_dialect.for_provider_config config in
     (match mode, config.thinking_budget with
      | ( ( Capabilities.Anthropic_adaptive_only
          | Capabilities.Anthropic_adaptive_preferred
          | Capabilities.Anthropic_always_adaptive )
-       , Some budget ) -> effort_of_budget budget
+       , Some budget ) -> effort_of_budget dialect budget
      | Capabilities.Anthropic_manual_budget, _
      | ( ( Capabilities.Anthropic_adaptive_only
          | Capabilities.Anthropic_adaptive_preferred

--- a/lib/llm_provider/reasoning_dialect.ml
+++ b/lib/llm_provider/reasoning_dialect.ml
@@ -21,6 +21,7 @@ type toggle_wire =
 type effort_alias_policy =
   | Preserve_effort
   | Deepseek_high_or_max
+  | Anthropic_output_max
 
 type sampling_policy =
   | Sampling_supported
@@ -266,6 +267,11 @@ let normalize_effort_value dialect effort =
     Some "high"
   | Deepseek_high_or_max, Reasoning_effort.XHigh -> Some "max"
   | Deepseek_high_or_max, (Reasoning_effort.None_ | Reasoning_effort.Minimal) -> None
+  | Anthropic_output_max, Reasoning_effort.XHigh -> Some "max"
+  | ( Anthropic_output_max
+    , (Reasoning_effort.Low | Reasoning_effort.Medium | Reasoning_effort.High) ) ->
+    Some (Reasoning_effort.to_string effort)
+  | Anthropic_output_max, (Reasoning_effort.None_ | Reasoning_effort.Minimal) -> None
   | Preserve_effort, effort -> Some (Reasoning_effort.to_string effort)
 ;;
 
@@ -368,6 +374,7 @@ let for_provider_config (config : Provider_config.t) =
       toggle_wire = Anthropic_thinking
     ; replay_policy = Preserve_always
     ; streaming = Delta_field "thinking_delta"
+    ; effort_alias_policy = Anthropic_output_max
     }
   | Gemini ->
     { default with

--- a/lib/llm_provider/reasoning_dialect.mli
+++ b/lib/llm_provider/reasoning_dialect.mli
@@ -31,6 +31,7 @@ type toggle_wire =
 type effort_alias_policy =
   | Preserve_effort
   | Deepseek_high_or_max
+  | Anthropic_output_max
 
 type sampling_policy =
   | Sampling_supported

--- a/lib/llm_provider/reasoning_effort.ml
+++ b/lib/llm_provider/reasoning_effort.ml
@@ -39,10 +39,4 @@ let of_budget = function
   | _ -> Some XHigh
 ;;
 
-let of_budget_with_xhigh = function
-  | n when n <= 0 -> None
-  | n when n <= low_budget_max_tokens -> Some Low
-  | n when n <= medium_budget_max_tokens -> Some Medium
-  | n when n <= high_budget_max_tokens -> Some High
-  | _ -> Some XHigh
-;;
+let of_budget_with_xhigh = of_budget

--- a/test/test_thinking_control_dialects.ml
+++ b/test/test_thinking_control_dialects.ml
@@ -931,7 +931,17 @@ let test_anthropic_reasoning_dialect_preserves_thinking () =
     string
     "replay policy"
     "preserve_always"
-    (RD.replay_policy_to_string dialect.replay_policy)
+    (RD.replay_policy_to_string dialect.replay_policy);
+  check
+    (option string)
+    "xhigh effort alias"
+    (Some "max")
+    (RD.normalize_effort_value dialect RE.XHigh);
+  check
+    (option string)
+    "minimal effort omitted"
+    None
+    (RD.normalize_effort_value dialect RE.Minimal)
 ;;
 
 let test_anthropic_manual_model_uses_budget_tokens () =


### PR DESCRIPTION
## Summary
- add an Anthropic output-effort alias policy to `Reasoning_dialect`
- route Anthropic adaptive `budget -> effort` serialization through the dialect normalizer
- collapse `Reasoning_effort.of_budget_with_xhigh` to the canonical `of_budget` implementation while keeping the compatibility surface
- add a dialect regression for Anthropic `XHigh -> max` and omitted `Minimal`

## Validation
- `opam exec -- ocamlformat --check lib/llm_provider/reasoning_dialect.ml lib/llm_provider/reasoning_dialect.mli lib/llm_provider/backend_anthropic.ml lib/llm_provider/reasoning_effort.ml test/test_thinking_control_dialects.ml`
- `git diff --check`
- `scripts/hardening-ratchet.sh --check`
- `scripts/ci-code-smell-ratchet.sh --check`

Local Dune build/test intentionally not run; CI is the build authority for this branch.