### PR TITLE
feat(agent): ensure_final_text convergence — fix tool-only turn with no reply (RFC-OAS-030 Fix 2)

### DIFF
--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -248,9 +248,45 @@ let run_loop ~sw ?clock ~api_strategy ?on_yield ?on_resume ?on_activity agent us
      timeouts requires knowing whether the budget was spent on many
      moderate turns or a single slow one. *)
   let run_start = Unix.gettimeofday () in
+  (* Convergence turn for [ensure_final_text]: the run's contract is to produce
+     a user-facing answer, but the model ended with tool activity and no visible
+     text (downstream renders this as "Tool-only turn ended without a final
+     reply"). We run exactly ONE more model turn with the tool set withheld
+     ([Tool_set.empty] — the same swap {!run_with_handoffs_blocks} uses). With no
+     tools the model cannot emit a tool call, so it must author a textual final
+     answer: the answer is LLM-authored, not synthesized, and this adds no
+     turn/token cap. This is a single [run_turn_core] call — never a recursion
+     into [loop] — so it runs at most once and cannot itself trigger another
+     final-answer turn. *)
+  let run_final_answer_turn () =
+    let tool_withheld_agent = { agent with tools = Tool_set.empty } in
+    let turn_index = agent.state.turn_count + 1 in
+    let max_turns = agent.state.config.max_turns in
+    let turn_start = Unix.gettimeofday () in
+    let result =
+      run_turn_core ~sw ?clock ~api_strategy ?raw_trace_run tool_withheld_agent
+    in
+    log_turn
+      ~run_start
+      ~turn_start
+      ~turn_index
+      ~max_turns
+      ~model:tool_withheld_agent.state.config.model
+      ~stop:"ensure_final_text";
+    result
+  in
   (* First turn: caller already holds slot, no resume needed *)
   let rec loop ~is_first_turn =
     match check_loop_guard agent with
+    | Some (Error.Agent (Error.MaxTurnsExceeded _) as err)
+      when agent.state.config.ensure_final_text ->
+      (* Hit the turn limit after a tool turn with no final text. Converge with
+         one tool-withheld answer turn before surfacing the limit error. If that
+         turn does not yield a [`Complete] response (degenerate [`ToolsExecuted],
+         or a hard error), fall back to the original MaxTurnsExceeded error. *)
+      (match run_final_answer_turn () with
+       | Ok (`Complete final_response) -> Ok final_response
+       | Ok `ToolsExecuted | Error _ -> Error err)
     | Some err -> Error err
     | None ->
       (* Resume slot before LLM turn (skip on first turn) *)
@@ -288,7 +324,20 @@ let run_loop ~sw ?clock ~api_strategy ?on_yield ?on_resume ?on_activity agent us
            ~max_turns
            ~model:response.model
            ~stop:(stop_reason_label response.stop_reason);
-         Ok response
+         if
+           agent.state.config.ensure_final_text
+           && Option.is_none (final_text_of_response response)
+         then (
+           (* Terminal turn carried no visible text: converge with one
+              tool-withheld answer turn. Return whatever it yields and do NOT
+              retry — a [`Complete] result is returned even if it is still
+              text-free; a degenerate [`ToolsExecuted] falls back to the
+              original response; a hard error is surfaced honestly. *)
+           match run_final_answer_turn () with
+           | Ok (`Complete final_response) -> Ok final_response
+           | Ok `ToolsExecuted -> Ok response
+           | Error e -> Error e)
+         else Ok response
        | Ok `ToolsExecuted ->
          log_turn
            ~run_start
@@ -886,4 +935,103 @@ let save_journal agent path =
   match agent.options.journal with
   | Some j -> Durable_event.save_to_file j path
   | None -> Error "no journal"
+;;
+
+(* ── ensure_final_text convergence ───────────────────────────── *)
+
+let%test
+    "ensure_final_text runs one tool-withheld answer turn on a text-free terminal turn; \
+     default leaves the run unchanged"
+  =
+  Eio_main.run
+  @@ fun env ->
+  let net = Eio.Stdenv.net env in
+  (* The model's terminal turn carries no user-facing text (thinking-only — the
+     real "tool-only turn ended without a final reply" symptom). With
+     [ensure_final_text] the loop must run exactly ONE more turn with tools
+     withheld so the model authors a textual answer; with the default it must
+     return the text-free terminal turn unchanged. *)
+  let thinking_only : Types.api_response =
+    { id = "r0"
+    ; model = "mock-model"
+    ; stop_reason = EndTurn
+    ; content = [ Thinking { signature = None; content = "private reasoning" } ]
+    ; usage = None
+    ; telemetry = None
+    }
+  in
+  let final_answer : Types.api_response =
+    { id = "r1"
+    ; model = "mock-model"
+    ; stop_reason = EndTurn
+    ; content = [ Text "the final answer" ]
+    ; usage = None
+    ; telemetry = None
+    }
+  in
+  let run_with ~ensure_final_text =
+    let call_index = ref 0 in
+    let tools_seen = ref [] in
+    let next (req : Llm_provider.Llm_transport.completion_request) =
+      tools_seen := !tools_seen @ [ List.length req.tools ];
+      let resp = if !call_index = 0 then thinking_only else final_answer in
+      incr call_index;
+      resp
+    in
+    let transport : Llm_provider.Llm_transport.t =
+      { complete_sync =
+          (fun req ->
+            { Llm_provider.Llm_transport.response = Ok (next req); latency_ms = None })
+      ; complete_stream = (fun ?on_telemetry:_ ~on_event:_ req -> Ok (next req))
+      }
+    in
+    let options =
+      { default_options with
+        transport = Some transport
+      ; provider =
+          Some
+            { Provider.provider = Provider.Local { base_url = "http://mock:0/v1" }
+            ; model_id = "mock-model"
+            ; api_key_env = ""
+            }
+      }
+    in
+    let tool =
+      Agent_tool.create_simple ~name:"noop" ~description:"noop" (fun _ -> Ok final_answer)
+    in
+    let agent =
+      create
+        ~net
+        ~config:
+          { Types.default_config with
+            name = "ensure-final-text-test"
+          ; max_turns = 4
+          ; ensure_final_text
+          }
+        ~tools:[ tool ]
+        ~options
+        ()
+    in
+    Eio.Switch.run
+    @@ fun sw ->
+    let result = run_blocks ~sw agent [ Text "hi" ] in
+    result, !call_index, !tools_seen
+  in
+  let has_text = function
+    | Ok resp -> Option.is_some (final_text_of_response resp)
+    | Error _ -> false
+  in
+  let on_result, on_calls, on_tools = run_with ~ensure_final_text:true in
+  let off_result, off_calls, _off_tools = run_with ~ensure_final_text:false in
+  (* ON: the extra tool-withheld turn ran (2 transport calls), the second
+     carried no tools while the first carried the registered tool, and the run
+     ends with visible text. *)
+  has_text on_result
+  && on_calls = 2
+  && (match on_tools with
+      | [ first; 0 ] -> first >= 1
+      | _ -> false)
+  (* OFF (default): no extra turn — the run ends on the text-free terminal turn. *)
+  && off_calls = 1
+  && not (has_text off_result)
 ;;

--- a/lib/agent/agent_trace.mli
+++ b/lib/agent/agent_trace.mli
@@ -47,6 +47,13 @@ val trace_assistant_blocks
   -> Types.content_block list
   -> (unit, Error.sdk_error) result
 
+(** {1 Response inspection} *)
+
+(** The user-facing final text of a response, or [None] when the response
+    carries no visible text (e.g. thinking-only or tool-only turns).  Thinking
+    blocks are excluded; whitespace-only text is treated as absent. *)
+val final_text_of_response : Types.api_response -> string option
+
 (** {1 Run lifecycle} *)
 
 (** Execute [f] within a raw-trace run, handling start/finish recording

--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -62,6 +62,7 @@ type t =
   ; priority : Llm_provider.Request_priority.t option
   ; yield_on_tool : bool
   ; exit_condition : (int -> bool) option
+  ; ensure_final_text : bool
   ; tool_selector : Tool_selector.strategy option
   ; disclosure_level : Tool.disclosure_level option
   ; disclosure_resolver : (Types.tool_result list -> Tool.disclosure_level option) option
@@ -141,6 +142,7 @@ let create ~net ~model =
   ; priority = None
   ; yield_on_tool = false
   ; exit_condition = None
+  ; ensure_final_text = default_config.ensure_final_text
   ; tool_selector = None
   ; disclosure_level = None
   ; disclosure_resolver = None
@@ -311,6 +313,7 @@ let with_cache_system_prompt v b = { b with cache_system_prompt = v }
 let with_cache_extended_ttl v b = { b with cache_extended_ttl = v }
 let with_yield_on_tool v b = { b with yield_on_tool = v }
 let with_exit_condition pred b = { b with exit_condition = Some pred }
+let with_ensure_final_text v b = { b with ensure_final_text = v }
 let with_event_bus bus b = { b with event_bus = Some bus }
 let without_event_bus b = { b with event_bus = None }
 let with_max_execution_time s b = { b with max_execution_time_s = Some s }
@@ -382,6 +385,7 @@ let build b =
     ; priority = b.priority
     ; yield_on_tool = b.yield_on_tool
     ; exit_condition = b.exit_condition
+    ; ensure_final_text = b.ensure_final_text
     ; call_time_pruner_keep_recent = Types.default_config.call_time_pruner_keep_recent
     ; call_time_pruner_keep_last = Types.default_config.call_time_pruner_keep_last
     }

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -56,6 +56,17 @@ val with_yield_on_tool : bool -> t -> t
     @since 0.115.0 *)
 val with_exit_condition : (int -> bool) -> t -> t
 
+(** Require the run to end with user-facing final text.
+
+    When [true], if a run is about to terminate with tool activity but no
+    visible text (the "tool-only turn ended without a final reply" symptom) —
+    either a terminal turn with no text, or [max_turns] reached after a tool
+    turn — the agent performs exactly ONE additional model turn with tools
+    withheld, so the model itself authors a textual answer. This adds no
+    turn/token limit (the answer is LLM-authored, not synthesized) and runs at
+    most once per run. Default [false]. *)
+val with_ensure_final_text : bool -> t -> t
+
 (** {2 Tools and MCP} *)
 
 val with_tools : Tool.t list -> t -> t

--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -224,6 +224,7 @@ let create_agent
     ; priority = default_config.priority
     ; yield_on_tool = default_config.yield_on_tool
     ; exit_condition = default_config.exit_condition
+    ; ensure_final_text = default_config.ensure_final_text
     ; call_time_pruner_keep_recent = default_config.call_time_pruner_keep_recent
     ; call_time_pruner_keep_last = default_config.call_time_pruner_keep_last
     }

--- a/lib/base/types.ml
+++ b/lib/base/types.ml
@@ -144,6 +144,15 @@ type agent_config =
     (** Release LLM slot during tool execution, re-acquire before next turn. @since 0.100.0 *)
   ; exit_condition : ((int -> bool)[@opaque]) option
     (** Custom exit predicate called with turn_count after each turn. @since 0.115.0 *)
+  ; ensure_final_text : bool
+    (** When [true], a run must not terminate with tool activity but no
+        user-facing final text (downstream renders this as "Tool-only turn
+        ended without a final reply"). If the run is about to end that way —
+        either a terminal turn with no visible text, or [max_turns] reached
+        after a tool turn — the agent performs exactly ONE additional model
+        turn with the tool set withheld, so the model itself authors a textual
+        answer. This is convergence, not a cap: it adds no turn/token limit and
+        the answer is LLM-authored. Default [false] preserves prior behavior. *)
   ; call_time_pruner_keep_recent : int
     (** Number of most recent turns whose tool results are NOT stubbed by the
         call-time pruner in [Agent_turn.prepare_messages].  Default 2. *)
@@ -178,6 +187,7 @@ let default_config_value ?getenv () =
   ; priority = None
   ; yield_on_tool = false
   ; exit_condition = None
+  ; ensure_final_text = false
   ; call_time_pruner_keep_recent = 2
   ; call_time_pruner_keep_last = 100
   }

--- a/lib/base/types.mli
+++ b/lib/base/types.mli
@@ -63,6 +63,15 @@ type agent_config =
   ; yield_on_tool : bool (** Release LLM slot during tool execution. @since 0.100.0 *)
   ; exit_condition : ((int -> bool)[@opaque]) option
     (** Custom exit predicate called with turn_count after each turn. When it returns true the agent loop exits cleanly. @since 0.115.0 *)
+  ; ensure_final_text : bool
+    (** When [true], a run must not terminate with tool activity but no
+        user-facing final text (downstream renders this as "Tool-only turn
+        ended without a final reply"). If the run is about to end that way —
+        either a terminal turn with no visible text, or [max_turns] reached
+        after a tool turn — the agent performs exactly ONE additional model
+        turn with the tool set withheld, so the model itself authors a textual
+        answer. Convergence, not a cap: it adds no turn/token limit and the
+        answer is LLM-authored. Default [false] preserves prior behavior. *)
   ; call_time_pruner_keep_recent : int
     (** Number of most recent turns whose tool results are NOT stubbed by the
         call-time pruner in {!Agent_turn.prepare_messages}.  Default [2]. *)


### PR DESCRIPTION
## 목표
대시보드 키퍼 채팅에서 나오는 **"Tool-only turn ended without a final reply"** 증상을 제거하는 OAS-canonical 메커니즘. RFC-OAS-030 Fix 2 구현.

## 근본원인
3축 라이브 감사(2026-06-30) + glm-coding 라이브 probe 결과:
- **I/O는 정상** — probe로 GLM Thinking+Tools+Reasoning replay가 라이브 서버 기준 올바르게 round-trip하고 해결 가능한 task는 자연 수렴(`finish_reason=stop`)함을 확인 (PR #2378 참조).
- 증상의 실제 원인은 **perseveration + 수렴 메커니즘 부재**: 멀티턴 tool 루프(OAS `agent.ml`)가 tool 작업 후 visible text 없이 종료(Complete-no-text 또는 max_turns)되면 사용자에게 답이 안 감. (sangsu는 task가 환경적으로 막혀 모델이 계속 tool만 호출 → 빈 종료.)

## 변경
`ensure_final_text` config flag(**default false**, 기존 동작 보존) 추가. 켜지면 run이 visible text 없이 종료되려 할 때 **tool set을 비운 채(`Tool_set.empty`) 모델 turn을 정확히 1회** 더 돌려 텍스트 최종답을 받음.

- 종료 두 경로 모두 커버: `Complete`인데 `final_text_of_response = None`, 그리고 `max_turns` guard (pipeline에 별도 retry/turn gate 없어 final turn 실행됨, `pipeline.ml:544` 주석).
- **재귀 안전**: `run_final_answer_turn`은 단일 `run_turn_core` 호출(loop 재진입 안 함), tools 없어 tool call 불가 → 1회로 끝, 자기 재유발 불가.
- 관측: `log_turn ~stop:"ensure_final_text"`.
- 파일: `types.ml/.mli`(config field), `builder.ml/.mli`(`with_ensure_final_text`), `agent_sdk.ml`(legacy create 경로), `agent_trace.mli`(`final_text_of_response` 노출), `agent.ml`(루프 wiring + 테스트).

## 왜 cap-workaround가 아닌가
turn/token 제한을 추가하지 않고, agent를 pause/stop하지 않음. max_turns guard 후 **에러로 죽는 대신 run의 "답을 낸다" 계약을 LLM이 작성한 답으로 완성**함. CLAUDE.md workaround 시그니처(cap/cooldown/dedup/repair)에 해당하지 않음 — symptom 억제가 아니라 종료 동작의 root fix.

## 경계 (OAS Canonical)
메커니즘은 전적으로 OAS(agent 루프 = OAS 소유). MASC 참조 없음. 증상이 실제로 사라지려면 MASC가 **reactive(chat) run에 이 flag를 활성화**해야 함 — 위치: `masc lib/runtime/runtime_agent_context.ml`의 Builder 체인(`with_max_idle_turns` 옆)에 `with_ensure_final_text true`, reactive/autonomous 구분은 `keeper_runtime_resolved.ml`에 이미 존재. **이는 OAS 릴리즈 후 별도 MASC PR**(2-PR 시퀀스).

## 검증
- `scripts/dune-local.sh build lib/`: PASS (exit 0)
- `scripts/dune-local.sh runtest lib/agent/`: PASS — 신규 inline 테스트 `ensure_final_text runs one tool-withheld answer turn...`가 scripted `Llm_transport`로 `run_blocks`를 end-to-end 구동: `ensure_final_text:true` → visible text로 종료 + transport 2회 호출(2번째 tools=0), `false` → 1회 + text 없음. (revert 시 red = 비-vacuous)
- ocamlformat: 편집 7파일 전부 PASS
- 로컬 잔존 실패(llm_provider pricing/capability)는 `~/.masc` manifest + `OAS_PRICING_OVERRIDES` 환경 노이즈로, `git stash`로 clean base에서도 동일함을 확인 — 본 변경 무관

## 미검증 / 후속
- max_turns 수렴 경로는 코드 대칭 + pipeline 무게이트로 동작 보장되나 직접 테스트는 Complete-no-text 경로만 커버 — max_turns 케이스 inline 테스트 추가 권장(저위험 follow-up)
- MASC reactive-chat 활성화 PR (OAS 릴리즈 + pin bump 후)

RFC 인용: RFC-OAS-030 Fix 2 (PR #2378에 도입).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
