### PR TITLE
feat(provider): parse catalog capability controls

### DIFF
--- a/docs/provider-catalog.md
+++ b/docs/provider-catalog.md
@@ -156,9 +156,12 @@ The `capabilities` object accepts the same capability field names used by
 - `assistant_tool_content_format`
 - `supports_runtime_mcp_tools`, `supports_runtime_tool_events`
 - `supports_reasoning`, `supports_extended_thinking`, `supports_reasoning_budget`
+- `accepted_reasoning_efforts`
 - `thinking_control_format`, `preserve_thinking_control_format`
+- `reasoning_output_format`, `reasoning_streaming_format`
 - `supports_response_format_json`, `supports_structured_output`
 - `supports_image_input`, `supports_audio_input`, `supports_video_input`
+- `modality_priority`
 - `supports_native_streaming`, `supports_system_prompt`
 - `supports_top_k`, `supports_min_p`, `supports_seed`
 - `emits_usage_tokens`, `supported_models`
@@ -191,6 +194,30 @@ Accepted `reasoning_output_format` values are:
 
 - `none`
 - `split_reasoning_fields` (emit provider split control such as `reasoning_split=true`)
+
+Accepted `reasoning_streaming_format` values are:
+
+- `default`
+- `none`
+- `template_parser`
+- `delta:<field>` (parse the named streaming delta field as reasoning)
+
+Accepted `accepted_reasoning_efforts` values are:
+
+- `none`
+- `minimal`
+- `low`
+- `medium`
+- `high`
+- `xhigh`
+
+Accepted `modality_priority` values are:
+
+- `preserve_input_order`
+- `preserve-input-order`
+- `preserve`
+- `visual_first`
+- `visual-first`
 
 Accepted `assistant_tool_content_format` values are:
 

--- a/lib/llm_provider/provider_catalog.ml
+++ b/lib/llm_provider/provider_catalog.ml
@@ -283,6 +283,42 @@ let parse_reasoning_streaming_format = function
             Capability_vocab.reasoning_streaming_format_syntax))
 ;;
 
+let parse_modality_priority = function
+  | None -> Ok None
+  | Some raw ->
+    let normalized = String.lowercase_ascii (String.trim raw) in
+    (match normalized with
+     | "" -> Ok None
+     | "preserve_input_order" | "preserve-input-order" | "preserve" ->
+       Ok (Some Modality.Preserve_input_order)
+     | "visual_first" | "visual-first" -> Ok (Some Modality.Visual_first)
+     | other ->
+       Error
+         (Printf.sprintf
+            "unknown modality_priority %S (canonical: %s)"
+            other
+            (String.concat ", " Capability_vocab.modality_priority_values)))
+;;
+
+let parse_accepted_reasoning_efforts = function
+  | None -> Ok None
+  | Some values ->
+    let rec loop acc = function
+      | [] -> Ok (Some (List.rev acc))
+      | raw :: rest ->
+        let normalized = String.lowercase_ascii (String.trim raw) in
+        (match Reasoning_effort.of_string normalized with
+         | Some effort -> loop (effort :: acc) rest
+         | None ->
+           Error
+             (Printf.sprintf
+                "unknown accepted_reasoning_efforts value %S (canonical: %s)"
+                normalized
+                (String.concat ", " Reasoning_effort.all_wire_values)))
+    in
+    loop [] values
+;;
+
 let member_supported_models json = member_string_list "supported_models" json
 
 let capability_base json =
@@ -349,6 +385,14 @@ let parse_capabilities provider_json =
   let* reasoning_streaming_format =
     let* raw = member_string_strict "reasoning_streaming_format" cap_json in
     parse_reasoning_streaming_format raw
+  in
+  let* modality_priority =
+    let* raw = member_string_strict "modality_priority" cap_json in
+    parse_modality_priority raw
+  in
+  let* accepted_reasoning_efforts =
+    parse_accepted_reasoning_efforts
+      (member_string_list "accepted_reasoning_efforts" cap_json)
   in
   let caps =
     base
@@ -495,6 +539,10 @@ let parse_capabilities provider_json =
       (fun caps v -> { caps with Capabilities.supports_video_input = v })
       cap_json
     |> fun caps ->
+    (match modality_priority with
+     | Some modality_priority -> { caps with Capabilities.modality_priority }
+     | None -> caps)
+    |> fun caps ->
     override_bool
       "supports_native_streaming"
       caps
@@ -587,6 +635,14 @@ let parse_capabilities provider_json =
   let caps =
     match member_supported_models cap_json with
     | Some models -> { caps with Capabilities.supported_models = Some models }
+    | None -> caps
+  in
+  let caps =
+    match accepted_reasoning_efforts with
+    | Some accepted_reasoning_efforts ->
+      { caps with
+        Capabilities.accepted_reasoning_efforts = Some accepted_reasoning_efforts
+      }
     | None -> caps
   in
   Ok caps

--- a/test/test_provider_catalog_coverage.ml
+++ b/test/test_provider_catalog_coverage.ml
@@ -74,6 +74,8 @@ let test_full_entry_parses_auth_transport_and_capabilities () =
               "supports_code_execution": true,
               "emits_usage_tokens": true,
               "thinking_control_format": "chat_template_kwargs",
+              "accepted_reasoning_efforts": ["low", "high"],
+              "modality_priority": "visual_first",
               "reasoning_replay": "preserve_always",
               "supported_models": [" rich-model ", "", 3, "rich-fast"]
             }
@@ -132,6 +134,12 @@ let test_full_entry_parses_auth_transport_and_capabilities () =
   check bool "computer use" true caps.supports_computer_use;
   check bool "code execution" true caps.supports_code_execution;
   check bool "usage tokens" true caps.emits_usage_tokens;
+  check
+    (option (list string))
+    "accepted reasoning efforts"
+    (Some [ "low"; "high" ])
+    (Option.map (List.map Reasoning_effort.to_string) caps.accepted_reasoning_efforts);
+  check bool "visual first" true (caps.modality_priority = Modality.Visual_first);
   check
     bool
     "thinking format"
@@ -374,7 +382,15 @@ let test_removed_catalog_aliases_are_rejected () =
   assert_reject
     "reasoning replay type rejected"
     {|{"schema_version":1,"providers":[{"id":"p","capabilities":{"reasoning_replay":true}}]}|}
-    "expected string"
+    "expected string";
+  assert_reject
+    "accepted reasoning effort rejected"
+    {|{"schema_version":1,"providers":[{"id":"p","capabilities":{"accepted_reasoning_efforts":["low","turbo"]}}]}|}
+    "unknown accepted_reasoning_efforts";
+  assert_reject
+    "modality priority rejected"
+    {|{"schema_version":1,"providers":[{"id":"p","capabilities":{"modality_priority":"image_only"}}]}|}
+    "unknown modality_priority"
 ;;
 
 let test_non_list_providers_is_empty_catalog () =


### PR DESCRIPTION
## Summary
- parse catalog accepted_reasoning_efforts and modality_priority into provider capabilities
- document accepted catalog capability values for reasoning and modality controls
- add coverage for accepted fields and fail-closed unknown values

## Validation
- opam exec -- ocamlformat --check lib/llm_provider/provider_catalog.ml test/test_provider_catalog_coverage.ml
- git diff --check
- scripts/hardening-ratchet.sh --check
- scripts/ci-code-smell-ratchet.sh --check
- Dune build/test: GitHub CI only per workflow