### PR TITLE
feat(provider): report tool pair repair drops

### DIFF
--- a/lib/llm_provider/backend_openai_serialize.ml
+++ b/lib/llm_provider/backend_openai_serialize.ml
@@ -425,7 +425,15 @@ let ollama_messages_of_message ?(model_id = "") msg =
     Pure function — no I/O, no mutation. *)
 let strip_orphaned_tool_results = Tool_message_pairs.strip_orphaned_tool_results
 
+let strip_orphaned_tool_results_with_report =
+  Tool_message_pairs.strip_orphaned_tool_results_with_report
+;;
+
 let close_tool_message_pairs_for_request = Tool_message_pairs.close_for_provider_request
+
+let close_tool_message_pairs_for_request_with_report =
+  Tool_message_pairs.close_for_provider_request_with_report
+;;
 
 (** Strip Thinking blocks from all messages.
 

--- a/lib/llm_provider/backend_openai_serialize.mli
+++ b/lib/llm_provider/backend_openai_serialize.mli
@@ -37,10 +37,18 @@ val build_openai_tool_json : Yojson.Safe.t -> Yojson.Safe.t
 *)
 val strip_orphaned_tool_results : Types.message list -> Types.message list
 
+val strip_orphaned_tool_results_with_report
+  :  Types.message list
+  -> Types.message list * Tool_message_pairs.repair_report
+
 (** Normalize tool-call pairing before provider request serialization:
     orphan ToolResult blocks are removed and dangling Assistant ToolUse blocks
     receive synthetic error ToolResult messages. *)
 val close_tool_message_pairs_for_request : Types.message list -> Types.message list
+
+val close_tool_message_pairs_for_request_with_report
+  :  Types.message list
+  -> Types.message list * Tool_message_pairs.repair_report
 
 (** Remove Thinking blocks from all messages. Deepseek-compatible APIs
     reject [reasoning_content] in request messages — it is response-only.

--- a/lib/llm_provider/tool_message_pairs.ml
+++ b/lib/llm_provider/tool_message_pairs.ml
@@ -1,5 +1,34 @@
 open Types
 
+type dropped_tool_result_reason =
+  | Orphaned_tool_result
+  | Duplicate_tool_result
+
+type dropped_tool_result =
+  { tool_use_id : string
+  ; reason : dropped_tool_result_reason
+  }
+
+type repair_report =
+  { dropped_tool_results : dropped_tool_result list
+  ; synthesized_tool_result_ids : string list
+  }
+
+let empty_repair_report = { dropped_tool_results = []; synthesized_tool_result_ids = [] }
+
+let normalize_report report =
+  { dropped_tool_results = List.rev report.dropped_tool_results
+  ; synthesized_tool_result_ids = List.rev report.synthesized_tool_result_ids
+  }
+;;
+
+let append_report a b =
+  { dropped_tool_results = a.dropped_tool_results @ b.dropped_tool_results
+  ; synthesized_tool_result_ids =
+      a.synthesized_tool_result_ids @ b.synthesized_tool_result_ids
+  }
+;;
+
 let tool_use_ids (msg : message) =
   List.filter_map
     (function
@@ -55,63 +84,85 @@ let split_tool_result_span messages =
   loop [] messages
 ;;
 
-let strip_orphaned_tool_results (messages : message list) : message list =
-  let filter_tool_results allowed seen (msg : message) =
-    let seen_ref = ref seen in
-    let content =
-      List.filter
-        (function
-          | ToolResult { tool_use_id; _ } ->
-            let keep =
-              List.mem tool_use_id allowed && not (List.mem tool_use_id !seen_ref)
-            in
-            if keep then seen_ref := tool_use_id :: !seen_ref;
-            keep
-          | Text _
-          | Thinking _
-          | ReasoningDetails _
-          | RedactedThinking _
-          | ToolUse _
-          | Image _
-          | Document _
-          | Audio _ -> true)
+let strip_orphaned_tool_results_with_report (messages : message list)
+  : message list * repair_report
+  =
+  let filter_tool_results allowed seen report (msg : message) =
+    let content, seen, report =
+      List.fold_left
+        (fun (content, seen, report) block ->
+           match block with
+           | ToolResult { tool_use_id; _ } ->
+             if not (List.mem tool_use_id allowed)
+             then
+               ( content
+               , seen
+               , { report with
+                   dropped_tool_results =
+                     { tool_use_id; reason = Orphaned_tool_result }
+                     :: report.dropped_tool_results
+                 } )
+             else if List.mem tool_use_id seen
+             then
+               ( content
+               , seen
+               , { report with
+                   dropped_tool_results =
+                     { tool_use_id; reason = Duplicate_tool_result }
+                     :: report.dropped_tool_results
+                 } )
+             else block :: content, tool_use_id :: seen, report
+           | Text _
+           | Thinking _
+           | ReasoningDetails _
+           | RedactedThinking _
+           | ToolUse _
+           | Image _
+           | Document _
+           | Audio _ -> block :: content, seen, report)
+        ([], seen, report)
         msg.content
     in
+    let content = List.rev content in
     let msg = if content = [] then None else Some { msg with content } in
-    msg, !seen_ref
+    msg, seen, report
   in
-  let filter_result_span allowed span =
-    let filtered, _seen =
+  let filter_result_span allowed report span =
+    let filtered, _seen, report =
       List.fold_left
-        (fun (acc, seen) msg ->
-           let msg, seen = filter_tool_results allowed seen msg in
+        (fun (acc, seen, report) msg ->
+           let msg, seen, report = filter_tool_results allowed seen report msg in
            match msg with
-           | Some msg -> msg :: acc, seen
-           | None -> acc, seen)
-        ([], [])
+           | Some msg -> msg :: acc, seen, report
+           | None -> acc, seen, report)
+        ([], [], report)
         span
     in
-    List.rev filtered
+    List.rev filtered, report
   in
-  let rec aux acc = function
-    | [] -> List.rev acc
+  let rec aux acc report = function
+    | [] -> List.rev acc, normalize_report report
     | (msg : message) :: rest ->
       let use_ids = if msg.role = Assistant then tool_use_ids msg else [] in
       if use_ids = []
       then (
-        let msg, _seen = filter_tool_results [] [] msg in
+        let msg, _seen, report = filter_tool_results [] [] report msg in
         let acc =
           match msg with
           | Some msg -> msg :: acc
           | None -> acc
         in
-        aux acc rest)
+        aux acc report rest)
       else (
         let span, tail = split_tool_result_span rest in
-        let filtered_span = filter_result_span use_ids span in
-        aux (List.rev_append filtered_span (msg :: acc)) tail)
+        let filtered_span, report = filter_result_span use_ids report span in
+        aux (List.rev_append filtered_span (msg :: acc)) report tail)
   in
-  aux [] messages
+  aux [] empty_repair_report messages
+;;
+
+let strip_orphaned_tool_results (messages : message list) : message list =
+  fst (strip_orphaned_tool_results_with_report messages)
 ;;
 
 let synthetic_tool_result_message (id, _name) =
@@ -137,13 +188,15 @@ let synthetic_tool_result_message (id, _name) =
   }
 ;;
 
-let repair_dangling_tool_calls (messages : message list) : message list =
-  let rec aux acc = function
-    | [] -> List.rev acc
+let repair_dangling_tool_calls_with_report (messages : message list)
+  : message list * repair_report
+  =
+  let rec aux acc report = function
+    | [] -> List.rev acc, normalize_report report
     | (msg : message) :: rest ->
       let uses = if msg.role = Assistant then tool_uses msg else [] in
       if uses = []
-      then aux (msg :: acc) rest
+      then aux (msg :: acc) report rest
       else (
         let result_span, tail = split_tool_result_span rest in
         let result_ids = List.concat_map tool_result_ids result_span in
@@ -151,12 +204,28 @@ let repair_dangling_tool_calls (messages : message list) : message list =
           List.filter (fun (id, _name) -> not (List.mem id result_ids)) uses
         in
         let repairs = List.map synthetic_tool_result_message dangling in
+        let report =
+          { report with
+            synthesized_tool_result_ids =
+              List.rev_append (List.map fst dangling) report.synthesized_tool_result_ids
+          }
+        in
         let segment = (msg :: result_span) @ repairs in
-        aux (List.rev_append segment acc) tail)
+        aux (List.rev_append segment acc) report tail)
   in
-  aux [] messages
+  aux [] empty_repair_report messages
+;;
+
+let repair_dangling_tool_calls (messages : message list) : message list =
+  fst (repair_dangling_tool_calls_with_report messages)
+;;
+
+let close_for_provider_request_with_report messages =
+  let stripped, strip_report = strip_orphaned_tool_results_with_report messages in
+  let repaired, repair_report = repair_dangling_tool_calls_with_report stripped in
+  repaired, append_report strip_report repair_report
 ;;
 
 let close_for_provider_request messages =
-  messages |> strip_orphaned_tool_results |> repair_dangling_tool_calls
+  fst (close_for_provider_request_with_report messages)
 ;;

--- a/lib/llm_provider/tool_message_pairs.mli
+++ b/lib/llm_provider/tool_message_pairs.mli
@@ -5,11 +5,38 @@
     common provider contract that assistant tool calls are immediately followed
     by matching tool results. *)
 
+type dropped_tool_result_reason =
+  | Orphaned_tool_result
+  | Duplicate_tool_result
+
+type dropped_tool_result =
+  { tool_use_id : string
+  ; reason : dropped_tool_result_reason
+  }
+
+type repair_report =
+  { dropped_tool_results : dropped_tool_result list
+  ; synthesized_tool_result_ids : string list
+  }
+
+val empty_repair_report : repair_report
 val strip_orphaned_tool_results : Types.message list -> Types.message list
+
+val strip_orphaned_tool_results_with_report
+  :  Types.message list
+  -> Types.message list * repair_report
 
 (** Insert synthetic error ToolResult messages for assistant ToolUse blocks that
     do not have a matching ToolResult in the immediate result span. *)
 val repair_dangling_tool_calls : Types.message list -> Types.message list
 
+val repair_dangling_tool_calls_with_report
+  :  Types.message list
+  -> Types.message list * repair_report
+
 (** Drop orphan ToolResult blocks, then close dangling ToolUse blocks. *)
 val close_for_provider_request : Types.message list -> Types.message list
+
+val close_for_provider_request_with_report
+  :  Types.message list
+  -> Types.message list * repair_report

--- a/test/test_tool_middleware.ml
+++ b/test/test_tool_middleware.ml
@@ -487,6 +487,7 @@ let test_heal_max_retries_zero () =
 (* ── strip_orphaned_tool_results ──────────────────────────── *)
 
 module Serialize = Llm_provider.Backend_openai_serialize
+module Tool_pairs = Llm_provider.Tool_message_pairs
 
 let mk_msg role content : Types.message =
   { role; content; name = None; tool_call_id = None; metadata = [] }
@@ -535,6 +536,45 @@ let test_strip_removes_orphan () =
   match List.hd user_msg.content with
   | Text _ -> ()
   | _ -> Alcotest.fail "expected Text to survive"
+;;
+
+let test_strip_report_names_orphaned_and_duplicate_results () =
+  let msgs =
+    [ mk_msg Assistant [ ToolUse { id = "t1"; name = "f"; input = `Null } ]
+    ; mk_msg
+        User
+        [ ToolResult
+            { tool_use_id = "t1"
+            ; content = "ok"
+            ; is_error = false
+            ; json = None
+            ; content_blocks = None
+            }
+        ; ToolResult
+            { tool_use_id = "t1"
+            ; content = "duplicate"
+            ; is_error = false
+            ; json = None
+            ; content_blocks = None
+            }
+        ; ToolResult
+            { tool_use_id = "orphan-id"
+            ; content = "stale"
+            ; is_error = true
+            ; json = None
+            ; content_blocks = None
+            }
+        ]
+    ]
+  in
+  let result, report = Serialize.strip_orphaned_tool_results_with_report msgs in
+  let user_msg = List.nth result 1 in
+  Alcotest.(check int) "one result survives" 1 (List.length user_msg.content);
+  match report.dropped_tool_results with
+  | [ { tool_use_id = "t1"; reason = Tool_pairs.Duplicate_tool_result }
+    ; { tool_use_id = "orphan-id"; reason = Tool_pairs.Orphaned_tool_result }
+    ] -> ()
+  | drops -> Alcotest.failf "unexpected drop report length=%d" (List.length drops)
 ;;
 
 let test_strip_preserves_matched () =
@@ -635,6 +675,44 @@ let test_strip_keeps_tool_role_results_before_nudge_text () =
   Alcotest.(check int) "nudge preserved" 1 (List.length nudge_msg.content)
 ;;
 
+let test_close_report_names_dropped_result_and_synthetic_repair () =
+  let msgs =
+    [ mk_msg Assistant [ ToolUse { id = "t1"; name = "f"; input = `Null } ]
+    ; mk_msg User [ Text "nudge: try a different tool" ]
+    ; mk_msg
+        Tool
+        [ ToolResult
+            { tool_use_id = "t1"
+            ; content = "late"
+            ; is_error = false
+            ; json = None
+            ; content_blocks = None
+            }
+        ]
+    ]
+  in
+  let result, report = Serialize.close_tool_message_pairs_for_request_with_report msgs in
+  Alcotest.(check int) "closed length" 3 (List.length result);
+  (match List.nth result 1 with
+   | { Types.metadata; content = [ ToolResult { tool_use_id; is_error; _ } ]; _ } ->
+     Alcotest.(check string) "synthetic id" "t1" tool_use_id;
+     Alcotest.(check bool) "synthetic error" true is_error;
+     Alcotest.(check (option bool))
+       "synthetic metadata"
+       (Some true)
+       (match List.assoc_opt "oas.synthetic_tool_result" metadata with
+        | Some (`Bool value) -> Some value
+        | _ -> None)
+   | _ -> Alcotest.fail "expected synthetic result immediately after assistant");
+  match report.dropped_tool_results, report.synthesized_tool_result_ids with
+  | [ { tool_use_id = "t1"; reason = Tool_pairs.Orphaned_tool_result } ], [ "t1" ] -> ()
+  | drops, synthetic ->
+    Alcotest.failf
+      "unexpected close report drops=%d synthetic=%d"
+      (List.length drops)
+      (List.length synthetic)
+;;
+
 (* ── Runner ──────────────────────────────────────────────── *)
 
 let () =
@@ -701,6 +779,10 @@ let () =
       , [ Alcotest.test_case "no orphans" `Quick test_strip_no_orphans
         ; Alcotest.test_case "removes orphaned result" `Quick test_strip_removes_orphan
         ; Alcotest.test_case
+            "report names orphaned and duplicate results"
+            `Quick
+            test_strip_report_names_orphaned_and_duplicate_results
+        ; Alcotest.test_case
             "preserves matched result"
             `Quick
             test_strip_preserves_matched
@@ -713,6 +795,10 @@ let () =
             "tool role result before nudge keeps results"
             `Quick
             test_strip_keeps_tool_role_results_before_nudge_text
+        ; Alcotest.test_case
+            "close report names drop and repair"
+            `Quick
+            test_close_report_names_dropped_result_and_synthetic_repair
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- add report-bearing Tool_message_pairs APIs for orphan/duplicate ToolResult drops and dangling ToolUse synthetic repairs
- expose the report-bearing provider serialization helpers through Backend_openai_serialize
- cover dropped ToolResult ids and synthetic repair ids in tool middleware tests

## Verification
- `opam exec -- ocamlformat --check lib/llm_provider/tool_message_pairs.ml lib/llm_provider/tool_message_pairs.mli lib/llm_provider/backend_openai_serialize.ml lib/llm_provider/backend_openai_serialize.mli test/test_tool_middleware.ml`
- `git diff --check`
- `scripts/hardening-ratchet.sh --self-test`
- `scripts/hardening-ratchet.sh --check`
- `scripts/ci-code-smell-ratchet.sh --check`

No local Dune run; Dune build/test is left to GitHub CI per workflow guidance.