### PR TITLE
refactor(provider): centralize Gemini thinking classification

### DIFF
--- a/lib/llm_provider/backend_gemini.ml
+++ b/lib/llm_provider/backend_gemini.ml
@@ -55,8 +55,7 @@ let thinking_level_of_budget ~supports_minimal = function
 ;;
 
 let thinking_config_of_config (config : Provider_config.t) =
-  let model_id = String.lowercase_ascii (String.trim config.model_id) in
-  match Capabilities.gemini_thinking_control_of_id model_id with
+  match Capabilities.gemini_thinking_control_of_id config.model_id with
   | Capabilities.Gemini_thinking_level { supports_minimal } ->
     (match config.enable_thinking with
      | Some false ->

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -523,7 +523,8 @@ let gemini_family_of_id (id : string) : gemini_family =
   else Gemini_other id
 ;;
 
-let gemini_thinking_control_of_id id =
+let gemini_thinking_control_of_id raw_id =
+  let id = String.lowercase_ascii (String.trim raw_id) in
   match gemini_family_of_id id with
   | Gemini_3_1 ->
     (* Per ai.google.dev/gemini-api/docs/thinking and the gemini-3.1-flash-lite

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -192,7 +192,8 @@ type gemini_thinking_control =
 val gemini_family_of_id : string -> gemini_family
 
 (** Return the documented thinking-control protocol for a Gemini model id.
-    Input is expected lowercased, matching {!gemini_family_of_id}. *)
+    Accepts raw config values; trims and lowercases before delegating to the
+    bounded {!gemini_family_of_id} classifier. *)
 val gemini_thinking_control_of_id : string -> gemini_thinking_control
 
 (** Look up capabilities for [model_id] in the loaded model catalog only

--- a/test/test_backend_gemini.ml
+++ b/test/test_backend_gemini.ml
@@ -148,9 +148,12 @@ let test_gemini3_disable_uses_low_level () =
 
 let test_gemini31_flash_lite_disable_uses_minimal_level () =
   (* gemini-3.1-flash-lite is the only family that accepts [minimal] (and it is
-     the default there), so a disabled turn maps to [minimal]. *)
+     the default there), so a disabled turn maps to [minimal]. The config value
+     is intentionally raw-cased/padded: backend_gemini must not reclassify model
+     strings itself; [Capabilities.gemini_thinking_control_of_id] owns the
+     normalization boundary. *)
   let config =
-    gemini_config ~model_id:"gemini-3.1-flash-lite" ~enable_thinking:false ()
+    gemini_config ~model_id:" Gemini-3.1-Flash-Lite " ~enable_thinking:false ()
   in
   let body = Backend_gemini.build_request ~config ~messages:[ Types.user_msg "Hi." ] () in
   let tc = parse_body body |> member "generationConfig" |> member "thinkingConfig" in


### PR DESCRIPTION
## Summary
- move raw Gemini model-id normalization into Capabilities.gemini_thinking_control_of_id
- remove backend_gemini local model-id string classifier so Gemini thinking selection uses the capability boundary
- cover raw-cased/padded Gemini flash-lite config input in the backend request test

## Verification
- opam exec -- ocamlformat --check lib/llm_provider/backend_gemini.ml lib/llm_provider/capabilities.ml lib/llm_provider/capabilities.mli test/test_backend_gemini.ml
- git diff --check
- scripts/hardening-ratchet.sh --check
- scripts/ci-code-smell-ratchet.sh --check
- Local Dune not run per workflow; GitHub CI is the build/test authority