### PR TITLE
refactor(provider): route secret env reads through boundary

### DIFF
--- a/lib/llm_provider/secret.ml
+++ b/lib/llm_provider/secret.ml
@@ -11,8 +11,8 @@ type t = string
 
 let of_string s = s
 
-let of_env var =
-  match Sys.getenv_opt var with
+let of_env ?(getenv = Cli_common_env.default_getenv) var =
+  match Cli_common_env.get ~getenv var with
   | Some s -> Some (of_string s)
   | None -> None
 ;;
@@ -39,4 +39,16 @@ let%test "empty secret is empty" = is_empty empty
 
 let%test "secret of string round-trips through header_value" =
   header_value (of_string "k") = "k"
+;;
+
+let%test "secret of_env honors injected env boundary" =
+  let getenv name = if String.equal name "OAS_TEST_SECRET" then Some "  k  " else None in
+  match of_env ~getenv "OAS_TEST_SECRET" with
+  | Some secret -> header_value secret = "k"
+  | None -> false
+;;
+
+let%test "secret of_env treats empty env value as absent" =
+  let getenv name = if String.equal name "OAS_TEST_SECRET" then Some "   " else None in
+  of_env ~getenv "OAS_TEST_SECRET" = None
 ;;

--- a/lib/llm_provider/secret.mli
+++ b/lib/llm_provider/secret.mli
@@ -10,7 +10,12 @@
 type t = private string
 
 val of_string : string -> t
-val of_env : string -> t option
+
+(** [of_env ?getenv var] reads [var] through the canonical environment
+    boundary and wraps a non-empty value as a secret. [?getenv] is useful for
+    tests/callers that need to resolve values without reading process env. *)
+val of_env : ?getenv:(string -> string option) -> string -> t option
+
 val empty : t
 val is_empty : t -> bool
 


### PR DESCRIPTION
## Summary
- route Secret.of_env through Cli_common_env instead of a direct process env read
- add an optional getenv seam while preserving existing Secret.of_env var callers
- cover injected env and empty-value behavior without mutating process env

## Verification
- opam exec -- ocamlformat --check lib/llm_provider/secret.ml lib/llm_provider/secret.mli
- git diff --check
- scripts/hardening-ratchet.sh --check
- scripts/ci-code-smell-ratchet.sh --check
- Local Dune not run per workflow; GitHub CI is the build/test authority