### PR TITLE
refactor(eval): route code snippet flag through env boundary

### DIFF
--- a/lib/code_snippet_eval.ml
+++ b/lib/code_snippet_eval.ml
@@ -192,7 +192,7 @@ let truthy_env value =
   | _ -> false
 ;;
 
-let is_experiment_enabled ?(getenv = Sys.getenv_opt) () =
+let is_experiment_enabled ?(getenv = Llm_provider.Cli_common_env.default_getenv) () =
   match getenv experimental_env_var with
   | Some value -> truthy_env value
   | None -> false

--- a/lib/code_snippet_eval.mli
+++ b/lib/code_snippet_eval.mli
@@ -61,6 +61,10 @@ val compare_task
 val evaluate : ?gate:gate -> comparison list -> gate_result
 val metrics_of_gate_result : gate_result -> Eval.metric list
 val verdict_of_gate_result : gate_result -> Harness.verdict
+
+(** [is_experiment_enabled ?getenv ()] reads the experiment flag through the
+    canonical environment boundary by default. [?getenv] lets tests/callers
+    avoid reading process env directly. *)
 val is_experiment_enabled : ?getenv:(string -> string option) -> unit -> bool
 
 val require_experiment_enabled


### PR DESCRIPTION
## Summary
- route Code_snippet_eval's default experiment flag lookup through Llm_provider.Cli_common_env
- preserve the existing optional getenv seam for tests and callers
- document that the default lookup uses the canonical env boundary

## Verification
- opam exec -- ocamlformat --check lib/code_snippet_eval.ml lib/code_snippet_eval.mli
- git diff --check
- scripts/hardening-ratchet.sh --check
- scripts/ci-code-smell-ratchet.sh --check
- Local Dune not run per workflow; GitHub CI is the build/test authority