### PR TITLE
refactor(provider): route constants env reads through boundary

### DIFF
--- a/lib/llm_provider/constants.ml
+++ b/lib/llm_provider/constants.ml
@@ -14,9 +14,10 @@ module Env = struct
   let anthropic_thinking_budget = "OAS_ANTHROPIC_THINKING_BUDGET"
   let gemini_thinking_budget = "OAS_GEMINI_THINKING_BUDGET"
   let prompt_cache_min_chars = "OAS_PROMPT_CACHE_MIN_CHARS"
+  let default_seed = "OAS_DEFAULT_SEED"
 end
 
-let positive_int_env_opt ?(getenv = Sys.getenv_opt) var =
+let positive_int_env_opt ?(getenv = Cli_common_env.default_getenv) var =
   match getenv var with
   | None -> None
   | Some s ->
@@ -245,14 +246,14 @@ module Deterministic = struct
       @since 0.185.0 *)
   let default_seed = 42
 
-  let seed_of_env () =
-    match Sys.getenv "OAS_DEFAULT_SEED" with
-    | exception Not_found -> None
-    | s ->
+  let seed_of_env ?(getenv = Cli_common_env.default_getenv) () =
+    match getenv Env.default_seed with
+    | None -> None
+    | Some s ->
       (match int_of_string_opt s with
        | Some n -> Some n
        | None ->
-         Diag.warn "constants" "OAS_DEFAULT_SEED=%S is not a valid int, ignoring" s;
+         Diag.warn "constants" "%s=%S is not a valid int, ignoring" Env.default_seed s;
          None)
   ;;
 end

--- a/test/test_llm_provider_cov.ml
+++ b/test/test_llm_provider_cov.ml
@@ -808,6 +808,7 @@ let test_constants_env_helpers () =
       ; Constants.Env.anthropic_thinking_budget, "2048"
       ; Constants.Env.gemini_thinking_budget, "3072"
       ; Constants.Env.prompt_cache_min_chars, "4096"
+      ; Constants.Env.default_seed, "123"
       ]
   in
   Alcotest.(check int)
@@ -830,10 +831,15 @@ let test_constants_env_helpers () =
     "prompt cache chars env override"
     4096
     (Constants.Anthropic.prompt_cache_min_chars_for_env ~getenv ());
+  Alcotest.(check (option int))
+    "seed env override"
+    (Some 123)
+    (Constants.Deterministic.seed_of_env ~getenv ());
   let invalid_getenv =
     getenv_from
       [ Constants.Env.max_tokens_default, "0"
       ; Constants.Env.prompt_cache_min_chars, "not-an-int"
+      ; Constants.Env.default_seed, "not-an-int"
       ]
   in
   Alcotest.(check int)
@@ -844,16 +850,10 @@ let test_constants_env_helpers () =
     "prompt cache invalid env fallback"
     Constants.Anthropic.default_prompt_cache_min_chars
     (Constants.Anthropic.prompt_cache_min_chars_for_env ~getenv:invalid_getenv ());
-  with_env "OAS_DEFAULT_SEED" (Some "123") (fun () ->
-    Alcotest.(check (option int))
-      "seed valid"
-      (Some 123)
-      (Constants.Deterministic.seed_of_env ()));
-  with_env "OAS_DEFAULT_SEED" (Some "not-an-int") (fun () ->
-    Alcotest.(check (option int))
-      "seed invalid"
-      None
-      (Constants.Deterministic.seed_of_env ()));
+  Alcotest.(check (option int))
+    "seed invalid"
+    None
+    (Constants.Deterministic.seed_of_env ~getenv:invalid_getenv ());
   with_env "OAS_THINKING_BUDGET_DEFAULT" (Some "4096") (fun () ->
     Alcotest.(check (option int))
       "env budget valid"


### PR DESCRIPTION
## Summary

- route constants env defaults through `Cli_common_env.default_getenv`
- expose `OAS_DEFAULT_SEED` via the existing constants env-name module
- cover seed parsing with injected env readers instead of process env mutation

## Verification

- `opam exec -- ocamlformat --check lib/llm_provider/constants.ml test/test_llm_provider_cov.ml`
- `git diff --check`
- `scripts/hardening-ratchet.sh --check`
- `scripts/ci-code-smell-ratchet.sh --check`

Local Dune was intentionally not run; GitHub CI is the Dune build/test authority for this PR.
