### PR TITLE
feat(capabilities): derive show+eq on thinking_control_format

### DIFF
--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -22,6 +22,15 @@ type thinking_control_format = Capability_vocab.thinking_control_format =
   | Ollama_think
   | Reasoning_effort
   | Enable_thinking
+  (** DashScope-style top-level [enable_thinking] / [preserve_thinking] bools
+      plus optional [thinking_budget]. *)
+[@@deriving show, eq]
+
+let%test "thinking_control_format derives equal and show" =
+  equal_thinking_control_format No_thinking_control No_thinking_control
+  && (not (equal_thinking_control_format No_thinking_control Enable_thinking))
+  && String.length (show_thinking_control_format Enable_thinking) > 0
+;;
 
 type preserve_thinking_control_format =
       Capability_vocab.preserve_thinking_control_format =

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -16,6 +16,9 @@ type thinking_control_format = Capability_vocab.thinking_control_format =
   | Ollama_think
   | Reasoning_effort
   | Enable_thinking
+  (** DashScope-style top-level [enable_thinking] / [preserve_thinking] bools
+      plus optional [thinking_budget]. *)
+[@@deriving show, eq]
 
 type preserve_thinking_control_format =
       Capability_vocab.preserve_thinking_control_format =

--- a/lib/llm_provider/dune
+++ b/lib/llm_provider/dune
@@ -20,6 +20,6 @@
   uri)
  (inline_tests)
  (preprocess
-  (pps ppx_deriving_yojson ppx_deriving.show ppx_inline_test))
+  (pps ppx_deriving_yojson ppx_deriving.show ppx_deriving.eq ppx_inline_test))
  (instrumentation
   (backend bisect_ppx)))


### PR DESCRIPTION
## 목표

`Llm_provider.Capabilities.thinking_control_format`(9-constructor variant)에 `[@@deriving show, eq]`를 추가해, consumer가 그 9개 변형을 **재선언**(drift원)하지 않고 drift-free 축약으로 소비하게 합니다.

## 동기

thinking_control_format은 현재 `[@@deriving]`이 전혀 없어, OAS 내부는 polymorphic `=`만 사용(capabilities.ml의 `=` 비교). 그런데 downstream consumer(MASC `runtime_schema`)는 이 타입을 `= Llm_provider.Capabilities.thinking_control_format = | No_thinking_control | ... | Enable_thinking [@@deriving show, eq]`로 **재선언**해 `equal_thinking_control_format`/`show_`를 local에서 생성합니다. 그 이유:
- `Runtime_schema.equal_thinking_control_format`를 config 검증 테스트 4곳에서 직접 호출.
- `model_capabilities` record가 `[@@deriving show, eq]`라 thinking_control_format 필드의 `equal_`/`show_`가 scope에 필요(전이).

OAS가 eq/show derive를 안 줘서 강제된 재선언입니다. 9-variant 재-list는 OAS가 변형을 추가하면 drift(=이전 `reasoning_output_format` 추가 시 빌드 깨짐 사례). 이는 #2355(`Provider.capabilities` 등식 숨김)와 **같은 OAS-consumer-ergonomics 갭**입니다. 전수 감사 workflow로 확인(actionable 1건 = 이 케이스; keeper_failure_policy 등 zero-dep deliberate-decoupling 2건은 fix 대상 제외; refuted 6/8).

## 변경

- `lib/llm_provider/dune`: `(pps ...)`에 `ppx_deriving.eq` 추가(ppx_deriving 패키지 내장, 새 opam 의존성 아님; show는 이미 있음).
- `lib/llm_provider/capabilities.ml` / `.mli`: thinking_control_format에 `[@@deriving show, eq]`.
- inline 테스트: `equal_`/`show_` derive 동작 증명.

## 영향 / 경계

- **순수 additive**: 새 함수(`equal_`/`show_`/`pp_thinking_control_format`)만 추가. OAS는 polymorphic `=` 사용 중이라 기존 call site 무영향.
- OAS-internal. MASC를 참조하지 않음(경계 준수).
- 이 release 후 MASC가 재선언을 `type thinking_control_format = Llm_provider.Capabilities.thinking_control_format [@@deriving show, eq]` 한 줄 축약으로 교체(ppx가 OAS의 `equal_`/`show_`에 위임 → drift 0).

## 검증

- 로컬 빌드는 machine-wide dune 락(병렬 세션 빌드 점유)으로 미실행 → CI. eq deriver 가용성(ppx_deriving.eq 미존재) 확인 후 pps에 추가함.
