### PR TITLE
fix(provider): resolve dot-qualified catalog models

### DIFF
--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -1136,8 +1136,14 @@ let provider_qualified_model_id_candidates ~provider_label ~model_id =
          else None)
       provider_prefixes
   in
+  (* When [model_id] is already provider-qualified, only the stripped bare
+     suffix is a useful candidate for re-qualification below in
+     [provider_qualified_catalog_keys]. Including the original [model_id]
+     alongside it used to make that function re-prepend [provider_label] onto
+     an already-qualified id (e.g. "runpod_mtp/runpod_mtp.qwen..."), which
+     never matches a real catalog [id_prefix] — pure wasted lookups. *)
   match stripped with
-  | Some suffix when String.trim suffix <> "" -> [ suffix; model_id ]
+  | Some suffix when String.trim suffix <> "" -> [ suffix ]
   | Some _ | None -> [ model_id ]
 ;;
 

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -1119,6 +1119,44 @@ let apply_catalog_entry (entry : Model_catalog.model_entry) : capabilities =
     no entry whose [id_prefix] matches [model_id]. There is no in-code
     fallback table: the former built-in static table was removed when
     model specifications were externalized to the TOML catalog. *)
+let provider_qualified_separators = [ "/"; ":"; "." ]
+
+let provider_qualified_model_id_candidates ~provider_label ~model_id =
+  let normalized_model_id = String.lowercase_ascii model_id in
+  let provider_prefixes =
+    List.map (fun separator -> provider_label ^ separator) provider_qualified_separators
+  in
+  let stripped =
+    List.find_map
+      (fun prefix ->
+         if String.starts_with ~prefix normalized_model_id
+         then (
+           let prefix_len = String.length prefix in
+           Some (String.sub model_id prefix_len (String.length model_id - prefix_len)))
+         else None)
+      provider_prefixes
+  in
+  match stripped with
+  | Some suffix when String.trim suffix <> "" -> [ suffix; model_id ]
+  | Some _ | None -> [ model_id ]
+;;
+
+let provider_qualified_catalog_keys ~provider_label ~model_id =
+  let provider_label = String.lowercase_ascii (String.trim provider_label) in
+  let model_id = String.trim model_id in
+  let keys =
+    provider_qualified_model_id_candidates ~provider_label ~model_id
+    |> List.concat_map (fun model_id ->
+      List.map
+        (fun separator -> provider_label ^ separator ^ model_id)
+        provider_qualified_separators)
+  in
+  let prefixes =
+    List.map (fun separator -> provider_label ^ separator) provider_qualified_separators
+  in
+  keys, prefixes
+;;
+
 let for_model_id_catalog model_id =
   match Model_catalog.global () with
   | Some catalog ->
@@ -1158,10 +1196,9 @@ let for_model_id model_id =
 ;;
 
 let for_provider_model_id_catalog ~(provider_label : string) ~(model_id : string) =
-  let provider_label = String.lowercase_ascii (String.trim provider_label) in
-  let model_id = String.trim model_id in
-  let candidates = [ provider_label ^ "/" ^ model_id; provider_label ^ ":" ^ model_id ] in
-  let qualified_prefixes = [ provider_label ^ "/"; provider_label ^ ":" ] in
+  let candidates, qualified_prefixes =
+    provider_qualified_catalog_keys ~provider_label ~model_id
+  in
   match Model_catalog.global () with
   | None -> None
   | Some catalog ->
@@ -1233,10 +1270,9 @@ let thinking_control_token_for_provider_model_id
       ~(provider_label : string)
       ~(model_id : string)
   =
-  let provider_label = String.lowercase_ascii (String.trim provider_label) in
-  let model_id = String.trim model_id in
-  let candidates = [ provider_label ^ "/" ^ model_id; provider_label ^ ":" ^ model_id ] in
-  let qualified_prefixes = [ provider_label ^ "/"; provider_label ^ ":" ] in
+  let candidates, qualified_prefixes =
+    provider_qualified_catalog_keys ~provider_label ~model_id
+  in
   let provider_catalog_match =
     match Model_catalog.global () with
     | None -> None

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -216,13 +216,15 @@ val for_model_id_catalog : string -> capabilities option
 (** Look up capabilities for [model_id] with a provider-qualified catalog
     override first.
 
-    Provider-qualified entries use [<provider_label>/<model_id>] or
-    [<provider_label>:<model_id>] prefixes in [models.toml]. When no qualified
-    entry matches, [allow_bare_fallback] controls whether this falls back to
-    {!for_model_id}. This lets transports such as Ollama Cloud override bare
-    model-family entries that are shared with other providers (for example
-    [glm-5] or [kimi-k2.6]) without coupling the catalog to any embedding
-    application. *)
+    Provider-qualified entries use [<provider_label>/<model_id>],
+    [<provider_label>:<model_id>], or [<provider_label>.<model_id>] prefixes in
+    [models.toml]. The dot form covers embedding runtimes that flatten
+    [provider_label] and [model_id] into one model identifier while keeping the
+    same provider-qualified catalog semantics. When no qualified entry matches,
+    [allow_bare_fallback] controls whether this falls back to {!for_model_id}.
+    This lets transports such as Ollama Cloud override bare model-family entries
+    that are shared with other providers (for example [glm-5] or [kimi-k2.6])
+    without coupling the catalog to any embedding application. *)
 val for_provider_model_id
   :  allow_bare_fallback:bool
   -> provider_label:string

--- a/lib/llm_provider/model_catalog.ml
+++ b/lib/llm_provider/model_catalog.ml
@@ -385,18 +385,43 @@ let load_runtime_file path =
     None
 ;;
 
+let dot_qualified_aliases model_id =
+  let original_model_id = String.trim model_id in
+  match String.index_opt original_model_id '.' with
+  | None -> []
+  | Some index when index = 0 || index = String.length original_model_id - 1 -> []
+  | Some index ->
+    let provider_label = String.lowercase_ascii (String.sub original_model_id 0 index) in
+    let model_id =
+      String.sub
+        original_model_id
+        (index + 1)
+        (String.length original_model_id - index - 1)
+    in
+    [ provider_label ^ "/" ^ model_id; provider_label ^ ":" ^ model_id ]
+;;
+
 let lookup t model_id =
-  let m = String.lowercase_ascii (String.trim model_id) in
   let sorted_t =
     List.fast_sort
       (fun a b -> compare (String.length b.id_prefix) (String.length a.id_prefix))
       t
   in
-  List.find_opt
-    (fun entry ->
-       let prefix = String.lowercase_ascii entry.id_prefix in
-       String.starts_with ~prefix m)
-    sorted_t
+  let rec lookup_candidates = function
+    | [] -> None
+    | candidate :: rest ->
+      let m = String.lowercase_ascii (String.trim candidate) in
+      (match
+         List.find_opt
+           (fun entry ->
+              let prefix = String.lowercase_ascii entry.id_prefix in
+              String.starts_with ~prefix m)
+           sorted_t
+       with
+       | Some _ as entry -> entry
+       | None -> lookup_candidates rest)
+  in
+  lookup_candidates (model_id :: dot_qualified_aliases model_id)
 ;;
 
 let provider_name_for_model_id t model_id =

--- a/lib/llm_provider/model_catalog.mli
+++ b/lib/llm_provider/model_catalog.mli
@@ -54,6 +54,15 @@ type t = model_entry list
 
 val load_file : string -> (t, string) result
 val load_runtime_file : string -> t option
+
+(** Longest-prefix lookup for catalog model IDs.
+
+    In addition to exact catalog syntax, [lookup] accepts a flattened
+    [<provider_label>.<model_id>] value and resolves it against
+    [<provider_label>/<model_id>] or [<provider_label>:<model_id>] entries. This
+    keeps embedding runtimes that use dot-qualified model identifiers on the
+    same provider-qualified catalog path rather than falling back to generic
+    OpenAI-compatible capabilities. *)
 val lookup : t -> string -> model_entry option
 
 (** Return the catalog-declared provider identity for the longest matching

--- a/lib/provider_runtime_binding.ml
+++ b/lib/provider_runtime_binding.ml
@@ -386,7 +386,15 @@ let capabilities_for_provider_config (cfg : PConfig.t) =
   let caps =
     match PConfig.capabilities_for_config_model cfg with
     | Some model_caps -> model_caps
-    | None -> caps
+    | None ->
+      (match
+         Llm_provider.Capabilities.for_provider_model_id
+           ~allow_bare_fallback:false
+           ~provider_label:(provider_id_of_provider_config cfg)
+           ~model_id:cfg.model_id
+       with
+       | Some model_caps -> model_caps
+       | None -> caps)
   in
   match cfg.supports_tool_choice_override with
   | Some supports_tool_choice ->

--- a/models.toml
+++ b/models.toml
@@ -1853,6 +1853,7 @@ supports_min_p = true
 [[models]]
 id_prefix = "runpod_mtp/qwen36-35b-a3b-mtp"
 base = "openai_chat"
+provider_name = "runpod_mtp"
 max_context_tokens = 131072
 supports_tools = true
 supports_tool_choice = true

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -434,6 +434,21 @@ let test_lookup_provider_m_runpod_name () =
   | None -> fail "should match qwen3.6 runpod model id"
 ;;
 
+let test_lookup_provider_m_runpod_dot_name () =
+  match Capabilities.for_model_id "runpod_mtp.qwen36-35b-a3b-mtp" with
+  | Some c ->
+    check (option int) "context 128K" (Some 131_072) c.max_context_tokens;
+    check bool "tools" true c.supports_tools;
+    check bool "parallel tools" true c.supports_parallel_tool_calls;
+    check bool "reasoning" true c.supports_reasoning;
+    check
+      bool
+      "runpod dot-qualified qwen3.6 uses chat_template_kwargs"
+      true
+      (c.thinking_control_format = Capabilities.Chat_template_kwargs)
+  | None -> fail "should match dot-qualified qwen3.6 runpod model id"
+;;
+
 let test_lookup_deepseek_v4_flash () =
   match Capabilities.for_model_id "deepseek-v4-flash" with
   | Some c ->
@@ -2137,6 +2152,10 @@ let () =
             test_lookup_kimi_k2_native_cloud_suffix
         ; test_case "dashscope" `Quick test_lookup_provider_m
         ; test_case "dashscope runpod name" `Quick test_lookup_provider_m_runpod_name
+        ; test_case
+            "dashscope runpod dot-qualified name"
+            `Quick
+            test_lookup_provider_m_runpod_dot_name
         ; test_case "deepseek v4 flash" `Quick test_lookup_deepseek_v4_flash
         ; test_case "deepseek v4 pro" `Quick test_lookup_deepseek_v4_pro
         ; test_case

--- a/test/test_provider_agnostic_reasoning_replay.ml
+++ b/test/test_provider_agnostic_reasoning_replay.ml
@@ -42,9 +42,12 @@ let msg role content : message =
 let reasoning_marker = "REASONING_MUST_NOT_BECOME_ANSWER"
 let answer_text = "the visible answer"
 
-(* Every exported provider capability profile. Adding a provider profile to
-   capabilities.ml and here keeps the invariant coverage exhaustive. *)
-let provider_profiles : (string * Capabilities.capabilities) list =
+(* Every exported provider capability profile plus representative catalog model
+   entries for current frontier families. Provider profiles cover protocol base
+   behavior; catalog entries cover model-specific thinking / replay overrides
+   where the latest Kimi, MiniMax, GLM, DeepSeek, Qwen, MiMo, and DashScope
+   contracts actually live. *)
+let base_provider_profiles : (string * Capabilities.capabilities) list =
   [ "default", Capabilities.default_capabilities
   ; "anthropic", Capabilities.anthropic_capabilities
   ; "kimi", Capabilities.kimi_capabilities
@@ -57,6 +60,42 @@ let provider_profiles : (string * Capabilities.capabilities) list =
   ; "glm", Capabilities.glm_capabilities
   ; "provider_l", Capabilities.provider_l_capabilities
   ]
+;;
+
+let catalog_model_profile_resolvers
+  : (string * (unit -> Capabilities.capabilities option)) list
+  =
+  [ ("model:mimo-v2.5-pro", fun () -> Capabilities.for_model_id "mimo-v2.5-pro")
+  ; ("model:deepseek-v4-flash", fun () -> Capabilities.for_model_id "deepseek-v4-flash")
+  ; ("model:deepseek-v4-pro", fun () -> Capabilities.for_model_id "deepseek-v4-pro")
+  ; ("model:minimax-m3", fun () -> Capabilities.for_model_id "minimax-m3")
+  ; ("model:kimi-k2.7-code", fun () -> Capabilities.for_model_id "kimi-k2.7-code")
+  ; ("model:glm-5.2", fun () -> Capabilities.for_model_id "glm-5.2")
+  ; ( "model:qwen/qwen3.6-35b-a3b"
+    , fun () -> Capabilities.for_model_id "qwen/qwen3.6-35b-a3b" )
+  ; ( "model:dashscope-3.5-35b-a3b"
+    , fun () -> Capabilities.for_model_id "dashscope-3.5-35b-a3b" )
+  ; ( "provider:runpod_mtp.runpod_mtp.qwen36-35b-a3b-mtp"
+    , fun () ->
+        Capabilities.for_provider_model_id
+          ~allow_bare_fallback:false
+          ~provider_label:"runpod_mtp"
+          ~model_id:"runpod_mtp.qwen36-35b-a3b-mtp" )
+  ]
+;;
+
+let profile_cases () =
+  Model_catalog_test_support.install_repo_model_catalog
+    ~suite:"provider_agnostic_reasoning_replay";
+  let catalog_profiles =
+    List.map
+      (fun (name, resolve) ->
+         match resolve () with
+         | Some caps -> name, caps
+         | None -> Alcotest.failf "expected catalog capabilities for %s" name)
+      catalog_model_profile_resolvers
+  in
+  base_provider_profiles @ catalog_profiles
 ;;
 
 let serialized_assistant dialect msg =
@@ -119,7 +158,7 @@ let test_reasoning_never_in_content_any_provider () =
               false
               (contains ~needle:reasoning_marker c))
          shapes)
-    provider_profiles
+    (profile_cases ())
 ;;
 
 (* INV2: the replay decision is one shared function of (policy, had_tool_call),
@@ -177,7 +216,7 @@ let test_replay_matches_should_replay_reasoning_any_provider () =
          (Printf.sprintf "[%s] plain answer content is the answer text only" name)
          answer_text
          (content_string j_plain))
-    provider_profiles
+    (profile_cases ())
 ;;
 
 (* INV3 (recursion closure): simulate N replay rounds of a reasoning-only reply
@@ -199,7 +238,7 @@ let test_reasoning_only_replay_does_not_accumulate () =
            ""
            c
        done)
-    provider_profiles
+    (profile_cases ())
 ;;
 
 (* End-to-end loop closure: parse a real provider response carrying
@@ -272,7 +311,7 @@ let test_parse_then_serialize_round_trip_any_provider () =
          (Printf.sprintf "[%s] reasoning marker absent from answer content" name)
          false
          (contains ~needle:reasoning_marker (content_string j)))
-    provider_profiles
+    (profile_cases ())
 ;;
 
 let () =

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -675,6 +675,33 @@ thinking_control_format = "chat_template_kwargs"
          (Option.is_none (Provider_config.capabilities_for_config_model cfg)))
 ;;
 
+let test_openai_compat_raw_dot_qualified_provider_row_requires_endpoint_declaration () =
+  with_model_catalog_toml
+    {|
+[[models]]
+id_prefix = "runpod_mtp/qwen36-35b-a3b-mtp"
+base = "openai_chat"
+provider_name = "runpod_mtp"
+supports_tools = true
+supports_tool_choice = true
+supports_reasoning = true
+supports_extended_thinking = true
+thinking_control_format = "chat_template_kwargs"
+|}
+    (fun () ->
+       let cfg =
+         Provider_config.make
+           ~kind:OpenAI_compat
+           ~model_id:"runpod_mtp.qwen36-35b-a3b-mtp"
+           ~base_url:"https://unknown-openai-compatible.example/v1"
+           ()
+       in
+       check_bool
+         "provider_name alone is not raw endpoint identity proof"
+         true
+         (Option.is_none (Provider_config.capabilities_for_config_model cfg)))
+;;
+
 let test_validate_responses_request_path_allows_structured_output () =
   let cfg =
     Provider_config.make
@@ -2043,6 +2070,10 @@ let () =
             "raw compat template dialect requires endpoint declaration"
             `Quick
             test_openai_compat_raw_template_dialect_requires_endpoint_declaration
+        ; Alcotest.test_case
+            "raw compat dot-qualified provider row requires endpoint declaration"
+            `Quick
+            test_openai_compat_raw_dot_qualified_provider_row_requires_endpoint_declaration
         ; Alcotest.test_case
             "responses structured path accepted"
             `Quick

--- a/test/test_provider_runtime_binding.ml
+++ b/test/test_provider_runtime_binding.ml
@@ -277,6 +277,66 @@ reasoning_replay = "preserve_always"
          (caps.reasoning_replay_override = Llm_provider.Capabilities.Force_preserve_always))
 ;;
 
+let test_capabilities_for_provider_config_uses_dot_qualified_model_catalog () =
+  with_provider_catalog
+    {|
+{
+  "schema_version": 1,
+  "providers": [
+    {
+      "id": "runpod_mtp",
+      "kind": "openai_compat",
+      "transport": "http",
+      "base_url": "https://runpod.example.invalid/v1",
+      "request_path": "/chat/completions",
+      "auth": {"type": "none"},
+      "capabilities_base": "openai_chat"
+    }
+  ]
+}
+|}
+    (fun () ->
+       with_model_catalog
+         {|
+[[models]]
+id_prefix = "runpod_mtp/qwen36-35b-a3b-mtp"
+base = "openai_chat"
+provider_name = "runpod_mtp"
+supports_tools = true
+supports_tool_choice = true
+supports_parallel_tool_calls = true
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "chat_template_kwargs"
+preserve_thinking_control_format = "chat_template_kwargs_preserve_thinking"
+|}
+         (fun () ->
+            let cfg =
+              Llm_provider.Provider_config.make
+                ~kind:Llm_provider.Provider_config.OpenAI_compat
+                ~model_id:"runpod_mtp.qwen36-35b-a3b-mtp"
+                ~base_url:"https://runpod.example.invalid/v1"
+                ~request_path:"/chat/completions"
+                ()
+            in
+            let caps = Provider_runtime_binding.capabilities_for_provider_config cfg in
+            Alcotest.(check bool) "runpod row keeps tools" true caps.supports_tools;
+            Alcotest.(check bool)
+              "runpod row keeps parallel tools"
+              true
+              caps.supports_parallel_tool_calls;
+            Alcotest.(check bool)
+              "runpod row keeps reasoning"
+              true
+              caps.supports_reasoning;
+            Alcotest.(check bool)
+              "runpod row uses chat_template_kwargs"
+              true
+              (caps.thinking_control_format
+               = Llm_provider.Capabilities.Chat_template_kwargs)))
+;;
+
 let expect_tool_choice_ok label cfg =
   match Llm_provider.Provider_config.validate_tool_choice_request_typed cfg with
   | Ok () -> ()
@@ -662,6 +722,10 @@ let () =
             "provider-qualified model catalog capabilities"
             `Quick
             test_capabilities_for_provider_config_uses_provider_qualified_model_catalog
+        ; Alcotest.test_case
+            "dot-qualified model catalog capabilities"
+            `Quick
+            test_capabilities_for_provider_config_uses_dot_qualified_model_catalog
         ; Alcotest.test_case
             "forced tool_choice provider invariants"
             `Quick


### PR DESCRIPTION
## Summary

- Resolve flattened `provider.model` catalog IDs through provider-qualified model catalog lookup.
- Keep the raw OpenAI-compatible rich capability guard, but allow endpoint-confirmed/provider-name-declared catalog rows.
- Mark `runpod_mtp/qwen36-35b-a3b-mtp` with `provider_name` and cover `runpod_mtp.qwen36-35b-a3b-mtp`.
- Extend the provider-agnostic reasoning replay harness from base provider profiles to representative catalog profiles for current frontier model families: Kimi, MiniMax, GLM, DeepSeek, Qwen, MiMo, DashScope, and the dotted RunPod route.

## Verification

- `scripts/dune-local.sh build @fmt`
- `scripts/dune-local.sh build test/test_property_advanced.exe test/test_capabilities.exe test/test_provider_runtime_binding.exe test/test_provider_config.exe`
- `scripts/dune-local.sh build test/test_provider_agnostic_reasoning_replay.exe test/test_capabilities.exe`
- `env OAS_MODEL_CATALOG=models.toml ./_build/default/test/test_property_advanced.exe`
- `env OAS_MODEL_CATALOG=models.toml ./_build/default/test/test_provider_runtime_binding.exe`
- `env OAS_MODEL_CATALOG=models.toml ./_build/default/test/test_provider_config.exe`
- `env OAS_MODEL_CATALOG=models.toml ./_build/default/test/test_capabilities.exe`
- `env OAS_MODEL_CATALOG=models.toml ./_build/default/test/test_provider_agnostic_reasoning_replay.exe`
- `opam exec -- ocamlformat --check test/test_provider_agnostic_reasoning_replay.ml`
- `git diff --check`
