### PR TITLE
fix(retry): classify HTTP 402 as first-class PaymentRequired

### DIFF
--- a/lib/error_domain.ml
+++ b/lib/error_domain.ml
@@ -14,6 +14,7 @@ type provider_error =
   | `Invalid_request of string
   | `Not_found of string
   | `Context_overflow of string * int option
+  | `Payment_required of string
   ]
 
 type tool_error =
@@ -91,6 +92,7 @@ let of_api_error (err : Retry.api_error) : provider_error =
   | Retry.InvalidRequest r -> `Invalid_request r.message
   | Retry.NotFound r -> `Not_found r.message
   | Retry.ContextOverflow r -> `Context_overflow (r.message, r.limit)
+  | Retry.PaymentRequired r -> `Payment_required r.message
 ;;
 
 let of_provider_error (err : Llm_provider.Error.provider_error) : provider_error =
@@ -170,6 +172,7 @@ let provider_to_sdk : provider_error -> Error.sdk_error = function
   | `Not_found msg -> Error.Api (Retry.NotFound { message = msg })
   | `Context_overflow (msg, limit) ->
     Error.Api (Retry.ContextOverflow { message = msg; limit })
+  | `Payment_required msg -> Error.Api (Retry.PaymentRequired { message = msg })
 ;;
 
 let to_sdk_error (err : sdk_error_poly) : Error.sdk_error =
@@ -261,6 +264,7 @@ let is_retryable (err : [< sdk_error_poly ]) : bool =
   | `Invalid_request _
   | `Not_found _
   | `Context_overflow _
+  | `Payment_required _
   | `Tool_exec_failed _
   | `Tool_timeout _
   | `Max_turns_exceeded _

--- a/lib/error_domain.mli
+++ b/lib/error_domain.mli
@@ -32,6 +32,9 @@ type provider_error =
   | `Invalid_request of string
   | `Not_found of string
   | `Context_overflow of string * int option
+  | `Payment_required of string
+    (** HTTP 402 — hard billing/quota exhaustion, distinct from
+        [`Invalid_request]. Always non-retryable. *)
   ]
 
 (** {1 Tool errors} *)

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -243,6 +243,7 @@ let complete_with_retry
              | Retry.Overloaded _
              | Retry.ServerError _
              | Retry.AuthError _
+             | Retry.PaymentRequired _
              | Retry.InvalidRequest _
              | Retry.NotFound _
              | Retry.ContextOverflow _
@@ -410,6 +411,7 @@ let complete_stream_with_retry
              | Retry.Overloaded _
              | Retry.ServerError _
              | Retry.AuthError _
+             | Retry.PaymentRequired _
              | Retry.InvalidRequest _
              | Retry.NotFound _
              | Retry.ContextOverflow _

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -107,6 +107,7 @@ let%test "stream rate-limit converges to typed RateLimited (not NetworkError Unk
      | Retry.Overloaded _
      | Retry.ServerError _
      | Retry.AuthError _
+     | Retry.PaymentRequired _
      | Retry.InvalidRequest _
      | Retry.NotFound _
      | Retry.ContextOverflow _

--- a/lib/llm_provider/error.ml
+++ b/lib/llm_provider/error.ml
@@ -194,6 +194,13 @@ let of_retry_api_error ?provider err =
       ; detail = r.message
       }
   | Retry.AuthError r -> AuthError { provider; detail = r.message }
+  | Retry.PaymentRequired r ->
+    (* HTTP 402 is a hard billing-exhaustion signal by status code alone —
+       map directly onto the existing [HardQuota] provider_error rather than
+       [InvalidRequest], so downstream consumers (health trackers) see the
+       same "stop retrying, apply long cooldown" signal a hard-quota 429
+       would produce. *)
+    HardQuota { provider; retry_after = None; detail = r.message }
   | Retry.InvalidRequest r -> InvalidRequest { provider; reason = r.message }
   | Retry.NotFound r -> NotFound { provider; detail = r.message }
   | Retry.ContextOverflow r ->

--- a/lib/llm_provider/retry.ml
+++ b/lib/llm_provider/retry.ml
@@ -15,6 +15,7 @@ type api_error =
       ; message : string
       }
   | AuthError of { message : string }
+  | PaymentRequired of { message : string }
   | InvalidRequest of
       { message : string
       ; reason : invalid_request_reason
@@ -68,6 +69,7 @@ let error_message = function
   | Overloaded r -> Printf.sprintf "Overloaded: %s" r.message
   | ServerError r -> Printf.sprintf "Server error %d: %s" r.status r.message
   | AuthError r -> Printf.sprintf "Auth error: %s" r.message
+  | PaymentRequired r -> Printf.sprintf "Payment required: %s" r.message
   | InvalidRequest r ->
     Printf.sprintf
       "Invalid request (%s): %s"
@@ -212,10 +214,20 @@ let is_retryable = function
     true
   | InvalidRequest _ -> false
   | AuthError _ | ContextOverflow _ | NotFound _ -> false
+  | PaymentRequired _ ->
+    (* HTTP 402 is definitionally non-retryable: the account has zero
+       balance/credit. No message-substring check needed — the status code
+       alone is the signal (unlike RateLimited, where most 429s are
+       transient throttles and only some are hard quota exhaustion). *)
+    false
 ;;
 
 let is_hard_quota = function
   | RateLimited { message; _ } -> is_hard_quota_message message
+  | PaymentRequired _ ->
+    (* HTTP 402 Payment Required IS a hard quota/billing exhaustion signal
+       by HTTP semantics alone — independent of the message body. *)
+    true
   | Overloaded _
   | ServerError _
   | AuthError _
@@ -355,6 +367,7 @@ let classify_error ~status ~body : api_error =
   let message = extract_error_message body in
   match status with
   | 401 -> AuthError { message }
+  | 402 -> PaymentRequired { message }
   | 400 | 422 ->
     if is_context_overflow_message body
     then ContextOverflow { message; limit = parse_context_overflow_limit body }
@@ -447,6 +460,7 @@ let with_retry_map_error
       | Overloaded _
       | ServerError _
       | AuthError _
+      | PaymentRequired _
       | InvalidRequest _
       | NotFound _
       | ContextOverflow _
@@ -559,6 +573,7 @@ let%test "is_retryable: flat Ollama provider prose is not retryable" =
   | Overloaded _
   | ServerError _
   | AuthError _
+  | PaymentRequired _
   | NotFound _
   | ContextOverflow _
   | NetworkError _
@@ -585,6 +600,7 @@ let%test "classify_error returns ContextOverflow for overflow body" =
   | Overloaded _
   | ServerError _
   | AuthError _
+  | PaymentRequired _
   | InvalidRequest _
   | NotFound _
   | NetworkError _
@@ -600,6 +616,7 @@ let%test "classify_error returns Unknown InvalidRequest for non-overflow 400" =
   | Overloaded _
   | ServerError _
   | AuthError _
+  | PaymentRequired _
   | NotFound _
   | ContextOverflow _
   | NetworkError _
@@ -870,6 +887,7 @@ let%test "classify_error 429 hard-quota clears retry_after" =
   | Overloaded _
   | ServerError _
   | AuthError _
+  | PaymentRequired _
   | InvalidRequest _
   | NotFound _
   | ContextOverflow _
@@ -884,6 +902,41 @@ let%test "classify_error 429 transient preserves retry_after" =
   match classify_error ~status:429 ~body with
   | RateLimited { retry_after = Some ra; _ } -> Float.equal ra 3.0
   | RateLimited { retry_after = None; _ }
+  | Overloaded _
+  | ServerError _
+  | AuthError _
+  | PaymentRequired _
+  | InvalidRequest _
+  | NotFound _
+  | ContextOverflow _
+  | NetworkError _
+  | Timeout _ -> false
+;;
+
+(* HTTP 402 Payment Required — first-class classification, not the
+   Unknown_invalid_request catch-all (see PaymentRequired variant doc). *)
+let%test "classify_error 402 maps to PaymentRequired" =
+  let body = {|{"error":{"message":"Insufficient Balance"}}|} in
+  match classify_error ~status:402 ~body with
+  | PaymentRequired { message } -> String.equal message "Insufficient Balance"
+  | RateLimited _
+  | Overloaded _
+  | ServerError _
+  | AuthError _
+  | InvalidRequest _
+  | NotFound _
+  | ContextOverflow _
+  | NetworkError _
+  | Timeout _ -> false
+;;
+
+let%test "classify_error 402 (DeepSeek-shaped body) is not retryable and is hard quota" =
+  let body =
+    {|{"error":{"message":"Insufficient Balance","type":"insufficient_balance_error"}}|}
+  in
+  match classify_error ~status:402 ~body with
+  | PaymentRequired _ as err -> (not (is_retryable err)) && is_hard_quota err
+  | RateLimited _
   | Overloaded _
   | ServerError _
   | AuthError _

--- a/lib/llm_provider/retry.mli
+++ b/lib/llm_provider/retry.mli
@@ -20,6 +20,7 @@ type api_error =
       ; message : string
       }
   | AuthError of { message : string }
+  | PaymentRequired of { message : string }
   | InvalidRequest of
       { message : string
       ; reason : invalid_request_reason
@@ -58,7 +59,9 @@ val is_context_overflow_message : string -> bool
     A retry of the exact same request will never succeed until billing /
     capacity is restored out-of-band.
 
-    Only [RateLimited] messages are inspected; other variants return [false].
+    [RateLimited] messages are inspected via substring match; [PaymentRequired]
+    (HTTP 402) is always [true] by status-code semantics alone (no message
+    inspection needed). Other variants return [false].
 
     Consumers (e.g. health trackers) use this to apply an immediate
     long cooldown instead of transient backoff.

--- a/test/test_error_domain.ml
+++ b/test/test_error_domain.ml
@@ -417,6 +417,25 @@ let test_retryable_context_overflow () =
     (Error_domain.is_retryable (`Context_overflow ("overflow", Some 8192)))
 ;;
 
+let test_roundtrip_api_payment_required () =
+  let orig = Error.Api (Retry.PaymentRequired { message = "Insufficient Balance" }) in
+  let poly = Error_domain.of_sdk_error orig in
+  (match poly with
+   | `Payment_required "Insufficient Balance" -> ()
+   | _ -> Alcotest.fail "expected Payment_required");
+  let back = Error_domain.to_sdk_error poly in
+  match back with
+  | Error.Api (Retry.PaymentRequired { message = "Insufficient Balance" }) -> ()
+  | _ -> Alcotest.fail "roundtrip mismatch for PaymentRequired"
+;;
+
+let test_retryable_payment_required () =
+  Alcotest.(check bool)
+    "payment_required not retryable"
+    false
+    (Error_domain.is_retryable (`Payment_required "Insufficient Balance"))
+;;
+
 let test_roundtrip_agent_idle_detected () =
   let orig = Error.Agent (IdleDetected { consecutive_idle_turns = 3 }) in
   let poly = Error_domain.of_sdk_error orig in
@@ -806,6 +825,10 @@ let () =
             "api context_overflow_no_limit"
             `Quick
             test_roundtrip_api_context_overflow_no_limit
+        ; Alcotest.test_case
+            "api payment_required"
+            `Quick
+            test_roundtrip_api_payment_required
         ; Alcotest.test_case "agent max_turns" `Quick test_roundtrip_agent_max_turns
         ; Alcotest.test_case
             "agent execution_timeout"
@@ -857,6 +880,7 @@ let () =
         ; Alcotest.test_case "auth_error" `Quick test_retryable_auth_error
         ; Alcotest.test_case "invalid_request" `Quick test_retryable_invalid_request
         ; Alcotest.test_case "context_overflow" `Quick test_retryable_context_overflow
+        ; Alcotest.test_case "payment_required" `Quick test_retryable_payment_required
         ; Alcotest.test_case "max_turns" `Quick test_retryable_max_turns
         ; Alcotest.test_case "idle_detected" `Quick test_retryable_idle_detected
         ; Alcotest.test_case "unrecognized_stop" `Quick test_retryable_unrecognized_stop

--- a/test/test_llm_provider_error.ml
+++ b/test/test_llm_provider_error.ml
@@ -216,6 +216,23 @@ let test_retry_hard_quota_mapping () =
   | _ -> fail "expected HardQuota"
 ;;
 
+let test_retry_payment_required_mapping () =
+  (* HTTP 402 (e.g. DeepSeek's "Insufficient Balance") is a hard billing
+     signal by status code alone — it maps onto the same [HardQuota]
+     provider_error a hard-quota 429 would produce, not [InvalidRequest]. *)
+  let err =
+    Error.of_retry_api_error
+      ~provider:"deepseek"
+      (Retry.PaymentRequired { message = "Insufficient Balance" })
+  in
+  match err with
+  | Error.HardQuota { provider; retry_after; detail } ->
+    check string "provider" "deepseek" provider;
+    check (option (float 0.001)) "retry_after" None retry_after;
+    check string "detail" "Insufficient Balance" detail
+  | _ -> fail "expected HardQuota"
+;;
+
 let test_retry_overloaded_unknown_provider_mapping () =
   let check_unknown_provider provider =
     let err =
@@ -582,6 +599,7 @@ let () =
     ; ( "mapping"
       , [ test_case "Retry RateLimited" `Quick test_retry_rate_limit_mapping
         ; test_case "Retry hard quota" `Quick test_retry_hard_quota_mapping
+        ; test_case "Retry payment required" `Quick test_retry_payment_required_mapping
         ; test_case
             "Retry overloaded unknown provider"
             `Quick

--- a/test/test_retry.ml
+++ b/test/test_retry.ml
@@ -67,6 +67,28 @@ let test_classify_error_edge_cases () =
   | _ -> fail "expected NotFound for 404"
 ;;
 
+(* HTTP 402 (Payment Required): DeepSeek returns this with a plain
+   "Insufficient Balance" body when the account has zero balance. Before this
+   fix, 402 fell through the [classify_error] catch-all and became an
+   [InvalidRequest { reason = Unknown_invalid_request }], rendering as
+   "Invalid request (unknown): Insufficient Balance" — misleading, and
+   [is_hard_quota] never fired for it since only [RateLimited] is inspected. *)
+let test_classify_error_402_payment_required () =
+  let body = {|{"error":{"message":"Insufficient Balance"}}|} in
+  let err = Retry.classify_error ~status:402 ~body in
+  (match err with
+   | Retry.PaymentRequired { message } ->
+     check string "402 message" "Insufficient Balance" message
+   | _ -> fail "expected PaymentRequired for 402");
+  check bool "402 is not retryable" false (Retry.is_retryable err);
+  check bool "402 is a hard quota signal" true (Retry.is_hard_quota err);
+  check
+    string
+    "402 error_message rendering"
+    "Payment required: Insufficient Balance"
+    (Retry.error_message err)
+;;
+
 let test_is_retryable () =
   check
     bool
@@ -108,7 +130,12 @@ let test_is_retryable () =
     bool
     "not found not retryable"
     false
-    (Retry.is_retryable (Retry.NotFound { message = "" }))
+    (Retry.is_retryable (Retry.NotFound { message = "" }));
+  check
+    bool
+    "payment required not retryable"
+    false
+    (Retry.is_retryable (Retry.PaymentRequired { message = "" }))
 ;;
 
 let test_invalid_request_reason_boundary () =
@@ -142,6 +169,8 @@ let test_error_message_all_variants () =
     ; Retry.Overloaded { message = "busy" }, "Overloaded: busy"
     ; Retry.ServerError { status = 503; message = "down" }, "Server error 503: down"
     ; Retry.AuthError { message = "bad key" }, "Auth error: bad key"
+    ; ( Retry.PaymentRequired { message = "Insufficient Balance" }
+      , "Payment required: Insufficient Balance" )
     ; ( Retry.InvalidRequest { message = "wrong"; reason = Unknown_invalid_request }
       , "Invalid request (unknown): wrong" )
     ; Retry.NotFound { message = "no model" }, "Not found: no model"
@@ -392,6 +421,10 @@ let () =
     [ ( "classify"
       , [ test_case "http status mapping" `Quick test_classify_error
         ; test_case "edge cases" `Quick test_classify_error_edge_cases
+        ; test_case
+            "402 payment required"
+            `Quick
+            test_classify_error_402_payment_required
         ] )
     ; ( "retryability"
       , [ test_case "retryable predicates" `Quick test_is_retryable


### PR DESCRIPTION
## Summary
- `Retry.classify_error` had no case for HTTP 402, so it fell through to `InvalidRequest { reason = Unknown_invalid_request }`. This produced the exact string seen in a production masc keeper crash log: `error=Invalid request (unknown): Insufficient Balance` (DeepSeek returns 402 with body "Insufficient Balance" on a zero-balance account).
- The existing `hard_quota_indicators` substring list already lists "insufficient balance" as an indicator, but it was only wired to the `RateLimited` (429) branch, so it never fired for 402.
- Adds a first-class `PaymentRequired of { message : string }` variant: `classify_error` maps status 402 to it explicitly, `is_retryable` is unconditionally `false` (402 alone is the signal, no message inspection needed), `is_hard_quota` is unconditionally `true`. Wired through every other exhaustive match on `api_error` (`error.ml`, `error_domain.ml`, `complete.ml`, `complete_stream.ml`) with no silent catch-all.

## Test plan
- [x] `scripts/dune-local.sh build @all` — clean, no warnings-as-errors
- [x] `test/test_retry.ml`, `test_error_domain.ml`, `test_llm_provider_error.ml` — new coverage for the 402 path, all pass
- [x] Verified byte-for-byte identical pre-existing failure counts against a clean `origin/main` checkout (zero regressions from this change)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>