### PR TITLE
fix(provider): scope capability_provider_label to RunPod proxy endpoints

### DIFF
--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -208,15 +208,54 @@ let base_url_targets_openai base_url =
   | Some host -> String.equal (String.lowercase_ascii host) "api.openai.com"
 ;;
 
+(* RunPod serves OpenAI-compatible endpoints from per-pod subdomains of the
+   shared [proxy.runpod.net] host (e.g. [https://<pod-id>.proxy.runpod.net]).
+   That host is RunPod's own documented proxy domain -- not an
+   operator-supplied or model-supplied value -- so classifying it here is the
+   same "explicit endpoint registry binding" shape as
+   [base_url_targets_ollama_cloud] / [base_url_targets_openai] above.
+
+   This does NOT resurrect the model-id -> transport-identity inference that
+   oas#2373 (fixing #2329) removed from
+   [Provider_registry.provider_name_of_config]: that fix correctly bars
+   deriving *transport/telemetry* identity from catalog model provenance
+   (a "grok" model id served through an arbitrary compatible gateway is not
+   evidence the gateway is xAI). This label is scoped to capability *lookup*
+   only and is keyed on the actual endpoint host, never on [config.model_id]
+   or catalog [provider_name] metadata -- so the same collision risk does not
+   apply. *)
+let base_url_targets_runpod_proxy base_url =
+  match Uri.of_string base_url |> Uri.host with
+  | None -> false
+  | Some host ->
+    let host = String.lowercase_ascii (String.trim host) in
+    String.equal host "proxy.runpod.net"
+    || String.ends_with ~suffix:".proxy.runpod.net" host
+;;
+
 let capability_provider_label (config : t) =
   if base_url_targets_ollama_cloud config.base_url
   then "ollama_cloud"
-  else string_of_provider_kind config.kind
+  else (
+    match config.kind with
+    | OpenAI_compat when base_url_targets_runpod_proxy config.base_url -> "runpod_mtp"
+    | Anthropic | Kimi | OpenAI_compat | Ollama | Gemini | Glm | DashScope ->
+      string_of_provider_kind config.kind)
 ;;
 
+(* [runpod_mtp] stays in the "raw, no built-in source" bucket alongside
+   [openai_compat]: the label only proves the wire transport is a known
+   RunPod proxy, not that every model served through it is declared. A
+   provider-qualified catalog row (["runpod_mtp/<model_id>"]) still has to
+   exist for {!capabilities_for_config_model} to trust a model's
+   capabilities; models the catalog does not know fall through to the same
+   fail-closed bare/global check as any other undeclared OpenAI-compatible
+   endpoint -- this label change does not grant RunPod proxies a blanket
+   capability preset. *)
 let raw_openai_compat_without_builtin_source config provider_label =
   match config.kind, provider_label with
-  | OpenAI_compat, "openai_compat" -> not (base_url_targets_openai config.base_url)
+  | OpenAI_compat, ("openai_compat" | "runpod_mtp") ->
+    not (base_url_targets_openai config.base_url)
   | (Anthropic | Kimi | OpenAI_compat | Ollama | Gemini | Glm | DashScope), _ -> false
 ;;
 
@@ -318,6 +357,12 @@ let capabilities_for_config_model (config : t) =
     let provider_label = capability_provider_label config in
     if raw_openai_compat_without_builtin_source config provider_label
     then (
+      (* A provider-qualified catalog hit (e.g. "runpod_mtp/<model_id>") IS
+         the explicit endpoint declaration this fail-closed policy requires;
+         it must return immediately without being re-checked by
+         [raw_openai_compat_requires_endpoint_declaration] below, which exists
+         only to gate the bare/global fallback that has no provider
+         qualification at all. *)
       match
         Capabilities.for_provider_model_id
           ~allow_bare_fallback:false

--- a/lib/llm_provider/provider_config.mli
+++ b/lib/llm_provider/provider_config.mli
@@ -407,9 +407,22 @@ val reasoning_effort_of_config : t -> string option
 
 (** Capability catalog provider namespace for [config].
 
-    This is usually {!string_of_provider_kind}, except official Ollama Cloud
-    endpoints are scoped as ["ollama_cloud"] even when they use the
-    OpenAI-compatible wire kind. *)
+    This is usually {!string_of_provider_kind}, except endpoint families that
+    publish provider-qualified catalog rows while using the OpenAI-compatible
+    wire kind:
+
+    - official Ollama Cloud endpoints are scoped as ["ollama_cloud"];
+    - RunPod proxy endpoints ([proxy.runpod.net] and subdomains) are scoped as
+      ["runpod_mtp"].
+
+    This namespace is for model capability lookup only; it does not
+    determine provider/transport identity for telemetry or routing (see
+    {!Provider_registry.provider_name_of_config}, which intentionally keeps
+    those axes separate). ["runpod_mtp"] is catalog-qualified-only, not a
+    provider-level preset: raw OpenAI-compatible endpoints (RunPod included)
+    still reject undeclared model capabilities unless a provider-qualified
+    catalog row or an explicit capability override proves the runtime
+    contract. *)
 val capability_provider_label : t -> string
 
 (** Resolve model capabilities using provider-qualified catalog entries first.

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -1256,6 +1256,85 @@ let with_repository_model_catalog f =
        Fun.protect f ~finally:restore)
 ;;
 
+(* ── RunPod proxy capability label ───────────────────────
+   Root cause: [capability_provider_label] derived the catalog namespace
+   purely from [config.kind] (plus an Ollama Cloud base_url special-case),
+   so a RunPod-hosted OpenAI-compatible config always got "openai_compat".
+   The repo's own [models.toml] declares this model under the
+   provider-qualified id_prefix "runpod_mtp/qwen36-35b-a3b-mtp"; without the
+   base_url classifier below, that qualified row could never match, the
+   lookup fell back to the bare "qwen36-35b-a3b-mtp" row, and that bare row's
+   [chat_template_kwargs] dialect made
+   [raw_openai_compat_requires_endpoint_declaration] reject it (correctly --
+   an undeclared endpoint should not inherit a thinking dialect for free). *)
+let test_openai_compat_runpod_proxy_label_resolves_qualified_catalog_row () =
+  with_repository_model_catalog (fun () ->
+    let cfg =
+      Provider_config.make
+        ~kind:OpenAI_compat
+        ~model_id:"qwen36-35b-a3b-mtp"
+        ~base_url:"https://abc123.proxy.runpod.net/v1"
+        ()
+    in
+    check_string
+      "RunPod proxy resolves to the runpod_mtp capability namespace"
+      "runpod_mtp"
+      (Provider_config.capability_provider_label cfg);
+    match Provider_config.capabilities_for_config_model cfg with
+    | None ->
+      Alcotest.fail
+        "runpod_mtp/qwen36-35b-a3b-mtp is a real, provider-qualified models.toml row; it \
+         must not be treated as an undeclared endpoint"
+    | Some caps ->
+      check_bool
+        "declared chat_template_kwargs thinking dialect is honored"
+        true
+        (caps.thinking_control_format = Capabilities.Chat_template_kwargs))
+;;
+
+(* Same host family, but a model_id the catalog does not declare under
+   "runpod_mtp/": this must stay fail-closed. The base_url classifier only
+   changes *which namespace* is searched; it must not grant RunPod proxies a
+   blanket capability preset for arbitrary/unknown models. *)
+let test_openai_compat_runpod_proxy_label_stays_fail_closed_for_unknown_model () =
+  with_repository_model_catalog (fun () ->
+    let cfg =
+      Provider_config.make
+        ~kind:OpenAI_compat
+        ~model_id:"totally-unknown-model-id"
+        ~base_url:"https://abc123.proxy.runpod.net/v1"
+        ()
+    in
+    check_bool
+      "unknown model on a RunPod proxy endpoint is not trusted"
+      true
+      (Option.is_none (Provider_config.capabilities_for_config_model cfg)))
+;;
+
+(* The capability namespace change must not leak into provider/transport
+   identity: RunPod proxy endpoints are not a registered endpoint binding, so
+   [provider_name_of_config] must keep reporting the honest generic
+   "openai_compat" label (mirrors the identity/provenance separation from
+   oas#2373, fixing #2329). *)
+let test_provider_name_of_config_runpod_proxy_stays_openai_compat () =
+  with_repository_model_catalog (fun () ->
+    let cfg =
+      Provider_config.make
+        ~kind:OpenAI_compat
+        ~model_id:"qwen36-35b-a3b-mtp"
+        ~base_url:"https://abc123.proxy.runpod.net/v1"
+        ()
+    in
+    check_string
+      "RunPod proxy capability namespace"
+      "runpod_mtp"
+      (Provider_config.capability_provider_label cfg);
+    check_string
+      "RunPod proxy transport/telemetry identity stays generic"
+      "openai_compat"
+      (Provider_registry.provider_name_of_config cfg))
+;;
+
 let test_validate_output_schema_openai_official_catalog () =
   with_repository_model_catalog (fun () ->
     let cfg =
@@ -2044,6 +2123,14 @@ let () =
             `Quick
             test_openai_compat_raw_template_dialect_requires_endpoint_declaration
         ; Alcotest.test_case
+            "runpod proxy label resolves qualified catalog row"
+            `Quick
+            test_openai_compat_runpod_proxy_label_resolves_qualified_catalog_row
+        ; Alcotest.test_case
+            "runpod proxy label stays fail-closed for unknown model"
+            `Quick
+            test_openai_compat_runpod_proxy_label_stays_fail_closed_for_unknown_model
+        ; Alcotest.test_case
             "responses structured path accepted"
             `Quick
             test_validate_responses_request_path_allows_structured_output
@@ -2133,6 +2220,10 @@ let () =
             "unmatched openai_compat"
             `Quick
             test_provider_name_of_config_unmatched_openai_compat
+        ; Alcotest.test_case
+            "runpod proxy capability label is not transport identity"
+            `Quick
+            test_provider_name_of_config_runpod_proxy_stays_openai_compat
         ; Alcotest.test_case
             "ignores xai catalog model"
             `Quick


### PR DESCRIPTION
## Summary
- `capability_provider_label` derived its catalog namespace purely from `config.kind` (plus an Ollama Cloud base_url special-case), so any RunPod-hosted `OpenAI_compat` config resolved to `"openai_compat"`. `models.toml` declares such models under the provider-qualified `id_prefix` `"runpod_mtp/<model_id>"`, so the qualified capability lookup never matched, and `qwen36-35b-a3b-mtp` fell back to the bare row — correctly rejected by `raw_openai_compat_requires_endpoint_declaration` since its `chat_template_kwargs` dialect requires an endpoint declaration. This exactly matches masc's `runtime.toml` pin comment for this binding (currently disabled as dead config).
- Adds `base_url_targets_runpod_proxy` (recognizes `proxy.runpod.net` / subdomains), same shape as the existing `base_url_targets_ollama_cloud`. Unknown models on a RunPod proxy still fail closed — only a genuine `runpod_mtp/<model_id>` catalog row is trusted.
- Deliberately does **not** make the label catalog/model_id-driven. `oas#2373` (fixing jeong-sik/oas#2329) already established that model catalog provenance must not stand in for endpoint/transport identity — a model_id string is not proof of which host serves it. Since this label gates the fail-closed endpoint-declaration check, a catalog-driven label would have reopened that exact hole for every `provider_name` already in `models.toml` (deepseek, xai, mistral, cohere, mimo). Keying on the actual base_url host avoids that. Converges with the same design as the already-open `#2374`.

## Test plan
- [x] `scripts/dune-local.sh build @all` — clean
- [x] `test/test_provider_config.ml` — 3 new tests: qualified catalog row now resolves (previously `None`), unknown model_id on the same host stays `None` (fail-closed preserved), `Provider_registry.provider_name_of_config` still reports `"openai_compat"` (capability label ≠ transport identity)
- [x] `scripts/hardening-ratchet.sh --check`, `scripts/ci-code-smell-ratchet.sh --check`, `ocamlformat --check` — all pass

## Follow-up (not in this PR)
Once merged, masc's `.masc/config/runtime.toml` `[runpod_mtp.qwen36-35b-a3b-mtp]` binding can be re-enabled — it is currently commented out as dead config referencing exactly this bug.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>