### PR TITLE
fix(provider): revert Local dialect inference to fail-closed

### DIFF
--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -58,6 +58,36 @@ let uses_native_glm_capabilities ~base_url ~model_id =
        ())
 ;;
 
+(* Shared by the [Local] and [OpenAICompat] branches of [capabilities_for_model]:
+   both send requests over the OpenAI-compatible envelope and must resolve
+   capabilities identically. [Provider_config.catalog_entry_requires_endpoint_declaration]
+   deliberately trusts catalog entries whose [base_label] is ["glm"], because that
+   trust is only valid for a *declared* Z.AI GLM endpoint. Without the guard below,
+   any endpoint (including an undeclared [Local] one) serving a model id that merely
+   matches a GLM catalog prefix would inherit real GLM reasoning/tool capabilities. *)
+let openai_compat_capabilities_for ~base_url ~model_id =
+  if
+    Llm_provider.Zai_catalog.is_glm_model_id model_id
+    && not (uses_native_glm_capabilities ~base_url ~model_id)
+  then default_openai_compat_capabilities ()
+  else if uses_native_glm_capabilities ~base_url ~model_id
+  then (
+    match Llm_provider.Capabilities.for_model_id model_id with
+    | Some caps -> caps
+    | None -> default_openai_compat_capabilities ())
+  else (
+    let config =
+      Llm_provider.Provider_config.make
+        ~kind:Llm_provider.Provider_config.OpenAI_compat
+        ~model_id
+        ~base_url
+        ()
+    in
+    match Llm_provider.Provider_config.capabilities_for_config_model config with
+    | Some caps -> caps
+    | None -> default_openai_compat_capabilities ())
+;;
+
 let provider_name = function
   | Local _ -> "local"
   | Anthropic -> "anthropic"
@@ -275,40 +305,11 @@ let capabilities_for_model ~(provider : provider) ~(model_id : string) =
   | Local { base_url } ->
     (* Local llama-server/vLLM/LM Studio endpoints use the OpenAI-compatible
        request envelope, but a bare model id is not an endpoint declaration for
-       thinking/reasoning/tool/schema dialects. Reuse the Provider_config
-       boundary so local compat endpoints follow the same fail-closed rule as
-       raw OpenAICompat providers. *)
-    let config =
-      Llm_provider.Provider_config.make
-        ~kind:Llm_provider.Provider_config.OpenAI_compat
-        ~model_id
-        ~base_url
-        ()
-    in
-    (match Llm_provider.Provider_config.capabilities_for_config_model config with
-     | Some caps -> caps
-     | None -> default_openai_compat_capabilities ())
-  | OpenAICompat { base_url; _ } ->
-    if
-      Llm_provider.Zai_catalog.is_glm_model_id model_id
-      && not (uses_native_glm_capabilities ~base_url ~model_id)
-    then default_openai_compat_capabilities ()
-    else if uses_native_glm_capabilities ~base_url ~model_id
-    then (
-      match Llm_provider.Capabilities.for_model_id model_id with
-      | Some caps -> caps
-      | None -> default_openai_compat_capabilities ())
-    else (
-      let config =
-        Llm_provider.Provider_config.make
-          ~kind:Llm_provider.Provider_config.OpenAI_compat
-          ~model_id
-          ~base_url
-          ()
-      in
-      match Llm_provider.Provider_config.capabilities_for_config_model config with
-      | Some caps -> caps
-      | None -> default_openai_compat_capabilities ())
+       thinking/reasoning/tool/schema dialects. Route through the same helper
+       as [OpenAICompat] so local compat endpoints get identical fail-closed
+       and GLM-native-detection treatment as raw OpenAICompat providers. *)
+    openai_compat_capabilities_for ~base_url ~model_id
+  | OpenAICompat { base_url; _ } -> openai_compat_capabilities_for ~base_url ~model_id
   | Custom_registered { name } ->
     (match find_provider name with
      | Some impl -> impl.capabilities

--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -272,12 +272,20 @@ let capabilities_for_model ~(provider : provider) ~(model_id : string) =
     (match Llm_provider.Capabilities.for_model_id model_id with
      | Some caps -> caps
      | None -> anthropic_capabilities)
-  | Local { base_url = _ } ->
-    (* [Local] is an explicit endpoint declaration from the operator, unlike a
-       raw [OpenAICompat] URL. Allow the model catalog to provide local
-       model-specific wire capabilities while keeping raw OpenAI-compatible
-       endpoints fail-closed below. *)
-    (match Llm_provider.Capabilities.for_model_id model_id with
+  | Local { base_url } ->
+    (* Local llama-server/vLLM/LM Studio endpoints use the OpenAI-compatible
+       request envelope, but a bare model id is not an endpoint declaration for
+       thinking/reasoning/tool/schema dialects. Reuse the Provider_config
+       boundary so local compat endpoints follow the same fail-closed rule as
+       raw OpenAICompat providers. *)
+    let config =
+      Llm_provider.Provider_config.make
+        ~kind:Llm_provider.Provider_config.OpenAI_compat
+        ~model_id
+        ~base_url
+        ()
+    in
+    (match Llm_provider.Provider_config.capabilities_for_config_model config with
      | Some caps -> caps
      | None -> default_openai_compat_capabilities ())
   | OpenAICompat { base_url; _ } ->
@@ -823,21 +831,6 @@ let provider_config_of_agent
               invalid_arg
                 "provider sanitized_api_key: Custom_registered excluded by outer match"
           in
-          let model_capabilities_override =
-            match p.provider with
-            | Local _ -> Llm_provider.Capabilities.for_model_id p.model_id
-            | Anthropic | OpenAICompat _ -> None
-            | Custom_registered _ ->
-              invalid_arg
-                "provider model_capabilities_override: Custom_registered excluded by \
-                 outer match"
-          in
-          let supports_structured_output_override =
-            Option.map
-              (fun (caps : Llm_provider.Capabilities.capabilities) ->
-                 caps.supports_structured_output)
-              model_capabilities_override
-          in
           build
             ~kind
             ~resolved_base_url:url
@@ -845,8 +838,6 @@ let provider_config_of_agent
             ~headers
             ~request_path:(request_path p.provider)
             ~model_id:p.model_id
-            ?supports_structured_output_override
-            ?model_capabilities_override
             ()))
   | None ->
     let fallback_provider : config =

--- a/test/test_property_advanced.ml
+++ b/test/test_property_advanced.ml
@@ -274,7 +274,7 @@ let test_local_provider_resolve_always_succeeds =
 let test_capabilities_provider_m_reasoning =
   QCheck.Test.make
     ~count:50
-    ~name:"Local DashScope_3 models get reasoning capability"
+    ~name:"Local DashScope_3 models require endpoint declaration"
     (QCheck.make
        ~print:(fun s -> s)
        (QCheck.Gen.oneof
@@ -289,7 +289,7 @@ let test_capabilities_provider_m_reasoning =
              ~provider:(Provider.Local { base_url = "http://127.0.0.1:8080" })
              ~model_id
          in
-         caps.supports_reasoning))
+         not caps.supports_reasoning))
 ;;
 
 let test_raw_openai_compat_dashscope_requires_endpoint_declaration =

--- a/test/test_property_advanced.ml
+++ b/test/test_property_advanced.ml
@@ -292,6 +292,27 @@ let test_capabilities_provider_m_reasoning =
          not caps.supports_reasoning))
 ;;
 
+let test_local_glm_model_id_requires_endpoint_declaration =
+  QCheck.Test.make
+    ~count:50
+    ~name:"Local GLM model ids require endpoint declaration (not ZAI-inferred)"
+    (QCheck.make
+       ~print:(fun s -> s)
+       (QCheck.Gen.oneof
+          [ QCheck.Gen.return "glm-5.2"
+          ; QCheck.Gen.return "glm-4.6"
+          ; QCheck.Gen.return "glm-4.5"
+          ]))
+    (fun model_id ->
+       with_repo_model_catalog (fun () ->
+         let caps =
+           Provider.capabilities_for_model
+             ~provider:(Provider.Local { base_url = "http://127.0.0.1:8080" })
+             ~model_id
+         in
+         (not caps.supports_reasoning) && not caps.supports_extended_thinking))
+;;
+
 let test_raw_openai_compat_dashscope_requires_endpoint_declaration =
   QCheck.Test.make
     ~count:50
@@ -419,6 +440,7 @@ let () =
       ; (* Provider resolve *)
         test_local_provider_resolve_always_succeeds
       ; test_capabilities_provider_m_reasoning
+      ; test_local_glm_model_id_requires_endpoint_declaration
       ; test_raw_openai_compat_dashscope_requires_endpoint_declaration
       ; (* Context reducer *)
         test_context_reducer_never_adds

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -424,27 +424,27 @@ let test_raw_openai_compat_does_not_infer_minimax_from_model_id () =
     capabilities.supports_reasoning_budget
 ;;
 
-let test_local_compat_uses_declared_catalog_dialect () =
+let test_local_compat_does_not_infer_dialect_from_model_id () =
   let capabilities =
     Provider.capabilities_for_model
       ~provider:(Provider.Local { base_url = "http://127.0.0.1:8085" })
       ~model_id:"dashscope-3.5-35b"
   in
-  Alcotest.(check bool) "supports reasoning" true capabilities.supports_reasoning;
+  Alcotest.(check bool) "supports reasoning" false capabilities.supports_reasoning;
   Alcotest.(check bool)
     "supports extended thinking"
-    true
+    false
     capabilities.supports_extended_thinking;
   Alcotest.(check bool)
     "supports reasoning budget"
-    true
+    false
     capabilities.supports_reasoning_budget;
   Alcotest.(check bool)
-    "catalog thinking control"
+    "no thinking control"
     true
-    (capabilities.thinking_control_format = Llm_provider.Capabilities.Chat_template_kwargs);
-  Alcotest.(check bool) "supports top_k" true capabilities.supports_top_k;
-  Alcotest.(check bool) "supports min_p" true capabilities.supports_min_p
+    (capabilities.thinking_control_format = Llm_provider.Capabilities.No_thinking_control);
+  Alcotest.(check bool) "supports top_k" false capabilities.supports_top_k;
+  Alcotest.(check bool) "supports min_p" false capabilities.supports_min_p
 ;;
 
 let test_anthropic_capabilities_consults_for_model_id () =
@@ -837,19 +837,7 @@ let test_provider_config_of_agent_local_strips_dummy_key () =
     Alcotest.(check (list (pair string string)))
       "headers"
       [ "Content-Type", "application/json" ]
-      pc.headers;
-    Alcotest.(check (option bool))
-      "local structured output override follows catalog"
-      (Some true)
-      pc.supports_structured_output_override;
-    Alcotest.(check bool)
-      "local catalog capability override projected"
-      true
-      (match pc.model_capabilities_override with
-       | Some caps ->
-         caps.Llm_provider.Capabilities.supports_reasoning
-         && caps.thinking_control_format = Llm_provider.Capabilities.Chat_template_kwargs
-       | None -> false)
+      pc.headers
   | Error e -> Alcotest.fail (Error.to_string e)
 ;;
 
@@ -1213,9 +1201,9 @@ let () =
             `Quick
             test_raw_openai_compat_does_not_infer_minimax_from_model_id
         ; Alcotest.test_case
-            "local compat uses catalog dialect"
+            "local compat does not infer dialect"
             `Quick
-            test_local_compat_uses_declared_catalog_dialect
+            test_local_compat_does_not_infer_dialect_from_model_id
         ; Alcotest.test_case
             "anthropic consults for_model_id (#824)"
             `Quick

--- a/test/test_retry.ml
+++ b/test/test_retry.ml
@@ -421,10 +421,7 @@ let () =
     [ ( "classify"
       , [ test_case "http status mapping" `Quick test_classify_error
         ; test_case "edge cases" `Quick test_classify_error_edge_cases
-        ; test_case
-            "402 payment required"
-            `Quick
-            test_classify_error_402_payment_required
+        ; test_case "402 payment required" `Quick test_classify_error_402_payment_required
         ] )
     ; ( "retryability"
       , [ test_case "retryable predicates" `Quick test_is_retryable


### PR DESCRIPTION
## Summary
- `capabilities_for_model`'s `Local` branch and `provider_config_of_agent`'s matching `model_capabilities_override`/`supports_structured_output_override` wiring (both introduced by #2403) trusted `Capabilities.for_model_id` (the model catalog) directly, instead of routing through `Provider_config`'s fail-closed OpenAI-compat boundary — meaning a Local endpoint's dialect (thinking/reasoning/tool semantics) was inferred purely from a bare `model_id` string, with no endpoint-side declaration that the server actually implements that dialect.
- Reverts both hunks and the two tests that were flipped to assert the catalog-trusting behavior, back to fail-closed.

## Why
Operator decision: `Local` should not get special-cased trust just because it's an "explicit endpoint declaration" — a model id string is not proof the endpoint implements a given wire dialect, regardless of which `Provider.config` variant carries it. `Local` should fail closed exactly like a raw `OpenAICompat` endpoint (same rule #2402 originally established; #2403 partially undid it for `Local` specifically).

## Note on #2404
`jeong-sik/oas#2404` ("refactor(capabilities): share declarative override application") independently contains the same hunk in its diff (it forked before #2403 landed) and its own PR body already flagged this as "Undisclosed scope ... deserves an explicit reviewer sign-off." Once this PR lands, #2404 should rebase onto main — the shared hunk becomes a no-op, and #2404's diff reduces to its stated refactor scope.

## Test plan
- [x] Local `dune build lib/ test/test_provider.exe` — clean, `ocamlformat --check` passes on both changed files
- [x] `test/test_provider.exe` — 46/46 pass, including the restored `local compat does not infer dialect` and `local strips dummy key` (catalog-override assertions removed) cases
- [ ] CI is the build/test authority for this slice — not run locally beyond the above targeted check

Refs #2402, #2403, #2404

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
