### PR TITLE
style(test): fix ocamlformat drift from #2407

### DIFF
--- a/test/test_retry.ml
+++ b/test/test_retry.ml
@@ -421,10 +421,7 @@ let () =
     [ ( "classify"
       , [ test_case "http status mapping" `Quick test_classify_error
         ; test_case "edge cases" `Quick test_classify_error_edge_cases
-        ; test_case
-            "402 payment required"
-            `Quick
-            test_classify_error_402_payment_required
+        ; test_case "402 payment required" `Quick test_classify_error_402_payment_required
         ] )
     ; ( "retryability"
       , [ test_case "retryable predicates" `Quick test_is_retryable


### PR DESCRIPTION
## Summary
`#2407` landed with `test/test_retry.ml`'s `"402 payment required"` test_case call split across 4 lines when ocamlformat 0.29.0 (the version pinned in CI) collapses it onto one line (fits under the line-width limit).

CI's `dune build @fmt` gate currently FAILs on `main` itself for this file — every new PR against main inherits this failure regardless of what the PR touches (confirmed while opening jeong-sik/oas#2410, unrelated).

## Test plan
- [x] `dune build @fmt` — clean after `--auto-promote`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
