### PR TITLE
fix: let resume config override thinking policy

### DIFF
--- a/lib/agent/agent_checkpoint.ml
+++ b/lib/agent/agent_checkpoint.ml
@@ -18,6 +18,14 @@ let build_resume ~(checkpoint : Checkpoint.t) ?(eio_context = false) ?config ?co
     | Some c -> c
     | None -> default_config
   in
+  let call_time_or_checkpoint project checkpoint_value =
+    match config with
+    | Some c ->
+      (match project c with
+       | Some _ as explicit -> explicit
+       | None -> checkpoint_value)
+    | None -> checkpoint_value
+  in
   let restored_config =
     { base_config with
       name = checkpoint.agent_name
@@ -27,10 +35,15 @@ let build_resume ~(checkpoint : Checkpoint.t) ?(eio_context = false) ?config ?co
     ; top_p = checkpoint.top_p
     ; top_k = checkpoint.top_k
     ; min_p = checkpoint.min_p
-    ; enable_thinking = checkpoint.enable_thinking
-    ; preserve_thinking = checkpoint.preserve_thinking
+    ; enable_thinking =
+        call_time_or_checkpoint (fun c -> c.enable_thinking) checkpoint.enable_thinking
+    ; preserve_thinking =
+        call_time_or_checkpoint
+          (fun c -> c.preserve_thinking)
+          checkpoint.preserve_thinking
     ; response_format = checkpoint.response_format
-    ; thinking_budget = checkpoint.thinking_budget
+    ; thinking_budget =
+        call_time_or_checkpoint (fun c -> c.thinking_budget) checkpoint.thinking_budget
     ; tool_choice = checkpoint.tool_choice
     ; disable_parallel_tool_use = checkpoint.disable_parallel_tool_use
     ; cache_system_prompt = checkpoint.cache_system_prompt

--- a/test/test_checkpoint.ml
+++ b/test/test_checkpoint.ml
@@ -23,6 +23,9 @@ let make_checkpoint
       ?(tools = [])
       ?(tool_choice = None)
       ?(context = Context.create ~eio:false ())
+      ?(enable_thinking = None)
+      ?(preserve_thinking = None)
+      ?(thinking_budget = None)
       ?(mcp_sessions = [])
       ()
   : Checkpoint.t
@@ -43,10 +46,10 @@ let make_checkpoint
   ; top_p = None
   ; top_k = None
   ; min_p = None
-  ; enable_thinking = None
-  ; preserve_thinking = None
+  ; enable_thinking
+  ; preserve_thinking
   ; response_format = Types.Off
-  ; thinking_budget = None
+  ; thinking_budget
   ; cache_system_prompt = false
   ; context
   ; mcp_sessions
@@ -604,16 +607,70 @@ let () =
               (Context.get ctx2 "key" = Some (`String "val")))
         ; test_case "override config takes precedence" `Quick (fun () ->
             let cp =
-              make_checkpoint ~agent_name:"orig-agent" ~model:"claude-sonnet-4-6" ()
+              make_checkpoint
+                ~agent_name:"orig-agent"
+                ~model:"claude-sonnet-4-6"
+                ~enable_thinking:(Some true)
+                ~preserve_thinking:(Some true)
+                ~thinking_budget:(Some 2048)
+                ()
             in
             let override =
-              { Types.default_config with name = "should-be-ignored"; max_turns = 99 }
+              { Types.default_config with
+                name = "should-be-ignored"
+              ; max_turns = 99
+              ; enable_thinking = Some false
+              ; preserve_thinking = Some false
+              ; thinking_budget = Some 512
+              }
             in
             let { Agent_checkpoint.state; _ } =
               Agent_checkpoint.build_resume ~checkpoint:cp ~config:override ()
             in
             check string "agent_name from checkpoint" "orig-agent" state.config.name;
-            check int "max_turns from override" 99 state.config.max_turns)
+            check int "max_turns from override" 99 state.config.max_turns;
+            check
+              (option bool)
+              "enable_thinking from override"
+              (Some false)
+              state.config.enable_thinking;
+            check
+              (option bool)
+              "preserve_thinking from override"
+              (Some false)
+              state.config.preserve_thinking;
+            check
+              (option int)
+              "thinking_budget from override"
+              (Some 512)
+              state.config.thinking_budget)
+        ; test_case "unset override keeps checkpoint thinking policy" `Quick (fun () ->
+            let cp =
+              make_checkpoint
+                ~enable_thinking:(Some true)
+                ~preserve_thinking:(Some true)
+                ~thinking_budget:(Some 2048)
+                ()
+            in
+            let override = { Types.default_config with max_turns = 99 } in
+            let { Agent_checkpoint.state; _ } =
+              Agent_checkpoint.build_resume ~checkpoint:cp ~config:override ()
+            in
+            check
+              (option bool)
+              "enable_thinking from checkpoint"
+              (Some true)
+              state.config.enable_thinking;
+            check
+              (option bool)
+              "preserve_thinking from checkpoint"
+              (Some true)
+              state.config.preserve_thinking;
+            check
+              (option int)
+              "thinking_budget from checkpoint"
+              (Some 2048)
+              state.config.thinking_budget)
         ; test_case "override context replaces checkpoint context" `Quick (fun () ->
             let cp_ctx = Context.create ~eio:false () in
             Context.set cp_ctx "old" (`String "old-val");

--- a/test/test_session_resume.ml
+++ b/test/test_session_resume.ml
@@ -14,6 +14,9 @@ let make_checkpoint
       ?(tools = [])
       ?(tool_choice = None)
       ?(context = Context.create ~eio:false ())
+      ?(enable_thinking = None)
+      ?(preserve_thinking = None)
+      ?(thinking_budget = None)
       ()
   : Checkpoint.t
   =
@@ -33,10 +36,10 @@ let make_checkpoint
   ; top_p = None
   ; top_k = None
   ; min_p = None
-  ; enable_thinking = None
-  ; preserve_thinking = None
+  ; enable_thinking
+  ; preserve_thinking
   ; response_format = Types.Off
-  ; thinking_budget = None
+  ; thinking_budget
   ; cache_system_prompt = false
   ; context
   ; mcp_sessions = []
@@ -384,8 +387,23 @@ let test_resume_restores_tool_result_relocation_state () =
 let test_resume_with_config_override () =
   with_net
   @@ fun net ->
-  let cp = make_checkpoint ~agent_name:"cp-name" () in
-  let cfg = { Types.default_config with max_turns = 50; max_tokens = Some 8192 } in
+  let cp =
+    make_checkpoint
+      ~agent_name:"cp-name"
+      ~enable_thinking:(Some true)
+      ~preserve_thinking:(Some true)
+      ~thinking_budget:(Some 2048)
+      ()
+  in
+  let cfg =
+    { Types.default_config with
+      max_turns = 50
+    ; max_tokens = Some 8192
+    ; enable_thinking = Some false
+    ; preserve_thinking = Some false
+    ; thinking_budget = Some 512
+    }
+  in
   let agent = Agent.resume ~net ~checkpoint:cp ~config:cfg () in
   (* checkpoint fields override config *)
   Alcotest.(check string) "name from checkpoint" "cp-name" (Agent.state agent).config.name;
@@ -394,7 +412,19 @@ let test_resume_with_config_override () =
   Alcotest.(check (option int))
     "max_tokens from config"
     (Some 8192)
-    (Agent.state agent).config.max_tokens
+    (Agent.state agent).config.max_tokens;
+  Alcotest.(check (option bool))
+    "enable_thinking from config"
+    (Some false)
+    (Agent.state agent).config.enable_thinking;
+  Alcotest.(check (option bool))
+    "preserve_thinking from config"
+    (Some false)
+    (Agent.state agent).config.preserve_thinking;
+  Alcotest.(check (option int))
+    "thinking_budget from config"
+    (Some 512)
+    (Agent.state agent).config.thinking_budget
 ;;
 
 let test_resume_empty_checkpoint () =


### PR DESCRIPTION
## Summary
- let explicit resume config thinking fields override stale checkpoint values
- keep checkpoint identity/history precedence for fields already covered by existing resume semantics
- add checkpoint and public Agent.resume regressions for explicit override and unset override fallback

## Rationale
MASC can correctly send preserve_thinking=false, but an existing OAS worker checkpoint created with preserve_thinking=true could rehydrate that stale policy during Agent.resume. That defeats the current runtime policy and can keep reasoning replay active across long-running worker checkpoints.

The change is narrow: only explicit call-time thinking fields override checkpoint values. If the supplied config leaves a thinking field unset, the checkpoint value is preserved.

## Verification
- opam exec -- ocamlformat --check lib/agent/agent_checkpoint.ml test/test_checkpoint.ml test/test_session_resume.ml
- scripts/dune-local.sh build test/test_checkpoint.exe test/test_session_resume.exe
- ./_build/default/test/test_checkpoint.exe (59 tests)
- ./_build/default/test/test_session_resume.exe (30 tests)
