### PR TITLE
docs(rfc): RFC-OAS-034 endpoint capability boundary — host is not capability provenance

### DIFF
--- a/docs/rfc/RFC-OAS-034-endpoint-capability-boundary.md
+++ b/docs/rfc/RFC-OAS-034-endpoint-capability-boundary.md
@@ -64,7 +64,7 @@ capability(MTP, tool_choice, reasoning dialect, structured output)를 결정하�
 
 ## 3. 미비 사항 인벤토리 (감사 확정)
 
-### P1 — PR #2374 / #2408 (미머지, 머지 차단) · host → capability namespace
+### P1 — PR #2374 / #2408 (미병합, 병합 차단) · host → capability namespace
 
 | # | 위치 | 증상 | severity |
 |---|------|------|----------|

--- a/docs/rfc/RFC-OAS-034-endpoint-capability-boundary.md
+++ b/docs/rfc/RFC-OAS-034-endpoint-capability-boundary.md
@@ -27,7 +27,7 @@ RFC-OAS-023이 이미 축을 선언했다 — capability = `model_caps ∩ trans
 
 2026-07-01 감사 (`oas-endpoint-capability-boundary-audit`, 29 agents, 7 finder 차원 + 적대 검증): 41 dedup 사이트 중 **confirmed 4 / borderline 5 / legit 32**.
 
-핵심은 `runpod_mtp`가 신규 실수 하나가 아니라 **이미 main에 사는 계열의 재발**이라는 것이다. main에 `provider_registry.ml`의 `is_local → "nous"`가 이미 있었고(§3 B3), #2374·#2408은 그 선례를 두 번 따랐다. `~/me/instructions/software-development.md` §워크어라운드 거부 기준의 "한 번 들어간 패턴이 *합리적 선례*로 학습돼 누적되는 나선"이 코드로 실측된 사례다.
+핵심은 `runpod_mtp`가 신규 실수 하나가 아니라 **이미 main에 사는 계열의 재발**이라는 것이다. main에 `provider_registry.ml`의 `is_local → "nous"`가 이미 있었고(§3 B3), #2374·#2408은 그 선례를 두 번 따랐다. 한 번 워크어라운드 패턴이 main에 들어가면 이후 코드 생성(AI든 사람이든)이 그 패턴을 *합리적 선례*로 학습해 누적되는 나선 — 이 RFC가 문서화하는 반복이 바로 그 실측 사례다.
 
 ### 1.2 구체 증거 — host를 옮기면 capability가 사라진다
 
@@ -87,8 +87,8 @@ capability(MTP, tool_choice, reasoning dialect, structured output)를 결정하�
 | # | 위치 | 증상 | 조치 |
 |---|------|------|------|
 | B4 | `provider_config.ml:199` `base_url_targets_ollama_cloud` | vendor-canonical `ollama.com`은 정당하나 loose `String.starts_with` prefix라 `https://ollama.com.attacker.example` look-alike가 `ollama_cloud` namespace 상속. 형제 `base_url_targets_openai`(205)·`openai_host_supports_output_schema`(789)는 이미 `Uri.host` 정확 비교. | prefix → `Uri.host` 파싱 후 `= "ollama.com" || ends_with ".ollama.com"`. |
-| B5 | `discovery.ml:287` `infer_capabilities` | unknown model_id의 probed generic 엔드포인트가 `structured_output`/`image_input`/`required·named tool_choice`=true를 무근거 부여. reasoning/thinking은 올바르게 fail-closed(정상). blast radius는 discovery 리포팅 메타로 제한(completion-contract 미사용). | generic base를 해당 필드 false로 시작, `/props`·catalog 선언 시 상향. reasoning에 이미 적용한 declaration-over-probing을 이 필드들에도. |
-| B6 | `capabilities.ml:761` `apply_manifest_entry` | manifest 오타 `base_label`이 `capabilities_for_provider_label = None`을 거쳐 **경고 없이** `default_capabilities`로 붕괴. 형제 필드 핸들러(805·856)는 `Diag.warn`함. 함수 docstring 자체가 fail-closed를 명시. host 무관(config→capability), 권한 손실이라 low. | `Some label` + `None` lookup 시 `Diag.warn` 또는 `None` 반환으로 오타 표면화. |
+| B5 | `discovery.ml:287` `infer_capabilities` | unknown model_id의 probed generic 엔드포인트가 `structured_output`/`image_input`/`required·named tool_choice`=true를 무근거 부여. reasoning/thinking은 올바르게 fail-closed(정상). blast radius는 discovery 리포팅 메타로 제한(completion-contract 미사용). | **false-positive로 강등, 조치 없음** — discovery capability는 애초 `f(probed runtime)`이 legit contract이라 §4/§7 재감사에서 기각. |
+| B6 | `capabilities.ml:761` `apply_manifest_entry` | manifest 오타 `base_label`이 `capabilities_for_provider_label = None`을 거쳐 **경고 없이** `default_capabilities`로 붕괴. 형제 필드 핸들러(805·856)는 `Diag.warn`함. 함수 docstring 자체가 fail-closed를 명시. host 무관(config→capability), 권한 손실이라 low. | **false-positive로 강등, 조치 없음** — 이미 fail-closed(권한 상승 아님)라 §4/§7 재감사에서 기각. |
 | B7 | `complete_sampling.ml:57` `openai_compat_should_default_min_p` | capabilities 미상일 때 `None → is_local`로 min_p default 결정. host locality가 sampling default 선택. `config.min_p` 명시값 우선이라 blast radius 최소. | 명시 runtime/model capability 우선; 미상이면 미설정 또는 선언된 runtime kind로 키잉. |
 
 ### Legit 32건 (대조군 — 변경 없음, 경계의 정답례)
@@ -146,7 +146,7 @@ stale-high(monotone-safe)이며, 전체 rebaseline은 별도 hygiene 작업으�
 - **RFC-OAS-018** provider-model catalog externalization — namespace의 선언 출처가 catalog임을 전제.
 - **PR #2404** declarative override SSOT — B1/B2/B3의 root fix가 안착할 기반.
 - **PR #2374, #2408** — 본 RFC가 흡수하는 트리거 (host→capability namespace, 중복 구현).
-- `~/me/instructions/software-development.md` §워크어라운드 거부 기준, AI 코드 생성 안티패턴 #1(scattered hardcoded)·#2(unknown→permissive)·#3(boundary violation).
+- AI 코드 생성 안티패턴 3종(§1.1의 재발 논의가 근거하는 분류): #1 scattered hardcoded defaults(같은 설정값이 여러 파일에 리터럴로 산포), #2 unknown → permissive default(모르는 입력을 에러 대신 편리한 기본값으로 매핑 — 본 RFC의 B1-B7이 정확히 이 패턴), #3 boundary violation(하위 모듈이 상위 소비자의 타입/모듈을 참조).
 
 ### 구현 현황 (추적 이슈 #2414)
 

--- a/docs/rfc/RFC-OAS-034-endpoint-capability-boundary.md
+++ b/docs/rfc/RFC-OAS-034-endpoint-capability-boundary.md
@@ -1,0 +1,133 @@
+# RFC-OAS-034: Endpoint capability boundary — host는 capability의 provenance가 아니다
+
+| | |
+|---|---|
+| Status | Draft |
+| Author | jeong-sik (Claude Opus 4.8 조사) |
+| Created | 2026-07-01 |
+| Target | `agent_sdk` (oas) — `lib/llm_provider/` (`provider_endpoint.ml`, `provider_config.ml`, `provider_registry.ml`, `discovery.ml`, `capabilities.ml`, `complete_sampling.ml`) |
+| Supplements | RFC-OAS-023 (capability axis = model × transport) — 034는 그 원칙의 *집행* 레이어 |
+| Mirrors | RFC-OAS-022 (monotone-decrease ratchet) — 신규 위반 사이트를 CI에서 0으로 고정 |
+| Aligned infra | RFC-OAS-018 (catalog externalization), PR #2404 (declarative override SSOT) |
+| Triggering PRs | #2374, #2408 (둘 다 host `*.proxy.runpod.net` → capability namespace `runpod_mtp`) |
+
+## 0. Summary
+
+OAS가 엔드포인트의 **capability set / catalog namespace를 배포 host·URL에서 추론**하는 사이트가 여럿 있다. capability는 `(serving runtime) × (model)`의 함수이고 host는 직교하는 전송 주소일 뿐이다. capability를 host에 키잉하면 **동일 server+model이 임대 위치를 옮기는 순간 다르게 동작하거나 capability를 통째로 잃는다(silent fail-closed)**.
+
+RFC-OAS-023이 이미 축을 선언했다 — capability = `model_caps ∩ transport_caps`, host/provider는 model 축이 아니다. 그럼에도 2026-06~07 사이 **같은 host→capability 패턴으로 PR이 2개 열렸다**(#2374 via `provider_endpoint.ml`, #2408 via `provider_config.ml`). 원칙 문서만으로는 재발이 막히지 않는다는 실측이다. 본 RFC는 원칙을 집행 가능한 형태로 못박는다:
+
+1. 위반 유형을 명명하고 감사 인벤토리를 고정한다 (§3).
+2. 신규 `base_url_targets_* → capability-label` 사이트를 금지하는 ratchet을 추가한다 (§5, RFC-OAS-022 미러).
+3. host 변경에 capability가 불변임을 증명하는 회귀 테스트를 추가한다 (§6).
+
+## 1. Problem
+
+### 1.1 재발하는 계열 (원칙 RFC만으로 안 막힘)
+
+2026-07-01 감사 (`oas-endpoint-capability-boundary-audit`, 29 agents, 7 finder 차원 + 적대 검증): 41 dedup 사이트 중 **confirmed 4 / borderline 5 / legit 32**.
+
+핵심은 `runpod_mtp`가 신규 실수 하나가 아니라 **이미 main에 사는 계열의 재발**이라는 것이다. main에 `provider_registry.ml`의 `is_local → "nous"`가 이미 있었고(§3 B3), #2374·#2408은 그 선례를 두 번 따랐다. `~/me/instructions/software-development.md` §워크어라운드 거부 기준의 "한 번 들어간 패턴이 *합리적 선례*로 학습돼 누적되는 나선"이 코드로 실측된 사례다.
+
+### 1.2 구체 증거 — host를 옮기면 capability가 사라진다
+
+```ocaml
+(* PR #2374 자체 테스트 *)
+Provider_config.make ~kind:OpenAI_compat
+  ~model_id:"qwen36-35b-a3b-mtp"                 (* namespace 미포함 *)
+  ~base_url:"https://abc123.proxy.runpod.net/v1"
+(* capability_provider_label = "runpod_mtp"  ← host에서 유도 *)
+(* catalog 키 = "runpod_mtp/qwen36-35b-a3b-mtp" = <host유도namespace>/<model_id> *)
+```
+
+같은 server+model을 `https://mybox.example.com/v1`로 옮기면 → label=`openai_compat` → `runpod_mtp/…` row miss → `capabilities_for_config_model = None` → tools/reasoning/thinking-dialect 전부 상실. RunPod은 임의의 server(vLLM/SGLang/llama.cpp)+model을 얹는 generic GPU-rental edge이므로, "RunPod ⟹ MTP" 가정이 공유 라우팅 코드에 박히면 임대처마다(`_vastai`, `_lambda` …) branch 하나씩 누적되는 나선이 열린다.
+
+### 1.3 왜 host가 아니라 runtime×model인가
+
+capability(MTP, tool_choice, reasoning dialect, structured output)를 결정하는 것은 **무엇이 떠 있냐**(serving runtime × model)이지 **어디에 떠 있냐**(host)가 아니다. 임대 host는 어떤 server+model이든 담을 수 있으므로 host로부터의 capability 추론은 논리적으로 부당하다. 유일한 예외는 **host가 곧 vendor인 canonical 도메인**(`api.openai.com`, `ollama.com`, `api.z.ai`)뿐이다 — 거긴 host==provider가 참이다.
+
+## 2. 경계 원칙 (What vs Where)
+
+| 축 | 결정 요소 | 정당한 출처 |
+|----|-----------|------------|
+| **WHAT** (capability / namespace) | serving runtime × model | config 필드 / model catalog row / manifest (선언) |
+| **WHERE** (transport) | host / URL / request path | auth, base path, edge 튜닝, pricing |
+
+규칙:
+
+1. **capability/namespace provenance = 명시적 config·model 선언.** generic host·URL 유도 금지.
+   - namespace는 `model_id` prefix(`<namespace>/<model_id>`) 또는 provider config의 명시 필드(serving-contract 식별자)에서 온다.
+   - namespace 이름은 host-무관 serving-contract로: `runpod_mtp` → 예 `vllm-qwen3-mtp` / `qwen3-mtp` (host 제거).
+2. **vendor-canonical 도메인 → provider는 허용**, 단 **정확 `Uri.host` 등가**로 (prefix 금지, look-alike 차단). generic rental host → capability는 금지.
+3. **path → wire-protocol**(Responses vs Chat)은 path가 실제 API envelope를 결정하는 경우에만, 정확 문자열 등가 + 비대상 kind는 catch-all 없는 exhaustive match로 fail-closed (`request_path_targets_responses_api`/`validate_request_path`가 정답례).
+4. **unknown host/provider/model/label → Unknown/None/fail-closed.** permissive/specific default 금지 (CLAUDE.md AI코드생성 #2).
+
+## 3. 미비 사항 인벤토리 (감사 확정)
+
+### P1 — PR #2374 / #2408 (미머지, 머지 차단) · host → capability namespace
+
+| # | 위치 | 증상 | severity |
+|---|------|------|----------|
+| B1 | `provider_endpoint.ml:31` `capability_provider_label` (#2374) | `OpenAI_compat when base_url_targets_runpod_proxy → "runpod_mtp"`. label이 `Capabilities.for_provider_model_id ~provider_label`로 흘러 catalog namespace `runpod_mtp/<model>` 선택. host가 namespace의 유일한 provenance. | medium |
+| B2 | `provider_endpoint.ml:17` `base_url_targets_runpod_proxy` (#2374) | `host == proxy.runpod.net || *.proxy.runpod.net` predicate. B1에 먹이는 host matcher. 저자가 ollama(broad preset) vs runpod(catalog-scoped) 비대칭을 둔 것 = rental≠vendor를 알면서도 rental host에 provenance를 키잉. | medium |
+| B1' | `provider_config.ml` `capability_provider_label` (#2408) | #2374와 **경쟁하는 중복 구현** — 같은 runpod_mtp를 다른 파일 경로로. 같은 root, 같은 조치. | medium |
+
+**조치**: #2374·#2408을 현 형태로 머지하지 않는다. host branch 삭제 → namespace를 §2 규칙 1의 명시 선언에서만 유도. RunPod-MTP를 신호해야 하면 base_url이 아니라 catalog의 runtime+model 키로.
+
+### P2 — main 기존 (선행 결함, 같은 계열) · host locality → vendor + 권한 인플레이션
+
+| # | 위치 | 증상 | severity |
+|---|------|------|----------|
+| B3 | `provider_registry.ml:533-534` `provider_name_of_config` (`OpenAI_compat + is_local → "nous"`) | 임의 로컬 OpenAI-compat 엔드포인트(bare llama.cpp/vLLM)가 loopback host만으로 특정 벤더 "nous"(Nous Research)로 라벨링. (a) `complete.ml`의 `~provider:` 텔레메트리가 모든 로컬 요청을 nous로 **무조건 오귀속**(+ free-pricing); (b) `registry_capabilities_for_provider_config` fallback이 `nous → openai_compat_chat_extended_capabilities`를 주어 uncatalogued 로컬 모델에 `supports_reasoning`/`extended_thinking`/`reasoning_budget` **권한 인플레이션**. 자기 `.mli` 계약(§69-78 "stable kind-derived label")과 `capabilities.ml:388-409` declaration-over-probing 철학에 모순. | medium |
+
+**조치**: `is_local → "nous"` 특례 삭제. 로컬은 중립 `"openai_compat"`(또는 locality-무관 `"local"`)로. 확장 caps는 catalog/manifest row나 명시 override에서만. `is_local`은 auth-less/zero-pricing 같은 전송·비용 관심사에만 — 그건 `provider.ml:670`(`is_local → Provider.Local`, 동일 wire dialect, capability 누수 0)에서 이미 올바르게 분리돼 있다(legit 대조군).
+
+### P3 — Borderline (경화 / 일관성, 낮은 우선순위)
+
+| # | 위치 | 증상 | 조치 |
+|---|------|------|------|
+| B4 | `provider_config.ml:199` `base_url_targets_ollama_cloud` | vendor-canonical `ollama.com`은 정당하나 loose `String.starts_with` prefix라 `https://ollama.com.attacker.example` look-alike가 `ollama_cloud` namespace 상속. 형제 `base_url_targets_openai`(205)·`openai_host_supports_output_schema`(789)는 이미 `Uri.host` 정확 비교. | prefix → `Uri.host` 파싱 후 `= "ollama.com" || ends_with ".ollama.com"`. |
+| B5 | `discovery.ml:287` `infer_capabilities` | unknown model_id의 probed generic 엔드포인트가 `structured_output`/`image_input`/`required·named tool_choice`=true를 무근거 부여. reasoning/thinking은 올바르게 fail-closed(정상). blast radius는 discovery 리포팅 메타로 제한(completion-contract 미사용). | generic base를 해당 필드 false로 시작, `/props`·catalog 선언 시 상향. reasoning에 이미 적용한 declaration-over-probing을 이 필드들에도. |
+| B6 | `capabilities.ml:761` `apply_manifest_entry` | manifest 오타 `base_label`이 `capabilities_for_provider_label = None`을 거쳐 **경고 없이** `default_capabilities`로 붕괴. 형제 필드 핸들러(805·856)는 `Diag.warn`함. 함수 docstring 자체가 fail-closed를 명시. host 무관(config→capability), 권한 손실이라 low. | `Some label` + `None` lookup 시 `Diag.warn` 또는 `None` 반환으로 오타 표면화. |
+| B7 | `complete_sampling.ml:57` `openai_compat_should_default_min_p` | capabilities 미상일 때 `None → is_local`로 min_p default 결정. host locality가 sampling default 선택. `config.min_p` 명시값 우선이라 blast radius 최소. | 명시 runtime/model capability 우선; 미상이면 미설정 또는 선언된 runtime kind로 키잉. |
+
+### Legit 32건 (대조군 — 변경 없음, 경계의 정답례)
+
+- `ollama.com → ollama_cloud`(`provider_config.ml:211`) — vendor-canonical host==provider (case a).
+- `zai_catalog.ml` `is_zai/is_coding_base_url` — 정확 `Uri.host` 등가 + path prefix + env override, look-alike 거부 테스트 핀 (a+c).
+- `http_client.ml:242` `cdn_per_header_limit_bytes = 8192` — RunPod/Cloudflare edge per-header-line 한계를 host-gate 없는 generic 전송 상수로, 진단에만 (b). **B1/B2가 어떻게 달랐어야 하는지의 정답.**
+- `provider.ml:670` `is_local → Provider.Local` — 동일 wire dialect·path, auth 없음·zero-pricing만 차이, capability 누수 0 (b). **B3의 `is_local`이 어디까지만 써야 했는지.**
+- `request_path_targets_responses_api`(832) + `validate_request_path`(842) — path가 실제 API envelope 결정, 정확 문자열 등가 + exhaustive match fail-closed (c).
+
+## 4. Migration
+
+1. namespace provenance를 명시 선언으로 도입 (`model_id` prefix 또는 config 필드). PR #2404(declarative override SSOT)와 정렬.
+2. `base_url_targets_runpod_proxy → "runpod_mtp"`(B1/B2) 및 `is_local → "nous"`(B3)를 포함한 모든 generic-host→capability 매핑 삭제.
+3. host-결합 namespace를 serving-contract 식별자로 rename.
+4. P3 경화(B4~B7): `Uri.host` 정확 비교, unknown→false 시작, manifest 오타 warn.
+5. §5 ratchet 추가로 재발 차단.
+
+## 5. Ratchet (RFC-OAS-022 미러)
+
+`.ci/endpoint-capability-baseline.json` + `scripts/ci-endpoint-capability-ratchet.sh` + workflow로 다음 metric을 monotone-decrease 고정:
+
+- **host_to_capability_label** — `base_url_targets_*` 또는 `is_local` 결과가 `capability_provider_label` / `provider_name_of_config`의 capability-선택 label로 흘러가는 사이트 수. baseline = P1·P2 삭제 후 **0**, 이후 증가 금지.
+- 판정: `capability_provider_label` / `provider_name_of_config`의 반환 label 중 vendor-canonical allowlist(`ollama_cloud`, `openai`, `glm`, `glm-coding` 등 정확-host 근거) 외의 host-유도 label = 위반.
+
+RFC-OAS-022의 script/workflow shape를 그대로 미러하되 metric set만 교체한다. baseline 없이 두면 다음 리팩터 wave에서 `_targets_<rental>` branch가 다시 들어온다(#2374·#2408이 실측).
+
+## 6. Verification (완료 정의)
+
+- **host-불변 회귀 테스트**: 동일 `~kind` + `~model_id`를 서로 다른 `~base_url`(`*.proxy.runpod.net`, 임의 도메인, localhost)로 만들어 `capabilities_for_config_model` / `provider_name_of_config`가 **동일 capability로 resolve**됨을 assert. vendor-canonical 도메인은 의도적 예외로 별도 명시.
+- generic-host→capability 사이트 0건 (§5 ratchet green).
+- vendor-canonical/transport/path-protocol 사이트는 유지되되 근거를 코드 주석 또는 RFC로 명시.
+- `ocamlformat --check` clean, 기존 test suite green.
+
+## 7. Related
+
+- **RFC-OAS-023** capability axis reshape — 034는 그 원칙(model × transport)의 집행. 023이 축을 정의하고 034가 host-유도 위반을 금지.
+- **RFC-OAS-022** monotone-decrease ratchet — §5가 script/workflow shape를 미러.
+- **RFC-OAS-018** provider-model catalog externalization — namespace의 선언 출처가 catalog임을 전제.
+- **PR #2404** declarative override SSOT — B1/B2/B3의 root fix가 안착할 기반.
+- **PR #2374, #2408** — 본 RFC가 흡수하는 트리거 (host→capability namespace, 중복 구현).
+- `~/me/instructions/software-development.md` §워크어라운드 거부 기준, AI 코드 생성 안티패턴 #1(scattered hardcoded)·#2(unknown→permissive)·#3(boundary violation).

--- a/docs/rfc/RFC-OAS-034-endpoint-capability-boundary.md
+++ b/docs/rfc/RFC-OAS-034-endpoint-capability-boundary.md
@@ -104,17 +104,33 @@ capability(MTP, tool_choice, reasoning dialect, structured output)를 결정하�
 1. namespace provenance를 명시 선언으로 도입 (`model_id` prefix 또는 config 필드). PR #2404(declarative override SSOT)와 정렬.
 2. `base_url_targets_runpod_proxy → "runpod_mtp"`(B1/B2) 및 `is_local → "nous"`(B3)를 포함한 모든 generic-host→capability 매핑 삭제.
 3. host-결합 namespace를 serving-contract 식별자로 rename.
-4. P3 경화(B4~B7): `Uri.host` 정확 비교, unknown→false 시작, manifest 오타 warn.
-5. §5 ratchet 추가로 재발 차단.
+4. P3 경화 — 적대적 재감사(#2414) 후 착지: **B4**=ollama `Uri.host` 정확 비교(#2420), **B7**=min_p를 `is_local` 대신 catalog-declared로(#2425), **model_catalog**=unknown TOML 키 fail-closed(#2426). **B5/B6는 false-positive로 강등**(discovery=capability=f(runtime) legit / manifest=이미 fail-closed). **B4'(:804 host→output_schema capability), :840(unknown base label→silent default)는 설계 변경 필요로 defer**(§7 참조).
+5. §5 ratchet 추가로 재발 차단 — **#2419 착지**(hardening ratchet 확장).
 
-## 5. Ratchet (RFC-OAS-022 미러)
+## 5. Ratchet (RFC-OAS-022/023 미러) — 구현: PR #2419
 
-`.ci/endpoint-capability-baseline.json` + `scripts/ci-endpoint-capability-ratchet.sh` + workflow로 다음 metric을 monotone-decrease 고정:
+초안은 standalone `scripts/ci-endpoint-capability-ratchet.sh` +
+`.ci/endpoint-capability-baseline.json`을 제안했으나, **기존 production hardening
+ratchet**(`scripts/hardening-ratchet.sh`, RFC-OAS-023)에 metric 1개를 추가하는
+방식으로 구현했다. scan/waiver/baseline/reporting 인프라를 재사용해 중복
+(anti-pattern #1 scattered infra)을 피한다. 이미 `model_id_string_classifiers_outside_catalog`라는 정확한 대칭 metric이 존재한다.
 
-- **host_to_capability_label** — `base_url_targets_*` 또는 `is_local` 결과가 `capability_provider_label` / `provider_name_of_config`의 capability-선택 label로 흘러가는 사이트 수. baseline = P1·P2 삭제 후 **0**, 이후 증가 금지.
-- 판정: `capability_provider_label` / `provider_name_of_config`의 반환 label 중 vendor-canonical allowlist(`ollama_cloud`, `openai`, `glm`, `glm-coding` 등 정확-host 근거) 외의 host-유도 label = 위반.
+- **`base_url_host_fuzzy_classifiers`** (`.ci/hardening-baseline.json`) —
+  `base_url`/`host`/`Uri.host`에 대한 fuzzy `String` 매칭
+  (`starts_with`/`ends_with`/`contains`/`is_substring`) 사이트 수를
+  monotone-decrease 고정. baseline = 기존 `ollama.com` 매처(B4 reducible debt),
+  이후 증가 금지.
+- 판정 경계: exact `String.equal (Uri.host …) "vendor"`
+  (vendor-canonical identity)와 정규화(`lowercase_ascii`/`trim`)는 **제외** →
+  legit 패턴 오탐 없음. `is_local`(hand-rolled `String.sub`)도 transport
+  predicate라 제외.
+- **차단 실증 (mutation test)**: #2374의
+  `String.ends_with ~suffix:".proxy.runpod.net" host` 주입 시 count가 baseline을
+  초과해 `--check`가 FAIL(+1) → revert 시 OK. 원칙 RFC만으론 못 막던 host→capability
+  재도입을 기계적으로 차단(#2374·#2408이 재발 실측).
 
-RFC-OAS-022의 script/workflow shape를 그대로 미러하되 metric set만 교체한다. baseline 없이 두면 다음 리팩터 wave에서 `_targets_<rental>` branch가 다시 들어온다(#2374·#2408이 실측).
+baseline은 신규 metric만 수술적으로 add한다. 나머지 hardening metric은 drift로
+stale-high(monotone-safe)이며, 전체 rebaseline은 별도 hygiene 작업으로 분리.
 
 ## 6. Verification (완료 정의)
 
@@ -131,3 +147,16 @@ RFC-OAS-022의 script/workflow shape를 그대로 미러하되 metric set만 교
 - **PR #2404** declarative override SSOT — B1/B2/B3의 root fix가 안착할 기반.
 - **PR #2374, #2408** — 본 RFC가 흡수하는 트리거 (host→capability namespace, 중복 구현).
 - `~/me/instructions/software-development.md` §워크어라운드 거부 기준, AI 코드 생성 안티패턴 #1(scattered hardcoded)·#2(unknown→permissive)·#3(boundary violation).
+
+### 구현 현황 (추적 이슈 #2414)
+
+| finding | 상태 | PR |
+|---|---|---|
+| B3 `is_local → "nous"` 중립화 | merged | #2415 |
+| §5 ratchet (`base_url_host_fuzzy_classifiers`) | Draft | #2419 |
+| B4 ollama `Uri.host` 정확 비교 | Draft | #2420 |
+| B7 min_p catalog-declared (host 비의존) | Draft | #2425 |
+| model_catalog unknown 키 fail-closed | Draft | #2426 |
+| B5 discovery / B6 manifest | false-positive (미구현) | — |
+| B4'(:804 host→output_schema) / :840(base label) | defer (설계 변경) | — |
+| B1/B2 (#2374·#2408 흡수) | 미착수 | — |


### PR DESCRIPTION
## 무엇

`RFC-OAS-034: Endpoint capability boundary` — host·URL을 capability/namespace의 provenance로 쓰는 안티패턴을 명명하고, 2026-07-01 감사 인벤토리를 고정합니다. capability = `(serving runtime) × (model)`, host/URL = 전송. generic rental host(`proxy.runpod.net`, `localhost`)에서 capability를 유도하면 동일 server+model이 위치를 옮길 때 capability를 잃습니다(silent fail-closed).

docs-only 변경입니다 (`docs/rfc/RFC-OAS-034-endpoint-capability-boundary.md` 1개).

## 왜

RFC-OAS-023이 이미 축(capability = model × transport)을 선언했는데도, 같은 host→capability 패턴으로 **PR이 2개** 열렸습니다:

- **#2374** `provider_endpoint.ml` — `*.proxy.runpod.net → "runpod_mtp"`
- **#2408** `provider_config.ml` — 같은 runpod_mtp를 다른 파일로 (중복 구현)

그리고 같은 계열이 **이미 main에** 있습니다 — `provider_registry.ml`의 `is_local → "nous"`(텔레메트리 오귀속 + 권한 인플레이션). 원칙 문서만으로는 재발이 막히지 않는다는 실측이라, 034는 집행 레이어(ratchet + host-불변 회귀 테스트)를 얹습니다.

## 감사 근거

`oas-endpoint-capability-boundary-audit` (29 agents, 7 finder 차원 + 적대 검증). 41 dedup 사이트 → confirmed 4 / borderline 5 / legit 32. 각 사이트를 3개 legit 예외(vendor-canonical host / 전송 튜닝 / path→wire-protocol)로 반증 시도해 살아남은 것만 bug로 확정.

- P1 (미머지, 머지 차단): B1/B2 (#2374), B1' (#2408)
- P2 (main 선행 결함): B3 `is_local → "nous"`
- P3 (경화): B4~B7
- Legit 대조군: `http_client.ml` RunPod 전송 상수, `provider.ml` `is_local → Local`, `request_path_targets_responses_api` — B1/B2/B3가 어떻게 달랐어야 하는지의 정답례.

## 검증

docs-only. 코드 변경 없음. RFC는 후속 구현 PR의 계약이며, §5(ratchet)·§6(host-불변 회귀 테스트)이 완료 정의입니다.

## RFC

이 PR 자체가 RFC 문서입니다 (`docs/rfc/RFC-OAS-034-...md`). llm_provider capability 경계는 workflow-pr §11의 RFC-게이트 subsystem 목록(credential/operator/sandbox/hooks) 밖이지만, 재발 계열이라 RFC로 흡수합니다.

## 후속

구현은 별도 PR로 분리: (1) B1/B2/B3 삭제 + namespace 명시 선언, (2) §5 ratchet, (3) §6 회귀 테스트. #2374/#2408은 본 RFC 원칙에 맞게 재작성 또는 흡수.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
