### PR TITLE
fix(provider): resolve local OpenAI-compat endpoints to neutral label, not vendor "nous" (RFC-OAS-034 B3)

### DIFF
--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -530,8 +530,17 @@ let provider_name_of_config (config : Provider_config.t) =
     else "ollama"
   | DashScope -> "dashscope"
   | OpenAI_compat ->
+    (* A local OpenAI-compatible endpoint (llama.cpp / vLLM / LM Studio / ...) is
+       a generic gateway that can serve any model; locality is a transport fact,
+       not a vendor identity. Resolve it to the neutral kind label rather than the
+       "nous" vendor entry, so telemetry is not misattributed to a specific vendor
+       and host locality does not, by itself, grant the extended capability
+       preset. The canonical local llama endpoint still receives its declared
+       capabilities through the exact endpoint binding in
+       [Provider_runtime_binding], not from this name. See RFC-OAS-034 (endpoint
+       capability boundary). *)
     if Provider_config.is_local config
-    then "nous"
+    then "openai_compat"
     else (
       let request_path = String.trim config.request_path in
       let base_url = normalize_url config.base_url in

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -1409,6 +1409,10 @@ let test_provider_name_of_config_glm_coding () =
 ;;
 
 let test_provider_name_of_config_local_openai_compat () =
+  (* A local OpenAI-compatible endpoint resolves to the neutral kind label, not
+     the "nous" vendor entry: locality is transport, not vendor identity
+     (RFC-OAS-034). Capabilities for the canonical local llama endpoint come from
+     its explicit endpoint binding, not from this name. *)
   let cfg =
     Provider_config.make
       ~kind:OpenAI_compat
@@ -1417,8 +1421,8 @@ let test_provider_name_of_config_local_openai_compat () =
       ()
   in
   check_string
-    "local openai compat resolves to llama"
-    "nous"
+    "local openai compat resolves to neutral kind label"
+    "openai_compat"
     (Provider_registry.provider_name_of_config cfg)
 ;;
 

--- a/test/test_provider_registry.ml
+++ b/test/test_provider_registry.ml
@@ -990,9 +990,9 @@ let test_requires_any () =
 (* ── Kind ↔ registry integrity ────────────────────────── *)
 
 (** Minimal [Provider_config.t] construction for a given kind, using a
-    localhost base URL so [is_local = true] for [OpenAI_compat] (resolves
-    to the registry's "nous" entry) and a plain (non-coding) URL for
-    [Glm] (resolves to "glm"). *)
+    localhost base URL for [OpenAI_compat] (a local endpoint resolves to the
+    neutral "openai_compat" label per RFC-OAS-034, not a vendor entry) and a
+    plain (non-coding) URL for [Glm] (resolves to "glm"). *)
 let mk_config_for_kind kind =
   let base_url =
     match kind with
@@ -1038,11 +1038,24 @@ let test_every_kind_resolves_in_registry () =
            name
            entry.name
        | None ->
-         failf
-           "%s: provider_name_of_config returned %S but registry has no entry for it; \
-            either register the provider or fix the naming function"
-           label
-           name)
+         (* OpenAI_compat is the generic compatibility kind: a local or otherwise
+            unmatched OpenAI-compatible endpoint resolves to the neutral
+            "openai_compat" label, which is intentionally not a registered vendor
+            entry (RFC-OAS-034). Every other kind must resolve to a registered
+            entry, so adding a variant without registration still fails here. *)
+         (match kind with
+          | Provider_config.OpenAI_compat ->
+            check
+              string
+              (Printf.sprintf "%s: neutral compat fallback" label)
+              "openai_compat"
+              name
+          | _ ->
+            failf
+              "%s: provider_name_of_config returned %S but registry has no entry for it; \
+               either register the provider or fix the naming function"
+              label
+              name))
     Provider_config.all_provider_kinds
 ;;
 

--- a/test/test_provider_runtime_binding.ml
+++ b/test/test_provider_runtime_binding.ml
@@ -209,6 +209,62 @@ let test_capabilities_for_provider_config_honors_override () =
       caps.supports_named_tool_choice)
 ;;
 
+let test_local_openai_compat_capabilities_not_inflated_by_locality () =
+  (* RFC-OAS-034: host locality must not grant the extended capability preset.
+     A local OpenAI-compatible endpoint on a non-default port serving an
+     uncatalogued model resolves to base openai_compat capabilities — reasoning
+     and extended thinking are NOT inferred from the endpoint being local. Before
+     the fix, [is_local -> "nous"] routed this to the extended preset. *)
+  let cfg =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.OpenAI_compat
+      ~model_id:"uncatalogued-local-model"
+      ~base_url:"http://127.0.0.1:8199"
+      ~request_path:"/v1/chat/completions"
+      ()
+  in
+  let caps = Provider_runtime_binding.capabilities_for_provider_config cfg in
+  Alcotest.(check bool) "no reasoning from locality" false caps.supports_reasoning;
+  Alcotest.(check bool)
+    "no extended thinking from locality"
+    false
+    caps.supports_extended_thinking;
+  Alcotest.(check bool)
+    "no reasoning budget from locality"
+    false
+    caps.supports_reasoning_budget
+;;
+
+let test_capabilities_host_invariant_local_vs_remote () =
+  (* RFC-OAS-034: capability = f(runtime x model), not f(host). The same kind +
+     uncatalogued model resolves to the same reasoning capability whether the
+     endpoint is local (non-default port) or remote. *)
+  let make base_url =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.OpenAI_compat
+      ~model_id:"uncatalogued-model"
+      ~base_url
+      ~request_path:"/v1/chat/completions"
+      ()
+  in
+  let local =
+    Provider_runtime_binding.capabilities_for_provider_config
+      (make "http://127.0.0.1:8199")
+  in
+  let remote =
+    Provider_runtime_binding.capabilities_for_provider_config
+      (make "https://remote.example/v1")
+  in
+  Alcotest.(check bool)
+    "reasoning capability is host-invariant"
+    remote.supports_reasoning
+    local.supports_reasoning;
+  Alcotest.(check bool)
+    "both resolve to base (no reasoning)"
+    false
+    local.supports_reasoning
+;;
+
 let test_catalog_structured_output_capability_projects_to_provider_config () =
   with_provider_catalog catalog_json (fun () ->
     let binding = expect_binding "subscriber-local" in
@@ -678,6 +734,14 @@ let () =
             "find and provider config fallbacks"
             `Quick
             test_find_empty_missing_and_provider_config_fallbacks
+        ; Alcotest.test_case
+            "local capabilities not inflated by locality"
+            `Quick
+            test_local_openai_compat_capabilities_not_inflated_by_locality
+        ; Alcotest.test_case
+            "capabilities host-invariant local vs remote"
+            `Quick
+            test_capabilities_host_invariant_local_vs_remote
         ] )
     ; ( "builtins"
       , [ Alcotest.test_case "builtin resolves" `Quick test_builtin_binding_resolves


### PR DESCRIPTION
## Problem

`Provider_registry.provider_name_of_config` mapped **any** local
(`127.0.0.1`/`localhost`) OpenAI-compatible endpoint to the specific vendor name
`"nous"` from host locality alone. `is_local` is a pure transport predicate — it
tests nothing about the serving runtime or model — yet it selected a vendor
identity. Two effects, both host→capability inference (RFC-OAS-034 finding B3,
jeong-sik/masc#27917):

- **Telemetry misattribution**: every local request was attributed to `"nous"`
  (a specific vendor, Nous Research) in `Complete`'s `~provider:` label,
  regardless of the actual server (llama.cpp / vLLM / LM Studio) or model.
- **Capability inflation**: `registry_capabilities_for_provider_config` falls
  back to `provider_name_of_config` → `find "nous"` →
  `openai_compat_chat_extended_capabilities`, granting `supports_reasoning` /
  `supports_extended_thinking` / `supports_reasoning_budget` to any uncatalogued
  local model purely because the endpoint is local. A text-only local model on a
  non-default port was advertised as reasoning-capable.

This also contradicted the function's own `.mli` contract (unmatched
OpenAI-compatible endpoints get a "stable kind-derived label") and the
declaration-over-probing philosophy in `capabilities.ml`.

## Fix

Resolve local OpenAI-compatible endpoints to the neutral `"openai_compat"` kind
label — the same label a remote unmatched OpenAI-compatible endpoint gets.

- **Telemetry** is no longer misattributed to a vendor; local is reported as the
  honest generic-compat label.
- **Capability is decoupled from the name.** The canonical local llama endpoint
  keeps its declared extended capabilities through the *exact endpoint registry
  binding* (`registry_entry_matches_config`, which matches by base_url/path/kind
  and is independent of this name). Non-default local endpoints fall to base
  `openai_compat` capabilities — reasoning is no longer inferred from locality.

Behavioral delta vs `main` is narrow: local OpenAI-compatible endpoints are named
`"openai_compat"` instead of `"nous"`, and an **uncatalogued, non-default-port**
local endpoint gets base (not extended) capabilities. Pricing is unaffected
(`static_free_alias_matches` keys on `model_id`, not on this label). The `"nous"`
registry entry is unchanged and still serves `Custom_registered { name = "nous" }`
and the canonical local llama endpoint binding.

## Files

- `lib/llm_provider/provider_registry.ml` — `is_local` local branch returns
  `"openai_compat"` (neutral) instead of `"nous"`.
- `test/test_provider_config.ml` — local OpenAI-compat resolves to
  `"openai_compat"`.
- `test/test_provider_registry.ml` — integrity guard accepts the neutral compat
  fallback for `OpenAI_compat`, stays strict (must-be-registered) for all other
  kinds.
- `test/test_provider_runtime_binding.ml` — host-invariant capability regression:
  local (non-default port) and remote uncatalogued endpoints resolve to the same
  base capabilities (`supports_reasoning = false`); locality does not inflate.

## Validation

- `dune exec --root . test/test_provider_registry.exe` — Test Successful, 43 tests.
- `dune exec --root . test/test_provider_runtime_binding.exe` — Test Successful,
  18 tests (incl. 2 new host-invariance tests).
- `dune exec --root . test/test_provider_config.exe` — 104/108. The 4 `output_schema`
  failures (`official openai` / `ollama cloud` acceptance) are **pre-existing on
  clean `origin/main` HEAD** (release 0.208.10, CI-green) and are
  environment-dependent in this sandbox (no catalog/network for those hosts) —
  unrelated to this change; verified identical failure set with the lib change
  reverted.
- `ocamlformat --check` clean on all 4 changed files (0.29.0).

## RFC

Implements finding **B3** of RFC-OAS-034 (endpoint capability boundary, jeong-sik/oas#2413),
tracked in jeong-sik/masc#27917. RFC-OAS-034 is the governing design for this capability/identity
boundary change.

Refs jeong-sik/masc#27917 (B3), RFC-OAS-034 (#2413).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
