### PR TITLE
fix: accept declared provider-qualified compat models

### DIFF
--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -1111,6 +1111,15 @@ let apply_catalog_entry (entry : Model_catalog.model_entry) : capabilities =
     model specifications were externalized to the TOML catalog. *)
 let provider_qualified_separators = [ "/"; ":"; "." ]
 
+let model_id_has_provider_label ~provider_label ~model_id =
+  let provider_label = String.lowercase_ascii (String.trim provider_label) in
+  let model_id = String.lowercase_ascii (String.trim model_id) in
+  provider_label <> ""
+  && List.exists
+       (fun separator -> String.starts_with ~prefix:(provider_label ^ separator) model_id)
+       provider_qualified_separators
+;;
+
 let provider_qualified_model_id_candidates ~provider_label ~model_id =
   let normalized_model_id = String.lowercase_ascii model_id in
   let provider_prefixes =

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -225,6 +225,12 @@ val for_model_id_catalog : string -> capabilities option
     This lets transports such as Ollama Cloud override bare model-family entries
     that are shared with other providers (for example [glm-5] or [kimi-k2.6])
     without coupling the catalog to any embedding application. *)
+val model_id_has_provider_label : provider_label:string -> model_id:string -> bool
+(** True when [model_id] explicitly carries [provider_label] using the same
+    provider-qualified separators as {!for_provider_model_id}. This is syntax
+    recognition only; callers still decide whether the declaration is
+    authoritative for their boundary. *)
+
 val for_provider_model_id
   :  allow_bare_fallback:bool
   -> provider_label:string

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -213,6 +213,12 @@ val gemini_thinking_control_of_id : string -> gemini_thinking_control
     prefix-matches [model_id]; there is no in-code fallback table. *)
 val for_model_id_catalog : string -> capabilities option
 
+(** True when [model_id] explicitly carries [provider_label] using the same
+    provider-qualified separators as {!for_provider_model_id}. This is syntax
+    recognition only; callers still decide whether the declaration is
+    authoritative for their boundary. *)
+val model_id_has_provider_label : provider_label:string -> model_id:string -> bool
+
 (** Look up capabilities for [model_id] with a provider-qualified catalog
     override first.
 
@@ -225,12 +231,6 @@ val for_model_id_catalog : string -> capabilities option
     This lets transports such as Ollama Cloud override bare model-family entries
     that are shared with other providers (for example [glm-5] or [kimi-k2.6])
     without coupling the catalog to any embedding application. *)
-val model_id_has_provider_label : provider_label:string -> model_id:string -> bool
-(** True when [model_id] explicitly carries [provider_label] using the same
-    provider-qualified separators as {!for_provider_model_id}. This is syntax
-    recognition only; callers still decide whether the declaration is
-    authoritative for their boundary. *)
-
 val for_provider_model_id
   :  allow_bare_fallback:bool
   -> provider_label:string

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -303,12 +303,23 @@ let catalog_entry_requires_endpoint_declaration (entry : Model_catalog.model_ent
   | None, None -> true
 ;;
 
-let raw_openai_compat_requires_endpoint_declaration config caps =
-  capability_requires_endpoint_declaration caps
-  ||
-  match catalog_entry_for_model_id config.model_id with
-  | Some entry -> catalog_entry_requires_endpoint_declaration entry
+let catalog_entry_explicitly_declared_by_model_id
+      config
+      (entry : Model_catalog.model_entry)
+  =
+  match normalized_catalog_label entry.provider_name with
+  | Some provider_label ->
+    Capabilities.model_id_has_provider_label ~provider_label ~model_id:config.model_id
   | None -> false
+;;
+
+let raw_openai_compat_requires_endpoint_declaration config caps =
+  match catalog_entry_for_model_id config.model_id with
+  | Some entry when catalog_entry_explicitly_declared_by_model_id config entry -> false
+  | Some entry ->
+    capability_requires_endpoint_declaration caps
+    || catalog_entry_requires_endpoint_declaration entry
+  | None -> capability_requires_endpoint_declaration caps
 ;;
 
 let capabilities_for_config_model (config : t) =

--- a/lib/llm_provider/provider_config.mli
+++ b/lib/llm_provider/provider_config.mli
@@ -415,7 +415,9 @@ val capability_provider_label : t -> string
 (** Resolve model capabilities using provider-qualified catalog entries first.
     Raw OpenAI-compatible endpoints may use bare catalog entries only for
     generic model facts; entries that change thinking/reasoning/replay wire
-    semantics require an explicit endpoint capability declaration. *)
+    semantics require an explicit endpoint capability declaration or an
+    explicitly provider-qualified model id whose prefix matches the catalog
+    entry's [provider_name]. *)
 val capabilities_for_config_model : t -> Capabilities.capabilities option
 
 (** Resolve the exact chat-template token for token-based thinking control,

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -675,7 +675,7 @@ thinking_control_format = "chat_template_kwargs"
          (Option.is_none (Provider_config.capabilities_for_config_model cfg)))
 ;;
 
-let test_openai_compat_raw_dot_qualified_provider_row_requires_endpoint_declaration () =
+let test_openai_compat_explicit_provider_qualified_model_id_resolves_catalog_row () =
   with_model_catalog_toml
     {|
 [[models]]
@@ -696,8 +696,48 @@ thinking_control_format = "chat_template_kwargs"
            ~base_url:"https://unknown-openai-compatible.example/v1"
            ()
        in
+       match Provider_config.capabilities_for_config_model cfg with
+       | Some caps ->
+         check_bool
+           "explicit provider-qualified model keeps tools"
+           true
+           caps.supports_tools;
+         check_bool
+           "explicit provider-qualified model keeps reasoning"
+           true
+           caps.supports_reasoning;
+         check_bool
+           "explicit provider-qualified model uses chat template kwargs"
+           true
+           (caps.thinking_control_format = Capabilities.Chat_template_kwargs)
+       | None ->
+         Alcotest.fail
+           "explicit provider-qualified model id should resolve its catalog row")
+;;
+
+let test_openai_compat_bare_model_id_does_not_resolve_provider_qualified_row () =
+  with_model_catalog_toml
+    {|
+[[models]]
+id_prefix = "runpod_mtp/qwen36-35b-a3b-mtp"
+base = "openai_chat"
+provider_name = "runpod_mtp"
+supports_tools = true
+supports_tool_choice = true
+supports_reasoning = true
+supports_extended_thinking = true
+thinking_control_format = "chat_template_kwargs"
+|}
+    (fun () ->
+       let cfg =
+         Provider_config.make
+           ~kind:OpenAI_compat
+           ~model_id:"qwen36-35b-a3b-mtp"
+           ~base_url:"https://unknown-openai-compatible.example/v1"
+           ()
+       in
        check_bool
-         "provider_name alone is not raw endpoint identity proof"
+         "bare raw model id does not inherit provider-qualified row"
          true
          (Option.is_none (Provider_config.capabilities_for_config_model cfg)))
 ;;
@@ -2075,9 +2115,13 @@ let () =
             `Quick
             test_openai_compat_raw_template_dialect_requires_endpoint_declaration
         ; Alcotest.test_case
-            "raw compat dot-qualified provider row requires endpoint declaration"
+            "explicit provider-qualified model id resolves catalog row"
             `Quick
-            test_openai_compat_raw_dot_qualified_provider_row_requires_endpoint_declaration
+            test_openai_compat_explicit_provider_qualified_model_id_resolves_catalog_row
+        ; Alcotest.test_case
+            "bare model id does not resolve provider-qualified row"
+            `Quick
+            test_openai_compat_bare_model_id_does_not_resolve_provider_qualified_row
         ; Alcotest.test_case
             "responses structured path accepted"
             `Quick


### PR DESCRIPTION
## Summary
- add a shared provider-qualified model id grammar helper in `Capabilities`
- let raw OpenAI-compatible configs use a provider-qualified catalog row only when `model_id` explicitly carries the catalog `provider_name`
- keep bare/raw model ids fail-closed so capability namespace is not inferred from endpoint host

## Verification
- `opam exec -- ocamlformat --check lib/llm_provider/capabilities.ml lib/llm_provider/capabilities.mli lib/llm_provider/provider_config.ml lib/llm_provider/provider_config.mli test/test_provider_config.ml`
- `git diff --check origin/main...HEAD`
- `scripts/dune-local.sh build test/test_provider_config.exe`
- `env -u OAS_CAPABILITY_MANIFEST OAS_MODEL_CATALOG=models.toml ./_build/default/test/test_provider_config.exe`

## Boundary
This intentionally does not classify RunPod or any other host as a provider. Host remains transport address; capability namespace comes only from explicit config/model_id syntax plus catalog provider_name.