### PR TITLE
feat(ratchet): host/base_url fuzzy-classifier hardening metric (RFC-OAS-034 §5)

### DIFF
--- a/.ci/hardening-baseline.json
+++ b/.ci/hardening-baseline.json
@@ -1,6 +1,11 @@
 {
   "_comment": "Production hardening ratchet baseline. Source: docs/rfc/RFC-OAS-023-hardening-ratchet.md. Regenerate with scripts/hardening-ratchet.sh --rebaseline.",
   "examples": {
+    "base_url_host_fuzzy_classifiers": [
+      "lib/llm_provider/provider_config.ml:201:String.starts_with ~prefix:\"https://ollama.com\" base_url",
+      "lib/llm_provider/provider_config.ml:202:|| String.starts_with ~prefix:\"http://ollama.com\" base_url",
+      "lib/llm_provider/provider_config.ml:796:|| String.ends_with ~suffix:\".ollama.com\" host"
+    ],
     "direct_env_reads": [
       "lib/code_snippet_eval.ml:195:let is_experiment_enabled ?(getenv = Sys.getenv_opt) () =",
       "lib/llm_provider/backend_ollama.ml:367:let orig = Sys.getenv_opt \"OAS_OLLAMA_KEEP_ALIVE\" in",
@@ -48,6 +53,7 @@
   },
   "lastUpdatedCommit": "66170abd52fe8265fb97e6c54eece06ce55b279f",
   "metrics": {
+    "base_url_host_fuzzy_classifiers": 3,
     "direct_env_reads": 21,
     "direct_env_reads_outside_env_boundary": 16,
     "exception_message_classifiers": 1,
@@ -59,6 +65,7 @@
     "workaround_markers": 0
   },
   "removalTargets": {
+    "base_url_host_fuzzy_classifiers": "RFC-OAS-034: host/URL is transport, not capability provenance. New fuzzy String matching (starts_with/ends_with/contains/is_substring) on base_url/host is forbidden; bind vendor identity via exact Uri.host equality and capability via the model catalog. Existing ollama.com matchers are reducible debt (migrate to exact Uri.host).",
     "direct_env_reads": "RFC-OAS-023: reduce by moving runtime env access behind config/env boundary modules.",
     "direct_env_reads_outside_env_boundary": "RFC-OAS-023: target zero outside explicit envBoundaryPaths.",
     "exception_message_classifiers": "RFC-OAS-023: target zero after typed Unix_error/Eio/http_error classifiers land.",

--- a/.ci/hardening-ratchet-config.json
+++ b/.ci/hardening-ratchet-config.json
@@ -63,6 +63,7 @@
     "heuristic_markers": "RFC-OAS-023/RFC-OAS-029: target zero for untyped heuristic runtime routing; new heuristic code requires a waiver and sunset plan.",
     "local_workspace_path_literals": "RFC-OAS-023: target zero; new local developer paths are never accepted without waiver.",
     "model_id_string_classifiers_outside_catalog": "RFC-OAS-029: keep model-id string classification inside catalog/capability boundary modules; scattered model matching is SSOT drift.",
+    "base_url_host_fuzzy_classifiers": "RFC-OAS-034: host/URL is transport, not capability provenance. New fuzzy String matching (starts_with/ends_with/contains/is_substring) on base_url/host is forbidden; bind vendor identity via exact Uri.host equality and capability via the model catalog. Existing ollama.com matchers are reducible debt (migrate to exact Uri.host).",
     "stub_markers": "RFC-OAS-023: target zero; assert false is excluded because it is commonly used for unreachable proof arms.",
     "workaround_markers": "RFC-OAS-023/RFC-OAS-029: target zero for permanent runtime workaround debt; temporary additions require waiver and sunset issue.",
     "wildcard_silent_defaults": "RFC-OAS-023: reduce by replacing permissive catch-all defaults with typed/default-explicit handling."

--- a/scripts/hardening-ratchet.sh
+++ b/scripts/hardening-ratchet.sh
@@ -30,6 +30,7 @@ METRICS = (
     "heuristic_markers",
     "workaround_markers",
     "model_id_string_classifiers_outside_catalog",
+    "base_url_host_fuzzy_classifiers",
     "stub_markers",
     "wildcard_silent_defaults",
 )
@@ -47,6 +48,19 @@ MODEL_ID_STRING_CLASSIFIER_RE = re.compile(
     r".*\b(?:config\.)?model(?:_id)?\b"
     r"|\b(?:config\.)?model(?:_id)?\b"
     r".*\bString\.(?:lowercase_ascii|uppercase_ascii|starts_with|ends_with|contains|equal)\b"
+)
+# Fuzzy string classification of a base_url / host, forbidden by RFC-OAS-034
+# (host/URL is transport, not capability provenance). Only the inexact matchers
+# are flagged: [String.equal] is intentionally excluded because exact
+# [Uri.host] equality is the sanctioned way to bind a vendor-canonical host to a
+# provider identity. Normalisation-only calls ([lowercase_ascii]/[trim]) are not
+# classifiers and are excluded too. New matches must migrate to exact host
+# equality or a model-catalog capability binding.
+HOST_URL_FUZZY_CLASSIFIER_RE = re.compile(
+    r"\bString\.(?:starts_with|ends_with|contains|is_substring)\b"
+    r".*\b(?:base_url|host)\b"
+    r"|\b(?:base_url|host)\b"
+    r".*\bString\.(?:starts_with|ends_with|contains|is_substring)\b"
 )
 STUB_RE = re.compile(
     r"\bNot_implemented\b"
@@ -231,6 +245,16 @@ def measure_texts(files, config):
                         lineno,
                         raw_line,
                     )
+                if HOST_URL_FUZZY_CLASSIFIER_RE.search(code_line):
+                    bump(
+                        metrics,
+                        examples,
+                        max_examples,
+                        "base_url_host_fuzzy_classifiers",
+                        path,
+                        lineno,
+                        raw_line,
+                    )
                 if STUB_RE.search(line):
                     bump(metrics, examples, max_examples, "stub_markers", path, lineno, raw_line)
                 if WILDCARD_SILENT_RE.search(line):
@@ -322,6 +346,8 @@ def self_test(config):
             "let workaround_flag = true",
             "let model_norm = String.lowercase_ascii model_id",
             "let model_is_qwen = String.starts_with ~prefix:\"qwen\" model_id",
+            "let is_proxy = String.ends_with ~suffix:sfx host",
+            "let host_ok = String.equal host api_host",
             "| _ -> None",
             "let path = \\\\\"/home/alice/me/tmp\\\\\"",
             "let impossible = assert false",
@@ -338,6 +364,7 @@ def self_test(config):
         "heuristic_markers": 1,
         "local_workspace_path_literals": 1,
         "model_id_string_classifiers_outside_catalog": 2,
+        "base_url_host_fuzzy_classifiers": 1,
         "stub_markers": 0,
         "workaround_markers": 1,
         "wildcard_silent_defaults": 1,

--- a/scripts/hardening-ratchet.sh
+++ b/scripts/hardening-ratchet.sh
@@ -56,11 +56,29 @@ MODEL_ID_STRING_CLASSIFIER_RE = re.compile(
 # provider identity. Normalisation-only calls ([lowercase_ascii]/[trim]) are not
 # classifiers and are excluded too. New matches must migrate to exact host
 # equality or a model-catalog capability binding.
+#
+# [Uri.host ...] is tracked as an equivalent host token (not just the bare
+# identifiers [host]/[base_url]) so fuzzy matching performed directly on a
+# freshly-extracted `Uri.host` value -- without first binding it to a `host`-
+# named variable -- is still caught.
 HOST_URL_FUZZY_CLASSIFIER_RE = re.compile(
     r"\bString\.(?:starts_with|ends_with|contains|is_substring)\b"
-    r".*\b(?:base_url|host)\b"
-    r"|\b(?:base_url|host)\b"
+    r".*\b(?:base_url|host|Uri\.host)\b"
+    r"|\b(?:base_url|host|Uri\.host)\b"
     r".*\bString\.(?:starts_with|ends_with|contains|is_substring)\b"
+)
+# ocamlformat commonly breaks a long application by putting the callee alone
+# on one line and its arguments (which may include the host/base_url token)
+# on the next. This "dangling call at end of line" regex identifies that
+# specific continuation shape so the 2-line join below only fires on it.
+# Deliberately one-directional: only a bare qualified stdlib function name
+# alone at line-end is a rare, specific signal that the call continues.
+# Joining on a dangling *token* (bare `host`/`base_url` identifier at
+# line-end) was tried and reverted -- those identifiers are common enough
+# as the tail of an unrelated statement that it produced false joins across
+# two independent statements (verified via self-test).
+HOST_FUZZY_DANGLING_CALL_RE = re.compile(
+    r"\bString\.(?:starts_with|ends_with|contains|is_substring)\s*$"
 )
 STUB_RE = re.compile(
     r"\bNot_implemented\b"
@@ -210,9 +228,10 @@ def measure_texts(files, config):
     metrics, examples, max_examples = empty_result(config)
     for path, text in files.items():
         try:
-            line_iter = uncomment_lines(text)
-            for lineno, (line, raw_line) in enumerate(line_iter, 1):
-                code_line = mask_string_literals(line)
+            lines = list(uncomment_lines(text))
+            code_lines = [mask_string_literals(line) for line, _ in lines]
+            for lineno, (line, raw_line) in enumerate(lines, 1):
+                code_line = code_lines[lineno - 1]
                 env_matches = list(ENV_READ_RE.finditer(code_line))
                 if env_matches:
                     metrics["direct_env_reads"] += len(env_matches)
@@ -245,7 +264,23 @@ def measure_texts(files, config):
                         lineno,
                         raw_line,
                     )
-                if HOST_URL_FUZZY_CLASSIFIER_RE.search(code_line):
+                # ocamlformat routinely splits a matcher call and its host/
+                # base_url argument across two physical lines (e.g.
+                # `String.starts_with\n  ~prefix:base_url ...`), so neither
+                # line alone contains both tokens even though the AST is a
+                # fuzzy host match. Only join with the next line when this
+                # line ends dangling on exactly the matcher-call shape
+                # ocamlformat produces -- joining every adjacent line pair
+                # unconditionally would false-match two unrelated statements
+                # that each happen to contain one half of the pattern.
+                joined_next = (
+                    f"{code_line} {code_lines[lineno]}"
+                    if HOST_FUZZY_DANGLING_CALL_RE.search(code_line) and lineno < len(code_lines)
+                    else None
+                )
+                if HOST_URL_FUZZY_CLASSIFIER_RE.search(code_line) or (
+                    joined_next is not None and HOST_URL_FUZZY_CLASSIFIER_RE.search(joined_next)
+                ):
                     bump(
                         metrics,
                         examples,
@@ -348,6 +383,9 @@ def self_test(config):
             "let model_is_qwen = String.starts_with ~prefix:\"qwen\" model_id",
             "let is_proxy = String.ends_with ~suffix:sfx host",
             "let host_ok = String.equal host api_host",
+            "  String.starts_with",
+            "    ~prefix:sfx host",
+            "let direct_uri_check = String.ends_with (Uri.host uri) ~suffix:\".ollama.com\"",
             "| _ -> None",
             "let path = \\\\\"/home/alice/me/tmp\\\\\"",
             "let impossible = assert false",
@@ -364,7 +402,9 @@ def self_test(config):
         "heuristic_markers": 1,
         "local_workspace_path_literals": 1,
         "model_id_string_classifiers_outside_catalog": 2,
-        "base_url_host_fuzzy_classifiers": 1,
+        # 1 original single-line match + 1 caught only via the 2-line dangling-
+        # call join (the ocamlformat split shape) + 1 via the Uri.host token.
+        "base_url_host_fuzzy_classifiers": 3,
         "stub_markers": 0,
         "workaround_markers": 1,
         "wildcard_silent_defaults": 1,


### PR DESCRIPTION
## Problem

RFC-OAS-034 established that host/URL is **transport**, orthogonal to
**capability provenance**. But a principle RFC alone did not stop the recurring
family: PR jeong-sik/oas#2374 and jeong-sik/oas#2408 both re-opened host→capability inference (a
`.proxy.runpod.net` host suffix → the `runpod_mtp` capability namespace). The
audit (#2414) found this pattern independently reintroduced twice after the axis
was already declared. Enforcement, not documentation, is what closes it.

This mirrors RFC-OAS-022 (code-smell) / RFC-OAS-023 (hardening): a
monotone-decrease ratchet that fails CI when a forbidden pattern count rises
above baseline.

## Change

Add one metric to the existing production hardening ratchet
(`scripts/hardening-ratchet.sh`) rather than a standalone script — this reuses
the centralised scan / waiver / baseline / reporting machinery instead of
duplicating it.

**Metric `base_url_host_fuzzy_classifiers`**: counts fuzzy `String` matching
(`starts_with` / `ends_with` / `contains` / `is_substring`) applied to a
`base_url` / `host` token.

- **`String.equal` is excluded.** Exact `Uri.host` equality is the sanctioned
  way to bind a vendor-canonical host (e.g. `api.openai.com`) to a provider
  identity. The anti-pattern is *fuzzy* matching that lets a generic rental host
  drift into a capability decision.
- Normalisation-only calls (`lowercase_ascii` / `trim`) are not classifiers and
  are excluded.
- `is_local` is **not** matched: it routes through `has_host_prefix`
  (`String.sub`), a transport predicate, not a `String.starts_with` idiom.

**Baseline = 3**: the existing `ollama.com` prefix/suffix matchers in
`provider_config.ml:201,202,796`. These are reducible debt (RFC-OAS-034 finding
B4: migrate to exact `Uri.host`), not an allowlist — reducing them lowers the
baseline monotonically.

## Why this actually blocks the family (not telemetry theatre)

Mutation test (TLA+ bug-model discipline: clean passes, buggy fails):

```
# inject jeong-sik/oas#2374's exact pattern into a tracked lib file:
let base_url_targets_runpod_proxy host =
  String.ends_with ~suffix:".proxy.runpod.net" host

$ scripts/hardening-ratchet.sh --check
base_url_host_fuzzy_classifiers   3   4   FAIL (+1)   → exit 1
# revert → OK again
```

So jeong-sik/oas#2374 / jeong-sik/oas#2408 cannot re-land their host→capability classifier without either
exceeding the baseline (CI red) or using exact `Uri.host` equality + a catalog
capability binding.

## Scope discipline

- The baseline change is a **surgical add of the new metric only**. Running
  `--rebaseline` revealed the committed baseline is stale-high (e.g.
  `direct_env_reads` 21→11, `model_id_string_classifiers` 2→0) because main
  improved without rebaselining. That drift is monotone-safe (ratchet only fails
  on *increase*) and **out of scope here** — a full rebaseline is a separate
  hygiene PR. This PR leaves those metrics at their last full-rebaseline values.
- **Deviation from the RFC-OAS-034 §5 draft**, which sketched a standalone
  `scripts/ci-endpoint-capability-ratchet.sh` + `.ci/endpoint-capability-baseline.json`.
  Reusing the hardening ratchet is strictly better (no duplicated infra). The
  RFC §5 text should be updated to match on jeong-sik/oas#2413.

## Files

- `scripts/hardening-ratchet.sh` — new metric, regex (with rationale comment),
  measurement, and self-test (positive + negative samples).
- `.ci/hardening-ratchet-config.json` — `removalTargets` entry (RFC-OAS-034).
- `.ci/hardening-baseline.json` — new metric at baseline 3.

## Validation

- `scripts/hardening-ratchet.sh --self-test` — OK (positive `ends_with host`
  counts 1; negative `String.equal host` counts 0, guarding against
  over-broadening the regex to catch exact equality).
- `scripts/hardening-ratchet.sh --measure` — `base_url_host_fuzzy_classifiers` = 3.
- `scripts/hardening-ratchet.sh --check` — OK (held).
- Mutation: injecting the jeong-sik/oas#2374 pattern → `--check` FAIL (+1); revert → OK.

WORKAROUND-WAIVED: this PR adds a ratchet **detector** that forbids fuzzy host
classifiers; it is the prescribed anti-workaround mechanism (RFC-OAS-022/023/034),
not a new string classifier in product code.

Refs jeong-sik/masc#27917 (RFC-OAS-034 §5 enforcement), RFC-OAS-034 (#2413).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
