### PR TITLE
fix(provider): match ollama cloud host by exact Uri.host, not URL prefix (RFC-OAS-034 B4)

### DIFF
--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -197,9 +197,17 @@ let provider_kind_to_yojson = Provider_kind.to_yojson
 let provider_kind_of_yojson = Provider_kind.of_yojson
 
 let base_url_targets_ollama_cloud base_url =
-  let base_url = String.lowercase_ascii (String.trim base_url) in
-  String.starts_with ~prefix:"https://ollama.com" base_url
-  || String.starts_with ~prefix:"http://ollama.com" base_url
+  (* Match the ollama cloud vendor host by exact [Uri.host] equality, mirroring
+     [base_url_targets_openai]. A raw prefix match on the URL string
+     ([String.starts_with ~prefix:"https://ollama.com"]) also accepts
+     lookalike hosts such as [https://ollama.company.com] and
+     [https://ollama.com.evil.example], because the prefix ends inside a longer
+     hostname. Parsing the host first and comparing it exactly is the sanctioned
+     vendor-identity binding (RFC-OAS-034: host is transport/identity, matched by
+     exact host equality, not fuzzy string prefix). *)
+  match Uri.of_string base_url |> Uri.host with
+  | None -> false
+  | Some host -> String.equal (String.lowercase_ascii host) "ollama.com"
 ;;
 
 let base_url_targets_openai base_url =

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -1903,7 +1903,14 @@ let test_capability_provider_label_ollama_cloud_exact_host () =
   Alcotest.(check bool)
     "suffix lookalike rejected"
     false
-    (String.equal "ollama_cloud" (label "https://ollama.com.evil.example/v1"))
+    (String.equal "ollama_cloud" (label "https://ollama.com.evil.example/v1"));
+  (* A prefix matcher also accepts a userinfo-based lookalike: the authority
+     [ollama.com@evil.example] makes [starts_with "https://ollama.com"] true
+     while the real [Uri.host] is [evil.example]. Exact host equality rejects it. *)
+  Alcotest.(check bool)
+    "userinfo lookalike rejected"
+    false
+    (String.equal "ollama_cloud" (label "https://ollama.com@evil.example/v1"))
 ;;
 
 (* ── Suite ────────────────────────────────────────────── *)

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -1884,6 +1884,28 @@ let test_wire_kind_roundtrip_via_yojson () =
   | None -> Alcotest.fail "roundtrip produced None"
 ;;
 
+let test_capability_provider_label_ollama_cloud_exact_host () =
+  let label base_url =
+    Provider_config.capability_provider_label
+      (Provider_config.make ~kind:Ollama ~model_id:"m" ~base_url ())
+  in
+  (* Apex ollama.com resolves to the cloud vendor label regardless of scheme. *)
+  check_string "https apex is cloud" "ollama_cloud" (label "https://ollama.com/v1");
+  check_string "http apex is cloud" "ollama_cloud" (label "http://ollama.com");
+  (* RFC-OAS-034 B4: a raw URL-prefix match ([starts_with "https://ollama.com"])
+     wrongly accepted these lookalike hosts because the prefix ends inside a
+     longer hostname. Exact [Uri.host] equality must reject them so a hostile or
+     accidental lookalike cannot inherit the ollama-cloud identity. *)
+  Alcotest.(check bool)
+    "subdomain lookalike rejected"
+    false
+    (String.equal "ollama_cloud" (label "https://ollama.company.com/v1"));
+  Alcotest.(check bool)
+    "suffix lookalike rejected"
+    false
+    (String.equal "ollama_cloud" (label "https://ollama.com.evil.example/v1"))
+;;
+
 (* ── Suite ────────────────────────────────────────────── *)
 
 let () =
@@ -2265,6 +2287,12 @@ let () =
             "record JSON roundtrip preserves variant"
             `Quick
             test_wire_kind_roundtrip_via_yojson
+        ] )
+    ; ( "capability_provider_label"
+      , [ Alcotest.test_case
+            "ollama cloud matched by exact host, lookalikes rejected"
+            `Quick
+            test_capability_provider_label_ollama_cloud_exact_host
         ] )
     ]
 ;;


### PR DESCRIPTION
## Problem

`base_url_targets_ollama_cloud` classified a base URL as the ollama-cloud vendor
host with a raw string prefix:

```ocaml
String.starts_with ~prefix:"https://ollama.com" base_url
|| String.starts_with ~prefix:"http://ollama.com" base_url
```

Because the prefix ends *inside* a longer hostname, it also accepts lookalikes:

- `https://ollama.company.com/v1` — different vendor
- `https://ollama.com.evil.example/v1` — attacker-controlled host

Both wrongly inherit the `"ollama_cloud"` label from `capability_provider_label`.
This is RFC-OAS-034 finding **B4**: host identity must be bound by exact
`Uri.host` equality, not a fuzzy URL prefix (host is transport/identity, matched
exactly — never substring-matched).

## Fix

Parse the host and compare it exactly, mirroring the sibling
`base_url_targets_openai`:

```ocaml
match Uri.of_string base_url |> Uri.host with
| None -> false
| Some host -> String.equal (String.lowercase_ascii host) "ollama.com"
```

- Apex `ollama.com` still resolves to `"ollama_cloud"` regardless of scheme.
- Lookalike hosts fall through to the plain kind label (`"ollama"`).

## Validation

- New test `capability_provider_label / ollama cloud matched by exact host,
  lookalikes rejected` — passes on the fix.
- **Mutation-confirmed**: reverting the lib change (keeping the test) makes it
  FAIL at `subdomain lookalike rejected` (`Received: true` — old prefix code
  accepts `ollama.company.com`). So the test is a real regression guard.
- Full `test_provider_config` suite: the only failures are 4 pre-existing
  `output_schema` cases (`official openai`, `ollama cloud` schema *acceptance*)
  that fail identically with the lib change reverted — they are
  catalog/network-dependent in this sandbox and unrelated to host matching
  (verified by stashing the lib change: identical failure set).
- `ocamlformat --check` clean on both files.

## Relationship to jeong-sik/oas#2419

This reduces the `base_url_host_fuzzy_classifiers` hardening metric (added in
jeong-sik/oas#2419) from 3 to 1 once both land — a live demonstration of the ratchet's
monotone-decrease direction. The §2419 baseline can be tightened 3→1 in the
deferred hygiene rebaseline.

Refs jeong-sik/masc#27917 (RFC-OAS-034 B4).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
