### PR TITLE
[codex] Trigger release for default unbounded turn budget

### DIFF
--- a/docs/analysis/2026-07-01-default-unbounded-turn-budget-release-gap.md
+++ b/docs/analysis/2026-07-01-default-unbounded-turn-budget-release-gap.md
@@ -1,0 +1,50 @@
+# Default Unbounded Turn Budget Release Gap
+
+Date: 2026-07-01
+
+## Context
+
+PR #2417 changed the OAS agent default so omitted `max_turns` resolves to
+`0`, the documented no-turn-count-limit sentinel. The change is needed by
+downstream MASC keeper runs because MASC delegates its default runtime
+`max_turns` to `Agent_sdk.Types.default_config.max_turns`.
+
+## Release Gap
+
+PR #2417 merged with the squash title:
+
+```text
+Make default agent turn budget unbounded (#2417)
+```
+
+That title is not a conventional commit, so release-please skipped publishing a
+new `agent_sdk` release for the already-merged behavior.
+
+The relevant release-please log said:
+
+```text
+commit could not be parsed: 75b615ee784e460661ed4622317a891df158abb5
+Make default agent turn budget unbounded (#2417)
+
+No user facing commits found since 79260f042b476dda498952c71519195859ea3910
+- skipping
+```
+
+## Downstream Impact
+
+Until a release containing #2417 exists, downstream MASC cannot safely bump its
+`agent_sdk` floor/pin to consume the default-unbounded behavior. The MASC-side
+resume compatibility patch can preserve `max_turns = 0`, but it still needs an
+OAS release where that is the SDK default.
+
+## Intended Release Trigger
+
+This note accompanies a conventional commit:
+
+```text
+fix(agent): release default unbounded turn budget
+```
+
+The commit has no runtime code delta beyond this documentation. Its purpose is
+to let the normal release-please pipeline publish the already-merged #2417
+behavior so downstream consumers can pin it normally.


### PR DESCRIPTION
## Summary

Adds a conventional release-trigger commit plus a short release-gap note so release-please can publish the already-merged default-unbounded turn-budget change from #2417.

## Root Cause

OAS #2417 merged with the squash title `Make default agent turn budget unbounded (#2417)`. release-please could not parse that as a conventional commit and skipped the release:

- `commit could not be parsed: 75b615ee... Make default agent turn budget unbounded (#2417)`
- `No user facing commits found since 79260f0... - skipping`

That leaves downstream MASC unable to consume an `agent_sdk` release containing #2417.

## Impact

No runtime source files change in this PR. Once merged, release-please should see:

`fix(agent): release default unbounded turn budget`

and produce the next patch release from current `main`, including #2417.

The added note records why this PR exists:

- `docs/analysis/2026-07-01-default-unbounded-turn-budget-release-gap.md`

## Validation

- `git status --short --branch`
- release-please run log inspected: `gh run view 28513365727 --repo jeong-sik/oas --log`
- `git diff --cached --check`

No local Dune build was run; Dune validation remains CI-owned.
