### PR TITLE
feat(llm_provider): expose packaged model catalog

### DIFF
--- a/agent_sdk.opam
+++ b/agent_sdk.opam
@@ -12,6 +12,7 @@ bug-reports: "https://github.com/jeong-sik/agent-sdk/issues"
 depends: [
   "ocaml" {>= "5.1"}
   "dune" {>= "3.22" & >= "3.22"}
+  "dune-site" {>= "3.22"}
   "eio_main" {>= "1.3"}
   "cohttp-eio" {>= "6.2.0"}
   "tls" {>= "2.0.0"}

--- a/dune
+++ b/dune
@@ -1,0 +1,7 @@
+(install
+ (section
+  (site
+   (agent_sdk model_catalog)))
+ (package agent_sdk)
+ (files
+  (models.toml as models.toml)))

--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,9 @@
 (lang dune 3.22)
+(using dune_site 0.1)
 (name agent_sdk)
 (version 0.208.12) ; x-release-please-version
+
+(package
+ (name agent_sdk)
+ (sites
+  (share model_catalog)))

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -1100,10 +1100,11 @@ let apply_catalog_entry (entry : Model_catalog.model_entry) : capabilities =
 
     The catalog itself is resolved by {!Model_catalog.global}, in order:
     runtime override installed via {!Model_catalog.set_global}, then the
-    [OAS_MODEL_CATALOG] environment variable. The env discovery is cached
-    after first load; embedding hosts and test harnesses can call
-    [Model_catalog.preload_global] or inject [OAS_MODEL_CATALOG] during
-    bootstrap.
+    [OAS_MODEL_CATALOG] environment variable, then the packaged default
+    [models.toml]. Ambient discovery is cached after first load; embedding
+    hosts and test harnesses can call [Model_catalog.preload_global], inject
+    [OAS_MODEL_CATALOG] during bootstrap, or install an explicit runtime
+    override.
 
     Returns [None] when no catalog is available or when the catalog has
     no entry whose [id_prefix] matches [model_id]. There is no in-code

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -204,10 +204,11 @@ val gemini_thinking_control_of_id : string -> gemini_thinking_control
 
     The catalog is resolved by {!Model_catalog.global}, in order: runtime
     override installed via {!Model_catalog.set_global}, the
-    [OAS_MODEL_CATALOG] environment variable. The env discovery is cached
-    after first load; embedding hosts and test harnesses can call
-    [Model_catalog.preload_global] or inject [OAS_MODEL_CATALOG] during
-    bootstrap.
+    [OAS_MODEL_CATALOG] environment variable, then the packaged default
+    [models.toml]. Ambient discovery is cached after first load; embedding
+    hosts and test harnesses can call [Model_catalog.preload_global], inject
+    [OAS_MODEL_CATALOG] during bootstrap, or install an explicit runtime
+    override.
 
     Returns [None] when no catalog is available or when no catalog entry
     prefix-matches [model_id]; there is no in-code fallback table. *)

--- a/lib/llm_provider/dune
+++ b/lib/llm_provider/dune
@@ -6,6 +6,7 @@
  (libraries
   yojson
   otoml
+  dune-site
   ppx_deriving_yojson.runtime
   eio
   eio.unix
@@ -23,3 +24,8 @@
   (pps ppx_deriving_yojson ppx_deriving.show ppx_deriving.eq ppx_inline_test))
  (instrumentation
   (backend bisect_ppx)))
+
+(generate_sites_module
+ (module model_catalog_sites)
+ (sourceroot)
+ (sites agent_sdk))

--- a/lib/llm_provider/model_catalog.ml
+++ b/lib/llm_provider/model_catalog.ml
@@ -46,6 +46,8 @@ type model_entry =
 
 type t = model_entry list
 
+let default_catalog_filename = "models.toml"
+
 let find_string_opt toml path =
   match Otoml.find_opt toml Otoml.get_string path with
   | Some s -> Some s
@@ -385,6 +387,54 @@ let load_runtime_file path =
     None
 ;;
 
+let is_existing_file path =
+  try Sys.file_exists path && not (Sys.is_directory path) with
+  | Sys_error _ -> false
+;;
+
+let dedupe_paths paths =
+  List.fold_left
+    (fun seen path -> if List.mem path seen then seen else path :: seen)
+    []
+    paths
+  |> List.rev
+;;
+
+let default_catalog_paths () =
+  let site_paths =
+    List.map
+      (fun dir -> Filename.concat dir default_catalog_filename)
+      Model_catalog_sites.Sites.model_catalog
+  in
+  let source_paths =
+    match Model_catalog_sites.sourceroot with
+    | None -> []
+    | Some root -> [ Filename.concat root default_catalog_filename ]
+  in
+  site_paths @ source_paths |> dedupe_paths
+;;
+
+let load_default () =
+  match default_catalog_paths () with
+  | [] -> Error "default model catalog has no Dune site or source-root candidate paths"
+  | paths ->
+    let rec first_loaded errors = function
+      | [] ->
+        Error
+          (Printf.sprintf
+             "default model catalog failed to load from candidate path(s): %s"
+             (String.concat "; " (List.rev errors)))
+      | path :: rest ->
+        let load_result =
+          if is_existing_file path then load_file path else Error "file not found"
+        in
+        (match load_result with
+         | Ok catalog -> Ok catalog
+         | Error msg -> first_loaded (Printf.sprintf "%s: %s" path msg :: errors) rest)
+    in
+    first_loaded [] paths
+;;
+
 let dot_qualified_aliases model_id =
   let original_model_id = String.trim model_id in
   match String.index_opt original_model_id '.' with
@@ -436,8 +486,22 @@ type env_cache =
 
 let load_ambient_catalog () =
   match Cli_common_env.get "OAS_MODEL_CATALOG" with
-  | None -> None
   | Some path -> load_runtime_file path
+  | None ->
+    (match load_default () with
+     | Ok catalog ->
+       Diag.info
+         "model_catalog"
+         "loaded %d default model entries from packaged catalog"
+         (List.length catalog);
+       Some catalog
+     | Error msg ->
+       Diag.warn
+         "model_catalog"
+         "failed to load packaged default model catalog: %s; set OAS_MODEL_CATALOG to an \
+          explicit catalog path to override"
+         msg;
+       None)
 ;;
 
 let env_loaded_catalog : env_cache Atomic.t = Atomic.make Unloaded
@@ -457,7 +521,12 @@ let load_ambient_once () =
 
 let runtime_override : t option Atomic.t = Atomic.make None
 let set_global t = Atomic.set runtime_override (Some t)
-let clear_global () = Atomic.set runtime_override None
+
+let clear_global () =
+  Atomic.set runtime_override None;
+  Atomic.set env_loaded_catalog Unloaded
+;;
+
 let preload_global () = ignore (load_ambient_once () : t option)
 
 let global () =

--- a/lib/llm_provider/model_catalog.mli
+++ b/lib/llm_provider/model_catalog.mli
@@ -55,6 +55,20 @@ type t = model_entry list
 val load_file : string -> (t, string) result
 val load_runtime_file : string -> t option
 
+(** Candidate locations for the packaged default [models.toml].
+
+    The paths come from Dune's site metadata and, for uninstalled development
+    builds, Dune's source-root metadata. The list preserves missing candidates
+    so {!load_default} can report exactly what it tried. *)
+val default_catalog_paths : unit -> string list
+
+(** Load the packaged default [models.toml].
+
+    Returns [Error] when the default catalog cannot be found or parsed; callers
+    that require catalog-backed capability decisions should propagate that error
+    rather than falling back silently. *)
+val load_default : unit -> (t, string) result
+
 (** Longest-prefix lookup for catalog model IDs.
 
     In addition to exact catalog syntax, [lookup] accepts a flattened
@@ -69,7 +83,19 @@ val lookup : t -> string -> model_entry option
     [id_prefix], if that entry declares one. *)
 val provider_name_for_model_id : t -> string -> string option
 
+(** Return the active model catalog.
+
+    Resolution order:
+    - runtime override installed with {!set_global}
+    - [OAS_MODEL_CATALOG], when set to a non-empty path
+    - packaged default [models.toml] installed through the agent_sdk
+      [model_catalog] Dune site, or the source-root [models.toml] when running
+      from an uninstalled Dune build
+
+    The ambient result is cached after the first load. {!clear_global} clears
+    the runtime override and the ambient cache. *)
 val global : unit -> t option
+
 val preload_global : unit -> unit
 val set_global : t -> unit
 val clear_global : unit -> unit

--- a/test/dune
+++ b/test/dune
@@ -334,7 +334,6 @@
   test_mcp_session
   test_metric_contract
   test_metrics
-  test_model_catalog_default
   test_model_registry
   test_module_check
   test_multimodal

--- a/test/dune
+++ b/test/dune
@@ -131,6 +131,7 @@
   test_mcp_session
   test_metric_contract
   test_metrics
+  test_model_catalog_default
   test_model_registry
   test_module_check
   test_multimodal
@@ -333,6 +334,7 @@
   test_mcp_session
   test_metric_contract
   test_metrics
+  test_model_catalog_default
   test_model_registry
   test_module_check
   test_multimodal

--- a/test/test_model_catalog_default.ml
+++ b/test/test_model_catalog_default.ml
@@ -1,0 +1,70 @@
+open Alcotest
+module Capabilities = Llm_provider.Capabilities
+module Model_catalog = Llm_provider.Model_catalog
+
+let id_prefixes catalog =
+  List.map (fun (entry : Model_catalog.model_entry) -> entry.id_prefix) catalog
+;;
+
+let first_id_prefix ~suite = function
+  | [] -> failf "%s: repo model catalog should not be empty" suite
+  | (entry : Model_catalog.model_entry) :: _ -> entry.id_prefix
+;;
+
+let with_oas_model_catalog_unset f =
+  let previous = Sys.getenv_opt "OAS_MODEL_CATALOG" in
+  Unix.putenv "OAS_MODEL_CATALOG" "";
+  Model_catalog.clear_global ();
+  Fun.protect
+    ~finally:(fun () ->
+      (match previous with
+       | Some value -> Unix.putenv "OAS_MODEL_CATALOG" value
+       | None -> Unix.putenv "OAS_MODEL_CATALOG" "");
+      Model_catalog.clear_global ())
+    f
+;;
+
+let test_load_default_catalog () =
+  let expected =
+    Model_catalog_test_support.load_repo_model_catalog ~suite:"model catalog default"
+  in
+  match Model_catalog.load_default () with
+  | Error msg -> failf "default model catalog should load: %s" msg
+  | Ok catalog ->
+    check
+      (list string)
+      "default catalog id_prefixes match repo catalog"
+      (id_prefixes expected)
+      (id_prefixes catalog)
+;;
+
+let test_global_loads_default_catalog_for_capabilities () =
+  let expected =
+    Model_catalog_test_support.load_repo_model_catalog
+      ~suite:"model catalog default production path"
+  in
+  let model_id =
+    first_id_prefix ~suite:"model catalog default production path" expected
+  in
+  with_oas_model_catalog_unset (fun () ->
+    match Capabilities.for_model_id_catalog model_id with
+    | Some _ -> ()
+    | None ->
+      failf
+        "Capabilities.for_model_id_catalog should resolve %S through packaged/default \
+         Model_catalog.global"
+        model_id)
+;;
+
+let () =
+  run
+    "model catalog default"
+    [ ( "packaged catalog"
+      , [ test_case "load_default" `Quick test_load_default_catalog
+        ; test_case
+            "global uses packaged default"
+            `Quick
+            test_global_loads_default_catalog_for_capabilities
+        ] )
+    ]
+;;


### PR DESCRIPTION
Summary:
- install models.toml as the agent_sdk model_catalog Dune site instead of requiring downstream copies as the only default path
- add Model_catalog.default_catalog_paths/load_default for explicit default catalog loading with Error on missing or invalid catalog
- preserve attempted candidate paths in load_default errors so missing packaged/source catalogs are not silent
- add coverage for loading the packaged/default catalog

Validation:
- opam exec -- ocamlformat --check lib/llm_provider/model_catalog.ml lib/llm_provider/model_catalog.mli test/test_model_catalog_default.ml
- git diff --check
- opam lint agent_sdk.opam
- Full build/test intentionally left to CI per operator instruction