### PR TITLE
fix(sampling): do not default min_p from host locality for uncatalogued models (RFC-OAS-034 B7)

### DIFF
--- a/lib/llm_provider/complete_sampling.ml
+++ b/lib/llm_provider/complete_sampling.ml
@@ -375,7 +375,10 @@ let%test "provider_sampling_defaults Gemini has no min_p" =
   d.default_min_p = None
 ;;
 
-let%test "apply_sampling_defaults does not default min_p for uncatalogued local OpenAI_compat (RFC-OAS-034)" =
+let%test
+    "apply_sampling_defaults does not default min_p for uncatalogued local OpenAI_compat \
+     (RFC-OAS-034)"
+  =
   (* An uncatalogued model on a local endpoint must NOT receive the min_p floor:
      locality is transport, not a declared min_p capability. Before RFC-OAS-034
      this asserted [Some ...] purely because [is_local] was true. *)
@@ -458,7 +461,10 @@ let%test "apply_sampling_defaults OpenAI_compat Gemini model does not set min_p"
   applied.min_p = None
 ;;
 
-let%test "apply_sampling_defaults DashScope model keeps min_p default (kind-declared, not host)" =
+let%test
+    "apply_sampling_defaults DashScope model keeps min_p default (kind-declared, not \
+     host)"
+  =
   (* DashScope carries the min_p floor via provider_sampling_defaults regardless
      of host — the kind declares the capability. Uses kind=DashScope (qwen is a
      DashScope model) so the assertion no longer relies on is_local, which

--- a/lib/llm_provider/complete_sampling.ml
+++ b/lib/llm_provider/complete_sampling.ml
@@ -20,7 +20,10 @@ let gemini_url ~(config : Provider_config.t) ~stream =
 ;;
 
 (** Provider-aware sampling parameter defaults.
-    Local providers get min_p=0.05 (2026 llama.cpp standard).
+    OpenAI_compat / DashScope / Kimi carry the min_p=0.05 floor (2026 llama.cpp
+    standard); for OpenAI_compat it is applied only when the model's catalog
+    entry declares [supports_min_p] — capability is catalog-declared, not
+    inferred from host locality (RFC-OAS-034).
     Anthropic gets no top_p (incompatible with temperature).
     Explicit agent_config values always take priority (overlay pattern). *)
 type sampling_defaults =
@@ -54,7 +57,16 @@ let provider_sampling_defaults (kind : Provider_config.provider_kind) : sampling
 let openai_compat_should_default_min_p (config : Provider_config.t) : bool =
   match Provider_config.capabilities_for_config_model config with
   | Some caps -> caps.supports_min_p
-  | None -> Provider_config.is_local config
+  | None ->
+    (* Unknown capability: do NOT inject the min_p floor. min_p support is a
+       model capability (catalog-declared), not a property of host locality
+       (RFC-OAS-034: host/transport is orthogonal to capability). The previous
+       [Provider_config.is_local config] made an uncatalogued *local* model
+       receive min_p while the identical model served remotely did not, and it
+       diverged from the send-time gate (default_capabilities.supports_min_p =
+       false), which then dropped the floor and emitted a misleading
+       "remove the field" WARN. Fail closed to the send-time behavior. *)
+    false
 ;;
 
 (** Apply provider defaults to a config, preserving explicit values (overlay pattern).
@@ -363,7 +375,10 @@ let%test "provider_sampling_defaults Gemini has no min_p" =
   d.default_min_p = None
 ;;
 
-let%test "apply_sampling_defaults fills min_p for OpenAI_compat" =
+let%test "apply_sampling_defaults does not default min_p for uncatalogued local OpenAI_compat (RFC-OAS-034)" =
+  (* An uncatalogued model on a local endpoint must NOT receive the min_p floor:
+     locality is transport, not a declared min_p capability. Before RFC-OAS-034
+     this asserted [Some ...] purely because [is_local] was true. *)
   let config : Provider_config.t =
     { kind = OpenAI_compat
     ; model_id = "local-model"
@@ -400,7 +415,7 @@ let%test "apply_sampling_defaults fills min_p for OpenAI_compat" =
     }
   in
   let applied = apply_sampling_defaults config in
-  applied.min_p = Some Constants.Sampling.openai_compat_min_p
+  applied.min_p = None
 ;;
 
 let%test "apply_sampling_defaults OpenAI_compat Gemini model does not set min_p" =
@@ -443,9 +458,13 @@ let%test "apply_sampling_defaults OpenAI_compat Gemini model does not set min_p"
   applied.min_p = None
 ;;
 
-let%test "apply_sampling_defaults OpenAI_compat dashscope model keeps min_p default" =
+let%test "apply_sampling_defaults DashScope model keeps min_p default (kind-declared, not host)" =
+  (* DashScope carries the min_p floor via provider_sampling_defaults regardless
+     of host — the kind declares the capability. Uses kind=DashScope (qwen is a
+     DashScope model) so the assertion no longer relies on is_local, which
+     RFC-OAS-034 removes from the capability decision. *)
   let config : Provider_config.t =
-    { kind = OpenAI_compat
+    { kind = DashScope
     ; model_id = "qwen-turbo"
     ; base_url = "http://localhost:11434"
     ; api_key = Secret.empty

--- a/test/test_complete_ext.ml
+++ b/test/test_complete_ext.ml
@@ -292,8 +292,8 @@ let test_sampling_defaults_and_overlay () =
   let local_defaulted = Complete.apply_sampling_defaults local in
   check
     (option (float 0.001))
-    "local min_p defaulted"
-    (Some Constants.Sampling.openai_compat_min_p)
+    "uncatalogued local OpenAI_compat min_p not defaulted (RFC-OAS-034)"
+    None
     local_defaulted.min_p;
   let explicit = make_config ~min_p:0.2 ~top_p:0.7 ~top_k:17 () in
   let explicit_defaulted = Complete.apply_sampling_defaults explicit in


### PR DESCRIPTION
## Problem

`openai_compat_should_default_min_p` decided whether to inject the `min_p=0.05`
floor from the model's catalog capability — but when the model had **no** catalog
entry it fell back to host locality:

```ocaml
| None -> Provider_config.is_local config
```

Two problems (RFC-OAS-034 finding B7):

1. **host → capability inference** (anti-pattern jeong-sik/oas#4): an uncatalogued model on a
   local endpoint received `min_p`, while the *same* model served remotely did
   not. Locality is transport; it does not declare a min_p capability.
2. **divergence from the send-time gate**: `backend_openai`'s send path uses
   `default_capabilities.supports_min_p = false` for uncatalogued models, so it
   **dropped** the floor this function injected and emitted a misleading
   `dropping sampling field min_p ... remove the field from your request config`
   WARN — for a value the SDK itself had added.

## Fix

```ocaml
| None -> false
```

Unknown capability ⇒ do not inject `min_p`. Support is catalog-declared
(`supports_min_p`), not derived from locality. This fails closed to the exact
behavior the send gate already enforces.

**Wire behavior is unchanged** on the affected path (the send gate already
dropped `min_p` there); the change removes the spurious floor, the misleading
WARN, and the discarded `config.min_p` pollution. Catalogued models that declare
`supports_min_p = true`, and the kind-level `DashScope`/`Kimi` floors, are
unaffected.

## Tests

- `complete_sampling.ml` inline: the local-model case is renamed and now asserts
  `min_p = None` (it previously asserted `Some` *only* because `is_local` was
  true). The "dashscope keeps min_p" case is reworked to `kind = DashScope` so it
  exercises the **kind-declared** floor (`provider_sampling_defaults`),
  host-independent.
- `test_complete_ext.ml`: the "local min_p defaulted" check now asserts `None`.
- **Mutation-confirmed**: restoring `| None -> Provider_config.is_local config`
  makes both new assertions FAIL (`... does not default min_p for uncatalogued
  local OpenAI_compat (RFC-OAS-034) is false`), so they are genuine regression
  guards.

## Validation

- `dune runtest --root . lib/llm_provider` — the complete_sampling inline tests
  pass. (16 `pricing.ml` failures are pre-existing sandbox-catalog-absence
  failures, identical with this change reverted — unrelated to sampling.)
- `dune exec --root . test/test_complete_ext.exe` — Test Successful, 21 tests.
- `ocamlformat --check` clean on both files.

## Provenance

Found by an adversarial re-audit of the RFC-OAS-034 P3 findings (B5/B6/B7 + a
completeness sweep). B5 (`discovery.infer_capabilities`) and B6
(`capabilities.apply_manifest_entry`) were re-confirmed as **legit** (config- /
runtime-declared capability, fail-closed on unknown) and are intentionally not
touched. B7 is the one that survived three independent verification lenses.

Refs jeong-sik/masc#27917 (RFC-OAS-034 B7).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
