### PR TITLE
fix(catalog): reject unknown fields in model catalog entries (RFC-OAS-034 silent-swallow)

### DIFF
--- a/lib/llm_provider/model_catalog.ml
+++ b/lib/llm_provider/model_catalog.ml
@@ -177,11 +177,77 @@ let reasoning_streaming_format_opt ~entry_id key toml =
             Capability_vocab.reasoning_streaming_format_syntax))
 ;;
 
+(* Every field [parse_entry] reads below. A misspelled or stale key (e.g.
+   [suports_tools]) would otherwise be silently ignored, leaving the capability
+   at its default and hiding the misconfiguration. Enumerate the table keys and
+   fail closed on anything unknown, mirroring
+   [Capability_manifest.reject_unknown_keys]. Keep this list in sync with the
+   record construction below. *)
+let known_entry_keys =
+  [ "id_prefix"
+  ; "base"
+  ; "provider_name"
+  ; "max_context_tokens"
+  ; "max_output_tokens"
+  ; "supports_tools"
+  ; "supports_tool_choice"
+  ; "supports_required_tool_choice"
+  ; "supports_named_tool_choice"
+  ; "supports_parallel_tool_calls"
+  ; "assistant_tool_content_format"
+  ; "supports_reasoning"
+  ; "supports_extended_thinking"
+  ; "supports_reasoning_budget"
+  ; "accepted_reasoning_efforts"
+  ; "supports_response_format_json"
+  ; "supports_structured_output"
+  ; "supports_multimodal_inputs"
+  ; "supports_image_input"
+  ; "supports_audio_input"
+  ; "supports_video_input"
+  ; "modality_priority"
+  ; "supports_native_streaming"
+  ; "supports_system_prompt"
+  ; "supports_caching"
+  ; "supports_prompt_caching"
+  ; "supports_top_k"
+  ; "supports_min_p"
+  ; "supports_seed"
+  ; "supports_computer_use"
+  ; "supports_code_execution"
+  ; "thinking_control_format"
+  ; "thinking_control_token"
+  ; "preserve_thinking_control_format"
+  ; "reasoning_output_format"
+  ; "reasoning_streaming_format"
+  ; "reasoning_replay"
+  ; "input_per_million"
+  ; "output_per_million"
+  ; "cache_write_multiplier"
+  ; "cache_read_multiplier"
+  ]
+;;
+
+let reject_unknown_entry_keys ~entry_id entry_toml =
+  match Otoml.list_table_keys_result entry_toml with
+  | Error _ -> Ok () (* not a table; the id_prefix shape check already handled it *)
+  | Ok keys ->
+    (match List.filter (fun k -> not (List.mem k known_entry_keys)) keys with
+     | [] -> Ok ()
+     | unknown ->
+       Error
+         (Printf.sprintf
+            "model entry %S contains unknown field(s): %s"
+            entry_id
+            (String.concat ", " unknown)))
+;;
+
 let parse_entry entry_toml =
   match find_string_opt entry_toml [ "id_prefix" ] with
   | None -> Error "model entry missing required \"id_prefix\" field"
   | Some id_prefix ->
     let id_prefix = String.trim id_prefix in
+    let unknown_keys_result = reject_unknown_entry_keys ~entry_id:id_prefix entry_toml in
     let reasoning_replay_result =
       canonical_string_opt
         ~entry_id:id_prefix
@@ -204,12 +270,17 @@ let parse_entry entry_toml =
         entry_toml
     in
     (match
-       ( reasoning_replay_result
+       ( unknown_keys_result
+       , reasoning_replay_result
        , assistant_tool_content_format_result
        , accepted_reasoning_efforts_result )
      with
-     | (Error _ as e), _, _ | _, (Error _ as e), _ | _, _, (Error _ as e) -> e
-     | ( Ok reasoning_replay
+     | (Error _ as e), _, _, _
+     | _, (Error _ as e), _, _
+     | _, _, (Error _ as e), _
+     | _, _, _, (Error _ as e) -> e
+     | ( Ok ()
+       , Ok reasoning_replay
        , Ok assistant_tool_content_format
        , Ok accepted_reasoning_efforts ) ->
        let base_label_result = find_string_field ~entry_id:id_prefix "base" entry_toml in
@@ -339,6 +410,22 @@ let parse_entry entry_toml =
             ; cache_read_multiplier =
                 find_float_opt entry_toml [ "cache_read_multiplier" ]
             }))
+;;
+
+let%test "parse_entry rejects an unknown/misspelled field, not silently dropped" =
+  (* A typo like [suports_tools] must fail closed rather than leave
+     supports_tools at its default with no signal (RFC-OAS-034 silent-swallow). *)
+  let entry = Otoml.Parser.from_string "id_prefix = \"m\"\nsuports_tools = true" in
+  match parse_entry entry with
+  | Error _ -> true
+  | Ok _ -> false
+;;
+
+let%test "parse_entry accepts an entry whose fields are all known" =
+  let entry = Otoml.Parser.from_string "id_prefix = \"m\"\nsupports_tools = true" in
+  match parse_entry entry with
+  | Ok _ -> true
+  | Error _ -> false
 ;;
 
 let load_file path =


### PR DESCRIPTION
## Problem

`Model_catalog.parse_entry` reads catalog fields one by one via
`find_string_opt`/`find_bool_opt`/`find_int_opt`/`canonical_*`, keyed on fixed
strings. It never enumerates the entry table's actual keys, so a **misspelled or
stale field is silently dropped**:

```toml
[[models]]
id_prefix = "gpt-4"
suports_tools = true   # typo — never read
```

`supports_tools` stays at its default (`None`) and the operator gets **no warn,
no error** — a silent-swallow anti-pattern (RFC-OAS-034 family). The JSON sibling
already guards against exactly this via `Capability_manifest.reject_unknown_keys`;
the TOML catalog path did not.

## Fix

Enumerate the entry's keys with `Otoml.list_table_keys_result` and fail closed on
any key not in `known_entry_keys` — the exact set `parse_entry` consumes (derived
from its own field reads, kept adjacent to the record construction):

```ocaml
let reject_unknown_entry_keys ~entry_id entry_toml =
  match Otoml.list_table_keys_result entry_toml with
  | Error _ -> Ok ()            (* not a table; id_prefix shape check handled it *)
  | Ok keys ->
    (match List.filter (fun k -> not (List.mem k known_entry_keys)) keys with
     | [] -> Ok ()
     | unknown -> Error (Printf.sprintf "model entry %S contains unknown field(s): %s" ...))
```

The result is threaded into `parse_entry`'s existing first error-collecting tuple
(no re-indentation of the body). `load_file` already aggregates a `parse_entry`
`Error`, and `load_runtime_file` surfaces it via `Diag.warn` then skips the
overlay — the same fail-closed loudness as an unknown `auth` type or a removed
field.

## Safety

The built-in `models.toml` uses **only known keys** (verified: every one of its
37 distinct keys is in `known_entry_keys`, `comm -23` empty), so no shipped
catalog is affected. A user runtime-overlay catalog with an unknown key now
warns and is skipped (falling back to built-in defaults) instead of loading a
half-applied entry — a misconfiguration surfaced, not a crash.

## Tests (inline `let%test` in model_catalog.ml)

- **rejects** a misspelled field (`suports_tools`) → `Error`, not silent `Ok`.
- **accepts** an entry whose fields are all known → no over-rejection.
- **Mutation-confirmed**: adding `suports_tools` to `known_entry_keys` makes the
  reject test FAIL (`... rejects an unknown/misspelled field ... is false`), so
  it is a genuine regression guard.

## Validation

- `dune build --root . lib/` — clean.
- `dune runtest --root . lib/llm_provider` — no new failures vs baseline
  (identical failure set with the change stashed; the pre-existing `pricing.ml`
  failures are sandbox-catalog-absence, unrelated).
- `ocamlformat --check` clean.

## Provenance

Surfaced by an adversarial re-audit sweep of the RFC-OAS-034 anti-pattern
families and confirmed real by independent is-it-real / fix-correctness lenses.
The sibling manifest finding (`apply_manifest_entry`) was re-confirmed **legit**
(already fail-closed) and left untouched.

Refs jeong-sik/masc#27917 (RFC-OAS-034, silent-swallow family).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
