### PR TITLE
fix(provider): recognize api.deepseek.com as deepseek vendor host (RFC-OAS-034)

### DIFF
--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -208,7 +208,8 @@ let base_url_targets_openai base_url =
   | Some host -> String.equal (String.lowercase_ascii host) "api.openai.com"
 ;;
 
-(* RFC-OAS-034 §2 rule 2: a vendor-canonical domain (host == vendor) may bind a
+(* RFC-OAS-034 §2 rule 2: a vendor-canonical domain (the host is itself the
+   vendor's canonical domain, so host identifies the provider) may bind a
    provider label, matched by exact [Uri.host] equality (no prefix, no look-alike).
    [api.deepseek.com] is DeepSeek's canonical vendor host, so its endpoint carries
    the vendor identity "deepseek" rather than the generic transport kind

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -208,9 +208,24 @@ let base_url_targets_openai base_url =
   | Some host -> String.equal (String.lowercase_ascii host) "api.openai.com"
 ;;
 
+(* RFC-OAS-034 §2 rule 2: a vendor-canonical domain (host == vendor) may bind a
+   provider label, matched by exact [Uri.host] equality (no prefix, no look-alike).
+   [api.deepseek.com] is DeepSeek's canonical vendor host, so its endpoint carries
+   the vendor identity "deepseek" rather than the generic transport kind
+   "openai_compat". This is host->identity (allowed), not host->capability of a
+   generic rental edge (forbidden, e.g. *.proxy.runpod.net). Mirrors
+   [base_url_targets_openai]. *)
+let base_url_targets_deepseek base_url =
+  match Uri.of_string base_url |> Uri.host with
+  | None -> false
+  | Some host -> String.equal (String.lowercase_ascii host) "api.deepseek.com"
+;;
+
 let capability_provider_label (config : t) =
   if base_url_targets_ollama_cloud config.base_url
   then "ollama_cloud"
+  else if base_url_targets_deepseek config.base_url
+  then "deepseek"
   else string_of_provider_kind config.kind
 ;;
 

--- a/lib/llm_provider/provider_config.mli
+++ b/lib/llm_provider/provider_config.mli
@@ -407,8 +407,10 @@ val reasoning_effort_of_config : t -> string option
 
 (** Capability catalog provider namespace for [config].
 
-    This is usually {!string_of_provider_kind}, except official Ollama Cloud
-    endpoints are scoped as ["ollama_cloud"] even when they use the
+    This is usually {!string_of_provider_kind}, except vendor-canonical hosts
+    matched by exact [Uri.host] equality (RFC-OAS-034 §2 rule 2): official
+    Ollama Cloud endpoints are scoped as ["ollama_cloud"], and DeepSeek's
+    canonical host [api.deepseek.com] as ["deepseek"], even when they use the
     OpenAI-compatible wire kind. *)
 val capability_provider_label : t -> string
 

--- a/lib/llm_provider/provider_config.mli
+++ b/lib/llm_provider/provider_config.mli
@@ -408,10 +408,11 @@ val reasoning_effort_of_config : t -> string option
 (** Capability catalog provider namespace for [config].
 
     This is usually {!string_of_provider_kind}, except vendor-canonical hosts
-    matched by exact [Uri.host] equality (RFC-OAS-034 §2 rule 2): official
-    Ollama Cloud endpoints are scoped as ["ollama_cloud"], and DeepSeek's
-    canonical host [api.deepseek.com] as ["deepseek"], even when they use the
-    OpenAI-compatible wire kind. *)
+    (RFC-OAS-034 §2 rule 2): official Ollama Cloud endpoints are scoped as
+    ["ollama_cloud"], and DeepSeek's canonical host [api.deepseek.com] as
+    ["deepseek"], even when they use the OpenAI-compatible wire kind. DeepSeek is
+    matched by exact [Uri.host] equality; Ollama Cloud currently uses a
+    lowercased/trimmed URL-prefix check. *)
 val capability_provider_label : t -> string
 
 (** Resolve model capabilities using provider-qualified catalog entries first.

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -1527,8 +1527,11 @@ let test_capability_provider_label_deepseek_exact_host () =
   in
   (* RFC-OAS-034 rule 2: api.deepseek.com is DeepSeek's canonical vendor host, so
      its endpoint carries the vendor identity regardless of scheme. *)
-  check_string "https apex is deepseek" "deepseek" (label "https://api.deepseek.com/v1");
-  check_string "http apex is deepseek" "deepseek" (label "http://api.deepseek.com");
+  check_string
+    "https canonical host is deepseek"
+    "deepseek"
+    (label "https://api.deepseek.com/v1");
+  check_string "http canonical host is deepseek" "deepseek" (label "http://api.deepseek.com");
   (* Exact [Uri.host] equality must reject look-alikes so a hostile or accidental
      host cannot inherit the deepseek vendor identity. Falls back to the transport
      kind label ("openai_compat") rather than "deepseek". *)

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -1531,7 +1531,10 @@ let test_capability_provider_label_deepseek_exact_host () =
     "https canonical host is deepseek"
     "deepseek"
     (label "https://api.deepseek.com/v1");
-  check_string "http canonical host is deepseek" "deepseek" (label "http://api.deepseek.com");
+  check_string
+    "http canonical host is deepseek"
+    "deepseek"
+    (label "http://api.deepseek.com");
   (* Exact [Uri.host] equality must reject look-alikes so a hostile or accidental
      host cannot inherit the deepseek vendor identity. Falls back to the transport
      kind label ("openai_compat") rather than "deepseek". *)

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -1520,6 +1520,28 @@ let test_provider_name_of_config_unmatched_openai_compat () =
     (Provider_registry.provider_name_of_config cfg)
 ;;
 
+let test_capability_provider_label_deepseek_exact_host () =
+  let label base_url =
+    Provider_config.capability_provider_label
+      (Provider_config.make ~kind:OpenAI_compat ~model_id:"deepseek-v4-pro" ~base_url ())
+  in
+  (* RFC-OAS-034 rule 2: api.deepseek.com is DeepSeek's canonical vendor host, so
+     its endpoint carries the vendor identity regardless of scheme. *)
+  check_string "https apex is deepseek" "deepseek" (label "https://api.deepseek.com/v1");
+  check_string "http apex is deepseek" "deepseek" (label "http://api.deepseek.com");
+  (* Exact [Uri.host] equality must reject look-alikes so a hostile or accidental
+     host cannot inherit the deepseek vendor identity. Falls back to the transport
+     kind label ("openai_compat") rather than "deepseek". *)
+  check_string
+    "subdomain lookalike is not deepseek"
+    "openai_compat"
+    (label "https://api.deepseek.com.evil.example/v1");
+  check_string
+    "userinfo lookalike is not deepseek"
+    "openai_compat"
+    (label "https://api.deepseek.com@evil.example/v1")
+;;
+
 let check_unmatched_provider_name_ignores_catalog_model ~label ~model_id =
   with_repository_model_catalog (fun () ->
     let cfg =
@@ -2208,6 +2230,10 @@ let () =
             `Quick
             test_provider_name_of_config_local_openai_compat
         ; Alcotest.test_case "openrouter" `Quick test_provider_name_of_config_openrouter
+        ; Alcotest.test_case
+            "deepseek vendor host label (exact Uri.host, RFC-OAS-034)"
+            `Quick
+            test_capability_provider_label_deepseek_exact_host
         ; Alcotest.test_case
             "unmatched openai_compat"
             `Quick


### PR DESCRIPTION
## 목적 (RFC-OAS-034 §2 rule 2 근본 fix)

masc main이 `test_runtime_config_validity`에서 red입니다:
```
FAIL runtime binding deepseek.deepseek-v4-pro:
  openai_compat/deepseek-v4-pro must resolve through repo OAS catalog
```
원인: OAS `capability_provider_label`이 DeepSeek canonical endpoint(`api.deepseek.com`)를 generic transport kind `"openai_compat"`로 라벨 → 바인딩이 `openai_compat/deepseek-v4-pro` catalog namespace로 resolve. 그 row는 각 소비자가 명시 등록해야 하는 host-유도 namespace라, `deepseek-v4-flash`(#22935에서 masc catalog에 추가)와 달리 `deepseek-v4-pro` qualified row는 누락되어 있었습니다.

## 변경

`api.deepseek.com`을 vendor-canonical host로 인식(exact `Uri.host` 등가, `base_url_targets_openai` mirror)하여 라벨을 `"deepseek"`로 반환.

RFC-OAS-034 §2 rule 2: **host == vendor인 canonical 도메인은 provider 라벨 바인딩 허용**(단 정확 Uri.host, prefix/look-alike 금지). `api.deepseek.com`은 여기 해당(host==vendor). 이는 host→vendor **identity**(허용)이지 generic rental edge(`*.proxy.runpod.net`)의 host→**capability** 추론(금지, #2374/#2408이 위반)이 아닙니다.

- `base_url_targets_deepseek` 추가 (exact Uri.host).
- `capability_provider_label`에 deepseek 분기 추가.
- 테스트: exact host→"deepseek"; subdomain(`api.deepseek.com.evil.example`)·userinfo(`api.deepseek.com@evil.example`) look-alike는 kind 라벨로 fallback(스푸핑 차단).

## 심각도

- **P0**: masc main red의 OAS측 근본 원인. 이 라벨링이 `deepseek/<model>` namespace를 산출하면 host-유도 qualified row(`openai_compat/deepseek-*`)가 불필요해짐.
- **P1**: 없음(코드 결함 아님).
- **P2 (남은점 — cross-repo, 이 PR 범위 밖)**:
  1. **OAS 릴리즈 + masc pin bump**: 이 변경이 masc에 반영되려면 OAS 새 버전 릴리즈 후 masc의 agent_sdk pin bump 필요.
  2. **masc catalog 정리**: pin bump 후 `oas-models.toml`의 `openai_compat/deepseek-*` host-유도 row를 제거하고 `deepseek/` 또는 bare row로 통일(현재 bare `deepseek-v4-pro` 존재).
  3. **`Provider_registry.provider_name_of_config` 확인**: 이 함수는 별도 메커니즘(등록 defaults base_url 비교)으로 이미 `deepseek_defaults`(base_url api.deepseek.com)를 알고 있음. masc catalog 해석이 `capability_provider_label`을 쓰는지 `provider_name_of_config`를 쓰는지에 따라 완전성이 갈림 — **CI/리뷰로 어느 경로가 실제 사용되는지 확인 필요**(둘 다면 N-of-M 방지 위해 양쪽 정렬).
- **P3**: 없음.

## 병합 가능성

OAS측 변경은 RFC-OAS-034 정합·surgical(15+26라인). CI(build+test) green 시 병합 가능. 단 masc main 복구는 위 P2(릴리즈+pin+catalog+해석경로 확인) 완료가 전제. 로컬 빌드 미실행 — CI가 build authority.

WORKAROUND-WAIVED: root fix — host-유도 qualified catalog row(workaround)를 제거하는 방향의 RFC-OAS-034 §2 정합 recognizer 추가. 새 분류기/우회 도입 아님.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
