### PR TITLE
fix(test): list model catalog default test module

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -334,6 +334,7 @@
   test_mcp_session
   test_metric_contract
   test_metrics
+  test_model_catalog_default
   test_model_registry
   test_module_check
   test_multimodal


### PR DESCRIPTION
Fixes the post-merge Dune executable/modules mismatch from #2424. CI is build authority. Local checks: git diff --check; rg test_model_catalog_default test/dune.