### PR TITLE
fix(ratchet): host/base_url fuzzy-classifier detector precision + recall (#2419 follow-up)

### DIFF
--- a/scripts/hardening-ratchet.sh
+++ b/scripts/hardening-ratchet.sh
@@ -62,14 +62,14 @@ MODEL_ID_STRING_CLASSIFIER_RE = re.compile(
 # freshly-extracted `Uri.host` value -- without first binding it to a `host`-
 # named variable -- is still caught.
 # The gap between the matcher and the host token is a "tempered dot": it spans
-# arbitrary text but stops at an OCaml statement separator (`in` / `let` / `;`).
+# arbitrary text but stops at OCaml statement/branch/tuple separators.
 # Without this bound the greedy `.*` matched across independent statements on
 # one physical line -- e.g. `let host = Uri.host uri in
 # String.starts_with ~prefix:"qwen" model_id` counted as a host classifier even
 # though the classifier operates on `model_id`, not the host binding that
 # precedes it. Genuine same-statement classifiers (including `host |> String.x`
 # pipelines) contain no separator between the tokens and still match.
-_HOST_FUZZY_GAP = r"(?:(?!\b(?:in|let)\b|;).)*"
+_HOST_FUZZY_GAP = r"(?:(?!\b(?:in|let|then|else)\b|[;,]|->).)*"
 HOST_URL_FUZZY_CLASSIFIER_RE = re.compile(
     r"\bString\.(?:starts_with|ends_with|contains|is_substring)\b"
     + _HOST_FUZZY_GAP
@@ -93,7 +93,7 @@ STRING_MATCHER_RE = re.compile(
 MAX_HOST_FUZZY_JOIN = 2
 HOST_FUZZY_DANGLING_RE = re.compile(
     r"\bString\.(?:starts_with|ends_with|contains|is_substring)\s*$"
-    r"|~\w+:\S+\s*$"
+    r"|~\w+:[^\s,)\]}]+\s*$"
 )
 STUB_RE = re.compile(
     r"\bNot_implemented\b"
@@ -428,6 +428,13 @@ def self_test(config):
             # classifier on `model_id` must NOT count -- the tempered gap stops
             # at `in`, so `Uri.host` never reaches `String.starts_with`.
             "let host = Uri.host uri in String.starts_with ~prefix:\"Bearer \" auth_header",
+            "let route = if String.contains user_agent ~sub:\"bot\" then host else fallback",
+            "let tuple = (String.starts_with ~prefix:\"qwen\" request_name, host)",
+            "| Some host -> String.ends_with ~suffix:\"qwen\" request_name",
+            "  String.contains user_agent ~sub:bot_name",
+            "  then host else fallback",
+            "  String.ends_with ~suffix:model_suffix)",
+            "  host",
             "| _ -> None",
             "let path = \\\\\"/home/alice/me/tmp\\\\\"",
             "let impossible = assert false",

--- a/scripts/hardening-ratchet.sh
+++ b/scripts/hardening-ratchet.sh
@@ -61,24 +61,39 @@ MODEL_ID_STRING_CLASSIFIER_RE = re.compile(
 # identifiers [host]/[base_url]) so fuzzy matching performed directly on a
 # freshly-extracted `Uri.host` value -- without first binding it to a `host`-
 # named variable -- is still caught.
+# The gap between the matcher and the host token is a "tempered dot": it spans
+# arbitrary text but stops at an OCaml statement separator (`in` / `let` / `;`).
+# Without this bound the greedy `.*` matched across independent statements on
+# one physical line -- e.g. `let host = Uri.host uri in
+# String.starts_with ~prefix:"qwen" model_id` counted as a host classifier even
+# though the classifier operates on `model_id`, not the host binding that
+# precedes it. Genuine same-statement classifiers (including `host |> String.x`
+# pipelines) contain no separator between the tokens and still match.
+_HOST_FUZZY_GAP = r"(?:(?!\b(?:in|let)\b|;).)*"
 HOST_URL_FUZZY_CLASSIFIER_RE = re.compile(
     r"\bString\.(?:starts_with|ends_with|contains|is_substring)\b"
-    r".*\b(?:base_url|host|Uri\.host)\b"
+    + _HOST_FUZZY_GAP
+    + r"\b(?:base_url|host|Uri\.host)\b"
     r"|\b(?:base_url|host|Uri\.host)\b"
-    r".*\bString\.(?:starts_with|ends_with|contains|is_substring)\b"
+    + _HOST_FUZZY_GAP
+    + r"\bString\.(?:starts_with|ends_with|contains|is_substring)\b"
 )
-# ocamlformat commonly breaks a long application by putting the callee alone
-# on one line and its arguments (which may include the host/base_url token)
-# on the next. This "dangling call at end of line" regex identifies that
-# specific continuation shape so the 2-line join below only fires on it.
-# Deliberately one-directional: only a bare qualified stdlib function name
-# alone at line-end is a rare, specific signal that the call continues.
-# Joining on a dangling *token* (bare `host`/`base_url` identifier at
-# line-end) was tried and reverted -- those identifiers are common enough
-# as the tail of an unrelated statement that it produced false joins across
-# two independent statements (verified via self-test).
-HOST_FUZZY_DANGLING_CALL_RE = re.compile(
+STRING_MATCHER_RE = re.compile(
+    r"\bString\.(?:starts_with|ends_with|contains|is_substring)\b"
+)
+# ocamlformat breaks a long matcher application across lines, leaving the
+# host/base_url argument one or two physical lines below the callee. Two split
+# shapes end a line "dangling" (the call is not yet complete): the bare callee
+# alone (`String.ends_with`), or the callee plus a labelled argument with the
+# haystack still pending (`String.ends_with ~suffix:sfx`). host_fuzzy_classifier_hit
+# joins forward only while the accumulated text stays dangling AND still holds a
+# String matcher, bounded to MAX_HOST_FUZZY_JOIN extra lines, so two unrelated
+# adjacent statements are never stitched together (an earlier attempt to join on
+# a dangling bare identifier was reverted for exactly that false-join reason).
+MAX_HOST_FUZZY_JOIN = 2
+HOST_FUZZY_DANGLING_RE = re.compile(
     r"\bString\.(?:starts_with|ends_with|contains|is_substring)\s*$"
+    r"|~\w+:\S+\s*$"
 )
 STUB_RE = re.compile(
     r"\bNot_implemented\b"
@@ -224,6 +239,31 @@ def bump(metrics, examples, max_examples, metric: str, path: str, lineno: int, l
         examples[metric].append(f"{path}:{lineno}:{line.strip()}")
 
 
+def host_fuzzy_classifier_hit(code_lines, idx):
+    """Return True if the (already string-masked) line at 0-based ``idx`` -- on
+    its own or once ocamlformat's line-wrapped continuation is stitched back --
+    fuzzy-classifies a base_url/host. Forward joins are bounded and only occur
+    while the accumulated text still dangles on an incomplete String matcher, so
+    two unrelated adjacent statements are never merged into a spurious match."""
+    acc = code_lines[idx]
+    if HOST_URL_FUZZY_CLASSIFIER_RE.search(acc):
+        return True
+    joins = 0
+    j = idx
+    while (
+        joins < MAX_HOST_FUZZY_JOIN
+        and j + 1 < len(code_lines)
+        and STRING_MATCHER_RE.search(acc)
+        and HOST_FUZZY_DANGLING_RE.search(acc)
+    ):
+        j += 1
+        acc = f"{acc} {code_lines[j]}"
+        joins += 1
+        if HOST_URL_FUZZY_CLASSIFIER_RE.search(acc):
+            return True
+    return False
+
+
 def measure_texts(files, config):
     metrics, examples, max_examples = empty_result(config)
     for path, text in files.items():
@@ -265,22 +305,11 @@ def measure_texts(files, config):
                         raw_line,
                     )
                 # ocamlformat routinely splits a matcher call and its host/
-                # base_url argument across two physical lines (e.g.
-                # `String.starts_with\n  ~prefix:base_url ...`), so neither
-                # line alone contains both tokens even though the AST is a
-                # fuzzy host match. Only join with the next line when this
-                # line ends dangling on exactly the matcher-call shape
-                # ocamlformat produces -- joining every adjacent line pair
-                # unconditionally would false-match two unrelated statements
-                # that each happen to contain one half of the pattern.
-                joined_next = (
-                    f"{code_line} {code_lines[lineno]}"
-                    if HOST_FUZZY_DANGLING_CALL_RE.search(code_line) and lineno < len(code_lines)
-                    else None
-                )
-                if HOST_URL_FUZZY_CLASSIFIER_RE.search(code_line) or (
-                    joined_next is not None and HOST_URL_FUZZY_CLASSIFIER_RE.search(joined_next)
-                ):
+                # base_url argument across physical lines, so neither line alone
+                # contains both tokens even though the AST is a fuzzy host match.
+                # host_fuzzy_classifier_hit re-stitches only the dangling
+                # continuation shapes ocamlformat produces (see its docstring).
+                if host_fuzzy_classifier_hit(code_lines, lineno - 1):
                     bump(
                         metrics,
                         examples,
@@ -386,6 +415,19 @@ def self_test(config):
             "  String.starts_with",
             "    ~prefix:sfx host",
             "let direct_uri_check = String.ends_with (Uri.host uri) ~suffix:\".ollama.com\"",
+            # RFC-OAS-034 detector mutation cases -- guard both failure modes of
+            # the line-regex host classifier. FN: ocamlformat wraps the host arg
+            # one or two lines below the matcher; the forward join must re-stitch
+            # it. Each block counts exactly once (at the callee line).
+            "    String.ends_with",
+            "      ~suffix:proxy_a",
+            "      host",
+            "  String.ends_with ~suffix:proxy_b",
+            "    host",
+            # FP: an unrelated host binding sharing one physical line with a
+            # classifier on `model_id` must NOT count -- the tempered gap stops
+            # at `in`, so `Uri.host` never reaches `String.starts_with`.
+            "let host = Uri.host uri in String.starts_with ~prefix:\"Bearer \" auth_header",
             "| _ -> None",
             "let path = \\\\\"/home/alice/me/tmp\\\\\"",
             "let impossible = assert false",
@@ -402,9 +444,12 @@ def self_test(config):
         "heuristic_markers": 1,
         "local_workspace_path_literals": 1,
         "model_id_string_classifiers_outside_catalog": 2,
-        # 1 original single-line match + 1 caught only via the 2-line dangling-
-        # call join (the ocamlformat split shape) + 1 via the Uri.host token.
-        "base_url_host_fuzzy_classifiers": 3,
+        # 3 baseline (single-line + 2-line dangling join + Uri.host token) plus 2
+        # multi-line wraps re-stitched by the forward join (~suffix on its own
+        # line, and a 3-line split). The same-line `Uri.host ... in ... model_id`
+        # false positive is deliberately excluded, so a detector that regressed
+        # either fix would not land on exactly 5.
+        "base_url_host_fuzzy_classifiers": 5,
         "stub_markers": 0,
         "workaround_markers": 1,
         "wildcard_silent_defaults": 1,


### PR DESCRIPTION
## 목적

머지된 #2419에 미해소로 남은 chatgpt-codex-connector P2 리뷰 스레드 2건을 해소합니다. `base_url_host_fuzzy_classifiers` ratchet metric의 line-regex detector가 가진 두 실패 모드를 고칩니다. (#2419 브랜치는 이미 머지되어 push할 수 없으므로 follow-up PR로 처리)

## 문제 (리뷰에서 지적)

- **False positive** (thread @ `scripts/hardening-ratchet.sh:68`): host 토큰과 String matcher 사이의 greedy `.*`가 OCaml statement separator를 넘어가, host 바인딩과 무관한 `model_id` classifier가 같은 물리 줄에 있으면 오탐 → 무관한 PR이 CI red.
  - 예: `let host = Uri.host uri in String.starts_with ~prefix:"qwen" model_id`
- **False negative** (thread @ `scripts/hardening-ratchet.sh:278`): forward join이 bare-callee dangling만 1줄 join → ocamlformat이 host 인자를 자기 줄 또는 2줄 아래로 wrap하면, ratchet이 막으려던 fuzzy host classifier가 줄바꿈만으로 CI를 통과.

## 수정

- matcher↔host gap을 `in`/`let`/`;`에서 멈추는 tempered dot으로 제한. 같은 statement 내 genuine classifier(`host |> String.x` 파이프 포함)는 계속 매칭.
- 단일 join → `MAX_HOST_FUZZY_JOIN`까지 bounded forward join. ocamlformat의 두 dangling shape(bare callee / `~label:val` 후 haystack pending) 모두 재봉합. accumulated 텍스트가 dangling이고 String matcher를 포함하는 동안에만 join하므로 무관한 인접 statement는 봉합되지 않음.

## 검증 (적대적 mutation testing)

- NEW self-test: 5에서 PASS.
- FP 수정만 revert (greedy `.*`) → actual **6** → self-test FAIL (FP 라인 재카운트).
- FN 수정만 revert (`~label` dangling shape 제거) → actual **3** → self-test FAIL (두 wrap 케이스 놓침).
- both-broken=4 / FP-only=6 / FN-only=3 / both-fixed=5 — 네 시나리오가 모두 5와 달라, 단일 aggregate 5가 "둘 다 수정됨"을 유일하게 식별.
- 실제 repo `--check`: **3→3** (동일한 3개 genuine `ollama.com` matcher: `provider_config.ml:201,202,807`). CI green 유지, detector는 더 견고하되 baseline-neutral.

## 범위

`scripts/hardening-ratchet.sh` 단일 파일 (detector 로직 + self-test). 프로덕션 lib 코드 무변경.

RFC-OAS-034 §5(host/URL = 전송, capability 아님) 집행 인프라의 정밀도/재현율 개선입니다.

WORKAROUND-WAIVED: hardening-ratchet detector 정밀도/재현율 수정 (RFC 집행 인프라). 프로덕션 string classifier를 추가하는 것이 아니라, string-classifier를 차단하는 guard 자체의 오탐/누락을 줄이는 개선.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
