### PR TITLE
fix(catalog): add runpod gemma4 coder capabilities

### DIFF
--- a/models.toml
+++ b/models.toml
@@ -2021,6 +2021,45 @@ supports_native_streaming = true
 supports_seed = true
 
 [[models]]
+id_prefix = "runpod_rtxa6000/gemma4-coder-fable5-q4km"
+base = "openai_chat"
+provider_name = "runpod_rtxa6000"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = true
+supports_parallel_tool_calls = true
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = false
+thinking_control_format = "chat_template_token"
+thinking_control_token = "<|think|>"
+supports_response_format_json = true
+supports_native_streaming = true
+supports_top_k = true
+supports_seed = true
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[models]]
+id_prefix = "gemma4-coder-fable5-q4km"
+base = "openai_chat"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = true
+supports_parallel_tool_calls = true
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = false
+thinking_control_format = "chat_template_token"
+thinking_control_token = "<|think|>"
+supports_response_format_json = true
+supports_native_streaming = true
+supports_top_k = true
+supports_seed = true
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[models]]
 id_prefix = "hf.co/google/gemma-4"
 base = "ollama"
 max_context_tokens = 262144

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -455,7 +455,7 @@ let test_lookup_provider_m_qwen3_mtp_dot_name () =
 ;;
 
 let test_lookup_runpod_rtxa6000_gemma4_coder_catalog () =
-  let check_gemma4_coder label c =
+  let check_gemma4_coder label (c : Capabilities.capabilities) =
     check (option int) (label ^ " context 256K") (Some 262_144) c.max_context_tokens;
     check bool (label ^ " tools") true c.supports_tools;
     check bool (label ^ " tool_choice") true c.supports_tool_choice;

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -480,6 +480,10 @@ let test_lookup_runpod_rtxa6000_gemma4_coder_catalog () =
    with
    | Some c -> check_gemma4_coder "runpod_rtxa6000 gemma4 coder" c
    | None -> fail "strict provider lookup should match runpod_rtxa6000 gemma4 coder");
+  (match Capabilities.for_model_id "runpod_rtxa6000.gemma4-coder-fable5-q4km" with
+   | Some c -> check_gemma4_coder "dot-qualified runpod_rtxa6000 gemma4 coder" c
+   | None ->
+     fail "dot-qualified runtime id should match runpod_rtxa6000.gemma4-coder-fable5-q4km");
   match Capabilities.for_model_id "gemma4-coder-fable5-q4km" with
   | Some c -> check_gemma4_coder "bare gemma4 coder" c
   | None -> fail "bare lookup should match gemma4-coder-fable5-q4km"

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -454,6 +454,37 @@ let test_lookup_provider_m_qwen3_mtp_dot_name () =
   | None -> fail "should match dot-qualified qwen3.6 model id"
 ;;
 
+let test_lookup_runpod_rtxa6000_gemma4_coder_catalog () =
+  let check_gemma4_coder label c =
+    check (option int) (label ^ " context 256K") (Some 262_144) c.max_context_tokens;
+    check bool (label ^ " tools") true c.supports_tools;
+    check bool (label ^ " tool_choice") true c.supports_tool_choice;
+    check bool (label ^ " parallel tools") true c.supports_parallel_tool_calls;
+    check bool (label ^ " reasoning") true c.supports_reasoning;
+    check bool (label ^ " extended thinking") true c.supports_extended_thinking;
+    check
+      bool
+      (label ^ " chat_template_token thinking control")
+      true
+      (c.thinking_control_format = Capabilities.Chat_template_token);
+    check bool (label ^ " json response format") true c.supports_response_format_json;
+    check bool (label ^ " native streaming") true c.supports_native_streaming;
+    check bool (label ^ " top_k") true c.supports_top_k;
+    check bool (label ^ " seed") true c.supports_seed
+  in
+  (match
+     Capabilities.for_provider_model_id
+       ~allow_bare_fallback:false
+       ~provider_label:"runpod_rtxa6000"
+       ~model_id:"gemma4-coder-fable5-q4km"
+   with
+   | Some c -> check_gemma4_coder "runpod_rtxa6000 gemma4 coder" c
+   | None -> fail "strict provider lookup should match runpod_rtxa6000 gemma4 coder");
+  match Capabilities.for_model_id "gemma4-coder-fable5-q4km" with
+  | Some c -> check_gemma4_coder "bare gemma4 coder" c
+  | None -> fail "bare lookup should match gemma4-coder-fable5-q4km"
+;;
+
 let test_lookup_deepseek_v4_flash () =
   match Capabilities.for_model_id "deepseek-v4-flash" with
   | Some c ->
@@ -2312,6 +2343,10 @@ let () =
             "vllm-qwen3-mtp dot-qualified name"
             `Quick
             test_lookup_provider_m_qwen3_mtp_dot_name
+        ; test_case
+            "runpod rtxa6000 gemma4 coder catalog"
+            `Quick
+            test_lookup_runpod_rtxa6000_gemma4_coder_catalog
         ; test_case "deepseek v4 flash" `Quick test_lookup_deepseek_v4_flash
         ; test_case "deepseek v4 pro" `Quick test_lookup_deepseek_v4_pro
         ; test_case


### PR DESCRIPTION
## Summary
- add provider-qualified `runpod_rtxa6000/gemma4-coder-fable5-q4km` capability catalog row
- add bare `gemma4-coder-fable5-q4km` row for direct model IDs
- add regression coverage for strict provider lookup with `allow_bare_fallback:false`

## Runtime Evidence
MASC strict boot fails closed when `/Users/dancer/me/.masc/config/runtime.toml` references `runpod_rtxa6000.gemma4-coder-fable5-q4km` but the OAS catalog lacks a provider-qualified row:

`Runtime.init_default_strict failed (fatal, refusing to boot): ... absent from the OAS capability catalog ... runpod_rtxa6000.gemma4-coder-fable5-q4km`

## Capability Evidence
- live MASC runtime config declares this model with 262144 context, tools, thinking, streaming, and JSON support
- Google Gemma 4 docs describe thinking via chat-template thinking token, matching `thinking_control_format = "chat_template_token"`

## Local Checks
- `git diff --check`
- `ocamlformat --check test/test_capabilities.ml`

Full build/test intentionally left to CI.
