### PR TITLE
fix(provider): rename runpod_mtp namespace to host-agnostic vllm-qwen3-mtp (RFC-OAS-034 B1/B2)

### DIFF
--- a/docs/rfc/RFC-OAS-034-endpoint-capability-boundary.md
+++ b/docs/rfc/RFC-OAS-034-endpoint-capability-boundary.md
@@ -159,4 +159,4 @@ stale-high(monotone-safe)이며, 전체 rebaseline은 별도 hygiene 작업으�
 | model_catalog unknown 키 fail-closed | Draft | #2426 |
 | B5 discovery / B6 manifest | false-positive (미구현) | — |
 | B4'(:804 host→output_schema) / :840(base label) | defer (설계 변경) | — |
-| B1/B2 (#2374·#2408 흡수) | 미착수 | — |
+| B1/B2 (#2374·#2408 흡수) | Draft — namespace `runpod_mtp`→`qwen3-mtp` rename + host-불변 회귀 테스트. #2374·#2408은 불필요(명시 선언 경로가 이미 작동)로 close | 이 PR |

--- a/docs/rfc/RFC-OAS-034-endpoint-capability-boundary.md
+++ b/docs/rfc/RFC-OAS-034-endpoint-capability-boundary.md
@@ -57,7 +57,7 @@ capability(MTP, tool_choice, reasoning dialect, structured output)를 결정하�
 
 1. **capability/namespace provenance = 명시적 config·model 선언.** generic host·URL 유도 금지.
    - namespace는 `model_id` prefix(`<namespace>/<model_id>`) 또는 provider config의 명시 필드(serving-contract 식별자)에서 온다.
-   - namespace 이름은 host-무관 serving-contract로: `runpod_mtp` → 예 `vllm-qwen3-mtp` / `qwen3-mtp` (host 제거).
+   - namespace 이름은 host-무관 serving-contract로: `runpod_mtp` → `vllm-qwen3-mtp` (host 제거). serving runtime(vLLM MTP) × model(qwen3)을 식별하되, 기존 catalog family prefix(`qwen3`)로 시작하지 않아야 dot-qualified lookup이 family row로 shadowing되지 않는다.
 2. **vendor-canonical 도메인 → provider는 허용**, 단 **정확 `Uri.host` 등가**로 (prefix 금지, look-alike 차단). generic rental host → capability는 금지.
 3. **path → wire-protocol**(Responses vs Chat)은 path가 실제 API envelope를 결정하는 경우에만, 정확 문자열 등가 + 비대상 kind는 catch-all 없는 exhaustive match로 fail-closed (`request_path_targets_responses_api`/`validate_request_path`가 정답례).
 4. **unknown host/provider/model/label → Unknown/None/fail-closed.** permissive/specific default 금지 (CLAUDE.md AI코드생성 #2).
@@ -159,4 +159,4 @@ stale-high(monotone-safe)이며, 전체 rebaseline은 별도 hygiene 작업으�
 | model_catalog unknown 키 fail-closed | Draft | #2426 |
 | B5 discovery / B6 manifest | false-positive (미구현) | — |
 | B4'(:804 host→output_schema) / :840(base label) | defer (설계 변경) | — |
-| B1/B2 (#2374·#2408 흡수) | Draft — namespace `runpod_mtp`→`qwen3-mtp` rename + host-불변 회귀 테스트. #2374·#2408은 불필요(명시 선언 경로가 이미 작동)로 close | 이 PR |
+| B1/B2 (#2374·#2408 흡수) | Draft — namespace `runpod_mtp`→`vllm-qwen3-mtp` rename + host-불변 회귀 테스트. #2374·#2408은 불필요(명시 선언 경로가 이미 작동)로 close | 이 PR |

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -1140,7 +1140,7 @@ let provider_qualified_model_id_candidates ~provider_label ~model_id =
      suffix is a useful candidate for re-qualification below in
      [provider_qualified_catalog_keys]. Including the original [model_id]
      alongside it used to make that function re-prepend [provider_label] onto
-     an already-qualified id (e.g. "qwen3-mtp/qwen3-mtp.qwen..."), which
+     an already-qualified id (e.g. "vllm-qwen3-mtp/vllm-qwen3-mtp.qwen..."), which
      never matches a real catalog [id_prefix] — pure wasted lookups. *)
   match stripped with
   | Some suffix when String.trim suffix <> "" -> [ suffix ]

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -1140,7 +1140,7 @@ let provider_qualified_model_id_candidates ~provider_label ~model_id =
      suffix is a useful candidate for re-qualification below in
      [provider_qualified_catalog_keys]. Including the original [model_id]
      alongside it used to make that function re-prepend [provider_label] onto
-     an already-qualified id (e.g. "runpod_mtp/runpod_mtp.qwen..."), which
+     an already-qualified id (e.g. "qwen3-mtp/qwen3-mtp.qwen..."), which
      never matches a real catalog [id_prefix] — pure wasted lookups. *)
   match stripped with
   | Some suffix when String.trim suffix <> "" -> [ suffix ]
@@ -1703,7 +1703,7 @@ let%test "for_model_id_catalog qwen3.5 routes to Qwen_3 family" =
     | None -> false)
 ;;
 
-let%test "for_model_id_catalog qwen36 runpod alias routes to Qwen_3 family" =
+let%test "for_model_id_catalog qwen36 model routes to Qwen_3 family" =
   with_test_catalog (fun () ->
     match for_model_id_catalog "qwen36-35b-a3b-mtp" with
     | Some c ->

--- a/models.toml
+++ b/models.toml
@@ -1850,10 +1850,18 @@ supports_native_streaming = true
 supports_top_k = true
 supports_min_p = true
 
+# Serving-contract namespace (RFC-OAS-034 §2 rule 1): the capability set below
+# (MTP, chat_template_kwargs thinking, tools, reasoning) is a function of the
+# serving runtime x model, NOT of where the endpoint is rented. The namespace is
+# named for that contract ("qwen3-mtp"), not for a hosting provider. A consumer
+# selects it by declaring model_id = "qwen3-mtp/<model>" (or "qwen3-mtp.<model>"),
+# so capability provenance is an explicit declaration — never inferred from a
+# host such as *.proxy.runpod.net. (Renamed from "runpod_mtp"; RunPod is an
+# opaque transport alias OAS does not classify on.)
 [[models]]
-id_prefix = "runpod_mtp/qwen36-35b-a3b-mtp"
+id_prefix = "qwen3-mtp/qwen36-35b-a3b-mtp"
 base = "openai_chat"
-provider_name = "runpod_mtp"
+provider_name = "qwen3-mtp"
 max_context_tokens = 131072
 supports_tools = true
 supports_tool_choice = true

--- a/models.toml
+++ b/models.toml
@@ -1853,15 +1853,15 @@ supports_min_p = true
 # Serving-contract namespace (RFC-OAS-034 §2 rule 1): the capability set below
 # (MTP, chat_template_kwargs thinking, tools, reasoning) is a function of the
 # serving runtime x model, NOT of where the endpoint is rented. The namespace is
-# named for that contract ("qwen3-mtp"), not for a hosting provider. A consumer
-# selects it by declaring model_id = "qwen3-mtp/<model>" (or "qwen3-mtp.<model>"),
+# named for that contract ("vllm-qwen3-mtp"), not for a hosting provider. A consumer
+# selects it by declaring model_id = "vllm-qwen3-mtp/<model>" (or "vllm-qwen3-mtp.<model>"),
 # so capability provenance is an explicit declaration — never inferred from a
 # host such as *.proxy.runpod.net. (Renamed from "runpod_mtp"; RunPod is an
 # opaque transport alias OAS does not classify on.)
 [[models]]
-id_prefix = "qwen3-mtp/qwen36-35b-a3b-mtp"
+id_prefix = "vllm-qwen3-mtp/qwen36-35b-a3b-mtp"
 base = "openai_chat"
-provider_name = "qwen3-mtp"
+provider_name = "vllm-qwen3-mtp"
 max_context_tokens = 131072
 supports_tools = true
 supports_tool_choice = true

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -428,19 +428,19 @@ let test_lookup_provider_m () =
   | None -> fail "should match qwen3"
 ;;
 
-let test_lookup_provider_m_runpod_name () =
+let test_lookup_provider_m_dashscope_gguf_name () =
   match Capabilities.for_model_id "DashScope_3.6-35B-A3B-UD-Q4_K_XL.gguf" with
   | Some c ->
     check
       bool
-      "runpod qwen3.6 uses chat_template_kwargs"
+      "dashscope qwen3.6 uses chat_template_kwargs"
       true
       (c.thinking_control_format = Capabilities.Chat_template_kwargs)
-  | None -> fail "should match qwen3.6 runpod model id"
+  | None -> fail "should match qwen3.6 model id"
 ;;
 
-let test_lookup_provider_m_runpod_dot_name () =
-  match Capabilities.for_model_id "runpod_mtp.qwen36-35b-a3b-mtp" with
+let test_lookup_provider_m_qwen3_mtp_dot_name () =
+  match Capabilities.for_model_id "qwen3-mtp.qwen36-35b-a3b-mtp" with
   | Some c ->
     check (option int) "context 128K" (Some 131_072) c.max_context_tokens;
     check bool "tools" true c.supports_tools;
@@ -448,10 +448,10 @@ let test_lookup_provider_m_runpod_dot_name () =
     check bool "reasoning" true c.supports_reasoning;
     check
       bool
-      "runpod dot-qualified qwen3.6 uses chat_template_kwargs"
+      "qwen3-mtp dot-qualified qwen3.6 uses chat_template_kwargs"
       true
       (c.thinking_control_format = Capabilities.Chat_template_kwargs)
-  | None -> fail "should match dot-qualified qwen3.6 runpod model id"
+  | None -> fail "should match dot-qualified qwen3.6 model id"
 ;;
 
 let test_lookup_deepseek_v4_flash () =
@@ -2265,11 +2265,11 @@ let () =
             `Quick
             test_lookup_kimi_k2_native_cloud_suffix
         ; test_case "dashscope" `Quick test_lookup_provider_m
-        ; test_case "dashscope runpod name" `Quick test_lookup_provider_m_runpod_name
+        ; test_case "dashscope gguf name" `Quick test_lookup_provider_m_dashscope_gguf_name
         ; test_case
-            "dashscope runpod dot-qualified name"
+            "qwen3-mtp dot-qualified name"
             `Quick
-            test_lookup_provider_m_runpod_dot_name
+            test_lookup_provider_m_qwen3_mtp_dot_name
         ; test_case "deepseek v4 flash" `Quick test_lookup_deepseek_v4_flash
         ; test_case "deepseek v4 pro" `Quick test_lookup_deepseek_v4_pro
         ; test_case

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -2265,7 +2265,10 @@ let () =
             `Quick
             test_lookup_kimi_k2_native_cloud_suffix
         ; test_case "dashscope" `Quick test_lookup_provider_m
-        ; test_case "dashscope gguf name" `Quick test_lookup_provider_m_dashscope_gguf_name
+        ; test_case
+            "dashscope gguf name"
+            `Quick
+            test_lookup_provider_m_dashscope_gguf_name
         ; test_case
             "qwen3-mtp dot-qualified name"
             `Quick

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -440,7 +440,7 @@ let test_lookup_provider_m_dashscope_gguf_name () =
 ;;
 
 let test_lookup_provider_m_qwen3_mtp_dot_name () =
-  match Capabilities.for_model_id "qwen3-mtp.qwen36-35b-a3b-mtp" with
+  match Capabilities.for_model_id "vllm-qwen3-mtp.qwen36-35b-a3b-mtp" with
   | Some c ->
     check (option int) "context 128K" (Some 131_072) c.max_context_tokens;
     check bool "tools" true c.supports_tools;
@@ -448,7 +448,7 @@ let test_lookup_provider_m_qwen3_mtp_dot_name () =
     check bool "reasoning" true c.supports_reasoning;
     check
       bool
-      "qwen3-mtp dot-qualified qwen3.6 uses chat_template_kwargs"
+      "vllm-qwen3-mtp dot-qualified qwen3.6 uses chat_template_kwargs"
       true
       (c.thinking_control_format = Capabilities.Chat_template_kwargs)
   | None -> fail "should match dot-qualified qwen3.6 model id"
@@ -2270,7 +2270,7 @@ let () =
             `Quick
             test_lookup_provider_m_dashscope_gguf_name
         ; test_case
-            "qwen3-mtp dot-qualified name"
+            "vllm-qwen3-mtp dot-qualified name"
             `Quick
             test_lookup_provider_m_qwen3_mtp_dot_name
         ; test_case "deepseek v4 flash" `Quick test_lookup_deepseek_v4_flash

--- a/test/test_provider_agnostic_reasoning_replay.ml
+++ b/test/test_provider_agnostic_reasoning_replay.ml
@@ -75,12 +75,12 @@ let catalog_model_profile_resolvers
     , fun () -> Capabilities.for_model_id "qwen/qwen3.6-35b-a3b" )
   ; ( "model:dashscope-3.5-35b-a3b"
     , fun () -> Capabilities.for_model_id "dashscope-3.5-35b-a3b" )
-  ; ( "provider:qwen3-mtp.qwen3-mtp.qwen36-35b-a3b-mtp"
+  ; ( "provider:vllm-qwen3-mtp.vllm-qwen3-mtp.qwen36-35b-a3b-mtp"
     , fun () ->
         Capabilities.for_provider_model_id
           ~allow_bare_fallback:false
-          ~provider_label:"qwen3-mtp"
-          ~model_id:"qwen3-mtp.qwen36-35b-a3b-mtp" )
+          ~provider_label:"vllm-qwen3-mtp"
+          ~model_id:"vllm-qwen3-mtp.qwen36-35b-a3b-mtp" )
   ]
 ;;
 

--- a/test/test_provider_agnostic_reasoning_replay.ml
+++ b/test/test_provider_agnostic_reasoning_replay.ml
@@ -75,12 +75,12 @@ let catalog_model_profile_resolvers
     , fun () -> Capabilities.for_model_id "qwen/qwen3.6-35b-a3b" )
   ; ( "model:dashscope-3.5-35b-a3b"
     , fun () -> Capabilities.for_model_id "dashscope-3.5-35b-a3b" )
-  ; ( "provider:runpod_mtp.runpod_mtp.qwen36-35b-a3b-mtp"
+  ; ( "provider:qwen3-mtp.qwen3-mtp.qwen36-35b-a3b-mtp"
     , fun () ->
         Capabilities.for_provider_model_id
           ~allow_bare_fallback:false
-          ~provider_label:"runpod_mtp"
-          ~model_id:"runpod_mtp.qwen36-35b-a3b-mtp" )
+          ~provider_label:"qwen3-mtp"
+          ~model_id:"qwen3-mtp.qwen36-35b-a3b-mtp" )
   ]
 ;;
 

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -746,10 +746,9 @@ thinking_control_format = "chat_template_kwargs"
    serving runtime x model (the WHAT), never of the endpoint host (the WHERE).
    The same OpenAI-compatible kind + same provider-qualified model_id must
    resolve to the SAME capabilities whether the endpoint is rented on RunPod, on
-   an arbitrary domain, or served on localhost. This pins that no host branch
-   (e.g. base_url_targets_runpod_proxy -> "runpod_mtp") can ever re-key
-   capability provenance to the host: moving the endpoint must not silently
-   change or drop capabilities. *)
+   an arbitrary domain, or served on localhost. This pins that host-derived
+   classification can never re-key capability provenance: moving the endpoint
+   must not silently change or drop capabilities. *)
 let test_capabilities_are_invariant_across_host () =
   with_model_catalog_toml
     {|

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -679,9 +679,9 @@ let test_openai_compat_explicit_provider_qualified_model_id_resolves_catalog_row
   with_model_catalog_toml
     {|
 [[models]]
-id_prefix = "runpod_mtp/qwen36-35b-a3b-mtp"
+id_prefix = "qwen3-mtp/qwen36-35b-a3b-mtp"
 base = "openai_chat"
-provider_name = "runpod_mtp"
+provider_name = "qwen3-mtp"
 supports_tools = true
 supports_tool_choice = true
 supports_reasoning = true
@@ -692,7 +692,7 @@ thinking_control_format = "chat_template_kwargs"
        let cfg =
          Provider_config.make
            ~kind:OpenAI_compat
-           ~model_id:"runpod_mtp.qwen36-35b-a3b-mtp"
+           ~model_id:"qwen3-mtp.qwen36-35b-a3b-mtp"
            ~base_url:"https://unknown-openai-compatible.example/v1"
            ()
        in
@@ -719,9 +719,9 @@ let test_openai_compat_bare_model_id_does_not_resolve_provider_qualified_row () 
   with_model_catalog_toml
     {|
 [[models]]
-id_prefix = "runpod_mtp/qwen36-35b-a3b-mtp"
+id_prefix = "qwen3-mtp/qwen36-35b-a3b-mtp"
 base = "openai_chat"
-provider_name = "runpod_mtp"
+provider_name = "qwen3-mtp"
 supports_tools = true
 supports_tool_choice = true
 supports_reasoning = true
@@ -740,6 +740,62 @@ thinking_control_format = "chat_template_kwargs"
          "bare raw model id does not inherit provider-qualified row"
          true
          (Option.is_none (Provider_config.capabilities_for_config_model cfg)))
+;;
+
+(* RFC-OAS-034 §6: host-invariant regression. Capability is a function of the
+   serving runtime x model (the WHAT), never of the endpoint host (the WHERE).
+   The same OpenAI-compatible kind + same provider-qualified model_id must
+   resolve to the SAME capabilities whether the endpoint is rented on RunPod, on
+   an arbitrary domain, or served on localhost. This pins that no host branch
+   (e.g. base_url_targets_runpod_proxy -> "runpod_mtp") can ever re-key
+   capability provenance to the host: moving the endpoint must not silently
+   change or drop capabilities. *)
+let test_capabilities_are_invariant_across_host () =
+  with_model_catalog_toml
+    {|
+[[models]]
+id_prefix = "qwen3-mtp/qwen36-35b-a3b-mtp"
+base = "openai_chat"
+provider_name = "qwen3-mtp"
+supports_tools = true
+supports_tool_choice = true
+supports_reasoning = true
+supports_extended_thinking = true
+thinking_control_format = "chat_template_kwargs"
+|}
+    (fun () ->
+       let caps_for base_url =
+         Provider_config.make
+           ~kind:OpenAI_compat
+           ~model_id:"qwen3-mtp/qwen36-35b-a3b-mtp"
+           ~base_url
+           ()
+         |> Provider_config.capabilities_for_config_model
+       in
+       let runpod = caps_for "https://abc123.proxy.runpod.net/v1" in
+       let arbitrary = caps_for "https://mybox.example.com/v1" in
+       let localhost = caps_for "http://127.0.0.1:8085/v1" in
+       match runpod, arbitrary, localhost with
+       | Some on_runpod, Some on_arbitrary, Some on_localhost ->
+         check_bool
+           "capability identical on RunPod host and arbitrary domain"
+           true
+           (on_runpod = on_arbitrary);
+         check_bool
+           "capability identical on remote host and localhost"
+           true
+           (on_arbitrary = on_localhost);
+         (* The resolved capability is the real serving-contract row, not an
+            empty default — so the invariance above is over a non-trivial set. *)
+         check_bool "resolved row keeps tools" true on_runpod.supports_tools;
+         check_bool "resolved row keeps reasoning" true on_runpod.supports_reasoning;
+         check_bool
+           "resolved row keeps chat_template_kwargs dialect"
+           true
+           (on_runpod.thinking_control_format = Capabilities.Chat_template_kwargs)
+       | _ ->
+         Alcotest.fail
+           "provider-qualified serving-contract model must resolve on every host")
 ;;
 
 let test_validate_responses_request_path_allows_structured_output () =
@@ -2122,6 +2178,10 @@ let () =
             "bare model id does not resolve provider-qualified row"
             `Quick
             test_openai_compat_bare_model_id_does_not_resolve_provider_qualified_row
+        ; Alcotest.test_case
+            "capabilities are invariant across endpoint host"
+            `Quick
+            test_capabilities_are_invariant_across_host
         ; Alcotest.test_case
             "responses structured path accepted"
             `Quick

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -679,9 +679,9 @@ let test_openai_compat_explicit_provider_qualified_model_id_resolves_catalog_row
   with_model_catalog_toml
     {|
 [[models]]
-id_prefix = "qwen3-mtp/qwen36-35b-a3b-mtp"
+id_prefix = "vllm-qwen3-mtp/qwen36-35b-a3b-mtp"
 base = "openai_chat"
-provider_name = "qwen3-mtp"
+provider_name = "vllm-qwen3-mtp"
 supports_tools = true
 supports_tool_choice = true
 supports_reasoning = true
@@ -692,7 +692,7 @@ thinking_control_format = "chat_template_kwargs"
        let cfg =
          Provider_config.make
            ~kind:OpenAI_compat
-           ~model_id:"qwen3-mtp.qwen36-35b-a3b-mtp"
+           ~model_id:"vllm-qwen3-mtp.qwen36-35b-a3b-mtp"
            ~base_url:"https://unknown-openai-compatible.example/v1"
            ()
        in
@@ -719,9 +719,9 @@ let test_openai_compat_bare_model_id_does_not_resolve_provider_qualified_row () 
   with_model_catalog_toml
     {|
 [[models]]
-id_prefix = "qwen3-mtp/qwen36-35b-a3b-mtp"
+id_prefix = "vllm-qwen3-mtp/qwen36-35b-a3b-mtp"
 base = "openai_chat"
-provider_name = "qwen3-mtp"
+provider_name = "vllm-qwen3-mtp"
 supports_tools = true
 supports_tool_choice = true
 supports_reasoning = true
@@ -754,9 +754,9 @@ let test_capabilities_are_invariant_across_host () =
   with_model_catalog_toml
     {|
 [[models]]
-id_prefix = "qwen3-mtp/qwen36-35b-a3b-mtp"
+id_prefix = "vllm-qwen3-mtp/qwen36-35b-a3b-mtp"
 base = "openai_chat"
-provider_name = "qwen3-mtp"
+provider_name = "vllm-qwen3-mtp"
 supports_tools = true
 supports_tool_choice = true
 supports_reasoning = true
@@ -767,7 +767,7 @@ thinking_control_format = "chat_template_kwargs"
        let caps_for base_url =
          Provider_config.make
            ~kind:OpenAI_compat
-           ~model_id:"qwen3-mtp/qwen36-35b-a3b-mtp"
+           ~model_id:"vllm-qwen3-mtp/qwen36-35b-a3b-mtp"
            ~base_url
            ()
          |> Provider_config.capabilities_for_config_model

--- a/test/test_provider_runtime_binding.ml
+++ b/test/test_provider_runtime_binding.ml
@@ -340,7 +340,7 @@ let test_capabilities_for_provider_config_uses_dot_qualified_model_catalog () =
   "schema_version": 1,
   "providers": [
     {
-      "id": "qwen3-mtp",
+      "id": "vllm-qwen3-mtp",
       "kind": "openai_compat",
       "transport": "http",
       "base_url": "https://runpod.example.invalid/v1",
@@ -355,9 +355,9 @@ let test_capabilities_for_provider_config_uses_dot_qualified_model_catalog () =
        with_model_catalog
          {|
 [[models]]
-id_prefix = "qwen3-mtp/qwen36-35b-a3b-mtp"
+id_prefix = "vllm-qwen3-mtp/qwen36-35b-a3b-mtp"
 base = "openai_chat"
-provider_name = "qwen3-mtp"
+provider_name = "vllm-qwen3-mtp"
 supports_tools = true
 supports_tool_choice = true
 supports_parallel_tool_calls = true
@@ -371,23 +371,26 @@ preserve_thinking_control_format = "chat_template_kwargs_preserve_thinking"
             let cfg =
               Llm_provider.Provider_config.make
                 ~kind:Llm_provider.Provider_config.OpenAI_compat
-                ~model_id:"qwen3-mtp.qwen36-35b-a3b-mtp"
+                ~model_id:"vllm-qwen3-mtp.qwen36-35b-a3b-mtp"
                 ~base_url:"https://runpod.example.invalid/v1"
                 ~request_path:"/chat/completions"
                 ()
             in
             let caps = Provider_runtime_binding.capabilities_for_provider_config cfg in
-            Alcotest.(check bool) "qwen3-mtp row keeps tools" true caps.supports_tools;
             Alcotest.(check bool)
-              "qwen3-mtp row keeps parallel tools"
+              "vllm-qwen3-mtp row keeps tools"
+              true
+              caps.supports_tools;
+            Alcotest.(check bool)
+              "vllm-qwen3-mtp row keeps parallel tools"
               true
               caps.supports_parallel_tool_calls;
             Alcotest.(check bool)
-              "qwen3-mtp row keeps reasoning"
+              "vllm-qwen3-mtp row keeps reasoning"
               true
               caps.supports_reasoning;
             Alcotest.(check bool)
-              "qwen3-mtp row uses chat_template_kwargs"
+              "vllm-qwen3-mtp row uses chat_template_kwargs"
               true
               (caps.thinking_control_format
                = Llm_provider.Capabilities.Chat_template_kwargs)))

--- a/test/test_provider_runtime_binding.ml
+++ b/test/test_provider_runtime_binding.ml
@@ -340,7 +340,7 @@ let test_capabilities_for_provider_config_uses_dot_qualified_model_catalog () =
   "schema_version": 1,
   "providers": [
     {
-      "id": "runpod_mtp",
+      "id": "qwen3-mtp",
       "kind": "openai_compat",
       "transport": "http",
       "base_url": "https://runpod.example.invalid/v1",
@@ -355,9 +355,9 @@ let test_capabilities_for_provider_config_uses_dot_qualified_model_catalog () =
        with_model_catalog
          {|
 [[models]]
-id_prefix = "runpod_mtp/qwen36-35b-a3b-mtp"
+id_prefix = "qwen3-mtp/qwen36-35b-a3b-mtp"
 base = "openai_chat"
-provider_name = "runpod_mtp"
+provider_name = "qwen3-mtp"
 supports_tools = true
 supports_tool_choice = true
 supports_parallel_tool_calls = true
@@ -371,23 +371,23 @@ preserve_thinking_control_format = "chat_template_kwargs_preserve_thinking"
             let cfg =
               Llm_provider.Provider_config.make
                 ~kind:Llm_provider.Provider_config.OpenAI_compat
-                ~model_id:"runpod_mtp.qwen36-35b-a3b-mtp"
+                ~model_id:"qwen3-mtp.qwen36-35b-a3b-mtp"
                 ~base_url:"https://runpod.example.invalid/v1"
                 ~request_path:"/chat/completions"
                 ()
             in
             let caps = Provider_runtime_binding.capabilities_for_provider_config cfg in
-            Alcotest.(check bool) "runpod row keeps tools" true caps.supports_tools;
+            Alcotest.(check bool) "qwen3-mtp row keeps tools" true caps.supports_tools;
             Alcotest.(check bool)
-              "runpod row keeps parallel tools"
+              "qwen3-mtp row keeps parallel tools"
               true
               caps.supports_parallel_tool_calls;
             Alcotest.(check bool)
-              "runpod row keeps reasoning"
+              "qwen3-mtp row keeps reasoning"
               true
               caps.supports_reasoning;
             Alcotest.(check bool)
-              "runpod row uses chat_template_kwargs"
+              "qwen3-mtp row uses chat_template_kwargs"
               true
               (caps.thinking_control_format
                = Llm_provider.Capabilities.Chat_template_kwargs)))


### PR DESCRIPTION
## 목적 (RFC-OAS-034 B1/B2 — 마지막 미착수 항목)

RunPod은 OAS 입장에서 **opaque transport alias**다. OAS는 그것을 capability 분류 근거로 삼지 않는다. catalog namespace `runpod_mtp`는 hosting provider(runpod)를 capability provenance에 새게 한 이름이었다. capability는 `serving-runtime × model`의 함수이지 **어디에 임대됐는가(host)**의 함수가 아니다 (RFC-OAS-034 §2 rule 1, §1.3).

## 왜 rename만으로 충분한가 (host 유도 불필요)

명시-선언 해석 경로가 **이미 작동**한다:

- `provider_config.ml`의 `catalog_entry_explicitly_declared_by_model_id` → `model_id_has_provider_label`: 소비자가 `model_id = "qwen3-mtp/<model>"`(또는 `.`/`:` 구분자)로 주면 fail-closed 게이트를 우회해 해석된다.
- `#2374`/`#2408`은 오직 **bare model_id**(namespace 미포함)를 `*.proxy.runpod.net` **host에서 namespace를 유도**해 해석하려 한 것 — §2가 금지하는 host→capability이고, 명시 선언이 되는 이상 **불필요**하다.

따라서 이 PR은 host 유도를 추가하는 대신, host를 새는 이름을 serving-contract 이름으로 바꾼다.

## 변경

- `models.toml`: `runpod_mtp/qwen36-35b-a3b-mtp` → `qwen3-mtp/qwen36-35b-a3b-mtp`, `provider_name = "qwen3-mtp"`. 근거 주석 추가.
- `lib/llm_provider/capabilities.ml`: 주석/테스트명에서 "runpod alias" 표현 제거 (동작 무변).
- `test/` 4파일: namespace 토큰 rename. **`*.proxy.runpod.net` base_url은 유지** — transport 축(WHERE)이라 정당하며, 이제 host가 runpod여도 아무것도 그걸로 분류하지 않음을 시연한다.
- **host-불변 회귀 테스트 신규** (`test_capabilities_are_invariant_across_host`, RFC-OAS-034 §6): 동일 `~kind` + 동일 qualified `~model_id`를 RunPod host / 임의 도메인 / localhost 세 base_url로 만들어 `capabilities_for_config_model`이 **동일 capability로 resolve**됨을 assert. host를 옮겨도 capability가 안 변함을 고정.
- `docs/rfc/RFC-OAS-034`: §7 상태표에서 B1/B2를 이 PR로 갱신.

## 후속 (이 PR 범위 밖)

- **#2374 / #2408 close**: 명시-선언 경로 + rename으로 대체됨. host→capability 유도는 §2 위반이자 불필요.
- **cross-repo (masc)**: `runpod_mtp` 참조는 대부분 dashboard 테스트 fixture(운영자 runtime_id 예시, dot 표기)와 `config/keepers/base.toml` 주석. 활성 코드 의존 아님. serving-contract 이름 정합을 위해 별도 masc 정리 가능(선택).

## 검증

- `ocamlformat --check` clean (변경 .ml 파일).
- 로컬 빌드 미실행 — **CI가 build/test authority** (§6 host-불변 테스트 + 기존 catalog 해석 테스트 포함).

RFC-WAIVED: `lib/llm_provider/`는 credential/keeper/operator subsystem 이 아니며, 본 변경 자체가 RFC-OAS-034 집행이다.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
