### PR TITLE
fix(catalog): validate base preset label at parse time, not silent default (RFC-OAS-034 :840)

### DIFF
--- a/docs/capability-manifest.md
+++ b/docs/capability-manifest.md
@@ -112,20 +112,24 @@ must update the parser and this schema together.
 ### Base presets
 
 The `base` field names a provider preset from
-`Capabilities.capabilities_for_provider_label`.  The absent-or-unrecognised
-default is `default_capabilities` (all flags false, no limits).
+`Capabilities.capabilities_for_provider_label`.  When `base` is absent, OAS uses
+`default_capabilities` (all flags false, no limits).  Unrecognised `base` values
+are rejected when the manifest is parsed.
 
 | Label | Description |
 |-------|-------------|
-| `openai_chat` | OpenAI GPT (chat completions, 128K ctx) |
-| `openai_chat_extended` | OpenAI GPT with reasoning + top\_k/min\_p |
-| `anthropic` | Claude (1M ctx, extended thinking, caching) |
+| `anthropic`, `claude` | Claude (1M ctx, extended thinking, caching) |
+| `dashscope` | DashScope |
 | `gemini` | Gemini (1M ctx, audio/video, code execution) |
-| `ollama` | Ollama local server |
-| `ollama_cloud` | Ollama Cloud native `/api/chat`; parsed reasoning may be final visible text |
-| `glm` | GLM / ZhipuAI |
+| `glm`, `zhipu`, `glm-coding` | GLM / ZhipuAI |
 | `kimi` | Kimi (262K ctx, reasoning) |
-| `nemotron` | NVIDIA NIM Nemotron (chat\_template\_kwargs thinking) |
+| `openai_compat` | OpenAI-compatible base preset |
+| `ollama` | Ollama local server |
+| `openai_chat` | OpenAI GPT (chat completions, 128K ctx) |
+| `openai`, `openai_compat_chat_extended` | OpenAI-compatible aliases |
+| `openai_chat_extended` | OpenAI GPT with reasoning + top\_k/min\_p |
+| `ollama_cloud` | Ollama Cloud native `/api/chat`; parsed reasoning may be final visible text |
+| `xai`, `mistral`, `cohere`, `mimo`, `nvidia` | Hosted provider presets |
 
 ## OCaml API
 
@@ -149,9 +153,15 @@ let caps = Capabilities.for_model_id "my-llama-q4-k4"
 ### Apply a manifest entry directly
 
 ```ocaml
+let base_label =
+  match Capability_manifest.base_label_of_string "openai_chat" with
+  | Ok label -> label
+  | Error msg -> invalid_arg msg
+in
+
 let entry : Capability_manifest.entry =
   { id_prefix = "my-model"
-  ; base_label = Some "openai_chat"
+  ; base_label = Some base_label
   ; max_context_tokens = Some 65536
   ; supports_tools = Some true
   ; (* all other fields: None = inherit from base *)

--- a/docs/rfc/RFC-OAS-034-endpoint-capability-boundary.md
+++ b/docs/rfc/RFC-OAS-034-endpoint-capability-boundary.md
@@ -158,5 +158,6 @@ stale-high(monotone-safe)이며, 전체 rebaseline은 별도 hygiene 작업으�
 | B7 min_p catalog-declared (host 비의존) | Draft | #2425 |
 | model_catalog unknown 키 fail-closed | Draft | #2426 |
 | B5 discovery / B6 manifest | false-positive (미구현) | — |
-| B4'(:804 host→output_schema) / :840(base label) | defer (설계 변경) | — |
+| :840 (unknown base label → silent default) | Draft — 기존 `Capability_vocab` SSOT 패턴으로 catalog+manifest parse fail-closed (설계 변경 아님) | 이 PR |
+| B4'(:804 host→output_schema) | defer (override 우선이라 fallback 제거 시 behavior 파손 → catalog-declared 마이그레이션) | — |
 | B1/B2 (#2374·#2408 흡수) | Draft — namespace `runpod_mtp`→`vllm-qwen3-mtp` rename + host-불변 회귀 테스트. #2374·#2408은 불필요(명시 선언 경로가 이미 작동)로 close | 이 PR |

--- a/docs/rfc/RFC-OAS-034-endpoint-capability-boundary.md
+++ b/docs/rfc/RFC-OAS-034-endpoint-capability-boundary.md
@@ -104,7 +104,8 @@ capability(MTP, tool_choice, reasoning dialect, structured output)를 결정하�
 1. namespace provenance를 명시 선언으로 도입 (`model_id` prefix 또는 config 필드). PR #2404(declarative override SSOT)와 정렬.
 2. `base_url_targets_runpod_proxy → "runpod_mtp"`(B1/B2) 및 `is_local → "nous"`(B3)를 포함한 모든 generic-host→capability 매핑 삭제.
 3. host-결합 namespace를 serving-contract 식별자로 rename.
-4. P3 경화 — 적대적 재감사(#2414) 후 착지: **B4**=ollama `Uri.host` 정확 비교(#2420), **B7**=min_p를 `is_local` 대신 catalog-declared로(#2425), **model_catalog**=unknown TOML 키 fail-closed(#2426). **B5/B6는 false-positive로 강등**(discovery=capability=f(runtime) legit / manifest=이미 fail-closed). **B4'(:804 host→output_schema capability), :840(unknown base label→silent default)는 설계 변경 필요로 defer**(§7 참조).
+4. P3 경화 — 적대적 재감사(#2414) 후 착지: **B4**=ollama `Uri.host` 정확 비교(#2420), **B7**=min_p를 `is_local` 대신 catalog-declared로(#2425), **model_catalog**=unknown TOML 키 fail-closed(#2426), **:840**=unknown base label parse-time fail-closed(이 PR). **B5/B6는 false-positive로 강등**(discovery=capability=f(runtime) legit / manifest=이미 fail-closed).
+   **B4'(:804 host→output_schema capability)는 설계 변경 필요로 defer**(§7 참조).
 5. §5 ratchet 추가로 재발 차단 — **#2419 착지**(hardening ratchet 확장).
 
 ## 5. Ratchet (RFC-OAS-022/023 미러) — 구현: PR #2419

--- a/docs/schemas/capability-manifest-v1.json
+++ b/docs/schemas/capability-manifest-v1.json
@@ -40,7 +40,29 @@
         },
         "base": {
           "type": "string",
-          "description": "Provider preset to use as a starting point before applying overrides. One of: 'openai_chat', 'openai_chat_extended', 'anthropic', 'gemini', 'ollama', 'glm', 'kimi', 'nemotron'. Defaults to OAS default_capabilities if absent or unrecognised.",
+          "enum": [
+            "anthropic",
+            "kimi",
+            "openai_compat",
+            "ollama",
+            "gemini",
+            "glm",
+            "dashscope",
+            "claude",
+            "openai",
+            "openai_chat",
+            "zhipu",
+            "glm-coding",
+            "openai_compat_chat_extended",
+            "openai_chat_extended",
+            "xai",
+            "mistral",
+            "cohere",
+            "mimo",
+            "ollama_cloud",
+            "nvidia"
+          ],
+          "description": "Provider preset to use as a starting point before applying overrides. If absent, OAS starts from default_capabilities. Unknown values are rejected.",
           "examples": ["openai_chat", "anthropic", "gemini", "ollama"]
         },
         "max_context_tokens": {

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -840,7 +840,7 @@ type declarative_capability_overrides =
   }
 
 let overrides_of_manifest_entry (entry : Capability_manifest.entry) =
-  { base_label = entry.base_label
+  { base_label = Option.map Capability_manifest.base_label_to_string entry.base_label
   ; max_context_tokens = entry.max_context_tokens
   ; max_output_tokens = entry.max_output_tokens
   ; supports_tools = entry.supports_tools

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -700,6 +700,26 @@ let%test "capabilities_of_kind aliases the same presets as the label classifier"
     ]
 ;;
 
+let%test "every base_label vocab value resolves to a preset (no false-reject)" =
+  (* SSOT drift-guard (RFC-OAS-034): [Capability_vocab.base_label_values] is what
+     the catalog/manifest parsers accept for a [base] field. If a listed value
+     did NOT resolve here, the parser would accept a label that then silently
+     collapses to [default_capabilities] — reopening the gap this closes. So
+     every vocab value must resolve to [Some]. (The reverse — resolver labels not
+     in the vocab — is caught loudly at parse time, not silently.) *)
+  List.for_all
+    (fun label -> Option.is_some (capabilities_for_provider_label label))
+    Capability_vocab.base_label_values
+;;
+
+let%test "unknown base label resolves to None, not a permissive default" =
+  (* The classifier fails closed on unrecognised labels; the parsers turn that
+     [None] into a parse Error rather than [default_capabilities]. *)
+  List.for_all
+    (fun label -> Option.is_none (capabilities_for_provider_label label))
+    [ "runpod_mtp"; "vllm"; "typo_label"; "" ]
+;;
+
 (** Merge Discovery ctx_size into capabilities. *)
 let with_context_size caps ~ctx_size = { caps with max_context_tokens = Some ctx_size }
 

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -301,9 +301,9 @@ val with_tool_support : capabilities -> supports_tools:bool -> capabilities
 
 (** Apply a {!Capability_manifest.entry} on top of a provider-preset base.
 
-    [entry.base_label] (if present) is resolved via
-    {!capabilities_for_provider_label}; unknown or absent labels fall back
-    to {!default_capabilities}.  Each [Some] field in [entry] overrides the
+    [entry.base_label] (if present) is a parsed {!Capability_manifest.base_label}
+    and is resolved via {!capabilities_for_provider_label}; an absent label falls
+    back to {!default_capabilities}.  Each [Some] field in [entry] overrides the
     corresponding field; [None] fields inherit from the base.
 
     @since 0.188.0 *)

--- a/lib/llm_provider/capability_manifest.ml
+++ b/lib/llm_provider/capability_manifest.ml
@@ -300,7 +300,12 @@ let parse_entry json =
     | Ok None -> Error "entry missing required \"id_prefix\" field"
     | Ok (Some id_prefix) -> Ok id_prefix
   in
-  let* base_label = member_string_closed "base" json in
+  (* Validate [base] against the closed preset vocab at parse time (mirrors the
+     other canonical fields below) so an unknown label fails closed instead of
+     silently resolving to [default_capabilities] downstream (RFC-OAS-034). *)
+  let* base_label =
+    canonical_choice "base" ~allowed:Capability_vocab.base_label_values json
+  in
   let* thinking_control_format =
     canonical_choice
       "thinking_control_format"
@@ -632,6 +637,18 @@ let%test "of_json: unknown root fields return error" =
   in
   match of_json json with
   | Error msg -> String.equal msg "manifest contains unknown field(s): future_field"
+  | Ok _ -> false
+;;
+
+let%test "of_json: unknown base preset returns error, not silent default" =
+  (* A [base] value outside the closed preset vocab must fail closed at parse
+     rather than resolve to [default_capabilities] downstream (RFC-OAS-034). *)
+  let json =
+    Yojson.Safe.from_string
+      {|{"schema_version":1,"models":[{"id_prefix":"m","base":"not_a_preset"}]}|}
+  in
+  match of_json json with
+  | Error _ -> true
   | Ok _ -> false
 ;;
 

--- a/lib/llm_provider/capability_manifest.ml
+++ b/lib/llm_provider/capability_manifest.ml
@@ -2,9 +2,27 @@
 
     @since 0.188.0 *)
 
+type base_label = string
+
+let normalize_base_label raw = String.lowercase_ascii (String.trim raw)
+
+let base_label_of_string raw =
+  let normalized = normalize_base_label raw in
+  if List.mem normalized Capability_vocab.base_label_values
+  then Ok normalized
+  else
+    Error
+      (Printf.sprintf
+         "unknown base preset %S (canonical: %s)"
+         normalized
+         (String.concat ", " Capability_vocab.base_label_values))
+;;
+
+let base_label_to_string label = label
+
 type entry =
   { id_prefix : string
-  ; base_label : string option
+  ; base_label : base_label option
   ; max_context_tokens : int option
   ; max_output_tokens : int option
   ; supports_tools : bool option
@@ -303,8 +321,13 @@ let parse_entry json =
   (* Validate [base] against the closed preset vocab at parse time (mirrors the
      other canonical fields below) so an unknown label fails closed instead of
      silently resolving to [default_capabilities] downstream (RFC-OAS-034). *)
-  let* base_label =
+  let* base_label_raw =
     canonical_choice "base" ~allowed:Capability_vocab.base_label_values json
+  in
+  let* base_label =
+    match base_label_raw with
+    | None -> Ok None
+    | Some raw -> Result.map (fun label -> Some label) (base_label_of_string raw)
   in
   let* thinking_control_format =
     canonical_choice

--- a/lib/llm_provider/capability_manifest.mli
+++ b/lib/llm_provider/capability_manifest.mli
@@ -35,19 +35,29 @@
 
     @since 0.188.0 *)
 
+(** Canonical provider capability preset label accepted by the manifest parser. *)
+type base_label = private string
+
+(** Validate and canonicalize a provider capability preset label. *)
+val base_label_of_string : string -> (base_label, string) result
+
+(** Return the canonical wire label. *)
+val base_label_to_string : base_label -> string
+
 (** One entry in the capability manifest.
 
     [id_prefix] is matched as a case-insensitive prefix against the
     model ID being looked up.  [base] names a provider preset from
     {!Capabilities.capabilities_for_provider_label} (e.g.
-    ["openai_chat"], ["anthropic"]); when absent or unrecognised the
-    built-in [default_capabilities] is used.
+    ["openai_chat"], ["anthropic"]); when absent, the built-in
+    [default_capabilities] is used.  Unrecognised labels are rejected
+    by {!base_label_of_string} and by the JSON parser.
 
     All other fields are optional overrides: a [None] value means
     "inherit from the base", a [Some v] value replaces the base value. *)
 type entry =
   { id_prefix : string
-  ; base_label : string option
+  ; base_label : base_label option
     (** Provider preset label, e.g. ["openai_chat"] or ["anthropic"]. *)
   ; max_context_tokens : int option (** [None] = inherit from base. *)
   ; max_output_tokens : int option (** [None] = inherit from base. *)
@@ -114,9 +124,10 @@ type t = entry list
 
     Returns [Error msg] when [schema_version] is missing or not 1,
     the root object contains an unknown field, a model entry contains
-    an unknown field, or a model entry is missing the required
-    [id_prefix] field.  The non-operational [_comment] field is
-    accepted at the root and entry levels. *)
+    an unknown field, a model entry is missing the required [id_prefix]
+    field, or [base] names an unknown provider preset.  The
+    non-operational [_comment] field is accepted at the root and entry
+    levels. *)
 val of_json : Yojson.Safe.t -> (t, string) result
 
 (** [load_file path] reads and parses a manifest from the given file

--- a/lib/llm_provider/capability_vocab.ml
+++ b/lib/llm_provider/capability_vocab.ml
@@ -220,3 +220,41 @@ let reasoning_streaming_format_of_string raw =
     else Some (Delta_reasoning_field field)
   | _ -> None
 ;;
+
+(* Closed vocabulary of catalog/manifest [base] labels — the provider presets a
+   model entry may name as its capability base. This is the SSOT that the catalog
+   ([Model_catalog.parse_entry]) and manifest ([Capability_manifest]) parsers
+   validate against at parse time, so an unknown/misspelled [base] fails closed
+   instead of silently resolving to [default_capabilities]
+   (RFC-OAS-034 §2 rule 4 — unknown -> None, not permissive default).
+
+   Must stay in sync with the set of labels [Capabilities.capabilities_for_provider_label]
+   resolves to [Some]; a drift-guard test in [test/test_capabilities.ml] pins the
+   forward direction (every value here resolves). Labels are normalized
+   (lowercase + trim) before membership checks, matching that resolver. *)
+let base_label_values =
+  [ (* Provider_kind.of_string canonical kinds *)
+    "anthropic"
+  ; "kimi"
+  ; "openai_compat"
+  ; "ollama"
+  ; "gemini"
+  ; "glm"
+  ; "dashscope"
+  ; (* provider-kind aliases *)
+    "claude"
+  ; "openai"
+  ; "openai_chat"
+  ; "zhipu"
+  ; "glm-coding"
+  ; (* string-only presets not expressible as a Provider_kind.t *)
+    "openai_compat_chat_extended"
+  ; "openai_chat_extended"
+  ; "xai"
+  ; "mistral"
+  ; "cohere"
+  ; "mimo"
+  ; "ollama_cloud"
+  ; "nvidia"
+  ]
+;;

--- a/lib/llm_provider/capability_vocab.ml
+++ b/lib/llm_provider/capability_vocab.ml
@@ -229,8 +229,8 @@ let reasoning_streaming_format_of_string raw =
    (RFC-OAS-034 §2 rule 4 — unknown -> None, not permissive default).
 
    Must stay in sync with the set of labels [Capabilities.capabilities_for_provider_label]
-   resolves to [Some]; a drift-guard test in [test/test_capabilities.ml] pins the
-   forward direction (every value here resolves). Labels are normalized
+   resolves to [Some]; a drift-guard test in [Capabilities] pins the forward
+   direction (every value here resolves). Labels are normalized
    (lowercase + trim) before membership checks, matching that resolver. *)
 let base_label_values =
   [ (* Provider_kind.of_string canonical kinds *)

--- a/lib/llm_provider/model_catalog.ml
+++ b/lib/llm_provider/model_catalog.ml
@@ -308,7 +308,17 @@ let parse_entry entry_toml =
        , Ok reasoning_replay
        , Ok assistant_tool_content_format
        , Ok accepted_reasoning_efforts ) ->
-       let base_label_result = find_string_field ~entry_id:id_prefix "base" entry_toml in
+       (* [base] names a provider preset; validate it against the closed vocab at
+          parse time so an unknown/misspelled label fails closed here rather than
+          silently resolving to [default_capabilities] downstream in
+          [Capabilities.apply_declarative_capability_overrides] (RFC-OAS-034). *)
+       let base_label_result =
+         canonical_string_opt
+           ~entry_id:id_prefix
+           "base"
+           ~allowed:Capability_vocab.base_label_values
+           entry_toml
+       in
        let provider_name_result =
          non_empty_string_field ~entry_id:id_prefix "provider_name" entry_toml
        in
@@ -477,6 +487,22 @@ let%test "parse_entry leaves task undeclared as None" =
   match parse_entry entry with
   | Ok { task = None; _ } -> true
   | Ok _ | Error _ -> false
+;;
+
+let%test "parse_entry rejects an unknown base preset, not silent default" =
+  (* An unknown [base] must fail closed here rather than resolve to
+     [default_capabilities] downstream (RFC-OAS-034 §2 rule 4). *)
+  let entry = Otoml.Parser.from_string "id_prefix = \"m\"\nbase = \"not_a_preset\"" in
+  match parse_entry entry with
+  | Error _ -> true
+  | Ok _ -> false
+;;
+
+let%test "parse_entry accepts a known base preset" =
+  let entry = Otoml.Parser.from_string "id_prefix = \"m\"\nbase = \"openai_chat\"" in
+  match parse_entry entry with
+  | Ok _ -> true
+  | Error _ -> false
 ;;
 
 let load_file path =

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -1439,6 +1439,23 @@ let test_manifest_base_absent_uses_default () =
   | None -> fail "expected Some"
 ;;
 
+let test_manifest_base_label_constructor_rejects_unknown () =
+  match Capability_manifest.base_label_of_string "not_a_preset" with
+  | Error _ -> ()
+  | Ok _ -> fail "unknown base label should not be constructible"
+;;
+
+let test_manifest_base_label_constructor_canonicalizes () =
+  match Capability_manifest.base_label_of_string " OpenAI_CHAT " with
+  | Ok label ->
+    check
+      string
+      "canonical base label"
+      "openai_chat"
+      (Capability_manifest.base_label_to_string label)
+  | Error msg -> failf "known base label should parse: %s" msg
+;;
+
 let test_example_manifest_base_labels_are_canonical () =
   let path =
     [ "docs/example-capability-manifest.json"
@@ -1462,6 +1479,7 @@ let test_example_manifest_base_labels_are_canonical () =
            then
              check bool (Printf.sprintf "expected base for %s" entry.id_prefix) true false
          | Some label ->
+           let label = Capability_manifest.base_label_to_string label in
            check
              bool
              (Printf.sprintf "base label resolves for %s: %s" entry.id_prefix label)
@@ -2409,6 +2427,14 @@ let () =
         ; test_case "base openai_chat" `Quick test_manifest_base_label_openai_chat
         ; test_case "base anthropic" `Quick test_manifest_base_label_anthropic
         ; test_case "base absent = default" `Quick test_manifest_base_absent_uses_default
+        ; test_case
+            "base label constructor rejects unknown"
+            `Quick
+            test_manifest_base_label_constructor_rejects_unknown
+        ; test_case
+            "base label constructor canonicalizes"
+            `Quick
+            test_manifest_base_label_constructor_canonicalizes
         ; test_case
             "example base labels are canonical"
             `Quick


### PR DESCRIPTION
## 목적 (RFC-OAS-034 `:840` — defer 항목 해소)

model catalog / manifest 엔트리는 `base` 필드로 capability 프리셋을 지정한다. 그런데 `base` 값이 **알 수 없는/오타 라벨**(예 `base = "openai-chat"`)이면 문자열 타입만 검사되고 프리셋 유효성은 검증되지 않은 채 `Capabilities.apply_declarative_capability_overrides`로 흘러 `capabilities_for_provider_label = None` → **경고도 에러도 없이 `default_capabilities`로 붕괴**했다. Unknown → permissive default 안티패턴(RFC-OAS-034 §2 rule 4)이며, #2426(unknown **필드** 거부)의 **값 레벨** 형제다.

`capabilities_for_provider_label`의 docstring 자체가 "callers can fail closed rather than silently treating unknown providers as having default"라고 명시하는데, 호출자(`:840`)가 정반대로 동작하고 있었다.

## 왜 "설계 변경"이 아니라 contained fix인가

`model_catalog.parse_entry`는 이미 **7개 enum 필드**(reasoning_replay / assistant_tool_content / modality_priority / thinking_control / preserve_thinking / reasoning_output / reasoning_streaming)를 `Capability_vocab.*_values`에 대해 parse-time fail-closed 검증한다. `base`만 raw-string 경로에 남아 있었다. 즉 기존 SSOT 패턴에 `base`를 편입하면 된다.

## 변경

- **`capability_vocab.ml`**: `base_label_values` 추가 — 프리셋 라벨의 폐집합(Provider_kind kinds + aliases + string-only presets). 양쪽 parser가 검증하는 SSOT.
- **`model_catalog.ml`**: `base`를 `find_string_field` → `canonical_string_opt ~allowed:base_label_values`(형제 필드와 동일 헬퍼).
- **`capability_manifest.ml`**: `base`를 `member_string_closed` → `canonical_choice ~allowed:base_label_values`(manifest 대응 헬퍼).
- **테스트**: (1) `capabilities.ml` drift-guard — 모든 `base_label_values`가 resolve됨(false-reject 방지) + unknown은 None. (2) catalog/manifest parse-거부 테스트(unknown base → Error, known → Ok).

## 안전성 (false-reject 없음)

기존 catalog + manifest의 모든 `base` 값(`openai_chat`, `glm`, `anthropic`, `ollama`, `nvidia`, `ollama_cloud`, `openai_chat_extended`, `kimi`, `dashscope`, `gemini`)이 vocab에 포함됨을 확인. 테스트 fixture의 실제 base 값(`anthropic`/`openai_chat`)도 포함. 유효 엔트리는 거부되지 않는다.

## Drift 방지

`base_label_values`(SSOT)와 `capabilities_for_provider_label`(resolver)의 동기화는 drift-guard 테스트가 forward 방향(모든 vocab 라벨 resolve)으로 고정. resolver에만 있고 vocab에 없는 라벨은 parse 시점에 **큰 소리로**(Error) 드러나므로(silent 아님) self-correcting.

## RFC-OAS-034 §7

`:840`은 "설계 변경 필요"로 defer됐으나, 기존 Capability_vocab SSOT 패턴을 따르는 contained fix임을 보였다. `:804`(host→output_schema, override 우선이라 fallback 제거 시 파손)는 계속 defer.

## 검증

- `ocamlformat --check` clean (변경 4 .ml).
- 로컬 빌드 미실행 — CI가 build/test authority.

RFC-WAIVED: `lib/llm_provider/` 는 credential/keeper/operator subsystem 이 아니며, 본 변경 자체가 RFC-OAS-034 집행이다.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
