### PR TITLE
refactor(oas): Eio fiber-safe mutex hygiene and typed pipeline errors

### DIFF
--- a/examples/builder_patterns.ml
+++ b/examples/builder_patterns.ml
@@ -111,7 +111,7 @@ let demo_context () =
   Printf.printf "\n--- 4. Context Sharing ---\n";
   Eio_main.run
   @@ fun env ->
-  let ctx = Context.create ~eio:false () in
+  let ctx = Context.create_sync () in
   Context.set ctx "shared_key" (`String "shared_value");
   let agent =
     Builder.create ~net:env#net ~model:"test-model"

--- a/examples/builder_patterns.ml
+++ b/examples/builder_patterns.ml
@@ -111,7 +111,7 @@ let demo_context () =
   Printf.printf "\n--- 4. Context Sharing ---\n";
   Eio_main.run
   @@ fun env ->
-  let ctx = Context.create_sync () in
+  let ctx = Context.create () in
   Context.set ctx "shared_key" (`String "shared_value");
   let agent =
     Builder.create ~net:env#net ~model:"test-model"

--- a/lib/agent/agent_registry.ml
+++ b/lib/agent/agent_registry.ml
@@ -24,8 +24,12 @@ type agent_entry =
       ; card : Agent_card.agent_card
       }
 
+type mutex =
+  | Stdlib_mu of Mutex.t
+  | Eio_mu of Eio.Mutex.t
+
 type t =
-  { mu : Mutex.t
+  { mu : mutex
   ; agents : (string, agent_entry) Hashtbl.t
   ; log : Log.t
   }
@@ -33,15 +37,25 @@ type t =
 (* ── Constructor ─────────────────────────────────────────── *)
 
 let create () =
-  { mu = Mutex.create ()
+  { mu = Eio_mu (Eio.Mutex.create ())
+  ; agents = Hashtbl.create 16
+  ; log = Log.create ~module_name:"agent_registry" ()
+  }
+;;
+
+let create_sync () =
+  { mu = Stdlib_mu (Mutex.create ())
   ; agents = Hashtbl.create 16
   ; log = Log.create ~module_name:"agent_registry" ()
   }
 ;;
 
 let with_lock t f =
-  Mutex.lock t.mu;
-  Fun.protect f ~finally:(fun () -> Mutex.unlock t.mu)
+  match t.mu with
+  | Stdlib_mu mu ->
+    Mutex.lock mu;
+    Fun.protect f ~finally:(fun () -> Mutex.unlock mu)
+  | Eio_mu mu -> Eio.Mutex.use_rw ~protect:true mu f
 ;;
 
 (* ── Registration ────────────────────────────────────────── *)

--- a/lib/agent/agent_registry.mli
+++ b/lib/agent/agent_registry.mli
@@ -19,6 +19,11 @@ type agent_entry =
 type t
 
 val create : unit -> t
+
+(** Create a registry backed by {!Stdlib.Mutex} for synchronous tests and
+    serialization code that runs outside of an Eio scheduler. *)
+val create_sync : unit -> t
+
 val register_local : t -> name:string -> Agent.t -> unit
 val register_remote : t -> name:string -> url:string -> Agent_card.agent_card -> unit
 val unregister : t -> string -> unit

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -388,9 +388,7 @@ let create
 ;;
 
 let clone ?(copy_context = false) agent =
-  let ctx =
-    if copy_context then Context.copy agent.context else Context.create ()
-  in
+  let ctx = if copy_context then Context.copy agent.context else Context.create () in
   let state =
     { config = agent.state.config
     ; messages = agent.state.messages

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -371,7 +371,7 @@ let create
   let ctx =
     match context with
     | Some c -> c
-    | None -> Context.create ~eio:true ()
+    | None -> Context.create ()
   in
   { mu = Eio.Mutex.create ()
   ; state
@@ -389,7 +389,7 @@ let create
 
 let clone ?(copy_context = false) agent =
   let ctx =
-    if copy_context then Context.copy agent.context else Context.create ~eio:true ()
+    if copy_context then Context.copy agent.context else Context.create ()
   in
   let state =
     { config = agent.state.config

--- a/lib/base/context.ml
+++ b/lib/base/context.ml
@@ -31,10 +31,9 @@ type concurrency_backend =
   | Stdlib_mutex
   | Eio_mutex
 
-let create ~(eio : bool) () : t =
-  let mu = if eio then Eio_mu (Eio.Mutex.create ()) else Stdlib_mu (Mutex.create ()) in
-  { mu; tbl = Hashtbl.create 16 }
-;;
+let create () : t = { mu = Eio_mu (Eio.Mutex.create ()); tbl = Hashtbl.create 16 }
+
+let create_sync () : t = { mu = Stdlib_mu (Mutex.create ()); tbl = Hashtbl.create 16 };;
 
 let is_eio_backed ctx =
   match ctx.mu with
@@ -136,7 +135,7 @@ let to_json (ctx : t) : Yojson.Safe.t =
 let of_json ?(eio = false) (json : Yojson.Safe.t) : t =
   match json with
   | `Assoc pairs ->
-    let ctx = create ~eio () in
+    let ctx = if eio then create () else create_sync () in
     List.iter (fun (k, v) -> Hashtbl.replace ctx.tbl k v) pairs;
     ctx
   | _ -> invalid_arg "Context.of_json: expected JSON object"
@@ -149,7 +148,7 @@ let copy ?eio (ctx : t) : t =
       | Some value -> value
       | None -> is_eio_backed ctx
     in
-    let new_ctx = create ~eio:use_eio () in
+    let new_ctx = if use_eio then create () else create_sync () in
     Hashtbl.iter (fun k v -> Hashtbl.replace new_ctx.tbl k v) ctx.tbl;
     new_ctx)
 ;;
@@ -172,7 +171,7 @@ type isolated_scope =
     Only keys listed in [propagate_down] are copied to the local context.
     Reads from parent under lock, then populates new local context. *)
 let create_scope ~parent ~propagate_down ~propagate_up =
-  let local = create ~eio:(is_eio_backed parent) () in
+  let local = if is_eio_backed parent then create () else create_sync () in
   let pairs =
     with_lock parent (fun () ->
       List.filter_map

--- a/lib/base/context.ml
+++ b/lib/base/context.ml
@@ -32,8 +32,7 @@ type concurrency_backend =
   | Eio_mutex
 
 let create () : t = { mu = Eio_mu (Eio.Mutex.create ()); tbl = Hashtbl.create 16 }
-
-let create_sync () : t = { mu = Stdlib_mu (Mutex.create ()); tbl = Hashtbl.create 16 };;
+let create_sync () : t = { mu = Stdlib_mu (Mutex.create ()); tbl = Hashtbl.create 16 }
 
 let is_eio_backed ctx =
   match ctx.mu with

--- a/lib/base/context.mli
+++ b/lib/base/context.mli
@@ -24,14 +24,17 @@ type concurrency_backend =
   | Stdlib_mutex
   | Eio_mutex
 
-(** Create a new context.
+(** Create a new context using {!Eio.Mutex}.
 
-    [~eio:true] uses {!Eio.Mutex} for synchronization, which is required when
-    the context is shared across parallel fibers under an Eio scheduler.
-    [~eio:false] keeps the {!Stdlib.Mutex} implementation for use outside of an
-    Eio fiber (e.g. synchronous tests or serialization). The argument is
-    required so callers explicitly choose the concurrency model. *)
-val create : eio:bool -> unit -> t
+    This is the default for agent execution paths where the context may be
+    shared across parallel fibers under an Eio scheduler. *)
+val create : unit -> t
+
+(** Create a new context using {!Stdlib.Mutex}.
+
+    Use this for synchronous tests, serialization, or any code that runs
+    outside of an Eio fiber. *)
+val create_sync : unit -> t
 
 val get : t -> string -> Yojson.Safe.t option
 val set : t -> string -> Yojson.Safe.t -> unit

--- a/lib/checkpoint_codec.ml
+++ b/lib/checkpoint_codec.ml
@@ -469,7 +469,7 @@ let of_json json =
         json |> member "tools" |> to_list |> List.map tool_schema_of_json |> result_all
       and* context =
         match json |> member "context" with
-        | `Null -> Ok (Context.create ~eio:false ())
+        | `Null -> Ok (Context.create_sync ())
         | `Assoc _ as value -> Ok (Context.of_json value)
         | _ ->
           Error

--- a/lib/content_replacement_state.ml
+++ b/lib/content_replacement_state.ml
@@ -45,9 +45,7 @@ let with_lock t f =
   | Stdlib_mu mu ->
     Mutex.lock mu;
     Fun.protect f ~finally:(fun () -> Mutex.unlock mu)
-  | Eio_mu mu ->
-    Eio.Mutex.lock mu;
-    Fun.protect ~finally:(fun () -> Eio.Mutex.unlock mu) f
+  | Eio_mu mu -> Eio.Mutex.use_rw ~protect:true mu f
 ;;
 
 (* ── Query ──────────────────────────────────────────────────── *)

--- a/lib/content_replacement_state.ml
+++ b/lib/content_replacement_state.ml
@@ -40,7 +40,15 @@ let create_sync () =
   }
 ;;
 
-let with_lock t f =
+let with_read_lock t f =
+  match t.mu with
+  | Stdlib_mu mu ->
+    Mutex.lock mu;
+    Fun.protect f ~finally:(fun () -> Mutex.unlock mu)
+  | Eio_mu mu -> Eio.Mutex.use_ro mu f
+;;
+
+let with_write_lock t f =
   match t.mu with
   | Stdlib_mu mu ->
     Mutex.lock mu;
@@ -50,40 +58,54 @@ let with_lock t f =
 
 (* ── Query ──────────────────────────────────────────────────── *)
 
-let seen_count t = with_lock t (fun () -> Hashtbl.length t.seen_ids)
-let is_frozen t id = with_lock t (fun () -> Hashtbl.mem t.seen_ids id)
-let lookup_replacement t id = with_lock t (fun () -> Hashtbl.find_opt t.replacements id)
+let seen_count t = with_read_lock t (fun () -> Hashtbl.length t.seen_ids)
+let is_frozen t id = with_read_lock t (fun () -> Hashtbl.mem t.seen_ids id)
+
+let lookup_replacement t id =
+  with_read_lock t (fun () -> Hashtbl.find_opt t.replacements id)
+;;
 
 (* ── Record decisions ───────────────────────────────────────── *)
 
 let record_replacement t (r : replacement) =
-  with_lock t (fun () ->
-    if Hashtbl.mem t.seen_ids r.tool_use_id
-    then
-      invalid_arg
-        (Printf.sprintf
-           "Content_replacement_state.record_replacement: tool_use_id %S already frozen"
-           r.tool_use_id)
-    else (
-      Hashtbl.replace t.seen_ids r.tool_use_id ();
-      Hashtbl.replace t.replacements r.tool_use_id r))
+  match
+    with_write_lock t (fun () ->
+      if Hashtbl.mem t.seen_ids r.tool_use_id
+      then Error r.tool_use_id
+      else (
+        Hashtbl.replace t.seen_ids r.tool_use_id ();
+        Hashtbl.replace t.replacements r.tool_use_id r;
+        Ok ()))
+  with
+  | Ok () -> ()
+  | Error tool_use_id ->
+    invalid_arg
+      (Printf.sprintf
+         "Content_replacement_state.record_replacement: tool_use_id %S already frozen"
+         tool_use_id)
 ;;
 
 let record_kept t id =
-  with_lock t (fun () ->
-    if Hashtbl.mem t.seen_ids id
-    then
-      invalid_arg
-        (Printf.sprintf
-           "Content_replacement_state.record_kept: tool_use_id %S already frozen"
-           id)
-    else Hashtbl.replace t.seen_ids id ())
+  match
+    with_write_lock t (fun () ->
+      if Hashtbl.mem t.seen_ids id
+      then Error id
+      else (
+        Hashtbl.replace t.seen_ids id ();
+        Ok ()))
+  with
+  | Ok () -> ()
+  | Error tool_use_id ->
+    invalid_arg
+      (Printf.sprintf
+         "Content_replacement_state.record_kept: tool_use_id %S already frozen"
+         tool_use_id)
 ;;
 
 (* ── Apply to messages ──────────────────────────────────────── *)
 
 let apply_frozen t blocks =
-  with_lock t (fun () ->
+  with_read_lock t (fun () ->
     let fresh = ref [] in
     let modified =
       List.map
@@ -118,7 +140,7 @@ let apply_frozen t blocks =
 (* ── Serialization ──────────────────────────────────────────── *)
 
 let to_json t =
-  with_lock t (fun () ->
+  with_read_lock t (fun () ->
     let seen_list = Hashtbl.fold (fun id () acc -> `String id :: acc) t.seen_ids [] in
     let replacements_list =
       Hashtbl.fold
@@ -142,24 +164,22 @@ let to_json t =
 let of_json ?(eio = false) json =
   try
     let open Yojson.Safe.Util in
-    let seen_list = json |> member "seen_ids" |> to_list in
-    let replacements_list = json |> member "replacements" |> to_list in
+    let seen_list = json |> member "seen_ids" |> to_list |> List.map to_string in
+    let replacements_list =
+      json
+      |> member "replacements"
+      |> to_list
+      |> List.map (fun j ->
+        let tool_use_id = j |> member "tool_use_id" |> to_string in
+        let preview = j |> member "preview" |> to_string in
+        let original_chars = j |> member "original_chars" |> to_int in
+        { tool_use_id; preview; original_chars })
+    in
     let t = if eio then create () else create_sync () in
-    with_lock t (fun () ->
+    with_write_lock t (fun () ->
+      List.iter (fun id -> Hashtbl.replace t.seen_ids id ()) seen_list;
       List.iter
-        (fun j ->
-           let id = to_string j in
-           Hashtbl.replace t.seen_ids id ())
-        seen_list;
-      List.iter
-        (fun j ->
-           let tool_use_id = j |> member "tool_use_id" |> to_string in
-           let preview = j |> member "preview" |> to_string in
-           let original_chars = j |> member "original_chars" |> to_int in
-           Hashtbl.replace
-             t.replacements
-             tool_use_id
-             { tool_use_id; preview; original_chars })
+        (fun r -> Hashtbl.replace t.replacements r.tool_use_id r)
         replacements_list);
     Ok t
   with
@@ -317,4 +337,34 @@ let%test "to_json / of_json round-trip" =
         | Some r -> r.preview = "p1" && r.original_chars = 100
         | None -> false)
     && lookup_replacement t2 "t2" = None
+;;
+
+let%test "record_replacement duplicate keeps Eio mutex usable" =
+  Eio_main.run
+  @@ fun _env ->
+  let t = create () in
+  record_kept t "t1";
+  let raised =
+    try
+      record_replacement t { tool_use_id = "t1"; preview = "p"; original_chars = 10 };
+      false
+    with
+    | Invalid_argument _ -> true
+  in
+  raised && seen_count t = 1
+;;
+
+let%test "record_kept duplicate keeps Eio mutex usable" =
+  Eio_main.run
+  @@ fun _env ->
+  let t = create () in
+  record_replacement t { tool_use_id = "t1"; preview = "p"; original_chars = 10 };
+  let raised =
+    try
+      record_kept t "t1";
+      false
+    with
+    | Invalid_argument _ -> true
+  in
+  raised && lookup_replacement t "t1" <> None
 ;;

--- a/lib/content_replacement_state.ml
+++ b/lib/content_replacement_state.ml
@@ -14,8 +14,12 @@ type replacement =
   ; original_chars : int
   }
 
+type mutex =
+  | Stdlib_mu of Mutex.t
+  | Eio_mu of Eio.Mutex.t
+
 type t =
-  { mu : Mutex.t
+  { mu : mutex
   ; seen_ids : (string, unit) Hashtbl.t
   ; replacements : (string, replacement) Hashtbl.t
   }
@@ -23,12 +27,27 @@ type t =
 (* ── Lifecycle ──────────────────────────────────────────────── *)
 
 let create () =
-  { mu = Mutex.create (); seen_ids = Hashtbl.create 64; replacements = Hashtbl.create 32 }
+  { mu = Eio_mu (Eio.Mutex.create ())
+  ; seen_ids = Hashtbl.create 64
+  ; replacements = Hashtbl.create 32
+  }
+;;
+
+let create_sync () =
+  { mu = Stdlib_mu (Mutex.create ())
+  ; seen_ids = Hashtbl.create 64
+  ; replacements = Hashtbl.create 32
+  }
 ;;
 
 let with_lock t f =
-  Mutex.lock t.mu;
-  Fun.protect f ~finally:(fun () -> Mutex.unlock t.mu)
+  match t.mu with
+  | Stdlib_mu mu ->
+    Mutex.lock mu;
+    Fun.protect f ~finally:(fun () -> Mutex.unlock mu)
+  | Eio_mu mu ->
+    Eio.Mutex.lock mu;
+    Fun.protect ~finally:(fun () -> Eio.Mutex.unlock mu) f
 ;;
 
 (* ── Query ──────────────────────────────────────────────────── *)
@@ -122,12 +141,12 @@ let to_json t =
       ])
 ;;
 
-let of_json json =
+let of_json ?(eio = false) json =
   try
     let open Yojson.Safe.Util in
     let seen_list = json |> member "seen_ids" |> to_list in
     let replacements_list = json |> member "replacements" |> to_list in
-    let t = create () in
+    let t = if eio then create () else create_sync () in
     with_lock t (fun () ->
       List.iter
         (fun j ->
@@ -160,10 +179,11 @@ let context_key = "session:crs"
 let persist_to_context (ctx : Context.t) t = Context.set ctx context_key (to_json t)
 
 let restore_from_context (ctx : Context.t) =
+  let eio = Context.concurrency_backend ctx = Context.Eio_mutex in
   match Context.get ctx context_key with
-  | None -> create ()
+  | None -> if eio then create () else create_sync ()
   | Some json ->
-    (match of_json json with
+    (match of_json ~eio json with
      | Ok t -> t
      | Error e ->
        Printf.eprintf
@@ -171,30 +191,30 @@ let restore_from_context (ctx : Context.t) =
           failed (%s), starting fresh\n\
           %!"
          (Error.to_string e);
-       create ())
+       if eio then create () else create_sync ())
 ;;
 
 (* === Inline tests === *)
 
 let%test "create: empty state" =
-  let t = create () in
+  let t = create_sync () in
   seen_count t = 0
 ;;
 
 let%test "record_replacement: freezes ID" =
-  let t = create () in
+  let t = create_sync () in
   record_replacement t { tool_use_id = "t1"; preview = "pre"; original_chars = 100 };
   is_frozen t "t1" && not (is_frozen t "t2")
 ;;
 
 let%test "record_kept: freezes without replacement" =
-  let t = create () in
+  let t = create_sync () in
   record_kept t "t1";
   is_frozen t "t1" && lookup_replacement t "t1" = None
 ;;
 
 let%test "record_replacement on frozen raises" =
-  let t = create () in
+  let t = create_sync () in
   record_kept t "t1";
   try
     record_replacement t { tool_use_id = "t1"; preview = "p"; original_chars = 10 };
@@ -204,7 +224,7 @@ let%test "record_replacement on frozen raises" =
 ;;
 
 let%test "record_kept on frozen raises" =
-  let t = create () in
+  let t = create_sync () in
   record_replacement t { tool_use_id = "t1"; preview = "p"; original_chars = 10 };
   try
     record_kept t "t1";
@@ -214,7 +234,7 @@ let%test "record_kept on frozen raises" =
 ;;
 
 let%test "lookup_replacement: returns recorded preview" =
-  let t = create () in
+  let t = create_sync () in
   record_replacement
     t
     { tool_use_id = "t1"; preview = "preview text"; original_chars = 5000 };
@@ -224,7 +244,7 @@ let%test "lookup_replacement: returns recorded preview" =
 ;;
 
 let%test "apply_frozen: replaces frozen, collects fresh" =
-  let t = create () in
+  let t = create_sync () in
   record_replacement t { tool_use_id = "t1"; preview = "short"; original_chars = 9000 };
   record_kept t "t2";
   let blocks =
@@ -267,7 +287,7 @@ let%test "apply_frozen: replaces frozen, collects fresh" =
 ;;
 
 let%test "apply_frozen: idempotent" =
-  let t = create () in
+  let t = create_sync () in
   record_replacement t { tool_use_id = "t1"; preview = "p"; original_chars = 100 };
   let blocks =
     [ ToolResult
@@ -285,7 +305,7 @@ let%test "apply_frozen: idempotent" =
 ;;
 
 let%test "to_json / of_json round-trip" =
-  let t = create () in
+  let t = create_sync () in
   record_replacement t { tool_use_id = "t1"; preview = "p1"; original_chars = 100 };
   record_kept t "t2";
   let json = to_json t in

--- a/lib/content_replacement_state.mli
+++ b/lib/content_replacement_state.mli
@@ -33,8 +33,11 @@ type replacement =
     Not thread-safe; each agent/session owns one instance. *)
 type t
 
-(** Create empty state. *)
+(** Create empty state using {!Eio.Mutex} for fiber-safe use inside an Eio agent run. *)
 val create : unit -> t
+
+(** Create empty state using {!Stdlib.Mutex} for synchronous tests and serialization. *)
+val create_sync : unit -> t
 
 (** {1 Query} *)
 
@@ -79,8 +82,9 @@ val apply_frozen : t -> Types.content_block list -> Types.content_block list * s
 val to_json : t -> Yojson.Safe.t
 
 (** Deserialize state from JSON.
-    Returns [Error] on malformed input. *)
-val of_json : Yojson.Safe.t -> (t, Error.sdk_error) result
+    [~eio:true] rehydrates with an {!Eio.Mutex}; the default [~eio:false]
+    is for synchronous deserialization. Returns [Error] on malformed input. *)
+val of_json : ?eio:bool -> Yojson.Safe.t -> (t, Error.sdk_error) result
 
 (** {1 Context checkpoint persistence}
 

--- a/lib/contract.ml
+++ b/lib/contract.ml
@@ -307,7 +307,7 @@ let context_with_contract ?context contract =
     let ctx =
       match context with
       | Some value -> value
-      | None -> Context.create ~eio:false ()
+      | None -> Context.create_sync ()
     in
     Context.set ctx context_key (to_json contract);
     Some ctx)

--- a/lib/llm_provider/metrics.ml
+++ b/lib/llm_provider/metrics.ml
@@ -244,11 +244,12 @@ let empty_state () : aggregate_state =
   }
 ;;
 
-(** Fiber-safe aggregating metrics backend.
+(** Thread-safe aggregating metrics backend.
     Accumulates per-provider counters in a hash table guarded by an
-    {!Eio.Mutex}. All updates happen inside Eio fibers (provider hot path), so
-    the Eio mutex avoids blocking OS threads. Call {!Aggregating.snapshot} to
-    read all counters as an immutable list.
+    {!Stdlib.Mutex}. The guarded sections are pure counter updates, so this
+    remains safe on Eio callback paths without requiring exporters/tests to run
+    inside an Eio scheduler. Call {!Aggregating.snapshot} to read all counters
+    as an immutable list.
 
     @since 0.188.0 *)
 type hooks = t
@@ -257,16 +258,18 @@ module Aggregating = struct
   type t =
     { hooks : hooks
     ; states : (aggregate_key, aggregate_state) Hashtbl.t
-    ; mutex : Eio.Mutex.t
+    ; mutex : Mutex.t
     }
 
   let key ~provider ~model_id = provider ^ "/" ^ model_id
 
   let create ?(inner = noop) () : t =
-    { hooks = inner; states = Hashtbl.create 16; mutex = Eio.Mutex.create () }
+    { hooks = inner; states = Hashtbl.create 16; mutex = Mutex.create () }
   ;;
 
-  let with_lock agg f = Eio.Mutex.use_rw ~protect:true agg.mutex f
+  let with_lock agg f =
+    Mutex.lock agg.mutex;
+    Fun.protect f ~finally:(fun () -> Mutex.unlock agg.mutex)
   ;;
 
   let with_state agg key f =

--- a/lib/llm_provider/metrics.ml
+++ b/lib/llm_provider/metrics.ml
@@ -244,12 +244,11 @@ let empty_state () : aggregate_state =
   }
 ;;
 
-(** Thread-safe aggregating metrics backend.
-    Accumulates per-provider counters in a hash table guarded by a Mutex.
-    The critical sections are pure counter/Hashtbl updates with no I/O or
-    scheduler yield points, so a Stdlib mutex keeps the public snapshot/export
-    API usable from both Eio fibers and ordinary OCaml threads.
-    Call {!Aggregating.snapshot} to read all counters as an immutable list.
+(** Fiber-safe aggregating metrics backend.
+    Accumulates per-provider counters in a hash table guarded by an
+    {!Eio.Mutex}. All updates happen inside Eio fibers (provider hot path), so
+    the Eio mutex avoids blocking OS threads. Call {!Aggregating.snapshot} to
+    read all counters as an immutable list.
 
     @since 0.188.0 *)
 type hooks = t
@@ -258,18 +257,16 @@ module Aggregating = struct
   type t =
     { hooks : hooks
     ; states : (aggregate_key, aggregate_state) Hashtbl.t
-    ; mutex : Mutex.t
+    ; mutex : Eio.Mutex.t
     }
 
   let key ~provider ~model_id = provider ^ "/" ^ model_id
 
   let create ?(inner = noop) () : t =
-    { hooks = inner; states = Hashtbl.create 16; mutex = Mutex.create () }
+    { hooks = inner; states = Hashtbl.create 16; mutex = Eio.Mutex.create () }
   ;;
 
-  let with_lock agg f =
-    Mutex.lock agg.mutex;
-    Fun.protect ~finally:(fun () -> Mutex.unlock agg.mutex) f
+  let with_lock agg f = Eio.Mutex.use_rw ~protect:true agg.mutex f
   ;;
 
   let with_state agg key f =

--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -423,10 +423,10 @@ let normalize_url value =
 ;;
 
 let default () =
-  (* The default registry is populated once and then treated as read-only.
-     It is accessed from both Eio fibers and synchronous config-building code,
-     so we avoid any mutex on the read path after construction. *)
-  let t = { mu = None; entries = Hashtbl.create 8 } in
+  (* The default registry uses Stdlib.Mutex because its guarded sections are
+     short Hashtbl operations and the returned value still exposes the mutable
+     registry API. *)
+  let t = create_sync () in
   let max_context_from_capabilities ~default caps =
     match caps.Capabilities.max_context_tokens with
     | Some ctx when ctx > default -> ctx

--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -22,23 +22,19 @@ type mutex =
   | Eio_mu of Eio.Mutex.t
 
 type t =
-  { mu : mutex option
+  { mu : mutex
   ; entries : (string, entry) Hashtbl.t
   }
 
-let create () = { mu = Some (Eio_mu (Eio.Mutex.create ())); entries = Hashtbl.create 8 }
-
-let create_sync () =
-  { mu = Some (Stdlib_mu (Mutex.create ())); entries = Hashtbl.create 8 }
-;;
+let create () = { mu = Eio_mu (Eio.Mutex.create ()); entries = Hashtbl.create 8 }
+let create_sync () = { mu = Stdlib_mu (Mutex.create ()); entries = Hashtbl.create 8 }
 
 let with_lock t f =
   match t.mu with
-  | None -> f ()
-  | Some (Stdlib_mu mu) ->
+  | Stdlib_mu mu ->
     Mutex.lock mu;
     Fun.protect f ~finally:(fun () -> Mutex.unlock mu)
-  | Some (Eio_mu mu) -> Eio.Mutex.use_rw ~protect:true mu f
+  | Eio_mu mu -> Eio.Mutex.use_rw ~protect:true mu f
 ;;
 
 let register' t entry = Hashtbl.replace t.entries entry.name entry

--- a/lib/llm_provider/provider_registry.ml
+++ b/lib/llm_provider/provider_registry.ml
@@ -17,16 +17,28 @@ type entry =
   ; is_available : unit -> bool
   }
 
+type mutex =
+  | Stdlib_mu of Mutex.t
+  | Eio_mu of Eio.Mutex.t
+
 type t =
-  { mu : Mutex.t
+  { mu : mutex option
   ; entries : (string, entry) Hashtbl.t
   }
 
-let create () = { mu = Mutex.create (); entries = Hashtbl.create 8 }
+let create () = { mu = Some (Eio_mu (Eio.Mutex.create ())); entries = Hashtbl.create 8 }
+
+let create_sync () =
+  { mu = Some (Stdlib_mu (Mutex.create ())); entries = Hashtbl.create 8 }
+;;
 
 let with_lock t f =
-  Mutex.lock t.mu;
-  Fun.protect f ~finally:(fun () -> Mutex.unlock t.mu)
+  match t.mu with
+  | None -> f ()
+  | Some (Stdlib_mu mu) ->
+    Mutex.lock mu;
+    Fun.protect f ~finally:(fun () -> Mutex.unlock mu)
+  | Some (Eio_mu mu) -> Eio.Mutex.use_rw ~protect:true mu f
 ;;
 
 let register' t entry = Hashtbl.replace t.entries entry.name entry
@@ -411,7 +423,10 @@ let normalize_url value =
 ;;
 
 let default () =
-  let t = create () in
+  (* The default registry is populated once and then treated as read-only.
+     It is accessed from both Eio fibers and synchronous config-building code,
+     so we avoid any mutex on the read path after construction. *)
+  let t = { mu = None; entries = Hashtbl.create 8 } in
   let max_context_from_capabilities ~default caps =
     match caps.Capabilities.max_context_tokens with
     | Some ctx when ctx > default -> ctx

--- a/lib/llm_provider/provider_registry.mli
+++ b/lib/llm_provider/provider_registry.mli
@@ -31,8 +31,12 @@ type entry =
 (** Mutable provider registry. *)
 type t
 
-(** Create an empty registry. *)
+(** Create an empty registry using {!Eio.Mutex}. *)
 val create : unit -> t
+
+(** Create an empty registry using {!Stdlib.Mutex} for synchronous tests and
+    serialization code that runs outside of an Eio scheduler. *)
+val create_sync : unit -> t
 
 (** Register a provider. Overwrites if name already exists. *)
 val register : t -> entry -> unit

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -24,6 +24,14 @@ let hook_failed_sdk_error ~hook_name ~stage ~detail =
   Error.Internal (Printf.sprintf "hook %s failed at %s: %s" hook_name stage detail)
 ;;
 
+let illegal_hook_decision ~stage ~decision =
+  Error.Internal
+    (Printf.sprintf
+       "illegal hook decision %s in %s"
+       (Agent_lifecycle.hook_decision_to_string decision)
+       stage)
+;;
+
 (* Shared with Pipeline_stage_prepare via Pipeline_common (re-raises Eio
    cancellation); the thin wrapper keeps this module's log label. *)
 let safe_publish bus event = Pipeline_common.safe_publish ~log:_log bus event
@@ -491,9 +499,14 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses_nonempty 
          | Hooks.ApprovalRequired
          | Hooks.AdjustParams _
          | Hooks.ElicitInput _ ->
-           (* Unreachable after [Hooks.invoke_validated] for on_idle. Fail-fast
-              so a validation bypass cannot silently change idle behavior. *)
-           assert false);
+           (* Reject illegal hook decisions with a typed error instead of crashing.
+              Stash the failure so the existing idle-hook error path returns it. *)
+           idle_hook_failed
+             := Some
+                  ( "illegal_decision"
+                  , Printf.sprintf
+                      "illegal hook decision %s in on_idle"
+                      (Agent_lifecycle.hook_decision_to_string idle_decision) ));
        (* Early exit: skip tool execution when on_idle hook says Skip.
           Prevents executing redundant tools and avoids further counter drift. *)
        match !idle_hook_failed with
@@ -823,22 +836,21 @@ let compact_messages
       true)
   in
   match hook_decision with
-  | Hooks.Skip -> false
-  | Hooks.Continue -> run_compaction ()
+  | Hooks.Skip -> Ok false
+  | Hooks.Continue -> Ok (run_compaction ())
   | Hooks.HookFailed { stage; detail } ->
     Log.error
       _log
       "pre_compact hook failed; skipping compaction"
       [ Log.S ("stage", stage); Log.S ("detail", detail) ];
-    false
+    Error (hook_failed_sdk_error ~hook_name:"pre_compact" ~stage ~detail)
   | Hooks.Override _
   | Hooks.ApprovalRequired
   | Hooks.AdjustParams _
   | Hooks.ElicitInput _
   | Hooks.Nudge _ ->
-    (* Unreachable after [Hooks.invoke_validated] for pre_compact. Fail-fast
-       so a validation bypass cannot silently compact. *)
-    assert false
+    (* Reject illegal hook decisions with a typed error instead of crashing. *)
+    Error (illegal_hook_decision ~stage:"pre_compact" ~decision:hook_decision)
 ;;
 
 (** Apply proactive compaction when context usage exceeds the configured
@@ -861,7 +873,7 @@ let proactive_compact ?raw_trace_run ?clock agent ~watermark () =
   let context_window_tokens = proactive_context_window_tokens agent in
   let usage_ratio = float_of_int est_tokens /. float_of_int context_window_tokens in
   if usage_ratio < watermark
-  then false
+  then Ok false
   else (
     (* Remap [watermark, 1.0] → [0.5, 1.0] so Budget_strategy always picks
        at least the Compact phase when the watermark is crossed.  Without
@@ -969,7 +981,7 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
      triggers compaction.
      This prevents the silent pass-through that caused a downstream consumer's
      CTX 101% overrun (observed in upstream issue #7083). *)
-  let prep =
+  let* prep =
     let watermark = proactive_watermark agent in
     let est_tokens = total_prompt_tokens_for_agent agent agent.state.messages in
     let context_window = proactive_context_window_tokens agent in
@@ -1004,9 +1016,9 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
                  { agent_name = agent.state.config.name; trigger = "proactive" }
            }
        | None -> ());
-      let compacted = proactive_compact ?raw_trace_run ?clock agent ~watermark () in
-      if compacted then prepare_turn_for_agent agent ~turn_params else prep)
-    else prep
+      let* compacted = proactive_compact ?raw_trace_run ?clock agent ~watermark () in
+      if compacted then Ok (prepare_turn_for_agent agent ~turn_params) else Ok prep)
+    else Ok prep
   in
   (* Stage 2.5: Async input validation *)
   let async_guard = agent.options.guardrails_async in
@@ -1033,7 +1045,7 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
       in
       if ratio >= watermark
       then (
-        let compacted = proactive_compact ?raw_trace_run ?clock agent ~watermark () in
+        let* compacted = proactive_compact ?raw_trace_run ?clock agent ~watermark () in
         if compacted
         then (
           update_state agent (fun s -> { s with config = original_config });
@@ -1107,7 +1119,7 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
                    { agent_name = agent.state.config.name; trigger = "emergency" }
              }
          | None -> ());
-        let compacted = emergency_compact ?raw_trace_run ?clock agent ?limit () in
+        let* compacted = emergency_compact ?raw_trace_run ?clock agent ?limit () in
         if not compacted
         then api_result
         else (

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -502,11 +502,11 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses_nonempty 
            (* Reject illegal hook decisions with a typed error instead of crashing.
               Stash the failure so the existing idle-hook error path returns it. *)
            idle_hook_failed
-             := Some
-                  ( "illegal_decision"
-                  , Printf.sprintf
-                      "illegal hook decision %s in on_idle"
-                      (Agent_lifecycle.hook_decision_to_string idle_decision) ));
+           := Some
+                ( "illegal_decision"
+                , Printf.sprintf
+                    "illegal hook decision %s in on_idle"
+                    (Agent_lifecycle.hook_decision_to_string idle_decision) ));
        (* Early exit: skip tool execution when on_idle hook says Skip.
           Prevents executing redundant tools and avoids further counter drift. *)
        match !idle_hook_failed with
@@ -843,7 +843,7 @@ let compact_messages
       _log
       "pre_compact hook failed; skipping compaction"
       [ Log.S ("stage", stage); Log.S ("detail", detail) ];
-    Error (hook_failed_sdk_error ~hook_name:"pre_compact" ~stage ~detail)
+    Ok false
   | Hooks.Override _
   | Hooks.ApprovalRequired
   | Hooks.AdjustParams _
@@ -1044,7 +1044,7 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
           ~limit_tokens:context_window
       in
       if ratio >= watermark
-      then (
+      then
         let* compacted = proactive_compact ?raw_trace_run ?clock agent ~watermark () in
         if compacted
         then (
@@ -1053,7 +1053,7 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
             stage_parse ?raw_trace_run ?clock agent |> tag_error "parse"
           in
           Ok prep')
-        else Ok prep)
+        else Ok prep
       else Ok prep
     in
     (* Stage 3: Route — with compact-and-retry on context overflow *)

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -19,6 +19,14 @@ let hook_failed_sdk_error ~hook_name ~stage ~detail =
   Error.Internal (Printf.sprintf "hook %s failed at %s: %s" hook_name stage detail)
 ;;
 
+let illegal_hook_decision ~stage ~decision =
+  Error.Internal
+    (Printf.sprintf
+       "illegal hook decision %s in %s"
+       (Agent_lifecycle.hook_decision_to_string decision)
+       stage)
+;;
+
 let stage_input ?raw_trace_run ?clock agent =
   let ts = Pipeline_common.timestamp_now ?clock () in
   set_lifecycle agent ~ready_at:ts Ready;
@@ -80,9 +88,10 @@ let stage_input ?raw_trace_run ?clock agent =
   | Hooks.HookFailed { stage; detail } ->
     Error (hook_failed_sdk_error ~hook_name:"before_turn" ~stage ~detail)
   | Hooks.Skip | Hooks.Override _ | Hooks.ApprovalRequired | Hooks.AdjustParams _ ->
-    (* Unreachable after [Hooks.invoke_validated] for before_turn. Fail-fast
-       so a validation bypass cannot silently start a turn. *)
-    assert false
+    (* Reject illegal hook decisions with a typed error instead of crashing.
+       [Hooks.invoke_validated] normally filters these out; this branch guards
+       against a validation bypass or future hook matrix drift. *)
+    Error (illegal_hook_decision ~stage:"before_turn" ~decision:before_decision)
 ;;
 
 (* Lower a canonical tool-result projection to the [Types.tool_result] the
@@ -298,10 +307,8 @@ let stage_parse ?raw_trace_run ?clock agent =
        | Hooks.ApprovalRequired
        | Hooks.ElicitInput _
        | Hooks.Nudge _ ->
-         (* Unreachable after [Hooks.invoke_validated] for before_turn_params.
-            Fail-fast so a validation bypass cannot silently use default
-            parameters. *)
-         assert false)
+         (* Reject illegal hook decisions with a typed error instead of crashing. *)
+         Error (illegal_hook_decision ~stage:"before_turn_params" ~decision))
   in
   let original_config = agent.state.config in
   let new_config =

--- a/lib/session.ml
+++ b/lib/session.ml
@@ -18,7 +18,7 @@ let generate_id () =
   Printf.sprintf "session-%06x%04x" hi lo
 ;;
 
-let create ?id ?resumed_from ?cwd ?(metadata = Context.create ~eio:false ()) () =
+let create ?id ?resumed_from ?cwd ?(metadata = Context.create_sync ()) () =
   let now = Unix.gettimeofday () in
   { id = Option.value id ~default:(generate_id ())
   ; started_at = now
@@ -75,7 +75,7 @@ let of_json json =
     let open Yojson.Safe.Util in
     let metadata =
       match json |> member "metadata" with
-      | `Null -> Context.create ~eio:false ()
+      | `Null -> Context.create_sync ()
       | v -> Context.of_json v
     in
     Ok

--- a/test/dune
+++ b/test/dune
@@ -68,6 +68,7 @@
   test_consumer
   test_content_replacement_event_bridge
   test_context
+  test_context_concurrency
   test_context_flow_proof
   test_context_intent
   test_context_offload
@@ -144,6 +145,7 @@
   test_pipeline
   test_pipeline_common_coverage
   test_pipeline_deep
+  test_pipeline_illegal_hook
   test_pipeline_metrics
   test_plan
   test_policy
@@ -271,6 +273,7 @@
   test_consumer
   test_content_replacement_event_bridge
   test_context
+  test_context_concurrency
   test_context_flow_proof
   test_context_intent
   test_context_offload
@@ -347,6 +350,7 @@
   test_pipeline
   test_pipeline_common_coverage
   test_pipeline_deep
+  test_pipeline_illegal_hook
   test_pipeline_metrics
   test_plan
   test_policy

--- a/test/test_agent_pipeline.ml
+++ b/test/test_agent_pipeline.ml
@@ -727,6 +727,57 @@ let test_proactive_compaction_phase_and_checkpoint () =
   | Exit -> ()
 ;;
 
+let test_pre_compact_hook_failure_skips_compaction_and_continues () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let url =
+      start_multi_mock ~sw ~net:env#net ~port:20032 [ openai_text_response "continued" ]
+    in
+    let provider : Provider.config =
+      { provider = Provider.Local { base_url = url }
+      ; model_id = "mock-model"
+      ; api_key_env = ""
+      }
+    in
+    let post_compact_seen = ref false in
+    let hooks =
+      { Hooks.empty with
+        pre_compact =
+          Some (fun _ -> Hooks.HookFailed { stage = "pre_compact"; detail = "boom" })
+      ; post_compact =
+          Some
+            (function
+              | Hooks.PostCompact _ ->
+                post_compact_seen := true;
+                Hooks.Continue
+              | _ -> Hooks.Continue)
+      }
+    in
+    let config =
+      { Types.default_config with
+        name = "pre-compact-failure-owner"
+      ; max_turns = 3
+      ; context_compact_ratio = Some 0.01
+      }
+    in
+    let options =
+      { Agent.default_options with base_url = url; provider = Some provider; hooks }
+    in
+    let agent = Agent.create ~net:env#net ~config ~options () in
+    Agent.update_state agent (fun state -> { state with messages = big_tool_history () });
+    (match Agent.run ~sw agent "continue" with
+     | Error e -> fail (Error.to_string e)
+     | Ok resp ->
+       check string "response text" "continued" (extract_text resp);
+       check bool "post_compact not fired" false !post_compact_seen);
+    Eio.Switch.fail sw Exit
+  with
+  | Exit -> ()
+;;
+
 let test_emergency_compaction_phase_and_checkpoint () =
   Eio_main.run
   @@ fun env ->
@@ -862,6 +913,10 @@ let () =
             "proactive phase and checkpoint labels"
             `Quick
             test_proactive_compaction_phase_and_checkpoint
+        ; test_case
+            "pre_compact HookFailed skips compaction"
+            `Quick
+            test_pre_compact_hook_failure_skips_compaction_and_continues
         ; test_case
             "emergency phase and checkpoint labels"
             `Quick

--- a/test/test_agent_registry.ml
+++ b/test/test_agent_registry.ml
@@ -88,7 +88,7 @@ let start_card_server ~sw ~net card =
 (* ── Registration and lookup ────────────────────────────── *)
 
 let test_register_local () =
-  let reg = Agent_registry.create () in
+  let reg = Agent_registry.create_sync () in
   let agent = make_agent () in
   Agent_registry.register_local reg ~name:"test-agent" agent;
   match Agent_registry.lookup reg "test-agent" with
@@ -99,7 +99,7 @@ let test_register_local () =
 ;;
 
 let test_register_remote () =
-  let reg = Agent_registry.create () in
+  let reg = Agent_registry.create_sync () in
   let card : Agent_card.agent_card =
     { name = "remote-agent"
     ; description = Some "A remote agent"
@@ -131,14 +131,14 @@ let test_register_remote () =
 ;;
 
 let test_lookup_missing () =
-  let reg = Agent_registry.create () in
+  let reg = Agent_registry.create_sync () in
   check bool "none" true (Option.is_none (Agent_registry.lookup reg "nope"))
 ;;
 
 (* ── List operations ────────────────────────────────────── *)
 
 let test_list_all () =
-  let reg = Agent_registry.create () in
+  let reg = Agent_registry.create_sync () in
   let agent = make_agent () in
   Agent_registry.register_local reg ~name:"a" agent;
   Agent_registry.register_local reg ~name:"b" agent;
@@ -147,7 +147,7 @@ let test_list_all () =
 ;;
 
 let test_count () =
-  let reg = Agent_registry.create () in
+  let reg = Agent_registry.create_sync () in
   check int "empty" 0 (Agent_registry.count reg);
   let agent = make_agent () in
   Agent_registry.register_local reg ~name:"x" agent;
@@ -157,7 +157,7 @@ let test_count () =
 (* ── Capability filtering ───────────────────────────────── *)
 
 let test_list_by_capability () =
-  let reg = Agent_registry.create () in
+  let reg = Agent_registry.create_sync () in
   let card_tools : Agent_card.agent_card =
     { name = "tools-agent"
     ; description = None
@@ -198,7 +198,7 @@ let test_list_by_capability () =
 (* ── Tool filtering ─────────────────────────────────────── *)
 
 let test_list_by_tool () =
-  let reg = Agent_registry.create () in
+  let reg = Agent_registry.create_sync () in
   let card : Agent_card.agent_card =
     { name = "tool-owner"
     ; description = None
@@ -230,7 +230,7 @@ let test_list_by_tool () =
 (* ── Unregister ─────────────────────────────────────────── *)
 
 let test_unregister () =
-  let reg = Agent_registry.create () in
+  let reg = Agent_registry.create_sync () in
   let agent = make_agent () in
   Agent_registry.register_local reg ~name:"temp" agent;
   check int "before" 1 (Agent_registry.count reg);
@@ -269,7 +269,7 @@ let test_discover_unreachable () =
   let net = Eio.Stdenv.net env in
   Eio.Switch.run
   @@ fun sw ->
-  let reg = Agent_registry.create () in
+  let reg = Agent_registry.create_sync () in
   match
     Agent_registry.discover_and_register
       ~sw
@@ -326,7 +326,7 @@ let test_fetch_card_http_client () =
 (* ── Overwrite registration ─────────────────────────────── *)
 
 let test_overwrite () =
-  let reg = Agent_registry.create () in
+  let reg = Agent_registry.create_sync () in
   let card1 : Agent_card.agent_card =
     { name = "v1"
     ; description = None

--- a/test/test_agent_turn.ml
+++ b/test/test_agent_turn.ml
@@ -808,7 +808,7 @@ let test_idle_reset_breaks_streak () =
 (* ── apply_context_injection ─────────────────────────────── *)
 
 let test_apply_context_injection_no_injector () =
-  let context = Context.create ~eio:false () in
+  let context = Context.create_sync () in
   let messages =
     [ { Types.role = Types.User
       ; content = [ Types.Text "hi" ]
@@ -837,7 +837,7 @@ let test_apply_context_injection_no_injector () =
 ;;
 
 let test_apply_context_injection_with_context_update () =
-  let context = Context.create ~eio:false () in
+  let context = Context.create_sync () in
   let messages =
     [ { Types.role = Types.User
       ; content = [ Types.Text "hi" ]
@@ -874,7 +874,7 @@ let test_apply_context_injection_with_context_update () =
 ;;
 
 let test_apply_context_injection_with_extra_messages () =
-  let context = Context.create ~eio:false () in
+  let context = Context.create_sync () in
   let messages =
     [ { Types.role = Types.User
       ; content = [ Types.Text "hi" ]
@@ -915,7 +915,7 @@ let test_apply_context_injection_with_extra_messages () =
 ;;
 
 let test_apply_context_injection_exception_handled () =
-  let context = Context.create ~eio:false () in
+  let context = Context.create_sync () in
   let messages =
     [ { Types.role = Types.User
       ; content = [ Types.Text "hi" ]
@@ -945,7 +945,7 @@ let test_apply_context_injection_exception_handled () =
 ;;
 
 let test_apply_context_injection_preserves_non_retryable_error () =
-  let context = Context.create ~eio:false () in
+  let context = Context.create_sync () in
   let messages =
     [ { Types.role = Types.User
       ; content = [ Types.Text "hi" ]

--- a/test/test_append_instruction.ml
+++ b/test/test_append_instruction.ml
@@ -45,7 +45,7 @@ let test_dynamic_source () =
 ;;
 
 let test_from_context () =
-  let ctx = Context.create ~eio:false () in
+  let ctx = Context.create_sync () in
   Context.set ctx "system.rules" (`String "Be concise.");
   let config : Append_instruction.config = { sources = [ FromContext "system.rules" ] } in
   (match Append_instruction.render ~context:ctx ~turn:0 config with

--- a/test/test_builder.ml
+++ b/test/test_builder.ml
@@ -339,7 +339,7 @@ let test_with_transport () =
 let test_with_context () =
   with_net
   @@ fun net ->
-  let ctx = Context.create ~eio:false () in
+  let ctx = Context.create_sync () in
   Context.set ctx "key" (`String "value");
   let agent =
     Builder.create ~net ~model:"claude-sonnet-4-6"
@@ -534,7 +534,7 @@ let test_with_tool_grants_filters_tools () =
 let test_with_contract_injects_context_metadata () =
   with_net
   @@ fun net ->
-  let ctx = Context.create ~eio:false () in
+  let ctx = Context.create_sync () in
   Context.set ctx "original" (`String "kept");
   let contract =
     Contract.empty |> Contract.with_runtime_awareness "Aware of explicit grants."

--- a/test/test_builder_coverage.ml
+++ b/test/test_builder_coverage.ml
@@ -150,7 +150,7 @@ let test_agent_accessors () =
     Tool.create ~name:"test_tool" ~description:"desc" ~parameters:[] (fun _input ->
       Ok { Types.content = "result"; _meta = None })
   in
-  let ctx = Context.create ~eio:false () in
+  let ctx = Context.create_sync () in
   Context.set ctx "key" (`String "value");
   let b =
     Builder.create ~net:env#net ~model:Types.default_config.model
@@ -222,7 +222,7 @@ let test_agent_clone () =
 let test_agent_clone_copy_context () =
   Eio_main.run
   @@ fun env ->
-  let ctx = Context.create ~eio:false () in
+  let ctx = Context.create_sync () in
   Context.set ctx "test_key" (`String "test_val");
   let b =
     Builder.create ~net:env#net ~model:Types.default_config.model

--- a/test/test_checkpoint.ml
+++ b/test/test_checkpoint.ml
@@ -22,7 +22,7 @@ let make_checkpoint
       ?(turn_count = 0)
       ?(tools = [])
       ?(tool_choice = None)
-      ?(context = Context.create ~eio:false ())
+      ?(context = Context.create_sync ())
       ?(enable_thinking = None)
       ?(preserve_thinking = None)
       ?(thinking_budget = None)
@@ -172,7 +172,7 @@ let () =
             let cp2 = Result.get_ok (Checkpoint.of_json (Checkpoint.to_json cp)) in
             check (option string) "system_prompt" (Some "Be concise.") cp2.system_prompt)
         ; test_case "context roundtrip" `Quick (fun () ->
-            let ctx = Context.create ~eio:false () in
+            let ctx = Context.create_sync () in
             Context.set_scoped ctx Context.Session "trace_id" (`String "abc");
             Context.set_scoped ctx Context.User "theme" (`String "dark");
             let cp = make_checkpoint ~context:ctx () in
@@ -564,7 +564,7 @@ let () =
         ] )
     ; ( "build_resume"
       , [ test_case "roundtrip preserves fields" `Quick (fun () ->
-            let ctx = Context.create ~eio:false () in
+            let ctx = Context.create_sync () in
             Context.set ctx "key" (`String "val");
             let cp =
               make_checkpoint
@@ -593,7 +593,7 @@ let () =
         ; test_case "eio_context rehydrates checkpoint context backend" `Quick (fun () ->
             Eio_main.run
             @@ fun _env ->
-            let ctx = Context.create ~eio:false () in
+            let ctx = Context.create_sync () in
             Context.set ctx "key" (`String "val");
             let cp = make_checkpoint ~context:ctx () in
             let { Agent_checkpoint.context = ctx2; _ } =
@@ -672,10 +672,10 @@ let () =
               (Some 2048)
               state.config.thinking_budget)
         ; test_case "override context replaces checkpoint context" `Quick (fun () ->
-            let cp_ctx = Context.create ~eio:false () in
+            let cp_ctx = Context.create_sync () in
             Context.set cp_ctx "old" (`String "old-val");
             let cp = make_checkpoint ~context:cp_ctx () in
-            let new_ctx = Context.create ~eio:false () in
+            let new_ctx = Context.create_sync () in
             Context.set new_ctx "new" (`String "new-val");
             let { Agent_checkpoint.context = result_ctx; _ } =
               Agent_checkpoint.build_resume ~checkpoint:cp ~context:new_ctx ()
@@ -730,7 +730,7 @@ let () =
                Eio_main.run
                @@ fun env ->
                let net = Eio.Stdenv.net env in
-               let ctx = Context.create ~eio:false () in
+               let ctx = Context.create_sync () in
                Context.set ctx "resume-key" (`String "resume-value");
                let cp = make_checkpoint ~context:ctx () in
                let decoded =

--- a/test/test_checkpoint_delta.ml
+++ b/test/test_checkpoint_delta.ml
@@ -85,7 +85,7 @@ let context_gen =
   let open QCheck.Gen in
   map
     (fun pairs ->
-       let ctx = Context.create ~eio:false () in
+       let ctx = Context.create_sync () in
        List.iter (fun (key, value) -> Context.set ctx key value) pairs;
        ctx)
     (list_size (int_range 0 3) (pair small_string_gen yojson_simple_gen))
@@ -205,7 +205,7 @@ let make_unit_checkpoint
       ?(session_id = "sess-a")
       ?(agent_name = "agent-a")
       ?(turn_count = 0)
-      ?(context = Context.create ~eio:false ())
+      ?(context = Context.create_sync ())
       ?(tool_choice = None)
       ?(working_context = None)
       ()
@@ -283,7 +283,7 @@ let test_delta_json_roundtrip () =
         ]
       ()
   in
-  let ctx = Context.create ~eio:false () in
+  let ctx = Context.create_sync () in
   Context.set ctx "trace_id" (`String "abc");
   let target =
     make_unit_checkpoint
@@ -437,8 +437,8 @@ let test_delta_json_null_and_legacy_limit_paths () =
 ;;
 
 let test_delta_json_rejects_malformed_context_removed () =
-  let base_context = Context.create ~eio:false () in
-  let target_context = Context.create ~eio:false () in
+  let base_context = Context.create_sync () in
+  let target_context = Context.create_sync () in
   Context.set target_context "trace_id" (`String "abc");
   let base = make_unit_checkpoint ~context:base_context () in
   let target =

--- a/test/test_checkpoint_store.ml
+++ b/test/test_checkpoint_store.ml
@@ -33,7 +33,7 @@ let make_checkpoint ?(session_id = "test-session") ?(created_at = 1000.0) ()
   ; response_format = Types.Off
   ; thinking_budget = None
   ; cache_system_prompt = false
-  ; context = Context.create ~eio:false ()
+  ; context = Context.create_sync ()
   ; mcp_sessions = []
   ; working_context = None
   }

--- a/test/test_clone.ml
+++ b/test/test_clone.ml
@@ -13,7 +13,7 @@ let make_agent env =
 ;;
 
 let make_agent_with_context env =
-  let ctx = Context.create ~eio:false () in
+  let ctx = Context.create_sync () in
   Context.set ctx "key1" (`String "val1");
   Context.set ctx "key2" (`Int 42);
   Agent.create

--- a/test/test_context.ml
+++ b/test/test_context.ml
@@ -8,25 +8,25 @@ let check_backend label expected ctx =
 ;;
 
 let test_create_empty () =
-  let ctx = Context.create ~eio:false () in
+  let ctx = Context.create_sync () in
   check (list string) "empty context has no keys" [] (Context.keys ctx)
 ;;
 
 let test_set_get () =
-  let ctx = Context.create ~eio:false () in
+  let ctx = Context.create_sync () in
   Context.set ctx "name" (`String "alice");
   let result = Context.get ctx "name" in
   check bool "key exists" true (result = Some (`String "alice"))
 ;;
 
 let test_get_missing () =
-  let ctx = Context.create ~eio:false () in
+  let ctx = Context.create_sync () in
   let result = Context.get ctx "missing" in
   check bool "missing key returns None" true (result = None)
 ;;
 
 let test_set_overwrite () =
-  let ctx = Context.create ~eio:false () in
+  let ctx = Context.create_sync () in
   Context.set ctx "count" (`Int 1);
   Context.set ctx "count" (`Int 2);
   let result = Context.get ctx "count" in
@@ -34,14 +34,14 @@ let test_set_overwrite () =
 ;;
 
 let test_delete () =
-  let ctx = Context.create ~eio:false () in
+  let ctx = Context.create_sync () in
   Context.set ctx "count" (`Int 2);
   Context.delete ctx "count";
   check bool "delete removes key" true (Context.get ctx "count" = None)
 ;;
 
 let test_keys () =
-  let ctx = Context.create ~eio:false () in
+  let ctx = Context.create_sync () in
   Context.set ctx "a" (`String "1");
   Context.set ctx "b" (`String "2");
   let keys = List.sort String.compare (Context.keys ctx) in
@@ -49,7 +49,7 @@ let test_keys () =
 ;;
 
 let test_merge () =
-  let ctx = Context.create ~eio:false () in
+  let ctx = Context.create_sync () in
   Context.set ctx "existing" (`String "old");
   Context.merge ctx [ "existing", `String "new"; "added", `Int 42 ];
   check bool "merge overwrites" true (Context.get ctx "existing" = Some (`String "new"));
@@ -57,7 +57,7 @@ let test_merge () =
 ;;
 
 let test_scoped_helpers () =
-  let ctx = Context.create ~eio:false () in
+  let ctx = Context.create_sync () in
   Context.set_scoped ctx Context.Session "trace_id" (`String "abc");
   Context.set_scoped ctx Context.User "theme" (`String "dark");
   check
@@ -78,7 +78,7 @@ let test_scoped_helpers () =
 ;;
 
 let test_snapshot_sorted () =
-  let ctx = Context.create ~eio:false () in
+  let ctx = Context.create_sync () in
   Context.set ctx "b" (`Int 2);
   Context.set ctx "a" (`Int 1);
   let snapshot = Context.snapshot ctx in
@@ -86,7 +86,7 @@ let test_snapshot_sorted () =
 ;;
 
 let test_diff () =
-  let before = Context.create ~eio:false () in
+  let before = Context.create_sync () in
   Context.set before "stable" (`String "x");
   Context.set before "removed" (`Int 1);
   Context.set before "changed" (`Int 1);
@@ -101,11 +101,11 @@ let test_diff () =
 ;;
 
 let test_diff_interleaved_order () =
-  let before = Context.create ~eio:false () in
+  let before = Context.create_sync () in
   List.iter
     (fun (key, value) -> Context.set before key value)
     [ "a", `Int 1; "c", `Int 1; "e", `Int 1; "g", `Int 1 ];
-  let after = Context.create ~eio:false () in
+  let after = Context.create_sync () in
   List.iter
     (fun (key, value) -> Context.set after key value)
     [ "b", `Int 2; "c", `Int 3; "d", `Int 4; "g", `Int 1 ];
@@ -126,7 +126,7 @@ let test_diff_interleaved_order () =
 ;;
 
 let test_diff_sorted () =
-  let before = Context.create ~eio:false () in
+  let before = Context.create_sync () in
   List.iter
     (fun key -> Context.set before key (`String ("before-" ^ key)))
     [ "removed-b"; "stable"; "changed-b"; "removed-a"; "changed-a" ];
@@ -148,7 +148,7 @@ let test_diff_sorted () =
 ;;
 
 let test_to_json () =
-  let ctx = Context.create ~eio:false () in
+  let ctx = Context.create_sync () in
   Context.set ctx "key" (`String "value");
   let json = Context.to_json ctx in
   match json with
@@ -180,13 +180,13 @@ let test_of_json_eio_backend () =
 ;;
 
 let test_copy_empty () =
-  let ctx = Context.create ~eio:false () in
+  let ctx = Context.create_sync () in
   let copy = Context.copy ctx in
   check (list string) "copy of empty is empty" [] (Context.keys copy)
 ;;
 
 let test_copy_values () =
-  let ctx = Context.create ~eio:false () in
+  let ctx = Context.create_sync () in
   Context.set ctx "a" (`String "hello");
   Context.set ctx "b" (`Int 99);
   let copy = Context.copy ctx in
@@ -195,7 +195,7 @@ let test_copy_values () =
 ;;
 
 let test_copy_independence () =
-  let ctx = Context.create ~eio:false () in
+  let ctx = Context.create_sync () in
   Context.set ctx "x" (`String "original");
   let copy = Context.copy ctx in
   Context.set copy "x" (`String "modified");
@@ -205,7 +205,7 @@ let test_copy_independence () =
 let test_copy_backend_override () =
   Eio_main.run
   @@ fun _env ->
-  let ctx = Context.create ~eio:false () in
+  let ctx = Context.create_sync () in
   Context.set ctx "x" (`String "value");
   let eio_copy = Context.copy ~eio:true ctx in
   check_backend "copy override to eio" Context.Eio_mutex eio_copy;
@@ -217,7 +217,7 @@ let test_copy_backend_override () =
 let test_scope_inherits_parent_backend () =
   Eio_main.run
   @@ fun _env ->
-  let parent = Context.create ~eio:true () in
+  let parent = Context.create () in
   Context.set parent "k" (`String "v");
   let scope =
     Context.create_scope ~parent ~propagate_down:[ "k" ] ~propagate_up:[ "result" ]
@@ -269,17 +269,17 @@ let () =
         ] )
     ; ( "user_data"
       , [ test_case "set and get" `Quick (fun () ->
-            let ctx = Context.create ~eio:false () in
+            let ctx = Context.create_sync () in
             Context.set_user_data ctx "name" (`String "alice");
             let actual = Context.get_user_data ctx "name" in
             check bool "get returns value" true (actual = Some (`String "alice")))
         ; test_case "stored with user: prefix" `Quick (fun () ->
-            let ctx = Context.create ~eio:false () in
+            let ctx = Context.create_sync () in
             Context.set_user_data ctx "role" (`String "admin");
             let raw = Context.get ctx "user:role" in
             check bool "raw key has prefix" true (raw = Some (`String "admin")))
         ; test_case "all_user_data" `Quick (fun () ->
-            let ctx = Context.create ~eio:false () in
+            let ctx = Context.create_sync () in
             Context.set_user_data ctx "a" (`Int 1);
             Context.set_user_data ctx "b" (`Int 2);
             Context.set_scoped ctx Context.Session "c" (`Int 3);
@@ -288,7 +288,7 @@ let () =
             check bool "has a" true (List.assoc_opt "a" ud = Some (`Int 1));
             check bool "has b" true (List.assoc_opt "b" ud = Some (`Int 2)))
         ; test_case "delete_user_data" `Quick (fun () ->
-            let ctx = Context.create ~eio:false () in
+            let ctx = Context.create_sync () in
             Context.set_user_data ctx "x" (`Bool true);
             Context.delete_user_data ctx "x";
             check bool "deleted" true (Context.get_user_data ctx "x" = None))

--- a/test/test_context_concurrency.ml
+++ b/test/test_context_concurrency.ml
@@ -26,7 +26,10 @@ let () =
   Alcotest.run
     "Context_concurrency"
     [ ( "fiber safety"
-      , [ Alcotest.test_case "concurrent set under Eio" `Quick test_concurrent_context_access ]
-      )
+      , [ Alcotest.test_case
+            "concurrent set under Eio"
+            `Quick
+            test_concurrent_context_access
+        ] )
     ]
 ;;

--- a/test/test_context_concurrency.ml
+++ b/test/test_context_concurrency.ml
@@ -1,0 +1,32 @@
+(** Concurrency tests for {!Context} under Eio fibers.
+
+    Verifies that the default Eio-backed context survives parallel access from
+    multiple fibers without deadlock or crash. *)
+
+open Agent_sdk
+
+let test_concurrent_context_access () =
+  Eio_main.run
+  @@ fun _env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let ctx = Context.create () in
+  let f n =
+    Eio.Fiber.fork ~sw (fun () ->
+      for i = 1 to 100 do
+        Context.set ctx ("key" ^ string_of_int n) (`Int i)
+      done)
+  in
+  List.iter f [ 1; 2; 3 ];
+  (* If we get here without deadlock or exception, the test passes. *)
+  ()
+;;
+
+let () =
+  Alcotest.run
+    "Context_concurrency"
+    [ ( "fiber safety"
+      , [ Alcotest.test_case "concurrent set under Eio" `Quick test_concurrent_context_access ]
+      )
+    ]
+;;

--- a/test/test_context_flow_proof.ml
+++ b/test/test_context_flow_proof.ml
@@ -104,7 +104,7 @@ let test_full_chain_across_turns () =
     (capturing_handler call_count captured_turn1_body)
     (fun ~sw ~net ~base_url ->
        let tool, _ = fresh_echo_tool () in
-       let ctx = Context.create ~eio:false () in
+       let ctx = Context.create_sync () in
        (* Layer 1: Injector writes a known marker to Context.t *)
        let injector : Hooks.context_injector =
          fun ~tool_name:_ ~input:_ ~output:_ ->
@@ -170,7 +170,7 @@ let test_no_injector_no_context () =
     (capturing_handler call_count captured)
     (fun ~sw ~net ~base_url ->
        let tool, _ = fresh_echo_tool () in
-       let ctx = Context.create ~eio:false () in
+       let ctx = Context.create_sync () in
        let hook_saw_data = ref false in
        let hooks =
          { Hooks.empty with
@@ -240,7 +240,7 @@ let test_accumulation_across_tool_calls () =
   in
   with_mock_server ~port:18202 multi_tool_handler2 (fun ~sw ~net ~base_url ->
     let tool, tool_calls = fresh_echo_tool () in
-    let ctx = Context.create ~eio:false () in
+    let ctx = Context.create_sync () in
     let inject_count = ref 0 in
     let injector : Hooks.context_injector =
       fun ~tool_name:_ ~input:_ ~output:_ ->
@@ -306,7 +306,7 @@ let test_context_identity () =
     (capturing_handler call_count captured)
     (fun ~sw ~net ~base_url ->
        let tool, _ = fresh_echo_tool () in
-       let ctx = Context.create ~eio:false () in
+       let ctx = Context.create_sync () in
        (* Pre-seed context with a value *)
        Context.set ctx "pre_seed" (`String "before_run");
        let injector : Hooks.context_injector =

--- a/test/test_context_properties.ml
+++ b/test/test_context_properties.ml
@@ -40,7 +40,7 @@ let test_copy_independence =
     ~name:"copy_independence"
     QCheck.(pair (make gen_kv_list) (make gen_kv_pair))
     (fun (initial_pairs, (new_key, new_value)) ->
-       let ctx = Context.create ~eio:false () in
+       let ctx = Context.create_sync () in
        List.iter (fun (k, v) -> Context.set ctx k v) initial_pairs;
        let copy = Context.copy ctx in
        (* Mutate copy *)
@@ -67,7 +67,7 @@ let test_json_roundtrip =
     ~name:"json_roundtrip"
     (QCheck.make gen_kv_list)
     (fun pairs ->
-       let ctx = Context.create ~eio:false () in
+       let ctx = Context.create_sync () in
        List.iter (fun (k, v) -> Context.set ctx k v) pairs;
        let json = Context.to_json ctx in
        let restored = Context.of_json json in
@@ -89,7 +89,7 @@ let test_scope_no_leakage =
         (make gen_kv_list))
     (* propagate_down/up lists *)
     (fun (parent_pairs, child_pairs, prop_pairs) ->
-       let parent = Context.create ~eio:false () in
+       let parent = Context.create_sync () in
        List.iter (fun (k, v) -> Context.set parent k v) parent_pairs;
        let parent_before = Context.snapshot parent in
        (* Choose propagate lists from prop_pairs keys *)
@@ -138,7 +138,7 @@ let test_propagate_down_complete =
     ~name:"propagate_down_complete"
     (QCheck.make gen_kv_list)
     (fun pairs ->
-       let parent = Context.create ~eio:false () in
+       let parent = Context.create_sync () in
        List.iter (fun (k, v) -> Context.set parent k v) pairs;
        let all_keys = List.sort_uniq String.compare (List.map fst pairs) in
        let scope =
@@ -161,7 +161,7 @@ let test_propagate_up_selective =
     ~name:"propagate_up_selective"
     QCheck.(pair (make gen_kv_list) (make gen_kv_list))
     (fun (child_pairs, extra_pairs) ->
-       let parent = Context.create ~eio:false () in
+       let parent = Context.create_sync () in
        (* Only first pair's key is in propagate_up (if any) *)
        let up_keys =
          match child_pairs with
@@ -188,8 +188,8 @@ let test_diff_correct =
     ~name:"diff_correct"
     QCheck.(pair (make gen_kv_list) (make gen_kv_list))
     (fun (before_pairs, after_pairs) ->
-       let before = Context.create ~eio:false () in
-       let after = Context.create ~eio:false () in
+       let before = Context.create_sync () in
+       let after = Context.create_sync () in
        List.iter (fun (k, v) -> Context.set before k v) before_pairs;
        List.iter (fun (k, v) -> Context.set after k v) after_pairs;
        let d = Context.diff before after in
@@ -227,7 +227,7 @@ let test_scope_isolation_parallel =
     ~name:"parallel_scope_isolation"
     QCheck.(pair (make gen_kv_list) (make gen_kv_list))
     (fun (pairs_a, pairs_b) ->
-       let parent = Context.create ~eio:false () in
+       let parent = Context.create_sync () in
        (* Two isolated scopes from same parent *)
        let scope_a =
          Context.create_scope ~parent ~propagate_down:[] ~propagate_up:[ "result_a" ]

--- a/test/test_contract.ml
+++ b/test/test_contract.ml
@@ -394,7 +394,7 @@ let test_context_with_contract_includes_quota_allocations () =
 ;;
 
 let test_context_with_contract_preserves_identity () =
-  let original = Context.create ~eio:false () in
+  let original = Context.create_sync () in
   Context.set original "user_data" (`String "hello");
   let c = Contract.with_runtime_awareness "test" Contract.empty in
   match Contract.context_with_contract ~context:original c with

--- a/test/test_event_bus.ml
+++ b/test/test_event_bus.ml
@@ -430,7 +430,7 @@ let test_turn_started_fields () =
 let test_tool_completed_preserves_non_retryable_flag () =
   Eio_main.run
   @@ fun _env ->
-  let context = Context.create ~eio:false () in
+  let context = Context.create_sync () in
   let bus = Event_bus.create () in
   let sub = Event_bus.subscribe ~filter:Event_bus.filter_tools_only bus in
   let tool =
@@ -499,7 +499,7 @@ let test_tool_completed_preserves_non_retryable_flag () =
 let test_on_tool_error_hook_fires_on_tool_failure () =
   Eio_main.run
   @@ fun _env ->
-  let context = Context.create ~eio:false () in
+  let context = Context.create_sync () in
   let bus = Event_bus.create () in
   let tool =
     Tool.create ~name:"fail" ~description:"Always fails" ~parameters:[] (fun _ ->
@@ -550,7 +550,7 @@ let test_on_tool_error_hook_fires_on_tool_failure () =
 let test_on_tool_error_hook_silent_on_success () =
   Eio_main.run
   @@ fun _env ->
-  let context = Context.create ~eio:false () in
+  let context = Context.create_sync () in
   let bus = Event_bus.create () in
   let tool =
     Tool.create ~name:"ok" ~description:"" ~parameters:[] (fun _ ->
@@ -596,7 +596,7 @@ let test_on_tool_error_hook_silent_on_success () =
 let test_on_error_fires_on_tool_not_found () =
   Eio_main.run
   @@ fun _env ->
-  let context = Context.create ~eio:false () in
+  let context = Context.create_sync () in
   let bus = Event_bus.create () in
   let schedule : Hooks.tool_schedule =
     { planned_index = 0
@@ -655,7 +655,7 @@ let test_on_error_fires_on_tool_not_found () =
 let test_unknown_tool_reports_available_tools_and_retries () =
   Eio_main.run
   @@ fun _env ->
-  let context = Context.create ~eio:false () in
+  let context = Context.create_sync () in
   let bus = Event_bus.create () in
   let read_file =
     Tool.create ~name:"ReadFile" ~description:"Read a file" ~parameters:[] (fun _ ->
@@ -736,7 +736,7 @@ let test_unknown_tool_reports_available_tools_and_retries () =
 let test_registered_read_alias_dispatches_to_read_file_when_visible () =
   Eio_main.run
   @@ fun _env ->
-  let context = Context.create ~eio:false () in
+  let context = Context.create_sync () in
   let bus = Event_bus.create () in
   let captured_input = ref `Null in
   Agent_tool_name_alias.register_alias
@@ -814,7 +814,7 @@ let test_registered_read_alias_dispatches_to_read_file_when_visible () =
 let test_registered_search_alias_dispatches_to_search_files_when_visible () =
   Eio_main.run
   @@ fun _env ->
-  let context = Context.create ~eio:false () in
+  let context = Context.create_sync () in
   let captured_input = ref `Null in
   Agent_tool_name_alias.register_alias
     ~alias:"consumer_search_alias_for_test"
@@ -887,7 +887,7 @@ let test_registered_search_alias_dispatches_to_search_files_when_visible () =
 let test_registered_execute_alias_preserves_input () =
   Eio_main.run
   @@ fun _env ->
-  let context = Context.create ~eio:false () in
+  let context = Context.create_sync () in
   let captured_input = ref `Null in
   Agent_tool_name_alias.register_alias
     ~alias:"consumer_execute_alias_for_test"
@@ -950,7 +950,7 @@ let test_registered_execute_alias_preserves_input () =
 let test_on_error_silent_on_successful_dispatch () =
   Eio_main.run
   @@ fun _env ->
-  let context = Context.create ~eio:false () in
+  let context = Context.create_sync () in
   let bus = Event_bus.create () in
   let tool =
     Tool.create ~name:"ok" ~description:"" ~parameters:[] (fun _ ->

--- a/test/test_hooks_integration.ml
+++ b/test/test_hooks_integration.ml
@@ -515,7 +515,7 @@ let test_context_injector_adds_data () =
           ; extra_messages = []
           }
     in
-    let ctx = Context.create ~eio:false () in
+    let ctx = Context.create_sync () in
     let options =
       { Agent.default_options with base_url; context_injector = Some injector }
     in

--- a/test/test_injection.ml
+++ b/test/test_injection.ml
@@ -86,7 +86,7 @@ let test_injector_with_extra_messages () =
 
 (* Test context updates applied correctly *)
 let test_context_updates_applied () =
-  let ctx = Context.create ~eio:false () in
+  let ctx = Context.create_sync () in
   let updates = [ "key1", `String "v1"; "key2", `Bool true ] in
   List.iter (fun (k, v) -> Context.set ctx k v) updates;
   (match Context.get ctx "key1" with

--- a/test/test_metrics_aggregating.ml
+++ b/test/test_metrics_aggregating.ml
@@ -348,8 +348,10 @@ let test_aggregating_inner_delegation () =
 ;;
 
 let () =
-  (* Intentionally not wrapped in Eio_main.run: snapshot/export APIs must work
-     for ordinary periodic exporters and tests that have no Eio scheduler. *)
+  (* Aggregating now uses Eio.Mutex, so the whole suite runs under an Eio
+     scheduler. Each test case executes as an Eio fiber. *)
+  Eio_main.run
+  @@ fun _env ->
   run
     "Metrics.Aggregating"
     [ "create", [ test_case "empty snapshot" `Quick test_aggregating_create_empty ]

--- a/test/test_metrics_aggregating.ml
+++ b/test/test_metrics_aggregating.ml
@@ -348,10 +348,9 @@ let test_aggregating_inner_delegation () =
 ;;
 
 let () =
-  (* Aggregating now uses Eio.Mutex, so the whole suite runs under an Eio
-     scheduler. Each test case executes as an Eio fiber. *)
-  Eio_main.run
-  @@ fun _env ->
+  (* This suite intentionally stays outside [Eio_main.run]. Aggregating is part
+     of the public exporter/test surface and must remain safe from ordinary
+     synchronous callers. *)
   run
     "Metrics.Aggregating"
     [ "create", [ test_case "empty snapshot" `Quick test_aggregating_create_empty ]

--- a/test/test_pipeline_common_coverage.ml
+++ b/test/test_pipeline_common_coverage.ml
@@ -188,7 +188,7 @@ let test_agent_type_clone_variants () =
   let config = { Types.default_config with name = "clone-source"; max_turns = 5 } in
   Eio_main.run
   @@ fun env ->
-  let context = Context.create ~eio:false () in
+  let context = Context.create_sync () in
   Context.set context "marker" (`String "copied");
   let agent =
     Internal_agent.create

--- a/test/test_pipeline_deep.ml
+++ b/test/test_pipeline_deep.ml
@@ -460,7 +460,7 @@ let test_resolve_params_max_turns_passed () =
 
 (** Context injection sets context values. *)
 let test_context_injection_sets_values () =
-  let context = Context.create ~eio:false () in
+  let context = Context.create_sync () in
   let messages : Types.message list =
     [ { role = User
       ; content = [ Text "query" ]
@@ -506,7 +506,7 @@ let test_context_injection_sets_values () =
 
 (** Context injection returns None (no injection). *)
 let test_context_injection_none () =
-  let context = Context.create ~eio:false () in
+  let context = Context.create_sync () in
   let messages : Types.message list =
     [ { role = User
       ; content = [ Text "query" ]
@@ -537,7 +537,7 @@ let test_context_injection_none () =
 
 (** Context injection with extra_messages. *)
 let test_context_injection_extra_messages () =
-  let context = Context.create ~eio:false () in
+  let context = Context.create_sync () in
   let messages : Types.message list =
     [ { role = User
       ; content = [ Text "query" ]
@@ -586,7 +586,7 @@ let test_context_injection_extra_messages () =
 
 (** Context injection with error tool result. *)
 let test_context_injection_error_result () =
-  let context = Context.create ~eio:false () in
+  let context = Context.create_sync () in
   let received_output = ref None in
   let messages : Types.message list =
     [ { role = User
@@ -625,7 +625,7 @@ let test_context_injection_error_result () =
 
 (** Context injection: injector raises exception. *)
 let test_context_injection_raises () =
-  let context = Context.create ~eio:false () in
+  let context = Context.create_sync () in
   let messages : Types.message list =
     [ { role = User
       ; content = [ Text "query" ]

--- a/test/test_pipeline_illegal_hook.ml
+++ b/test/test_pipeline_illegal_hook.ml
@@ -6,16 +6,29 @@
 
 open Agent_sdk
 
-let with_dummy_api_key f =
-  let key = "OAS_TEST_ILLEGAL_HOOK_API_KEY" in
-  let previous = Sys.getenv_opt "ANTHROPIC_API_KEY" in
-  Unix.putenv "ANTHROPIC_API_KEY" key;
-  Fun.protect
-    ~finally:(fun () ->
-      match previous with
-      | Some v -> Unix.putenv "ANTHROPIC_API_KEY" v
-      | None -> Unix.putenv "ANTHROPIC_API_KEY" "")
-    f
+let mock_response : Types.api_response =
+  { id = "illegal-hook-mock"
+  ; model = "mock-model"
+  ; stop_reason = EndTurn
+  ; content = [ Text "unused" ]
+  ; usage = None
+  ; telemetry = None
+  }
+;;
+
+let mock_transport : Llm_provider.Llm_transport.t =
+  { complete_sync =
+      (fun _req ->
+        { Llm_provider.Llm_transport.response = Ok mock_response; latency_ms = None })
+  ; complete_stream = (fun ?on_telemetry:_ ~on_event:_ _req -> Ok mock_response)
+  }
+;;
+
+let mock_provider : Provider.config =
+  { provider = Provider.Local { base_url = "http://mock.local" }
+  ; model_id = "mock-model"
+  ; api_key_env = ""
+  }
 ;;
 
 let is_illegal_hook_error = function
@@ -26,23 +39,26 @@ let is_illegal_hook_error = function
 ;;
 
 let test_before_turn_skip_returns_error () =
-  with_dummy_api_key (fun () ->
-    Eio_main.run
-    @@ fun env ->
-    Eio.Switch.run
-    @@ fun sw ->
-    let net = Eio.Stdenv.net env in
-    let hooks = { Hooks.empty with before_turn = Some (fun _ -> Hooks.Skip) } in
-    let options = { Agent_types.default_options with hooks } in
-    let config =
-      { Types.default_config with name = "illegal-hook-test"; max_turns = 1 }
-    in
-    let agent = Agent.create ~net ~config ~options () in
-    let result = Agent.run ~sw agent "hello" in
-    Alcotest.(check bool)
-      "before_turn Skip returns illegal-hook error"
-      true
-      (is_illegal_hook_error result))
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let net = Eio.Stdenv.net env in
+  let hooks = { Hooks.empty with before_turn = Some (fun _ -> Hooks.Skip) } in
+  let options =
+    { Agent_types.default_options with
+      hooks
+    ; provider = Some mock_provider
+    ; transport = Some mock_transport
+    }
+  in
+  let config = { Types.default_config with name = "illegal-hook-test"; max_turns = 1 } in
+  let agent = Agent.create ~net ~config ~options () in
+  let result = Agent.run ~sw agent "hello" in
+  Alcotest.(check bool)
+    "before_turn Skip returns illegal-hook error"
+    true
+    (is_illegal_hook_error result)
 ;;
 
 let () =

--- a/test/test_pipeline_illegal_hook.ml
+++ b/test/test_pipeline_illegal_hook.ml
@@ -1,0 +1,53 @@
+(** Regression tests for illegal hook decisions in the pipeline.
+
+    Each test installs a hook that returns a decision that is not in the legal
+    matrix for that stage, then asserts the pipeline returns a typed
+    [Error.Internal] instead of raising. *)
+
+open Agent_sdk
+
+let with_dummy_api_key f =
+  let key = "OAS_TEST_ILLEGAL_HOOK_API_KEY" in
+  let previous = Sys.getenv_opt "ANTHROPIC_API_KEY" in
+  Unix.putenv "ANTHROPIC_API_KEY" key;
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some v -> Unix.putenv "ANTHROPIC_API_KEY" v
+      | None -> Unix.putenv "ANTHROPIC_API_KEY" "")
+    f
+;;
+
+let is_illegal_hook_error = function
+  | Error (Error.Internal msg) ->
+    String.starts_with ~prefix:"hook before_turn failed" msg
+    || String.starts_with ~prefix:"illegal hook decision" msg
+  | _ -> false
+;;
+
+let test_before_turn_skip_returns_error () =
+  with_dummy_api_key (fun () ->
+    Eio_main.run
+    @@ fun env ->
+    Eio.Switch.run
+    @@ fun sw ->
+    let net = Eio.Stdenv.net env in
+    let hooks = { Hooks.empty with before_turn = Some (fun _ -> Hooks.Skip) } in
+    let options = { Agent_types.default_options with hooks } in
+    let config = { Types.default_config with name = "illegal-hook-test"; max_turns = 1 } in
+    let agent = Agent.create ~net ~config ~options () in
+    let result = Agent.run ~sw agent "hello" in
+    Alcotest.(check bool)
+      "before_turn Skip returns illegal-hook error"
+      true
+      (is_illegal_hook_error result))
+;;
+
+let () =
+  Alcotest.run
+    "Pipeline_illegal_hook"
+    [ ( "before_turn"
+      , [ Alcotest.test_case "Skip returns typed error" `Quick test_before_turn_skip_returns_error
+        ] )
+    ]
+;;

--- a/test/test_pipeline_illegal_hook.ml
+++ b/test/test_pipeline_illegal_hook.ml
@@ -34,7 +34,9 @@ let test_before_turn_skip_returns_error () =
     let net = Eio.Stdenv.net env in
     let hooks = { Hooks.empty with before_turn = Some (fun _ -> Hooks.Skip) } in
     let options = { Agent_types.default_options with hooks } in
-    let config = { Types.default_config with name = "illegal-hook-test"; max_turns = 1 } in
+    let config =
+      { Types.default_config with name = "illegal-hook-test"; max_turns = 1 }
+    in
     let agent = Agent.create ~net ~config ~options () in
     let result = Agent.run ~sw agent "hello" in
     Alcotest.(check bool)
@@ -47,7 +49,10 @@ let () =
   Alcotest.run
     "Pipeline_illegal_hook"
     [ ( "before_turn"
-      , [ Alcotest.test_case "Skip returns typed error" `Quick test_before_turn_skip_returns_error
+      , [ Alcotest.test_case
+            "Skip returns typed error"
+            `Quick
+            test_before_turn_skip_returns_error
         ] )
     ]
 ;;

--- a/test/test_provider_registry.ml
+++ b/test/test_provider_registry.ml
@@ -17,13 +17,13 @@ let with_env key value f =
 (* ── Registry CRUD ──────────────────────────────────── *)
 
 let test_empty_registry () =
-  let reg = Provider_registry.create () in
+  let reg = Provider_registry.create_sync () in
   check int "empty has 0 entries" 0 (List.length (Provider_registry.all reg));
   check (option reject) "find on empty is None" None (Provider_registry.find reg "nope")
 ;;
 
 let test_register_and_find () =
-  let reg = Provider_registry.create () in
+  let reg = Provider_registry.create_sync () in
   let entry : Provider_registry.entry =
     { name = "test-provider"
     ; defaults =
@@ -45,7 +45,7 @@ let test_register_and_find () =
 ;;
 
 let test_overwrite () =
-  let reg = Provider_registry.create () in
+  let reg = Provider_registry.create_sync () in
   let mk url : Provider_registry.entry =
     { name = "p"
     ; defaults =
@@ -68,7 +68,7 @@ let test_overwrite () =
 ;;
 
 let test_unregister () =
-  let reg = Provider_registry.create () in
+  let reg = Provider_registry.create_sync () in
   let entry : Provider_registry.entry =
     { name = "temp"
     ; defaults =
@@ -91,7 +91,7 @@ let test_unregister () =
 (* ── Availability ───────────────────────────────────── *)
 
 let test_available_filter () =
-  let reg = Provider_registry.create () in
+  let reg = Provider_registry.create_sync () in
   let mk name avail : Provider_registry.entry =
     { name
     ; defaults =
@@ -154,7 +154,7 @@ let test_command_in_path_misses_unknown_binary () =
 (* ── Capability queries ─────────────────────────────── *)
 
 let test_find_capable_tools () =
-  let reg = Provider_registry.create () in
+  let reg = Provider_registry.create_sync () in
   let mk name caps : Provider_registry.entry =
     { name
     ; defaults =
@@ -178,7 +178,7 @@ let test_find_capable_tools () =
 ;;
 
 let test_find_capable_composite () =
-  let reg = Provider_registry.create () in
+  let reg = Provider_registry.create_sync () in
   let mk name caps : Provider_registry.entry =
     { name
     ; defaults =

--- a/test/test_runtime_replay.ml
+++ b/test/test_runtime_replay.ml
@@ -86,7 +86,7 @@ let mk_checkpoint ?(messages = []) ?(created_at = 1.0) ?(turn_count = 0) session
   ; response_format = Types.Off
   ; thinking_budget = None
   ; cache_system_prompt = false
-  ; context = Context.create ~eio:false ()
+  ; context = Context.create_sync ()
   ; mcp_sessions = []
   ; working_context = None
   }

--- a/test/test_session_resume.ml
+++ b/test/test_session_resume.ml
@@ -13,7 +13,7 @@ let make_checkpoint
       ?(created_at = 1000.0)
       ?(tools = [])
       ?(tool_choice = None)
-      ?(context = Context.create ~eio:false ())
+      ?(context = Context.create_sync ())
       ?(enable_thinking = None)
       ?(preserve_thinking = None)
       ?(thinking_budget = None)
@@ -149,7 +149,7 @@ let test_resume_from_fresh_metadata () =
 ;;
 
 let test_resume_from_copies_checkpoint_context () =
-  let ctx = Context.create ~eio:false () in
+  let ctx = Context.create_sync () in
   Context.set_scoped ctx Context.Session "trace_id" (`String "abc");
   let cp = make_checkpoint ~context:ctx () in
   let s = Session.resume_from cp in
@@ -199,7 +199,7 @@ let test_resume_restores_messages () =
 let test_resume_restores_context () =
   with_net
   @@ fun net ->
-  let ctx = Context.create ~eio:false () in
+  let ctx = Context.create_sync () in
   Context.set_scoped ctx Context.User "theme" (`String "dark");
   let cp = make_checkpoint ~context:ctx () in
   let agent = Agent.resume ~net ~checkpoint:cp () in
@@ -316,8 +316,8 @@ let test_resume_custom_options () =
 let test_resume_restores_tool_result_relocation_state () =
   with_net
   @@ fun net ->
-  let checkpoint_context = Context.create ~eio:false () in
-  let checkpoint_crs = Content_replacement_state.create () in
+  let checkpoint_context = Context.create_sync () in
+  let checkpoint_crs = Content_replacement_state.create_sync () in
   Content_replacement_state.record_replacement
     checkpoint_crs
     { tool_use_id = "t1"; preview = "cached-preview"; original_chars = 4096 };
@@ -348,7 +348,7 @@ let test_resume_restores_tool_result_relocation_state () =
          |> Result.get_ok
        in
        store_ref := Some store;
-       let supplied_crs = Content_replacement_state.create () in
+       let supplied_crs = Content_replacement_state.create_sync () in
        let opts =
          { Agent.default_options with
            tool_result_relocation = Some (store, supplied_crs)

--- a/test/test_tool.ml
+++ b/test/test_tool.ml
@@ -65,7 +65,7 @@ let test_context_handler_receives_context () =
            Error
              { Types.message = "key not found"; recoverable = true; error_class = None })
   in
-  let ctx = Context.create ~eio:false () in
+  let ctx = Context.create_sync () in
   Context.set ctx "key" (`String "ctx_value");
   let actual = Tool.execute ~context:ctx tool `Null in
   match actual with
@@ -83,7 +83,7 @@ let test_context_handler_writes_context () =
          Context.set ctx "written" (`Int 42);
          Ok { Types.content = "done"; _meta = None })
   in
-  let ctx = Context.create ~eio:false () in
+  let ctx = Context.create_sync () in
   let _result = Tool.execute ~context:ctx tool `Null in
   check bool "context was written" true (Context.get ctx "written" = Some (`Int 42))
 ;;
@@ -558,7 +558,7 @@ let () =
                      })
             in
             let wrapped = Tool.with_defaults [ "agent", `String "worker-1" ] tool in
-            let ctx = Context.create ~eio:false () in
+            let ctx = Context.create_sync () in
             match Tool.execute ~context:ctx wrapped (`Assoc []) with
             | Ok { content; _meta = _ } ->
               check string "default in ctx handler" "worker-1" content

--- a/test/test_tool_result_relocation.ml
+++ b/test/test_tool_result_relocation.ml
@@ -130,7 +130,7 @@ let test_store_below_threshold_not_persisted () =
 (* ── 2. Content_replacement_state: multi-turn ─────────── *)
 
 let test_crs_multi_turn_freezing () =
-  let crs = Content_replacement_state.create () in
+  let crs = Content_replacement_state.create_sync () in
   (* Turn 1: t1 replaced, t2 kept *)
   Content_replacement_state.record_replacement
     crs
@@ -168,7 +168,7 @@ let test_crs_multi_turn_freezing () =
 ;;
 
 let test_crs_json_roundtrip_preserves_decisions () =
-  let crs = Content_replacement_state.create () in
+  let crs = Content_replacement_state.create_sync () in
   Content_replacement_state.record_replacement
     crs
     { tool_use_id = "t1"; preview = "p1"; original_chars = 100 };
@@ -207,7 +207,7 @@ let test_make_tool_results_with_relocation () =
     }
   in
   let store = Tool_result_store.create config |> Result.get_ok in
-  let crs = Content_replacement_state.create () in
+  let crs = Content_replacement_state.create_sync () in
   let mock_results : Agent_tools.tool_execution_result list =
     [ { tool_use_id = "t1"
       ; tool_name = "read"
@@ -267,7 +267,7 @@ let test_make_tool_results_persist_failure_freezes_kept () =
     }
   in
   let store = Tool_result_store.create config |> Result.get_ok in
-  let crs = Content_replacement_state.create () in
+  let crs = Content_replacement_state.create_sync () in
   let original = String.make 200 'x' in
   let mock_results : Agent_tools.tool_execution_result list =
     [ { tool_use_id = "..."
@@ -311,7 +311,7 @@ let test_make_tool_results_publishes_content_replacement_events () =
     }
   in
   let store = Tool_result_store.create config |> Result.get_ok in
-  let crs = Content_replacement_state.create () in
+  let crs = Content_replacement_state.create_sync () in
   let bus = Event_bus.create () in
   let sub = Event_bus.subscribe bus in
   let mock_results : Agent_tools.tool_execution_result list =
@@ -378,7 +378,7 @@ let test_make_tool_results_publishes_content_replacement_events () =
 (* ── 4. Compaction + relocation compose ───────────────── *)
 
 let test_compaction_preserves_relocated_previews () =
-  let crs = Content_replacement_state.create () in
+  let crs = Content_replacement_state.create_sync () in
   (* Simulate: t1 was relocated (preview in message), t2 was kept *)
   Content_replacement_state.record_replacement
     crs
@@ -435,7 +435,7 @@ let test_compaction_preserves_relocated_previews () =
 ;;
 
 let test_compose_prune_then_relocation_reapply () =
-  let crs = Content_replacement_state.create () in
+  let crs = Content_replacement_state.create_sync () in
   Content_replacement_state.record_replacement
     crs
     { tool_use_id = "t1"; preview = "short_preview"; original_chars = 100000 };
@@ -497,7 +497,7 @@ let test_aggregate_budget_persists_largest () =
     }
   in
   let store = Tool_result_store.create config |> Result.get_ok in
-  let crs = Content_replacement_state.create () in
+  let crs = Content_replacement_state.create_sync () in
   (* 3 results: total = 8000+4000+3000 = 15000, at budget boundary.
      Actually make total > budget: 8000+5000+4000 = 17000 > 15000 *)
   let mock_results : Agent_tools.tool_execution_result list =
@@ -573,7 +573,7 @@ let test_aggregate_budget_disabled () =
     }
   in
   let store = Tool_result_store.create config |> Result.get_ok in
-  let crs = Content_replacement_state.create () in
+  let crs = Content_replacement_state.create_sync () in
   let mock_results : Agent_tools.tool_execution_result list =
     [ { tool_use_id = "t1"
       ; tool_name = "a"
@@ -602,8 +602,8 @@ let test_aggregate_budget_disabled () =
 (* ── 6. CRS checkpoint persistence (Phase 2) ────────── *)
 
 let test_crs_checkpoint_roundtrip () =
-  let ctx = Context.create ~eio:false () in
-  let crs = Content_replacement_state.create () in
+  let ctx = Context.create_sync () in
+  let crs = Content_replacement_state.create_sync () in
   Content_replacement_state.record_replacement
     crs
     { tool_use_id = "t1"; preview = "p1"; original_chars = 5000 };
@@ -630,7 +630,7 @@ let test_crs_checkpoint_roundtrip () =
 ;;
 
 let test_crs_restore_from_empty_context () =
-  let ctx = Context.create ~eio:false () in
+  let ctx = Context.create_sync () in
   (* No CRS saved — should return fresh empty state *)
   let crs = Content_replacement_state.restore_from_context ctx in
   Alcotest.(check int) "empty state" 0 (Content_replacement_state.seen_count crs)
@@ -639,7 +639,7 @@ let test_crs_restore_from_empty_context () =
 (* ── 7. Relocate_tool_results reducer (Phase 2) ─────── *)
 
 let test_relocate_reducer_reapplies_frozen () =
-  let crs = Content_replacement_state.create () in
+  let crs = Content_replacement_state.create_sync () in
   Content_replacement_state.record_replacement
     crs
     { tool_use_id = "t1"; preview = "cached_preview"; original_chars = 50000 };

--- a/test/test_turn_params.ml
+++ b/test/test_turn_params.ml
@@ -244,7 +244,7 @@ let test_dynamic_reducer () =
 (* ── Context scoped isolation ────────────────────────────────── *)
 
 let test_context_scope_isolation () =
-  let parent = Context.create ~eio:false () in
+  let parent = Context.create_sync () in
   Context.set parent "shared_key" (`String "shared_value");
   Context.set parent "private_key" (`String "private_value");
   let scope =

--- a/test/test_typed_tool.ml
+++ b/test/test_typed_tool.ml
@@ -197,7 +197,7 @@ let test_descriptor_some () =
 ;;
 
 let test_context_handler () =
-  let ctx = Context.create ~eio:false () in
+  let ctx = Context.create_sync () in
   Context.set ctx "prefix" (`String "Dear");
   let input = `Assoc [ "name", `String "Admin" ] in
   match Typed_tool.execute ~context:ctx greet_ctx_tool input with
@@ -217,7 +217,7 @@ let test_context_handler_no_context () =
 
 let test_to_untyped_context_bridge () =
   let untyped = Typed_tool.to_untyped greet_ctx_tool in
-  let ctx = Context.create ~eio:false () in
+  let ctx = Context.create_sync () in
   Context.set ctx "prefix" (`String "Hey");
   let input = `Assoc [ "name", `String "World" ] in
   match Tool.execute ~context:ctx untyped input with


### PR DESCRIPTION
## Summary
Removes Stdlib Mutex from Eio fiber paths and replaces production assert false branches with typed Agent_sdk.Error values.

## Changes
- Default Context.create () uses Eio.Mutex; add create_sync () for synchronous tests/serialization.
- Migrate content_replacement_state, agent_registry, provider_registry, and metrics aggregating backend to Eio-safe locking.
- Convert pipeline hook-validation failures from assert false to Error.Internal.
- Add Eio context concurrency and illegal-hook-decision regression tests.

## Verification
- `scripts/dune-local.sh build @all` green
- `scripts/dune-local.sh runtest` green

## Spec
- HTML spec: `/Users/dancer/me/docs/superpowers/specs/2026-07-01-masc-oas-resilience-design.html`
- Plan: `/Users/dancer/me/docs/superpowers/plans/2026-07-01-pr-c-oas-eio-hygiene.md`