### PR TITLE
feat(llm_provider): raw stream wire capture 관측 하네스 (Phase O)

### DIFF
--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -763,6 +763,12 @@ let complete_stream_http
                 | Some evt -> emit_telemetry evt
                 | None -> ()
               in
+              (* Phase O observability: env-gated ([OAS_WIRE_CAPTURE_DIR])
+                 redacted tee of raw pre-parse stream chunks. The environment is
+                 read once here; when unset [wire_sink] is a no-op so the hot
+                 loop below pays only an indirect call. Attributes a
+                 degenerate-repetition bug to the model vs. the stream parser. *)
+              let wire_sink = Wire_capture.make_sink ~provider ~model in
               let stream_read_result =
                 try
                   (match config.kind with
@@ -772,6 +778,7 @@ let complete_stream_http
                        ?idle_timeout:stream_idle_timeout_s
                        ~reader
                        ~on_line:(fun line ->
+                         wire_sink line;
                          match Streaming.parse_ollama_ndjson_chunk line with
                          | None ->
                            dispatch
@@ -797,6 +804,7 @@ let complete_stream_http
                        ?idle_timeout:stream_idle_timeout_s
                        ~reader
                        ~on_data:(fun ~event_type data ->
+                         wire_sink data;
                          let events =
                            match config.kind with
                            | Provider_config.Anthropic ->

--- a/lib/llm_provider/wire_capture.ml
+++ b/lib/llm_provider/wire_capture.ml
@@ -7,40 +7,45 @@ type sink = string -> unit
 let noop : sink = fun _ -> ()
 
 let write_line ~dir ~provider ~model chunk =
-  (try if not (Sys.file_exists dir) then Unix.mkdir dir 0o700 with _ -> ());
+  (try if not (Sys.file_exists dir) then Unix.mkdir dir 0o700 with
+   | _ -> ());
   let path = Filename.concat dir "raw-stream.jsonl" in
   try
     let oc = open_out_gen [ Open_append; Open_creat ] 0o600 path in
     Fun.protect
       ~finally:(fun () -> close_out_noerr oc)
       (fun () ->
-        let json : Yojson.Safe.t =
-          `Assoc
-            [
-              ("provider", `String provider);
-              ("model", `String model);
-              ("chunk", `String (Secret_redactor.redact_string chunk));
-            ]
-        in
-        output_string oc (Yojson.Safe.to_string json ^ "\n"))
-  with _ -> ()
+         let json : Yojson.Safe.t =
+           `Assoc
+             [ "provider", `String provider
+             ; "model", `String model
+             ; "chunk", `String (Secret_redactor.redact_string chunk)
+             ]
+         in
+         output_string oc (Yojson.Safe.to_string json ^ "\n"))
+  with
+  | _ -> ()
+;;
 
 let make_sink ~provider ~model =
   match Sys.getenv_opt env_dir with
   | None | Some "" -> noop
   | Some dir -> fun chunk -> write_line ~dir ~provider ~model chunk
+;;
 
 (* ── Inline tests ─────────────────────────────────────────────── *)
 
 let contains ~needle haystack =
-  let nl = String.length needle and hl = String.length haystack in
-  if nl = 0 then true
-  else
+  let nl = String.length needle
+  and hl = String.length haystack in
+  if nl = 0
+  then true
+  else (
     let rec loop i =
-      i + nl <= hl
-      && (String.equal (String.sub haystack i nl) needle || loop (i + 1))
+      i + nl <= hl && (String.equal (String.sub haystack i nl) needle || loop (i + 1))
     in
-    loop 0
+    loop 0)
+;;
 
 let%test "make_sink is a no-op when env is unset" =
   Unix.putenv env_dir "";
@@ -48,6 +53,7 @@ let%test "make_sink is a no-op when env is unset" =
   s "raw chunk";
   (* no exception, no output path assumed *)
   true
+;;
 
 let%test "make_sink writes a redacted line when env is set" =
   let dir = Filename.temp_dir "oas_wire" "" in
@@ -67,6 +73,7 @@ let%test "make_sink writes a redacted line when env is set" =
   (not (contains ~needle:token content))
   && contains ~needle:"[REDACTED]" content
   && contains ~needle:"deepseek-v4-flash" content
+;;
 
 let%test "disabled sink writes nothing" =
   let dir = Filename.temp_dir "oas_wire_off" "" in
@@ -74,3 +81,4 @@ let%test "disabled sink writes nothing" =
   let s = make_sink ~provider:"p" ~model:"m" in
   s "chunk";
   not (Sys.file_exists (Filename.concat dir "raw-stream.jsonl"))
+;;

--- a/lib/llm_provider/wire_capture.ml
+++ b/lib/llm_provider/wire_capture.ml
@@ -1,39 +1,87 @@
 (** See [wire_capture.mli]. *)
 
 let env_dir = "OAS_WIRE_CAPTURE_DIR"
+let capture_filename = "raw-stream.jsonl"
 
 type sink = string -> unit
 
 let noop : sink = fun _ -> ()
 
-let write_line ~dir ~provider ~model chunk =
-  (try if not (Sys.file_exists dir) then Unix.mkdir dir 0o700 with
-   | _ -> ());
-  let path = Filename.concat dir "raw-stream.jsonl" in
-  try
-    let oc = open_out_gen [ Open_append; Open_creat ] 0o600 path in
-    Fun.protect
-      ~finally:(fun () -> close_out_noerr oc)
-      (fun () ->
-         let json : Yojson.Safe.t =
-           `Assoc
-             [ "provider", `String provider
-             ; "model", `String model
-             ; "chunk", `String (Secret_redactor.redact_string chunk)
-             ]
-         in
-         output_string oc (Yojson.Safe.to_string json ^ "\n"))
-  with
-  | _ -> ()
+let unix_error_message err fn arg =
+  Printf.sprintf "%s(%S): %s" fn arg (Unix.error_message err)
 ;;
 
-let make_sink ~provider ~model =
-  match Sys.getenv_opt env_dir with
-  | None | Some "" -> noop
-  | Some dir -> fun chunk -> write_line ~dir ~provider ~model chunk
+let warn_activation_failure ~dir reason =
+  Diag.warn "wire_capture" "disabled OAS wire capture for %S: %s" dir reason
+;;
+
+let ensure_capture_dir dir =
+  try
+    match (Unix.stat dir).st_kind with
+    | Unix.S_DIR -> Ok ()
+    | _ -> Error "path exists but is not a directory"
+  with
+  | Unix.Unix_error (Unix.ENOENT, _, _) ->
+    (try Ok (Unix.mkdir dir 0o700) with
+     | Unix.Unix_error (err, fn, arg) -> Error (unix_error_message err fn arg))
+  | Unix.Unix_error (err, fn, arg) -> Error (unix_error_message err fn arg)
+;;
+
+let append_json_line ~path line =
+  let oc =
+    open_out_gen [ Open_wronly; Open_append; Open_creat; Open_binary ] 0o600 path
+  in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () ->
+       output_string oc line;
+       flush oc)
+;;
+
+let write_line ~path ~provider ~model ~warned chunk =
+  let json : Yojson.Safe.t =
+    `Assoc
+      [ "provider", `String provider
+      ; "model", `String model
+      ; "chunk", `String (Secret_redactor.redact_string chunk)
+      ]
+  in
+  let line = Yojson.Safe.to_string json ^ "\n" in
+  try append_json_line ~path line with
+  | Sys_error msg ->
+    if not !warned
+    then (
+      warned := true;
+      Diag.warn "wire_capture" "write failed for %S: %s" path msg)
+  | Unix.Unix_error (err, fn, arg) ->
+    if not !warned
+    then (
+      warned := true;
+      Diag.warn
+        "wire_capture"
+        "write failed for %S: %s"
+        path
+        (unix_error_message err fn arg))
+;;
+
+let make_sink ?getenv ~provider ~model =
+  match Cli_common_env.get ?getenv env_dir with
+  | None -> noop
+  | Some dir ->
+    (match ensure_capture_dir dir with
+     | Error reason ->
+       warn_activation_failure ~dir reason;
+       noop
+     | Ok () ->
+       let path = Filename.concat dir capture_filename in
+       let warned = ref false in
+       fun chunk -> write_line ~path ~provider ~model ~warned chunk)
 ;;
 
 (* ── Inline tests ─────────────────────────────────────────────── *)
+
+let getenv_of_pairs pairs name = List.assoc_opt name pairs
+let capture_getenv dir name = if String.equal name env_dir then Some dir else None
 
 let contains ~needle haystack =
   let nl = String.length needle
@@ -47,38 +95,62 @@ let contains ~needle haystack =
     loop 0)
 ;;
 
-let%test "make_sink is a no-op when env is unset" =
-  Unix.putenv env_dir "";
-  let s = make_sink ~provider:"p" ~model:"m" in
-  s "raw chunk";
+let read_file path =
+  let ic = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in ic)
+    (fun () -> really_input_string ic (in_channel_length ic))
+;;
+
+let%test "make_sink is a no-op when env is unset or empty" =
+  let unset = make_sink ~getenv:(fun _ -> None) ~provider:"p" ~model:"m" in
+  let empty =
+    make_sink ~getenv:(getenv_of_pairs [ env_dir, "   " ]) ~provider:"p" ~model:"m"
+  in
+  unset "raw chunk";
+  empty "raw chunk";
   (* no exception, no output path assumed *)
   true
 ;;
 
-let%test "make_sink writes a redacted line when env is set" =
+let%test "make_sink writes redacted binary JSONL when env is set" =
   let dir = Filename.temp_dir "oas_wire" "" in
-  Unix.putenv env_dir dir;
-  let s = make_sink ~provider:"ollama_cloud" ~model:"deepseek-v4-flash" in
+  let s =
+    make_sink
+      ~getenv:(capture_getenv dir)
+      ~provider:"ollama_cloud"
+      ~model:"deepseek-v4-flash"
+  in
   (* Built at runtime so no literal secret appears in source. *)
   let token = "ghp_" ^ String.make 36 '7' in
   s ("delta content " ^ token ^ " end");
-  Unix.putenv env_dir "";
-  let path = Filename.concat dir "raw-stream.jsonl" in
-  let ic = open_in path in
-  let content =
-    Fun.protect
-      ~finally:(fun () -> close_in ic)
-      (fun () -> really_input_string ic (in_channel_length ic))
-  in
+  let path = Filename.concat dir capture_filename in
+  let content = read_file path in
   (not (contains ~needle:token content))
   && contains ~needle:"[REDACTED]" content
   && contains ~needle:"deepseek-v4-flash" content
 ;;
 
+let%test "make_sink disables capture when env path is a file" =
+  let path = Filename.temp_file "oas_wire_file" ".txt" in
+  let warnings = ref [] in
+  let s =
+    Diag.with_sink
+      (fun level ~ctx msg -> warnings := (level, ctx, msg) :: !warnings)
+      (fun () -> make_sink ~getenv:(capture_getenv path) ~provider:"p" ~model:"m")
+  in
+  s "chunk";
+  List.exists
+    (fun (level, ctx, msg) ->
+       level = Diag.Warn
+       && String.equal ctx "wire_capture"
+       && contains ~needle:"not a directory" msg)
+    !warnings
+;;
+
 let%test "disabled sink writes nothing" =
   let dir = Filename.temp_dir "oas_wire_off" "" in
-  Unix.putenv env_dir "";
-  let s = make_sink ~provider:"p" ~model:"m" in
+  let s = make_sink ~getenv:(fun _ -> None) ~provider:"p" ~model:"m" in
   s "chunk";
-  not (Sys.file_exists (Filename.concat dir "raw-stream.jsonl"))
+  not (Sys.file_exists (Filename.concat dir capture_filename))
 ;;

--- a/lib/llm_provider/wire_capture.ml
+++ b/lib/llm_provider/wire_capture.ml
@@ -15,6 +15,15 @@ let warn_activation_failure ~dir reason =
   Diag.warn "wire_capture" "disabled OAS wire capture for %S: %s" dir reason
 ;;
 
+let require_capture_dir dir =
+  try
+    match (Unix.stat dir).st_kind with
+    | Unix.S_DIR -> Ok ()
+    | _ -> Error "path exists but is not a directory"
+  with
+  | Unix.Unix_error (err, fn, arg) -> Error (unix_error_message err fn arg)
+;;
+
 let ensure_capture_dir dir =
   try
     match (Unix.stat dir).st_kind with
@@ -23,19 +32,54 @@ let ensure_capture_dir dir =
   with
   | Unix.Unix_error (Unix.ENOENT, _, _) ->
     (try Ok (Unix.mkdir dir 0o700) with
+     | Unix.Unix_error (Unix.EEXIST, _, _) -> require_capture_dir dir
      | Unix.Unix_error (err, fn, arg) -> Error (unix_error_message err fn arg))
   | Unix.Unix_error (err, fn, arg) -> Error (unix_error_message err fn arg)
 ;;
 
+let append_mutex = Mutex.create ()
+
+let with_append_mutex f =
+  Mutex.lock append_mutex;
+  Fun.protect f ~finally:(fun () -> Mutex.unlock append_mutex)
+;;
+
+let close_noerr fd =
+  try Unix.close fd with
+  | Unix.Unix_error _ -> ()
+;;
+
+let unlock_noerr fd =
+  try Unix.lockf fd Unix.F_ULOCK 0 with
+  | Unix.Unix_error _ -> ()
+;;
+
+let rec write_all fd line offset remaining =
+  if remaining > 0
+  then (
+    match Unix.write_substring fd line offset remaining with
+    | 0 -> raise (Sys_error "write returned 0")
+    | written -> write_all fd line (offset + written) (remaining - written))
+;;
+
 let append_json_line ~path line =
-  let oc =
-    open_out_gen [ Open_wronly; Open_append; Open_creat; Open_binary ] 0o600 path
-  in
-  Fun.protect
-    ~finally:(fun () -> close_out_noerr oc)
-    (fun () ->
-       output_string oc line;
-       flush oc)
+  with_append_mutex (fun () ->
+    let fd =
+      Unix.openfile
+        path
+        [ Unix.O_WRONLY; Unix.O_APPEND; Unix.O_CREAT; Unix.O_CLOEXEC ]
+        0o600
+    in
+    let locked = ref false in
+    Fun.protect
+      ~finally:(fun () ->
+        if !locked then unlock_noerr fd;
+        close_noerr fd)
+      (fun () ->
+         ignore (Unix.lseek fd 0 Unix.SEEK_SET : int);
+         Unix.lockf fd Unix.F_TLOCK 0;
+         locked := true;
+         write_all fd line 0 (String.length line)))
 ;;
 
 let write_line ~path ~provider ~model ~warned chunk =
@@ -102,6 +146,15 @@ let read_file path =
     (fun () -> really_input_string ic (in_channel_length ic))
 ;;
 
+let with_cwd dir f =
+  let original = Sys.getcwd () in
+  Fun.protect
+    ~finally:(fun () -> Sys.chdir original)
+    (fun () ->
+       Sys.chdir dir;
+       f ())
+;;
+
 let%test "make_sink is a no-op when env is unset or empty" =
   let unset = make_sink ~getenv:(fun _ -> None) ~provider:"p" ~model:"m" in
   let empty =
@@ -131,6 +184,21 @@ let%test "make_sink writes redacted binary JSONL when env is set" =
   && contains ~needle:"deepseek-v4-flash" content
 ;;
 
+let%test "multiple active sinks append complete JSONL lines" =
+  let dir = Filename.temp_dir "oas_wire_multi" "" in
+  let s1 = make_sink ~getenv:(capture_getenv dir) ~provider:"p1" ~model:"m1" in
+  let s2 = make_sink ~getenv:(capture_getenv dir) ~provider:"p2" ~model:"m2" in
+  s1 (String.make 4096 'a');
+  s2 (String.make 4096 'b');
+  let content = read_file (Filename.concat dir capture_filename) in
+  let lines = String.split_on_char '\n' content |> List.filter (fun line -> line <> "") in
+  match lines with
+  | [ line1; line2 ] ->
+    contains ~needle:"\"provider\":\"p1\"" line1
+    && contains ~needle:"\"provider\":\"p2\"" line2
+  | _ -> false
+;;
+
 let%test "make_sink disables capture when env path is a file" =
   let path = Filename.temp_file "oas_wire_file" ".txt" in
   let warnings = ref [] in
@@ -151,6 +219,7 @@ let%test "make_sink disables capture when env path is a file" =
 let%test "disabled sink writes nothing" =
   let dir = Filename.temp_dir "oas_wire_off" "" in
   let s = make_sink ~getenv:(fun _ -> None) ~provider:"p" ~model:"m" in
-  s "chunk";
-  not (Sys.file_exists (Filename.concat dir capture_filename))
+  with_cwd dir (fun () ->
+    s "chunk";
+    not (Sys.file_exists capture_filename))
 ;;

--- a/lib/llm_provider/wire_capture.ml
+++ b/lib/llm_provider/wire_capture.ml
@@ -1,0 +1,76 @@
+(** See [wire_capture.mli]. *)
+
+let env_dir = "OAS_WIRE_CAPTURE_DIR"
+
+type sink = string -> unit
+
+let noop : sink = fun _ -> ()
+
+let write_line ~dir ~provider ~model chunk =
+  (try if not (Sys.file_exists dir) then Unix.mkdir dir 0o700 with _ -> ());
+  let path = Filename.concat dir "raw-stream.jsonl" in
+  try
+    let oc = open_out_gen [ Open_append; Open_creat ] 0o600 path in
+    Fun.protect
+      ~finally:(fun () -> close_out_noerr oc)
+      (fun () ->
+        let json : Yojson.Safe.t =
+          `Assoc
+            [
+              ("provider", `String provider);
+              ("model", `String model);
+              ("chunk", `String (Secret_redactor.redact_string chunk));
+            ]
+        in
+        output_string oc (Yojson.Safe.to_string json ^ "\n"))
+  with _ -> ()
+
+let make_sink ~provider ~model =
+  match Sys.getenv_opt env_dir with
+  | None | Some "" -> noop
+  | Some dir -> fun chunk -> write_line ~dir ~provider ~model chunk
+
+(* ── Inline tests ─────────────────────────────────────────────── *)
+
+let contains ~needle haystack =
+  let nl = String.length needle and hl = String.length haystack in
+  if nl = 0 then true
+  else
+    let rec loop i =
+      i + nl <= hl
+      && (String.equal (String.sub haystack i nl) needle || loop (i + 1))
+    in
+    loop 0
+
+let%test "make_sink is a no-op when env is unset" =
+  Unix.putenv env_dir "";
+  let s = make_sink ~provider:"p" ~model:"m" in
+  s "raw chunk";
+  (* no exception, no output path assumed *)
+  true
+
+let%test "make_sink writes a redacted line when env is set" =
+  let dir = Filename.temp_dir "oas_wire" "" in
+  Unix.putenv env_dir dir;
+  let s = make_sink ~provider:"ollama_cloud" ~model:"deepseek-v4-flash" in
+  (* Built at runtime so no literal secret appears in source. *)
+  let token = "ghp_" ^ String.make 36 '7' in
+  s ("delta content " ^ token ^ " end");
+  Unix.putenv env_dir "";
+  let path = Filename.concat dir "raw-stream.jsonl" in
+  let ic = open_in path in
+  let content =
+    Fun.protect
+      ~finally:(fun () -> close_in ic)
+      (fun () -> really_input_string ic (in_channel_length ic))
+  in
+  (not (contains ~needle:token content))
+  && contains ~needle:"[REDACTED]" content
+  && contains ~needle:"deepseek-v4-flash" content
+
+let%test "disabled sink writes nothing" =
+  let dir = Filename.temp_dir "oas_wire_off" "" in
+  Unix.putenv env_dir "";
+  let s = make_sink ~provider:"p" ~model:"m" in
+  s "chunk";
+  not (Sys.file_exists (Filename.concat dir "raw-stream.jsonl"))

--- a/lib/llm_provider/wire_capture.mli
+++ b/lib/llm_provider/wire_capture.mli
@@ -8,18 +8,24 @@
 
     Content is redacted via {!Secret_redactor} before it is written.
 
-    Disabled unless [OAS_WIRE_CAPTURE_DIR] names a directory. When disabled,
-    {!make_sink} returns a no-op closure so the streaming hot loop pays only an
-    indirect call — the environment is read once per stream, never per chunk.
+    Disabled unless [OAS_WIRE_CAPTURE_DIR] is set to a non-empty path that can
+    be used as a capture directory. When disabled, {!make_sink} returns a no-op
+    closure so the streaming hot loop pays only an indirect call — the
+    environment is read once per stream, never per chunk.
 
     @since introduced for the keeper repetition investigation (Phase O). *)
 
 (** A per-chunk capture function. Call with each raw pre-parse chunk. *)
 type sink = string -> unit
 
-(** [make_sink ~provider ~model] reads [OAS_WIRE_CAPTURE_DIR] once. If unset or
-    empty it returns a no-op sink. Otherwise it returns a sink that appends one
-    redacted JSON line ([{provider, model, chunk}]) per chunk to
-    [<dir>/raw-stream.jsonl]. All I/O is best-effort; failures are swallowed so
-    capture never perturbs the stream. *)
-val make_sink : provider:string -> model:string -> sink
+(** [make_sink ~provider ~model] reads [OAS_WIRE_CAPTURE_DIR] once through the
+    llm_provider env boundary. If unset or empty it returns a no-op sink.
+    Otherwise it validates or creates the capture directory once and returns a
+    sink that appends one redacted JSON line ([{provider, model, chunk}]) per
+    chunk to [<dir>/raw-stream.jsonl]. Expected I/O failures are reported once
+    via {!Diag.warn}; capture never perturbs the stream. *)
+val make_sink
+  :  ?getenv:(string -> string option)
+  -> provider:string
+  -> model:string
+  -> sink

--- a/lib/llm_provider/wire_capture.mli
+++ b/lib/llm_provider/wire_capture.mli
@@ -1,0 +1,25 @@
+(** Env-gated capture of raw provider stream chunks, before parsing.
+
+    The streaming success path discards the raw wire (only parse *failures*
+    preserve a bounded [raw] excerpt). This tees each raw pre-parse chunk
+    (Ollama NDJSON line / SSE data) to a file so a degenerate-repetition bug can
+    be attributed to the model vs. the OAS stream parser: the captured wire shows
+    exactly what the provider sent, alongside how it was parsed.
+
+    Content is redacted via {!Secret_redactor} before it is written.
+
+    Disabled unless [OAS_WIRE_CAPTURE_DIR] names a directory. When disabled,
+    {!make_sink} returns a no-op closure so the streaming hot loop pays only an
+    indirect call — the environment is read once per stream, never per chunk.
+
+    @since introduced for the keeper repetition investigation (Phase O). *)
+
+type sink = string -> unit
+(** A per-chunk capture function. Call with each raw pre-parse chunk. *)
+
+val make_sink : provider:string -> model:string -> sink
+(** [make_sink ~provider ~model] reads [OAS_WIRE_CAPTURE_DIR] once. If unset or
+    empty it returns a no-op sink. Otherwise it returns a sink that appends one
+    redacted JSON line ([{provider, model, chunk}]) per chunk to
+    [<dir>/raw-stream.jsonl]. All I/O is best-effort; failures are swallowed so
+    capture never perturbs the stream. *)

--- a/lib/llm_provider/wire_capture.mli
+++ b/lib/llm_provider/wire_capture.mli
@@ -14,12 +14,12 @@
 
     @since introduced for the keeper repetition investigation (Phase O). *)
 
-type sink = string -> unit
 (** A per-chunk capture function. Call with each raw pre-parse chunk. *)
+type sink = string -> unit
 
-val make_sink : provider:string -> model:string -> sink
 (** [make_sink ~provider ~model] reads [OAS_WIRE_CAPTURE_DIR] once. If unset or
     empty it returns a no-op sink. Otherwise it returns a sink that appends one
     redacted JSON line ([{provider, model, chunk}]) per chunk to
     [<dir>/raw-stream.jsonl]. All I/O is best-effort; failures are swallowed so
     capture never perturbs the stream. *)
+val make_sink : provider:string -> model:string -> sink


### PR DESCRIPTION
## 목표

keeper 반복 생성 조사(Phase O)의 **provider wire 관측**. 스트리밍 성공 경로는 raw wire를 버리고, 파싱 실패 시에만 bounded excerpt만 남긴다. 이 때문에 반복이 **모델 degeneration**인지 **OAS 스트림 파서의 content mangling**인지 구분할 수 없다. 이 PR은 파싱 직전 raw chunk를 redacted로 tee해 그 판별을 가능하게 한다.

MASC 측 요청 관측은 jeong-sik/masc#22966에서 완료. 이건 그 반대편(provider→OAS wire).

## 변경

- `lib/llm_provider/wire_capture.ml` / `.mli` (신규) — env-gated redacted sink.
- `lib/llm_provider/complete_stream.ml` — sink을 스트림당 1회 계산, Ollama(`on_line`)/SSE(`on_data`) 콜백에서 파싱 전 raw chunk를 tee (2줄).

## 안전 / 성능

- **기본 비활성**: `OAS_WIRE_CAPTURE_DIR`가 디렉토리를 가리킬 때만 동작.
- **hot loop zero-overhead**: env는 스트림당 1회만 읽음. 비활성 시 `make_sink`가 no-op 클로저를 반환 → chunk마다 간접 호출 1회뿐.
- redaction: `Secret_redactor.redact_string` 경유(Bearer/API key/GitHub token/PEM 등).
- 모든 I/O best-effort — 예외를 삼켜 스트림에 영향 없음.
- inline `let%test` 3개(no-op/redacted write/disabled) — coverage floor 충족.

## 이건 fix가 아니라 관측이다 (Harness First)

반복 자체의 fix가 아니다. wire 데이터로 "모델 vs 파서" 판별 후, 파서 결함이면 `streaming.ml`/`complete_stream_acc.ml`에서, 모델 degeneration이면 소비자(MASC) 측 content-level dedup으로 대응한다.

WORKAROUND-WAIVED: 진단 관측 하네스(Phase O), fix 아님. default-off env-gated, hot-path zero-overhead.

## 검증

- 로컬 dune 대신 CI 빌드 위임.
- inline test로 sink 동작(redaction/off no-op) 검증. 라이브 wire 수집은 배포(pin bump) 후.

## 미검증

- 라이브 스트림 tee는 배포 전 미수집.
- OpenAI-compat(non-ollama) 경로도 `on_data` tee로 커버되나, sangsu는 Ollama 경로.
