### PR TITLE
refactor(provider): catalog-declared typed task instead of model-id substring inference

### DIFF
--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -101,6 +101,7 @@ let llm_capabilities_of_provider_capabilities (caps : Provider.capabilities)
   ; supports_audio_input = caps.supports_audio_input
   ; supports_video_input = caps.supports_video_input
   ; modality_priority = caps.modality_priority
+  ; task = caps.task
   ; supports_native_streaming = caps.supports_native_streaming
   ; supports_system_prompt = caps.supports_system_prompt
   ; supports_caching = caps.supports_caching

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -66,6 +66,15 @@ type reasoning_streaming_format = Capability_vocab.reasoning_streaming_format =
   | Delta_reasoning_field of string
   | Template_reasoning_streaming
 
+(** Catalog-declared inference task for non-chat models. [None] on every
+    chat/completion model; a value is only ever set by an explicit [task]
+    field on a model catalog entry — never inferred from the model id. *)
+type task = Capability_vocab.task =
+  | Transcription
+  | Speech
+  | Image_generation
+  | Video_generation
+
 type capabilities =
   { (* ── Numeric limits ────────────────────────────────── *)
     max_context_tokens : int option (** Model's context window. None = unknown. *)
@@ -129,6 +138,11 @@ type capabilities =
     (** Block ordering applied to multimodal user messages just before
         serialization. [Visual_first] for Gemma 4 family.
         @since 0.193.0 *)
+  ; (* ── Inference task ────────────────────────────────── *)
+    task : task option
+    (** Inference task declared by the model catalog entry (transcription,
+        speech, image/video generation). [None] = no declared task; there is
+        no model-id inference fallback. *)
   ; (* ── Protocol ──────────────────────────────────────── *)
     supports_native_streaming : bool
   ; supports_system_prompt : bool
@@ -188,6 +202,7 @@ let default_capabilities =
   ; supports_audio_input = false
   ; supports_video_input = false
   ; modality_priority = Modality.Preserve_input_order
+  ; task = None
   ; supports_native_streaming = false
   ; supports_system_prompt = true
   ; (* most models support it *)
@@ -776,6 +791,7 @@ type declarative_capability_overrides =
   ; supports_audio_input : bool option
   ; supports_video_input : bool option
   ; modality_priority : string option
+  ; task : Capability_vocab.task option
   ; supports_native_streaming : bool option
   ; supports_system_prompt : bool option
   ; supports_caching : bool option
@@ -813,6 +829,9 @@ let overrides_of_manifest_entry (entry : Capability_manifest.entry) =
   ; supports_audio_input = entry.supports_audio_input
   ; supports_video_input = entry.supports_video_input
   ; modality_priority = None
+  ; (* The JSON capability manifest carries no task field; task is
+       catalog-only vocabulary. *)
+    task = None
   ; supports_native_streaming = entry.supports_native_streaming
   ; supports_system_prompt = entry.supports_system_prompt
   ; supports_caching = entry.supports_caching
@@ -924,6 +943,11 @@ let apply_declarative_capability_overrides overrides =
             warn_unknown_capability_value ~field:"modality_priority" s;
             base.modality_priority)
        | None -> base.modality_priority)
+  ; task =
+      (* Already typed at the catalog parse boundary; no string re-parse. *)
+      (match overrides.task with
+       | Some _ as task -> task
+       | None -> base.task)
   ; supports_native_streaming =
       override_bool base.supports_native_streaming overrides.supports_native_streaming
   ; supports_system_prompt =
@@ -1075,6 +1099,7 @@ let overrides_of_catalog_entry (entry : Model_catalog.model_entry) =
   ; supports_audio_input = entry.supports_audio_input
   ; supports_video_input = entry.supports_video_input
   ; modality_priority = entry.modality_priority
+  ; task = entry.task
   ; supports_native_streaming = entry.supports_native_streaming
   ; supports_system_prompt = entry.supports_system_prompt
   ; supports_caching = entry.supports_caching
@@ -1441,6 +1466,7 @@ let test_catalog_entry id_prefix : Model_catalog.model_entry =
   ; supports_audio_input = None
   ; supports_video_input = None
   ; modality_priority = None
+  ; task = None
   ; supports_native_streaming = None
   ; supports_system_prompt = None
   ; supports_caching = None

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -48,6 +48,15 @@ type reasoning_streaming_format = Capability_vocab.reasoning_streaming_format =
   | Delta_reasoning_field of string
   | Template_reasoning_streaming
 
+(** Catalog-declared inference task for non-chat models. [None] on every
+    chat/completion model; a value is only ever set by an explicit [task]
+    field on a model catalog entry — never inferred from the model id. *)
+type task = Capability_vocab.task =
+  | Transcription
+  | Speech
+  | Image_generation
+  | Video_generation
+
 type capabilities =
   { (* Numeric limits *)
     max_context_tokens : int option
@@ -84,6 +93,11 @@ type capabilities =
   ; supports_audio_input : bool
   ; supports_video_input : bool
   ; modality_priority : Modality.priority
+  ; (* Inference task *)
+    task : task option
+    (** Inference task declared by the model catalog entry (transcription,
+        speech, image/video generation). [None] = no declared task; there is
+        no model-id inference fallback. *)
   ; (* Protocol *)
     supports_native_streaming : bool
   ; supports_system_prompt : bool

--- a/lib/llm_provider/capability_vocab.ml
+++ b/lib/llm_provider/capability_vocab.ml
@@ -43,6 +43,15 @@ type reasoning_streaming_format =
   | Delta_reasoning_field of string
   | Template_reasoning_streaming
 
+(** Inference task a catalog entry declares for non-chat models (audio
+    transcription, speech synthesis, image/video generation). Chat and
+    completion models declare no task. *)
+type task =
+  | Transcription
+  | Speech
+  | Image_generation
+  | Video_generation
+
 let normalize raw = String.lowercase_ascii (String.trim raw)
 
 let thinking_control_format_table =
@@ -104,6 +113,40 @@ let modality_priority_values =
   ; "visual_first"
   ; "visual-first"
   ]
+;;
+
+let task_table =
+  [ "transcription", Transcription
+  ; "speech", Speech
+  ; "image_generation", Image_generation
+  ; "video_generation", Video_generation
+  ]
+;;
+
+let task_values = List.map fst task_table
+
+let task_of_string raw =
+  match normalize raw with
+  | "" -> None
+  | normalized -> List.assoc_opt normalized task_table
+;;
+
+let task_to_string = function
+  | Transcription -> "transcription"
+  | Speech -> "speech"
+  | Image_generation -> "image_generation"
+  | Video_generation -> "video_generation"
+;;
+
+let%test "task values parse through the canonical table" =
+  List.for_all (fun raw -> Option.is_some (task_of_string raw)) task_values
+;;
+
+let%test "task round-trips through to_string and of_string" =
+  List.for_all
+    (fun (raw, task) ->
+       task_to_string task = raw && task_of_string (task_to_string task) = Some task)
+    task_table
 ;;
 
 let reasoning_replay_table =

--- a/lib/llm_provider/model_catalog.ml
+++ b/lib/llm_provider/model_catalog.ml
@@ -23,6 +23,7 @@ type model_entry =
   ; supports_audio_input : bool option
   ; supports_video_input : bool option
   ; modality_priority : string option
+  ; task : Capability_vocab.task option
   ; supports_native_streaming : bool option
   ; supports_system_prompt : bool option
   ; supports_caching : bool option
@@ -179,6 +180,27 @@ let reasoning_streaming_format_opt ~entry_id key toml =
             Capability_vocab.reasoning_streaming_format_syntax))
 ;;
 
+(* Typed at the parse boundary: an entry either declares a canonical task or
+   fails the whole catalog load. Storing the raw string here would defer the
+   unknown-value decision to a warn-and-keep-base fallback at capability
+   application time. *)
+let task_opt ~entry_id key toml =
+  match find_string_field ~entry_id key toml with
+  | Error e -> Error e
+  | Ok None -> Ok None
+  | Ok (Some raw) ->
+    (match Capability_vocab.task_of_string raw with
+     | Some _ as task -> Ok task
+     | None ->
+       Error
+         (Printf.sprintf
+            "model entry %S field %S has unknown value %S (canonical: %s)"
+            entry_id
+            key
+            (String.lowercase_ascii (String.trim raw))
+            (String.concat ", " Capability_vocab.task_values)))
+;;
+
 (* Every field [parse_entry] reads below. A misspelled or stale key (e.g.
    [suports_tools]) would otherwise be silently ignored, leaving the capability
    at its default and hiding the misconfiguration. Enumerate the table keys and
@@ -208,6 +230,7 @@ let known_entry_keys =
   ; "supports_audio_input"
   ; "supports_video_input"
   ; "modality_priority"
+  ; "task"
   ; "supports_native_streaming"
   ; "supports_system_prompt"
   ; "supports_caching"
@@ -296,6 +319,7 @@ let parse_entry entry_toml =
            ~allowed:Capability_vocab.modality_priority_values
            entry_toml
        in
+       let task_result = task_opt ~entry_id:id_prefix "task" entry_toml in
        let thinking_control_format_result =
          canonical_string_opt
            ~entry_id:id_prefix
@@ -333,23 +357,26 @@ let parse_entry entry_toml =
           ( base_label_result
           , provider_name_result
           , modality_priority_result
+          , task_result
           , thinking_control_format_result
           , preserve_thinking_control_format_result
           , reasoning_output_format_result
           , reasoning_streaming_format_result
           , thinking_control_token_result )
         with
-        | (Error _ as e), _, _, _, _, _, _, _
-        | _, (Error _ as e), _, _, _, _, _, _
-        | _, _, (Error _ as e), _, _, _, _, _
-        | _, _, _, (Error _ as e), _, _, _, _
-        | _, _, _, _, (Error _ as e), _, _, _
-        | _, _, _, _, _, (Error _ as e), _, _
-        | _, _, _, _, _, _, (Error _ as e), _
-        | _, _, _, _, _, _, _, (Error _ as e) -> e
+        | (Error _ as e), _, _, _, _, _, _, _, _
+        | _, (Error _ as e), _, _, _, _, _, _, _
+        | _, _, (Error _ as e), _, _, _, _, _, _
+        | _, _, _, (Error _ as e), _, _, _, _, _
+        | _, _, _, _, (Error _ as e), _, _, _, _
+        | _, _, _, _, _, (Error _ as e), _, _, _
+        | _, _, _, _, _, _, (Error _ as e), _, _
+        | _, _, _, _, _, _, _, (Error _ as e), _
+        | _, _, _, _, _, _, _, _, (Error _ as e) -> e
         | ( Ok base_label
           , Ok provider_name
           , Ok modality_priority
+          , Ok task
           , Ok thinking_control_format
           , Ok preserve_thinking_control_format
           , Ok reasoning_output_format
@@ -386,6 +413,7 @@ let parse_entry entry_toml =
             ; supports_audio_input = find_bool_opt entry_toml [ "supports_audio_input" ]
             ; supports_video_input = find_bool_opt entry_toml [ "supports_video_input" ]
             ; modality_priority
+            ; task
             ; supports_native_streaming =
                 find_bool_opt entry_toml [ "supports_native_streaming" ]
             ; supports_system_prompt =
@@ -428,6 +456,27 @@ let%test "parse_entry accepts an entry whose fields are all known" =
   match parse_entry entry with
   | Ok _ -> true
   | Error _ -> false
+;;
+
+let%test "parse_entry parses a canonical task value into the closed variant" =
+  let entry = Otoml.Parser.from_string "id_prefix = \"m\"\ntask = \"transcription\"" in
+  match parse_entry entry with
+  | Ok { task = Some Capability_vocab.Transcription; _ } -> true
+  | Ok _ | Error _ -> false
+;;
+
+let%test "parse_entry rejects an unknown task value, not silently dropped" =
+  let entry = Otoml.Parser.from_string "id_prefix = \"m\"\ntask = \"chat\"" in
+  match parse_entry entry with
+  | Error _ -> true
+  | Ok _ -> false
+;;
+
+let%test "parse_entry leaves task undeclared as None" =
+  let entry = Otoml.Parser.from_string "id_prefix = \"m\"" in
+  match parse_entry entry with
+  | Ok { task = None; _ } -> true
+  | Ok _ | Error _ -> false
 ;;
 
 let load_file path =

--- a/lib/llm_provider/model_catalog.mli
+++ b/lib/llm_provider/model_catalog.mli
@@ -29,6 +29,11 @@ type model_entry =
   ; supports_audio_input : bool option
   ; supports_video_input : bool option
   ; modality_priority : string option
+  ; task : Capability_vocab.task option
+    (** Catalog-declared inference task for non-chat models (transcription,
+        speech, image/video generation). Parsed fail-closed against
+        {!Capability_vocab.task_values}; [None] means the entry declares no
+        task — it is never inferred from the model id. *)
   ; supports_native_streaming : bool option
   ; supports_system_prompt : bool option
   ; supports_caching : bool option

--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -35,7 +35,7 @@ type inference_contract =
   { provider : provider
   ; model_id : string
   ; modality : modality
-  ; task : string option
+  ; task : task option
   }
 
 type model_spec =
@@ -120,32 +120,7 @@ let modality_of_capabilities (caps : capabilities) =
   else Text
 ;;
 
-let task_of_model_id model_id =
-  let has needle = Util.contains_substring_ci ~haystack:model_id ~needle in
-  if has "whisper" || has "transcribe" || has "transcription" || has "stt"
-  then Some "transcription"
-  else if has "tts" || has "text-to-speech" || has "voice"
-  then Some "speech"
-  else if
-    has "imagegen"
-    || has "image-gen"
-    || has "gpt-image"
-    || has "cogview"
-    || has "glm-image"
-    || has "seedream"
-    || has "flux"
-  then Some "image_generation"
-  else if
-    has "video-gen"
-    || has "veo"
-    || has "kling"
-    || has "sora"
-    || has "wan"
-    || has "cogvideox"
-    || has "vidu"
-  then Some "video_generation"
-  else None
-;;
+let task_to_string = Llm_provider.Capability_vocab.task_to_string
 
 let modality_supported (caps : capabilities) = function
   | Text -> true
@@ -379,7 +354,10 @@ let build_inference_contract ~provider ~model_id ~(capabilities : capabilities) 
     { provider
     ; model_id
     ; modality = modality_of_capabilities capabilities
-    ; task = task_of_model_id model_id
+    ; (* Catalog-declared only (models.toml [task] field via capabilities);
+         undeclared models carry no task — the former model-id substring
+         classifier was removed. *)
+      task = capabilities.task
     }
   in
   match validate_inference_contract ~capabilities contract with

--- a/lib/provider.mli
+++ b/lib/provider.mli
@@ -93,6 +93,17 @@ type reasoning_streaming_format = Llm_provider.Capabilities.reasoning_streaming_
   | Delta_reasoning_field of string
   | Template_reasoning_streaming
 
+(** Catalog-declared inference task for non-chat models (audio transcription,
+    speech synthesis, image/video generation). A value is only ever set by an
+    explicit [task] field on a [models.toml] catalog entry — it is never
+    inferred from the model id. This closed variant replaced the former
+    model-id substring heuristic and the [string option] payload it produced. *)
+type task = Llm_provider.Capabilities.task =
+  | Transcription
+  | Speech
+  | Image_generation
+  | Video_generation
+
 (* Re-export the canonical capabilities record from [Llm_provider.Capabilities]
    with its type equality exposed, so downstream consumers (e.g. catalog
    overlays) can pass an [Llm_provider.Capabilities.capabilities] straight into
@@ -127,6 +138,7 @@ type capabilities = Llm_provider.Capabilities.capabilities =
   ; supports_audio_input : bool
   ; supports_video_input : bool
   ; modality_priority : Llm_provider.Modality.priority
+  ; task : task option
   ; supports_native_streaming : bool
   ; supports_system_prompt : bool
   ; supports_caching : bool
@@ -147,7 +159,9 @@ type inference_contract =
   { provider : provider
   ; model_id : string
   ; modality : modality
-  ; task : string option
+  ; task : task option
+    (** Catalog-declared task threaded from [capabilities.task]; [None] for
+        every model whose catalog entry declares no [task] field. *)
   }
 
 type model_spec =
@@ -162,6 +176,7 @@ type model_spec =
 val request_kind : provider -> request_kind
 val request_path : provider -> string
 val modality_to_string : modality -> string
+val task_to_string : task -> string
 val modality_of_capabilities : capabilities -> modality
 val default_capabilities : capabilities
 val capabilities_for_model : provider:provider -> model_id:string -> capabilities

--- a/lib/provider_runtime_binding.ml
+++ b/lib/provider_runtime_binding.ml
@@ -100,6 +100,7 @@ let public_capabilities (caps : Llm_provider.Capabilities.capabilities)
   ; supports_audio_input = caps.supports_audio_input
   ; supports_video_input = caps.supports_video_input
   ; modality_priority = caps.modality_priority
+  ; task = caps.task
   ; supports_native_streaming = caps.supports_native_streaming
   ; supports_system_prompt = caps.supports_system_prompt
   ; supports_caching = caps.supports_caching

--- a/test/test_custom_provider.ml
+++ b/test/test_custom_provider.ml
@@ -38,6 +38,12 @@ let make_test_impl ?(name = "test-provider") ?(request_path = "/v1/test") ()
 (* Wrap a test body in Eio_main.run to provide the Eio effect handler *)
 let with_eio f () = Eio_main.run @@ fun _env -> f ()
 
+let task_testable =
+  Alcotest.testable
+    (fun ppf task -> Format.pp_print_string ppf (Provider.task_to_string task))
+    ( = )
+;;
+
 (* ── Registry CRUD ──────────────────────────────────────────── *)
 
 let test_register_and_find () =
@@ -176,7 +182,7 @@ let test_model_spec_registered () =
     "contract modality"
     "text"
     (Provider.modality_to_string contract.modality);
-  Alcotest.(check (option string)) "contract task" None contract.task;
+  Alcotest.(check (option task_testable)) "contract task" None contract.task;
   Alcotest.(check bool) "supports_tools" true spec.capabilities.supports_tools
 ;;
 

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -57,6 +57,62 @@ let with_empty_capability_sources f =
     f
 ;;
 
+let task_testable =
+  Alcotest.testable
+    (fun ppf task -> Format.pp_print_string ppf (Provider.task_to_string task))
+    ( = )
+;;
+
+(* Install a synthetic catalog from inline TOML for the duration of [f], then
+   restore the original. Goes through [Model_catalog.load_file] so the tests
+   exercise the real fail-closed parse path. *)
+let with_catalog_toml content f =
+  let path = Filename.temp_file "oas_provider_task_catalog" ".toml" in
+  let original = Llm_provider.Model_catalog.global () in
+  Fun.protect
+    ~finally:(fun () ->
+      (try Sys.remove path with
+       | Sys_error _ -> ());
+      match original with
+      | Some c -> Llm_provider.Model_catalog.set_global c
+      | None -> Llm_provider.Model_catalog.clear_global ())
+    (fun () ->
+       let oc = open_out path in
+       output_string oc content;
+       close_out oc;
+       match Llm_provider.Model_catalog.load_file path with
+       | Ok catalog ->
+         Llm_provider.Model_catalog.set_global catalog;
+         f ()
+       | Error e -> Alcotest.fail ("test catalog load failed: " ^ e))
+;;
+
+let task_catalog_toml =
+  {|
+[[models]]
+id_prefix = "acme-transcribe"
+supports_audio_input = true
+task = "transcription"
+
+[[models]]
+id_prefix = "acme-tts"
+task = "speech"
+
+[[models]]
+id_prefix = "acme-image"
+supports_image_input = true
+task = "image_generation"
+
+[[models]]
+id_prefix = "acme-video"
+supports_video_input = true
+task = "video_generation"
+
+[[models]]
+id_prefix = "acme-chat"
+|}
+;;
+
 let test_missing_env_var () =
   (* Anthropic provider checks env var; nonexistent key -> Error *)
   let cfg : Provider.config =
@@ -224,7 +280,7 @@ let test_model_spec_openrouter_capabilities () =
     "contract modality"
     "multimodal"
     (Provider.modality_to_string contract.modality);
-  Alcotest.(check (option string)) "contract task" None contract.task;
+  Alcotest.(check (option task_testable)) "contract task" None contract.task;
   Alcotest.(check bool) "supports tools" true spec.capabilities.supports_tools;
   Alcotest.(check bool) "supports reasoning" false spec.capabilities.supports_reasoning;
   Alcotest.(check bool) "supports top_k" false spec.capabilities.supports_top_k;
@@ -242,55 +298,95 @@ let test_inference_contract_anthropic_multimodal () =
     (Provider.modality_to_string contract.modality)
 ;;
 
-let test_inference_contract_task_transcription () =
-  let cfg : Provider.config =
-    { provider =
-        OpenAICompat
-          { base_url = "https://api.openai.com/v1"
-          ; auth_header = Some "Authorization"
-          ; path = "/audio/transcriptions"
-          ; static_token = None
-          }
-    ; model_id = "whisper-1"
-    ; api_key_env = "OPENAI_API_KEY"
-    }
-  in
-  let contract = Provider.inference_contract_of_config cfg in
-  Alcotest.(check (option string)) "task" (Some "transcription") contract.task
+let test_capabilities_task_catalog_declared () =
+  with_catalog_toml task_catalog_toml (fun () ->
+    let task_of model_id =
+      match Llm_provider.Capabilities.for_model_id model_id with
+      | Some (caps : Provider.capabilities) -> caps.task
+      | None -> Alcotest.failf "catalog entry expected for %s" model_id
+    in
+    Alcotest.(check (option task_testable))
+      "transcription"
+      (Some Provider.Transcription)
+      (task_of "acme-transcribe-1");
+    Alcotest.(check (option task_testable))
+      "speech"
+      (Some Provider.Speech)
+      (task_of "acme-tts-1");
+    Alcotest.(check (option task_testable))
+      "image generation"
+      (Some Provider.Image_generation)
+      (task_of "acme-image-1");
+    Alcotest.(check (option task_testable))
+      "video generation"
+      (Some Provider.Video_generation)
+      (task_of "acme-video-1");
+    Alcotest.(check (option task_testable))
+      "entry without a task field declares no task"
+      None
+      (task_of "acme-chat-1"))
 ;;
 
-let test_inference_contract_task_image_generation () =
-  let cfg : Provider.config =
-    { provider =
-        OpenAICompat
-          { base_url = Llm_provider.Zai_catalog.general_base_url
-          ; auth_header = None
-          ; path = "/images/generations"
-          ; static_token = None
-          }
-    ; model_id = "glm-image"
-    ; api_key_env = ""
-    }
-  in
-  let contract = Provider.inference_contract_of_config cfg in
-  Alcotest.(check (option string)) "task" (Some "image_generation") contract.task
+let test_inference_contract_task_catalog_declared () =
+  with_catalog_toml task_catalog_toml (fun () ->
+    (* The [Anthropic] branch of [capabilities_for_model] consults the model
+       catalog without the raw-endpoint declaration gate, so this exercises
+       the full config -> capabilities -> contract threading. *)
+    let cfg : Provider.config =
+      { provider = Anthropic
+      ; model_id = "acme-transcribe-1"
+      ; api_key_env = "ANTHROPIC_API_KEY"
+      }
+    in
+    let contract = Provider.inference_contract_of_config cfg in
+    Alcotest.(check (option task_testable))
+      "catalog-declared task reaches the contract"
+      (Some Provider.Transcription)
+      contract.task)
 ;;
 
-let test_inference_contract_task_video_generation () =
-  let cfg : Provider.config =
-    { provider =
-        OpenAICompat
-          { base_url = Llm_provider.Zai_catalog.general_base_url
-          ; auth_header = None
-          ; path = "/videos/generations"
-          ; static_token = None
-          }
-    ; model_id = "cogvideox-2"
-    ; api_key_env = ""
-    }
-  in
-  let contract = Provider.inference_contract_of_config cfg in
-  Alcotest.(check (option string)) "task" (Some "video_generation") contract.task
+(* Regression for the deleted model-id substring classifier: these ids used to
+   be classified as transcription/image_generation/video_generation purely by
+   substring. Without a catalog-declared [task] they must stay [None]. *)
+let test_inference_contract_task_never_inferred_from_model_id () =
+  with_catalog_toml task_catalog_toml (fun () ->
+    let contract_task provider model_id =
+      let cfg : Provider.config = { provider; model_id; api_key_env = "" } in
+      (Provider.inference_contract_of_config cfg).task
+    in
+    Alcotest.(check (option task_testable))
+      "whisper-style id declares no task"
+      None
+      (contract_task
+         (OpenAICompat
+            { base_url = "https://api.openai.com/v1"
+            ; auth_header = Some "Authorization"
+            ; path = "/audio/transcriptions"
+            ; static_token = None
+            })
+         "whisper-1");
+    Alcotest.(check (option task_testable))
+      "glm-image id declares no task"
+      None
+      (contract_task
+         (OpenAICompat
+            { base_url = Llm_provider.Zai_catalog.general_base_url
+            ; auth_header = None
+            ; path = "/images/generations"
+            ; static_token = None
+            })
+         "glm-image");
+    Alcotest.(check (option task_testable))
+      "cogvideox id declares no task"
+      None
+      (contract_task
+         (OpenAICompat
+            { base_url = Llm_provider.Zai_catalog.general_base_url
+            ; auth_header = None
+            ; path = "/videos/generations"
+            ; static_token = None
+            })
+         "cogvideox-2"))
 ;;
 
 let test_zai_glm5v_capabilities_include_image_input () =
@@ -1165,17 +1261,17 @@ let () =
             `Quick
             test_inference_contract_anthropic_multimodal
         ; Alcotest.test_case
-            "task inference transcription"
+            "task catalog declared capabilities"
             `Quick
-            test_inference_contract_task_transcription
+            test_capabilities_task_catalog_declared
         ; Alcotest.test_case
-            "task inference image generation"
+            "task catalog declared contract"
             `Quick
-            test_inference_contract_task_image_generation
+            test_inference_contract_task_catalog_declared
         ; Alcotest.test_case
-            "task inference video generation"
+            "task never inferred from model id"
             `Quick
-            test_inference_contract_task_video_generation
+            test_inference_contract_task_never_inferred_from_model_id
         ; Alcotest.test_case
             "zai glm-5v image capabilities"
             `Quick


### PR DESCRIPTION
## 문제

원 보고서: 03-resilience-48h-spec `oas-task-of-model-id-substring` (adversarial triage problem-18, P3 latent-API hygiene로 재분류).

`Provider.task_of_model_id`가 model id의 대소문자 무시 substring(`whisper`/`stt`/`tts`/`voice`/`imagegen`/`flux`/`sora`/`wan` 등)으로 inference task를 추론해 공개 API `inference_contract.task`(raw `string option`)를 채우고 있었다. task의 SSOT인 catalog(`models.toml`)에는 task 필드가 없었고, 테스트가 substring 동작을 drift-guard로 고정하고 있어 분류기 제거를 막는 상태였다. 현재 oas/masc 프로덕션 코드에 `.task` 소비자는 없으므로 능동적 라우팅 버그가 아니라 공개 API에 잠복한 오분류원이다.

## 적대적 검증 근거

pinned base `2d88271786331978f91001f73ff7f2711fed8775`에서 재검증:

- `lib/provider.ml:123-148` — `task_of_model_id` substring 분류기 (`Util.contains_substring_ci` 기반)
- `lib/provider.ml:382` — `build_inference_contract`에 `task = task_of_model_id model_id` 배선
- `lib/provider.mli:150` — 공개 `inference_contract`에 `task : string option` 노출
- `test/test_provider.ml:259,276,293` — `whisper-1`/`glm-image`/`cogvideox-2` substring 추론을 고정하는 테스트
- `models.toml` / `lib/llm_provider/model_catalog.mli` — task 필드 부재 (catalog SSOT 없음)
- masc HEAD에 `inference_contract`/`task_of_model_id` 참조 0건 → cross-repo 변경 불필요

## 근본 수정

substring 분류기를 삭제하고 task를 catalog 선언 기반 closed variant로 교체 (RFC-OAS-034 catalog 기계 활용):

1. `Capability_vocab.task` — `Transcription | Speech | Image_generation | Video_generation` closed variant + canonical table (`task_values`, `task_of_string`, `task_to_string`). leaf vocab 모듈에 위치.
2. `Model_catalog.model_entry.task : Capability_vocab.task option` — TOML `task` 필드를 parse 경계에서 typed로 파싱. 알 수 없는 값은 catalog load 전체를 Error로 거부 (fail-closed, #2426의 unknown-key 거부와 동일 방향). string 저장 후 적용 시점 warn-fallback 재파싱 경로를 만들지 않음.
3. `Capabilities.capabilities.task : task option` — `default_capabilities`는 `None`, catalog override(`overrides_of_catalog_entry`)로만 값이 설정됨. JSON capability manifest에는 task 필드가 없음 (catalog 전용 vocabulary).
4. `Provider.build_inference_contract` — `task = capabilities.task`. 미선언 = `None`, 추론 없음. `inference_contract.task`는 `task option`으로 교체, `task_to_string` 공개.
5. `provider_runtime_binding.ml` / `api_openai.ml` — capabilities 전사 literal에 `task` 필드 반영.

설계 결정 2건:

- `Provider_config.capability_requires_endpoint_declaration` 게이트에 task를 추가하지 않았다. 이 게이트는 request wire 구성을 바꾸는 capability(tools/reasoning/thinking dialect)를 미선언 endpoint에서 차단하는 목적이고, task는 contract 메타데이터로 요청 구성을 바꾸지 않는다.
- 현재 `models.toml`의 160개 entry는 전부 chat/completion 모델이므로 task를 선언하는 entry는 추가하지 않았다. 파서와 threading만 준비되며, 실제 non-chat 모델이 catalog에 들어올 때 선언한다.

## 테스트

- `test/test_provider.ml`
  - `task catalog declared capabilities` — 인라인 TOML catalog(4개 task 값 + task 미선언 entry)를 `Model_catalog.load_file` 실경로로 설치해 `Capabilities.for_model_id`가 typed task를 반환하는지 확인
  - `task catalog declared contract` — config → capabilities → contract end-to-end threading (`Some Transcription`)
  - `task never inferred from model id` — 회귀 테스트: 구 분류기가 매칭하던 `whisper-1`/`glm-image`/`cogvideox-2`가 catalog 미선언 시 `None` 유지 (substring drift-guard 테스트 3건은 이 테스트로 대체)
- `lib/llm_provider/model_catalog.ml` inline `%test` — canonical task 파싱 / unknown 값 거부 / 미선언 `None`
- `lib/llm_provider/capability_vocab.ml` inline `%test` — vocabulary table round-trip
- `test/test_custom_provider.ml` — `contract.task` 타입 변경 반영 (`option task_testable`)

기존 substring 추론 테스트는 사전 수정 코드에서 이 브랜치의 테스트와 컴파일 자체가 불가하며(`string option` → `task option`), `task never inferred from model id`는 추론 재도입 시 실패한다.

## 검증

로컬에서 `dune build`/`dune runtest`를 실행하지 않았다 — 이 repo는 CI가 빌드/테스트 authority다. 변경 파일 전체에 `ocamlformat --inplace`(janestreet profile) 적용, 포맷 delta 없음. 전체 record literal 전수 스캔(`supported_models =`/`supports_seed_with_images =`/`cache_read_multiplier =`)으로 capabilities/model_entry를 exhaustive 구성하는 4개 사이트(default_capabilities, public_capabilities, llm_capabilities_of_provider_capabilities, test_catalog_entry)를 모두 갱신했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
