### PR TITLE
refactor(api): replace glm- prefix classifier with typed dialect resolution in agent request path (RFC-OAS-023)

### DIFF
--- a/.ci/hardening-baseline.json
+++ b/.ci/hardening-baseline.json
@@ -35,8 +35,7 @@
     ],
     "local_workspace_path_literals": [],
     "model_id_string_classifiers_outside_catalog": [
-      "lib/llm_provider/backend_gemini.ml:53:let model_id = String.lowercase_ascii (String.trim config.model_id) in",
-      "lib/provider.ml:53:let normalized = String.lowercase_ascii (String.trim model_id) in"
+      "lib/provider.ml:70:if Llm_provider.Zai_catalog.is_glm_model_id model_id && not is_native_glm"
     ],
     "stub_markers": [],
     "wildcard_silent_defaults": [
@@ -59,7 +58,7 @@
     "exception_message_classifiers": 1,
     "heuristic_markers": 2,
     "local_workspace_path_literals": 0,
-    "model_id_string_classifiers_outside_catalog": 2,
+    "model_id_string_classifiers_outside_catalog": 1,
     "stub_markers": 0,
     "wildcard_silent_defaults": 251,
     "workaround_markers": 0

--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -20,14 +20,48 @@ let system_message_json (config : agent_state) : Yojson.Safe.t list =
   | _ -> []
 ;;
 
-let capabilities_for_custom_registered name =
+let provider_config_kind_of_request_kind = function
+  | Provider.Anthropic_messages -> PConfig.Anthropic
+  | Provider.Openai_chat_completions | Provider.Custom _ -> PConfig.OpenAI_compat
+;;
+
+(* Single typed resolution of a [Provider.Custom_registered] name, shared by
+   the tool-choice validation context, the serializer's dialect projection
+   ([serialization_provider_config]) and [capabilities_for_request], so a
+   registered provider's dialect cannot drift between validation and
+   serialization. Runtime impls registered via [Provider.register_provider]
+   keep their [request_kind]-derived dispatch; they declare no static endpoint,
+   so they project to an empty [base_url] (their kind is already final and is
+   never [Glm]). Names without an impl resolve through
+   {!Llm_provider.Provider_registry.default} and keep the registry-declared
+   [defaults.kind] / [defaults.base_url] — the same SSOT
+   [Provider.provider_config_of_agent] reads — so [glm] / [glm-coding]
+   (declared [kind = Glm]) stay GLM in every consumer. Unknown names fail
+   closed with this one error in both paths. *)
+let custom_registered_projection name
+  : (PConfig.provider_kind * string * Provider.capabilities, string) result
+  =
   match Provider.find_provider name with
-  | Some impl -> Some impl.Provider.capabilities
+  | Some impl ->
+    Ok
+      ( provider_config_kind_of_request_kind impl.Provider.request_kind
+      , ""
+      , impl.Provider.capabilities )
   | None ->
     let registry = Llm_provider.Provider_registry.default () in
     (match Llm_provider.Provider_registry.find registry name with
-     | Some entry -> Some entry.capabilities
-     | None -> None)
+     | Some entry -> Ok (entry.defaults.kind, entry.defaults.base_url, entry.capabilities)
+     | None ->
+       Error
+         (Printf.sprintf
+            "Custom_registered provider %S not found in provider registries"
+            name))
+;;
+
+let capabilities_for_custom_registered name =
+  match custom_registered_projection name with
+  | Ok (_kind, _base_url, capabilities) -> Some capabilities
+  | Error _ -> None
 ;;
 
 let capabilities_for_request ?provider_config (config : agent_state) =
@@ -60,32 +94,43 @@ let capabilities_for_request ?provider_config (config : agent_state) =
 
    Enumerate every [Provider.provider] variant (the type of [cfg.provider])
    so the compiler flags any new constructor here. ZAI detection depends on a
-   declared [base_url]; [Anthropic] carries none and [Custom_registered]
-   providers keep their registry-declared dispatch (non-GLM in this builder
-   today), so both project to a non-ZAI config. A missing [?provider_config]
+   declared endpoint; [Anthropic] carries none, and [Custom_registered]
+   resolves through [custom_registered_projection] — the same typed lookup the
+   tool-choice validation context uses — so registry-declared GLM providers
+   ([glm], [glm-coding]) project to [PConfig.Glm] here exactly as they
+   validate, and unknown names fail closed with the validation path's error
+   instead of degrading to a generic config. A missing [?provider_config]
    fails closed to an empty [base_url]: a bare "glm-…" model id without a
    declared Z.AI endpoint never acquires GLM dialect, coercions, or
    capabilities ([PConfig.is_zai_glm_config] is [false] for every non-ZAI
    projection), matching the endpoint-declaration guard in
    [Provider.capabilities_for_model]. *)
-let serialization_provider_config ?provider_config (config : agent_state) : PConfig.t =
-  let kind, base_url, model_id =
+let serialization_provider_config ?provider_config (config : agent_state)
+  : (PConfig.t, string) result
+  =
+  let projection =
     match provider_config with
     | Some (cfg : Provider.config) ->
       (match cfg.provider with
        | Provider.OpenAICompat { base_url; _ } | Provider.Local { base_url } ->
-         PConfig.OpenAI_compat, base_url, cfg.model_id
-       | Provider.Anthropic -> PConfig.Anthropic, "", cfg.model_id
-       | Provider.Custom_registered _ -> PConfig.OpenAI_compat, "", cfg.model_id)
-    | None -> PConfig.OpenAI_compat, "", model_to_string config.config.model
+         Ok (PConfig.OpenAI_compat, base_url, cfg.model_id)
+       | Provider.Anthropic -> Ok (PConfig.Anthropic, "", cfg.model_id)
+       | Provider.Custom_registered { name } ->
+         (match custom_registered_projection name with
+          | Ok (kind, base_url, _capabilities) -> Ok (kind, base_url, cfg.model_id)
+          | Error msg -> Error msg))
+    | None -> Ok (PConfig.OpenAI_compat, "", model_to_string config.config.model)
   in
-  PConfig.make
-    ~kind
-    ~model_id
-    ~base_url
-    ?enable_thinking:config.config.enable_thinking
-    ?preserve_thinking:config.config.preserve_thinking
-    ()
+  Result.map
+    (fun (kind, base_url, model_id) ->
+       PConfig.make
+         ~kind
+         ~model_id
+         ~base_url
+         ?enable_thinking:config.config.enable_thinking
+         ?preserve_thinking:config.config.preserve_thinking
+         ())
+    projection
 ;;
 
 let llm_capabilities_of_provider_capabilities (caps : Provider.capabilities)
@@ -141,31 +186,15 @@ let provider_config_kind_for_openai_compat ~base_url ~model_id =
   else PConfig.OpenAI_compat
 ;;
 
-let provider_config_kind_of_request_kind = function
-  | Provider.Anthropic_messages -> PConfig.Anthropic
-  | Provider.Openai_chat_completions | Provider.Custom _ -> PConfig.OpenAI_compat
-;;
-
 let tool_choice_validation_context ?provider_config (config : agent_state) =
   match provider_config with
   | Some
       ({ Provider.provider = Provider.Custom_registered { name }; model_id; _ } :
         Provider.config) ->
-    (match Provider.find_provider name with
-     | Some impl ->
-       Ok
-         ( provider_config_kind_of_request_kind impl.Provider.request_kind
-         , model_id
-         , llm_capabilities_of_provider_capabilities impl.capabilities )
-     | None ->
-       let registry = Llm_provider.Provider_registry.default () in
-       (match Llm_provider.Provider_registry.find registry name with
-        | Some entry -> Ok (entry.defaults.kind, model_id, entry.capabilities)
-        | None ->
-          Error
-            (Printf.sprintf
-               "Custom_registered provider %S not found in provider registries"
-               name)))
+    (match custom_registered_projection name with
+     | Ok (kind, _base_url, capabilities) ->
+       Ok (kind, model_id, llm_capabilities_of_provider_capabilities capabilities)
+     | Error msg -> Error msg)
   | Some ({ provider = Provider.Anthropic; model_id; _ } : Provider.config) ->
     let caps = capabilities_for_request ?provider_config config in
     Ok (PConfig.Anthropic, model_id, llm_capabilities_of_provider_capabilities caps)
@@ -254,6 +283,7 @@ let add_sampling_field dialect (config : agent_state) field value body_assoc =
 
 (* [is_zai_glm] is [PConfig.is_zai_glm_config] of the request-boundary
    [serialization_provider_config], resolved once in
+   [build_openai_body_result] and threaded into
    [build_openai_body_unchecked] — the same typed source that drives the
    dialect and clear_thinking sites. GLM has no [tool_choice:"none"]
    representation, so the field is omitted and [should_include_tools] drops
@@ -283,10 +313,17 @@ let should_include_tools ~is_zai_glm (config : agent_state) =
   | _ -> true
 ;;
 
-let build_openai_body_unchecked ?provider_config ~config ~messages ?tools ?slot_id () =
+let build_openai_body_unchecked
+      ~(serialization_config : PConfig.t)
+      ?provider_config
+      ~config
+      ~messages
+      ?tools
+      ?slot_id
+      ()
+  =
   let model_str = model_to_string config.config.model in
   let capabilities = capabilities_for_request ?provider_config config in
-  let serialization_config = serialization_provider_config ?provider_config config in
   let is_zai_glm = PConfig.is_zai_glm_config serialization_config in
   let dialect = reasoning_dialect_for_request ~serialization_config capabilities config in
   let assistant_tool_content_format =
@@ -427,7 +464,22 @@ let build_openai_body_result ?provider_config ~config ~messages ?tools ?slot_id 
   match validate_tool_choice_request ?provider_config config with
   | Error reason -> Error reason
   | Ok () ->
-    Ok (build_openai_body_unchecked ?provider_config ~config ~messages ?tools ?slot_id ())
+    (* Same [custom_registered_projection] source as validation above: an
+       unknown registered name can only surface the one shared error, and a
+       registered GLM provider reaches the serializer with the same [Glm]
+       kind it validated under. *)
+    (match serialization_provider_config ?provider_config config with
+     | Error reason -> Error reason
+     | Ok serialization_config ->
+       Ok
+         (build_openai_body_unchecked
+            ~serialization_config
+            ?provider_config
+            ~config
+            ~messages
+            ?tools
+            ?slot_id
+            ()))
 ;;
 
 let build_openai_body ?provider_config ~config ~messages ?tools ?slot_id () =
@@ -436,4 +488,61 @@ let build_openai_body ?provider_config ~config ~messages ?tools ?slot_id () =
   with
   | Ok body -> body
   | Error reason -> invalid_arg ("build_openai_body: " ^ reason)
+;;
+
+[@@@coverage off]
+
+(* === Inline tests ===
+
+   Serializer-side dialect projection proofs (PR #2439 review): the
+   [Custom_registered] kind seen by the serializer must come from the shared
+   [custom_registered_projection] — never from a "glm-" model-id prefix — and
+   unknown names must fail closed with exactly the validation path's error.
+   [Provider_registry.default] declares [glm] / [glm-coding] with
+   [kind = Glm]; "charglm-3" is a Z.AI model id outside the "glm-" prefix
+   family, so a prefix classifier could not produce these results. *)
+let inline_test_agent_state model =
+  { Types.config = { Types.default_config with model }
+  ; messages = []
+  ; turn_count = 0
+  ; usage = Types.empty_usage
+  }
+;;
+
+let inline_test_registered_provider name model_id : Provider.config =
+  { Provider.provider = Provider.Custom_registered { name }; model_id; api_key_env = "" }
+;;
+
+let%test "serializer projects registered glm to GLM dialect without model-id prefix" =
+  let provider_config = inline_test_registered_provider "glm" "charglm-3" in
+  match
+    serialization_provider_config ~provider_config (inline_test_agent_state "charglm-3")
+  with
+  | Ok projected -> PConfig.is_zai_glm_config projected
+  | Error _ -> false
+;;
+
+let%test
+    "serializer projects registered glm-coding to GLM dialect without model-id prefix"
+  =
+  let provider_config = inline_test_registered_provider "glm-coding" "charglm-3" in
+  match
+    serialization_provider_config ~provider_config (inline_test_agent_state "charglm-3")
+  with
+  | Ok projected -> PConfig.is_zai_glm_config projected
+  | Error _ -> false
+;;
+
+let%test "serializer and validation fail closed identically for unknown registered name" =
+  let provider_config =
+    inline_test_registered_provider "no-such-registered-provider" "charglm-3"
+  in
+  let state = inline_test_agent_state "charglm-3" in
+  match
+    ( serialization_provider_config ~provider_config state
+    , validate_tool_choice_request ~provider_config state )
+  with
+  | Error serialization_error, Error validation_error ->
+    String.equal serialization_error validation_error
+  | Ok _, Ok _ | Ok _, Error _ | Error _, Ok _ -> false
 ;;

--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -51,25 +51,41 @@ let capabilities_for_request ?provider_config (config : agent_state) =
       ~model_id:(model_to_string config.config.model)
 ;;
 
-let is_zai_provider_config (cfg : Provider.config) =
-  (* Enumerate every [Provider.provider] variant (the type of
-     [cfg.provider]) so the compiler flags any new constructor here.
-     ZAI detection depends on a [base_url] field; [Anthropic] and
-     [Custom_registered] don't carry one so they are non-ZAI today,
-     but a future base_url-carrying variant (e.g. [Provider_n_server],
-     [Openrouter]) would silently inherit "non-ZAI" under the previous
-     [_ -> false] catch-all even if its URL was a ZAI endpoint. *)
-  match cfg.provider with
-  | Provider.OpenAICompat { base_url; _ } | Provider.Local { base_url } ->
-    Llm_provider.Zai_catalog.is_zai_base_url base_url
-  | Provider.Anthropic | Provider.Custom_registered _ -> false
-;;
+(* Typed request-boundary projection for GLM (Z.AI) dialect decisions,
+   mirroring the provider-client path's [Provider_config.t] boundary in
+   [Backend_openai_request]. Only [kind]/[base_url]/[model_id] and the
+   thinking fields feeding [PConfig.glm_should_replay_reasoning] /
+   [PConfig.zai_glm_clear_thinking_request_field] are populated; do not read
+   sampling or transport fields from it.
 
-let is_glm_request ?provider_config (config : agent_state) =
-  match provider_config with
-  | Some (cfg : Provider.config) ->
-    is_zai_provider_config cfg && Llm_provider.Zai_catalog.is_glm_model_id cfg.model_id
-  | None -> Llm_provider.Zai_catalog.is_glm_model_id (model_to_string config.config.model)
+   Enumerate every [Provider.provider] variant (the type of [cfg.provider])
+   so the compiler flags any new constructor here. ZAI detection depends on a
+   declared [base_url]; [Anthropic] carries none and [Custom_registered]
+   providers keep their registry-declared dispatch (non-GLM in this builder
+   today), so both project to a non-ZAI config. A missing [?provider_config]
+   fails closed to an empty [base_url]: a bare "glm-…" model id without a
+   declared Z.AI endpoint never acquires GLM dialect, coercions, or
+   capabilities ([PConfig.is_zai_glm_config] is [false] for every non-ZAI
+   projection), matching the endpoint-declaration guard in
+   [Provider.capabilities_for_model]. *)
+let serialization_provider_config ?provider_config (config : agent_state) : PConfig.t =
+  let kind, base_url, model_id =
+    match provider_config with
+    | Some (cfg : Provider.config) ->
+      (match cfg.provider with
+       | Provider.OpenAICompat { base_url; _ } | Provider.Local { base_url } ->
+         PConfig.OpenAI_compat, base_url, cfg.model_id
+       | Provider.Anthropic -> PConfig.Anthropic, "", cfg.model_id
+       | Provider.Custom_registered _ -> PConfig.OpenAI_compat, "", cfg.model_id)
+    | None -> PConfig.OpenAI_compat, "", model_to_string config.config.model
+  in
+  PConfig.make
+    ~kind
+    ~model_id
+    ~base_url
+    ?enable_thinking:config.config.enable_thinking
+    ?preserve_thinking:config.config.preserve_thinking
+    ()
 ;;
 
 let llm_capabilities_of_provider_capabilities (caps : Provider.capabilities)
@@ -119,8 +135,8 @@ let llm_capabilities_of_provider_capabilities (caps : Provider.capabilities)
 
 let provider_config_kind_for_openai_compat ~base_url ~model_id =
   if
-    Llm_provider.Zai_catalog.is_zai_base_url base_url
-    && Llm_provider.Zai_catalog.is_glm_model_id model_id
+    PConfig.is_zai_glm_config
+      (PConfig.make ~kind:PConfig.OpenAI_compat ~model_id ~base_url ())
   then PConfig.Glm
   else PConfig.OpenAI_compat
 ;;
@@ -174,12 +190,14 @@ let tool_choice_validation_context ?provider_config (config : agent_state) =
     in
     Ok (provider_kind, model_id, caps)
   | None ->
+    (* No declared provider endpoint: fail closed to the generic
+       OpenAI-compatible contract. A bare "glm-…" model id is not an endpoint
+       declaration, so it acquires neither GLM kind nor GLM capabilities here
+       (endpoint-declaration guard parity with
+       [Provider.capabilities_for_model]). *)
     let model_id = model_to_string config.config.model in
-    if Llm_provider.Zai_catalog.is_glm_model_id model_id
-    then Ok (PConfig.Glm, model_id, Llm_provider.Capabilities.glm_capabilities)
-    else (
-      let caps = capabilities_for_request config in
-      Ok (PConfig.OpenAI_compat, model_id, llm_capabilities_of_provider_capabilities caps))
+    let caps = capabilities_for_request config in
+    Ok (PConfig.OpenAI_compat, model_id, llm_capabilities_of_provider_capabilities caps)
 ;;
 
 let validate_tool_choice_request ?provider_config (config : agent_state) =
@@ -195,12 +213,33 @@ let validate_tool_choice_request ?provider_config (config : agent_state) =
          caps)
 ;;
 
-let reasoning_dialect_for_request capabilities (config : agent_state) =
-  capabilities
-  |> llm_capabilities_of_provider_capabilities
-  |> Llm_provider.Reasoning_dialect.of_capabilities
-  |> Llm_provider.Reasoning_dialect.with_preserve_thinking
-       ~preserve_thinking:config.config.preserve_thinking
+let reasoning_dialect_for_request
+      ~(serialization_config : PConfig.t)
+      capabilities
+      (config : agent_state)
+  =
+  let dialect =
+    capabilities
+    |> llm_capabilities_of_provider_capabilities
+    |> Llm_provider.Reasoning_dialect.of_capabilities
+    |> Llm_provider.Reasoning_dialect.with_preserve_thinking
+         ~preserve_thinking:config.config.preserve_thinking
+  in
+  (* RFC-OAS-029 S3.1: GLM Preserved-Thinking replay resolves to a typed
+     [replay_policy] at this single dialect boundary (mirroring
+     [Reasoning_dialect.for_provider_config]), so the message serializer below
+     consumes only the typed policy via
+     [Backend_openai_serialize.dialect_messages_of_message] instead of
+     re-deriving GLM-ness at serialize time. *)
+  if PConfig.is_zai_glm_config serialization_config
+  then
+    { dialect with
+      Llm_provider.Reasoning_dialect.replay_policy =
+        (if PConfig.glm_should_replay_reasoning serialization_config
+         then Llm_provider.Reasoning_dialect.Preserve_always
+         else Llm_provider.Reasoning_dialect.No_replay)
+    }
+  else dialect
 ;;
 
 let add_sampling_field dialect (config : agent_state) field value body_assoc =
@@ -213,15 +252,23 @@ let add_sampling_field dialect (config : agent_state) field value body_assoc =
   else (field, value) :: body_assoc
 ;;
 
+(* [is_zai_glm] is [PConfig.is_zai_glm_config] of the request-boundary
+   [serialization_provider_config], resolved once in
+   [build_openai_body_unchecked] — the same typed source that drives the
+   dialect and clear_thinking sites. GLM has no [tool_choice:"none"]
+   representation, so the field is omitted and [should_include_tools] drops
+   the tools list; GLM only documents ["auto"] (see
+   [Capabilities.glm_capabilities]), so [Auto]/[Any] serialize as ["auto"]
+   ([Any] is already rejected by [validate_tool_choice_request] before
+   serialization). *)
 let effective_tool_choice_json
       (capabilities : Provider.capabilities)
-      ?provider_config
+      ~is_zai_glm
       (config : agent_state)
   =
-  let is_glm = is_glm_request ?provider_config config in
   match config.config.tool_choice with
-  | Some Types.None_ when is_glm -> None
-  | Some (Types.Auto | Types.Any) when is_glm ->
+  | Some Types.None_ when is_zai_glm -> None
+  | Some (Types.Auto | Types.Any) when is_zai_glm ->
     Some (tool_choice_to_openai_json Types.Auto)
   | Some Types.Auto when capabilities.supports_tool_choice ->
     Some (tool_choice_to_openai_json Types.Auto)
@@ -230,16 +277,18 @@ let effective_tool_choice_json
   | _ -> None
 ;;
 
-let should_include_tools ?provider_config (config : agent_state) =
+let should_include_tools ~is_zai_glm (config : agent_state) =
   match config.config.tool_choice with
-  | Some Types.None_ when is_glm_request ?provider_config config -> false
+  | Some Types.None_ when is_zai_glm -> false
   | _ -> true
 ;;
 
 let build_openai_body_unchecked ?provider_config ~config ~messages ?tools ?slot_id () =
   let model_str = model_to_string config.config.model in
   let capabilities = capabilities_for_request ?provider_config config in
-  let dialect = reasoning_dialect_for_request capabilities config in
+  let serialization_config = serialization_provider_config ?provider_config config in
+  let is_zai_glm = PConfig.is_zai_glm_config serialization_config in
+  let dialect = reasoning_dialect_for_request ~serialization_config capabilities config in
   let assistant_tool_content_format =
     capabilities.Provider.assistant_tool_content_format
   in
@@ -248,29 +297,25 @@ let build_openai_body_unchecked ?provider_config ~config ~messages ?tools ?slot_
     | Some entries
       when entries <> []
            && capabilities.supports_tools
-           && should_include_tools ?provider_config config -> Some entries
+           && should_include_tools ~is_zai_glm config -> Some entries
     | _ -> None
   in
   let sanitized_messages =
     Llm_provider.Backend_openai_serialize.close_tool_message_pairs_for_request messages
   in
   let provider_messages =
+    (* Reasoning replay is decided by the typed dialect
+       ([Reasoning_dialect.should_replay_reasoning] via [replay_policy]),
+       resolved once in [reasoning_dialect_for_request]; the serializer no
+       longer branches on GLM-ness. GLM's tool-only assistant content shape
+       comes from [assistant_tool_content_format]
+       ([Assistant_tool_content_empty_string] in
+       [Capabilities.glm_capabilities]), matching the provider-client path in
+       [Backend_openai_request.build_request_assoc]. *)
     let message_serializer =
-      (* Gate GLM reasoning_content replay on Preserved Thinking, matching the
-         provider-client path in Backend_openai_request via the same SSOT
-         predicate. [Types.agent_config] carries no [clear_thinking] field, so it
-         resolves from [preserve_thinking]. *)
-      if
-        is_glm_request ?provider_config config
-        && Llm_provider.Provider_config.glm_should_replay_reasoning_fields
-             ~enable_thinking:config.config.enable_thinking
-             ~clear_thinking:None
-             ~preserve_thinking:config.config.preserve_thinking
-      then Llm_provider.Backend_openai_serialize.glm_messages_of_message
-      else
-        Llm_provider.Backend_openai_serialize.dialect_messages_of_message
-          ~assistant_tool_content_format
-          dialect
+      Llm_provider.Backend_openai_serialize.dialect_messages_of_message
+        ~assistant_tool_content_format
+        dialect
     in
     system_message_json config @ List.concat_map message_serializer sanitized_messages
   in
@@ -312,11 +357,14 @@ let build_openai_body_unchecked ?provider_config ~config ~messages ?tools ?slot_
     then body_assoc
     else (
       let zai_glm_clear_thinking =
+        (* [Types.agent_config] carries no [clear_thinking] field, so the
+           projection's [clear_thinking = None] resolves from
+           [preserve_thinking] inside the SSOT resolver. *)
         Llm_provider.Provider_config.zai_glm_clear_thinking_request_field
           ~thinking_control_format:capabilities.thinking_control_format
-          ~is_zai_glm:(is_glm_request ?provider_config config)
-          ~clear_thinking:None
-          ~preserve_thinking:config.config.preserve_thinking
+          ~is_zai_glm
+          ~clear_thinking:serialization_config.PConfig.clear_thinking
+          ~preserve_thinking:serialization_config.PConfig.preserve_thinking
       in
       Llm_provider.Reasoning_dialect.request_control_fields
         dialect
@@ -338,7 +386,7 @@ let build_openai_body_unchecked ?provider_config ~config ~messages ?tools ?slot_
     | None -> body_assoc
   in
   let body_assoc =
-    match effective_tool_choice_json capabilities ?provider_config config with
+    match effective_tool_choice_json capabilities ~is_zai_glm config with
     | Some choice_json -> ("tool_choice", choice_json) :: body_assoc
     | None -> body_assoc
   in

--- a/scripts/hardening-ratchet.sh
+++ b/scripts/hardening-ratchet.sh
@@ -48,6 +48,12 @@ MODEL_ID_STRING_CLASSIFIER_RE = re.compile(
     r".*\b(?:config\.)?model(?:_id)?\b"
     r"|\b(?:config\.)?model(?:_id)?\b"
     r".*\bString\.(?:lowercase_ascii|uppercase_ascii|starts_with|ends_with|contains|equal)\b"
+    # Delegated model-id prefix classification: calling the Zai_catalog GLM
+    # prefix classifier outside the catalog/capability boundary is the same
+    # SSOT drift as inlining String.starts_with on a model id, but the lexical
+    # String.* patterns above cannot see the delegation (RFC-OAS-023/029;
+    # the api_openai.ml is_glm_request removal is the reference cleanup).
+    r"|\bis_glm_model_id\b"
 )
 # Fuzzy string classification of a base_url / host, forbidden by RFC-OAS-034
 # (host/URL is transport, not capability provenance). Only the inexact matchers

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -1453,6 +1453,146 @@ let test_build_openai_body_glm_tool_choice_none_omits_tools () =
   check bool "tools omitted for glm none" false (List.mem_assoc "tools" assoc)
 ;;
 
+(* PR #2439 review regression: a provider registered in
+   [Provider_registry.default] with [kind = Glm] must serialize with the full
+   GLM dialect even though the model id carries no "glm-" prefix — the
+   serializer resolves [Custom_registered] through the same typed registry
+   projection as validation. Before the shared projection, the serializer
+   degraded every [Custom_registered] to a synthetic (OpenAI_compat, "")
+   config: validation classified the request as GLM while the body below
+   lost the reasoning_content replay and the thinking.clear_thinking field. *)
+let test_build_openai_body_registered_glm_gets_glm_dialect () =
+  let model_id = "charglm-3" in
+  check
+    bool
+    "premise: model id has no glm- prefix"
+    false
+    (Llm_provider.Zai_catalog.is_glm_model_id model_id);
+  let provider_config = declared_provider_config "glm" model_id in
+  let messages =
+    [ { Types.role = Types.Assistant
+      ; content =
+          [ Types.Thinking { signature = None; content = "I should call the calculator." }
+          ; Types.ToolUse
+              { id = "call_1"
+              ; name = "calculator"
+              ; input = `Assoc [ "expr", `String "2+2" ]
+              }
+          ]
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = []
+      }
+    ]
+  in
+  let state =
+    { Types.config =
+        { Types.default_config with
+          model = model_id
+        ; enable_thinking = Some true
+        ; preserve_thinking = Some true
+        }
+    ; messages = []
+    ; turn_count = 0
+    ; usage = Types.empty_usage
+    }
+  in
+  let json =
+    Api.build_openai_body ~provider_config ~config:state ~messages ()
+    |> Yojson.Safe.from_string
+  in
+  let open Yojson.Safe.Util in
+  let assistant = json |> member "messages" |> index 0 in
+  check
+    string
+    "reasoning_content replayed for registered glm"
+    "I should call the calculator."
+    (assistant |> member "reasoning_content" |> to_string);
+  check
+    bool
+    "preserved registered glm request clears no thinking"
+    false
+    (json |> member "thinking" |> member "clear_thinking" |> to_bool)
+;;
+
+(* Same registry-kind proof for [glm-coding] through the tool-choice coercion
+   arm: GLM has no [tool_choice:"none"] representation, so both the field and
+   the tools list are dropped. Before the shared projection, the degraded
+   generic config serialized ["none"] and kept the tools list. *)
+let test_build_openai_body_registered_glm_coding_tool_choice_none_omits_tools () =
+  let model_id = "charglm-3" in
+  check
+    bool
+    "premise: model id has no glm- prefix"
+    false
+    (Llm_provider.Zai_catalog.is_glm_model_id model_id);
+  let provider_config = declared_provider_config "glm-coding" model_id in
+  let state =
+    { Types.config =
+        { Types.default_config with model = model_id; tool_choice = Some Types.None_ }
+    ; messages = []
+    ; turn_count = 0
+    ; usage = Types.empty_usage
+    }
+  in
+  let tool_json =
+    `Assoc
+      [ "name", `String "calculator"
+      ; "description", `String "math"
+      ; "input_schema", `Assoc [ "type", `String "object" ]
+      ]
+  in
+  let json =
+    Api.build_openai_body
+      ~provider_config
+      ~config:state
+      ~messages:[]
+      ~tools:[ tool_json ]
+      ()
+    |> Yojson.Safe.from_string
+  in
+  let open Yojson.Safe.Util in
+  let assoc = to_assoc json in
+  check
+    bool
+    "tool_choice omitted for registered glm-coding none"
+    false
+    (List.mem_assoc "tool_choice" assoc);
+  check
+    bool
+    "tools omitted for registered glm-coding none"
+    false
+    (List.mem_assoc "tools" assoc)
+;;
+
+(* A [Custom_registered] name absent from both provider registries fails
+   closed through the public builder: validation and the serializer's dialect
+   projection share one [custom_registered_projection] resolver, so the only
+   observable outcome is this single typed error — never a silently degraded
+   generic body. *)
+let test_build_openai_body_unknown_registered_provider_fails_closed () =
+  let provider_config =
+    declared_provider_config "no-such-registered-provider" "charglm-3"
+  in
+  let state =
+    { Types.config = { Types.default_config with model = "charglm-3" }
+    ; messages = []
+    ; turn_count = 0
+    ; usage = Types.empty_usage
+    }
+  in
+  match Api.build_openai_body_result ~provider_config ~config:state ~messages:[] () with
+  | Ok _ -> fail "expected fail-closed error for unknown Custom_registered provider"
+  | Error reason ->
+    check
+      bool
+      "names the unknown provider"
+      true
+      (contains_substring
+         ~sub:{|"no-such-registered-provider" not found in provider registries|}
+         reason)
+;;
+
 (* ------------------------------------------------------------------ *)
 (* parse_response                                                       *)
 (* ------------------------------------------------------------------ *)
@@ -2321,6 +2461,18 @@ let () =
             "glm none tool_choice omits tools"
             `Quick
             test_build_openai_body_glm_tool_choice_none_omits_tools
+        ; test_case
+            "registered glm gets glm dialect"
+            `Quick
+            test_build_openai_body_registered_glm_gets_glm_dialect
+        ; test_case
+            "registered glm-coding none tool_choice omits tools"
+            `Quick
+            test_build_openai_body_registered_glm_coding_tool_choice_none_omits_tools
+        ; test_case
+            "unknown registered provider fails closed"
+            `Quick
+            test_build_openai_body_unknown_registered_provider_fails_closed
         ; test_case "with cache_system_prompt" `Quick test_build_body_with_cache
         ; test_case
             "tools cache_control with flag"

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -1027,7 +1027,15 @@ let test_build_openai_body_rejects_glm_forced_tool_choice () =
   | Ok _ -> fail "expected Result.Error for unsupported GLM named tool_choice"
 ;;
 
-let test_build_openai_body_rejects_bare_glm_forced_tool_choice () =
+(* Endpoint-declaration fail-closed guard: a bare "glm-…" model id without a
+   declared Z.AI [?provider_config] endpoint is not a GLM request. It resolves
+   to the generic OpenAI-compatible contract, so the named tool_choice that a
+   declared GLM endpoint rejects
+   ([test_build_openai_body_rejects_glm_forced_tool_choice]) validates and
+   serializes as the standard function form here. Before the typed-dialect
+   reshape, [is_glm_request] classified this request as GLM from the model-id
+   prefix alone and rejected it. *)
+let test_build_openai_body_bare_glm_named_tool_choice_is_generic () =
   let state =
     { Types.config =
         { Types.default_config with
@@ -1051,9 +1059,164 @@ let test_build_openai_body_rejects_bare_glm_forced_tool_choice () =
     Api.build_openai_body_result ~config:state ~messages:[] ~tools:[ tool_json ] ()
   with
   | Error reason ->
-    check bool "mentions tool_choice" true (contains_substring ~sub:"tool_choice" reason);
-    check bool "mentions tool name" true (contains_substring ~sub:"calculator" reason)
-  | Ok _ -> fail "expected Result.Error for unsupported bare GLM named tool_choice"
+    fail ("expected generic OpenAI-compat acceptance for bare glm model id: " ^ reason)
+  | Ok body ->
+    let json = Yojson.Safe.from_string body in
+    let open Yojson.Safe.Util in
+    check
+      string
+      "named function form preserved"
+      "calculator"
+      (json |> member "tool_choice" |> member "function" |> member "name" |> to_string);
+    check bool "tools preserved" true (List.mem_assoc "tools" (to_assoc json))
+;;
+
+(* Complement of [test_build_openai_body_glm_preserves_reasoning_content]: the
+   same Preserved-Thinking configuration WITHOUT a declared Z.AI endpoint gets
+   no GLM dialect behavior. Before the typed-dialect reshape, the prefix-only
+   [is_glm_request] None-branch replayed prior-turn reasoning_content for any
+   "glm-…" model id regardless of endpoint. *)
+let test_build_openai_body_bare_glm_gets_no_glm_dialect () =
+  let messages =
+    [ { Types.role = Types.Assistant
+      ; content =
+          [ Types.Thinking { signature = None; content = "I should call the calculator." }
+          ; Types.ToolUse
+              { id = "call_1"
+              ; name = "calculator"
+              ; input = `Assoc [ "expr", `String "2+2" ]
+              }
+          ]
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = []
+      }
+    ]
+  in
+  let state =
+    { Types.config =
+        { Types.default_config with
+          model = "glm-5"
+        ; enable_thinking = Some true
+        ; preserve_thinking = Some true
+        }
+    ; messages = []
+    ; turn_count = 0
+    ; usage = Types.empty_usage
+    }
+  in
+  let json =
+    Api.build_openai_body ~config:state ~messages () |> Yojson.Safe.from_string
+  in
+  let open Yojson.Safe.Util in
+  let assistant = json |> member "messages" |> index 0 in
+  check
+    bool
+    "no reasoning_content replay without declared endpoint"
+    false
+    (List.mem_assoc "reasoning_content" (to_assoc assistant));
+  check
+    bool
+    "no GLM thinking object without declared endpoint"
+    false
+    (List.mem_assoc "thinking" (to_assoc json))
+;;
+
+(* GLM's tool_choice [None_] coercion (omit the field, drop the tools list —
+   [test_build_openai_body_glm_tool_choice_none_omits_tools]) applies only
+   behind a declared Z.AI endpoint; a bare "glm-…" model id keeps the generic
+   OpenAI-compatible ["none"] serialization with tools intact. Before the
+   typed-dialect reshape, the prefix classifier dropped both. *)
+let test_build_openai_body_bare_glm_tool_choice_none_is_generic () =
+  let state =
+    { Types.config =
+        { Types.default_config with model = "glm-5"; tool_choice = Some Types.None_ }
+    ; messages = []
+    ; turn_count = 0
+    ; usage = Types.empty_usage
+    }
+  in
+  let tool_json =
+    `Assoc
+      [ "name", `String "calculator"
+      ; "description", `String "math"
+      ; "input_schema", `Assoc [ "type", `String "object" ]
+      ]
+  in
+  let json =
+    Api.build_openai_body ~config:state ~messages:[] ~tools:[ tool_json ] ()
+    |> Yojson.Safe.from_string
+  in
+  let open Yojson.Safe.Util in
+  check
+    string
+    "generic none tool_choice serialized"
+    "none"
+    (json |> member "tool_choice" |> to_string);
+  check bool "tools preserved" true (List.mem_assoc "tools" (to_assoc json))
+;;
+
+(* Declared Z.AI GLM endpoint under the default clear_thinking=true (no
+   [preserve_thinking]): the typed dialect resolves to No_replay, so
+   prior-turn reasoning_content stays out of the request history even though
+   the request is GLM (RFC-OAS-030). Locks the non-replay arm of the typed
+   [replay_policy] promotion in [reasoning_dialect_for_request]. *)
+let test_build_openai_body_glm_default_clear_thinking_skips_replay () =
+  let provider_config =
+    { Provider.provider =
+        Provider.OpenAICompat
+          { base_url = Llm_provider.Zai_catalog.general_base_url
+          ; auth_header = None
+          ; path = "/chat/completions"
+          ; static_token = None
+          }
+    ; model_id = "glm-5"
+    ; api_key_env = ""
+    }
+  in
+  let messages =
+    [ { Types.role = Types.Assistant
+      ; content =
+          [ Types.Thinking { signature = None; content = "I should call the calculator." }
+          ; Types.ToolUse
+              { id = "call_1"
+              ; name = "calculator"
+              ; input = `Assoc [ "expr", `String "2+2" ]
+              }
+          ]
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = []
+      }
+    ]
+  in
+  let state =
+    { Types.config =
+        { Types.default_config with
+          model = provider_config.model_id
+        ; enable_thinking = Some true
+        }
+    ; messages = []
+    ; turn_count = 0
+    ; usage = Types.empty_usage
+    }
+  in
+  let json =
+    Api.build_openai_body ~provider_config ~config:state ~messages ()
+    |> Yojson.Safe.from_string
+  in
+  let open Yojson.Safe.Util in
+  let assistant = json |> member "messages" |> index 0 in
+  check
+    bool
+    "no reasoning_content replay under default clear_thinking"
+    false
+    (List.mem_assoc "reasoning_content" (to_assoc assistant));
+  check
+    bool
+    "clearing GLM request clears thinking"
+    true
+    (json |> member "thinking" |> member "clear_thinking" |> to_bool)
 ;;
 
 let test_build_openai_body_glm_preserves_reasoning_content () =
@@ -2123,9 +2286,21 @@ let () =
             `Quick
             test_build_openai_body_rejects_glm_forced_tool_choice
         ; test_case
-            "bare glm rejects unsupported forced tool choice"
+            "bare glm named tool choice is generic"
             `Quick
-            test_build_openai_body_rejects_bare_glm_forced_tool_choice
+            test_build_openai_body_bare_glm_named_tool_choice_is_generic
+        ; test_case
+            "bare glm gets no glm dialect"
+            `Quick
+            test_build_openai_body_bare_glm_gets_no_glm_dialect
+        ; test_case
+            "bare glm none tool_choice is generic"
+            `Quick
+            test_build_openai_body_bare_glm_tool_choice_none_is_generic
+        ; test_case
+            "glm default clear_thinking skips replay"
+            `Quick
+            test_build_openai_body_glm_default_clear_thinking_skips_replay
         ; test_case
             "glm preserved reasoning replay"
             `Quick


### PR DESCRIPTION
## 문제

원 보고서: 05-oas-pr2232-adversarial 스윕 `oas-glm-string-classifier-remains` (triage brief problem-11, oas HEAD 3592c0553 기준 검증).

RFC-OAS-023가 금지하는 model-id string classifier가 agent 요청 경로에 남아 있었습니다. provider-client 경로는 PR #2378 (62292f3b8)에서 typed dialect로 재구성되었지만, `lib/api_openai.ml`은 serialize 시점마다 `Zai_catalog.is_glm_model_id` prefix classifier로 GLM 여부를 5개 분기에서 재유도했고, `?provider_config:None` 분기는 endpoint 선언 없이 model-id prefix만으로 GLM dialect/capabilities를 부여했습니다.

## 적대적 검증 근거

pinned base 2d88271786331978f91001f73ff7f2711fed8775에서 재검증 완료 (evidence는 3592c0553 기준이었으나 동일 코드가 base에 그대로 존재):

- `lib/api_openai.ml:68-73` — `is_glm_request`; None 분기(line 72)는 prefix-only, endpoint gate 없음
- `lib/api_openai.ml:176-182` — `tool_choice_validation_context` None 분기가 bare prefix에 `PConfig.Glm` + `glm_capabilities` 부여
- `lib/api_openai.ml:221-231, 233-237` — GLM tool_choice coercion/tools drop이 `is_glm_request` 재호출로 분기
- `lib/api_openai.ml:263-274` — serialize 시점에 `is_glm_request`로 `glm_messages_of_message` 선택 (RFC-OAS-029 S3.1 anti-pattern, `reasoning_dialect.ml:396-414` 주석이 명시적으로 지목)
- `lib/api_openai.ml:314-319` — `zai_glm_clear_thinking` gate가 별도 `is_glm_request` 호출
- `lib/llm_provider/zai_catalog.ml:11-14` — `is_glm_model_id` (boundary 모듈, 유지)
- `.ci/hardening-ratchet-config.json` — ratchet lexical scan은 위임 호출(`is_glm_model_id`)을 감지하지 못함

내부 runtime 호출자 3곳(`lib/api.ml:130`, `lib/streaming.ml:149`, `lib/provider_intf.ml:118`)은 모두 host-gated `~provider_config`를 전달하므로, ungated 경로는 public `Api.build_openai_body` surface로만 도달 가능 (P1이 아닌 P2로 평가된 근거).

## 근본 수정

PR #2378의 reshape를 agent 경로로 이식:

1. **typed request-boundary projection** — `serialization_provider_config`가 요청당 1회 `Provider_config.t`를 구성하고, GLM 여부는 `PConfig.is_zai_glm_config` (endpoint + model id, typed SSOT)로만 판정. `Provider.provider` variant를 exhaustive match (catch-all 없음).
2. **serializer 분기 제거** — `reasoning_dialect_for_request`가 `Reasoning_dialect.for_provider_config`와 동일하게 GLM Preserved-Thinking replay를 typed `replay_policy`로 승격, serializer는 `dialect_messages_of_message` 단일 경로로 typed policy만 소비. `glm_messages_of_message` 특수 분기 삭제 (GLM tool-only content shape는 `glm_capabilities`의 `Assistant_tool_content_empty_string`이 담당 — provider-client 경로와 동일).
3. **tool_choice coercion/drop** — serialize 시점 재유도 대신 boundary에서 1회 해석한 `is_zai_glm`을 소비 (`zai_glm_clear_thinking_request_field ~is_zai_glm`와 동일한 관례).
4. **clear_thinking** — 동일한 typed projection의 필드(`clear_thinking`/`preserve_thinking`)에서 공급.
5. **fail-closed None 분기** — `?provider_config` 없이 bare "glm-" model id는 GLM kind/capabilities/coercion을 획득하지 못하고 generic OpenAI-compatible 계약으로 해석 (#2383/#2410 endpoint-declaration guard와 정합).
6. **`is_glm_request`/`is_zai_provider_config` 삭제** — `api_openai.ml`에서 `Zai_catalog` 참조 0건.
7. **ratchet 강화** — `MODEL_ID_STRING_CLASSIFIER_RE`에 위임 호출 토큰 `is_glm_model_id` 추가 (lexical scan이 위임을 놓치던 갭). boundary 외 잔존 호출은 `lib/provider.ml:70` (endpoint-declaration guard 자체) 1건이며, baseline을 2→1로 조임 — 재유입 시 즉시 gate 실패. brief의 "boundary paths에 api_openai.ml 추가"는 allowlist 완화라서 채택하지 않고, 감지 강화 + baseline 조임으로 대체.

## 테스트

`test/test_api.ml`:

- `test_build_openai_body_bare_glm_named_tool_choice_is_generic` — bare "glm-5" + named tool_choice가 generic 계약으로 수용/직렬화 (pre-fix: GLM으로 오분류되어 Error → 수정 전 코드에서 실패)
- `test_build_openai_body_bare_glm_gets_no_glm_dialect` — Preserved-Thinking 설정이라도 endpoint 선언 없으면 reasoning_content replay 없음 (pre-fix: prefix만으로 replay → 수정 전 코드에서 실패)
- `test_build_openai_body_bare_glm_tool_choice_none_is_generic` — bare glm + `None_`은 generic `"none"` 직렬화 + tools 유지 (pre-fix: GLM drop → 수정 전 코드에서 실패)
- `test_build_openai_body_glm_default_clear_thinking_skips_replay` — 선언된 Z.AI endpoint + 기본 clear_thinking=true에서 typed No_replay arm lock (RFC-OAS-030 parity)
- 기존 declared-endpoint GLM 테스트(`glm_preserves_reasoning_content`, `glm_clears_thinking_when_not_preserving`, `glm_tool_choice_none_omits_tools`, `rejects_glm_forced_tool_choice`, `does_not_treat_non_zai_glm_as_glm`)는 무수정 유지 — typed 경로의 wire parity 증명
- 구 `test_build_openai_body_rejects_bare_glm_forced_tool_choice`는 제거된 prefix-classifier 동작을 lock하고 있어 fail-closed 의미론으로 대체

ratchet: `bash scripts/hardening-ratchet.sh --self-test` OK, `--check` OK (`model_id_string_classifiers_outside_catalog` 1 ≤ 1, `wildcard_silent_defaults` 251 held).

## 검증

- 로컬 dune build/runtest 미실행 — 이 repo는 CI가 빌드/테스트 authority (worktree dune 오염 방지 정책). 변경 파일은 ocamlformat --inplace 적용 완료.
- `scripts/hardening-ratchet.sh --self-test / --check / --measure` 로컬 실행 green.
- `rg`로 `api_openai.ml` 내 `Zai_catalog`/`is_glm_request`/`glm_messages_of_message` 참조 0건 확인.

Refs: RFC-OAS-023, RFC-OAS-029 S3.1, RFC-OAS-030, RFC-OAS-034 / PR #2378, #2377, #2380, #2381, #2383, #2410

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
