### PR TITLE
fix(provider): Ollama Cloud /v1 does not guarantee structured output

### DIFF
--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -436,8 +436,18 @@ let ollama_capabilities =
    replies still reach the user through the display path
    ([Api.text_blocks_to_string] includes [Thinking] blocks); they are no longer
    promoted into assistant answer text, which previously re-injected reasoning on
-   replay and caused the CoT loop (#2236). *)
-let ollama_cloud_capabilities = ollama_capabilities
+   replay and caused the CoT loop (#2236).
+
+   IMPORTANT: do not inherit [supports_structured_output] from local Ollama.
+   MASC and other consumers reach Ollama Cloud through the OpenAI-compatible
+   [/v1/chat/completions] transport, which accepts [response_format.type =
+   json_schema] but does NOT guarantee schema-shaped output. The native Ollama
+   [/api/chat] transport (provider kind [Ollama]) enforces schemas via the
+   [format] field and keeps [supports_structured_output = true]. Models that
+   have been live-verified to return exact schema-shaped JSON through the
+   [/v1] path opt in per-row in [models.toml]. *)
+let ollama_cloud_capabilities =
+  { ollama_capabilities with supports_structured_output = false }
 
 let dashscope_capabilities =
   { openai_compat_chat_extended_capabilities with

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -448,6 +448,7 @@ let ollama_capabilities =
    [/v1] path opt in per-row in [models.toml]. *)
 let ollama_cloud_capabilities =
   { ollama_capabilities with supports_structured_output = false }
+;;
 
 let dashscope_capabilities =
   { openai_compat_chat_extended_capabilities with

--- a/models.toml
+++ b/models.toml
@@ -414,6 +414,8 @@ thinking_control_format = "ollama_think"
 supports_multimodal_inputs = false
 supports_image_input = false
 supports_native_streaming = true
+# OpenAI-compatible /v1 transport does not guarantee schema-shaped output.
+supports_structured_output = false
 
 [[models]]
 id_prefix = "ollama_cloud/devstral-2:123b"
@@ -624,6 +626,8 @@ supports_multimodal_inputs = true
 supports_image_input = true
 modality_priority = "visual_first"
 supports_native_streaming = true
+# OpenAI-compatible /v1 transport does not guarantee schema-shaped output.
+supports_structured_output = false
 
 [[models]]
 id_prefix = "ollama_cloud/kimi-k2.6"
@@ -642,6 +646,8 @@ supports_multimodal_inputs = true
 supports_image_input = true
 modality_priority = "visual_first"
 supports_native_streaming = true
+# OpenAI-compatible /v1 transport does not guarantee schema-shaped output.
+supports_structured_output = false
 
 [[models]]
 id_prefix = "ollama_cloud/kimi-k2.7-code"
@@ -660,6 +666,8 @@ supports_multimodal_inputs = true
 supports_image_input = true
 modality_priority = "visual_first"
 supports_native_streaming = true
+# OpenAI-compatible /v1 transport does not guarantee schema-shaped output.
+supports_structured_output = false
 
 [[models]]
 id_prefix = "ollama_cloud/minimax-m2.1"
@@ -718,7 +726,9 @@ supports_multimodal_inputs = true
 supports_image_input = true
 modality_priority = "visual_first"
 supports_response_format_json = true
-supports_structured_output = true
+# OpenAI-compatible /v1 transport accepts json_schema but does not guarantee
+# schema-shaped output; use the native /api/chat lane for strict schemas.
+supports_structured_output = false
 supports_native_streaming = true
 
 [[models]]

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -757,7 +757,11 @@ let test_ollama_cloud_grouped_non_so_rows_do_not_advertise_so () =
        with
        | None -> failf "ollama_cloud/%s should resolve" model_id
        | Some c ->
-         check bool (model_id ^ " no structured output") false c.supports_structured_output)
+         check
+           bool
+           (model_id ^ " no structured output")
+           false
+           c.supports_structured_output)
     cases
 ;;
 

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -731,8 +731,9 @@ let test_ollama_cloud_grouped_rows_have_required_axes () =
 
 let test_ollama_cloud_grouped_non_so_rows_do_not_advertise_so () =
   (* The OpenAI-compatible /v1 transport used by the ollama_cloud provider
-     identity accepts json_schema requests but does not enforce schema-shaped
-     output for these models. They must not advertise native structured output. *)
+     identity keeps JSON response-format requests available but does not enforce
+     schema-shaped output for these models. They must preserve JSON mode while
+     not advertising native structured output. *)
   let cases =
     [ "kimi-k2.5"
     ; "kimi-k2.6"
@@ -757,6 +758,11 @@ let test_ollama_cloud_grouped_non_so_rows_do_not_advertise_so () =
        with
        | None -> failf "ollama_cloud/%s should resolve" model_id
        | Some c ->
+         check
+           bool
+           (model_id ^ " json response format")
+           true
+           c.supports_response_format_json;
          check
            bool
            (model_id ^ " no structured output")
@@ -1106,10 +1112,12 @@ let check_frontier_model
          (streaming_reasoning_to_string dialect.streaming))
 ;;
 
-let test_frontier_grouped_tool_thinking_structured_models () =
+let test_frontier_grouped_tool_thinking_provider_contracts () =
   (* This matrix is intentionally named after current production-provider
      evidence, not broad model families. Every row must keep the axes needed by
-     multi-turn + thinking/reasoning + tool-use + structured-output workflows.
+     multi-turn + thinking/reasoning + tool-use + provider output-contract
+     workflows. The structured_contract field covers strict schema support,
+     native structured support, and explicit no-structured-output rows.
      Replay semantics are provider-specific: Kimi/Anthropic preserve every
      turn, DeepSeek preserves tool-call turns, and other side-channel providers
      only need stream separation here. *)
@@ -2337,9 +2345,9 @@ let () =
             `Quick
             test_ollama_cloud_provider_qualified_preserves_shared_bare_family
         ; test_case
-            "frontier grouped tool/thinking/structured models"
+            "frontier grouped tool/thinking/provider contracts"
             `Quick
-            test_frontier_grouped_tool_thinking_structured_models
+            test_frontier_grouped_tool_thinking_provider_contracts
         ; test_case "mimo-v2.5-pro" `Quick test_lookup_mimo_v25_pro
         ; test_case "qwen3 thinking control" `Quick test_lookup_qwen3_thinking_control
         ; test_case "unknown" `Quick test_lookup_unknown

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -683,12 +683,13 @@ let test_ollama_cloud_current_catalog_resolves () =
     cases
 ;;
 
-let test_ollama_cloud_grouped_so_rows_have_required_axes () =
-  (* Live grouped SO smokes for these Ollama Cloud rows exercise the same
-     production workflow: tool call -> tool_result replay -> final
-     response_format/json_schema answer while reasoning may stream on a side
-     channel. The catalog must not regress any one of those axes to a generic
-     text-only or no-structured-output profile. *)
+let test_ollama_cloud_grouped_rows_have_required_axes () =
+  (* Live grouped smokes for these Ollama Cloud rows exercise the same
+     production workflow: tool call -> tool_result replay -> final answer while
+     reasoning may stream on a side channel. The catalog must not regress any
+     one of these axes to a generic text-only profile. Structured output is
+     checked separately because the OpenAI-compatible /v1 transport does not
+     guarantee schema-shaped output for every model. *)
   let cases =
     [ "qwen3.5:397b"
     ; "gemma4:31b"
@@ -721,11 +722,42 @@ let test_ollama_cloud_grouped_so_rows_have_required_axes () =
            (model_id ^ " json response format")
            true
            c.supports_response_format_json;
-         check bool (model_id ^ " structured output") true c.supports_structured_output;
          check_thinking_control
            (model_id ^ " uses Ollama native think")
            Capabilities.Ollama_think
            c.thinking_control_format)
+    cases
+;;
+
+let test_ollama_cloud_grouped_non_so_rows_do_not_advertise_so () =
+  (* The OpenAI-compatible /v1 transport used by the ollama_cloud provider
+     identity accepts json_schema requests but does not enforce schema-shaped
+     output for these models. They must not advertise native structured output. *)
+  let cases =
+    [ "kimi-k2.5"
+    ; "kimi-k2.6"
+    ; "kimi-k2.7-code"
+    ; "minimax-m3"
+    ; "deepseek-v4-pro"
+    ; "deepseek-v4-flash"
+    ; "glm-5.2"
+    ; "gpt-oss:20b"
+    ; "gpt-oss:120b"
+    ; "nemotron-3-ultra"
+    ; "qwen3.5:397b"
+    ]
+  in
+  List.iter
+    (fun model_id ->
+       match
+         Capabilities.for_provider_model_id
+           ~allow_bare_fallback:true
+           ~provider_label:"ollama_cloud"
+           ~model_id
+       with
+       | None -> failf "ollama_cloud/%s should resolve" model_id
+       | Some c ->
+         check bool (model_id ^ " no structured output") false c.supports_structured_output)
     cases
 ;;
 
@@ -982,12 +1014,7 @@ let check_frontier_model
          true
          c.supports_structured_output
      | No_structured_output ->
-       check bool (label ^ " no structured output") false c.supports_structured_output;
-       check
-         bool
-         (label ^ " no response_format/json_schema")
-         false
-         c.supports_response_format_json);
+       check bool (label ^ " no structured output") false c.supports_structured_output);
     let dialect = frontier_dialect route model_id c in
     (match replay_contract with
      | Replay_not_required ->
@@ -1157,70 +1184,70 @@ let test_frontier_grouped_tool_thinking_structured_models () =
       , Provider_qualified "ollama_cloud"
       , "qwen3.5:397b"
       , Extended_thinking
-      , Response_format_json_schema
+      , No_structured_output
       , Replay_not_required
       , Delta_stream "thinking" )
     ; ( "Ollama Cloud Gemma4"
       , Provider_qualified "ollama_cloud"
       , "gemma4:31b"
       , Extended_thinking
-      , Response_format_json_schema
+      , No_structured_output
       , Replay_not_required
       , Delta_stream "thinking" )
     ; ( "Ollama Cloud Kimi K2.7 Code"
       , Provider_qualified "ollama_cloud"
       , "kimi-k2.7-code"
       , Extended_thinking
-      , Response_format_json_schema
+      , No_structured_output
       , Replay_every_turn
       , Delta_stream "thinking" )
     ; ( "Ollama Cloud MiniMax M3"
       , Provider_qualified "ollama_cloud"
       , "minimax-m3"
       , Extended_thinking
-      , Response_format_json_schema
+      , No_structured_output
       , Replay_not_required
       , Delta_stream "reasoning" )
     ; ( "Ollama Cloud Nemotron 3 Ultra"
       , Provider_qualified "ollama_cloud"
       , "nemotron-3-ultra"
       , Extended_thinking
-      , Response_format_json_schema
+      , No_structured_output
       , Replay_not_required
       , Delta_stream "thinking" )
     ; ( "Ollama Cloud DeepSeek V4 Pro"
       , Provider_qualified "ollama_cloud"
       , "deepseek-v4-pro"
       , Extended_thinking
-      , Response_format_json_schema
+      , No_structured_output
       , Replay_not_required
       , Delta_stream "thinking" )
     ; ( "Ollama Cloud DeepSeek V4 Flash"
       , Provider_qualified "ollama_cloud"
       , "deepseek-v4-flash"
       , Extended_thinking
-      , Response_format_json_schema
+      , No_structured_output
       , Replay_not_required
       , Delta_stream "thinking" )
     ; ( "Ollama Cloud GLM 5.2"
       , Provider_qualified "ollama_cloud"
       , "glm-5.2"
       , Extended_thinking
-      , Response_format_json_schema
+      , No_structured_output
       , Replay_not_required
       , Delta_stream "thinking" )
     ; ( "Ollama Cloud GPT-OSS 20B"
       , Provider_qualified "ollama_cloud"
       , "gpt-oss:20b"
       , Extended_thinking
-      , Response_format_json_schema
+      , No_structured_output
       , Replay_not_required
       , Delta_stream "thinking" )
     ; ( "Ollama Cloud GPT-OSS 120B"
       , Provider_qualified "ollama_cloud"
       , "gpt-oss:120b"
       , Extended_thinking
-      , Response_format_json_schema
+      , No_structured_output
       , Replay_not_required
       , Delta_stream "thinking" )
     ]
@@ -2286,9 +2313,13 @@ let () =
             `Quick
             test_ollama_cloud_current_catalog_resolves
         ; test_case
-            "ollama cloud grouped SO rows keep required axes"
+            "ollama cloud grouped rows keep required axes"
             `Quick
-            test_ollama_cloud_grouped_so_rows_have_required_axes
+            test_ollama_cloud_grouped_rows_have_required_axes
+        ; test_case
+            "ollama cloud grouped non-SO rows do not advertise SO"
+            `Quick
+            test_ollama_cloud_grouped_non_so_rows_do_not_advertise_so
         ; test_case
             "ollama cloud Kimi preserves historical reasoning"
             `Quick

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -298,7 +298,7 @@ let test_validate_output_schema_unknown_openai_compat_rejected () =
     (Result.is_error (Provider_config.validate_output_schema_request cfg))
 ;;
 
-let test_validate_output_schema_ollama_cloud_minimax_accepted () =
+let test_validate_output_schema_ollama_cloud_minimax_rejected () =
   let cfg =
     Provider_config.make
       ~kind:OpenAI_compat
@@ -308,10 +308,13 @@ let test_validate_output_schema_ollama_cloud_minimax_accepted () =
       ~output_schema:(`Assoc [ "type", `String "object" ])
       ()
   in
-  check_bool
-    "Ollama Cloud minimax accepted"
-    true
-    (Result.is_ok (Provider_config.validate_output_schema_request cfg))
+  match Provider_config.validate_output_schema_request cfg with
+  | Error msg ->
+    check_string
+      "rejection"
+      "model minimax-m3 does not advertise native structured output"
+      msg
+  | Ok () -> Alcotest.fail "expected Ollama Cloud minimax-m3 capability rejection"
 ;;
 
 let test_validate_output_schema_ollama_cloud_mistral_rejected () =
@@ -369,7 +372,7 @@ let test_validate_output_schema_openai_compat_declared_endpoint_accepted () =
     (Result.is_ok (Provider_config.validate_output_schema_request cfg))
 ;;
 
-let test_validate_output_schema_ollama_cloud_accepted () =
+let test_validate_output_schema_ollama_cloud_minimax_output_schema_rejected () =
   let cfg =
     Provider_config.make
       ~kind:OpenAI_compat
@@ -378,10 +381,13 @@ let test_validate_output_schema_ollama_cloud_accepted () =
       ~output_schema:(`Assoc [ "type", `String "object" ])
       ()
   in
-  check_bool
-    "ollama cloud model with native SO guarantee accepted"
-    true
-    (Result.is_ok (Provider_config.validate_output_schema_request cfg))
+  match Provider_config.validate_output_schema_request cfg with
+  | Error msg ->
+    check_string
+      "rejection"
+      "model minimax-m3 does not advertise native structured output"
+      msg
+  | Ok () -> Alcotest.fail "expected Ollama Cloud minimax-m3 capability rejection"
 ;;
 
 let test_validate_output_schema_ollama_cloud_rejects_unverified_model () =
@@ -1340,7 +1346,7 @@ let test_validate_output_schema_openai_official_catalog () =
       (Result.is_ok (Provider_config.validate_output_schema_request cfg)))
 ;;
 
-let test_validate_output_schema_ollama_cloud_catalog_accepted () =
+let test_validate_output_schema_ollama_cloud_catalog_minimax_rejected () =
   with_repository_model_catalog (fun () ->
     let cfg =
       Provider_config.make
@@ -1351,10 +1357,13 @@ let test_validate_output_schema_ollama_cloud_catalog_accepted () =
         ~output_schema:(`Assoc [ "type", `String "object" ])
         ()
     in
-    check_bool
-      "catalog Ollama Cloud model accepts json_schema"
-      true
-      (Result.is_ok (Provider_config.validate_output_schema_request cfg)))
+    match Provider_config.validate_output_schema_request cfg with
+    | Error msg ->
+      check_string
+        "rejection reason"
+        "model minimax-m3 does not advertise native structured output"
+        msg
+    | Ok () -> Alcotest.fail "expected Ollama Cloud minimax-m3 capability rejection")
 ;;
 
 let test_validate_output_schema_ollama_cloud_catalog_rejects_model_without_so () =
@@ -2078,7 +2087,7 @@ let () =
         ; Alcotest.test_case
             "ollama cloud minimax accepted"
             `Quick
-            test_validate_output_schema_ollama_cloud_minimax_accepted
+            test_validate_output_schema_ollama_cloud_minimax_rejected
         ; Alcotest.test_case
             "ollama cloud mistral rejected"
             `Quick
@@ -2094,7 +2103,7 @@ let () =
         ; Alcotest.test_case
             "ollama cloud accepted"
             `Quick
-            test_validate_output_schema_ollama_cloud_accepted
+            test_validate_output_schema_ollama_cloud_minimax_output_schema_rejected
         ; Alcotest.test_case
             "ollama cloud rejects unverified model"
             `Quick
@@ -2142,7 +2151,7 @@ let () =
         ; Alcotest.test_case
             "ollama cloud catalog accepted"
             `Quick
-            test_validate_output_schema_ollama_cloud_catalog_accepted
+            test_validate_output_schema_ollama_cloud_catalog_minimax_rejected
         ; Alcotest.test_case
             "ollama cloud catalog rejects model without SO"
             `Quick

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -2085,7 +2085,7 @@ let () =
             `Quick
             test_validate_output_schema_unknown_openai_compat_rejected
         ; Alcotest.test_case
-            "ollama cloud minimax accepted"
+            "ollama cloud minimax rejected"
             `Quick
             test_validate_output_schema_ollama_cloud_minimax_rejected
         ; Alcotest.test_case
@@ -2101,7 +2101,7 @@ let () =
             `Quick
             test_validate_output_schema_openai_compat_declared_endpoint_accepted
         ; Alcotest.test_case
-            "ollama cloud accepted"
+            "ollama cloud minimax output_schema rejected"
             `Quick
             test_validate_output_schema_ollama_cloud_minimax_output_schema_rejected
         ; Alcotest.test_case
@@ -2149,7 +2149,7 @@ let () =
             `Quick
             test_validate_output_schema_capability_rejected
         ; Alcotest.test_case
-            "ollama cloud catalog accepted"
+            "ollama cloud catalog minimax rejected"
             `Quick
             test_validate_output_schema_ollama_cloud_catalog_minimax_rejected
         ; Alcotest.test_case


### PR DESCRIPTION
## Summary
- Correct Ollama Cloud capability default: OpenAI-compatible /v1/chat/completions does not guarantee schema-shaped output.
- Set ollama_cloud_capabilities.supports_structured_output = false.
- Explicitly mark affected ollama_cloud/* rows and keep verified opt-ins.
- Update capability and provider-config tests.

## Test Plan
- scripts/dune-local.sh build @check
- scripts/dune-local.sh runtest test/test_capabilities.ml test/test_provider_config.ml