### PR TITLE
fix(boundary): remove coordinator-specific term from wire_capture doc comment (main CI red)

### DIFF
--- a/lib/llm_provider/wire_capture.mli
+++ b/lib/llm_provider/wire_capture.mli
@@ -13,7 +13,7 @@
     closure so the streaming hot loop pays only an indirect call — the
     environment is read once per stream, never per chunk.
 
-    @since introduced for the keeper repetition investigation (Phase O). *)
+    @since introduced for the agent output repetition investigation (Phase O). *)
 
 (** A per-chunk capture function. Call with each raw pre-parse chunk. *)
 type sink = string -> unit


### PR DESCRIPTION
## 문제

oas main CI가 red 상태입니다 (run 28569556647, HEAD e5940991e). SDK Independence Gate가 `lib/llm_provider/wire_capture.mli:16`의 doc comment에서 coordinator-specific term(`\bkeeper\b`)을 검출했습니다.

## 원인

#2435 (raw stream wire capture 관측 하네스, Phase O)가 추가한 `@since` 주석이 소비자(coordinator)의 keeper 개념을 이름으로 참조했습니다. OAS는 MASC를 알면 안 된다는 경계 규칙의 lexical gate 위반입니다.

## 근본 수정

주석을 소비자를 특정하지 않는 표현으로 reword했습니다 (`keeper repetition investigation` → `agent output repetition investigation`). 코드 변경 없음, 1줄 diff.

## 검증

`bash scripts/check-sdk-independence.sh` 로컬 실행 → `OK: SDK independence check passed`. 나머지는 CI가 authority입니다.

이 수정이 main에 들어가면 #2436의 동일 gate 실패도 재실행으로 해소됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
