### PR TITLE
fix(boundary): remove coordinator-specific term from capabilities doc comment

### DIFF
--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -454,7 +454,7 @@ let ollama_capabilities =
    replay and caused the CoT loop (#2236).
 
    IMPORTANT: do not inherit [supports_structured_output] from local Ollama.
-   MASC and other consumers reach Ollama Cloud through the OpenAI-compatible
+   Host applications reach Ollama Cloud through the OpenAI-compatible
    [/v1/chat/completions] transport, which accepts [response_format.type =
    json_schema] but does NOT guarantee schema-shaped output. The native Ollama
    [/api/chat] transport (provider kind [Ollama]) enforces schemas via the


### PR DESCRIPTION
## 문제

oas main CI가 red입니다 (run 28578947886, HEAD 2084e5f70). SDK Independence Gate가 `lib/llm_provider/capabilities.ml:457`의 doc comment에서 coordinator-specific term(`\bmasc\b`, strict)을 검출했습니다.

## 원인

#2440이 추가한 `ollama_cloud_capabilities` doc comment가 소비자(coordinator)를 이름으로 참조했습니다 ("MASC and other consumers ..."). #2435의 "keeper" 사건(→ #2441 fix)과 동일한 위반 클래스입니다.

## 수정

`MASC and other consumers` → `Host applications` reword. 코드 변경 없음, 1줄 diff.

## 검증

- `bash scripts/check-sdk-independence.sh` 로컬 실행 → `OK: SDK independence check passed`
- `ocamlformat --check lib/llm_provider/capabilities.ml` PASS
- 나머지는 CI가 authority입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
