### PR TITLE
fix(llm_provider): harden redaction for large media payloads

### DIFF
--- a/lib/llm_provider/secret_redactor.ml
+++ b/lib/llm_provider/secret_redactor.ml
@@ -111,8 +111,15 @@ let find_data_url_comma s pos =
     else (
       match s.[i] with
       | ',' -> Some i
-      | ch when is_data_url_header_terminal ch -> None
-      | _ -> loop (i + 1))
+      | '"' | '\'' | '<' | '>' | ' ' | '\t' | '\n' | '\r' -> None
+      | '\000' .. '\b'
+      | '\011' | '\012' | '\014'
+      | '\015' .. '!'
+      | '#' .. '&'
+      | '(' .. '+'
+      | '-' .. ';'
+      | '='
+      | '?' .. '\255' -> loop (i + 1))
   in
   loop pos
 ;;
@@ -345,9 +352,8 @@ let%test "redact_string masks private key block" =
 ;;
 
 let%test "redact_json preserves structure" =
-  match redact_json (`Assoc [ "key", `String "Bearer tok" ]) with
-  | `Assoc [ ("key", `String "Bearer [REDACTED]") ] -> true
-  | _ -> false
+  redact_json (`Assoc [ "key", `String "Bearer tok" ])
+  = `Assoc [ "key", `String "Bearer [REDACTED]" ]
 ;;
 
 let%test "redact_string collapses base64 media data url" =

--- a/lib/llm_provider/secret_redactor.ml
+++ b/lib/llm_provider/secret_redactor.ml
@@ -55,15 +55,24 @@ let token_len s pos =
 let redaction_marker = "[REDACTED]"
 let media_redaction_marker = "[REDACTED_MEDIA]"
 
-let starts_with_ci s ~prefix =
+let is_uri_scheme_char ch =
+  ('a' <= ch && ch <= 'z')
+  || ('A' <= ch && ch <= 'Z')
+  || ('0' <= ch && ch <= '9')
+  || Char.equal ch '+'
+  || Char.equal ch '-'
+  || Char.equal ch '.'
+;;
+
+let starts_with_ci_at s pos ~prefix =
   let len = String.length s in
   let prefix_len = String.length prefix in
-  if prefix_len > len
+  if pos < 0 || pos + prefix_len > len
   then false
   else (
     let rec loop i =
       i = prefix_len
-      || (Char.equal (Char.lowercase_ascii s.[i]) (Char.lowercase_ascii prefix.[i])
+      || (Char.equal (Char.lowercase_ascii s.[pos + i]) (Char.lowercase_ascii prefix.[i])
           && loop (i + 1))
     in
     loop 0)
@@ -81,17 +90,82 @@ let contains_substring_ci s needle =
   needle_len = 0 || scan 0
 ;;
 
+let is_data_url_boundary s pos = pos = 0 || not (is_uri_scheme_char s.[pos - 1])
+
+let is_data_url_header_terminal ch =
+  Char.equal ch '"'
+  || Char.equal ch '\''
+  || Char.equal ch '<'
+  || Char.equal ch '>'
+  || Char.equal ch ' '
+  || Char.equal ch '\t'
+  || Char.equal ch '\n'
+  || Char.equal ch '\r'
+;;
+
+let find_data_url_comma s pos =
+  let len = String.length s in
+  let rec loop i =
+    if i >= len
+    then None
+    else (
+      match s.[i] with
+      | ',' -> Some i
+      | ch when is_data_url_header_terminal ch -> None
+      | _ -> loop (i + 1))
+  in
+  loop pos
+;;
+
+let is_base64_payload_char ch =
+  ('a' <= ch && ch <= 'z')
+  || ('A' <= ch && ch <= 'Z')
+  || ('0' <= ch && ch <= '9')
+  || Char.equal ch '+'
+  || Char.equal ch '/'
+  || Char.equal ch '='
+;;
+
+let base64_payload_end s pos =
+  let len = String.length s in
+  let rec loop i = if i < len && is_base64_payload_char s.[i] then loop (i + 1) else i in
+  loop pos
+;;
+
+let find_media_data_url s pos =
+  let len = String.length s in
+  let rec scan i =
+    if i >= len
+    then None
+    else if is_data_url_boundary s i && starts_with_ci_at s i ~prefix:"data:"
+    then (
+      match find_data_url_comma s i with
+      | None -> scan (i + 1)
+      | Some comma ->
+        let header = String.sub s i (comma - i) in
+        if contains_substring_ci header ";base64"
+        then Some (i, comma, base64_payload_end s (comma + 1))
+        else scan (i + 1))
+    else scan (i + 1)
+  in
+  scan pos
+;;
+
 let redact_media_data_url s =
-  if not (starts_with_ci s ~prefix:"data:")
-  then None
-  else (
-    match String.index_opt s ',' with
-    | None -> None
-    | Some comma ->
-      let header = String.sub s 0 comma in
-      if contains_substring_ci header ";base64"
-      then Some (String.sub s 0 (comma + 1) ^ media_redaction_marker)
-      else None)
+  match find_media_data_url s 0 with
+  | None -> None
+  | Some first ->
+    let buf = Buffer.create (String.length s) in
+    let rec loop pos (start, comma, payload_end) =
+      Buffer.add_substring buf s pos (start - pos);
+      Buffer.add_substring buf s start (comma - start + 1);
+      Buffer.add_string buf media_redaction_marker;
+      match find_media_data_url s payload_end with
+      | None -> Buffer.add_substring buf s payload_end (String.length s - payload_end)
+      | Some next -> loop payload_end next
+    in
+    loop 0 first;
+    Some (Buffer.contents buf)
 ;;
 
 let has_prefix_at s pos prefix =
@@ -286,6 +360,22 @@ let%test "redact_string still masks tokens in media data url header" =
   let payload = String.make (128 * 1024) 'A' in
   redact_string ("data:image/png;name=sk-media-secret;base64," ^ payload)
   = "data:image/png;name=[REDACTED];base64,[REDACTED_MEDIA]"
+;;
+
+let%test "redact_string collapses embedded base64 media data url" =
+  let payload = String.make (128 * 1024) 'A' in
+  redact_string ("prefix data:image/png;base64," ^ payload ^ " suffix")
+  = "prefix data:image/png;base64,[REDACTED_MEDIA] suffix"
+;;
+
+let%test "redact_string collapses media data url inside json text" =
+  let payload = String.make (128 * 1024) 'A' in
+  redact_string ("{\"url\":\"data:image/png;base64," ^ payload ^ "\",\"ok\":true}")
+  = "{\"url\":\"data:image/png;base64,[REDACTED_MEDIA]\",\"ok\":true}"
+;;
+
+let%test "redact_string does not treat metadata key as data url" =
+  redact_string "metadata:text/plain;base64,AAAA" = "metadata:text/plain;base64,AAAA"
 ;;
 
 let%test "redact_json collapses image_url data url" =

--- a/lib/llm_provider/secret_redactor.ml
+++ b/lib/llm_provider/secret_redactor.ml
@@ -224,14 +224,17 @@ let redact_known_tokens s =
   Buffer.contents buf
 ;;
 
+let redact_common_tokens s =
+  let s = redact_url_userinfo s in
+  let s = redact_private_key_block s in
+  let s = redact_prefixes s builtin_prefixes in
+  redact_known_tokens s
+;;
+
 let redact_string s =
   match redact_media_data_url s with
-  | Some redacted -> redacted
-  | None ->
-    let s = redact_url_userinfo s in
-    let s = redact_private_key_block s in
-    let s = redact_prefixes s builtin_prefixes in
-    redact_known_tokens s
+  | Some redacted -> redact_common_tokens redacted
+  | None -> redact_common_tokens s
 ;;
 
 let rec redact_json = function
@@ -277,6 +280,12 @@ let%test "redact_string collapses base64 media data url" =
   let payload = String.make (128 * 1024) 'A' in
   redact_string ("data:image/png;base64," ^ payload)
   = "data:image/png;base64,[REDACTED_MEDIA]"
+;;
+
+let%test "redact_string still masks tokens in media data url header" =
+  let payload = String.make (128 * 1024) 'A' in
+  redact_string ("data:image/png;name=sk-media-secret;base64," ^ payload)
+  = "data:image/png;name=[REDACTED];base64,[REDACTED_MEDIA]"
 ;;
 
 let%test "redact_json collapses image_url data url" =

--- a/lib/llm_provider/secret_redactor.ml
+++ b/lib/llm_provider/secret_redactor.ml
@@ -5,8 +5,9 @@
     tool arguments, or provider error bodies, the redactor scrubs common
     patterns before persistence or emission.
 
-    The scanner is intentionally simple (substring-based) to avoid pulling in
-    a regex library and to keep latency predictable in the hot trace path.
+    The scanner is intentionally simple (allocation-conscious string scanning)
+    to avoid pulling in a regex library and to keep latency predictable in the
+    hot trace path.
 
     @since 0.207.0 *)
 
@@ -52,20 +53,62 @@ let token_len s pos =
 ;;
 
 let redaction_marker = "[REDACTED]"
+let media_redaction_marker = "[REDACTED_MEDIA]"
+
+let starts_with_ci s ~prefix =
+  let len = String.length s in
+  let prefix_len = String.length prefix in
+  if prefix_len > len
+  then false
+  else (
+    let rec loop i =
+      i = prefix_len
+      || (Char.equal (Char.lowercase_ascii s.[i]) (Char.lowercase_ascii prefix.[i])
+          && loop (i + 1))
+    in
+    loop 0)
+;;
+
+let contains_substring_ci s needle =
+  let len = String.length s in
+  let needle_len = String.length needle in
+  let rec matches_at pos i =
+    i = needle_len
+    || (Char.equal (Char.lowercase_ascii s.[pos + i]) (Char.lowercase_ascii needle.[i])
+        && matches_at pos (i + 1))
+  in
+  let rec scan pos = pos + needle_len <= len && (matches_at pos 0 || scan (pos + 1)) in
+  needle_len = 0 || scan 0
+;;
+
+let redact_media_data_url s =
+  if not (starts_with_ci s ~prefix:"data:")
+  then None
+  else (
+    match String.index_opt s ',' with
+    | None -> None
+    | Some comma ->
+      let header = String.sub s 0 comma in
+      if contains_substring_ci header ";base64"
+      then Some (String.sub s 0 (comma + 1) ^ media_redaction_marker)
+      else None)
+;;
 
 let has_prefix_at s pos prefix =
+  let len = String.length s in
   let n = String.length prefix in
-  pos + n <= String.length s && String.sub s pos n = prefix
+  if pos < 0 || pos + n > len
+  then false
+  else (
+    let rec loop i = i = n || (Char.equal s.[pos + i] prefix.[i] && loop (i + 1)) in
+    loop 0)
 ;;
 
 let find_prefix s pos prefix =
+  let len = String.length s in
   let n = String.length prefix in
   let rec scan i =
-    if i + n > String.length s
-    then None
-    else if has_prefix_at s i prefix
-    then Some i
-    else scan (i + 1)
+    if i + n > len then None else if has_prefix_at s i prefix then Some i else scan (i + 1)
   in
   scan pos
 ;;
@@ -76,16 +119,14 @@ let redact_prefixes s prefixes =
   let buf = Buffer.create (String.length s) in
   let rec loop pos =
     if pos >= String.length s
-    then Buffer.add_substring buf s pos (String.length s - pos)
+    then ()
     else (
       match
         List.find_map
           (fun prefix -> Option.map (fun i -> i, prefix) (find_prefix s pos prefix))
           prefixes
       with
-      | None ->
-        Buffer.add_char buf s.[pos];
-        loop (pos + 1)
+      | None -> Buffer.add_substring buf s pos (String.length s - pos)
       | Some (i, prefix) ->
         Buffer.add_substring buf s pos (i - pos);
         Buffer.add_string buf prefix;
@@ -184,10 +225,13 @@ let redact_known_tokens s =
 ;;
 
 let redact_string s =
-  let s = redact_url_userinfo s in
-  let s = redact_private_key_block s in
-  let s = redact_prefixes s builtin_prefixes in
-  redact_known_tokens s
+  match redact_media_data_url s with
+  | Some redacted -> redacted
+  | None ->
+    let s = redact_url_userinfo s in
+    let s = redact_private_key_block s in
+    let s = redact_prefixes s builtin_prefixes in
+    redact_known_tokens s
 ;;
 
 let rec redact_json = function
@@ -227,6 +271,26 @@ let%test "redact_json preserves structure" =
   match redact_json (`Assoc [ "key", `String "Bearer tok" ]) with
   | `Assoc [ ("key", `String "Bearer [REDACTED]") ] -> true
   | _ -> false
+;;
+
+let%test "redact_string collapses base64 media data url" =
+  let payload = String.make (128 * 1024) 'A' in
+  redact_string ("data:image/png;base64," ^ payload)
+  = "data:image/png;base64,[REDACTED_MEDIA]"
+;;
+
+let%test "redact_json collapses image_url data url" =
+  let payload = String.make (128 * 1024) 'A' in
+  redact_json
+    (`Assoc
+        [ "image_url", `Assoc [ "url", `String ("data:image/png;base64," ^ payload) ] ])
+  = `Assoc
+      [ "image_url", `Assoc [ "url", `String "data:image/png;base64,[REDACTED_MEDIA]" ] ]
+;;
+
+let%test "redact_string preserves large non-secret payload" =
+  let payload = String.make (128 * 1024) 'A' in
+  redact_string payload = payload
 ;;
 
 let%test "redact_string leaves ordinary text alone" =

--- a/lib/llm_provider/secret_redactor.mli
+++ b/lib/llm_provider/secret_redactor.mli
@@ -4,8 +4,9 @@
 
 (** [redact_string s] scans [s] for common secret patterns (Bearer tokens,
     AWS access key IDs, GitHub tokens, URL userinfo, PEM private key blocks,
-    etc.) and replaces them with [[REDACTED]].  Ordinary text is returned
-    unchanged. *)
+    etc.) and replaces them with [[REDACTED]].  Base64 media data URLs are
+    collapsed before token scanning so image/document payloads do not dominate
+    trace/log CPU or storage. Ordinary text is returned unchanged. *)
 val redact_string : string -> string
 
 (** [redact_json j] recursively redacts string values inside a JSON tree.


### PR DESCRIPTION
## Summary
- make secret prefix checks allocation-free instead of using String.sub for every position
- avoid per-character full-tail rescans when a large payload contains no redaction prefixes
- collapse base64 media data URLs before token scanning so trace/log persistence does not replay full inline image payloads
- add large non-secret payload and media data URL regression tests for image/Fusion-sized strings

## Incident evidence
- MASC 8935 health timed out while main_eio.exe stayed running
- sample of PID 89985 showed the hot path in Llm_provider__Secret_redactor plus caml_blit_bytes, with 1.6G physical footprint / 2.3G peak
- screenshots showed dashboard transport offline / client WS disconnected / logs stuck loading

## Local MASC recovery proof
- locally pinned agent_sdk to this OAS worktree with AGENT_SDK_PIN_URL and rebuilt MASC using MASC_SKIP_PIN_CHECK=1 because the repo pin still intentionally points at the old OAS main SHA
- replaced wedged PID 89985, then refreshed the listener after the media data-URL hardening; current rebuilt listener PID is 92896 on 127.0.0.1:8935
- GET /health?full=1 returned 200 in 0.546029s after the media hardening rebuild, and later 200 in 0.001469s
- GET /dashboard#keepers returned 200 in 0.581833s
- GET /api/v1/dashboard/logs?limit=50 returned 200 in 0.549899s, then 200 in 0.000990s
- sample of PID 92896 did not show the previous Secret_redactor/String.sub hot path; main thread was in poll

## Validation
- ocamlformat --check lib/llm_provider/secret_redactor.ml lib/llm_provider/secret_redactor.mli
- git diff --check -- lib/llm_provider/secret_redactor.ml lib/llm_provider/secret_redactor.mli
- bash scripts/hardening-ratchet.sh --check
- bash scripts/ci-code-smell-ratchet.sh --check
- scripts/dune-local.sh build @lib/llm_provider/runtest