### PR TITLE
ci: add OCaml 5.5 canary lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,14 @@ jobs:
     name: Build & Test (OCaml ${{ matrix.ocaml-compiler }})
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        ocaml-compiler: ['5.4.1']
+        include:
+          - ocaml-compiler: '5.4.1'
+            experimental: false
+          - ocaml-compiler: '5.5.0'
+            experimental: true
       fail-fast: false
     env:
       OAS_MODEL_CATALOG: ${{ github.workspace }}/models.toml

--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -396,13 +396,13 @@ let parse_ollama_response json_str =
 
 (** Run [f] with the [OAS_OLLAMA_KEEP_ALIVE] env var set to [value], then
     restore the caller's original setting. Guaranteed restore on exception.
-    OCaml's [Unix]/[Sys] modules have no portable unsetenv (verified against
-    the installed 5.4.1 Unix.mli/Sys.mli — neither declares one), so a var
-    that was originally unset is restored to [""] rather than truly removed
-    from the process environment. This is equivalent for every current
-    reader ([Cli_common_env.get] treats [Some ""] the same as [None] via
-    [trim_non_empty_opt]), but is not a true unset for code that reads the
-    var via bare [Sys.getenv_opt]/[Cli_common_env.default_getenv]. *)
+    OCaml 5.5 adds [Unix.unsetenv], but the supported 5.4.1 floor used here
+    does not expose it (nor does [Sys]). A var that was originally unset is
+    restored to [""] rather than truly removed from the process environment.
+    This is equivalent for every current reader ([Cli_common_env.get] treats
+    [Some ""] the same as [None] via [trim_non_empty_opt]), but is not a true
+    unset for code that reads the var via bare
+    [Sys.getenv_opt]/[Cli_common_env.default_getenv]. *)
 let with_keep_alive_env value f =
   let orig = Cli_common_env.default_getenv keep_alive_env_var in
   let restore () =

--- a/lib/llm_provider/env_parse.ml
+++ b/lib/llm_provider/env_parse.ml
@@ -16,9 +16,9 @@ let with_env name value f =
   let original = Sys.getenv_opt name in
   let restore () =
     match original with
-    (* OCaml's Unix module does not expose portable unsetenv. All readers in
-       this module treat the empty string as unset/default, so tests can safely
-       restore absent variables to an empty value. *)
+    (* OCaml 5.5 adds Unix.unsetenv, but this library still supports the 5.4
+       floor. All readers in this module treat the empty string as unset/default,
+       so tests can safely restore absent variables to an empty value. *)
     | None -> Unix.putenv name ""
     | Some v -> Unix.putenv name v
   in

--- a/lib/llm_provider/env_parse.mli
+++ b/lib/llm_provider/env_parse.mli
@@ -16,7 +16,8 @@ val bool_env : ?default:bool -> string -> bool
 
 (** Temporarily set [name] while [f] runs, then restore the previous value.
 
-    OCaml's Unix module does not expose portable unsetenv. If [name] was absent,
-    this restores it to [""]. The parsers in this module treat [""]
+    OCaml 5.5 adds [Unix.unsetenv], but this library still supports the 5.4
+    floor. If [name] was absent, this restores it to [""]. The parsers in this
+    module treat [""]
     equivalently to an absent value. *)
 val with_env : string -> string -> (unit -> 'a) -> 'a

--- a/test/test_checkpoint_delta.ml
+++ b/test/test_checkpoint_delta.ml
@@ -192,8 +192,9 @@ let with_env key value f =
     | Some previous -> Unix.putenv key previous
     | None -> Unix.putenv key ""
   in
-  (* OCaml's Unix module on our supported switches does not provide unsetenv.
-     For this feature flag helper, the empty string is equivalent to "off". *)
+  (* OCaml 5.5 adds Unix.unsetenv, but our supported switches are still on the
+     5.4 floor. For this feature flag helper, the empty string is equivalent to
+     "off". *)
   (match value with
    | Some next -> Unix.putenv key next
    | None -> Unix.putenv key "");

--- a/test/test_defaults.ml
+++ b/test/test_defaults.ml
@@ -9,8 +9,9 @@ open Alcotest
 let setenv k v = Unix.putenv k v
 
 let unsetenv k =
-  (* Unix has no portable unsetenv; setting empty triggers the
-     "empty → default" branch in env_or, which is what we want. *)
+  (* On the current supported 5.4 floor there is no Unix.unsetenv; setting
+     empty triggers the "empty → default" branch in env_or, which is what we
+     want. *)
   try Unix.putenv k "" with
   | _ -> ()
 ;;

--- a/test/test_mcp_http.ml
+++ b/test/test_mcp_http.ml
@@ -13,8 +13,8 @@ open Agent_sdk
 
 let with_env key value f =
   let previous = Sys.getenv_opt key in
-  (* OCaml's Unix module has no portable unsetenv; OAS env readers treat an
-     empty value as unset. *)
+  (* On the current supported 5.4 floor there is no Unix.unsetenv; OAS env
+     readers treat an empty value as unset. *)
   let restore () =
     match previous with
     | Some previous -> Unix.putenv key previous


### PR DESCRIPTION
## Summary
- add an experimental OCaml 5.5.0 CI matrix entry for the main build/test job
- keep OCaml 5.4.1 as the required coverage/doc lane
- make the 5.5.0 lane non-blocking with job-level continue-on-error so ecosystem breakage is visible without blocking normal PRs

## Evidence
- [근거] GitHub official OCaml release page: OCaml 5.5.0 released June 19, 2026; checked 2026-07-03 01:41:59 KST; confidence High.
- [근거] opam package page: ocaml-base-compiler 5.5.0 is latest and published June 19, 2026; checked 2026-07-03 01:41:59 KST; confidence High.
- [근거] local opam switch: current local compiler remains 5.4.1 via opam switch show / ocamlc -version; checked 2026-07-03 01:41:59 KST; confidence High.

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'
- git diff --check
- actionlint .github/workflows/ci.yml

## Notes
This is intentionally a canary rather than a production compiler pin bump. OAS still supports the existing 5.4.1 lane while CI starts collecting real 5.5.0 compatibility signal.