### PR TITLE
fix(provider): remove last model-id GLM classifier, gate GLM base entries by endpoint declaration

### DIFF
--- a/.ci/hardening-baseline.json
+++ b/.ci/hardening-baseline.json
@@ -34,9 +34,7 @@
       "lib/context_intent.mli:38:val heuristic_classify : string -> classification"
     ],
     "local_workspace_path_literals": [],
-    "model_id_string_classifiers_outside_catalog": [
-      "lib/provider.ml:70:if Llm_provider.Zai_catalog.is_glm_model_id model_id && not is_native_glm"
-    ],
+    "model_id_string_classifiers_outside_catalog": [],
     "stub_markers": [],
     "wildcard_silent_defaults": [
       "lib/agent/agent_handoff.ml:36:| _ -> None))",
@@ -50,7 +48,7 @@
     ],
     "workaround_markers": []
   },
-  "lastUpdatedCommit": "66170abd52fe8265fb97e6c54eece06ce55b279f",
+  "lastUpdatedCommit": "8a6e5fede943f3e8d277b54b80018e7615ca3cb4",
   "metrics": {
     "base_url_host_fuzzy_classifiers": 3,
     "direct_env_reads": 21,
@@ -58,7 +56,7 @@
     "exception_message_classifiers": 1,
     "heuristic_markers": 2,
     "local_workspace_path_literals": 0,
-    "model_id_string_classifiers_outside_catalog": 1,
+    "model_id_string_classifiers_outside_catalog": 0,
     "stub_markers": 0,
     "wildcard_silent_defaults": 251,
     "workaround_markers": 0

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -321,7 +321,10 @@ let catalog_entry_requires_endpoint_declaration (entry : Model_catalog.model_ent
   with
   | Some ("openai_chat" | "openai_chat_extended"), Some _ -> false
   | Some ("openai_chat" | "openai_chat_extended"), None -> true
-  | Some "glm", _ -> false
+  (* GLM capabilities (reasoning, tools, thinking dialects) require a declared
+     Z.AI GLM endpoint. A raw OpenAI-compatible or local endpoint serving a
+     model id that merely matches a GLM catalog prefix must not inherit them. *)
+  | Some "glm", _ -> true
   | Some _, _ -> true
   | None, Some _ -> false
   | None, None -> true

--- a/lib/llm_provider/provider_config.mli
+++ b/lib/llm_provider/provider_config.mli
@@ -410,9 +410,8 @@ val reasoning_effort_of_config : t -> string option
     This is usually {!string_of_provider_kind}, except vendor-canonical hosts
     (RFC-OAS-034 §2 rule 2): official Ollama Cloud endpoints are scoped as
     ["ollama_cloud"], and DeepSeek's canonical host [api.deepseek.com] as
-    ["deepseek"], even when they use the OpenAI-compatible wire kind. DeepSeek is
-    matched by exact [Uri.host] equality; Ollama Cloud currently uses a
-    lowercased/trimmed URL-prefix check. *)
+    ["deepseek"], even when they use the OpenAI-compatible wire kind. Both are
+    matched by exact [Uri.host] equality (no prefix, no look-alike). *)
 val capability_provider_label : t -> string
 
 (** Resolve model capabilities using provider-qualified catalog entries first.

--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -61,15 +61,15 @@ let uses_native_glm_capabilities ~base_url ~model_id =
 (* Shared by the [Local] and [OpenAICompat] branches of [capabilities_for_model]:
    both send requests over the OpenAI-compatible envelope and must resolve
    capabilities identically. [Provider_config.catalog_entry_requires_endpoint_declaration]
-   deliberately trusts catalog entries whose [base_label] is ["glm"], because that
-   trust is only valid for a *declared* Z.AI GLM endpoint. Without the guard below,
-   any endpoint (including an undeclared [Local] one) serving a model id that merely
-   matches a GLM catalog prefix would inherit real GLM reasoning/tool capabilities. *)
+   now treats catalog entries whose [base_label] is ["glm"] as requiring an
+   endpoint declaration, so a raw OpenAI-compatible or [Local] endpoint can no
+   longer inherit GLM reasoning/tool capabilities from a bare model-id match.
+   Declared Z.AI GLM endpoints are detected via
+   [Provider_config.is_zai_glm_config] (endpoint + model id, typed SSOT) and
+   keep the full catalog capabilities. *)
 let openai_compat_capabilities_for ~base_url ~model_id =
   let is_native_glm = uses_native_glm_capabilities ~base_url ~model_id in
-  if Llm_provider.Zai_catalog.is_glm_model_id model_id && not is_native_glm
-  then default_openai_compat_capabilities ()
-  else if is_native_glm
+  if is_native_glm
   then (
     match Llm_provider.Capabilities.for_model_id model_id with
     | Some caps -> caps

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -410,6 +410,15 @@ let test_zai_glm5v_capabilities_include_image_input () =
     capabilities.supports_multimodal_inputs
 ;;
 
+let non_glm_prefixed_glm_catalog_toml =
+  {|
+[[models]]
+id_prefix = "fake-glm-model"
+base = "glm"
+max_context_tokens = 999999
+|}
+;;
+
 let test_non_zai_glm_capabilities_stay_openai_compat () =
   let cfg : Provider.config =
     { provider =
@@ -429,6 +438,32 @@ let test_non_zai_glm_capabilities_stay_openai_compat () =
     "extended thinking disabled"
     false
     capabilities.supports_extended_thinking
+;;
+
+(* Regression for the provider.ml model-id classifier removal: a catalog entry
+   with [base = "glm"] but no "glm-" model-id prefix must be gated by endpoint
+   declaration, not by a model-id substring check. A raw OpenAI-compatible
+   endpoint must fall back to generic defaults even when the entry declares no
+   capability that triggers [capability_requires_endpoint_declaration]. *)
+let test_glm_base_requires_endpoint_declaration_not_model_id_prefix () =
+  with_catalog_toml non_glm_prefixed_glm_catalog_toml (fun () ->
+    let cfg : Provider.config =
+      { provider =
+          OpenAICompat
+            { base_url = "https://openrouter.ai/api/v1"
+            ; auth_header = None
+            ; path = "/chat/completions"
+            ; static_token = None
+            }
+      ; model_id = "fake-glm-model"
+      ; api_key_env = ""
+      }
+    in
+    let capabilities = Provider.capabilities_for_config cfg in
+    Alcotest.(check (option int))
+      "non-zai endpoint does not inherit glm base context window"
+      (Some 128_000)
+      capabilities.max_context_tokens)
 ;;
 
 let test_validate_inference_contract_rejects_unsupported_modality () =
@@ -1280,6 +1315,10 @@ let () =
             "non-zai glm stays openai compat"
             `Quick
             test_non_zai_glm_capabilities_stay_openai_compat
+        ; Alcotest.test_case
+            "glm base requires endpoint declaration not model-id prefix"
+            `Quick
+            test_glm_base_requires_endpoint_declaration_not_model_id_prefix
         ; Alcotest.test_case
             "invalid modality gets actionable error"
             `Quick


### PR DESCRIPTION
## Summary

Adversarial review follow-up for the provider classification cleanup cluster (#2439, #2438, #2432, #2427, #2426, #2425).

The cluster removed most model-id string classifiers but left one delegated classifier in `lib/provider.ml`: `Zai_catalog.is_glm_model_id` was used to force non-ZAI GLM-looking ids to generic OpenAI-compat capabilities. This PR replaces it with a typed catalog decision.

## Changes

- `lib/llm_provider/provider_config.ml`: `catalog_entry_requires_endpoint_declaration` now treats `base = "glm"` entries as requiring a declared Z.AI endpoint.
- `lib/provider.ml`: removed the `is_glm_model_id` guard in `openai_compat_capabilities_for`; the catalog gate now covers GLM entries.
- `lib/llm_provider/provider_config.mli`: corrected the #2427 doc comment — Ollama Cloud is matched by exact `Uri.host` (#2420), not URL-prefix.
- `.ci/hardening-baseline.json`: `model_id_string_classifiers_outside_catalog` count dropped from 1 to 0.
- `test/test_provider.ml`: added regression test with a synthetic `[base = "glm"]` entry whose id has no "glm-" prefix, proving the endpoint gate works without the prefix classifier.

## Verification

- `dune build --root . @check` — pass
- `dune exec --root . test/test_provider.exe` — pass (47 tests)
- `dune exec --root . test/test_api.exe` — pass (86 tests)
- `dune exec --root . test/test_provider_config.exe` — pass (113 tests)
- `dune exec --root . test/test_capabilities.exe` — pass (86 tests)
- `dune exec --root . test/test_complete_ext.exe` — pass (21 tests)
- `dune exec --root . test/test_provider_runtime_binding.exe` — pass (19 tests)
- `dune exec --root . test/test_property_advanced.exe` — pass (18 tests)
- `scripts/hardening-ratchet.sh --check` — pass
- `ocamlformat --check` on changed .ml/.mli files — pass

## Out of scope / follow-up

- The `runpod_rtxa6000` namespace added in #2431 is another host-derived catalog name (RFC-OAS-034 §2 rule 1), but it was not part of this cluster.
- `Provider_config.openai_host_supports_output_schema` still uses `String.ends_with ~suffix:".ollama.com"`; that predates this cluster and is tracked under the existing `base_url_host_fuzzy_classifiers` ratchet.
- The Anthropic branch of `Provider.capabilities_for_model` still calls `Capabilities.for_model_id` without an endpoint gate; left unchanged to keep this PR focused on the GLM classifier cleanup.