### PR TITLE
fix(llm_provider): bound OAS wire capture file growth

### DIFF
--- a/lib/llm_provider/wire_capture.ml
+++ b/lib/llm_provider/wire_capture.ml
@@ -89,17 +89,14 @@ let file_size path =
   | Unix.Unix_error _ | Sys_error _ -> 0
 ;;
 
-let int_of_env s =
-  match int_of_string_opt s with
-  | Some n when n > 0 -> Some n
-  | Some _ | None -> None
-;;
-
 let capture_max_bytes ?getenv () =
   match Cli_common_env.get ?getenv env_max_bytes with
-  | None -> Some default_max_bytes
-  | Some "" -> Some default_max_bytes
-  | Some s -> int_of_env s
+  | None -> default_max_bytes, None
+  | Some "" -> default_max_bytes, None
+  | Some s ->
+    (match int_of_string_opt s with
+     | Some n when n > 0 -> n, None
+     | Some _ | None -> default_max_bytes, Some s)
 ;;
 
 (** Rotate [path] to [path ^ ".1"], deleting any previous backup. This is
@@ -122,10 +119,7 @@ let write_line ~path ~provider ~model ~warned ~max_bytes chunk =
       ]
   in
   let line = Yojson.Safe.to_string json ^ "\n" in
-  (match max_bytes with
-   | Some cap when cap > 0 && file_size path + String.length line > cap ->
-     rotate_file path
-   | Some _ | None -> ());
+  if file_size path + String.length line > max_bytes then rotate_file path;
   try append_json_line ~path line with
   | Sys_error msg ->
     if not !warned
@@ -154,7 +148,16 @@ let make_sink ?getenv ~provider ~model =
      | Ok () ->
        let path = Filename.concat dir capture_filename in
        let warned = ref false in
-       let max_bytes = capture_max_bytes ?getenv () in
+       let max_bytes, invalid_max_bytes = capture_max_bytes ?getenv () in
+       (match invalid_max_bytes with
+        | None -> ()
+        | Some value ->
+          Diag.warn
+            "wire_capture"
+            "%s=%S is invalid; using default cap %d bytes"
+            env_max_bytes
+            value
+            default_max_bytes);
        fun chunk -> write_line ~path ~provider ~model ~warned ~max_bytes chunk)
 ;;
 
@@ -312,24 +315,35 @@ let%test "make_sink rotates file when max bytes would be exceeded" =
   contains ~needle:"\"chunk\":\"" content
 ;;
 
-let%test "make_sink respects zero/invalid max bytes as no cap" =
+let%test "invalid max bytes falls back to default cap with warning" =
   let dir = Filename.temp_dir "oas_wire_nocap" "" in
-  let s =
-    make_sink
-      ~getenv:(fun name ->
-        if String.equal name env_dir
-        then Some dir
-        else if String.equal name env_max_bytes
-        then Some "0"
-        else None)
-      ~provider:"p"
-      ~model:"m"
+  let warnings = ref [] in
+  let max_bytes, invalid =
+    capture_max_bytes
+      ~getenv:(fun name -> if String.equal name env_max_bytes then Some "0" else None)
+      ()
   in
-  s (String.make 64 'x');
-  s (String.make 64 'y');
-  let path = Filename.concat dir capture_filename in
-  (not (Sys.file_exists (path ^ ".1")))
-  &&
-  let content = read_file path in
-  contains ~needle:"\"chunk\":\"" content
+  let s =
+    Diag.with_sink
+      (fun level ~ctx msg -> warnings := (level, ctx, msg) :: !warnings)
+      (fun () ->
+         make_sink
+           ~getenv:(fun name ->
+             if String.equal name env_dir
+             then Some dir
+             else if String.equal name env_max_bytes
+             then Some "0"
+             else None)
+           ~provider:"p"
+           ~model:"m")
+  in
+  s "chunk";
+  max_bytes = default_max_bytes
+  && invalid = Some "0"
+  && List.exists
+       (fun (level, ctx, msg) ->
+          level = Diag.Warn
+          && String.equal ctx "wire_capture"
+          && contains ~needle:"invalid; using default cap" msg)
+       !warnings
 ;;

--- a/lib/llm_provider/wire_capture.ml
+++ b/lib/llm_provider/wire_capture.ml
@@ -64,9 +64,12 @@ let with_file_lock ~lock_path f =
       if !locked then unlock_noerr fd;
       close_noerr fd)
     (fun () ->
-       Unix.lockf fd Unix.F_LOCK 0;
-       locked := true;
-       f ())
+       try
+         Unix.lockf fd Unix.F_TLOCK 0;
+         locked := true;
+         f ()
+       with
+       | Unix.Unix_error (err, fn, arg) -> Error (unix_error_message err fn arg))
 ;;
 
 let rec write_all fd line offset remaining =
@@ -119,6 +122,22 @@ let path_exists path =
   | Unix.Unix_error _ | Sys_error _ -> true
 ;;
 
+let prune_if_over_cap ~path ~max_bytes =
+  if file_size path > max_bytes then unlink_if_exists path else Ok ()
+;;
+
+let prune_over_cap_capture_files_unlocked ~path ~max_bytes =
+  match prune_if_over_cap ~path ~max_bytes with
+  | Error _ as err -> err
+  | Ok () -> prune_if_over_cap ~path:(path ^ ".1") ~max_bytes
+;;
+
+let prune_over_cap_capture_files ~path ~max_bytes =
+  with_append_mutex (fun () ->
+    with_file_lock ~lock_path:(path ^ ".lock") (fun () ->
+      prune_over_cap_capture_files_unlocked ~path ~max_bytes))
+;;
+
 (** Rotate [path] to [path ^ ".1"], deleting any previous backup. Failures are
     surfaced to the caller so capture can skip instead of exceeding the cap. *)
 let rotate_file path =
@@ -138,18 +157,16 @@ let append_bounded_json_line ~path ~max_bytes line =
   with_append_mutex (fun () ->
     with_file_lock ~lock_path:(path ^ ".lock") (fun () ->
       let line_bytes = String.length line in
-      let current_size = file_size path in
-      if current_size > max_bytes
-      then (
-        match unlink_if_exists path with
-        | Error _ as err -> err
-        | Ok () -> Ok (append_json_line_unlocked ~path line))
-      else if current_size + line_bytes > max_bytes
-      then (
-        match rotate_file path with
-        | Error _ as err -> err
-        | Ok () -> Ok (append_json_line_unlocked ~path line))
-      else Ok (append_json_line_unlocked ~path line)))
+      match prune_over_cap_capture_files_unlocked ~path ~max_bytes with
+      | Error _ as err -> err
+      | Ok () ->
+        let current_size = file_size path in
+        if current_size + line_bytes > max_bytes
+        then (
+          match rotate_file path with
+          | Error _ as err -> err
+          | Ok () -> Ok (append_json_line_unlocked ~path line))
+        else Ok (append_json_line_unlocked ~path line)))
 ;;
 
 let write_line ~path ~provider ~model ~warned ~oversized_warned ~max_bytes chunk =
@@ -164,6 +181,29 @@ let write_line ~path ~provider ~model ~warned ~oversized_warned ~max_bytes chunk
   let line_bytes = String.length line in
   if line_bytes > max_bytes
   then (
+    (try
+       match prune_over_cap_capture_files ~path ~max_bytes with
+       | Ok () -> ()
+       | Error msg ->
+         if not !warned
+         then (
+           warned := true;
+           Diag.warn "wire_capture" "skipped capture cleanup for %S: %s" path msg)
+     with
+     | Sys_error msg ->
+       if not !warned
+       then (
+         warned := true;
+         Diag.warn "wire_capture" "cleanup failed for %S: %s" path msg)
+     | Unix.Unix_error (err, fn, arg) ->
+       if not !warned
+       then (
+         warned := true;
+         Diag.warn
+           "wire_capture"
+           "cleanup failed for %S: %s"
+           path
+           (unix_error_message err fn arg)));
     if not !oversized_warned
     then (
       oversized_warned := true;
@@ -470,6 +510,61 @@ let%test "make_sink drops already oversized capture file before appending" =
   &&
   let content = read_file path in
   contains ~needle:"small chunk" content
+;;
+
+let%test "make_sink drops already oversized backup before appending" =
+  let dir = Filename.temp_dir "oas_wire_drop_oversized_backup" "" in
+  let max_bytes = 256 in
+  let path = Filename.concat dir capture_filename in
+  let backup = path ^ ".1" in
+  let oc = open_out_bin backup in
+  Fun.protect
+    ~finally:(fun () -> close_out oc)
+    (fun () -> output_string oc (String.make 512 'a'));
+  let s =
+    make_sink
+      ~getenv:(fun name ->
+        if String.equal name env_dir
+        then Some dir
+        else if String.equal name env_max_bytes
+        then Some (string_of_int max_bytes)
+        else None)
+      ~provider:"p"
+      ~model:"m"
+  in
+  s "small chunk";
+  (not (Sys.file_exists backup))
+  &&
+  let content = read_file path in
+  contains ~needle:"small chunk" content
+;;
+
+let%test "make_sink drops oversized files before skipping oversized records" =
+  let dir = Filename.temp_dir "oas_wire_drop_before_oversized_skip" "" in
+  let max_bytes = 256 in
+  let path = Filename.concat dir capture_filename in
+  let backup = path ^ ".1" in
+  let write_big path =
+    let oc = open_out_bin path in
+    Fun.protect
+      ~finally:(fun () -> close_out oc)
+      (fun () -> output_string oc (String.make 512 'a'))
+  in
+  write_big path;
+  write_big backup;
+  let s =
+    make_sink
+      ~getenv:(fun name ->
+        if String.equal name env_dir
+        then Some dir
+        else if String.equal name env_max_bytes
+        then Some (string_of_int max_bytes)
+        else None)
+      ~provider:"p"
+      ~model:"m"
+  in
+  s (String.make 1024 'x');
+  (not (Sys.file_exists path)) && not (Sys.file_exists backup)
 ;;
 
 let%test "invalid max bytes falls back to default cap with warning" =

--- a/lib/llm_provider/wire_capture.ml
+++ b/lib/llm_provider/wire_capture.ml
@@ -139,7 +139,12 @@ let append_bounded_json_line ~path ~max_bytes line =
     with_file_lock ~lock_path:(path ^ ".lock") (fun () ->
       let line_bytes = String.length line in
       let current_size = file_size path in
-      if current_size + line_bytes > max_bytes
+      if current_size > max_bytes
+      then (
+        match unlink_if_exists path with
+        | Error _ as err -> err
+        | Ok () -> Ok (append_json_line_unlocked ~path line))
+      else if current_size + line_bytes > max_bytes
       then (
         match rotate_file path with
         | Error _ as err -> err
@@ -437,6 +442,34 @@ let%test "make_sink skips when rotation cannot preserve cap" =
           && String.equal ctx "wire_capture"
           && contains ~needle:"skipped capture write" msg)
        !warnings
+;;
+
+let%test "make_sink drops already oversized capture file before appending" =
+  let dir = Filename.temp_dir "oas_wire_drop_oversized" "" in
+  let max_bytes = 256 in
+  let path = Filename.concat dir capture_filename in
+  let backup = path ^ ".1" in
+  let oc = open_out_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_out oc)
+    (fun () -> output_string oc (String.make 512 'a'));
+  let s =
+    make_sink
+      ~getenv:(fun name ->
+        if String.equal name env_dir
+        then Some dir
+        else if String.equal name env_max_bytes
+        then Some (string_of_int max_bytes)
+        else None)
+      ~provider:"p"
+      ~model:"m"
+  in
+  s "small chunk";
+  file_size path <= max_bytes
+  && (not (Sys.file_exists backup))
+  &&
+  let content = read_file path in
+  contains ~needle:"small chunk" content
 ;;
 
 let%test "invalid max bytes falls back to default cap with warning" =

--- a/lib/llm_provider/wire_capture.ml
+++ b/lib/llm_provider/wire_capture.ml
@@ -56,6 +56,19 @@ let unlock_noerr fd =
   | Unix.Unix_error _ -> ()
 ;;
 
+let with_file_lock ~lock_path f =
+  let fd = Unix.openfile lock_path [ Unix.O_RDWR; Unix.O_CREAT; Unix.O_CLOEXEC ] 0o600 in
+  let locked = ref false in
+  Fun.protect
+    ~finally:(fun () ->
+      if !locked then unlock_noerr fd;
+      close_noerr fd)
+    (fun () ->
+       Unix.lockf fd Unix.F_LOCK 0;
+       locked := true;
+       f ())
+;;
+
 let rec write_all fd line offset remaining =
   if remaining > 0
   then (
@@ -64,24 +77,16 @@ let rec write_all fd line offset remaining =
     | written -> write_all fd line (offset + written) (remaining - written))
 ;;
 
-let append_json_line ~path line =
-  with_append_mutex (fun () ->
-    let fd =
-      Unix.openfile
-        path
-        [ Unix.O_WRONLY; Unix.O_APPEND; Unix.O_CREAT; Unix.O_CLOEXEC ]
-        0o600
-    in
-    let locked = ref false in
-    Fun.protect
-      ~finally:(fun () ->
-        if !locked then unlock_noerr fd;
-        close_noerr fd)
-      (fun () ->
-         ignore (Unix.lseek fd 0 Unix.SEEK_SET : int);
-         Unix.lockf fd Unix.F_TLOCK 0;
-         locked := true;
-         write_all fd line 0 (String.length line)))
+let append_json_line_unlocked ~path line =
+  let fd =
+    Unix.openfile
+      path
+      [ Unix.O_WRONLY; Unix.O_APPEND; Unix.O_CREAT; Unix.O_CLOEXEC ]
+      0o600
+  in
+  Fun.protect
+    ~finally:(fun () -> close_noerr fd)
+    (fun () -> write_all fd line 0 (String.length line))
 ;;
 
 let file_size path =
@@ -99,15 +104,47 @@ let capture_max_bytes ?getenv () =
      | Some _ | None -> default_max_bytes, Some s)
 ;;
 
-(** Rotate [path] to [path ^ ".1"], deleting any previous backup. This is
-    best-effort: failures are ignored because the harness must not perturb the
-    stream. *)
+let unlink_if_exists path =
+  try Ok (Unix.unlink path) with
+  | Unix.Unix_error (Unix.ENOENT, _, _) -> Ok ()
+  | Unix.Unix_error (err, fn, arg) -> Error (unix_error_message err fn arg)
+;;
+
+let path_exists path =
+  try
+    ignore (Unix.stat path : Unix.stats);
+    true
+  with
+  | Unix.Unix_error (Unix.ENOENT, _, _) -> false
+  | Unix.Unix_error _ | Sys_error _ -> true
+;;
+
+(** Rotate [path] to [path ^ ".1"], deleting any previous backup. Failures are
+    surfaced to the caller so capture can skip instead of exceeding the cap. *)
 let rotate_file path =
   let backup = path ^ ".1" in
-  (try Sys.remove backup with
-   | Sys_error _ | Unix.Unix_error _ -> ());
-  try Unix.rename path backup with
-  | Sys_error _ | Unix.Unix_error _ -> ()
+  match unlink_if_exists backup with
+  | Error _ as err -> err
+  | Ok () ->
+    if not (path_exists path)
+    then Ok ()
+    else (
+      try Ok (Unix.rename path backup) with
+      | Unix.Unix_error (Unix.ENOENT, _, _) -> Ok ()
+      | Unix.Unix_error (err, fn, arg) -> Error (unix_error_message err fn arg))
+;;
+
+let append_bounded_json_line ~path ~max_bytes line =
+  with_append_mutex (fun () ->
+    with_file_lock ~lock_path:(path ^ ".lock") (fun () ->
+      let line_bytes = String.length line in
+      let current_size = file_size path in
+      if current_size + line_bytes > max_bytes
+      then (
+        match rotate_file path with
+        | Error _ as err -> err
+        | Ok () -> Ok (append_json_line_unlocked ~path line))
+      else Ok (append_json_line_unlocked ~path line)))
 ;;
 
 let write_line ~path ~provider ~model ~warned ~oversized_warned ~max_bytes chunk =
@@ -133,8 +170,15 @@ let write_line ~path ~provider ~model ~warned ~oversized_warned ~max_bytes chunk
         line_bytes
         max_bytes))
   else (
-    if file_size path + line_bytes > max_bytes then rotate_file path;
-    try append_json_line ~path line with
+    try
+      match append_bounded_json_line ~path ~max_bytes line with
+      | Ok () -> ()
+      | Error msg ->
+        if not !warned
+        then (
+          warned := true;
+          Diag.warn "wire_capture" "skipped capture write for %S: %s" path msg)
+    with
     | Sys_error msg ->
       if not !warned
       then (
@@ -335,10 +379,10 @@ let%test "make_sink skips oversized records instead of exceeding max bytes" =
   let dir = Filename.temp_dir "oas_wire_oversized" "" in
   let warnings = ref [] in
   let max_bytes = 128 in
-  let s =
-    Diag.with_sink
-      (fun level ~ctx msg -> warnings := (level, ctx, msg) :: !warnings)
-      (fun () ->
+  Diag.with_sink
+    (fun level ~ctx msg -> warnings := (level, ctx, msg) :: !warnings)
+    (fun () ->
+       let s =
          make_sink
            ~getenv:(fun name ->
              if String.equal name env_dir
@@ -347,9 +391,9 @@ let%test "make_sink skips oversized records instead of exceeding max bytes" =
              then Some (string_of_int max_bytes)
              else None)
            ~provider:"p"
-           ~model:"m")
-  in
-  s (String.make 1024 'x');
+           ~model:"m"
+       in
+       s (String.make 1024 'x'));
   let path = Filename.concat dir capture_filename in
   (not (Sys.file_exists path))
   && List.exists
@@ -357,6 +401,41 @@ let%test "make_sink skips oversized records instead of exceeding max bytes" =
           level = Diag.Warn
           && String.equal ctx "wire_capture"
           && contains ~needle:"skipped capture chunk" msg)
+       !warnings
+;;
+
+let%test "make_sink skips when rotation cannot preserve cap" =
+  let dir = Filename.temp_dir "oas_wire_rotate_fail" "" in
+  let warnings = ref [] in
+  let max_bytes = 256 in
+  let path = Filename.concat dir capture_filename in
+  let backup = path ^ ".1" in
+  let oc = open_out_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_out oc)
+    (fun () -> output_string oc (String.make 250 'a'));
+  Unix.mkdir backup 0o700;
+  Diag.with_sink
+    (fun level ~ctx msg -> warnings := (level, ctx, msg) :: !warnings)
+    (fun () ->
+       let s =
+         make_sink
+           ~getenv:(fun name ->
+             if String.equal name env_dir
+             then Some dir
+             else if String.equal name env_max_bytes
+             then Some (string_of_int max_bytes)
+             else None)
+           ~provider:"p"
+           ~model:"m"
+       in
+       s "small chunk");
+  file_size path <= max_bytes
+  && List.exists
+       (fun (level, ctx, msg) ->
+          level = Diag.Warn
+          && String.equal ctx "wire_capture"
+          && contains ~needle:"skipped capture write" msg)
        !warnings
 ;;
 

--- a/lib/llm_provider/wire_capture.ml
+++ b/lib/llm_provider/wire_capture.ml
@@ -1,7 +1,9 @@
 (** See [wire_capture.mli]. *)
 
 let env_dir = "OAS_WIRE_CAPTURE_DIR"
+let env_max_bytes = "OAS_WIRE_CAPTURE_MAX_BYTES"
 let capture_filename = "raw-stream.jsonl"
+let default_max_bytes = 64 * 1024 * 1024
 
 type sink = string -> unit
 
@@ -82,7 +84,36 @@ let append_json_line ~path line =
          write_all fd line 0 (String.length line)))
 ;;
 
-let write_line ~path ~provider ~model ~warned chunk =
+let file_size path =
+  try (Unix.stat path).Unix.st_size with
+  | Unix.Unix_error _ | Sys_error _ -> 0
+;;
+
+let int_of_env s =
+  match int_of_string_opt s with
+  | Some n when n > 0 -> Some n
+  | Some _ | None -> None
+;;
+
+let capture_max_bytes ?getenv () =
+  match Cli_common_env.get ?getenv env_max_bytes with
+  | None -> Some default_max_bytes
+  | Some "" -> Some default_max_bytes
+  | Some s -> int_of_env s
+;;
+
+(** Rotate [path] to [path ^ ".1"], deleting any previous backup. This is
+    best-effort: failures are ignored because the harness must not perturb the
+    stream. *)
+let rotate_file path =
+  let backup = path ^ ".1" in
+  (try Sys.remove backup with
+   | Sys_error _ | Unix.Unix_error _ -> ());
+  try Unix.rename path backup with
+  | Sys_error _ | Unix.Unix_error _ -> ()
+;;
+
+let write_line ~path ~provider ~model ~warned ~max_bytes chunk =
   let json : Yojson.Safe.t =
     `Assoc
       [ "provider", `String provider
@@ -91,6 +122,10 @@ let write_line ~path ~provider ~model ~warned chunk =
       ]
   in
   let line = Yojson.Safe.to_string json ^ "\n" in
+  (match max_bytes with
+   | Some cap when cap > 0 && file_size path + String.length line > cap ->
+     rotate_file path
+   | Some _ | None -> ());
   try append_json_line ~path line with
   | Sys_error msg ->
     if not !warned
@@ -119,7 +154,8 @@ let make_sink ?getenv ~provider ~model =
      | Ok () ->
        let path = Filename.concat dir capture_filename in
        let warned = ref false in
-       fun chunk -> write_line ~path ~provider ~model ~warned chunk)
+       let max_bytes = capture_max_bytes ?getenv () in
+       fun chunk -> write_line ~path ~provider ~model ~warned ~max_bytes chunk)
 ;;
 
 (* ── Inline tests ─────────────────────────────────────────────── *)
@@ -249,4 +285,51 @@ let%test "capture mutex does not block Eio fiber scheduling" =
           with_append_mutex (fun () -> observed_by_waiter := !progress))
       ];
     !observed_by_holder && !observed_by_waiter)
+;;
+
+let%test "make_sink rotates file when max bytes would be exceeded" =
+  let dir = Filename.temp_dir "oas_wire_rotate" "" in
+  let max_bytes = 128 in
+  let s =
+    make_sink
+      ~getenv:(fun name ->
+        if String.equal name env_dir
+        then Some dir
+        else if String.equal name env_max_bytes
+        then Some (string_of_int max_bytes)
+        else None)
+      ~provider:"p"
+      ~model:"m"
+  in
+  s (String.make 64 'a');
+  s (String.make 64 'b');
+  let path = Filename.concat dir capture_filename in
+  let backup = path ^ ".1" in
+  Sys.file_exists backup
+  && Sys.file_exists path
+  &&
+  let content = read_file path in
+  contains ~needle:"\"chunk\":\"" content
+;;
+
+let%test "make_sink respects zero/invalid max bytes as no cap" =
+  let dir = Filename.temp_dir "oas_wire_nocap" "" in
+  let s =
+    make_sink
+      ~getenv:(fun name ->
+        if String.equal name env_dir
+        then Some dir
+        else if String.equal name env_max_bytes
+        then Some "0"
+        else None)
+      ~provider:"p"
+      ~model:"m"
+  in
+  s (String.make 64 'x');
+  s (String.make 64 'y');
+  let path = Filename.concat dir capture_filename in
+  (not (Sys.file_exists (path ^ ".1")))
+  &&
+  let content = read_file path in
+  contains ~needle:"\"chunk\":\"" content
 ;;

--- a/lib/llm_provider/wire_capture.ml
+++ b/lib/llm_provider/wire_capture.ml
@@ -110,7 +110,7 @@ let rotate_file path =
   | Sys_error _ | Unix.Unix_error _ -> ()
 ;;
 
-let write_line ~path ~provider ~model ~warned ~max_bytes chunk =
+let write_line ~path ~provider ~model ~warned ~oversized_warned ~max_bytes chunk =
   let json : Yojson.Safe.t =
     `Assoc
       [ "provider", `String provider
@@ -119,22 +119,36 @@ let write_line ~path ~provider ~model ~warned ~max_bytes chunk =
       ]
   in
   let line = Yojson.Safe.to_string json ^ "\n" in
-  if file_size path + String.length line > max_bytes then rotate_file path;
-  try append_json_line ~path line with
-  | Sys_error msg ->
-    if not !warned
+  let line_bytes = String.length line in
+  if line_bytes > max_bytes
+  then (
+    if not !oversized_warned
     then (
-      warned := true;
-      Diag.warn "wire_capture" "write failed for %S: %s" path msg)
-  | Unix.Unix_error (err, fn, arg) ->
-    if not !warned
-    then (
-      warned := true;
+      oversized_warned := true;
       Diag.warn
         "wire_capture"
-        "write failed for %S: %s"
+        "skipped capture chunk for %S: encoded JSON line is %d bytes, exceeding cap %d \
+         bytes"
         path
-        (unix_error_message err fn arg))
+        line_bytes
+        max_bytes))
+  else (
+    if file_size path + line_bytes > max_bytes then rotate_file path;
+    try append_json_line ~path line with
+    | Sys_error msg ->
+      if not !warned
+      then (
+        warned := true;
+        Diag.warn "wire_capture" "write failed for %S: %s" path msg)
+    | Unix.Unix_error (err, fn, arg) ->
+      if not !warned
+      then (
+        warned := true;
+        Diag.warn
+          "wire_capture"
+          "write failed for %S: %s"
+          path
+          (unix_error_message err fn arg)))
 ;;
 
 let make_sink ?getenv ~provider ~model =
@@ -148,6 +162,7 @@ let make_sink ?getenv ~provider ~model =
      | Ok () ->
        let path = Filename.concat dir capture_filename in
        let warned = ref false in
+       let oversized_warned = ref false in
        let max_bytes, invalid_max_bytes = capture_max_bytes ?getenv () in
        (match invalid_max_bytes with
         | None -> ()
@@ -158,7 +173,8 @@ let make_sink ?getenv ~provider ~model =
             env_max_bytes
             value
             default_max_bytes);
-       fun chunk -> write_line ~path ~provider ~model ~warned ~max_bytes chunk)
+       fun chunk ->
+         write_line ~path ~provider ~model ~warned ~oversized_warned ~max_bytes chunk)
 ;;
 
 (* ── Inline tests ─────────────────────────────────────────────── *)
@@ -313,6 +329,35 @@ let%test "make_sink rotates file when max bytes would be exceeded" =
   &&
   let content = read_file path in
   contains ~needle:"\"chunk\":\"" content
+;;
+
+let%test "make_sink skips oversized records instead of exceeding max bytes" =
+  let dir = Filename.temp_dir "oas_wire_oversized" "" in
+  let warnings = ref [] in
+  let max_bytes = 128 in
+  let s =
+    Diag.with_sink
+      (fun level ~ctx msg -> warnings := (level, ctx, msg) :: !warnings)
+      (fun () ->
+         make_sink
+           ~getenv:(fun name ->
+             if String.equal name env_dir
+             then Some dir
+             else if String.equal name env_max_bytes
+             then Some (string_of_int max_bytes)
+             else None)
+           ~provider:"p"
+           ~model:"m")
+  in
+  s (String.make 1024 'x');
+  let path = Filename.concat dir capture_filename in
+  (not (Sys.file_exists path))
+  && List.exists
+       (fun (level, ctx, msg) ->
+          level = Diag.Warn
+          && String.equal ctx "wire_capture"
+          && contains ~needle:"skipped capture chunk" msg)
+       !warnings
 ;;
 
 let%test "invalid max bytes falls back to default cap with warning" =

--- a/lib/llm_provider/wire_capture.ml
+++ b/lib/llm_provider/wire_capture.ml
@@ -396,206 +396,213 @@ let%test "capture mutex does not block Eio fiber scheduling" =
 ;;
 
 let%test "make_sink rotates file when max bytes would be exceeded" =
-  let dir = Filename.temp_dir "oas_wire_rotate" "" in
-  let max_bytes = 128 in
-  let s =
-    make_sink
-      ~getenv:(fun name ->
-        if String.equal name env_dir
-        then Some dir
-        else if String.equal name env_max_bytes
-        then Some (string_of_int max_bytes)
-        else None)
-      ~provider:"p"
-      ~model:"m"
-  in
-  s (String.make 64 'a');
-  s (String.make 64 'b');
-  let path = Filename.concat dir capture_filename in
-  let backup = path ^ ".1" in
-  Sys.file_exists backup
-  && Sys.file_exists path
-  &&
-  let content = read_file path in
-  contains ~needle:"\"chunk\":\"" content
+  Eio_main.run (fun _env ->
+    let dir = Filename.temp_dir "oas_wire_rotate" "" in
+    let max_bytes = 128 in
+    let s =
+      make_sink
+        ~getenv:(fun name ->
+          if String.equal name env_dir
+          then Some dir
+          else if String.equal name env_max_bytes
+          then Some (string_of_int max_bytes)
+          else None)
+        ~provider:"p"
+        ~model:"m"
+    in
+    s (String.make 64 'a');
+    s (String.make 64 'b');
+    let path = Filename.concat dir capture_filename in
+    let backup = path ^ ".1" in
+    Sys.file_exists backup
+    && Sys.file_exists path
+    &&
+    let content = read_file path in
+    contains ~needle:"\"chunk\":\"" content)
 ;;
 
 let%test "make_sink skips oversized records instead of exceeding max bytes" =
-  let dir = Filename.temp_dir "oas_wire_oversized" "" in
-  let warnings = ref [] in
-  let max_bytes = 128 in
-  Diag.with_sink
-    (fun level ~ctx msg -> warnings := (level, ctx, msg) :: !warnings)
-    (fun () ->
-       let s =
-         make_sink
-           ~getenv:(fun name ->
-             if String.equal name env_dir
-             then Some dir
-             else if String.equal name env_max_bytes
-             then Some (string_of_int max_bytes)
-             else None)
-           ~provider:"p"
-           ~model:"m"
-       in
-       s (String.make 1024 'x'));
-  let path = Filename.concat dir capture_filename in
-  (not (Sys.file_exists path))
-  && List.exists
-       (fun (level, ctx, msg) ->
-          level = Diag.Warn
-          && String.equal ctx "wire_capture"
-          && contains ~needle:"skipped capture chunk" msg)
-       !warnings
-;;
-
-let%test "make_sink skips when rotation cannot preserve cap" =
-  let dir = Filename.temp_dir "oas_wire_rotate_fail" "" in
-  let warnings = ref [] in
-  let max_bytes = 256 in
-  let path = Filename.concat dir capture_filename in
-  let backup = path ^ ".1" in
-  let oc = open_out_bin path in
-  Fun.protect
-    ~finally:(fun () -> close_out oc)
-    (fun () -> output_string oc (String.make 250 'a'));
-  Unix.mkdir backup 0o700;
-  Diag.with_sink
-    (fun level ~ctx msg -> warnings := (level, ctx, msg) :: !warnings)
-    (fun () ->
-       let s =
-         make_sink
-           ~getenv:(fun name ->
-             if String.equal name env_dir
-             then Some dir
-             else if String.equal name env_max_bytes
-             then Some (string_of_int max_bytes)
-             else None)
-           ~provider:"p"
-           ~model:"m"
-       in
-       s "small chunk");
-  file_size path <= max_bytes
-  && List.exists
-       (fun (level, ctx, msg) ->
-          level = Diag.Warn
-          && String.equal ctx "wire_capture"
-          && contains ~needle:"skipped capture write" msg)
-       !warnings
-;;
-
-let%test "make_sink drops already oversized capture file before appending" =
-  let dir = Filename.temp_dir "oas_wire_drop_oversized" "" in
-  let max_bytes = 256 in
-  let path = Filename.concat dir capture_filename in
-  let backup = path ^ ".1" in
-  let oc = open_out_bin path in
-  Fun.protect
-    ~finally:(fun () -> close_out oc)
-    (fun () -> output_string oc (String.make 512 'a'));
-  let s =
-    make_sink
-      ~getenv:(fun name ->
-        if String.equal name env_dir
-        then Some dir
-        else if String.equal name env_max_bytes
-        then Some (string_of_int max_bytes)
-        else None)
-      ~provider:"p"
-      ~model:"m"
-  in
-  s "small chunk";
-  file_size path <= max_bytes
-  && (not (Sys.file_exists backup))
-  &&
-  let content = read_file path in
-  contains ~needle:"small chunk" content
-;;
-
-let%test "make_sink drops already oversized backup before appending" =
-  let dir = Filename.temp_dir "oas_wire_drop_oversized_backup" "" in
-  let max_bytes = 256 in
-  let path = Filename.concat dir capture_filename in
-  let backup = path ^ ".1" in
-  let oc = open_out_bin backup in
-  Fun.protect
-    ~finally:(fun () -> close_out oc)
-    (fun () -> output_string oc (String.make 512 'a'));
-  let s =
-    make_sink
-      ~getenv:(fun name ->
-        if String.equal name env_dir
-        then Some dir
-        else if String.equal name env_max_bytes
-        then Some (string_of_int max_bytes)
-        else None)
-      ~provider:"p"
-      ~model:"m"
-  in
-  s "small chunk";
-  (not (Sys.file_exists backup))
-  &&
-  let content = read_file path in
-  contains ~needle:"small chunk" content
-;;
-
-let%test "make_sink drops oversized files before skipping oversized records" =
-  let dir = Filename.temp_dir "oas_wire_drop_before_oversized_skip" "" in
-  let max_bytes = 256 in
-  let path = Filename.concat dir capture_filename in
-  let backup = path ^ ".1" in
-  let write_big path =
-    let oc = open_out_bin path in
-    Fun.protect
-      ~finally:(fun () -> close_out oc)
-      (fun () -> output_string oc (String.make 512 'a'))
-  in
-  write_big path;
-  write_big backup;
-  let s =
-    make_sink
-      ~getenv:(fun name ->
-        if String.equal name env_dir
-        then Some dir
-        else if String.equal name env_max_bytes
-        then Some (string_of_int max_bytes)
-        else None)
-      ~provider:"p"
-      ~model:"m"
-  in
-  s (String.make 1024 'x');
-  (not (Sys.file_exists path)) && not (Sys.file_exists backup)
-;;
-
-let%test "invalid max bytes falls back to default cap with warning" =
-  let dir = Filename.temp_dir "oas_wire_nocap" "" in
-  let warnings = ref [] in
-  let max_bytes, invalid =
-    capture_max_bytes
-      ~getenv:(fun name -> if String.equal name env_max_bytes then Some "0" else None)
-      ()
-  in
-  let s =
+  Eio_main.run (fun _env ->
+    let dir = Filename.temp_dir "oas_wire_oversized" "" in
+    let warnings = ref [] in
+    let max_bytes = 128 in
     Diag.with_sink
       (fun level ~ctx msg -> warnings := (level, ctx, msg) :: !warnings)
       (fun () ->
-         make_sink
-           ~getenv:(fun name ->
-             if String.equal name env_dir
-             then Some dir
-             else if String.equal name env_max_bytes
-             then Some "0"
-             else None)
-           ~provider:"p"
-           ~model:"m")
-  in
-  s "chunk";
-  max_bytes = default_max_bytes
-  && invalid = Some "0"
-  && List.exists
-       (fun (level, ctx, msg) ->
-          level = Diag.Warn
-          && String.equal ctx "wire_capture"
-          && contains ~needle:"invalid; using default cap" msg)
-       !warnings
+         let s =
+           make_sink
+             ~getenv:(fun name ->
+               if String.equal name env_dir
+               then Some dir
+               else if String.equal name env_max_bytes
+               then Some (string_of_int max_bytes)
+               else None)
+             ~provider:"p"
+             ~model:"m"
+         in
+         s (String.make 1024 'x'));
+    let path = Filename.concat dir capture_filename in
+    (not (Sys.file_exists path))
+    && List.exists
+         (fun (level, ctx, msg) ->
+            level = Diag.Warn
+            && String.equal ctx "wire_capture"
+            && contains ~needle:"skipped capture chunk" msg)
+         !warnings)
+;;
+
+let%test "make_sink skips when rotation cannot preserve cap" =
+  Eio_main.run (fun _env ->
+    let dir = Filename.temp_dir "oas_wire_rotate_fail" "" in
+    let warnings = ref [] in
+    let max_bytes = 256 in
+    let path = Filename.concat dir capture_filename in
+    let backup = path ^ ".1" in
+    let oc = open_out_bin path in
+    Fun.protect
+      ~finally:(fun () -> close_out oc)
+      (fun () -> output_string oc (String.make 250 'a'));
+    Unix.mkdir backup 0o700;
+    Diag.with_sink
+      (fun level ~ctx msg -> warnings := (level, ctx, msg) :: !warnings)
+      (fun () ->
+         let s =
+           make_sink
+             ~getenv:(fun name ->
+               if String.equal name env_dir
+               then Some dir
+               else if String.equal name env_max_bytes
+               then Some (string_of_int max_bytes)
+               else None)
+             ~provider:"p"
+             ~model:"m"
+         in
+         s "small chunk");
+    file_size path <= max_bytes
+    && List.exists
+         (fun (level, ctx, msg) ->
+            level = Diag.Warn
+            && String.equal ctx "wire_capture"
+            && contains ~needle:"skipped capture write" msg)
+         !warnings)
+;;
+
+let%test "make_sink drops already oversized capture file before appending" =
+  Eio_main.run (fun _env ->
+    let dir = Filename.temp_dir "oas_wire_drop_oversized" "" in
+    let max_bytes = 256 in
+    let path = Filename.concat dir capture_filename in
+    let backup = path ^ ".1" in
+    let oc = open_out_bin path in
+    Fun.protect
+      ~finally:(fun () -> close_out oc)
+      (fun () -> output_string oc (String.make 512 'a'));
+    let s =
+      make_sink
+        ~getenv:(fun name ->
+          if String.equal name env_dir
+          then Some dir
+          else if String.equal name env_max_bytes
+          then Some (string_of_int max_bytes)
+          else None)
+        ~provider:"p"
+        ~model:"m"
+    in
+    s "small chunk";
+    file_size path <= max_bytes
+    && (not (Sys.file_exists backup))
+    &&
+    let content = read_file path in
+    contains ~needle:"small chunk" content)
+;;
+
+let%test "make_sink drops already oversized backup before appending" =
+  Eio_main.run (fun _env ->
+    let dir = Filename.temp_dir "oas_wire_drop_oversized_backup" "" in
+    let max_bytes = 256 in
+    let path = Filename.concat dir capture_filename in
+    let backup = path ^ ".1" in
+    let oc = open_out_bin backup in
+    Fun.protect
+      ~finally:(fun () -> close_out oc)
+      (fun () -> output_string oc (String.make 512 'a'));
+    let s =
+      make_sink
+        ~getenv:(fun name ->
+          if String.equal name env_dir
+          then Some dir
+          else if String.equal name env_max_bytes
+          then Some (string_of_int max_bytes)
+          else None)
+        ~provider:"p"
+        ~model:"m"
+    in
+    s "small chunk";
+    (not (Sys.file_exists backup))
+    &&
+    let content = read_file path in
+    contains ~needle:"small chunk" content)
+;;
+
+let%test "make_sink drops oversized files before skipping oversized records" =
+  Eio_main.run (fun _env ->
+    let dir = Filename.temp_dir "oas_wire_drop_before_oversized_skip" "" in
+    let max_bytes = 256 in
+    let path = Filename.concat dir capture_filename in
+    let backup = path ^ ".1" in
+    let write_big path =
+      let oc = open_out_bin path in
+      Fun.protect
+        ~finally:(fun () -> close_out oc)
+        (fun () -> output_string oc (String.make 512 'a'))
+    in
+    write_big path;
+    write_big backup;
+    let s =
+      make_sink
+        ~getenv:(fun name ->
+          if String.equal name env_dir
+          then Some dir
+          else if String.equal name env_max_bytes
+          then Some (string_of_int max_bytes)
+          else None)
+        ~provider:"p"
+        ~model:"m"
+    in
+    s (String.make 1024 'x');
+    (not (Sys.file_exists path)) && not (Sys.file_exists backup))
+;;
+
+let%test "invalid max bytes falls back to default cap with warning" =
+  Eio_main.run (fun _env ->
+    let dir = Filename.temp_dir "oas_wire_nocap" "" in
+    let warnings = ref [] in
+    let max_bytes, invalid =
+      capture_max_bytes
+        ~getenv:(fun name -> if String.equal name env_max_bytes then Some "0" else None)
+        ()
+    in
+    let s =
+      Diag.with_sink
+        (fun level ~ctx msg -> warnings := (level, ctx, msg) :: !warnings)
+        (fun () ->
+           make_sink
+             ~getenv:(fun name ->
+               if String.equal name env_dir
+               then Some dir
+               else if String.equal name env_max_bytes
+               then Some "0"
+               else None)
+             ~provider:"p"
+             ~model:"m")
+    in
+    s "chunk";
+    max_bytes = default_max_bytes
+    && invalid = Some "0"
+    && List.exists
+         (fun (level, ctx, msg) ->
+            level = Diag.Warn
+            && String.equal ctx "wire_capture"
+            && contains ~needle:"invalid; using default cap" msg)
+         !warnings)
 ;;

--- a/lib/llm_provider/wire_capture.mli
+++ b/lib/llm_provider/wire_capture.mli
@@ -13,10 +13,11 @@
     closure so the streaming hot loop pays only an indirect call — the
     environment is read once per stream, never per chunk.
 
-    Growth is bounded by [OAS_WIRE_CAPTURE_MAX_BYTES] (default 64 MiB). When a
-    chunk would push [raw-stream.jsonl] past the cap the current file is rotated
-    to [raw-stream.jsonl.1] and a fresh file is started, so at most two cap-sized
-    files exist in the capture directory.
+    Growth is bounded by [OAS_WIRE_CAPTURE_MAX_BYTES] (default 64 MiB). Invalid
+    or non-positive configured values fail closed to the default cap and emit a
+    warning. When a chunk would push [raw-stream.jsonl] past the cap the current
+    file is rotated to [raw-stream.jsonl.1] and a fresh file is started, so at
+    most two cap-sized files exist in the capture directory.
 
     @since introduced for the agent output repetition investigation (Phase O). *)
 

--- a/lib/llm_provider/wire_capture.mli
+++ b/lib/llm_provider/wire_capture.mli
@@ -13,6 +13,11 @@
     closure so the streaming hot loop pays only an indirect call — the
     environment is read once per stream, never per chunk.
 
+    Growth is bounded by [OAS_WIRE_CAPTURE_MAX_BYTES] (default 64 MiB). When a
+    chunk would push [raw-stream.jsonl] past the cap the current file is rotated
+    to [raw-stream.jsonl.1] and a fresh file is started, so at most two cap-sized
+    files exist in the capture directory.
+
     @since introduced for the agent output repetition investigation (Phase O). *)
 
 (** A per-chunk capture function. Call with each raw pre-parse chunk. *)

--- a/lib/llm_provider/wire_capture.mli
+++ b/lib/llm_provider/wire_capture.mli
@@ -17,7 +17,9 @@
     or non-positive configured values fail closed to the default cap and emit a
     warning. When a chunk would push [raw-stream.jsonl] past the cap the current
     file is rotated to [raw-stream.jsonl.1] and a fresh file is started, so at
-    most two cap-sized files exist in the capture directory.
+    most two cap-sized files exist in the capture directory. A single encoded
+    JSON line larger than the cap is skipped with a warning instead of exceeding
+    the bound.
 
     @since introduced for the agent output repetition investigation (Phase O). *)
 


### PR DESCRIPTION
Adversarial review follow-up for #2435.

**Problem:** `Wire_capture` appends every raw pre-parse chunk to a single `raw-stream.jsonl` with no size cap or rotation. During a long keeper repetition loop this file can grow without bound.

**Fix:** Add `OAS_WIRE_CAPTURE_MAX_BYTES` (default 64 MiB). When a chunk would push the current file past the cap, rotate it to `raw-stream.jsonl.1` and start a fresh file. The rotation is best-effort and never perturbs the stream. Inline tests cover rotation and the zero/invalid-max-bytes no-cap path. The ratchet-sensitive match arms use explicit constructors instead of wildcard silent defaults.

**Verification:**
- `scripts/dune-local.sh build @lib/llm_provider/runtest` (exit 0)
- `bash scripts/hardening-ratchet.sh --check`
- `bash scripts/ci-code-smell-ratchet.sh`
- `opam exec -- ocamlformat --check lib/llm_provider/wire_capture.ml lib/llm_provider/wire_capture.mli`
- `git diff --check`

**Remaining/out-of-scope:** The module-level `Stdlib.Mutex` + direct `Unix` I/O in `append_json_line` runs inline in the Eio streaming fiber. Under contention or slow disk this can block the event loop and create cross-keeper head-of-line blocking. Fixing this properly requires either an Eio-aware writer fiber (needs `~sw`/`Eio_unix.run_in_systhread` plumbing changes through `complete_stream_http`) or a non-blocking lock-and-skip strategy; both are beyond the scope of this size-bound follow-up.