### PR TITLE
docs(capabilities): correct stale Kimi structured-output rationale with measured path-dependence

### DIFF
--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -354,9 +354,17 @@ let kimi_capabilities =
        same replay contract for catalog rows whose per-entry capabilities inherit
        base="kimi" without repeating the policy. *)
   ; supports_response_format_json = true
-  ; (* Native Moonshot/Kimi docs used for K2/K2.7 do not document an OpenAI
-       json_schema-equivalent strict structured-output field. Ollama Cloud
-       Kimi rows are provider-qualified and declare their own schema support. *)
+  ; (* Path-dependent, so keep the builtin declaration false. The platform
+       chat-completions API documents response_format json_schema with
+       strict=true (MFJS spec) — platform.kimi.ai/docs/api/chat, checked
+       2026-07-03 — and the Kimi Code coding-plan gateway honors it on its
+       OpenAI-compatible path (measured 10/10 schema compliance at
+       api.kimi.com/coding/v1/chat/completions). But this builtin speaks the
+       Anthropic-compatible /v1/messages path, which silently ignores
+       output_format and returns free text (measured 2026-07-03). A deployment
+       that routes Kimi through an OpenAI-compatible provider config can
+       override per-entry via the model catalog. Ollama Cloud Kimi rows are
+       provider-qualified and declare their own schema support. *)
     supports_structured_output = false
   ; supports_system_prompt = true
   ; supports_native_streaming = true

--- a/models.toml
+++ b/models.toml
@@ -1624,6 +1624,18 @@ supports_tool_choice = false
 supports_native_streaming = true
 
 # Kimi Models
+#
+# kimi-for-coding is the Kimi Code *coding plan* alias (api.kimi.com/coding),
+# not the pay-per-token platform API: the key comes from the Kimi Code console,
+# the two credentials are not interchangeable, and the gateway picks the served
+# version (Thinking on = K2.7 Code, off = K2.6 — kimi.com/code docs, checked
+# 2026-07-03). Pricing 0.0 means subscription-included, not free-tier.
+# Structured output is path-dependent on this gateway: the OpenAI-compatible
+# /v1/chat/completions path honors response_format json_schema (measured 10/10,
+# 2026-07-03) while the Anthropic-compatible /v1/messages path — the one the
+# builtin "kimi" provider uses — silently ignores output_format. The row
+# inherits supports_structured_output=false from base="kimi"; override
+# per-entry only for a deployment that routes through the OpenAI path.
 [[models]]
 id_prefix = "kimi-for-coding"
 base = "kimi"


### PR DESCRIPTION
## 문제

`kimi_capabilities`의 `supports_structured_output = false` 근거 주석("Native Moonshot/Kimi docs do not document an OpenAI json_schema-equivalent strict structured-output field", checked 2026-06-29)이 stale — 현행 공식 문서(platform.kimi.ai/docs/api/chat)는 `response_format`에 `json_schema` + `strict`(기본 true, MFJS 스펙)를 명시 지원한다.

## 실측 (2026-07-03, Kimi Code coding plan 게이트웨이)

| 경로 | json_schema 동작 |
|---|---|
| OpenAI-compat `/v1/chat/completions` | **10/10 스키마 준수** (프롬프트에 없는 판별 필드명 사용 확인, max_tokens 충분 조건) |
| Anthropic-compat `/v1/messages` (builtin kimi가 쓰는 경로) | `output_format` **조용히 무시**, 자유 텍스트 반환 |

## 수정 (동작 무변화 — 주석/문서만)

- `capabilities.ml`: 선언값 `false`는 유지 (builtin의 Anthropic 경로 기준으로 여전히 정확) — 근거를 경로 의존성 실측으로 교체. OpenAI 경로 배포는 카탈로그 per-entry override로 켤 수 있음을 명시.
- `models.toml` kimi-for-coding 행: coding plan alias 의미론 주석 — 구독제(0.0 = subscription-included, free-tier 아님), 키 비호환(플랫폼 API와 별개), 서빙 버전은 게이트웨이가 결정(Thinking on=K2.7/off=K2.6), structured output 경로 의존성.

## 검증

- `dune build lib/llm_provider/` green + `@fmt` 통과 (주석-only 변경)
- Evidence Record: `~/me/memory/procedural-memory/2026-07-03-kimi-coding-plan-structured-output-evidence-record.md`

관련: masc에서 coding plan 바인딩 추가 작업의 선행 정리. 후속 후보: `provider_runtime_binding.ml`의 `"moonshot"→"kimi"` 매핑이 종량제 플랫폼 API 사용자를 coding plan builtin으로 끌어가는 혼동 지점 — 별도 이슈로 기록 예정.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)