### PR TITLE
ci(oas): rebalance hardening baseline after provider boundary fixes

### DIFF
--- a/.ci/hardening-baseline.json
+++ b/.ci/hardening-baseline.json
@@ -2,32 +2,30 @@
   "_comment": "Production hardening ratchet baseline. Source: docs/rfc/RFC-OAS-023-hardening-ratchet.md. Regenerate with scripts/hardening-ratchet.sh --rebaseline.",
   "examples": {
     "base_url_host_fuzzy_classifiers": [
-      "lib/llm_provider/provider_config.ml:201:String.starts_with ~prefix:\"https://ollama.com\" base_url",
-      "lib/llm_provider/provider_config.ml:202:|| String.starts_with ~prefix:\"http://ollama.com\" base_url",
-      "lib/llm_provider/provider_config.ml:796:|| String.ends_with ~suffix:\".ollama.com\" host"
+      "lib/llm_provider/provider_config.ml:834:|| String.ends_with ~suffix:\".ollama.com\" host"
     ],
     "direct_env_reads": [
-      "lib/code_snippet_eval.ml:195:let is_experiment_enabled ?(getenv = Sys.getenv_opt) () =",
-      "lib/llm_provider/backend_ollama.ml:367:let orig = Sys.getenv_opt \"OAS_OLLAMA_KEEP_ALIVE\" in",
       "lib/llm_provider/cli_common_env.ml:11:let default_getenv = Sys.getenv_opt",
-      "lib/llm_provider/complete_sync.ml:115:Sys.getenv_opt \"OAS_DEBUG_REQUEST_BODY\"",
-      "lib/llm_provider/constants.ml:19:let positive_int_env_opt ?(getenv = Sys.getenv_opt) var =",
-      "lib/llm_provider/constants.ml:249:match Sys.getenv \"OAS_DEFAULT_SEED\" with",
-      "lib/llm_provider/discovery.ml:729:(match Sys.getenv_opt \"LLM_ENDPOINTS\" with",
-      "lib/llm_provider/discovery.ml:758:(match Sys.getenv_opt \"LLM_ENDPOINTS\" with"
+      "lib/llm_provider/env_parse.ml:10:match Sys.getenv_opt name with",
+      "lib/llm_provider/env_parse.ml:16:let original = Sys.getenv_opt name in",
+      "lib/otel_tracer.ml:75:let default_config_from_env ?(getenv = Sys.getenv_opt) () =",
+      "lib/protocol/mcp.ml:418:match Sys.getenv_opt \"OAS_MCP_ALLOW_SHELL_COMMANDS\" with",
+      "lib/protocol/mcp.ml:609:(match Sys.getenv_opt \"OAS_MCP_OUTPUT_MAX_TOKENS\" with",
+      "lib/protocol/mcp.ml:618:(match Sys.getenv_opt \"OAS_MCP_OUTPUT_MAX_TOKENS\" with",
+      "lib/provider.ml:400:(match Sys.getenv_opt cfg.api_key_env with"
     ],
     "direct_env_reads_outside_env_boundary": [
-      "lib/code_snippet_eval.ml:195:let is_experiment_enabled ?(getenv = Sys.getenv_opt) () =",
-      "lib/llm_provider/backend_ollama.ml:367:let orig = Sys.getenv_opt \"OAS_OLLAMA_KEEP_ALIVE\" in",
-      "lib/llm_provider/complete_sync.ml:115:Sys.getenv_opt \"OAS_DEBUG_REQUEST_BODY\"",
-      "lib/llm_provider/discovery.ml:729:(match Sys.getenv_opt \"LLM_ENDPOINTS\" with",
-      "lib/llm_provider/discovery.ml:758:(match Sys.getenv_opt \"LLM_ENDPOINTS\" with",
-      "lib/llm_provider/pricing.ml:503:match Sys.getenv_opt \"OAS_PRICING_FILE\" with",
-      "lib/llm_provider/pricing.ml:517:(match Sys.getenv_opt \"OAS_PRICING_OVERRIDES\" with",
-      "lib/llm_provider/secret.ml:15:match Sys.getenv_opt var with"
+      "lib/otel_tracer.ml:75:let default_config_from_env ?(getenv = Sys.getenv_opt) () =",
+      "lib/protocol/mcp.ml:418:match Sys.getenv_opt \"OAS_MCP_ALLOW_SHELL_COMMANDS\" with",
+      "lib/protocol/mcp.ml:609:(match Sys.getenv_opt \"OAS_MCP_OUTPUT_MAX_TOKENS\" with",
+      "lib/protocol/mcp.ml:618:(match Sys.getenv_opt \"OAS_MCP_OUTPUT_MAX_TOKENS\" with",
+      "lib/provider.ml:400:(match Sys.getenv_opt cfg.api_key_env with",
+      "lib/provider.ml:419:(match Sys.getenv_opt cfg.api_key_env with",
+      "lib/provider.ml:575:match Sys.getenv_opt name with",
+      "lib/streaming.ml:80:(match Sys.getenv_opt \"ANTHROPIC_API_KEY\" with"
     ],
     "exception_message_classifiers": [
-      "lib/llm_provider/retry.ml:307:let msg = String.lowercase_ascii (extract_error_message body) in"
+      "lib/llm_provider/retry.ml:319:let msg = String.lowercase_ascii (extract_error_message body) in"
     ],
     "heuristic_markers": [
       "lib/context_intent.ml:84:let heuristic_classify query =",
@@ -37,22 +35,22 @@
     "model_id_string_classifiers_outside_catalog": [],
     "stub_markers": [],
     "wildcard_silent_defaults": [
+      "lib/agent/agent.ml:1035:| _ -> false)",
       "lib/agent/agent_handoff.ml:36:| _ -> None))",
       "lib/agent/agent_handoff.ml:79:| _ -> false)",
-      "lib/agent/builder.ml:498:| _ -> Ok (build b)))",
+      "lib/agent/builder.ml:502:| _ -> Ok (build b)))",
       "lib/agent_tool.ml:33:| _ -> None)",
       "lib/api_openai.ml:20:| _ -> []",
-      "lib/api_openai.ml:220:| _ -> None",
-      "lib/api_openai.ml:226:| _ -> true",
-      "lib/api_openai.ml:242:| _ -> None"
+      "lib/api_openai.ml:308:| _ -> None",
+      "lib/api_openai.ml:314:| _ -> true"
     ],
     "workaround_markers": []
   },
-  "lastUpdatedCommit": "8a6e5fede943f3e8d277b54b80018e7615ca3cb4",
+  "lastUpdatedCommit": "b46951c86eb666bf75e7ae5a6464ad067cd77776",
   "metrics": {
-    "base_url_host_fuzzy_classifiers": 3,
-    "direct_env_reads": 21,
-    "direct_env_reads_outside_env_boundary": 16,
+    "base_url_host_fuzzy_classifiers": 1,
+    "direct_env_reads": 11,
+    "direct_env_reads_outside_env_boundary": 8,
     "exception_message_classifiers": 1,
     "heuristic_markers": 2,
     "local_workspace_path_literals": 0,


### PR DESCRIPTION
적대적 검토 후속. #2446/#2447 머지로 hardening baseline 예시/카운트가 stale해진 부분을 재생성합니다.\n\n- base_url_host_fuzzy_classifiers: 3 -> 1\n- direct_env_reads / outside-env-boundary / exception_message_classifiers / wildcard_silent_defaults 라인 번호 및 카운트 갱신\n\nSSOT: docs/rfc/RFC-OAS-023-hardening-ratchet.md