### PR TITLE
fix(provider): map api.kimi.com coding-plan host to kimi vendor identity (#2452)

### DIFF
--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -230,11 +230,31 @@ let base_url_targets_deepseek base_url =
   | Some host -> String.equal (String.lowercase_ascii host) "api.deepseek.com"
 ;;
 
+(* RFC-OAS-034 §2 rule 2: [api.kimi.com] is the Kimi Code coding-plan gateway's
+   canonical vendor host, so an OpenAI-compatible endpoint served from it carries
+   the vendor identity "kimi" (and its [kimi_capabilities] preset) rather than the
+   generic transport kind "openai_compat". Without this mapping an OpenAI-compat
+   runtime pointed at api.kimi.com/coding/v1 resolves its label to "openai_compat",
+   trips [raw_openai_compat_requires_endpoint_declaration], and is rejected by the
+   capability gate as absent from the catalog (oas#2452). Scope is deliberately the
+   coding-plan host only: the pay-per-token Moonshot platform (api.moonshot.ai) is
+   a separate product with an incompatible key/billing contract (oas#2452), so it
+   is not mapped here. Matched by exact [Uri.host] equality, mirroring
+   [base_url_targets_deepseek]: host->identity (allowed), not host->capability of a
+   generic rental edge (forbidden). *)
+let base_url_targets_kimi base_url =
+  match Uri.of_string base_url |> Uri.host with
+  | None -> false
+  | Some host -> String.equal (String.lowercase_ascii host) "api.kimi.com"
+;;
+
 let capability_provider_label (config : t) =
   if base_url_targets_ollama_cloud config.base_url
   then "ollama_cloud"
   else if base_url_targets_deepseek config.base_url
   then "deepseek"
+  else if base_url_targets_kimi config.base_url
+  then "kimi"
   else string_of_provider_kind config.kind
 ;;
 

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -1667,6 +1667,39 @@ let test_capability_provider_label_deepseek_exact_host () =
     (label "https://api.deepseek.com@evil.example/v1")
 ;;
 
+let test_capability_provider_label_kimi_exact_host () =
+  let label base_url =
+    Provider_config.capability_provider_label
+      (Provider_config.make ~kind:OpenAI_compat ~model_id:"kimi-for-coding" ~base_url ())
+  in
+  (* RFC-OAS-034 rule 2: api.kimi.com is the Kimi Code coding-plan gateway's
+     canonical vendor host, so an OpenAI-compatible endpoint pointed at it carries
+     the vendor identity "kimi" regardless of scheme (oas#2452). This routes
+     kimi-for-coding to [kimi_capabilities] instead of provider_default, so the
+     runtime capability gate accepts it. *)
+  check_string
+    "https canonical host is kimi"
+    "kimi"
+    (label "https://api.kimi.com/coding/v1");
+  check_string "http canonical host is kimi" "kimi" (label "http://api.kimi.com/coding/v1");
+  (* Exact [Uri.host] equality rejects look-alikes, and the separate pay-per-token
+     Moonshot platform host (api.moonshot.ai) is deliberately not mapped — it is an
+     incompatible key/billing product (oas#2452). Both fall back to the transport
+     kind label ("openai_compat"). *)
+  check_string
+    "subdomain lookalike is not kimi"
+    "openai_compat"
+    (label "https://api.kimi.com.evil.example/v1");
+  check_string
+    "userinfo lookalike is not kimi"
+    "openai_compat"
+    (label "https://api.kimi.com@evil.example/v1");
+  check_string
+    "moonshot platform host is not mapped to kimi"
+    "openai_compat"
+    (label "https://api.moonshot.ai/v1")
+;;
+
 let check_unmatched_provider_name_ignores_catalog_model ~label ~model_id =
   with_repository_model_catalog (fun () ->
     let cfg =
@@ -2406,6 +2439,10 @@ let () =
             "deepseek vendor host label (exact Uri.host, RFC-OAS-034)"
             `Quick
             test_capability_provider_label_deepseek_exact_host
+        ; Alcotest.test_case
+            "kimi coding-plan vendor host label (exact Uri.host, RFC-OAS-034, oas#2452)"
+            `Quick
+            test_capability_provider_label_kimi_exact_host
         ; Alcotest.test_case
             "unmatched openai_compat"
             `Quick


### PR DESCRIPTION
## 요약

Kimi Code 코딩플랜 게이트웨이(`api.kimi.com/coding/v1`)를 향한 OpenAI-compat 런타임이 `capability_provider_label`에서 generic `openai_compat`으로 떨어져, `raw_openai_compat_requires_endpoint_declaration` 게이트에 거부되고 masc keeper가 `Runtime.init_default_strict`로 부팅을 거부하던 문제를 해소합니다(#2452).

## 근본 원인

`kimi_code` provider(OpenAI_compat kind, base_url `api.kimi.com/coding/v1`)의 `capability_provider_label`이 host를 인식하지 못해 `openai_compat`을 반환 → `raw_openai_compat_without_builtin_source`=true → bare `kimi-for-coding` catalog row가 `capability_requires_endpoint_declaration`(tools/thinking 있으면 true)에 걸려 `None` 반환 → 모델이 catalog에 없는 것으로 처리 → fail-closed 부팅 거부.

## 변경

`base_url_targets_kimi`(host `api.kimi.com` 정확 일치)를 추가하고 `capability_provider_label`에 배선. RFC-OAS-034 §2 rule 2(vendor-canonical domain → host→identity)를 `api.deepseek.com` 선례 그대로 확장. 결과: label=`kimi` → `raw_openai_compat_without_builtin_source`=false → `capabilities_for_config_model`의 else 분기에서 `kimi_capabilities` 상속. kind=OpenAI_compat는 유지되어 `/chat/completions`(coding-plan 경로) 라우팅은 그대로.

## 스코프 결정 (트레이드오프)

- coding-plan host(`api.kimi.com`)만 매핑. 종량제 Moonshot 플랫폼(`api.moonshot.ai`)은 **키·과금이 다른 별개 제품**(#2452)이라 의도적으로 제외 — 테스트로 `openai_compat` 폴백을 고정.
- structured_output은 base=kimi 기본값(false, Anthropic 경로 기준)을 상속. coding-plan OpenAI 경로는 이를 지원(10/10)하므로 소비자(masc runtime.toml)가 per-entry로 활성화 가능.

## 검증

- 신규 테스트 `test_capability_provider_label_kimi_exact_host`: `api.kimi.com`→`kimi`(https/http), lookalike(subdomain/userinfo)→`openai_compat`, `api.moonshot.ai`→`openai_compat`(미매핑).
- `ocamlformat --check` 통과. dune build/test는 CI 위임.

Refs jeong-sik/oas#2452, jeong-sik/masc#27917 (RFC-OAS-034)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
