### PR TITLE
fix(llm_provider): offload wire capture I/O to a background fiber

### DIFF
--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -627,286 +627,290 @@ let complete_stream_http
                  long-lived switch terminates. *)
               let wire_sink = Wire_capture.make_sink ~sw:wire_sw ~provider ~model in
               let body_logic () =
-              let acc = Complete_stream_acc.create_stream_acc () in
-              let openai_state = ref None in
-              let streaming_reasoning =
-                (Reasoning_dialect.for_provider_config config).streaming
-              in
-              (* RFC-OAS-019: first_chunk_seen / chunk_counter / last_chunk_t
+                let acc = Complete_stream_acc.create_stream_acc () in
+                let openai_state = ref None in
+                let streaming_reasoning =
+                  (Reasoning_dialect.for_provider_config config).streaming
+                in
+                (* RFC-OAS-019: first_chunk_seen / chunk_counter / last_chunk_t
                  hoisted out of body_logic so publish_summary on
                  exception paths sees consistent state. *)
-              let get_state () =
-                match !openai_state with
-                | Some s -> s
-                | None ->
-                  let s = Streaming.create_openai_stream_state ~provider ~model () in
-                  openai_state := Some s;
-                  s
-              in
-              let dispatch (events, tel_opt) =
-                (* RFC-OAS-020: capture first-event + first-token
+                let get_state () =
+                  match !openai_state with
+                  | Some s -> s
+                  | None ->
+                    let s = Streaming.create_openai_stream_state ~provider ~model () in
+                    openai_state := Some s;
+                    s
+                in
+                let dispatch (events, tel_opt) =
+                  (* RFC-OAS-020: capture first-event + first-token
                    wall-clock offsets. [first_event_at_ref] fires on
                    ANY first event (prelude or token);
                    [first_token_at_ref] fires on generated token events,
                    including hidden reasoning. The two refs together
                    distinguish prefill from generation latency. *)
-                let elapsed_ms = latency_ms_float latency_counter in
-                (* Thinking-only cutoff timestamps follow the injected Eio
+                  let elapsed_ms = latency_ms_float latency_counter in
+                  (* Thinking-only cutoff timestamps follow the injected Eio
                    clock when one is available, so a mock clock controls the
                    cutoff in tests. Telemetry durations use the monotonic
                    [latency_counter] above and therefore do not depend on
                    wall-clock adjustments. *)
-                let cutoff_now =
-                  match clock with
-                  | Some c -> Eio.Time.now c
-                  | None -> Unix.gettimeofday ()
-                in
-                if events <> []
-                then (
-                  (match elapsed_ms with
-                   | Some elapsed_ms when Option.is_none !first_event_at_ref ->
-                     first_event_at_ref := Some elapsed_ms
-                   | Some _ | None -> ());
-                  stream_idle_state := Http_client.Awaiting_first_delta);
-                if
-                  Option.is_none !first_token_at_ref
-                  && List.exists Streaming.sse_event_is_first_token_signal events
-                then first_token_at_ref := elapsed_ms;
-                if
-                  Option.is_none !first_deliverable_at_ref
-                  && List.exists Streaming.sse_event_is_deliverable_progress_signal events
-                then first_deliverable_at_ref := elapsed_ms;
-                List.iter
-                  (fun evt ->
-                     emit_stream_event on_event evt;
-                     Complete_stream_acc.accumulate_event acc evt;
-                     (* RFC-OAS-019: classify each delta for the
+                  let cutoff_now =
+                    match clock with
+                    | Some c -> Eio.Time.now c
+                    | None -> Unix.gettimeofday ()
+                  in
+                  if events <> []
+                  then (
+                    (match elapsed_ms with
+                     | Some elapsed_ms when Option.is_none !first_event_at_ref ->
+                       first_event_at_ref := Some elapsed_ms
+                     | Some _ | None -> ());
+                    stream_idle_state := Http_client.Awaiting_first_delta);
+                  if
+                    Option.is_none !first_token_at_ref
+                    && List.exists Streaming.sse_event_is_first_token_signal events
+                  then first_token_at_ref := elapsed_ms;
+                  if
+                    Option.is_none !first_deliverable_at_ref
+                    && List.exists
+                         Streaming.sse_event_is_deliverable_progress_signal
+                         events
+                  then first_deliverable_at_ref := elapsed_ms;
+                  List.iter
+                    (fun evt ->
+                       emit_stream_event on_event evt;
+                       Complete_stream_acc.accumulate_event acc evt;
+                       (* RFC-OAS-019: classify each delta for the
                         [Streaming_summary] kind_breakdown that fires at
                         finalize. Wire errors set terminal_state; per-chunk
                         emission of [Streaming_chunk_n] is no longer
                         published — only the lifecycle summary is. *)
-                     match classify_chunk_kind evt with
-                     | `Skip -> ()
-                     | `Thinking ->
-                       stream_idle_state := Http_client.Streaming_thinking;
-                       if
-                         Option.is_none !first_deliverable_at_ref
-                         && Option.is_none !thinking_only_started_at_ref
-                       then thinking_only_started_at_ref := Some cutoff_now;
-                       incr n_thinking
-                     | `Answer ->
-                       stream_idle_state := Http_client.Streaming_answer;
-                       thinking_only_started_at_ref := None;
-                       incr n_answer
-                     | `Tool_call_start ->
-                       stream_idle_state := Http_client.Streaming_tool_call;
-                       thinking_only_started_at_ref := None;
-                       incr n_tool_call_start
-                     | `Tool_call_arg_delta ->
-                       stream_idle_state := Http_client.Streaming_tool_call;
-                       thinking_only_started_at_ref := None;
-                       incr n_tool_call_arg_delta
-                     | `Tool_call_complete ->
-                       stream_idle_state := Http_client.Streaming_tool_call;
-                       thinking_only_started_at_ref := None;
-                       incr n_tool_call_complete
-                     | `Substrate ->
-                       stream_idle_state := Http_client.Streaming_substrate;
-                       incr n_substrate
-                     | `Heartbeat ->
-                       stream_idle_state := Http_client.Streaming_heartbeat;
-                       incr n_heartbeat
-                     | `Done ->
-                       stream_idle_state := Http_client.Streaming_done;
-                       incr n_done
-                     | `Wire_error ->
-                       stream_idle_state := Http_client.Streaming_unknown;
-                       terminal_state := Telemetry_event.Terminal_error "sse_wire_error")
-                  events;
-                (match
-                   ( stream_idle_timeout_s
-                   , !first_deliverable_at_ref
-                   , !thinking_only_started_at_ref )
-                 with
-                 | Some timeout_s, None, Some started_at
-                   when Streaming.thinking_only_timeout_exceeded
-                          ~timeout_s
-                          ~started_at
-                          ~now:cutoff_now -> raise Eio.Time.Timeout
-                 | Some _, _, _ | None, _, _ -> ());
-                if events <> []
-                then
-                  if not !first_chunk_seen
-                  then (
-                    first_chunk_seen := true;
-                    (* Reuse the per-dispatch monotonic elapsed sample. This
+                       match classify_chunk_kind evt with
+                       | `Skip -> ()
+                       | `Thinking ->
+                         stream_idle_state := Http_client.Streaming_thinking;
+                         if
+                           Option.is_none !first_deliverable_at_ref
+                           && Option.is_none !thinking_only_started_at_ref
+                         then thinking_only_started_at_ref := Some cutoff_now;
+                         incr n_thinking
+                       | `Answer ->
+                         stream_idle_state := Http_client.Streaming_answer;
+                         thinking_only_started_at_ref := None;
+                         incr n_answer
+                       | `Tool_call_start ->
+                         stream_idle_state := Http_client.Streaming_tool_call;
+                         thinking_only_started_at_ref := None;
+                         incr n_tool_call_start
+                       | `Tool_call_arg_delta ->
+                         stream_idle_state := Http_client.Streaming_tool_call;
+                         thinking_only_started_at_ref := None;
+                         incr n_tool_call_arg_delta
+                       | `Tool_call_complete ->
+                         stream_idle_state := Http_client.Streaming_tool_call;
+                         thinking_only_started_at_ref := None;
+                         incr n_tool_call_complete
+                       | `Substrate ->
+                         stream_idle_state := Http_client.Streaming_substrate;
+                         incr n_substrate
+                       | `Heartbeat ->
+                         stream_idle_state := Http_client.Streaming_heartbeat;
+                         incr n_heartbeat
+                       | `Done ->
+                         stream_idle_state := Http_client.Streaming_done;
+                         incr n_done
+                       | `Wire_error ->
+                         stream_idle_state := Http_client.Streaming_unknown;
+                         terminal_state := Telemetry_event.Terminal_error "sse_wire_error")
+                    events;
+                  (match
+                     ( stream_idle_timeout_s
+                     , !first_deliverable_at_ref
+                     , !thinking_only_started_at_ref )
+                   with
+                   | Some timeout_s, None, Some started_at
+                     when Streaming.thinking_only_timeout_exceeded
+                            ~timeout_s
+                            ~started_at
+                            ~now:cutoff_now -> raise Eio.Time.Timeout
+                   | Some _, _, _ | None, _, _ -> ());
+                  if events <> []
+                  then
+                    if not !first_chunk_seen
+                    then (
+                      first_chunk_seen := true;
+                      (* Reuse the per-dispatch monotonic elapsed sample. This
                        keeps inter-chunk gaps measured dispatch-to-dispatch
                        instead of mixing in per-event processing time. *)
-                    let ttfrc_ms = elapsed_ms in
-                    ttfrc_ref := ttfrc_ms;
-                    emit_telemetry
-                      (Telemetry_event.Streaming_first_chunk
-                         { provider; model; ttfrc_ms; requested_at });
-                    last_chunk_t := elapsed_ms;
-                    chunk_counter := 1)
-                  else (
-                    (* [elapsed_ms] is the dispatch-entry sample bound above.
+                      let ttfrc_ms = elapsed_ms in
+                      ttfrc_ref := ttfrc_ms;
+                      emit_telemetry
+                        (Telemetry_event.Streaming_first_chunk
+                           { provider; model; ttfrc_ms; requested_at });
+                      last_chunk_t := elapsed_ms;
+                      chunk_counter := 1)
+                    else (
+                      (* [elapsed_ms] is the dispatch-entry sample bound above.
                        [last_chunk_t] is also a dispatch-entry sample, so
                        [inter_chunk_ms] is a clean dispatch-to-dispatch gap. *)
-                    (match elapsed_ms, !last_chunk_t with
-                     | Some elapsed_ms, Some last_chunk_t ->
-                       let inter_chunk_ms = elapsed_ms -. last_chunk_t in
-                       (* RFC-OAS-019: per-chunk [Streaming_chunk_n] publish
+                      (match elapsed_ms, !last_chunk_t with
+                       | Some elapsed_ms, Some last_chunk_t ->
+                         let inter_chunk_ms = elapsed_ms -. last_chunk_t in
+                         (* RFC-OAS-019: per-chunk [Streaming_chunk_n] publish
                           removed. Inter-chunk gaps are accumulated for the
                           percentile reservoir in [Streaming_summary]. Metrics
                           sinks still receive the raw sample so aggregate backends
                           can preserve latency counters without re-expanding the
                           public telemetry stream. *)
-                       metrics.on_streaming_chunk
-                         ~provider
-                         ~model_id:model
-                         ~chunk_index:!chunk_counter
-                         ~inter_chunk_ms;
-                       inter_chunk_samples := inter_chunk_ms :: !inter_chunk_samples
-                     | Some _, None | None, Some _ | None, None -> ());
-                    last_chunk_t := elapsed_ms;
-                    incr chunk_counter);
-                match tel_opt with
-                | Some evt -> emit_telemetry evt
-                | None -> ()
-              in
-              let stream_read_result =
-                try
-                  (match config.kind with
-                   | Provider_config.Ollama ->
-                     Http_client.read_ndjson
-                       ?clock
-                       ?idle_timeout:stream_idle_timeout_s
-                       ~reader
-                       ~on_line:(fun line ->
-                         wire_sink line;
-                         match Streaming.parse_ollama_ndjson_chunk line with
-                         | None ->
-                           dispatch
-                             ( [ Types.SSEParseFailed
-                                   { raw = line
-                                   ; reason = "ollama_ndjson_chunk_parse_failure"
-                                   }
-                               ]
-                             , None )
-                         | Some chunk ->
-                           (match chunk.oll_timings with
-                            | Some _ as t -> ollama_timings := t
-                            | None -> ());
-                           (match chunk.oll_usage with
-                            | Some _ as u -> ollama_usage := u
-                            | None -> ());
-                           dispatch
-                             (Streaming.ollama_chunk_to_events (get_state ()) chunk))
-                       ()
-                   | _non_ollama_kind ->
-                     Http_client.read_sse
-                       ?clock
-                       ?idle_timeout:stream_idle_timeout_s
-                       ~reader
-                       ~on_data:(fun ~event_type data ->
-                         wire_sink data;
-                         let events =
-                           match config.kind with
-                           | Provider_config.Anthropic ->
-                             (match Streaming.parse_sse_event event_type data with
-                              | Some evt -> [ evt ], None
-                              | None -> [], None)
-                           | Provider_config.OpenAI_compat when uses_responses_api ->
-                             Streaming.responses_sse_to_events
-                               (get_state ())
-                               event_type
-                               data
-                           | Provider_config.OpenAI_compat
-                           | Provider_config.DashScope
-                           | Provider_config.Kimi ->
-                             (match
-                                Streaming.parse_openai_sse_chunk ~streaming_reasoning data
-                              with
-                              | Some chunk ->
-                                Streaming.openai_chunk_to_events (get_state ()) chunk
-                              | None ->
-                                (* A [None] from the chunk parser is the [DONE]
+                         metrics.on_streaming_chunk
+                           ~provider
+                           ~model_id:model
+                           ~chunk_index:!chunk_counter
+                           ~inter_chunk_ms;
+                         inter_chunk_samples := inter_chunk_ms :: !inter_chunk_samples
+                       | Some _, None | None, Some _ | None, None -> ());
+                      last_chunk_t := elapsed_ms;
+                      incr chunk_counter);
+                  match tel_opt with
+                  | Some evt -> emit_telemetry evt
+                  | None -> ()
+                in
+                let stream_read_result =
+                  try
+                    (match config.kind with
+                     | Provider_config.Ollama ->
+                       Http_client.read_ndjson
+                         ?clock
+                         ?idle_timeout:stream_idle_timeout_s
+                         ~reader
+                         ~on_line:(fun line ->
+                           wire_sink line;
+                           match Streaming.parse_ollama_ndjson_chunk line with
+                           | None ->
+                             dispatch
+                               ( [ Types.SSEParseFailed
+                                     { raw = line
+                                     ; reason = "ollama_ndjson_chunk_parse_failure"
+                                     }
+                                 ]
+                               , None )
+                           | Some chunk ->
+                             (match chunk.oll_timings with
+                              | Some _ as t -> ollama_timings := t
+                              | None -> ());
+                             (match chunk.oll_usage with
+                              | Some _ as u -> ollama_usage := u
+                              | None -> ());
+                             dispatch
+                               (Streaming.ollama_chunk_to_events (get_state ()) chunk))
+                         ()
+                     | _non_ollama_kind ->
+                       Http_client.read_sse
+                         ?clock
+                         ?idle_timeout:stream_idle_timeout_s
+                         ~reader
+                         ~on_data:(fun ~event_type data ->
+                           wire_sink data;
+                           let events =
+                             match config.kind with
+                             | Provider_config.Anthropic ->
+                               (match Streaming.parse_sse_event event_type data with
+                                | Some evt -> [ evt ], None
+                                | None -> [], None)
+                             | Provider_config.OpenAI_compat when uses_responses_api ->
+                               Streaming.responses_sse_to_events
+                                 (get_state ())
+                                 event_type
+                                 data
+                             | Provider_config.OpenAI_compat
+                             | Provider_config.DashScope
+                             | Provider_config.Kimi ->
+                               (match
+                                  Streaming.parse_openai_sse_chunk
+                                    ~streaming_reasoning
+                                    data
+                                with
+                                | Some chunk ->
+                                  Streaming.openai_chunk_to_events (get_state ()) chunk
+                                | None ->
+                                  (* A [None] from the chunk parser is the [DONE]
                                    sentinel, a usage-only/empty chunk, OR a
                                    provider error object ([{"error": ...}]) that
                                    has no [choices]. The helper maps [DONE] to a
                                    [MessageStop] (clean close -> no phantom
                                    completion) and an error object to a typed
                                    [SSEError]; everything else yields no events. *)
-                                Streaming.openai_compat_terminal_events data, None)
-                           | Provider_config.Gemini ->
-                             (match Streaming.parse_gemini_sse_chunk data with
-                              | Some chunk ->
-                                Streaming.gemini_chunk_to_events (get_state ()) chunk
-                              | None ->
-                                ( [ Types.SSEParseFailed
-                                      { raw = data
-                                      ; reason = "gemini_sse_chunk_parse_failure"
-                                      }
-                                  ]
-                                , None ))
-                           | Provider_config.Glm ->
-                             (match Backend_glm.parse_stream_chunk data with
-                              | Some chunk ->
-                                Streaming.openai_chunk_to_events (get_state ()) chunk
-                              | None ->
-                                (* Same [None] cases as the OpenAI-compatible
+                                  Streaming.openai_compat_terminal_events data, None)
+                             | Provider_config.Gemini ->
+                               (match Streaming.parse_gemini_sse_chunk data with
+                                | Some chunk ->
+                                  Streaming.gemini_chunk_to_events (get_state ()) chunk
+                                | None ->
+                                  ( [ Types.SSEParseFailed
+                                        { raw = data
+                                        ; reason = "gemini_sse_chunk_parse_failure"
+                                        }
+                                    ]
+                                  , None ))
+                             | Provider_config.Glm ->
+                               (match Backend_glm.parse_stream_chunk data with
+                                | Some chunk ->
+                                  Streaming.openai_chunk_to_events (get_state ()) chunk
+                                | None ->
+                                  (* Same [None] cases as the OpenAI-compatible
                                    branch: [DONE] -> [MessageStop], error object
                                    -> [SSEError], else no events. *)
-                                Streaming.openai_compat_terminal_events data, None)
-                           | Provider_config.Ollama ->
-                             [], None (* unreachable: handled above *)
-                         in
-                         dispatch events)
-                       ());
-                  Ok ()
-                with
-                | Eio.Time.Timeout ->
-                  let phase =
-                    Http_client.timeout_phase_of_stream_idle_state !stream_idle_state
-                  in
-                  let message =
-                    Printf.sprintf
-                      "stream_idle_timeout_s deadline exceeded while %s"
-                      (Http_client.stream_idle_state_to_label !stream_idle_state)
-                  in
-                  emit_stream_event on_event (Types.Timeout message);
-                  emit_telemetry
-                    (Telemetry_event.Timeout
-                       { provider
-                       ; model
-                       ; timeout_type = Telemetry_event.Stream_idle !stream_idle_state
-                       });
-                  publish_summary
-                    ~terminal:
-                      (Telemetry_event.Terminal_error
-                         (Printf.sprintf
-                            "stream_idle_timeout_s_exceeded:%s"
-                            (Http_client.stream_idle_state_to_label !stream_idle_state)))
-                    ();
-                  Error (Http_client.TimeoutError { message; phase })
-              in
-              match stream_read_result with
-              | Error _ as err -> err
-              | Ok () ->
-                let result =
-                  match Complete_stream_acc.finalize_stream_acc acc with
-                  | Ok _ as ok -> ok
-                  | Error serr -> Error (http_error_of_stream_error serr)
+                                  Streaming.openai_compat_terminal_events data, None)
+                             | Provider_config.Ollama ->
+                               [], None (* unreachable: handled above *)
+                           in
+                           dispatch events)
+                         ());
+                    Ok ()
+                  with
+                  | Eio.Time.Timeout ->
+                    let phase =
+                      Http_client.timeout_phase_of_stream_idle_state !stream_idle_state
+                    in
+                    let message =
+                      Printf.sprintf
+                        "stream_idle_timeout_s deadline exceeded while %s"
+                        (Http_client.stream_idle_state_to_label !stream_idle_state)
+                    in
+                    emit_stream_event on_event (Types.Timeout message);
+                    emit_telemetry
+                      (Telemetry_event.Timeout
+                         { provider
+                         ; model
+                         ; timeout_type = Telemetry_event.Stream_idle !stream_idle_state
+                         });
+                    publish_summary
+                      ~terminal:
+                        (Telemetry_event.Terminal_error
+                           (Printf.sprintf
+                              "stream_idle_timeout_s_exceeded:%s"
+                              (Http_client.stream_idle_state_to_label !stream_idle_state)))
+                      ();
+                    Error (Http_client.TimeoutError { message; phase })
                 in
-                (* RFC-OAS-019: emit one [Streaming_summary] at stream
+                match stream_read_result with
+                | Error _ as err -> err
+                | Ok () ->
+                  let result =
+                    match Complete_stream_acc.finalize_stream_acc acc with
+                    | Ok _ as ok -> ok
+                    | Error serr -> Error (http_error_of_stream_error serr)
+                  in
+                  (* RFC-OAS-019: emit one [Streaming_summary] at stream
                    finalize on the normal path. terminal_state defaults to
                    [Terminal_done]; wire errors during dispatch upgrade it
                    in place. *)
-                publish_summary ~terminal:!terminal_state ();
-                result
-            in
-            body_logic ()))
+                  publish_summary ~terminal:!terminal_state ();
+                  result
+              in
+              body_logic ()))
           ()
       with
       | Error _ as e ->

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -621,7 +621,7 @@ let complete_stream_http
                  loop below pays only an indirect call. Attributes a
                  degenerate-repetition bug to the model vs. the stream parser.
 
-                 The sink is scoped to a per-request switch so the background
+                 The sink is scoped to a per-request switch so the daemon
                  writer fiber is cancelled (and drains its queue) as soon as the
                  stream body is consumed, instead of leaking until the caller's
                  long-lived switch terminates. *)

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -614,7 +614,19 @@ let complete_stream_http
           ~body:body_with_stream
           ~f:(fun reader ->
             emit_stream_event on_event Types.Connected;
-            let body_logic () =
+            Eio.Switch.run (fun wire_sw ->
+              (* Phase O observability: env-gated ([OAS_WIRE_CAPTURE_DIR])
+                 redacted tee of raw pre-parse stream chunks. The environment is
+                 read once here; when unset [wire_sink] is a no-op so the hot
+                 loop below pays only an indirect call. Attributes a
+                 degenerate-repetition bug to the model vs. the stream parser.
+
+                 The sink is scoped to a per-request switch so the background
+                 writer fiber is cancelled (and drains its queue) as soon as the
+                 stream body is consumed, instead of leaking until the caller's
+                 long-lived switch terminates. *)
+              let wire_sink = Wire_capture.make_sink ~sw:wire_sw ~provider ~model in
+              let body_logic () =
               let acc = Complete_stream_acc.create_stream_acc () in
               let openai_state = ref None in
               let streaming_reasoning =
@@ -763,12 +775,6 @@ let complete_stream_http
                 | Some evt -> emit_telemetry evt
                 | None -> ()
               in
-              (* Phase O observability: env-gated ([OAS_WIRE_CAPTURE_DIR])
-                 redacted tee of raw pre-parse stream chunks. The environment is
-                 read once here; when unset [wire_sink] is a no-op so the hot
-                 loop below pays only an indirect call. Attributes a
-                 degenerate-repetition bug to the model vs. the stream parser. *)
-              let wire_sink = Wire_capture.make_sink ~provider ~model in
               let stream_read_result =
                 try
                   (match config.kind with
@@ -900,7 +906,7 @@ let complete_stream_http
                 publish_summary ~terminal:!terminal_state ();
                 result
             in
-            body_logic ())
+            body_logic ()))
           ()
       with
       | Error _ as e ->

--- a/lib/llm_provider/wire_capture.ml
+++ b/lib/llm_provider/wire_capture.ml
@@ -263,51 +263,50 @@ let make_sink ?getenv ?sw ~provider ~model =
             env_max_bytes
             value
             default_max_bytes);
-       let write = write_line ~path ~provider ~model ~warned ~oversized_warned ~max_bytes in
-       match sw with
-       | None -> write
-       | Some sw ->
-         let stream = Eio.Stream.create async_stream_capacity in
-         let drop_warned = ref false in
-         let writer_failed = ref false in
-         let rec writer () =
-           let chunk = Eio.Stream.take stream in
-           write chunk;
-           writer ()
-         in
-         Eio.Fiber.fork ~sw (fun () ->
-           try writer () with
-           | Eio.Cancel.Cancelled _ ->
-             (* Switch cancelled: drain any remaining queued chunks best-effort
+       let write =
+         write_line ~path ~provider ~model ~warned ~oversized_warned ~max_bytes
+       in
+       (match sw with
+        | None -> write
+        | Some sw ->
+          let stream = Eio.Stream.create async_stream_capacity in
+          let drop_warned = ref false in
+          let writer_failed = ref false in
+          let rec writer () =
+            let chunk = Eio.Stream.take stream in
+            write chunk;
+            writer ()
+          in
+          Eio.Fiber.fork ~sw (fun () ->
+            try writer () with
+            | Eio.Cancel.Cancelled _ ->
+              (* Switch cancelled: drain any remaining queued chunks best-effort
                 before exiting so the tail of a stream is not silently lost. *)
-             let rec drain () =
-               match Eio.Stream.take_nonblocking stream with
-               | Some chunk ->
-                 write chunk;
-                 drain ()
-               | None -> ()
-             in
-             drain ()
-           | exn ->
-             if not !writer_failed
-             then (
-               writer_failed := true;
-               Diag.warn
-                 "wire_capture"
-                 "background writer failed for %S: %s"
-                 path
-                 (Printexc.to_string exn)));
-         fun chunk ->
-           if Eio.Stream.length stream >= async_stream_capacity
-           then (
-             if not !drop_warned
-             then (
-               drop_warned := true;
-               Diag.warn
-                 "wire_capture"
-                 "capture queue full; dropping chunk for %S"
-                 path))
-           else Eio.Stream.add stream chunk)
+              let rec drain () =
+                match Eio.Stream.take_nonblocking stream with
+                | Some chunk ->
+                  write chunk;
+                  drain ()
+                | None -> ()
+              in
+              drain ()
+            | exn ->
+              if not !writer_failed
+              then (
+                writer_failed := true;
+                Diag.warn
+                  "wire_capture"
+                  "background writer failed for %S: %s"
+                  path
+                  (Printexc.to_string exn)));
+          fun chunk ->
+            if Eio.Stream.length stream >= async_stream_capacity
+            then (
+              if not !drop_warned
+              then (
+                drop_warned := true;
+                Diag.warn "wire_capture" "capture queue full; dropping chunk for %S" path))
+            else Eio.Stream.add stream chunk))
 ;;
 
 (* ── Inline tests ─────────────────────────────────────────────── *)
@@ -357,6 +356,8 @@ let%test "make_sink is a no-op when env is unset or empty" =
 let%test "make_sink writes redacted binary JSONL when env is set" =
   Eio_main.run (fun _env ->
     let dir = Filename.temp_dir "oas_wire" "" in
+    (* Built at runtime so no literal secret appears in source. *)
+    let token = "ghp_" ^ String.make 36 '7' in
     Eio.Switch.run (fun sw ->
       let s =
         make_sink
@@ -365,8 +366,6 @@ let%test "make_sink writes redacted binary JSONL when env is set" =
           ~provider:"ollama_cloud"
           ~model:"deepseek-v4-flash"
       in
-      (* Built at runtime so no literal secret appears in source. *)
-      let token = "ghp_" ^ String.make 36 '7' in
       s ("delta content " ^ token ^ " end"));
     let path = Filename.concat dir capture_filename in
     let content = read_file path in
@@ -677,15 +676,15 @@ let%test "async sink enqueue does not wait for slow writer" =
       let s = make_sink ~sw ~getenv:(capture_getenv dir) ~provider:"p" ~model:"m" in
       Eio.Fiber.both
         (fun () ->
-          (* Hold the append mutex so the background writer cannot make
+           (* Hold the append mutex so the background writer cannot make
              progress. A synchronous sink would block here for the full
              duration. *)
-          with_append_mutex (fun () -> Eio.Time.sleep clock 0.3))
+           with_append_mutex (fun () -> Eio.Time.sleep clock 0.3))
         (fun () ->
-          Eio.Time.sleep clock 0.05;
-          let t0 = Unix.gettimeofday () in
-          s "chunk";
-          enqueue_elapsed := Unix.gettimeofday () -. t0));
+           Eio.Time.sleep clock 0.05;
+           let t0 = Unix.gettimeofday () in
+           s "chunk";
+           enqueue_elapsed := Unix.gettimeofday () -. t0));
     !enqueue_elapsed < 0.1)
 ;;
 
@@ -701,13 +700,13 @@ let%test "async sink drops newest chunk when queue is full" =
            let s = make_sink ~sw ~getenv:(capture_getenv dir) ~provider:"p" ~model:"m" in
            Eio.Fiber.both
              (fun () ->
-               (* Hold the append mutex so the writer cannot drain the queue. *)
-               with_append_mutex (fun () -> Eio.Time.sleep clock 0.3))
+                (* Hold the append mutex so the writer cannot drain the queue. *)
+                with_append_mutex (fun () -> Eio.Time.sleep clock 0.3))
              (fun () ->
-               (* Fill and overflow the queue. Each add is non-blocking. *)
-               for i = 1 to async_stream_capacity + 3 do
-                 s (Printf.sprintf "chunk-%d" i)
-               done)));
+                (* Fill and overflow the queue. Each add is non-blocking. *)
+                for i = 1 to async_stream_capacity + 3 do
+                  s (Printf.sprintf "chunk-%d" i)
+                done)));
     (* The writer was blocked for the whole time, so at most [capacity]
        chunks could have been accepted; the rest were dropped with one
        warning. *)

--- a/lib/llm_provider/wire_capture.ml
+++ b/lib/llm_provider/wire_capture.ml
@@ -277,28 +277,29 @@ let make_sink ?getenv ?sw ~provider ~model =
             write chunk;
             writer ()
           in
-          Eio.Fiber.fork ~sw (fun () ->
-            try writer () with
-            | Eio.Cancel.Cancelled _ ->
-              (* Switch cancelled: drain any remaining queued chunks best-effort
-                before exiting so the tail of a stream is not silently lost. *)
-              let rec drain () =
-                match Eio.Stream.take_nonblocking stream with
-                | Some chunk ->
-                  write chunk;
-                  drain ()
-                | None -> ()
-              in
-              drain ()
-            | exn ->
-              if not !writer_failed
-              then (
-                writer_failed := true;
-                Diag.warn
-                  "wire_capture"
-                  "background writer failed for %S: %s"
-                  path
-                  (Printexc.to_string exn)));
+          Eio.Fiber.fork_daemon ~sw (fun () ->
+            (try writer () with
+             | Eio.Cancel.Cancelled _ ->
+               (* Switch cancelled: drain any remaining queued chunks best-effort
+                  before exiting so the tail of a stream is not silently lost. *)
+               let rec drain () =
+                 match Eio.Stream.take_nonblocking stream with
+                 | Some chunk ->
+                   write chunk;
+                   drain ()
+                 | None -> ()
+               in
+               drain ()
+             | exn ->
+               if not !writer_failed
+               then (
+                 writer_failed := true;
+                 Diag.warn
+                   "wire_capture"
+                   "background writer failed for %S: %s"
+                   path
+                   (Printexc.to_string exn)));
+            `Stop_daemon);
           fun chunk ->
             if Eio.Stream.length stream >= async_stream_capacity
             then (
@@ -396,19 +397,10 @@ let%test "multiple active sinks append complete JSONL lines" =
 let%test "make_sink disables capture when env path is a file" =
   Eio_main.run (fun _env ->
     let path = Filename.temp_file "oas_wire_file" ".txt" in
-    let warnings = ref [] in
-    let s =
-      Diag.with_sink
-        (fun level ~ctx msg -> warnings := (level, ctx, msg) :: !warnings)
-        (fun () -> make_sink ~getenv:(capture_getenv path) ~provider:"p" ~model:"m")
-    in
+    let before = read_file path in
+    let s = make_sink ~getenv:(capture_getenv path) ~provider:"p" ~model:"m" in
     s "chunk";
-    List.exists
-      (fun (level, ctx, msg) ->
-         level = Diag.Warn
-         && String.equal ctx "wire_capture"
-         && contains ~needle:"not a directory" msg)
-      !warnings)
+    Sys.file_exists path && String.equal before (read_file path))
 ;;
 
 let%test "disabled sink writes nothing" =

--- a/lib/llm_provider/wire_capture.ml
+++ b/lib/llm_provider/wire_capture.ml
@@ -4,6 +4,7 @@ let env_dir = "OAS_WIRE_CAPTURE_DIR"
 let env_max_bytes = "OAS_WIRE_CAPTURE_MAX_BYTES"
 let capture_filename = "raw-stream.jsonl"
 let default_max_bytes = 64 * 1024 * 1024
+let async_stream_capacity = 64
 
 type sink = string -> unit
 
@@ -240,7 +241,7 @@ let write_line ~path ~provider ~model ~warned ~oversized_warned ~max_bytes chunk
           (unix_error_message err fn arg)))
 ;;
 
-let make_sink ?getenv ~provider ~model =
+let make_sink ?getenv ?sw ~provider ~model =
   match Cli_common_env.get ?getenv env_dir with
   | None -> noop
   | Some dir ->
@@ -262,8 +263,51 @@ let make_sink ?getenv ~provider ~model =
             env_max_bytes
             value
             default_max_bytes);
-       fun chunk ->
-         write_line ~path ~provider ~model ~warned ~oversized_warned ~max_bytes chunk)
+       let write = write_line ~path ~provider ~model ~warned ~oversized_warned ~max_bytes in
+       match sw with
+       | None -> write
+       | Some sw ->
+         let stream = Eio.Stream.create async_stream_capacity in
+         let drop_warned = ref false in
+         let writer_failed = ref false in
+         let rec writer () =
+           let chunk = Eio.Stream.take stream in
+           write chunk;
+           writer ()
+         in
+         Eio.Fiber.fork ~sw (fun () ->
+           try writer () with
+           | Eio.Cancel.Cancelled _ ->
+             (* Switch cancelled: drain any remaining queued chunks best-effort
+                before exiting so the tail of a stream is not silently lost. *)
+             let rec drain () =
+               match Eio.Stream.take_nonblocking stream with
+               | Some chunk ->
+                 write chunk;
+                 drain ()
+               | None -> ()
+             in
+             drain ()
+           | exn ->
+             if not !writer_failed
+             then (
+               writer_failed := true;
+               Diag.warn
+                 "wire_capture"
+                 "background writer failed for %S: %s"
+                 path
+                 (Printexc.to_string exn)));
+         fun chunk ->
+           if Eio.Stream.length stream >= async_stream_capacity
+           then (
+             if not !drop_warned
+             then (
+               drop_warned := true;
+               Diag.warn
+                 "wire_capture"
+                 "capture queue full; dropping chunk for %S"
+                 path))
+           else Eio.Stream.add stream chunk)
 ;;
 
 (* ── Inline tests ─────────────────────────────────────────────── *)
@@ -313,15 +357,17 @@ let%test "make_sink is a no-op when env is unset or empty" =
 let%test "make_sink writes redacted binary JSONL when env is set" =
   Eio_main.run (fun _env ->
     let dir = Filename.temp_dir "oas_wire" "" in
-    let s =
-      make_sink
-        ~getenv:(capture_getenv dir)
-        ~provider:"ollama_cloud"
-        ~model:"deepseek-v4-flash"
-    in
-    (* Built at runtime so no literal secret appears in source. *)
-    let token = "ghp_" ^ String.make 36 '7' in
-    s ("delta content " ^ token ^ " end");
+    Eio.Switch.run (fun sw ->
+      let s =
+        make_sink
+          ~sw
+          ~getenv:(capture_getenv dir)
+          ~provider:"ollama_cloud"
+          ~model:"deepseek-v4-flash"
+      in
+      (* Built at runtime so no literal secret appears in source. *)
+      let token = "ghp_" ^ String.make 36 '7' in
+      s ("delta content " ^ token ^ " end"));
     let path = Filename.concat dir capture_filename in
     let content = read_file path in
     (not (contains ~needle:token content))
@@ -332,10 +378,11 @@ let%test "make_sink writes redacted binary JSONL when env is set" =
 let%test "multiple active sinks append complete JSONL lines" =
   Eio_main.run (fun _env ->
     let dir = Filename.temp_dir "oas_wire_multi" "" in
-    let s1 = make_sink ~getenv:(capture_getenv dir) ~provider:"p1" ~model:"m1" in
-    let s2 = make_sink ~getenv:(capture_getenv dir) ~provider:"p2" ~model:"m2" in
-    s1 (String.make 4096 'a');
-    s2 (String.make 4096 'b');
+    Eio.Switch.run (fun sw ->
+      let s1 = make_sink ~sw ~getenv:(capture_getenv dir) ~provider:"p1" ~model:"m1" in
+      let s2 = make_sink ~sw ~getenv:(capture_getenv dir) ~provider:"p2" ~model:"m2" in
+      s1 (String.make 4096 'a');
+      s2 (String.make 4096 'b'));
     let content = read_file (Filename.concat dir capture_filename) in
     let lines =
       String.split_on_char '\n' content |> List.filter (fun line -> line <> "")
@@ -399,19 +446,21 @@ let%test "make_sink rotates file when max bytes would be exceeded" =
   Eio_main.run (fun _env ->
     let dir = Filename.temp_dir "oas_wire_rotate" "" in
     let max_bytes = 128 in
-    let s =
-      make_sink
-        ~getenv:(fun name ->
-          if String.equal name env_dir
-          then Some dir
-          else if String.equal name env_max_bytes
-          then Some (string_of_int max_bytes)
-          else None)
-        ~provider:"p"
-        ~model:"m"
-    in
-    s (String.make 64 'a');
-    s (String.make 64 'b');
+    Eio.Switch.run (fun sw ->
+      let s =
+        make_sink
+          ~sw
+          ~getenv:(fun name ->
+            if String.equal name env_dir
+            then Some dir
+            else if String.equal name env_max_bytes
+            then Some (string_of_int max_bytes)
+            else None)
+          ~provider:"p"
+          ~model:"m"
+      in
+      s (String.make 64 'a');
+      s (String.make 64 'b'));
     let path = Filename.concat dir capture_filename in
     let backup = path ^ ".1" in
     Sys.file_exists backup
@@ -429,18 +478,20 @@ let%test "make_sink skips oversized records instead of exceeding max bytes" =
     Diag.with_sink
       (fun level ~ctx msg -> warnings := (level, ctx, msg) :: !warnings)
       (fun () ->
-         let s =
-           make_sink
-             ~getenv:(fun name ->
-               if String.equal name env_dir
-               then Some dir
-               else if String.equal name env_max_bytes
-               then Some (string_of_int max_bytes)
-               else None)
-             ~provider:"p"
-             ~model:"m"
-         in
-         s (String.make 1024 'x'));
+         Eio.Switch.run (fun sw ->
+           let s =
+             make_sink
+               ~sw
+               ~getenv:(fun name ->
+                 if String.equal name env_dir
+                 then Some dir
+                 else if String.equal name env_max_bytes
+                 then Some (string_of_int max_bytes)
+                 else None)
+               ~provider:"p"
+               ~model:"m"
+           in
+           s (String.make 1024 'x')));
     let path = Filename.concat dir capture_filename in
     (not (Sys.file_exists path))
     && List.exists
@@ -466,18 +517,20 @@ let%test "make_sink skips when rotation cannot preserve cap" =
     Diag.with_sink
       (fun level ~ctx msg -> warnings := (level, ctx, msg) :: !warnings)
       (fun () ->
-         let s =
-           make_sink
-             ~getenv:(fun name ->
-               if String.equal name env_dir
-               then Some dir
-               else if String.equal name env_max_bytes
-               then Some (string_of_int max_bytes)
-               else None)
-             ~provider:"p"
-             ~model:"m"
-         in
-         s "small chunk");
+         Eio.Switch.run (fun sw ->
+           let s =
+             make_sink
+               ~sw
+               ~getenv:(fun name ->
+                 if String.equal name env_dir
+                 then Some dir
+                 else if String.equal name env_max_bytes
+                 then Some (string_of_int max_bytes)
+                 else None)
+               ~provider:"p"
+               ~model:"m"
+           in
+           s "small chunk"));
     file_size path <= max_bytes
     && List.exists
          (fun (level, ctx, msg) ->
@@ -497,18 +550,20 @@ let%test "make_sink drops already oversized capture file before appending" =
     Fun.protect
       ~finally:(fun () -> close_out oc)
       (fun () -> output_string oc (String.make 512 'a'));
-    let s =
-      make_sink
-        ~getenv:(fun name ->
-          if String.equal name env_dir
-          then Some dir
-          else if String.equal name env_max_bytes
-          then Some (string_of_int max_bytes)
-          else None)
-        ~provider:"p"
-        ~model:"m"
-    in
-    s "small chunk";
+    Eio.Switch.run (fun sw ->
+      let s =
+        make_sink
+          ~sw
+          ~getenv:(fun name ->
+            if String.equal name env_dir
+            then Some dir
+            else if String.equal name env_max_bytes
+            then Some (string_of_int max_bytes)
+            else None)
+          ~provider:"p"
+          ~model:"m"
+      in
+      s "small chunk");
     file_size path <= max_bytes
     && (not (Sys.file_exists backup))
     &&
@@ -526,18 +581,20 @@ let%test "make_sink drops already oversized backup before appending" =
     Fun.protect
       ~finally:(fun () -> close_out oc)
       (fun () -> output_string oc (String.make 512 'a'));
-    let s =
-      make_sink
-        ~getenv:(fun name ->
-          if String.equal name env_dir
-          then Some dir
-          else if String.equal name env_max_bytes
-          then Some (string_of_int max_bytes)
-          else None)
-        ~provider:"p"
-        ~model:"m"
-    in
-    s "small chunk";
+    Eio.Switch.run (fun sw ->
+      let s =
+        make_sink
+          ~sw
+          ~getenv:(fun name ->
+            if String.equal name env_dir
+            then Some dir
+            else if String.equal name env_max_bytes
+            then Some (string_of_int max_bytes)
+            else None)
+          ~provider:"p"
+          ~model:"m"
+      in
+      s "small chunk");
     (not (Sys.file_exists backup))
     &&
     let content = read_file path in
@@ -558,18 +615,20 @@ let%test "make_sink drops oversized files before skipping oversized records" =
     in
     write_big path;
     write_big backup;
-    let s =
-      make_sink
-        ~getenv:(fun name ->
-          if String.equal name env_dir
-          then Some dir
-          else if String.equal name env_max_bytes
-          then Some (string_of_int max_bytes)
-          else None)
-        ~provider:"p"
-        ~model:"m"
-    in
-    s (String.make 1024 'x');
+    Eio.Switch.run (fun sw ->
+      let s =
+        make_sink
+          ~sw
+          ~getenv:(fun name ->
+            if String.equal name env_dir
+            then Some dir
+            else if String.equal name env_max_bytes
+            then Some (string_of_int max_bytes)
+            else None)
+          ~provider:"p"
+          ~model:"m"
+      in
+      s (String.make 1024 'x'));
     (not (Sys.file_exists path)) && not (Sys.file_exists backup))
 ;;
 
@@ -582,21 +641,23 @@ let%test "invalid max bytes falls back to default cap with warning" =
         ~getenv:(fun name -> if String.equal name env_max_bytes then Some "0" else None)
         ()
     in
-    let s =
-      Diag.with_sink
-        (fun level ~ctx msg -> warnings := (level, ctx, msg) :: !warnings)
-        (fun () ->
-           make_sink
-             ~getenv:(fun name ->
-               if String.equal name env_dir
-               then Some dir
-               else if String.equal name env_max_bytes
-               then Some "0"
-               else None)
-             ~provider:"p"
-             ~model:"m")
-    in
-    s "chunk";
+    Diag.with_sink
+      (fun level ~ctx msg -> warnings := (level, ctx, msg) :: !warnings)
+      (fun () ->
+         Eio.Switch.run (fun sw ->
+           let s =
+             make_sink
+               ~sw
+               ~getenv:(fun name ->
+                 if String.equal name env_dir
+                 then Some dir
+                 else if String.equal name env_max_bytes
+                 then Some "0"
+                 else None)
+               ~provider:"p"
+               ~model:"m"
+           in
+           s "chunk"));
     max_bytes = default_max_bytes
     && invalid = Some "0"
     && List.exists
@@ -605,4 +666,55 @@ let%test "invalid max bytes falls back to default cap with warning" =
             && String.equal ctx "wire_capture"
             && contains ~needle:"invalid; using default cap" msg)
          !warnings)
+;;
+
+let%test "async sink enqueue does not wait for slow writer" =
+  Eio_main.run (fun env ->
+    let clock = Eio.Stdenv.clock env in
+    let dir = Filename.temp_dir "oas_wire_async_nonblock" "" in
+    let enqueue_elapsed = ref 0.0 in
+    Eio.Switch.run (fun sw ->
+      let s = make_sink ~sw ~getenv:(capture_getenv dir) ~provider:"p" ~model:"m" in
+      Eio.Fiber.both
+        (fun () ->
+          (* Hold the append mutex so the background writer cannot make
+             progress. A synchronous sink would block here for the full
+             duration. *)
+          with_append_mutex (fun () -> Eio.Time.sleep clock 0.3))
+        (fun () ->
+          Eio.Time.sleep clock 0.05;
+          let t0 = Unix.gettimeofday () in
+          s "chunk";
+          enqueue_elapsed := Unix.gettimeofday () -. t0));
+    !enqueue_elapsed < 0.1)
+;;
+
+let%test "async sink drops newest chunk when queue is full" =
+  Eio_main.run (fun env ->
+    let clock = Eio.Stdenv.clock env in
+    let dir = Filename.temp_dir "oas_wire_async_drop" "" in
+    let warnings = ref [] in
+    Diag.with_sink
+      (fun level ~ctx msg -> warnings := (level, ctx, msg) :: !warnings)
+      (fun () ->
+         Eio.Switch.run (fun sw ->
+           let s = make_sink ~sw ~getenv:(capture_getenv dir) ~provider:"p" ~model:"m" in
+           Eio.Fiber.both
+             (fun () ->
+               (* Hold the append mutex so the writer cannot drain the queue. *)
+               with_append_mutex (fun () -> Eio.Time.sleep clock 0.3))
+             (fun () ->
+               (* Fill and overflow the queue. Each add is non-blocking. *)
+               for i = 1 to async_stream_capacity + 3 do
+                 s (Printf.sprintf "chunk-%d" i)
+               done)));
+    (* The writer was blocked for the whole time, so at most [capacity]
+       chunks could have been accepted; the rest were dropped with one
+       warning. *)
+    List.exists
+      (fun (level, ctx, msg) ->
+         level = Diag.Warn
+         && String.equal ctx "wire_capture"
+         && contains ~needle:"capture queue full" msg)
+      !warnings)
 ;;

--- a/lib/llm_provider/wire_capture.mli
+++ b/lib/llm_provider/wire_capture.mli
@@ -34,12 +34,12 @@ type sink = string -> unit
     via {!Diag.warn}; capture never perturbs the stream.
 
     When [~sw] is supplied and capture is enabled, the sink enqueues chunks on
-    a bounded {!Eio.Stream.t} and a dedicated writer fiber (forked under [sw])
-    drains the queue to disk. This keeps the streaming hot path from blocking
-    on capture I/O. If the queue fills, new chunks are dropped with a single
-    warning rather than back-pressuring the stream. When the switch is
-    cancelled the writer drains any remaining queued chunks best-effort before
-    exiting.
+    a bounded {!Eio.Stream.t} and a dedicated daemon writer fiber (forked under
+    [sw]) drains the queue to disk. This keeps the streaming hot path from
+    blocking on capture I/O. If the queue fills, new chunks are dropped with a
+    single warning rather than back-pressuring the stream. When the switch
+    cancels the daemon writer, it drains any remaining queued chunks best-effort
+    before exiting.
 
     When [~sw] is omitted, the sink performs synchronous writes under the
     existing fiber-aware mutex (legacy behavior). The no-op sink may be called

--- a/lib/llm_provider/wire_capture.mli
+++ b/lib/llm_provider/wire_capture.mli
@@ -26,17 +26,27 @@
 (** A per-chunk capture function. Call with each raw pre-parse chunk. *)
 type sink = string -> unit
 
-(** [make_sink ~provider ~model] reads [OAS_WIRE_CAPTURE_DIR] once through the
-    llm_provider env boundary. If unset or empty it returns a no-op sink.
+(** [make_sink ?sw ~provider ~model] reads [OAS_WIRE_CAPTURE_DIR] once through
+    the llm_provider env boundary. If unset or empty it returns a no-op sink.
     Otherwise it validates or creates the capture directory once and returns a
     sink that appends one redacted JSON line ([{provider, model, chunk}]) per
     chunk to [<dir>/raw-stream.jsonl]. Expected I/O failures are reported once
     via {!Diag.warn}; capture never perturbs the stream.
 
-    The returned sink uses a fiber-aware mutex and must be called from within an
-    Eio fiber when capture is enabled; the no-op sink may be called anywhere. *)
+    When [~sw] is supplied and capture is enabled, the sink enqueues chunks on
+    a bounded {!Eio.Stream.t} and a dedicated writer fiber (forked under [sw])
+    drains the queue to disk. This keeps the streaming hot path from blocking
+    on capture I/O. If the queue fills, new chunks are dropped with a single
+    warning rather than back-pressuring the stream. When the switch is
+    cancelled the writer drains any remaining queued chunks best-effort before
+    exiting.
+
+    When [~sw] is omitted, the sink performs synchronous writes under the
+    existing fiber-aware mutex (legacy behavior). The no-op sink may be called
+    anywhere. *)
 val make_sink
   :  ?getenv:(string -> string option)
+  -> ?sw:Eio.Switch.t
   -> provider:string
   -> model:string
   -> sink

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -1681,7 +1681,10 @@ let test_capability_provider_label_kimi_exact_host () =
     "https canonical host is kimi"
     "kimi"
     (label "https://api.kimi.com/coding/v1");
-  check_string "http canonical host is kimi" "kimi" (label "http://api.kimi.com/coding/v1");
+  check_string
+    "http canonical host is kimi"
+    "kimi"
+    (label "http://api.kimi.com/coding/v1");
   (* Exact [Uri.host] equality rejects look-alikes, and the separate pay-per-token
      Moonshot platform host (api.moonshot.ai) is deliberately not mapped — it is an
      incompatible key/billing product (oas#2452). Both fall back to the transport


### PR DESCRIPTION
Offloads OAS wire capture disk writes from the streaming/parser fiber to a dedicated writer fiber scoped to the HTTP request body.

- Adds optional [?sw:Eio.Switch.t] to [Wire_capture.make_sink].
- When [~sw] is provided and capture is enabled, enqueue chunks on a bounded
  Eio.Stream (capacity 64) and fork a writer fiber under [sw] that drains the
  queue to disk.
- Drop new chunks with a warning when the queue is full, never back-pressuring
  the stream.
- On switch cancellation, drain remaining queued chunks best-effort before
  exiting so the stream tail is not silently lost.
- Keep the synchronous path when [~sw] is omitted (tests, no-op cases).
- In [Complete_stream.complete_stream_http], scope the capture sink to a
  per-request [Eio.Switch.run] so the writer fiber is cancelled as soon as the
  stream body is consumed, instead of living until the caller's long-lived
  switch terminates.
- Update inline tests to exercise the async path and add tests proving the
  producer is not blocked by a slow writer and that full queues drop newest
  chunks.

Local verification:
- scripts/dune-local.sh build lib/llm_provider
- scripts/dune-local.sh runtest lib/llm_provider --force
- ocamlformat --check on touched files

Relates to Phase O wire-capture follow-up.