### PR TITLE
fix(provider_config): replace fuzzy ollama host classifier with exact Uri.host equality

### DIFF
--- a/.ci/hardening-baseline.json
+++ b/.ci/hardening-baseline.json
@@ -1,9 +1,7 @@
 {
   "_comment": "Production hardening ratchet baseline. Source: docs/rfc/RFC-OAS-023-hardening-ratchet.md. Regenerate with scripts/hardening-ratchet.sh --rebaseline.",
   "examples": {
-    "base_url_host_fuzzy_classifiers": [
-      "lib/llm_provider/provider_config.ml:834:|| String.ends_with ~suffix:\".ollama.com\" host"
-    ],
+    "base_url_host_fuzzy_classifiers": [],
     "direct_env_reads": [
       "lib/llm_provider/cli_common_env.ml:11:let default_getenv = Sys.getenv_opt",
       "lib/llm_provider/env_parse.ml:10:match Sys.getenv_opt name with",
@@ -46,9 +44,9 @@
     ],
     "workaround_markers": []
   },
-  "lastUpdatedCommit": "b46951c86eb666bf75e7ae5a6464ad067cd77776",
+  "lastUpdatedCommit": "4d371c24d12ad5b55a2c3641391f2fd95b6a61cc",
   "metrics": {
-    "base_url_host_fuzzy_classifiers": 1,
+    "base_url_host_fuzzy_classifiers": 0,
     "direct_env_reads": 11,
     "direct_env_reads_outside_env_boundary": 8,
     "exception_message_classifiers": 1,

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -849,9 +849,7 @@ let openai_host_supports_output_schema base_url =
   | None -> false
   | Some host ->
     let host = String.lowercase_ascii host in
-    String.equal host "api.openai.com"
-    || String.equal host "ollama.com"
-    || String.ends_with ~suffix:".ollama.com" host
+    String.equal host "api.openai.com" || String.equal host "ollama.com"
 ;;
 
 let endpoint_supports_openai_compat_output_schema (config : t) =

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -1532,6 +1532,27 @@ let test_validate_output_schema_unknown_openai_compat_host_rejected () =
     (Result.is_error (Provider_config.validate_output_schema_request cfg))
 ;;
 
+let test_validate_output_schema_ollama_subdomain_rejected () =
+  with_repository_model_catalog (fun () ->
+    let cfg =
+      Provider_config.make
+        ~kind:OpenAI_compat
+        ~model_id:"gpt-4o"
+        ~base_url:"https://api.ollama.com/v1"
+        ~response_format_json:true
+        ~output_schema:(`Assoc [ "type", `String "object" ])
+        ()
+    in
+    match Provider_config.validate_output_schema_request cfg with
+    | Error msg ->
+      check_string
+        "rejection reason"
+        "native structured output is only wired for declared OpenAI-compatible \
+         endpoints, got https://api.ollama.com/v1"
+        msg
+    | Ok () -> Alcotest.fail "expected Ollama subdomain to fail closed")
+;;
+
 let test_validate_cli_sampling_params_accepts_anthropic_min_p () =
   let cfg =
     Provider_config.make
@@ -2310,6 +2331,10 @@ let () =
             "unknown openai compat host rejected"
             `Quick
             test_validate_output_schema_unknown_openai_compat_host_rejected
+        ; Alcotest.test_case
+            "ollama subdomain is not a declared endpoint"
+            `Quick
+            test_validate_output_schema_ollama_subdomain_rejected
         ; Alcotest.test_case
             "raw compat qwen does not inherit bare capability"
             `Quick


### PR DESCRIPTION
Closes residual gap from adversarial review: `openai_host_supports_output_schema` used `String.ends_with ~suffix:".ollama.com" host`, which is host-derived capability inference forbidden by RFC-OAS-034 and the production hardening ratchet.

- Replace fuzzy subdomain match with exact `Uri.host` equality (`ollama.com`).
- Rebaseline `base_url_host_fuzzy_classifiers` from 1 to 0.
- No functional change for canonical Ollama Cloud host; arbitrary subdomains now fail closed like other look-alike hosts.

Fixes oas hardening-ratchet stale baseline.