### PR TITLE
test(llm_provider): pin output_schema wire serialization for ollama and anthropic

### DIFF
--- a/test/test_snapshot_provider_serialization.ml
+++ b/test/test_snapshot_provider_serialization.ml
@@ -899,10 +899,7 @@ let () =
     ; "glm", [ test_case "tool_choice Any" `Quick test_glm_any ]
     ; "ollama", [ test_case "tool_choice Any" `Quick test_ollama_any ]
     ; ( "structured_output_wire"
-      , [ test_case
-            "ollama output_schema -> format"
-            `Quick
-            test_ollama_output_schema
+      , [ test_case "ollama output_schema -> format" `Quick test_ollama_output_schema
         ; test_case
             "anthropic output_schema -> format.json_schema"
             `Quick

--- a/test/test_snapshot_provider_serialization.ml
+++ b/test/test_snapshot_provider_serialization.ml
@@ -172,6 +172,42 @@ let deepseek_cfg ?enable_thinking ?thinking_budget ~tool_choice () =
     ()
 ;;
 
+(* Structured-output wire fixture. Pins the [output_schema] -> provider wire
+   field for the two native backends whose schema serialization path had no
+   snapshot: Ollama emits the raw schema under [format]; Anthropic wraps it as
+   [format].{type:"json_schema", schema}. Guards against a silent-drop
+   regression where a serializer refactor stops emitting the schema (the
+   structured-output boundary of RFC-OAS-023 / RFC-OAS-034). OpenAI and Gemini
+   already have this coverage in test_backend_openai_codec / test_backend_gemini;
+   these two backends did not. *)
+let output_schema_fixture =
+  `Assoc
+    [ "type", `String "object"
+    ; "properties", `Assoc [ "answer", `Assoc [ "type", `String "string" ] ]
+    ; "required", `List [ `String "answer" ]
+    ]
+;;
+
+let schema_cfg ~kind ~base_url =
+  Provider_config.make
+    ~kind
+    ~model_id:"oas-snapshot-fixture-model"
+    ~base_url
+    ~api_key:"test-key"
+    ~max_tokens:1024
+    ~temperature:0.7
+    ~output_schema:output_schema_fixture
+    ~supports_structured_output_override:true
+    ~keep_alive:"-1"
+    ()
+;;
+
+let ollama_schema_cfg = schema_cfg ~kind:Ollama ~base_url:"http://127.0.0.1:11434"
+
+let anthropic_schema_cfg =
+  schema_cfg ~kind:Anthropic ~base_url:"https://api.anthropic.com"
+;;
+
 (* ── Helpers ────────────────────────────────────────── *)
 
 let snapshot label expected actual = check string label expected actual
@@ -746,6 +782,48 @@ let test_ollama_any () =
   check bool "no tool_choice field" false (contains ~needle:{|"tool_choice"|} body)
 ;;
 
+(* ── Structured-output wire (output_schema serialization) ──── *)
+
+let test_ollama_output_schema () =
+  let body =
+    Backend_ollama.build_request
+      ~config:ollama_schema_cfg
+      ~messages:[ msg User [ Text "Answer as JSON." ] ]
+      ()
+  in
+  (* Ollama native /api/chat carries the raw JSON Schema under [format]. *)
+  check
+    bool
+    "ollama emits output_schema under the [format] field"
+    true
+    (contains ~needle:{|"format":{"type":"object"|} body);
+  check
+    bool
+    "ollama [format] schema retains the declared required key"
+    true
+    (contains ~needle:{|"required":["answer"]|} body)
+;;
+
+let test_anthropic_output_schema () =
+  let body =
+    Backend_anthropic.build_request
+      ~config:anthropic_schema_cfg
+      ~messages:[ msg User [ Text "Answer as JSON." ] ]
+      ()
+  in
+  (* Anthropic wraps the schema as [format].{type:"json_schema", schema}. *)
+  check
+    bool
+    {|anthropic emits [format] with type "json_schema"|}
+    true
+    (contains ~needle:{|"format":{"type":"json_schema","schema":{|} body);
+  check
+    bool
+    "anthropic [format] schema retains the declared required key"
+    true
+    (contains ~needle:{|"required":["answer"]|} body)
+;;
+
 (* ── Suite ──────────────────────────────────────────── *)
 
 let () =
@@ -820,5 +898,15 @@ let () =
         ] )
     ; "glm", [ test_case "tool_choice Any" `Quick test_glm_any ]
     ; "ollama", [ test_case "tool_choice Any" `Quick test_ollama_any ]
+    ; ( "structured_output_wire"
+      , [ test_case
+            "ollama output_schema -> format"
+            `Quick
+            test_ollama_output_schema
+        ; test_case
+            "anthropic output_schema -> format.json_schema"
+            `Quick
+            test_anthropic_output_schema
+        ] )
     ]
 ;;


### PR DESCRIPTION
## 목표

`output_schema → provider wire` 직렬화의 **회귀 가드 공백을 메운다**. request-serialization 스냅샷 스위트(`test_snapshot_provider_serialization.ml`)는 각 backend의 `tool_choice` wire shape는 고정하고 있었으나, **structured output(`output_schema`)이 실제로 wire에 나가는지**는 두 네이티브 backend에서 검증하지 않았다:

- **Ollama**: 스키마를 `format` 필드에 raw로 emit (`backend_ollama.ml:147`)
- **Anthropic**: `format.{type:"json_schema", schema}` 로 wrap (`backend_anthropic.ml:129`)

OpenAI·Gemini는 이미 커버(`test_backend_openai_codec` / `test_backend_gemini`)돼 있었으나 이 둘은 공백이라, serializer 리팩터가 스키마를 **silent-drop 해도 어떤 테스트도 실패하지 않았다**.

## 배경 (왜 지금)

Anthropic 에이전트-도구 문서를 MASC/OAS 경계와 대조 분석하던 중, "프로바이더 추가 시 스키마 wire를 누락할 위험"(5-backend 직렬화 산포)이 지목됐다. 실코드 검증 결과 현재 **silent-drop 버그는 없고**(4개 backend 모두 정상 emit), 5개 wire format이 본질적으로 달라 공통 함수 추출은 부적절했다. 남은 실재 리스크는 **테스트 공백**뿐이었고, 이를 실행 가능한 회귀 가드로 잠근다. RFC-OAS-023/034(structured-output/capability 경계)의 집행 테스트에 해당한다.

## 변경

- `test/test_snapshot_provider_serialization.ml` (테스트 전용, +2 case)
  - `output_schema_fixture` + `schema_cfg` 헬퍼 추가
  - `test_ollama_output_schema` / `test_anthropic_output_schema`
  - 신규 그룹 `structured_output_wire`
- **동작 변경 없음**. lib 무수정.

## 검증 (로컬)

- `test_snapshot_provider_serialization.exe` 전체 **23/23 통과** (기존 21 + 신규 2)
- **Mutation 검증**: `backend_ollama.ml:147`의 `format` emission을 임시 제거 → `structured_output_wire/ollama` 케이스 **FAIL** 확인, 복원 → 통과. 테스트가 진짜 silent-drop을 잡음을 증명.
- 필드 타깃 `contains`-needle assertion 사용(무관 필드 재정렬에 강건, full-string 스냅샷보다 노이즈 적음).

## 남은 미검증

- Gemini/OpenAI 경로는 기존 테스트가 이미 커버 → 본 PR 범위 밖.
- 6번째 backend 추가 시 자동 강제하는 컴파일-타임 completeness guard는 별도(RFC 레벨) — 본 PR은 현존 2 backend의 wire만 고정.

## Self-review (Best Programmer 기준)

- Parse-don't-validate: 테스트는 실제 wire 문자열을 검사(간접 mock 아님).
- Surgical: 단일 파일, 테스트 전용, 동작 불변.
- 근거 주석 포함(왜 이 2 backend만, 무엇을 가드하는지).
