### PR TITLE
fix(llm_provider): align kimi sampling prompt strategy

### DIFF
--- a/docs/design/provider-reasoning-dialects.md
+++ b/docs/design/provider-reasoning-dialects.md
@@ -24,7 +24,7 @@ accepting no request-time thinking parameter.
 | `Thinking_object_only` | `Thinking_object_keep_all` | Top-level `thinking` object without effort plus `thinking.keep="all"` when requested | Preserve historical `reasoning_content` when `preserve_thinking=true` |
 | `Chat_template_kwargs` | `Chat_template_kwargs_preserve_thinking` | Self-hosted chat-template kwargs such as Qwen `enable_thinking` / `preserve_thinking` | Preserve historical reasoning only when requested |
 | `Enable_thinking` | `Top_level_preserve_thinking` | DashScope-style top-level `enable_thinking` plus separate `preserve_thinking` | Preserve historical reasoning only when requested |
-| `No_thinking_control` | `Always_preserved_thinking` | Latest Kimi-style models whose thinking is provider-controlled and whose historical `reasoning_content` must remain in messages | Always replay historical reasoning; emit no thinking request field |
+| `No_thinking_control` | `Always_preserved_thinking` | Latest Kimi-style models whose thinking is provider-controlled and whose historical `reasoning_content` must remain in messages | Always replay historical reasoning; emit no thinking request field; omit fixed sampling knobs such as `temperature` / `top_p` |
 | `Chat_template_token` | `No_preserve_thinking_control` | Template token injection such as Gemma `<\|think\|>` | No mandatory replay; parse visible thought channel from generated text |
 | `Ollama_think` | `No_preserve_thinking_control` | Ollama native `/api/chat` top-level `think` bool/level, with thoughts in `message.thinking` | No mandatory replay; parse Ollama thinking side channel |
 | `Reasoning_effort` | `No_preserve_thinking_control` | OpenAI-compatible `reasoning_effort` field | No mandatory replay yet |
@@ -66,13 +66,16 @@ accepting no request-time thinking parameter.
   assistant reasoning forward. Source:
   <https://www.alibabacloud.com/help/en/model-studio/deep-thinking>, checked
   2026-06-14.
-- Kimi official docs: Kimi K2.7-code preserves thinking by default, should not
-  receive a request-time `thinking` parameter, and requires historical assistant
-  `reasoning_content` to remain in `messages`. Older Kimi variants can be
+- Kimi official docs: Kimi K2.7-code preserves thinking by default, does not
+  support non-thinking mode, accepts no useful request-time `thinking.disabled`
+  strategy, and requires historical assistant `reasoning_content` to remain in
+  `messages`. Kimi's thinking-model guide also says not to pass `temperature`
+  for K2.7-code / K2.6; the API reference documents K2.7-code fixed
+  `temperature=1.0` and fixed `top_p=0.95`. Older Kimi variants can be
   described through the separate preserve capability axis if an operator needs
-  them. Source:
-  <https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model>, checked
-  2026-06-29.
+  them. Sources:
+  <https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model>,
+  <https://platform.kimi.ai/docs/api/chat>, checked 2026-07-04.
 
 ## Boundary
 

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -918,18 +918,16 @@ let validate_output_schema_request (config : t) =
        Error
          "Glm supports JSON mode (json_object) only; native json_schema output is not \
           documented in the current Z.AI API"
-     | Kimi | OpenAI_compat ->
-       (match validate_model_structured_output_capability config with
-        | Error _ as error -> error
-        | Ok () ->
-          if endpoint_supports_openai_compat_output_schema config
-          then Ok ()
-          else
-            Error
-              (Printf.sprintf
-                 "native structured output is only wired for declared OpenAI-compatible \
-                  endpoints, got %s"
-                 config.base_url)))
+     | Kimi -> validate_model_structured_output_capability config
+     | OpenAI_compat ->
+       if endpoint_supports_openai_compat_output_schema config
+       then validate_model_structured_output_capability config
+       else
+         Error
+           (Printf.sprintf
+              "native structured output is only wired for declared OpenAI-compatible \
+               endpoints, got %s"
+              config.base_url))
 ;;
 
 (** Validate that sampling parameters not supported by CLI subprocess

--- a/lib/llm_provider/reasoning_dialect.ml
+++ b/lib/llm_provider/reasoning_dialect.ml
@@ -25,6 +25,7 @@ type effort_alias_policy =
 
 type sampling_policy =
   | Sampling_supported
+  | Ignored_always of string list
   | Ignored_when_thinking of string list
 
 type replay_policy =
@@ -75,6 +76,8 @@ let deepseek_ignored_sampling_params =
   [ "temperature"; "top_p"; "presence_penalty"; "frequency_penalty" ]
 ;;
 
+let kimi_fixed_sampling_params = [ "temperature"; "top_p" ]
+
 let base_of_capabilities (caps : Capabilities.capabilities) =
   let preserve_wire = caps.preserve_thinking_control_format in
   let output_wire =
@@ -90,6 +93,7 @@ let base_of_capabilities (caps : Capabilities.capabilities) =
        { dialect with
          replay_policy = Preserve_always
        ; streaming = Delta_field "reasoning_content"
+       ; sampling_policy = Ignored_always kimi_fixed_sampling_params
        }
      | No_preserve_thinking_control
      | Thinking_object_keep_all
@@ -242,11 +246,11 @@ let top_level_preserve_field dialect ~preserve_thinking =
 ;;
 
 let ignores_sampling_param dialect ~enable_thinking field =
-  thinking_enabled ~enable_thinking
-  &&
   match dialect.sampling_policy with
   | Sampling_supported -> false
-  | Ignored_when_thinking params -> List.mem field params
+  | Ignored_always params -> List.mem field params
+  | Ignored_when_thinking params ->
+    thinking_enabled ~enable_thinking && List.mem field params
 ;;
 
 let bool_field name = function
@@ -438,7 +442,7 @@ let normalize_effort dialect raw =
 let sampling_params_ignored_when_thinking dialect =
   match dialect.sampling_policy with
   | Sampling_supported -> []
-  | Ignored_when_thinking params -> params
+  | Ignored_always params | Ignored_when_thinking params -> params
 ;;
 
 (* Sampling params a wire format ignores while thinking is enabled, keyed purely

--- a/lib/llm_provider/reasoning_dialect.mli
+++ b/lib/llm_provider/reasoning_dialect.mli
@@ -35,6 +35,7 @@ type effort_alias_policy =
 
 type sampling_policy =
   | Sampling_supported
+  | Ignored_always of string list
   | Ignored_when_thinking of string list
 
 type replay_policy =
@@ -118,7 +119,9 @@ val sampling_params_ignored_when_thinking : t -> string list
 
 (** [true] when [field] is a sampling parameter the wire format ignores while
     thinking is enabled. Thinking defaults on: only an explicit
-    [enable_thinking = Some false] keeps the field. Keyed on
+    [enable_thinking = Some false] keeps the field. Some provider-controlled
+    dialects such as latest Kimi are represented by the full {!t} policy instead
+    of this format-only helper. Keyed on
     {!Capabilities.thinking_control_format} so both the [Provider_config]-based
     request builder ([Backend_openai_request]) and the agent-state-based one
     ([Api_openai.build_openai_body]) drop the same parameters; the public path

--- a/test/test_thinking_control_dialects.ml
+++ b/test/test_thinking_control_dialects.ml
@@ -143,7 +143,14 @@ let declared_qwen_openai_compat_config
     ()
 ;;
 
-let kimi_config ?enable_thinking ?preserve_thinking ?thinking_budget model_id =
+let kimi_config
+      ?enable_thinking
+      ?preserve_thinking
+      ?thinking_budget
+      ?temperature
+      ?top_p
+      model_id
+  =
   PC.make
     ~kind:Kimi
     ~model_id
@@ -151,6 +158,8 @@ let kimi_config ?enable_thinking ?preserve_thinking ?thinking_budget model_id =
     ?enable_thinking
     ?preserve_thinking
     ?thinking_budget
+    ?temperature
+    ?top_p
     ()
 ;;
 
@@ -769,6 +778,11 @@ let test_kimi_latest_always_preserved_omits_thinking_param () =
     "replay policy"
     "preserve_always"
     (RD.replay_policy_to_string dialect.replay_policy);
+  check
+    (list string)
+    "ignored sampling params"
+    [ "temperature"; "top_p" ]
+    (RD.sampling_params_ignored_when_thinking dialect);
   let user_json =
     BOR.build_request ~config ~messages:[ user_msg "hi" ] () |> json_of_body
   in
@@ -784,6 +798,16 @@ let test_kimi_latest_always_preserved_omits_thinking_param () =
     "reasoning_content"
     "plain thought"
     (assistant |> member "reasoning_content" |> to_string)
+;;
+
+let test_kimi_latest_omits_sampling_even_with_disabled_thinking_override () =
+  let config =
+    kimi_config ~enable_thinking:false ~temperature:0.7 ~top_p:0.9 "kimi-k2.7-code"
+  in
+  let json = BOR.build_request ~config ~messages:[ user_msg "hi" ] () |> json_of_body in
+  check_member_absent "thinking" json;
+  check_member_absent "temperature" json;
+  check_member_absent "top_p" json
 ;;
 
 let test_ollama_qwen_uses_native_think_bool () =
@@ -1160,6 +1184,10 @@ let () =
               "kimi latest always-preserved omits thinking param"
               `Quick
               test_kimi_latest_always_preserved_omits_thinking_param
+          ; test_case
+              "kimi latest omits fixed sampling params"
+              `Quick
+              test_kimi_latest_omits_sampling_even_with_disabled_thinking_override
           ] )
       ; ( "ollama"
         , [ test_case


### PR DESCRIPTION
## Summary

- add a dialect-level `Ignored_always` sampling policy for provider-controlled thinking models
- apply it to latest Kimi-style `No_thinking_control + Always_preserved_thinking` dialects so `temperature`/`top_p` are omitted even when callers pass `enable_thinking=false`
- update Kimi dialect docs and regression tests

## Why

Kimi K2 thinking-model behavior is provider-controlled/fixed, so OAS should encode fixed sampling omission in the provider dialect instead of relying on caller-side prompt tuning or model-name heuristics.

Official sources checked on 2026-07-04:

- Z.AI chat completion: https://docs.z.ai/api-reference/llm/chat-completion
- Z.AI thinking mode: https://docs.z.ai/guides/capabilities/thinking-mode
- Kimi thinking models: https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model
- Kimi chat API: https://platform.kimi.ai/docs/api/chat

## Validation

- `ocamlformat --check lib/llm_provider/reasoning_dialect.ml lib/llm_provider/reasoning_dialect.mli test/test_thinking_control_dialects.ml`
- `git diff --check`
- Dune build/test not run locally; CI is build authority per project instructions.
