### PR TITLE
[codex] Remove stream idle assert false

### DIFF
--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -1225,6 +1225,13 @@ let parse_sse_line line =
         , String.sub line value_start (String.length line - value_start) ))
 ;;
 
+let idle_timeout_without_clock site =
+  invalid_arg
+    (site
+     ^ ": idle_timeout is set but no clock was supplied — the idle deadline would be \
+        silently disarmed (pass ?clock, or drop ?idle_timeout)")
+;;
+
 let require_clock_when_idle ~site ~clock ~idle_timeout =
   match clock, idle_timeout with
   | None, Some _ ->
@@ -1232,10 +1239,7 @@ let require_clock_when_idle ~site ~clock ~idle_timeout =
        to silently disarm and leave a stalled stream blocking forever
        (the read_sse idle-disarm bug family). Misconfiguration must fail
        at the call site, not at 3 a.m. as a hung fiber. *)
-    invalid_arg
-      (site
-       ^ ": idle_timeout is set but no clock was supplied — the idle deadline would be \
-          silently disarmed (pass ?clock, or drop ?idle_timeout)")
+    idle_timeout_without_clock site
   | Some _, _ | None, None -> ()
 ;;
 
@@ -1254,9 +1258,7 @@ let read_sse ?clock ?idle_timeout ~reader ~on_data () =
     match clock, idle_timeout with
     | Some c, Some t -> Eio.Time.with_timeout_exn c t inner
     | Some _, None | None, None -> inner ()
-    | None, Some _ ->
-      (* Rejected by [require_clock_when_idle] above. *)
-      assert false
+    | None, Some _ -> idle_timeout_without_clock "read_sse"
   in
   let current_event_type = ref None in
   let rec loop () =
@@ -1299,9 +1301,7 @@ let read_ndjson ?clock ?idle_timeout ~reader ~on_line () =
     match clock, idle_timeout with
     | Some c, Some t -> Eio.Time.with_timeout_exn c t (fun () -> Eio.Buf_read.line reader)
     | Some _, None | None, None -> Eio.Buf_read.line reader
-    | None, Some _ ->
-      (* Rejected by [require_clock_when_idle] above. *)
-      assert false
+    | None, Some _ -> idle_timeout_without_clock "read_ndjson"
   in
   let rec loop () =
     match read_line () with

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -1244,7 +1244,8 @@ let require_clock_when_idle ~site ~clock ~idle_timeout =
 ;;
 
 let read_sse ?clock ?idle_timeout ~reader ~on_data () =
-  require_clock_when_idle ~site:"read_sse" ~clock ~idle_timeout;
+  let site = "read_sse" in
+  require_clock_when_idle ~site ~clock ~idle_timeout;
   (* SSE keepalive comments carry no payload. Skipping them inside the
      SAME [with_timeout_exn] window preserves the idle deadline so a
      provider that emits only keepalives still trips [idle_timeout]
@@ -1258,7 +1259,7 @@ let read_sse ?clock ?idle_timeout ~reader ~on_data () =
     match clock, idle_timeout with
     | Some c, Some t -> Eio.Time.with_timeout_exn c t inner
     | Some _, None | None, None -> inner ()
-    | None, Some _ -> idle_timeout_without_clock "read_sse"
+    | None, Some _ -> idle_timeout_without_clock site
   in
   let current_event_type = ref None in
   let rec loop () =
@@ -1296,12 +1297,13 @@ let read_sse ?clock ?idle_timeout ~reader ~on_data () =
     wrapped in [Eio.Time.with_timeout_exn] so a stalled stream raises
     [Eio.Time.Timeout] after [idle_timeout] seconds of silence. *)
 let read_ndjson ?clock ?idle_timeout ~reader ~on_line () =
-  require_clock_when_idle ~site:"read_ndjson" ~clock ~idle_timeout;
+  let site = "read_ndjson" in
+  require_clock_when_idle ~site ~clock ~idle_timeout;
   let read_line () =
     match clock, idle_timeout with
     | Some c, Some t -> Eio.Time.with_timeout_exn c t (fun () -> Eio.Buf_read.line reader)
     | Some _, None | None, None -> Eio.Buf_read.line reader
-    | None, Some _ -> idle_timeout_without_clock "read_ndjson"
+    | None, Some _ -> idle_timeout_without_clock site
   in
   let rec loop () =
     match read_line () with

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -918,18 +918,16 @@ let validate_output_schema_request (config : t) =
        Error
          "Glm supports JSON mode (json_object) only; native json_schema output is not \
           documented in the current Z.AI API"
-     | Kimi | OpenAI_compat ->
-       (match validate_model_structured_output_capability config with
-        | Error _ as error -> error
-        | Ok () ->
-          if endpoint_supports_openai_compat_output_schema config
-          then Ok ()
-          else
-            Error
-              (Printf.sprintf
-                 "native structured output is only wired for declared OpenAI-compatible \
-                  endpoints, got %s"
-                 config.base_url)))
+     | Kimi -> validate_model_structured_output_capability config
+     | OpenAI_compat ->
+       if endpoint_supports_openai_compat_output_schema config
+       then validate_model_structured_output_capability config
+       else
+         Error
+           (Printf.sprintf
+              "native structured output is only wired for declared OpenAI-compatible \
+               endpoints, got %s"
+              config.base_url))
 ;;
 
 (** Validate that sampling parameters not supported by CLI subprocess

--- a/test/test_http_client.ml
+++ b/test/test_http_client.ml
@@ -192,6 +192,24 @@ let test_read_sse_idle_without_clock_raises () =
       (Util.contains_substring_ci ~haystack:msg ~needle:"idle_timeout")
 ;;
 
+let test_read_ndjson_idle_without_clock_raises () =
+  Eio_main.run
+  @@ fun _env ->
+  let flow =
+    Eio.Flow.string_source
+      {|{"ok":true}
+|}
+  in
+  let reader = Eio.Buf_read.of_flow ~max_size:(1024 * 1024) flow in
+  match Http_client.read_ndjson ~idle_timeout:1.0 ~reader ~on_line:ignore () with
+  | () -> Alcotest.fail "expected Invalid_argument for idle_timeout without clock"
+  | exception Invalid_argument msg ->
+    Alcotest.(check bool)
+      "message names the disarm hazard"
+      true
+      (Util.contains_substring_ci ~haystack:msg ~needle:"idle_timeout")
+;;
+
 let test_post_stream_invalid_url_returns_network_error () =
   Eio_main.run
   @@ fun env ->
@@ -508,6 +526,12 @@ let () =
             "invalid url returns network error"
             `Quick
             test_post_stream_invalid_url_returns_network_error
+        ] )
+    ; ( "read_ndjson"
+      , [ Alcotest.test_case
+            "idle_timeout without clock raises"
+            `Quick
+            test_read_ndjson_idle_without_clock_raises
         ] )
     ; ( "timeout_phase"
       , [ Alcotest.test_case "policy labels" `Quick test_timeout_phase_policy_labels


### PR DESCRIPTION
## Summary

Remove the remaining production `assert false` arms from the OAS streaming idle-timeout readers.

## What changed

- Extract the existing `idle_timeout` without `clock` misconfiguration message into a shared helper.
- Replace the guarded `assert false` arms in `read_sse` and `read_ndjson` with the same explicit `Invalid_argument` path.
- Bind each stream reader's site label once and reuse it for both the entry guard and defensive fallback arm.
- Add a focused `read_ndjson` regression test for `idle_timeout` without `clock`, matching the existing `read_sse` guard.

## Why

The stream readers already fail loud at function entry when `idle_timeout` is configured without a clock. The nested match arms were intended as unreachable, but keeping `assert false` in production control flow violates the no-crash-only-path rule and weakens the typed/explicit failure contract.

No `provider_config` changes remain in this PR after rebasing on the Kimi sampling owner change.

## Validation

- `opam exec -- ocamlformat --check lib/llm_provider/http_client.ml`
- `git diff --check`
- `rg -n 'read_sse|read_ndjson|idle_timeout_without_clock' lib/llm_provider/http_client.ml`
- Local Dune build/test not run; GitHub CI is the build authority for this workspace.
