### PR TITLE
fix(llm_provider): align Kimi K2 thinking dialects

### DIFF
--- a/lib/llm_provider/reasoning_dialect.ml
+++ b/lib/llm_provider/reasoning_dialect.ml
@@ -121,10 +121,19 @@ let base_of_capabilities (caps : Capabilities.capabilities) =
     ; output_wire
     }
   | Thinking_object_only ->
+    let replay_policy =
+      match preserve_wire with
+      | Thinking_object_keep_all -> Drop_without_tool_preserve_with_tool
+      | No_preserve_thinking_control
+      | Chat_template_kwargs_preserve_thinking
+      | Top_level_preserve_thinking
+      | Always_preserved_thinking -> default.replay_policy
+    in
     { default with
       toggle_default = Provider_default
     ; toggle_wire = Thinking_object_only
     ; preserve_wire
+    ; replay_policy
     ; streaming = Delta_field "reasoning_content"
     ; output_wire
     }

--- a/models.toml
+++ b/models.toml
@@ -1644,6 +1644,34 @@ input_per_million = 0.0
 output_per_million = 0.0
 
 [[models]]
+id_prefix = "kimi-k2.6"
+base = "kimi"
+max_context_tokens = 256000
+supports_tool_choice = true
+supports_required_tool_choice = false
+supports_named_tool_choice = false
+supports_reasoning_budget = false
+thinking_control_format = "thinking_object_only"
+preserve_thinking_control_format = "thinking_object_keep_all"
+reasoning_replay = "default"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[models]]
+id_prefix = "kimi-k2.5"
+base = "kimi"
+max_context_tokens = 256000
+supports_tool_choice = true
+supports_required_tool_choice = false
+supports_named_tool_choice = false
+supports_reasoning_budget = false
+thinking_control_format = "thinking_object_only"
+preserve_thinking_control_format = "none"
+reasoning_replay = "default"
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[models]]
 id_prefix = "kimi-k2"
 base = "kimi"
 max_context_tokens = 256000

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -391,6 +391,55 @@ let test_lookup_kimi_k2_native_cloud_suffix () =
          true
          bare_native.supports_code_execution
      | None -> fail "should match native bare Kimi route");
+    (match Capabilities.for_model_id "kimi-k2.6" with
+     | Some k26 ->
+       check_thinking_control
+         "Kimi K2.6 has thinking object control"
+         Capabilities.Thinking_object_only
+         k26.thinking_control_format;
+       check
+         bool
+         "Kimi K2.6 supports thinking.keep all"
+         true
+         (k26.preserve_thinking_control_format = Capabilities.Thinking_object_keep_all);
+       let dialect = Reasoning_dialect.of_capabilities k26 in
+       check
+         string
+         "Kimi K2.6 replays only tool-call reasoning by default"
+         "drop_without_tool_preserve_with_tool"
+         (Reasoning_dialect.replay_policy_to_string dialect.replay_policy)
+     | None -> fail "should match Kimi K2.6 native route");
+    (match Capabilities.for_model_id "kimi-k2.5" with
+     | Some k25 ->
+       check_thinking_control
+         "Kimi K2.5 has thinking object control"
+         Capabilities.Thinking_object_only
+         k25.thinking_control_format;
+       check
+         bool
+         "Kimi K2.5 does not expose preserved thinking"
+         true
+         (k25.preserve_thinking_control_format = Capabilities.No_preserve_thinking_control);
+       let dialect = Reasoning_dialect.of_capabilities k25 in
+       check
+         string
+         "Kimi K2.5 does not replay historical reasoning"
+         "no_replay"
+         (Reasoning_dialect.replay_policy_to_string dialect.replay_policy)
+     | None -> fail "should match Kimi K2.5 native route");
+    (match Capabilities.for_model_id "kimi-k2.7-code-highspeed" with
+     | Some highspeed ->
+       check_thinking_control
+         "Kimi K2.7 highspeed inherits latest no-toggle behavior"
+         Capabilities.No_thinking_control
+         highspeed.thinking_control_format;
+       check
+         bool
+         "Kimi K2.7 highspeed always preserves reasoning"
+         true
+         (highspeed.preserve_thinking_control_format
+          = Capabilities.Always_preserved_thinking)
+     | None -> fail "should match Kimi K2.7 highspeed route");
     (match
        Capabilities.for_provider_model_id
          ~allow_bare_fallback:true

--- a/test/test_thinking_control_dialects.ml
+++ b/test/test_thinking_control_dialects.ml
@@ -769,6 +769,104 @@ let test_thinking_object_keep_all_axis_replays_reasoning () =
       (assistant |> member "reasoning_content" |> to_string))
 ;;
 
+let test_thinking_object_keep_all_axis_defaults_to_tool_replay () =
+  with_manifest keep_all_axis_manifest (fun () ->
+    let config = declared_catalog_openai_compat_config "keep-all-axis-test" in
+    let dialect = RD.for_provider_config config in
+    check
+      string
+      "replay policy"
+      "drop_without_tool_preserve_with_tool"
+      (RD.replay_policy_to_string dialect.replay_policy);
+    check
+      bool
+      "requires tool-call replay"
+      true
+      (RD.requires_reasoning_replay_on_tool_call dialect);
+    let plain =
+      BOR.build_request ~config ~messages:[ assistant_with_reasoning () ] ()
+      |> json_of_body
+    in
+    let tool =
+      BOR.build_request ~config ~messages:[ assistant_with_reasoning ~tool:true () ] ()
+      |> json_of_body
+    in
+    let plain_assistant = plain |> member "messages" |> index 0 in
+    let tool_assistant = tool |> member "messages" |> index 0 in
+    check_member_absent "reasoning_content" plain_assistant;
+    check
+      string
+      "tool reasoning_content"
+      "use calculator"
+      (tool_assistant |> member "reasoning_content" |> to_string))
+;;
+
+let test_kimi_k26_defaults_to_tool_call_replay () =
+  let config = kimi_config "kimi-k2.6" in
+  let dialect = RD.for_provider_config config in
+  check
+    string
+    "toggle wire"
+    "thinking_object_only"
+    (RD.toggle_wire_to_string dialect.toggle_wire);
+  check
+    string
+    "replay policy"
+    "drop_without_tool_preserve_with_tool"
+    (RD.replay_policy_to_string dialect.replay_policy);
+  check
+    bool
+    "requires tool-call replay"
+    true
+    (RD.requires_reasoning_replay_on_tool_call dialect);
+  let user_json =
+    BOR.build_request ~config ~messages:[ user_msg "hi" ] () |> json_of_body
+  in
+  check_member_absent "thinking" user_json;
+  let plain =
+    BOR.build_request ~config ~messages:[ assistant_with_reasoning () ] () |> json_of_body
+  in
+  let tool =
+    BOR.build_request ~config ~messages:[ assistant_with_reasoning ~tool:true () ] ()
+    |> json_of_body
+  in
+  check_member_absent "reasoning_content" (plain |> member "messages" |> index 0);
+  check
+    string
+    "tool reasoning_content"
+    "use calculator"
+    (tool |> member "messages" |> index 0 |> member "reasoning_content" |> to_string)
+;;
+
+let test_kimi_k26_preserve_requests_keep_all () =
+  let config = kimi_config ~preserve_thinking:true "kimi-k2.6" in
+  let dialect = RD.for_provider_config config in
+  check
+    string
+    "replay policy"
+    "preserve_always"
+    (RD.replay_policy_to_string dialect.replay_policy);
+  let json = BOR.build_request ~config ~messages:[ user_msg "hi" ] () |> json_of_body in
+  let thinking = json |> member "thinking" in
+  check string "thinking type" "enabled" (thinking |> member "type" |> to_string);
+  check string "thinking keep" "all" (thinking |> member "keep" |> to_string);
+  check_member_absent "chat_template_kwargs" json
+;;
+
+let test_kimi_k25_does_not_emit_keep_all () =
+  let config = kimi_config ~enable_thinking:true ~preserve_thinking:true "kimi-k2.5" in
+  let dialect = RD.for_provider_config config in
+  check
+    string
+    "replay policy"
+    "no_replay"
+    (RD.replay_policy_to_string dialect.replay_policy);
+  let json = BOR.build_request ~config ~messages:[ user_msg "hi" ] () |> json_of_body in
+  let thinking = json |> member "thinking" in
+  check string "thinking type" "enabled" (thinking |> member "type" |> to_string);
+  check_member_absent "keep" thinking
+;;
+
 let test_kimi_latest_always_preserved_omits_thinking_param () =
   let config = kimi_config "kimi-k2.7-code" in
   let dialect = RD.for_provider_config config in
@@ -798,6 +896,20 @@ let test_kimi_latest_always_preserved_omits_thinking_param () =
     "reasoning_content"
     "plain thought"
     (assistant |> member "reasoning_content" |> to_string)
+;;
+
+let test_kimi_latest_highspeed_uses_k27_semantics () =
+  let config = kimi_config "kimi-k2.7-code-highspeed" in
+  let dialect = RD.for_provider_config config in
+  check string "toggle wire" "no_toggle" (RD.toggle_wire_to_string dialect.toggle_wire);
+  check
+    string
+    "replay policy"
+    "preserve_always"
+    (RD.replay_policy_to_string dialect.replay_policy);
+  let json = BOR.build_request ~config ~messages:[ user_msg "hi" ] () |> json_of_body in
+  check_member_absent "thinking" json;
+  check_member_absent "chat_template_kwargs" json
 ;;
 
 let test_kimi_latest_omits_sampling_even_with_disabled_thinking_override () =
@@ -1181,9 +1293,29 @@ let () =
               `Quick
               test_thinking_object_keep_all_axis_replays_reasoning
           ; test_case
+              "thinking_object_keep_all axis defaults to tool-call replay"
+              `Quick
+              test_thinking_object_keep_all_axis_defaults_to_tool_replay
+          ; test_case
+              "kimi k2.6 defaults to tool-call replay"
+              `Quick
+              test_kimi_k26_defaults_to_tool_call_replay
+          ; test_case
+              "kimi k2.6 preserve requests keep all"
+              `Quick
+              test_kimi_k26_preserve_requests_keep_all
+          ; test_case
+              "kimi k2.5 does not emit keep all"
+              `Quick
+              test_kimi_k25_does_not_emit_keep_all
+          ; test_case
               "kimi latest always-preserved omits thinking param"
               `Quick
               test_kimi_latest_always_preserved_omits_thinking_param
+          ; test_case
+              "kimi latest highspeed uses k2.7 semantics"
+              `Quick
+              test_kimi_latest_highspeed_uses_k27_semantics
           ; test_case
               "kimi latest omits fixed sampling params"
               `Quick


### PR DESCRIPTION
## Summary
- keep native Kimi latest/default behavior on K2.7 Code and K2.7 Code HighSpeed: no request-side `thinking` parameter, always replay reasoning.
- add explicit catalog rows for `kimi-k2.6` and `kimi-k2.5` so those exact older ids do not inherit the latest K2.7 no-toggle/preserve-always dialect from the broad `kimi-k2` row.
- derive tool-call-only replay from `thinking_object_keep_all` so K2.6 preserves `reasoning_content` during tool loops without forcing full historical replay unless `preserve_thinking=true`.

## Evidence
- Kimi official docs, checked 2026-07-04: K2.7 Code/HighSpeed are latest, always think, and preserved thinking is always on; K2.6 supports `thinking.keep=all`; K2.5 has no preserved-thinking parameter. https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model
- Kimi K2.7 Code official quickstart, checked 2026-07-04: K2.7 Code does not support non-thinking mode, uses fixed sampling params, and tool workflows must keep `reasoning_content`. https://platform.kimi.ai/docs/guide/kimi-k2-7-code-quickstart

## Validation
- `scripts/dune-local.sh build test/test_thinking_control_dialects.exe test/test_capabilities.exe`
- `scripts/dune-local.sh build @fmt`
- `git diff --check`
- `OAS_MODEL_CATALOG=$PWD/models.toml ./_build/default/test/test_thinking_control_dialects.exe`
- `OAS_MODEL_CATALOG=$PWD/models.toml ./_build/default/test/test_capabilities.exe`
