### PR TITLE
fix(provider): type suppressed sampling parameters

### DIFF
--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -172,6 +172,7 @@ let llm_capabilities_of_provider_capabilities (caps : Provider.capabilities)
   ; supports_min_p = caps.supports_min_p
   ; supports_seed = caps.supports_seed
   ; supports_seed_with_images = caps.supports_seed_with_images
+  ; ignored_sampling_parameters = caps.ignored_sampling_parameters
   ; supports_computer_use = caps.supports_computer_use
   ; supports_code_execution = caps.supports_code_execution
   ; emits_usage_tokens = caps.emits_usage_tokens
@@ -272,12 +273,13 @@ let reasoning_dialect_for_request
   else dialect
 ;;
 
-let add_sampling_field dialect (config : agent_state) field value body_assoc =
+let add_sampling_field dialect (config : agent_state) parameter value body_assoc =
+  let field = Llm_provider.Capabilities.sampling_parameter_to_string parameter in
   if
     Llm_provider.Reasoning_dialect.ignores_sampling_param
       dialect
       ~enable_thinking:config.config.enable_thinking
-      field
+      parameter
   then body_assoc
   else (field, value) :: body_assoc
 ;;
@@ -366,17 +368,34 @@ let build_openai_body_unchecked
   let body_assoc =
     match config.config.temperature with
     | Some temp ->
-      add_sampling_field dialect config "temperature" (`Float temp) body_assoc
+      add_sampling_field
+        dialect
+        config
+        Llm_provider.Capabilities.Temperature
+        (`Float temp)
+        body_assoc
     | None -> body_assoc
   in
   let body_assoc =
     match config.config.top_p with
-    | Some top_p -> add_sampling_field dialect config "top_p" (`Float top_p) body_assoc
+    | Some top_p ->
+      add_sampling_field
+        dialect
+        config
+        Llm_provider.Capabilities.Top_p
+        (`Float top_p)
+        body_assoc
     | None -> body_assoc
   in
   let body_assoc =
     match config.config.top_k with
-    | Some top_k when capabilities.supports_top_k -> ("top_k", `Int top_k) :: body_assoc
+    | Some top_k when capabilities.supports_top_k ->
+      add_sampling_field
+        dialect
+        config
+        Llm_provider.Capabilities.Top_k
+        (`Int top_k)
+        body_assoc
     | None -> body_assoc
     | Some _ ->
       Llm_provider.Backend_openai.warn_capability_drop ~model_id:model_str ~field:"top_k";
@@ -384,7 +403,13 @@ let build_openai_body_unchecked
   in
   let body_assoc =
     match config.config.min_p with
-    | Some min_p when capabilities.supports_min_p -> ("min_p", `Float min_p) :: body_assoc
+    | Some min_p when capabilities.supports_min_p ->
+      add_sampling_field
+        dialect
+        config
+        Llm_provider.Capabilities.Min_p
+        (`Float min_p)
+        body_assoc
     | None -> body_assoc
     | Some _ ->
       Llm_provider.Backend_openai.warn_capability_drop ~model_id:model_str ~field:"min_p";

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -34,27 +34,29 @@ let warn_capability_drop ~model_id ~field =
       field)
 ;;
 
-let warn_dialect_ignored ~model_id ~field =
+let warn_dialect_ignored ~model_id ~parameter =
+  let field = Capabilities.sampling_parameter_to_string parameter in
   let key = model_id, field in
   if not (Hashtbl.mem dialect_ignored_warned key)
   then (
     Hashtbl.replace dialect_ignored_warned key ();
     Diag.warn
       "backend_openai"
-      "dropping request field %s for model %s: the selected reasoning dialect ignores \
-       this sampling parameter while thinking is enabled."
+      "dropping request field %s for model %s: the selected reasoning dialect \
+       suppresses this sampling parameter."
       field
       model_id)
 ;;
 
-let add_sampling_field dialect (config : Provider_config.t) field value body =
+let add_sampling_field dialect (config : Provider_config.t) parameter value body =
+  let field = Capabilities.sampling_parameter_to_string parameter in
   if
     Reasoning_dialect.ignores_sampling_param
       dialect
       ~enable_thinking:config.enable_thinking
-      field
+      parameter
   then (
-    warn_dialect_ignored ~model_id:config.model_id ~field;
+    warn_dialect_ignored ~model_id:config.model_id ~parameter;
     body)
   else (field, value) :: body
 ;;
@@ -254,12 +256,12 @@ let build_request_assoc
   in
   let body =
     match config.temperature with
-    | Some t -> add_sampling_field dialect config "temperature" (`Float t) body
+    | Some t -> add_sampling_field dialect config Capabilities.Temperature (`Float t) body
     | None -> body
   in
   let body =
     match config.top_p with
-    | Some p -> add_sampling_field dialect config "top_p" (`Float p) body
+    | Some p -> add_sampling_field dialect config Capabilities.Top_p (`Float p) body
     | None -> body
   in
   (* Silent drops of user-supplied sampling params are a debugging
@@ -271,7 +273,8 @@ let build_request_assoc
      double-warn at most once per key, which is harmless. *)
   let body =
     match config.top_k with
-    | Some k when caps.supports_top_k -> ("top_k", `Int k) :: body
+    | Some k when caps.supports_top_k ->
+      add_sampling_field dialect config Capabilities.Top_k (`Int k) body
     | Some _ ->
       warn_capability_drop ~model_id:config.model_id ~field:"top_k";
       body
@@ -279,7 +282,8 @@ let build_request_assoc
   in
   let body =
     match config.min_p with
-    | Some p when caps.supports_min_p -> ("min_p", `Float p) :: body
+    | Some p when caps.supports_min_p ->
+      add_sampling_field dialect config Capabilities.Min_p (`Float p) body
     | Some _ ->
       warn_capability_drop ~model_id:config.model_id ~field:"min_p";
       body

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -42,8 +42,8 @@ let warn_dialect_ignored ~model_id ~parameter =
     Hashtbl.replace dialect_ignored_warned key ();
     Diag.warn
       "backend_openai"
-      "dropping request field %s for model %s: the selected reasoning dialect \
-       suppresses this sampling parameter."
+      "dropping request field %s for model %s: the selected reasoning dialect suppresses \
+       this sampling parameter."
       field
       model_id)
 ;;

--- a/lib/llm_provider/backend_openai_request.mli
+++ b/lib/llm_provider/backend_openai_request.mli
@@ -21,13 +21,13 @@ val capabilities_of_config : Provider_config.t -> Capabilities.capabilities
     policy is single-sourced here. *)
 val effective_max_output_tokens : Provider_config.t -> int
 
-(** Prepend [(field, value)] to [body] unless the reasoning dialect ignores
-    the sampling parameter while thinking is enabled, in which case the field
-    is dropped with a one-shot WARN per ([model_id], [field]). *)
+(** Prepend the sampling [(field, value)] to [body] unless the reasoning
+    dialect suppresses that parameter, in which case the field is dropped with a
+    one-shot WARN per ([model_id], [field]). *)
 val add_sampling_field
   :  Reasoning_dialect.t
   -> Provider_config.t
-  -> string
+  -> Capabilities.sampling_parameter
   -> Yojson.Safe.t
   -> (string * Yojson.Safe.t) list
   -> (string * Yojson.Safe.t) list

--- a/lib/llm_provider/backend_openai_responses.ml
+++ b/lib/llm_provider/backend_openai_responses.ml
@@ -398,12 +398,12 @@ let build_request
   in
   let body =
     match config.temperature with
-    | Some t -> add_sampling_field dialect config "temperature" (`Float t) body
+    | Some t -> add_sampling_field dialect config Capabilities.Temperature (`Float t) body
     | None -> body
   in
   let body =
     match config.top_p with
-    | Some p -> add_sampling_field dialect config "top_p" (`Float p) body
+    | Some p -> add_sampling_field dialect config Capabilities.Top_p (`Float p) body
     | None -> body
   in
   let body =

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -66,6 +66,15 @@ type reasoning_streaming_format = Capability_vocab.reasoning_streaming_format =
   | Delta_reasoning_field of string
   | Template_reasoning_streaming
 
+type sampling_parameter = Capability_vocab.sampling_parameter =
+  | Temperature
+  | Top_p
+  | Top_k
+  | Min_p
+  | Presence_penalty
+  | Frequency_penalty
+  | Seed
+
 (** Catalog-declared inference task for non-chat models. [None] on every
     chat/completion model; a value is only ever set by an explicit [task]
     field on a model catalog entry — never inferred from the model id. *)
@@ -159,6 +168,10 @@ type capabilities =
       achieve near-perfect determinism on identical hardware; cloud
       providers (Openai, Gemini) do not guarantee deterministic output
       when images are in the prompt. *)
+  ; ignored_sampling_parameters : sampling_parameter list
+    (** Request sampling parameters that must not be serialized for this
+        provider/model even when a caller supplied them. This is catalog data,
+        not a model-id heuristic. *)
   ; (* ── Advanced modalities ───────────────────────────── *)
     supports_computer_use : bool
   ; supports_code_execution : bool
@@ -213,6 +226,7 @@ let default_capabilities =
   ; supports_min_p = false
   ; supports_seed = false
   ; supports_seed_with_images = false
+  ; ignored_sampling_parameters = []
   ; supports_computer_use = false
   ; supports_code_execution = false
   ; emits_usage_tokens = true (* stricter default: most providers report usage *)
@@ -762,6 +776,8 @@ let reasoning_replay_override_of_catalog_string raw =
   Capability_vocab.reasoning_replay_override_of_string raw
 ;;
 
+let sampling_parameter_to_string = Capability_vocab.sampling_parameter_to_string
+
 let assistant_tool_content_format_of_catalog_string raw =
   Capability_vocab.assistant_tool_content_format_of_string raw
 ;;
@@ -838,6 +854,7 @@ type declarative_capability_overrides =
   ; supports_top_k : bool option
   ; supports_min_p : bool option
   ; supports_seed : bool option
+  ; ignored_sampling_parameters : Capability_vocab.sampling_parameter list option
   ; supports_computer_use : bool option
   ; supports_code_execution : bool option
   ; thinking_control_format : string option
@@ -878,6 +895,7 @@ let overrides_of_manifest_entry (entry : Capability_manifest.entry) =
   ; supports_top_k = entry.supports_top_k
   ; supports_min_p = entry.supports_min_p
   ; supports_seed = entry.supports_seed
+  ; ignored_sampling_parameters = entry.ignored_sampling_parameters
   ; supports_computer_use = entry.supports_computer_use
   ; supports_code_execution = entry.supports_code_execution
   ; thinking_control_format = entry.thinking_control_format
@@ -997,6 +1015,10 @@ let apply_declarative_capability_overrides overrides =
   ; supports_top_k = override_bool base.supports_top_k overrides.supports_top_k
   ; supports_min_p = override_bool base.supports_min_p overrides.supports_min_p
   ; supports_seed = override_bool base.supports_seed overrides.supports_seed
+  ; ignored_sampling_parameters =
+      (match overrides.ignored_sampling_parameters with
+       | Some parameters -> parameters
+       | None -> base.ignored_sampling_parameters)
   ; supports_computer_use =
       override_bool base.supports_computer_use overrides.supports_computer_use
   ; supports_code_execution =
@@ -1146,6 +1168,7 @@ let overrides_of_catalog_entry (entry : Model_catalog.model_entry) =
   ; supports_top_k = entry.supports_top_k
   ; supports_min_p = entry.supports_min_p
   ; supports_seed = entry.supports_seed
+  ; ignored_sampling_parameters = entry.ignored_sampling_parameters
   ; supports_computer_use = entry.supports_computer_use
   ; supports_code_execution = entry.supports_code_execution
   ; thinking_control_format = entry.thinking_control_format
@@ -1513,6 +1536,7 @@ let test_catalog_entry id_prefix : Model_catalog.model_entry =
   ; supports_top_k = None
   ; supports_min_p = None
   ; supports_seed = None
+  ; ignored_sampling_parameters = None
   ; supports_computer_use = None
   ; supports_code_execution = None
   ; thinking_control_format = None
@@ -1556,6 +1580,7 @@ let test_manifest_entry id_prefix : Capability_manifest.entry =
   ; supports_top_k = None
   ; supports_min_p = None
   ; supports_seed = None
+  ; ignored_sampling_parameters = None
   ; supports_computer_use = None
   ; supports_code_execution = None
   ; thinking_control_format = None
@@ -2183,6 +2208,7 @@ let%test "capabilities_for_provider_label: aliases resolve to identical capabili
       && ca.reasoning_output_format = cb.reasoning_output_format
       && ca.reasoning_streaming_format = cb.reasoning_streaming_format
       && ca.assistant_tool_content_format = cb.assistant_tool_content_format
+      && ca.ignored_sampling_parameters = cb.ignored_sampling_parameters
       && ca.reasoning_replay_override = cb.reasoning_replay_override
     | _ -> false
   in

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -48,6 +48,15 @@ type reasoning_streaming_format = Capability_vocab.reasoning_streaming_format =
   | Delta_reasoning_field of string
   | Template_reasoning_streaming
 
+type sampling_parameter = Capability_vocab.sampling_parameter =
+  | Temperature
+  | Top_p
+  | Top_k
+  | Min_p
+  | Presence_penalty
+  | Frequency_penalty
+  | Seed
+
 (** Catalog-declared inference task for non-chat models. [None] on every
     chat/completion model; a value is only ever set by an explicit [task]
     field on a model catalog entry — never inferred from the model id. *)
@@ -115,6 +124,9 @@ type capabilities =
       Local providers (Ollama) achieve near-perfect reproducibility; cloud
       providers (Openai, Gemini) do not guarantee it.
       @since 0.185.0 *)
+  ; ignored_sampling_parameters : sampling_parameter list
+    (** Request sampling parameters that must not be serialized for this
+        provider/model even when a caller supplied them. *)
   ; (* Advanced modalities *)
     supports_computer_use : bool
   ; supports_code_execution : bool
@@ -145,6 +157,8 @@ val glm_capabilities : capabilities
 (** NVIDIA NIM Nvidia capabilities: Llama-based, chat_template_kwargs thinking.
     @since 0.185.0 *)
 val provider_l_capabilities : capabilities
+
+val sampling_parameter_to_string : sampling_parameter -> string
 
 (** Resolve the exact chat-template token for models whose
     [thinking_control_format] is [Chat_template_token]. The token is catalog /

--- a/lib/llm_provider/capability_manifest.ml
+++ b/lib/llm_provider/capability_manifest.ml
@@ -50,6 +50,7 @@ type entry =
   ; supports_top_k : bool option
   ; supports_min_p : bool option
   ; supports_seed : bool option
+  ; ignored_sampling_parameters : Capability_vocab.sampling_parameter list option
   ; supports_computer_use : bool option
   ; supports_code_execution : bool option
   ; thinking_control_format : string option
@@ -235,6 +236,30 @@ let canonical_string_list key ~allowed json =
             (String.concat ", " allowed)))
 ;;
 
+let canonical_sampling_parameters key json =
+  match member_string_list key json with
+  | None -> Ok None
+  | Some values ->
+    let parsed, unknown =
+      List.fold_right
+        (fun raw (parsed, unknown) ->
+           match Capability_vocab.sampling_parameter_of_string raw with
+           | Some parameter -> parameter :: parsed, unknown
+           | None -> parsed, String.lowercase_ascii (String.trim raw) :: unknown)
+        values
+        ([], [])
+    in
+    (match unknown with
+     | [] -> Ok (Some parsed)
+     | values ->
+       Error
+         (Printf.sprintf
+            "entry field %S has unknown value(s) %s (canonical: %s)"
+            key
+            (String.concat ", " values)
+            (String.concat ", " Capability_vocab.sampling_parameter_values)))
+;;
+
 let canonical_reasoning_streaming_format key json =
   let open Result_syntax in
   let* value = member_string_closed key json in
@@ -284,6 +309,7 @@ let known_entry_keys =
   ; "supports_top_k"
   ; "supports_min_p"
   ; "supports_seed"
+  ; "ignored_sampling_parameters"
   ; "supports_computer_use"
   ; "supports_code_execution"
   ; "thinking_control_format"
@@ -369,6 +395,9 @@ let parse_entry json =
       ~allowed:Reasoning_effort.all_wire_values
       json
   in
+  let* ignored_sampling_parameters =
+    canonical_sampling_parameters "ignored_sampling_parameters" json
+  in
   Ok
     { id_prefix
     ; base_label
@@ -397,6 +426,7 @@ let parse_entry json =
     ; supports_top_k = member_bool "supports_top_k" json
     ; supports_min_p = member_bool "supports_min_p" json
     ; supports_seed = member_bool "supports_seed" json
+    ; ignored_sampling_parameters
     ; supports_computer_use = member_bool "supports_computer_use" json
     ; supports_code_execution = member_bool "supports_code_execution" json
     ; thinking_control_format

--- a/lib/llm_provider/capability_manifest.mli
+++ b/lib/llm_provider/capability_manifest.mli
@@ -88,6 +88,9 @@ type entry =
   ; supports_top_k : bool option
   ; supports_min_p : bool option
   ; supports_seed : bool option
+  ; ignored_sampling_parameters : Capability_vocab.sampling_parameter list option
+    (** Request sampling parameters that this manifest row declares must not be
+        serialized. *)
   ; supports_computer_use : bool option
   ; supports_code_execution : bool option
   ; thinking_control_format : string option

--- a/lib/llm_provider/capability_vocab.ml
+++ b/lib/llm_provider/capability_vocab.ml
@@ -43,6 +43,15 @@ type reasoning_streaming_format =
   | Delta_reasoning_field of string
   | Template_reasoning_streaming
 
+type sampling_parameter =
+  | Temperature
+  | Top_p
+  | Top_k
+  | Min_p
+  | Presence_penalty
+  | Frequency_penalty
+  | Seed
+
 (** Inference task a catalog entry declares for non-chat models (audio
     transcription, speech synthesis, image/video generation). Chat and
     completion models declare no task. *)
@@ -219,6 +228,49 @@ let reasoning_streaming_format_of_string raw =
     then None
     else Some (Delta_reasoning_field field)
   | _ -> None
+;;
+
+let sampling_parameter_table =
+  [ "temperature", Temperature
+  ; "top_p", Top_p
+  ; "top_k", Top_k
+  ; "min_p", Min_p
+  ; "presence_penalty", Presence_penalty
+  ; "frequency_penalty", Frequency_penalty
+  ; "seed", Seed
+  ]
+;;
+
+let sampling_parameter_values = List.map fst sampling_parameter_table
+
+let sampling_parameter_of_string raw =
+  match normalize raw with
+  | "" -> None
+  | normalized -> List.assoc_opt normalized sampling_parameter_table
+;;
+
+let sampling_parameter_to_string = function
+  | Temperature -> "temperature"
+  | Top_p -> "top_p"
+  | Top_k -> "top_k"
+  | Min_p -> "min_p"
+  | Presence_penalty -> "presence_penalty"
+  | Frequency_penalty -> "frequency_penalty"
+  | Seed -> "seed"
+;;
+
+let%test "sampling_parameter values parse through the canonical table" =
+  List.for_all
+    (fun raw -> Option.is_some (sampling_parameter_of_string raw))
+    sampling_parameter_values
+;;
+
+let%test "sampling_parameter round-trips through to_string and of_string" =
+  List.for_all
+    (fun (_raw, parameter) ->
+       sampling_parameter_of_string (sampling_parameter_to_string parameter)
+       = Some parameter)
+    sampling_parameter_table
 ;;
 
 (* Closed vocabulary of catalog/manifest [base] labels — the provider presets a

--- a/lib/llm_provider/model_catalog.ml
+++ b/lib/llm_provider/model_catalog.ml
@@ -542,8 +542,7 @@ let%test "parse_entry parses ignored_sampling_parameters into closed variants" =
 
 let%test "parse_entry rejects unknown ignored_sampling_parameters" =
   let entry =
-    Otoml.Parser.from_string
-      "id_prefix = \"m\"\nignored_sampling_parameters = [\"temp\"]"
+    Otoml.Parser.from_string "id_prefix = \"m\"\nignored_sampling_parameters = [\"temp\"]"
   in
   match parse_entry entry with
   | Error _ -> true

--- a/lib/llm_provider/model_catalog.ml
+++ b/lib/llm_provider/model_catalog.ml
@@ -31,6 +31,7 @@ type model_entry =
   ; supports_top_k : bool option
   ; supports_min_p : bool option
   ; supports_seed : bool option
+  ; ignored_sampling_parameters : Capability_vocab.sampling_parameter list option
   ; supports_computer_use : bool option
   ; supports_code_execution : bool option
   ; thinking_control_format : string option
@@ -180,6 +181,31 @@ let reasoning_streaming_format_opt ~entry_id key toml =
             Capability_vocab.reasoning_streaming_format_syntax))
 ;;
 
+let sampling_parameters_opt ~entry_id key toml =
+  match find_string_list_opt toml [ key ] with
+  | None -> Ok None
+  | Some values ->
+    let parsed, unknown =
+      List.fold_right
+        (fun raw (parsed, unknown) ->
+           match Capability_vocab.sampling_parameter_of_string raw with
+           | Some parameter -> parameter :: parsed, unknown
+           | None -> parsed, String.lowercase_ascii (String.trim raw) :: unknown)
+        values
+        ([], [])
+    in
+    (match unknown with
+     | [] -> Ok (Some parsed)
+     | values ->
+       Error
+         (Printf.sprintf
+            "model entry %S field %S has unknown value(s) %s (canonical: %s)"
+            entry_id
+            key
+            (String.concat ", " values)
+            (String.concat ", " Capability_vocab.sampling_parameter_values)))
+;;
+
 (* Typed at the parse boundary: an entry either declares a canonical task or
    fails the whole catalog load. Storing the raw string here would defer the
    unknown-value decision to a warn-and-keep-base fallback at capability
@@ -238,6 +264,7 @@ let known_entry_keys =
   ; "supports_top_k"
   ; "supports_min_p"
   ; "supports_seed"
+  ; "ignored_sampling_parameters"
   ; "supports_computer_use"
   ; "supports_code_execution"
   ; "thinking_control_format"
@@ -330,6 +357,12 @@ let parse_entry entry_toml =
            entry_toml
        in
        let task_result = task_opt ~entry_id:id_prefix "task" entry_toml in
+       let ignored_sampling_parameters_result =
+         sampling_parameters_opt
+           ~entry_id:id_prefix
+           "ignored_sampling_parameters"
+           entry_toml
+       in
        let thinking_control_format_result =
          canonical_string_opt
            ~entry_id:id_prefix
@@ -368,25 +401,28 @@ let parse_entry entry_toml =
           , provider_name_result
           , modality_priority_result
           , task_result
+          , ignored_sampling_parameters_result
           , thinking_control_format_result
           , preserve_thinking_control_format_result
           , reasoning_output_format_result
           , reasoning_streaming_format_result
           , thinking_control_token_result )
         with
-        | (Error _ as e), _, _, _, _, _, _, _, _
-        | _, (Error _ as e), _, _, _, _, _, _, _
-        | _, _, (Error _ as e), _, _, _, _, _, _
-        | _, _, _, (Error _ as e), _, _, _, _, _
-        | _, _, _, _, (Error _ as e), _, _, _, _
-        | _, _, _, _, _, (Error _ as e), _, _, _
-        | _, _, _, _, _, _, (Error _ as e), _, _
-        | _, _, _, _, _, _, _, (Error _ as e), _
-        | _, _, _, _, _, _, _, _, (Error _ as e) -> e
+        | (Error _ as e), _, _, _, _, _, _, _, _, _
+        | _, (Error _ as e), _, _, _, _, _, _, _, _
+        | _, _, (Error _ as e), _, _, _, _, _, _, _
+        | _, _, _, (Error _ as e), _, _, _, _, _, _
+        | _, _, _, _, (Error _ as e), _, _, _, _, _
+        | _, _, _, _, _, (Error _ as e), _, _, _, _
+        | _, _, _, _, _, _, (Error _ as e), _, _, _
+        | _, _, _, _, _, _, _, (Error _ as e), _, _
+        | _, _, _, _, _, _, _, _, (Error _ as e), _
+        | _, _, _, _, _, _, _, _, _, (Error _ as e) -> e
         | ( Ok base_label
           , Ok provider_name
           , Ok modality_priority
           , Ok task
+          , Ok ignored_sampling_parameters
           , Ok thinking_control_format
           , Ok preserve_thinking_control_format
           , Ok reasoning_output_format
@@ -434,6 +470,7 @@ let parse_entry entry_toml =
             ; supports_top_k = find_bool_opt entry_toml [ "supports_top_k" ]
             ; supports_min_p = find_bool_opt entry_toml [ "supports_min_p" ]
             ; supports_seed = find_bool_opt entry_toml [ "supports_seed" ]
+            ; ignored_sampling_parameters
             ; supports_computer_use = find_bool_opt entry_toml [ "supports_computer_use" ]
             ; supports_code_execution =
                 find_bool_opt entry_toml [ "supports_code_execution" ]
@@ -487,6 +524,30 @@ let%test "parse_entry leaves task undeclared as None" =
   match parse_entry entry with
   | Ok { task = None; _ } -> true
   | Ok _ | Error _ -> false
+;;
+
+let%test "parse_entry parses ignored_sampling_parameters into closed variants" =
+  let entry =
+    Otoml.Parser.from_string
+      "id_prefix = \"m\"\nignored_sampling_parameters = [\"temperature\", \"top_p\"]"
+  in
+  match parse_entry entry with
+  | Ok
+      { ignored_sampling_parameters =
+          Some [ Capability_vocab.Temperature; Capability_vocab.Top_p ]
+      ; _
+      } -> true
+  | Ok _ | Error _ -> false
+;;
+
+let%test "parse_entry rejects unknown ignored_sampling_parameters" =
+  let entry =
+    Otoml.Parser.from_string
+      "id_prefix = \"m\"\nignored_sampling_parameters = [\"temp\"]"
+  in
+  match parse_entry entry with
+  | Error _ -> true
+  | Ok _ -> false
 ;;
 
 let%test "parse_entry rejects an unknown base preset, not silent default" =

--- a/lib/llm_provider/model_catalog.mli
+++ b/lib/llm_provider/model_catalog.mli
@@ -41,6 +41,10 @@ type model_entry =
   ; supports_top_k : bool option
   ; supports_min_p : bool option
   ; supports_seed : bool option
+  ; ignored_sampling_parameters : Capability_vocab.sampling_parameter list option
+    (** Request sampling parameters that this catalog row declares must not be
+        serialized. Parsed fail-closed against
+        {!Capability_vocab.sampling_parameter_values}. *)
   ; supports_computer_use : bool option
   ; supports_code_execution : bool option
   ; thinking_control_format : string option

--- a/lib/llm_provider/provider_catalog.ml
+++ b/lib/llm_provider/provider_catalog.ml
@@ -319,6 +319,25 @@ let parse_accepted_reasoning_efforts = function
     loop [] values
 ;;
 
+let parse_ignored_sampling_parameters = function
+  | None -> Ok None
+  | Some values ->
+    let rec loop acc = function
+      | [] -> Ok (Some (List.rev acc))
+      | raw :: rest ->
+        let normalized = String.lowercase_ascii (String.trim raw) in
+        (match Capability_vocab.sampling_parameter_of_string normalized with
+         | Some parameter -> loop (parameter :: acc) rest
+         | None ->
+           Error
+             (Printf.sprintf
+                "unknown ignored_sampling_parameters value %S (canonical: %s)"
+                normalized
+                (String.concat ", " Capability_vocab.sampling_parameter_values)))
+    in
+    loop [] values
+;;
+
 let member_supported_models json = member_string_list "supported_models" json
 
 let capability_base json =
@@ -393,6 +412,10 @@ let parse_capabilities provider_json =
   let* accepted_reasoning_efforts =
     parse_accepted_reasoning_efforts
       (member_string_list "accepted_reasoning_efforts" cap_json)
+  in
+  let* ignored_sampling_parameters =
+    parse_ignored_sampling_parameters
+      (member_string_list "ignored_sampling_parameters" cap_json)
   in
   let caps =
     base
@@ -596,6 +619,11 @@ let parse_capabilities provider_json =
       caps
       (fun caps v -> { caps with Capabilities.supports_seed_with_images = v })
       cap_json
+    |> fun caps ->
+    (match ignored_sampling_parameters with
+     | Some ignored_sampling_parameters ->
+       { caps with Capabilities.ignored_sampling_parameters }
+     | None -> caps)
     |> fun caps ->
     override_bool
       "supports_computer_use"

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -319,6 +319,7 @@ let capability_requires_endpoint_declaration (caps : Capabilities.capabilities) 
   || caps.supports_min_p
   || caps.supports_seed
   || caps.supports_seed_with_images
+  || caps.ignored_sampling_parameters <> []
   || caps.supports_computer_use
   || caps.supports_code_execution
 ;;

--- a/lib/llm_provider/reasoning_dialect.ml
+++ b/lib/llm_provider/reasoning_dialect.ml
@@ -459,8 +459,7 @@ let normalize_effort dialect raw =
 
 let sampling_params_ignored_when_thinking dialect =
   let params =
-    dialect.sampling_policy.ignored_always
-    @ dialect.sampling_policy.ignored_when_thinking
+    dialect.sampling_policy.ignored_always @ dialect.sampling_policy.ignored_when_thinking
   in
   List.fold_left
     (fun acc parameter -> if List.mem parameter acc then acc else acc @ [ parameter ])

--- a/lib/llm_provider/reasoning_dialect.ml
+++ b/lib/llm_provider/reasoning_dialect.ml
@@ -24,9 +24,9 @@ type effort_alias_policy =
   | Anthropic_output_max
 
 type sampling_policy =
-  | Sampling_supported
-  | Ignored_always of string list
-  | Ignored_when_thinking of string list
+  { ignored_always : Capabilities.sampling_parameter list
+  ; ignored_when_thinking : Capabilities.sampling_parameter list
+  }
 
 type replay_policy =
   | No_replay
@@ -60,12 +60,14 @@ type t =
   ; output_wire : output_wire
   }
 
+let sampling_supported = { ignored_always = []; ignored_when_thinking = [] }
+
 let default =
   { toggle_default = Provider_default
   ; toggle_wire = No_toggle
   ; preserve_wire = No_preserve_thinking_control
   ; effort_alias_policy = Preserve_effort
-  ; sampling_policy = Sampling_supported
+  ; sampling_policy = sampling_supported
   ; replay_policy = No_replay
   ; streaming = No_streaming_reasoning
   ; output_wire = No_output_control
@@ -73,10 +75,16 @@ let default =
 ;;
 
 let deepseek_ignored_sampling_params =
-  [ "temperature"; "top_p"; "presence_penalty"; "frequency_penalty" ]
+  [ Capabilities.Temperature
+  ; Capabilities.Top_p
+  ; Capabilities.Presence_penalty
+  ; Capabilities.Frequency_penalty
+  ]
 ;;
 
-let kimi_fixed_sampling_params = [ "temperature"; "top_p" ]
+let sampling_policy_of_capabilities (caps : Capabilities.capabilities) =
+  { sampling_supported with ignored_always = caps.ignored_sampling_parameters }
+;;
 
 let base_of_capabilities (caps : Capabilities.capabilities) =
   let preserve_wire = caps.preserve_thinking_control_format in
@@ -85,6 +93,7 @@ let base_of_capabilities (caps : Capabilities.capabilities) =
     | No_reasoning_output_format -> No_output_control
     | Split_reasoning_fields -> Reasoning_split
   in
+  let default = { default with sampling_policy = sampling_policy_of_capabilities caps } in
   match caps.thinking_control_format with
   | No_thinking_control ->
     let dialect = { default with preserve_wire; output_wire } in
@@ -93,7 +102,6 @@ let base_of_capabilities (caps : Capabilities.capabilities) =
        { dialect with
          replay_policy = Preserve_always
        ; streaming = Delta_field "reasoning_content"
-       ; sampling_policy = Ignored_always kimi_fixed_sampling_params
        }
      | No_preserve_thinking_control
      | Thinking_object_keep_all
@@ -104,7 +112,10 @@ let base_of_capabilities (caps : Capabilities.capabilities) =
     ; toggle_wire = Thinking_object { includes_reasoning_effort = true }
     ; preserve_wire
     ; effort_alias_policy = Deepseek_high_or_max
-    ; sampling_policy = Ignored_when_thinking deepseek_ignored_sampling_params
+    ; sampling_policy =
+        { ignored_always = caps.ignored_sampling_parameters
+        ; ignored_when_thinking = deepseek_ignored_sampling_params
+        }
     ; replay_policy = Drop_without_tool_preserve_with_tool
     ; streaming = Delta_field "reasoning_content"
     ; output_wire
@@ -254,12 +265,10 @@ let top_level_preserve_field dialect ~preserve_thinking =
   | Always_preserved_thinking -> None
 ;;
 
-let ignores_sampling_param dialect ~enable_thinking field =
-  match dialect.sampling_policy with
-  | Sampling_supported -> false
-  | Ignored_always params -> List.mem field params
-  | Ignored_when_thinking params ->
-    thinking_enabled ~enable_thinking && List.mem field params
+let ignores_sampling_param dialect ~enable_thinking parameter =
+  List.mem parameter dialect.sampling_policy.ignored_always
+  || (thinking_enabled ~enable_thinking
+      && List.mem parameter dialect.sampling_policy.ignored_when_thinking)
 ;;
 
 let bool_field name = function
@@ -449,9 +458,14 @@ let normalize_effort dialect raw =
 ;;
 
 let sampling_params_ignored_when_thinking dialect =
-  match dialect.sampling_policy with
-  | Sampling_supported -> []
-  | Ignored_always params | Ignored_when_thinking params -> params
+  let params =
+    dialect.sampling_policy.ignored_always
+    @ dialect.sampling_policy.ignored_when_thinking
+  in
+  List.fold_left
+    (fun acc parameter -> if List.mem parameter acc then acc else acc @ [ parameter ])
+    []
+    params
 ;;
 
 (* Sampling params a wire format ignores while thinking is enabled, keyed purely
@@ -459,7 +473,7 @@ let sampling_params_ignored_when_thinking dialect =
    Only DeepSeek-style [Thinking_object] suppresses sampling; the constant is the
    single source of truth, also used by [of_capabilities] above. *)
 let sampling_params_ignored_for_format
-  : Capabilities.thinking_control_format -> string list
+  : Capabilities.thinking_control_format -> Capabilities.sampling_parameter list
   = function
   | Capabilities.Thinking_object -> deepseek_ignored_sampling_params
   | Capabilities.No_thinking_control
@@ -472,14 +486,18 @@ let sampling_params_ignored_for_format
   | Capabilities.Enable_thinking -> []
 ;;
 
-let sampling_field_ignored_when_thinking ~thinking_control_format ~enable_thinking ~field =
+let sampling_field_ignored_when_thinking
+      ~thinking_control_format
+      ~enable_thinking
+      ~parameter
+  =
   let thinking_active =
     match enable_thinking with
     | Some false -> false
     | Some true | None -> true
   in
   thinking_active
-  && List.mem field (sampling_params_ignored_for_format thinking_control_format)
+  && List.mem parameter (sampling_params_ignored_for_format thinking_control_format)
 ;;
 
 let should_replay_reasoning dialect ~assistant_had_tool_call =

--- a/lib/llm_provider/reasoning_dialect.mli
+++ b/lib/llm_provider/reasoning_dialect.mli
@@ -88,6 +88,7 @@ val chat_template_kwargs_preserve_field
   -> bool option
 
 val top_level_preserve_field : t -> preserve_thinking:bool option -> bool option
+
 val ignores_sampling_param
   :  t
   -> enable_thinking:bool option

--- a/lib/llm_provider/reasoning_dialect.mli
+++ b/lib/llm_provider/reasoning_dialect.mli
@@ -34,9 +34,9 @@ type effort_alias_policy =
   | Anthropic_output_max
 
 type sampling_policy =
-  | Sampling_supported
-  | Ignored_always of string list
-  | Ignored_when_thinking of string list
+  { ignored_always : Capabilities.sampling_parameter list
+  ; ignored_when_thinking : Capabilities.sampling_parameter list
+  }
 
 type replay_policy =
   | No_replay
@@ -88,7 +88,11 @@ val chat_template_kwargs_preserve_field
   -> bool option
 
 val top_level_preserve_field : t -> preserve_thinking:bool option -> bool option
-val ignores_sampling_param : t -> enable_thinking:bool option -> string -> bool
+val ignores_sampling_param
+  :  t
+  -> enable_thinking:bool option
+  -> Capabilities.sampling_parameter
+  -> bool
 
 (** Canonical OpenAI-compatible thinking-control request fields for a dialect.
 
@@ -115,13 +119,13 @@ val normalize_effort_value : t -> Reasoning_effort.t -> string option
     Returns [None] when the input means "no reasoning effort field". *)
 val normalize_effort : t -> string -> string option
 
-val sampling_params_ignored_when_thinking : t -> string list
+val sampling_params_ignored_when_thinking : t -> Capabilities.sampling_parameter list
 
-(** [true] when [field] is a sampling parameter the wire format ignores while
-    thinking is enabled. Thinking defaults on: only an explicit
-    [enable_thinking = Some false] keeps the field. Some provider-controlled
-    dialects such as latest Kimi are represented by the full {!t} policy instead
-    of this format-only helper. Keyed on
+(** [true] when [parameter] is a sampling parameter the wire format ignores
+    while thinking is enabled. Thinking defaults on: only an explicit
+    [enable_thinking = Some false] keeps the field. Provider-controlled
+    always-suppressed parameters such as Kimi fixed sampling are represented by
+    the full {!t} policy instead of this format-only helper. Keyed on
     {!Capabilities.thinking_control_format} so both the [Provider_config]-based
     request builder ([Backend_openai_request]) and the agent-state-based one
     ([Api_openai.build_openai_body]) drop the same parameters; the public path
@@ -129,7 +133,7 @@ val sampling_params_ignored_when_thinking : t -> string list
 val sampling_field_ignored_when_thinking
   :  thinking_control_format:Capabilities.thinking_control_format
   -> enable_thinking:bool option
-  -> field:string
+  -> parameter:Capabilities.sampling_parameter
   -> bool
 
 (** Whether an assistant reasoning side-channel should be replayed into a

--- a/lib/provider.mli
+++ b/lib/provider.mli
@@ -93,6 +93,15 @@ type reasoning_streaming_format = Llm_provider.Capabilities.reasoning_streaming_
   | Delta_reasoning_field of string
   | Template_reasoning_streaming
 
+type sampling_parameter = Llm_provider.Capabilities.sampling_parameter =
+  | Temperature
+  | Top_p
+  | Top_k
+  | Min_p
+  | Presence_penalty
+  | Frequency_penalty
+  | Seed
+
 (** Catalog-declared inference task for non-chat models (audio transcription,
     speech synthesis, image/video generation). A value is only ever set by an
     explicit [task] field on a [models.toml] catalog entry — it is never
@@ -148,6 +157,7 @@ type capabilities = Llm_provider.Capabilities.capabilities =
   ; supports_min_p : bool
   ; supports_seed : bool
   ; supports_seed_with_images : bool
+  ; ignored_sampling_parameters : sampling_parameter list
   ; supports_computer_use : bool
   ; supports_code_execution : bool
   ; (* Usage reporting *)

--- a/lib/provider_runtime_binding.ml
+++ b/lib/provider_runtime_binding.ml
@@ -110,6 +110,7 @@ let public_capabilities (caps : Llm_provider.Capabilities.capabilities)
   ; supports_min_p = caps.supports_min_p
   ; supports_seed = caps.supports_seed
   ; supports_seed_with_images = caps.supports_seed_with_images
+  ; ignored_sampling_parameters = caps.ignored_sampling_parameters
   ; supports_computer_use = caps.supports_computer_use
   ; supports_code_execution = caps.supports_code_execution
   ; emits_usage_tokens = caps.emits_usage_tokens

--- a/models.toml
+++ b/models.toml
@@ -1640,6 +1640,10 @@ supports_native_streaming = true
 id_prefix = "kimi-for-coding"
 base = "kimi"
 max_context_tokens = 256000
+# Kimi API parameter docs checked 2026-07-04: K2.7/K2.6/K2.5 use fixed
+# temperature/top_p values and reject non-default overrides. OAS omits caller
+# values instead of sending invalid request fields.
+ignored_sampling_parameters = ["temperature", "top_p"]
 input_per_million = 0.0
 output_per_million = 0.0
 
@@ -1654,6 +1658,7 @@ supports_reasoning_budget = false
 thinking_control_format = "thinking_object_only"
 preserve_thinking_control_format = "thinking_object_keep_all"
 reasoning_replay = "default"
+ignored_sampling_parameters = ["temperature", "top_p"]
 input_per_million = 0.0
 output_per_million = 0.0
 
@@ -1668,6 +1673,7 @@ supports_reasoning_budget = false
 thinking_control_format = "thinking_object_only"
 preserve_thinking_control_format = "none"
 reasoning_replay = "default"
+ignored_sampling_parameters = ["temperature", "top_p"]
 input_per_million = 0.0
 output_per_million = 0.0
 
@@ -1691,6 +1697,7 @@ supports_named_tool_choice = false
 supports_reasoning_budget = false
 thinking_control_format = "none"
 preserve_thinking_control_format = "always_preserved"
+ignored_sampling_parameters = ["temperature", "top_p"]
 input_per_million = 0.0
 output_per_million = 0.0
 

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -438,7 +438,14 @@ let test_lookup_kimi_k2_native_cloud_suffix () =
          "Kimi K2.7 highspeed always preserves reasoning"
          true
          (highspeed.preserve_thinking_control_format
-          = Capabilities.Always_preserved_thinking)
+          = Capabilities.Always_preserved_thinking);
+       check
+         (list string)
+         "Kimi K2.7 highspeed ignores fixed sampling"
+         [ "temperature"; "top_p" ]
+         (List.map
+            Capabilities.sampling_parameter_to_string
+            highspeed.ignored_sampling_parameters)
      | None -> fail "should match Kimi K2.7 highspeed route");
     (match
        Capabilities.for_provider_model_id
@@ -1772,6 +1779,35 @@ let test_manifest_accepts_reasoning_streaming_format () =
   | Error msg -> Alcotest.failf "unexpected parse error: %s" msg
 ;;
 
+let test_manifest_applies_ignored_sampling_parameters () =
+  let json =
+    Yojson.Safe.from_string
+      {|{"schema_version":1,"models":[{"id_prefix":"sampling-manifest","ignored_sampling_parameters":["temperature","top_p"]}]}|}
+  in
+  match Capability_manifest.of_json json with
+  | Ok [ entry ] ->
+    let caps = Capabilities.apply_manifest_entry entry in
+    check
+      (list string)
+      "ignored sampling parameters"
+      [ "temperature"; "top_p" ]
+      (List.map
+         Capabilities.sampling_parameter_to_string
+         caps.ignored_sampling_parameters)
+  | Ok _ -> Alcotest.fail "expected one manifest entry"
+  | Error msg -> Alcotest.failf "unexpected parse error: %s" msg
+;;
+
+let test_manifest_rejects_unknown_ignored_sampling_parameter () =
+  let json =
+    Yojson.Safe.from_string
+      {|{"schema_version":1,"models":[{"id_prefix":"sampling-manifest","ignored_sampling_parameters":["temp"]}]}|}
+  in
+  match Capability_manifest.of_json json with
+  | Error msg -> check_contains "mentions field" msg "ignored_sampling"
+  | Ok _ -> Alcotest.fail "expected unknown ignored_sampling_parameters rejection"
+;;
+
 let test_manifest_rejects_unknown_preserve_thinking_control_format () =
   let json =
     Yojson.Safe.from_string
@@ -2537,6 +2573,14 @@ let () =
             "reasoning_streaming_format accepted"
             `Quick
             test_manifest_accepts_reasoning_streaming_format
+        ; test_case
+            "ignored sampling parameters applied"
+            `Quick
+            test_manifest_applies_ignored_sampling_parameters
+        ; test_case
+            "unknown ignored sampling parameter rejects"
+            `Quick
+            test_manifest_rejects_unknown_ignored_sampling_parameter
         ; test_case
             "unknown preserve_thinking_control_format rejects"
             `Quick

--- a/test/test_provider_catalog_coverage.ml
+++ b/test/test_provider_catalog_coverage.ml
@@ -70,6 +70,7 @@ let test_full_entry_parses_auth_transport_and_capabilities () =
               "supports_min_p": true,
               "supports_seed": true,
               "supports_seed_with_images": true,
+              "ignored_sampling_parameters": ["temperature", "top_p"],
               "supports_computer_use": true,
               "supports_code_execution": true,
               "emits_usage_tokens": true,
@@ -131,6 +132,11 @@ let test_full_entry_parses_auth_transport_and_capabilities () =
   check bool "min p" true caps.supports_min_p;
   check bool "seed" true caps.supports_seed;
   check bool "seed images" true caps.supports_seed_with_images;
+  check
+    (list string)
+    "ignored sampling"
+    [ "temperature"; "top_p" ]
+    (List.map Capabilities.sampling_parameter_to_string caps.ignored_sampling_parameters);
   check bool "computer use" true caps.supports_computer_use;
   check bool "code execution" true caps.supports_code_execution;
   check bool "usage tokens" true caps.emits_usage_tokens;
@@ -387,6 +393,10 @@ let test_removed_catalog_aliases_are_rejected () =
     "accepted reasoning effort rejected"
     {|{"schema_version":1,"providers":[{"id":"p","capabilities":{"accepted_reasoning_efforts":["low","turbo"]}}]}|}
     "unknown accepted_reasoning_efforts";
+  assert_reject
+    "ignored sampling parameter rejected"
+    {|{"schema_version":1,"providers":[{"id":"p","capabilities":{"ignored_sampling_parameters":["temp"]}}]}|}
+    "unknown ignored_sampling_parameters";
   assert_reject
     "modality priority rejected"
     {|{"schema_version":1,"providers":[{"id":"p","capabilities":{"modality_priority":"image_only"}}]}|}

--- a/test/test_thinking_control_dialects.ml
+++ b/test/test_thinking_control_dialects.ml
@@ -22,6 +22,10 @@ open Yojson.Safe.Util
 let json_of_body body = Yojson.Safe.from_string body
 let member_is_absent name json = json |> member name = `Null
 
+let sampling_parameter_names parameters =
+  List.map CAP.sampling_parameter_to_string parameters
+;;
+
 let string_contains_sub s sub =
   let len = String.length s
   and sub_len = String.length sub in
@@ -267,7 +271,7 @@ let test_declared_qwen36_reasoning_dialect_uses_chat_template_kwargs () =
     (list string)
     "no ignored sampling params"
     []
-    (RD.sampling_params_ignored_when_thinking dialect)
+    (sampling_parameter_names (RD.sampling_params_ignored_when_thinking dialect))
 ;;
 
 let test_qwen36_reasoning_dialect_without_preserve_drops_reasoning () =
@@ -636,7 +640,7 @@ let test_deepseek_reasoning_dialect_semantics () =
     (list string)
     "ignored sampling params"
     [ "temperature"; "top_p"; "presence_penalty"; "frequency_penalty" ]
-    (RD.sampling_params_ignored_when_thinking dialect)
+    (sampling_parameter_names (RD.sampling_params_ignored_when_thinking dialect))
 ;;
 
 let test_deepseek_sampling_suppressed_in_thinking_mode () =
@@ -819,6 +823,11 @@ let test_kimi_k26_defaults_to_tool_call_replay () =
     "requires tool-call replay"
     true
     (RD.requires_reasoning_replay_on_tool_call dialect);
+  check
+    (list string)
+    "ignored sampling params"
+    [ "temperature"; "top_p" ]
+    (sampling_parameter_names (RD.sampling_params_ignored_when_thinking dialect));
   let user_json =
     BOR.build_request ~config ~messages:[ user_msg "hi" ] () |> json_of_body
   in
@@ -836,6 +845,15 @@ let test_kimi_k26_defaults_to_tool_call_replay () =
     "tool reasoning_content"
     "use calculator"
     (tool |> member "messages" |> index 0 |> member "reasoning_content" |> to_string)
+;;
+
+let test_kimi_k26_omits_fixed_sampling_with_disabled_thinking () =
+  let config =
+    kimi_config ~enable_thinking:false ~temperature:0.7 ~top_p:0.9 "kimi-k2.6"
+  in
+  let json = BOR.build_request ~config ~messages:[ user_msg "hi" ] () |> json_of_body in
+  check_member_absent "temperature" json;
+  check_member_absent "top_p" json
 ;;
 
 let test_kimi_k26_preserve_requests_keep_all () =
@@ -880,7 +898,7 @@ let test_kimi_latest_always_preserved_omits_thinking_param () =
     (list string)
     "ignored sampling params"
     [ "temperature"; "top_p" ]
-    (RD.sampling_params_ignored_when_thinking dialect);
+    (sampling_parameter_names (RD.sampling_params_ignored_when_thinking dialect));
   let user_json =
     BOR.build_request ~config ~messages:[ user_msg "hi" ] () |> json_of_body
   in
@@ -1072,7 +1090,7 @@ let test_gemma4_reasoning_dialect_uses_template_parser () =
     (list string)
     "no ignored sampling params"
     []
-    (RD.sampling_params_ignored_when_thinking dialect)
+    (sampling_parameter_names (RD.sampling_params_ignored_when_thinking dialect))
 ;;
 
 let test_anthropic_reasoning_dialect_preserves_thinking () =
@@ -1300,6 +1318,10 @@ let () =
               "kimi k2.6 defaults to tool-call replay"
               `Quick
               test_kimi_k26_defaults_to_tool_call_replay
+          ; test_case
+              "kimi k2.6 omits fixed sampling with disabled thinking"
+              `Quick
+              test_kimi_k26_omits_fixed_sampling_with_disabled_thinking
           ; test_case
               "kimi k2.6 preserve requests keep all"
               `Quick


### PR DESCRIPTION
## Summary

- Add a typed `sampling_parameter` vocabulary and `ignored_sampling_parameters` capability axis.
- Parse `ignored_sampling_parameters` fail-closed from `models.toml`, capability manifests, and provider catalogs.
- Make OpenAI-compatible request builders drop catalog-declared suppressed sampling parameters via typed capability data instead of model-name or reasoning-replay coupling.
- Declare Kimi API K2.7/K2.6/K2.5 rows as suppressing `temperature` and `top_p` so caller-provided values are not serialized into invalid Kimi requests.

## Rationale

Kimi fixed sampling constraints are provider/model capability data. They should not be inferred from `Always_preserved_thinking` or hardcoded inside `Reasoning_dialect`; preserved reasoning history and request sampling suppression are separate provider axes.

I intentionally did not apply this to Ollama Cloud Kimi rows because the current evidence is Kimi API documentation, not Ollama Cloud wrapper behavior.

## Evidence

- [근거] Official Kimi Model Parameter Reference, checked 2026-07-04 KST, confidence High: `kimi-k2.7-code` and `kimi-k2.7-code-highspeed` share K2.7 constraints, thinking is always on and preserved thinking is always on. https://platform.kimi.ai/docs/api/models-overview
- [근거] Official Kimi K2.7 Code guide, checked 2026-07-04 KST, confidence High: K2.7/K2.6/K2.5 parameter differences recommend defaults; K2.7 uses fixed `temperature` 1.0 and `top_p` 0.95, and non-default values error. https://platform.kimi.ai/docs/guide/kimi-k2-7-code-quickstart

## Validation

- `git diff --check`
- `scripts/dune-local.sh build test/test_thinking_control_dialects.exe test/test_provider_catalog_coverage.exe test/test_capabilities.exe test/test_backend_openai_codec.exe`
- `env OAS_MODEL_CATALOG=models.toml _build/default/test/test_thinking_control_dialects.exe`
- `_build/default/test/test_provider_catalog_coverage.exe`
- `env OAS_MODEL_CATALOG=models.toml _build/default/test/test_capabilities.exe`
- `_build/default/test/test_backend_openai_codec.exe`
