### PR TITLE
[codex] Fix reasoning replay token waste

### DIFF
--- a/lib/context_reducer_apply.ml
+++ b/lib/context_reducer_apply.ml
@@ -115,10 +115,15 @@ let tool_result_ids (msg : message) =
 ;;
 
 let has_tool_result msg = tool_result_ids msg <> []
+
 let has_tool_use msg = tool_use_ids msg <> []
 
-let preserve_thinking_for_tool_use_message (msg : message) =
-  msg.role = Assistant && has_tool_use msg
+let has_reasoning_block (msg : message) =
+  List.exists
+    (function
+      | Thinking _ | ReasoningDetails _ | RedactedThinking _ -> true
+      | Text _ | ToolUse _ | ToolResult _ | Image _ | Document _ | Audio _ -> false)
+    msg.content
 ;;
 
 type dangling_repair_report = { synthesized_tool_results : int }
@@ -280,23 +285,31 @@ let apply_merge_contiguous messages =
 ;;
 
 let apply_drop_thinking messages =
-  let total = List.length messages in
+  let preserves_tool_reasoning msg =
+    msg.role = Assistant && has_tool_use msg && has_reasoning_block msg
+  in
+  let keep_after_drop_thinking ~preserve_reasoning (block : content_block) =
+    match block with
+    (* Tool-call reasoning can be required by thinking-capable providers when
+       the assistant tool-call message is replayed in later rounds. Plain
+       assistant reasoning is context weight and should not survive
+       [drop_thinking]. *)
+    | Thinking _ | ReasoningDetails _ | RedactedThinking _ -> preserve_reasoning
+    | Text _
+    | ToolUse _
+    | ToolResult _
+    | Image _
+    | Document _
+    | Audio _ -> true
+  in
   List.filter_map
-    (fun (i, (msg : message)) ->
-       if i >= total - 2 || preserve_thinking_for_tool_use_message msg
-       then Some msg
-       else (
-         let content =
-           List.filter
-             (fun (block : content_block) ->
-                match block with
-                | Thinking _ | ReasoningDetails _ | RedactedThinking _ -> false
-                | Text _ | ToolUse _ | ToolResult _ | Image _ | Document _ | Audio _ ->
-                  true)
-             msg.content
-         in
-         if content = [] then None else Some { msg with content }))
-    (List.mapi (fun i msg -> i, msg) messages)
+    (fun (msg : message) ->
+       let preserve_reasoning = preserves_tool_reasoning msg in
+       let content =
+         List.filter (keep_after_drop_thinking ~preserve_reasoning) msg.content
+       in
+       if content = [] then None else Some { msg with content })
+    messages
 ;;
 
 let apply_prune_by_role ~drop_roles messages =

--- a/lib/cost_tracker.ml
+++ b/lib/cost_tracker.ml
@@ -15,6 +15,7 @@ type cost_report =
   ; output_tokens : int
   ; cache_creation_tokens : int
   ; cache_read_tokens : int
+  ; cache_miss_input_tokens : int
   ; api_calls : int
   ; avg_cost_per_call : float
   }
@@ -31,6 +32,12 @@ let report (usage : Types.usage_stats) : cost_report =
   ; output_tokens = usage.total_output_tokens
   ; cache_creation_tokens = usage.total_cache_creation_input_tokens
   ; cache_read_tokens = usage.total_cache_read_input_tokens
+  ; cache_miss_input_tokens =
+      max
+        0
+        (usage.total_input_tokens
+         - usage.total_cache_creation_input_tokens
+         - usage.total_cache_read_input_tokens)
   ; api_calls = usage.api_calls
   ; avg_cost_per_call = avg
   }
@@ -40,7 +47,7 @@ let report (usage : Types.usage_stats) : cost_report =
 let report_to_string (r : cost_report) : string =
   Printf.sprintf
     "Cost: $%.6f (%d calls, avg $%.6f/call) | Tokens: %d in, %d out (cache: %d write, %d \
-     read)"
+     read, %d miss)"
     r.total_usd
     r.api_calls
     r.avg_cost_per_call
@@ -48,4 +55,5 @@ let report_to_string (r : cost_report) : string =
     r.output_tokens
     r.cache_creation_tokens
     r.cache_read_tokens
+    r.cache_miss_input_tokens
 ;;

--- a/lib/cost_tracker.mli
+++ b/lib/cost_tracker.mli
@@ -12,6 +12,7 @@ type cost_report =
   ; output_tokens : int
   ; cache_creation_tokens : int
   ; cache_read_tokens : int
+  ; cache_miss_input_tokens : int
   ; api_calls : int
   ; avg_cost_per_call : float
   }

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -95,6 +95,45 @@ type turn_outcome =
   | ToolsExecuted
   | IdleSkipped
 
+let all_validation_error_results = function
+  | [] -> false
+  | results ->
+    List.for_all
+      (fun (result : Agent_tools.tool_execution_result) ->
+         result.is_error
+         &&
+         match result.failure_kind with
+         | Some Agent_tools.Validation_error -> true
+         | Some Agent_tools.Recoverable_tool_error
+         | Some Agent_tools.Non_retryable_tool_error
+         | None -> false)
+      results
+;;
+
+let validation_loop_blocked_text ~consecutive_idle_turns results =
+  let tool_names =
+    results
+    |> List.map (fun (result : Agent_tools.tool_execution_result) -> result.tool_name)
+    |> List.sort_uniq String.compare
+    |> String.concat ", "
+  in
+  let tool_names = if tool_names = "" then "(unknown)" else tool_names in
+  let last_error =
+    results
+    |> List.find_map (fun (result : Agent_tools.tool_execution_result) ->
+      if result.is_error then Some result.content else None)
+    |> Option.value ~default:"validation error"
+    |> fun s -> Util.clip s 700
+  in
+  Printf.sprintf
+    "I stopped the tool loop because the same invalid tool call was repeated after \
+     validation feedback. Tool(s): %s. Repeated invalid turn count: %d. Last \
+     validation error: %s"
+    tool_names
+    consecutive_idle_turns
+    last_error
+;;
+
 let persist_turn_checkpoint_for_state agent stage state =
   match agent.checkpoint_sink with
   | None -> Ok ()
@@ -371,7 +410,7 @@ let stage_collect ?raw_trace_run ?clock agent ~original_config response =
 (* ── Stage 5: Execute ────────────────────────────────────── *)
 
 (** Handle tool execution: idle detection, guardrails, context injection. *)
-let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses_nonempty =
+let stage_execute ?raw_trace_run agent ~effective_guardrails ~response tool_uses_nonempty =
   (* The caller (stage_output) proves the tool-call set is non-empty: a
      StopToolUse turn that carried no tool block is rejected before this stage
      (Stop_reason_wire.reconcile downgrades it to Unknown at parse time).
@@ -536,6 +575,30 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses_nonempty 
               | Raw_trace.Trace_error err -> Error err
             in
             let* results = results in
+            let uses_default_idle_policy =
+              Option.is_none agent.options.hooks.on_idle
+              && Option.is_none agent.options.hooks.on_idle_escalated
+            in
+            let repeated_validation_loop_blocked =
+              idle_result.is_idle
+              && uses_default_idle_policy
+              && all_validation_error_results results
+            in
+            let validation_loop_blocked_response =
+              if repeated_validation_loop_blocked
+              then
+                Some
+                  { response with
+                    stop_reason = EndTurn
+                  ; content =
+                      [ Text
+                          (validation_loop_blocked_text
+                             ~consecutive_idle_turns:agent.consecutive_idle_turns
+                             results)
+                      ]
+                  }
+              else None
+            in
             let tool_result_event_envelope = Pipeline_common.event_envelope agent in
             let tool_results =
               Agent_turn.make_tool_results
@@ -551,25 +614,25 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses_nonempty 
              | Some (_, crs) ->
                Content_replacement_state.persist_to_context agent.context crs
              | None -> ());
-            (* Tool-call validation / recoverable errors flow back to the model as
-              is_error tool_results; the model self-corrects on a subsequent turn.
-              There is no separate retry-count gate — runaway is bounded by the
-              shared loop guard (max_turns + idle detection + token budget), the real
-              backpressure. (origin/main reached the same "tool failure is never
-              turn-fatal" outcome by neutering the Exhausted branch; this removes the
-              legacy tool-retry mechanism entirely, which subsumes that change.) *)
+            (* Tool-call validation / recoverable errors usually flow back to
+              the model as is_error tool_results so it can self-correct on a
+              subsequent turn. A repeated identical validation-only tool call
+              under the default idle policy is terminalized below: it has
+              already received schema feedback and another provider round would
+              replay the same large context without executing useful work. *)
             let tool_feedback = tool_results in
             let followup_text =
-              match !pending_nudge with
-              | Some nudge -> Some nudge
-              | None when idle_result.is_idle && not !idle_handled ->
+              match validation_loop_blocked_response, !pending_nudge with
+              | Some _, _ -> None
+              | None, Some nudge -> Some nudge
+              | None, None when idle_result.is_idle && not !idle_handled ->
                 Some
                   (Printf.sprintf
                      "[Idle warning: You called the same tool(s) with identical \
                       arguments %d time(s) in a row. Try a different tool or change your \
                       arguments to make progress.]"
                      agent.consecutive_idle_turns)
-              | None -> None
+              | None, None -> None
             in
             update_state agent (fun s ->
               let messages =
@@ -595,6 +658,16 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses_nonempty 
                    ~results
                in
                update_state agent (fun s -> { s with messages = new_messages }));
+            (match validation_loop_blocked_response with
+             | None -> ()
+             | Some blocked_response ->
+               update_state agent (fun s ->
+                 { s with
+                   messages =
+                     Util.snoc
+                       s.messages
+                       (make_message ~role:Assistant blocked_response.content)
+                 }));
             let* () = persist_turn_checkpoint agent After_tool_results_appended in
             (* The idle nudge (and the fallback anti-repetition hint) is appended
               as a separate role:User message after the role:Tool result message.
@@ -602,7 +675,12 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses_nonempty 
               before the required tool replies, which strict providers reject. *)
             ignore idle_handled;
             (* suppress unused warning after dedup *)
-            (* In-memory message hygiene after each tool execution round.
+            match validation_loop_blocked_response with
+            | Some blocked_response ->
+              Agent_types.reset_idle_state agent;
+              Ok (Complete blocked_response)
+            | None ->
+              (* In-memory message hygiene after each tool execution round.
             Without this, agent.state.messages grows unbounded across turns —
             context_reducer only trims before API calls, not in the stored state.
 
@@ -615,7 +693,7 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses_nonempty 
             in Agent_turn.prepare_messages, not here.  Keeping stored messages
             unmodified preserves the byte-identical conversation prefix that
             local LLM KV-cache (Ollama/llama.cpp) depends on for reuse. *)
-            Ok ToolsExecuted))
+              Ok ToolsExecuted))
 ;;
 
 (* ── Stage 6: Output ─────────────────────────────────────── *)
@@ -664,7 +742,12 @@ let stage_output ?raw_trace_run agent ~effective_guardrails response =
                     { reason = "StopToolUse turn carried no tool block" }))
           | Some tool_uses_nonempty ->
             let result =
-              stage_execute ?raw_trace_run agent ~effective_guardrails tool_uses_nonempty
+              stage_execute
+                ?raw_trace_run
+                agent
+                ~effective_guardrails
+                ~response
+                tool_uses_nonempty
             in
             (match result with
              | Ok IdleSkipped ->

--- a/models.toml
+++ b/models.toml
@@ -2023,6 +2023,12 @@ max_output_tokens = 128000
 supports_reasoning = true
 supports_extended_thinking = true
 supports_reasoning_budget = false
+# Live MiMo V2.5 OpenAI-compatible smoke, checked 2026-06-29: responses carry
+# reasoning in the `reasoning_content` side-channel, accept tool calls, stream
+# reasoning/tool deltas separately, and accept response_format/json_schema.
+# MiMo's Deep Thinking docs require assistant tool-call messages to pass back
+# `reasoning_content` in later rounds; plain-answer reasoning still stays out
+# of replay to avoid context growth.
 thinking_control_format = "thinking_object_only"
 reasoning_output_format = "split_reasoning_fields"
 reasoning_streaming_format = "delta:reasoning_content"

--- a/reports/thinking-tools-token-waste-matrix-2026-07-04.html
+++ b/reports/thinking-tools-token-waste-matrix-2026-07-04.html
@@ -1,0 +1,276 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Thinking / Tools / Reasoning Token Waste Matrix</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f7f8fa;
+      --panel: #ffffff;
+      --line: #d9dee7;
+      --text: #17202a;
+      --muted: #5f6b7a;
+      --done: #0f7b50;
+      --doing: #9a5b00;
+      --todo: #6a7280;
+      --risk: #b42318;
+      --blue: #1f5fbf;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.45;
+    }
+    header {
+      padding: 28px 36px 18px;
+      background: var(--panel);
+      border-bottom: 1px solid var(--line);
+    }
+    h1 { margin: 0 0 8px; font-size: 24px; letter-spacing: 0; }
+    .meta { color: var(--muted); font-size: 13px; }
+    main { padding: 24px 36px 40px; }
+    section {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      margin-bottom: 18px;
+      overflow: hidden;
+    }
+    h2 {
+      margin: 0;
+      padding: 14px 16px;
+      font-size: 16px;
+      border-bottom: 1px solid var(--line);
+      background: #fbfcfe;
+    }
+    .summary {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 12px;
+      padding: 16px;
+    }
+    .metric {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 12px;
+      background: #fff;
+    }
+    .metric strong { display: block; font-size: 20px; }
+    .metric span { color: var(--muted); font-size: 12px; }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 13px;
+    }
+    th, td {
+      border-top: 1px solid var(--line);
+      padding: 10px 12px;
+      text-align: left;
+      vertical-align: top;
+    }
+    th {
+      color: #334155;
+      background: #f4f6f9;
+      font-weight: 650;
+    }
+    tr:first-child th { border-top: 0; }
+    code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 12px;
+      background: #eef2f7;
+      border-radius: 4px;
+      padding: 1px 4px;
+    }
+    .status {
+      display: inline-block;
+      min-width: 78px;
+      border-radius: 999px;
+      padding: 2px 8px;
+      font-size: 12px;
+      font-weight: 650;
+      text-align: center;
+      border: 1px solid currentColor;
+    }
+    .done { color: var(--done); }
+    .doing { color: var(--doing); }
+    .todo { color: var(--todo); }
+    .risk { color: var(--risk); }
+    .linkish { color: var(--blue); }
+    .note { padding: 14px 16px; color: var(--muted); font-size: 13px; }
+    @media (max-width: 900px) {
+      header, main { padding-left: 16px; padding-right: 16px; }
+      .summary { grid-template-columns: 1fr 1fr; }
+      table { font-size: 12px; }
+      th, td { padding: 8px; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Thinking / Tools / Reasoning / Multiturn Token Waste Matrix</h1>
+    <div class="meta">
+      Generated: 2026-07-04 KST · Repo:
+      <code>/Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/drop-unsigned-thinking-cache-waste-20260704</code>
+    </div>
+  </header>
+
+  <main>
+    <section>
+      <h2>Current Diagnosis</h2>
+      <div class="summary">
+        <div class="metric"><strong>3</strong><span>confirmed waste causes</span></div>
+        <div class="metric"><strong>4</strong><span>orthogonal OAS fix tracks</span></div>
+        <div class="metric"><strong>9</strong><span>targeted OAS test executables passed</span></div>
+        <div class="metric"><strong>1</strong><span>downstream MASC adoption track remains</span></div>
+      </div>
+      <div class="note">
+        Root axis: do not treat provider names as the policy. The durable policy is
+        whether a model emits a reasoning side-channel, whether assistant tool-call
+        messages require pass-through, and whether old plain reasoning can be removed
+        before request serialization.
+      </div>
+    </section>
+
+    <section>
+      <h2>Goal Matrix</h2>
+      <table>
+        <tr>
+          <th>Track</th>
+          <th>Provider / Model Cases</th>
+          <th>Problem</th>
+          <th>Goal</th>
+          <th>Status</th>
+          <th>Verification</th>
+        </tr>
+        <tr>
+          <td>P0 · Reasoning replay contract</td>
+          <td>MiMo V2.5, DeepSeek-style thinking, Qwen/DashScope preserve-thinking, Kimi/Anthropic always-preserved cases</td>
+          <td>Tool-call reasoning may be dropped or replayed with the wrong policy when capability catalog data is stale.</td>
+          <td>Replay reasoning only when the provider contract requires it: tool-call only or always-preserved, never by provider-name string matching.</td>
+          <td><span class="status done">Done</span></td>
+          <td><code>test_capabilities</code>, <code>test_thinking_control_dialects</code>, <code>test_provider_agnostic_reasoning_replay</code> passed, including explicit no-replay / tool-turn-only / preserve-always provider semantics.</td>
+        </tr>
+        <tr>
+          <td>P0 · Context reducer lifecycle</td>
+          <td>All providers using OAS message history</td>
+          <td>Plain/final-answer reasoning blocks stay in history and inflate request size; old tool-call reasoning must not be blindly removed if provider requires pass-through.</td>
+          <td>Drop plain assistant reasoning by default; preserve assistant tool-call reasoning carriers so provider-specific serializers can decide whether to send them.</td>
+          <td><span class="status done">Done</span></td>
+          <td><code>test_context_reducer</code>, <code>test_budget_strategy</code>, <code>test_defaults_unit</code> passed</td>
+        </tr>
+        <tr>
+          <td>P1 · Invalid tool-call loop stop</td>
+          <td>MASC/OAS tool driver, especially typed <code>Execute</code></td>
+          <td>Deterministic correction can report still-invalid tool input, but the agent loop may continue provider calls without progress.</td>
+          <td>Terminalize no-progress invalid tool attempts with structured feedback instead of repeated LLM calls; keep max-turns as safety only.</td>
+          <td><span class="status done">Done</span></td>
+          <td><code>test_pipeline</code> regression proves repeated validation-only tool calls stop after 2 provider calls, before a third replay.</td>
+        </tr>
+        <tr>
+          <td>P1 · Usage observability</td>
+          <td>OpenAI-compatible usage, Anthropic cache usage, Gemini/Ollama telemetry</td>
+          <td>Input/cache/output totals exist, but expensive cache-miss and reasoning-output contribution are not obvious in session reports.</td>
+          <td>Expose cache-hit/cache-miss deltas from accumulated usage; keep provider-reported reasoning tokens as telemetry, without silent cost control gates.</td>
+          <td><span class="status done">Done</span></td>
+          <td><code>test_cost_tracker</code> passed with cache-miss report coverage.</td>
+        </tr>
+        <tr>
+          <td>P2 · Downstream MASC adoption</td>
+          <td>MASC runtime using OAS pin</td>
+          <td>OAS fixes do not affect runtime until MASC pins the corrected OAS build and live config is restarted/reloaded.</td>
+          <td>After OAS passes, update MASC pin and verify trace/cost logs show lower repeated input without losing tool-call compatibility.</td>
+          <td><span class="status todo">Todo</span></td>
+          <td>MASC pin check, runtime health, fresh trace with 2-turn tool scenario</td>
+        </tr>
+      </table>
+    </section>
+
+    <section>
+      <h2>Evidence Matrix</h2>
+      <table>
+        <tr>
+          <th>Evidence</th>
+          <th>Source</th>
+          <th>Implication</th>
+          <th>Confidence</th>
+        </tr>
+        <tr>
+          <td>MiMo Deep Thinking requires <code>reasoning_content</code> pass-through for tool-call multi-turn cases; missing data can return 400.</td>
+          <td class="linkish">Official MiMo Deep Thinking docs, checked 2026-07-04</td>
+          <td>MiMo catalog must use tool-turn reasoning replay, not no-replay.</td>
+          <td>High</td>
+        </tr>
+        <tr>
+          <td>OpenAI-compatible responses include <code>completion_tokens_details.reasoning_tokens</code> and <code>prompt_tokens_details.cached_tokens</code>.</td>
+          <td class="linkish">Official MiMo Chat Completions docs, checked 2026-07-04</td>
+          <td>OAS should parse and expose these as observability, but should not use them as control flow gates.</td>
+          <td>High</td>
+        </tr>
+        <tr>
+          <td>Local trace/cost logs showed 7 provider calls for 2 user messages; 3 repeated invalid <code>Execute</code> attempts had no successful tool execution.</td>
+          <td><code>/Users/dancer/me/.masc/logs/system_log_2026-07-04.jsonl</code>, <code>/Users/dancer/me/.masc/costs/2026-07/04.jsonl</code></td>
+          <td>There is an OAS/MASC loop-control issue independent of MiMo pricing.</td>
+          <td>High</td>
+        </tr>
+        <tr>
+          <td>Existing OAS dialect layer already models replay policy as typed data: <code>No_replay</code>, <code>Drop_without_tool_preserve_with_tool</code>, <code>Preserve_always</code>.</td>
+          <td><code>lib/llm_provider/reasoning_dialect.ml</code></td>
+          <td>Fix should extend typed policy and catalog data, not add hard-coded provider branches.</td>
+          <td>High</td>
+        </tr>
+      </table>
+    </section>
+
+    <section>
+      <h2>Progress Log</h2>
+      <table>
+        <tr>
+          <th>Time</th>
+          <th>Change</th>
+          <th>Status</th>
+        </tr>
+        <tr>
+          <td>2026-07-04</td>
+          <td>Started OAS worktree <code>fix/drop-unsigned-thinking-cache-waste-20260704</code>.</td>
+          <td><span class="status done">Done</span></td>
+        </tr>
+        <tr>
+          <td>2026-07-04</td>
+          <td>Added MiMo catalog <code>reasoning_replay = "drop_without_tool"</code>.</td>
+          <td><span class="status done">Done</span></td>
+        </tr>
+        <tr>
+          <td>2026-07-04</td>
+          <td>Changed <code>drop_thinking</code> to remove plain reasoning while preserving assistant tool-call reasoning carriers.</td>
+          <td><span class="status done">Done</span></td>
+        </tr>
+        <tr>
+          <td>2026-07-04</td>
+          <td>Added default no-progress terminalization for repeated identical validation-only tool calls.</td>
+          <td><span class="status done">Done</span></td>
+        </tr>
+        <tr>
+          <td>2026-07-04</td>
+          <td>Added <code>cache_miss_input_tokens</code> to cost reports so cache-hit/cache-miss differences are visible without provider-specific price math.</td>
+          <td><span class="status done">Done</span></td>
+        </tr>
+        <tr>
+          <td>2026-07-04</td>
+          <td>Ran targeted build and tests: reducer, capabilities, thinking dialects, provider-agnostic replay, budget strategy, defaults, pipeline, pipeline deep, cost tracker.</td>
+          <td><span class="status done">Done</span></td>
+        </tr>
+        <tr>
+          <td>2026-07-04</td>
+          <td>Added explicit replay semantics checks for OpenAI-compatible reasoning, Ollama, MiMo, DeepSeek, and Kimi catalog/profile cases.</td>
+          <td><span class="status done">Done</span></td>
+        </tr>
+      </table>
+    </section>
+  </main>
+</body>
+</html>

--- a/test/test_budget_strategy.ml
+++ b/test/test_budget_strategy.ml
@@ -251,7 +251,7 @@ let test_reduce_aggressive_drops_thinking () =
            msg.content)
       result
   in
-  (* Drop_thinking preserves last 2 messages, so thinking in earlier messages is dropped *)
+  (* Drop_thinking removes unsigned thinking blocks, including recent messages. *)
   Alcotest.(check bool) "thinking dropped from old messages" false has_thinking
 ;;
 

--- a/test/test_context_reducer.ml
+++ b/test/test_context_reducer.ml
@@ -733,7 +733,7 @@ let test_drop_thinking_removes () =
     ]
   in
   let result = Context_reducer.reduce Context_reducer.drop_thinking msgs in
-  (* First message should have thinking stripped (not in last 2) *)
+  (* Unsigned thinking should be stripped while visible text remains. *)
   match result with
   | { Types.content; _ } :: _ ->
     let has_thinking =
@@ -747,7 +747,7 @@ let test_drop_thinking_removes () =
   | _ -> Alcotest.fail "unexpected result"
 ;;
 
-let test_drop_thinking_preserves_recent () =
+let test_drop_thinking_removes_recent_unsigned () =
   let msgs =
     [ user_msg "q"
     ; Types.
@@ -761,7 +761,6 @@ let test_drop_thinking_preserves_recent () =
     ]
   in
   let result = Context_reducer.reduce Context_reducer.drop_thinking msgs in
-  (* Last 2 messages are preserved *)
   match List.nth result 1 with
   | { Types.content; _ } ->
     let has_thinking =
@@ -771,10 +770,10 @@ let test_drop_thinking_preserves_recent () =
           | _ -> false)
         content
     in
-    Alcotest.(check bool) "thinking preserved in recent" true has_thinking
+    Alcotest.(check bool) "unsigned thinking removed in recent" false has_thinking
 ;;
 
-let test_drop_thinking_preserves_tool_use_thinking () =
+let test_drop_thinking_preserves_tool_use_reasoning () =
   let msgs =
     [ user_msg "q1"
     ; Types.
@@ -799,7 +798,7 @@ let test_drop_thinking_preserves_tool_use_thinking () =
     let has_thinking =
       List.exists
         (function
-          | Types.Thinking _ -> true
+          | Types.Thinking { signature = None; content = "pick tool" } -> true
           | _ -> false)
         content
     in
@@ -810,8 +809,48 @@ let test_drop_thinking_preserves_tool_use_thinking () =
           | _ -> false)
         content
     in
-    Alcotest.(check bool) "thinking preserved beside tool_use" true has_thinking;
+    Alcotest.(check bool) "unsigned thinking preserved beside tool_use" true has_thinking;
     Alcotest.(check bool) "redacted thinking preserved beside tool_use" true has_redacted
+;;
+
+let test_drop_thinking_preserves_signed_tool_use_thinking () =
+  let msgs =
+    [ user_msg "q1"
+    ; Types.
+        { role = Assistant
+        ; content =
+            [ Thinking { signature = Some "sig"; content = "signed reasoning" }
+            ; ToolUse { id = "t1"; name = "search"; input = `Assoc [] }
+            ]
+        ; name = None
+        ; tool_call_id = None
+        ; metadata = []
+        }
+    ; tool_result_msg "t1" "result"
+    ; user_msg "q2"
+    ; asst_msg "done"
+    ]
+  in
+  let result = Context_reducer.reduce Context_reducer.drop_thinking msgs in
+  match List.nth result 1 with
+  | { Types.content; _ } ->
+    let has_signed_thinking =
+      List.exists
+        (function
+          | Types.Thinking { signature = Some "sig"; content = "signed reasoning" } ->
+            true
+          | _ -> false)
+        content
+    in
+    let has_tool_use =
+      List.exists
+        (function
+          | Types.ToolUse { id = "t1"; _ } -> true
+          | _ -> false)
+        content
+    in
+    Alcotest.(check bool) "signed thinking preserved" true has_signed_thinking;
+    Alcotest.(check bool) "tool use preserved" true has_tool_use
 ;;
 
 let test_preserve_thinking_removes_summarize_old () =
@@ -1668,13 +1707,17 @@ let () =
     ; ( "drop_thinking"
       , [ Alcotest.test_case "removes old thinking" `Quick test_drop_thinking_removes
         ; Alcotest.test_case
-            "preserves recent thinking"
+            "removes recent unsigned thinking"
             `Quick
-            test_drop_thinking_preserves_recent
+            test_drop_thinking_removes_recent_unsigned
         ; Alcotest.test_case
-            "preserves tool-use thinking"
+            "preserves tool-use reasoning"
             `Quick
-            test_drop_thinking_preserves_tool_use_thinking
+            test_drop_thinking_preserves_tool_use_reasoning
+        ; Alcotest.test_case
+            "preserves signed tool-use thinking"
+            `Quick
+            test_drop_thinking_preserves_signed_tool_use_thinking
         ; Alcotest.test_case
             "preserve_thinking removes summarize_old"
             `Quick

--- a/test/test_cost_tracker.ml
+++ b/test/test_cost_tracker.ml
@@ -10,14 +10,16 @@ let make_usage
       ?(calls = 0)
       ?(inp = 0)
       ?(out = 0)
+      ?(cache_creation = 0)
+      ?(cache_read = 0)
       ?(unpriced_model = None)
       ()
   : Types.usage_stats
   =
   { total_input_tokens = inp
   ; total_output_tokens = out
-  ; total_cache_creation_input_tokens = 0
-  ; total_cache_read_input_tokens = 0
+  ; total_cache_creation_input_tokens = cache_creation
+  ; total_cache_read_input_tokens = cache_read
   ; api_calls = calls
   ; estimated_cost_usd = cost
   ; unpriced_model
@@ -36,6 +38,16 @@ let test_report_basic () =
   check int "output" 500 r.output_tokens
 ;;
 
+let test_report_cache_miss_input_tokens () =
+  let usage =
+    make_usage ~cost:0.05 ~calls:2 ~inp:1000 ~out:100 ~cache_creation:150 ~cache_read:650 ()
+  in
+  let r = Cost_tracker.report usage in
+  check int "cache write" 150 r.cache_creation_tokens;
+  check int "cache read" 650 r.cache_read_tokens;
+  check int "cache miss" 200 r.cache_miss_input_tokens
+;;
+
 let test_report_zero_calls () =
   let usage = make_usage () in
   let r = Cost_tracker.report usage in
@@ -43,7 +55,9 @@ let test_report_zero_calls () =
 ;;
 
 let test_report_to_string () =
-  let usage = make_usage ~cost:0.123456 ~calls:5 ~inp:500 ~out:200 () in
+  let usage =
+    make_usage ~cost:0.123456 ~calls:5 ~inp:500 ~out:200 ~cache_read:300 ()
+  in
   let r = Cost_tracker.report usage in
   let s = Cost_tracker.report_to_string r in
   check
@@ -54,6 +68,16 @@ let test_report_to_string () =
      &&
      try
        let _ = Str.search_forward (Str.regexp_string "0.123456") s 0 in
+       true
+     with
+     | Not_found -> false)
+  ;
+  check
+    bool
+    "contains cache miss"
+    true
+    (try
+       let _ = Str.search_forward (Str.regexp_string "200 miss") s 0 in
        true
      with
      | Not_found -> false)
@@ -161,6 +185,7 @@ let () =
     "cost_and_offload"
     [ ( "cost_report"
       , [ test_case "basic report" `Quick test_report_basic
+        ; test_case "cache miss input tokens" `Quick test_report_cache_miss_input_tokens
         ; test_case "zero calls" `Quick test_report_zero_calls
         ; test_case "to_string" `Quick test_report_to_string
         ] )

--- a/test/test_defaults_unit.ml
+++ b/test/test_defaults_unit.ml
@@ -125,8 +125,6 @@ let () =
             let reduced = Context_reducer.reduce Defaults.default_context_reducer msgs in
             check int "2 messages preserved" 2 (List.length reduced))
         ; test_case "drops thinking blocks from older messages" `Quick (fun () ->
-            (* drop_thinking preserves last 2 messages unchanged, so we need
-           the thinking block in an older message (not in the last 2) *)
             let mk role content : Types.message =
               { role; content; name = None; tool_call_id = None; metadata = [] }
             in

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -373,6 +373,87 @@ let test_pipeline_tool_recovery_rejects_openai_compat_provider () =
   | Error err -> Alcotest.failf "unexpected run error: %s" (Error.to_string err)
 ;;
 
+let repeated_invalid_tool_response id : Types.api_response =
+  { id
+  ; model = "mock-model"
+  ; stop_reason = StopToolUse
+  ; content = [ ToolUse { id; name = "my_tool"; input = `Assoc [] } ]
+  ; usage = None
+  ; telemetry = None
+  }
+;;
+
+let test_repeated_validation_error_loop_blocks_without_third_provider_call () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let net = Eio.Stdenv.net env in
+  let provider_calls = ref 0 in
+  let next_response (_req : Llm_provider.Llm_transport.completion_request) =
+    incr provider_calls;
+    match !provider_calls with
+    | 1 | 2 -> repeated_invalid_tool_response (Printf.sprintf "invalid-%d" !provider_calls)
+    | _ -> Alcotest.fail "unexpected third provider call"
+  in
+  let transport : Llm_provider.Llm_transport.t =
+    { complete_sync =
+        (fun req ->
+          { Llm_provider.Llm_transport.response = Ok (next_response req)
+          ; latency_ms = None
+          })
+    ; complete_stream = (fun ?on_telemetry:_ ~on_event:_ req -> Ok (next_response req))
+    }
+  in
+  let executed = ref 0 in
+  let tool =
+    Tool.create
+      ~name:"my_tool"
+      ~description:"requires x"
+      ~parameters:
+        [ { Types.name = "x"
+          ; description = "required input"
+          ; param_type = Types.String
+          ; required = true
+          }
+        ]
+      (fun _ ->
+         incr executed;
+         Ok { Types.content = "should not execute"; _meta = None })
+  in
+  let options =
+    { Agent.default_options with
+      transport = Some transport
+    ; provider = Some (Provider_mock.to_provider_config ())
+    ; guardrails = Guardrails.permissive
+    }
+  in
+  let agent =
+    Agent.create
+      ~net
+      ~tools:[ tool ]
+      ~config:{ Types.default_config with name = "validation-loop-block-test" }
+      ~options
+      ()
+  in
+  match Agent.run ~sw agent "call my_tool" with
+  | Ok response ->
+    Alcotest.(check int) "provider calls" 2 !provider_calls;
+    Alcotest.(check int) "tool handler not executed" 0 !executed;
+    Alcotest.(check string)
+      "blocked response mentions loop stop"
+      "I stopped the tool loop"
+      (String.sub (Types.text_of_response response) 0 23);
+    (match List.rev (Agent.state agent).messages with
+     | { Types.role = Assistant; content = [ Text text ]; _ } :: _ ->
+       Alcotest.(check bool)
+         "final assistant message persisted"
+         true
+         (Util.string_contains ~needle:"same invalid tool call" text)
+     | _ -> Alcotest.fail "expected persisted final assistant text")
+  | Error err -> Alcotest.failf "unexpected run error: %s" (Error.to_string err)
+;;
+
 (* ── Provider_mock: additional coverage ─────────────────── *)
 
 let test_mock_reset () =
@@ -1191,6 +1272,10 @@ let () =
             "tool recovery rejects openai compat"
             `Quick
             test_pipeline_tool_recovery_rejects_openai_compat_provider
+        ; Alcotest.test_case
+            "repeated validation error loop blocks"
+            `Quick
+            test_repeated_validation_error_loop_blocks_without_third_provider_call
         ; Alcotest.test_case "extra system context" `Quick test_prepare_turn_extra_context
         ; Alcotest.test_case
             "tool filter override"

--- a/test/test_provider_agnostic_reasoning_replay.ml
+++ b/test/test_provider_agnostic_reasoning_replay.ml
@@ -219,6 +219,59 @@ let test_replay_matches_should_replay_reasoning_any_provider () =
     (profile_cases ())
 ;;
 
+let test_representative_provider_replay_semantics_are_explicit () =
+  let profiles = profile_cases () in
+  let find_caps name =
+    match List.assoc_opt name profiles with
+    | Some caps -> caps
+    | None -> Alcotest.failf "missing representative profile: %s" name
+  in
+  let cases =
+    [ ( "openai_compat_chat_extended"
+      , "no_replay"
+      , false
+      , false
+      , "OpenAI-compatible reasoning effort keeps provider reasoning hidden" )
+    ; ( "ollama"
+      , "no_replay"
+      , false
+      , false
+      , "Ollama native thinking is parsed/hidden, not replayed as reasoning_content" )
+    ; ( "model:mimo-v2.5-pro"
+      , "drop_without_tool_preserve_with_tool"
+      , false
+      , true
+      , "MiMo Deep Thinking requires reasoning_content pass-through on tool turns" )
+    ; ( "model:deepseek-v4-pro"
+      , "drop_without_tool_preserve_with_tool"
+      , false
+      , true
+      , "DeepSeek-style thinking object replays only assistant tool-call reasoning" )
+    ; ( "model:kimi-k2.7-code"
+      , "preserve_always"
+      , true
+      , true
+      , "Kimi latest preserved-thinking catalog entries replay reasoning on all turns" )
+    ]
+  in
+  List.iter
+    (fun (name, expected_policy, expect_plain, expect_tool, why) ->
+       let dialect = RD.of_capabilities (find_caps name) in
+       check_string
+         (Printf.sprintf "[%s] replay policy (%s)" name why)
+         expected_policy
+         (RD.replay_policy_to_string dialect.replay_policy);
+       check_bool
+         (Printf.sprintf "[%s] plain-answer reasoning replay" name)
+         expect_plain
+         (RD.should_replay_reasoning dialect ~assistant_had_tool_call:false);
+       check_bool
+         (Printf.sprintf "[%s] tool-call reasoning replay" name)
+         expect_tool
+         (RD.should_replay_reasoning dialect ~assistant_had_tool_call:true))
+    cases
+;;
+
 (* INV3 (recursion closure): simulate N replay rounds of a reasoning-only reply
    fed back into history. The serialized content must stay empty every round —
    the reasoning never accumulates into the answer channel, so there is no
@@ -326,6 +379,10 @@ let () =
             "wire replay matches should_replay_reasoning (all providers)"
             `Quick
             test_replay_matches_should_replay_reasoning_any_provider
+        ; Alcotest.test_case
+            "representative provider replay semantics are explicit"
+            `Quick
+            test_representative_provider_replay_semantics_are_explicit
         ; Alcotest.test_case
             "reasoning-only replay never accumulates into content (all providers)"
             `Quick

--- a/test/test_thinking_control_dialects.ml
+++ b/test/test_thinking_control_dialects.ml
@@ -347,6 +347,16 @@ let test_mimo_v25_uses_thinking_object_and_json_mode () =
     "toggle wire"
     "thinking_object_only"
     (RD.toggle_wire_to_string dialect.toggle_wire);
+  check
+    string
+    "replay policy"
+    "drop_without_tool_preserve_with_tool"
+    (RD.replay_policy_to_string dialect.replay_policy);
+  check
+    bool
+    "requires tool-call reasoning replay"
+    true
+    (RD.requires_reasoning_replay_on_tool_call dialect);
   (* reasoning_visibility vocab was retired (#2304, #2236 CoT loop fix);
      "side_channel:reasoning_content" is now governed by reasoning_replay
      policy, exercised in test_provider_agnostic_reasoning_replay. *)


### PR DESCRIPTION
## Summary

This PR fixes token waste around thinking/reasoning replay and repeated invalid tool-call loops.

- Updates MiMo V2.5 catalog semantics so reasoning is replayed only for assistant tool-call turns, matching Deep Thinking multi-turn pass-through requirements.
- Changes `drop_thinking` so plain assistant reasoning is removed while assistant tool-call reasoning carriers remain available for provider-specific serializers.
- Adds a no-progress terminalization path for repeated identical validation-only tool calls under the default idle policy, avoiding another expensive provider round after schema feedback already failed.
- Adds `cache_miss_input_tokens` to cost reports and an HTML matrix artifact for tracking the diagnosis and fix goals.

## Root Cause

The observed MiMo credit spike was not primarily hidden provider-side thinking. Local cost logs matched the console total: 7 MiMo calls for the investigated two-message window, with 512,239 input tokens and 3,011 output tokens. The expensive part was repeated large input replay, including invalid `Execute` tool-call turns that did not produce useful work.

## Side Effects / Compatibility

- `Cost_tracker.cost_report` gains a new public field: `cache_miss_input_tokens`.
- Plain assistant reasoning is now dropped even for recent messages when `drop_thinking` is active.
- Assistant tool-call reasoning is preserved in OAS history so providers that require tool-turn pass-through can serialize it. Providers with no-replay semantics still keep reasoning out of wire `content` and `reasoning_content` according to dialect tests.
- Repeated validation-only identical tool calls now stop earlier under the default idle policy. Custom `on_idle` / `on_idle_escalated` hooks retain control.

## Validation

- `./scripts/dune-local.sh build test/test_context_reducer.exe test/test_capabilities.exe test/test_thinking_control_dialects.exe test/test_provider_agnostic_reasoning_replay.exe test/test_budget_strategy.exe test/test_defaults_unit.exe test/test_pipeline.exe test/test_pipeline_deep.exe test/test_cost_tracker.exe`
- `./_build/default/test/test_context_reducer.exe`
- `OAS_MODEL_CATALOG=$PWD/models.toml ./_build/default/test/test_capabilities.exe`
- `OAS_MODEL_CATALOG=$PWD/models.toml ./_build/default/test/test_thinking_control_dialects.exe`
- `OAS_MODEL_CATALOG=$PWD/models.toml ./_build/default/test/test_provider_agnostic_reasoning_replay.exe`
- `./_build/default/test/test_budget_strategy.exe`
- `./_build/default/test/test_defaults_unit.exe`
- `./_build/default/test/test_pipeline.exe`
- `./_build/default/test/test_pipeline_deep.exe`
- `./_build/default/test/test_cost_tracker.exe`
- `git diff --cached --check` before commit

Representative provider replay semantics are explicitly covered for OpenAI-compatible reasoning, Ollama, MiMo, DeepSeek, and Kimi catalog/profile cases.