### PR TITLE
chore: format reasoning replay changes

### DIFF
--- a/lib/context_reducer_apply.ml
+++ b/lib/context_reducer_apply.ml
@@ -115,7 +115,6 @@ let tool_result_ids (msg : message) =
 ;;
 
 let has_tool_result msg = tool_result_ids msg <> []
-
 let has_tool_use msg = tool_use_ids msg <> []
 
 let has_reasoning_block (msg : message) =
@@ -295,12 +294,7 @@ let apply_drop_thinking messages =
        assistant reasoning is context weight and should not survive
        [drop_thinking]. *)
     | Thinking _ | ReasoningDetails _ | RedactedThinking _ -> preserve_reasoning
-    | Text _
-    | ToolUse _
-    | ToolResult _
-    | Image _
-    | Document _
-    | Audio _ -> true
+    | Text _ | ToolUse _ | ToolResult _ | Image _ | Document _ | Audio _ -> true
   in
   List.filter_map
     (fun (msg : message) ->

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -127,8 +127,8 @@ let validation_loop_blocked_text ~consecutive_idle_turns results =
   in
   Printf.sprintf
     "I stopped the tool loop because the same invalid tool call was repeated after \
-     validation feedback. Tool(s): %s. Repeated invalid turn count: %d. Last \
-     validation error: %s"
+     validation feedback. Tool(s): %s. Repeated invalid turn count: %d. Last validation \
+     error: %s"
     tool_names
     consecutive_idle_turns
     last_error
@@ -675,12 +675,12 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails ~response tool_uses
               before the required tool replies, which strict providers reject. *)
             ignore idle_handled;
             (* suppress unused warning after dedup *)
-            match validation_loop_blocked_response with
-            | Some blocked_response ->
-              Agent_types.reset_idle_state agent;
-              Ok (Complete blocked_response)
-            | None ->
-              (* In-memory message hygiene after each tool execution round.
+            (match validation_loop_blocked_response with
+             | Some blocked_response ->
+               Agent_types.reset_idle_state agent;
+               Ok (Complete blocked_response)
+             | None ->
+               (* In-memory message hygiene after each tool execution round.
             Without this, agent.state.messages grows unbounded across turns —
             context_reducer only trims before API calls, not in the stored state.
 
@@ -689,11 +689,11 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails ~response tool_uses
                with short stubs. Tool results are the largest allocation source.
             2. Hard message cap: keep last 100 messages. Prevents unbounded growth
                in long-running agents (600+ turns). *)
-            (* Tool-result stubbing and message cap are now applied at call-time
+               (* Tool-result stubbing and message cap are now applied at call-time
             in Agent_turn.prepare_messages, not here.  Keeping stored messages
             unmodified preserves the byte-identical conversation prefix that
             local LLM KV-cache (Ollama/llama.cpp) depends on for reuse. *)
-              Ok ToolsExecuted))
+               Ok ToolsExecuted)))
 ;;
 
 (* ── Stage 6: Output ─────────────────────────────────────── *)

--- a/test/test_cost_tracker.ml
+++ b/test/test_cost_tracker.ml
@@ -40,7 +40,14 @@ let test_report_basic () =
 
 let test_report_cache_miss_input_tokens () =
   let usage =
-    make_usage ~cost:0.05 ~calls:2 ~inp:1000 ~out:100 ~cache_creation:150 ~cache_read:650 ()
+    make_usage
+      ~cost:0.05
+      ~calls:2
+      ~inp:1000
+      ~out:100
+      ~cache_creation:150
+      ~cache_read:650
+      ()
   in
   let r = Cost_tracker.report usage in
   check int "cache write" 150 r.cache_creation_tokens;
@@ -55,9 +62,7 @@ let test_report_zero_calls () =
 ;;
 
 let test_report_to_string () =
-  let usage =
-    make_usage ~cost:0.123456 ~calls:5 ~inp:500 ~out:200 ~cache_read:300 ()
-  in
+  let usage = make_usage ~cost:0.123456 ~calls:5 ~inp:500 ~out:200 ~cache_read:300 () in
   let r = Cost_tracker.report usage in
   let s = Cost_tracker.report_to_string r in
   check
@@ -70,8 +75,7 @@ let test_report_to_string () =
        let _ = Str.search_forward (Str.regexp_string "0.123456") s 0 in
        true
      with
-     | Not_found -> false)
-  ;
+     | Not_found -> false);
   check
     bool
     "contains cache miss"

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -393,7 +393,8 @@ let test_repeated_validation_error_loop_blocks_without_third_provider_call () =
   let next_response (_req : Llm_provider.Llm_transport.completion_request) =
     incr provider_calls;
     match !provider_calls with
-    | 1 | 2 -> repeated_invalid_tool_response (Printf.sprintf "invalid-%d" !provider_calls)
+    | 1 | 2 ->
+      repeated_invalid_tool_response (Printf.sprintf "invalid-%d" !provider_calls)
     | _ -> Alcotest.fail "unexpected third provider call"
   in
   let transport : Llm_provider.Llm_transport.t =


### PR DESCRIPTION
## Summary
- apply ocamlformat to the files merged by #2470
- no semantic changes; this is the follow-up for the failed OCaml Format check

## Verification
- opam exec -- ocamlformat --check lib/context_reducer_apply.ml lib/cost_tracker.ml lib/cost_tracker.mli lib/pipeline/pipeline.ml test/test_budget_strategy.ml test/test_context_reducer.ml test/test_cost_tracker.ml test/test_defaults_unit.ml test/test_pipeline.ml test/test_provider_agnostic_reasoning_replay.ml test/test_thinking_control_dialects.ml
- opam exec -- ocamlc -stop-after parsing lib/context_reducer_apply.ml lib/cost_tracker.ml lib/cost_tracker.mli lib/pipeline/pipeline.ml test/test_budget_strategy.ml test/test_context_reducer.ml test/test_cost_tracker.ml test/test_defaults_unit.ml test/test_pipeline.ml test/test_provider_agnostic_reasoning_replay.ml test/test_thinking_control_dialects.ml
- git diff --check

Full dune build/test remains CI-owned.