### PR TITLE
feat: add local Gemma4 E2B Ollama catalog row

### DIFF
--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -1778,6 +1778,23 @@ let test_catalog_entries =
     ; modality_priority = Some "visual_first"
     ; supports_seed = Some true
     }
+  ; { (test_catalog_entry "hf.co/unsloth/gemma-4-e2b-it-qat-gguf") with
+      base_label = Some "ollama"
+    ; max_context_tokens = Some 131_072
+    ; supports_tools = Some true
+    ; supports_tool_choice = Some false
+    ; supports_named_tool_choice = Some false
+    ; supports_reasoning = Some true
+    ; supports_extended_thinking = Some true
+    ; supports_reasoning_budget = Some false
+    ; thinking_control_format = Some "chat_template_token"
+    ; thinking_control_token = Some "<|think|>"
+    ; supports_multimodal_inputs = Some true
+    ; supports_image_input = Some true
+    ; supports_audio_input = Some true
+    ; modality_priority = Some "visual_first"
+    ; supports_seed = Some true
+    }
   ; { (test_catalog_entry "claude-opus-4") with
       base_label = Some "anthropic"
     ; max_context_tokens = Some 1_000_000
@@ -2018,6 +2035,18 @@ let%test "for_model_id hf.co/unsloth Gemma 4 QAT uses template token thinking" =
   | None -> false
 ;;
 
+let%test "for_model_id hf.co/unsloth Gemma 4 E2B QAT keeps exact 128K audio row" =
+  match for_model_id "hf.co/unsloth/gemma-4-E2B-it-qat-GGUF:UD-Q4_K_XL" with
+  | Some c ->
+    c.supports_tools
+    && c.supports_image_input
+    && c.supports_audio_input
+    && c.max_context_tokens = Some 131_072
+    && c.thinking_control_format = Chat_template_token
+    && c.modality_priority = Modality.Visual_first
+  | None -> false
+;;
+
 let%test "for_model_id hf.co/google Gemma 4 QAT uses template token thinking" =
   match for_model_id "hf.co/google/gemma-4-26B-A4B-it-qat-q4_0-gguf" with
   | Some c ->
@@ -2161,6 +2190,11 @@ let%test
       ; ( "hf.co/unsloth/gemma-4-26B-A4B-it-qat-GGUF:UD-Q4_K_XL"
         , fun c -> c.supports_reasoning && c.thinking_control_format = Chat_template_token
         )
+      ; ( "hf.co/unsloth/gemma-4-E2B-it-qat-GGUF:UD-Q4_K_XL"
+        , fun c ->
+            c.supports_audio_input
+            && c.thinking_control_format = Chat_template_token
+            && c.max_context_tokens = Some 131_072 )
       ])
 ;;
 

--- a/models.toml
+++ b/models.toml
@@ -2211,6 +2211,49 @@ supports_seed = true
 input_per_million = 0.0
 output_per_million = 0.0
 
+# Local Ollama exact Gemma 4 E2B QAT row. Verified with:
+# `ollama show hf.co/unsloth/gemma-4-E2B-it-qat-GGUF:UD-Q4_K_XL`
+# on 2026-07-06: context 131072; capabilities tools, completion, vision, audio.
+[[models]]
+id_prefix = "hf.co/unsloth/gemma-4-E2B-it-qat-GGUF"
+base = "ollama"
+max_context_tokens = 131072
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = false
+thinking_control_format = "chat_template_token"
+thinking_control_token = "<|think|>"
+supports_multimodal_inputs = true
+supports_image_input = true
+supports_audio_input = true
+modality_priority = "visual_first"
+supports_native_streaming = true
+supports_seed = true
+input_per_million = 0.0
+output_per_million = 0.0
+
+[[models]]
+id_prefix = "ollama/hf.co/unsloth/gemma-4-E2B-it-qat-GGUF"
+base = "ollama"
+max_context_tokens = 131072
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = false
+thinking_control_format = "chat_template_token"
+thinking_control_token = "<|think|>"
+supports_multimodal_inputs = true
+supports_image_input = true
+supports_audio_input = true
+modality_priority = "visual_first"
+supports_native_streaming = true
+supports_seed = true
+input_per_million = 0.0
+output_per_million = 0.0
+
 # Generic/Ollama/Other Fallbacks
 [[models]]
 id_prefix = "ollama"

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -585,6 +585,52 @@ let test_lookup_runpod_rtxa6000_gemma4_coder_catalog () =
   | None -> fail "bare lookup should match gemma4-coder-fable5-q4km"
 ;;
 
+let test_lookup_local_ollama_gemma4_e2b_qat_catalog () =
+  let model_id = "hf.co/unsloth/gemma-4-E2B-it-qat-GGUF:UD-Q4_K_XL" in
+  let check_gemma4_e2b label (c : Capabilities.capabilities) =
+    check (option int) (label ^ " context 128K") (Some 131_072) c.max_context_tokens;
+    check bool (label ^ " tools") true c.supports_tools;
+    check bool (label ^ " forced tool_choice disabled") false c.supports_tool_choice;
+    check bool (label ^ " named tool_choice disabled") false c.supports_named_tool_choice;
+    check bool (label ^ " reasoning") true c.supports_reasoning;
+    check bool (label ^ " extended thinking") true c.supports_extended_thinking;
+    check bool (label ^ " reasoning budget disabled") false c.supports_reasoning_budget;
+    check
+      bool
+      (label ^ " chat_template_token thinking control")
+      true
+      (c.thinking_control_format = Capabilities.Chat_template_token);
+    check bool (label ^ " image input") true c.supports_image_input;
+    check bool (label ^ " audio input") true c.supports_audio_input;
+    check bool (label ^ " multimodal inputs") true c.supports_multimodal_inputs;
+    check
+      bool
+      (label ^ " visual-first priority")
+      true
+      (c.modality_priority = Modality.Visual_first);
+    check bool (label ^ " native streaming") true c.supports_native_streaming;
+    check bool (label ^ " seed") true c.supports_seed
+  in
+  (match
+     Capabilities.for_provider_model_id
+       ~allow_bare_fallback:false
+       ~provider_label:"ollama"
+       ~model_id
+   with
+   | Some c -> check_gemma4_e2b "strict ollama Gemma4 E2B QAT" c
+   | None -> fail "strict Ollama lookup should match local Gemma4 E2B QAT");
+  (match Capabilities.for_model_id model_id with
+   | Some c -> check_gemma4_e2b "bare local Gemma4 E2B QAT" c
+   | None -> fail "bare lookup should match local Gemma4 E2B QAT");
+  check
+    (option string)
+    "Gemma4 E2B chat-template token"
+    (Some "<|think|>")
+    (Capabilities.thinking_control_token_for_provider_model_id
+       ~provider_label:"ollama"
+       ~model_id)
+;;
+
 let test_lookup_deepseek_v4_flash () =
   match Capabilities.for_model_id "deepseek-v4-flash" with
   | Some c ->
@@ -2519,6 +2565,10 @@ let () =
             "runpod rtxa6000 gemma4 coder catalog"
             `Quick
             test_lookup_runpod_rtxa6000_gemma4_coder_catalog
+        ; test_case
+            "local ollama gemma4 e2b qat catalog"
+            `Quick
+            test_lookup_local_ollama_gemma4_e2b_qat_catalog
         ; test_case "deepseek v4 flash" `Quick test_lookup_deepseek_v4_flash
         ; test_case "deepseek v4 pro" `Quick test_lookup_deepseek_v4_pro
         ; test_case


### PR DESCRIPTION
## Summary
- Add exact OAS model catalog rows for `hf.co/unsloth/gemma-4-E2B-it-qat-GGUF:UD-Q4_K_XL` and strict `ollama/<model>` lookup.
- Declare the locally observed 131072 context window, tools, vision, audio, chat-template-token thinking, and `<|think|>` token without changing the broader Gemma 4 generic row.
- Add capability regressions for strict Ollama provider lookup, bare lookup, chat-template token lookup, audio input, and exact 128K context.

## Evidence
- [근거] `ollama show hf.co/unsloth/gemma-4-E2B-it-qat-GGUF:UD-Q4_K_XL` checked 2026-07-06 KST. Output reports architecture `gemma4`, context length `131072`, and capabilities `tools`, `completion`, `vision`, `audio`. Trust: High, local runtime command.

## Validation
- `python3 -c "import pathlib,tomllib; [tomllib.loads(pathlib.Path(p).read_text()) for p in [\"models.toml\"]]"` passed.
- `git diff --check` passed.
- `ocamlformat --inplace lib/llm_provider/capabilities.ml test/test_capabilities.ml` passed.
- `scripts/dune-local.sh exec ./test/test_capabilities.exe` was attempted but cancelled while waiting on `/tmp/me-dune-local.lock`, held by unrelated long-running MASC builds. CI remains the build authority.