### PR TITLE
refactor(catalog): make Chat_template_token carry its token — tokenless rows fail closed at load (#2482)

### DIFF
--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -21,17 +21,6 @@ let with_chat_template_thinking_token ~token = function
   | _ -> token
 ;;
 
-let chat_template_thinking_token_exn ~(config : Provider_config.t) =
-  match Provider_config.thinking_control_token_for_config_model config with
-  | Some token -> token
-  | None ->
-    invalid_arg
-      (Printf.sprintf
-         "Backend_ollama.build_request: model %S declares chat_template_token \
-          thinking_control_format but no thinking_control_token"
-         config.model_id)
-;;
-
 (** Build Ollama native [/api/chat] request body.
     Key differences from Openai compat:
     - [think] parameter (boolean) instead of [chat_template_kwargs], except
@@ -58,15 +47,20 @@ let build_request
     | Some c -> c
     | None -> Capabilities.ollama_capabilities
   in
+  (* The token is carried by [Chat_template_token] in the resolved capabilities
+     (fail-closed at catalog/manifest load), so there is no per-request token
+     lookup left that could be missing. *)
+  let chat_template_token =
+    Capability_vocab.token_of_thinking_control_format caps.thinking_control_format
+  in
   let chat_template_token_thinking =
-    think_requested && caps.thinking_control_format = Capabilities.Chat_template_token
+    think_requested && Option.is_some chat_template_token
   in
   let system_prompt =
-    if chat_template_token_thinking
-    then (
-      let token = chat_template_thinking_token_exn ~config in
-      Some (with_chat_template_thinking_token ~token config.system_prompt))
-    else config.system_prompt
+    match chat_template_token with
+    | Some token when think_requested ->
+      Some (with_chat_template_thinking_token ~token config.system_prompt)
+    | Some _ | None -> config.system_prompt
   in
   let messages = Tool_message_pairs.close_for_provider_request messages in
   let provider_messages =

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -18,7 +18,9 @@ type thinking_control_format = Capability_vocab.thinking_control_format =
   | Thinking_object_adaptive
   | Thinking_object_only
   | Chat_template_kwargs
-  | Chat_template_token
+  | Chat_template_token of string
+  (** Thinking toggled by a chat-template token (e.g. [<|think|>]) emitted in
+          the system turn; the token is carried in the constructor. *)
   | Ollama_think
   | Reasoning_effort
   | Enable_thinking
@@ -780,10 +782,6 @@ let with_tool_support caps ~supports_tools = { caps with supports_tools }
     when absent or unrecognised.  Each [Some] field in [entry] overrides
     the corresponding field of the base; [None] fields are left unchanged. *)
 
-let thinking_control_format_of_manifest_string raw =
-  Capability_vocab.thinking_control_format_of_string raw
-;;
-
 let preserve_thinking_control_format_of_manifest_string raw =
   Capability_vocab.preserve_thinking_control_format_of_string raw
 ;;
@@ -881,7 +879,9 @@ type declarative_capability_overrides =
   ; ignored_sampling_parameters : Capability_vocab.sampling_parameter list option
   ; supports_computer_use : bool option
   ; supports_code_execution : bool option
-  ; thinking_control_format : string option
+  ; thinking_control_format : Capability_vocab.thinking_control_format option
+    (* Already joined with its token by the catalog/manifest parser; the token
+       lives in the [Chat_template_token] constructor, not a sibling field. *)
   ; preserve_thinking_control_format : string option
   ; reasoning_output_format : string option
   ; reasoning_streaming_format : string option
@@ -1048,13 +1048,10 @@ let apply_declarative_capability_overrides overrides =
   ; supports_code_execution =
       override_bool base.supports_code_execution overrides.supports_code_execution
   ; thinking_control_format =
+      (* Typed and token-joined at catalog/manifest parse time (unknown labels
+         already failed closed there), so this is a plain override. *)
       (match overrides.thinking_control_format with
-       | Some s ->
-         (match thinking_control_format_of_manifest_string s with
-          | Some t -> t
-          | None ->
-            warn_unknown_capability_value ~field:"thinking_control_format" s;
-            base.thinking_control_format)
+       | Some fmt -> fmt
        | None -> base.thinking_control_format)
   ; preserve_thinking_control_format =
       (match overrides.preserve_thinking_control_format with
@@ -1345,24 +1342,25 @@ let for_provider_model_id
   | None -> if allow_bare_fallback then for_model_id model_id else None
 ;;
 
-let exact_token = function
-  | Some raw when String.trim raw = "" || raw <> String.trim raw -> None
-  | Some raw -> Some raw
-  | None -> None
+(* The token is the single source of truth carried by the entry's
+   [Chat_template_token] constructor (the parser validated its exactness), so it
+   is read back through the constructor rather than a sibling field. *)
+let token_of_declared_format format =
+  Option.bind format Capability_vocab.token_of_thinking_control_format
 ;;
 
 let thinking_control_token_for_model_id_catalog model_id =
   match Model_catalog.global () with
   | Some catalog ->
     (match Model_catalog.lookup catalog model_id with
-     | Some entry -> exact_token entry.thinking_control_token
+     | Some entry -> token_of_declared_format entry.thinking_control_format
      | None -> None)
   | None -> None
 ;;
 
 let thinking_control_token_for_model_id_with_manifest manifest model_id =
   match Capability_manifest.lookup manifest model_id with
-  | Some entry -> exact_token entry.thinking_control_token
+  | Some entry -> token_of_declared_format entry.thinking_control_format
   | None -> thinking_control_token_for_model_id_catalog model_id
 ;;
 
@@ -1370,7 +1368,7 @@ let thinking_control_token_for_model_id model_id =
   match Model_catalog.global () with
   | Some catalog ->
     (match Model_catalog.lookup catalog model_id with
-     | Some entry -> exact_token entry.thinking_control_token
+     | Some entry -> token_of_declared_format entry.thinking_control_format
      | None ->
        (match Capability_manifest.global () with
         | Some manifest ->
@@ -1404,7 +1402,8 @@ let thinking_control_token_for_provider_model_id
                        String.starts_with
                          ~prefix
                          (String.lowercase_ascii (String.trim entry.id_prefix)))
-                    qualified_prefixes -> Some (exact_token entry.thinking_control_token)
+                    qualified_prefixes ->
+             Some (token_of_declared_format entry.thinking_control_format)
            | Some _ | None -> loop rest)
       in
       loop candidates
@@ -1564,7 +1563,6 @@ let test_catalog_entry id_prefix : Model_catalog.model_entry =
   ; supports_computer_use = None
   ; supports_code_execution = None
   ; thinking_control_format = None
-  ; thinking_control_token = None
   ; preserve_thinking_control_format = None
   ; reasoning_output_format = None
   ; reasoning_streaming_format = None
@@ -1608,7 +1606,6 @@ let test_manifest_entry id_prefix : Capability_manifest.entry =
   ; supports_computer_use = None
   ; supports_code_execution = None
   ; thinking_control_format = None
-  ; thinking_control_token = None
   ; preserve_thinking_control_format = None
   ; reasoning_output_format = None
   ; reasoning_streaming_format = None
@@ -1627,7 +1624,7 @@ let qwen3_family_test_entry id_prefix : Model_catalog.model_entry =
   ; supports_named_tool_choice = Some true
   ; supports_reasoning = Some true
   ; supports_extended_thinking = Some true
-  ; thinking_control_format = Some "chat_template_kwargs"
+  ; thinking_control_format = Some Chat_template_kwargs
   ; preserve_thinking_control_format = Some "chat_template_kwargs_preserve_thinking"
   ; supports_native_streaming = Some true
   }
@@ -1665,7 +1662,7 @@ let deepseek_v4_test_entry id_prefix : Model_catalog.model_entry =
     supports_named_tool_choice = Some false
   ; supports_reasoning = Some true
   ; supports_extended_thinking = Some true
-  ; thinking_control_format = Some "thinking_object"
+  ; thinking_control_format = Some Thinking_object
   ; supports_native_streaming = Some true
   }
 ;;
@@ -1771,8 +1768,7 @@ let test_catalog_entries =
     ; supports_named_tool_choice = Some false
     ; supports_reasoning = Some true
     ; supports_extended_thinking = Some true
-    ; thinking_control_format = Some "chat_template_token"
-    ; thinking_control_token = Some "<|think|>"
+    ; thinking_control_format = Some (Chat_template_token "<|think|>")
     ; supports_multimodal_inputs = Some true
     ; supports_image_input = Some true
     ; modality_priority = Some "visual_first"
@@ -1787,8 +1783,7 @@ let test_catalog_entries =
     ; supports_reasoning = Some true
     ; supports_extended_thinking = Some true
     ; supports_reasoning_budget = Some false
-    ; thinking_control_format = Some "chat_template_token"
-    ; thinking_control_token = Some "<|think|>"
+    ; thinking_control_format = Some (Chat_template_token "<|think|>")
     ; supports_multimodal_inputs = Some true
     ; supports_image_input = Some true
     ; supports_audio_input = Some true
@@ -1893,47 +1888,37 @@ let%test "for_model_id_catalog empty catalog returns None" =
     Option.is_none (for_model_id_catalog "qwen3-32b"))
 ;;
 
-let%test "thinking_control_token catalog runtime override rejects blank or padded token" =
+let%test "thinking_control_token accessor reads the token from the catalog constructor" =
+  (* The token is the single source of truth carried by [Chat_template_token]; a
+     non-token format resolves to [None]. *)
   Model_catalog.set_global
     (Model_catalog.of_model_entries
-       [ { (test_catalog_entry "programmatic-blank-catalog-token") with
-           thinking_control_token = Some " \t "
+       [ { (test_catalog_entry "programmatic-catalog-token") with
+           thinking_control_format = Some (Chat_template_token "<|think|>")
          }
-       ; { (test_catalog_entry "programmatic-padded-catalog-token") with
-           thinking_control_token = Some " <|think|> "
-         }
-       ; { (test_catalog_entry "programmatic-exact-catalog-token") with
-           thinking_control_token = Some "<|think|>"
+       ; { (test_catalog_entry "programmatic-catalog-no-token") with
+           thinking_control_format = Some Chat_template_kwargs
          }
        ]);
   Fun.protect ~finally:Model_catalog.clear_global (fun () ->
-    Option.is_none
-      (thinking_control_token_for_model_id "programmatic-blank-catalog-token")
+    thinking_control_token_for_model_id "programmatic-catalog-token" = Some "<|think|>"
     && Option.is_none
-         (thinking_control_token_for_model_id "programmatic-padded-catalog-token")
-    && thinking_control_token_for_model_id "programmatic-exact-catalog-token"
-       = Some "<|think|>")
+         (thinking_control_token_for_model_id "programmatic-catalog-no-token"))
 ;;
 
-let%test "thinking_control_token manifest runtime override rejects blank or padded token" =
+let%test "thinking_control_token accessor reads the token from the manifest constructor" =
   Capability_manifest.set_global
-    [ { (test_manifest_entry "programmatic-blank-manifest-token") with
-        thinking_control_token = Some " \t "
+    [ { (test_manifest_entry "programmatic-manifest-token") with
+        thinking_control_format = Some (Chat_template_token "<|think|>")
       }
-    ; { (test_manifest_entry "programmatic-padded-manifest-token") with
-        thinking_control_token = Some " <|think|> "
-      }
-    ; { (test_manifest_entry "programmatic-exact-manifest-token") with
-        thinking_control_token = Some "<|think|>"
+    ; { (test_manifest_entry "programmatic-manifest-no-token") with
+        thinking_control_format = Some Chat_template_kwargs
       }
     ];
   Fun.protect ~finally:Capability_manifest.clear_global (fun () ->
-    Option.is_none
-      (thinking_control_token_for_model_id "programmatic-blank-manifest-token")
+    thinking_control_token_for_model_id "programmatic-manifest-token" = Some "<|think|>"
     && Option.is_none
-         (thinking_control_token_for_model_id "programmatic-padded-manifest-token")
-    && thinking_control_token_for_model_id "programmatic-exact-manifest-token"
-       = Some "<|think|>")
+         (thinking_control_token_for_model_id "programmatic-manifest-no-token"))
 ;;
 
 (* --- emits_usage_tokens / capabilities_for_provider_label --- *)
@@ -2030,7 +2015,7 @@ let%test "for_model_id hf.co/unsloth Gemma 4 QAT uses template token thinking" =
     c.supports_reasoning
     && c.supports_extended_thinking
     && (not c.supports_reasoning_budget)
-    && c.thinking_control_format = Chat_template_token
+    && c.thinking_control_format = Chat_template_token "<|think|>"
     && c.modality_priority = Modality.Visual_first
   | None -> false
 ;;
@@ -2042,7 +2027,7 @@ let%test "for_model_id hf.co/unsloth Gemma 4 E2B QAT keeps exact 128K audio row"
     && c.supports_image_input
     && c.supports_audio_input
     && c.max_context_tokens = Some 131_072
-    && c.thinking_control_format = Chat_template_token
+    && c.thinking_control_format = Chat_template_token "<|think|>"
     && c.modality_priority = Modality.Visual_first
   | None -> false
 ;;
@@ -2053,7 +2038,7 @@ let%test "for_model_id hf.co/google Gemma 4 QAT uses template token thinking" =
     c.supports_reasoning
     && c.supports_extended_thinking
     && (not c.supports_reasoning_budget)
-    && c.thinking_control_format = Chat_template_token
+    && c.thinking_control_format = Chat_template_token "<|think|>"
   | None -> false
 ;;
 
@@ -2188,12 +2173,13 @@ let%test
             && c.modality_priority = Modality.Visual_first
             && c.max_context_tokens = Some 262_144 )
       ; ( "hf.co/unsloth/gemma-4-26B-A4B-it-qat-GGUF:UD-Q4_K_XL"
-        , fun c -> c.supports_reasoning && c.thinking_control_format = Chat_template_token
-        )
+        , fun c ->
+            c.supports_reasoning
+            && c.thinking_control_format = Chat_template_token "<|think|>" )
       ; ( "hf.co/unsloth/gemma-4-E2B-it-qat-GGUF:UD-Q4_K_XL"
         , fun c ->
             c.supports_audio_input
-            && c.thinking_control_format = Chat_template_token
+            && c.thinking_control_format = Chat_template_token "<|think|>"
             && c.max_context_tokens = Some 131_072 )
       ])
 ;;

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -12,7 +12,9 @@ type thinking_control_format = Capability_vocab.thinking_control_format =
   | Thinking_object_adaptive
   | Thinking_object_only
   | Chat_template_kwargs
-  | Chat_template_token
+  | Chat_template_token of string
+  (** Thinking toggled by a chat-template token (e.g. [<|think|>]) emitted in
+          the system turn; the token is carried in the constructor. *)
   | Ollama_think
   | Reasoning_effort
   | Enable_thinking

--- a/lib/llm_provider/capability_manifest.ml
+++ b/lib/llm_provider/capability_manifest.ml
@@ -53,16 +53,18 @@ type entry =
   ; ignored_sampling_parameters : Capability_vocab.sampling_parameter list option
   ; supports_computer_use : bool option
   ; supports_code_execution : bool option
-  ; thinking_control_format : string option
+  ; thinking_control_format : Capability_vocab.thinking_control_format option
     (** Canonical thinking-wire format the model uses (none / thinking_object /
         thinking_object_adaptive / thinking_object_only / chat_template_kwargs /
         chat_template_token / reasoning_effort / enable_thinking). Parsed + applied in
         {!Capabilities.apply_manifest_entry}. Without this field a manifest
-        entry silently dropped the model's thinking knob (RFC-OAS-023). *)
-  ; thinking_control_token : string option
-    (** Exact chat-template token for [thinking_control_format =
-        chat_template_token], for example [<|think|>]. Parsed separately from
-        the enum so request builders do not hardcode model-family tokens. *)
+        entry silently dropped the model's thinking knob (RFC-OAS-023).
+
+        Joined from the JSON [thinking_control_format] and [thinking_control_token]
+        members at parse time: [chat_template_token] carries its token (for
+        example [<|think|>]) in the [Chat_template_token] constructor, so a
+        tokenless declaration — or a token without that format — fails closed in
+        {!parse_entry} rather than raising when a request builder needs it. *)
   ; preserve_thinking_control_format : string option
     (** Canonical historical reasoning preservation wire format (none /
         thinking_object_keep_all / chat_template_kwargs_preserve_thinking /
@@ -355,13 +357,19 @@ let parse_entry json =
     | None -> Ok None
     | Some raw -> Result.map (fun label -> Some label) (base_label_of_string raw)
   in
-  let* thinking_control_format =
-    canonical_choice
-      "thinking_control_format"
-      ~allowed:Capability_vocab.thinking_control_format_values
-      json
+  (* Read the raw label and the exact-validated token, then join them:
+     [thinking_control_format_of_label_and_token] validates the label against the
+     vocab and enforces the chat_template_token <-> token cross-field invariant. *)
+  let* thinking_control_format_raw =
+    member_string_closed "thinking_control_format" json
   in
   let* thinking_control_token = non_empty_member_string "thinking_control_token" json in
+  let* thinking_control_format =
+    Capability_vocab.thinking_control_format_of_label_and_token
+      ~format:thinking_control_format_raw
+      ~token:thinking_control_token
+    |> Result.map_error (fun msg -> Printf.sprintf "entry %S %s" id_prefix msg)
+  in
   let* preserve_thinking_control_format =
     canonical_choice
       "preserve_thinking_control_format"
@@ -430,7 +438,6 @@ let parse_entry json =
     ; supports_computer_use = member_bool "supports_computer_use" json
     ; supports_code_execution = member_bool "supports_code_execution" json
     ; thinking_control_format
-    ; thinking_control_token
     ; preserve_thinking_control_format
     ; reasoning_output_format
     ; reasoning_streaming_format

--- a/lib/llm_provider/capability_manifest.mli
+++ b/lib/llm_provider/capability_manifest.mli
@@ -93,14 +93,14 @@ type entry =
         serialized. *)
   ; supports_computer_use : bool option
   ; supports_code_execution : bool option
-  ; thinking_control_format : string option
+  ; thinking_control_format : Capability_vocab.thinking_control_format option
     (** Canonical thinking-wire format (none / thinking_object /
         thinking_object_adaptive / thinking_object_only / chat_template_kwargs /
         chat_template_token / reasoning_effort / enable_thinking); applied in
-        {!Capabilities.apply_manifest_entry}. *)
-  ; thinking_control_token : string option
-    (** Exact chat-template token used when [thinking_control_format] is
-        [chat_template_token]. *)
+        {!Capabilities.apply_manifest_entry}. Joined from the JSON
+        [thinking_control_format] and [thinking_control_token] members at parse
+        time — [chat_template_token] carries its token in the constructor, so a
+        tokenless declaration fails closed in {!of_json}. *)
   ; preserve_thinking_control_format : string option
     (** Canonical historical reasoning preservation wire format (none /
         thinking_object_keep_all / chat_template_kwargs_preserve_thinking /

--- a/lib/llm_provider/capability_vocab.ml
+++ b/lib/llm_provider/capability_vocab.ml
@@ -11,7 +11,12 @@ type thinking_control_format =
   | Thinking_object_adaptive
   | Thinking_object_only
   | Chat_template_kwargs
-  | Chat_template_token
+  | Chat_template_token of string
+  (** Thinking is toggled by emitting a chat-template token (e.g. [<|think|>])
+          in the system turn. The token is catalog/manifest data carried inside
+          the constructor: a [chat_template_token] wire format cannot exist
+          without its token, so a tokenless declaration fails closed at load
+          instead of raising per request. *)
   | Ollama_think
   | Reasoning_effort
   | Enable_thinking
@@ -63,25 +68,95 @@ type task =
 
 let normalize raw = String.lowercase_ascii (String.trim raw)
 
-let thinking_control_format_table =
+(* The chat-template-token label needs a companion token, so unlike the data-less
+   variants it cannot live in a plain [string -> t] table. The label is still
+   listed in [thinking_control_format_values] for vocab-membership validation;
+   build the full value with [thinking_control_format_of_label_and_token]. *)
+let chat_template_token_label = "chat_template_token"
+
+let thinking_control_format_tokenless_table =
   [ "none", No_thinking_control
   ; "thinking_object", Thinking_object
   ; "thinking_object_adaptive", Thinking_object_adaptive
   ; "thinking_object_only", Thinking_object_only
   ; "chat_template_kwargs", Chat_template_kwargs
-  ; "chat_template_token", Chat_template_token
   ; "ollama_think", Ollama_think
   ; "reasoning_effort", Reasoning_effort
   ; "enable_thinking", Enable_thinking
   ]
 ;;
 
-let thinking_control_format_values = List.map fst thinking_control_format_table
+let thinking_control_format_values =
+  List.map fst thinking_control_format_tokenless_table @ [ chat_template_token_label ]
+;;
 
-let thinking_control_format_of_string raw =
-  match normalize raw with
-  | "" -> None
-  | normalized -> List.assoc_opt normalized thinking_control_format_table
+(* The chat-template thinking token carried by [Chat_template_token], or [None]
+   for every other wire format. Exhaustive so a new [thinking_control_format]
+   variant is compiler-checked here. *)
+let token_of_thinking_control_format = function
+  | Chat_template_token token -> Some token
+  | No_thinking_control
+  | Thinking_object
+  | Thinking_object_adaptive
+  | Thinking_object_only
+  | Chat_template_kwargs
+  | Ollama_think
+  | Reasoning_effort
+  | Enable_thinking -> None
+;;
+
+(* Join a [thinking_control_format] wire label with its companion
+   [thinking_control_token]. The two are one concept: [chat_template_token]
+   carries its token in the constructor, so a chat_template_token label REQUIRES a
+   token, and a token REQUIRES the chat_template_token label. Every crossed
+   combination fails closed here rather than parsing into a value a request
+   builder would reject later.
+
+   Callers validate [format] against [thinking_control_format_values] and [token]
+   for exactness before calling; this function enforces only the cross-field
+   invariant and returns a message the caller prefixes with the offending entry
+   id. *)
+let thinking_control_format_of_label_and_token ~format ~token
+  : (thinking_control_format option, string) result
+  =
+  let token_present =
+    match token with
+    | Some t when String.trim t <> "" -> Some t
+    | Some _ | None -> None
+  in
+  let orphan_token_error =
+    Printf.sprintf
+      "thinking_control_token is only valid with thinking_control_format = %S"
+      chat_template_token_label
+  in
+  match format with
+  | None ->
+    (match token_present with
+     | None -> Ok None
+     | Some _ -> Error orphan_token_error)
+  | Some raw ->
+    let normalized = normalize raw in
+    if String.equal normalized chat_template_token_label
+    then (
+      match token_present with
+      | Some token -> Ok (Some (Chat_template_token token))
+      | None ->
+        Error
+          (Printf.sprintf
+             "thinking_control_format %S requires a non-empty thinking_control_token"
+             chat_template_token_label))
+    else (
+      match token_present with
+      | Some _ -> Error orphan_token_error
+      | None ->
+        (match List.assoc_opt normalized thinking_control_format_tokenless_table with
+         | Some fmt -> Ok (Some fmt)
+         | None ->
+           Error
+             (Printf.sprintf
+                "unknown thinking_control_format %S (canonical: %s)"
+                normalized
+                (String.concat ", " thinking_control_format_values))))
 ;;
 
 let preserve_thinking_control_format_table =
@@ -103,10 +178,48 @@ let preserve_thinking_control_format_of_string raw =
   | normalized -> List.assoc_opt normalized preserve_thinking_control_format_table
 ;;
 
-let%test "thinking_control_format values parse through the canonical table" =
+let%test "thinking_control_format labels resolve through the canonical vocab" =
   List.for_all
-    (fun raw -> Option.is_some (thinking_control_format_of_string raw))
+    (fun raw ->
+       let token =
+         if String.equal (normalize raw) chat_template_token_label
+         then Some "<|think|>"
+         else None
+       in
+       match thinking_control_format_of_label_and_token ~format:(Some raw) ~token with
+       | Ok (Some _) -> true
+       | Ok None | Error _ -> false)
     thinking_control_format_values
+;;
+
+let%test "chat_template_token label without a token fails closed" =
+  match
+    thinking_control_format_of_label_and_token
+      ~format:(Some chat_template_token_label)
+      ~token:None
+  with
+  | Error _ -> true
+  | Ok _ -> false
+;;
+
+let%test "chat_template_token label carries its token into the constructor" =
+  match
+    thinking_control_format_of_label_and_token
+      ~format:(Some chat_template_token_label)
+      ~token:(Some "<|think|>")
+  with
+  | Ok (Some (Chat_template_token "<|think|>")) -> true
+  | Ok _ | Error _ -> false
+;;
+
+let%test "a token declared without the chat_template_token label fails closed" =
+  match
+    thinking_control_format_of_label_and_token
+      ~format:(Some "thinking_object")
+      ~token:(Some "<|think|>")
+  with
+  | Error _ -> true
+  | Ok _ -> false
 ;;
 
 let%test "preserve_thinking_control_format values parse through the canonical table" =

--- a/lib/llm_provider/model_catalog.ml
+++ b/lib/llm_provider/model_catalog.ml
@@ -34,8 +34,13 @@ type model_entry =
   ; ignored_sampling_parameters : Capability_vocab.sampling_parameter list option
   ; supports_computer_use : bool option
   ; supports_code_execution : bool option
-  ; thinking_control_format : string option
-  ; thinking_control_token : string option
+  ; thinking_control_format : Capability_vocab.thinking_control_format option
+    (* Typed at the parse boundary (unlike the sibling string-valued format
+       fields) because it carries the chat-template thinking token in its
+       [Chat_template_token] constructor. The TOML still declares the
+       [thinking_control_format] and [thinking_control_token] keys separately;
+       [parse_entry] joins them so a [chat_template_token] row without a token —
+       or a token without that format — fails closed here. *)
   ; preserve_thinking_control_format : string option
   ; reasoning_output_format : string option
   ; reasoning_streaming_format : string option
@@ -383,12 +388,10 @@ let parse_entry entry_toml =
            "ignored_sampling_parameters"
            entry_toml
        in
-       let thinking_control_format_result =
-         canonical_string_opt
-           ~entry_id:id_prefix
-           "thinking_control_format"
-           ~allowed:Capability_vocab.thinking_control_format_values
-           entry_toml
+       (* Read the raw label here; [thinking_control_format_of_label_and_token]
+          validates it against the vocab and joins it with the token below. *)
+       let thinking_control_format_raw_result =
+         find_string_field ~entry_id:id_prefix "thinking_control_format" entry_toml
        in
        let preserve_thinking_control_format_result =
          canonical_string_opt
@@ -422,7 +425,7 @@ let parse_entry entry_toml =
           , modality_priority_result
           , task_result
           , ignored_sampling_parameters_result
-          , thinking_control_format_result
+          , thinking_control_format_raw_result
           , preserve_thinking_control_format_result
           , reasoning_output_format_result
           , reasoning_streaming_format_result
@@ -443,70 +446,81 @@ let parse_entry entry_toml =
           , Ok modality_priority
           , Ok task
           , Ok ignored_sampling_parameters
-          , Ok thinking_control_format
+          , Ok thinking_control_format_raw
           , Ok preserve_thinking_control_format
           , Ok reasoning_output_format
           , Ok reasoning_streaming_format
           , Ok thinking_control_token ) ->
-          Ok
-            { id_prefix
-            ; base_label
-            ; provider_name
-            ; max_context_tokens = find_int_opt entry_toml [ "max_context_tokens" ]
-            ; max_output_tokens = find_int_opt entry_toml [ "max_output_tokens" ]
-            ; supports_tools = find_bool_opt entry_toml [ "supports_tools" ]
-            ; supports_tool_choice = find_bool_opt entry_toml [ "supports_tool_choice" ]
-            ; supports_required_tool_choice =
-                find_bool_opt entry_toml [ "supports_required_tool_choice" ]
-            ; supports_named_tool_choice =
-                find_bool_opt entry_toml [ "supports_named_tool_choice" ]
-            ; supports_parallel_tool_calls =
-                find_bool_opt entry_toml [ "supports_parallel_tool_calls" ]
-            ; assistant_tool_content_format
-            ; supports_reasoning = find_bool_opt entry_toml [ "supports_reasoning" ]
-            ; supports_extended_thinking =
-                find_bool_opt entry_toml [ "supports_extended_thinking" ]
-            ; supports_reasoning_budget =
-                find_bool_opt entry_toml [ "supports_reasoning_budget" ]
-            ; accepted_reasoning_efforts
-            ; supports_response_format_json =
-                find_bool_opt entry_toml [ "supports_response_format_json" ]
-            ; supports_structured_output =
-                find_bool_opt entry_toml [ "supports_structured_output" ]
-            ; supports_multimodal_inputs =
-                find_bool_opt entry_toml [ "supports_multimodal_inputs" ]
-            ; supports_image_input = find_bool_opt entry_toml [ "supports_image_input" ]
-            ; supports_audio_input = find_bool_opt entry_toml [ "supports_audio_input" ]
-            ; supports_video_input = find_bool_opt entry_toml [ "supports_video_input" ]
-            ; modality_priority
-            ; task
-            ; supports_native_streaming =
-                find_bool_opt entry_toml [ "supports_native_streaming" ]
-            ; supports_system_prompt =
-                find_bool_opt entry_toml [ "supports_system_prompt" ]
-            ; supports_caching = find_bool_opt entry_toml [ "supports_caching" ]
-            ; supports_prompt_caching =
-                find_bool_opt entry_toml [ "supports_prompt_caching" ]
-            ; supports_top_k = find_bool_opt entry_toml [ "supports_top_k" ]
-            ; supports_min_p = find_bool_opt entry_toml [ "supports_min_p" ]
-            ; supports_seed = find_bool_opt entry_toml [ "supports_seed" ]
-            ; ignored_sampling_parameters
-            ; supports_computer_use = find_bool_opt entry_toml [ "supports_computer_use" ]
-            ; supports_code_execution =
-                find_bool_opt entry_toml [ "supports_code_execution" ]
-            ; thinking_control_format
-            ; thinking_control_token
-            ; preserve_thinking_control_format
-            ; reasoning_output_format
-            ; reasoning_streaming_format
-            ; reasoning_replay
-            ; input_per_million = find_float_opt entry_toml [ "input_per_million" ]
-            ; output_per_million = find_float_opt entry_toml [ "output_per_million" ]
-            ; cache_write_multiplier =
-                find_float_opt entry_toml [ "cache_write_multiplier" ]
-            ; cache_read_multiplier =
-                find_float_opt entry_toml [ "cache_read_multiplier" ]
-            }))
+          (match
+             Capability_vocab.thinking_control_format_of_label_and_token
+               ~format:thinking_control_format_raw
+               ~token:thinking_control_token
+           with
+           | Error msg -> Error (Printf.sprintf "model entry %S %s" id_prefix msg)
+           | Ok thinking_control_format ->
+             Ok
+               { id_prefix
+               ; base_label
+               ; provider_name
+               ; max_context_tokens = find_int_opt entry_toml [ "max_context_tokens" ]
+               ; max_output_tokens = find_int_opt entry_toml [ "max_output_tokens" ]
+               ; supports_tools = find_bool_opt entry_toml [ "supports_tools" ]
+               ; supports_tool_choice =
+                   find_bool_opt entry_toml [ "supports_tool_choice" ]
+               ; supports_required_tool_choice =
+                   find_bool_opt entry_toml [ "supports_required_tool_choice" ]
+               ; supports_named_tool_choice =
+                   find_bool_opt entry_toml [ "supports_named_tool_choice" ]
+               ; supports_parallel_tool_calls =
+                   find_bool_opt entry_toml [ "supports_parallel_tool_calls" ]
+               ; assistant_tool_content_format
+               ; supports_reasoning = find_bool_opt entry_toml [ "supports_reasoning" ]
+               ; supports_extended_thinking =
+                   find_bool_opt entry_toml [ "supports_extended_thinking" ]
+               ; supports_reasoning_budget =
+                   find_bool_opt entry_toml [ "supports_reasoning_budget" ]
+               ; accepted_reasoning_efforts
+               ; supports_response_format_json =
+                   find_bool_opt entry_toml [ "supports_response_format_json" ]
+               ; supports_structured_output =
+                   find_bool_opt entry_toml [ "supports_structured_output" ]
+               ; supports_multimodal_inputs =
+                   find_bool_opt entry_toml [ "supports_multimodal_inputs" ]
+               ; supports_image_input =
+                   find_bool_opt entry_toml [ "supports_image_input" ]
+               ; supports_audio_input =
+                   find_bool_opt entry_toml [ "supports_audio_input" ]
+               ; supports_video_input =
+                   find_bool_opt entry_toml [ "supports_video_input" ]
+               ; modality_priority
+               ; task
+               ; supports_native_streaming =
+                   find_bool_opt entry_toml [ "supports_native_streaming" ]
+               ; supports_system_prompt =
+                   find_bool_opt entry_toml [ "supports_system_prompt" ]
+               ; supports_caching = find_bool_opt entry_toml [ "supports_caching" ]
+               ; supports_prompt_caching =
+                   find_bool_opt entry_toml [ "supports_prompt_caching" ]
+               ; supports_top_k = find_bool_opt entry_toml [ "supports_top_k" ]
+               ; supports_min_p = find_bool_opt entry_toml [ "supports_min_p" ]
+               ; supports_seed = find_bool_opt entry_toml [ "supports_seed" ]
+               ; ignored_sampling_parameters
+               ; supports_computer_use =
+                   find_bool_opt entry_toml [ "supports_computer_use" ]
+               ; supports_code_execution =
+                   find_bool_opt entry_toml [ "supports_code_execution" ]
+               ; thinking_control_format
+               ; preserve_thinking_control_format
+               ; reasoning_output_format
+               ; reasoning_streaming_format
+               ; reasoning_replay
+               ; input_per_million = find_float_opt entry_toml [ "input_per_million" ]
+               ; output_per_million = find_float_opt entry_toml [ "output_per_million" ]
+               ; cache_write_multiplier =
+                   find_float_opt entry_toml [ "cache_write_multiplier" ]
+               ; cache_read_multiplier =
+                   find_float_opt entry_toml [ "cache_read_multiplier" ]
+               })))
 ;;
 
 let%test "parse_entry rejects an unknown/misspelled field, not silently dropped" =

--- a/lib/llm_provider/model_catalog.mli
+++ b/lib/llm_provider/model_catalog.mli
@@ -47,8 +47,11 @@ type model_entry =
         {!Capability_vocab.sampling_parameter_values}. *)
   ; supports_computer_use : bool option
   ; supports_code_execution : bool option
-  ; thinking_control_format : string option
-  ; thinking_control_token : string option
+  ; thinking_control_format : Capability_vocab.thinking_control_format option
+    (** Joined from the TOML [thinking_control_format] and [thinking_control_token]
+        keys at parse time: [chat_template_token] carries its token in the
+        [Chat_template_token] constructor, so a tokenless row (or a token without
+        that format) fails closed during {!load_file}. *)
   ; preserve_thinking_control_format : string option
   ; reasoning_output_format : string option
   ; reasoning_streaming_format : string option

--- a/lib/llm_provider/provider_catalog.ml
+++ b/lib/llm_provider/provider_catalog.ml
@@ -101,6 +101,20 @@ let member_string_strict key json =
     Error (Printf.sprintf "field %S expected string, got %s" key (json_kind actual))
 ;;
 
+let member_exact_non_empty_string_strict key json =
+  match member_string_strict key json with
+  | Error _ as error -> error
+  | Ok None -> Ok None
+  | Ok (Some raw) ->
+    let trimmed = String.trim raw in
+    if trimmed = ""
+    then Error (Printf.sprintf "field %S must not be empty" key)
+    else if raw <> trimmed
+    then
+      Error (Printf.sprintf "field %S must not have leading or trailing whitespace" key)
+    else Ok (Some raw)
+;;
+
 let member_bool key json =
   match member key json with
   | `Bool b -> Some b
@@ -379,7 +393,7 @@ let parse_capabilities provider_json =
        [thinking_control_token] key pair; join them so a chat_template_token
        preset without a token — or a token without that format — fails closed. *)
     let* raw = member_string_strict "thinking_control_format" cap_json in
-    let* token = member_string_strict "thinking_control_token" cap_json in
+    let* token = member_exact_non_empty_string_strict "thinking_control_token" cap_json in
     Capability_vocab.thinking_control_format_of_label_and_token ~format:raw ~token
   in
   let* preserve_thinking_control_format =

--- a/lib/llm_provider/provider_catalog.ml
+++ b/lib/llm_provider/provider_catalog.ml
@@ -216,13 +216,6 @@ let parse_optional_capability_value ~field ~canonical parse = function
         Error (Printf.sprintf "unknown %s %S (canonical: %s)" field normalized canonical))
 ;;
 
-let parse_thinking_control_format =
-  parse_optional_capability_value
-    ~field:"thinking_control_format"
-    ~canonical:(String.concat ", " Capability_vocab.thinking_control_format_values)
-    Capability_vocab.thinking_control_format_of_string
-;;
-
 let parse_preserve_thinking_control_format =
   parse_optional_capability_value
     ~field:"preserve_thinking_control_format"
@@ -382,8 +375,12 @@ let parse_capabilities provider_json =
   in
   let* base = capability_base provider_json in
   let* thinking_control_format =
+    (* Provider-level presets declare the same [thinking_control_format] /
+       [thinking_control_token] key pair; join them so a chat_template_token
+       preset without a token — or a token without that format — fails closed. *)
     let* raw = member_string_strict "thinking_control_format" cap_json in
-    parse_thinking_control_format raw
+    let* token = member_string_strict "thinking_control_token" cap_json in
+    Capability_vocab.thinking_control_format_of_label_and_token ~format:raw ~token
   in
   let* preserve_thinking_control_format =
     let* raw = member_string_strict "preserve_thinking_control_format" cap_json in

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -233,7 +233,7 @@ let capability_requires_endpoint_declaration (caps : Capabilities.capabilities) 
       | Thinking_object_adaptive
       | Thinking_object_only
       | Chat_template_kwargs
-      | Chat_template_token
+      | Chat_template_token _
       | Ollama_think
       | Reasoning_effort
       | Enable_thinking -> true)
@@ -339,12 +339,6 @@ let capabilities_for_config_model (config : t) =
         ~allow_bare_fallback:true
         ~provider_label
         ~model_id:config.model_id
-;;
-
-let thinking_control_token_for_config_model (config : t) =
-  Capabilities.thinking_control_token_for_provider_model_id
-    ~provider_label:(capability_provider_label config)
-    ~model_id:config.model_id
 ;;
 
 (** Compute auth headers from a provider kind and secret. This is the core
@@ -524,7 +518,7 @@ let zai_glm_clear_thinking_request_field
   | Capabilities.Thinking_object_adaptive
   | Capabilities.Thinking_object_only
   | Capabilities.Chat_template_kwargs
-  | Capabilities.Chat_template_token
+  | Capabilities.Chat_template_token _
   | Capabilities.Ollama_think
   | Capabilities.Reasoning_effort
   | Capabilities.Enable_thinking -> None

--- a/lib/llm_provider/provider_config.mli
+++ b/lib/llm_provider/provider_config.mli
@@ -422,10 +422,6 @@ val capability_provider_label : t -> string
     entry's [provider_name]. *)
 val capabilities_for_config_model : t -> Capabilities.capabilities option
 
-(** Resolve the exact chat-template token for token-based thinking control,
-    using the same provider-qualified lookup order as model capabilities. *)
-val thinking_control_token_for_config_model : t -> string option
-
 (** True when [config] targets Z.AI GLM semantics, either through the native
     [Glm] kind or an OpenAI-compatible Z.AI endpoint with a GLM model id. *)
 val is_zai_glm_config : t -> bool

--- a/lib/llm_provider/reasoning_dialect.ml
+++ b/lib/llm_provider/reasoning_dialect.ml
@@ -155,7 +155,7 @@ let base_of_capabilities (caps : Capabilities.capabilities) =
     ; streaming = Template_parser
     ; output_wire
     }
-  | Chat_template_token ->
+  | Chat_template_token _ ->
     { default with
       toggle_wire = Chat_template_token
     ; preserve_wire
@@ -479,7 +479,7 @@ let sampling_params_ignored_for_format
   | Capabilities.Thinking_object_adaptive
   | Capabilities.Thinking_object_only
   | Capabilities.Chat_template_kwargs
-  | Capabilities.Chat_template_token
+  | Capabilities.Chat_template_token _
   | Capabilities.Ollama_think
   | Capabilities.Reasoning_effort
   | Capabilities.Enable_thinking -> []

--- a/lib/provider.mli
+++ b/lib/provider.mli
@@ -59,7 +59,7 @@ type thinking_control_format = Llm_provider.Capabilities.thinking_control_format
   | Thinking_object_adaptive (** @since 0.207.33 *)
   | Thinking_object_only (** @since 0.196.11 *)
   | Chat_template_kwargs
-  | Chat_template_token
+  | Chat_template_token of string (** @since 0.207.22 — token carried in constructor *)
   | Ollama_think (** @since 0.207.22 *)
   | Reasoning_effort (** @since 0.195.0 *)
   | Enable_thinking (** @since 0.196.11 *)

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -562,7 +562,7 @@ let test_lookup_runpod_rtxa6000_gemma4_coder_catalog () =
       bool
       (label ^ " chat_template_token thinking control")
       true
-      (c.thinking_control_format = Capabilities.Chat_template_token);
+      (c.thinking_control_format = Capabilities.Chat_template_token "<|think|>");
     check bool (label ^ " json response format") true c.supports_response_format_json;
     check bool (label ^ " native streaming") true c.supports_native_streaming;
     check bool (label ^ " top_k") true c.supports_top_k;
@@ -599,7 +599,7 @@ let test_lookup_local_ollama_gemma4_e2b_qat_catalog () =
       bool
       (label ^ " chat_template_token thinking control")
       true
-      (c.thinking_control_format = Capabilities.Chat_template_token);
+      (c.thinking_control_format = Capabilities.Chat_template_token "<|think|>");
     check bool (label ^ " image input") true c.supports_image_input;
     check bool (label ^ " audio input") true c.supports_audio_input;
     check bool (label ^ " multimodal inputs") true c.supports_multimodal_inputs;
@@ -1783,12 +1783,25 @@ let test_manifest_accepts_thinking_control_token () =
   in
   match Capability_manifest.of_json json with
   | Ok [ entry ] ->
-    Alcotest.(check (option string))
-      "exact token"
-      (Some "<|custom_think|>")
-      entry.thinking_control_token
+    Alcotest.(check bool)
+      "token carried by the constructor"
+      true
+      (entry.thinking_control_format
+       = Some (Capabilities.Chat_template_token "<|custom_think|>"))
   | Ok _ -> Alcotest.fail "expected one manifest entry"
   | Error msg -> Alcotest.failf "unexpected parse error: %s" msg
+;;
+
+let test_manifest_rejects_tokenless_chat_template_token () =
+  let json =
+    Yojson.Safe.from_string
+      {|{"schema_version":1,"models":[{"id_prefix":"tokenless-template-model","thinking_control_format":"chat_template_token"}]}|}
+  in
+  match Capability_manifest.of_json json with
+  | Error msg ->
+    check_contains "names the offending id_prefix" msg "tokenless-template-model";
+    check_contains "mentions the required token" msg "thinking_control_token"
+  | Ok _ -> Alcotest.fail "chat_template_token without a token should fail closed"
 ;;
 
 let test_manifest_rejects_blank_thinking_control_token () =
@@ -2669,6 +2682,10 @@ let () =
             "thinking_control_token accepted"
             `Quick
             test_manifest_accepts_thinking_control_token
+        ; test_case
+            "tokenless chat_template_token rejects"
+            `Quick
+            test_manifest_rejects_tokenless_chat_template_token
         ; test_case
             "blank thinking_control_token rejects"
             `Quick

--- a/test/test_provider_catalog_coverage.ml
+++ b/test/test_provider_catalog_coverage.ml
@@ -382,6 +382,18 @@ let test_removed_catalog_aliases_are_rejected () =
     {|{"schema_version":1,"providers":[{"id":"p","capabilities":{"thinking_control_format":"thinking-object"}}]}|}
     "unknown thinking_control_format";
   assert_reject
+    "chat template token without token rejected"
+    {|{"schema_version":1,"providers":[{"id":"p","capabilities":{"thinking_control_format":"chat_template_token"}}]}|}
+    "thinking_control_token";
+  assert_reject
+    "thinking token without chat template format rejected"
+    {|{"schema_version":1,"providers":[{"id":"p","capabilities":{"thinking_control_token":"<|think|>"}}]}|}
+    "thinking_control_token is only valid";
+  assert_reject
+    "padded thinking token rejected"
+    {|{"schema_version":1,"providers":[{"id":"p","capabilities":{"thinking_control_format":"chat_template_token","thinking_control_token":" <|think|> "}}]}|}
+    "leading or trailing whitespace";
+  assert_reject
     "reasoning replay alias rejected"
     {|{"schema_version":1,"providers":[{"id":"p","capabilities":{"reasoning_replay":"preserve-allways"}}]}|}
     "unknown reasoning_replay";

--- a/test/test_provider_catalog_coverage.ml
+++ b/test/test_provider_catalog_coverage.ml
@@ -267,7 +267,7 @@ let test_transport_auth_and_thinking_canonical_matrix () =
           {
             "id": "template-token",
             "kind": "ollama",
-            "capabilities": {"thinking_control_format": "chat_template_token"}
+            "capabilities": {"thinking_control_format": "chat_template_token", "thinking_control_token": "<|think|>"}
           },
           {
             "id": "base-entry",
@@ -336,7 +336,7 @@ let test_transport_auth_and_thinking_canonical_matrix () =
     "template token thinking"
     true
     (template_token.capabilities.thinking_control_format
-     = Capabilities.Chat_template_token);
+     = Capabilities.Chat_template_token "<|think|>");
   let base = require_lookup catalog "base-entry" in
   check bool "capabilities_base supports tools" true base.capabilities.supports_tools;
   check

--- a/test/test_thinking_control_dialects.ml
+++ b/test/test_thinking_control_dialects.ml
@@ -1017,34 +1017,41 @@ thinking_control_token = "<|custom_think|>"
 ;;
 
 let test_ollama_chat_template_token_missing_token_fails_closed () =
-  with_catalog_toml
-    {|
+  (* The token is part of the [Chat_template_token] constructor, so a
+     chat_template_token row with no thinking_control_token now fails closed at
+     catalog LOAD naming the offending id_prefix — not per request. *)
+  let path = Filename.temp_file "oas-tokenless-template" ".toml" in
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () ->
+      close_out_noerr oc;
+      try Sys.remove path with
+      | Sys_error _ -> ())
+    (fun () ->
+       output_string
+         oc
+         {|
 [[models]]
 id_prefix = "tokenless-template-model"
 base = "ollama"
 supports_reasoning = true
 supports_extended_thinking = true
 thinking_control_format = "chat_template_token"
-|}
-    (fun () ->
-       let config =
-         ollama_config ~enable_thinking:true "tokenless-template-model:latest"
-       in
-       let rejection =
-         try
-           ignore (BOL.build_request ~config ~messages:[ user_msg "hi" ] ());
-           None
-         with
-         | Invalid_argument msg -> Some msg
-       in
-       match rejection with
-       | Some msg ->
+|};
+       close_out oc;
+       match MC.load_file path with
+       | Error msg ->
          check
            bool
-           "mentions missing token"
+           "names the offending id_prefix"
            true
-           (string_contains_sub msg "no thinking_control_token")
-       | None -> fail "missing thinking_control_token should reject the request")
+           (string_contains_sub msg "tokenless-template-model");
+         check
+           bool
+           "mentions the required token"
+           true
+           (string_contains_sub msg "thinking_control_token")
+       | Ok _ -> fail "tokenless chat_template_token row should fail closed at load")
 ;;
 
 let test_ollama_gemma4_disabled_uses_native_think_false () =


### PR DESCRIPTION
## 무엇/왜

`Chat_template_token`이 payload 없는 enum 생성자이고 실제 토큰은 별도 optional 필드에 있어서, "format은 선언했는데 token이 없는" 카탈로그 행이 로드를 통과했습니다. 유일한 강제 장치는 `Backend_ollama.build_request` 내부의 per-request `invalid_arg`였고, 2026-07-05~06 프로덕션에서 245회 반복 발생 후 masc에서 `internal_unhandled_exception`으로 세탁됐습니다 (#2482).

이 PR은 illegal state를 타입으로 불가화합니다 (parse, don't validate):

- `Chat_template_token of string` — 토큰이 생성자 안에 있으므로 tokenless 상태가 표현 불가능
- `Model_catalog`/`Capability_manifest`가 파싱 경계에서 두 키(`thinking_control_format` + `thinking_control_token`)를 join — tokenless 행(또는 format 없는 token)은 **offending id_prefix를 명시한 typed Error**로 로드 시점 fail-closed. TOML/JSON 파일 스키마는 하위호환 (키 구조 무변경)
- `Backend_ollama`는 생성자에서 토큰을 추출 — `chat_template_thinking_token_exn` 삭제, per-request raise 경로 소멸
- `token_of_thinking_control_format`은 variant 전체에 exhaustive — 새 format 추가 시 컴파일 타임에 검출

## 변경 파일

lib 13개 (`capability_vocab`, `capabilities(.mli)`, `capability_manifest(.mli)`, `model_catalog(.mli)`, `provider_catalog`, `provider_config(.mli)`, `reasoning_dialect`, `backend_ollama`, `provider.mli`) + test 3개 (`test_capabilities`, `test_provider_catalog_coverage`, `test_thinking_control_dialects`)

## 로컬 검증

- `dune build --root .` clean, `dune fmt` 적용
- 타겟 스위트 green: `test_capabilities`(94), `test_thinking_control_dialects`(42), `test_provider_catalog_coverage`(9), `test_model_catalog_default`(2), `test_capabilities_wiring`(10) + `@lib/llm_provider/runtest` inline 테스트 통과
- 전체 `dune runtest`는 로컬 미완주 — `test_multivendor_live`가 이 머신의 실제 provider key로 라이브 호출을 수행해 중단함. 전체 스위트 게이트는 repo CI에 위임
- 신규 테스트: tokenless 행 거부(id_prefix 명명 확인) — manifest JSON 경로 + TOML 카탈로그 경로 각각, accept-with-token 왕복, build_request 토큰 주입

## 미검증

- masc 쪽 소비자(pin bump 후 boot fail-closed 동작)는 masc 후속 PR에서 검증 — jeong-sik/masc#23443과 연동
- openai-compat 경로의 토큰 주입/거부 결정은 별도 이슈 jeong-sik/masc#27913 (이 PR 범위 밖)

## 관련

Refs jeong-sik/masc#27914. 계열: jeong-sik/masc#27913, jeong-sik/masc#23438, jeong-sik/masc#23444(seed 카탈로그 데이터 수정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
