### PR TITLE
fix(openai-compat): chat-template thinking token injection + empty-completion fail-close (#2483)

### DIFF
--- a/docs/rfc/RFC-OAS-035-openai-compat-thinking-token-and-empty-completion-failclose.md
+++ b/docs/rfc/RFC-OAS-035-openai-compat-thinking-token-and-empty-completion-failclose.md
@@ -1,0 +1,63 @@
+# RFC-OAS-035: OpenAI-compat chat-template thinking token injection + empty-completion fail-close
+
+| | |
+|---|---|
+| Status | Draft |
+| Author | jeong-sik (Claude Opus 4.8 조사·구현) |
+| Created | 2026-07-08 |
+| Target | `agent_sdk` (oas) — `lib/llm_provider/` (`backend_openai_serialize.ml`, `backend_openai_request.ml`, `backend_ollama.ml`, `backend_openai_parse.ml`, `http_client.ml`, `complete_sync.ml`, `error.ml`) |
+| Supplements | RFC-OAS-029 §thinking/reasoning (thinking control), RFC-OAS-033 (typed-vs-string classifier), RFC-OAS-034 (capability는 model×transport) |
+| Boundary | parse 계약 + openai-compat wire serialization 변경. OAS-side only; MASC는 typed outcome을 소비(RFC-OAS-029 §6: OAS는 MASC에 의존하지 않는다). |
+| Triggering issue | oas#2483 (blank 200 → Ok content=[] → empty-turn storm), 2026-07-06 오류폭풍 근본 분석 |
+
+## 0. Summary
+
+`thinking_control_format = "chat_template_token"` + `kind = OpenAI_compat` 조합에서 thinking 토글이 **조용히 무시**됐다. `backend_ollama`는 catalog-declared 토큰을 system prompt에 주입해 invariant를 집행하는데, openai-compat request serializer는 동일 토큰을 **주입하지 않았다**(`request_control_fields`가 `Chat_template_token`에 대해 빈 JSON 필드를 반환 — 토큰은 system prompt에 있어야 하는데 그 주입이 빠짐). 결과: 같은 catalog row가 backend에 따라 예외적으로 동작하거나 silent no-op. 토큰이 없으면 모델이 blank-content 200을 합법 반환할 수 있고, 파서는 그것을 `Ok content=[]`로 수용해 downstream(masc)에서 `Response_shape.Empty` → "Provider returned an empty assistant turn" **empty-turn storm**으로 드러났다. runpod_rtxa6000.gemma4-coder-fable5-q4km에서 관측.
+
+두 축으로 fail-closed 한다:
+
+- **A (원인)**: chat-template 토큰 주입을 두 backend의 **공유 SSOT**로 만들어 openai-compat도 대칭 주입 → 토큰 드롭 근절.
+- **B (안전망)**: all-empty completion(thinking·text·tool 전무)을 파싱 경계에서 **typed fail-closed outcome**으로 표면화 → 어떤 blank 200이든 silent `Ok content=[]` 대신 typed error.
+
+## 1. Fix A — 대칭 토큰 주입 (SSOT)
+
+`with_chat_template_thinking_token` / `thinking_requested` / `chat_template_thinking_active` / `system_prompt_with_thinking_token`를 `Backend_openai_serialize`로 승격(공유). `backend_openai_request.ml` build_request_assoc의 system-message 조립이 `system_prompt_with_thinking_token ~config ~caps`를 사용, `backend_ollama.ml`은 자체 복사본을 제거하고 공유본 호출.
+
+- **caps-gated**: `caps.thinking_control_format = Chat_template_token _` 인 row만 주입. 비-token 모델(GLM/Kimi/DashScope/plain OpenAI)은 wire byte-identical.
+- **think 조건**: 두 backend 동일 (`Some true`/`Some false` 명시, `None`은 `OAS_OLLAMA_THINK_DEFAULT`, 기본 off) — off-by-default 보수적. env 이름의 provider-neutral 일반화는 후속 정리(범위 밖).
+- **reject 안 함**: 이슈가 제안한 boot-reject(option b)는 채택하지 않음. 주입이 가능해지면 reject는 정상 config를 깨뜨리고, `validate_all`이 kind-agnostic이라 Ollama에도 오발동한다. RFC-OAS-023 DISABLE 가드(complete_common의 `validate_thinking_control_request`)는 직교이므로 유지.
+
+## 2. Fix B — typed empty-completion (parse 경계 fail-closed)
+
+`backend_openai_parse`에 typed 반환을 도입:
+
+```
+type empty_completion = { id; model; stop_reason; usage; telemetry }
+type parse_error = Provider_error of string | Empty_completion of empty_completion
+```
+
+파서 wrapper: `content = thinking @ text @ tool` 가 `[]`이면 `Error (Empty_completion …)`, 아니면 `Ok`. 가드는 **`content=[]`만** — blank text + tool_calls는 `content=[ToolUse ..]`(non-empty)라 Ok 유지(회귀 테스트로 고정). 반환 타입이 `(api_response, string) result` → `(api_response, parse_error) result`로 바뀌며 모든 caller가 컴파일 강제로 새 outcome을 처리(N-of-M 우회 방지).
+
+전파: `http_client.provider_failure_kind`에 `Empty_completion of { stop_reason }` 추가. `complete_sync`가 empty를 `ProviderFailure { Empty_completion }`로 매핑 → `retry_classify`의 `ProviderFailure _ -> None` 규칙으로 **non-retryable**(같은 binding 재시도는 또 empty). `error.of_provider_failure`는 이를 `ProviderUnavailable`(binding-health 성격)로 sdk_error에 투영.
+
+**문자열 분류기 아님**: string sentinel(`Error "empty_completion:…"`)은 RFC-OAS-033/RFC-0042가 금하는 substring 분류기라 채택 안 함. typed variant로 닫음.
+
+## 3. 범위에서 제외 (명시적 후속)
+
+### 3.1 Streaming symmetry (deferred)
+
+streaming 경로(`complete_stream_acc.finalize_stream_acc`)도 `Ok content=[]`를 낼 수 있다. 초기 구현에서 `Stream_empty_completion` 대칭 가드를 시도했으나, **기존 회귀 테스트가 empty-clean 스트림을 의도적으로 Ok로 검증**한다("clean stream finalizes Ok: OpenAI-compat/Anthropic/Ollama" — stop_reason만 있고 content 없는 스트림). 즉 streaming 경로엔 non-streaming과 **다른 확립된 불변식**이 있어, 그 불변식의 근거(왜 empty-clean 스트림을 Ok로 두는가)를 먼저 화해하지 않고 뒤엎으면 회귀다. 본 RFC는 streaming을 **범위에서 제외**하고, 이 불변식 재검토를 선행 조건으로 명시한다. (#2483 repro는 non-streaming openai-compat 200 경로다.)
+
+### 3.2 MASC 소비 (B-full, 별도 repo/PR)
+
+MASC는 OAS SHA를 pin하고 typed outcome을 소비한다(RFC-OAS-029 §6, 단방향). empty-completion을 runtime-binding-health 근거로 소비해 crash-count storm 대신 binding 관점 처리를 하는 것은 MASC PR의 몫이며, **본 OAS 변경이 main에 착지한 뒤** pin bump와 함께 진행한다. MASC-only cooldown을 OAS typed fix 없이 추가하면 CLAUDE.md 워크어라운드 거부 기준(cap/cooldown 증상억제)에 해당하므로, 순서는 OAS(A+B) → MASC(pin+consume)로 강제된다.
+
+## 4. 검증
+
+- `backend_openai_parse` 회귀: null-content 200 → `Empty_completion`(EndTurn), blank text + tool_calls → `Ok`(content 비어있지 않음). inline test green.
+- 두 backend 대칭: openai-compat + Chat_template_token + `enable_thinking=Some true` → system turn이 토큰으로 시작; 비-token 모델 → byte-identical.
+- 전 caller 컴파일 통과 + 기존 codec/api/cache 테스트 green (`Error msg` 사이트는 `parse_error_to_string`로 렌더).
+
+## 5. Rollout
+
+A+B는 하나의 OAS PR(#2483 참조)로 착지. release-please가 버전 bump. MASC는 그 main SHA를 `scripts/oas-agent-sdk-pin.sh`로 pin 후 B-full 소비 PR.

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -211,10 +211,17 @@ let create_message
                 Ok
                   (Llm_provider.Pricing.annotate_response_cost resp
                    |> fun r -> patch_latency r lat)
-              | Error msg ->
+              | Error parse_err ->
+                let message =
+                  match parse_err with
+                  | Llm_provider.Backend_openai_parse.Provider_error m -> m
+                  | Llm_provider.Backend_openai_parse.Empty_completion _ ->
+                    "provider returned an empty completion (no thinking, text, or tool \
+                     calls)"
+                in
                 Error
                   (Retry.InvalidRequest
-                     { message = msg; reason = Retry.Unknown_invalid_request }))
+                     { message; reason = Retry.Unknown_invalid_request }))
            | `HttpError (code, body_str) ->
              Error (Retry.classify_error ~status:code ~body:body_str)
            | `TransportError err -> Error err

--- a/lib/api.mli
+++ b/lib/api.mli
@@ -62,9 +62,13 @@ val build_openai_body
   -> unit
   -> string
 
-(** Parse an OpenAI-compatible JSON response.
-    Returns [Ok api_response] on success, [Error msg] on API error. *)
-val parse_openai_response_result : string -> (Types.api_response, string) result
+(** Parse an OpenAI-compatible JSON response. See
+    {!Llm_provider.Backend_openai_parse.parse_openai_response_result} for the
+    [parse_error] contract (oas#2483: an all-empty 200 fails closed as
+    [Empty_completion]). *)
+val parse_openai_response_result
+  :  string
+  -> (Types.api_response, Llm_provider.Backend_openai_parse.parse_error) result
 
 (** {1 Non-streaming request} *)
 

--- a/lib/llm_provider/backend_glm.ml
+++ b/lib/llm_provider/backend_glm.ml
@@ -232,7 +232,14 @@ let parse_response body =
   | None ->
     (try
        match Backend_openai_parse.parse_openai_response_result_json json with
-       | Error msg -> raise (glm_parse_error msg)
+       | Error (Backend_openai_parse.Provider_error msg) -> raise (glm_parse_error msg)
+       | Error (Backend_openai_parse.Empty_completion _) ->
+         (* oas#2483: GLM fails closed on an empty completion too (raises rather
+            than returning an empty turn). *)
+         raise
+           (glm_parse_error
+              "provider returned an empty assistant turn (no thinking, text, or tool \
+               calls)")
        | Ok resp -> extract_reasoning_content_json resp json
      with
      | Yojson.Safe.Util.Type_error (msg, _) -> raise (glm_parse_error msg)

--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -14,13 +14,6 @@ let keep_alive_env_var = "OAS_OLLAMA_KEEP_ALIVE"
 
 (* ── Request building ────────────────────────────────── *)
 
-let with_chat_template_thinking_token ~token = function
-  | Some prompt when not (Api_common.string_is_blank prompt) ->
-    let trimmed = String.trim prompt in
-    if String.starts_with ~prefix:token trimmed then trimmed else token ^ "\n" ^ trimmed
-  | _ -> token
-;;
-
 (** Build Ollama native [/api/chat] request body.
     Key differences from Openai compat:
     - [think] parameter (boolean) instead of [chat_template_kwargs], except
@@ -36,31 +29,23 @@ let build_request
       ?(tools : Yojson.Safe.t list = [])
       ()
   =
-  let think_requested =
-    match config.enable_thinking with
-    | Some true -> true
-    | Some false -> false
-    | None -> Cli_common_env.bool "OAS_OLLAMA_THINK_DEFAULT"
-  in
+  let think_requested = Backend_openai_serialize.thinking_requested config in
   let caps =
     match Provider_config.capabilities_for_config_model config with
     | Some c -> c
     | None -> Capabilities.ollama_capabilities
   in
-  (* The token is carried by [Chat_template_token] in the resolved capabilities
-     (fail-closed at catalog/manifest load), so there is no per-request token
-     lookup left that could be missing. *)
-  let chat_template_token =
-    Capability_vocab.token_of_thinking_control_format caps.thinking_control_format
-  in
+  (* The chat-template token injection is shared with the OpenAI-compat request
+     builder ([Backend_openai_serialize]) so the same catalog row cannot be
+     handled asymmetrically (oas#2483). The token is carried by
+     [Chat_template_token] in the resolved capabilities (fail-closed at
+     catalog/manifest load), so there is no per-request token lookup that could
+     be missing. *)
   let chat_template_token_thinking =
-    think_requested && Option.is_some chat_template_token
+    Backend_openai_serialize.chat_template_thinking_active ~config ~caps
   in
   let system_prompt =
-    match chat_template_token with
-    | Some token when think_requested ->
-      Some (with_chat_template_thinking_token ~token config.system_prompt)
-    | Some _ | None -> config.system_prompt
+    Backend_openai_serialize.system_prompt_with_thinking_token ~config ~caps
   in
   let messages = Tool_message_pairs.close_for_provider_request messages in
   let provider_messages =

--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -401,7 +401,8 @@ let%test "parse_openai_response_result error returns Error" =
       (`Assoc [ "error", `Assoc [ "message", `String "rate limited" ] ])
   in
   match parse_openai_response_result json_str with
-  | Error msg -> msg = "rate limited"
+  | Error (Backend_openai_parse.Provider_error msg) -> msg = "rate limited"
+  | Error (Backend_openai_parse.Empty_completion _) -> false
   | Ok _ -> false
 ;;
 
@@ -898,7 +899,7 @@ let%test "parse_openai_response_result end_turn finish_reason" =
   | Error _ -> false
 ;;
 
-let%test "parse_openai_response_result null content" =
+let%test "parse_openai_response_result null content fails closed (oas#2483)" =
   let json_str =
     Yojson.Safe.to_string
       (`Assoc
@@ -913,8 +914,53 @@ let%test "parse_openai_response_result null content" =
                 ] )
           ])
   in
+  (* A 200 with null content and no tool_calls/reasoning is an all-empty
+     completion: it now fails closed as [Empty_completion] instead of the old
+     [Ok content=[]] that stormed downstream. *)
   match parse_openai_response_result json_str with
-  | Ok resp -> resp.stop_reason = EndTurn
+  | Error (Backend_openai_parse.Empty_completion e) -> e.stop_reason = EndTurn
+  | Error (Backend_openai_parse.Provider_error _) | Ok _ -> false
+;;
+
+let%test "parse_openai_response_result blank content with tool_calls stays Ok (oas#2483)" =
+  let json_str =
+    Yojson.Safe.to_string
+      (`Assoc
+          [ "id", `String "c1"
+          ; "model", `String "m"
+          ; ( "choices"
+            , `List
+                [ `Assoc
+                    [ "finish_reason", `String "tool_calls"
+                    ; ( "message"
+                      , `Assoc
+                          [ "content", `Null
+                          ; ( "tool_calls"
+                            , `List
+                                [ `Assoc
+                                    [ "id", `String "call_1"
+                                    ; "type", `String "function"
+                                    ; ( "function"
+                                      , `Assoc
+                                          [ "name", `String "do_it"
+                                          ; "arguments", `String "{}"
+                                          ] )
+                                    ]
+                                ] )
+                          ] )
+                    ]
+                ] )
+          ])
+  in
+  (* Blank text WITH tool_calls has content=[ToolUse ..] (non-empty) and must
+     NOT trip the empty-completion guard. *)
+  match parse_openai_response_result json_str with
+  | Ok resp ->
+    List.exists
+      (function
+        | Types.ToolUse _ -> true
+        | _ -> false)
+      resp.content
   | Error _ -> false
 ;;
 
@@ -1035,7 +1081,8 @@ let%test "parse_openai_response_result JSON list wrapping" =
 let%test "parse_openai_response_result error without message" =
   let json_str = Yojson.Safe.to_string (`Assoc [ "error", `Assoc [] ]) in
   match parse_openai_response_result json_str with
-  | Error msg -> msg = "Unknown API error"
+  | Error (Backend_openai_parse.Provider_error msg) -> msg = "Unknown API error"
+  | Error (Backend_openai_parse.Empty_completion _) -> false
   | Ok _ -> false
 ;;
 

--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -955,13 +955,8 @@ let%test "parse_openai_response_result blank content with tool_calls stays Ok (o
   (* Blank text WITH tool_calls has content=[ToolUse ..] (non-empty) and must
      NOT trip the empty-completion guard. *)
   match parse_openai_response_result json_str with
-  | Ok resp ->
-    List.exists
-      (function
-        | Types.ToolUse _ -> true
-        | _ -> false)
-      resp.content
-  | Error _ -> false
+  | Ok { content = _ :: _; _ } -> true
+  | Ok { content = []; _ } | Error _ -> false
 ;;
 
 let%test "parse_openai_response_result list content" =

--- a/lib/llm_provider/backend_openai.mli
+++ b/lib/llm_provider/backend_openai.mli
@@ -15,9 +15,12 @@ val strip_orphaned_tool_results : Types.message list -> Types.message list
 val close_tool_message_pairs_for_request : Types.message list -> Types.message list
 val response_format_to_openai_json : Types.response_format -> Yojson.Safe.t option
 
-(** Parse an OpenAI-compatible JSON response.
-    Returns [Ok api_response] on success, [Error msg] on API error. *)
-val parse_openai_response_result : string -> (Types.api_response, string) result
+(** Parse an OpenAI-compatible JSON response. See
+    {!Backend_openai_parse.parse_openai_response_result} for the [parse_error]
+    contract (oas#2483: an all-empty 200 fails closed as [Empty_completion]). *)
+val parse_openai_response_result
+  :  string
+  -> (Types.api_response, Backend_openai_parse.parse_error) result
 
 val usage_of_openai_json : Yojson.Safe.t -> Types.api_usage option
 

--- a/lib/llm_provider/backend_openai_parse.ml
+++ b/lib/llm_provider/backend_openai_parse.ml
@@ -7,6 +7,31 @@
 
 open Types
 
+(* oas#2483: a blank-content 200 must not be accepted as [Ok content=[]] (a
+   silent empty turn that storms downstream). The parser fails closed with a
+   typed [Empty_completion] carrying the response identity so a consumer can
+   attribute the empty turn to a runtime binding instead of retrying blindly. *)
+type empty_completion =
+  { id : string
+  ; model : string
+  ; stop_reason : Types.stop_reason
+  ; usage : Types.api_usage option
+  ; telemetry : Types.inference_telemetry option
+  }
+
+type parse_error =
+  | Provider_error of string
+  | Empty_completion of empty_completion
+
+let parse_error_to_string = function
+  | Provider_error msg -> msg
+  | Empty_completion { stop_reason; model; _ } ->
+    Printf.sprintf
+      "empty completion (no thinking, text, or tool calls; model=%s, stop_reason=%s)"
+      model
+      (Types.stop_reason_to_string stop_reason)
+;;
+
 let ( let* ) = Result.bind
 
 let first_some a b =
@@ -352,7 +377,7 @@ let telemetry_of_openai_json json =
 
 (** Parse an OpenAI-compatible JSON response string into an [api_response].
     Returns [Error msg] when the response body contains an API error. *)
-let parse_openai_response_result_json (raw_json : Yojson.Safe.t) =
+let parse_openai_response_result_json_raw (raw_json : Yojson.Safe.t) =
   let open Yojson.Safe.Util in
   let json =
     match raw_json with
@@ -423,6 +448,18 @@ let parse_openai_response_result_json (raw_json : Yojson.Safe.t) =
       |> Option.value ~default:"Unknown API error"
     in
     Error msg
+;;
+
+(* oas#2483 fail-closed wrapper: an all-empty completion (no thinking, no text,
+   no tool_calls) becomes a typed [Empty_completion] instead of [Ok content=[]]
+   — the silent empty turn that stormed downstream. Blank text WITH tool_calls
+   has content=[ToolUse ..] (content <> []) and stays [Ok]. *)
+let parse_openai_response_result_json raw_json =
+  match parse_openai_response_result_json_raw raw_json with
+  | Error msg -> Error (Provider_error msg)
+  | Ok ({ content = []; id; model; stop_reason; usage; telemetry } : Types.api_response)
+    -> Error (Empty_completion { id; model; stop_reason; usage; telemetry })
+  | Ok resp -> Ok resp
 ;;
 
 (** [parse_openai_response_result] parses [json_str] then delegates to

--- a/lib/llm_provider/backend_openai_parse.mli
+++ b/lib/llm_provider/backend_openai_parse.mli
@@ -8,14 +8,37 @@
 val strip_json_markdown_fences : string -> string
 val usage_of_openai_json : Yojson.Safe.t -> Types.api_usage option
 
+(** Identity of an all-empty completion (oas#2483): a 200 that carried no
+    thinking, text, or tool_calls. Enough for a consumer to attribute the empty
+    turn to a runtime binding. *)
+type empty_completion =
+  { id : string
+  ; model : string
+  ; stop_reason : Types.stop_reason
+  ; usage : Types.api_usage option
+  ; telemetry : Types.inference_telemetry option
+  }
+
+(** Parse failure. [Provider_error] is a provider-reported API error (the JSON
+    [error] body). [Empty_completion] is a fail-closed all-empty 200 that would
+    otherwise have parsed as [Ok content=[]] and stormed downstream. *)
+type parse_error =
+  | Provider_error of string
+  | Empty_completion of empty_completion
+
+(** Human-readable rendering of a {!parse_error} for logs / test failures. *)
+val parse_error_to_string : parse_error -> string
+
 (** Parse an OpenAI-compatible JSON response (from an already-parsed
-    [Yojson.Safe.t]).  Returns [Ok api_response] on success, [Error msg] on
-    API error.  Use when the caller already holds the parsed JSON to avoid
-    re-parsing. *)
+    [Yojson.Safe.t]).  [Ok api_response] on success; [Error (Provider_error _)]
+    on API error; [Error (Empty_completion _)] when the completion has no
+    thinking/text/tool_calls (oas#2483). Blank text WITH tool_calls stays [Ok]
+    (content is non-empty). Use when the caller already holds the parsed JSON to
+    avoid re-parsing. *)
 val parse_openai_response_result_json
   :  Yojson.Safe.t
-  -> (Types.api_response, string) result
+  -> (Types.api_response, parse_error) result
 
-(** Parse an OpenAI-compatible JSON response.
-    Returns [Ok api_response] on success, [Error msg] on API error. *)
-val parse_openai_response_result : string -> (Types.api_response, string) result
+(** Parse an OpenAI-compatible JSON response. See
+    {!parse_openai_response_result_json} for the [parse_error] contract. *)
+val parse_openai_response_result : string -> (Types.api_response, parse_error) result

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -234,7 +234,16 @@ let build_request_assoc
         ~assistant_tool_content_format
         dialect
     in
-    (match config.system_prompt with
+    (* oas#2483: inject the chat-template thinking token into the system turn for
+       [Chat_template_token] rows, mirroring [backend_ollama]. Without this the
+       toggle is a silent no-op on the OpenAI-compat wire ([request_control_fields]
+       emits no JSON field for this format) and the model can return a
+       blank-content 200 that parses as an empty turn. Caps-gated, so non-token
+       models produce byte-identical wire bytes. *)
+    let system_prompt =
+      Backend_openai_serialize.system_prompt_with_thinking_token ~config ~caps
+    in
+    (match system_prompt with
      | Some s when not (Api_common.string_is_blank s) ->
        [ `Assoc
            [ "role", `String "system"; "content", `String (Utf8_sanitize.sanitize s) ]

--- a/lib/llm_provider/backend_openai_serialize.ml
+++ b/lib/llm_provider/backend_openai_serialize.ml
@@ -7,6 +7,119 @@
 
 open Types
 
+(* oas#2483 — chat-template thinking-token injection (SSOT for both backends).
+
+   The chat-template thinking token is pure system-prompt content, not a
+   provider-native request field. Ollama and the OpenAI-compat wire both build
+   their system message from [config.system_prompt], so the token is injected
+   here once. Before this was shared, [backend_ollama] injected the token while
+   the OpenAI-compat request builder silently dropped it: the same catalog row
+   toggled thinking on Ollama but not on the OpenAI-compat wire, so the model
+   could return a blank-content 200 that parsed as an empty turn (the empty-turn
+   storm downstream). Keeping the injection in one place stops the two backends
+   from diverging again. *)
+let with_chat_template_thinking_token ~token = function
+  | Some prompt when not (Api_common.string_is_blank prompt) ->
+    let trimmed = String.trim prompt in
+    if String.starts_with ~prefix:token trimmed then trimmed else token ^ "\n" ^ trimmed
+  | _ -> token
+;;
+
+(* Whether the request asks the model to think. Mirrors the Ollama builder
+   exactly so the two backends decide identically: [Some] is explicit, [None]
+   consults OAS_OLLAMA_THINK_DEFAULT (off by default). *)
+let thinking_requested (config : Provider_config.t) =
+  match config.enable_thinking with
+  | Some true -> true
+  | Some false -> false
+  | None -> Cli_common_env.bool "OAS_OLLAMA_THINK_DEFAULT"
+;;
+
+(* [true] when the resolved capabilities declare a [Chat_template_token] and
+   thinking is requested — i.e. the token must be injected into the system turn.
+   Ollama also uses this to omit the native [think] field for these rows. *)
+let chat_template_thinking_active
+      ~(config : Provider_config.t)
+      ~(caps : Capabilities.capabilities)
+  =
+  thinking_requested config
+  && Option.is_some
+       (Capability_vocab.token_of_thinking_control_format caps.thinking_control_format)
+;;
+
+(* [config.system_prompt] with the chat-template thinking token prepended when
+   [chat_template_thinking_active]; otherwise unchanged. When there is no prior
+   system prompt the token becomes the system turn on its own. *)
+let system_prompt_with_thinking_token
+      ~(config : Provider_config.t)
+      ~(caps : Capabilities.capabilities)
+  =
+  match
+    Capability_vocab.token_of_thinking_control_format caps.thinking_control_format
+  with
+  | Some token when thinking_requested config ->
+    Some (with_chat_template_thinking_token ~token config.system_prompt)
+  | Some _ | None -> config.system_prompt
+;;
+
+let%test
+    "oas#2483: Chat_template_token + enable_thinking injects the token on the \
+     OpenAI-compat side"
+  =
+  let caps =
+    { Capabilities.ollama_capabilities with
+      thinking_control_format = Capabilities.Chat_template_token "<THINK>"
+    }
+  in
+  let config =
+    Provider_config.make
+      ~kind:Provider_config.OpenAI_compat
+      ~model_id:"m"
+      ~base_url:"u"
+      ~system_prompt:"Base prompt."
+      ~enable_thinking:true
+      ~model_capabilities_override:caps
+      ()
+  in
+  match system_prompt_with_thinking_token ~config ~caps with
+  | Some s -> String.starts_with ~prefix:"<THINK>" s
+  | None -> false
+;;
+
+let%test "oas#2483: a non-token model leaves the system prompt byte-identical" =
+  let config =
+    Provider_config.make
+      ~kind:Provider_config.OpenAI_compat
+      ~model_id:"m"
+      ~base_url:"u"
+      ~system_prompt:"Base prompt."
+      ~enable_thinking:true
+      ()
+  in
+  (* Ollama_think is not a token format, so no injection. *)
+  system_prompt_with_thinking_token ~config ~caps:Capabilities.ollama_capabilities
+  = Some "Base prompt."
+;;
+
+let%test "oas#2483: enable_thinking=false does not inject the token" =
+  let caps =
+    { Capabilities.ollama_capabilities with
+      thinking_control_format = Capabilities.Chat_template_token "<THINK>"
+    }
+  in
+  let config =
+    Provider_config.make
+      ~kind:Provider_config.OpenAI_compat
+      ~model_id:"m"
+      ~base_url:"u"
+      ~system_prompt:"Base prompt."
+      ~enable_thinking:false
+      ~model_capabilities_override:caps
+      ()
+  in
+  system_prompt_with_thinking_token ~config ~caps = Some "Base prompt."
+;;
+
 let tool_calls_to_openai_json blocks =
   blocks
   |> List.filter_map (function

--- a/lib/llm_provider/backend_openai_serialize.mli
+++ b/lib/llm_provider/backend_openai_serialize.mli
@@ -5,6 +5,32 @@
     @stability Internal
     @since 0.93.1 *)
 
+(** [system_prompt_with_thinking_token ~config ~caps] returns [config.system_prompt]
+    with the chat-template thinking token prepended when the resolved [caps]
+    declare a [Chat_template_token] and thinking is requested, else the prompt
+    unchanged. SSOT for both the Ollama-native and OpenAI-compat request builders
+    so the same catalog row cannot be handled asymmetrically (oas#2483: the
+    OpenAI-compat wire used to drop the token silently, producing blank-content
+    200s / empty-turn storms). *)
+val system_prompt_with_thinking_token
+  :  config:Provider_config.t
+  -> caps:Capabilities.capabilities
+  -> string option
+
+(** [chat_template_thinking_active ~config ~caps] is [true] when a
+    [Chat_template_token] is declared and thinking is requested — i.e. the token
+    was injected into the system turn. Ollama uses it to omit the native [think]
+    field for these rows. *)
+val chat_template_thinking_active
+  :  config:Provider_config.t
+  -> caps:Capabilities.capabilities
+  -> bool
+
+(** Whether the request asks the model to think ([Some] explicit, [None]
+    consults OAS_OLLAMA_THINK_DEFAULT, off by default). Shared so both backends
+    decide identically. *)
+val thinking_requested : Provider_config.t -> bool
+
 val tool_calls_to_openai_json : Types.content_block list -> Yojson.Safe.t list
 val openai_content_parts_of_blocks : Types.content_block list -> Yojson.Safe.t list
 val openai_messages_of_message : Types.message -> Yojson.Safe.t list

--- a/lib/llm_provider/backend_tool_call_harness.ml
+++ b/lib/llm_provider/backend_tool_call_harness.ml
@@ -431,11 +431,17 @@ let validate_openai_response ~declared_tools json =
   let json_str = Yojson.Safe.to_string json in
   let parsed =
     try Backend_openai_parse.parse_openai_response_result json_str with
-    | exn -> Error (Printexc.to_string exn)
+    | exn -> Error (Backend_openai_parse.Provider_error (Printexc.to_string exn))
   in
   match parsed with
   | Ok resp -> Ok (validate_response ~declared_tools resp)
-  | Error response_parse_error ->
+  | Error parse_error ->
+    let response_parse_error =
+      match parse_error with
+      | Backend_openai_parse.Provider_error msg -> msg
+      | Backend_openai_parse.Empty_completion _ ->
+        "empty completion (no thinking, text, or tool calls)"
+    in
     Error { response_backend = "openai"; response_parse_error }
 ;;
 

--- a/lib/llm_provider/complete_sync.ml
+++ b/lib/llm_provider/complete_sync.ml
@@ -239,7 +239,22 @@ let complete_http
                 | Provider_config.Kimi ->
                   (match Backend_openai_parse.parse_openai_response_result body with
                    | Ok resp -> Ok resp
-                   | Error msg -> Error (Http_client.HttpError { code = 400; body = msg }))
+                   | Error (Backend_openai_parse.Provider_error msg) ->
+                     Error (Http_client.HttpError { code = 400; body = msg })
+                   | Error (Backend_openai_parse.Empty_completion e) ->
+                     (* oas#2483: a blank-content 200 fails closed as a typed
+                        provider failure (non-retryable — retrying the same
+                        binding returns empty) instead of Ok content=[]. *)
+                     Error
+                       (Http_client.ProviderFailure
+                          { kind =
+                              Http_client.Empty_completion
+                                { stop_reason = Types.stop_reason_to_string e.stop_reason
+                                }
+                          ; message =
+                              "provider returned an empty assistant turn (no thinking, \
+                               text, or tool calls)"
+                          }))
                 | Provider_config.Gemini ->
                   Ok (Backend_gemini.parse_response (Yojson.Safe.from_string body))
                 | Provider_config.Glm -> Ok (Backend_glm.parse_response body)

--- a/lib/llm_provider/error.ml
+++ b/lib/llm_provider/error.ml
@@ -263,6 +263,17 @@ let of_provider_failure ?provider kind message =
       | None -> "unknown_parser"
     in
     ParseError { detail = Printf.sprintf "%s: %s" parser message }
+  | Http_client.Empty_completion { stop_reason } ->
+    (* oas#2483: a blank-content 200 is a binding-health condition (the provider
+       produced nothing usable), not a malformed body — surface it as
+       [ProviderUnavailable] so consumers treat it as a candidate/binding fault
+       rather than a parse error, and so it never re-enters the silent
+       empty-turn path. *)
+    ProviderUnavailable
+      { provider
+      ; detail =
+          Printf.sprintf "empty completion (stop_reason=%s): %s" stop_reason message
+      }
   | Http_client.Unknown_provider_failure { reason } ->
     let reason =
       match reason with

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -81,6 +81,11 @@ type provider_failure_kind =
       }
   | Cli_startup_failed of { reason : string }
   | Provider_parse_error of { parser : string option }
+  (* oas#2483: the provider returned a 200 with no deliverable content (no
+     thinking, text, or tool_calls). Distinct from a parse error so consumers
+     can attribute it to a runtime binding rather than a malformed body, and so
+     it is non-retryable by default (retrying the same binding returns empty). *)
+  | Empty_completion of { stop_reason : string }
   | Unknown_provider_failure of { reason : string option }
 
 type http_error =
@@ -141,6 +146,7 @@ let provider_failure_kind_to_string = function
   | Provider_parse_error { parser = Some parser } ->
     Printf.sprintf "provider_parse_error:%s" parser
   | Provider_parse_error { parser = None } -> "provider_parse_error"
+  | Empty_completion { stop_reason } -> Printf.sprintf "empty_completion:%s" stop_reason
   | Unknown_provider_failure { reason = Some reason } ->
     Printf.sprintf "unknown_provider_failure:%s" reason
   | Unknown_provider_failure { reason = None } -> "unknown_provider_failure"

--- a/lib/llm_provider/http_client.mli
+++ b/lib/llm_provider/http_client.mli
@@ -132,6 +132,9 @@ type provider_failure_kind =
       }
   | Cli_startup_failed of { reason : string }
   | Provider_parse_error of { parser : string option }
+  (** oas#2483: a 200 with no deliverable content (no thinking/text/tool_calls).
+      Non-retryable by default — retrying the same binding returns empty. *)
+  | Empty_completion of { stop_reason : string }
   | Unknown_provider_failure of { reason : string option }
 
 (** Transport-level error. *)

--- a/lib/provider_intf.ml
+++ b/lib/provider_intf.ml
@@ -32,8 +32,15 @@ let parse_openai_response_result body_str =
   try
     match Llm_provider.Backend_openai_parse.parse_openai_response_result body_str with
     | Ok _ as ok -> ok
-    | Error message ->
+    | Error (Llm_provider.Backend_openai_parse.Provider_error message) ->
       Error (Retry.InvalidRequest { message; reason = Retry.Unknown_invalid_request })
+    | Error (Llm_provider.Backend_openai_parse.Empty_completion _) ->
+      Error
+        (Retry.InvalidRequest
+           { message =
+               "provider returned an empty completion (no thinking, text, or tool calls)"
+           ; reason = Retry.Unknown_invalid_request
+           })
   with
   | Yojson.Json_error msg ->
     Error

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -1680,7 +1680,9 @@ let test_parse_openai_response_strips_fenced_json () =
   }|}
   in
   match Api.parse_openai_response_result json_str with
-  | Error msg -> Alcotest.fail ("unexpected error: " ^ msg)
+  | Error msg ->
+    Alcotest.fail
+      ("unexpected error: " ^ Llm_provider.Backend_openai_parse.parse_error_to_string msg)
   | Ok resp ->
     (match resp.content with
      | [ Types.Text text ] ->
@@ -1709,7 +1711,9 @@ let test_parse_openai_response_reasoning_content () =
   }|}
   in
   match Api.parse_openai_response_result json_str with
-  | Error msg -> Alcotest.fail ("unexpected error: " ^ msg)
+  | Error msg ->
+    Alcotest.fail
+      ("unexpected error: " ^ Llm_provider.Backend_openai_parse.parse_error_to_string msg)
   | Ok resp ->
     check int "2 content blocks" 2 (List.length resp.content);
     (match resp.content with
@@ -1746,7 +1750,9 @@ let test_parse_openai_response_reasoning_with_tools () =
   }|}
   in
   match Api.parse_openai_response_result json_str with
-  | Error msg -> Alcotest.fail ("unexpected error: " ^ msg)
+  | Error msg ->
+    Alcotest.fail
+      ("unexpected error: " ^ Llm_provider.Backend_openai_parse.parse_error_to_string msg)
   | Ok resp ->
     check int "2 content blocks" 2 (List.length resp.content);
     (match resp.content with
@@ -1778,7 +1784,9 @@ let test_parse_openai_response_blank_reasoning () =
   }|}
   in
   match Api.parse_openai_response_result json_str with
-  | Error msg -> Alcotest.fail ("unexpected error: " ^ msg)
+  | Error msg ->
+    Alcotest.fail
+      ("unexpected error: " ^ Llm_provider.Backend_openai_parse.parse_error_to_string msg)
   | Ok resp ->
     check int "1 content block (blank reasoning filtered)" 1 (List.length resp.content);
     (match resp.content with
@@ -1802,7 +1810,9 @@ let test_parse_openai_response_no_reasoning () =
   }|}
   in
   match Api.parse_openai_response_result json_str with
-  | Error msg -> Alcotest.fail ("unexpected error: " ^ msg)
+  | Error msg ->
+    Alcotest.fail
+      ("unexpected error: " ^ Llm_provider.Backend_openai_parse.parse_error_to_string msg)
   | Ok resp ->
     check int "1 content block" 1 (List.length resp.content);
     (match resp.content with
@@ -1828,7 +1838,9 @@ let test_parse_openai_response_ollama_reasoning () =
   }|}
   in
   match Api.parse_openai_response_result json_str with
-  | Error msg -> Alcotest.fail ("unexpected error: " ^ msg)
+  | Error msg ->
+    Alcotest.fail
+      ("unexpected error: " ^ Llm_provider.Backend_openai_parse.parse_error_to_string msg)
   | Ok resp ->
     check int "2 content blocks (thinking + text)" 2 (List.length resp.content);
     (match resp.content with
@@ -1869,7 +1881,9 @@ let test_parse_openai_response_reasoning_content_preferred () =
   }|}
   in
   match Api.parse_openai_response_result json_str with
-  | Error msg -> Alcotest.fail ("unexpected error: " ^ msg)
+  | Error msg ->
+    Alcotest.fail
+      ("unexpected error: " ^ Llm_provider.Backend_openai_parse.parse_error_to_string msg)
   | Ok resp ->
     (match resp.content with
      | [ Types.Thinking { content = t; _ }; Types.Text text ] ->
@@ -2244,14 +2258,24 @@ let test_openai_api_error_returns_error () =
     {|{"error":{"message":"Invalid API key","type":"invalid_request_error"}}|}
   in
   match Api.parse_openai_response_result error_json with
-  | Error msg -> check string "error message" "Invalid API key" msg
+  | Error msg ->
+    check
+      string
+      "error message"
+      "Invalid API key"
+      (Llm_provider.Backend_openai_parse.parse_error_to_string msg)
   | Ok _ -> Alcotest.fail "expected Error on API error"
 ;;
 
 let test_openai_api_error_unknown_message () =
   let error_json = {|{"error":{}}|} in
   match Api.parse_openai_response_result error_json with
-  | Error msg -> check string "unknown error" "Unknown API error" msg
+  | Error msg ->
+    check
+      string
+      "unknown error"
+      "Unknown API error"
+      (Llm_provider.Backend_openai_parse.parse_error_to_string msg)
   | Ok _ -> Alcotest.fail "expected Error on empty error"
 ;;
 
@@ -2262,7 +2286,12 @@ let test_openai_api_error_unknown_message () =
 let test_openai_error_returns_result () =
   let error_json = {|{"error":{"message":"bad request"}}|} in
   match Api.parse_openai_response_result error_json with
-  | Error msg -> check string "error msg" "bad request" msg
+  | Error msg ->
+    check
+      string
+      "error (Llm_provider.Backend_openai_parse.parse_error_to_string msg)"
+      "bad request"
+      (Llm_provider.Backend_openai_parse.parse_error_to_string msg)
   | Ok _ -> Alcotest.fail "expected Error result"
 ;;
 

--- a/test/test_api_dispatch.ml
+++ b/test/test_api_dispatch.ml
@@ -147,7 +147,7 @@ let test_openai_parse_response () =
   let resp =
     match Api.parse_openai_response_result mock_body with
     | Ok r -> r
-    | Error msg -> failwith msg
+    | Error msg -> failwith (Llm_provider.Backend_openai_parse.parse_error_to_string msg)
   in
   check string "model" "gpt" resp.model;
   (match resp.stop_reason with

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -149,7 +149,8 @@ let response_json ?(content = `String "ok") ?(finish_reason = "stop") ?message_f
 let parse_ok json =
   match Parse.parse_openai_response_result (Yojson.Safe.to_string json) with
   | Ok response -> response
-  | Error msg -> Alcotest.fail ("unexpected parse error: " ^ msg)
+  | Error msg ->
+    Alcotest.fail ("unexpected parse error: " ^ Parse.parse_error_to_string msg)
 ;;
 
 let test_parse_reasoning_content_and_tool_calls_coexist () =
@@ -359,7 +360,11 @@ let test_parse_reasoning_details_rejects_malformed () =
         ()
     in
     match Parse.parse_openai_response_result (Yojson.Safe.to_string json) with
-    | Error msg -> check_bool label true (String.starts_with ~prefix:expected_prefix msg)
+    | Error msg ->
+      check_bool
+        label
+        true
+        (String.starts_with ~prefix:expected_prefix (Parse.parse_error_to_string msg))
     | Ok _ -> Alcotest.fail (label ^ " should fail closed")
   in
   expect_error
@@ -402,7 +407,8 @@ let test_reasoning_only_stays_thinking_and_never_reinjected_on_replay () =
   let response =
     match Parse.parse_openai_response_result (Yojson.Safe.to_string json) with
     | Ok r -> r
-    | Error msg -> Alcotest.fail ("unexpected parse error: " ^ msg)
+    | Error msg ->
+      Alcotest.fail ("unexpected parse error: " ^ Parse.parse_error_to_string msg)
   in
   let has_text =
     List.exists
@@ -1437,7 +1443,9 @@ let test_parse_tool_calls_rejects_malformed_and_does_not_drop () =
     check_bool
       "malformed tool call is not silently dropped"
       true
-      (String.starts_with ~prefix:"malformed_tool_call:index:1:" msg)
+      (String.starts_with
+         ~prefix:"malformed_tool_call:index:1:"
+         (Parse.parse_error_to_string msg))
   | Ok _ -> Alcotest.fail "expected malformed tool_calls to fail closed"
 ;;
 
@@ -1464,7 +1472,9 @@ let test_parse_tool_calls_rejects_malformed_arguments () =
     check_bool
       "malformed arguments are not repaired"
       true
-      (String.starts_with ~prefix:"malformed_tool_call_arguments:index:0:" msg)
+      (String.starts_with
+         ~prefix:"malformed_tool_call_arguments:index:0:"
+         (Parse.parse_error_to_string msg))
   | Ok _ -> Alcotest.fail "expected malformed tool arguments to fail closed"
 ;;
 
@@ -1490,14 +1500,15 @@ let test_parse_tool_calls_rejects_non_object_arguments () =
     check_string
       "non-object arguments rejected"
       "malformed_tool_call_arguments:index:0:not_object"
-      msg
+      (Parse.parse_error_to_string msg)
   | Ok _ -> Alcotest.fail "expected scalar tool arguments to fail closed"
 ;;
 
 let test_parse_error_default_message () =
   let json = `Assoc [ "error", `Assoc [] ] |> Yojson.Safe.to_string in
   match Parse.parse_openai_response_result json with
-  | Error msg -> check_string "default error" "Unknown API error" msg
+  | Error msg ->
+    check_string "default error" "Unknown API error" (Parse.parse_error_to_string msg)
   | Ok _ -> Alcotest.fail "expected API error"
 ;;
 

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -153,6 +153,18 @@ let parse_ok json =
     Alcotest.fail ("unexpected parse error: " ^ Parse.parse_error_to_string msg)
 ;;
 
+(* Symmetric to [parse_ok]: assert the fail-closed all-empty 200 path
+   (oas#2483). Returns the [Empty_completion] payload, which preserves
+   [stop_reason]/[usage]/[telemetry] for downstream inspection. *)
+let parse_empty json : Parse.empty_completion =
+  match Parse.parse_openai_response_result (Yojson.Safe.to_string json) with
+  | Error (Parse.Empty_completion e) -> e
+  | Error msg ->
+    Alcotest.fail
+      ("expected Empty_completion, got error: " ^ Parse.parse_error_to_string msg)
+  | Ok _ -> Alcotest.fail "expected Empty_completion, got Ok"
+;;
+
 let test_parse_reasoning_content_and_tool_calls_coexist () =
   (* 2025-2026 providers (DeepSeek, Kimi, Qwen, MiMo) return reasoning_content
      alongside tool_calls. Both must survive parsing into [content]: the
@@ -1519,8 +1531,13 @@ let test_parse_edge_shapes_for_text_and_telemetry () =
   (match invalid_fence.content with
    | [ Text "```json\nnot-json\n```" ] -> ()
    | _ -> Alcotest.fail "invalid JSON fence should keep original text");
+  (* Every content block is malformed (dropped) and whitespace-only
+     reasoning_content yields no Thinking block, so the completion is
+     all-empty and now fails closed as [Empty_completion] (oas#2483) instead
+     of the old [Ok content=[]]. The fail-closed payload still carries the
+     stop_reason. *)
   let no_text =
-    parse_ok
+    parse_empty
       (response_json
          ~content:
            (`List
@@ -1528,9 +1545,13 @@ let test_parse_edge_shapes_for_text_and_telemetry () =
          ~message_fields:[ "reasoning_content", `String "  " ]
          ())
   in
-  check_int "invalid content blocks produce no content" 0 (List.length no_text.content);
+  (match no_text.stop_reason with
+   | EndTurn -> ()
+   | _ -> Alcotest.fail "empty completion should preserve the stop finish_reason as EndTurn");
+  (* Malformed object content also parses to no blocks, but the fail-closed
+     [Empty_completion] payload still surfaces stop_reason and telemetry. *)
   let telemetry =
-    parse_ok
+    parse_empty
       (`Assoc
           [ "id", `String "chatcmpl-telemetry"
           ; "model", `String "provider-d-test"

--- a/test/test_cache.ml
+++ b/test/test_cache.ml
@@ -156,7 +156,7 @@ let test_openai_usage_with_cached_tokens () =
   let resp =
     match Agent_sdk.Api.parse_openai_response_result json_str with
     | Ok r -> r
-    | Error msg -> failwith msg
+    | Error msg -> failwith (Llm_provider.Backend_openai_parse.parse_error_to_string msg)
   in
   match resp.usage with
   | Some u ->
@@ -186,7 +186,7 @@ let test_openai_usage_without_cached_tokens () =
   let resp =
     match Agent_sdk.Api.parse_openai_response_result json_str with
     | Ok r -> r
-    | Error msg -> failwith msg
+    | Error msg -> failwith (Llm_provider.Backend_openai_parse.parse_error_to_string msg)
   in
   match resp.usage with
   | Some u ->

--- a/test/test_provider_agnostic_reasoning_replay.ml
+++ b/test/test_provider_agnostic_reasoning_replay.ml
@@ -330,7 +330,10 @@ let test_parse_then_serialize_round_trip_any_provider () =
         (Yojson.Safe.to_string reasoning_only_response_json)
     with
     | Ok r -> r
-    | Error msg -> Alcotest.failf "unexpected parse error: %s" msg
+    | Error msg ->
+      Alcotest.failf
+        "unexpected parse error: %s"
+        (Backend_openai_parse.parse_error_to_string msg)
   in
   (* Parse must keep reasoning typed as Thinking, never a Text answer block. *)
   let has_text =


### PR DESCRIPTION
## 문제 (#2483)

`thinking_control_format = "chat_template_token"` + `kind = OpenAI_compat` 조합에서 thinking 토글이 **조용히 무시**됐다. `backend_ollama`는 catalog-declared 토큰을 system prompt에 주입해 invariant를 집행하는데, OpenAI-compat serializer는 동일 토큰을 **주입하지 않았다** (`request_control_fields`가 이 format에 빈 JSON 필드를 반환, 그리고 system-prompt 주입도 없음). 토글이 no-op이라 모델이 blank-content 200을 반환할 수 있고, 파서가 그것을 `Ok content=[]`로 수용 → downstream **empty-turn storm** ("Provider returned an empty assistant turn"). runpod_rtxa6000.gemma4-coder-fable5-q4km에서 관측, 2026-07-06 오류폭풍 근원.

## 수정

### A (원인) — 대칭 토큰 주입 (SSOT)
- `with_chat_template_thinking_token` / `thinking_requested` / `chat_template_thinking_active` / `system_prompt_with_thinking_token`를 `Backend_openai_serialize`로 승격(공유). `backend_openai_request.build_request_assoc`가 system 메시지에 이를 사용, `backend_ollama`는 자체 복사본 제거 후 공유본 호출.
- **caps-gated**: `Chat_template_token` row만 주입, 비-token 모델은 wire byte-identical. 두 backend가 `think`를 동일하게 결정(`Some` 명시, `None`→`OAS_OLLAMA_THINK_DEFAULT`, off 기본).
- **주입만**(boot-reject 안 함): 주입이 동작하면 reject는 정상 config를 깨고 `validate_all`이 kind-agnostic이라 Ollama에도 오발동.

### B (안전망) — typed empty-completion (parse fail-closed)
- `backend_openai_parse`가 `(api_response, parse_error) result` 반환, `parse_error = Provider_error of string | Empty_completion of {...}`. all-empty completion(thinking·text·tool 전무)은 `Ok content=[]` 대신 `Empty_completion`으로 fail-closed. blank text + tool_calls는 `content=[ToolUse ..]`라 `Ok` 유지(회귀테스트).
- `http_client.provider_failure_kind`의 `Empty_completion`으로 전파. `complete_sync`가 `ProviderFailure`로 매핑 → `retry_classify`의 ProviderFailure wildcard로 **non-retryable**(같은 binding 재시도는 또 empty). `error.of_provider_failure`는 `ProviderUnavailable`(binding-health)로 sdk_error 투영.
- parse 반환 타입 변경이 **모든 caller 컴파일 강제** → 어떤 사이트도 `Ok content=[]`를 계속 흘리지 못함(N-of-M 우회 방지).

## 범위 제외 (RFC-OAS-035에 명시)

- **Streaming 대칭**: 기존 "clean stream finalizes Ok" 회귀 가드가 empty-clean 스트림(stop_reason만, content 없음)을 Ok로 검증 — streaming 경로엔 다른 확립된 불변식이 있어, 그 근거 화해를 선행 조건으로 둔다. (#2483 repro는 non-streaming 200 경로.)
- **MASC 소비 (B-full)**: MASC가 OAS SHA를 pin하고 typed outcome을 binding-health 근거로 소비하는 것은 별도 repo/PR. 순서 강제: OAS(A+B) main 착지 → MASC pin+consume (RFC-OAS-029 §6 단방향; MASC-only cooldown은 OAS typed fix 없이는 워크어라운드).

## 테스트

- `backend_openai_parse`: null-content 200 → `Empty_completion`(EndTurn); blank text + tool_calls → `Ok`.
- `backend_openai_serialize`: openai-compat + Chat_template_token + `enable_thinking=Some true` → 토큰 주입; 비-token 모델 → byte-identical; `enable_thinking=false` → no-op.
- `parse_error` ripple: codec/api/cache 테스트가 `parse_error_to_string`로 렌더, false-positive(`Responses.parse_response_result`) 정정.

## 검증

- `dune build --root . lib/ test/` green.
- `dune runtest --root . lib/llm_provider/` green (parse + serialize inline).

RFC: `docs/rfc/RFC-OAS-035-openai-compat-thinking-token-and-empty-completion-failclose.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
