### PR TITLE
fix(streaming): empty-completion fail-close at driver boundary (oas#2483 streaming symmetry)

### DIFF
--- a/docs/rfc/RFC-OAS-035-openai-compat-thinking-token-and-empty-completion-failclose.md
+++ b/docs/rfc/RFC-OAS-035-openai-compat-thinking-token-and-empty-completion-failclose.md
@@ -44,13 +44,21 @@ type parse_error = Provider_error of string | Empty_completion of empty_completi
 
 ## 3. 범위에서 제외 (명시적 후속)
 
-### 3.1 Streaming symmetry (deferred)
+### 3.1 Streaming symmetry (구현됨 — oas#2483 streaming follow-up PR)
 
-streaming 경로(`complete_stream_acc.finalize_stream_acc`)도 `Ok content=[]`를 낼 수 있다. 초기 구현에서 `Stream_empty_completion` 대칭 가드를 시도했으나, **기존 회귀 테스트가 empty-clean 스트림을 의도적으로 Ok로 검증**한다("clean stream finalizes Ok: OpenAI-compat/Anthropic/Ollama" — stop_reason만 있고 content 없는 스트림). 즉 streaming 경로엔 non-streaming과 **다른 확립된 불변식**이 있어, 그 불변식의 근거(왜 empty-clean 스트림을 Ok로 두는가)를 먼저 화해하지 않고 뒤엎으면 회귀다. 본 RFC는 streaming을 **범위에서 제외**하고, 이 불변식 재검토를 선행 조건으로 명시한다. (#2483 repro는 non-streaming openai-compat 200 경로다.)
+streaming 경로도 `Ok content=[]`를 낼 수 있어 non-streaming과 대칭으로 fail-close가 필요했다. 초기 시도는 `complete_stream_acc.finalize_stream_acc`(구조 조립기)에 직접 가드를 넣는 것이었는데, 이때 **21개 단위 테스트가 깨졌다** — 이들은 empty acc를 finalize해 usage/stop_reason plumbing만 검증하는 최소 fixture다. 이 실패가 **경계 오배치의 신호**였다.
+
+**수정된 통찰**: deferral 당시 가설("empty-clean → Ok가 확립된 불변식이라 충돌")은 부정확했다. 그 불변식은 사실 **`finalize_stream_acc`가 순수 구조 조립기**라는 것이다 — 잘 닫힌 스트림을 `Ok content=[]`로 조립하는 건 구조적으로 정당하다(truncated 스트림만 이미 `stream_terminated_without_stop_reason`로 거부). "empty completion은 실행 불가"는 **의미 정책**이고, 이는 완성을 어시스턴트 턴으로 반환하는 **소비 경계**(`lib/streaming.ml` `map_stream_finalize_result`)에 속한다. non-streaming의 `parse_openai_response_result`(정책 wrapper) ↔ raw parser 분리와 정확히 대칭.
+
+**구현**: `map_stream_finalize_result`의 `Ok (Ok resp) when resp.content = []` arm에서 `Stream_parse_failed{reason="empty_completion:<stop_reason>"}`로 fail-close(기존 truncated 거부와 동일 class·경로). 두 production 스트리밍 경로(Anthropic/OpenAI)가 이 어댑터를 공유하므로 단일 편집으로 커버되고, `finalize_stream_acc`는 순수하게 남아 **21개 단위 테스트가 회귀 0**. Custom provider는 sync fallback이라 §2의 non-streaming Fix B로 이미 커버. inline test(`map_stream_finalize_result fails closed on empty completion`) green.
+
+**string 분류기 아님**: reason 문자열은 진단용이고 소비자(`http_error_of_stream_error`)는 이를 opaque하게 http_error로 매핑한다(제어분기 없음). truncated 케이스가 이미 같은 `Stream_parse_failed{reason=…}` idiom을 쓰는 선례.
 
 ### 3.2 MASC 소비 (B-full, 별도 repo/PR)
 
 MASC는 OAS SHA를 pin하고 typed outcome을 소비한다(RFC-OAS-029 §6, 단방향). empty-completion을 runtime-binding-health 근거로 소비해 crash-count storm 대신 binding 관점 처리를 하는 것은 MASC PR의 몫이며, **본 OAS 변경이 main에 착지한 뒤** pin bump와 함께 진행한다. MASC-only cooldown을 OAS typed fix 없이 추가하면 CLAUDE.md 워크어라운드 거부 기준(cap/cooldown 증상억제)에 해당하므로, 순서는 OAS(A+B) → MASC(pin+consume)로 강제된다.
+
+**상태 업데이트 (실측)**: A+B는 oas#2488(aad819bb1)로 main 착지, MASC는 pin bump #23682으로 이를 흡수했다. 다만 MASC는 OAS 완성을 `Agent.run`+**streaming**으로 소비하고 OAS 에러 타입을 exhaustive match 없이 **opaque하게**(`provider_failure_to_string`, `sdk_error` 라우팅) 처리하므로, 원래 구상한 "typed Empty_completion을 코드로 소비"(B-full)는 **대부분 불필요**했다 — pin bump가 컴파일을 깨지 않았고, §2의 Fix B는 sync 전용이라 MASC streaming hot path엔 §3.1의 streaming fail-close가 실제 보호막이다. 즉 MASC 측 실효 = pin bump(Fix A 원인수정) + §3.1(streaming empty→provider failure→기존 failover). 별도 MASC 코드 소비는 관측 필요가 확인될 때만 추가한다.
 
 ## 4. 검증
 

--- a/lib/streaming.ml
+++ b/lib/streaming.ml
@@ -45,9 +45,57 @@ let map_http_error = Http_error_sdk.of_http_error
 
 let map_stream_finalize_result = function
   | Error e -> Error (map_http_error e)
+  | Ok (Ok resp) when resp.content = [] ->
+    (* oas#2483 streaming symmetry: a stream that finalized cleanly but with no
+       content block is the streaming analog of the blank-200 empty completion
+       the non-streaming parser rejects as [Empty_completion]. Fail closed at
+       this consumption boundary so the driver never returns an empty assistant
+       turn as success (the empty-turn storm root). [finalize_stream_acc] stays
+       a pure structural assembler -- its unit tests still observe
+       [Ok content=[]]; only the driver applies the completion policy, mirroring
+       the sync [parse_openai_response_result] wrapper over its raw parser. A
+       truncated stream is already rejected earlier in [finalize_stream_acc]
+       ([stream_terminated_without_stop_reason]); this covers the clean-close
+       empty case. *)
+    Error
+      (map_http_error
+         (Llm_provider.Complete_stream.http_error_of_stream_error
+            (Stream_parse_failed
+               { reason =
+                   Printf.sprintf
+                     "empty_completion:%s"
+                     (stop_reason_to_string resp.stop_reason)
+               ; raw = ""
+               })))
   | Ok (Ok resp) -> Ok (Llm_provider.Pricing.annotate_response_cost resp)
   | Ok (Error serr) ->
     Error (map_http_error (Llm_provider.Complete_stream.http_error_of_stream_error serr))
+;;
+
+let%test "map_stream_finalize_result fails closed on empty completion (oas#2483)" =
+  let empty_resp : api_response =
+    { id = "m"
+    ; model = "test"
+    ; stop_reason = EndTurn
+    ; content = []
+    ; usage = None
+    ; telemetry = None
+    }
+  in
+  let ok_resp = { empty_resp with content = [ Text "hi" ] } in
+  let empty_fails =
+    match map_stream_finalize_result (Ok (Ok empty_resp)) with
+    | Error _ -> true
+    | Ok _ -> false
+  in
+  (* A content-bearing completion still finalizes Ok: the guard fires only on
+     the all-empty clean close, not on every stream. *)
+  let nonempty_ok =
+    match map_stream_finalize_result (Ok (Ok ok_resp)) with
+    | Ok _ -> true
+    | Error _ -> false
+  in
+  empty_fails && nonempty_ok
 ;;
 
 (** Streaming variant of create_message.


### PR DESCRIPTION
## 배경

oas#2488(#2483)이 **non-streaming** openai-compat 경로의 blank-200 empty completion을 typed `Empty_completion`로 fail-close했습니다. 하지만 **streaming 경로**도 잘 닫힌 스트림이 content 블록 0개로 finalize되면 `Ok content=[]`를 반환합니다 — blank-200의 streaming 대칭입니다. 이 empty 어시스턴트 턴이 driver에 성공으로 반환되면 하류(masc)가 empty turn으로 취급해 **empty-turn storm**의 근원이 됩니다.

RFC-OAS-035 §3.1에서 deferred였던 항목의 근본 구현입니다.

## 핵심: 경계(structural vs policy) 배치

처음엔 `Complete_stream_acc.finalize_stream_acc`에 직접 가드를 넣었더니 **단위 테스트 21개가 깨졌습니다** — 이들은 empty acc를 finalize해 usage/stop_reason plumbing만 검증하는 최소 fixture입니다. 이 실패가 **경계 오배치의 신호**였습니다.

- `finalize_stream_acc`는 **순수 구조 조립기**입니다. 잘 닫힌 스트림을 `Ok content=[]`로 조립하는 건 구조적으로 정당합니다 (truncated 스트림만 이미 `stream_terminated_without_stop_reason`로 거부).
- "empty completion은 실행 불가"는 **의미 정책**이고, 완성을 어시스턴트 턴으로 반환하는 **소비 경계**에 속합니다.
- 두 production 스트리밍 경로(Anthropic/OpenAI)가 공유하는 `map_stream_finalize_result`에 가드를 넣어 **단일 편집으로 커버**하고, `finalize_stream_acc`는 순수하게 남아 **단위 테스트 회귀 0**.
- non-streaming의 `parse_openai_response_result`(정책 wrapper) ↔ raw parser 분리와 정확히 대칭입니다.

## 변경

- `lib/streaming.ml` `map_stream_finalize_result`: `Ok (Ok resp) when resp.content = []` → `Stream_parse_failed { reason = "empty_completion:<stop_reason>" }`로 fail-close (기존 truncated 거부와 **동일 class·매핑 경로**). inline test 추가(empty → Error, content-bearing → Ok).
- `docs/rfc/RFC-OAS-035` §3.1: deferred → 구현됨 + 수정된 boundary 근거. §3.2: MASC 측 실측 상태(pin bump #23682 착지, masc는 opaque 소비라 streaming fail-close가 실제 보호막).

## 워크어라운드 아님

- **string 분류기 아님**: reason 문자열은 진단용이고 소비자(`http_error_of_stream_error`)가 opaque하게 http_error로 매핑(제어분기 없음). truncated 케이스가 이미 같은 `Stream_parse_failed{reason=…}` idiom을 씀.
- **새 state 발명 아님**: 기존 `Stream_parse_failed` variant 재사용, 새 variant/플래그 없음.
- fail-**close** 근본 수정 (cap/cooldown/telemetry-as-fix 아님).

## 검증 (로컬)

- 스트리밍 test exe 6종(`test_stream_accumulator`, `test_streaming_openai`, `test_streaming_coverage`, `test_streaming_cov`, `test_streaming`, `test_backend_gemini`) 전부 green — **회귀 0**.
- `dune runtest lib` green — 신규 inline test(`map_stream_finalize_result fails closed on empty completion`) 포함.
- `ocamlformat --check` OK.
- full build/`@all`은 CI에서 검증.

RFC: RFC-OAS-035 §3.1
