### PR TITLE
fix(provider): isolate Ollama thinking defaults from OpenAI-compatible requests

### DIFF
--- a/docs/rfc/RFC-OAS-035-openai-compat-thinking-token-and-empty-completion-failclose.md
+++ b/docs/rfc/RFC-OAS-035-openai-compat-thinking-token-and-empty-completion-failclose.md
@@ -24,7 +24,7 @@
 `with_chat_template_thinking_token` / `thinking_requested` / `chat_template_thinking_active` / `system_prompt_with_thinking_token`를 `Backend_openai_serialize`로 승격(공유). `backend_openai_request.ml` build_request_assoc의 system-message 조립이 `system_prompt_with_thinking_token ~config ~caps`를 사용, `backend_ollama.ml`은 자체 복사본을 제거하고 공유본 호출.
 
 - **caps-gated**: `caps.thinking_control_format = Chat_template_token _` 인 row만 주입. 비-token 모델(GLM/Kimi/DashScope/plain OpenAI)은 wire byte-identical.
-- **think 조건**: 두 backend 동일 (`Some true`/`Some false` 명시, `None`은 `OAS_OLLAMA_THINK_DEFAULT`, 기본 off) — off-by-default 보수적. env 이름의 provider-neutral 일반화는 후속 정리(범위 밖).
+- **think 조건**: `Some true`/`Some false`는 두 backend에서 동일하게 명시적이다. `None`의 기본값은 backend가 소유한다. Ollama만 `OAS_OLLAMA_THINK_DEFAULT`를 읽고, OpenAI-compatible은 다른 provider 이름의 env에 영향받지 않도록 기본 off다.
 - **reject 안 함**: 이슈가 제안한 boot-reject(option b)는 채택하지 않음. 주입이 가능해지면 reject는 정상 config를 깨뜨리고, `validate_all`이 kind-agnostic이라 Ollama에도 오발동한다. RFC-OAS-023 DISABLE 가드(complete_common의 `validate_thinking_control_request`)는 직교이므로 유지.
 
 ## 2. Fix B — typed empty-completion (parse 경계 fail-closed)

--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -29,7 +29,11 @@ let build_request
       ?(tools : Yojson.Safe.t list = [])
       ()
   =
-  let think_requested = Backend_openai_serialize.thinking_requested config in
+  let think_requested =
+    Backend_openai_serialize.thinking_requested
+      ~default:(Cli_common_env.bool "OAS_OLLAMA_THINK_DEFAULT")
+      config
+  in
   let caps =
     match Provider_config.capabilities_for_config_model config with
     | Some c -> c
@@ -42,10 +46,15 @@ let build_request
      catalog/manifest load), so there is no per-request token lookup that could
      be missing. *)
   let chat_template_token_thinking =
-    Backend_openai_serialize.chat_template_thinking_active ~config ~caps
+    Backend_openai_serialize.chat_template_thinking_active
+      ~thinking_requested:think_requested
+      ~caps
   in
   let system_prompt =
-    Backend_openai_serialize.system_prompt_with_thinking_token ~config ~caps
+    Backend_openai_serialize.system_prompt_with_thinking_token
+      ~thinking_requested:think_requested
+      ~config
+      ~caps
   in
   let messages = Tool_message_pairs.close_for_provider_request messages in
   let provider_messages =

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -240,8 +240,14 @@ let build_request_assoc
        emits no JSON field for this format) and the model can return a
        blank-content 200 that parses as an empty turn. Caps-gated, so non-token
        models produce byte-identical wire bytes. *)
+    let thinking_requested =
+      Backend_openai_serialize.thinking_requested ~default:false config
+    in
     let system_prompt =
-      Backend_openai_serialize.system_prompt_with_thinking_token ~config ~caps
+      Backend_openai_serialize.system_prompt_with_thinking_token
+        ~thinking_requested
+        ~config
+        ~caps
     in
     (match system_prompt with
      | Some s when not (Api_common.string_is_blank s) ->

--- a/lib/llm_provider/backend_openai_serialize.ml
+++ b/lib/llm_provider/backend_openai_serialize.ml
@@ -25,24 +25,42 @@ let with_chat_template_thinking_token ~token = function
   | _ -> token
 ;;
 
-(* Whether the request asks the model to think. Mirrors the Ollama builder
-   exactly so the two backends decide identically: [Some] is explicit, [None]
-   consults OAS_OLLAMA_THINK_DEFAULT (off by default). *)
-let thinking_requested (config : Provider_config.t) =
+(* Resolve explicit request intent without reading backend-specific environment
+   state.  Each backend supplies its own default at the call site. *)
+let thinking_requested ~default (config : Provider_config.t) =
   match config.enable_thinking with
   | Some true -> true
   | Some false -> false
-  | None -> Cli_common_env.bool "OAS_OLLAMA_THINK_DEFAULT"
+  | None -> default
+;;
+
+let%test "explicit thinking flag wins the backend default" =
+  let disabled =
+    Provider_config.make
+      ~kind:Provider_config.Ollama
+      ~model_id:"m"
+      ~base_url:"u"
+      ~enable_thinking:false
+      ()
+  in
+  let enabled = { disabled with enable_thinking = Some true } in
+  (not (thinking_requested ~default:true disabled))
+  && thinking_requested ~default:false enabled
+;;
+
+let%test "absent thinking flag uses only the caller default" =
+  let config =
+    Provider_config.make ~kind:Provider_config.Ollama ~model_id:"m" ~base_url:"u" ()
+  in
+  thinking_requested ~default:true config
+  && not (thinking_requested ~default:false config)
 ;;
 
 (* [true] when the resolved capabilities declare a [Chat_template_token] and
    thinking is requested — i.e. the token must be injected into the system turn.
    Ollama also uses this to omit the native [think] field for these rows. *)
-let chat_template_thinking_active
-      ~(config : Provider_config.t)
-      ~(caps : Capabilities.capabilities)
-  =
-  thinking_requested config
+let chat_template_thinking_active ~thinking_requested ~(caps : Capabilities.capabilities) =
+  thinking_requested
   && Option.is_some
        (Capability_vocab.token_of_thinking_control_format caps.thinking_control_format)
 ;;
@@ -51,13 +69,14 @@ let chat_template_thinking_active
    [chat_template_thinking_active]; otherwise unchanged. When there is no prior
    system prompt the token becomes the system turn on its own. *)
 let system_prompt_with_thinking_token
+      ~thinking_requested
       ~(config : Provider_config.t)
       ~(caps : Capabilities.capabilities)
   =
   match
     Capability_vocab.token_of_thinking_control_format caps.thinking_control_format
   with
-  | Some token when thinking_requested config ->
+  | Some token when thinking_requested ->
     Some (with_chat_template_thinking_token ~token config.system_prompt)
   | Some _ | None -> config.system_prompt
 ;;
@@ -81,7 +100,7 @@ let%test
       ~model_capabilities_override:caps
       ()
   in
-  match system_prompt_with_thinking_token ~config ~caps with
+  match system_prompt_with_thinking_token ~thinking_requested:true ~config ~caps with
   | Some s -> String.starts_with ~prefix:"<THINK>" s
   | None -> false
 ;;
@@ -97,7 +116,10 @@ let%test "oas#2483: a non-token model leaves the system prompt byte-identical" =
       ()
   in
   (* Ollama_think is not a token format, so no injection. *)
-  system_prompt_with_thinking_token ~config ~caps:Capabilities.ollama_capabilities
+  system_prompt_with_thinking_token
+    ~thinking_requested:true
+    ~config
+    ~caps:Capabilities.ollama_capabilities
   = Some "Base prompt."
 ;;
 
@@ -117,7 +139,28 @@ let%test "oas#2483: enable_thinking=false does not inject the token" =
       ~model_capabilities_override:caps
       ()
   in
-  system_prompt_with_thinking_token ~config ~caps = Some "Base prompt."
+  system_prompt_with_thinking_token ~thinking_requested:false ~config ~caps
+  = Some "Base prompt."
+;;
+
+let%test "oas#2488 follow-up: OpenAI-compatible default stays provider-local" =
+  let caps =
+    { Capabilities.ollama_capabilities with
+      thinking_control_format = Capabilities.Chat_template_token "<THINK>"
+    }
+  in
+  let config =
+    Provider_config.make
+      ~kind:Provider_config.OpenAI_compat
+      ~model_id:"m"
+      ~base_url:"u"
+      ~system_prompt:"Base prompt."
+      ~model_capabilities_override:caps
+      ()
+  in
+  let requested = thinking_requested ~default:false config in
+  system_prompt_with_thinking_token ~thinking_requested:requested ~config ~caps
+  = Some "Base prompt."
 ;;
 
 let tool_calls_to_openai_json blocks =

--- a/lib/llm_provider/backend_openai_serialize.mli
+++ b/lib/llm_provider/backend_openai_serialize.mli
@@ -5,7 +5,8 @@
     @stability Internal
     @since 0.93.1 *)
 
-(** [system_prompt_with_thinking_token ~config ~caps] returns [config.system_prompt]
+(** [system_prompt_with_thinking_token ~thinking_requested ~config ~caps] returns
+    [config.system_prompt]
     with the chat-template thinking token prepended when the resolved [caps]
     declare a [Chat_template_token] and thinking is requested, else the prompt
     unchanged. SSOT for both the Ollama-native and OpenAI-compat request builders
@@ -13,23 +14,24 @@
     OpenAI-compat wire used to drop the token silently, producing blank-content
     200s / empty-turn storms). *)
 val system_prompt_with_thinking_token
-  :  config:Provider_config.t
+  :  thinking_requested:bool
+  -> config:Provider_config.t
   -> caps:Capabilities.capabilities
   -> string option
 
-(** [chat_template_thinking_active ~config ~caps] is [true] when a
+(** [chat_template_thinking_active ~thinking_requested ~caps] is [true] when a
     [Chat_template_token] is declared and thinking is requested — i.e. the token
     was injected into the system turn. Ollama uses it to omit the native [think]
     field for these rows. *)
 val chat_template_thinking_active
-  :  config:Provider_config.t
+  :  thinking_requested:bool
   -> caps:Capabilities.capabilities
   -> bool
 
-(** Whether the request asks the model to think ([Some] explicit, [None]
-    consults OAS_OLLAMA_THINK_DEFAULT, off by default). Shared so both backends
-    decide identically. *)
-val thinking_requested : Provider_config.t -> bool
+(** Resolve the explicit request flag, using [default] only when
+    [config.enable_thinking] is absent.  The caller owns the backend-specific
+    default; this shared serializer never reads provider environment variables. *)
+val thinking_requested : default:bool -> Provider_config.t -> bool
 
 val tool_calls_to_openai_json : Types.content_block list -> Yojson.Safe.t list
 val openai_content_parts_of_blocks : Types.content_block list -> Yojson.Safe.t list


### PR DESCRIPTION
## 문제

48시간 병합 감사에서 #2488이 shared serializer를 만들면서 `enable_thinking=None`의 해석까지 `OAS_OLLAMA_THINK_DEFAULT`에 결합한 것을 확인했소. 그 결과 Ollama 전용 env가 OpenAI-compatible, DashScope, Kimi 요청의 chat-template token 주입 여부까지 바꾸는 provider 경계 누수가 생겼소. RFC-OAS-035도 이를 후속 과제로 남겼다고 명시했소.

## 변경

- shared serializer는 환경변수를 읽지 않고 explicit flag + caller default만 해석하오.
- Ollama caller만 `OAS_OLLAMA_THINK_DEFAULT`를 기본값으로 제공하오.
- OpenAI-compatible caller는 명시값이 없으면 기존 보수 계약대로 off를 제공하오.
- token injection SSOT는 그대로 공유하여 backend 간 serialization 중복을 만들지 않았소.
- explicit flag 우선순위, caller default, OpenAI-compatible provider-local default를 inline test로 고정했소.
- RFC-OAS-035를 실제 경계와 동기화했소.

## 검증

- OCamlFormat 0.29.0 touched files: pass
- `git diff --check`: pass
- focused build: `llm_provider.cmxa`, `test_backend_openai_codec.exe`
- `test_backend_openai_codec.exe`: 49/49 pass
- `scripts/dune-local.sh runtest lib/llm_provider`: pass

## 감사 추적

- 원인 병합: #2488 (`aad819bb1977`)
- 감사 창: `2026-07-08T01:03:16Z..2026-07-10T01:03:16Z`

[근거] current `main=4fdf5deb4d`, #2488 merge diff와 current caller graph를 2026-07-10 KST에 확인했소. 신뢰도 High.