### PR TITLE
fix(ci)!: restore Block ratchets and the 0.209 release gate

### DIFF
--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -155,15 +155,23 @@ let resolve_tool_call tool_index name input =
      | None -> name, input, None, None)
 ;;
 
-let tool_exception_result ~id ~name exn =
-  let msg = Printf.sprintf "Tool '%s' raised: %s" name (Printexc.to_string exn) in
+let tool_failure_result ~id ~name ~content ~error_class =
   { tool_use_id = id
   ; tool_name = name
-  ; content = msg
+  ; content
   ; is_error = true
   ; failure_kind = Some Non_retryable_tool_error
-  ; error_class = Some Types.Unknown
+  ; error_class = Some error_class
   }
+;;
+
+let blocked_tool_result ~id ~name ~content =
+  tool_failure_result ~id ~name ~content ~error_class:Types.Deterministic
+;;
+
+let tool_exception_result ~id ~name exn =
+  let content = Printf.sprintf "Tool '%s' raised: %s" name (Printexc.to_string exn) in
+  tool_failure_result ~id ~name ~content ~error_class:Types.Unknown
 ;;
 
 let protect_tool_lifecycle_callback ~tool_name ~callback_name f =
@@ -184,13 +192,7 @@ let protect_tool_lifecycle_callback ~tool_name ~callback_name f =
 
 let approval_required_without_callback_result ~id ~name =
   let reason = "approval required but no approval callback is registered" in
-  { tool_use_id = id
-  ; tool_name = name
-  ; content = "Tool rejected: " ^ reason
-  ; is_error = true
-  ; failure_kind = Some Non_retryable_tool_error
-  ; error_class = Some Types.Deterministic
-  }
+  blocked_tool_result ~id ~name ~content:("Tool rejected: " ^ reason)
 ;;
 
 let schedule_tool_use ~tool_index index (id, name, input) =
@@ -771,13 +773,7 @@ let execute_scheduled_tool
                      input
                      id
                  | Hooks.Reject reason ->
-                   { tool_use_id = id
-                   ; tool_name = name
-                   ; content = "Tool rejected: " ^ reason
-                   ; is_error = true
-                   ; failure_kind = Some Non_retryable_tool_error
-                   ; error_class = Some Types.Deterministic
-                   }
+                   blocked_tool_result ~id ~name ~content:("Tool rejected: " ^ reason)
                  | Hooks.Edit new_input ->
                    find_and_execute_tool_with_index
                      ~context
@@ -843,29 +839,20 @@ let execute_scheduled_tool
                input
                id
            | Hooks.HookFailed { stage; detail } ->
-             { tool_use_id = id
-             ; tool_name = name
-             ; content =
-                 Printf.sprintf
-                   "Tool execution blocked: hook pre_tool_use failed at %s: %s"
-                   stage
-                   detail
-             ; is_error = true
-             ; failure_kind = Some Non_retryable_tool_error
-             ; error_class = Some Types.Deterministic
-             }
+             blocked_tool_result
+               ~id
+               ~name
+               ~content:
+                 (Printf.sprintf
+                    "Tool execution blocked: hook pre_tool_use failed at %s: %s"
+                    stage
+                    detail)
            | Hooks.Block reason ->
              (* Intentional policy rejection from a PreToolUse hook. The host
                 executes no tool; the reason string becomes the tool result
                 content verbatim. Distinct from [Hooks.Override] (soft nudge,
                 is_error=false) and [Hooks.HookFailed] (infra failure). *)
-             { tool_use_id = id
-             ; tool_name = name
-             ; content = reason
-             ; is_error = true
-             ; failure_kind = Some Non_retryable_tool_error
-             ; error_class = Some Types.Deterministic
-             }
+             blocked_tool_result ~id ~name ~content:reason
          with
          | Out_of_memory -> raise Out_of_memory
          | Stack_overflow -> raise Stack_overflow

--- a/lib/base/hooks.ml
+++ b/lib/base/hooks.ml
@@ -545,28 +545,24 @@ let%test "Block: classify_decision tags as K_Block" =
   classify_decision (Block "forbidden") = K_Block
 ;;
 
-let%test "Block: decision_kind_to_string" =
-  decision_kind_to_string K_Block = "Block"
-;;
+let%test "Block: decision_kind_to_string" = decision_kind_to_string K_Block = "Block"
 
 let%test "Block: legal only at pre_tool_use" =
   List.mem K_Block (legal_decisions_for_stage "pre_tool_use")
-  && not (List.mem K_Block (legal_decisions_for_stage "before_turn"))
-  && not (List.mem K_Block (legal_decisions_for_stage "on_idle"))
-  && not (List.mem K_Block (legal_decisions_for_stage "post_tool_use"))
+  && (not (List.mem K_Block (legal_decisions_for_stage "before_turn")))
+  && (not (List.mem K_Block (legal_decisions_for_stage "on_idle")))
+  && (not (List.mem K_Block (legal_decisions_for_stage "post_tool_use")))
   && not (List.mem K_Block (legal_decisions_for_stage "pre_compact"))
 ;;
 
 let%test "Block: validate_decision accepts at pre_tool_use" =
-  match validate_decision ~stage:"pre_tool_use" (Block "nope") with
-  | Ok (Block "nope") -> true
-  | _ -> false
+  validate_decision ~stage:"pre_tool_use" (Block "nope") = Ok (Block "nope")
 ;;
 
 let%test "Block: validate_decision rejects at on_idle" =
   match validate_decision ~stage:"on_idle" (Block "nope") with
   | Error msg -> String.length msg > 0
-  | _ -> false
+  | Ok _ -> false
 ;;
 
 let%test "Block: invoke_validated coerces illegal Block to HookFailed" =
@@ -574,6 +570,13 @@ let%test "Block: invoke_validated coerces illegal Block to HookFailed" =
   let blocking _ = Block "forbidden" in
   match invoke_validated (Some blocking) event with
   | HookFailed { stage = "on_idle"; detail } -> String.length detail > 0
-  | _ -> false
+  | HookFailed _ -> false
+  | Continue
+  | Skip
+  | Override _
+  | ApprovalRequired
+  | AdjustParams _
+  | ElicitInput _
+  | Nudge _
+  | Block _ -> false
 ;;
-

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -87,7 +87,11 @@ let stage_input ?raw_trace_run ?clock agent =
   | Hooks.Continue -> Ok ()
   | Hooks.HookFailed { stage; detail } ->
     Error (hook_failed_sdk_error ~hook_name:"before_turn" ~stage ~detail)
-  | Hooks.Skip | Hooks.Override _ | Hooks.ApprovalRequired | Hooks.AdjustParams _ | Hooks.Block _ ->
+  | Hooks.Skip
+  | Hooks.Override _
+  | Hooks.ApprovalRequired
+  | Hooks.AdjustParams _
+  | Hooks.Block _ ->
     (* Reject illegal hook decisions with a typed error instead of crashing.
        [Hooks.invoke_validated] normally filters these out; this branch guards
        against a validation bypass or future hook matrix drift. [Block] is

--- a/test/test_approval.ml
+++ b/test/test_approval.ml
@@ -241,6 +241,29 @@ let test_approval_reject () =
   | _ -> fail "expected exactly one result"
 ;;
 
+let test_block_is_deterministic_failure () =
+  let hooks =
+    { Hooks.empty with pre_tool_use = Some (fun _event -> Hooks.Block "policy denied") }
+  in
+  let results =
+    run_execute
+      ~hooks
+      [ ToolUse { id = "t1"; name = "dangerous"; input = `String "must not run" } ]
+  in
+  match results with
+  | [ result ] ->
+    check string "id" "t1" result.tool_use_id;
+    check string "reason is verbatim" "policy denied" result.content;
+    check bool "is error" true result.is_error;
+    (match result.failure_kind with
+     | Some Agent_tools.Non_retryable_tool_error -> ()
+     | _ -> fail "expected non-retryable tool error");
+    (match result.error_class with
+     | Some Types.Deterministic -> ()
+     | _ -> fail "expected deterministic error class")
+  | _ -> fail "expected exactly one result"
+;;
+
 let test_approval_edit () =
   let hooks =
     { Hooks.empty with pre_tool_use = Some (fun _event -> Hooks.ApprovalRequired) }
@@ -815,6 +838,10 @@ let () =
             test_approval_required_no_callback_fail_closed
         ; test_case "Approve = normal execution" `Quick test_approval_approve
         ; test_case "Reject with reason" `Quick test_approval_reject
+        ; test_case
+            "Block is a typed deterministic failure"
+            `Quick
+            test_block_is_deterministic_failure
         ; test_case "Edit modifies input" `Quick test_approval_edit
         ; test_case "selective by tool name" `Quick test_selective_approval
         ; test_case "Skip/Override unaffected" `Quick test_skip_override_unaffected

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -1547,7 +1547,8 @@ let test_parse_edge_shapes_for_text_and_telemetry () =
   in
   (match no_text.stop_reason with
    | EndTurn -> ()
-   | _ -> Alcotest.fail "empty completion should preserve the stop finish_reason as EndTurn");
+   | _ ->
+     Alcotest.fail "empty completion should preserve the stop finish_reason as EndTurn");
   (* Malformed object content also parses to no blocks, but the fail-closed
      [Empty_completion] payload still surfaces stop_reason and telemetry. *)
   let telemetry =


### PR DESCRIPTION
## 문제

48시간 병합 감사에서 #2487이 두 단조 감소 ratchet을 동시에 깨뜨린 상태로 병합된 것을 확인했소.

- `lib/agent/agent_tools.ml`이 999줄에서 1011줄로 늘어 godfile 수가 기준 10보다 1 증가했소.
- Block 회귀 테스트 세 곳이 `| _ -> false`를 추가해 `wildcard_silent_defaults`가 기준 251보다 3 증가했소.
- 따라서 변경 전 current `main` 자체가 `ci-code-smell-ratchet`과 `hardening-ratchet`을 실패했고, 후속 OAS PR도 자기 diff와 무관하게 차단됐소.

## 변경

- 예외와 의도적 정책 차단의 공통 실패 레코드 생성을 `tool_failure_result`로 모았소.
- 승인 거부, 승인 콜백 부재, HookFailed, Block의 deterministic failure 생성을 `blocked_tool_result` SSOT로 통합했소.
- `agent_tools.ml`을 1011줄에서 998줄로 되돌렸소.
- Block 테스트의 catch-all 세 곳을 결과/variant별 완전 패턴으로 바꿨소.
- 실제 Block 실행이 reason verbatim, `is_error=true`, `Non_retryable_tool_error`, `Deterministic`을 유지하는 회귀 테스트를 추가했소.

## 검증

- OCamlFormat 0.29.0 touched files: pass
- `git diff --check`: pass
- `scripts/ci-code-smell-ratchet.sh --check`: pass, godfile 11 -> 10
- `scripts/hardening-ratchet.sh --check`: pass, wildcard silent defaults 254 -> 251
- focused build: `agent_sdk.cmxa`, `test_hooks.exe`, `test_agent_tools_index.exe`, `test_approval.exe`
- Hooks: 35/35 pass
- Agent tools index: 5/5 pass
- Approval: 19/19 pass
- `scripts/dune-local.sh runtest lib`: pass

## 감사 추적

- 원인 병합: #2487 (`65c8cfea6`)
- 감사 창: `2026-07-08T01:03:16Z..2026-07-10T01:03:16Z`

[근거] `git show 65c8cfea6`, 두 repo-local ratchet 명령, current `origin/main=4fdf5deb4`를 2026-07-10 KST에 확인했소. 신뢰도 High.

## Current-main 포맷 복구

- #2487의 `lib/pipeline/pipeline_stage_prepare.ml`과 #2488의 `test/test_backend_openai_codec.ml`도 current `main`에서 `dune build @fmt`를 실패시키고 있었소.
- 두 잔여 파일을 OCamlFormat 0.29.0으로 정규화했소.
- `opam exec --switch=5.4.1 -- scripts/dune-local.sh build @fmt`: pass
