### PR TITLE
fix(release)!: declare the 0.209 public API boundary

### DIFF
--- a/.ci/hardening-baseline.json
+++ b/.ci/hardening-baseline.json
@@ -25,10 +25,7 @@
     "exception_message_classifiers": [
       "lib/llm_provider/retry.ml:319:let msg = String.lowercase_ascii (extract_error_message body) in"
     ],
-    "heuristic_markers": [
-      "lib/context_intent.ml:84:let heuristic_classify query =",
-      "lib/context_intent.mli:38:val heuristic_classify : string -> classification"
-    ],
+    "heuristic_markers": [],
     "local_workspace_path_literals": [],
     "model_id_string_classifiers_outside_catalog": [],
     "stub_markers": [],
@@ -44,13 +41,13 @@
     ],
     "workaround_markers": []
   },
-  "lastUpdatedCommit": "4d371c24d12ad5b55a2c3641391f2fd95b6a61cc",
+  "lastUpdatedCommit": "4fdf5deb4d9a7579cfd832fa720edf923c290cb0",
   "metrics": {
     "base_url_host_fuzzy_classifiers": 0,
     "direct_env_reads": 11,
     "direct_env_reads_outside_env_boundary": 8,
     "exception_message_classifiers": 1,
-    "heuristic_markers": 2,
+    "heuristic_markers": 0,
     "local_workspace_path_literals": 0,
     "model_id_string_classifiers_outside_catalog": 0,
     "stub_markers": 0,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ original tag dates. `0.100.4` was never tagged or released.
 
 ## Unreleased
 
+### Breaking Changes
+
+* **hooks:** establish 0.209 as the supported compatibility floor for
+  `Hooks.Block` and `K_Block`, which were incorrectly shipped in the 0.208.21
+  patch line. Exhaustive matches must handle the new variants; see the
+  [hook decision migration guide](docs/migrations/0.209-hook-block.md).
+* **context:** remove the public `Agent_sdk.Context_intent` module. Consumers
+  must move query-intent classification to their own typed boundary; see the
+  [0.209 migration guide](docs/migrations/0.209-context-intent-removal.md).
+  The usual deprecation window is waived as a safety exception: restoring the
+  removed implementation or a compatibility shim would preserve heuristic
+  string matching and a silent model-error fallback.
+
 ### Bug Fixes
 
 * **context_offload:** emit a diagnostic warning when tool-result offload write

--- a/docs/migrations/0.209-context-intent-removal.md
+++ b/docs/migrations/0.209-context-intent-removal.md
@@ -1,0 +1,31 @@
+# Migrating to 0.209: `Context_intent` removal
+
+OAS 0.209 removes the public `Agent_sdk.Context_intent` module. There is no
+replacement module in OAS.
+
+## Who needs to migrate
+
+Consumers that import `Agent_sdk.Context_intent` or the standalone
+`Context_intent` module will fail to compile. Find affected call sites with:
+
+```sh
+rg -n 'Agent_sdk\.Context_intent|Context_intent' .
+```
+
+Remove unused imports. If the consumer needs query-intent classification, move
+that policy downstream and use a typed model-output schema owned by the
+consumer. Model, parse, or schema failures must remain explicit errors; do not
+silently fall back to keyword scoring.
+
+## Deprecation-window safety exception
+
+Public APIs normally remain deprecated for a release window before removal.
+This removal is an explicit safety exception: the retired implementation used
+heuristic string matching, hard-coded scores, and silently downgraded model
+failures to heuristic results. Restoring it, or adding a compatibility shim
+with the same behavior, would preserve those failure modes and is rejected.
+
+Consumers that cannot migrate immediately may temporarily pin to the latest
+0.208 release, but must treat the pin as migration debt rather than a supported
+compatibility path. Validate the migration by rebuilding the consumer and by
+testing both typed classification success and explicit model/parse failure.

--- a/docs/migrations/0.209-hook-block.md
+++ b/docs/migrations/0.209-hook-block.md
@@ -1,0 +1,22 @@
+# Migrating to 0.209: hook `Block` decisions
+
+OAS 0.208.21 added `Block of string` to `Hooks.hook_decision` and `K_Block` to
+`Hooks.hook_decision_kind` without the breaking release marker required for a
+public variant. OAS 0.209 is the supported compatibility floor for that change.
+
+Consumers with exhaustive matches must add both variants. `Block reason` is
+legal only for `PreToolUse`: it prevents tool execution and returns the reason
+as a deterministic, non-retryable tool error. Use `Override` for a successful
+soft nudge and `HookFailed` for hook infrastructure failure; neither is a
+substitute for an intentional policy block.
+
+After updating matches, rebuild every downstream consumer and test these
+boundaries:
+
+- a `PreToolUse` `Block` does not execute the tool;
+- its result has `is_error = true` and preserves the reason;
+- `Block` from any other hook stage fails closed as an illegal decision.
+
+The original 0.208.21 patch release should not be treated as evidence that the
+addition was source-compatible. Pin consumers that cannot update immediately,
+then move their supported OAS floor to 0.209 after the exhaustive matches pass.

--- a/docs/sdk-independence-principle.md
+++ b/docs/sdk-independence-principle.md
@@ -10,27 +10,27 @@ MCP Protocol SDK  <--  OAS (Agent SDK)  <--  External coordinator
 ```
 
 OAS provides generic single-agent primitives: context, hooks, tool/runtime
-abstractions, provider-neutral runtime events, and intent classification.
-Coordinators consume these primitives and add their own orchestration
-semantics. OAS is not allowed to name, depend on, or adapt to any specific
-coordinator.
+abstractions, and provider-neutral runtime events. Coordinators consume these
+primitives and add their own query classification and orchestration semantics.
+OAS is not allowed to name, depend on, or adapt to any specific coordinator.
 
 ## What this means in practice
 
-1. **No coordinator keywords in heuristic classifiers.** Terms like "keeper",
-   "room", "broadcast", or coordinator-specific role names must not appear in
-   OAS keyword lists or prompt templates.
+1. **No coordinator-specific classifiers.** Terms like "keeper", "room",
+   "broadcast", or coordinator-specific role names must not appear in OAS
+   keyword lists or prompt templates.
 
 2. **No coordinator types imported.** OAS must never depend on a coordinator's
    opam package or reference coordinator-specific module names.
 
-3. **Generic vocabulary only.** Where OAS needs coordination-related keywords
-   (e.g. for intent classification), use domain-neutral terms: "assign",
-   "route", "transfer", "coordinate", "sync", "notify", "actor", "group".
+3. **Generic vocabulary only.** Where OAS needs coordination-related language
+   in generic documentation or protocol descriptions, use domain-neutral terms:
+   "assign", "route", "transfer", "coordinate", "sync", "notify", "actor",
+   "group".
 
-4. **Coordinator-specific aliases live downstream.** If a coordinator needs
-   "handoff" to map to `Coordination` intent, it should wrap
-   `Context_intent.intent_of_string` in its own adapter.
+4. **Query-intent classification lives downstream.** A coordinator that needs
+   terms such as "handoff" must own a typed classifier and its failure policy.
+   OAS intentionally provides no heuristic compatibility adapter.
 
 5. **Provider catalogs stay generic.** `OAS_PROVIDER_CATALOG` entries may
    describe provider ids, transport, auth mode, endpoint, default model, and
@@ -44,7 +44,6 @@ coordinator wraps these in is intentionally outside this document.
 
 | Module | Owner |
 |--------|-------|
-| `Context_intent` | OAS |
 | `Contract`, `Completion_contract` | OAS |
 | `Policy`, `Guardrails`, `Guardrail_*` | OAS |
 | `Runtime`, `Runtime_evidence` | OAS |
@@ -63,18 +62,19 @@ do not imply an `Agent_sdk` OCaml module.
 ## Enforcement
 
 - CI: `grep -rn` for a maintained blocklist of coordinator-specific terms in `lib/`.
-- Code review: any new keyword in `context_intent.ml` must be justified as
-  domain-neutral.
+- Code review: query-intent keyword scoring and silent fallback classifiers do
+  not belong in OAS.
 - README and top-level docs must not mention any specific external coordinator
   by name.
 
 ## History
 
-- 2026-03-29: Initial principle established. Removed "delegate", "handoff",
-  "agent", "team" from `context_intent.ml` heuristic keywords. Replaced with
-  "route", "transfer", "actor".
+- 2026-03-29: Initial principle established. Removed downstream vocabulary from
+  the former context-intent classifier and replaced it with generic terms.
 - 2026-04-17: Tightened. Owner/consumers table no longer names downstream
   coordinators; OAS docs do not depend on any specific consumer.
 - 2026-05-21: Removed stale CDAL module ownership after the 0.193.0 migration;
   proof artifacts are schema-level interoperability contracts, not OAS OCaml
   modules.
+- 2026-07-08: Removed the public query-intent classifier. The 0.209 migration
+  guide records the safety exception to the usual deprecation window.


### PR DESCRIPTION
## Audit finding

Two public API breaks entered the 0.208 patch line without a breaking release boundary:

- #2487 added Hooks.Block and K_Block; it shipped in v0.208.21 even though exhaustive matches can stop compiling.
- #2493 removed the public Evolving Agent_sdk.Context_intent surface after v0.208.22; release-please skipped its refactor commit as non-user-facing.

A later ordinary fix could otherwise ship the second break in 0.208.x, while the first already lacks a supported compatibility floor.

## Remediation

- declare 0.209 as the supported Hooks.Block compatibility floor
- add exhaustive-match and stage-legality migration guidance
- classify Context_intent removal as breaking and add its downstream migration
- record the deprecation-window safety exception: restoring the classifier would reintroduce heuristic scoring, hard-coded weights, or silent fallback
- remove stale Context_intent ownership guidance and refresh the hardening baseline from two removed heuristic markers to zero

## Stack and release ordering

This docs + baseline PR is based on #2495 because current main itself fails the godfile and wildcard ratchets introduced with #2487. Merge this child into the #2495 branch first; then merge #2495 to main with its breaking title intact. That makes the ratchet repair and 0.209 release marker reach main together, without a transient 0.208.23 release.

## Verification

- jq validation and stable JSON formatting: pass
- scripts/check-sdk-independence.sh: pass
- heuristic marker measurement: 0
- git diff --check and git show --check: pass
- full hardening on raw current main is repaired by base PR #2495; no waiver or rebaseline is added here

Policy wording mismatch tracked separately in #2496.

[근거] gh pr view 2487,2493; git tag ancestry for v0.208.21/v0.208.22; gh run view 28942053044 --log; release-please config and manifest / 확인일시 2026-07-10 11:48 KST / 신뢰도 High.