### PR TITLE
fix(provider): converge typed empty-completion boundaries

### DIFF
--- a/docs/rfc/RFC-OAS-035-openai-compat-thinking-token-and-empty-completion-failclose.md
+++ b/docs/rfc/RFC-OAS-035-openai-compat-thinking-token-and-empty-completion-failclose.md
@@ -38,7 +38,7 @@ type parse_error = Provider_error of string | Empty_completion of empty_completi
 
 파서 wrapper: `content = thinking @ text @ tool` 가 `[]`이면 `Error (Empty_completion …)`, 아니면 `Ok`. 가드는 **`content=[]`만** — blank text + tool_calls는 `content=[ToolUse ..]`(non-empty)라 Ok 유지(회귀 테스트로 고정). 반환 타입이 `(api_response, string) result` → `(api_response, parse_error) result`로 바뀌며 모든 caller가 컴파일 강제로 새 outcome을 처리(N-of-M 우회 방지).
 
-전파: `http_client.provider_failure_kind`에 `Empty_completion of { stop_reason }` 추가. `complete_sync`가 empty를 `ProviderFailure { Empty_completion }`로 매핑 → `retry_classify`의 `ProviderFailure _ -> None` 규칙으로 **non-retryable**(같은 binding 재시도는 또 empty). `error.of_provider_failure`는 이를 `ProviderUnavailable`(binding-health 성격)로 sdk_error에 투영.
+전파: `http_client.provider_failure_kind`에 `Empty_completion of { stop_reason : Types.stop_reason }`를 두고 모든 completion 경로가 공용 `Http_client.empty_completion_error`로 매핑한다. `retry_classify`의 `ProviderFailure _ -> None` 규칙으로 **non-retryable**이며, typed stop reason은 transport 경계까지 보존된다. 기존 공개 SDK 경계에서는 source compatibility를 위해 `ProviderUnavailable`로 일관되게 투영한다. 진단 문자열은 표시 전용이며 제어 흐름에서 다시 파싱하지 않는다.
 
 **문자열 분류기 아님**: string sentinel(`Error "empty_completion:…"`)은 RFC-OAS-033/RFC-0042가 금하는 substring 분류기라 채택 안 함. typed variant로 닫음.
 
@@ -48,21 +48,22 @@ type parse_error = Provider_error of string | Empty_completion of empty_completi
 
 streaming 경로도 `Ok content=[]`를 낼 수 있어 non-streaming과 대칭으로 fail-close가 필요했다. 초기 시도는 `complete_stream_acc.finalize_stream_acc`(구조 조립기)에 직접 가드를 넣는 것이었는데, 이때 **21개 단위 테스트가 깨졌다** — 이들은 empty acc를 finalize해 usage/stop_reason plumbing만 검증하는 최소 fixture다. 이 실패가 **경계 오배치의 신호**였다.
 
-**수정된 통찰**: deferral 당시 가설("empty-clean → Ok가 확립된 불변식이라 충돌")은 부정확했다. 그 불변식은 사실 **`finalize_stream_acc`가 순수 구조 조립기**라는 것이다 — 잘 닫힌 스트림을 `Ok content=[]`로 조립하는 건 구조적으로 정당하다(truncated 스트림만 이미 `stream_terminated_without_stop_reason`로 거부). "empty completion은 실행 불가"는 **의미 정책**이고, 이는 완성을 어시스턴트 턴으로 반환하는 **소비 경계**(`lib/streaming.ml` `map_stream_finalize_result`)에 속한다. non-streaming의 `parse_openai_response_result`(정책 wrapper) ↔ raw parser 분리와 정확히 대칭.
+**수정된 통찰**: deferral 당시 가설("empty-clean → Ok가 확립된 불변식이라 충돌")은 부정확했다. 그 불변식은 사실 **`finalize_stream_acc`가 순수 구조 조립기**라는 것이다 — 잘 닫힌 스트림을 `Ok content=[]`로 조립하는 건 구조적으로 정당하다(truncated 스트림만 이미 `stream_terminated_without_stop_reason`로 거부). "empty completion은 실행 불가"는 **의미 정책**이고, 실제 Agent 소비 경계는 `pipeline_stage_route`가 호출하는 `Llm_provider.Complete.complete` / `complete_stream`이다. `lib/streaming.ml`은 legacy `Provider_intf` 경로이며 Agent 경로의 SSOT가 아니다.
 
-**구현**: `map_stream_finalize_result`의 `Ok (Ok resp) when resp.content = []` arm에서 `Stream_parse_failed{reason="empty_completion:<stop_reason>"}`로 fail-close(기존 truncated 거부와 동일 class·경로). 두 production 스트리밍 경로(Anthropic/OpenAI)가 이 어댑터를 공유하므로 단일 편집으로 커버되고, `finalize_stream_acc`는 순수하게 남아 **21개 단위 테스트가 회귀 0**. Custom provider는 sync fallback이라 §2의 non-streaming Fix B로 이미 커버. inline test(`map_stream_finalize_result fails closed on empty completion`) green.
+**구현**: `Complete_common.ensure_nonempty_completion`이 `content=[]`를 typed `Http_client.empty_completion_error ~stop_reason`으로 바꾸며, `Complete.complete`(cache, HTTP, injected sync transport)와 `Complete.complete_stream`(HTTP, injected stream transport)이 이 단일 정책을 적용한다. Legacy `Api.create_message`, `Provider_intf`, `Streaming.create_message_stream`도 같은 helper를 사용하므로 custom sync→synthetic fallback까지 동일하게 fail-close한다. 구조 조립기인 `finalize_stream_acc`는 순수하게 남는다.
 
-**string 분류기 아님**: reason 문자열은 진단용이고 소비자(`http_error_of_stream_error`)는 이를 opaque하게 http_error로 매핑한다(제어분기 없음). truncated 케이스가 이미 같은 `Stream_parse_failed{reason=…}` idiom을 쓰는 선례.
+**parse-error 재사용 없음**: empty completion은 파싱 성공 뒤 의미 정책에서 거부되는 outcome이다. 따라서 `Stream_parse_failed`나 `Retry.InvalidRequest`를 만들지 않고, 모든 경로가 같은 typed `Http_client.Empty_completion`을 사용한 뒤 공개 SDK 경계에서 기존 `ProviderUnavailable`로 투영한다.
 
 ### 3.2 MASC 소비 (B-full, 별도 repo/PR)
 
-MASC는 OAS SHA를 pin하고 typed outcome을 소비한다(RFC-OAS-029 §6, 단방향). empty-completion을 runtime-binding-health 근거로 소비해 crash-count storm 대신 binding 관점 처리를 하는 것은 MASC PR의 몫이며, **본 OAS 변경이 main에 착지한 뒤** pin bump와 함께 진행한다. MASC-only cooldown을 OAS typed fix 없이 추가하면 CLAUDE.md 워크어라운드 거부 기준(cap/cooldown 증상억제)에 해당하므로, 순서는 OAS(A+B) → MASC(pin+consume)로 강제된다.
+MASC는 OAS SHA를 pin하고 기존 `Error.sdk_error`를 소비한다(RFC-OAS-029 §6, 단방향). 현재 실제 소비자는 typed stop reason을 분기하지 않으므로 새 공개 error variant를 추가하지 않는다. typed downstream 정책이 실제로 필요해질 때는 구체적 소비자와 함께 별도 API 변경으로 다룬다.
 
-**상태 업데이트 (실측)**: A+B는 oas#2488(aad819bb1)로 main 착지, MASC는 pin bump #23682으로 이를 흡수했다. 다만 MASC는 OAS 완성을 `Agent.run`+**streaming**으로 소비하고 OAS 에러 타입을 exhaustive match 없이 **opaque하게**(`provider_failure_to_string`, `sdk_error` 라우팅) 처리하므로, 원래 구상한 "typed Empty_completion을 코드로 소비"(B-full)는 **대부분 불필요**했다 — pin bump가 컴파일을 깨지 않았고, §2의 Fix B는 sync 전용이라 MASC streaming hot path엔 §3.1의 streaming fail-close가 실제 보호막이다. 즉 MASC 측 실효 = pin bump(Fix A 원인수정) + §3.1(streaming empty→provider failure→기존 failover). 별도 MASC 코드 소비는 관측 필요가 확인될 때만 추가한다.
+**상태 업데이트 (실측)**: A+B는 oas#2488(aad819bb1)로 main 착지, MASC는 pin bump #23682으로 이를 흡수했다. 이후 oas#2491은 legacy `lib/streaming.ml`에 fail-close를 추가했지만 Agent가 사용하는 canonical `Complete.complete_stream`과 injected transport는 보호하지 못했고 `Stream_parse_failed` 문자열을 경유했다. 현재 수렴 경로는 모든 completion 소비 경계에서 `Http_client.Empty_completion { stop_reason : Types.stop_reason }`, 공개 SDK 경계에서 기존 `ProviderUnavailable`이다.
 
 ## 4. 검증
 
 - `backend_openai_parse` 회귀: null-content 200 → `Empty_completion`(EndTurn), blank text + tool_calls → `Ok`(content 비어있지 않음). inline test green.
+- canonical 수렴: HTTP/injected sync·stream, cache, legacy API/Provider_intf/custom fallback의 `EndTurn`/`MaxTokens` empty가 모두 같은 typed `Http_client.Empty_completion`으로 fail-close하고 SDK에서는 `ProviderUnavailable`로 투영됨.
 - 두 backend 대칭: openai-compat + Chat_template_token + `enable_thinking=Some true` → system turn이 토큰으로 시작; 비-token 모델 → byte-identical.
 - 전 caller 컴파일 통과 + 기존 codec/api/cache 테스트 green (`Error msg` 사이트는 `parse_error_to_string`로 렌더).
 

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -5,26 +5,45 @@ open Types
 
 type response_accept = Types.api_response -> (unit, string) result
 
-let retry_error_of_http_error = function
+type create_message_error =
+  | Retry_error of Retry.api_error
+  | Completion_error of Llm_provider.Http_client.http_error
+
+let create_message_error_of_http_error = function
   | Llm_provider.Http_client.HttpError { code; body } ->
-    Retry.classify_error ~status:code ~body
+    Retry_error (Retry.classify_error ~status:code ~body)
   | Llm_provider.Http_client.NetworkError
       { message; kind = Llm_provider.Http_client.Timeout } ->
-    Retry.Timeout { message; phase = None }
+    Retry_error (Retry.Timeout { message; phase = None })
   | Llm_provider.Http_client.NetworkError { message; kind } ->
-    Retry.NetworkError { message; kind }
+    Retry_error (Retry.NetworkError { message; kind })
   | Llm_provider.Http_client.TimeoutError { message; phase } ->
-    Retry.Timeout { message; phase = Some phase }
+    Retry_error (Retry.Timeout { message; phase = Some phase })
   | Llm_provider.Http_client.AcceptRejected { reason } ->
-    Retry.InvalidRequest
-      { message = "Response rejected: " ^ reason; reason = Unknown_invalid_request }
+    Retry_error
+      (Retry.InvalidRequest
+         { message = "Response rejected: " ^ reason; reason = Unknown_invalid_request })
   | Llm_provider.Http_client.ProviderTerminal { message; _ } ->
-    Retry.InvalidRequest { message; reason = Unknown_invalid_request }
+    Retry_error (Retry.InvalidRequest { message; reason = Unknown_invalid_request })
+  | Llm_provider.Http_client.ProviderFailure
+      { kind = Llm_provider.Http_client.Empty_completion _; _ } as err ->
+    Completion_error err
   | Llm_provider.Http_client.ProviderFailure { kind; message } ->
-    Retry.InvalidRequest
-      { message = Llm_provider.Http_client.provider_failure_to_string ~kind ~message
-      ; reason = Unknown_invalid_request
-      }
+    Retry_error
+      (Retry.InvalidRequest
+         { message = Llm_provider.Http_client.provider_failure_to_string ~kind ~message
+         ; reason = Unknown_invalid_request
+         })
+;;
+
+let retry_error_of_create_message_error = function
+  | Retry_error err -> Some err
+  | Completion_error err -> Llm_provider.Retry_classify.classify_retry_error err
+;;
+
+let sdk_error_of_create_message_error = function
+  | Retry_error err -> Error.Api err
+  | Completion_error err -> Http_error_sdk.of_http_error err
 ;;
 
 (* Re-export Api_common *)
@@ -70,6 +89,24 @@ let patch_latency (resp : Types.api_response) (latency_ms : int option)
       Some { default with request_latency_ms = latency_ms }
   in
   { resp with telemetry }
+;;
+
+let ensure_nonempty_response resp =
+  Llm_provider.Complete_common.ensure_nonempty_completion (Ok resp)
+  |> Result.map_error (fun err -> Completion_error err)
+;;
+
+let parse_openai_completion body_str =
+  match parse_openai_response_result body_str with
+  | Ok resp -> ensure_nonempty_response resp
+  | Error (Llm_provider.Backend_openai_parse.Provider_error message) ->
+    Error
+      (Retry_error
+         (Retry.InvalidRequest { message; reason = Retry.Unknown_invalid_request }))
+  | Error (Llm_provider.Backend_openai_parse.Empty_completion empty) ->
+    Error
+      (Completion_error
+         (Llm_provider.Http_client.empty_completion_error ~stop_reason:empty.stop_reason))
 ;;
 
 (** Send a non-streaming message to the API, dispatching by provider.
@@ -175,7 +212,7 @@ let create_message
          with
          | Ok (200, body_str) -> `Ok body_str
          | Ok (code, body_str) -> `HttpError (code, body_str)
-         | Error err -> `TransportError (retry_error_of_http_error err)
+         | Error err -> `TransportError (create_message_error_of_http_error err)
        in
        let do_request () =
          let latency_counter = Llm_provider.Complete_common.start_latency_counter () in
@@ -194,51 +231,46 @@ let create_message
              let raw_resp_result =
                match kind with
                | Provider.Anthropic_messages ->
-                 Ok (parse_response (Yojson.Safe.from_string body_str))
+                 parse_response (Yojson.Safe.from_string body_str)
+                 |> ensure_nonempty_response
                | Provider.Openai_chat_completions ->
                  (* Reasoning stays typed as Thinking in the parsed response; it
                  is no longer promoted to a Text answer block (which caused the
                  #2236 CoT re-injection loop). Display surfacing is a read-side
                  projection concern, decoupled from parsing. *)
-                 parse_openai_response_result body_str
+                 parse_openai_completion body_str
                | Provider.Custom name ->
                  (match Provider.find_provider name with
-                  | Some impl -> Ok (impl.parse_response body_str)
-                  | None -> parse_openai_response_result body_str)
+                  | Some impl -> impl.parse_response body_str |> ensure_nonempty_response
+                  | None -> parse_openai_completion body_str)
              in
-             (match raw_resp_result with
-              | Ok resp ->
-                Ok
-                  (Llm_provider.Pricing.annotate_response_cost resp
-                   |> fun r -> patch_latency r lat)
-              | Error parse_err ->
-                let message =
-                  match parse_err with
-                  | Llm_provider.Backend_openai_parse.Provider_error m -> m
-                  | Llm_provider.Backend_openai_parse.Empty_completion _ ->
-                    "provider returned an empty completion (no thinking, text, or tool \
-                     calls)"
-                in
-                Error
-                  (Retry.InvalidRequest
-                     { message; reason = Retry.Unknown_invalid_request }))
+             Result.map
+               (fun resp ->
+                  Llm_provider.Pricing.annotate_response_cost resp
+                  |> fun r -> patch_latency r lat)
+               raw_resp_result
            | `HttpError (code, body_str) ->
-             Error (Retry.classify_error ~status:code ~body:body_str)
+             Error (Retry_error (Retry.classify_error ~status:code ~body:body_str))
            | `TransportError err -> Error err
          with
          | Eio.Time.Timeout ->
            Error
-             (Retry.Timeout
-                { message =
-                    Printf.sprintf
-                      "HTTP request exceeded %.1fs wall-clock timeout"
-                      request_timeout_s
-                ; phase = None
-                })
+             (Retry_error
+                (Retry.Timeout
+                   { message =
+                       Printf.sprintf
+                         "HTTP request exceeded %.1fs wall-clock timeout"
+                         request_timeout_s
+                   ; phase = None
+                   }))
          | Eio.Io _ as exn ->
-           Error (Retry.NetworkError { message = Printexc.to_string exn; kind = Unknown })
+           Error
+             (Retry_error
+                (Retry.NetworkError { message = Printexc.to_string exn; kind = Unknown }))
          | Unix.Unix_error _ as exn ->
-           Error (Retry.NetworkError { message = Printexc.to_string exn; kind = Unknown })
+           Error
+             (Retry_error
+                (Retry.NetworkError { message = Printexc.to_string exn; kind = Unknown }))
          (* Backend_gemini.Gemini_api_error and Backend_glm.Glm_api_error
        are intentionally NOT caught here: this function only
        dispatches [Anthropic_messages | Openai_chat_completions |
@@ -247,31 +279,41 @@ let create_message
        exceptions cannot reach here. They are caught at their real
        live site in [Llm_provider.Complete] — see
        lib/llm_provider/complete.ml:271,274. *)
-         | Failure msg -> Error (Retry.NetworkError { message = msg; kind = Unknown })
+         | Failure msg ->
+           Error (Retry_error (Retry.NetworkError { message = msg; kind = Unknown }))
          | Yojson.Json_error msg ->
            Error
-             (Retry.InvalidRequest
-                { message = "JSON parse error: " ^ msg; reason = Retry.Json_parse_error })
+             (Retry_error
+                (Retry.InvalidRequest
+                   { message = "JSON parse error: " ^ msg
+                   ; reason = Retry.Json_parse_error
+                   }))
          | Yojson.Safe.Util.Type_error (msg, _) ->
            Error
-             (Retry.InvalidRequest
-                { message = "JSON type error: " ^ msg; reason = Retry.Json_parse_error })
+             (Retry_error
+                (Retry.InvalidRequest
+                   { message = "JSON type error: " ^ msg
+                   ; reason = Retry.Json_parse_error
+                   }))
          | Yojson.Safe.Util.Undefined (msg, _) ->
            Error
-             (Retry.InvalidRequest
-                { message = "JSON undefined field error: " ^ msg
-                ; reason = Retry.Json_parse_error
-                })
+             (Retry_error
+                (Retry.InvalidRequest
+                   { message = "JSON undefined field error: " ^ msg
+                   ; reason = Retry.Json_parse_error
+                   }))
        in
-       (match clock with
-        | Some clock ->
-          (match Retry.with_retry ~clock ?config:retry_config do_request with
-           | Ok _ as success -> success
-           | Error err -> Error (Error.Api err))
-        | None ->
-          (match do_request () with
-           | Ok _ as success -> success
-           | Error err -> Error (Error.Api err))))
+       let result =
+         match clock with
+         | Some clock ->
+           Retry.with_retry_map_error
+             ~clock
+             ?config:retry_config
+             ~classify:retry_error_of_create_message_error
+             do_request
+         | None -> do_request ()
+       in
+       Result.map_error sdk_error_of_create_message_error result)
 ;;
 
 [@@@coverage off]

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -66,7 +66,7 @@ let complete
       | _, _ -> None
     in
     (match cached with
-     | Some result -> result
+     | Some result -> ensure_nonempty_completion result
      | None ->
        m.on_request_start ~model_id;
        let { Llm_transport.response = result; latency_ms } =
@@ -112,6 +112,7 @@ let complete
              ~model_id
              ~status:code
          | Error _ -> ());
+       let result = ensure_nonempty_completion result in
        (match result with
         | Ok resp ->
           let resp = Pricing.annotate_response_cost resp in
@@ -341,7 +342,7 @@ let complete_stream
            ~model_id:config.model_id
            resp;
          resp)
-      result
+      (ensure_nonempty_completion result)
 ;;
 
 let complete_stream_with_retry

--- a/lib/llm_provider/complete.mli
+++ b/lib/llm_provider/complete.mli
@@ -86,7 +86,9 @@ val make_http_transport
     When [metrics] is provided, fires lifecycle callbacks.
 
     @return [Ok api_response] on success (possibly from cache)
-    @return [Error http_error] on failure *)
+    @return [Error http_error] on failure. A response with no content blocks
+    fails closed as [ProviderFailure { kind = Empty_completion { stop_reason } }]
+    for built-in HTTP, cache, and injected transports alike. *)
 val complete
   :  sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
@@ -169,6 +171,10 @@ val complete_with_retry
 
     Supports both Anthropic native SSE and OpenAI-compatible SSE formats,
     dispatched by {!Provider_config.t.kind}.
+
+    A finalized response with no content blocks fails closed as
+    [ProviderFailure { kind = Empty_completion { stop_reason } }] for built-in
+    HTTP and injected transports alike.
 
     [clock] and [stream_idle_timeout_s] together bound two streaming
     stalls on every HTTP streaming path: inter-line idle, and

--- a/lib/llm_provider/complete_common.ml
+++ b/lib/llm_provider/complete_common.ml
@@ -207,6 +207,19 @@ let latency_ms_float = function
 let round_latency_ms ms = int_of_float (Float.round ms)
 let latency_ms_int counter = Option.map round_latency_ms (latency_ms_float counter)
 
+(** Enforce the deliverable-assistant-turn policy at completion consumption
+    boundaries. Structural parsers and injected transports may legitimately
+    assemble [content = []], but production completion entry points must fail
+    closed while preserving the typed stop reason. *)
+let ensure_nonempty_completion
+      (result : (Types.api_response, Http_client.http_error) result)
+  =
+  match result with
+  | Ok ({ content = []; stop_reason; _ } : Types.api_response) ->
+    Error (Http_client.empty_completion_error ~stop_reason)
+  | Ok _ | Error _ -> result
+;;
+
 let%test "latency counter yields non-negative elapsed duration when available" =
   match start_latency_counter () with
   | Unknown_latency -> true

--- a/lib/llm_provider/complete_sync.ml
+++ b/lib/llm_provider/complete_sync.ml
@@ -242,19 +242,10 @@ let complete_http
                    | Error (Backend_openai_parse.Provider_error msg) ->
                      Error (Http_client.HttpError { code = 400; body = msg })
                    | Error (Backend_openai_parse.Empty_completion e) ->
-                     (* oas#2483: a blank-content 200 fails closed as a typed
-                        provider failure (non-retryable — retrying the same
-                        binding returns empty) instead of Ok content=[]. *)
-                     Error
-                       (Http_client.ProviderFailure
-                          { kind =
-                              Http_client.Empty_completion
-                                { stop_reason = Types.stop_reason_to_string e.stop_reason
-                                }
-                          ; message =
-                              "provider returned an empty assistant turn (no thinking, \
-                               text, or tool calls)"
-                          }))
+                     (* oas#2483: fail closed through the same typed transport
+                        fact as streaming. Policy remains downstream of the
+                        preserved [stop_reason]. *)
+                     Error (Http_client.empty_completion_error ~stop_reason:e.stop_reason))
                 | Provider_config.Gemini ->
                   Ok (Backend_gemini.parse_response (Yojson.Safe.from_string body))
                 | Provider_config.Glm -> Ok (Backend_glm.parse_response body)

--- a/lib/llm_provider/error.ml
+++ b/lib/llm_provider/error.ml
@@ -264,15 +264,17 @@ let of_provider_failure ?provider kind message =
     in
     ParseError { detail = Printf.sprintf "%s: %s" parser message }
   | Http_client.Empty_completion { stop_reason } ->
-    (* oas#2483: a blank-content 200 is a binding-health condition (the provider
-       produced nothing usable), not a malformed body — surface it as
-       [ProviderUnavailable] so consumers treat it as a candidate/binding fault
-       rather than a parse error, and so it never re-enters the silent
-       empty-turn path. *)
+    (* [stop_reason] stays typed until this deliberate SDK boundary.  The public
+       error surface remains source-compatible: callers already handle an empty
+       completion as provider unavailability, and no control flow reparses this
+       diagnostic rendering. *)
     ProviderUnavailable
       { provider
       ; detail =
-          Printf.sprintf "empty completion (stop_reason=%s): %s" stop_reason message
+          Printf.sprintf
+            "empty completion (stop_reason=%s): %s"
+            (Types.stop_reason_to_string stop_reason)
+            message
       }
   | Http_client.Unknown_provider_failure { reason } ->
     let reason =

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -82,10 +82,9 @@ type provider_failure_kind =
   | Cli_startup_failed of { reason : string }
   | Provider_parse_error of { parser : string option }
   (* oas#2483: the provider returned a 200 with no deliverable content (no
-     thinking, text, or tool_calls). Distinct from a parse error so consumers
-     can attribute it to a runtime binding rather than a malformed body, and so
-     it is non-retryable by default (retrying the same binding returns empty). *)
-  | Empty_completion of { stop_reason : string }
+     thinking, text, or tool_calls). Distinct from a parse error. Preserve the
+     typed stop reason so policy remains outside this transport fact. *)
+  | Empty_completion of { stop_reason : Types.stop_reason }
   | Unknown_provider_failure of { reason : string option }
 
 type http_error =
@@ -146,7 +145,8 @@ let provider_failure_kind_to_string = function
   | Provider_parse_error { parser = Some parser } ->
     Printf.sprintf "provider_parse_error:%s" parser
   | Provider_parse_error { parser = None } -> "provider_parse_error"
-  | Empty_completion { stop_reason } -> Printf.sprintf "empty_completion:%s" stop_reason
+  | Empty_completion { stop_reason } ->
+    Printf.sprintf "empty_completion:%s" (Types.stop_reason_to_string stop_reason)
   | Unknown_provider_failure { reason = Some reason } ->
     Printf.sprintf "unknown_provider_failure:%s" reason
   | Unknown_provider_failure { reason = None } -> "unknown_provider_failure"
@@ -155,6 +155,14 @@ let provider_failure_kind_to_string = function
 let provider_failure_to_string ~kind ~message =
   let name = provider_failure_kind_to_string kind in
   if String.trim message = "" then name else Printf.sprintf "%s: %s" name message
+;;
+
+let empty_completion_error ~stop_reason =
+  ProviderFailure
+    { kind = Empty_completion { stop_reason }
+    ; message =
+        "provider returned an empty assistant turn (no thinking, text, or tool calls)"
+    }
 ;;
 
 let stream_idle_state_to_label = function

--- a/lib/llm_provider/http_client.mli
+++ b/lib/llm_provider/http_client.mli
@@ -133,8 +133,9 @@ type provider_failure_kind =
   | Cli_startup_failed of { reason : string }
   | Provider_parse_error of { parser : string option }
   (** oas#2483: a 200 with no deliverable content (no thinking/text/tool_calls).
-      Non-retryable by default — retrying the same binding returns empty. *)
-  | Empty_completion of { stop_reason : string }
+      The typed stop reason is preserved so downstream policy can distinguish,
+      for example, [MaxTokens] from [EndTurn] without parsing diagnostics. *)
+  | Empty_completion of { stop_reason : Types.stop_reason }
   | Unknown_provider_failure of { reason : string option }
 
 (** Transport-level error. *)
@@ -176,8 +177,17 @@ type http_error =
       invalid CLI policy, or a request that requires a capability the
       transport cannot provide. *)
 
+(** Diagnostic rendering only. Consumers must branch on [provider_failure_kind]
+    directly and never parse this string. *)
 val provider_failure_kind_to_string : provider_failure_kind -> string
+
 val provider_failure_to_string : kind:provider_failure_kind -> message:string -> string
+
+(** Construct the canonical fail-closed transport error for a provider response
+    with no thinking, text, or tool calls. Sync and streaming completion paths
+    must use this helper so the typed stop reason and diagnostic stay aligned. *)
+val empty_completion_error : stop_reason:Types.stop_reason -> http_error
+
 val stream_idle_state_to_label : stream_idle_state -> string
 val timeout_phase_of_stream_idle_state : stream_idle_state -> timeout_phase
 val timeout_phase_to_label : timeout_phase -> string

--- a/lib/provider_intf.ml
+++ b/lib/provider_intf.ml
@@ -9,53 +9,75 @@
 module Http_client = Llm_provider.Http_client
 module Retry = Llm_provider.Retry
 
-let retry_error_of_http_error = function
-  | Http_client.HttpError { code; body } -> Retry.classify_error ~status:code ~body
+type response_error =
+  | Retry_error of Retry.api_error
+  | Completion_error of Http_client.http_error
+
+let sdk_error_of_http_error = function
+  | Http_client.ProviderFailure { kind = Http_client.Empty_completion _; _ } as err ->
+    Http_error_sdk.of_http_error err
+  | Http_client.HttpError { code; body } ->
+    Error.Api (Retry.classify_error ~status:code ~body)
   | Http_client.NetworkError { message; kind = Http_client.Timeout } ->
-    Retry.Timeout { message; phase = None }
-  | Http_client.NetworkError { message; kind } -> Retry.NetworkError { message; kind }
+    Error.Api (Retry.Timeout { message; phase = None })
+  | Http_client.NetworkError { message; kind } ->
+    Error.Api (Retry.NetworkError { message; kind })
   | Http_client.TimeoutError { message; phase } ->
-    Retry.Timeout { message; phase = Some phase }
+    Error.Api (Retry.Timeout { message; phase = Some phase })
   | Http_client.AcceptRejected { reason } ->
-    Retry.InvalidRequest
-      { message = "Response rejected: " ^ reason; reason = Unknown_invalid_request }
+    Error.Api
+      (Retry.InvalidRequest
+         { message = "Response rejected: " ^ reason; reason = Unknown_invalid_request })
   | Http_client.ProviderTerminal { message; _ } ->
-    Retry.InvalidRequest { message; reason = Unknown_invalid_request }
+    Error.Api (Retry.InvalidRequest { message; reason = Unknown_invalid_request })
   | Http_client.ProviderFailure { kind; message } ->
-    Retry.InvalidRequest
-      { message = Http_client.provider_failure_to_string ~kind ~message
-      ; reason = Unknown_invalid_request
-      }
+    Error.Api
+      (Retry.InvalidRequest
+         { message = Http_client.provider_failure_to_string ~kind ~message
+         ; reason = Unknown_invalid_request
+         })
+;;
+
+let sdk_error_of_response_error = function
+  | Retry_error err -> Error.Api err
+  | Completion_error err -> sdk_error_of_http_error err
+;;
+
+let ensure_nonempty_response resp =
+  Llm_provider.Complete_common.ensure_nonempty_completion (Ok resp)
+  |> Result.map_error (fun err -> Completion_error err)
 ;;
 
 let parse_openai_response_result body_str =
   try
     match Llm_provider.Backend_openai_parse.parse_openai_response_result body_str with
-    | Ok _ as ok -> ok
+    | Ok resp -> ensure_nonempty_response resp
     | Error (Llm_provider.Backend_openai_parse.Provider_error message) ->
-      Error (Retry.InvalidRequest { message; reason = Retry.Unknown_invalid_request })
-    | Error (Llm_provider.Backend_openai_parse.Empty_completion _) ->
       Error
-        (Retry.InvalidRequest
-           { message =
-               "provider returned an empty completion (no thinking, text, or tool calls)"
-           ; reason = Retry.Unknown_invalid_request
-           })
+        (Retry_error
+           (Retry.InvalidRequest { message; reason = Retry.Unknown_invalid_request }))
+    | Error (Llm_provider.Backend_openai_parse.Empty_completion empty) ->
+      Error
+        (Completion_error
+           (Http_client.empty_completion_error ~stop_reason:empty.stop_reason))
   with
   | Yojson.Json_error msg ->
     Error
-      (Retry.InvalidRequest
-         { message = "JSON parse error: " ^ msg; reason = Retry.Json_parse_error })
+      (Retry_error
+         (Retry.InvalidRequest
+            { message = "JSON parse error: " ^ msg; reason = Retry.Json_parse_error }))
   | Yojson.Safe.Util.Type_error (msg, _) ->
     Error
-      (Retry.InvalidRequest
-         { message = "JSON type error: " ^ msg; reason = Retry.Json_parse_error })
+      (Retry_error
+         (Retry.InvalidRequest
+            { message = "JSON type error: " ^ msg; reason = Retry.Json_parse_error }))
   | Yojson.Safe.Util.Undefined (msg, _) ->
     Error
-      (Retry.InvalidRequest
-         { message = "JSON undefined field error: " ^ msg
-         ; reason = Retry.Json_parse_error
-         })
+      (Retry_error
+         (Retry.InvalidRequest
+            { message = "JSON undefined field error: " ^ msg
+            ; reason = Retry.Json_parse_error
+            }))
 ;;
 
 (** Synchronous provider: can send a message and get a response. *)
@@ -164,23 +186,22 @@ let of_config (provider_cfg : Provider.config) : (provider_module, Error.sdk_err
                ()
            with
            | Ok (200, body_str) ->
-             (match kind with
-              | Provider.Anthropic_messages ->
-                Ok (Api_anthropic.parse_response (Yojson.Safe.from_string body_str))
-              | Provider.Openai_chat_completions ->
-                (match parse_openai_response_result body_str with
-                 | Ok resp -> Ok resp
-                 | Error err -> Error (Error.Api err))
-              | Provider.Custom name ->
-                (match Provider.find_provider name with
-                 | Some impl -> Ok (impl.parse_response body_str)
-                 | None ->
-                   (match parse_openai_response_result body_str with
-                    | Ok resp -> Ok resp
-                    | Error err -> Error (Error.Api err))))
+             let result =
+               match kind with
+               | Provider.Anthropic_messages ->
+                 Api_anthropic.parse_response (Yojson.Safe.from_string body_str)
+                 |> ensure_nonempty_response
+               | Provider.Openai_chat_completions -> parse_openai_response_result body_str
+               | Provider.Custom name ->
+                 (match Provider.find_provider name with
+                  | Some impl -> impl.parse_response body_str |> ensure_nonempty_response
+                  | None -> parse_openai_response_result body_str)
+             in
+             Result.map_error sdk_error_of_response_error result
            | Ok (code, body_str) ->
-             Error (Error.Api (Retry.classify_error ~status:code ~body:body_str))
-           | Error err -> Error (Error.Api (retry_error_of_http_error err)))
+             Error
+               (sdk_error_of_http_error (Http_client.HttpError { code; body = body_str }))
+           | Error err -> Error (sdk_error_of_http_error err))
       ;;
     end
     in

--- a/lib/streaming.ml
+++ b/lib/streaming.ml
@@ -45,34 +45,17 @@ let map_http_error = Http_error_sdk.of_http_error
 
 let map_stream_finalize_result = function
   | Error e -> Error (map_http_error e)
-  | Ok (Ok resp) when resp.content = [] ->
-    (* oas#2483 streaming symmetry: a stream that finalized cleanly but with no
-       content block is the streaming analog of the blank-200 empty completion
-       the non-streaming parser rejects as [Empty_completion]. Fail closed at
-       this consumption boundary so the driver never returns an empty assistant
-       turn as success (the empty-turn storm root). [finalize_stream_acc] stays
-       a pure structural assembler -- its unit tests still observe
-       [Ok content=[]]; only the driver applies the completion policy, mirroring
-       the sync [parse_openai_response_result] wrapper over its raw parser. A
-       truncated stream is already rejected earlier in [finalize_stream_acc]
-       ([stream_terminated_without_stop_reason]); this covers the clean-close
-       empty case. *)
-    Error
-      (map_http_error
-         (Llm_provider.Complete_stream.http_error_of_stream_error
-            (Stream_parse_failed
-               { reason =
-                   Printf.sprintf
-                     "empty_completion:%s"
-                     (stop_reason_to_string resp.stop_reason)
-               ; raw = ""
-               })))
-  | Ok (Ok resp) -> Ok (Llm_provider.Pricing.annotate_response_cost resp)
-  | Ok (Error serr) ->
-    Error (map_http_error (Llm_provider.Complete_stream.http_error_of_stream_error serr))
+  | Ok result ->
+    let result =
+      Result.map_error Llm_provider.Complete_stream.http_error_of_stream_error result
+      |> Llm_provider.Complete_common.ensure_nonempty_completion
+    in
+    (match result with
+     | Ok resp -> Ok (Llm_provider.Pricing.annotate_response_cost resp)
+     | Error err -> Error (map_http_error err))
 ;;
 
-let%test "map_stream_finalize_result fails closed on empty completion (oas#2483)" =
+let%test "map_stream_finalize_result maps typed empty to provider unavailable (oas#2483)" =
   let empty_resp : api_response =
     { id = "m"
     ; model = "test"
@@ -82,11 +65,12 @@ let%test "map_stream_finalize_result fails closed on empty completion (oas#2483)
     ; telemetry = None
     }
   in
+  let max_tokens_resp = { empty_resp with stop_reason = MaxTokens } in
   let ok_resp = { empty_resp with content = [ Text "hi" ] } in
-  let empty_fails =
-    match map_stream_finalize_result (Ok (Ok empty_resp)) with
-    | Error _ -> true
-    | Ok _ -> false
+  let fails_closed response =
+    match map_stream_finalize_result (Ok (Ok response)) with
+    | Error (Error.Provider (Llm_provider.Error.ProviderUnavailable _)) -> true
+    | Error _ | Ok _ -> false
   in
   (* A content-bearing completion still finalizes Ok: the guard fires only on
      the all-empty clean close, not on every stream. *)
@@ -95,7 +79,7 @@ let%test "map_stream_finalize_result fails closed on empty completion (oas#2483)
     | Ok _ -> true
     | Error _ -> false
   in
-  empty_fails && nonempty_ok
+  fails_closed empty_resp && fails_closed max_tokens_resp && nonempty_ok
 ;;
 
 (** Streaming variant of create_message.

--- a/test/test_api_http_client.ml
+++ b/test/test_api_http_client.ml
@@ -5,12 +5,26 @@ let openai_response =
   {|{"id":"chatcmpl-legacy-api","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":2}}|}
 ;;
 
-let with_mock_server ~port handler f =
+let fresh_port () =
+  let socket = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+  Unix.setsockopt socket Unix.SO_REUSEADDR true;
+  Unix.bind socket (Unix.ADDR_INET (Unix.inet_addr_loopback, 0));
+  let port =
+    match Unix.getsockname socket with
+    | Unix.ADDR_INET (_, port) -> port
+    | _ -> Alcotest.fail "expected inet socket"
+  in
+  Unix.close socket;
+  port
+;;
+
+let with_mock_server ?port handler f =
   Eio_main.run
   @@ fun env ->
   try
     Eio.Switch.run
     @@ fun sw ->
+    let port = Option.value port ~default:(fresh_port ()) in
     let socket =
       Eio.Net.listen
         env#net
@@ -27,6 +41,41 @@ let with_mock_server ~port handler f =
     Eio.Switch.fail sw Exit
   with
   | Exit -> ()
+;;
+
+let empty_openai_response finish_reason =
+  Printf.sprintf
+    {|{"id":"chatcmpl-empty","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":null},"finish_reason":"%s"}],"usage":{"prompt_tokens":1,"completion_tokens":0}}|}
+    finish_reason
+;;
+
+let state_and_messages (provider : Provider.config) =
+  let config =
+    { default_config with
+      model = provider.model_id
+    ; system_prompt = Some "reply briefly"
+    ; max_turns = 1
+    ; max_tokens = Some 16
+    }
+  in
+  let state = { config; messages = []; turn_count = 0; usage = empty_usage } in
+  let messages =
+    [ { role = User
+      ; content = [ Text "hello" ]
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = []
+      }
+    ]
+  in
+  state, messages
+;;
+
+let expect_provider_unavailable = function
+  | Error (Error.Provider (Llm_provider.Error.ProviderUnavailable _)) -> ()
+  | Error err ->
+    Alcotest.failf "expected ProviderUnavailable, got %s" (Error.to_string err)
+  | Ok _ -> Alcotest.fail "expected ProviderUnavailable, got Ok"
 ;;
 
 let test_create_message_uses_hardened_http_client () =
@@ -89,6 +138,76 @@ let test_create_message_uses_hardened_http_client () =
               response.content)))
 ;;
 
+let test_create_message_empty_completion_maps_to_provider_unavailable () =
+  List.iter
+    (fun finish_reason ->
+       let handler _conn _req body =
+         ignore (Eio.Buf_read.(of_flow ~max_size:(1024 * 1024) body |> take_all) : string);
+         Cohttp_eio.Server.respond_string
+           ~status:`OK
+           ~body:(empty_openai_response finish_reason)
+           ()
+       in
+       with_mock_server handler (fun ~sw ~net ~clock ~base_url ->
+         let provider : Provider.config =
+           { provider = Local { base_url }; model_id = "mock"; api_key_env = "DUMMY_KEY" }
+         in
+         let config, messages = state_and_messages provider in
+         Api.create_message ~sw ~net ~clock ~provider ~config ~messages ()
+         |> expect_provider_unavailable))
+    [ "stop"; "length" ]
+;;
+
+let test_custom_stream_fallback_empty_maps_to_provider_unavailable () =
+  List.iter
+    (fun stop_reason ->
+       let handler _conn _req body =
+         ignore (Eio.Buf_read.(of_flow ~max_size:(1024 * 1024) body |> take_all) : string);
+         Cohttp_eio.Server.respond_string ~status:`OK ~body:"custom-empty" ()
+       in
+       with_mock_server handler (fun ~sw ~net ~clock:_ ~base_url ->
+         let name =
+           "api-custom-empty-" ^ Llm_provider.Types.stop_reason_to_string stop_reason
+         in
+         let impl : Provider.provider_impl =
+           { name
+           ; request_kind = Provider.Custom name
+           ; request_path = "/v1/custom"
+           ; capabilities =
+               { Provider.default_capabilities with supports_native_streaming = false }
+           ; build_body = (fun ~config:_ ~messages:_ ?tools:_ () -> "{}")
+           ; parse_response =
+               (fun _ ->
+                 { id = "custom-empty"
+                 ; model = "mock"
+                 ; stop_reason
+                 ; content = []
+                 ; usage = None
+                 ; telemetry = None
+                 })
+           ; resolve =
+               (fun _ -> Ok (base_url, "", [ "Content-Type", "application/json" ]))
+           }
+         in
+         Provider.register_provider impl;
+         let provider = Provider.custom_provider ~name ~model_id:"mock" () in
+         let config, messages = state_and_messages provider in
+         let events = ref [] in
+         let result =
+           Streaming.create_message_stream
+             ~sw
+             ~net
+             ~provider
+             ~config
+             ~messages
+             ~on_event:(fun event -> events := event :: !events)
+             ()
+         in
+         Alcotest.(check int) "no synthetic events" 0 (List.length !events);
+         expect_provider_unavailable result))
+    [ Llm_provider.Types.EndTurn; Llm_provider.Types.MaxTokens ]
+;;
+
 let () =
   Alcotest.run
     "Api_http_client"
@@ -97,6 +216,14 @@ let () =
             "uses hardened post_sync headers"
             `Quick
             test_create_message_uses_hardened_http_client
+        ; Alcotest.test_case
+            "empty completion maps to provider unavailable"
+            `Quick
+            test_create_message_empty_completion_maps_to_provider_unavailable
+        ; Alcotest.test_case
+            "custom stream fallback maps empty to provider unavailable"
+            `Quick
+            test_custom_stream_fallback_empty_maps_to_provider_unavailable
         ] )
     ]
 ;;

--- a/test/test_complete_ext.ml
+++ b/test/test_complete_ext.ml
@@ -38,14 +38,14 @@ let make_usage ?(input_tokens = 11) ?(output_tokens = 7) () : Types.api_usage =
   }
 ;;
 
-let make_response ?(model = "") ?(content = [ Types.Text "ok" ]) ?usage () =
-  { Types.id = "resp-complete-ext"
-  ; model
-  ; stop_reason = EndTurn
-  ; content
-  ; usage
-  ; telemetry = None
-  }
+let make_response
+      ?(model = "")
+      ?(stop_reason = Types.EndTurn)
+      ?(content = [ Types.Text "ok" ])
+      ?usage
+      ()
+  =
+  { Types.id = "resp-complete-ext"; model; stop_reason; content; usage; telemetry = None }
 ;;
 
 type metric_probe =
@@ -124,6 +124,16 @@ let string_of_http_error = function
   | ProviderTerminal { message; _ } -> message
   | ProviderFailure { kind; message } ->
     Http_client.provider_failure_to_string ~kind ~message
+;;
+
+let check_typed_empty_completion expected = function
+  | Error
+      (Http_client.ProviderFailure
+         { kind = Http_client.Empty_completion { stop_reason }; _ }) ->
+    check bool "typed stop reason" true (stop_reason = expected)
+  | Ok _ -> fail "expected empty completion error, got Ok"
+  | Error err ->
+    failf "expected typed empty completion, got %s" (string_of_http_error err)
 ;;
 
 (* ── is_retryable ────────────────────────────────────── *)
@@ -403,6 +413,119 @@ let test_complete_transport_success_cache_metrics_and_trace_headers () =
   check (list int) "tool calls" [ 1 ] (List.rev probe.tool_calls)
 ;;
 
+let test_complete_injected_transport_rejects_typed_empty () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let config = make_config ~model_id:"injected-sync-empty" () in
+  List.iter
+    (fun stop_reason ->
+       let response = make_response ~stop_reason ~content:[] () in
+       let transport =
+         transport_of_sync (fun () ->
+           { Llm_transport.response = Ok response; latency_ms = Some 1 })
+       in
+       Complete.complete
+         ~sw
+         ~net:(Eio.Stdenv.net env)
+         ~transport
+         ~config
+         ~messages:[ Types.user_msg "hello" ]
+         ()
+       |> check_typed_empty_completion stop_reason)
+    [ Types.EndTurn; Types.MaxTokens ]
+;;
+
+let test_complete_stream_injected_transport_rejects_typed_empty () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let config = make_config ~model_id:"injected-stream-empty" () in
+  List.iter
+    (fun stop_reason ->
+       let response = make_response ~stop_reason ~content:[] () in
+       let transport =
+         transport_of_sync (fun () ->
+           { Llm_transport.response = Ok response; latency_ms = Some 1 })
+       in
+       Complete.complete_stream
+         ~sw
+         ~net:(Eio.Stdenv.net env)
+         ~transport
+         ~config
+         ~messages:[ Types.user_msg "hello" ]
+         ~on_event:(fun _ -> ())
+         ()
+       |> check_typed_empty_completion stop_reason)
+    [ Types.EndTurn; Types.MaxTokens ]
+;;
+
+let test_complete_cached_empty_fails_before_transport () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let response = make_response ~stop_reason:Types.MaxTokens ~content:[] () in
+  let cached_json = Cache.response_to_json response in
+  let cache : Cache.t =
+    { get = (fun ~key:_ -> Some cached_json); set = (fun ~key:_ ~ttl_sec:_ _ -> ()) }
+  in
+  let transport_calls = ref 0 in
+  let transport =
+    transport_of_sync (fun () ->
+      incr transport_calls;
+      { Llm_transport.response = Ok (make_response ()); latency_ms = Some 1 })
+  in
+  let result =
+    Complete.complete
+      ~sw
+      ~net:(Eio.Stdenv.net env)
+      ~transport
+      ~config:(make_config ~model_id:"cached-empty" ())
+      ~messages:[ Types.user_msg "hello" ]
+      ~cache
+      ()
+  in
+  check int "transport not called" 0 !transport_calls;
+  check_typed_empty_completion Types.MaxTokens result
+;;
+
+let test_complete_with_retry_does_not_retry_empty_completion () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let calls = ref 0 in
+  let response = make_response ~stop_reason:Types.MaxTokens ~content:[] () in
+  let transport =
+    transport_of_sync (fun () ->
+      incr calls;
+      { Llm_transport.response = Ok response; latency_ms = Some 1 })
+  in
+  let retry_config =
+    { Complete.max_retries = 3
+    ; initial_delay_sec = 0.0
+    ; max_delay_sec = 0.0
+    ; backoff_multiplier = 1.0
+    }
+  in
+  let result =
+    Complete.complete_with_retry
+      ~sw
+      ~net:(Eio.Stdenv.net env)
+      ~transport
+      ~clock:(Eio.Stdenv.clock env)
+      ~config:(make_config ~model_id:"empty-no-retry" ())
+      ~messages:[ Types.user_msg "hello" ]
+      ~retry_config
+      ()
+  in
+  check int "single attempt" 1 !calls;
+  check_typed_empty_completion Types.MaxTokens result
+;;
+
 let test_complete_with_retry_retries_then_success () =
   Eio_main.run
   @@ fun env ->
@@ -571,6 +694,22 @@ let () =
             "retry retries then success"
             `Quick
             test_complete_with_retry_retries_then_success
+        ; test_case
+            "injected sync rejects typed empty"
+            `Quick
+            test_complete_injected_transport_rejects_typed_empty
+        ; test_case
+            "injected stream rejects typed empty"
+            `Quick
+            test_complete_stream_injected_transport_rejects_typed_empty
+        ; test_case
+            "cached empty fails before transport"
+            `Quick
+            test_complete_cached_empty_fails_before_transport
+        ; test_case
+            "empty completion is not retried"
+            `Quick
+            test_complete_with_retry_does_not_retry_empty_completion
         ; test_case
             "stream transport success metrics and telemetry"
             `Quick

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -16,6 +16,25 @@ let anthropic_response ?(id = "msg-1") ?(model = "mock") ?(stop_reason = "end_tu
     stop_reason
 ;;
 
+let anthropic_empty_response stop_reason =
+  Printf.sprintf
+    {|{"id":"msg-empty","type":"message","role":"assistant","model":"mock","content":[],"stop_reason":"%s","usage":{"input_tokens":10,"output_tokens":0}}|}
+    stop_reason
+;;
+
+let anthropic_empty_sse stop_reason =
+  Printf.sprintf
+    "event: message_start\n\
+     data: \
+     {\"type\":\"message_start\",\"message\":{\"id\":\"msg-empty\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"mock\",\"content\":[],\"stop_reason\":null,\"usage\":{\"input_tokens\":10,\"output_tokens\":0}}}\n\n\
+     event: message_delta\n\
+     data: \
+     {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"%s\"},\"usage\":{\"output_tokens\":0}}\n\n\
+     event: message_stop\n\
+     data: {\"type\":\"message_stop\"}\n\n"
+    stop_reason
+;;
+
 let openai_response text =
   Printf.sprintf
     {|{"id":"chatcmpl-1","object":"chat.completion","model":"gpt-4","choices":[{"index":0,"message":{"role":"assistant","content":"%s"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5}}|}
@@ -177,6 +196,15 @@ let make_transport response : Llm_transport.t =
   }
 ;;
 
+let check_typed_empty_completion expected = function
+  | Error
+      (Http_client.ProviderFailure
+         { kind = Http_client.Empty_completion { stop_reason }; _ }) ->
+    check bool "typed stop reason" true (stop_reason = expected)
+  | Ok _ -> fail "expected empty completion error, got Ok"
+  | Error _ -> fail "expected typed empty completion provider failure"
+;;
+
 (* ── complete: success ───────────────────────────────── *)
 
 let test_complete_anthropic_ok () =
@@ -203,6 +231,54 @@ let test_complete_anthropic_ok () =
     | Error _ -> fail "expected Ok"
   with
   | Exit -> ()
+;;
+
+let test_complete_http_rejects_typed_empty_completion () =
+  let run expected wire_stop_reason =
+    Eio_main.run
+    @@ fun env ->
+    try
+      Eio.Switch.run
+      @@ fun sw ->
+      let url =
+        start_mock_server ~sw ~net:env#net (anthropic_empty_response wire_stop_reason)
+      in
+      Complete.complete ~sw ~net:env#net ~config:(make_config url) ~messages ()
+      |> check_typed_empty_completion expected;
+      Eio.Switch.fail sw Exit
+    with
+    | Exit -> ()
+  in
+  List.iter
+    (fun (expected, wire) -> run expected wire)
+    [ Types.EndTurn, "end_turn"; Types.MaxTokens, "max_tokens" ]
+;;
+
+let test_complete_stream_http_rejects_typed_empty_completion () =
+  let run expected wire_stop_reason =
+    Eio_main.run
+    @@ fun env ->
+    try
+      Eio.Switch.run
+      @@ fun sw ->
+      let url =
+        start_mock_server ~sw ~net:env#net (anthropic_empty_sse wire_stop_reason)
+      in
+      Complete.complete_stream
+        ~sw
+        ~net:env#net
+        ~config:(make_config url)
+        ~messages
+        ~on_event:(fun _ -> ())
+        ()
+      |> check_typed_empty_completion expected;
+      Eio.Switch.fail sw Exit
+    with
+    | Exit -> ()
+  in
+  List.iter
+    (fun (expected, wire) -> run expected wire)
+    [ Types.EndTurn, "end_turn"; Types.MaxTokens, "max_tokens" ]
 ;;
 
 (* ── complete: HTTP error ────────────────────────────── *)
@@ -1819,6 +1895,10 @@ let () =
     "complete_http"
     [ ( "complete"
       , [ test_case "anthropic ok" `Quick test_complete_anthropic_ok
+        ; test_case
+            "HTTP rejects typed empty completion"
+            `Quick
+            test_complete_http_rejects_typed_empty_completion
         ; test_case "http error" `Quick test_complete_http_error
         ; test_case
             "empty http error body has context"
@@ -1884,6 +1964,10 @@ let () =
     ; "retry", [ test_case "first try ok" `Quick test_retry_first_try ]
     ; ( "stream"
       , [ test_case "sse ok" `Quick test_complete_stream_ok
+        ; test_case
+            "HTTP stream rejects typed empty completion"
+            `Quick
+            test_complete_stream_http_rejects_typed_empty_completion
         ; test_case
             "preserves thinking signature"
             `Quick

--- a/test/test_http_client.ml
+++ b/test/test_http_client.ml
@@ -327,6 +327,10 @@ let test_provider_failure_string_helpers () =
     ; Http_client.Cli_startup_failed { reason = "missing" }, "cli_startup_failed"
     ; Http_client.Provider_parse_error { parser = Some "glm" }, "provider_parse_error:glm"
     ; Http_client.Provider_parse_error { parser = None }, "provider_parse_error"
+    ; ( Http_client.Empty_completion { stop_reason = Types.EndTurn }
+      , "empty_completion:end_turn" )
+    ; ( Http_client.Empty_completion { stop_reason = Types.MaxTokens }
+      , "empty_completion:max_tokens" )
     ; ( Http_client.Unknown_provider_failure { reason = Some "exit_status" }
       , "unknown_provider_failure:exit_status" )
     ; Http_client.Unknown_provider_failure { reason = None }, "unknown_provider_failure"
@@ -351,6 +355,18 @@ let test_provider_failure_string_helpers () =
     (Http_client.provider_failure_to_string
        ~kind:(Http_client.Hard_quota { retry_after = None })
        ~message:"quota exhausted")
+;;
+
+let test_empty_completion_error_preserves_stop_reason () =
+  List.iter
+    (fun expected ->
+       match Http_client.empty_completion_error ~stop_reason:expected with
+       | Http_client.ProviderFailure
+           { kind = Http_client.Empty_completion { stop_reason }; message } ->
+         Alcotest.(check bool) "typed stop reason" true (stop_reason = expected);
+         Alcotest.(check bool) "nonempty detail" true (String.trim message <> "")
+       | _ -> Alcotest.fail "expected Empty_completion provider failure")
+    [ Types.EndTurn; Types.MaxTokens ]
 ;;
 
 let test_api_common_string_is_blank () =
@@ -542,6 +558,10 @@ let () =
         ] )
     ; ( "provider_failure"
       , [ Alcotest.test_case "string helpers" `Quick test_provider_failure_string_helpers
+        ; Alcotest.test_case
+            "empty completion preserves stop reason"
+            `Quick
+            test_empty_completion_error_preserves_stop_reason
         ] )
     ; ( "api_common"
       , [ Alcotest.test_case "string_is_blank" `Quick test_api_common_string_is_blank

--- a/test/test_llm_provider_error.ml
+++ b/test/test_llm_provider_error.ml
@@ -506,6 +506,22 @@ let test_provider_failure_remaining_variants_mapping () =
   | _ -> fail "expected ProviderUnavailable unknown failure"
 ;;
 
+let test_provider_failure_empty_completion_maps_to_unavailable () =
+  List.iter
+    (fun expected ->
+       let mapped =
+         Error.of_http_error
+           ~provider:"openai"
+           (Http_client.empty_completion_error ~stop_reason:expected)
+       in
+       match mapped with
+       | Error.ProviderUnavailable { provider; detail } ->
+         check string "provider" "openai" provider;
+         check bool "nonempty detail" true (String.trim detail <> "")
+       | _ -> fail "expected ProviderUnavailable")
+    [ Types.EndTurn; Types.MaxTokens ]
+;;
+
 let test_http_boundary_remaining_variants_mapping () =
   let accept =
     Error.of_http_error
@@ -621,6 +637,10 @@ let () =
             "Provider failure remaining variants"
             `Quick
             test_provider_failure_remaining_variants_mapping
+        ; test_case
+            "Provider failure empty completion maps to unavailable"
+            `Quick
+            test_provider_failure_empty_completion_maps_to_unavailable
         ; test_case
             "HTTP boundary remaining variants"
             `Quick

--- a/test/test_pipeline_metrics.ml
+++ b/test/test_pipeline_metrics.ml
@@ -53,6 +53,40 @@ let mk_header_capture_transport headers_ref : Llm_provider.Llm_transport.t =
   }
 ;;
 
+let mk_empty_transport stop_reason : Llm_provider.Llm_transport.t =
+  let response = { (mk_mock_response ()) with stop_reason; content = [] } in
+  { complete_sync = (fun _ -> { response = Ok response; latency_ms = Some 1 })
+  ; complete_stream = (fun ?on_telemetry:_ ~on_event:_ _ -> Ok response)
+  }
+;;
+
+let make_empty_agent ~net ~stop_reason ~name =
+  let options =
+    { Agent_types.default_options with
+      transport = Some (mk_empty_transport stop_reason)
+    ; provider = Some (Provider_mock.to_provider_config ())
+    ; guardrails = Guardrails.permissive
+    }
+  in
+  Agent.create ~net ~config:{ Types.default_config with name; max_turns = 1 } ~options ()
+;;
+
+let check_agent_empty_failure agent = function
+  | Error (Error.Provider (Llm_provider.Error.ProviderUnavailable _)) ->
+    let state = Agent.state agent in
+    Alcotest.(check int) "turn not advanced" 0 state.turn_count;
+    Alcotest.(check int)
+      "no assistant message"
+      0
+      (List.length
+         (List.filter
+            (fun (message : Types.message) -> message.role = Types.Assistant)
+            state.messages))
+  | Error err ->
+    Alcotest.failf "expected ProviderUnavailable, got %s" (Error.to_string err)
+  | Ok _ -> Alcotest.fail "expected ProviderUnavailable, got Ok"
+;;
+
 let test_sync_dispatches_via_complete_triggers_metrics () =
   Eio_main.run
   @@ fun env ->
@@ -148,6 +182,38 @@ let test_stage_route_passes_trace_context_headers () =
      | None -> Alcotest.fail "missing traceparent header")
 ;;
 
+let test_agent_run_rejects_injected_empty_completion () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  List.iter
+    (fun stop_reason ->
+       let agent =
+         make_empty_agent ~net:(Eio.Stdenv.net env) ~stop_reason ~name:"agent-sync-empty"
+       in
+       Agent.run ~sw agent "ping" |> check_agent_empty_failure agent)
+    [ Types.EndTurn; Types.MaxTokens ]
+;;
+
+let test_agent_run_stream_rejects_injected_empty_completion () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  List.iter
+    (fun stop_reason ->
+       let agent =
+         make_empty_agent
+           ~net:(Eio.Stdenv.net env)
+           ~stop_reason
+           ~name:"agent-stream-empty"
+       in
+       Agent.run_stream ~sw ~on_event:(fun _ -> ()) agent "ping"
+       |> check_agent_empty_failure agent)
+    [ Types.EndTurn; Types.MaxTokens ]
+;;
+
 let test_sdk_error_of_http_error_classifies () =
   (* Pure smoke test for the conversion helper introduced in pipeline.ml *)
   let _ : Error.sdk_error =
@@ -228,6 +294,14 @@ let () =
             "stage route forwards trace context"
             `Quick
             test_stage_route_passes_trace_context_headers
+        ; Alcotest.test_case
+            "Agent.run rejects injected empty completion"
+            `Quick
+            test_agent_run_rejects_injected_empty_completion
+        ; Alcotest.test_case
+            "Agent.run_stream rejects injected empty completion"
+            `Quick
+            test_agent_run_stream_rejects_injected_empty_completion
         ] )
     ]
 ;;

--- a/test/test_provider_intf.ml
+++ b/test/test_provider_intf.ml
@@ -72,6 +72,12 @@ let openai_response =
   {|{"id":"chatcmpl-provider-intf","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":2}}|}
 ;;
 
+let empty_openai_response finish_reason =
+  Printf.sprintf
+    {|{"id":"chatcmpl-empty","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":null},"finish_reason":"%s"}],"usage":{"prompt_tokens":1,"completion_tokens":0}}|}
+    finish_reason
+;;
+
 let user_messages =
   [ { role = User
     ; content = [ Text "hello" ]
@@ -130,6 +136,43 @@ let with_mock_server ?port handler f =
     Eio.Switch.fail sw Exit
   with
   | Exit -> ()
+;;
+
+let expect_provider_unavailable = function
+  | Error (Error.Provider (Llm_provider.Error.ProviderUnavailable _)) -> ()
+  | Error err ->
+    Alcotest.failf "expected ProviderUnavailable, got %s" (Error.to_string err)
+  | Ok _ -> Alcotest.fail "expected ProviderUnavailable, got Ok"
+;;
+
+let with_openai_response response_body check_result =
+  let handler _conn _req body =
+    ignore (Eio.Buf_read.(of_flow ~max_size:(1024 * 1024) body |> take_all) : string);
+    Cohttp_eio.Server.respond_string ~status:`OK ~body:response_body ()
+  in
+  with_mock_server handler (fun ~sw ~net ~base_url ->
+    let provider : Provider.config =
+      { provider = Local { base_url }; model_id = "mock"; api_key_env = "DUMMY_KEY" }
+    in
+    let (module P : Provider_intf.PROVIDER) = require_provider provider in
+    P.create_message
+      ~sw
+      ~net
+      ~config:(state_for_provider provider)
+      ~messages:user_messages
+      ()
+    |> check_result)
+;;
+
+let expect_invalid_request ~reason ~message_prefix = function
+  | Error (Error.Api (Retry.InvalidRequest { message; reason = actual_reason })) ->
+    Alcotest.(check bool) "reason preserved" true (actual_reason = reason);
+    Alcotest.(check bool)
+      "message prefix preserved"
+      true
+      (String.starts_with ~prefix:message_prefix message)
+  | Error err -> Alcotest.failf "expected InvalidRequest, got %s" (Error.to_string err)
+  | Ok _ -> Alcotest.fail "expected InvalidRequest, got Ok"
 ;;
 
 let test_provider_dispatch_uses_http_client () =
@@ -202,27 +245,104 @@ let test_provider_dispatch_maps_server_error () =
 ;;
 
 let test_provider_dispatch_rejects_malformed_openai_response () =
-  let handler _conn _req body =
-    ignore (Eio.Buf_read.(of_flow ~max_size:(1024 * 1024) body |> take_all) : string);
-    Cohttp_eio.Server.respond_string ~status:`OK ~body:{|{"choices":"not-a-list"}|} ()
-  in
-  with_mock_server handler (fun ~sw ~net ~base_url ->
-    let provider : Provider.config =
-      { provider = Local { base_url }; model_id = "mock"; api_key_env = "DUMMY_KEY" }
-    in
-    let (module P : Provider_intf.PROVIDER) = require_provider provider in
-    match
-      P.create_message
-        ~sw
-        ~net
-        ~config:(state_for_provider provider)
-        ~messages:user_messages
-        ()
-    with
-    | Error (Error.Api (Retry.InvalidRequest { message; _ })) ->
-      Alcotest.(check bool) "parse message present" true (String.length message > 0)
-    | Error err -> Alcotest.failf "unexpected error: %s" (Error.to_string err)
-    | Ok _ -> Alcotest.fail "expected malformed response rejection")
+  with_openai_response
+    {|{"choices":"not-a-list"}|}
+    (expect_invalid_request
+       ~reason:Retry.Json_parse_error
+       ~message_prefix:"JSON type error:")
+;;
+
+let test_provider_dispatch_preserves_provider_error_projection () =
+  with_openai_response
+    {|{"error":{"message":"context window exceeded"}}|}
+    (expect_invalid_request
+       ~reason:Retry.Unknown_invalid_request
+       ~message_prefix:"context window exceeded")
+;;
+
+let test_provider_dispatch_preserves_json_parse_error_projection () =
+  with_openai_response
+    "{"
+    (expect_invalid_request
+       ~reason:Retry.Json_parse_error
+       ~message_prefix:"JSON parse error:")
+;;
+
+let test_provider_dispatch_preserves_json_undefined_projection () =
+  with_openai_response
+    {|{"choices":[]}|}
+    (expect_invalid_request
+       ~reason:Retry.Json_parse_error
+       ~message_prefix:"JSON undefined field error:")
+;;
+
+let test_provider_dispatch_empty_openai_maps_to_unavailable () =
+  List.iter
+    (fun finish_reason ->
+       let handler _conn _req body =
+         ignore (Eio.Buf_read.(of_flow ~max_size:(1024 * 1024) body |> take_all) : string);
+         Cohttp_eio.Server.respond_string
+           ~status:`OK
+           ~body:(empty_openai_response finish_reason)
+           ()
+       in
+       with_mock_server handler (fun ~sw ~net ~base_url ->
+         let provider : Provider.config =
+           { provider = Local { base_url }; model_id = "mock"; api_key_env = "DUMMY_KEY" }
+         in
+         let (module P : Provider_intf.PROVIDER) = require_provider provider in
+         P.create_message
+           ~sw
+           ~net
+           ~config:(state_for_provider provider)
+           ~messages:user_messages
+           ()
+         |> expect_provider_unavailable))
+    [ "stop"; "length" ]
+;;
+
+let test_custom_provider_empty_maps_to_unavailable () =
+  List.iter
+    (fun stop_reason ->
+       let handler _conn _req body =
+         ignore (Eio.Buf_read.(of_flow ~max_size:(1024 * 1024) body |> take_all) : string);
+         Cohttp_eio.Server.respond_string ~status:`OK ~body:"custom-empty" ()
+       in
+       with_mock_server handler (fun ~sw ~net ~base_url ->
+         let name =
+           "provider-intf-empty-" ^ Llm_provider.Types.stop_reason_to_string stop_reason
+         in
+         let impl : Provider.provider_impl =
+           { name
+           ; request_kind = Provider.Custom name
+           ; request_path = "/v1/custom"
+           ; capabilities =
+               { Provider.default_capabilities with supports_native_streaming = false }
+           ; build_body = (fun ~config:_ ~messages:_ ?tools:_ () -> "{}")
+           ; parse_response =
+               (fun _ ->
+                 { id = "custom-empty"
+                 ; model = "custom-model"
+                 ; stop_reason
+                 ; content = []
+                 ; usage = None
+                 ; telemetry = None
+                 })
+           ; resolve =
+               (fun _ -> Ok (base_url, "", [ "Content-Type", "application/json" ]))
+           }
+         in
+         Provider.register_provider impl;
+         let provider = Provider.custom_provider ~name ~model_id:"custom-model" () in
+         let (module P : Provider_intf.PROVIDER) = require_provider provider in
+         P.create_message
+           ~sw
+           ~net
+           ~config:(state_for_provider provider)
+           ~messages:user_messages
+           ()
+         |> expect_provider_unavailable))
+    [ Llm_provider.Types.EndTurn; Llm_provider.Types.MaxTokens ]
 ;;
 
 let test_custom_provider_dispatch_uses_registered_impl () =
@@ -345,6 +465,26 @@ let () =
             "rejects malformed response"
             `Quick
             test_provider_dispatch_rejects_malformed_openai_response
+        ; Alcotest.test_case
+            "preserves provider error projection"
+            `Quick
+            test_provider_dispatch_preserves_provider_error_projection
+        ; Alcotest.test_case
+            "preserves JSON parse error projection"
+            `Quick
+            test_provider_dispatch_preserves_json_parse_error_projection
+        ; Alcotest.test_case
+            "preserves JSON undefined projection"
+            `Quick
+            test_provider_dispatch_preserves_json_undefined_projection
+        ; Alcotest.test_case
+            "empty OpenAI maps to provider unavailable"
+            `Quick
+            test_provider_dispatch_empty_openai_maps_to_unavailable
+        ; Alcotest.test_case
+            "custom empty maps to provider unavailable"
+            `Quick
+            test_custom_provider_empty_maps_to_unavailable
         ; Alcotest.test_case
             "custom provider dispatch"
             `Quick

--- a/test/test_stream_accumulator.ml
+++ b/test/test_stream_accumulator.ml
@@ -476,6 +476,20 @@ let test_map_http_error_provider_parse_failure () =
   | _ -> Alcotest.fail "expected provider ParseError"
 ;;
 
+let test_map_http_error_empty_completion_maps_to_unavailable () =
+  List.iter
+    (fun expected ->
+       let err =
+         Streaming.map_http_error
+           (Llm_provider.Http_client.empty_completion_error ~stop_reason:expected)
+       in
+       match err with
+       | Error.Provider (Llm_provider.Error.ProviderUnavailable { detail; _ }) ->
+         Alcotest.(check bool) "nonempty detail" true (String.trim detail <> "")
+       | _ -> Alcotest.fail "expected provider unavailable")
+    [ Llm_provider.Types.EndTurn; Llm_provider.Types.MaxTokens ]
+;;
+
 (* ── Runner ───────────────────────────────────────────────── *)
 
 let () =
@@ -555,6 +569,10 @@ let () =
             "provider parse failure"
             `Quick
             test_map_http_error_provider_parse_failure
+        ; Alcotest.test_case
+            "empty completion maps to unavailable"
+            `Quick
+            test_map_http_error_empty_completion_maps_to_unavailable
         ] )
     ]
 ;;


### PR DESCRIPTION
## Audit finding

The jeong-sik/oas#2488/#2491 family did not converge empty-completion policy at the real Agent boundary. Sync parsing had typed Empty_completion, legacy streaming fabricated Stream_parse_failed with an encoded reason string, and Agent.run_stream plus injected transports still passed through Llm_provider.Complete without the guard.

## Change

- add one Complete_common.ensure_nonempty_completion policy helper
- enforce it at Complete.complete for cache, built-in HTTP, and injected sync transport
- enforce it at Complete.complete_stream for built-in HTTP and injected stream transport
- converge legacy Api, Provider_intf, Streaming, OpenAI, Anthropic, and custom fallback paths
- preserve Types.stop_reason in Http_client.Empty_completion until the existing SDK projection
- keep the public Error.sdk_error surface source-compatible as ProviderUnavailable
- preserve every pre-existing non-empty Provider_intf parse/error projection and retryability

No control flow parses diagnostic strings, and no new public Error or Error_domain constructor is added.

## Verification

- focused 9-suite matrix: 235 tests pass
- final Provider_intf regression suite: 15/15
- Api HTTP boundary: 3/3
- Agent.run and Agent.run_stream injected-empty state invariants: pass
- scripts/dune-local.sh runtest lib: pass
- scripts/dune-local.sh build lib/ test/: pass
- OCamlFormat 0.29.0 and git diff --check: pass
- two independent adversarial reviews: final P0/P1/P2/P3 = 0

## Dependency / CI truth

Raw current main still carries the jeong-sik/oas#2487 ratchet and formatting debt. This PR holds those counts rather than waiving or rebaselining them, so merge readiness depends on jeong-sik/oas#2495. The 0.209 release/migration boundary in child jeong-sik/oas#2497 must also be incorporated before any ordinary OAS fix reaches main.

Audit source: jeong-sik/oas#2491 (and jeong-sik/oas#2488 lineage).

[근거] origin/main=4fdf5deb; focused wrapper builds/tests and current diff; gh pr view 2488,2491 / 확인일시 2026-07-10 11:52 KST / 신뢰도 High.