### PR TITLE
Keep summarizer contract domain-agnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4652,7 +4652,7 @@ Signature: `val default_summarizer : Types.message list -> string`. No behavior 
 - `pipeline.ml` (`proactive_compact` + `emergency_compact`) threads `?summarizer:agent.options.summarizer` into `Budget_strategy.reduce_for_budget`.
 - The existing `?summarizer` optional parameter on `Budget_strategy.reduce_for_budget` is unchanged; it is simply now reachable from `Agent.options`.
 
-Motivation: consumers that embed application-specific structured markers in message bodies (e.g. `[STATE]...[/STATE]` blocks) need a way to strip or transform those markers before they are re-injected as compacted history. Previously the only path was post-hoc scrubbing via `context_reducer`, which runs **after** `reduce_for_budget` — by that point the `[Summary of N earlier messages]` string is already materialized. Exposing the summarizer on `Agent.options` closes that gap while keeping OAS agnostic of any specific marker syntax.
+Motivation: consumers may need application-specific summary semantics before messages are re-injected as compacted history. Previously the only customization path was post-hoc transformation via `context_reducer`, which runs **after** `reduce_for_budget` — by that point the `[Summary of N earlier messages]` string is already materialized. Exposing the summarizer on `Agent.options` makes that boundary explicit while keeping OAS domain-agnostic.
 
 PR #973.
 

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -108,11 +108,9 @@ type options =
         {!Budget_strategy.reduce_for_budget} when the Emergency phase
         triggers [Summarize_old].  When [None], the built-in
         [Budget_strategy.default_summarizer] is used (first text block
-        of each message, truncated to 100 chars).  Consumers that embed
-        domain-specific structured markers in message bodies (for example
-        their own [STATE] blocks or other custom envelopes) can supply a
-        summarizer that strips or transforms those markers before they are
-        re-injected as compacted history.
+        of each message, truncated to 100 chars). Consumers that need
+        application-specific summary semantics can supply a summarizer that
+        transforms messages before they are re-injected as compacted history.
         @since 0.150.0 *)
   }
 


### PR DESCRIPTION
## What
- remove the MASC-specific structured-state example from the public summarizer contract
- describe the existing summarizer hook in application-neutral terms
- align the historical changelog rationale with the OAS boundary

## Why
OAS is the generic provider/model and agent-lifecycle SDK. Application-specific state protocols belong to consumers such as MASC and must not leak into the OAS API contract.

## Behavior
No runtime or API behavior changes. This is a boundary and documentation correction only.

## Validation
- ocamlc parse check for lib/agent/agent_types.ml
- git diff --check
- full Dune validation delegated to CI