### PR TITLE
fix(streaming): delete the thinking-only wall-clock cutoff (#10 campaign)

### DIFF
--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -484,7 +484,6 @@ let complete_stream_http
       let first_token_at_ref : float option ref = ref None in
       let first_deliverable_at_ref : float option ref = ref None in
       let first_event_at_ref : float option ref = ref None in
-      let thinking_only_started_at_ref : float option ref = ref None in
       (* Ollama-specific side channel: prompt_eval_count / eval_count and
      the four duration fields only appear on the [done:true] line, so
      stream_acc (which only sees content/tool deltas) cannot capture
@@ -651,16 +650,6 @@ let complete_stream_http
                    including hidden reasoning. The two refs together
                    distinguish prefill from generation latency. *)
                   let elapsed_ms = latency_ms_float latency_counter in
-                  (* Thinking-only cutoff timestamps follow the injected Eio
-                   clock when one is available, so a mock clock controls the
-                   cutoff in tests. Telemetry durations use the monotonic
-                   [latency_counter] above and therefore do not depend on
-                   wall-clock adjustments. *)
-                  let cutoff_now =
-                    match clock with
-                    | Some c -> Eio.Time.now c
-                    | None -> Unix.gettimeofday ()
-                  in
                   if events <> []
                   then (
                     (match elapsed_ms with
@@ -691,26 +680,18 @@ let complete_stream_http
                        | `Skip -> ()
                        | `Thinking ->
                          stream_idle_state := Http_client.Streaming_thinking;
-                         if
-                           Option.is_none !first_deliverable_at_ref
-                           && Option.is_none !thinking_only_started_at_ref
-                         then thinking_only_started_at_ref := Some cutoff_now;
                          incr n_thinking
                        | `Answer ->
                          stream_idle_state := Http_client.Streaming_answer;
-                         thinking_only_started_at_ref := None;
                          incr n_answer
                        | `Tool_call_start ->
                          stream_idle_state := Http_client.Streaming_tool_call;
-                         thinking_only_started_at_ref := None;
                          incr n_tool_call_start
                        | `Tool_call_arg_delta ->
                          stream_idle_state := Http_client.Streaming_tool_call;
-                         thinking_only_started_at_ref := None;
                          incr n_tool_call_arg_delta
                        | `Tool_call_complete ->
                          stream_idle_state := Http_client.Streaming_tool_call;
-                         thinking_only_started_at_ref := None;
                          incr n_tool_call_complete
                        | `Substrate ->
                          stream_idle_state := Http_client.Streaming_substrate;
@@ -725,17 +706,14 @@ let complete_stream_http
                          stream_idle_state := Http_client.Streaming_unknown;
                          terminal_state := Telemetry_event.Terminal_error "sse_wire_error")
                     events;
-                  (match
-                     ( stream_idle_timeout_s
-                     , !first_deliverable_at_ref
-                     , !thinking_only_started_at_ref )
-                   with
-                   | Some timeout_s, None, Some started_at
-                     when Streaming.thinking_only_timeout_exceeded
-                            ~timeout_s
-                            ~started_at
-                            ~now:cutoff_now -> raise Eio.Time.Timeout
-                   | Some _, _, _ | None, _, _ -> ());
+                  (* No thinking-only wall-clock cutoff: active reasoning
+                     deltas ARE stream liveness. [stream_idle_timeout_s]
+                     keeps its documented inter-event meaning (a stalled
+                     socket still times out); bounding total turn duration
+                     is the caller's contract, not the stream driver's
+                     (38-bug campaign #10: the cutoff killed models that
+                     legitimately think longer than the idle budget, and
+                     retries re-ran and re-killed the round). *)
                   if events <> []
                   then
                     if not !first_chunk_seen

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -474,15 +474,12 @@ let complete_stream_http
       (* RFC-OAS-020 — TTFT (Time To First Token) capture.
          [first_token_at_ref] fires on the first chunk that carries a
          non-empty generated delta (text / reasoning / tool-call arg).
-         [first_deliverable_at_ref] fires on the first non-reasoning
-         progress signal that downstream applications can act on.
          [first_event_at_ref] fires on the very first SSE
          event of any kind — used to derive [prefill_ms] when the
          provider exposes a separable prelude marker
          (e.g. Anthropic [MessageStart] arrives before the first
          [ContentBlockDelta]). *)
       let first_token_at_ref : float option ref = ref None in
-      let first_deliverable_at_ref : float option ref = ref None in
       let first_event_at_ref : float option ref = ref None in
       (* Ollama-specific side channel: prompt_eval_count / eval_count and
      the four duration fields only appear on the [done:true] line, so
@@ -661,12 +658,6 @@ let complete_stream_http
                     Option.is_none !first_token_at_ref
                     && List.exists Streaming.sse_event_is_first_token_signal events
                   then first_token_at_ref := elapsed_ms;
-                  if
-                    Option.is_none !first_deliverable_at_ref
-                    && List.exists
-                         Streaming.sse_event_is_deliverable_progress_signal
-                         events
-                  then first_deliverable_at_ref := elapsed_ms;
                   List.iter
                     (fun evt ->
                        emit_stream_event on_event evt;

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -188,10 +188,6 @@ let sse_event_is_deliverable_progress_signal (e : sse_event) : bool =
   | StreamIncomplete _ -> false
 ;;
 
-let thinking_only_timeout_exceeded ~timeout_s ~started_at ~now =
-  now -. started_at >= timeout_s
-;;
-
 (** Emit synthetic SSE events from a complete [api_response].
     Used as fallback for non-Anthropic providers that don't support SSE. *)
 let emit_synthetic_events (response : api_response) on_event =

--- a/lib/llm_provider/streaming.mli
+++ b/lib/llm_provider/streaming.mli
@@ -41,18 +41,6 @@ val sse_event_is_first_token_signal : sse_event -> bool
     @since 0.205.12 *)
 val sse_event_is_deliverable_progress_signal : sse_event -> bool
 
-(** [true] when a stream has spent at least [timeout_s] seconds in
-    hidden-reasoning-only generation before any deliverable signal.
-    Pure helper for {!Complete}'s semantic stream timeout guard.
-
-    @stability Internal
-    @since 0.205.12 *)
-val thinking_only_timeout_exceeded
-  :  timeout_s:float
-  -> started_at:float
-  -> now:float
-  -> bool
-
 (** {1 Openai SSE} *)
 
 (** Wire shape of streamed tool-call arguments. [Args_fragment] is an incremental

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -1436,16 +1436,16 @@ let test_complete_stream_idle_timeout_still_fires () =
   | Exit -> ()
 ;;
 
-(* T12 audit — the thinking-only cutoff (#2011) must read the injected
-   Eio clock, not [Unix.gettimeofday]. A mock clock drives the cutoff:
-   each hidden-reasoning delta advances mock time by 6s. Every
-   inter-event gap (6s) stays under the 10s idle deadline — so the
-   line-idle timer cannot be the thing that fires — but the cumulative
-   thinking-only span crosses 10s on the third delta (mock 12s).
-   Wall-clock time elapsed here is milliseconds, so an implementation
-   still reading [Unix.gettimeofday] never reaches the 10s cutoff and
-   returns [Ok] — which this test rejects. *)
-let test_complete_stream_thinking_only_cutoff_follows_injected_clock () =
+(* Bug #10 regression (38-bug campaign): actively streaming reasoning
+   deltas are stream LIVENESS, not idleness. Each hidden-reasoning delta
+   advances the injected mock clock by 6s, so the cumulative
+   thinking-only span crosses the 10s idle budget on the third delta —
+   the exact condition the deleted thinking-only wall-clock cutoff used
+   to abort on (TimeoutError{Stream_idle Streaming_thinking}, then MASC
+   retried and re-killed the round, losing the turn). Inter-event gaps
+   (6s) stay under the 10s idle deadline, so the line-idle timer must
+   not fire either: the stream must finalize [Ok] with the answer. *)
+let test_complete_stream_long_thinking_is_not_cut_off () =
   Eio_main.run
   @@ fun env ->
   try
@@ -1463,9 +1463,6 @@ let test_complete_stream_thinking_only_cutoff_follows_injected_clock () =
     let mock_now = ref 0.0 in
     let on_event = function
       | Types.ContentBlockDelta { delta = Types.ThinkingDelta _; _ } ->
-        (* [on_data] in read_sse invokes this outside any
-           [with_timeout_exn] window, so advancing the mock here cannot
-           wake the line-idle timer fiber. *)
         mock_now := !mock_now +. 6.0;
         Eio_mock.Clock.set_time mock_clock !mock_now
       | _ -> ()
@@ -1481,66 +1478,13 @@ let test_complete_stream_thinking_only_cutoff_follows_injected_clock () =
         ~on_event
         ()
     with
-    | Error
-        (Http_client.TimeoutError
-           { phase = Http_client.Stream_idle Http_client.Streaming_thinking; message }) ->
-      let prefix = "stream_idle_timeout_s deadline exceeded" in
-      check
-        bool
-        "thinking-only cutoff message"
-        true
-        (String.length message >= String.length prefix
-         && String.equal (String.sub message 0 (String.length prefix)) prefix);
-      Eio.Switch.fail sw Exit
-    | Error (Http_client.TimeoutError { phase; _ }) ->
-      fail
-        (Printf.sprintf
-           "unexpected timeout phase %s"
-           (Http_client.timeout_phase_to_label phase))
-    | Ok _ ->
-      fail "expected thinking-only cutoff via mock clock — is the cutoff on wall time?"
-    | Error _ -> fail "expected TimeoutError{phase=Stream_idle Streaming_thinking}"
-  with
-  | Exit -> ()
-;;
-
-(* Control for the test above: same stream, same mock clock, but mock
-   time is never advanced. The cutoff comparison therefore always sees
-   elapsed = 0 and the stream finalizes [Ok] with the block-1 answer,
-   pinning that the cutoff follows ONLY the injected clock. *)
-let test_complete_stream_thinking_only_cutoff_idle_without_clock_advance () =
-  Eio_main.run
-  @@ fun env ->
-  try
-    Eio.Switch.run
-    @@ fun sw ->
-    let mock_clock = Eio_mock.Clock.make () in
-    let url =
-      start_raw_sse_server
-        ~sw
-        ~net:env#net
-        ~clock:env#clock
-        (anthropic_thinking_then_answer_frames ~frame_gap_s:0.01)
-    in
-    let config = make_config url in
-    match
-      Complete.complete_stream
-        ~sw
-        ~net:env#net
-        ~clock:mock_clock
-        ~stream_idle_timeout_s:10.0
-        ~config
-        ~messages
-        ~on_event:(fun _ -> ())
-        ()
-    with
     | Ok resp ->
       check string "text" "answer" (text_of_response resp);
       Eio.Switch.fail sw Exit
     | Error err ->
       fail
         (Printf.sprintf
-           "expected Ok without clock advance, got %s"
+           "long thinking must stream to completion, got %s"
            (match err with
             | Http_client.NetworkError { message; _ }
             | Http_client.TimeoutError { message; _ } -> message
@@ -1914,13 +1858,9 @@ let () =
             `Quick
             test_complete_stream_transport_arm_idle_timeout
         ; test_case
-            "thinking-only cutoff follows injected clock (T12)"
+            "long thinking is not cut off (bug #10 regression)"
             `Quick
-            test_complete_stream_thinking_only_cutoff_follows_injected_clock
-        ; test_case
-            "thinking-only cutoff idle without clock advance (T12 control)"
-            `Quick
-            test_complete_stream_thinking_only_cutoff_idle_without_clock_advance
+            test_complete_stream_long_thinking_is_not_cut_off
         ] )
     ]
 ;;

--- a/test/test_streaming_edge_cases.ml
+++ b/test/test_streaming_edge_cases.ml
@@ -174,24 +174,6 @@ let test_deliverable_progress_classifier_edges () =
        (ContentBlockDelta { index = 0; delta = TextDelta "" }))
 ;;
 
-let test_thinking_only_timeout_exceeded () =
-  check
-    bool
-    "below timeout"
-    false
-    (S.thinking_only_timeout_exceeded ~timeout_s:120.0 ~started_at:10.0 ~now:129.9);
-  check
-    bool
-    "at timeout"
-    true
-    (S.thinking_only_timeout_exceeded ~timeout_s:120.0 ~started_at:10.0 ~now:130.0);
-  check
-    bool
-    "past timeout"
-    true
-    (S.thinking_only_timeout_exceeded ~timeout_s:120.0 ~started_at:10.0 ~now:131.0)
-;;
-
 let test_synthetic_events_media_blocks () =
   let response : api_response =
     { id = "r1"
@@ -562,10 +544,6 @@ let () =
             "deliverable progress classifier edges"
             `Quick
             test_deliverable_progress_classifier_edges
-        ; test_case
-            "thinking-only timeout predicate"
-            `Quick
-            test_thinking_only_timeout_exceeded
         ; test_case "synthetic media events" `Quick test_synthetic_events_media_blocks
         ] )
     ; ( "openai_sse"


### PR DESCRIPTION
## 무엇이 고장이었나 (38버그 캠페인 #10: "Thinking이 몇 회 이상 계속되면 표시가 멈추고 타임아웃, 대화 소실")

`stream_idle_timeout_s`는 문서상 **이벤트 간 최대 간격**(idle) 노브인데, thinking-only 가드(0.205.12부터)가 같은 노브를 **hidden-reasoning 총량 캡**으로 전용했습니다:

- `streaming.ml`의 `sse_event_is_deliverable_progress_signal`이 ThinkingDelta/ReasoningDetailsDelta를 진행으로 안 침
- `complete_stream.ml` cutoff arm이 deliverable 신호 전 누적 thinking이 idle 예산(MASC 기본 120s)을 넘으면 **활발히 스트리밍 중인데도** `Eio.Time.Timeout`을 raise
- 호출자(MASC) 재시도가 라운드를 다시 돌리고 다시 사살 → 턴 타임아웃 → 축적된 출력 소실

120초 넘게 생각하는 모델(장고 reasoning 모델 전반)은 결정론적으로 사고 중에 죽었습니다.

## 수정 (bulldozer — 하위호환 없이 삭제)

- `thinking_only_started_at_ref` 배관 + cutoff match arm + `cutoff_now` 샘플링 + `Streaming.thinking_only_timeout_exceeded` **전부 삭제**
- 의미 복원: **활성 reasoning 델타 = 스트림 liveness**. 소켓이 실제로 멈추면 기존 inter-event idle 타임아웃이 그대로 잡음. 턴 총량 제한은 스트림 드라이버가 아니라 호출자(agent/turn 레벨)의 계약
- `first_deliverable_at_ref`는 TTFT 텔레메트리에 소비되지 않는 write-only 상태였으므로 함께 삭제

## 테스트

- T12 cutoff 테스트 2건을 회귀 테스트 1건으로 교체: 동일한 mock-clock 셋업(6s 스텝, 10s idle 예산 초과)에서 이제 abort가 아니라 `Ok "answer"`로 완주함을 증명 — 삭제된 동작의 정확한 반증.

## 남은 후속 (MASC측, 별도 PR)

- 증분 persist(터미널 전용 persist가 부분 소실의 나머지 절반) — `Keeper_chat_store` upsert-partial
- 서버 소유 SSE heartbeat (UI 멈춤 체감의 원인)
- provider별 reasoning dialect의 카탈로그 필수 선언

Diagnosis: bug-level dive workflow `wf_f98e2cdb-9e4` (confidence 0.82, cutoff 경로 전 단계 CONFIRMED)

🤖 Generated with [Claude Code](https://claude.com/claude-code)