### PR TITLE
Preserve typed terminal stop outcomes

### DIFF
--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -205,6 +205,7 @@ let stop_reason_label : Types.stop_reason -> string = function
   | PauseTurn -> "pause_turn"
   | Compaction -> "compaction"
   | ContextWindowExceeded -> "model_context_window_exceeded"
+  | UnmatchedToolCalls -> "unmatched_tool_calls"
   | Unknown s -> "unknown:" ^ s
 ;;
 

--- a/lib/llm_provider/backend_tool_call_harness.ml
+++ b/lib/llm_provider/backend_tool_call_harness.ml
@@ -271,8 +271,8 @@ let schema_tool_call_check schema_lookup = function
 
 let stop_reason_matches_tool_calls ~has_tool_calls = function
   | StopToolUse -> has_tool_calls
-  | Unknown _ as stop_reason ->
-    (not has_tool_calls) && Stop_reason_wire.is_unmatched_tool_calls stop_reason
+  | UnmatchedToolCalls -> not has_tool_calls
+  | Unknown _ -> false
   | EndTurn
   | MaxTokens
   | StopSequence

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -592,10 +592,11 @@ let%test "finalize_stream_acc assembles thinking block" =
 
 (* Drift guard for the infinite-Thinking fix: a reasoning-only stream that the
    provider tagged finish_reason="tool_calls" (provisional StopToolUse) must be
-   reconciled to Unknown when no tool block was assembled, so the driver does not
+   reconciled to the typed UnmatchedToolCalls outcome when no tool block was
+   assembled, so the driver does not
    re-issue the identical Thinking turn forever. Reverting the reconcile in
    finalize_stream_acc turns this RED. *)
-let%test "finalize downgrades StopToolUse with no tool block to Unknown" =
+let%test "finalize downgrades StopToolUse with no tool block to typed outcome" =
   let acc = create_stream_acc () in
   Hashtbl.replace acc.block_types 0 "thinking";
   let buf = Buffer.create 16 in
@@ -605,7 +606,7 @@ let%test "finalize downgrades StopToolUse with no tool block to Unknown" =
   acc.stop_reason_received := true;
   match finalize_stream_acc acc with
   | Error _ -> false
-  | Ok result -> result.stop_reason = Types.Unknown "tool_calls"
+  | Ok result -> result.stop_reason = Types.UnmatchedToolCalls
 ;;
 
 let%test "finalize keeps StopToolUse when a tool block is present" =

--- a/lib/llm_provider/stop_reason_wire.ml
+++ b/lib/llm_provider/stop_reason_wire.ml
@@ -5,11 +5,6 @@ type wire_finish =
   | Refusal
   | Other of string
 
-(* The canonical [Unknown] payload for a tool-use finish that delivered no tool
-   block. One named value so the parse-time mapping and the streaming
-   reconciliation agree on the exact string instead of scattering the literal. *)
-let unmatched_tool_calls = "tool_calls"
-
 let wire_finish_of_string s =
   match String.lowercase_ascii s with
   | "tool_calls" -> Tool_calls
@@ -22,7 +17,7 @@ let wire_finish_of_string s =
 let of_finish (w : wire_finish) ~has_tool_blocks : Types.stop_reason =
   match w with
   | Tool_calls ->
-    if has_tool_blocks then Types.StopToolUse else Types.Unknown unmatched_tool_calls
+    if has_tool_blocks then Types.StopToolUse else Types.UnmatchedToolCalls
   | Length -> Types.MaxTokens
   | Stop -> Types.EndTurn
   | Refusal -> Types.Refusal
@@ -43,7 +38,8 @@ let provisional_of_string s : Types.stop_reason =
 
 let reconcile (sr : Types.stop_reason) ~has_tool_blocks : Types.stop_reason =
   match sr with
-  | Types.StopToolUse when not has_tool_blocks -> Types.Unknown unmatched_tool_calls
+  | Types.StopToolUse when not has_tool_blocks -> Types.UnmatchedToolCalls
+  | Types.UnmatchedToolCalls when has_tool_blocks -> Types.StopToolUse
   | Types.Unknown _ when has_tool_blocks -> Types.StopToolUse
   | Types.StopToolUse
   | Types.EndTurn
@@ -53,11 +49,13 @@ let reconcile (sr : Types.stop_reason) ~has_tool_blocks : Types.stop_reason =
   | Types.PauseTurn
   | Types.Compaction
   | Types.ContextWindowExceeded
+  | Types.UnmatchedToolCalls
   | Types.Unknown _ -> sr
 ;;
 
 let is_unmatched_tool_calls = function
-  | Types.Unknown reason -> String.equal reason unmatched_tool_calls
+  | Types.UnmatchedToolCalls -> true
+  | Types.Unknown _ -> false
   | Types.StopToolUse
   | Types.EndTurn
   | Types.MaxTokens
@@ -78,8 +76,8 @@ let is_unmatched_tool_calls = function
    vocabulary and already guard at their own (accumulating) finish chunk; their
    coverage belongs with the pipeline no-reissue test. *)
 
-let%test "of_finish tool_calls without tools fails closed to Unknown" =
-  of_finish Tool_calls ~has_tool_blocks:false = Types.Unknown "tool_calls"
+let%test "of_finish tool_calls without tools fails closed to typed outcome" =
+  of_finish Tool_calls ~has_tool_blocks:false = Types.UnmatchedToolCalls
 ;;
 
 let%test "of_finish tool_calls with tools is StopToolUse" =
@@ -87,7 +85,7 @@ let%test "of_finish tool_calls with tools is StopToolUse" =
 ;;
 
 let%test "reconcile downgrades StopToolUse without tools" =
-  reconcile Types.StopToolUse ~has_tool_blocks:false = Types.Unknown "tool_calls"
+  reconcile Types.StopToolUse ~has_tool_blocks:false = Types.UnmatchedToolCalls
 ;;
 
 let%test "reconcile preserves StopToolUse with tools" =
@@ -95,7 +93,8 @@ let%test "reconcile preserves StopToolUse with tools" =
 ;;
 
 let%test "is_unmatched_tool_calls recognizes only canonical fail-closed value" =
-  is_unmatched_tool_calls (Types.Unknown "tool_calls")
+  is_unmatched_tool_calls Types.UnmatchedToolCalls
+  && (not (is_unmatched_tool_calls (Types.Unknown "tool_calls")))
   && (not (is_unmatched_tool_calls (Types.Unknown "other")))
   && not (is_unmatched_tool_calls Types.StopToolUse)
 ;;

--- a/lib/llm_provider/stop_reason_wire.ml
+++ b/lib/llm_provider/stop_reason_wire.ml
@@ -16,8 +16,7 @@ let wire_finish_of_string s =
 
 let of_finish (w : wire_finish) ~has_tool_blocks : Types.stop_reason =
   match w with
-  | Tool_calls ->
-    if has_tool_blocks then Types.StopToolUse else Types.UnmatchedToolCalls
+  | Tool_calls -> if has_tool_blocks then Types.StopToolUse else Types.UnmatchedToolCalls
   | Length -> Types.MaxTokens
   | Stop -> Types.EndTurn
   | Refusal -> Types.Refusal

--- a/lib/llm_provider/stop_reason_wire.mli
+++ b/lib/llm_provider/stop_reason_wire.mli
@@ -28,7 +28,7 @@ val wire_finish_of_string : string -> wire_finish
 
 (** Canonical parse-time mapping for backends that know the assembled tool-block
     set at parse time (the non-streaming OpenAI parser). [Tool_calls] and [Other]
-    with [has_tool_blocks = false] fail closed to [Unknown] rather than asserting
+    with [has_tool_blocks = false] fail closed to [UnmatchedToolCalls] rather than asserting
     a tool-use turn that carries no tool. *)
 val of_finish : wire_finish -> has_tool_blocks:bool -> Types.stop_reason
 
@@ -39,16 +39,15 @@ val of_finish : wire_finish -> has_tool_blocks:bool -> Types.stop_reason
 val provisional_of_string : string -> Types.stop_reason
 
 (** Enforce parse-time parity after streaming accumulation. Maps [StopToolUse]
-    with [has_tool_blocks = false] to [Unknown "tool_calls"], and maps
+    with [has_tool_blocks = false] to [UnmatchedToolCalls], and maps
     [Unknown _] with [has_tool_blocks = true] to [StopToolUse] so nonstandard
     finish labels that carried tool blocks follow {!of_finish}. Leaves other
     reasons unchanged. Total over {!Types.stop_reason}: no catch-all, so a new
     [stop_reason] constructor forces a compile error here. *)
 val reconcile : Types.stop_reason -> has_tool_blocks:bool -> Types.stop_reason
 
-(** [true] only for the canonical fail-closed value produced when a provider
+(** [true] only for the typed fail-closed value produced when a provider
     reported a tool-use finish but the assembled response carried no tool
     block. Consumers that need to distinguish this executable-shape invariant
-    from arbitrary unknown stop reasons should use this predicate instead of
-    matching the payload string themselves. *)
+    from arbitrary unknown stop reasons should use this predicate. *)
 val is_unmatched_tool_calls : Types.stop_reason -> bool

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -347,7 +347,7 @@ type stop_reason =
   | Compaction (** Anthropic context compaction. *)
   | ContextWindowExceeded (** Anthropic context window exceeded. *)
   | UnmatchedToolCalls
-      (** Internal fail-closed response shape: a provider claimed a tool turn
+  (** Internal fail-closed response shape: a provider claimed a tool turn
           but no executable tool block was assembled. This is not a provider
           terminal reason and is constructed only after wire reconciliation. *)
   | Unknown of string

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -346,6 +346,10 @@ type stop_reason =
   | PauseTurn (** Anthropic long-running turn pause. *)
   | Compaction (** Anthropic context compaction. *)
   | ContextWindowExceeded (** Anthropic context window exceeded. *)
+  | UnmatchedToolCalls
+      (** Internal fail-closed response shape: a provider claimed a tool turn
+          but no executable tool block was assembled. This is not a provider
+          terminal reason and is constructed only after wire reconciliation. *)
   | Unknown of string
 [@@deriving show]
 
@@ -358,6 +362,7 @@ let stop_reason_of_string = function
   | "pause_turn" -> PauseTurn
   | "compaction" -> Compaction
   | "model_context_window_exceeded" -> ContextWindowExceeded
+  | "unmatched_tool_calls" -> UnmatchedToolCalls
   | other -> Unknown other
 ;;
 
@@ -377,6 +382,7 @@ let stop_reason_to_string = function
   | PauseTurn -> "pause_turn"
   | Compaction -> "compaction"
   | ContextWindowExceeded -> "model_context_window_exceeded"
+  | UnmatchedToolCalls -> "unmatched_tool_calls"
   | Unknown s -> s
 ;;
 
@@ -395,7 +401,8 @@ let stop_reason_to_metric_label = function
     | Refusal
     | PauseTurn
     | Compaction
-    | ContextWindowExceeded ) as r -> stop_reason_to_string r
+    | ContextWindowExceeded
+    | UnmatchedToolCalls ) as r -> stop_reason_to_string r
 ;;
 
 (** API usage from a single response *)

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -202,6 +202,7 @@ type stop_reason =
   | PauseTurn
   | Compaction
   | ContextWindowExceeded
+  | UnmatchedToolCalls
   | Unknown of string
 [@@deriving show]
 

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -757,13 +757,23 @@ let stage_output ?raw_trace_run agent ~effective_guardrails response =
                Agent_types.reset_idle_state agent;
                Ok (Complete response)
              | other -> other))
+       | UnmatchedToolCalls ->
+         (* The wire boundary has already classified this response shape as
+            malformed. Keep rejecting it; arbitrary provider terminal reasons
+            remain in the [Unknown _] terminal branch below. *)
+         Agent_types.reset_idle_state agent;
+         Error
+           (Error.Agent
+              (UnrecognizedStopReason
+                 { reason = Types.stop_reason_to_string response.stop_reason }))
        | EndTurn
        | MaxTokens
        | StopSequence
        | Refusal
        | PauseTurn
        | Compaction
-       | ContextWindowExceeded ->
+       | ContextWindowExceeded
+       | Unknown _ ->
          (* Invoke on_stop before resetting idle counters, so observers
             (hooks, tracers, telemetry callbacks) can read the actual
             consecutive_idle_turns value that drove this turn's behavior. *)
@@ -780,10 +790,7 @@ let stage_output ?raw_trace_run agent ~effective_guardrails response =
             Error (hook_failed_sdk_error ~hook_name:"on_stop" ~stage ~detail)
           | _ ->
             Agent_types.reset_idle_state agent;
-            Ok (Complete response))
-       | Unknown reason ->
-         Agent_types.reset_idle_state agent;
-         Error (Error.Agent (UnrecognizedStopReason { reason })))
+            Ok (Complete response)))
 ;;
 
 (* ── Proactive watermark compaction (Phase 2) ───────────── *)

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -760,7 +760,7 @@ let stage_output ?raw_trace_run agent ~effective_guardrails response =
        | UnmatchedToolCalls ->
          (* The wire boundary has already classified this response shape as
             malformed. Keep rejecting it; arbitrary provider terminal reasons
-            remain in the [Unknown _] terminal branch below. *)
+            remain fail-closed in their own branch below. *)
          Agent_types.reset_idle_state agent;
          Error
            (Error.Agent
@@ -772,8 +772,7 @@ let stage_output ?raw_trace_run agent ~effective_guardrails response =
        | Refusal
        | PauseTurn
        | Compaction
-       | ContextWindowExceeded
-       | Unknown _ ->
+       | ContextWindowExceeded ->
          (* Invoke on_stop before resetting idle counters, so observers
             (hooks, tracers, telemetry callbacks) can read the actual
             consecutive_idle_turns value that drove this turn's behavior. *)
@@ -790,7 +789,10 @@ let stage_output ?raw_trace_run agent ~effective_guardrails response =
             Error (hook_failed_sdk_error ~hook_name:"on_stop" ~stage ~detail)
           | _ ->
             Agent_types.reset_idle_state agent;
-            Ok (Complete response)))
+            Ok (Complete response))
+       | Unknown reason ->
+         Agent_types.reset_idle_state agent;
+         Error (Error.Agent (UnrecognizedStopReason { reason })))
 ;;
 
 (* ── Proactive watermark compaction (Phase 2) ───────────── *)

--- a/test/test_backend_tool_call_harness.ml
+++ b/test/test_backend_tool_call_harness.ml
@@ -308,7 +308,7 @@ let test_anthropic_tool_use_stop_without_tool_block_fails_closed () =
     bool
     "tool_use stop without a ToolUse block is not executable"
     true
-    (response.stop_reason = T.Unknown "tool_calls");
+    (response.stop_reason = T.UnmatchedToolCalls);
   let result = H.validate_response ~declared_tools:[ "lookup" ] response in
   check bool "validation sees non-tool stop" true result.stop_reason_correct;
   check int "no tool calls found" 0 (List.length result.tool_calls_found)

--- a/test/test_llm_call.ml
+++ b/test/test_llm_call.ml
@@ -60,6 +60,7 @@ let run_live_test () =
        | Types.PauseTurn -> "pause_turn"
        | Types.Compaction -> "compaction"
        | Types.ContextWindowExceeded -> "model_context_window_exceeded"
+       | Types.UnmatchedToolCalls -> "unmatched_tool_calls"
        | Types.Unknown s -> s);
     List.iter
       (fun block ->

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -316,7 +316,7 @@ let test_pipeline_output_resets_idle_on_end_turn () =
   assert_pipeline_idle_reset agent
 ;;
 
-let test_pipeline_output_resets_idle_on_unknown () =
+let test_pipeline_output_completes_unknown_terminal () =
   Eio_main.run
   @@ fun env ->
   Eio.Switch.run
@@ -326,10 +326,31 @@ let test_pipeline_output_resets_idle_on_unknown () =
     make_pipeline_test_agent ~net ~response:(pipeline_response (Unknown "mystery-stop"))
   in
   (match Internal_pipeline.run_turn ~sw ~api_strategy:Internal_pipeline.Sync agent with
-   | Error (Error.Agent (UnrecognizedStopReason { reason })) ->
-     Alcotest.(check string) "unknown reason" "mystery-stop" reason
+   | Ok (Internal_pipeline.Complete response) ->
+     Alcotest.(check bool)
+       "unknown provider terminal reason is preserved"
+       true
+       (response.stop_reason = Unknown "mystery-stop")
    | Error err -> Alcotest.failf "unexpected run error: %s" (Error.to_string err)
-   | Ok _ -> Alcotest.fail "expected unrecognized stop reason");
+   | Ok Internal_pipeline.ToolsExecuted -> Alcotest.fail "unexpected tool execution"
+   | Ok Internal_pipeline.IdleSkipped -> Alcotest.fail "unexpected idle skip");
+  assert_pipeline_idle_reset agent
+;;
+
+let test_pipeline_output_rejects_unmatched_tool_stop () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let net = Eio.Stdenv.net env in
+  let agent =
+    make_pipeline_test_agent ~net ~response:(pipeline_response UnmatchedToolCalls)
+  in
+  (match Internal_pipeline.run_turn ~sw ~api_strategy:Internal_pipeline.Sync agent with
+   | Error (Error.Agent (UnrecognizedStopReason { reason })) ->
+     Alcotest.(check string) "unmatched tool stop reason" "unmatched_tool_calls" reason
+   | Error err -> Alcotest.failf "unexpected run error: %s" (Error.to_string err)
+   | Ok _ -> Alcotest.fail "expected malformed tool-stop rejection");
   assert_pipeline_idle_reset agent
 ;;
 
@@ -1262,9 +1283,13 @@ let () =
             `Quick
             test_pipeline_output_resets_idle_on_end_turn
         ; Alcotest.test_case
-            "output resets idle on unknown"
+            "output completes unknown terminal"
             `Quick
-            test_pipeline_output_resets_idle_on_unknown
+            test_pipeline_output_completes_unknown_terminal
+        ; Alcotest.test_case
+            "output rejects unmatched tool stop"
+            `Quick
+            test_pipeline_output_rejects_unmatched_tool_stop
         ; Alcotest.test_case
             "tool recovery allows glm"
             `Quick

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -316,7 +316,7 @@ let test_pipeline_output_resets_idle_on_end_turn () =
   assert_pipeline_idle_reset agent
 ;;
 
-let test_pipeline_output_completes_unknown_terminal () =
+let test_pipeline_output_rejects_unknown_terminal () =
   Eio_main.run
   @@ fun env ->
   Eio.Switch.run
@@ -326,14 +326,10 @@ let test_pipeline_output_completes_unknown_terminal () =
     make_pipeline_test_agent ~net ~response:(pipeline_response (Unknown "mystery-stop"))
   in
   (match Internal_pipeline.run_turn ~sw ~api_strategy:Internal_pipeline.Sync agent with
-   | Ok (Internal_pipeline.Complete response) ->
-     Alcotest.(check bool)
-       "unknown provider terminal reason is preserved"
-       true
-       (response.stop_reason = Unknown "mystery-stop")
+   | Error (Error.Agent (UnrecognizedStopReason { reason })) ->
+     Alcotest.(check string) "unknown reason" "mystery-stop" reason
    | Error err -> Alcotest.failf "unexpected run error: %s" (Error.to_string err)
-   | Ok Internal_pipeline.ToolsExecuted -> Alcotest.fail "unexpected tool execution"
-   | Ok Internal_pipeline.IdleSkipped -> Alcotest.fail "unexpected idle skip");
+   | Ok _ -> Alcotest.fail "expected unknown stop reason rejection");
   assert_pipeline_idle_reset agent
 ;;
 
@@ -1283,9 +1279,9 @@ let () =
             `Quick
             test_pipeline_output_resets_idle_on_end_turn
         ; Alcotest.test_case
-            "output completes unknown terminal"
+            "output rejects unknown terminal"
             `Quick
-            test_pipeline_output_completes_unknown_terminal
+            test_pipeline_output_rejects_unknown_terminal
         ; Alcotest.test_case
             "output rejects unmatched tool stop"
             `Quick

--- a/test/test_stop_reason_ssot.ml
+++ b/test/test_stop_reason_ssot.ml
@@ -20,6 +20,7 @@ let all_known_variants =
   ; Types.PauseTurn
   ; Types.Compaction
   ; Types.ContextWindowExceeded
+  ; Types.UnmatchedToolCalls
   ]
 ;;
 

--- a/test/test_streaming_coverage.ml
+++ b/test/test_streaming_coverage.ml
@@ -206,10 +206,11 @@ let test_acc_message_delta_stop_reason () =
    | StopToolUse -> ()
    | _ -> Alcotest.fail "expected accumulated StopToolUse");
   let resp = finalize_ok acc in
-  (* Finalization reconciles a tool-stop with no tool blocks to Unknown. *)
+  (* Finalization reconciles a tool-stop with no tool blocks to the typed
+     UnmatchedToolCalls outcome. *)
   match resp.stop_reason with
-  | Unknown "tool_calls" -> ()
-  | _ -> Alcotest.fail "expected reconciled Unknown tool_calls"
+  | UnmatchedToolCalls -> ()
+  | _ -> Alcotest.fail "expected reconciled UnmatchedToolCalls"
 ;;
 
 let test_acc_message_delta_none_stop_reason () =


### PR DESCRIPTION
## Summary

- Keep the typed UnmatchedToolCalls outcome for the malformed tool-stop shape.
- Preserve the existing fail-closed behavior for arbitrary Unknown provider stop reasons.
- Reconcile the wire shape with a typed constructor instead of using a raw sentinel string in pipeline control flow.
- Keep OAS independent of MASC.

## Root cause

A provider-reported tool-use finish with no executable tool block is a malformed response shape and must not re-enter the same thinking turn. It is distinct from an arbitrary Unknown provider terminal reason. Unknown reasons remain explicit UnrecognizedStopReason errors so protocol drift cannot be reported as a successful completion.

## Validation

- Pipeline, stop-reason, backend harness, streaming, and type changes checked with focused OCaml parsing and touched-file OCaml format checks.
- git diff --check passed.
- Full Dune remains CI authority.

## Dependency / CI truth

The current head is 14d05d72e7114d49fecde16e4231b1b43b1cce01. Fresh CI is running. The shared OAS format and ratchet baseline is currently carried by prerequisite PR #2495; this PR must remain blocked until its required checks are green.