### PR TITLE
Type documented provider terminal reasons

### DIFF
--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -202,6 +202,8 @@ let stop_reason_label : Types.stop_reason -> string = function
   | MaxTokens -> "max_tokens"
   | StopSequence -> "stop_sequence"
   | Refusal -> "refusal"
+  | ContentFilter -> "content_filter"
+  | RepetitionTruncation -> "repetition_truncation"
   | PauseTurn -> "pause_turn"
   | Compaction -> "compaction"
   | ContextWindowExceeded -> "model_context_window_exceeded"

--- a/lib/llm_provider/backend_tool_call_harness.ml
+++ b/lib/llm_provider/backend_tool_call_harness.ml
@@ -277,6 +277,8 @@ let stop_reason_matches_tool_calls ~has_tool_calls = function
   | MaxTokens
   | StopSequence
   | Refusal
+  | ContentFilter
+  | RepetitionTruncation
   | PauseTurn
   | Compaction
   | ContextWindowExceeded -> not has_tool_calls

--- a/lib/llm_provider/responses_stop_reason.ml
+++ b/lib/llm_provider/responses_stop_reason.ml
@@ -7,6 +7,7 @@ let normalized_status status =
 let incomplete_stop_reason incomplete_reason =
   match incomplete_reason with
   | Some "max_output_tokens" -> Types.MaxTokens
+  | Some "content_filter" -> Types.ContentFilter
   | Some reason -> Types.Unknown reason
   | None -> Types.Unknown "incomplete"
 ;;
@@ -35,6 +36,24 @@ let%test "incomplete max output tokens wins over tool calls" =
     ~failed_message:None
     ~has_tool_calls:true
   = Types.MaxTokens
+;;
+
+let%test "incomplete content filter is typed" =
+  of_status
+    ~status:(Some "incomplete")
+    ~incomplete_reason:(Some "content_filter")
+    ~failed_message:None
+    ~has_tool_calls:true
+  = Types.ContentFilter
+;;
+
+let%test "unknown incomplete reason remains unknown" =
+  of_status
+    ~status:(Some "incomplete")
+    ~incomplete_reason:(Some "tool_use")
+    ~failed_message:None
+    ~has_tool_calls:true
+  = Types.Unknown "tool_use"
 ;;
 
 let%test "failed message wins over tool calls" =

--- a/lib/llm_provider/stop_reason_wire.ml
+++ b/lib/llm_provider/stop_reason_wire.ml
@@ -3,6 +3,8 @@ type wire_finish =
   | Length
   | Stop
   | Refusal
+  | Content_filter
+  | Repetition_truncation
   | Other of string
 
 let wire_finish_of_string s =
@@ -11,6 +13,8 @@ let wire_finish_of_string s =
   | "length" -> Length
   | "stop" | "end_turn" -> Stop
   | "refusal" -> Refusal
+  | "content_filter" -> Content_filter
+  | "repetition_truncation" -> Repetition_truncation
   | other -> Other other
 ;;
 
@@ -20,6 +24,8 @@ let of_finish (w : wire_finish) ~has_tool_blocks : Types.stop_reason =
   | Length -> Types.MaxTokens
   | Stop -> Types.EndTurn
   | Refusal -> Types.Refusal
+  | Content_filter -> Types.ContentFilter
+  | Repetition_truncation -> Types.RepetitionTruncation
   (* "trust content over label": a non-tool finish that nonetheless carried tool
      blocks is a tool-use turn (mirrors the historical non-streaming guard);
      without tool blocks it is surfaced verbatim as [Unknown]. *)
@@ -32,6 +38,8 @@ let provisional_of_string s : Types.stop_reason =
   | Length -> Types.MaxTokens
   | Stop -> Types.EndTurn
   | Refusal -> Types.Refusal
+  | Content_filter -> Types.ContentFilter
+  | Repetition_truncation -> Types.RepetitionTruncation
   | Other other -> Types.Unknown other
 ;;
 
@@ -45,6 +53,8 @@ let reconcile (sr : Types.stop_reason) ~has_tool_blocks : Types.stop_reason =
   | Types.MaxTokens
   | Types.StopSequence
   | Types.Refusal
+  | Types.ContentFilter
+  | Types.RepetitionTruncation
   | Types.PauseTurn
   | Types.Compaction
   | Types.ContextWindowExceeded
@@ -60,6 +70,8 @@ let is_unmatched_tool_calls = function
   | Types.MaxTokens
   | Types.StopSequence
   | Types.Refusal
+  | Types.ContentFilter
+  | Types.RepetitionTruncation
   | Types.PauseTurn
   | Types.Compaction
   | Types.ContextWindowExceeded -> false
@@ -119,9 +131,14 @@ let%test
   = of_finish (wire_finish_of_string s) ~has_tool_blocks:true
 ;;
 
-let%test "stop/length/refusal map identically on both paths" =
+let%test "known terminal reasons map identically on both paths" =
   let same s =
     provisional_of_string s = of_finish (wire_finish_of_string s) ~has_tool_blocks:false
   in
-  same "stop" && same "end_turn" && same "length" && same "refusal"
+  same "stop"
+  && same "end_turn"
+  && same "length"
+  && same "refusal"
+  && same "content_filter"
+  && same "repetition_truncation"
 ;;

--- a/lib/llm_provider/stop_reason_wire.mli
+++ b/lib/llm_provider/stop_reason_wire.mli
@@ -21,15 +21,17 @@ type wire_finish =
   | Length
   | Stop
   | Refusal
+  | Content_filter
+  | Repetition_truncation
   | Other of string
 
 (** Case-insensitive OpenAI-compatible vocabulary. ["end_turn"] maps to [Stop]. *)
 val wire_finish_of_string : string -> wire_finish
 
 (** Canonical parse-time mapping for backends that know the assembled tool-block
-    set at parse time (the non-streaming OpenAI parser). [Tool_calls] and [Other]
-    with [has_tool_blocks = false] fail closed to [UnmatchedToolCalls] rather than asserting
-    a tool-use turn that carries no tool. *)
+    set at parse time (the non-streaming OpenAI parser). [Tool_calls] without a
+    tool block fails closed to [UnmatchedToolCalls]. [Other] preserves the raw
+    terminal label as [Unknown] when no tool block exists. *)
 val of_finish : wire_finish -> has_tool_blocks:bool -> Types.stop_reason
 
 (** Faithful wire claim for the streaming chunk boundary, where the accumulated

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -882,8 +882,7 @@ let openai_chunk_to_events (state : openai_stream_state) (chunk : openai_chunk)
           recorded as a provisional StopToolUse and reconciled against the
           assembled content in Complete_stream_acc.finalize_stream_acc
           (Stop_reason_wire.reconcile). SSOT: the wire vocabulary lives in
-          Stop_reason_wire, not in an unguarded chunk-level match.
-          "content_filter" stays Unknown — a moderation cutoff, not a refusal. *)
+          Stop_reason_wire, not in an unguarded chunk-level match. *)
          Stop_reason_wire.provisional_of_string reason
        in
        (* Close every block this message opened before the terminal MessageDelta,

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -336,13 +336,16 @@ type message =
 (** {1 Response Types} *)
 
 (** Stop reason from API.
-    2025-2026 extended: Refusal, PauseTurn, Compaction, ContextWindowExceeded. *)
+    2025-2026 extended: Refusal, ContentFilter, RepetitionTruncation,
+    PauseTurn, Compaction, ContextWindowExceeded. *)
 type stop_reason =
   | EndTurn
   | StopToolUse
   | MaxTokens
   | StopSequence
   | Refusal (** Policy refusal (Anthropic, OpenAI, Gemini SAFETY). *)
+  | ContentFilter (** Provider content-policy filter terminated generation. *)
+  | RepetitionTruncation (** Provider repetition guard terminated generation. *)
   | PauseTurn (** Anthropic long-running turn pause. *)
   | Compaction (** Anthropic context compaction. *)
   | ContextWindowExceeded (** Anthropic context window exceeded. *)
@@ -359,6 +362,8 @@ let stop_reason_of_string = function
   | "max_tokens" -> MaxTokens
   | "stop_sequence" -> StopSequence
   | "refusal" -> Refusal
+  | "content_filter" -> ContentFilter
+  | "repetition_truncation" -> RepetitionTruncation
   | "pause_turn" -> PauseTurn
   | "compaction" -> Compaction
   | "model_context_window_exceeded" -> ContextWindowExceeded
@@ -379,6 +384,8 @@ let stop_reason_to_string = function
   | MaxTokens -> "max_tokens"
   | StopSequence -> "stop_sequence"
   | Refusal -> "refusal"
+  | ContentFilter -> "content_filter"
+  | RepetitionTruncation -> "repetition_truncation"
   | PauseTurn -> "pause_turn"
   | Compaction -> "compaction"
   | ContextWindowExceeded -> "model_context_window_exceeded"
@@ -399,6 +406,8 @@ let stop_reason_to_metric_label = function
     | MaxTokens
     | StopSequence
     | Refusal
+    | ContentFilter
+    | RepetitionTruncation
     | PauseTurn
     | Compaction
     | ContextWindowExceeded

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -199,6 +199,8 @@ type stop_reason =
   | MaxTokens
   | StopSequence
   | Refusal
+  | ContentFilter
+  | RepetitionTruncation
   | PauseTurn
   | Compaction
   | ContextWindowExceeded

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -770,6 +770,8 @@ let stage_output ?raw_trace_run agent ~effective_guardrails response =
        | MaxTokens
        | StopSequence
        | Refusal
+       | ContentFilter
+       | RepetitionTruncation
        | PauseTurn
        | Compaction
        | ContextWindowExceeded ->

--- a/test/test_llm_call.ml
+++ b/test/test_llm_call.ml
@@ -51,17 +51,7 @@ let run_live_test () =
     Printf.printf
       "Response OK: model=%s stop_reason=%s\n%!"
       resp.Types.model
-      (match resp.stop_reason with
-       | Types.EndTurn -> "end_turn"
-       | Types.StopToolUse -> "tool_use"
-       | Types.MaxTokens -> "max_tokens"
-       | Types.StopSequence -> "stop_sequence"
-       | Types.Refusal -> "refusal"
-       | Types.PauseTurn -> "pause_turn"
-       | Types.Compaction -> "compaction"
-       | Types.ContextWindowExceeded -> "model_context_window_exceeded"
-       | Types.UnmatchedToolCalls -> "unmatched_tool_calls"
-       | Types.Unknown s -> s);
+      (Types.stop_reason_to_string resp.stop_reason);
     List.iter
       (fun block ->
          match block with

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -333,6 +333,29 @@ let test_pipeline_output_rejects_unknown_terminal () =
   assert_pipeline_idle_reset agent
 ;;
 
+let test_pipeline_output_completes_repetition_truncation () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let net = Eio.Stdenv.net env in
+  let agent =
+    make_pipeline_test_agent ~net ~response:(pipeline_response RepetitionTruncation)
+  in
+  (match Internal_pipeline.run_turn ~sw ~api_strategy:Internal_pipeline.Sync agent with
+   | Ok (Internal_pipeline.Complete response) ->
+     Alcotest.(check bool)
+       "documented provider terminal reason is preserved"
+       true
+       (response.stop_reason = RepetitionTruncation)
+   | Ok Internal_pipeline.ToolsExecuted ->
+     Alcotest.fail "expected Complete, got ToolsExecuted"
+   | Ok Internal_pipeline.IdleSkipped ->
+     Alcotest.fail "expected Complete, got IdleSkipped"
+   | Error err -> Alcotest.failf "unexpected run error: %s" (Error.to_string err));
+  assert_pipeline_idle_reset agent
+;;
+
 let test_pipeline_output_rejects_unmatched_tool_stop () =
   Eio_main.run
   @@ fun env ->
@@ -1282,6 +1305,10 @@ let () =
             "output rejects unknown terminal"
             `Quick
             test_pipeline_output_rejects_unknown_terminal
+        ; Alcotest.test_case
+            "output completes repetition truncation"
+            `Quick
+            test_pipeline_output_completes_repetition_truncation
         ; Alcotest.test_case
             "output rejects unmatched tool stop"
             `Quick

--- a/test/test_stop_reason_ssot.ml
+++ b/test/test_stop_reason_ssot.ml
@@ -17,6 +17,8 @@ let all_known_variants =
   ; Types.MaxTokens
   ; Types.StopSequence
   ; Types.Refusal
+  ; Types.ContentFilter
+  ; Types.RepetitionTruncation
   ; Types.PauseTurn
   ; Types.Compaction
   ; Types.ContextWindowExceeded

--- a/test/test_streaming_openai.ml
+++ b/test/test_streaming_openai.ml
@@ -1129,9 +1129,9 @@ let test_responses_stream_incomplete_content_filter_drops_tool () =
   | Error _ -> Alcotest.fail "expected Ok response for incomplete terminal"
   | Ok response ->
     Alcotest.(check bool)
-      "content_filter incomplete -> Unknown, not MaxTokens"
+      "content_filter incomplete -> ContentFilter, not MaxTokens"
       true
-      (response.stop_reason = Unknown "content_filter");
+      (response.stop_reason = ContentFilter);
     Alcotest.(check bool)
       "partial function_call dropped for non-token incomplete reason"
       false

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -26,6 +26,14 @@ let test_known_stop_reasons () =
     "Types.Refusal"
     (Types.show_stop_reason (Types.stop_reason_of_string "refusal"));
   Alcotest.(check string)
+    "content_filter"
+    "Types.ContentFilter"
+    (Types.show_stop_reason (Types.stop_reason_of_string "content_filter"));
+  Alcotest.(check string)
+    "repetition_truncation"
+    "Types.RepetitionTruncation"
+    (Types.show_stop_reason (Types.stop_reason_of_string "repetition_truncation"));
+  Alcotest.(check string)
     "pause_turn"
     "Types.PauseTurn"
     (Types.show_stop_reason (Types.stop_reason_of_string "pause_turn"));


### PR DESCRIPTION
## What changed

- add first-class `ContentFilter` and `RepetitionTruncation` stop reasons
- map the documented OpenAI-compatible wire values through the shared stop-reason catalog
- keep arbitrary `Unknown` values and malformed `UnmatchedToolCalls` fail-closed
- preserve documented terminal outcomes through `on_stop` without coupling OAS to MASC
- keep OpenAI Responses `incomplete_reason` parsing domain-specific so unrelated known stop tokens cannot be promoted accidentally

## Why

MiMo V2.5 returned `repetition_truncation`, which its official OpenAI- and Anthropic-compatible API documentation defines as a terminal reason. OAS lacked that constructor, downgraded the value to `Unknown`, and the pipeline rejected a documented provider outcome as `UnrecognizedStopReason`.

This PR extends the typed provider boundary instead of string-matching in MASC or treating every future unknown value as successful.

Official contracts:

- https://mimo.mi.com/docs/en-US/api/chat/openai-api
- https://mimo.mi.com/docs/en-US/api/chat/anthropic-api

[근거] Xiaomi MiMo official OpenAI/Anthropic-compatible API contracts; checked 2026-07-10 14:52 KST; confidence High. Both enumerate `content_filter` and `repetition_truncation` as terminal reasons.

## Validation

- focused compiler targets passed before the final domain-narrowing edit
- `test_types.exe`: 61 passed
- `test_stop_reason_ssot.exe`: 4 passed
- `test_streaming_openai.exe`: 40 passed
- `test_pipeline.exe`: 50 passed
- all touched OCaml files pass `ocamlformat --check`
- `git diff --check` passes
- full OCaml 5.4/5.5 proof remains PR CI authority

## Relationship

Builds on the typed malformed-tool-stop boundary merged in #2503. This PR only adds documented provider terminal catalog entries and their exhaustive consumers.
