### PR TITLE
fix(provider): serialize tool_choice none for capable providers

### DIFF
--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -299,13 +299,23 @@ let add_sampling_field dialect (config : agent_state) parameter value body_assoc
    the tools list; GLM only documents ["auto"] (see
    [Capabilities.glm_capabilities]), so [Auto]/[Any] serialize as ["auto"]
    ([Any] is already rejected by [validate_tool_choice_request] before
-   serialization). *)
+   serialization).
+
+   [None_] on a non-GLM provider with [supports_tool_choice] serializes as
+   ["none"] with the tools list kept, so the provider itself enforces the
+   caller's prohibition. Without [supports_tool_choice] the prohibition has no
+   wire representation, so both the field and the tools list are dropped —
+   attaching tools with no [tool_choice] would let the provider default
+   ([auto]) resurrect calls the caller explicitly forbade (#2505). *)
 let effective_tool_choice_json
       (capabilities : Provider.capabilities)
       ~is_zai_glm
       (config : agent_state)
   =
   match config.config.tool_choice with
+  | Some Types.None_ when is_zai_glm -> None
+  | Some Types.None_ when capabilities.supports_tool_choice ->
+    Some (tool_choice_to_openai_json Types.None_)
   | Some Types.None_ -> None
   | Some (Types.Auto | Types.Any) when is_zai_glm ->
     Some (tool_choice_to_openai_json Types.Auto)
@@ -319,9 +329,13 @@ let effective_tool_choice_json
   | Some (Types.Auto | Types.Any | Types.Tool _) -> None
 ;;
 
-let should_include_tools ~is_zai_glm (config : agent_state) =
+let should_include_tools
+      ~is_zai_glm
+      (capabilities : Provider.capabilities)
+      (config : agent_state)
+  =
   match config.config.tool_choice with
-  | Some Types.None_ -> not is_zai_glm
+  | Some Types.None_ -> (not is_zai_glm) && capabilities.supports_tool_choice
   | None | Some (Types.Auto | Types.Any | Types.Tool _) -> true
 ;;
 
@@ -346,7 +360,7 @@ let build_openai_body_unchecked
     | Some entries
       when entries <> []
            && capabilities.supports_tools
-           && should_include_tools ~is_zai_glm config -> Some entries
+           && should_include_tools ~is_zai_glm capabilities config -> Some entries
     | None | Some _ -> None
   in
   let sanitized_messages =

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -719,6 +719,63 @@ let test_build_openai_body_deepseek_disabled_thinking_keeps_sampling () =
       (json |> member "top_p" |> to_float_option))
 ;;
 
+(* [None_] on a non-GLM provider that supports tool_choice must serialize as
+   ["none"] with the tools list kept, so the provider enforces the caller's
+   prohibition. Regression for #2505: an unconditional-omit arm attached tools
+   with no tool_choice, letting the provider default (auto) resurrect calls
+   the caller explicitly forbade. *)
+let test_build_openai_body_tool_choice_none_serializes () =
+  with_declared_openai_compat_provider_catalog (fun () ->
+    let provider_config =
+      declared_provider_config "api-deepseek-v4" "deepseek-v4-flash"
+    in
+    let state = make_state ~tool_choice:Types.None_ () in
+    let state =
+      { state with config = { state.config with model = provider_config.model_id } }
+    in
+    let tool_json = `Assoc [ "name", `String "calc"; "description", `String "calc" ] in
+    let json =
+      Api.build_openai_body
+        ~provider_config
+        ~config:state
+        ~messages:[]
+        ~tools:[ tool_json ]
+        ()
+      |> Yojson.Safe.from_string
+    in
+    let open Yojson.Safe.Util in
+    check
+      string
+      "tool_choice none serialized"
+      "none"
+      (json |> member "tool_choice" |> to_string);
+    check int "tools kept" 1 (json |> member "tools" |> to_list |> List.length))
+;;
+
+(* When the provider cannot express tool_choice at all, [None_] must drop the
+   tools list along with the field: tools with no tool_choice would default to
+   auto on the provider side, violating the prohibition (#2505). *)
+let test_build_openai_body_tool_choice_none_without_capability_drops_tools () =
+  with_declared_openai_compat_provider_catalog (fun () ->
+    let provider_config = declared_provider_config "api-minimax-m3" "minimax-m3" in
+    let state = make_state ~tool_choice:Types.None_ () in
+    let state =
+      { state with config = { state.config with model = provider_config.model_id } }
+    in
+    let tool_json = `Assoc [ "name", `String "calc"; "description", `String "calc" ] in
+    let json =
+      Api.build_openai_body
+        ~provider_config
+        ~config:state
+        ~messages:[]
+        ~tools:[ tool_json ]
+        ()
+      |> Yojson.Safe.from_string
+    in
+    check bool "tool_choice absent" true (member_absent json "tool_choice");
+    check bool "tools absent" true (member_absent json "tools"))
+;;
+
 let test_build_openai_body_with_qwen_preserve_thinking () =
   with_declared_openai_compat_provider_catalog (fun () ->
     let provider_config = declared_provider_config "api-qwen36" "qwen36-35b-a3b-mtp" in
@@ -2464,6 +2521,14 @@ let () =
             "deepseek disabled thinking keeps sampling"
             `Quick
             test_build_openai_body_deepseek_disabled_thinking_keeps_sampling
+        ; test_case
+            "tool_choice none serializes for capable provider"
+            `Quick
+            test_build_openai_body_tool_choice_none_serializes
+        ; test_case
+            "tool_choice none drops tools without capability"
+            `Quick
+            test_build_openai_body_tool_choice_none_without_capability_drops_tools
         ; test_case
             "qwen preserve thinking"
             `Quick


### PR DESCRIPTION
## 문제 (#2505, #2499 사후 리뷰 P1)

`tool_choice = None_`(도구 호출 명시적 금지)가 비-GLM provider에서 조용히 증발했습니다. #2499의 exhaustive 재작성이 GLM 특례(none 미표현 → omit)를 전 provider로 일반화하면서, tools 배열은 그대로 첨부되고 `tool_choice` 필드만 사라져 provider 기본값(`auto`)이 금지를 무효화할 수 있었습니다.

## 수정

`lib/api_openai.ml`:

| 조건 | tool_choice | tools |
|------|-------------|-------|
| GLM + `None_` | omit (표현 불가) | 드롭 (기존 동작 유지) |
| 비-GLM + `supports_tool_choice` + `None_` | `"none"` 직렬화 (#2499 이전 동작 복원) | 유지 |
| 비-GLM + 미지원 + `None_` | omit | **드롭** — 금지를 wire에서 표현할 수 없으면 tools 자체를 내리지 않아 auto 부활 차단 |

`should_include_tools`가 capabilities를 받도록 확장했습니다 (호출자 1곳).

## 테스트

`test/test_api.ml` — 기존 declared provider 픽스처 재사용:
- `api-deepseek-v4`(supports_tool_choice=true): body에 `"tool_choice":"none"` + tools 1건 유지 고정
- `api-minimax-m3`(supports_tool_choice=false, supports_tools=true): tool_choice·tools 모두 부재 고정

## 검증

- 변경 2파일 `ocamlformat --check` 통과
- 로컬 dune 미실행 — 빌드/테스트는 CI가 검증
- main의 OCaml Format / Code Smell Ratchet red는 base 상속분 (이 PR 무관)

Closes #2505

🤖 Generated with [Claude Code](https://claude.com/claude-code)
