### PR TITLE
fix(ci): restore OAS 0.209 main build

### DIFF
--- a/lib/api_anthropic.ml
+++ b/lib/api_anthropic.ml
@@ -73,7 +73,8 @@ let build_body_assoc
        | None when config.config.enable_thinking = Some true ->
          invalid_arg
            (Printf.sprintf
-              "Api_anthropic.build_body_assoc: model %S has no catalog-declared Anthropic thinking-control policy"
+              "Api_anthropic.build_body_assoc: model %S has no catalog-declared \
+               Anthropic thinking-control policy"
               model_str)
        | None -> Llm_provider.Capabilities.Anthropic_manual_budget)
     | Llm_provider.Provider_config.OpenAI_compat
@@ -90,7 +91,8 @@ let build_body_assoc
    | Llm_provider.Capabilities.Anthropic_always_adaptive, Some false ->
      invalid_arg
        (Printf.sprintf
-          "Api_anthropic.build_body_assoc: model %S cannot disable always-on adaptive thinking"
+          "Api_anthropic.build_body_assoc: model %S cannot disable always-on adaptive \
+           thinking"
           model_str)
    | _, _ -> ());
   (match config.config.min_p with
@@ -105,8 +107,8 @@ let build_body_assoc
   let body_assoc =
     [ "model", `String model_str
     ; ( "max_tokens"
-      , `Int
-          (Llm_provider.Backend_anthropic.effective_max_output_tokens provider_config) )
+      , `Int (Llm_provider.Backend_anthropic.effective_max_output_tokens provider_config)
+      )
     ; "messages", `List (List.map message_to_json messages)
     ; "stream", `Bool stream
     ]

--- a/lib/llm_provider/backend_anthropic.ml
+++ b/lib/llm_provider/backend_anthropic.ml
@@ -108,8 +108,8 @@ let thinking_config_for_config mode (config : Provider_config.t) =
   | ( Some true
     , ( Capabilities.Anthropic_adaptive_default
       | Capabilities.Anthropic_adaptive_only
-      | Capabilities.Anthropic_adaptive_preferred ) )
-    -> Some (`Assoc [ "type", `String "adaptive" ])
+      | Capabilities.Anthropic_adaptive_preferred ) ) ->
+    Some (`Assoc [ "type", `String "adaptive" ])
   | Some true, Capabilities.Anthropic_manual_budget ->
     let budget =
       match config.thinking_budget with
@@ -185,8 +185,9 @@ let build_request
       ~tools_present
   in
   (match config.min_p with
-   | Some _ -> Backend_openai_request.warn_capability_drop ~model_id:config.model_id ~field:"min_p"
-  | None -> ());
+   | Some _ ->
+     Backend_openai_request.warn_capability_drop ~model_id:config.model_id ~field:"min_p"
+   | None -> ());
   let thinking_mode =
     match config.kind with
     | Provider_config.Kimi -> Capabilities.Anthropic_manual_budget
@@ -196,7 +197,8 @@ let build_request
        | None when config.enable_thinking = Some true ->
          invalid_arg
            (Printf.sprintf
-              "Backend_anthropic.build_request: model %S has no catalog-declared Anthropic thinking-control policy"
+              "Backend_anthropic.build_request: model %S has no catalog-declared \
+               Anthropic thinking-control policy"
               config.model_id)
        | None -> Capabilities.Anthropic_manual_budget)
     | Provider_config.OpenAI_compat
@@ -213,7 +215,8 @@ let build_request
    | Capabilities.Anthropic_always_adaptive, Some false ->
      invalid_arg
        (Printf.sprintf
-          "Backend_anthropic.build_request: model %S cannot disable always-on adaptive thinking"
+          "Backend_anthropic.build_request: model %S cannot disable always-on adaptive \
+           thinking"
           config.model_id)
    | _, _ -> ());
   let messages =
@@ -225,8 +228,7 @@ let build_request
   let msgs_json = List.map message_to_json messages in
   let body =
     [ "model", `String config.model_id
-    ; ( "max_tokens"
-      , `Int (effective_max_output_tokens config) )
+    ; "max_tokens", `Int (effective_max_output_tokens config)
     ; "messages", `List msgs_json
     ; "stream", `Bool stream
     ]

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -264,11 +264,10 @@ let anthropic_thinking_control_for_model_id model_id =
     match Capability_manifest.global () with
     | None -> None
     | Some manifest ->
-      Capability_manifest.lookup manifest model_id
-      |> Option.bind (fun entry ->
-           Option.map
-             anthropic_thinking_control_of_vocab_value
-             entry.anthropic_thinking_control)
+      Option.bind (Capability_manifest.lookup manifest model_id) (fun entry ->
+        Option.map
+          anthropic_thinking_control_of_vocab_value
+          entry.anthropic_thinking_control)
   in
   match Model_catalog.global () with
   | None -> manifest_value ()
@@ -1887,8 +1886,8 @@ let%test "Anthropic thinking policy resolves from the model catalog declaration"
          }
        ]);
   Fun.protect ~finally:Model_catalog.clear_global (fun () ->
-    anthropic_thinking_control_for_model_id "declared-anthropic-model" =
-    Some Anthropic_adaptive_preferred)
+    anthropic_thinking_control_for_model_id "declared-anthropic-model"
+    = Some Anthropic_adaptive_preferred)
 ;;
 
 let%test "Anthropic thinking policy falls back to manifest when catalog has no row" =
@@ -1903,8 +1902,8 @@ let%test "Anthropic thinking policy falls back to manifest when catalog has no r
       Model_catalog.clear_global ();
       Capability_manifest.clear_global ())
     (fun () ->
-      anthropic_thinking_control_for_model_id "manifest-anthropic-model" =
-      Some Anthropic_adaptive_only)
+       anthropic_thinking_control_for_model_id "manifest-anthropic-model"
+       = Some Anthropic_adaptive_only)
 ;;
 
 let%test "thinking_control_token accessor reads the token from the catalog constructor" =

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -202,8 +202,7 @@ type anthropic_thinking_control =
 (** Resolve Anthropic thinking control from the model catalog, then the
     capability manifest when the catalog has no matching row. [None] means
     neither source declares an Anthropic thinking policy. *)
-val anthropic_thinking_control_for_model_id
-  : string -> anthropic_thinking_control option
+val anthropic_thinking_control_for_model_id : string -> anthropic_thinking_control option
 
 (** Typed Gemini model family. SSOT for the [gemini-*] prefix dispatch that
     used to live as scattered [String.starts_with] calls. Downstream code

--- a/lib/llm_provider/complete_common.ml
+++ b/lib/llm_provider/complete_common.ml
@@ -345,6 +345,7 @@ let requires_non_http_transport = function
   | Provider_config.Gemini
   | Provider_config.Glm
   | Provider_config.DashScope -> false
+;;
 
 let validate_output_schema_request (config : Provider_config.t) =
   match Provider_config.validate_output_schema_request config with
@@ -398,10 +399,10 @@ let thinking_control_disable_unsatisfiable
        (match Capabilities.anthropic_thinking_control_for_model_id config.model_id with
         | Some Capabilities.Anthropic_always_adaptive -> true
         | Some
-            (Capabilities.Anthropic_manual_budget
+            ( Capabilities.Anthropic_manual_budget
             | Capabilities.Anthropic_adaptive_default
             | Capabilities.Anthropic_adaptive_preferred
-            | Capabilities.Anthropic_adaptive_only) -> false
+            | Capabilities.Anthropic_adaptive_only ) -> false
         | None -> caps.supports_reasoning)
      | Provider_config.Kimi
      | Provider_config.OpenAI_compat

--- a/lib/llm_provider/model_catalog.ml
+++ b/lib/llm_provider/model_catalog.ml
@@ -598,10 +598,12 @@ let%test "parse_entry leaves task undeclared as None" =
 let%test "parse_entry parses Anthropic thinking control as typed catalog data" =
   let entry =
     Otoml.Parser.from_string
-      "id_prefix = \"claude-sonnet-4-6\"\nanthropic_thinking_control = \"adaptive_preferred\""
+      "id_prefix = \"claude-sonnet-4-6\"\n\
+       anthropic_thinking_control = \"adaptive_preferred\""
   in
   match parse_entry entry with
-  | Ok { anthropic_thinking_control = Some Capability_vocab.Adaptive_preferred; _ } -> true
+  | Ok { anthropic_thinking_control = Some Capability_vocab.Adaptive_preferred; _ } ->
+    true
   | Ok _ | Error _ -> false
 ;;
 

--- a/lib/otel_tracer.ml
+++ b/lib/otel_tracer.ml
@@ -73,7 +73,7 @@ let otel_endpoint_env_var = "OTEL_EXPORTER_OTLP_ENDPOINT"
 let default_config = { service_name = default_service_name; endpoint = None }
 
 let default_config_from_env
-      ?(getenv = Llm_provider.Cli_common_env.get)
+      ?(getenv = fun name -> Llm_provider.Cli_common_env.get name)
       ()
   =
   { default_config with endpoint = getenv otel_endpoint_env_var }

--- a/lib/protocol/mcp.ml
+++ b/lib/protocol/mcp.ml
@@ -415,9 +415,7 @@ let has_shell_meta s = String.exists is_shell_meta s
 let interpreters = [ "sh"; "bash"; "zsh"; "python"; "python3"; "node"; "ruby"; "perl" ]
 
 let shell_commands_allowed () =
-  Llm_provider.Cli_common_env.bool
-    ~default:false
-    "OAS_MCP_ALLOW_SHELL_COMMANDS"
+  Llm_provider.Cli_common_env.bool ~default:false "OAS_MCP_ALLOW_SHELL_COMMANDS"
 ;;
 
 let validate_command_and_args ~command ~args =

--- a/test/test_llm_provider_cov.ml
+++ b/test/test_llm_provider_cov.ml
@@ -873,9 +873,7 @@ let test_constants_env_helpers () =
     (Constants.Deterministic.seed_of_env ~getenv ());
   let invalid_getenv =
     getenv_from
-      [ Constants.Env.max_tokens_default, "0"
-      ; Constants.Env.default_seed, "not-an-int"
-      ]
+      [ Constants.Env.max_tokens_default, "0"; Constants.Env.default_seed, "not-an-int" ]
   in
   Alcotest.(check int)
     "max tokens invalid env fallback"
@@ -901,7 +899,7 @@ let test_constants_env_helpers () =
       2048
       (Constants.Thinking.anthropic_budget ()));
   with_env "OAS_GEMINI_THINKING_BUDGET" (Some "3072") (fun () ->
-    Alcotest.(check int) "gemini override" 3072 (Constants.Thinking.gemini_budget ()));
+    Alcotest.(check int) "gemini override" 3072 (Constants.Thinking.gemini_budget ()))
 ;;
 
 let test_slot_cache_helpers () =


### PR DESCRIPTION
## Summary

- fix the reversed `Option.bind` arguments in the catalog-backed Anthropic thinking lookup
- eta-expand the canonical environment getter so `default_config_from_env` keeps the declared injected-getter type and call-time trimming semantics
- apply repository `ocamlformat` output only to the nine files left red by #2499

Closes #2507.

## Why one atomic PR

The release-main run failed both supported OCaml builds, Lint, and OCaml Format from the same #2499 merge. Splitting the two compile repairs from the formatter output would leave current main red between merges.

## Verification

- `env OCAMLPARAM=_,warn-error=+a scripts/dune-local.sh build --force lib/agent_sdk.cma lib/llm_provider/llm_provider.cma`
- `scripts/dune-local.sh runtest lib/llm_provider`
- `scripts/dune-local.sh exec ./test/test_otel_tracer.exe` — 42/42
- `scripts/dune-local.sh exec ./test/test_llm_provider_cov.exe` — 145/145
- rebased onto `origin/main@90cd9b502`; focused library build rerun green
- `scripts/dune-local.sh build @fmt`
- `git diff --check`

CI remains authoritative for OCaml 5.4.1 and the full repository matrix.

[근거] GitHub Actions main run 29072375408, issue #2507, focused local wrapper commands above; checked 2026-07-10 15:40 KST; confidence High.
