### PR TITLE
test: align catalog boundary fixtures

### DIFF
--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -368,10 +368,10 @@ let test_build_body_uses_catalog_output_cap () =
   check int "catalog max_tokens" 64_000 (json |> member "max_tokens" |> to_int)
 ;;
 
-(* The legacy OpenAI-compatible Agent SDK builder must also use the typed
-   provider/model resolver. This guards the path on a model whose catalog
-   ceiling is neither the old 4096 literal nor the unknown-model fallback. *)
-let test_build_openai_body_uses_catalog_output_cap () =
+(* A raw OpenAI-compatible endpoint is not an endpoint declaration for a bare
+   OpenAI model id. It must therefore use the unknown-model fallback instead
+   of inheriting the gpt-4.1 catalog row from a different provider boundary. *)
+let test_build_openai_body_uses_unknown_model_fallback () =
   let provider_config : Provider.config =
     { provider =
         Provider.OpenAICompat
@@ -390,7 +390,11 @@ let test_build_openai_body_uses_catalog_output_cap () =
     |> Yojson.Safe.from_string
   in
   let open Yojson.Safe.Util in
-  check int "catalog max_tokens" 32_000 (body |> member "max_tokens" |> to_int)
+  check
+    int
+    "unknown-provider fallback max_tokens"
+    (Llm_provider.Constants.resolve_unknown_model_max_tokens_fallback ())
+    (body |> member "max_tokens" |> to_int)
 ;;
 
 let test_build_body_with_thinking_budget () =
@@ -2480,9 +2484,9 @@ let () =
             `Quick
             test_build_body_uses_catalog_output_cap
         ; test_case
-            "OpenAI catalog output cap"
+            "OpenAI unknown-provider output fallback"
             `Quick
-            test_build_openai_body_uses_catalog_output_cap
+            test_build_openai_body_uses_unknown_model_fallback
         ; test_case "with thinking_budget" `Quick test_build_body_with_thinking_budget
         ; test_case
             "enable_thinking default budget"

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -1127,10 +1127,12 @@ let agent_state_with_schema schema : Types.agent_state =
   { base with config = cfg }
 ;;
 
-let test_provider_config_of_agent_custom_registered_ollama_cloud_row_honors_so () =
-  (* Regression for the P1 masking issue in #2440: Custom_registered ollama_cloud
-     must not let the provider default (supports_structured_output=false) hide
-     per-model catalog rows.  devstral-2:123b is declared as schema-capable. *)
+let test_provider_config_of_agent_custom_registered_ollama_cloud_row_separates_json_mode
+      ()
+  =
+  (* Custom_registered ollama_cloud must resolve the provider-qualified model
+     row. devstral-2:123b advertises JSON mode, but #2499 correctly removed the
+     stronger native-schema guarantee from the Ollama Cloud /v1 boundary. *)
   with_env "OLLAMA_CLOUD_API_KEY" (Some "ollama-cloud-test-key") (fun () ->
     let schema = `Assoc [ "type", `String "object" ] in
     let cfg : Provider.config =
@@ -1156,10 +1158,21 @@ let test_provider_config_of_agent_custom_registered_ollama_cloud_row_honors_so (
         "provider kind stays Ollama"
         true
         (pc.kind = Llm_provider.Provider_config.Ollama);
+      (match Llm_provider.Provider_config.capabilities_for_config_model pc with
+       | Some caps ->
+         Alcotest.(check bool)
+           "row advertises JSON mode"
+           true
+           caps.supports_response_format_json;
+         Alcotest.(check bool)
+           "row does not advertise native structured output"
+           false
+           caps.supports_structured_output
+       | None -> Alcotest.fail "provider-qualified catalog row was not resolved");
       Alcotest.(check bool)
-        "schema request accepted because row advertises SO"
+        "native schema rejected because JSON mode is not structured output"
         true
-        (Result.is_ok (Llm_provider.Provider_config.validate_output_schema_request pc))
+        (Result.is_error (Llm_provider.Provider_config.validate_output_schema_request pc))
     | Error e -> Alcotest.fail (Printf.sprintf "unexpected error: %s" (Error.to_string e)))
 ;;
 
@@ -1526,9 +1539,9 @@ let () =
             `Quick
             test_provider_config_of_agent_custom_registered_ollama_cloud_api_key_fallback
         ; Alcotest.test_case
-            "custom registered ollama_cloud row honors structured output"
+            "custom registered ollama_cloud row separates JSON mode from schema"
             `Quick
-            test_provider_config_of_agent_custom_registered_ollama_cloud_row_honors_so
+            test_provider_config_of_agent_custom_registered_ollama_cloud_row_separates_json_mode
         ; Alcotest.test_case
             "custom registered ollama_cloud row rejects structured output"
             `Quick


### PR DESCRIPTION
## Summary

- make the raw OpenAI-compatible builder test assert the canonical unknown-model fallback instead of inheriting a bare `gpt-4.1` catalog row across an undeclared endpoint boundary
- keep the Ollama Cloud row-authority regression test, but distinguish JSON mode from native structured-output support and assert the documented fail-closed schema result

No production code changes. Refs #2507.

## Root cause

#2499 added an OpenAI expectation that contradicted the endpoint-declaration guard, and its `models.toml` change removed Ollama Cloud's native-schema guarantee without updating the older devstral assertion. Release-main run 29074474494 reproduced both stale fixtures on OCaml 5.4.1 and 5.5.0; every non-build gate passed.

## Verification

- warning-as-errors build of `test/test_api.exe` and `test/test_provider.exe`
- `test_api.exe` — 90/90
- `test_provider.exe` with the repo model catalog — 50/50
- `scripts/dune-local.sh build @fmt`
- `git diff --check`
- independent read-only review: no blockers; production behavior matches typed catalog/endpoint SSOT

CI remains authoritative for both compiler versions and the full repository matrix.

[근거] release-main run 29074474494, #2499 blame/diff, focused local commands above; checked 2026-07-10 15:58 KST; confidence High.
