### PR TITLE
feat(llm_provider)!: stop inventing max_tokens for catalog-silent models

### DIFF
--- a/lib/api_anthropic.ml
+++ b/lib/api_anthropic.ml
@@ -107,8 +107,7 @@ let build_body_assoc
   let body_assoc =
     [ "model", `String model_str
     ; ( "max_tokens"
-      , `Int (Llm_provider.Backend_anthropic.effective_max_output_tokens provider_config)
-      )
+      , `Int (Llm_provider.Backend_anthropic.required_max_output_tokens provider_config) )
     ; "messages", `List (List.map message_to_json messages)
     ; "stream", `Bool stream
     ]

--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -382,14 +382,13 @@ let build_openai_body_unchecked
     in
     system_message_json config @ List.concat_map message_serializer sanitized_messages
   in
+  let body_assoc = [ "model", `String model_str; "messages", `List provider_messages ] in
   let body_assoc =
-    [ "model", `String model_str
-    ; "messages", `List provider_messages
-    ; ( "max_tokens"
-      , `Int
-          (Llm_provider.Backend_openai_request.effective_max_output_tokens
-             serialization_config) )
-    ]
+    match
+      Llm_provider.Backend_openai_request.effective_max_output_tokens serialization_config
+    with
+    | Some mt -> body_assoc @ [ "max_tokens", `Int mt ]
+    | None -> body_assoc
   in
   let body_assoc =
     match config.config.temperature with

--- a/lib/llm_provider/backend_anthropic.ml
+++ b/lib/llm_provider/backend_anthropic.ml
@@ -147,10 +147,28 @@ let output_config_for_config mode (config : Provider_config.t) =
 
 (* Anthropic and OpenAI-compatible request envelopes have different field
    names, but the output-budget policy is provider-config policy: caller
-   override, catalog ceiling, then the explicit unknown-model fallback.  The
-   OpenAI request module owns that policy so the legacy Agent SDK path and the
-   standalone backend cannot drift. *)
+   override, then catalog ceiling.  The OpenAI request module owns that
+   policy so the legacy Agent SDK path and the standalone backend cannot
+   drift. *)
 let effective_max_output_tokens = Backend_openai_request.effective_max_output_tokens
+
+(* The Messages API requires [max_tokens] on every request, so this wire
+   cannot omit the field the way the optional-field envelopes do. When
+   neither the caller nor the capability catalog declares a value the
+   request fails loudly instead of inventing a number: an invented cap is
+   shared by thinking and answer and silently truncates long reasoning. *)
+let required_max_output_tokens (config : Provider_config.t) =
+  match effective_max_output_tokens config with
+  | Some n -> n
+  | None ->
+    invalid_arg
+      (Printf.sprintf
+         "Backend_anthropic.required_max_output_tokens: model %s declares no \
+          max_output_tokens and the caller passed none; the Anthropic Messages API \
+          requires max_tokens — declare max_output_tokens in the model catalog or pass \
+          ~max_tokens"
+         config.model_id)
+;;
 
 (** Build Anthropic Messages API request body from {!Provider_config.t}.
     Returns a JSON string ready for HTTP POST. *)
@@ -228,7 +246,7 @@ let build_request
   let msgs_json = List.map message_to_json messages in
   let body =
     [ "model", `String config.model_id
-    ; "max_tokens", `Int (effective_max_output_tokens config)
+    ; "max_tokens", `Int (required_max_output_tokens config)
     ; "messages", `List msgs_json
     ; "stream", `Bool stream
     ]

--- a/lib/llm_provider/backend_anthropic.mli
+++ b/lib/llm_provider/backend_anthropic.mli
@@ -22,12 +22,18 @@ val output_config_for_config
   -> Provider_config.t
   -> Yojson.Safe.t option
 
-(** Resolve the output-token budget emitted on the Anthropic wire.  The
-    caller override is clamped to the selected model capability, otherwise
-    the catalog ceiling is used, with the call-time unknown-model fallback as
-    the final layer.  This is shared with the legacy Agent SDK builder so it
-    cannot invent a separate default. *)
-val effective_max_output_tokens : Provider_config.t -> int
+(** Resolve the output-token budget for the Anthropic wire.  The caller
+    override is clamped to the selected model capability, otherwise the
+    catalog ceiling is used; [None] when neither declares a value.  Shared
+    with the legacy Agent SDK builder so it cannot invent a separate
+    default. *)
+val effective_max_output_tokens : Provider_config.t -> int option
+
+(** The Messages API requires [max_tokens] on every request.  Returns the
+    resolved budget, or raises [Invalid_argument] naming the model when
+    neither the caller nor the capability catalog declares one — no value
+    is invented. *)
+val required_max_output_tokens : Provider_config.t -> int
 
 val build_request
   :  ?stream:bool

--- a/lib/llm_provider/backend_gemini.ml
+++ b/lib/llm_provider/backend_gemini.ml
@@ -323,12 +323,13 @@ let build_request
   in
   (* generationConfig *)
   let gen_config = ref [] in
-  (let mt =
-     Option.value
-       ~default:(Constants.resolve_unknown_model_max_tokens_fallback ())
-       config.max_tokens
-   in
-   gen_config := ("maxOutputTokens", `Int mt) :: !gen_config);
+  (* Shared budget policy (caller override clamped to catalog ceiling,
+     omitted when both are unknown) — [maxOutputTokens] is optional on
+     generateContent, and omission lets Gemini apply the model's own
+     limit instead of an invented 16384. *)
+  (match Backend_openai_request.effective_max_output_tokens config with
+   | Some mt -> gen_config := ("maxOutputTokens", `Int mt) :: !gen_config
+   | None -> ());
   (match config.temperature with
    | Some t -> gen_config := ("temperature", `Float t) :: !gen_config
    | None -> ());

--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -160,12 +160,13 @@ let build_request
      or [supports_top_k = false] for a specific Ollama variant — at
      which point the one-shot WARN from Backend_openai also fires. *)
   let options = ref [] in
-  (let mt =
-     Option.value
-       ~default:(Constants.resolve_unknown_model_max_tokens_fallback ())
-       config.max_tokens
-   in
-   options := ("num_predict", `Int mt) :: !options);
+  (* Shared budget policy (caller override clamped to catalog ceiling,
+     omitted when both are unknown) — Ollama's [num_predict] is optional,
+     and omission lets the server apply the model's own limit. Previously
+     this arm bypassed the capability catalog and invented 16384. *)
+  (match Backend_openai_request.effective_max_output_tokens config with
+   | Some mt -> options := ("num_predict", `Int mt) :: !options
+   | None -> ());
   (match config.temperature with
    | Some t -> options := ("temperature", `Float t) :: !options
    | None -> ());

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -153,30 +153,35 @@ let capabilities_of_config (config : Provider_config.t) =
         | Provider_config.DashScope -> Capabilities.dashscope_capabilities))
 ;;
 
-(* Resolve the output-token budget from three layers:
+(* Resolve the output-token budget from two layers of declared facts:
    1. Caller override ([config.max_tokens = Some n]) - explicit request
    2. Model capability ([caps.max_output_tokens]) - provider's ceiling
-   3. Fallback [Constants.resolve_unknown_model_max_tokens_fallback] -
-      last resort when both are unknown
 
    When the caller sends [None], they want the model's own maximum.
    When the caller sends [Some n], we clamp to the capability ceiling
    to avoid 400 errors that corrupt partial-commit state.
 
-   The resolved value is always emitted - Anthropic and most
-   OpenAI-compat endpoints REQUIRE the field. Chat Completions emits it
-   as [max_tokens], the Responses envelope as [max_output_tokens]: the
-   field name is per-envelope, the resolution policy (clamp WARN
-   included) is single-sourced here. *)
+   When BOTH are unknown, [None] is returned and the field is omitted
+   from the wire. max_tokens is optional on Chat Completions /
+   Responses / Ollama / Gemini; omission lets the provider apply the
+   model's real ceiling. The former 16384 fallback capped thinking and
+   answer jointly on catalog-silent models, truncating long reasoning
+   mid-thought (stop_reason=max_tokens, zero answer text). Anthropic
+   Messages requires the field on the wire; that path resolves through
+   [Backend_anthropic.required_max_output_tokens], which fails loudly
+   on [None] instead of inventing a number. Chat Completions emits the
+   value as [max_tokens], the Responses envelope as
+   [max_output_tokens]: the field name is per-envelope, the resolution
+   policy (clamp WARN included) is single-sourced here. *)
 let effective_max_output_tokens (config : Provider_config.t) =
   let caps = capabilities_of_config config in
   match config.max_tokens, caps.max_output_tokens with
-  | None, Some cap -> cap
-  | None, None -> Constants.resolve_unknown_model_max_tokens_fallback ()
+  | None, (Some _ as cap) -> cap
+  | None, None -> None
   | Some n, Some cap when n > cap ->
     warn_capability_drop ~model_id:config.model_id ~field:"max_tokens:clamp";
-    cap
-  | Some n, _ -> n
+    Some cap
+  | (Some _ as n), _ -> n
 ;;
 
 (* Shared tool_choice emission gate for the Chat and Responses envelopes.
@@ -261,13 +266,13 @@ let build_request_assoc
      sampling-field gates further down; the output-token budget (clamp
      WARN included) is resolved by the shared
      [effective_max_output_tokens] policy and emitted here under the
-     Chat Completions [max_tokens] field name. *)
-  let effective_max_tokens = effective_max_output_tokens config in
+     Chat Completions [max_tokens] field name — omitted entirely when
+     neither caller nor catalog declares a value. *)
+  let body = [ "model", `String config.model_id; "messages", `List provider_messages ] in
   let body =
-    [ "model", `String config.model_id
-    ; "messages", `List provider_messages
-    ; "max_tokens", `Int effective_max_tokens
-    ]
+    match effective_max_output_tokens config with
+    | Some mt -> body @ [ "max_tokens", `Int mt ]
+    | None -> body
   in
   let body =
     match config.temperature with

--- a/lib/llm_provider/backend_openai_request.mli
+++ b/lib/llm_provider/backend_openai_request.mli
@@ -15,11 +15,13 @@ val capabilities_of_config : Provider_config.t -> Capabilities.capabilities
 
 (** Resolve the output-token budget emitted on the wire: caller override
     clamped to the capability ceiling (one-shot WARN on clamp), the model
-    capability when the caller sends none, then the unknown-model fallback.
-    Chat Completions emits the value as [max_tokens], the Responses envelope
-    as [max_output_tokens] — the field name is per-envelope, the resolution
-    policy is single-sourced here. *)
-val effective_max_output_tokens : Provider_config.t -> int
+    capability when the caller sends none, [None] when both are unknown —
+    the emitters then omit the field so the provider applies the model's
+    real ceiling (no invented fallback). Chat Completions emits the value
+    as [max_tokens], the Responses envelope as [max_output_tokens] — the
+    field name is per-envelope, the resolution policy is single-sourced
+    here. *)
+val effective_max_output_tokens : Provider_config.t -> int option
 
 (** Prepend the sampling [(field, value)] to [body] unless the reasoning
     dialect suppresses that parameter, in which case the field is dropped with a

--- a/lib/llm_provider/backend_openai_responses.ml
+++ b/lib/llm_provider/backend_openai_responses.ml
@@ -381,8 +381,12 @@ let build_request
   let body =
     [ "model", `String config.model_id
     ; "input", `List (List.concat_map input_items_of_message sanitized_messages)
-    ; "max_output_tokens", `Int (effective_max_output_tokens config)
     ]
+  in
+  let body =
+    match effective_max_output_tokens config with
+    | Some mt -> body @ [ "max_output_tokens", `Int mt ]
+    | None -> body
   in
   let body =
     match config.previous_response_id with

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -384,8 +384,15 @@ let kimi_capabilities =
 
 let openai_compat_chat_capabilities =
   { default_capabilities with
-    max_context_tokens = Some 128_000
-  ; max_output_tokens = Some 16_384
+    max_context_tokens =
+      Some 128_000
+      (* [max_output_tokens] stays [None]: this preset covers arbitrary
+       OpenAI-compatible endpoints whose real output ceiling the SDK
+       cannot know. A family-level guess here becomes the wire
+       [max_tokens] for every catalog-silent model and truncates long
+       thinking (thinking and answer share the value). Unknown means
+       unknown — request builders omit the field and the server applies
+       the model's own limit; per-model rows declare real ceilings. *)
   ; supports_tools = true
   ; supports_tool_choice = true
   ; supports_required_tool_choice = true

--- a/lib/llm_provider/constants.ml
+++ b/lib/llm_provider/constants.ml
@@ -9,7 +9,6 @@
 (* ── HTTP retry / handoff codes ──────────────────── *)
 
 module Env = struct
-  let max_tokens_default = "OAS_MAX_TOKENS_DEFAULT"
   let thinking_budget_default = "OAS_THINKING_BUDGET_DEFAULT"
   let anthropic_thinking_budget = "OAS_ANTHROPIC_THINKING_BUDGET"
   let gemini_thinking_budget = "OAS_GEMINI_THINKING_BUDGET"
@@ -99,27 +98,14 @@ module Inference_profile = struct
   let deterministic = { no_sampling_overrides with temperature = 0.0; max_tokens = 4096 }
 end
 
-(** Fallback [max_tokens] when both caller override and model capability
-    are absent. Emitted as a required field by OpenAI-compat and Anthropic
-    backends. Env override resolution is intentionally done by
-    {!resolve_unknown_model_max_tokens_fallback} at request-build time,
-    not during module initialization.
-
-    16384 is a last-resort ceiling for modern high-context models. Models with
-    lower caps should be declared in [Capabilities.for_model_id] so the
-    capability-gated path (not this fallback) applies.
-    @since 0.188.0
-    @since 0.185.0 — raised from 4096 to 16384
-    @since 0.208.0 — env override moved to call-time resolver *)
-let unknown_model_max_tokens_fallback = 16384
-
-let resolve_unknown_model_max_tokens_fallback ?getenv () =
-  positive_int_env_or
-    ?getenv
-    ~var:Env.max_tokens_default
-    ~default:unknown_model_max_tokens_fallback
-    ()
-;;
+(* The former unknown-model [max_tokens] fallback (16384, env
+   OAS_MAX_TOKENS_DEFAULT) was removed: when neither the caller nor the
+   capability catalog declares an output ceiling, request builders omit
+   the field and the provider applies the model's real limit. An
+   invented value is shared by thinking and answer and truncates long
+   reasoning mid-thought on catalog-silent models. Anthropic (the one
+   wire that requires the field) fails loudly via
+   [Backend_anthropic.required_max_output_tokens]. *)
 
 (* ── Cache ───────────────────────────────────────── *)
 

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -390,11 +390,15 @@ let test_build_openai_body_uses_unknown_model_fallback () =
     |> Yojson.Safe.from_string
   in
   let open Yojson.Safe.Util in
+  (* No caller override and no catalog ceiling: the field is omitted so the
+     provider applies the model's own limit — no invented fallback. *)
   check
-    int
-    "unknown-provider fallback max_tokens"
-    (Llm_provider.Constants.resolve_unknown_model_max_tokens_fallback ())
-    (body |> member "max_tokens" |> to_int)
+    bool
+    "unknown-model max_tokens omitted"
+    true
+    (match body |> member "max_tokens" with
+     | `Null -> true
+     | _ -> false)
 ;;
 
 let test_build_body_with_thinking_budget () =

--- a/test/test_llm_provider_cov.ml
+++ b/test/test_llm_provider_cov.ml
@@ -844,17 +844,12 @@ let test_constants_retry_cache_sampling_and_endpoints () =
 let test_constants_env_helpers () =
   let getenv =
     getenv_from
-      [ Constants.Env.max_tokens_default, "8192"
-      ; Constants.Env.thinking_budget_default, "4096"
+      [ Constants.Env.thinking_budget_default, "4096"
       ; Constants.Env.anthropic_thinking_budget, "2048"
       ; Constants.Env.gemini_thinking_budget, "3072"
       ; Constants.Env.default_seed, "123"
       ]
   in
-  Alcotest.(check int)
-    "max tokens env override"
-    8192
-    (Constants.resolve_unknown_model_max_tokens_fallback ~getenv ());
   Alcotest.(check int)
     "default thinking env override"
     4096
@@ -871,14 +866,7 @@ let test_constants_env_helpers () =
     "seed env override"
     (Some 123)
     (Constants.Deterministic.seed_of_env ~getenv ());
-  let invalid_getenv =
-    getenv_from
-      [ Constants.Env.max_tokens_default, "0"; Constants.Env.default_seed, "not-an-int" ]
-  in
-  Alcotest.(check int)
-    "max tokens invalid env fallback"
-    Constants.unknown_model_max_tokens_fallback
-    (Constants.resolve_unknown_model_max_tokens_fallback ~getenv:invalid_getenv ());
+  let invalid_getenv = getenv_from [ Constants.Env.default_seed, "not-an-int" ] in
   Alcotest.(check (option int))
     "seed invalid"
     None


### PR DESCRIPTION
## 무엇

카탈로그·호출자 모두 출력 상한을 선언하지 않은 모델에 대해 `max_tokens`를 발명(16384)해 전송하던 것을 중단하고, 필드를 **생략**합니다. 생략하면 provider가 모델의 실제 상한을 적용합니다.

## 왜 (실측 근거)

thinking 모델에서 thinking과 answer가 단일 `max_tokens`를 공유합니다. 카탈로그가 침묵한 모델(`ollama_cloud/deepseek-v4-flash`, `qwen36-35b-a3b-mtp` 등)은 발명된 16384가 그대로 wire에 실렸고, 긴 사고가 이 상한을 사고 중간에 소진하면 `stop_reason=max_tokens` + `content=[thinking]`(답변 0자)로 끝나 하류(masc accept 계약)에서 턴 전체가 폐기되었습니다.

- keeper_chat 실측: "Keeper request failed" 327건 중 87.2%가 10분+ dead-end, 76.8%는 사용자 재핑 후에야 회복
- fleet trace(2026-06-30, 111 trajectories): thinking_only+max_tokens 거부 73건
- mad-improver: 동일 거부가 07-07/07-08까지 10일간 재현 (masc RFC-0271 §9 진단과 일치)
- taskmaster: 47.8시간 간격으로 바이트 동일한 `shape=empty stop_reason=max_tokens` 거부 재현

## 변경

| 지점 | 전 | 후 |
|---|---|---|
| `effective_max_output_tokens` | `int` (None+None→16384 발명) | `int option` (None+None→`None`) |
| Chat Completions / Responses | 항상 `max_tokens`/`max_output_tokens` emit | `None`이면 필드 생략 |
| Ollama `num_predict` | **카탈로그 무시**, caller-or-16384 | 공유 정책 경유(카탈로그 참조), `None`이면 생략 |
| Gemini `maxOutputTokens` | caller-or-16384 | 공유 정책 경유, `None`이면 생략 |
| Anthropic Messages (`max_tokens` 프로토콜 필수) | 16384 발명 가능 | `required_max_output_tokens` — 값 없으면 모델명을 담아 즉시 실패 (발명 금지) |
| `openai_compat_chat` preset | `max_output_tokens = Some 16_384` (가족 추정치) | `None` (모름은 모름; 모델 행이 실제 값 선언) |
| `Constants.unknown_model_max_tokens_fallback` / `OAS_MAX_TOKENS_DEFAULT` | 존재 | 삭제 |

유지한 것: caller override의 카탈로그 ceiling clamp(one-shot WARN, provider 400 방지), 모델별 선언값(glm 40960 서버 강제, anthropic 8192 등 문서화된 사실), 카탈로그 선언 시 그 값 emit.

## 검증

- 로컬 `scripts/dune-local.sh build @check` green, `dune build @fmt` clean
- 테스트 갱신: `test_api.ml` unknown-model은 `max_tokens` 부재를 단언, `test_llm_provider_cov.ml`의 삭제된 fallback env 검증 제거
- 전체 테스트는 CI에 위임 (repo 규약)

## Breaking

- `effective_max_output_tokens : Provider_config.t -> int option` (기존 `int`)
- `Backend_anthropic.required_max_output_tokens` 신설
- unknown-model 요청은 더 이상 `max_tokens`를 싣지 않음

masc 소비 경로는 keeper 턴에서 항상 명시적 `max_tokens`를 전달하므로 이 PR 단독으로는 keeper 동작 불변. 후속 masc PR(클램프 32768·flat 8192 숙청)이 pin bump 후 `None` 전달을 시작하면 이 생략 경로가 활성화됩니다.

RFC: masc `docs/rfc/RFC-0271-in-turn-recovery-accept-rejected-and-thinking-budget.md` §9 (2026-07-09 진단)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
