### PR TITLE
fix(llm_provider)!: separate output ceiling from request default

### DIFF
--- a/lib/llm_provider/backend_anthropic.ml
+++ b/lib/llm_provider/backend_anthropic.ml
@@ -158,12 +158,11 @@ let effective_max_output_tokens = Backend_openai_request.effective_max_output_to
    resolver above:
    - caller [Some n] -> clamped to the catalog ceiling with a one-shot
      WARN (shared clamp semantics via [effective_max_output_tokens]).
-   - caller [None] -> the catalog-declared model maximum. This is the
-     required-envelope DEFAULT, stated explicitly here rather than a
-     ceiling silently leaking through an optional-envelope path; for the
-     Anthropic family the declared maxima are small relative to the
-     context window, so the sum-of-parts context concern that forbids
-     ceiling injection on optional envelopes does not bind.
+   - caller [None] -> the catalog-declared model maximum. This is OAS's
+     explicit required-envelope fallback, not a claim that the provider
+     supplies that value as its default. Reusing the declared maximum keeps
+     known-model calls simple without inventing a second numeric policy;
+     callers that need a smaller request bound can still pass one explicitly.
    - neither declared -> fail loudly naming the model; an invented
      constant is shared by thinking and answer and silently truncates
      long reasoning. *)

--- a/lib/llm_provider/backend_anthropic.ml
+++ b/lib/llm_provider/backend_anthropic.ml
@@ -146,28 +146,42 @@ let output_config_for_config mode (config : Provider_config.t) =
 ;;
 
 (* Anthropic and OpenAI-compatible request envelopes have different field
-   names, but the output-budget policy is provider-config policy: caller
-   override, then catalog ceiling.  The OpenAI request module owns that
-   policy so the legacy Agent SDK path and the standalone backend cannot
-   drift. *)
+   names, but the optional-envelope output-budget policy (caller override
+   clamped to the ceiling, omission on [None]) is owned by the OpenAI
+   request module so the legacy Agent SDK path and the standalone backend
+   cannot drift. *)
 let effective_max_output_tokens = Backend_openai_request.effective_max_output_tokens
 
 (* The Messages API requires [max_tokens] on every request, so this wire
-   cannot omit the field the way the optional-field envelopes do. When
-   neither the caller nor the capability catalog declares a value the
-   request fails loudly instead of inventing a number: an invented cap is
-   shared by thinking and answer and silently truncates long reasoning. *)
+   cannot express omission the way the optional-field envelopes do (#2517).
+   Explicit required-envelope policy, distinct from the optional-envelope
+   resolver above:
+   - caller [Some n] -> clamped to the catalog ceiling with a one-shot
+     WARN (shared clamp semantics via [effective_max_output_tokens]).
+   - caller [None] -> the catalog-declared model maximum. This is the
+     required-envelope DEFAULT, stated explicitly here rather than a
+     ceiling silently leaking through an optional-envelope path; for the
+     Anthropic family the declared maxima are small relative to the
+     context window, so the sum-of-parts context concern that forbids
+     ceiling injection on optional envelopes does not bind.
+   - neither declared -> fail loudly naming the model; an invented
+     constant is shared by thinking and answer and silently truncates
+     long reasoning. *)
 let required_max_output_tokens (config : Provider_config.t) =
   match effective_max_output_tokens config with
   | Some n -> n
   | None ->
-    invalid_arg
-      (Printf.sprintf
-         "Backend_anthropic.required_max_output_tokens: model %s declares no \
-          max_output_tokens and the caller passed none; the Anthropic Messages API \
-          requires max_tokens — declare max_output_tokens in the model catalog or pass \
-          ~max_tokens"
-         config.model_id)
+    let caps = Backend_openai_request.capabilities_of_config config in
+    (match caps.max_output_tokens with
+     | Some cap -> cap
+     | None ->
+       invalid_arg
+         (Printf.sprintf
+            "Backend_anthropic.required_max_output_tokens: model %s declares no \
+             max_output_tokens and the caller passed none; the Anthropic Messages API \
+             requires max_tokens — declare max_output_tokens in the model catalog or \
+             pass ~max_tokens"
+            config.model_id))
 ;;
 
 (** Build Anthropic Messages API request body from {!Provider_config.t}.

--- a/lib/llm_provider/backend_anthropic.mli
+++ b/lib/llm_provider/backend_anthropic.mli
@@ -22,17 +22,18 @@ val output_config_for_config
   -> Provider_config.t
   -> Yojson.Safe.t option
 
-(** Resolve the output-token budget for the Anthropic wire.  The caller
-    override is clamped to the selected model capability, otherwise the
-    catalog ceiling is used; [None] when neither declares a value.  Shared
-    with the legacy Agent SDK builder so it cannot invent a separate
-    default. *)
+(** Optional-envelope resolver re-exported from
+    {!Backend_openai_request.effective_max_output_tokens}: caller override
+    clamped to the model capability (one-shot WARN), [None] on caller
+    [None] — the ceiling is never injected as a request value. *)
 val effective_max_output_tokens : Provider_config.t -> int option
 
-(** The Messages API requires [max_tokens] on every request.  Returns the
-    resolved budget, or raises [Invalid_argument] naming the model when
-    neither the caller nor the capability catalog declares one — no value
-    is invented. *)
+(** The Messages API requires [max_tokens] on every request, so this
+    envelope carries an explicit required-envelope policy: caller override
+    clamped to the catalog ceiling; caller [None] resolves to the
+    catalog-declared model maximum (the stated required-envelope default);
+    raises [Invalid_argument] naming the model when neither the caller nor
+    the catalog declares a value — no value is invented. *)
 val required_max_output_tokens : Provider_config.t -> int
 
 val build_request

--- a/lib/llm_provider/backend_anthropic.mli
+++ b/lib/llm_provider/backend_anthropic.mli
@@ -29,11 +29,11 @@ val output_config_for_config
 val effective_max_output_tokens : Provider_config.t -> int option
 
 (** The Messages API requires [max_tokens] on every request, so this
-    envelope carries an explicit required-envelope policy: caller override
-    clamped to the catalog ceiling; caller [None] resolves to the
-    catalog-declared model maximum (the stated required-envelope default);
-    raises [Invalid_argument] naming the model when neither the caller nor
-    the catalog declares a value — no value is invented. *)
+    envelope carries an explicit OAS required-envelope policy: caller
+    override clamped to the catalog ceiling; caller [None] falls back to the
+    catalog-declared model maximum (this is not a provider default); raises
+    [Invalid_argument] naming the model when neither the caller nor the
+    catalog declares a value — no second numeric policy is invented. *)
 val required_max_output_tokens : Provider_config.t -> int
 
 val build_request

--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -1540,6 +1540,26 @@ let%test "max_tokens passed through when within capability cap" =
   json |> member "max_tokens" |> to_int = 2_000
 ;;
 
+let%test "max_tokens omitted on caller None even when the catalog declares a cap" =
+  (* #2517: the catalog cap is a validation ceiling, not a request
+     default. glm-4-flash declares max_output_tokens = Some 4_096, but a
+     caller that sends None wants the provider's own default policy — the
+     field must be absent from the wire, not populated with the ceiling
+     (on GLM the context window bounds input + reasoning + output jointly,
+     so ceiling injection can overflow the contract on long prompts). *)
+  let config =
+    Provider_config.make
+      ~kind:Provider_config.Glm
+      ~model_id:"glm-4-flash"
+      ~base_url:Zai_catalog.general_base_url
+      ()
+  in
+  let body = build_request ~config ~messages:[] () in
+  let json = Yojson.Safe.from_string body in
+  let open Yojson.Safe.Util in
+  json |> member "max_tokens" = `Null
+;;
+
 let%test
     "build_request emits chat_template_kwargs for declared nvidia (Chat_template_kwargs)"
   =

--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -1556,8 +1556,9 @@ let%test "max_tokens omitted on caller None even when the catalog declares a cap
   in
   let body = build_request ~config ~messages:[] () in
   let json = Yojson.Safe.from_string body in
-  let open Yojson.Safe.Util in
-  json |> member "max_tokens" = `Null
+  match json with
+  | `Assoc fields -> not (List.mem_assoc "max_tokens" fields)
+  | _ -> false
 ;;
 
 let%test

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -178,9 +178,9 @@ let capabilities_of_config (config : Provider_config.t) =
 
    Anthropic Messages REQUIRES the field on the wire; that envelope
    resolves through [Backend_anthropic.required_max_output_tokens],
-   which applies an explicit required-envelope default (the
-   catalog-declared model maximum) and fails loudly when no value is
-   declared anywhere — no invented constants. *)
+   which applies an explicit OAS required-envelope fallback (the
+   catalog-declared model maximum, not a provider default) and fails loudly
+   when no value is declared anywhere — no invented constants. *)
 let effective_max_output_tokens (config : Provider_config.t) =
   let caps = capabilities_of_config config in
   match config.max_tokens, caps.max_output_tokens with

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -153,31 +153,38 @@ let capabilities_of_config (config : Provider_config.t) =
         | Provider_config.DashScope -> Capabilities.dashscope_capabilities))
 ;;
 
-(* Resolve the output-token budget from two layers of declared facts:
-   1. Caller override ([config.max_tokens = Some n]) - explicit request
-   2. Model capability ([caps.max_output_tokens]) - provider's ceiling
+(* Resolve the output-token budget for optional request envelopes (#2517).
 
-   When the caller sends [None], they want the model's own maximum.
-   When the caller sends [Some n], we clamp to the capability ceiling
-   to avoid 400 errors that corrupt partial-commit state.
+   [Capabilities.max_output_tokens] is a VALIDATION CEILING — the maximum
+   the provider accepts — not a request default. The two roles must not
+   conflate: injecting the ceiling whenever the caller sends [None] turns
+   "use the provider's default policy" into "always request the maximum
+   output", and on providers whose context window bounds
+   input + reasoning + output jointly (e.g. Z.AI GLM: 200K context,
+   default max_tokens 65536, maximum 131072) a long prompt plus a
+   ceiling-sized output request can exceed the context contract even
+   though each half is individually legal.
 
-   When BOTH are unknown, [None] is returned and the field is omitted
-   from the wire. max_tokens is optional on Chat Completions /
-   Responses / Ollama / Gemini; omission lets the provider apply the
-   model's real ceiling. The former 16384 fallback capped thinking and
-   answer jointly on catalog-silent models, truncating long reasoning
-   mid-thought (stop_reason=max_tokens, zero answer text). Anthropic
-   Messages requires the field on the wire; that path resolves through
-   [Backend_anthropic.required_max_output_tokens], which fails loudly
-   on [None] instead of inventing a number. Chat Completions emits the
-   value as [max_tokens], the Responses envelope as
-   [max_output_tokens]: the field name is per-envelope, the resolution
-   policy (clamp WARN included) is single-sourced here. *)
+   Policy, single-sourced here for Chat Completions ([max_tokens]),
+   Responses ([max_output_tokens]), Ollama ([num_predict]) and Gemini
+   ([maxOutputTokens]) — all optional fields:
+   - caller [None]  -> [None]: the field is omitted and the provider
+     applies its own default sized to the model's real limits. The
+     catalog ceiling is never injected as a request value.
+   - caller [Some n] with n above the catalog ceiling -> clamped to the
+     ceiling with a one-shot WARN (avoids 400s that corrupt
+     partial-commit state).
+   - caller [Some n] otherwise -> emitted as-is.
+
+   Anthropic Messages REQUIRES the field on the wire; that envelope
+   resolves through [Backend_anthropic.required_max_output_tokens],
+   which applies an explicit required-envelope default (the
+   catalog-declared model maximum) and fails loudly when no value is
+   declared anywhere — no invented constants. *)
 let effective_max_output_tokens (config : Provider_config.t) =
   let caps = capabilities_of_config config in
   match config.max_tokens, caps.max_output_tokens with
-  | None, (Some _ as cap) -> cap
-  | None, None -> None
+  | None, _ -> None
   | Some n, Some cap when n > cap ->
     warn_capability_drop ~model_id:config.model_id ~field:"max_tokens:clamp";
     Some cap

--- a/lib/llm_provider/backend_openai_request.mli
+++ b/lib/llm_provider/backend_openai_request.mli
@@ -13,14 +13,18 @@ val effective_tools : Provider_config.t -> Yojson.Safe.t list -> Yojson.Safe.t l
 val structured_schema_of_config : Provider_config.t -> Yojson.Safe.t option
 val capabilities_of_config : Provider_config.t -> Capabilities.capabilities
 
-(** Resolve the output-token budget emitted on the wire: caller override
-    clamped to the capability ceiling (one-shot WARN on clamp), the model
-    capability when the caller sends none, [None] when both are unknown —
-    the emitters then omit the field so the provider applies the model's
-    real ceiling (no invented fallback). Chat Completions emits the value
-    as [max_tokens], the Responses envelope as [max_output_tokens] — the
-    field name is per-envelope, the resolution policy is single-sourced
-    here. *)
+(** Resolve the output-token budget for optional request envelopes.
+    [Capabilities.max_output_tokens] is a validation ceiling, not a
+    request default: caller [Some n] is clamped to it (one-shot WARN on
+    clamp); caller [None] resolves to [None] and the emitters omit the
+    field so the provider applies its own default — the ceiling is never
+    injected as a request value (#2517; on providers whose context window
+    bounds input+output jointly, ceiling injection can overflow the
+    contract). Chat Completions emits the value as [max_tokens], the
+    Responses envelope as [max_output_tokens] — the field name is
+    per-envelope, the resolution policy is single-sourced here. The
+    required Anthropic envelope uses
+    [Backend_anthropic.required_max_output_tokens] instead. *)
 val effective_max_output_tokens : Provider_config.t -> int option
 
 (** Prepend the sampling [(field, value)] to [body] unless the reasoning


### PR DESCRIPTION
## 무엇 (#2517 요구 계약 구현)

`Capabilities.max_output_tokens`의 두 역할을 분리합니다. optional envelope(Chat Completions/Responses/Ollama/Gemini)에서 caller `None`은 catalog ceiling으로 치환되지 않고 wire field가 생략됩니다.

## 계약

| caller | catalog ceiling | optional envelope | Anthropic Messages |
|---|---|---|---|
| `None` | 있음 | field 생략 | catalog maximum을 OAS required-envelope fallback으로 사용 |
| `None` | 없음 | field 생략 | 모델명을 포함해 명시적 실패 |
| `Some n > ceiling` | 있음 | clamp + one-shot WARN | 동일 clamp |
| `Some n <= ceiling` | 무관 | 그대로 전달 | 그대로 전달 |

Anthropic의 fallback은 provider가 제공하는 default라는 뜻이 아닙니다. Messages wire가 `max_tokens`를 요구하므로, OAS가 알려진 모델 호출을 간결하게 유지하기 위해 이미 선언된 maximum을 재사용하는 별도 envelope 정책입니다. 별도의 숫자를 발명하지 않으며 caller override는 보존됩니다.

## 왜

catalog ceiling을 optional request default로 주입하면 caller의 생략 의도가 항상 최대 출력 요청으로 바뀝니다. Z.AI GLM은 context 안에서 input, reasoning/intermediate, output을 함께 계산하므로 긴 입력과 maximum output 요청을 독립적으로 허용할 수 없습니다.

- Z.AI Core Parameters: https://docs.z.ai/guides/overview/concept-param
- Z.AI GLM-5-Turbo: https://docs.z.ai/guides/llm/glm-5-turbo
- Anthropic Messages API: https://platform.claude.com/docs/en/api/messages/create

[근거] 위 공식 문서, 2026-07-11 KST 확인, 신뢰도 High.

## 회귀 증거

- `None + known ceiling`에서 `max_tokens` key 자체가 없음을 단언합니다. JSON `null`과 key absence를 같은 것으로 취급하지 않습니다.
- 기존 clamp, passthrough, Anthropic required-envelope fallback 테스트를 유지합니다.
- exact head `315fb0ceda36694e6910981e79dfefa40e3c8f6f`:
  - OCaml 5.4.1 `ocamlc -stop-after parsing` PASS
  - `ocamlformat --check` PASS
  - `git diff --check` PASS
  - 로컬 Dune 미실행, exact-head CI가 권위
- precursor `62c9a5db87`의 OCaml 5.4.1/5.5.0 전체 CI는 green이었지만 exact-head 증거로 과대계상하지 않습니다.

## 연계

- Closes #2517
- MASC 후속: jeong-sik/masc#24067
- OAS는 MASC를 참조하지 않습니다.
