### PR TITLE
fix(retry): classify HTTP 403 as authorization failure

### DIFF
--- a/lib/error_domain.ml
+++ b/lib/error_domain.ml
@@ -6,6 +6,7 @@ module Http_client = Llm_provider.Http_client
 type provider_error =
   [ `Rate_limited of float option
   | `Auth_error of string
+  | `Authorization_error of string
   | `Server_error of int * string
   | `Network_error of string
   | `Provider_timeout of Http_client.timeout_phase option * string
@@ -81,6 +82,7 @@ let of_api_error (err : Retry.api_error) : provider_error =
   match err with
   | Retry.RateLimited r -> `Rate_limited r.retry_after
   | Retry.AuthError r -> `Auth_error r.message
+  | Retry.AuthorizationError r -> `Authorization_error r.message
   | Retry.ServerError r -> `Server_error (r.status, r.message)
   | Retry.NetworkError r -> `Network_error r.message
   | Retry.Timeout r ->
@@ -100,6 +102,7 @@ let of_provider_error (err : Llm_provider.Error.provider_error) : provider_error
   | Llm_provider.Error.RateLimit r -> `Rate_limited r.retry_after
   | Llm_provider.Error.HardQuota r -> `Rate_limited r.retry_after
   | Llm_provider.Error.AuthError r -> `Auth_error r.detail
+  | Llm_provider.Error.AuthorizationError r -> `Authorization_error r.detail
   | Llm_provider.Error.ServerError r -> `Server_error (r.code, r.detail)
   | Llm_provider.Error.NetworkError r -> `Network_error r.detail
   | Llm_provider.Error.Timeout r ->
@@ -158,6 +161,7 @@ let provider_to_sdk : provider_error -> Error.sdk_error = function
   | `Rate_limited after ->
     Error.Api (Retry.RateLimited { retry_after = after; message = "rate limited" })
   | `Auth_error msg -> Error.Api (Retry.AuthError { message = msg })
+  | `Authorization_error msg -> Error.Api (Retry.AuthorizationError { message = msg })
   | `Server_error (status, msg) -> Error.Api (Retry.ServerError { status; message = msg })
   | `Network_error msg -> Error.Api (Retry.NetworkError { message = msg; kind = Unknown })
   | `Provider_timeout (phase, msg) -> Error.Api (Retry.Timeout { message = msg; phase })
@@ -261,6 +265,7 @@ let is_retryable (err : [< sdk_error_poly ]) : bool =
      eliminate defensive catch-alls; this matches the exhaustive sibling
      Error.is_retryable. *)
   | `Auth_error _
+  | `Authorization_error _
   | `Invalid_request _
   | `Not_found _
   | `Context_overflow _

--- a/lib/error_domain.mli
+++ b/lib/error_domain.mli
@@ -24,6 +24,7 @@
 type provider_error =
   [ `Rate_limited of float option (** retry_after seconds *)
   | `Auth_error of string
+  | `Authorization_error of string
   | `Server_error of int * string (** status, message *)
   | `Network_error of string
   | `Provider_timeout of Llm_provider.Http_client.timeout_phase option * string

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -244,6 +244,7 @@ let complete_with_retry
              | Retry.Overloaded _
              | Retry.ServerError _
              | Retry.AuthError _
+             | Retry.AuthorizationError _
              | Retry.PaymentRequired _
              | Retry.InvalidRequest _
              | Retry.NotFound _
@@ -412,6 +413,7 @@ let complete_stream_with_retry
              | Retry.Overloaded _
              | Retry.ServerError _
              | Retry.AuthError _
+             | Retry.AuthorizationError _
              | Retry.PaymentRequired _
              | Retry.InvalidRequest _
              | Retry.NotFound _

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -107,6 +107,7 @@ let%test "stream rate-limit converges to typed RateLimited (not NetworkError Unk
      | Retry.Overloaded _
      | Retry.ServerError _
      | Retry.AuthError _
+     | Retry.AuthorizationError _
      | Retry.PaymentRequired _
      | Retry.InvalidRequest _
      | Retry.NotFound _

--- a/lib/llm_provider/error.ml
+++ b/lib/llm_provider/error.ml
@@ -40,6 +40,10 @@ type provider_error =
       { provider : string
       ; detail : string
       }
+  | AuthorizationError of
+      { provider : string
+      ; detail : string
+      }
   | ServerError of
       { provider : string
       ; code : int
@@ -145,6 +149,8 @@ let to_string = function
       (affected_suffix r.affected)
       (retry_after_suffix r.retry_after)
   | AuthError r -> Printf.sprintf "Provider '%s' auth error: %s" r.provider r.detail
+  | AuthorizationError r ->
+    Printf.sprintf "Provider '%s' authorization error: %s" r.provider r.detail
   | ServerError r ->
     Printf.sprintf
       "Provider '%s' server error %d (transient=%b): %s"
@@ -194,6 +200,7 @@ let of_retry_api_error ?provider err =
       ; detail = r.message
       }
   | Retry.AuthError r -> AuthError { provider; detail = r.message }
+  | Retry.AuthorizationError r -> AuthorizationError { provider; detail = r.message }
   | Retry.PaymentRequired r ->
     (* HTTP 402 is a hard billing-exhaustion signal by status code alone —
        map directly onto the existing [HardQuota] provider_error rather than
@@ -324,6 +331,7 @@ let is_retryable = function
   | ProviderUnavailable _
   | HardQuota _
   | AuthError _
+  | AuthorizationError _
   | InvalidRequest _
   | NotFound _
   | ProviderTerminal _ -> false

--- a/lib/llm_provider/error.mli
+++ b/lib/llm_provider/error.mli
@@ -40,6 +40,10 @@ type provider_error =
       { provider : string
       ; detail : string
       }
+  | AuthorizationError of
+      { provider : string
+      ; detail : string
+      }
   | ServerError of
       { provider : string
       ; code : int

--- a/lib/llm_provider/retry.ml
+++ b/lib/llm_provider/retry.ml
@@ -368,6 +368,14 @@ let classify_error ~status ~body : api_error =
   match status with
   | 401 -> AuthError { message }
   | 402 -> PaymentRequired { message }
+  | 403 ->
+    (* HTTP 403 is an authorization refusal.  Providers may use it for a
+       disabled account, a missing entitlement, or an exhausted subscription
+       allowance.  The status alone does not distinguish those causes, but it
+       does establish that replaying the same request is not a transport retry.
+       Preserve the provider detail and route through the existing typed,
+       non-retryable authorization class without inspecting prose. *)
+    AuthError { message }
   | 400 | 422 ->
     if is_context_overflow_message body
     then ContextOverflow { message; limit = parse_context_overflow_limit body }

--- a/lib/llm_provider/retry.ml
+++ b/lib/llm_provider/retry.ml
@@ -15,6 +15,7 @@ type api_error =
       ; message : string
       }
   | AuthError of { message : string }
+  | AuthorizationError of { message : string }
   | PaymentRequired of { message : string }
   | InvalidRequest of
       { message : string
@@ -69,6 +70,7 @@ let error_message = function
   | Overloaded r -> Printf.sprintf "Overloaded: %s" r.message
   | ServerError r -> Printf.sprintf "Server error %d: %s" r.status r.message
   | AuthError r -> Printf.sprintf "Auth error: %s" r.message
+  | AuthorizationError r -> Printf.sprintf "Authorization error: %s" r.message
   | PaymentRequired r -> Printf.sprintf "Payment required: %s" r.message
   | InvalidRequest r ->
     Printf.sprintf
@@ -213,7 +215,7 @@ let is_retryable = function
     (* Malformed JSON from model output is transient — retry may produce valid JSON. *)
     true
   | InvalidRequest _ -> false
-  | AuthError _ | ContextOverflow _ | NotFound _ -> false
+  | AuthError _ | AuthorizationError _ | ContextOverflow _ | NotFound _ -> false
   | PaymentRequired _ ->
     (* HTTP 402 is definitionally non-retryable: the account has zero
        balance/credit. No message-substring check needed — the status code
@@ -231,6 +233,7 @@ let is_hard_quota = function
   | Overloaded _
   | ServerError _
   | AuthError _
+  | AuthorizationError _
   | InvalidRequest _
   | NotFound _
   | ContextOverflow _
@@ -369,13 +372,13 @@ let classify_error ~status ~body : api_error =
   | 401 -> AuthError { message }
   | 402 -> PaymentRequired { message }
   | 403 ->
-    (* HTTP 403 is an authorization refusal.  Providers may use it for a
-       disabled account, a missing entitlement, or an exhausted subscription
-       allowance.  The status alone does not distinguish those causes, but it
-       does establish that replaying the same request is not a transport retry.
-       Preserve the provider detail and route through the existing typed,
-       non-retryable authorization class without inspecting prose. *)
-    AuthError { message }
+    (* HTTP 403 is an authorization refusal, distinct from HTTP 401
+       authentication failure. Providers may use it for a disabled account, a
+       missing entitlement, or an exhausted subscription allowance. The status
+       alone does not distinguish those causes, but it does establish that
+       replaying the same request is not a transport retry. Preserve that exact
+       boundary without inspecting provider prose. *)
+    AuthorizationError { message }
   | 400 | 422 ->
     if is_context_overflow_message body
     then ContextOverflow { message; limit = parse_context_overflow_limit body }
@@ -468,6 +471,7 @@ let with_retry_map_error
       | Overloaded _
       | ServerError _
       | AuthError _
+      | AuthorizationError _
       | PaymentRequired _
       | InvalidRequest _
       | NotFound _
@@ -503,9 +507,9 @@ let with_retry_map_error
 (** Retry a function with exponential backoff.
     [f] should return [Ok result] on success or [Error api_error] on failure.
     Uses Eio.Time for sleeping between retries.
-    Non-retryable errors (AuthError, ContextOverflow, and most InvalidRequest)
-    are returned immediately.  InvalidRequest caused by malformed JSON in the
-    model output is treated as retryable. *)
+    Non-retryable errors (AuthError, AuthorizationError, ContextOverflow, and
+    most InvalidRequest) are returned immediately. InvalidRequest caused by
+    malformed JSON in the model output is treated as retryable. *)
 let with_retry ~clock ?config (f : unit -> ('a, api_error) result)
   : ('a, api_error) result
   =
@@ -581,6 +585,7 @@ let%test "is_retryable: flat Ollama provider prose is not retryable" =
   | Overloaded _
   | ServerError _
   | AuthError _
+  | AuthorizationError _
   | PaymentRequired _
   | NotFound _
   | ContextOverflow _
@@ -608,6 +613,7 @@ let%test "classify_error returns ContextOverflow for overflow body" =
   | Overloaded _
   | ServerError _
   | AuthError _
+  | AuthorizationError _
   | PaymentRequired _
   | InvalidRequest _
   | NotFound _
@@ -624,6 +630,7 @@ let%test "classify_error returns Unknown InvalidRequest for non-overflow 400" =
   | Overloaded _
   | ServerError _
   | AuthError _
+  | AuthorizationError _
   | PaymentRequired _
   | NotFound _
   | ContextOverflow _
@@ -873,6 +880,7 @@ let%test "is_hard_quota non-RateLimited variants are false" =
   (not (is_hard_quota (Overloaded { message = "insufficient balance" })))
   && (not (is_hard_quota (ServerError { status = 500; message = "quota exceeded" })))
   && (not (is_hard_quota (AuthError { message = "invalid key" })))
+  && (not (is_hard_quota (AuthorizationError { message = "forbidden" })))
   && (not (is_hard_quota (NetworkError { message = "connection reset"; kind = Unknown })))
   && (not (is_hard_quota (Timeout { message = "deadline exceeded"; phase = None })))
   && (not
@@ -895,6 +903,7 @@ let%test "classify_error 429 hard-quota clears retry_after" =
   | Overloaded _
   | ServerError _
   | AuthError _
+  | AuthorizationError _
   | PaymentRequired _
   | InvalidRequest _
   | NotFound _
@@ -913,6 +922,7 @@ let%test "classify_error 429 transient preserves retry_after" =
   | Overloaded _
   | ServerError _
   | AuthError _
+  | AuthorizationError _
   | PaymentRequired _
   | InvalidRequest _
   | NotFound _
@@ -931,6 +941,7 @@ let%test "classify_error 402 maps to PaymentRequired" =
   | Overloaded _
   | ServerError _
   | AuthError _
+  | AuthorizationError _
   | InvalidRequest _
   | NotFound _
   | ContextOverflow _
@@ -948,6 +959,7 @@ let%test "classify_error 402 (DeepSeek-shaped body) is not retryable and is hard
   | Overloaded _
   | ServerError _
   | AuthError _
+  | AuthorizationError _
   | InvalidRequest _
   | NotFound _
   | ContextOverflow _

--- a/lib/llm_provider/retry.mli
+++ b/lib/llm_provider/retry.mli
@@ -20,6 +20,7 @@ type api_error =
       ; message : string
       }
   | AuthError of { message : string }
+  (** Authentication or authorization failed (HTTP 401/403). *)
   | PaymentRequired of { message : string }
   | InvalidRequest of
       { message : string

--- a/lib/llm_provider/retry.mli
+++ b/lib/llm_provider/retry.mli
@@ -19,8 +19,9 @@ type api_error =
       { status : int
       ; message : string
       }
-  | AuthError of { message : string }
-  (** Authentication or authorization failed (HTTP 401/403). *)
+  | AuthError of { message : string } (** Authentication failed (HTTP 401). *)
+  | AuthorizationError of { message : string }
+  (** Authorization was refused (HTTP 403). *)
   | PaymentRequired of { message : string }
   | InvalidRequest of
       { message : string
@@ -62,7 +63,9 @@ val is_context_overflow_message : string -> bool
 
     [RateLimited] messages are inspected via substring match; [PaymentRequired]
     (HTTP 402) is always [true] by status-code semantics alone (no message
-    inspection needed). Other variants return [false].
+    inspection needed). [AuthorizationError] remains [false] because HTTP 403
+    does not distinguish quota, entitlement, and account-policy refusals. Other
+    variants return [false].
 
     Consumers (e.g. health trackers) use this to apply an immediate
     long cooldown instead of transient backoff.

--- a/test/test_error_domain.ml
+++ b/test/test_error_domain.ml
@@ -110,7 +110,11 @@ let test_retryable_auth_error () =
   Alcotest.(check bool)
     "auth_error not retryable"
     false
-    (Error_domain.is_retryable (`Auth_error "bad key"))
+    (Error_domain.is_retryable (`Auth_error "bad key"));
+  Alcotest.(check bool)
+    "authorization_error not retryable"
+    false
+    (Error_domain.is_retryable (`Authorization_error "forbidden"))
 ;;
 
 let test_retryable_max_turns () =
@@ -147,6 +151,7 @@ let test_to_string_each_variant () =
     [ `Rate_limited (Some 2.0)
     ; `Rate_limited None
     ; `Auth_error "forbidden"
+    ; `Authorization_error "permission refused"
     ; `Server_error (503, "unavailable")
     ; `Network_error "connection refused"
     ; `Provider_timeout (None, "3s elapsed")
@@ -186,6 +191,7 @@ let test_all_variants_convert () =
   let all_polys : Error_domain.sdk_error_poly list =
     [ `Rate_limited None
     ; `Auth_error "x"
+    ; `Authorization_error "x"
     ; `Server_error (500, "x")
     ; `Network_error "x"
     ; `Provider_timeout (None, "x")
@@ -232,6 +238,18 @@ let test_roundtrip_api_auth_error () =
   match back with
   | Error.Api (Retry.AuthError { message = "forbidden" }) -> ()
   | _ -> Alcotest.fail "roundtrip mismatch for AuthError"
+;;
+
+let test_roundtrip_api_authorization_error () =
+  let orig = Error.Api (Retry.AuthorizationError { message = "permission refused" }) in
+  let poly = Error_domain.of_sdk_error orig in
+  (match poly with
+   | `Authorization_error "permission refused" -> ()
+   | _ -> Alcotest.fail "expected Authorization_error");
+  let back = Error_domain.to_sdk_error poly in
+  match back with
+  | Error.Api (Retry.AuthorizationError { message = "permission refused" }) -> ()
+  | _ -> Alcotest.fail "roundtrip mismatch for AuthorizationError"
 ;;
 
 let test_roundtrip_api_server_error () =
@@ -763,6 +781,7 @@ let test_provider_roundtrip_all_via_to_sdk () =
     [ `Rate_limited (Some 1.0)
     ; `Rate_limited None
     ; `Auth_error "x"
+    ; `Authorization_error "x"
     ; `Server_error (500, "x")
     ; `Network_error "x"
     ; `Provider_timeout (None, "x")
@@ -793,6 +812,10 @@ let () =
     [ ( "roundtrip"
       , [ Alcotest.test_case "api rate_limited" `Quick test_roundtrip_api_rate_limited
         ; Alcotest.test_case "api auth_error" `Quick test_roundtrip_api_auth_error
+        ; Alcotest.test_case
+            "api authorization_error"
+            `Quick
+            test_roundtrip_api_authorization_error
         ; Alcotest.test_case "api server_error" `Quick test_roundtrip_api_server_error
         ; Alcotest.test_case "api network_error" `Quick test_roundtrip_api_network_error
         ; Alcotest.test_case "api timeout" `Quick test_roundtrip_api_timeout

--- a/test/test_llm_provider_error.ml
+++ b/test/test_llm_provider_error.ml
@@ -100,6 +100,15 @@ let test_auth_error () =
        (Error.AuthError { provider = "openai"; detail = "invalid API key" }))
 ;;
 
+let test_authorization_error () =
+  check
+    string
+    "AuthorizationError format"
+    "Provider 'openai' authorization error: forbidden"
+    (Error.to_string
+       (Error.AuthorizationError { provider = "openai"; detail = "forbidden" }))
+;;
+
 let test_server_error () =
   check
     string
@@ -380,6 +389,10 @@ let test_retry_remaining_variants_mapping () =
       , "auth" )
     ; ( Error.of_retry_api_error
           ~provider:"openai"
+          (Retry.AuthorizationError { message = "forbidden" })
+      , "authorization" )
+    ; ( Error.of_retry_api_error
+          ~provider:"openai"
           (Retry.InvalidRequest
              { message = "bad payload"; reason = Unknown_invalid_request })
       , "invalid" )
@@ -406,6 +419,8 @@ let test_retry_remaining_variants_mapping () =
        match expected, err with
        | "auth", Error.AuthError { detail; _ } ->
          check string "auth detail" "bad key" detail
+       | "authorization", Error.AuthorizationError { detail; _ } ->
+         check string "authorization detail" "forbidden" detail
        | "invalid", Error.InvalidRequest { reason; _ } ->
          check string "invalid reason" "bad payload" reason
        | "not_found", Error.NotFound { detail; _ } ->
@@ -588,6 +603,7 @@ let test_is_retryable_matrix () =
     (Error.HardQuota { provider = "p"; retry_after = None; detail = "billing" });
   not_retryable (Error.ProviderUnavailable { provider = "p"; detail = "missing" });
   not_retryable (Error.AuthError { provider = "p"; detail = "bad key" });
+  not_retryable (Error.AuthorizationError { provider = "p"; detail = "forbidden" });
   not_retryable (Error.NotFound { provider = "p"; detail = "model" })
 ;;
 
@@ -604,6 +620,7 @@ let () =
         ; test_case "HardQuota" `Quick test_hard_quota
         ; test_case "CapacityExhausted" `Quick test_capacity_exhausted
         ; test_case "AuthError" `Quick test_auth_error
+        ; test_case "AuthorizationError" `Quick test_authorization_error
         ; test_case "ServerError" `Quick test_server_error
         ; test_case "NetworkError" `Quick test_network_error
         ; test_case "Timeout" `Quick test_timeout

--- a/test/test_retry.ml
+++ b/test/test_retry.ml
@@ -95,13 +95,13 @@ let test_classify_error_403_authorization_denied () =
   in
   let err = Retry.classify_error ~status:403 ~body in
   (match err with
-   | Retry.AuthError { message } ->
+   | Retry.AuthorizationError { message } ->
      check
        string
        "403 provider detail"
        "You've reached your usage limit for this billing cycle"
        message
-   | _ -> fail "expected AuthError for 403");
+   | _ -> fail "expected AuthorizationError for 403");
   check bool "403 is not retryable" false (Retry.is_retryable err);
   check
     bool
@@ -190,6 +190,7 @@ let test_error_message_all_variants () =
     ; Retry.Overloaded { message = "busy" }, "Overloaded: busy"
     ; Retry.ServerError { status = 503; message = "down" }, "Server error 503: down"
     ; Retry.AuthError { message = "bad key" }, "Auth error: bad key"
+    ; Retry.AuthorizationError { message = "forbidden" }, "Authorization error: forbidden"
     ; ( Retry.PaymentRequired { message = "Insufficient Balance" }
       , "Payment required: Insufficient Balance" )
     ; ( Retry.InvalidRequest { message = "wrong"; reason = Unknown_invalid_request }

--- a/test/test_retry.ml
+++ b/test/test_retry.ml
@@ -89,6 +89,27 @@ let test_classify_error_402_payment_required () =
     (Retry.error_message err)
 ;;
 
+let test_classify_error_403_authorization_denied () =
+  let body =
+    {|{"error":{"message":"You've reached your usage limit for this billing cycle"}}|}
+  in
+  let err = Retry.classify_error ~status:403 ~body in
+  (match err with
+   | Retry.AuthError { message } ->
+     check
+       string
+       "403 provider detail"
+       "You've reached your usage limit for this billing cycle"
+       message
+   | _ -> fail "expected AuthError for 403");
+  check bool "403 is not retryable" false (Retry.is_retryable err);
+  check
+    bool
+    "403 alone does not guess a hard-quota subtype"
+    false
+    (Retry.is_hard_quota err)
+;;
+
 let test_is_retryable () =
   check
     bool
@@ -422,6 +443,10 @@ let () =
       , [ test_case "http status mapping" `Quick test_classify_error
         ; test_case "edge cases" `Quick test_classify_error_edge_cases
         ; test_case "402 payment required" `Quick test_classify_error_402_payment_required
+        ; test_case
+            "403 authorization denied"
+            `Quick
+            test_classify_error_403_authorization_denied
         ] )
     ; ( "retryability"
       , [ test_case "retryable predicates" `Quick test_is_retryable


### PR DESCRIPTION
## 요약

- HTTP 401은 `AuthError`, HTTP 403은 `AuthorizationError`로 분리했어용.
- 403 의미를 Retry → provider error → `Error_domain`까지 손실 없이 보존했어용.
- 두 오류는 즉시 재시도하지 않으며, 403 본문 문자열로 quota 원인을 추측하지 않도록 했어용.
- 분류·변환·round-trip·retryability 회귀 테스트를 보강했어용.

## 경계

Provider-generic OAS HTTP 의미만 다뤘어용. MASC 의존성이나 Keeper 정책은 추가하지 않았어용.

## 검증

- touched ML/MLI OCaml parser PASS
- `ocamlformat --check` PASS
- `git diff --check` PASS
- SDK independence PASS
- hardening/code-smell ratchet PASS
- 전체 Dune build/test는 저장소 정책대로 PR CI에 위임했어용.

## 근거

- [근거] RFC 9110 15.5.4: HTTP 403은 요청을 이해했지만 인가를 거부한 상태예용. https://www.rfc-editor.org/rfc/rfc9110.html — 확인 2026-07-11 14:56 KST — 신뢰도 High
- [근거] Kimi Code 공식 오류 문서: 401 인증 오류와 403 권한·billing-cycle·account 오류를 구분해용. https://www.kimi.com/code/docs/en/kimi-code/error-reference.html — 확인 2026-07-11 14:56 KST — 신뢰도 High
