### PR TITLE
fix(streaming): preserve authorization error parity

### DIFF
--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -131,6 +131,41 @@ let%test "stream auth error converges to typed AuthError" =
   | _ -> false
 ;;
 
+let%test "stream permission errors converge to typed non-retryable AuthorizationError" =
+  List.for_all
+    (fun error_type ->
+       match
+         http_error_of_stream_error
+           (Types.Stream_provider_error
+              { message = "permission refused"
+              ; error_type = Some error_type
+              ; raw =
+                  {|{"error":{"type":"permission_denied","message":"permission refused"}}|}
+              })
+       with
+       | Http_client.HttpError { code; body } ->
+         code = 403
+         &&
+           (match Retry.classify_error ~status:code ~body with
+           | Retry.AuthorizationError _ as error -> not (Retry.is_retryable error)
+           | Retry.RateLimited _
+           | Retry.Overloaded _
+           | Retry.ServerError _
+           | Retry.AuthError _
+           | Retry.PaymentRequired _
+           | Retry.InvalidRequest _
+           | Retry.NotFound _
+           | Retry.ContextOverflow _
+           | Retry.NetworkError _
+           | Retry.Timeout _ -> false)
+       | Http_client.NetworkError _
+       | Http_client.TimeoutError _
+       | Http_client.AcceptRejected _
+       | Http_client.ProviderTerminal _
+       | Http_client.ProviderFailure _ -> false)
+    [ "permission_error"; "permission_denied" ]
+;;
+
 let%test "stream unknown error type stays non-retryable provider failure" =
   match
     http_error_of_stream_error

--- a/lib/llm_provider/retry.ml
+++ b/lib/llm_provider/retry.ml
@@ -427,8 +427,8 @@ let classify_error ~status ~body : api_error =
 let status_of_provider_error_type = function
   | "rate_limit_exceeded" | "rate_limit_error" | "insufficient_quota" | "quota_exceeded"
     -> Some 429
-  | "authentication_error" | "invalid_api_key" | "permission_error" | "permission_denied"
-    -> Some 401
+  | "authentication_error" | "invalid_api_key" -> Some 401
+  | "permission_error" | "permission_denied" -> Some 403
   | "invalid_request_error"
   | "invalid_request"
   | "context_length_exceeded"


### PR DESCRIPTION
## What changed

- split streamed provider credential discriminators (401) from permission discriminators (403) in the existing retry classification SSOT
- add an end-to-end inline regression for both `permission_error` and `permission_denied`
- prove the streamed result becomes typed `AuthorizationError` and remains non-retryable

## Why

Merged PR #2520 added typed HTTP 403 handling but left the streaming projection table mapping permission failures to HTTP 401. The same authorization refusal therefore became `AuthorizationError` for a non-streaming response and `AuthError` for an SSE error.

This change preserves status semantics without inspecting provider prose or adding provider-specific branches.

Closes #2523.
Follow-up to #2520 and https://github.com/jeong-sik/oas/pull/2520#discussion_r3563654463.

## Validation

- `ocamlformat --check lib/llm_provider/retry.ml lib/llm_provider/complete_stream.ml`
- `git diff --check`
- `scripts/dune-local.sh build @lib/llm_provider/runtest test/test_retry.exe`
- `./_build/default/test/test_retry.exe` (19/19)
