### PR TITLE
feat(telemetry): carry exact output-token wire receipt

### DIFF
--- a/lib/api.ml
+++ b/lib/api.ml
@@ -2,6 +2,7 @@
 
 module Retry = Llm_provider.Retry
 open Types
+open Result_syntax
 
 type response_accept = Types.api_response -> (unit, string) result
 
@@ -114,6 +115,15 @@ let parse_openai_completion body_str =
          (Llm_provider.Http_client.empty_completion_error ~stop_reason:empty.stop_reason))
 ;;
 
+let parse_openai_responses_completion body_str =
+  match Llm_provider.Backend_openai_responses.parse_response_result body_str with
+  | Ok resp -> ensure_nonempty_response resp
+  | Error message ->
+    Error
+      (Retry_error
+         (Retry.InvalidRequest { message; reason = Retry.Unknown_invalid_request }))
+;;
+
 (** Send a non-streaming message to the API, dispatching by provider.
     When [clock] is supplied the HTTP request is wrapped in
     [Eio.Time.with_timeout_exn] using [request_timeout_s] (default
@@ -134,6 +144,7 @@ let create_message
       ~messages
       ?tools
       ?slot_id
+      ?on_output_token_receipt
       ()
   =
   let request_timeout_s =
@@ -159,16 +170,24 @@ let create_message
   match resolve_result with
   | Error e -> Error e
   | Ok (provider_cfg, base_url, api_key, header_list) ->
+    let* wire_config =
+      Provider.provider_config_of_agent ~state:config ~base_url (Some provider_cfg)
+    in
     let model_spec = Provider.model_spec_of_config provider_cfg in
     let kind = model_spec.request_kind in
-    let path = model_spec.request_path in
+    let path = wire_config.request_path in
     let body_result =
       match kind with
       | Provider.Anthropic_messages ->
-        let artifact = build_body_artifact ~config ~messages ?tools ~stream:false () in
+        let artifact =
+          Llm_provider.Backend_anthropic.build_request_with_receipt
+            ~config:wire_config
+            ~messages
+            ?tools
+            ()
+        in
         Ok
-          ( Yojson.Safe.to_string
-              (`Assoc (Llm_provider.Provider_request_artifact.payload artifact))
+          ( Llm_provider.Provider_request_artifact.payload artifact
           , Some (Llm_provider.Provider_request_artifact.output_token_receipt artifact) )
       | Provider.Openai_chat_completions ->
         Result.map
@@ -186,7 +205,11 @@ let create_message
       | Provider.Custom name ->
         (match Provider.find_provider name with
          | Some impl -> Ok (impl.build_body ~config ~messages ?tools (), None)
-         | None -> Ok (Yojson.Safe.to_string (`Assoc []), None))
+         | None ->
+           Error
+             (Printf.sprintf
+                "Custom provider %S disappeared after successful resolution"
+                name))
     in
     (match body_result with
      | Error reason ->
@@ -197,18 +220,16 @@ let create_message
                ; reason = Retry.Unknown_invalid_request
                }))
      | Ok (body_str, output_token_receipt) ->
+       Option.iter
+         (Llm_provider.Complete_common.emit_output_token_receipt on_output_token_receipt)
+         output_token_receipt;
        let url = base_url ^ path in
-       let provider_kind_of_request_kind = function
-         | Provider.Anthropic_messages -> Llm_provider.Provider_config.Anthropic
-         | Provider.Openai_chat_completions -> Llm_provider.Provider_config.OpenAI_compat
-         | Provider.Custom _ -> Llm_provider.Provider_config.OpenAI_compat
-       in
        let do_http_call () =
          (* Merge auth headers at request time via Provider_config so that
          [header_list] (from [Provider.resolve]) never carries sensitive tokens. *)
          let auth_hdrs =
            Llm_provider.Provider_config.auth_headers_for_kind_and_key
-             ~kind:(provider_kind_of_request_kind kind)
+             ~kind:wire_config.kind
              ~api_key
          in
          match
@@ -243,30 +264,36 @@ let create_message
              let raw_resp_result =
                match kind with
                | Provider.Anthropic_messages ->
-                 parse_response (Yojson.Safe.from_string body_str)
+                 Llm_provider.Backend_anthropic.parse_response
+                   (Yojson.Safe.from_string body_str)
                  |> ensure_nonempty_response
                | Provider.Openai_chat_completions ->
                  (* Reasoning stays typed as Thinking in the parsed response; it
                  is no longer promoted to a Text answer block (which caused the
                  #2236 CoT re-injection loop). Display surfacing is a read-side
                  projection concern, decoupled from parsing. *)
-                 parse_openai_completion body_str
+                 if
+                   Llm_provider.Provider_config.request_path_targets_responses_api
+                     wire_config.request_path
+                 then parse_openai_responses_completion body_str
+                 else parse_openai_completion body_str
                | Provider.Custom name ->
                  (match Provider.find_provider name with
                   | Some impl -> impl.parse_response body_str |> ensure_nonempty_response
-                  | None -> parse_openai_completion body_str)
+                  | None ->
+                    Error
+                      (Retry_error
+                         (Retry.InvalidRequest
+                            { message =
+                                Printf.sprintf
+                                  "Custom provider %S disappeared before response parsing"
+                                  name
+                            ; reason = Retry.Unknown_invalid_request
+                            })))
              in
              Result.map
                (fun resp ->
                   let response = Llm_provider.Pricing.annotate_response_cost resp in
-                  let response =
-                    match output_token_receipt with
-                    | Some receipt ->
-                      Llm_provider.Complete_common.attach_output_token_receipt
-                        response
-                        receipt
-                    | None -> response
-                  in
                   patch_latency response lat)
                raw_resp_result
            | `HttpError (code, body_str) ->

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -167,11 +167,15 @@ let create_message
       | Provider.Anthropic_messages ->
         let artifact = build_body_artifact ~config ~messages ?tools ~stream:false () in
         Ok
-          ( Yojson.Safe.to_string (`Assoc artifact.payload)
-          , Some artifact.output_token_receipt )
+          ( Yojson.Safe.to_string
+              (`Assoc (Llm_provider.Provider_request_artifact.payload artifact))
+          , Some (Llm_provider.Provider_request_artifact.output_token_receipt artifact) )
       | Provider.Openai_chat_completions ->
         Result.map
-          (fun artifact -> artifact.payload, Some artifact.output_token_receipt)
+          (fun artifact ->
+             ( Llm_provider.Provider_request_artifact.payload artifact
+             , Some (Llm_provider.Provider_request_artifact.output_token_receipt artifact)
+             ))
           (Api_openai.build_openai_body_artifact_result
              ~provider_config:provider_cfg
              ~config

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -124,6 +124,33 @@ let parse_openai_responses_completion body_str =
          (Retry.InvalidRequest { message; reason = Retry.Unknown_invalid_request }))
 ;;
 
+type request_plan =
+  | Anthropic_request of Llm_provider.Provider_config.t
+  | Openai_request of Llm_provider.Provider_config.t
+  | Custom_request of Provider.provider_impl
+
+let resolve_request_plan ~state ~base_url (provider_cfg : Provider.config) =
+  match Provider.request_kind provider_cfg.provider with
+  | Provider.Custom name ->
+    (match Provider.find_provider name with
+     | Some impl -> Ok (Custom_request impl)
+     | None ->
+       Error
+         (Error.Config
+            (InvalidConfig
+               { field = "provider"
+               ; detail = Printf.sprintf "Custom provider %S is no longer registered" name
+               })))
+  | Provider.Anthropic_messages ->
+    Result.map
+      (fun config -> Anthropic_request config)
+      (Provider.provider_config_of_agent ~state ~base_url (Some provider_cfg))
+  | Provider.Openai_chat_completions ->
+    Result.map
+      (fun config -> Openai_request config)
+      (Provider.provider_config_of_agent ~state ~base_url (Some provider_cfg))
+;;
+
 (** Send a non-streaming message to the API, dispatching by provider.
     When [clock] is supplied the HTTP request is wrapped in
     [Eio.Time.with_timeout_exn] using [request_timeout_s] (default
@@ -170,15 +197,15 @@ let create_message
   match resolve_result with
   | Error e -> Error e
   | Ok (provider_cfg, base_url, api_key, header_list) ->
-    let* wire_config =
-      Provider.provider_config_of_agent ~state:config ~base_url (Some provider_cfg)
+    let* request_plan = resolve_request_plan ~state:config ~base_url provider_cfg in
+    let path =
+      match request_plan with
+      | Anthropic_request config | Openai_request config -> config.request_path
+      | Custom_request impl -> impl.request_path
     in
-    let model_spec = Provider.model_spec_of_config provider_cfg in
-    let kind = model_spec.request_kind in
-    let path = wire_config.request_path in
     let body_result =
-      match kind with
-      | Provider.Anthropic_messages ->
+      match request_plan with
+      | Anthropic_request wire_config ->
         let artifact =
           Llm_provider.Backend_anthropic.build_request_with_receipt
             ~config:wire_config
@@ -189,7 +216,7 @@ let create_message
         Ok
           ( Llm_provider.Provider_request_artifact.payload artifact
           , Some (Llm_provider.Provider_request_artifact.output_token_receipt artifact) )
-      | Provider.Openai_chat_completions ->
+      | Openai_request _wire_config ->
         Result.map
           (fun artifact ->
              ( Llm_provider.Provider_request_artifact.payload artifact
@@ -202,14 +229,7 @@ let create_message
              ?tools
              ?slot_id
              ())
-      | Provider.Custom name ->
-        (match Provider.find_provider name with
-         | Some impl -> Ok (impl.build_body ~config ~messages ?tools (), None)
-         | None ->
-           Error
-             (Printf.sprintf
-                "Custom provider %S disappeared after successful resolution"
-                name))
+      | Custom_request impl -> Ok (impl.build_body ~config ~messages ?tools (), None)
     in
     (match body_result with
      | Error reason ->
@@ -228,9 +248,12 @@ let create_message
          (* Merge auth headers at request time via Provider_config so that
          [header_list] (from [Provider.resolve]) never carries sensitive tokens. *)
          let auth_hdrs =
-           Llm_provider.Provider_config.auth_headers_for_kind_and_key
-             ~kind:wire_config.kind
-             ~api_key
+           match request_plan with
+           | Anthropic_request config | Openai_request config ->
+             Llm_provider.Provider_config.auth_headers_for_kind_and_key
+               ~kind:config.kind
+               ~api_key
+           | Custom_request _ -> []
          in
          match
            Llm_provider.Http_client.post_sync
@@ -262,12 +285,12 @@ let create_message
            | `Ok body_str ->
              let lat = measured_latency_ms () in
              let raw_resp_result =
-               match kind with
-               | Provider.Anthropic_messages ->
+               match request_plan with
+               | Anthropic_request _ ->
                  Llm_provider.Backend_anthropic.parse_response
                    (Yojson.Safe.from_string body_str)
                  |> ensure_nonempty_response
-               | Provider.Openai_chat_completions ->
+               | Openai_request wire_config ->
                  (* Reasoning stays typed as Thinking in the parsed response; it
                  is no longer promoted to a Text answer block (which caused the
                  #2236 CoT re-injection loop). Display surfacing is a read-side
@@ -277,19 +300,8 @@ let create_message
                      wire_config.request_path
                  then parse_openai_responses_completion body_str
                  else parse_openai_completion body_str
-               | Provider.Custom name ->
-                 (match Provider.find_provider name with
-                  | Some impl -> impl.parse_response body_str |> ensure_nonempty_response
-                  | None ->
-                    Error
-                      (Retry_error
-                         (Retry.InvalidRequest
-                            { message =
-                                Printf.sprintf
-                                  "Custom provider %S disappeared before response parsing"
-                                  name
-                            ; reason = Retry.Unknown_invalid_request
-                            })))
+               | Custom_request impl ->
+                 impl.parse_response body_str |> ensure_nonempty_response
              in
              Result.map
                (fun resp ->

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -65,10 +65,15 @@ let build_body_assoc ~config ~messages ?tools ~stream () =
   Api_anthropic.build_body_assoc ~config ~messages ?tools ~stream ()
 ;;
 
+let build_body_artifact ~config ~messages ?tools ~stream () =
+  Api_anthropic.build_body_artifact ~config ~messages ?tools ~stream ()
+;;
+
 (* Re-export Api_openai *)
 let openai_messages_of_message = Api_openai.openai_messages_of_message
 let openai_content_parts_of_blocks = Api_openai.openai_content_parts_of_blocks
 let build_openai_body_result = Api_openai.build_openai_body_result
+let build_openai_body_artifact_result = Api_openai.build_openai_body_artifact_result
 let build_openai_body = Api_openai.build_openai_body
 
 let parse_openai_response_result =
@@ -160,21 +165,24 @@ let create_message
     let body_result =
       match kind with
       | Provider.Anthropic_messages ->
+        let artifact = build_body_artifact ~config ~messages ?tools ~stream:false () in
         Ok
-          (Yojson.Safe.to_string
-             (`Assoc (build_body_assoc ~config ~messages ?tools ~stream:false ())))
+          ( Yojson.Safe.to_string (`Assoc artifact.payload)
+          , Some artifact.output_token_receipt )
       | Provider.Openai_chat_completions ->
-        Api_openai.build_openai_body_result
-          ~provider_config:provider_cfg
-          ~config
-          ~messages
-          ?tools
-          ?slot_id
-          ()
+        Result.map
+          (fun artifact -> artifact.payload, Some artifact.output_token_receipt)
+          (Api_openai.build_openai_body_artifact_result
+             ~provider_config:provider_cfg
+             ~config
+             ~messages
+             ?tools
+             ?slot_id
+             ())
       | Provider.Custom name ->
         (match Provider.find_provider name with
-         | Some impl -> Ok (impl.build_body ~config ~messages ?tools ())
-         | None -> Ok (Yojson.Safe.to_string (`Assoc [])))
+         | Some impl -> Ok (impl.build_body ~config ~messages ?tools (), None)
+         | None -> Ok (Yojson.Safe.to_string (`Assoc []), None))
     in
     (match body_result with
      | Error reason ->
@@ -184,7 +192,7 @@ let create_message
                { message = "Request rejected: " ^ reason
                ; reason = Retry.Unknown_invalid_request
                }))
-     | Ok body_str ->
+     | Ok (body_str, output_token_receipt) ->
        let url = base_url ^ path in
        let provider_kind_of_request_kind = function
          | Provider.Anthropic_messages -> Llm_provider.Provider_config.Anthropic
@@ -246,8 +254,16 @@ let create_message
              in
              Result.map
                (fun resp ->
-                  Llm_provider.Pricing.annotate_response_cost resp
-                  |> fun r -> patch_latency r lat)
+                  let response = Llm_provider.Pricing.annotate_response_cost resp in
+                  let response =
+                    match output_token_receipt with
+                    | Some receipt ->
+                      Llm_provider.Complete_common.attach_output_token_receipt
+                        response
+                        receipt
+                    | None -> response
+                  in
+                  patch_latency response lat)
                raw_resp_result
            | `HttpError (code, body_str) ->
              Error (Retry_error (Retry.classify_error ~status:code ~body:body_str))

--- a/lib/api.mli
+++ b/lib/api.mli
@@ -36,14 +36,22 @@ val build_body_assoc
   -> unit
   -> (string * Yojson.Safe.t) list
 
+val build_body_artifact
+  :  config:Types.agent_state
+  -> messages:Types.message list
+  -> ?tools:Yojson.Safe.t list
+  -> stream:bool
+  -> unit
+  -> (string * Yojson.Safe.t) list Llm_provider.Provider_request_artifact.t
+
 (** {1 Re-exports from Api_openai} *)
 
 val openai_messages_of_message : Types.message -> Yojson.Safe.t list
 val openai_content_parts_of_blocks : Types.content_block list -> Yojson.Safe.t list
 
-(** Result-returning OpenAI-compatible request body builder. Live request paths
-    should use this form so unsupported provider contracts surface as typed
-    errors before HTTP dispatch. *)
+(** Compatibility projection returning only the serialized body. Live request
+    paths use {!build_openai_body_artifact_result} so observation cannot drift
+    from serialization. *)
 val build_openai_body_result
   :  ?provider_config:Provider.config
   -> config:Types.agent_state
@@ -52,6 +60,15 @@ val build_openai_body_result
   -> ?slot_id:int
   -> unit
   -> (string, string) result
+
+val build_openai_body_artifact_result
+  :  ?provider_config:Provider.config
+  -> config:Types.agent_state
+  -> messages:Types.message list
+  -> ?tools:Yojson.Safe.t list
+  -> ?slot_id:int
+  -> unit
+  -> (string Llm_provider.Provider_request_artifact.t, string) result
 
 val build_openai_body
   :  ?provider_config:Provider.config

--- a/lib/api.mli
+++ b/lib/api.mli
@@ -105,5 +105,6 @@ val create_message
   -> messages:Types.message list
   -> ?tools:Yojson.Safe.t list
   -> ?slot_id:int
+  -> ?on_output_token_receipt:(Llm_provider.Types.output_token_receipt -> unit)
   -> unit
   -> (Types.api_response, Error.sdk_error) result

--- a/lib/api_anthropic.ml
+++ b/lib/api_anthropic.ml
@@ -239,13 +239,6 @@ let build_body_artifact
 ;;
 
 let build_body_assoc ~config ~messages ?message_to_json ?provider_kind ?tools ~stream () =
-  (build_body_artifact
-     ~config
-     ~messages
-     ?message_to_json
-     ?provider_kind
-     ?tools
-     ~stream
-     ())
-    .payload
+  build_body_artifact ~config ~messages ?message_to_json ?provider_kind ?tools ~stream ()
+  |> Llm_provider.Provider_request_artifact.payload
 ;;

--- a/lib/api_anthropic.ml
+++ b/lib/api_anthropic.ml
@@ -10,7 +10,7 @@ open Types
 let parse_response = Llm_provider.Backend_anthropic.parse_response
 
 (** Build request body assoc list shared between stream and non-stream calls *)
-let build_body_assoc
+let build_body_artifact
       ~config
       ~messages
       ?(message_to_json = Api_common.message_to_json)
@@ -104,10 +104,19 @@ let build_body_assoc
     |> Llm_provider.Tool_message_pairs.close_for_provider_request
     |> Llm_provider.Api_common.merge_tool_result_followup_user_messages
   in
+  let output_token_receipt =
+    Llm_provider.Backend_anthropic.required_output_token_receipt_exn provider_config
+  in
+  let max_tokens =
+    match Llm_provider.Types.output_token_receipt_effective output_token_receipt with
+    | Some value -> value
+    | None ->
+      invalid_arg
+        "Api_anthropic.build_body_artifact: required receipt has no effective wire value"
+  in
   let body_assoc =
     [ "model", `String model_str
-    ; ( "max_tokens"
-      , `Int (Llm_provider.Backend_anthropic.required_max_output_tokens provider_config) )
+    ; "max_tokens", `Int max_tokens
     ; "messages", `List (List.map message_to_json messages)
     ; "stream", `Bool stream
     ]
@@ -226,5 +235,17 @@ let build_body_assoc
     | Some k -> ("top_k", `Int k) :: body_assoc
     | None -> body_assoc
   in
-  body_assoc
+  Llm_provider.Provider_request_artifact.make ~payload:body_assoc ~output_token_receipt
+;;
+
+let build_body_assoc ~config ~messages ?message_to_json ?provider_kind ?tools ~stream () =
+  (build_body_artifact
+     ~config
+     ~messages
+     ?message_to_json
+     ?provider_kind
+     ?tools
+     ~stream
+     ())
+    .payload
 ;;

--- a/lib/api_anthropic.mli
+++ b/lib/api_anthropic.mli
@@ -18,3 +18,13 @@ val build_body_assoc
   -> stream:bool
   -> unit
   -> (string * Yojson.Safe.t) list
+
+val build_body_artifact
+  :  config:Types.agent_state
+  -> messages:Types.message list
+  -> ?message_to_json:(Types.message -> Yojson.Safe.t)
+  -> ?provider_kind:Llm_provider.Provider_config.provider_kind
+  -> ?tools:Yojson.Safe.t list
+  -> stream:bool
+  -> unit
+  -> (string * Yojson.Safe.t) list Llm_provider.Provider_request_artifact.t

--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -39,18 +39,24 @@ let provider_config_kind_of_request_kind = function
    (declared [kind = Glm]) stay GLM in every consumer. Unknown names fail
    closed with this one error in both paths. *)
 let custom_registered_projection name
-  : (PConfig.provider_kind * string * Provider.capabilities, string) result
+  : (PConfig.provider_kind * string * string * Provider.capabilities, string) result
   =
   match Provider.find_provider name with
   | Some impl ->
     Ok
       ( provider_config_kind_of_request_kind impl.Provider.request_kind
       , ""
+      , impl.Provider.request_path
       , impl.Provider.capabilities )
   | None ->
     let registry = Llm_provider.Provider_registry.default () in
     (match Llm_provider.Provider_registry.find registry name with
-     | Some entry -> Ok (entry.defaults.kind, entry.defaults.base_url, entry.capabilities)
+     | Some entry ->
+       Ok
+         ( entry.defaults.kind
+         , entry.defaults.base_url
+         , entry.defaults.request_path
+         , entry.capabilities )
      | None ->
        Error
          (Printf.sprintf
@@ -60,7 +66,7 @@ let custom_registered_projection name
 
 let capabilities_for_custom_registered name =
   match custom_registered_projection name with
-  | Ok (_kind, _base_url, capabilities) -> Some capabilities
+  | Ok (_kind, _base_url, _request_path, capabilities) -> Some capabilities
   | Error _ -> None
 ;;
 
@@ -161,27 +167,51 @@ let serialization_provider_config ?provider_config (config : agent_state)
     match provider_config with
     | Some (cfg : Provider.config) ->
       (match cfg.provider with
-       | Provider.OpenAICompat { base_url; _ } | Provider.Local { base_url } ->
-         Ok (PConfig.OpenAI_compat, base_url, cfg.model_id)
-       | Provider.Anthropic -> Ok (PConfig.Anthropic, "", cfg.model_id)
+       | Provider.OpenAICompat { base_url; path; _ } ->
+         Ok (PConfig.OpenAI_compat, base_url, cfg.model_id, path)
+       | Provider.Local { base_url } ->
+         Ok
+           ( PConfig.OpenAI_compat
+           , base_url
+           , cfg.model_id
+           , Provider.request_path cfg.provider )
+       | Provider.Anthropic ->
+         Ok (PConfig.Anthropic, "", cfg.model_id, Provider.request_path cfg.provider)
        | Provider.Custom_registered { name } ->
          (match custom_registered_projection name with
-          | Ok (kind, base_url, _capabilities) -> Ok (kind, base_url, cfg.model_id)
+          | Ok (kind, base_url, request_path, _capabilities) ->
+            Ok (kind, base_url, cfg.model_id, request_path)
           | Error msg -> Error msg))
-    | None -> Ok (PConfig.OpenAI_compat, "", model_to_string config.config.model)
+    | None ->
+      Ok
+        ( PConfig.OpenAI_compat
+        , ""
+        , model_to_string config.config.model
+        , PConfig.request_path_default_for_kind PConfig.OpenAI_compat )
   in
   Result.map
-    (fun (kind, base_url, model_id) ->
+    (fun (kind, base_url, model_id, request_path) ->
        PConfig.make
          ~kind
          ~model_id
          ~base_url
+         ~request_path
          ?max_tokens:config.config.max_tokens
+         ?temperature:config.config.temperature
+         ?top_p:config.config.top_p
+         ?top_k:config.config.top_k
+         ?min_p:config.config.min_p
+         ?system_prompt:config.config.system_prompt
          ~model_capabilities_override:
            (llm_capabilities_of_provider_capabilities
               (capabilities_for_request ?provider_config config))
          ?enable_thinking:config.config.enable_thinking
          ?preserve_thinking:config.config.preserve_thinking
+         ?thinking_budget:config.config.thinking_budget
+         ?tool_choice:config.config.tool_choice
+         ~disable_parallel_tool_use:config.config.disable_parallel_tool_use
+         ~response_format:config.config.response_format
+         ~cache_system_prompt:config.config.cache_system_prompt
          ())
     projection
 ;;
@@ -200,7 +230,7 @@ let tool_choice_validation_context ?provider_config (config : agent_state) =
       ({ Provider.provider = Provider.Custom_registered { name }; model_id; _ } :
         Provider.config) ->
     (match custom_registered_projection name with
-     | Ok (kind, _base_url, capabilities) ->
+     | Ok (kind, _base_url, _request_path, capabilities) ->
        Ok (kind, model_id, llm_capabilities_of_provider_capabilities capabilities)
      | Error msg -> Error msg)
   | Some ({ provider = Provider.Anthropic; model_id; _ } : Provider.config) ->
@@ -534,15 +564,27 @@ let build_openai_body_artifact_result
     (match serialization_provider_config ?provider_config config with
      | Error reason -> Error reason
      | Ok serialization_config ->
-       Ok
-         (build_openai_body_artifact_unchecked
-            ~serialization_config
-            ?provider_config
-            ~config
-            ~messages
-            ?tools
-            ?slot_id
-            ()))
+       if PConfig.request_path_targets_responses_api serialization_config.request_path
+       then (
+         match slot_id with
+         | Some _ -> Error "slot_id is not supported by the OpenAI Responses API"
+         | None ->
+           Ok
+             (Llm_provider.Backend_openai_responses.build_request_with_receipt
+                ~config:serialization_config
+                ~messages
+                ~tools:(Option.value tools ~default:[])
+                ()))
+       else
+         Ok
+           (build_openai_body_artifact_unchecked
+              ~serialization_config
+              ?provider_config
+              ~config
+              ~messages
+              ?tools
+              ?slot_id
+              ()))
 ;;
 
 let build_openai_body_result ?provider_config ~config ~messages ?tools ?slot_id () =

--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -339,7 +339,7 @@ let should_include_tools
   | None | Some (Types.Auto | Types.Any | Types.Tool _) -> true
 ;;
 
-let build_openai_body_unchecked
+let build_openai_body_artifact_unchecked
       ~(serialization_config : PConfig.t)
       ?provider_config
       ~config
@@ -352,6 +352,11 @@ let build_openai_body_unchecked
   let capabilities = capabilities_for_request ?provider_config config in
   let is_zai_glm = PConfig.is_zai_glm_config serialization_config in
   let dialect = reasoning_dialect_for_request ~serialization_config capabilities config in
+  let output_token_receipt =
+    Llm_provider.Backend_openai_request.output_token_receipt
+      ~envelope:Llm_provider.Types.Openai_chat_max_tokens
+      serialization_config
+  in
   let assistant_tool_content_format =
     capabilities.Provider.assistant_tool_content_format
   in
@@ -384,9 +389,7 @@ let build_openai_body_unchecked
   in
   let body_assoc = [ "model", `String model_str; "messages", `List provider_messages ] in
   let body_assoc =
-    match
-      Llm_provider.Backend_openai_request.effective_max_output_tokens serialization_config
-    with
+    match Llm_provider.Types.output_token_receipt_effective output_token_receipt with
     | Some mt -> body_assoc @ [ "max_tokens", `Int mt ]
     | None -> body_assoc
   in
@@ -508,10 +511,19 @@ let build_openai_body_unchecked
     | Some id -> ("id_slot", `Int id) :: body_assoc
     | None -> body_assoc
   in
-  Yojson.Safe.to_string (`Assoc body_assoc)
+  Llm_provider.Provider_request_artifact.make
+    ~payload:(Yojson.Safe.to_string (`Assoc body_assoc))
+    ~output_token_receipt
 ;;
 
-let build_openai_body_result ?provider_config ~config ~messages ?tools ?slot_id () =
+let build_openai_body_artifact_result
+      ?provider_config
+      ~config
+      ~messages
+      ?tools
+      ?slot_id
+      ()
+  =
   match validate_tool_choice_request ?provider_config config with
   | Error reason -> Error reason
   | Ok () ->
@@ -523,7 +535,7 @@ let build_openai_body_result ?provider_config ~config ~messages ?tools ?slot_id 
      | Error reason -> Error reason
      | Ok serialization_config ->
        Ok
-         (build_openai_body_unchecked
+         (build_openai_body_artifact_unchecked
             ~serialization_config
             ?provider_config
             ~config
@@ -531,6 +543,18 @@ let build_openai_body_result ?provider_config ~config ~messages ?tools ?slot_id 
             ?tools
             ?slot_id
             ()))
+;;
+
+let build_openai_body_result ?provider_config ~config ~messages ?tools ?slot_id () =
+  Result.map
+    (fun artifact -> artifact.Llm_provider.Provider_request_artifact.payload)
+    (build_openai_body_artifact_result
+       ?provider_config
+       ~config
+       ~messages
+       ?tools
+       ?slot_id
+       ())
 ;;
 
 let build_openai_body ?provider_config ~config ~messages ?tools ?slot_id () =

--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -547,7 +547,7 @@ let build_openai_body_artifact_result
 
 let build_openai_body_result ?provider_config ~config ~messages ?tools ?slot_id () =
   Result.map
-    (fun artifact -> artifact.Llm_provider.Provider_request_artifact.payload)
+    Llm_provider.Provider_request_artifact.payload
     (build_openai_body_artifact_result
        ?provider_config
        ~config

--- a/lib/api_openai.mli
+++ b/lib/api_openai.mli
@@ -7,9 +7,9 @@
 
 include module type of Llm_provider.Backend_openai
 
-(** Result-returning form of {!build_openai_body}. Live request paths should use
-    this function so unsupported provider contracts surface as typed errors
-    before HTTP dispatch rather than as serializer exceptions. *)
+(** Compatibility projection returning only the serialized body. Live request
+    paths use {!build_openai_body_artifact_result} so the exact output-token
+    decision travels with the body. *)
 val build_openai_body_result
   :  ?provider_config:Provider.config
   -> config:Types.agent_state
@@ -18,6 +18,15 @@ val build_openai_body_result
   -> ?slot_id:int
   -> unit
   -> (string, string) result
+
+val build_openai_body_artifact_result
+  :  ?provider_config:Provider.config
+  -> config:Types.agent_state
+  -> messages:Types.message list
+  -> ?tools:Yojson.Safe.t list
+  -> ?slot_id:int
+  -> unit
+  -> (string Llm_provider.Provider_request_artifact.t, string) result
 
 (** Build OpenAI-compatible request body JSON string.
     Respects provider capabilities for tool_choice, top_k, min_p,

--- a/lib/llm_provider/backend_anthropic.ml
+++ b/lib/llm_provider/backend_anthropic.ml
@@ -166,26 +166,49 @@ let effective_max_output_tokens = Backend_openai_request.effective_max_output_to
    - neither declared -> fail loudly naming the model; an invented
      constant is shared by thinking and answer and silently truncates
      long reasoning. *)
-let required_max_output_tokens (config : Provider_config.t) =
-  match effective_max_output_tokens config with
-  | Some n -> n
+let required_output_token_receipt (config : Provider_config.t) =
+  let optional_receipt =
+    Backend_openai_request.output_token_receipt
+      ~envelope:Types.Anthropic_messages_max_tokens
+      config
+  in
+  match Types.output_token_receipt_policy optional_receipt with
+  | Types.Omitted ->
+    Types.required_output_token_receipt
+      ~envelope:Types.Anthropic_messages_max_tokens
+      ~requested:config.max_tokens
+      ~ceiling:(Types.output_token_receipt_ceiling optional_receipt)
+  | Explicit | Explicit_clamped | Required_catalog_fallback -> Ok optional_receipt
+;;
+
+let required_output_token_receipt_exn (config : Provider_config.t) =
+  match required_output_token_receipt config with
+  | Ok receipt -> receipt
+  | Error Types.Required_output_token_ceiling_missing ->
+    invalid_arg
+      (Printf.sprintf
+         "Backend_anthropic.required_max_output_tokens: model %s declares no \
+          max_output_tokens and the caller passed none; the Anthropic Messages API \
+          requires max_tokens — declare max_output_tokens in the model catalog or pass \
+          ~max_tokens"
+         config.model_id)
+;;
+
+let required_output_token_value_exn receipt =
+  match Types.output_token_receipt_effective receipt with
+  | Some value -> value
   | None ->
-    let caps = Backend_openai_request.capabilities_of_config config in
-    (match caps.max_output_tokens with
-     | Some cap -> cap
-     | None ->
-       invalid_arg
-         (Printf.sprintf
-            "Backend_anthropic.required_max_output_tokens: model %s declares no \
-             max_output_tokens and the caller passed none; the Anthropic Messages API \
-             requires max_tokens — declare max_output_tokens in the model catalog or \
-             pass ~max_tokens"
-            config.model_id))
+    invalid_arg
+      "Backend_anthropic: required output-token receipt has no effective wire value"
+;;
+
+let required_max_output_tokens config =
+  required_output_token_receipt_exn config |> required_output_token_value_exn
 ;;
 
 (** Build Anthropic Messages API request body from {!Provider_config.t}.
     Returns a JSON string ready for HTTP POST. *)
-let build_request
+let build_request_with_receipt
       ?(stream = false)
       ~(config : Provider_config.t)
       ~(messages : message list)
@@ -257,9 +280,11 @@ let build_request
   in
   let message_to_json = Api_common.message_to_json in
   let msgs_json = List.map message_to_json messages in
+  let output_token_receipt = required_output_token_receipt_exn config in
+  let max_tokens = required_output_token_value_exn output_token_receipt in
   let body =
     [ "model", `String config.model_id
-    ; "max_tokens", `Int (required_max_output_tokens config)
+    ; "max_tokens", `Int max_tokens
     ; "messages", `List msgs_json
     ; "stream", `Bool stream
     ]
@@ -370,5 +395,11 @@ let build_request
         ("tool_choice", tc) :: body)
       else body
   in
-  Yojson.Safe.to_string (`Assoc body)
+  Provider_request_artifact.make
+    ~payload:(Yojson.Safe.to_string (`Assoc body))
+    ~output_token_receipt
+;;
+
+let build_request ?stream ~config ~messages ?tools () =
+  (build_request_with_receipt ?stream ~config ~messages ?tools ()).payload
 ;;

--- a/lib/llm_provider/backend_anthropic.ml
+++ b/lib/llm_provider/backend_anthropic.ml
@@ -401,5 +401,6 @@ let build_request_with_receipt
 ;;
 
 let build_request ?stream ~config ~messages ?tools () =
-  (build_request_with_receipt ?stream ~config ~messages ?tools ()).payload
+  build_request_with_receipt ?stream ~config ~messages ?tools ()
+  |> Provider_request_artifact.payload
 ;;

--- a/lib/llm_provider/backend_anthropic.ml
+++ b/lib/llm_provider/backend_anthropic.ml
@@ -184,7 +184,7 @@ let required_output_token_receipt (config : Provider_config.t) =
 let required_output_token_receipt_exn (config : Provider_config.t) =
   match required_output_token_receipt config with
   | Ok receipt -> receipt
-  | Error Types.Required_output_token_ceiling_missing ->
+  | Error Types.Required_output_token_catalog_ceiling_missing ->
     invalid_arg
       (Printf.sprintf
          "Backend_anthropic.required_max_output_tokens: model %s declares no \

--- a/lib/llm_provider/backend_anthropic.ml
+++ b/lib/llm_provider/backend_anthropic.ml
@@ -172,13 +172,7 @@ let required_output_token_receipt (config : Provider_config.t) =
       ~envelope:Types.Anthropic_messages_max_tokens
       config
   in
-  match Types.output_token_receipt_policy optional_receipt with
-  | Types.Omitted ->
-    Types.required_output_token_receipt
-      ~envelope:Types.Anthropic_messages_max_tokens
-      ~requested:config.max_tokens
-      ~ceiling:(Types.output_token_receipt_ceiling optional_receipt)
-  | Explicit | Explicit_clamped | Required_catalog_fallback -> Ok optional_receipt
+  Types.required_output_token_receipt optional_receipt
 ;;
 
 let required_output_token_receipt_exn (config : Provider_config.t) =

--- a/lib/llm_provider/backend_anthropic.mli
+++ b/lib/llm_provider/backend_anthropic.mli
@@ -36,6 +36,12 @@ val effective_max_output_tokens : Provider_config.t -> int option
     catalog declares a value — no second numeric policy is invented. *)
 val required_max_output_tokens : Provider_config.t -> int
 
+val required_output_token_receipt
+  :  Provider_config.t
+  -> (Types.output_token_receipt, Types.required_output_token_error) result
+
+val required_output_token_receipt_exn : Provider_config.t -> Types.output_token_receipt
+
 val build_request
   :  ?stream:bool
   -> config:Provider_config.t
@@ -43,3 +49,11 @@ val build_request
   -> ?tools:Yojson.Safe.t list
   -> unit
   -> string
+
+val build_request_with_receipt
+  :  ?stream:bool
+  -> config:Provider_config.t
+  -> messages:Types.message list
+  -> ?tools:Yojson.Safe.t list
+  -> unit
+  -> string Provider_request_artifact.t

--- a/lib/llm_provider/backend_anthropic.mli
+++ b/lib/llm_provider/backend_anthropic.mli
@@ -30,8 +30,8 @@ val effective_max_output_tokens : Provider_config.t -> int option
 
 (** The Messages API requires [max_tokens] on every request, so this
     envelope carries an explicit OAS required-envelope policy: caller
-    override clamped to the catalog ceiling; caller [None] falls back to the
-    catalog-declared model maximum (this is not a provider default); raises
+    override clamped to a catalog or declared override ceiling; caller [None]
+    falls back only to the catalog-declared model maximum (this is not a provider default); raises
     [Invalid_argument] naming the model when neither the caller nor the
     catalog declares a value — no second numeric policy is invented. *)
 val required_max_output_tokens : Provider_config.t -> int

--- a/lib/llm_provider/backend_gemini.ml
+++ b/lib/llm_provider/backend_gemini.ml
@@ -288,7 +288,7 @@ let build_function_declaration = function
 
 (* ── Build request body ─────────────────────────────── *)
 
-let build_request
+let build_request_with_receipt
       ?(stream = false)
       ~(config : Provider_config.t)
       ~(messages : message list)
@@ -297,6 +297,11 @@ let build_request
   =
   ignore stream;
   (* Gemini streaming is URL-based, not body-based *)
+  let output_token_receipt =
+    Backend_openai_request.output_token_receipt
+      ~envelope:Types.Gemini_generation_config_max_output_tokens
+      config
+  in
   let contents, system_instruction = contents_of_messages messages in
   (* Prepend system_prompt from config if present *)
   let system_instruction =
@@ -327,7 +332,7 @@ let build_request
      omitted when both are unknown) — [maxOutputTokens] is optional on
      generateContent, and omission lets Gemini apply the model's own
      limit instead of an invented 16384. *)
-  (match Backend_openai_request.effective_max_output_tokens config with
+  (match Types.output_token_receipt_effective output_token_receipt with
    | Some mt -> gen_config := ("maxOutputTokens", `Int mt) :: !gen_config
    | None -> ());
   (match config.temperature with
@@ -411,7 +416,13 @@ let build_request
       :: body
     | None -> body
   in
-  Yojson.Safe.to_string (`Assoc body)
+  Provider_request_artifact.make
+    ~payload:(Yojson.Safe.to_string (`Assoc body))
+    ~output_token_receipt
+;;
+
+let build_request ?stream ~config ~messages ?tools () =
+  (build_request_with_receipt ?stream ~config ~messages ?tools ()).payload
 ;;
 
 (* ── Parse response ─────────────────────────────────── *)

--- a/lib/llm_provider/backend_gemini.ml
+++ b/lib/llm_provider/backend_gemini.ml
@@ -422,7 +422,8 @@ let build_request_with_receipt
 ;;
 
 let build_request ?stream ~config ~messages ?tools () =
-  (build_request_with_receipt ?stream ~config ~messages ?tools ()).payload
+  build_request_with_receipt ?stream ~config ~messages ?tools ()
+  |> Provider_request_artifact.payload
 ;;
 
 (* ── Parse response ─────────────────────────────────── *)

--- a/lib/llm_provider/backend_gemini.mli
+++ b/lib/llm_provider/backend_gemini.mli
@@ -24,6 +24,14 @@ val build_request
   -> unit
   -> string
 
+val build_request_with_receipt
+  :  ?stream:bool
+  -> config:Provider_config.t
+  -> messages:Types.message list
+  -> ?tools:Yojson.Safe.t list
+  -> unit
+  -> string Provider_request_artifact.t
+
 (** Parse a Gemini [generateContent] response JSON into {!Types.api_response}. *)
 val parse_response : Yojson.Safe.t -> Types.api_response
 

--- a/lib/llm_provider/backend_glm.ml
+++ b/lib/llm_provider/backend_glm.ml
@@ -152,7 +152,8 @@ let build_request_with_receipt
 ;;
 
 let build_request ?stream ~config ~messages ?tools () =
-  (build_request_with_receipt ?stream ~config ~messages ?tools ()).payload
+  build_request_with_receipt ?stream ~config ~messages ?tools ()
+  |> Provider_request_artifact.payload
 ;;
 
 (* ── Response parsing ────────────────────────────── *)

--- a/lib/llm_provider/backend_glm.ml
+++ b/lib/llm_provider/backend_glm.ml
@@ -124,31 +124,32 @@ let build_request_with_receipt
   let base_artifact =
     Backend_openai.build_request_assoc_with_receipt ~stream ~config ~messages ~tools ()
   in
-  Provider_request_artifact.map_payload
-    (function
-      | `Assoc fields ->
-        (* GLM thinking-control fields are emitted by the shared
+  let payload =
+    match Provider_request_artifact.payload base_artifact with
+    | `Assoc fields ->
+      (* GLM thinking-control fields are emitted by the shared
        [Reasoning_dialect.request_control_fields] path inside the OpenAI
        request builder. Keep Backend_glm limited to GLM-only post-processing
        that is not a thinking builder: Z.AI's [tool_choice=auto] normalization
        and [tool_stream]. *)
-        let fields =
-          normalize_tool_choice_fields ~tool_choice:config.tool_choice fields
-        in
-        let fields =
-          (* GLM streams tool-call arguments incrementally only when both
+      let fields = normalize_tool_choice_fields ~tool_choice:config.tool_choice fields in
+      let fields =
+        (* GLM streams tool-call arguments incrementally only when both
          [stream] and [tool_stream] are set; [config.tool_stream] defaults
          false, so a streaming request carrying tools would otherwise buffer
          tool args. Default [tool_stream] on when tools are present
          (RFC-OAS-023). *)
-          if stream && (config.tool_stream || tools <> [])
-          then ("tool_stream", `Bool true) :: fields
-          else fields
-        in
-        Yojson.Safe.to_string (`Assoc fields)
-      | (`List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null) as other
-        -> Yojson.Safe.to_string other)
-    base_artifact
+        if stream && (config.tool_stream || tools <> [])
+        then ("tool_stream", `Bool true) :: fields
+        else fields
+      in
+      Yojson.Safe.to_string (`Assoc fields)
+    | (`List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null) as other ->
+      Yojson.Safe.to_string other
+  in
+  Provider_request_artifact.make
+    ~payload
+    ~output_token_receipt:(Provider_request_artifact.output_token_receipt base_artifact)
 ;;
 
 let build_request ?stream ~config ~messages ?tools () =

--- a/lib/llm_provider/backend_glm.ml
+++ b/lib/llm_provider/backend_glm.ml
@@ -110,7 +110,7 @@ let normalize_tool_choice_fields ~(tool_choice : Types.tool_choice option) field
   | Some (Tool _ | None_) | None -> without_field "tool_choice" fields
 ;;
 
-let build_request
+let build_request_with_receipt
       ?(stream = false)
       ~(config : Provider_config.t)
       ~(messages : message list)
@@ -121,30 +121,38 @@ let build_request
      serializing then parsing the whole message body back — removes one full
      [Yojson.Safe.to_string] (OpenAI) + one [Yojson.Safe.from_string] (here)
      per GLM turn. Byte-identical: [from_string (to_string assoc) = assoc]. *)
-  let base_assoc =
-    Backend_openai.build_request_assoc ~stream ~config ~messages ~tools ()
+  let base_artifact =
+    Backend_openai.build_request_assoc_with_receipt ~stream ~config ~messages ~tools ()
   in
-  match base_assoc with
-  | `Assoc fields ->
-    (* GLM thinking-control fields are emitted by the shared
+  Provider_request_artifact.map_payload
+    (function
+      | `Assoc fields ->
+        (* GLM thinking-control fields are emitted by the shared
        [Reasoning_dialect.request_control_fields] path inside the OpenAI
        request builder. Keep Backend_glm limited to GLM-only post-processing
        that is not a thinking builder: Z.AI's [tool_choice=auto] normalization
        and [tool_stream]. *)
-    let fields = normalize_tool_choice_fields ~tool_choice:config.tool_choice fields in
-    let fields =
-      (* GLM streams tool-call arguments incrementally only when both
+        let fields =
+          normalize_tool_choice_fields ~tool_choice:config.tool_choice fields
+        in
+        let fields =
+          (* GLM streams tool-call arguments incrementally only when both
          [stream] and [tool_stream] are set; [config.tool_stream] defaults
          false, so a streaming request carrying tools would otherwise buffer
          tool args. Default [tool_stream] on when tools are present
          (RFC-OAS-023). *)
-      if stream && (config.tool_stream || tools <> [])
-      then ("tool_stream", `Bool true) :: fields
-      else fields
-    in
-    Yojson.Safe.to_string (`Assoc fields)
-  | (`List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null) as other ->
-    Yojson.Safe.to_string other
+          if stream && (config.tool_stream || tools <> [])
+          then ("tool_stream", `Bool true) :: fields
+          else fields
+        in
+        Yojson.Safe.to_string (`Assoc fields)
+      | (`List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null) as other
+        -> Yojson.Safe.to_string other)
+    base_artifact
+;;
+
+let build_request ?stream ~config ~messages ?tools () =
+  (build_request_with_receipt ?stream ~config ~messages ?tools ()).payload
 ;;
 
 (* ── Response parsing ────────────────────────────── *)

--- a/lib/llm_provider/backend_glm.mli
+++ b/lib/llm_provider/backend_glm.mli
@@ -55,6 +55,14 @@ val build_request
   -> unit
   -> string
 
+val build_request_with_receipt
+  :  ?stream:bool
+  -> config:Provider_config.t
+  -> messages:Types.message list
+  -> ?tools:Yojson.Safe.t list
+  -> unit
+  -> string Provider_request_artifact.t
+
 (** Parse a Glm chat completion response.
     Handles Glm-specific string error codes and extracts
     [reasoning_content] as {!Types.Thinking} content block. *)

--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -22,7 +22,7 @@ let keep_alive_env_var = "OAS_OLLAMA_KEEP_ALIVE"
     - Sampling params go inside [options] object
     - [num_predict] instead of [max_tokens]
     - No [tool_choice] support *)
-let build_request
+let build_request_with_receipt
       ?(stream = false)
       ~(config : Provider_config.t)
       ~(messages : message list)
@@ -38,6 +38,11 @@ let build_request
     match Provider_config.capabilities_for_config_model config with
     | Some c -> c
     | None -> Capabilities.ollama_capabilities
+  in
+  let output_token_receipt =
+    Backend_openai_request.output_token_receipt
+      ~envelope:Types.Ollama_options_num_predict
+      config
   in
   (* The chat-template token injection is shared with the OpenAI-compat request
      builder ([Backend_openai_serialize]) so the same catalog row cannot be
@@ -164,7 +169,7 @@ let build_request
      omitted when both are unknown) — Ollama's [num_predict] is optional,
      and omission lets the server apply the model's own limit. Previously
      this arm bypassed the capability catalog and invented 16384. *)
-  (match Backend_openai_request.effective_max_output_tokens config with
+  (match Types.output_token_receipt_effective output_token_receipt with
    | Some mt -> options := ("num_predict", `Int mt) :: !options
    | None -> ());
   (match config.temperature with
@@ -191,7 +196,13 @@ let build_request
    | Some n when n > 0 -> options := ("num_ctx", `Int n) :: !options
    | _ -> ());
   let body = ("options", `Assoc !options) :: body in
-  Yojson.Safe.to_string (`Assoc body)
+  Provider_request_artifact.make
+    ~payload:(Yojson.Safe.to_string (`Assoc body))
+    ~output_token_receipt
+;;
+
+let build_request ?stream ~config ~messages ?tools () =
+  (build_request_with_receipt ?stream ~config ~messages ?tools ()).payload
 ;;
 
 (* ── Response parsing ────────────────────────────────── *)

--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -202,7 +202,8 @@ let build_request_with_receipt
 ;;
 
 let build_request ?stream ~config ~messages ?tools () =
-  (build_request_with_receipt ?stream ~config ~messages ?tools ()).payload
+  build_request_with_receipt ?stream ~config ~messages ?tools ()
+  |> Provider_request_artifact.payload
 ;;
 
 (* ── Response parsing ────────────────────────────────── *)

--- a/lib/llm_provider/backend_ollama.mli
+++ b/lib/llm_provider/backend_ollama.mli
@@ -13,4 +13,12 @@ val build_request
   -> unit
   -> string
 
+val build_request_with_receipt
+  :  ?stream:bool
+  -> config:Provider_config.t
+  -> messages:Types.message list
+  -> ?tools:Yojson.Safe.t list
+  -> unit
+  -> string Provider_request_artifact.t
+
 val parse_ollama_response : string -> (Types.api_response, string) result

--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -46,6 +46,11 @@ let response_format_to_openai_json = Backend_openai_request.response_format_to_o
 let response_format_of_config = Backend_openai_request.response_format_of_config
 let build_request = Backend_openai_request.build_request
 let build_request_assoc = Backend_openai_request.build_request_assoc
+let build_request_with_receipt = Backend_openai_request.build_request_with_receipt
+
+let build_request_assoc_with_receipt =
+  Backend_openai_request.build_request_assoc_with_receipt
+;;
 
 [@@@coverage off]
 (* === Inline tests === *)

--- a/lib/llm_provider/backend_openai.mli
+++ b/lib/llm_provider/backend_openai.mli
@@ -32,6 +32,14 @@ val build_request_assoc
   -> unit
   -> Yojson.Safe.t
 
+val build_request_assoc_with_receipt
+  :  ?stream:bool
+  -> config:Provider_config.t
+  -> messages:Types.message list
+  -> ?tools:Yojson.Safe.t list
+  -> unit
+  -> Yojson.Safe.t Provider_request_artifact.t
+
 val build_request
   :  ?stream:bool
   -> config:Provider_config.t
@@ -39,6 +47,14 @@ val build_request
   -> ?tools:Yojson.Safe.t list
   -> unit
   -> string
+
+val build_request_with_receipt
+  :  ?stream:bool
+  -> config:Provider_config.t
+  -> messages:Types.message list
+  -> ?tools:Yojson.Safe.t list
+  -> unit
+  -> string Provider_request_artifact.t
 
 (** Emit a one-shot stderr WARN the first time a capability-gated
     sampling field is dropped for a given [(model_id, field)] pair.

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -181,6 +181,20 @@ let capabilities_of_config (config : Provider_config.t) =
    which applies an explicit OAS required-envelope fallback (the
    catalog-declared model maximum, not a provider default) and fails loudly
    when no value is declared anywhere — no invented constants. *)
+let output_token_ceiling (config : Provider_config.t) =
+  match config.model_capabilities_override with
+  | Some caps ->
+    Option.map
+      (fun value ->
+         Types.output_token_ceiling ~value ~source:Types.Declared_capability_override)
+      caps.max_output_tokens
+  | None ->
+    Option.bind (Provider_config.capabilities_for_config_model config) (fun caps ->
+      Option.map
+        (fun value -> Types.output_token_ceiling ~value ~source:Types.Catalog_model)
+        caps.max_output_tokens)
+;;
+
 let output_token_receipt_with_ceiling ~envelope (config : Provider_config.t) ~ceiling =
   let receipt =
     Types.optional_output_token_receipt ~envelope ~requested:config.max_tokens ~ceiling
@@ -193,8 +207,10 @@ let output_token_receipt_with_ceiling ~envelope (config : Provider_config.t) ~ce
 ;;
 
 let output_token_receipt ~envelope (config : Provider_config.t) =
-  let caps = capabilities_of_config config in
-  output_token_receipt_with_ceiling ~envelope config ~ceiling:caps.max_output_tokens
+  output_token_receipt_with_ceiling
+    ~envelope
+    config
+    ~ceiling:(output_token_ceiling config)
 ;;
 
 let effective_max_output_tokens (config : Provider_config.t) =
@@ -425,8 +441,10 @@ let build_request_with_receipt
       ?(tools : Yojson.Safe.t list = [])
       ()
   =
-  build_request_assoc_with_receipt ~stream ~config ~messages ~tools ()
-  |> Provider_request_artifact.map_payload Yojson.Safe.to_string
+  let artifact = build_request_assoc_with_receipt ~stream ~config ~messages ~tools () in
+  Provider_request_artifact.make
+    ~payload:(Yojson.Safe.to_string (Provider_request_artifact.payload artifact))
+    ~output_token_receipt:(Provider_request_artifact.output_token_receipt artifact)
 ;;
 
 let build_request ?stream ~config ~messages ?tools () =

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -409,7 +409,8 @@ let build_request_assoc_with_receipt
 ;;
 
 let build_request_assoc ?stream ~config ~messages ?tools () =
-  (build_request_assoc_with_receipt ?stream ~config ~messages ?tools ()).payload
+  build_request_assoc_with_receipt ?stream ~config ~messages ?tools ()
+  |> Provider_request_artifact.payload
 ;;
 
 (** [build_request] serializes [build_request_assoc] to a JSON string.
@@ -429,5 +430,6 @@ let build_request_with_receipt
 ;;
 
 let build_request ?stream ~config ~messages ?tools () =
-  (build_request_with_receipt ?stream ~config ~messages ?tools ()).payload
+  build_request_with_receipt ?stream ~config ~messages ?tools ()
+  |> Provider_request_artifact.payload
 ;;

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -181,14 +181,25 @@ let capabilities_of_config (config : Provider_config.t) =
    which applies an explicit OAS required-envelope fallback (the
    catalog-declared model maximum, not a provider default) and fails loudly
    when no value is declared anywhere — no invented constants. *)
-let effective_max_output_tokens (config : Provider_config.t) =
+let output_token_receipt_with_ceiling ~envelope (config : Provider_config.t) ~ceiling =
+  let receipt =
+    Types.optional_output_token_receipt ~envelope ~requested:config.max_tokens ~ceiling
+  in
+  (match Types.output_token_receipt_policy receipt with
+   | Types.Explicit_clamped ->
+     warn_capability_drop ~model_id:config.model_id ~field:"max_tokens:clamp"
+   | Omitted | Explicit | Required_catalog_fallback -> ());
+  receipt
+;;
+
+let output_token_receipt ~envelope (config : Provider_config.t) =
   let caps = capabilities_of_config config in
-  match config.max_tokens, caps.max_output_tokens with
-  | None, _ -> None
-  | Some n, Some cap when n > cap ->
-    warn_capability_drop ~model_id:config.model_id ~field:"max_tokens:clamp";
-    Some cap
-  | (Some _ as n), _ -> n
+  output_token_receipt_with_ceiling ~envelope config ~ceiling:caps.max_output_tokens
+;;
+
+let effective_max_output_tokens (config : Provider_config.t) =
+  output_token_receipt ~envelope:Types.Openai_chat_max_tokens config
+  |> Types.output_token_receipt_effective
 ;;
 
 (* Shared tool_choice emission gate for the Chat and Responses envelopes.
@@ -215,7 +226,7 @@ let is_zai_glm_request = Provider_config.is_zai_glm_config
 
 (** Build Openai Chat Completions request body from {!Provider_config.t}.
     Returns a JSON string ready for HTTP POST. *)
-let build_request_assoc
+let build_request_assoc_with_receipt
       ?(stream = false)
       ~(config : Provider_config.t)
       ~(messages : message list)
@@ -228,6 +239,12 @@ let build_request_assoc
   in
   let dialect = Reasoning_dialect.for_provider_config config in
   let caps = capabilities_of_config config in
+  let output_token_receipt =
+    output_token_receipt_with_ceiling
+      ~envelope:Types.Openai_chat_max_tokens
+      config
+      ~ceiling:caps.max_output_tokens
+  in
   let assistant_tool_content_format = caps.Capabilities.assistant_tool_content_format in
   let provider_messages =
     (* RFC-OAS-029 S3.1: reasoning replay is decided by the typed dialect
@@ -277,7 +294,7 @@ let build_request_assoc
      neither caller nor catalog declares a value. *)
   let body = [ "model", `String config.model_id; "messages", `List provider_messages ] in
   let body =
-    match effective_max_output_tokens config with
+    match Types.output_token_receipt_effective output_token_receipt with
     | Some mt -> body @ [ "max_tokens", `Int mt ]
     | None -> body
   in
@@ -388,7 +405,11 @@ let build_request_assoc
       ("seed", `Int seed) :: body)
     else body
   in
-  `Assoc body
+  Provider_request_artifact.make ~payload:(`Assoc body) ~output_token_receipt
+;;
+
+let build_request_assoc ?stream ~config ~messages ?tools () =
+  (build_request_assoc_with_receipt ?stream ~config ~messages ?tools ()).payload
 ;;
 
 (** [build_request] serializes [build_request_assoc] to a JSON string.
@@ -396,12 +417,17 @@ let build_request_assoc
     {!Backend_glm}) mutate the request Assoc directly instead of parsing the
     serialized string back — one fewer full [Yojson.Safe.from_string] +
     [Yojson.Safe.to_string] of the message body per turn. *)
-let build_request
+let build_request_with_receipt
       ?(stream = false)
       ~(config : Provider_config.t)
       ~(messages : message list)
       ?(tools : Yojson.Safe.t list = [])
       ()
   =
-  build_request_assoc ~stream ~config ~messages ~tools () |> Yojson.Safe.to_string
+  build_request_assoc_with_receipt ~stream ~config ~messages ~tools ()
+  |> Provider_request_artifact.map_payload Yojson.Safe.to_string
+;;
+
+let build_request ?stream ~config ~messages ?tools () =
+  (build_request_with_receipt ?stream ~config ~messages ?tools ()).payload
 ;;

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -256,10 +256,7 @@ let build_request_assoc_with_receipt
   let dialect = Reasoning_dialect.for_provider_config config in
   let caps = capabilities_of_config config in
   let output_token_receipt =
-    output_token_receipt_with_ceiling
-      ~envelope:Types.Openai_chat_max_tokens
-      config
-      ~ceiling:caps.max_output_tokens
+    output_token_receipt ~envelope:Types.Openai_chat_max_tokens config
   in
   let assistant_tool_content_format = caps.Capabilities.assistant_tool_content_format in
   let provider_messages =

--- a/lib/llm_provider/backend_openai_request.mli
+++ b/lib/llm_provider/backend_openai_request.mli
@@ -27,6 +27,11 @@ val capabilities_of_config : Provider_config.t -> Capabilities.capabilities
     [Backend_anthropic.required_max_output_tokens] instead. *)
 val effective_max_output_tokens : Provider_config.t -> int option
 
+val output_token_receipt
+  :  envelope:Types.output_token_envelope
+  -> Provider_config.t
+  -> Types.output_token_receipt
+
 (** Prepend the sampling [(field, value)] to [body] unless the reasoning
     dialect suppresses that parameter, in which case the field is dropped with a
     one-shot WARN per ([model_id], [field]). *)
@@ -60,6 +65,14 @@ val build_request_assoc
   -> unit
   -> Yojson.Safe.t
 
+val build_request_assoc_with_receipt
+  :  ?stream:bool
+  -> config:Provider_config.t
+  -> messages:Types.message list
+  -> ?tools:Yojson.Safe.t list
+  -> unit
+  -> Yojson.Safe.t Provider_request_artifact.t
+
 val build_request
   :  ?stream:bool
   -> config:Provider_config.t
@@ -67,3 +80,11 @@ val build_request
   -> ?tools:Yojson.Safe.t list
   -> unit
   -> string
+
+val build_request_with_receipt
+  :  ?stream:bool
+  -> config:Provider_config.t
+  -> messages:Types.message list
+  -> ?tools:Yojson.Safe.t list
+  -> unit
+  -> string Provider_request_artifact.t

--- a/lib/llm_provider/backend_openai_responses.ml
+++ b/lib/llm_provider/backend_openai_responses.ml
@@ -471,7 +471,8 @@ let build_request_with_receipt
 ;;
 
 let build_request ?stream ~config ~messages ?tools () =
-  (build_request_with_receipt ?stream ~config ~messages ?tools ()).payload
+  build_request_with_receipt ?stream ~config ~messages ?tools ()
+  |> Provider_request_artifact.payload
 ;;
 
 let output_text_of_content = function

--- a/lib/llm_provider/backend_openai_responses.ml
+++ b/lib/llm_provider/backend_openai_responses.ml
@@ -353,7 +353,7 @@ let capabilities_of_config = Backend_openai_request.capabilities_of_config
 let effective_max_output_tokens = Backend_openai_request.effective_max_output_tokens
 let add_sampling_field = Backend_openai_request.add_sampling_field
 
-let build_request
+let build_request_with_receipt
       ?(stream = false)
       ~(config : Provider_config.t)
       ~(messages : message list)
@@ -365,6 +365,11 @@ let build_request
     Backend_openai_serialize.close_tool_message_pairs_for_request messages
   in
   let dialect = Reasoning_dialect.for_provider_config config in
+  let output_token_receipt =
+    Backend_openai_request.output_token_receipt
+      ~envelope:Types.Openai_responses_max_output_tokens
+      config
+  in
   let reasoning_effort =
     (match Provider_config.validate_reasoning_effort_request config with
      | Ok () -> ()
@@ -384,7 +389,7 @@ let build_request
     ]
   in
   let body =
-    match effective_max_output_tokens config with
+    match Types.output_token_receipt_effective output_token_receipt with
     | Some mt -> body @ [ "max_output_tokens", `Int mt ]
     | None -> body
   in
@@ -460,7 +465,13 @@ let build_request
     @ body
   in
   let body = if stream then ("stream", `Bool true) :: body else body in
-  Yojson.Safe.to_string (`Assoc body)
+  Provider_request_artifact.make
+    ~payload:(Yojson.Safe.to_string (`Assoc body))
+    ~output_token_receipt
+;;
+
+let build_request ?stream ~config ~messages ?tools () =
+  (build_request_with_receipt ?stream ~config ~messages ?tools ()).payload
 ;;
 
 let output_text_of_content = function

--- a/lib/llm_provider/backend_openai_responses.mli
+++ b/lib/llm_provider/backend_openai_responses.mli
@@ -25,6 +25,14 @@ val build_request
   -> unit
   -> string
 
+val build_request_with_receipt
+  :  ?stream:bool
+  -> config:Provider_config.t
+  -> messages:Types.message list
+  -> ?tools:Yojson.Safe.t list
+  -> unit
+  -> string Provider_request_artifact.t
+
 (** Parse a Responses API JSON response into OAS canonical content blocks.
 
     Reasoning summary items become {!Types.Thinking}; function call items become

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -27,6 +27,7 @@ let complete
       ?(metrics : Metrics.t option)
       ?(priority : Request_priority.t option)
       ?body_timeout_s
+      ?on_output_token_receipt
       ()
   =
   match validate_all config with
@@ -87,6 +88,7 @@ let complete
                ?clock
                ~on_http_status:m.on_http_status
                ?body_timeout_s
+               ?on_output_token_receipt
                ?connection_cache
                ~config:request_config
                ~messages
@@ -195,6 +197,7 @@ let complete_with_retry
       ?metrics
       ?priority
       ?body_timeout_s
+      ?on_output_token_receipt
       ()
   =
   let m = Option.value metrics ~default:(Metrics.get_global ()) in
@@ -217,6 +220,7 @@ let complete_with_retry
       ~metrics:m
       ?priority
       ?body_timeout_s
+      ?on_output_token_receipt
       ()
   in
   let rec loop attempt =
@@ -277,6 +281,7 @@ let complete_stream
       ?(priority : Request_priority.t option)
       ?(connection_cache : Http_client.cache option)
       ?(on_telemetry : (Telemetry_event.t -> unit) option)
+      ?on_output_token_receipt
       ()
   =
   match validate_all config with
@@ -319,6 +324,7 @@ let complete_stream
           ~net
           ?clock
           ?stream_idle_timeout_s
+          ?on_output_token_receipt
           ~latency_counter
           ?on_telemetry
           ~metrics
@@ -363,6 +369,7 @@ let complete_stream_with_retry
       ?connection_cache
       ?stream_idle_timeout_s
       ?on_telemetry
+      ?on_output_token_receipt
       ()
   =
   let m = Option.value metrics ~default:(Metrics.get_global ()) in
@@ -386,6 +393,7 @@ let complete_stream_with_retry
       ?connection_cache
       ?stream_idle_timeout_s
       ?on_telemetry
+      ?on_output_token_receipt
       ()
   in
   let rec loop attempt =

--- a/lib/llm_provider/complete.mli
+++ b/lib/llm_provider/complete.mli
@@ -85,6 +85,12 @@ val make_http_transport
     connections. It has no effect when a custom [transport] is supplied.
     When [metrics] is provided, fires lifecycle callbacks.
 
+    [on_output_token_receipt] is invoked after the built-in HTTP path has
+    constructed its immutable request artifact and before it performs I/O.
+    Cache hits and injected transports never invoke it: they did not construct
+    the observed wire payload. Observer failures are logged; Eio cancellation
+    still propagates.
+
     @return [Ok api_response] on success (possibly from cache)
     @return [Error http_error] on failure. A response with no content blocks
     fails closed as [ProviderFailure { kind = Empty_completion { stop_reason } }]
@@ -104,6 +110,7 @@ val complete
   -> ?metrics:Metrics.t
   -> ?priority:Request_priority.t
   -> ?body_timeout_s:float
+  -> ?on_output_token_receipt:(Types.output_token_receipt -> unit)
   -> unit
   -> (Types.api_response, Http_client.http_error) result
 (** [body_timeout_s] caps the total HTTP round-trip time, in seconds,
@@ -155,6 +162,7 @@ val complete_with_retry
   -> ?metrics:Metrics.t
   -> ?priority:Request_priority.t
   -> ?body_timeout_s:float
+  -> ?on_output_token_receipt:(Types.output_token_receipt -> unit)
   -> unit
   -> (Types.api_response, Http_client.http_error) result
 (** [body_timeout_s] is forwarded to each underlying {!complete} call.
@@ -195,7 +203,11 @@ val complete_with_retry
     completion. Retry layers treat this as retryable while
     downstream policy can distinguish streaming/thinking idleness from
     total-call deadlines. Non-HTTP transports (CLI subprocess) ignore
-    [stream_idle_timeout_s]. *)
+    [stream_idle_timeout_s].
+
+    [on_output_token_receipt] has the same provenance contract as in
+    {!complete}: only the built-in HTTP request builder invokes it; injected
+    transports do not. *)
 val complete_stream
   :  sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
@@ -212,6 +224,7 @@ val complete_stream
   -> ?priority:Request_priority.t
   -> ?connection_cache:Http_client.cache
   -> ?on_telemetry:(Telemetry_event.t -> unit)
+  -> ?on_output_token_receipt:(Types.output_token_receipt -> unit)
   -> unit
   -> (Types.api_response, Http_client.http_error) result
 
@@ -234,5 +247,6 @@ val complete_stream_with_retry
   -> ?connection_cache:Http_client.cache
   -> ?stream_idle_timeout_s:float
   -> ?on_telemetry:(Telemetry_event.t -> unit)
+  -> ?on_output_token_receipt:(Types.output_token_receipt -> unit)
   -> unit
   -> (Types.api_response, Http_client.http_error) result

--- a/lib/llm_provider/complete_common.ml
+++ b/lib/llm_provider/complete_common.ml
@@ -237,21 +237,17 @@ let%test "integer latency rounds sub-millisecond samples" =
   round_latency_ms 0.49 = 0 && round_latency_ms 0.5 = 1 && round_latency_ms 0.9 = 1
 ;;
 
-let attach_output_token_receipt
-      (resp : Types.api_response)
-      (output_token_receipt : Types.output_token_receipt)
-  =
-  let telemetry =
-    match resp.telemetry with
-    | Some telemetry ->
-      Some { telemetry with output_token_receipt = Some output_token_receipt }
-    | None ->
-      Some
-        { Types.default_inference_telemetry with
-          output_token_receipt = Some output_token_receipt
-        }
-  in
-  { resp with telemetry }
+let emit_output_token_receipt observer receipt =
+  match observer with
+  | None -> ()
+  | Some observe ->
+    (try observe receipt with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn ->
+       Diag.warn
+         "complete"
+         "output-token receipt observer failed: %s"
+         (Printexc.to_string exn))
 ;;
 
 (** Patch {!Types.api_response} telemetry with transport latency and provider

--- a/lib/llm_provider/complete_common.ml
+++ b/lib/llm_provider/complete_common.ml
@@ -237,6 +237,23 @@ let%test "integer latency rounds sub-millisecond samples" =
   round_latency_ms 0.49 = 0 && round_latency_ms 0.5 = 1 && round_latency_ms 0.9 = 1
 ;;
 
+let attach_output_token_receipt
+      (resp : Types.api_response)
+      (output_token_receipt : Types.output_token_receipt)
+  =
+  let telemetry =
+    match resp.telemetry with
+    | Some telemetry ->
+      Some { telemetry with output_token_receipt = Some output_token_receipt }
+    | None ->
+      Some
+        { Types.default_inference_telemetry with
+          output_token_receipt = Some output_token_receipt
+        }
+  in
+  { resp with telemetry }
+;;
+
 (** Patch {!Types.api_response} telemetry with transport latency and provider
     metadata.
     The JSON parser sets [request_latency_ms = None] because it cannot see the

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -420,6 +420,7 @@ let complete_stream_http
       ?(on_telemetry : (Telemetry_event.t -> unit) option)
       ?(metrics = Metrics.get_global ())
       ?(connection_cache : Http_client.cache option)
+      ?on_output_token_receipt
       ~(config : Provider_config.t)
       ~(messages : Types.message list)
       ~tools
@@ -506,6 +507,9 @@ let complete_stream_http
         | Provider_config.Glm ->
           Backend_glm.build_request_with_receipt ~stream:true ~config ~messages ~tools ()
       in
+      emit_output_token_receipt
+        on_output_token_receipt
+        (Provider_request_artifact.output_token_receipt request_artifact);
       let body_str = Provider_request_artifact.payload request_artifact in
       let url =
         match config.kind with
@@ -990,11 +994,6 @@ let complete_stream_http
                 { provider; model; prompt_eval_tokens; prompt_eval_ms; cache_hit })
          | Some _ | None -> ());
         let prefill_ms = Option.bind !ollama_timings (fun t -> t.prompt_ms) in
-        let resp =
-          attach_output_token_receipt
-            resp
-            (Provider_request_artifact.output_token_receipt request_artifact)
-        in
         Ok (patch_telemetry resp ~config ~ttfrc_ms:!ttfrc_ref ~prefill_ms latency_ms)
       | Ok (Error (Http_client.TimeoutError _ as err)) ->
         publish_summary ~terminal:(Telemetry_event.Terminal_error "timeout_error") ();

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -460,7 +460,9 @@ let complete_stream_http
       let uses_responses_api =
         Provider_config.request_path_targets_responses_api config.request_path
       in
-      let build_request build = build ~stream:true ~config ~messages ~tools () in
+      let build_request build =
+        build ?stream:(Some true) ~config ~messages ?tools:(Some tools) ()
+      in
       let request_artifact =
         match config.kind with
         | Provider_config.Anthropic ->

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -457,17 +457,15 @@ let complete_stream_http
            })
     else (
       let config = apply_sampling_defaults config in
-      let uses_responses_api =
-        Provider_config.request_path_targets_responses_api config.request_path
-      in
+      let http_codec = Provider_config.http_codec config in
       let build_request build =
         build ?stream:(Some true) ~config ~messages ?tools:(Some tools) ()
       in
       let request_artifact =
-        match config.kind with
-        | Provider_config.Anthropic ->
+        match http_codec with
+        | Provider_config.Anthropic_messages_codec ->
           build_request Backend_anthropic.build_request_with_receipt
-        | Provider_config.Ollama ->
+        | Provider_config.Ollama_chat_codec ->
           (* Native /api/chat + NDJSON. The Backend_openai detour was a
            deferred work-around (#849) that dropped Ollama's
            prompt_eval_count / eval_count / *_duration fields and
@@ -475,13 +473,14 @@ let complete_stream_http
            for every streaming caller. NDJSON parser is now in
            Streaming.parse_ollama_ndjson_chunk. *)
           build_request Backend_ollama.build_request_with_receipt
-        | Provider_config.OpenAI_compat when uses_responses_api ->
+        | Provider_config.Openai_responses_codec ->
           build_request Backend_openai_responses.build_request_with_receipt
-        | Provider_config.OpenAI_compat | Provider_config.DashScope | Provider_config.Kimi
-          -> build_request Backend_openai.build_request_with_receipt
-        | Provider_config.Gemini ->
+        | Provider_config.Openai_chat_codec ->
+          build_request Backend_openai.build_request_with_receipt
+        | Provider_config.Gemini_generate_content_codec ->
           build_request Backend_gemini.build_request_with_receipt
-        | Provider_config.Glm -> build_request Backend_glm.build_request_with_receipt
+        | Provider_config.Glm_chat_codec ->
+          build_request Backend_glm.build_request_with_receipt
       in
       emit_output_token_receipt
         on_output_token_receipt
@@ -494,11 +493,12 @@ let complete_stream_http
           config.base_url ^ config.request_path
       in
       let body_with_stream =
-        match config.kind with
-        | Provider_config.Gemini -> body_str
-        | Anthropic | Ollama -> Http_client.inject_stream_param body_str
-        | OpenAI_compat when uses_responses_api -> body_str
-        | OpenAI_compat | Kimi | Glm | DashScope ->
+        match http_codec with
+        | Provider_config.Gemini_generate_content_codec
+        | Provider_config.Openai_responses_codec -> body_str
+        | Provider_config.Anthropic_messages_codec | Provider_config.Ollama_chat_codec ->
+          Http_client.inject_stream_param body_str
+        | Provider_config.Openai_chat_codec | Provider_config.Glm_chat_codec ->
           (* OpenAI-compatible streaming returns token usage only when the
              request also sets stream_options.include_usage. Anthropic and
              Ollama carry usage natively (message_start/message_delta and the
@@ -791,8 +791,8 @@ let complete_stream_http
                 in
                 let stream_read_result =
                   try
-                    (match config.kind with
-                     | Provider_config.Ollama ->
+                    (match http_codec with
+                     | Provider_config.Ollama_chat_codec ->
                        Http_client.read_ndjson
                          ?clock
                          ?idle_timeout:stream_idle_timeout_s
@@ -826,19 +826,17 @@ let complete_stream_http
                          ~on_data:(fun ~event_type data ->
                            wire_sink data;
                            let events =
-                             match config.kind with
-                             | Provider_config.Anthropic ->
+                             match http_codec with
+                             | Provider_config.Anthropic_messages_codec ->
                                (match Streaming.parse_sse_event event_type data with
                                 | Some evt -> [ evt ], None
                                 | None -> [], None)
-                             | Provider_config.OpenAI_compat when uses_responses_api ->
+                             | Provider_config.Openai_responses_codec ->
                                Streaming.responses_sse_to_events
                                  (get_state ())
                                  event_type
                                  data
-                             | Provider_config.OpenAI_compat
-                             | Provider_config.DashScope
-                             | Provider_config.Kimi ->
+                             | Provider_config.Openai_chat_codec ->
                                (match
                                   Streaming.parse_openai_sse_chunk
                                     ~streaming_reasoning
@@ -855,7 +853,7 @@ let complete_stream_http
                                    completion) and an error object to a typed
                                    [SSEError]; everything else yields no events. *)
                                   Streaming.openai_compat_terminal_events data, None)
-                             | Provider_config.Gemini ->
+                             | Provider_config.Gemini_generate_content_codec ->
                                (match Streaming.parse_gemini_sse_chunk data with
                                 | Some chunk ->
                                   Streaming.gemini_chunk_to_events (get_state ()) chunk
@@ -866,7 +864,7 @@ let complete_stream_http
                                         }
                                     ]
                                   , None ))
-                             | Provider_config.Glm ->
+                             | Provider_config.Glm_chat_codec ->
                                (match Backend_glm.parse_stream_chunk data with
                                 | Some chunk ->
                                   Streaming.openai_chunk_to_events (get_state ()) chunk
@@ -875,7 +873,7 @@ let complete_stream_http
                                    branch: [DONE] -> [MessageStop], error object
                                    -> [SSEError], else no events. *)
                                   Streaming.openai_compat_terminal_events data, None)
-                             | Provider_config.Ollama ->
+                             | Provider_config.Ollama_chat_codec ->
                                [], None (* unreachable: handled above *)
                            in
                            dispatch events)

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -459,10 +459,15 @@ let complete_stream_http
       let uses_responses_api =
         Provider_config.request_path_targets_responses_api config.request_path
       in
-      let body_str =
+      let request_artifact =
         match config.kind with
         | Provider_config.Anthropic ->
-          Backend_anthropic.build_request ~stream:true ~config ~messages ~tools ()
+          Backend_anthropic.build_request_with_receipt
+            ~stream:true
+            ~config
+            ~messages
+            ~tools
+            ()
         | Provider_config.Ollama ->
           (* Native /api/chat + NDJSON. The Backend_openai detour was a
            deferred work-around (#849) that dropped Ollama's
@@ -470,16 +475,38 @@ let complete_stream_http
            silently disabled prompt_tok_s / decode_tok_s telemetry
            for every streaming caller. NDJSON parser is now in
            Streaming.parse_ollama_ndjson_chunk. *)
-          Backend_ollama.build_request ~stream:true ~config ~messages ~tools ()
+          Backend_ollama.build_request_with_receipt
+            ~stream:true
+            ~config
+            ~messages
+            ~tools
+            ()
         | Provider_config.OpenAI_compat when uses_responses_api ->
-          Backend_openai_responses.build_request ~stream:true ~config ~messages ~tools ()
+          Backend_openai_responses.build_request_with_receipt
+            ~stream:true
+            ~config
+            ~messages
+            ~tools
+            ()
         | Provider_config.OpenAI_compat | Provider_config.DashScope | Provider_config.Kimi
-          -> Backend_openai.build_request ~stream:true ~config ~messages ~tools ()
+          ->
+          Backend_openai.build_request_with_receipt
+            ~stream:true
+            ~config
+            ~messages
+            ~tools
+            ()
         | Provider_config.Gemini ->
-          Backend_gemini.build_request ~stream:true ~config ~messages ~tools ()
+          Backend_gemini.build_request_with_receipt
+            ~stream:true
+            ~config
+            ~messages
+            ~tools
+            ()
         | Provider_config.Glm ->
-          Backend_glm.build_request ~stream:true ~config ~messages ~tools ()
+          Backend_glm.build_request_with_receipt ~stream:true ~config ~messages ~tools ()
       in
+      let body_str = request_artifact.payload in
       let url =
         match config.kind with
         | Provider_config.Gemini -> gemini_url ~config ~stream:true
@@ -963,6 +990,9 @@ let complete_stream_http
                 { provider; model; prompt_eval_tokens; prompt_eval_ms; cache_hit })
          | Some _ | None -> ());
         let prefill_ms = Option.bind !ollama_timings (fun t -> t.prompt_ms) in
+        let resp =
+          attach_output_token_receipt resp request_artifact.output_token_receipt
+        in
         Ok (patch_telemetry resp ~config ~ttfrc_ms:!ttfrc_ref ~prefill_ms latency_ms)
       | Ok (Error (Http_client.TimeoutError _ as err)) ->
         publish_summary ~terminal:(Telemetry_event.Terminal_error "timeout_error") ();

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -460,15 +460,11 @@ let complete_stream_http
       let uses_responses_api =
         Provider_config.request_path_targets_responses_api config.request_path
       in
+      let build_request build = build ~stream:true ~config ~messages ~tools () in
       let request_artifact =
         match config.kind with
         | Provider_config.Anthropic ->
-          Backend_anthropic.build_request_with_receipt
-            ~stream:true
-            ~config
-            ~messages
-            ~tools
-            ()
+          build_request Backend_anthropic.build_request_with_receipt
         | Provider_config.Ollama ->
           (* Native /api/chat + NDJSON. The Backend_openai detour was a
            deferred work-around (#849) that dropped Ollama's
@@ -476,36 +472,14 @@ let complete_stream_http
            silently disabled prompt_tok_s / decode_tok_s telemetry
            for every streaming caller. NDJSON parser is now in
            Streaming.parse_ollama_ndjson_chunk. *)
-          Backend_ollama.build_request_with_receipt
-            ~stream:true
-            ~config
-            ~messages
-            ~tools
-            ()
+          build_request Backend_ollama.build_request_with_receipt
         | Provider_config.OpenAI_compat when uses_responses_api ->
-          Backend_openai_responses.build_request_with_receipt
-            ~stream:true
-            ~config
-            ~messages
-            ~tools
-            ()
+          build_request Backend_openai_responses.build_request_with_receipt
         | Provider_config.OpenAI_compat | Provider_config.DashScope | Provider_config.Kimi
-          ->
-          Backend_openai.build_request_with_receipt
-            ~stream:true
-            ~config
-            ~messages
-            ~tools
-            ()
+          -> build_request Backend_openai.build_request_with_receipt
         | Provider_config.Gemini ->
-          Backend_gemini.build_request_with_receipt
-            ~stream:true
-            ~config
-            ~messages
-            ~tools
-            ()
-        | Provider_config.Glm ->
-          Backend_glm.build_request_with_receipt ~stream:true ~config ~messages ~tools ()
+          build_request Backend_gemini.build_request_with_receipt
+        | Provider_config.Glm -> build_request Backend_glm.build_request_with_receipt
       in
       emit_output_token_receipt
         on_output_token_receipt

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -506,7 +506,7 @@ let complete_stream_http
         | Provider_config.Glm ->
           Backend_glm.build_request_with_receipt ~stream:true ~config ~messages ~tools ()
       in
-      let body_str = request_artifact.payload in
+      let body_str = Provider_request_artifact.payload request_artifact in
       let url =
         match config.kind with
         | Provider_config.Gemini -> gemini_url ~config ~stream:true
@@ -991,7 +991,9 @@ let complete_stream_http
          | Some _ | None -> ());
         let prefill_ms = Option.bind !ollama_timings (fun t -> t.prompt_ms) in
         let resp =
-          attach_output_token_receipt resp request_artifact.output_token_receipt
+          attach_output_token_receipt
+            resp
+            (Provider_request_artifact.output_token_receipt request_artifact)
         in
         Ok (patch_telemetry resp ~config ~ttfrc_ms:!ttfrc_ref ~prefill_ms latency_ms)
       | Ok (Error (Http_client.TimeoutError _ as err)) ->

--- a/lib/llm_provider/complete_sync.ml
+++ b/lib/llm_provider/complete_sync.ml
@@ -86,7 +86,7 @@ let complete_http
         | Provider_config.Glm ->
           Backend_glm.build_request_with_receipt ~config ~messages ~tools ()
       in
-      let body_str = request_artifact.payload in
+      let body_str = Provider_request_artifact.payload request_artifact in
       let url =
         match config.kind with
         | Provider_config.Gemini -> gemini_url ~config ~stream:false
@@ -352,7 +352,9 @@ let complete_http
         let result =
           Result.map
             (fun response ->
-               attach_output_token_receipt response request_artifact.output_token_receipt)
+               attach_output_token_receipt
+                 response
+                 (Provider_request_artifact.output_token_receipt request_artifact))
             result
         in
         result, latency_ms))

--- a/lib/llm_provider/complete_sync.ml
+++ b/lib/llm_provider/complete_sync.ml
@@ -36,6 +36,7 @@ let complete_http
          (provider:string -> model_id:string -> status:int -> unit) option)
       ?body_timeout_s
       ?(connection_cache : Http_client.cache option)
+      ?on_output_token_receipt
       ~(config : Provider_config.t)
       ~(messages : Types.message list)
       ~tools
@@ -86,6 +87,9 @@ let complete_http
         | Provider_config.Glm ->
           Backend_glm.build_request_with_receipt ~config ~messages ~tools ()
       in
+      emit_output_token_receipt
+        on_output_token_receipt
+        (Provider_request_artifact.output_token_receipt request_artifact);
       let body_str = Provider_request_artifact.payload request_artifact in
       let url =
         match config.kind with
@@ -349,14 +353,6 @@ let complete_http
               Error (Http_client.HttpError { code; body }))
         in
         let latency_ms = latency_ms_int latency_counter in
-        let result =
-          Result.map
-            (fun response ->
-               attach_output_token_receipt
-                 response
-                 (Provider_request_artifact.output_token_receipt request_artifact))
-            result
-        in
         result, latency_ms))
 ;;
 

--- a/lib/llm_provider/complete_sync.ml
+++ b/lib/llm_provider/complete_sync.ml
@@ -69,22 +69,20 @@ let complete_http
              { kind = Http_client.Provider_parse_error { parser }; message })
       in
       let config = apply_sampling_defaults config in
-      let uses_responses_api =
-        Provider_config.request_path_targets_responses_api config.request_path
-      in
+      let http_codec = Provider_config.http_codec config in
       let request_artifact =
-        match config.kind with
-        | Provider_config.Anthropic ->
+        match http_codec with
+        | Provider_config.Anthropic_messages_codec ->
           Backend_anthropic.build_request_with_receipt ~config ~messages ~tools ()
-        | Provider_config.Ollama ->
+        | Provider_config.Ollama_chat_codec ->
           Backend_ollama.build_request_with_receipt ~config ~messages ~tools ()
-        | Provider_config.OpenAI_compat when uses_responses_api ->
+        | Provider_config.Openai_responses_codec ->
           Backend_openai_responses.build_request_with_receipt ~config ~messages ~tools ()
-        | Provider_config.OpenAI_compat | Provider_config.DashScope | Provider_config.Kimi
-          -> Backend_openai.build_request_with_receipt ~config ~messages ~tools ()
-        | Provider_config.Gemini ->
+        | Provider_config.Openai_chat_codec ->
+          Backend_openai.build_request_with_receipt ~config ~messages ~tools ()
+        | Provider_config.Gemini_generate_content_codec ->
           Backend_gemini.build_request_with_receipt ~config ~messages ~tools ()
-        | Provider_config.Glm ->
+        | Provider_config.Glm_chat_codec ->
           Backend_glm.build_request_with_receipt ~config ~messages ~tools ()
       in
       emit_output_token_receipt
@@ -227,22 +225,18 @@ let complete_http
             if code >= 200 && code < 300
             then (
               try
-                match config.kind with
-                | Provider_config.Anthropic ->
+                match http_codec with
+                | Provider_config.Anthropic_messages_codec ->
                   Ok (Backend_anthropic.parse_response (Yojson.Safe.from_string body))
-                | Provider_config.Ollama ->
+                | Provider_config.Ollama_chat_codec ->
                   (match Backend_ollama.parse_ollama_response body with
                    | Ok resp -> Ok resp
                    | Error msg -> Error (Http_client.HttpError { code = 400; body = msg }))
-                | Provider_config.OpenAI_compat
-                  when Provider_config.request_path_targets_responses_api
-                         config.request_path ->
+                | Provider_config.Openai_responses_codec ->
                   (match Backend_openai_responses.parse_response_result body with
                    | Ok resp -> Ok resp
                    | Error msg -> Error (Http_client.HttpError { code = 400; body = msg }))
-                | Provider_config.OpenAI_compat
-                | Provider_config.DashScope
-                | Provider_config.Kimi ->
+                | Provider_config.Openai_chat_codec ->
                   (match Backend_openai_parse.parse_openai_response_result body with
                    | Ok resp -> Ok resp
                    | Error (Backend_openai_parse.Provider_error msg) ->
@@ -252,9 +246,9 @@ let complete_http
                         fact as streaming. Policy remains downstream of the
                         preserved [stop_reason]. *)
                      Error (Http_client.empty_completion_error ~stop_reason:e.stop_reason))
-                | Provider_config.Gemini ->
+                | Provider_config.Gemini_generate_content_codec ->
                   Ok (Backend_gemini.parse_response (Yojson.Safe.from_string body))
-                | Provider_config.Glm -> Ok (Backend_glm.parse_response body)
+                | Provider_config.Glm_chat_codec -> Ok (Backend_glm.parse_response body)
               with
               | Yojson.Json_error msg ->
                 Diag.error "complete" "JSON parse error: %s" msg;

--- a/lib/llm_provider/complete_sync.ml
+++ b/lib/llm_provider/complete_sync.ml
@@ -71,20 +71,22 @@ let complete_http
       let uses_responses_api =
         Provider_config.request_path_targets_responses_api config.request_path
       in
-      let body_str =
+      let request_artifact =
         match config.kind with
         | Provider_config.Anthropic ->
-          Backend_anthropic.build_request ~config ~messages ~tools ()
+          Backend_anthropic.build_request_with_receipt ~config ~messages ~tools ()
         | Provider_config.Ollama ->
-          Backend_ollama.build_request ~config ~messages ~tools ()
+          Backend_ollama.build_request_with_receipt ~config ~messages ~tools ()
         | Provider_config.OpenAI_compat when uses_responses_api ->
-          Backend_openai_responses.build_request ~config ~messages ~tools ()
+          Backend_openai_responses.build_request_with_receipt ~config ~messages ~tools ()
         | Provider_config.OpenAI_compat | Provider_config.DashScope | Provider_config.Kimi
-          -> Backend_openai.build_request ~config ~messages ~tools ()
+          -> Backend_openai.build_request_with_receipt ~config ~messages ~tools ()
         | Provider_config.Gemini ->
-          Backend_gemini.build_request ~config ~messages ~tools ()
-        | Provider_config.Glm -> Backend_glm.build_request ~config ~messages ~tools ()
+          Backend_gemini.build_request_with_receipt ~config ~messages ~tools ()
+        | Provider_config.Glm ->
+          Backend_glm.build_request_with_receipt ~config ~messages ~tools ()
       in
+      let body_str = request_artifact.payload in
       let url =
         match config.kind with
         | Provider_config.Gemini -> gemini_url ~config ~stream:false
@@ -347,6 +349,12 @@ let complete_http
               Error (Http_client.HttpError { code; body }))
         in
         let latency_ms = latency_ms_int latency_counter in
+        let result =
+          Result.map
+            (fun response ->
+               attach_output_token_receipt response request_artifact.output_token_receipt)
+            result
+        in
         result, latency_ms))
 ;;
 

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -20,7 +20,7 @@ type provider_kind = Provider_kind.t =
     it does not dispatch over an HTTP path. *)
 let request_path_default_for_kind = function
   | Anthropic -> "/v1/messages"
-  | Kimi -> "/v1/chat/completions"
+  | Kimi -> "/v1/messages"
   | OpenAI_compat -> "/v1/chat/completions"
   | Ollama -> "/api/chat"
   | Gemini -> ""
@@ -827,6 +827,25 @@ let request_path_targets_responses_api request_path =
     | None -> lower
   in
   String.equal path "/v1/responses" || String.equal path "/responses"
+;;
+
+type http_codec =
+  | Anthropic_messages_codec
+  | Openai_chat_codec
+  | Openai_responses_codec
+  | Ollama_chat_codec
+  | Gemini_generate_content_codec
+  | Glm_chat_codec
+
+let http_codec (config : t) =
+  match config.kind with
+  | Anthropic | Kimi -> Anthropic_messages_codec
+  | OpenAI_compat when request_path_targets_responses_api config.request_path ->
+    Openai_responses_codec
+  | OpenAI_compat | DashScope -> Openai_chat_codec
+  | Ollama -> Ollama_chat_codec
+  | Gemini -> Gemini_generate_content_codec
+  | Glm -> Glm_chat_codec
 ;;
 
 let validate_request_path (config : t) =

--- a/lib/llm_provider/provider_config.mli
+++ b/lib/llm_provider/provider_config.mli
@@ -462,6 +462,19 @@ val validate_output_schema_request : t -> (unit, string) result
     format rather than Chat Completions. *)
 val request_path_targets_responses_api : string -> bool
 
+(** Typed serializer/parser selection for one resolved HTTP config.  Kimi's
+    direct endpoint shares the Anthropic Messages codec; an OpenAI-compatible
+    endpoint selects Responses only through its validated request path. *)
+type http_codec =
+  | Anthropic_messages_codec
+  | Openai_chat_codec
+  | Openai_responses_codec
+  | Ollama_chat_codec
+  | Gemini_generate_content_codec
+  | Glm_chat_codec
+
+val http_codec : t -> http_codec
+
 (** Validate that [request_path] names a wire format implemented by this
     provider kind. OpenAI Responses API paths require [OpenAI_compat] and use a
     Responses-specific sync serializer/parser. *)

--- a/lib/llm_provider/provider_request_artifact.ml
+++ b/lib/llm_provider/provider_request_artifact.ml
@@ -1,0 +1,10 @@
+type 'a t =
+  { payload : 'a
+  ; output_token_receipt : Types.output_token_receipt
+  }
+
+let make ~payload ~output_token_receipt = { payload; output_token_receipt }
+
+let map_payload f artifact =
+  { payload = f artifact.payload; output_token_receipt = artifact.output_token_receipt }
+;;

--- a/lib/llm_provider/provider_request_artifact.ml
+++ b/lib/llm_provider/provider_request_artifact.ml
@@ -6,7 +6,3 @@ type 'a t =
 let make ~payload ~output_token_receipt = { payload; output_token_receipt }
 let payload artifact = artifact.payload
 let output_token_receipt artifact = artifact.output_token_receipt
-
-let map_payload f artifact =
-  { payload = f artifact.payload; output_token_receipt = artifact.output_token_receipt }
-;;

--- a/lib/llm_provider/provider_request_artifact.ml
+++ b/lib/llm_provider/provider_request_artifact.ml
@@ -4,6 +4,8 @@ type 'a t =
   }
 
 let make ~payload ~output_token_receipt = { payload; output_token_receipt }
+let payload artifact = artifact.payload
+let output_token_receipt artifact = artifact.output_token_receipt
 
 let map_payload f artifact =
   { payload = f artifact.payload; output_token_receipt = artifact.output_token_receipt }

--- a/lib/llm_provider/provider_request_artifact.mli
+++ b/lib/llm_provider/provider_request_artifact.mli
@@ -1,0 +1,10 @@
+(** Immutable provider request payload paired with the exact output-token
+    decision used to construct it. *)
+
+type 'a t = private
+  { payload : 'a
+  ; output_token_receipt : Types.output_token_receipt
+  }
+
+val make : payload:'a -> output_token_receipt:Types.output_token_receipt -> 'a t
+val map_payload : ('a -> 'b) -> 'a t -> 'b t

--- a/lib/llm_provider/provider_request_artifact.mli
+++ b/lib/llm_provider/provider_request_artifact.mli
@@ -7,6 +7,5 @@ type 'a t = private
   }
 
 val make : payload:'a -> output_token_receipt:Types.output_token_receipt -> 'a t
-val map_payload : ('a -> 'b) -> 'a t -> 'b t
 val payload : 'a t -> 'a
 val output_token_receipt : 'a t -> Types.output_token_receipt

--- a/lib/llm_provider/provider_request_artifact.mli
+++ b/lib/llm_provider/provider_request_artifact.mli
@@ -8,3 +8,5 @@ type 'a t = private
 
 val make : payload:'a -> output_token_receipt:Types.output_token_receipt -> 'a t
 val map_payload : ('a -> 'b) -> 'a t -> 'b t
+val payload : 'a t -> 'a
+val output_token_receipt : 'a t -> Types.output_token_receipt

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -542,6 +542,10 @@ let output_token_receipt_ceiling_source receipt =
 ;;
 
 let optional_output_token_receipt ~envelope ~requested ~ceiling =
+  (match requested with
+   | Some value when value < 0 ->
+     invalid_arg "optional_output_token_receipt: requested value must be non-negative"
+   | None | Some _ -> ());
   let resolution =
     match requested, ceiling with
     | None, ceiling -> Omitted_resolution { ceiling }
@@ -586,17 +590,23 @@ let output_token_receipt_to_yojson receipt =
 
 let output_token_receipt_of_yojson json =
   let open Yojson.Safe.Util in
-  let int_option = function
+  let token_value_option = function
+    | `Null -> Ok None
+    | `Int value when value >= 0 -> Ok (Some value)
+    | `Int _ -> Error "output_token_receipt: token values must be non-negative"
+    | _ -> Error "output_token_receipt: expected integer or null"
+  in
+  let ceiling_option = function
     | `Null -> Ok None
     | `Int value when value > 0 -> Ok (Some value)
-    | `Int _ -> Error "output_token_receipt: token values must be positive"
+    | `Int _ -> Error "output_token_receipt: ceiling must be positive"
     | _ -> Error "output_token_receipt: expected integer or null"
   in
   let ( let* ) result f = Result.bind result f in
   try
-    let* requested = int_option (member "requested" json) in
-    let* effective = int_option (member "effective" json) in
-    let* ceiling = int_option (member "ceiling" json) in
+    let* requested = token_value_option (member "requested" json) in
+    let* effective = token_value_option (member "effective" json) in
+    let* ceiling = ceiling_option (member "ceiling" json) in
     let* ceiling_source =
       match member "ceiling_source" json with
       | `Null -> Ok None

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -455,17 +455,34 @@ type output_token_policy =
   | Required_catalog_fallback
 [@@deriving show, yojson]
 
+type output_token_ceiling_source =
+  | Catalog_model
+  | Declared_capability_override
+[@@deriving show, yojson]
+
+type output_token_ceiling =
+  { value : int
+  ; source : output_token_ceiling_source
+  }
+[@@deriving show]
+
+let output_token_ceiling ~value ~source =
+  if value <= 0
+  then invalid_arg "output_token_ceiling: value must be positive"
+  else { value; source }
+;;
+
 type output_token_resolution =
-  | Omitted_resolution of { ceiling : int option }
+  | Omitted_resolution of { ceiling : output_token_ceiling option }
   | Explicit_resolution of
       { value : int
-      ; ceiling : int option
+      ; ceiling : output_token_ceiling option
       }
   | Explicit_clamped_resolution of
       { requested : int
-      ; ceiling : int
+      ; ceiling : output_token_ceiling
       }
-  | Required_catalog_fallback_resolution of { ceiling : int }
+  | Required_catalog_fallback_resolution of { ceiling : output_token_ceiling }
 [@@deriving show]
 
 (** Construction-controlled receipt for the output-token value serialized on
@@ -478,7 +495,7 @@ type output_token_receipt =
   }
 [@@deriving show]
 
-type required_output_token_error = Required_output_token_ceiling_missing
+type required_output_token_error = Required_output_token_catalog_ceiling_missing
 [@@deriving show, eq]
 
 let output_token_receipt_requested receipt =
@@ -493,7 +510,7 @@ let output_token_receipt_effective receipt =
   | Omitted_resolution _ -> None
   | Explicit_resolution { value; _ } -> Some value
   | Explicit_clamped_resolution { ceiling; _ }
-  | Required_catalog_fallback_resolution { ceiling } -> Some ceiling
+  | Required_catalog_fallback_resolution { ceiling } -> Some ceiling.value
 ;;
 
 let output_token_receipt_policy receipt =
@@ -505,17 +522,30 @@ let output_token_receipt_policy receipt =
 ;;
 
 let output_token_receipt_ceiling receipt =
-  match receipt.resolution with
-  | Omitted_resolution { ceiling } | Explicit_resolution { ceiling; _ } -> ceiling
-  | Explicit_clamped_resolution { ceiling; _ }
-  | Required_catalog_fallback_resolution { ceiling } -> Some ceiling
+  let ceiling =
+    match receipt.resolution with
+    | Omitted_resolution { ceiling } | Explicit_resolution { ceiling; _ } -> ceiling
+    | Explicit_clamped_resolution { ceiling; _ }
+    | Required_catalog_fallback_resolution { ceiling } -> Some ceiling
+  in
+  Option.map (fun value -> value.value) ceiling
+;;
+
+let output_token_receipt_ceiling_source receipt =
+  let ceiling =
+    match receipt.resolution with
+    | Omitted_resolution { ceiling } | Explicit_resolution { ceiling; _ } -> ceiling
+    | Explicit_clamped_resolution { ceiling; _ }
+    | Required_catalog_fallback_resolution { ceiling } -> Some ceiling
+  in
+  Option.map (fun value -> value.source) ceiling
 ;;
 
 let optional_output_token_receipt ~envelope ~requested ~ceiling =
   let resolution =
     match requested, ceiling with
     | None, ceiling -> Omitted_resolution { ceiling }
-    | Some requested, Some ceiling when requested > ceiling ->
+    | Some requested, Some ceiling when requested > ceiling.value ->
       Explicit_clamped_resolution { requested; ceiling }
     | Some value, ceiling -> Explicit_resolution { value; ceiling }
   in
@@ -524,10 +554,15 @@ let optional_output_token_receipt ~envelope ~requested ~ceiling =
 
 let required_output_token_receipt ~envelope ~requested ~ceiling =
   match optional_output_token_receipt ~envelope ~requested ~ceiling with
-  | { resolution = Omitted_resolution { ceiling = Some ceiling }; _ } ->
-    Ok { envelope; resolution = Required_catalog_fallback_resolution { ceiling } }
-  | { resolution = Omitted_resolution { ceiling = None }; _ } ->
-    Error Required_output_token_ceiling_missing
+  | { resolution =
+        Omitted_resolution { ceiling = Some ({ source = Catalog_model; _ } as ceiling) }
+    ; _
+    } -> Ok { envelope; resolution = Required_catalog_fallback_resolution { ceiling } }
+  | { resolution =
+        Omitted_resolution
+          { ceiling = Some { source = Declared_capability_override; _ } | None }
+    ; _
+    } -> Error Required_output_token_catalog_ceiling_missing
   | receipt -> Ok receipt
 ;;
 
@@ -541,6 +576,10 @@ let output_token_receipt_to_yojson receipt =
     ; "effective", option_int_to_yojson (output_token_receipt_effective receipt)
     ; "policy", output_token_policy_to_yojson (output_token_receipt_policy receipt)
     ; "ceiling", option_int_to_yojson (output_token_receipt_ceiling receipt)
+    ; ( "ceiling_source"
+      , match output_token_receipt_ceiling_source receipt with
+        | Some source -> output_token_ceiling_source_to_yojson source
+        | None -> `Null )
     ; "envelope", output_token_envelope_to_yojson receipt.envelope
     ]
 ;;
@@ -549,7 +588,8 @@ let output_token_receipt_of_yojson json =
   let open Yojson.Safe.Util in
   let int_option = function
     | `Null -> Ok None
-    | `Int value -> Ok (Some value)
+    | `Int value when value > 0 -> Ok (Some value)
+    | `Int _ -> Error "output_token_receipt: token values must be positive"
     | _ -> Error "output_token_receipt: expected integer or null"
   in
   let ( let* ) result f = Result.bind result f in
@@ -557,6 +597,21 @@ let output_token_receipt_of_yojson json =
     let* requested = int_option (member "requested" json) in
     let* effective = int_option (member "effective" json) in
     let* ceiling = int_option (member "ceiling" json) in
+    let* ceiling_source =
+      match member "ceiling_source" json with
+      | `Null -> Ok None
+      | source_json ->
+        Result.map
+          (fun source -> Some source)
+          (output_token_ceiling_source_of_yojson source_json)
+    in
+    let* ceiling =
+      match ceiling, ceiling_source with
+      | None, None -> Ok None
+      | Some value, Some source -> Ok (Some (output_token_ceiling ~value ~source))
+      | Some _, None | None, Some _ ->
+        Error "output_token_receipt: ceiling and ceiling_source must appear together"
+    in
     let* policy = output_token_policy_of_yojson (member "policy" json) in
     let* envelope = output_token_envelope_of_yojson (member "envelope" json) in
     match policy, requested, effective, ceiling with
@@ -566,14 +621,14 @@ let output_token_receipt_of_yojson json =
       when requested = effective
            &&
            match ceiling with
-           | Some cap -> effective <= cap
+           | Some cap -> effective <= cap.value
            | None -> true ->
       Ok { envelope; resolution = Explicit_resolution { value = effective; ceiling } }
     | Explicit_clamped, Some requested, Some effective, Some ceiling
-      when effective = ceiling && requested > ceiling ->
+      when effective = ceiling.value && requested > ceiling.value ->
       Ok { envelope; resolution = Explicit_clamped_resolution { requested; ceiling } }
     | Required_catalog_fallback, None, Some effective, Some ceiling
-      when effective = ceiling ->
+      when ceiling.source = Catalog_model && effective = ceiling.value ->
       Ok { envelope; resolution = Required_catalog_fallback_resolution { ceiling } }
     | _ -> Error "output_token_receipt: inconsistent requested/effective policy fields"
   with
@@ -581,8 +636,9 @@ let output_token_receipt_of_yojson json =
 ;;
 
 (** Per-call inference telemetry assembled from provider responses and
-    OAS-owned request/transport receipts. Downstream consumers never recompute
-    provider decisions. *)
+    transport measurements. Request-side output-token receipts are delivered
+    separately by {!Complete.complete}'s observer so a cached or injected
+    response cannot impersonate an OAS-built wire request. *)
 type inference_telemetry =
   { system_fingerprint : string option
   ; timings : inference_timings option
@@ -597,7 +653,6 @@ type inference_telemetry =
   ; provider_internal_action_count : int option
   ; ttfrc_ms : float option
   ; prefill_ms : float option
-  ; output_token_receipt : output_token_receipt option [@default None]
   }
 [@@deriving show, yojson]
 
@@ -615,7 +670,6 @@ let default_inference_telemetry : inference_telemetry =
   ; provider_internal_action_count = None
   ; ttfrc_ms = None
   ; prefill_ms = None
-  ; output_token_receipt = None
   }
 ;;
 

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -552,12 +552,12 @@ let optional_output_token_receipt ~envelope ~requested ~ceiling =
   { envelope; resolution }
 ;;
 
-let required_output_token_receipt ~envelope ~requested ~ceiling =
-  match optional_output_token_receipt ~envelope ~requested ~ceiling with
+let required_output_token_receipt receipt =
+  match receipt with
   | { resolution =
         Omitted_resolution { ceiling = Some ({ source = Catalog_model; _ } as ceiling) }
     ; _
-    } -> Ok { envelope; resolution = Required_catalog_fallback_resolution { ceiling } }
+    } -> Ok { receipt with resolution = Required_catalog_fallback_resolution { ceiling } }
   | { resolution =
         Omitted_resolution
           { ceiling = Some { source = Declared_capability_override; _ } | None }

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -437,8 +437,152 @@ type inference_timings =
   }
 [@@deriving show, yojson]
 
-(** Per-call inference telemetry.
-    Parsed from the raw API response; never computed by downstream. *)
+(** Provider request envelope that carries the output-token budget.
+    This identifies the wire contract, not the provider brand: providers
+    using an OpenAI-compatible endpoint share the corresponding envelope. *)
+type output_token_envelope =
+  | Openai_chat_max_tokens
+  | Openai_responses_max_output_tokens
+  | Anthropic_messages_max_tokens
+  | Gemini_generation_config_max_output_tokens
+  | Ollama_options_num_predict
+[@@deriving show, yojson]
+
+type output_token_policy =
+  | Omitted
+  | Explicit
+  | Explicit_clamped
+  | Required_catalog_fallback
+[@@deriving show, yojson]
+
+type output_token_resolution =
+  | Omitted_resolution of { ceiling : int option }
+  | Explicit_resolution of
+      { value : int
+      ; ceiling : int option
+      }
+  | Explicit_clamped_resolution of
+      { requested : int
+      ; ceiling : int
+      }
+  | Required_catalog_fallback_resolution of { ceiling : int }
+[@@deriving show]
+
+(** Construction-controlled receipt for the output-token value serialized on
+    the provider wire. The flat JSON projection exposes requested/effective,
+    policy, ceiling, and envelope while the internal sum type prevents invalid
+    combinations in OCaml. *)
+type output_token_receipt =
+  { envelope : output_token_envelope
+  ; resolution : output_token_resolution
+  }
+[@@deriving show]
+
+type required_output_token_error = Required_output_token_ceiling_missing
+[@@deriving show, eq]
+
+let output_token_receipt_requested receipt =
+  match receipt.resolution with
+  | Omitted_resolution _ | Required_catalog_fallback_resolution _ -> None
+  | Explicit_resolution { value; _ } -> Some value
+  | Explicit_clamped_resolution { requested; _ } -> Some requested
+;;
+
+let output_token_receipt_effective receipt =
+  match receipt.resolution with
+  | Omitted_resolution _ -> None
+  | Explicit_resolution { value; _ } -> Some value
+  | Explicit_clamped_resolution { ceiling; _ }
+  | Required_catalog_fallback_resolution { ceiling } -> Some ceiling
+;;
+
+let output_token_receipt_policy receipt =
+  match receipt.resolution with
+  | Omitted_resolution _ -> Omitted
+  | Explicit_resolution _ -> Explicit
+  | Explicit_clamped_resolution _ -> Explicit_clamped
+  | Required_catalog_fallback_resolution _ -> Required_catalog_fallback
+;;
+
+let output_token_receipt_ceiling receipt =
+  match receipt.resolution with
+  | Omitted_resolution { ceiling } | Explicit_resolution { ceiling; _ } -> ceiling
+  | Explicit_clamped_resolution { ceiling; _ }
+  | Required_catalog_fallback_resolution { ceiling } -> Some ceiling
+;;
+
+let optional_output_token_receipt ~envelope ~requested ~ceiling =
+  let resolution =
+    match requested, ceiling with
+    | None, ceiling -> Omitted_resolution { ceiling }
+    | Some requested, Some ceiling when requested > ceiling ->
+      Explicit_clamped_resolution { requested; ceiling }
+    | Some value, ceiling -> Explicit_resolution { value; ceiling }
+  in
+  { envelope; resolution }
+;;
+
+let required_output_token_receipt ~envelope ~requested ~ceiling =
+  match optional_output_token_receipt ~envelope ~requested ~ceiling with
+  | { resolution = Omitted_resolution { ceiling = Some ceiling }; _ } ->
+    Ok { envelope; resolution = Required_catalog_fallback_resolution { ceiling } }
+  | { resolution = Omitted_resolution { ceiling = None }; _ } ->
+    Error Required_output_token_ceiling_missing
+  | receipt -> Ok receipt
+;;
+
+let output_token_receipt_to_yojson receipt =
+  let option_int_to_yojson = function
+    | Some value -> `Int value
+    | None -> `Null
+  in
+  `Assoc
+    [ "requested", option_int_to_yojson (output_token_receipt_requested receipt)
+    ; "effective", option_int_to_yojson (output_token_receipt_effective receipt)
+    ; "policy", output_token_policy_to_yojson (output_token_receipt_policy receipt)
+    ; "ceiling", option_int_to_yojson (output_token_receipt_ceiling receipt)
+    ; "envelope", output_token_envelope_to_yojson receipt.envelope
+    ]
+;;
+
+let output_token_receipt_of_yojson json =
+  let open Yojson.Safe.Util in
+  let int_option = function
+    | `Null -> Ok None
+    | `Int value -> Ok (Some value)
+    | _ -> Error "output_token_receipt: expected integer or null"
+  in
+  let ( let* ) result f = Result.bind result f in
+  try
+    let* requested = int_option (member "requested" json) in
+    let* effective = int_option (member "effective" json) in
+    let* ceiling = int_option (member "ceiling" json) in
+    let* policy = output_token_policy_of_yojson (member "policy" json) in
+    let* envelope = output_token_envelope_of_yojson (member "envelope" json) in
+    match policy, requested, effective, ceiling with
+    | Omitted, None, None, ceiling ->
+      Ok { envelope; resolution = Omitted_resolution { ceiling } }
+    | Explicit, Some requested, Some effective, ceiling
+      when requested = effective
+           &&
+           match ceiling with
+           | Some cap -> effective <= cap
+           | None -> true ->
+      Ok { envelope; resolution = Explicit_resolution { value = effective; ceiling } }
+    | Explicit_clamped, Some requested, Some effective, Some ceiling
+      when effective = ceiling && requested > ceiling ->
+      Ok { envelope; resolution = Explicit_clamped_resolution { requested; ceiling } }
+    | Required_catalog_fallback, None, Some effective, Some ceiling
+      when effective = ceiling ->
+      Ok { envelope; resolution = Required_catalog_fallback_resolution { ceiling } }
+    | _ -> Error "output_token_receipt: inconsistent requested/effective policy fields"
+  with
+  | Yojson.Safe.Util.Type_error (message, _) -> Error message
+;;
+
+(** Per-call inference telemetry assembled from provider responses and
+    OAS-owned request/transport receipts. Downstream consumers never recompute
+    provider decisions. *)
 type inference_telemetry =
   { system_fingerprint : string option
   ; timings : inference_timings option
@@ -453,6 +597,7 @@ type inference_telemetry =
   ; provider_internal_action_count : int option
   ; ttfrc_ms : float option
   ; prefill_ms : float option
+  ; output_token_receipt : output_token_receipt option [@default None]
   }
 [@@deriving show, yojson]
 
@@ -470,6 +615,7 @@ let default_inference_telemetry : inference_telemetry =
   ; provider_internal_action_count = None
   ; ttfrc_ms = None
   ; prefill_ms = None
+  ; output_token_receipt = None
   }
 ;;
 

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -256,29 +256,49 @@ type output_token_policy =
   | Required_catalog_fallback
 [@@deriving show, yojson]
 
+type output_token_ceiling_source =
+  | Catalog_model
+  | Declared_capability_override
+[@@deriving show, yojson]
+
+type output_token_ceiling = private
+  { value : int
+  ; source : output_token_ceiling_source
+  }
+
+val output_token_ceiling
+  :  value:int
+  -> source:output_token_ceiling_source
+  -> output_token_ceiling
+
 (** Construction-controlled receipt for the output-token value serialized on
     the provider wire. *)
 type output_token_receipt
 
-type required_output_token_error = Required_output_token_ceiling_missing
+type required_output_token_error = Required_output_token_catalog_ceiling_missing
 [@@deriving show, eq]
 
 val optional_output_token_receipt
   :  envelope:output_token_envelope
   -> requested:int option
-  -> ceiling:int option
+  -> ceiling:output_token_ceiling option
   -> output_token_receipt
 
 val required_output_token_receipt
   :  envelope:output_token_envelope
   -> requested:int option
-  -> ceiling:int option
+  -> ceiling:output_token_ceiling option
   -> (output_token_receipt, required_output_token_error) result
 
 val output_token_receipt_requested : output_token_receipt -> int option
 val output_token_receipt_effective : output_token_receipt -> int option
 val output_token_receipt_policy : output_token_receipt -> output_token_policy
 val output_token_receipt_ceiling : output_token_receipt -> int option
+
+val output_token_receipt_ceiling_source
+  :  output_token_receipt
+  -> output_token_ceiling_source option
+
 val output_token_receipt_to_yojson : output_token_receipt -> Yojson.Safe.t
 
 val output_token_receipt_of_yojson
@@ -289,8 +309,9 @@ val pp_output_token_receipt : Format.formatter -> output_token_receipt -> unit
 val show_output_token_receipt : output_token_receipt -> string
 
 (** Per-call inference telemetry assembled from provider responses and
-    OAS-owned request/transport receipts. Downstream consumers never recompute
-    provider decisions. *)
+    transport measurements. Request-side output-token receipts are delivered
+    separately by {!Complete.complete}'s observer so a cached or injected
+    response cannot impersonate an OAS-built wire request. *)
 type inference_telemetry =
   { system_fingerprint : string option
   ; timings : inference_timings option
@@ -316,10 +337,6 @@ type inference_telemetry =
   ; ttfrc_ms : float option
     (** Time-to-first-response-chunk in milliseconds (wall-clock). *)
   ; prefill_ms : float option (** Prompt evaluation (prefill) duration in milliseconds. *)
-  ; output_token_receipt : output_token_receipt option [@default None]
-    (** Exact requested/effective output-token decision used by the OAS-owned
-        provider request builder. Absent when OAS did not build a provider wire
-        request (for example an opaque external transport or a cache replay). *)
   }
 [@@deriving show, yojson]
 

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -241,6 +241,56 @@ type inference_timings =
   }
 [@@deriving show, yojson]
 
+type output_token_envelope =
+  | Openai_chat_max_tokens
+  | Openai_responses_max_output_tokens
+  | Anthropic_messages_max_tokens
+  | Gemini_generation_config_max_output_tokens
+  | Ollama_options_num_predict
+[@@deriving show, yojson]
+
+type output_token_policy =
+  | Omitted
+  | Explicit
+  | Explicit_clamped
+  | Required_catalog_fallback
+[@@deriving show, yojson]
+
+(** Construction-controlled receipt for the output-token value serialized on
+    the provider wire. *)
+type output_token_receipt
+
+type required_output_token_error = Required_output_token_ceiling_missing
+[@@deriving show, eq]
+
+val optional_output_token_receipt
+  :  envelope:output_token_envelope
+  -> requested:int option
+  -> ceiling:int option
+  -> output_token_receipt
+
+val required_output_token_receipt
+  :  envelope:output_token_envelope
+  -> requested:int option
+  -> ceiling:int option
+  -> (output_token_receipt, required_output_token_error) result
+
+val output_token_receipt_requested : output_token_receipt -> int option
+val output_token_receipt_effective : output_token_receipt -> int option
+val output_token_receipt_policy : output_token_receipt -> output_token_policy
+val output_token_receipt_ceiling : output_token_receipt -> int option
+val output_token_receipt_to_yojson : output_token_receipt -> Yojson.Safe.t
+
+val output_token_receipt_of_yojson
+  :  Yojson.Safe.t
+  -> (output_token_receipt, string) result
+
+val pp_output_token_receipt : Format.formatter -> output_token_receipt -> unit
+val show_output_token_receipt : output_token_receipt -> string
+
+(** Per-call inference telemetry assembled from provider responses and
+    OAS-owned request/transport receipts. Downstream consumers never recompute
+    provider decisions. *)
 type inference_telemetry =
   { system_fingerprint : string option
   ; timings : inference_timings option
@@ -266,6 +316,10 @@ type inference_telemetry =
   ; ttfrc_ms : float option
     (** Time-to-first-response-chunk in milliseconds (wall-clock). *)
   ; prefill_ms : float option (** Prompt evaluation (prefill) duration in milliseconds. *)
+  ; output_token_receipt : output_token_receipt option [@default None]
+    (** Exact requested/effective output-token decision used by the OAS-owned
+        provider request builder. Absent when OAS did not build a provider wire
+        request (for example an opaque external transport or a cache replay). *)
   }
 [@@deriving show, yojson]
 

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -285,9 +285,7 @@ val optional_output_token_receipt
   -> output_token_receipt
 
 val required_output_token_receipt
-  :  envelope:output_token_envelope
-  -> requested:int option
-  -> ceiling:output_token_ceiling option
+  :  output_token_receipt
   -> (output_token_receipt, required_output_token_error) result
 
 val output_token_receipt_requested : output_token_receipt -> int option

--- a/lib/pipeline/pipeline_stage_route.ml
+++ b/lib/pipeline/pipeline_stage_route.ml
@@ -1,7 +1,30 @@
 open Agent_types
 open Result_syntax
 
+let _log = Log.create ~module_name:"pipeline_stage_route" ()
 let sdk_error_of_http_error = Http_error_sdk.of_http_error
+
+let output_token_receipt_observer agent ~model_id =
+  match agent.options.event_bus with
+  | None -> None
+  | Some bus ->
+    Some
+      (fun receipt ->
+        Pipeline_common.safe_publish
+          ~log:_log
+          bus
+          { Event_bus.meta = Pipeline_common.event_envelope agent
+          ; payload =
+              Event_bus.Custom
+                ( "oas.output_token_receipt"
+                , `Assoc
+                    [ "agent_name", `String agent.state.config.name
+                    ; "turn", `Int agent.state.turn_count
+                    ; "model_id", `String model_id
+                    ; "receipt", Llm_provider.Types.output_token_receipt_to_yojson receipt
+                    ] )
+          })
+;;
 
 let dispatch_sync
       ~sw
@@ -16,6 +39,9 @@ let dispatch_sync
       ~state:agent.state
       ~base_url:agent.options.base_url
       agent.options.provider
+  in
+  let on_output_token_receipt =
+    output_token_receipt_observer agent ~model_id:pc.model_id
   in
   let call () =
     match clock with
@@ -32,6 +58,7 @@ let dispatch_sync
         ~trace_context
         ?priority:agent.options.priority
         ?body_timeout_s:agent.options.body_timeout_s
+        ?on_output_token_receipt
         ()
     | None ->
       Llm_provider.Complete.complete
@@ -45,6 +72,7 @@ let dispatch_sync
         ~trace_context
         ?priority:agent.options.priority
         ?body_timeout_s:agent.options.body_timeout_s
+        ?on_output_token_receipt
         ()
   in
   match call () with
@@ -69,6 +97,9 @@ let dispatch_stream
       ~base_url:agent.options.base_url
       agent.options.provider
   in
+  let on_output_token_receipt =
+    output_token_receipt_observer agent ~model_id:pc.model_id
+  in
   let call () =
     match clock with
     | Some clock ->
@@ -86,6 +117,7 @@ let dispatch_stream
         ?on_telemetry
         ?priority:agent.options.priority
         ?stream_idle_timeout_s:agent.options.stream_idle_timeout_s
+        ?on_output_token_receipt
         ()
     | None ->
       Llm_provider.Complete.complete_stream
@@ -101,6 +133,7 @@ let dispatch_stream
         ?on_telemetry
         ?priority:agent.options.priority
         ?stream_idle_timeout_s:agent.options.stream_idle_timeout_s
+        ?on_output_token_receipt
         ()
   in
   match call () with

--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -158,11 +158,15 @@ type provider_impl =
   }
 
 let registry : (string, provider_impl) Hashtbl.t = Hashtbl.create 8
-let registry_mu = Eio.Mutex.create ()
+let registry_mu = Mutex.create ()
+
+let with_registry_lock f =
+  Mutex.lock registry_mu;
+  Fun.protect f ~finally:(fun () -> Mutex.unlock registry_mu)
+;;
 
 let register_provider impl =
-  Eio.Mutex.use_rw ~protect:true registry_mu (fun () ->
-    Hashtbl.replace registry impl.name impl)
+  with_registry_lock (fun () -> Hashtbl.replace registry impl.name impl)
 ;;
 
 let find_builtin_provider name = function
@@ -249,12 +253,12 @@ let builtin_provider_impls = [ kimi_provider_impl ]
 let find_provider name =
   match find_builtin_provider name builtin_provider_impls with
   | Some impl -> Some impl
-  | None -> Eio.Mutex.use_ro registry_mu (fun () -> Hashtbl.find_opt registry name)
+  | None -> with_registry_lock (fun () -> Hashtbl.find_opt registry name)
 ;;
 
 let registered_providers () =
   let dynamic =
-    Eio.Mutex.use_ro registry_mu (fun () ->
+    with_registry_lock (fun () ->
       Hashtbl.fold (fun name _ acc -> name :: acc) registry [])
   in
   builtin_provider_impls

--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -159,11 +159,7 @@ type provider_impl =
 
 let registry : (string, provider_impl) Hashtbl.t = Hashtbl.create 8
 let registry_mu = Mutex.create ()
-
-let with_registry_lock f =
-  Mutex.lock registry_mu;
-  Fun.protect f ~finally:(fun () -> Mutex.unlock registry_mu)
-;;
+let with_registry_lock f = Mutex.protect registry_mu f
 
 let register_provider impl =
   with_registry_lock (fun () -> Hashtbl.replace registry impl.name impl)

--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -726,30 +726,47 @@ let provider_config_of_agent
   | Some p ->
     (match p.provider with
      | Custom_registered { name } ->
-       (* Preserve the registry-declared provider_kind
-              (Gemini/Glm/Ollama/Claude_code/etc.) instead of flattening
-              to OpenAI_compat.
-
-              Source of truth is {!Llm_provider.Provider_registry.default},
-              which carries [entry.defaults.{kind, base_url, api_key_env,
-              request_path}] per registered name. We read api_key from
-              env directly rather than going through {!resolve}, because
-              [resolve] dispatches via a separate {!Provider.registry}
-              Hashtbl that is not guaranteed to contain the registry
-              entries defined in {!Llm_provider.Provider_registry}. *)
+       let build_runtime_only_provider impl =
+         let kind_result =
+           match impl.request_kind with
+           | Anthropic_messages -> Ok Llm_provider.Provider_config.Anthropic
+           | Openai_chat_completions -> Ok Llm_provider.Provider_config.OpenAI_compat
+           | Custom _ ->
+             Error
+               (Error.Config
+                  (InvalidConfig
+                     { field = "provider"
+                     ; detail =
+                         Printf.sprintf
+                           "Custom provider '%s' owns a custom wire contract and cannot \
+                            be projected to Provider_config"
+                           name
+                     }))
+         in
+         match kind_result with
+         | Error _ as error -> error
+         | Ok kind ->
+           (match impl.resolve p with
+            | Error _ as error -> error
+            | Ok (resolved_base_url, api_key, headers) ->
+              build
+                ~kind
+                ~resolved_base_url
+                ~api_key
+                ~headers
+                ~request_path:impl.request_path
+                ~model_id:p.model_id
+                ~supports_structured_output_override:
+                  impl.capabilities.supports_structured_output
+                ~model_capabilities_override:impl.capabilities
+                ())
+       in
+       (* A catalog descriptor owns the provider kind/capabilities when one
+          exists.  A legacy runtime implementation with the same name may own
+          transport resolution, but cannot silently flatten a catalog Kimi,
+          Gemini, GLM, or Ollama entry to its wire-family kind. *)
        let registry = Llm_provider.Provider_registry.default () in
        (match Llm_provider.Provider_registry.find registry name with
-        | None ->
-          Error
-            (Error.Config
-               (InvalidConfig
-                  { field = "provider"
-                  ; detail =
-                      Printf.sprintf
-                        "Custom_registered provider '%s' not found in \
-                         Provider_registry.default"
-                        name
-                  }))
         | Some entry ->
           (* If a provider-qualified model catalog row exists for this
              registered provider, let the row be authoritative instead of
@@ -777,7 +794,7 @@ let provider_config_of_agent
           (match find_provider name with
            | Some impl ->
              (match impl.resolve p with
-              | Error e -> Error e
+              | Error _ as error -> error
               | Ok (resolved_base_url, api_key, headers) ->
                 build
                   ~kind:entry.defaults.kind
@@ -808,7 +825,21 @@ let provider_config_of_agent
                ~model_id:p.model_id
                ?supports_structured_output_override:registry_so_override
                ?model_capabilities_override:registry_caps_override
-               ()))
+               ())
+        | None ->
+          (match find_provider name with
+           | Some impl -> build_runtime_only_provider impl
+           | None ->
+             Error
+               (Error.Config
+                  (InvalidConfig
+                     { field = "provider"
+                     ; detail =
+                         Printf.sprintf
+                           "Custom_registered provider '%s' not found in provider \
+                            registries"
+                           name
+                     }))))
      | Anthropic | Local _ | OpenAICompat _ ->
        (match resolve p with
         | Error e -> Error e

--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -784,7 +784,7 @@ let provider_config_of_agent
                 ~model_id:p.model_id
             with
             | Some _ -> None
-            | None -> Some entry.capabilities
+            | None -> Some { entry.capabilities with max_output_tokens = None }
           in
           let registry_so_override =
             Option.map

--- a/lib/provider_intf.ml
+++ b/lib/provider_intf.ml
@@ -134,26 +134,25 @@ let of_config (provider_cfg : Provider.config) : (provider_module, Error.sdk_err
         let body_result =
           match kind with
           | Provider.Anthropic_messages ->
+            let artifact =
+              Api_anthropic.build_body_artifact ~config ~messages ?tools ~stream:false ()
+            in
             Ok
-              (Yojson.Safe.to_string
-                 (`Assoc
-                     (Api_anthropic.build_body_assoc
-                        ~config
-                        ~messages
-                        ?tools
-                        ~stream:false
-                        ())))
+              ( Yojson.Safe.to_string (`Assoc artifact.payload)
+              , Some artifact.output_token_receipt )
           | Provider.Openai_chat_completions ->
-            Api_openai.build_openai_body_result
-              ~provider_config:provider_cfg
-              ~config
-              ~messages
-              ?tools
-              ()
+            Result.map
+              (fun artifact -> artifact.payload, Some artifact.output_token_receipt)
+              (Api_openai.build_openai_body_artifact_result
+                 ~provider_config:provider_cfg
+                 ~config
+                 ~messages
+                 ?tools
+                 ())
           | Provider.Custom name ->
             (match Provider.find_provider name with
-             | Some impl -> Ok (impl.build_body ~config ~messages ?tools ())
-             | None -> Ok (Yojson.Safe.to_string (`Assoc [])))
+             | Some impl -> Ok (impl.build_body ~config ~messages ?tools (), None)
+             | None -> Ok (Yojson.Safe.to_string (`Assoc []), None))
         in
         match body_result with
         | Error reason ->
@@ -163,7 +162,7 @@ let of_config (provider_cfg : Provider.config) : (provider_module, Error.sdk_err
                   { message = "Request rejected: " ^ reason
                   ; reason = Retry.Unknown_invalid_request
                   }))
-        | Ok body_str ->
+        | Ok (body_str, output_token_receipt) ->
           let url = base_url ^ path in
           (* Merge auth headers at request time so that [headers] (from
          [Provider.resolve]) never carries sensitive tokens. *)
@@ -197,7 +196,13 @@ let of_config (provider_cfg : Provider.config) : (provider_module, Error.sdk_err
                   | Some impl -> impl.parse_response body_str |> ensure_nonempty_response
                   | None -> parse_openai_response_result body_str)
              in
-             Result.map_error sdk_error_of_response_error result
+             result
+             |> Result.map (fun response ->
+               match output_token_receipt with
+               | Some receipt ->
+                 Llm_provider.Complete_common.attach_output_token_receipt response receipt
+               | None -> response)
+             |> Result.map_error sdk_error_of_response_error
            | Ok (code, body_str) ->
              Error
                (sdk_error_of_http_error (Http_client.HttpError { code; body = body_str }))

--- a/lib/provider_intf.ml
+++ b/lib/provider_intf.ml
@@ -119,101 +119,25 @@ type streaming_provider_module = (module STREAMING_PROVIDER)
 (** Runtime dispatch: resolve a provider config to a first-class module.
     Returns an error if provider configuration or credentials cannot be
     resolved. *)
-let of_config (provider_cfg : Provider.config) : (provider_module, Error.sdk_error) result
+let of_config ?on_output_token_receipt (provider_cfg : Provider.config)
+  : (provider_module, Error.sdk_error) result
   =
   match Provider.resolve provider_cfg with
   | Error err -> Error err
-  | Ok (base_url, api_key, headers) ->
-    let spec = Provider.model_spec_of_config provider_cfg in
+  | Ok _ ->
     let module P = struct
       type t = unit
 
       let create_message ~sw ~net ~config ~messages ?tools () =
-        let kind = spec.request_kind in
-        let path = spec.request_path in
-        let body_result =
-          match kind with
-          | Provider.Anthropic_messages ->
-            let artifact =
-              Api_anthropic.build_body_artifact ~config ~messages ?tools ~stream:false ()
-            in
-            Ok
-              ( Yojson.Safe.to_string
-                  (`Assoc (Llm_provider.Provider_request_artifact.payload artifact))
-              , Some
-                  (Llm_provider.Provider_request_artifact.output_token_receipt artifact)
-              )
-          | Provider.Openai_chat_completions ->
-            Result.map
-              (fun artifact ->
-                 ( Llm_provider.Provider_request_artifact.payload artifact
-                 , Some
-                     (Llm_provider.Provider_request_artifact.output_token_receipt
-                        artifact) ))
-              (Api_openai.build_openai_body_artifact_result
-                 ~provider_config:provider_cfg
-                 ~config
-                 ~messages
-                 ?tools
-                 ())
-          | Provider.Custom name ->
-            (match Provider.find_provider name with
-             | Some impl -> Ok (impl.build_body ~config ~messages ?tools (), None)
-             | None -> Ok (Yojson.Safe.to_string (`Assoc []), None))
-        in
-        match body_result with
-        | Error reason ->
-          Error
-            (Error.Api
-               (Retry.InvalidRequest
-                  { message = "Request rejected: " ^ reason
-                  ; reason = Retry.Unknown_invalid_request
-                  }))
-        | Ok (body_str, output_token_receipt) ->
-          let url = base_url ^ path in
-          (* Merge auth headers at request time so that [headers] (from
-         [Provider.resolve]) never carries sensitive tokens. *)
-          let auth_hdrs =
-            if api_key = ""
-            then []
-            else (
-              match kind with
-              | Provider.Anthropic_messages -> [ "x-api-key", api_key ]
-              | Provider.Openai_chat_completions | Provider.Custom _ ->
-                [ "Authorization", "Bearer " ^ api_key ])
-          in
-          (match
-             Http_client.post_sync
-               ~sw
-               ~net
-               ~url
-               ~headers:(headers @ auth_hdrs)
-               ~body:body_str
-               ()
-           with
-           | Ok (200, body_str) ->
-             let result =
-               match kind with
-               | Provider.Anthropic_messages ->
-                 Api_anthropic.parse_response (Yojson.Safe.from_string body_str)
-                 |> ensure_nonempty_response
-               | Provider.Openai_chat_completions -> parse_openai_response_result body_str
-               | Provider.Custom name ->
-                 (match Provider.find_provider name with
-                  | Some impl -> impl.parse_response body_str |> ensure_nonempty_response
-                  | None -> parse_openai_response_result body_str)
-             in
-             result
-             |> Result.map (fun response ->
-               match output_token_receipt with
-               | Some receipt ->
-                 Llm_provider.Complete_common.attach_output_token_receipt response receipt
-               | None -> response)
-             |> Result.map_error sdk_error_of_response_error
-           | Ok (code, body_str) ->
-             Error
-               (sdk_error_of_http_error (Http_client.HttpError { code; body = body_str }))
-           | Error err -> Error (sdk_error_of_http_error err))
+        Api.create_message
+          ~sw
+          ~net
+          ~provider:provider_cfg
+          ~config
+          ~messages
+          ?tools
+          ?on_output_token_receipt
+          ()
       ;;
     end
     in
@@ -230,13 +154,13 @@ let supports_streaming (provider_cfg : Provider.config) : bool =
     Returns [Ok (Some _)] when native streaming is supported, [Ok None]
     otherwise (caller should fall back to sync + synthetic). Returns an
     error if provider configuration or credentials cannot be resolved. *)
-let of_config_streaming (provider_cfg : Provider.config)
+let of_config_streaming ?on_output_token_receipt (provider_cfg : Provider.config)
   : (streaming_provider_module option, Error.sdk_error) result
   =
   if not (supports_streaming provider_cfg)
   then Ok None
   else (
-    match of_config provider_cfg with
+    match of_config ?on_output_token_receipt provider_cfg with
     | Error err -> Error err
     | Ok base_module ->
       let module Base = (val base_module : PROVIDER) in
@@ -270,6 +194,7 @@ let of_config_streaming (provider_cfg : Provider.config)
             ~messages
             ?tools
             ~on_event
+            ?on_output_token_receipt
             ()
         ;;
       end

--- a/lib/provider_intf.ml
+++ b/lib/provider_intf.ml
@@ -138,11 +138,18 @@ let of_config (provider_cfg : Provider.config) : (provider_module, Error.sdk_err
               Api_anthropic.build_body_artifact ~config ~messages ?tools ~stream:false ()
             in
             Ok
-              ( Yojson.Safe.to_string (`Assoc artifact.payload)
-              , Some artifact.output_token_receipt )
+              ( Yojson.Safe.to_string
+                  (`Assoc (Llm_provider.Provider_request_artifact.payload artifact))
+              , Some
+                  (Llm_provider.Provider_request_artifact.output_token_receipt artifact)
+              )
           | Provider.Openai_chat_completions ->
             Result.map
-              (fun artifact -> artifact.payload, Some artifact.output_token_receipt)
+              (fun artifact ->
+                 ( Llm_provider.Provider_request_artifact.payload artifact
+                 , Some
+                     (Llm_provider.Provider_request_artifact.output_token_receipt
+                        artifact) ))
               (Api_openai.build_openai_body_artifact_result
                  ~provider_config:provider_cfg
                  ~config

--- a/lib/provider_intf.mli
+++ b/lib/provider_intf.mli
@@ -41,7 +41,10 @@ type streaming_provider_module = (module STREAMING_PROVIDER)
 (** Resolve a provider config to a first-class PROVIDER module.
     Returns an error if provider configuration or credentials cannot be
     resolved (e.g. a required environment variable is missing). *)
-val of_config : Provider.config -> (provider_module, Error.sdk_error) result
+val of_config
+  :  ?on_output_token_receipt:(Llm_provider.Types.output_token_receipt -> unit)
+  -> Provider.config
+  -> (provider_module, Error.sdk_error) result
 
 (** Check if a provider config supports native streaming. *)
 val supports_streaming : Provider.config -> bool
@@ -51,5 +54,6 @@ val supports_streaming : Provider.config -> bool
     Returns an error if provider configuration or credentials cannot be
     resolved. *)
 val of_config_streaming
-  :  Provider.config
+  :  ?on_output_token_receipt:(Llm_provider.Types.output_token_receipt -> unit)
+  -> Provider.config
   -> (streaming_provider_module option, Error.sdk_error) result

--- a/lib/streaming.ml
+++ b/lib/streaming.ml
@@ -131,8 +131,8 @@ let create_message_stream
          ; "anthropic-version", Api.api_version
          ]
        in
-       let body_assoc = Api.build_body_assoc ~config ~messages ?tools ~stream:true () in
-       let body = Yojson.Safe.to_string (`Assoc body_assoc) in
+       let artifact = Api.build_body_artifact ~config ~messages ?tools ~stream:true () in
+       let body = Yojson.Safe.to_string (`Assoc artifact.payload) in
        let url = base_url ^ "/v1/messages" in
        Llm_provider.Http_client.with_post_stream
          ?clock
@@ -165,6 +165,10 @@ let create_message_stream
            finalize_stream_acc acc)
          ()
        |> map_stream_finalize_result
+       |> Result.map (fun response ->
+         Llm_provider.Complete_common.attach_output_token_receipt
+           response
+           artifact.output_token_receipt)
      | Provider.Openai_chat_completions ->
        (* OpenAI-compatible SSE streaming. *)
        let openai_compat_kind = Llm_provider.Provider_config.OpenAI_compat in
@@ -178,7 +182,7 @@ let create_message_stream
        in
        let stream_path = Provider.request_path provider_cfg.provider in
        (match
-          Api_openai.build_openai_body_result
+          Api_openai.build_openai_body_artifact_result
             ~provider_config:provider_cfg
             ~config
             ~messages
@@ -192,9 +196,9 @@ let create_message_stream
                   { message = "Request rejected: " ^ reason
                   ; reason = Llm_provider.Retry.Unknown_invalid_request
                   }))
-        | Ok body ->
+        | Ok artifact ->
           let body =
-            body
+            artifact.payload
             (* Streaming must request both SSE chunks and usage deltas so the
                accumulator can surface final token/cost metrics. *)
             |> Llm_provider.Http_client.inject_stream_and_options
@@ -251,7 +255,11 @@ let create_message_stream
               if !(acc.stop_reason_received) then on_event MessageStop;
               finalize_stream_acc acc)
             ()
-          |> map_stream_finalize_result)
+          |> map_stream_finalize_result
+          |> Result.map (fun response ->
+            Llm_provider.Complete_common.attach_output_token_receipt
+              response
+              artifact.output_token_receipt))
      | Provider.Custom _ ->
        (* Sync fallback: non-streaming call + synthetic events *)
        (match

--- a/lib/streaming.ml
+++ b/lib/streaming.ml
@@ -99,6 +99,7 @@ let create_message_stream
       ~messages
       ?tools
       ~on_event
+      ?on_output_token_receipt
       ()
   : (api_response, Error.sdk_error) result
   =
@@ -122,147 +123,26 @@ let create_message_stream
   in
   match resolve_result with
   | Error e -> Error e
-  | Ok (provider_cfg, base_url, api_key) ->
+  | Ok (provider_cfg, base_url, _api_key) ->
     (match Provider.request_kind provider_cfg.provider with
-     | Provider.Anthropic_messages ->
-       let headers =
-         [ "Content-Type", "application/json"
-         ; "x-api-key", api_key
-         ; "anthropic-version", Api.api_version
-         ]
-       in
-       let artifact = Api.build_body_artifact ~config ~messages ?tools ~stream:true () in
-       let body =
-         Yojson.Safe.to_string
-           (`Assoc (Llm_provider.Provider_request_artifact.payload artifact))
-       in
-       let url = base_url ^ "/v1/messages" in
-       Llm_provider.Http_client.with_post_stream
-         ?clock
-         ~net
-         ~url
-         ~headers
-         ~body
-         ~f:(fun reader ->
-           let acc = create_stream_acc () in
-           Llm_provider.Http_client.read_sse
-             ?clock
-             ?idle_timeout
-             ~reader
-             ~on_data:(fun ~event_type data ->
-               if data <> "[DONE]"
-               then (
-                 match parse_sse_event event_type data with
-                 | None ->
-                   let evt =
-                     SSEParseFailed
-                       { raw = data; reason = "anthropic_sse_chunk_parse_failure" }
-                   in
-                   on_event evt;
-                   accumulate_event acc evt
-                 | Some evt ->
-                   on_event evt;
-                   accumulate_event acc evt))
-             ();
-           if !(acc.stop_reason_received) then on_event MessageStop;
-           finalize_stream_acc acc)
-         ()
-       |> map_stream_finalize_result
-       |> Result.map (fun response ->
-         Llm_provider.Complete_common.attach_output_token_receipt
-           response
-           (Llm_provider.Provider_request_artifact.output_token_receipt artifact))
-     | Provider.Openai_chat_completions ->
-       (* OpenAI-compatible SSE streaming. *)
-       let openai_compat_kind = Llm_provider.Provider_config.OpenAI_compat in
-       let auth_headers =
-         Provider.auth_headers_only_for_kind ~kind:openai_compat_kind ~api_key
-       in
-       let headers =
-         match Provider.resolve provider_cfg with
-         | Ok (_, _, h) -> h @ auth_headers
-         | Error _ -> [ "Content-Type", "application/json" ] @ auth_headers
-       in
-       let stream_path = Provider.request_path provider_cfg.provider in
+     | Provider.Anthropic_messages | Provider.Openai_chat_completions ->
        (match
-          Api_openai.build_openai_body_artifact_result
-            ~provider_config:provider_cfg
-            ~config
-            ~messages
-            ?tools
-            ()
+          Provider.provider_config_of_agent ~state:config ~base_url (Some provider_cfg)
         with
-        | Error reason ->
-          Error
-            (Error.Api
-               (Llm_provider.Retry.InvalidRequest
-                  { message = "Request rejected: " ^ reason
-                  ; reason = Llm_provider.Retry.Unknown_invalid_request
-                  }))
-        | Ok artifact ->
-          let body =
-            Llm_provider.Provider_request_artifact.payload artifact
-            (* Streaming must request both SSE chunks and usage deltas so the
-               accumulator can surface final token/cost metrics. *)
-            |> Llm_provider.Http_client.inject_stream_and_options
-          in
-          let url = base_url ^ stream_path in
-          Llm_provider.Http_client.with_post_stream
-            ?clock
+        | Error _ as error -> error
+        | Ok wire_config ->
+          Llm_provider.Complete.complete_stream
+            ~sw
             ~net
-            ~url
-            ~headers
-            ~body
-            ~f:(fun reader ->
-              let acc = create_stream_acc () in
-              let oai_state = Llm_provider.Streaming.create_openai_stream_state () in
-              let msg_started = ref false in
-              Llm_provider.Http_client.read_sse
-                ?clock
-                ?idle_timeout
-                ~reader
-                ~on_data:(fun ~event_type:_ data ->
-                  if data = "[DONE]"
-                  then ()
-                  else (
-                    match Llm_provider.Streaming.parse_openai_sse_chunk data with
-                    | None ->
-                      let evt =
-                        SSEParseFailed
-                          { raw = data; reason = "openai_sse_chunk_parse_failure" }
-                      in
-                      on_event evt;
-                      accumulate_event acc evt
-                    | Some chunk ->
-                      if not !msg_started
-                      then (
-                        msg_started := true;
-                        let evt =
-                          MessageStart
-                            { id = chunk.chunk_id
-                            ; model = chunk.chunk_model
-                            ; usage = None
-                            }
-                        in
-                        on_event evt;
-                        accumulate_event acc evt);
-                      let evs, _tel =
-                        Llm_provider.Streaming.openai_chunk_to_events oai_state chunk
-                      in
-                      List.iter
-                        (fun evt ->
-                           on_event evt;
-                           accumulate_event acc evt)
-                        evs))
-                ();
-              if !(acc.stop_reason_received) then on_event MessageStop;
-              finalize_stream_acc acc)
+            ?clock
+            ?stream_idle_timeout_s:idle_timeout
+            ~config:wire_config
+            ~messages
+            ~tools:(Option.value tools ~default:[])
+            ~on_event
+            ?on_output_token_receipt
             ()
-          |> map_stream_finalize_result
-          |> Result.map (fun response ->
-            Llm_provider.Complete_common.attach_output_token_receipt
-              response
-              (Llm_provider.Provider_request_artifact.output_token_receipt artifact)))
+          |> Result.map_error map_http_error)
      | Provider.Custom _ ->
        (* Sync fallback: non-streaming call + synthetic events *)
        (match
@@ -274,6 +154,7 @@ let create_message_stream
             ~config
             ~messages
             ?tools
+            ?on_output_token_receipt
             ()
         with
         | Ok response ->

--- a/lib/streaming.ml
+++ b/lib/streaming.ml
@@ -132,7 +132,10 @@ let create_message_stream
          ]
        in
        let artifact = Api.build_body_artifact ~config ~messages ?tools ~stream:true () in
-       let body = Yojson.Safe.to_string (`Assoc artifact.payload) in
+       let body =
+         Yojson.Safe.to_string
+           (`Assoc (Llm_provider.Provider_request_artifact.payload artifact))
+       in
        let url = base_url ^ "/v1/messages" in
        Llm_provider.Http_client.with_post_stream
          ?clock
@@ -168,7 +171,7 @@ let create_message_stream
        |> Result.map (fun response ->
          Llm_provider.Complete_common.attach_output_token_receipt
            response
-           artifact.output_token_receipt)
+           (Llm_provider.Provider_request_artifact.output_token_receipt artifact))
      | Provider.Openai_chat_completions ->
        (* OpenAI-compatible SSE streaming. *)
        let openai_compat_kind = Llm_provider.Provider_config.OpenAI_compat in
@@ -198,7 +201,7 @@ let create_message_stream
                   }))
         | Ok artifact ->
           let body =
-            artifact.payload
+            Llm_provider.Provider_request_artifact.payload artifact
             (* Streaming must request both SSE chunks and usage deltas so the
                accumulator can surface final token/cost metrics. *)
             |> Llm_provider.Http_client.inject_stream_and_options
@@ -259,7 +262,7 @@ let create_message_stream
           |> Result.map (fun response ->
             Llm_provider.Complete_common.attach_output_token_receipt
               response
-              artifact.output_token_receipt))
+              (Llm_provider.Provider_request_artifact.output_token_receipt artifact)))
      | Provider.Custom _ ->
        (* Sync fallback: non-streaming call + synthetic events *)
        (match

--- a/lib/streaming.mli
+++ b/lib/streaming.mli
@@ -51,5 +51,6 @@ val create_message_stream
   -> messages:Types.message list
   -> ?tools:Yojson.Safe.t list
   -> on_event:(Types.sse_event -> unit)
+  -> ?on_output_token_receipt:(Llm_provider.Types.output_token_receipt -> unit)
   -> unit
   -> (Types.api_response, Error.sdk_error) result

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -877,6 +877,43 @@ let test_build_openai_body_kimi_latest_replays_reasoning () =
     (assistant |> member "reasoning_content" |> to_string)
 ;;
 
+let test_build_openai_body_responses_path_uses_responses_envelope () =
+  let provider_config : Provider.config =
+    { provider =
+        Provider.OpenAICompat
+          { base_url = "https://api.openai.com"
+          ; auth_header = None
+          ; path = "/v1/responses"
+          ; static_token = None
+          }
+    ; model_id = "gpt-5.5"
+    ; api_key_env = "OPENAI_API_KEY"
+    }
+  in
+  let state = make_state ~model:provider_config.model_id () in
+  let state = { state with config = { state.config with max_tokens = Some 123 } } in
+  match
+    Api.build_openai_body_artifact_result ~provider_config ~config:state ~messages:[] ()
+  with
+  | Error reason -> fail reason
+  | Ok artifact ->
+    let json =
+      Llm_provider.Provider_request_artifact.payload artifact |> Yojson.Safe.from_string
+    in
+    let open Yojson.Safe.Util in
+    check bool "chat messages absent" true (member_absent json "messages");
+    check bool "responses input present" false (member_absent json "input");
+    check int "responses output cap" 123 (json |> member "max_output_tokens" |> to_int);
+    let receipt = Llm_provider.Provider_request_artifact.output_token_receipt artifact in
+    check
+      bool
+      "responses receipt envelope"
+      true
+      (member "envelope" (Llm_provider.Types.output_token_receipt_to_yojson receipt)
+       = Llm_provider.Types.output_token_envelope_to_yojson
+           Llm_provider.Types.Openai_responses_max_output_tokens)
+;;
+
 let deepseek_provider_config : Provider.config =
   declared_provider_config "api-deepseek-v4" "deepseek-v4-pro"
 ;;
@@ -2553,6 +2590,10 @@ let () =
             "kimi latest replays reasoning"
             `Quick
             test_build_openai_body_kimi_latest_replays_reasoning
+        ; test_case
+            "responses path uses Responses envelope"
+            `Quick
+            test_build_openai_body_responses_path_uses_responses_envelope
         ; test_case
             "deepseek dialect controls"
             `Quick

--- a/test/test_api_http_client.ml
+++ b/test/test_api_http_client.ml
@@ -127,6 +127,23 @@ let test_create_message_uses_hardened_http_client () =
          | Some raw -> int_of_string_opt raw |> Option.value ~default:0 > 0
          | None -> false);
       Alcotest.(check string) "model" "mock" response.model;
+      (match response.telemetry with
+       | Some { output_token_receipt = Some receipt; _ } ->
+         Alcotest.(check (option int))
+           "legacy receipt requested"
+           (Some 16)
+           (output_token_receipt_requested receipt);
+         Alcotest.(check (option int))
+           "legacy receipt effective"
+           (Some 16)
+           (output_token_receipt_effective receipt);
+         Alcotest.(check bool)
+           "legacy receipt envelope"
+           true
+           (Yojson.Safe.Util.member "envelope" (output_token_receipt_to_yojson receipt)
+            = output_token_envelope_to_yojson Openai_chat_max_tokens)
+       | Some { output_token_receipt = None; _ } | None ->
+         Alcotest.fail "expected legacy API output-token receipt");
       Alcotest.(check int)
         "text blocks"
         1

--- a/test/test_api_http_client.ml
+++ b/test/test_api_http_client.ml
@@ -112,7 +112,18 @@ let test_create_message_uses_hardened_http_client () =
         }
       ]
     in
-    match Api.create_message ~sw ~net ~clock ~provider ~config:state ~messages () with
+    let output_token_receipt = ref None in
+    match
+      Api.create_message
+        ~sw
+        ~net
+        ~clock
+        ~provider
+        ~config:state
+        ~messages
+        ~on_output_token_receipt:(fun receipt -> output_token_receipt := Some receipt)
+        ()
+    with
     | Error err -> Alcotest.failf "expected Ok, got %s" (Error.to_string err)
     | Ok response ->
       Alcotest.(check (option string))
@@ -127,8 +138,8 @@ let test_create_message_uses_hardened_http_client () =
          | Some raw -> int_of_string_opt raw |> Option.value ~default:0 > 0
          | None -> false);
       Alcotest.(check string) "model" "mock" response.model;
-      (match response.telemetry with
-       | Some { output_token_receipt = Some receipt; _ } ->
+      (match !output_token_receipt with
+       | Some receipt ->
          Alcotest.(check (option int))
            "legacy receipt requested"
            (Some 16)
@@ -142,8 +153,7 @@ let test_create_message_uses_hardened_http_client () =
            true
            (Yojson.Safe.Util.member "envelope" (output_token_receipt_to_yojson receipt)
             = output_token_envelope_to_yojson Openai_chat_max_tokens)
-       | Some { output_token_receipt = None; _ } | None ->
-         Alcotest.fail "expected legacy API output-token receipt");
+       | None -> Alcotest.fail "expected legacy API output-token receipt");
       Alcotest.(check int)
         "text blocks"
         1

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -205,15 +205,9 @@ let check_typed_empty_completion expected = function
   | Error _ -> fail "expected typed empty completion provider failure"
 ;;
 
-let check_response_output_token_receipt
-      ~requested
-      ~effective
-      ~policy
-      ~envelope
-      (response : Types.api_response)
-  =
-  match response.telemetry with
-  | Some { output_token_receipt = Some receipt; _ } ->
+let check_response_output_token_receipt ~requested ~effective ~policy ~envelope receipt =
+  match receipt with
+  | Some receipt ->
     check
       (option int)
       "receipt requested"
@@ -231,8 +225,7 @@ let check_response_output_token_receipt
       true
       (Yojson.Safe.Util.member "envelope" (Types.output_token_receipt_to_yojson receipt)
        = Types.output_token_envelope_to_yojson envelope)
-  | Some { output_token_receipt = None; _ } | None ->
-    fail "expected OAS-owned output-token receipt in response telemetry"
+  | None -> fail "expected OAS-owned output-token receipt callback"
 ;;
 
 (* ── complete: success ───────────────────────────────── *)
@@ -245,7 +238,16 @@ let test_complete_anthropic_ok () =
     @@ fun sw ->
     let url = start_mock_server ~sw ~net:env#net (anthropic_response "mock response") in
     let config = make_config url in
-    match Complete.complete ~sw ~net:env#net ~config ~messages () with
+    let output_token_receipt = ref None in
+    match
+      Complete.complete
+        ~sw
+        ~net:env#net
+        ~config
+        ~messages
+        ~on_output_token_receipt:(fun receipt -> output_token_receipt := Some receipt)
+        ()
+    with
     | Ok resp ->
       check string "model" "mock" resp.model;
       check_response_output_token_receipt
@@ -253,7 +255,7 @@ let test_complete_anthropic_ok () =
         ~effective:(Some 100)
         ~policy:Types.Explicit
         ~envelope:Types.Anthropic_messages_max_tokens
-        resp;
+        !output_token_receipt;
       let text =
         List.filter_map
           (function
@@ -553,6 +555,7 @@ let test_complete_stream_openai_responses_ok () =
         ()
     in
     let events = ref [] in
+    let output_token_receipt = ref None in
     match
       Complete.complete_stream
         ~sw
@@ -560,6 +563,7 @@ let test_complete_stream_openai_responses_ok () =
         ~config
         ~messages
         ~on_event:(fun evt -> events := evt :: !events)
+        ~on_output_token_receipt:(fun receipt -> output_token_receipt := Some receipt)
         ()
     with
     | Ok resp ->
@@ -571,7 +575,7 @@ let test_complete_stream_openai_responses_ok () =
         ~effective:(Some 100)
         ~policy:Types.Explicit
         ~envelope:Types.Openai_responses_max_output_tokens
-        resp;
+        !output_token_receipt;
       (match resp.content with
        | [ Types.RedactedThinking raw_reasoning; Types.ToolUse { id; name; input } ] ->
          let reasoning = Yojson.Safe.from_string raw_reasoning in
@@ -761,12 +765,34 @@ let test_complete_cache_store_and_hit () =
       ; set = (fun ~key ~ttl_sec:_ value -> Hashtbl.replace store key value)
       }
     in
+    let receipt_count = ref 0 in
+    let on_output_token_receipt _receipt = incr receipt_count in
     (* First call — cache miss, HTTP hit *)
-    (match Complete.complete ~sw ~net:env#net ~config ~messages ~cache () with
-     | Ok _ -> check bool "stored in cache" true (Hashtbl.length store > 0)
+    (match
+       Complete.complete
+         ~sw
+         ~net:env#net
+         ~config
+         ~messages
+         ~cache
+         ~on_output_token_receipt
+         ()
+     with
+     | Ok _ ->
+       check bool "stored in cache" true (Hashtbl.length store > 0);
+       check int "wire receipt emitted once" 1 !receipt_count
      | Error _ -> fail "expected Ok first call");
     (* Second call — cache hit, no HTTP *)
-    match Complete.complete ~sw ~net:env#net ~config ~messages ~cache () with
+    match
+      Complete.complete
+        ~sw
+        ~net:env#net
+        ~config
+        ~messages
+        ~cache
+        ~on_output_token_receipt
+        ()
+    with
     | Ok resp ->
       let text =
         List.filter_map
@@ -777,6 +803,7 @@ let test_complete_cache_store_and_hit () =
         |> String.concat ""
       in
       check string "from cache" "cached" text;
+      check int "cache replay emits no wire receipt" 1 !receipt_count;
       Eio.Switch.fail sw Exit
     | Error _ -> fail "expected Ok second call"
   with
@@ -971,8 +998,24 @@ let test_complete_transport_http_metrics_ok () =
       }
     in
     let transport = make_transport (Ok (mock_transport_response "transport ok")) in
-    match Complete.complete ~sw ~net:env#net ~transport ~config ~messages ~metrics () with
+    let output_token_receipt = ref None in
+    match
+      Complete.complete
+        ~sw
+        ~net:env#net
+        ~transport
+        ~config
+        ~messages
+        ~metrics
+        ~on_output_token_receipt:(fun receipt -> output_token_receipt := Some receipt)
+        ()
+    with
     | Ok _ ->
+      check
+        bool
+        "injected transport emits no wire receipt"
+        true
+        (Option.is_none !output_token_receipt);
       (match !status_calls with
        | [ ("openai_compat", "gpt-4", 200) ] -> Eio.Switch.fail sw Exit
        | [ (_, _, code) ] -> fail (Printf.sprintf "expected 200, got %d" code)

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -205,6 +205,36 @@ let check_typed_empty_completion expected = function
   | Error _ -> fail "expected typed empty completion provider failure"
 ;;
 
+let check_response_output_token_receipt
+      ~requested
+      ~effective
+      ~policy
+      ~envelope
+      (response : Types.api_response)
+  =
+  match response.telemetry with
+  | Some { output_token_receipt = Some receipt; _ } ->
+    check
+      (option int)
+      "receipt requested"
+      requested
+      (Types.output_token_receipt_requested receipt);
+    check
+      (option int)
+      "receipt effective"
+      effective
+      (Types.output_token_receipt_effective receipt);
+    check bool "receipt policy" true (Types.output_token_receipt_policy receipt = policy);
+    check
+      bool
+      "receipt envelope"
+      true
+      (Yojson.Safe.Util.member "envelope" (Types.output_token_receipt_to_yojson receipt)
+       = Types.output_token_envelope_to_yojson envelope)
+  | Some { output_token_receipt = None; _ } | None ->
+    fail "expected OAS-owned output-token receipt in response telemetry"
+;;
+
 (* ── complete: success ───────────────────────────────── *)
 
 let test_complete_anthropic_ok () =
@@ -218,6 +248,12 @@ let test_complete_anthropic_ok () =
     match Complete.complete ~sw ~net:env#net ~config ~messages () with
     | Ok resp ->
       check string "model" "mock" resp.model;
+      check_response_output_token_receipt
+        ~requested:(Some 100)
+        ~effective:(Some 100)
+        ~policy:Types.Explicit
+        ~envelope:Types.Anthropic_messages_max_tokens
+        resp;
       let text =
         List.filter_map
           (function
@@ -530,6 +566,12 @@ let test_complete_stream_openai_responses_ok () =
       check string "stream id" "resp-stream-1" resp.id;
       check bool "stop tool use" true (resp.stop_reason = Types.StopToolUse);
       check bool "events emitted" true (List.length !events >= 5);
+      check_response_output_token_receipt
+        ~requested:(Some 100)
+        ~effective:(Some 100)
+        ~policy:Types.Explicit
+        ~envelope:Types.Openai_responses_max_output_tokens
+        resp;
       (match resp.content with
        | [ Types.RedactedThinking raw_reasoning; Types.ToolUse { id; name; input } ] ->
          let reasoning = Yojson.Safe.from_string raw_reasoning in

--- a/test/test_custom_provider.ml
+++ b/test/test_custom_provider.ml
@@ -1,5 +1,6 @@
 (** Tests for Custom_registered provider variant and registry integration.
-    Registry uses Eio.Mutex, so all registry tests run inside Eio_main.run. *)
+    The registry itself is safe to use without an Eio runtime. Integration tests
+    that exercise provider request paths retain their Eio wrapper. *)
 
 open Agent_sdk
 
@@ -35,7 +36,7 @@ let make_test_impl ?(name = "test-provider") ?(request_path = "/v1/test") ()
   }
 ;;
 
-(* Wrap a test body in Eio_main.run to provide the Eio effect handler *)
+(* Provide the Eio effect handler for provider request-path integration tests. *)
 let with_eio f () = Eio_main.run @@ fun _env -> f ()
 
 let task_testable =
@@ -244,16 +245,13 @@ let () =
   Alcotest.run
     "Custom Provider"
     [ ( "registry"
-      , [ Alcotest.test_case "register and find" `Quick (with_eio test_register_and_find)
-        ; Alcotest.test_case "find unregistered" `Quick (with_eio test_find_unregistered)
+      , [ Alcotest.test_case "register and find" `Quick test_register_and_find
+        ; Alcotest.test_case "find unregistered" `Quick test_find_unregistered
         ; Alcotest.test_case
             "registered_providers listing"
             `Quick
-            (with_eio test_registered_providers_listing)
-        ; Alcotest.test_case
-            "register overwrites"
-            `Quick
-            (with_eio test_register_overwrites)
+            test_registered_providers_listing
+        ; Alcotest.test_case "register overwrites" `Quick test_register_overwrites
         ] )
     ; ( "config"
       , [ Alcotest.test_case "custom_provider default" `Quick test_custom_provider_config

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -999,6 +999,48 @@ let test_provider_config_of_agent_custom_registered_preserves_kind () =
   | Error e -> Alcotest.fail (Printf.sprintf "unexpected error: %s" (Error.to_string e))
 ;;
 
+let test_provider_config_of_agent_runtime_only_preserves_declared_wire () =
+  let name = "provider-config-runtime-only" in
+  let capabilities =
+    { Provider.default_capabilities with supports_native_streaming = false }
+  in
+  let impl : Provider.provider_impl =
+    { name
+    ; request_kind = Provider.Openai_chat_completions
+    ; request_path = "/runtime/chat"
+    ; capabilities
+    ; build_body = (fun ~config:_ ~messages:_ ?tools:_ () -> "{}")
+    ; parse_response =
+        (fun _ ->
+          { id = "runtime-only"
+          ; model = "runtime-model"
+          ; stop_reason = EndTurn
+          ; content = [ Text "ok" ]
+          ; usage = None
+          ; telemetry = None
+          })
+    ; resolve =
+        (fun _ ->
+          Ok ("https://runtime-only.invalid", "", [ "Content-Type", "application/json" ]))
+    }
+  in
+  Provider.register_provider impl;
+  let cfg = Provider.custom_provider ~name ~model_id:"runtime-model" () in
+  let state = agent_state_with_params () in
+  match
+    Provider.provider_config_of_agent ~state ~base_url:"unused-fallback" (Some cfg)
+  with
+  | Ok pc ->
+    Alcotest.(check bool)
+      "runtime wire kind"
+      true
+      (pc.kind = Llm_provider.Provider_config.OpenAI_compat);
+    Alcotest.(check string) "runtime request path" "/runtime/chat" pc.request_path;
+    Alcotest.(check string) "runtime base URL" "https://runtime-only.invalid" pc.base_url
+  | Error error ->
+    Alcotest.failf "runtime-only provider projection failed: %s" (Error.to_string error)
+;;
+
 let test_provider_config_of_agent_custom_registered_kimi_preserves_headers () =
   let env_var = "KIMI_PROVIDER_TEST_KEY" in
   Unix.putenv env_var "kimi-provider-test-key";
@@ -1522,6 +1564,10 @@ let () =
             "custom registered preserves kind (#1003)"
             `Quick
             test_provider_config_of_agent_custom_registered_preserves_kind
+        ; Alcotest.test_case
+            "runtime-only custom preserves declared wire"
+            `Quick
+            test_provider_config_of_agent_runtime_only_preserves_declared_wire
         ; Alcotest.test_case
             "custom registered kimi preserves headers"
             `Quick

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -1082,6 +1082,7 @@ let test_provider_config_of_agent_kimi_default_is_not_output_ceiling () =
       }
     in
     let state = agent_state_with_params () in
+    let state = { state with config = { state.config with max_tokens = None } } in
     match
       Provider.provider_config_of_agent ~state ~base_url:"unused-fallback" (Some cfg)
     with

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -1072,6 +1072,36 @@ let test_provider_config_of_agent_custom_registered_kimi_preserves_headers () =
   | Error e -> Alcotest.fail (Printf.sprintf "unexpected error: %s" (Error.to_string e))
 ;;
 
+let test_provider_config_of_agent_kimi_default_is_not_output_ceiling () =
+  let env_var = "KIMI_PROVIDER_CEILING_TEST_KEY" in
+  with_env env_var (Some "kimi-provider-test-key") (fun () ->
+    let cfg : Provider.config =
+      { provider = Custom_registered { name = "kimi" }
+      ; model_id = "unknown-kimi-model-with-no-catalog-row"
+      ; api_key_env = env_var
+      }
+    in
+    let state = agent_state_with_params () in
+    match
+      Provider.provider_config_of_agent ~state ~base_url:"unused-fallback" (Some cfg)
+    with
+    | Ok pc ->
+      (match pc.model_capabilities_override with
+       | Some caps ->
+         Alcotest.(check (option int))
+           "provider default is not a ceiling"
+           None
+           caps.max_output_tokens
+       | None -> Alcotest.fail "expected non-ceiling provider capability projection");
+      Alcotest.(check bool)
+        "required Messages budget still needs caller or catalog"
+        true
+        (Llm_provider.Backend_anthropic.required_output_token_receipt pc
+         = Error Llm_provider.Types.Required_output_token_catalog_ceiling_missing)
+    | Error error ->
+      Alcotest.failf "Kimi provider projection failed: %s" (Error.to_string error))
+;;
+
 let test_provider_config_of_agent_custom_registered_nous_uses_calltime_default () =
   with_env "LLM_ENDPOINTS" (Some "") (fun () ->
     with_env
@@ -1273,6 +1303,13 @@ let test_provider_config_of_agent_custom_registered_ollama_cloud_unknown_uses_de
         "registry default override is present when no row exists"
         true
         (Option.is_some pc.model_capabilities_override);
+      (match pc.model_capabilities_override with
+       | Some caps ->
+         Alcotest.(check (option int))
+           "provider default does not claim model output ceiling"
+           None
+           caps.max_output_tokens
+       | None -> Alcotest.fail "expected registry default capability projection");
       Alcotest.(check bool)
         "schema request rejected by provider default"
         true
@@ -1572,6 +1609,10 @@ let () =
             "custom registered kimi preserves headers"
             `Quick
             test_provider_config_of_agent_custom_registered_kimi_preserves_headers
+        ; Alcotest.test_case
+            "Kimi provider default is not an output ceiling"
+            `Quick
+            test_provider_config_of_agent_kimi_default_is_not_output_ceiling
         ; Alcotest.test_case
             "custom registered nous uses call-time default"
             `Quick

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -38,6 +38,172 @@ let catalog_capabilities model_id =
   | None -> Alcotest.failf "expected catalog capabilities for %s" model_id
 ;;
 
+let capabilities_with_max_output_tokens max_output_tokens =
+  { Llm_provider.Capabilities.default_capabilities with max_output_tokens }
+;;
+
+let check_receipt
+      ~requested
+      ~effective
+      ~policy
+      ~ceiling
+      ~envelope
+      (receipt : output_token_receipt)
+  =
+  Alcotest.(check (option int))
+    "receipt requested"
+    requested
+    (output_token_receipt_requested receipt);
+  Alcotest.(check (option int))
+    "receipt effective"
+    effective
+    (output_token_receipt_effective receipt);
+  Alcotest.(check bool)
+    "receipt policy"
+    true
+    (output_token_receipt_policy receipt = policy);
+  Alcotest.(check (option int))
+    "receipt ceiling"
+    ceiling
+    (output_token_receipt_ceiling receipt);
+  let json = output_token_receipt_to_yojson receipt in
+  let decoded =
+    match output_token_receipt_of_yojson json with
+    | Ok decoded -> decoded
+    | Error message -> Alcotest.fail message
+  in
+  Alcotest.(check bool)
+    "receipt envelope"
+    true
+    (output_token_receipt_to_yojson decoded = json
+     && Yojson.Safe.Util.member "envelope" json = output_token_envelope_to_yojson envelope
+    )
+;;
+
+let test_output_token_receipt_optional_omission () =
+  let config =
+    PC.make
+      ~kind:OpenAI_compat
+      ~model_id:"receipt-optional-omission"
+      ~base_url:""
+      ~model_capabilities_override:(capabilities_with_max_output_tokens (Some 100))
+      ()
+  in
+  let artifact = BO.build_request_with_receipt ~config ~messages:[ user_msg "hi" ] () in
+  let json = Yojson.Safe.from_string artifact.payload in
+  Alcotest.(check bool)
+    "optional max_tokens omitted"
+    true
+    (Yojson.Safe.Util.member "max_tokens" json = `Null);
+  check_receipt
+    ~requested:None
+    ~effective:None
+    ~policy:Omitted
+    ~ceiling:(Some 100)
+    ~envelope:Openai_chat_max_tokens
+    artifact.output_token_receipt
+;;
+
+let test_output_token_receipt_explicit_exact () =
+  let config =
+    PC.make
+      ~kind:OpenAI_compat
+      ~model_id:"receipt-explicit-exact"
+      ~base_url:""
+      ~max_tokens:80
+      ~model_capabilities_override:(capabilities_with_max_output_tokens (Some 100))
+      ()
+  in
+  let artifact = BOR.build_request_with_receipt ~config ~messages:[ user_msg "hi" ] () in
+  let json = Yojson.Safe.from_string artifact.payload in
+  Alcotest.(check int)
+    "exact max_output_tokens"
+    80
+    Yojson.Safe.Util.(json |> member "max_output_tokens" |> to_int);
+  check_receipt
+    ~requested:(Some 80)
+    ~effective:(Some 80)
+    ~policy:Explicit
+    ~ceiling:(Some 100)
+    ~envelope:Openai_responses_max_output_tokens
+    artifact.output_token_receipt
+;;
+
+let test_output_token_receipt_explicit_clamp () =
+  let config =
+    PC.make
+      ~kind:Gemini
+      ~model_id:"receipt-explicit-clamp"
+      ~base_url:""
+      ~max_tokens:200
+      ~model_capabilities_override:(capabilities_with_max_output_tokens (Some 100))
+      ()
+  in
+  let artifact =
+    BGemini.build_request_with_receipt ~config ~messages:[ user_msg "hi" ] ()
+  in
+  let json = Yojson.Safe.from_string artifact.payload in
+  Alcotest.(check int)
+    "clamped maxOutputTokens"
+    100
+    Yojson.Safe.Util.(
+      json |> member "generationConfig" |> member "maxOutputTokens" |> to_int);
+  check_receipt
+    ~requested:(Some 200)
+    ~effective:(Some 100)
+    ~policy:Explicit_clamped
+    ~ceiling:(Some 100)
+    ~envelope:Gemini_generation_config_max_output_tokens
+    artifact.output_token_receipt
+;;
+
+let test_output_token_receipt_anthropic_required_fallback () =
+  let config =
+    PC.make
+      ~kind:Anthropic
+      ~model_id:"receipt-required-fallback"
+      ~base_url:""
+      ~model_capabilities_override:(capabilities_with_max_output_tokens (Some 100))
+      ()
+  in
+  let artifact = BA.build_request_with_receipt ~config ~messages:[ user_msg "hi" ] () in
+  let json = Yojson.Safe.from_string artifact.payload in
+  Alcotest.(check int)
+    "required max_tokens fallback"
+    100
+    Yojson.Safe.Util.(json |> member "max_tokens" |> to_int);
+  check_receipt
+    ~requested:None
+    ~effective:(Some 100)
+    ~policy:Required_catalog_fallback
+    ~ceiling:(Some 100)
+    ~envelope:Anthropic_messages_max_tokens
+    artifact.output_token_receipt
+;;
+
+let test_output_token_receipt_anthropic_missing_required_ceiling () =
+  let config =
+    PC.make
+      ~kind:Anthropic
+      ~model_id:"receipt-required-missing"
+      ~base_url:""
+      ~model_capabilities_override:(capabilities_with_max_output_tokens None)
+      ()
+  in
+  Alcotest.(check bool)
+    "typed missing required ceiling"
+    true
+    (BA.required_output_token_receipt config = Error Required_output_token_ceiling_missing);
+  Alcotest.check_raises
+    "builder rejects missing required ceiling"
+    (Invalid_argument
+       "Backend_anthropic.required_max_output_tokens: model receipt-required-missing \
+        declares no max_output_tokens and the caller passed none; the Anthropic Messages \
+        API requires max_tokens — declare max_output_tokens in the model catalog or pass \
+        ~max_tokens")
+    (fun () -> ignore (BA.build_request ~config ~messages:[ user_msg "hi" ] ()))
+;;
+
 (* ── Anthropic build_request ─────────────────────────── *)
 
 let test_anthropic_basic_body () =
@@ -1444,7 +1610,20 @@ let () =
   let open Alcotest in
   run
     "provider_complete"
-    [ ( "anthropic_build_request"
+    [ ( "output_token_receipt"
+      , [ test_case "optional omission" `Quick test_output_token_receipt_optional_omission
+        ; test_case "explicit exact" `Quick test_output_token_receipt_explicit_exact
+        ; test_case "explicit clamp" `Quick test_output_token_receipt_explicit_clamp
+        ; test_case
+            "Anthropic required fallback"
+            `Quick
+            test_output_token_receipt_anthropic_required_fallback
+        ; test_case
+            "Anthropic missing required ceiling"
+            `Quick
+            test_output_token_receipt_anthropic_missing_required_ceiling
+        ] )
+    ; ( "anthropic_build_request"
       , [ test_case "basic body" `Quick test_anthropic_basic_body
         ; test_case "with system" `Quick test_anthropic_with_system
         ; test_case "with thinking" `Quick test_anthropic_with_thinking

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -190,6 +190,52 @@ let test_output_token_receipt_anthropic_required_fallback () =
     (Artifact.output_token_receipt artifact)
 ;;
 
+let test_output_token_receipt_anthropic_zero_cache_prewarm () =
+  let config =
+    PC.make
+      ~kind:Anthropic
+      ~model_id:"claude-sonnet-4-6"
+      ~base_url:""
+      ~max_tokens:0
+      ~cache_system_prompt:true
+      ~system_prompt:"cache this system prompt"
+      ()
+  in
+  let artifact =
+    BA.build_request_with_receipt ~config ~messages:[ user_msg "warmup" ] ()
+  in
+  let json = Yojson.Safe.from_string (Artifact.payload artifact) in
+  Alcotest.(check int)
+    "Anthropic cache prewarm max_tokens"
+    0
+    Yojson.Safe.Util.(json |> member "max_tokens" |> to_int);
+  check_receipt
+    ~requested:(Some 0)
+    ~effective:(Some 0)
+    ~policy:Explicit
+    ~ceiling:
+      (Some
+         (match (catalog_capabilities "claude-sonnet-4-6").max_output_tokens with
+          | Some value -> value
+          | None -> Alcotest.fail "catalog model must declare max_output_tokens"))
+    ~ceiling_source:(Some Catalog_model)
+    ~envelope:Anthropic_messages_max_tokens
+    (Artifact.output_token_receipt artifact)
+;;
+
+let test_output_token_receipt_rejects_negative_requested_value () =
+  Alcotest.check_raises
+    "negative requested tokens rejected at construction"
+    (Invalid_argument
+       "optional_output_token_receipt: requested value must be non-negative")
+    (fun () ->
+       ignore
+         (optional_output_token_receipt
+            ~envelope:Openai_chat_max_tokens
+            ~requested:(Some (-1))
+            ~ceiling:None))
+;;
+
 let test_output_token_receipt_ollama_envelope () =
   let config =
     PC.make
@@ -1702,6 +1748,14 @@ let () =
             "Anthropic required fallback"
             `Quick
             test_output_token_receipt_anthropic_required_fallback
+        ; test_case
+            "Anthropic zero-token cache prewarm"
+            `Quick
+            test_output_token_receipt_anthropic_zero_cache_prewarm
+        ; test_case
+            "negative requested tokens rejected"
+            `Quick
+            test_output_token_receipt_rejects_negative_requested_value
         ; test_case
             "Anthropic missing required ceiling"
             `Quick

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -181,6 +181,31 @@ let test_output_token_receipt_anthropic_required_fallback () =
     artifact.output_token_receipt
 ;;
 
+let test_output_token_receipt_ollama_envelope () =
+  let config =
+    PC.make
+      ~kind:Ollama
+      ~model_id:"receipt-ollama-envelope"
+      ~base_url:""
+      ~max_tokens:60
+      ~model_capabilities_override:(capabilities_with_max_output_tokens (Some 100))
+      ()
+  in
+  let artifact = BOL.build_request_with_receipt ~config ~messages:[ user_msg "hi" ] () in
+  let json = Yojson.Safe.from_string artifact.payload in
+  Alcotest.(check int)
+    "Ollama num_predict"
+    60
+    Yojson.Safe.Util.(json |> member "options" |> member "num_predict" |> to_int);
+  check_receipt
+    ~requested:(Some 60)
+    ~effective:(Some 60)
+    ~policy:Explicit
+    ~ceiling:(Some 100)
+    ~envelope:Ollama_options_num_predict
+    artifact.output_token_receipt
+;;
+
 let test_output_token_receipt_anthropic_missing_required_ceiling () =
   let config =
     PC.make
@@ -1614,6 +1639,7 @@ let () =
       , [ test_case "optional omission" `Quick test_output_token_receipt_optional_omission
         ; test_case "explicit exact" `Quick test_output_token_receipt_explicit_exact
         ; test_case "explicit clamp" `Quick test_output_token_receipt_explicit_clamp
+        ; test_case "Ollama envelope" `Quick test_output_token_receipt_ollama_envelope
         ; test_case
             "Anthropic required fallback"
             `Quick

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -1259,7 +1259,7 @@ let test_config_default_paths () =
   let anth = PC.make ~kind:Anthropic ~model_id:"m" ~base_url:"" () in
   Alcotest.(check string) "anthropic path" "/v1/messages" anth.request_path;
   let kimi = PC.make ~kind:Kimi ~model_id:"m" ~base_url:"" () in
-  Alcotest.(check string) "kimi path" "/v1/chat/completions" kimi.request_path;
+  Alcotest.(check string) "kimi path" "/v1/messages" kimi.request_path;
   let oai = PC.make ~kind:OpenAI_compat ~model_id:"m" ~base_url:"" () in
   Alcotest.(check string) "openai path" "/v1/chat/completions" oai.request_path
 ;;

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -7,6 +7,7 @@ module BOR = Llm_provider.Backend_openai_responses
 module BGlm = Llm_provider.Backend_glm
 module BOL = Llm_provider.Backend_ollama
 module BGemini = Llm_provider.Backend_gemini
+module Artifact = Llm_provider.Provider_request_artifact
 open Llm_provider.Types
 
 let () =
@@ -90,7 +91,7 @@ let test_output_token_receipt_optional_omission () =
       ()
   in
   let artifact = BO.build_request_with_receipt ~config ~messages:[ user_msg "hi" ] () in
-  let json = Yojson.Safe.from_string artifact.payload in
+  let json = Yojson.Safe.from_string (Artifact.payload artifact) in
   Alcotest.(check bool)
     "optional max_tokens omitted"
     true
@@ -101,7 +102,7 @@ let test_output_token_receipt_optional_omission () =
     ~policy:Omitted
     ~ceiling:(Some 100)
     ~envelope:Openai_chat_max_tokens
-    artifact.output_token_receipt
+    (Artifact.output_token_receipt artifact)
 ;;
 
 let test_output_token_receipt_explicit_exact () =
@@ -115,7 +116,7 @@ let test_output_token_receipt_explicit_exact () =
       ()
   in
   let artifact = BOR.build_request_with_receipt ~config ~messages:[ user_msg "hi" ] () in
-  let json = Yojson.Safe.from_string artifact.payload in
+  let json = Yojson.Safe.from_string (Artifact.payload artifact) in
   Alcotest.(check int)
     "exact max_output_tokens"
     80
@@ -126,7 +127,7 @@ let test_output_token_receipt_explicit_exact () =
     ~policy:Explicit
     ~ceiling:(Some 100)
     ~envelope:Openai_responses_max_output_tokens
-    artifact.output_token_receipt
+    (Artifact.output_token_receipt artifact)
 ;;
 
 let test_output_token_receipt_explicit_clamp () =
@@ -142,7 +143,7 @@ let test_output_token_receipt_explicit_clamp () =
   let artifact =
     BGemini.build_request_with_receipt ~config ~messages:[ user_msg "hi" ] ()
   in
-  let json = Yojson.Safe.from_string artifact.payload in
+  let json = Yojson.Safe.from_string (Artifact.payload artifact) in
   Alcotest.(check int)
     "clamped maxOutputTokens"
     100
@@ -154,7 +155,7 @@ let test_output_token_receipt_explicit_clamp () =
     ~policy:Explicit_clamped
     ~ceiling:(Some 100)
     ~envelope:Gemini_generation_config_max_output_tokens
-    artifact.output_token_receipt
+    (Artifact.output_token_receipt artifact)
 ;;
 
 let test_output_token_receipt_anthropic_required_fallback () =
@@ -167,7 +168,7 @@ let test_output_token_receipt_anthropic_required_fallback () =
       ()
   in
   let artifact = BA.build_request_with_receipt ~config ~messages:[ user_msg "hi" ] () in
-  let json = Yojson.Safe.from_string artifact.payload in
+  let json = Yojson.Safe.from_string (Artifact.payload artifact) in
   Alcotest.(check int)
     "required max_tokens fallback"
     100
@@ -178,7 +179,7 @@ let test_output_token_receipt_anthropic_required_fallback () =
     ~policy:Required_catalog_fallback
     ~ceiling:(Some 100)
     ~envelope:Anthropic_messages_max_tokens
-    artifact.output_token_receipt
+    (Artifact.output_token_receipt artifact)
 ;;
 
 let test_output_token_receipt_ollama_envelope () =
@@ -192,7 +193,7 @@ let test_output_token_receipt_ollama_envelope () =
       ()
   in
   let artifact = BOL.build_request_with_receipt ~config ~messages:[ user_msg "hi" ] () in
-  let json = Yojson.Safe.from_string artifact.payload in
+  let json = Yojson.Safe.from_string (Artifact.payload artifact) in
   Alcotest.(check int)
     "Ollama num_predict"
     60
@@ -203,7 +204,7 @@ let test_output_token_receipt_ollama_envelope () =
     ~policy:Explicit
     ~ceiling:(Some 100)
     ~envelope:Ollama_options_num_predict
-    artifact.output_token_receipt
+    (Artifact.output_token_receipt artifact)
 ;;
 
 let test_output_token_receipt_anthropic_missing_required_ceiling () =

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -48,6 +48,7 @@ let check_receipt
       ~effective
       ~policy
       ~ceiling
+      ~ceiling_source
       ~envelope
       (receipt : output_token_receipt)
   =
@@ -67,6 +68,10 @@ let check_receipt
     "receipt ceiling"
     ceiling
     (output_token_receipt_ceiling receipt);
+  Alcotest.(check bool)
+    "receipt ceiling source"
+    true
+    (output_token_receipt_ceiling_source receipt = ceiling_source);
   let json = output_token_receipt_to_yojson receipt in
   let decoded =
     match output_token_receipt_of_yojson json with
@@ -101,6 +106,7 @@ let test_output_token_receipt_optional_omission () =
     ~effective:None
     ~policy:Omitted
     ~ceiling:(Some 100)
+    ~ceiling_source:(Some Declared_capability_override)
     ~envelope:Openai_chat_max_tokens
     (Artifact.output_token_receipt artifact)
 ;;
@@ -126,6 +132,7 @@ let test_output_token_receipt_explicit_exact () =
     ~effective:(Some 80)
     ~policy:Explicit
     ~ceiling:(Some 100)
+    ~ceiling_source:(Some Declared_capability_override)
     ~envelope:Openai_responses_max_output_tokens
     (Artifact.output_token_receipt artifact)
 ;;
@@ -154,30 +161,31 @@ let test_output_token_receipt_explicit_clamp () =
     ~effective:(Some 100)
     ~policy:Explicit_clamped
     ~ceiling:(Some 100)
+    ~ceiling_source:(Some Declared_capability_override)
     ~envelope:Gemini_generation_config_max_output_tokens
     (Artifact.output_token_receipt artifact)
 ;;
 
 let test_output_token_receipt_anthropic_required_fallback () =
-  let config =
-    PC.make
-      ~kind:Anthropic
-      ~model_id:"receipt-required-fallback"
-      ~base_url:""
-      ~model_capabilities_override:(capabilities_with_max_output_tokens (Some 100))
-      ()
+  let model_id = "claude-sonnet-4-6" in
+  let ceiling =
+    match (catalog_capabilities model_id).max_output_tokens with
+    | Some value -> value
+    | None -> Alcotest.fail "catalog model must declare max_output_tokens"
   in
+  let config = PC.make ~kind:Anthropic ~model_id ~base_url:"" () in
   let artifact = BA.build_request_with_receipt ~config ~messages:[ user_msg "hi" ] () in
   let json = Yojson.Safe.from_string (Artifact.payload artifact) in
   Alcotest.(check int)
     "required max_tokens fallback"
-    100
+    ceiling
     Yojson.Safe.Util.(json |> member "max_tokens" |> to_int);
   check_receipt
     ~requested:None
-    ~effective:(Some 100)
+    ~effective:(Some ceiling)
     ~policy:Required_catalog_fallback
-    ~ceiling:(Some 100)
+    ~ceiling:(Some ceiling)
+    ~ceiling_source:(Some Catalog_model)
     ~envelope:Anthropic_messages_max_tokens
     (Artifact.output_token_receipt artifact)
 ;;
@@ -203,23 +211,20 @@ let test_output_token_receipt_ollama_envelope () =
     ~effective:(Some 60)
     ~policy:Explicit
     ~ceiling:(Some 100)
+    ~ceiling_source:(Some Declared_capability_override)
     ~envelope:Ollama_options_num_predict
     (Artifact.output_token_receipt artifact)
 ;;
 
 let test_output_token_receipt_anthropic_missing_required_ceiling () =
   let config =
-    PC.make
-      ~kind:Anthropic
-      ~model_id:"receipt-required-missing"
-      ~base_url:""
-      ~model_capabilities_override:(capabilities_with_max_output_tokens None)
-      ()
+    PC.make ~kind:Anthropic ~model_id:"receipt-required-missing" ~base_url:"" ()
   in
   Alcotest.(check bool)
     "typed missing required ceiling"
     true
-    (BA.required_output_token_receipt config = Error Required_output_token_ceiling_missing);
+    (BA.required_output_token_receipt config
+     = Error Required_output_token_catalog_ceiling_missing);
   Alcotest.check_raises
     "builder rejects missing required ceiling"
     (Invalid_argument
@@ -228,6 +233,50 @@ let test_output_token_receipt_anthropic_missing_required_ceiling () =
         API requires max_tokens — declare max_output_tokens in the model catalog or pass \
         ~max_tokens")
     (fun () -> ignore (BA.build_request ~config ~messages:[ user_msg "hi" ] ()))
+;;
+
+let test_provider_default_ceiling_does_not_clamp_unknown_model () =
+  let config =
+    PC.make
+      ~kind:Gemini
+      ~model_id:"receipt-unknown-gemini"
+      ~base_url:""
+      ~max_tokens:70_000
+      ()
+  in
+  let artifact =
+    BGemini.build_request_with_receipt ~config ~messages:[ user_msg "hi" ] ()
+  in
+  let json = Yojson.Safe.from_string (Artifact.payload artifact) in
+  Alcotest.(check int)
+    "unknown model keeps explicit caller value"
+    70_000
+    Yojson.Safe.Util.(
+      json |> member "generationConfig" |> member "maxOutputTokens" |> to_int);
+  check_receipt
+    ~requested:(Some 70_000)
+    ~effective:(Some 70_000)
+    ~policy:Explicit
+    ~ceiling:None
+    ~ceiling_source:None
+    ~envelope:Gemini_generation_config_max_output_tokens
+    (Artifact.output_token_receipt artifact)
+;;
+
+let test_declared_override_is_not_anthropic_catalog_fallback () =
+  let config =
+    PC.make
+      ~kind:Anthropic
+      ~model_id:"receipt-declared-override-no-fallback"
+      ~base_url:""
+      ~model_capabilities_override:(capabilities_with_max_output_tokens (Some 100))
+      ()
+  in
+  Alcotest.(check bool)
+    "declared override cannot impersonate catalog fallback"
+    true
+    (BA.required_output_token_receipt config
+     = Error Required_output_token_catalog_ceiling_missing)
 ;;
 
 (* ── Anthropic build_request ─────────────────────────── *)
@@ -362,7 +411,7 @@ let test_anthropic_thinking_forced_tool_choice_rejected_before_request () =
 ;;
 
 let test_anthropic_stream_flag () =
-  let config = PC.make ~kind:Anthropic ~model_id:"m" ~base_url:"" () in
+  let config = PC.make ~kind:Anthropic ~model_id:"m" ~base_url:"" ~max_tokens:128 () in
   let body = BA.build_request ~stream:true ~config ~messages:[ user_msg "hi" ] () in
   let json = Yojson.Safe.from_string body in
   let open Yojson.Safe.Util in
@@ -1562,6 +1611,7 @@ let test_cache_short_prompt_preserves_opt_in () =
       ~kind:Anthropic
       ~model_id:"m"
       ~base_url:""
+      ~max_tokens:128
       ~system_prompt:"Short."
       ~cache_system_prompt:true
       ()
@@ -1585,6 +1635,7 @@ let test_cache_no_system_no_cache () =
       ~kind:Anthropic
       ~model_id:"m"
       ~base_url:""
+      ~max_tokens:128
       ~system_prompt:"Hello."
       ~cache_system_prompt:false
       ()
@@ -1601,7 +1652,13 @@ let test_cache_no_system_no_cache () =
 
 let test_cache_tools () =
   let config =
-    PC.make ~kind:Anthropic ~model_id:"m" ~base_url:"" ~cache_system_prompt:true ()
+    PC.make
+      ~kind:Anthropic
+      ~model_id:"m"
+      ~base_url:""
+      ~max_tokens:128
+      ~cache_system_prompt:true
+      ()
   in
   let tool1 = `Assoc [ "name", `String "a"; "description", `String "tool a" ] in
   let tool2 = `Assoc [ "name", `String "b"; "description", `String "tool b" ] in
@@ -1649,6 +1706,14 @@ let () =
             "Anthropic missing required ceiling"
             `Quick
             test_output_token_receipt_anthropic_missing_required_ceiling
+        ; test_case
+            "provider default does not clamp unknown model"
+            `Quick
+            test_provider_default_ceiling_does_not_clamp_unknown_model
+        ; test_case
+            "declared override is not catalog fallback"
+            `Quick
+            test_declared_override_is_not_anthropic_catalog_fallback
         ] )
     ; ( "anthropic_build_request"
       , [ test_case "basic body" `Quick test_anthropic_basic_body

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -51,7 +51,7 @@ let test_request_path_anthropic () =
 
 let test_request_path_provider_c () =
   let cfg = Provider_config.make ~kind:Kimi ~model_id:"m" ~base_url:"" () in
-  check_string "kimi path" "/v1/chat/completions" cfg.request_path
+  check_string "kimi path" "/v1/messages" cfg.request_path
 ;;
 
 let test_request_path_openai () =
@@ -89,6 +89,33 @@ let test_request_path_override () =
       ()
   in
   check_string "custom path" "/custom/path" cfg.request_path
+;;
+
+let test_http_codec_is_typed_from_kind_and_path () =
+  let codec ?request_path kind =
+    Provider_config.make ?request_path ~kind ~model_id:"m" ~base_url:"" ()
+    |> Provider_config.http_codec
+  in
+  let check label expected actual =
+    Alcotest.(check bool) label true (expected = actual)
+  in
+  check "Anthropic Messages" Provider_config.Anthropic_messages_codec (codec Anthropic);
+  check
+    "Kimi direct uses Anthropic Messages"
+    Provider_config.Anthropic_messages_codec
+    (codec Kimi);
+  check "OpenAI chat" Provider_config.Openai_chat_codec (codec OpenAI_compat);
+  check
+    "OpenAI Responses"
+    Provider_config.Openai_responses_codec
+    (codec ~request_path:"/v1/responses" OpenAI_compat);
+  check "Ollama native" Provider_config.Ollama_chat_codec (codec Ollama);
+  check
+    "Gemini generateContent"
+    Provider_config.Gemini_generate_content_codec
+    (codec Gemini);
+  check "GLM chat" Provider_config.Glm_chat_codec (codec Glm);
+  check "DashScope chat" Provider_config.Openai_chat_codec (codec DashScope)
 ;;
 
 (* ── auth headers ────────────────────────────────────── *)
@@ -2201,6 +2228,10 @@ let () =
         ; Alcotest.test_case "ollama" `Quick test_request_path_ollama
         ; Alcotest.test_case "dashscope" `Quick test_request_path_dashscope
         ; Alcotest.test_case "override" `Quick test_request_path_override
+        ; Alcotest.test_case
+            "typed HTTP codec"
+            `Quick
+            test_http_codec_is_typed_from_kind_and_path
         ] )
     ; ( "auth_headers"
       , [ Alcotest.test_case

--- a/test/test_streaming_e2e.ml
+++ b/test/test_streaming_e2e.ml
@@ -35,6 +35,7 @@ let test_stream_basic () =
   (* Collect SSE events *)
   let events = ref [] in
   let text_buf = Buffer.create 256 in
+  let output_token_receipt = ref None in
   let on_event ev =
     events := ev :: !events;
     match ev with
@@ -51,6 +52,7 @@ let test_stream_basic () =
       ~config:state
       ~messages
       ~on_event
+      ~on_output_token_receipt:(fun receipt -> output_token_receipt := Some receipt)
       ()
   with
   | Ok resp ->
@@ -61,12 +63,11 @@ let test_stream_basic () =
     Printf.printf "Response id: %s\n%!" resp.Types.id;
     Printf.printf "Response model: %s\n%!" resp.Types.model;
     Printf.printf "Content blocks: %d\n%!" (List.length resp.Types.content);
-    (match resp.Types.telemetry with
-     | Some { Types.output_token_receipt = Some receipt; _ } ->
+    (match !output_token_receipt with
+     | Some receipt ->
        assert (Types.output_token_receipt_requested receipt = Some 200);
        assert (Types.output_token_receipt_effective receipt = Some 200)
-     | Some { Types.output_token_receipt = None; _ } | None ->
-       failwith "stream response is missing the OAS output-token receipt");
+     | None -> failwith "stream request did not emit the OAS output-token receipt");
     (* Verify we got events *)
     assert (event_count > 0);
     (* Verify accumulated text is non-empty *)

--- a/test/test_streaming_e2e.ml
+++ b/test/test_streaming_e2e.ml
@@ -61,6 +61,12 @@ let test_stream_basic () =
     Printf.printf "Response id: %s\n%!" resp.Types.id;
     Printf.printf "Response model: %s\n%!" resp.Types.model;
     Printf.printf "Content blocks: %d\n%!" (List.length resp.Types.content);
+    (match resp.Types.telemetry with
+     | Some { Types.output_token_receipt = Some receipt; _ } ->
+       assert (Types.output_token_receipt_requested receipt = Some 200);
+       assert (Types.output_token_receipt_effective receipt = Some 200)
+     | Some { Types.output_token_receipt = None; _ } | None ->
+       failwith "stream response is missing the OAS output-token receipt");
     (* Verify we got events *)
     assert (event_count > 0);
     (* Verify accumulated text is non-empty *)

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -592,7 +592,6 @@ let test_usage_and_inference_telemetry_yojson_roundtrip () =
     ; provider_internal_action_count = Some 2
     ; ttfrc_ms = Some 10.0
     ; prefill_ms = Some 11.0
-    ; output_token_receipt = None
     }
   in
   match
@@ -631,10 +630,6 @@ let test_default_inference_telemetry () =
     None
     telemetry.peak_memory_gb;
   Alcotest.(check bool)
-    "default output-token receipt unknown"
-    true
-    (Option.is_none telemetry.output_token_receipt);
-  Alcotest.(check bool)
     "default provider kind unknown"
     true
     (Option.is_none telemetry.provider_kind);
@@ -659,22 +654,6 @@ let test_default_inference_telemetry () =
     "default prefill unknown"
     None
     telemetry.prefill_ms
-;;
-
-let test_inference_telemetry_missing_output_receipt_defaults_to_none () =
-  let json =
-    match Types.inference_telemetry_to_yojson Types.default_inference_telemetry with
-    | `Assoc fields -> `Assoc (List.remove_assoc "output_token_receipt" fields)
-    | (`List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null) as
-      unexpected -> unexpected
-  in
-  match Types.inference_telemetry_of_yojson json with
-  | Ok telemetry ->
-    Alcotest.(check bool)
-      "missing receipt is backward-compatible None"
-      true
-      (Option.is_none telemetry.output_token_receipt)
-  | Error message -> Alcotest.fail message
 ;;
 
 (* ── role_of_string ──────────────────────────────────────── *)
@@ -1254,10 +1233,6 @@ let () =
             "default inference telemetry"
             `Quick
             test_default_inference_telemetry
-        ; Alcotest.test_case
-            "missing output receipt defaults to none"
-            `Quick
-            test_inference_telemetry_missing_output_receipt_defaults_to_none
         ] )
     ; ( "config"
       , [ Alcotest.test_case "default_config" `Quick test_default_config

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -592,6 +592,7 @@ let test_usage_and_inference_telemetry_yojson_roundtrip () =
     ; provider_internal_action_count = Some 2
     ; ttfrc_ms = Some 10.0
     ; prefill_ms = Some 11.0
+    ; output_token_receipt = None
     }
   in
   match
@@ -630,6 +631,10 @@ let test_default_inference_telemetry () =
     None
     telemetry.peak_memory_gb;
   Alcotest.(check bool)
+    "default output-token receipt unknown"
+    true
+    (Option.is_none telemetry.output_token_receipt);
+  Alcotest.(check bool)
     "default provider kind unknown"
     true
     (Option.is_none telemetry.provider_kind);
@@ -654,6 +659,22 @@ let test_default_inference_telemetry () =
     "default prefill unknown"
     None
     telemetry.prefill_ms
+;;
+
+let test_inference_telemetry_missing_output_receipt_defaults_to_none () =
+  let json =
+    match Types.inference_telemetry_to_yojson Types.default_inference_telemetry with
+    | `Assoc fields -> `Assoc (List.remove_assoc "output_token_receipt" fields)
+    | (`List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null) as
+      unexpected -> unexpected
+  in
+  match Types.inference_telemetry_of_yojson json with
+  | Ok telemetry ->
+    Alcotest.(check bool)
+      "missing receipt is backward-compatible None"
+      true
+      (Option.is_none telemetry.output_token_receipt)
+  | Error message -> Alcotest.fail message
 ;;
 
 (* ── role_of_string ──────────────────────────────────────── *)
@@ -1233,6 +1254,10 @@ let () =
             "default inference telemetry"
             `Quick
             test_default_inference_telemetry
+        ; Alcotest.test_case
+            "missing output receipt defaults to none"
+            `Quick
+            test_inference_telemetry_missing_output_receipt_defaults_to_none
         ] )
     ; ( "config"
       , [ Alcotest.test_case "default_config" `Quick test_default_config


### PR DESCRIPTION
## Summary

- add a construction-controlled output-token receipt with requested/effective values, closed policy, catalog ceiling, and typed wire-envelope identity
- pair every OAS-owned provider request payload with that exact receipt in one immutable artifact
- carry the artifact through native `Llm_provider` and Agent SDK compatibility sync/stream paths
- preserve the existing simple `build_request -> string` and `build_openai_body -> string` APIs as payload-only projections
- leave receipt absent for opaque custom transports and cache replays, where OAS did not build a provider wire request

## Root cause

OAS owned output-token omission, clamping, and Anthropic required-envelope fallback, but request builders returned only strings. Telemetry later had only caller config and could not prove what the wire serializer emitted. Recomputing in telemetry would create a second policy authority.

## Design

- closed envelopes: OpenAI Chat `max_tokens`, OpenAI Responses `max_output_tokens`, Anthropic Messages `max_tokens`, Gemini `generationConfig.maxOutputTokens`, Ollama `options.num_predict`
- internally valid-by-construction resolution sum; flat validated JSON projection for downstream observation
- receipt-aware builders return `{ payload; output_token_receipt }`; compatibility builders discard only the receipt, never recompute it
- native HTTP response parsing attaches the same artifact receipt before responses cross transport boundaries; later latency/provider telemetry patching preserves it
- old telemetry JSON without the new optional field decodes as `None`

## Verification

- focused policy coverage: optional omission, explicit exact, explicit clamp, Anthropic catalog fallback, missing required ceiling
- sync and streaming response telemetry coverage for native `Llm_provider`
- legacy Agent SDK HTTP path receipt coverage; live streaming contract assertion added
- exact-head OCaml parse, `ocamlformat`, `git diff --check`: pass
- code-smell, hardening, core/CDAL boundary, SDK independence, reasoning-effort SSOT ratchets: pass
- local Dune build/test intentionally not run; PR CI is the build authority

## Current provider evidence

- [근거] OpenAI Responses `max_output_tokens`: https://developers.openai.com/api/reference/resources/responses/methods/create — 확인일시 2026-07-11 17:59 KST — 신뢰도 High
- [근거] Anthropic Messages `max_tokens`: https://platform.claude.com/docs/en/api/go/messages/create — 확인일시 2026-07-11 17:59 KST — 신뢰도 High
- [근거] Gemini optional/model-defaulted `maxOutputTokens`: https://ai.google.dev/api/generate-content — 확인일시 2026-07-11 17:59 KST — 신뢰도 High
- [근거] Ollama request `options` and `num_predict`: https://docs.ollama.com/api/chat and https://docs.ollama.com/modelfile — 확인일시 2026-07-11 17:59 KST — 신뢰도 High

Separate discovered cache-identity defect: jeong-sik/masc#27906.

Closes jeong-sik/masc#27905.

## Merge gate

Draft until full CI type/build/test truth and adversarial review are complete.
