### PR TITLE
fix(reasoning): capture Qwen3.6 streamed thinking

### DIFF
--- a/models.toml
+++ b/models.toml
@@ -1942,6 +1942,8 @@ supports_reasoning = true
 supports_extended_thinking = true
 thinking_control_format = "chat_template_kwargs"
 preserve_thinking_control_format = "chat_template_kwargs_preserve_thinking"
+reasoning_streaming_format = "delta:reasoning_content"
+reasoning_replay = "drop_without_tool_preserve_with_tool"
 supports_response_format_json = true
 supports_structured_output = true
 supports_native_streaming = true
@@ -1969,6 +1971,8 @@ supports_extended_thinking = true
 supports_reasoning_budget = true
 thinking_control_format = "chat_template_kwargs"
 preserve_thinking_control_format = "chat_template_kwargs_preserve_thinking"
+reasoning_streaming_format = "delta:reasoning_content"
+reasoning_replay = "drop_without_tool_preserve_with_tool"
 supports_native_streaming = true
 
 [[models]]
@@ -1983,6 +1987,8 @@ supports_extended_thinking = true
 supports_reasoning_budget = true
 thinking_control_format = "chat_template_kwargs"
 preserve_thinking_control_format = "chat_template_kwargs_preserve_thinking"
+reasoning_streaming_format = "delta:reasoning_content"
+reasoning_replay = "drop_without_tool_preserve_with_tool"
 supports_native_streaming = true
 
 # Llama Models

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -546,7 +546,20 @@ let test_lookup_provider_m_qwen3_mtp_dot_name () =
       bool
       "vllm-qwen3-mtp dot-qualified qwen3.6 uses chat_template_kwargs"
       true
-      (c.thinking_control_format = Capabilities.Chat_template_kwargs)
+      (c.thinking_control_format = Capabilities.Chat_template_kwargs);
+    let dialect = Reasoning_dialect.of_capabilities c in
+    (match dialect.streaming with
+     | Reasoning_dialect.Delta_field field ->
+       check string "vllm-qwen3-mtp reasoning delta field" "reasoning_content" field
+     | Reasoning_dialect.No_streaming_reasoning
+     | Reasoning_dialect.Delta_reasoning_details
+     | Reasoning_dialect.Template_parser ->
+       fail "vllm-qwen3-mtp should stream reasoning_content as a typed delta field");
+    check
+      string
+      "vllm-qwen3-mtp replays tool-call reasoning by default"
+      "drop_without_tool_preserve_with_tool"
+      (Reasoning_dialect.replay_policy_to_string dialect.replay_policy)
   | None -> fail "should match dot-qualified qwen3.6 model id"
 ;;
 
@@ -1366,8 +1379,8 @@ let test_frontier_grouped_tool_thinking_provider_contracts () =
       , "qwen/qwen3.6-35b-a3b"
       , Extended_thinking
       , Response_format_json_schema
-      , Replay_not_required
-      , Template_stream )
+      , Replay_tool_turn_only
+      , Delta_stream "reasoning_content" )
     ; ( "Ollama Cloud Qwen3.5"
       , Provider_qualified "ollama_cloud"
       , "qwen3.5:397b"

--- a/test/test_provider_agnostic_reasoning_replay.ml
+++ b/test/test_provider_agnostic_reasoning_replay.ml
@@ -247,6 +247,11 @@ let test_representative_provider_replay_semantics_are_explicit () =
       , false
       , true
       , "DeepSeek-style thinking object replays only assistant tool-call reasoning" )
+    ; ( "model:qwen/qwen3.6-35b-a3b"
+      , "drop_without_tool_preserve_with_tool"
+      , false
+      , true
+      , "Qwen3.6 replays tool-call reasoning while dropping plain-turn reasoning" )
     ; ( "model:kimi-k2.7-code"
       , "preserve_always"
       , true

--- a/test/test_thinking_control_dialects.ml
+++ b/test/test_thinking_control_dialects.ml
@@ -129,6 +129,8 @@ let declared_qwen_openai_compat_capabilities =
   ; supports_reasoning_budget = true
   ; thinking_control_format = CAP.Chat_template_kwargs
   ; preserve_thinking_control_format = CAP.Chat_template_kwargs_preserve_thinking
+  ; reasoning_streaming_format = CAP.Delta_reasoning_field "reasoning_content"
+  ; reasoning_replay_override = CAP.Force_drop_without_tool_preserve_with_tool
   }
 ;;
 
@@ -276,7 +278,7 @@ let test_declared_qwen36_reasoning_dialect_uses_chat_template_kwargs () =
     (sampling_parameter_names (RD.sampling_params_ignored_when_thinking dialect))
 ;;
 
-let test_qwen36_reasoning_dialect_without_preserve_drops_reasoning () =
+let test_qwen36_reasoning_dialect_without_preserve_keeps_tool_reasoning () =
   let config =
     declared_qwen_openai_compat_config
       ~enable_thinking:true
@@ -287,8 +289,18 @@ let test_qwen36_reasoning_dialect_without_preserve_drops_reasoning () =
   check
     string
     "replay policy"
-    "no_replay"
-    (RD.replay_policy_to_string dialect.replay_policy)
+    "drop_without_tool_preserve_with_tool"
+    (RD.replay_policy_to_string dialect.replay_policy);
+  check
+    bool
+    "plain assistant reasoning is omitted"
+    false
+    (RD.should_replay_reasoning dialect ~assistant_had_tool_call:false);
+  check
+    bool
+    "assistant tool-call reasoning is retained"
+    true
+    (RD.should_replay_reasoning dialect ~assistant_had_tool_call:true)
 ;;
 
 let test_qwen36_dashscope_uses_top_level_enable_thinking () =
@@ -721,6 +733,37 @@ let test_qwen_preserve_replays_reasoning_content () =
     "reasoning_content"
     "plain thought"
     (assistant |> member "reasoning_content" |> to_string)
+;;
+
+let test_qwen_reasoning_content_streams_as_typed_thinking () =
+  let config =
+    declared_qwen_openai_compat_config
+      ~enable_thinking:true
+      ~preserve_thinking:false
+      "Qwen/Qwen3.6-35B-A3B"
+  in
+  let dialect = RD.for_provider_config config in
+  let raw =
+    {|{"id":"qwen-live-1","model":"Qwen3.6-35B-A3B","choices":[{"index":0,"delta":{"reasoning_content":"inspect repository"},"finish_reason":null}]}|}
+  in
+  let chunk =
+    match S.parse_openai_sse_chunk ~streaming_reasoning:dialect.streaming raw with
+    | Some chunk -> chunk
+    | None -> fail "expected Qwen reasoning_content SSE chunk"
+  in
+  check
+    (option string)
+    "typed reasoning delta"
+    (Some "inspect repository")
+    chunk.delta_reasoning;
+  check (option string) "reasoning is not visible content" None chunk.delta_content;
+  let state = S.create_openai_stream_state () in
+  let events, _ = S.openai_chunk_to_events state chunk in
+  match events with
+  | [ ContentBlockStart { index = 0; content_type = "thinking"; _ }
+    ; ContentBlockDelta { index = 0; delta = ThinkingDelta "inspect repository" }
+    ] -> ()
+  | _ -> fail "expected Qwen reasoning_content to become a typed Thinking block"
 ;;
 
 let keep_all_axis_manifest =
@@ -1254,9 +1297,9 @@ let () =
               `Quick
               test_declared_qwen36_reasoning_dialect_uses_chat_template_kwargs
           ; test_case
-              "declared qwen3.6 dialect without preserve drops reasoning"
+              "declared qwen3.6 dialect keeps tool reasoning"
               `Quick
-              test_qwen36_reasoning_dialect_without_preserve_drops_reasoning
+              test_qwen36_reasoning_dialect_without_preserve_keeps_tool_reasoning
           ; test_case
               "qwen3.6 dashscope uses top-level enable_thinking"
               `Quick
@@ -1309,6 +1352,10 @@ let () =
               "qwen preserve replays reasoning_content"
               `Quick
               test_qwen_preserve_replays_reasoning_content
+          ; test_case
+              "qwen reasoning_content streams as typed thinking"
+              `Quick
+              test_qwen_reasoning_content_streams_as_typed_thinking
           ; test_case
               "thinking_object_keep_all axis uses thinking keep all"
               `Quick


### PR DESCRIPTION
## Problem

The Qwen3.6 Chat Completions catalog used `thinking_control_format = chat_template_kwargs`, whose default streaming dialect is `Template_parser`. That parser is currently a no-op. The live llama.cpp endpoint emits Qwen reasoning in `delta.reasoning_content`, so OAS reported `thinking_present=false` for every subturn and did not carry the reasoning block into the next tool round.

This keeps request control and response carrier as separate typed axes. It does not add model-name branching or parse `<think>` strings.

## Contract

- declare `reasoning_streaming_format = delta:reasoning_content` for the explicit Qwen3.6/self-hosted catalog rows
- declare `reasoning_replay = drop_without_tool_preserve_with_tool` so default Qwen tool rounds retain typed reasoning while plain completed turns do not
- keep `preserve_thinking=true` as the existing explicit opt-in that promotes replay to all history
- prove raw `reasoning_content` SSE becomes `ThinkingDelta`, never visible `TextDelta`
- prove the provider-qualified MTP row and direct Qwen3.6 row resolve the same carrier/replay contract

Qwen’s official model card says default template behavior retains thinking generated while handling the latest user message, while `preserve_thinking=true` opts into all historical reasoning. The official chat template performs that history scoping. llama.cpp documents `reasoning_content` as its parsed reasoning response field.

## Incident evidence

For the 2026-07-11 sangsu RunPod turn, OAS turns 21839–21844 completed provider calls but every record had `thinking_present=false`; MASC then spent the 300-second deadline in repeated failed `Execute` recovery. This PR fixes the missing Qwen carrier. It does not claim to fix the separate MASC timeout persistence, pending-scope replay, provider-capacity, or stream-retry correlation defects.

## Validation

- `ocamlformat --check` passed for all three changed OCaml test files
- Python `tomllib` parsed `models.toml`
- `git diff --check` passed
- full Dune build/test intentionally delegated to GitHub CI per repository workflow

## Sources

- Qwen3.6 preserve-thinking contract: https://huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8#preserve-thinking
- Qwen3.6 official chat template: https://huggingface.co/Qwen/Qwen3.6-35B-A3B/blob/main/chat_template.jinja
- llama.cpp reasoning response contract: https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md#reasoning-support

[근거] official Qwen/llama.cpp docs and live OAS/MASC trace inspected 2026-07-11 KST; confidence High.