### PR TITLE
fix(streaming): stop retries after observable output

### DIFF
--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -346,6 +346,30 @@ let complete_stream
       (ensure_nonempty_completion result)
 ;;
 
+(* A streaming retry can reuse the caller's [on_event] callback only while the
+   failed attempt is still observationally empty.  Once content, a terminal
+   signal, or a typed stream failure has crossed that callback boundary, OAS has
+   no rollback event with which to retract it.  Retrying at that point would
+   splice two provider attempts into one consumer-visible stream.
+
+   Prelude-only events do not commit an attempt: [Connected], [Ping], and
+   [MessageStart] carry no assistant content and leave the content accumulator
+   empty.  Every other constructor either mutates the assistant turn, closes
+   part of it, or reports a terminal failure to the consumer. *)
+let stream_event_commits_attempt : Types.sse_event -> bool = function
+  | Types.Connected | Types.Ping | Types.MessageStart _ -> false
+  | Types.ContentBlockStart _
+  | Types.ContentBlockDelta _
+  | Types.ContentBlockStop _
+  | Types.MessageDelta _
+  | Types.MessageStop
+  | Types.SSEError _
+  | Types.SSEParseFailed _
+  | Types.SSEUnknownEventType _
+  | Types.Timeout _
+  | Types.StreamIncomplete _ -> true
+;;
+
 let complete_stream_with_retry
       ~sw
       ~net
@@ -370,31 +394,50 @@ let complete_stream_with_retry
   let provider = Provider_registry.provider_name_of_config config in
   let model_id = config.model_id in
   let f () =
-    complete_stream
-      ~sw
-      ~net
-      ~clock
-      ?transport
-      ~config
-      ~messages
-      ~tools
-      ?runtime_mcp_policy
-      ?trace_context
-      ~on_event
-      ~metrics:m
-      ?priority
-      ?connection_cache
-      ?stream_idle_timeout_s
-      ?on_telemetry
-      ()
+    let attempt_committed = Atomic.make false in
+    let on_attempt_event event =
+      if stream_event_commits_attempt event then Atomic.set attempt_committed true;
+      on_event event
+    in
+    let result =
+      complete_stream
+        ~sw
+        ~net
+        ~clock
+        ?transport
+        ~config
+        ~messages
+        ~tools
+        ?runtime_mcp_policy
+        ?trace_context
+        ~on_event:on_attempt_event
+        ~metrics:m
+        ?priority
+        ?connection_cache
+        ?stream_idle_timeout_s
+        ?on_telemetry
+        ()
+    in
+    result, Atomic.get attempt_committed
   in
   let rec loop attempt =
     match f () with
-    | Ok _ as success -> success
-    | Error err ->
+    | (Ok _ as success), _ -> success
+    | Error err, attempt_committed ->
       (match classify_retry_error err with
        | Some api_err when Retry.is_retryable api_err ->
-         if attempt >= rc.max_retries
+         if attempt_committed
+         then (
+           Diag.warn
+             "complete"
+             "not retrying stream provider %s model %s after attempt %d emitted \
+              consumer-visible events: %s"
+             provider
+             model_id
+             (attempt + 1)
+             (Retry.error_message api_err);
+           Error err)
+         else if attempt >= rc.max_retries
          then Error err
          else (
            Diag.warn

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -352,12 +352,17 @@ let complete_stream
    no rollback event with which to retract it.  Retrying at that point would
    splice two provider attempts into one consumer-visible stream.
 
-   Prelude-only events do not commit an attempt: [Connected], [Ping], and
-   [MessageStart] carry no assistant content and leave the content accumulator
-   empty.  Every other constructor either mutates the assistant turn, closes
-   part of it, or reports a terminal failure to the consumer. *)
+   Only [Connected] and [Ping] are rollback-safe preludes: they carry no
+   assistant-turn state.  [MessageStart] is NOT prelude-only — it commits the
+   message identity (provider message id, model, and any prelude usage) to the
+   consumer callback and to the stream accumulator ({!Complete_stream_acc}
+   sets [id]/[model]/[usage] on it).  Retrying after [MessageStart] would emit
+   a second provider message identity into the same consumer stream.  Every
+   other constructor either mutates the assistant turn, closes part of it, or
+   reports a terminal failure to the consumer. *)
 let stream_event_commits_attempt : Types.sse_event -> bool = function
-  | Types.Connected | Types.Ping | Types.MessageStart _ -> false
+  | Types.Connected | Types.Ping -> false
+  | Types.MessageStart _
   | Types.ContentBlockStart _
   | Types.ContentBlockDelta _
   | Types.ContentBlockStop _

--- a/lib/llm_provider/complete.mli
+++ b/lib/llm_provider/complete.mli
@@ -218,11 +218,14 @@ val complete_stream
 (** Streaming completion with exponential backoff retry.
     Passes [transport], [connection_cache] and [metrics] through to each attempt.
 
-    Retries are permitted only while the failed attempt has emitted no
-    consumer-visible content, terminal signal, or typed stream failure. Once an
-    attempt crosses that boundary, the original typed error is returned without
-    retry because the SSE protocol exposes no attempt rollback event; appending
-    another attempt to the same [on_event] callback would corrupt the observable
+    Retries are permitted only while the failed attempt is still
+    observationally empty — only the [Connected] and [Ping] transport preludes
+    have crossed [on_event]. Once the attempt emits committed assistant-turn
+    state — the [MessageStart] message identity (id/model/usage), any content
+    or tool delta, a terminal signal, or a typed stream failure — the original
+    typed error is returned without retry, because the SSE protocol exposes no
+    attempt rollback event; appending another attempt to the same [on_event]
+    callback would splice a second provider message into the observable
     stream. *)
 val complete_stream_with_retry
   :  sw:Eio.Switch.t

--- a/lib/llm_provider/complete.mli
+++ b/lib/llm_provider/complete.mli
@@ -216,7 +216,14 @@ val complete_stream
   -> (Types.api_response, Http_client.http_error) result
 
 (** Streaming completion with exponential backoff retry.
-    Passes [transport], [connection_cache] and [metrics] through to each attempt. *)
+    Passes [transport], [connection_cache] and [metrics] through to each attempt.
+
+    Retries are permitted only while the failed attempt has emitted no
+    consumer-visible content, terminal signal, or typed stream failure. Once an
+    attempt crosses that boundary, the original typed error is returned without
+    retry because the SSE protocol exposes no attempt rollback event; appending
+    another attempt to the same [on_event] callback would corrupt the observable
+    stream. *)
 val complete_stream_with_retry
   :  sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t

--- a/test/complete_retry/test_complete_retry.ml
+++ b/test/complete_retry/test_complete_retry.ml
@@ -261,7 +261,11 @@ let test_complete_stream_with_retry_stops_on_provider_parse_error () =
 ;;
 
 let semantic_stream_events : (string * Types.sse_event) list =
-  [ "text delta", Types.ContentBlockDelta { index = 0; delta = Types.TextDelta "partial" }
+  [ ( "message start"
+      (* MessageStart commits the provider message identity (id/model/usage) to
+         the consumer; a retry after it would splice a second identity. *)
+    , Types.MessageStart { id = "msg-attempt-1"; model = "mock"; usage = None } )
+  ; "text delta", Types.ContentBlockDelta { index = 0; delta = Types.TextDelta "partial" }
   ; ( "thinking delta"
     , Types.ContentBlockDelta { index = 0; delta = Types.ThinkingDelta "partial" } )
   ; ( "tool start"

--- a/test/complete_retry/test_complete_retry.ml
+++ b/test/complete_retry/test_complete_retry.ml
@@ -32,17 +32,33 @@ let scripted_transport scripted_responses request_count : Llm_transport.t =
   }
 ;;
 
-let make_config base_url =
+let eventful_stream_transport scripted_attempts request_count : Llm_transport.t =
+  let attempts = ref scripted_attempts in
+  { complete_sync =
+      (fun _req -> invalid_arg "eventful_stream_transport.complete_sync is not used")
+  ; complete_stream =
+      (fun ?on_telemetry:_ ~on_event _req ->
+        incr request_count;
+        match !attempts with
+        | (events, response) :: rest ->
+          attempts := rest;
+          List.iter on_event events;
+          response
+        | [] -> invalid_arg "eventful_stream_transport exhausted")
+  }
+;;
+
+let make_config_for_kind kind base_url =
   Provider_config.make
-    ~kind:Provider_config.Anthropic
+    ~kind
     ~model_id:"test-model"
     ~base_url
-    ~request_path:"/v1/messages"
     ~temperature:0.0
     ~max_tokens:100
     ()
 ;;
 
+let make_config = make_config_for_kind Provider_config.Anthropic
 let messages = [ Types.user_msg "hello" ]
 
 let fast_retry_config : Complete.retry_config =
@@ -66,6 +82,11 @@ let provider_parse_error =
     { kind = Http_client.Provider_parse_error { parser = Some "glm" }
     ; message = "Unexpected end of input"
     }
+;;
+
+let retryable_stream_error =
+  Http_client.NetworkError
+    { message = "stream connection closed"; kind = Http_client.Unknown }
 ;;
 
 let test_is_retryable_hard_quota_429 () =
@@ -239,6 +260,110 @@ let test_complete_stream_with_retry_stops_on_provider_parse_error () =
   | Exit -> ()
 ;;
 
+let semantic_stream_events : (string * Types.sse_event) list =
+  [ "text delta", Types.ContentBlockDelta { index = 0; delta = Types.TextDelta "partial" }
+  ; ( "thinking delta"
+    , Types.ContentBlockDelta { index = 0; delta = Types.ThinkingDelta "partial" } )
+  ; ( "tool start"
+    , Types.ContentBlockStart
+        { index = 0
+        ; content_type = "tool_use"
+        ; tool_id = Some "call-1"
+        ; tool_name = Some "lookup"
+        } )
+  ; ( "tool argument delta"
+    , Types.ContentBlockDelta
+        { index = 0; delta = Types.InputJsonDelta {|{"query":"partial"}|} } )
+  ]
+;;
+
+let provider_kinds : (string * Provider_config.provider_kind) list =
+  [ "Anthropic", Provider_config.Anthropic
+  ; "OpenAI-compatible", Provider_config.OpenAI_compat
+  ; "Gemini", Provider_config.Gemini
+  ]
+;;
+
+let test_stream_retry_stops_after_semantic_event_for_every_provider () =
+  Eio_main.run
+  @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run
+  @@ fun sw ->
+  List.iter
+    (fun (provider_label, kind) ->
+       List.iter
+         (fun (event_label, event) ->
+            let request_count = ref 0 in
+            let observed_events = ref [] in
+            let transport =
+              eventful_stream_transport
+                [ [ event ], Error retryable_stream_error
+                ; [ event ], Ok (mock_response "must not be appended")
+                ]
+                request_count
+            in
+            let config = make_config_for_kind kind "http://unused.test" in
+            let result =
+              Complete.complete_stream_with_retry
+                ~sw
+                ~net:env#net
+                ~transport
+                ~clock
+                ~config
+                ~messages
+                ~retry_config:fast_retry_config
+                ~on_event:(fun observed ->
+                  observed_events := observed :: !observed_events)
+                ()
+            in
+            let label = provider_label ^ " / " ^ event_label in
+            (match result with
+             | Error
+                 (Http_client.NetworkError
+                    { message = "stream connection closed"; kind = Http_client.Unknown })
+               -> ()
+             | Error _ -> fail (label ^ ": expected the original typed stream error")
+             | Ok _ -> fail (label ^ ": retry appended a second provider attempt"));
+            check int (label ^ ": one provider request") 1 !request_count;
+            check int (label ^ ": one observable event") 1 (List.length !observed_events))
+         semantic_stream_events)
+    provider_kinds
+;;
+
+let test_stream_retry_remains_available_before_semantic_event () =
+  Eio_main.run
+  @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run
+  @@ fun sw ->
+  let request_count = ref 0 in
+  let transport =
+    eventful_stream_transport
+      [ [], Error retryable_stream_error; [], Ok (mock_response "retried") ]
+      request_count
+  in
+  let config = make_config "http://unused.test" in
+  match
+    Complete.complete_stream_with_retry
+      ~sw
+      ~net:env#net
+      ~transport
+      ~clock
+      ~config
+      ~messages
+      ~retry_config:fast_retry_config
+      ~on_event:(fun _ -> ())
+      ()
+  with
+  | Error _ -> fail "expected a pre-stream retry to succeed"
+  | Ok response ->
+    check int "two provider requests" 2 !request_count;
+    (match response.Types.content with
+     | [ Types.Text "retried" ] -> ()
+     | _ -> fail "expected the second attempt response")
+;;
+
 let () =
   run
     "complete_retry"
@@ -267,6 +392,14 @@ let () =
             "stream provider parse error stops immediately"
             `Quick
             test_complete_stream_with_retry_stops_on_provider_parse_error
+        ; test_case
+            "stream semantic event commits attempt across providers"
+            `Quick
+            test_stream_retry_stops_after_semantic_event_for_every_provider
+        ; test_case
+            "stream pre-event failure remains retryable"
+            `Quick
+            test_stream_retry_remains_available_before_semantic_event
         ] )
     ]
 ;;


### PR DESCRIPTION
## Problem

`Complete.complete_stream_with_retry` reused the same `on_event` callback for every provider attempt. If an attempt emitted partial text, thinking, or a tool call and then returned a retryable transport error, the retry appended a second provider response to the same consumer-visible stream. This can produce repeated narration, duplicate tool starts, and orphan/missing tool-result projections regardless of model family.

## Change

- classify normalized SSE constructors by whether they commit observable assistant-turn state;
- retry only while an attempt has emitted no content, terminal signal, or typed stream failure;
- after the boundary, return the original typed `Http_client.http_error` and log the suppressed retry explicitly;
- preserve existing exponential retry behavior for pre-stream failures;
- document the transaction contract in `complete.mli`.

No provider/model name matching or retry-count heuristic is introduced.

## Verification

- provider-neutral event cases: text delta, thinking delta, tool start, tool argument delta;
- each case runs through Anthropic, OpenAI-compatible, and Gemini configurations;
- regression asserts one provider request, one observable event, and preservation of the original typed error;
- pre-event retry regression asserts the second attempt still succeeds;
- `ocamlformat --check` passed for all touched OCaml files;
- `git diff --check` passed.

Per repository policy, no local Dune build/test was run; CI is the build authority.

## Follow-up kept separate

ID-less streaming tool calls can expose `tool_id=None` at block start and a different synthesized ID at finalize. That is a separate identity-contract issue: #2528.
