### PR TITLE
fix(streaming): stabilize id-less tool identities

### DIFF
--- a/docs/masc-oas-design/RFC-canonical-tool-contract.md
+++ b/docs/masc-oas-design/RFC-canonical-tool-contract.md
@@ -5,7 +5,7 @@
 | Status | Draft — needs owner sign-off on 2 decisions (see §0) |
 | Author | jeong-sik (with Claude Opus analysis) |
 | Created | 2026-06-03 |
-| Verified against | `origin/main` head `9598bc99` (release 0.200.10, on top of `4409e194`) |
+| Verified against | `origin/main` head `0c2aef991` + issue #2528 identity invariant (2026-07-11) |
 | Target | `agent_sdk` (oas) — `lib/llm_provider` only |
 | Supersedes | None |
 | Related | RFC-OAS-005 (tool-result relocation), RFC-OAS-008 (typed tool identification), RFC-OAS-016 (mcp optional dependency), RFC-OAS-023 (capability axis reshape); WP1/WP2/WP4 (already in `origin/main`) |
@@ -19,7 +19,7 @@
 
 | # | 항목 | 상태 | 근거 / 필요한 결정 |
 |---|---|---|---|
-| **K** | **Keystone: `id_origin` 유지 vs 제거** | **SIGN-OFF** | `id_origin`은 순수 사후-파싱 projection에서 도출 불가(Ollama mixed-origin, §3.3). dedup은 origin과 무관하게 `call_id` 동등성으로 동일하게 동작 → 소비자 분기가 없으면 unconsumed. **권고: 제거.** §6 D2/D4. |
+| **K** | **Keystone: `id_origin` 유지 vs 제거** | **SIGN-OFF** | `id_origin`은 순수 사후-파싱 projection에서 도출 불가(Ollama mixed-origin, §3.3). correlation은 origin과 무관하게 occurrence-unique `call_id` 동등성으로 동작 → 소비자 분기가 없으면 unconsumed. **권고: 제거.** §6 D2/D4. |
 | **M** | **`canonical_tool.ml` 모듈을 실제로 머지할지** | **SIGN-OFF** | in-repo 소비자(handoff serializer)가 없으면 fan-in==0 dead code. **권고: 소비자 커밋 전까지 spec-level 유지.** §7. |
 | D1 | SSOT vs side projection | RESOLVED | side projection (content_block이 in-memory SSOT). Keystone 제거 시 "zero blast radius" 주장 성립. §6 D1. |
 | D3 | parallel call `order_index` | RESOLVED | tool-call들만의 인덱스(filter+mapi), `next_block_index` 아님. §3.3, §6 D3, §8.2. |
@@ -33,7 +33,7 @@
 
 ## 1. Context & Boundary
 
-OAS는 provider wire format을 하나의 in-memory 표현(`lib/llm_provider/types.ml`)으로 canonicalize 하고, provider별로 다시 serialize 한다. 오늘날 이 canonicalization의 **tool-call 차원**은 암묵적이다. tool call은 `{ id; name; input }`을 담은 `ToolUse` content block이고(`types.ml:209-213`), tool result는 `ToolResult` block이다(`types.ml:214-243`). *어느 provider가* call을 emit했는지, parallel call이 *어떤 순서로* 도착했는지, *native wire id인지 synthesized id인지*, *어떤 reasoning이* 특정 call에 붙었는지에 대한 일급 개념이 없다.
+OAS는 provider wire format을 하나의 in-memory 표현(`lib/llm_provider/types.ml`)으로 canonicalize 하고, provider별로 다시 serialize 한다. 오늘날 이 canonicalization의 **tool-call 차원**은 암묵적이다. tool call은 `{ id; name; input }`을 담은 `ToolUse` content block이고(`types.ml:209-213`), tool result는 `ToolResult` block이다(`types.ml:214-243`). *어느 provider가* call을 emit했는지, parallel call이 *어떤 순서로* 도착했는지, *native wire id인지 OAS-allocated id인지*, *어떤 reasoning이* 특정 call에 붙었는지에 대한 일급 개념이 없다.
 
 WP8은 **typed canonical tool-call contract**를 도입한다. OAS가 downstream coordinator(MASC)에게 넘기는 surface로, 그 coordinator가 call↔result를 correlate 하고, reasoning을 replay 하고, 결정론적으로 reorder/dedup 할 수 있게 한다 — **OAS가 그 call들이 어떻게 실행되는지는 전혀 모르는 상태로**.
 
@@ -48,7 +48,7 @@ MASC는 본 문서에서 **이름이 붙은 소비자(named consumer)** 로만 �
 ### Goals
 1. **typed, closed** canonical tool-call core (string/carrier blob 없음). 이것은 *provider boundary에서의 projection*이지, 두 번째 in-memory SSOT가 아니다.
 2. coordinator가 parallel call을 **stream reconstruction을 가로질러 안정적으로** correlate/order 할 수 있게 하는 일급 `order_index`.
-3. id 전략은 `synthesize_tool_use_id`(`api_common.ml:29-31`)를 **확장**하며 rebuild 하지 않는다.
+3. provider가 id를 주면 byte-for-byte 보존하고, id-less call은 name/arguments와 무관한 occurrence-unique opaque id를 block start 전에 한 번만 발급한다.
 4. *reasoning 없음* 과 *config에 의해 reasoning suppressed* 를 구분하는 reasoning 링크.
 5. tool call에서 provider identity 도달 가능 — 기존 `inference_telemetry.provider_kind` 필드를 duplicate 하지 않고.
 
@@ -56,7 +56,7 @@ MASC는 본 문서에서 **이름이 붙은 소비자(named consumer)** 로만 �
 - `output_schema`를 `tool_schema`로 relocate 하지 않음 (D7).
 - tool-name → variant migration 없음 — 그것은 RFC-OAS-008의 일이다. 본 RFC는 `tool_schema.name : string`을 유지.
 - execution, policy, effect 개념 없음.
-- OpenAI Responses-API나 MCP `tools/call` *구현* 없음 (둘 다 OAS에 오늘 존재하지 않음 — §3.4). forward-compatible spec mapping만.
+- MCP `tools/call` 구현 없음. OpenAI Responses API canonicalization은 현재 구현되어 있으므로 Chat Completions와 같은 identity 불변식을 적용한다.
 - telemetry-only 필드 없음: 추가되는 모든 필드는 이름 붙은 소비자를 가진다.
 
 ## 3. Current State (`origin/main` `9598bc99`, verified reads)
@@ -72,38 +72,43 @@ MASC는 본 문서에서 **이름이 붙은 소비자(named consumer)** 로만 �
 - `tool_schema = { name : string; description; parameters; strict : bool option }` (WP2 `strict`).
 
 ### 3.2 id 도출 (확장할 기존 인프라)
-`api_common.ml:29-31`:
+`api_common.ml`:
 ```ocaml
-let synthesize_tool_use_id ~name args =
-  Printf.sprintf "call_%s_%s" name Digest.(to_hex (string (Yojson.Safe.to_string args)))
+let fresh_tool_use_id () =
+  let sequence = Atomic.fetch_and_add tool_use_id_sequence 1 in
+  Printf.sprintf "call_oas_%s_%x_%x" process_scope (Unix.getpid ()) sequence
 ```
-name+args의 결정론적 MD5(`Digest`). native wire id가 없는 parse 지점에서 호출된다.
+프로세스 namespace와 OCaml 5 `Atomic.fetch_and_add` sequence로 발급한다. name/arguments를 읽지 않으므로 동일 입력의 반복 call도 서로 다른 occurrence로 남고, 스트림 start에서 발급한 동일 id가 final `ToolUse`까지 유지된다.
 
 ### 3.3 provider별 call 구성 (오늘 id/order가 비롯되는 곳)
 | Provider | Parse 지점 (verified) | id 출처 | 비고 |
 |---|---|---|---|
 | **Anthropic** | `api_common.ml:145-149` (`content_block_of_json`, `Some "tool_use"` arm) | native `"id"` | real wire id. parts 순서 = 등장 순서 |
 | **OpenAI Chat Completions** | `backend_openai_parse.ml:283-284` (`tc \|> member "id" \|> to_string`) | native `"id"` | array index = 등장 순서 |
-| **Gemini** | `backend_gemini.ml:333` (`synthesize_tool_use_id`) | synthesized | `functionCall`에 wire id 없음 |
-| **Ollama** | `backend_ollama.ml:198-211` | **native-first, synth fallback** | 아래 정정 참조 |
-| **Streaming (전부)** | `streaming.ml:540,548` (`synthesize_tool_use_id`) | synthesized | `next_block_index`는 아래 정정 참조 |
+| **Gemini** | `backend_gemini.ml` | native-first, OAS allocation fallback | `FunctionCall.id`는 optional |
+| **Ollama** | `backend_ollama.ml` | **native-first, OAS allocation fallback** | 아래 정정 참조 |
+| **Streaming (전부)** | `streaming.ml` | native-first, OAS allocation fallback | start와 final identity가 동일 |
 
-**정정 — Ollama는 "synthesized"가 아니다.** 실제 코드(`backend_ollama.ml:198-211`):
+Gemini request lowering은 canonical `ToolUse.id`를 `functionCall.id`로, 대응하는
+`ToolResult.tool_use_id`를 `functionResponse.id`로 그대로 내보낸다. name은 API의
+필수 필드이므로 별도로 보존하되 correlation SSOT는 id다. 이 두 optional id
+필드는 [Google Generative Language v1beta `content.proto`](https://github.com/googleapis/googleapis/blob/master/google/ai/generativelanguage/v1beta/content.proto)의
+`FunctionCall.id`/`FunctionResponse.id` 계약을 따른다(확인 2026-07-11).
+
+**정정 — Ollama는 native-only가 아니다.** 실제 코드는 provider id를 우선하고, 없으면 새 opaque id를 한 번 발급한다:
 ```ocaml
-( ToolUse
-    { id =
-        tc |> member "id" |> to_string_option
-        |> Option.value ~default:synthetic_id   (* synthetic_id = synth(...) ^ "_" ^ idx *)
-    ; name; input }
-  :: acc, dropped )
+let id =
+  match provider_id with
+  | Some id -> id
+  | None -> Api_common.fresh_tool_use_id ()
 ```
-Ollama는 native `"id"`를 먼저 읽고, 없을 때만 `synthesize_tool_use_id ~name input` 뒤에 `_idx`를 붙인 fallback을 쓴다. 따라서 Ollama는 **per-call mixed-origin** 이다. 결정적으로, fallback 문자열은 `idx`를 포함하므로 **사후-파싱 시점에 재계산 불가** 다 — 이것이 §6 Keystone의 근거다.
+따라서 Ollama는 **per-call mixed-origin** 이다. OAS-allocated id도 opaque하고 사후-파싱 시점에 origin을 재계산할 수 없다 — 이것이 §6 Keystone의 근거다.
 
 **정정 — `next_block_index`는 all-block-types 카운터다.** `streaming.ml`에서 이 카운터는 thinking(`:347,356`), text(`:383,392`), tool(`:405,414` 및 `:540,548`) 블록 모두에서 증가한다. 따라서 tool call들이 받는 인덱스는 text/thinking 블록과 interleave 되어 **non-contiguous** 하다. `order_index`를 이 카운터에 직접 묶으면 D3 stability test가 두 path의 블록-대-블록 정렬을 가정하게 된다(§6 D3, §8.2에서 정정).
 
-### 3.4 존재하지 않는 것 (verified)
+### 3.4 구현 경계 (verified)
 - `git grep 'provider_call_id\|order_index'` over `lib/` → **zero**. 두 개념 모두 신규.
-- OpenAI **Responses-API** parse path 없음. `lib/llm_provider`에서 `responses`/`output_text`/`response.output` 검색 → `discovery.ml:548`의 `/v1/models` 주석뿐. OAS는 **Chat Completions만** parse 한다.
+- OpenAI **Responses API**는 `Streaming.responses_sse_to_events`가 `call_id`를 우선 보존하고, id-less output item에는 같은 OAS allocation invariant를 적용한다. `item_id`는 output-item routing identity이며 tool `call_id`로 재해석하지 않는다.
 - `lib/llm_provider`에 **MCP `tools/call`** converter 없음. `mcp` 참조는 부수적: capability flag `supports_runtime_mcp_tools`(`capabilities.ml`), policy passthrough `runtime_mcp_policy`(`complete.ml`), HTTP header byte 주석(`http_client.ml`). MCP transport/optional-dep는 RFC-OAS-016, 소비자 측.
 
 ### 3.5 request-level structured output (D7 boundary)
@@ -144,8 +149,8 @@ type reasoning_link =
 type provider_tool_call =
   { call_id : string
       (** coordinator가 result↔call correlate에 쓰는 id.
-          native wire id가 있으면 그것, 없으면 synthesize_tool_use_id의 결과
-          (Ollama fallback의 경우 그 결과에 _idx가 붙은 값). *)
+          native wire id가 있으면 그것, 없으면 해당 call occurrence에 대해
+          block start 전에 한 번 발급된 opaque OAS id. *)
   ; provider_kind : Provider_kind.t
       (** 이 call을 emit한 provider. projection 시점에 thread됨;
           optional telemetry 필드에서 읽지 않음 (D5). *)
@@ -185,7 +190,7 @@ val tool_result_of_block : Types.content_block -> provider_tool_result option
 
 ### 4.1 의도적으로 뺀 것 (anti-pattern bar를 우리 타입에도 적용)
 - **`raw_provider_item : Yojson.Safe.t` 없음.** 연구 초안이 제안했으나 unconsumed blob carrier — telemetry-as-fix 시그니처 그 자체. round-trip 충실도는 이미 `content_block`(in-memory SSOT)이 provider별 재serialize로 제공한다. byte-exact replay가 미래에 필요하면 이름 붙은 소비자와 함께 별도 RFC로. 제거.
-- **`canonical_call_id`를 `call_id`와 별도로 두지 않음.** id 필드는 하나. native-id provider는 native id, id-less provider는 synthesized id. 두 번째 "cross-provider stable" id는 `synthesize_tool_use_id`의 일을 duplicate 한다.
+- **`canonical_call_id`를 `call_id`와 별도로 두지 않음.** id 필드는 하나. native-id provider는 native id, id-less provider는 occurrence-unique OAS allocation을 쓴다. 두 번째 "cross-provider stable" id는 correlation SSOT를 duplicate 한다.
 - **tool *선언* 에 `namespace`/`portable_name`/`stable_id` 없음.** tool-name typing은 RFC-OAS-008. 여기서 decl을 widen 하면 그것을 선점한다. WP8은 *call/result* 에 관한 것이지 *decl* 이 아니다.
 - **tool decl에 `output_schema?` 생략** (D7). MCP per-tool `outputSchema` passthrough가 필요해지면 strict passthrough로 RFC-OAS-016 뒤에 gate, `tool_schema` 변경이 아니다.
 - **`id_origin`은 Keystone(§6 K) 결정에 종속.** 권고는 제거. 유지 시 parse-site threading 필요(lane-B).
@@ -198,14 +203,14 @@ val tool_result_of_block : Types.content_block -> provider_tool_result option
 |---|---|---|---|---|
 | **Anthropic** | `api_common.ml:145-149` | native `id` | tool-call 필터 후 위치 | 같은 `content`의 인접 `Thinking`/`RedactedThinking` 블록 |
 | **OpenAI_compat (Chat Completions)** | `backend_openai_parse.ml:283-284` | native `id` | tool-call 필터 후 위치 | `reasoning_content` 필드 (있으면) |
-| **Gemini** | `backend_gemini.ml:333` | synthesized | tool-call 필터 후 위치 | `part.thought` 텍스트 블록 |
-| **Ollama** | `backend_ollama.ml:198-211` | native-first, synth fallback | tool-call 필터 후 위치 | `reasoning` 필드 |
-| **Streaming (전부)** | `streaming.ml:540,548` | synthesized | tool-call 필터 후 위치 | stream state에 누적된 thinking delta |
+| **Gemini** | `backend_gemini.ml` | native-first, OAS allocation fallback | tool-call 필터 후 위치 | `part.thought` 텍스트 블록 |
+| **Ollama** | `backend_ollama.ml` | native-first, OAS allocation fallback | tool-call 필터 후 위치 | `reasoning` 필드 |
+| **Streaming (전부)** | `streaming.ml` | native-first, OAS allocation fallback | tool-call 필터 후 위치 | stream state에 누적된 thinking delta |
 
 > D5 표기 주의: `OpenAI_compat`은 **family(계열)이지 vendor가 아니다.** `Provider_kind.t = Anthropic \| Kimi \| OpenAI_compat \| Ollama \| Gemini \| Glm \| DashScope`이며 별도의 `OpenAI` variant는 없다(`provider_kind.mli` 확인). OpenAI와 일부 compat host가 이 variant를 공유하고, `Glm`/`Kimi`/`DashScope`는 별도다.
 
-**Forward / spec-level mapping (오늘 OAS에 구현되지 않음 — §3.4):**
-- **OpenAI Responses API**: parse path 없음. *추가될 때*, `function_call` output item이 `call_id`(native)를 담고, output array 순서 → `order_index`, `reasoning` item → `Available`. forward-compatible로 라벨; **존재하지 않으므로 file:line 인용 없음.**
+**구현/forward mapping:**
+- **OpenAI Responses API**: `Streaming.responses_sse_to_events`가 `function_call.call_id`를 tool identity로 보존하고, `output_index`를 구조적 route로 사용한다. `item_id`는 call identity가 아니다. id-less item이면 block start 전에 OAS id를 발급한다.
 - **MCP `tools/call`**: `lib/llm_provider`에 converter 없음. MCP는 소비자 측(RFC-OAS-016). *spec-level*: MCP `CallToolResult`가 `provider_tool_result`로 매핑(`content`→`content`, `structuredContent`→`structured_content`, `isError`→`is_error`). MCP per-tool `outputSchema`는 decl-level passthrough로 RFC-OAS-016에 deferred. MCP call의 id correlation은 coordinator의 관심사지 OAS의 것이 아니다.
 
 이로써 N-of-M anti-pattern을 회피한다: **하나의** `tool_calls_of_response` 함수가 모든 provider의 projection을 하고, 각 backend가 canonical struct를 hand-roll 하지 않는다.
@@ -219,8 +224,8 @@ canonical 타입은 provider boundary에서 `tool_calls_of_response`로 계산�
 
 ### D2 / D4 — **SIGN-OFF (Keystone). `id_origin`은 순수 사후-파싱 projection에서 도출 불가.**
 
-**문제 (검증됨):** `tool_calls_of_response : api_response -> _`는 parse *후* 에 돈다. 그 시점에 `ToolUse`는 `{ id; name; input }`(`types.ml:209-213`)이고 native-vs-synthesized 구분은 **parse 지점에서만 알려졌다가 버려진** 상태다.
-- Ollama(`backend_ollama.ml:198-211`)는 native-id-first, synth fallback이며 fallback 문자열에 `idx`가 포함되어 **재계산 불가** — per-call mixed-origin(§3.3).
+**문제 (검증됨):** `tool_calls_of_response : api_response -> _`는 parse *후* 에 돈다. 그 시점에 `ToolUse`는 `{ id; name; input }`(`types.ml:209-213`)이고 native-vs-OAS-allocated 구분은 **parse 지점에서만 알려졌다가 버려진** 상태다.
+- Ollama는 native-id-first, OAS allocation fallback인 per-call mixed-origin이며 opaque allocation의 origin은 **재계산 불가** 다(§3.3).
 - 문자열 모양(`call_..._...`)으로 origin을 역추정하는 것은 reparse / substring-classifier anti-pattern으로 금지.
 
 따라서 `id_origin`을 채우려면 둘 중 하나다:
@@ -230,7 +235,7 @@ canonical 타입은 provider boundary에서 `tool_calls_of_response`로 계산�
 **판별 질문 (오너가 답해야 함):**
 > `id_origin`으로 분기하는, `call_id` 동등성 dedup과 *구별되는* coordinator-side 소비자가 존재하는가?
 
-추적: coordinator는 "같은 `call_id` → 같은 call"로 dedup 한다. native provider는 per-call-unique id를 주므로 동일-args call이 distinct하게 남고(정상), synthesized id는 동일 name+args에 collide 하므로 collapse(R2의 "intentional dedup"). **두 경우 모두 dedup 연산은 동일** — `id_origin`은 어떤 분기도 gate 하지 않는다. 행위를 바꾸지 않는 필드는 anti-pattern bar상 unconsumed.
+추적: coordinator는 "같은 `call_id` → 같은 call occurrence"로 correlate 한다. native provider id와 OAS allocation 모두 occurrence-unique이므로 동일 name+args의 반복 call도 distinct하게 남는다. content equality를 identity/dedup으로 사용하지 않는다. **두 origin 모두 correlation 연산은 동일** — `id_origin`은 어떤 분기도 gate 하지 않는다. 행위를 바꾸지 않는 필드는 anti-pattern bar상 unconsumed.
 
 | Lane | 내용 | 결과 | 권고 |
 |---|---|---|---|
@@ -263,15 +268,15 @@ Anthropic parallel tool use는 본질적 순서가 없으므로 등장 순서를
 
 - **Increment 1 (smallest, 가장 먼저):** `canonical_tool.ml/.mli`에 타입 + `tool_result_of_block`(result projection — 기존 `ToolResult` 필드만 읽음, provider plumbing 없음). property test: `ToolResult → provider_tool_result` round-trip이 `content`/`is_error`/`structured_content` 보존. **backend 무변경.** 5개 `ToolResult` 필드(`tool_use_id`/`content`/`is_error`/`json`/`content_blocks`)는 origin/main에 존재 확인됨 → 진짜로 blast-radius 0인 유일한 increment. projection 타입이 컴파일되고 result path가 isolation에서 옳음을 증명.
 - **Increment 2:** `tool_calls_of_response ~provider_kind ~reasoning_suppressed`. backend 하나 먼저 — OpenAI_compat Chat(native id, order = 필터 후 인덱스) — snapshot test. reasoning link = `No_reasoning`/`Available`만(config plumbing 없이는 `Suppressed` 불가; 둘 다 test). (Keystone lane-B 채택 시 여기서 parse-site threading 비용 발생.)
-- **Increment 3:** Anthropic(native id + 인접 thinking → `Available`)과 Gemini(synthesized id, `part.thought` → reasoning) wiring.
+- **Increment 3:** Anthropic(native id + 인접 thinking → `Available`)과 Gemini(native-first/OAS fallback id, `part.thought` → reasoning) wiring.
 - **Increment 4:** streaming reconstruction wiring — 같은 논리적 response에 대해 streaming-reconstructed `order_index` == non-streamed `order_index` 단언(D3 stability를 test로). 이때 `order_index`는 양쪽에서 **tool-call 필터 후 인덱스** 로 동일 계산하므로 all-block 정렬 가정이 없다.
-- **Increment 5 (optional, deferred):** Ollama; OpenAI Responses + MCP는 그 parse path가 생길 때까지 spec-only.
+- **Increment 5:** Ollama와 OpenAI Responses는 구현됨. MCP는 converter가 생길 때까지 spec-only.
 
 ## 8. Test Strategy
 
 1. **Closedness / exhaustiveness:** `reasoning_kind`, `reasoning_link`(+lane-B의 `id_origin`)는 closed variant — projection의 `match`가 compile-time coverage를 강제. variant 추가 시 컴파일 깨짐(`Provider_kind.all`의 WP8 대응물).
 2. **D3 stability (load-bearing):** 고정된 multi-tool response에 대해 batch parse path의 `order_index` == streaming-reconstructed path의 `order_index`. **양쪽 모두 ToolUse 필터 후 인덱스로 계산** — text/thinking 블록 정렬을 가정하지 않는다(§3.3 정정 반영). 1–4 call 생성 response에 대한 property test.
-3. **D4 id correctness:** native-id provider → `call_id` == wire id; Gemini → `call_id` == `synthesize_tool_use_id ~name args`(기존 함수 출력 그대로 단언 — "extend, not rebuild" 증명); Ollama → native 있으면 native, 없으면 synth+`_idx` fallback. (lane-B 채택 시에만 `id_origin` 값 단언 추가.)
+3. **D4 id correctness:** native-id provider → `call_id` == wire id; id-less provider → block start와 finalized `ToolUse`의 id가 같고 별도 stream/call occurrence끼리는 다름; 동일 name+args도 collapse하지 않음. Ollama → native가 있으면 그대로 보존. (lane-B 채택 시에만 `id_origin` 값 단언 추가.)
 4. **D6 distinguishability:** suppressed-config response → `Suppressed`, no-reasoning response → `No_reasoning`, thinking response → `Available` — 세 distinct 값 단언(`option` 기반 설계는 이 test를 통과 못 함, 그것이 핵심).
 5. **D7 non-coupling:** `structured_content`는 `ToolResult.json`이 `Some`일 때만 채워짐; projection이 `provider_config.output_schema`를 절대 읽지 않음을 단언(module boundary로 검증 — `canonical_tool`이 `Provider_config`에 의존하지 않음).
 6. **Boundary guard:** `canonical_tool.ml`의 의존 집합이 `{Types; Provider_kind; Yojson}` 임을 test/lint로 단언 — masc-mcp/policy/execution 모듈 없음. §1 boundary를 checkable invariant로 encode.
@@ -289,4 +294,4 @@ Anthropic parallel tool use는 본질적 순서가 없으므로 등장 순서를
 
 **Verified-absent (grep, zero hits):** `provider_call_id`, `order_index`, OpenAI Responses parse path, `lib/llm_provider` 내 MCP `tools/call` converter.
 
-**검증된 정정 (초안 대비):** Ollama는 native-id-first + synth fallback(`backend_ollama.ml:198-211`)이며 "synthesized" 아님; `next_block_index`는 all-block 카운터(`streaming.ml`)라 `order_index`는 tool-call 필터 후 인덱스여야 함; `Provider_kind.t`에 `OpenAI` variant 없음 — `OpenAI_compat`(family); 헤더 SHA `9598bc99`.
+**검증된 정정 (초안 대비):** Ollama는 native-id-first + OAS allocation fallback이며; `next_block_index`는 all-block 카운터(`streaming.ml`)라 `order_index`는 tool-call 필터 후 인덱스여야 함; `Provider_kind.t`에 `OpenAI` variant 없음 — `OpenAI_compat`(family); OpenAI Responses path는 현재 구현됨; 헤더 SHA `0c2aef991`.

--- a/lib/llm_provider/api_common.ml
+++ b/lib/llm_provider/api_common.ml
@@ -24,10 +24,25 @@ let max_stdio_buffer = 16 * 1024 * 1024
     [Retry.Timeout] so [Retry.with_retry] can retry or surface the failure. *)
 let default_request_timeout_s = 60.0
 
-(** Synthesize a deterministic tool_use_id from function name and args.
-    Gemini API does not return tool IDs; we generate stable ones via MD5. *)
-let synthesize_tool_use_id ~name args =
-  Printf.sprintf "call_%s_%s" name Digest.(to_hex (string (Yojson.Safe.to_string args)))
+(** Process-scoped entropy for OAS-allocated tool-use identities.
+
+    The identity must not depend on model-generated names or arguments: those
+    values are incomplete at streaming block start and repeated calls may have
+    identical payloads.  [Random.State.make_self_init] obtains an independent
+    system-seeded state, while the atomic sequence makes allocation unique
+    within this process even when several OCaml 5 domains open streams at the
+    same time.  The process id prevents a post-[fork] child from sharing the
+    parent's namespace. *)
+let tool_use_id_process_scope =
+  let state = Random.State.make_self_init () in
+  Printf.sprintf "%016Lx%016Lx" (Random.State.bits64 state) (Random.State.bits64 state)
+;;
+
+let tool_use_id_sequence = Atomic.make 0
+
+let fresh_tool_use_id () =
+  let sequence = Atomic.fetch_and_add tool_use_id_sequence 1 in
+  Printf.sprintf "call_oas_%s_%x_%x" tool_use_id_process_scope (Unix.getpid ()) sequence
 ;;
 
 let string_is_blank s = String.trim s = ""

--- a/lib/llm_provider/api_common.mli
+++ b/lib/llm_provider/api_common.mli
@@ -12,7 +12,13 @@ val max_stdio_buffer : int
     Used by [Api.create_message] to bound HTTP stalls. *)
 val default_request_timeout_s : float
 
-val synthesize_tool_use_id : name:string -> Yojson.Safe.t -> string
+(** Allocate an opaque, process-unique tool-use identity.
+
+    Use this only when the provider does not supply an identity.  The result is
+    independent of model-generated tool names and arguments and is safe to
+    allocate concurrently from multiple OCaml 5 domains. *)
+val fresh_tool_use_id : unit -> string
+
 val string_is_blank : string -> bool
 val text_blocks_to_string : Types.content_block list -> string
 val json_of_string_or_raw : string -> Yojson.Safe.t

--- a/lib/llm_provider/backend_gemini.ml
+++ b/lib/llm_provider/backend_gemini.ml
@@ -183,7 +183,9 @@ let part_of_content_block id_to_name tool_signatures = function
   | Document { media_type; data; source_type } ->
     inline_data_part ~block:"document" ~media_type ~data source_type
   | ToolUse { id; name; input } ->
-    let fields = [ "functionCall", `Assoc [ "name", `String name; "args", input ] ] in
+    let fields =
+      [ "functionCall", `Assoc [ "id", `String id; "name", `String name; "args", input ] ]
+    in
     let fields =
       match Hashtbl.find_opt tool_signatures id with
       | Some signature -> ("thoughtSignature", `String signature) :: fields
@@ -209,7 +211,8 @@ let part_of_content_block id_to_name tool_signatures = function
       (`Assoc
           [ ( "functionResponse"
             , `Assoc
-                [ "name", `String name
+                [ "id", `String tool_use_id
+                ; "name", `String name
                 ; ( "response"
                   , `Assoc [ "result", `String (Utf8_sanitize.sanitize content) ] )
                 ] )
@@ -446,7 +449,11 @@ let parse_response json =
               | `Assoc _ as fc ->
                 let name = fc |> member "name" |> to_string in
                 let args = fc |> member "args" in
-                let id = Api_common.synthesize_tool_use_id ~name args in
+                let id =
+                  match string_field_opt "id" fc with
+                  | Some id -> id
+                  | None -> Api_common.fresh_tool_use_id ()
+                in
                 let tool_use = ToolUse { id; name; input = args } in
                 (match part |> member "thoughtSignature" |> to_string_option with
                  | Some thought_signature

--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -239,13 +239,10 @@ let parse_ollama_tool_call ~tool_index tc =
       Error (Printf.sprintf "malformed_ollama_tool_call:index:%d:missing_name" tool_index)
   in
   let* input = parse_ollama_tool_arguments ~tool_index (fn |> member "arguments") in
-  let synthetic_id =
-    Printf.sprintf "%s_%d" (Api_common.synthesize_tool_use_id ~name input) tool_index
-  in
   let id =
     match tc |> member "id" |> to_string_option with
     | Some id when not (Api_common.string_is_blank id) -> id
-    | Some _ | None -> synthetic_id
+    | Some _ | None -> Api_common.fresh_tool_use_id ()
   in
   Ok (ToolUse { id; name; input })
 ;;

--- a/lib/llm_provider/canonical_tool.ml
+++ b/lib/llm_provider/canonical_tool.ml
@@ -13,8 +13,8 @@
     contiguous reasoning blocks immediately before a ToolUse are linked.
 
     Lane A (Keystone K): no [id_origin]. [call_id] is the block's id verbatim,
-    already the native wire id or a synthesized id depending on the provider
-    parse path; ids are neither re-synthesized nor re-classified here. *)
+    already the native wire id or an opaque OAS allocation depending on the
+    provider parse path; ids are neither reallocated nor reclassified here. *)
 
 type provider_reasoning_kind =
   | Visible_thinking

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -356,18 +356,27 @@ let finalize_stream_acc (acc : stream_acc) =
                    ; raw = text
                    }))
         in
-        let id =
+        let* id =
           match Hashtbl.find_opt acc.block_tool_ids idx with
-          | Some s when not (Api_common.string_is_blank s) -> s
+          | Some s when not (Api_common.string_is_blank s) -> Ok s
           | Some _ | None ->
-            Printf.sprintf "%s_%d" (Api_common.synthesize_tool_use_id ~name input) idx
+            Error
+              (Types.Stream_parse_failed
+                 { reason = Printf.sprintf "malformed_tool_use:index:%d:missing_id" idx
+                 ; raw = ""
+                 })
         in
         Ok (Some (Types.ToolUse { id; name; input }))
       | Some (Tool_result_block { is_error }) ->
-        let tool_use_id =
+        let* tool_use_id =
           match Hashtbl.find_opt acc.block_tool_ids idx with
-          | Some s -> s
-          | None -> ""
+          | Some s when not (Api_common.string_is_blank s) -> Ok s
+          | Some _ | None ->
+            Error
+              (Types.Stream_parse_failed
+                 { reason = Printf.sprintf "malformed_tool_result:index:%d:missing_id" idx
+                 ; raw = ""
+                 })
         in
         Ok
           (Some
@@ -1294,7 +1303,7 @@ let%test "finalize_stream_acc tool_use missing name fails closed" =
     false
 ;;
 
-let%test "finalize_stream_acc tool_use missing id synthesizes stable id" =
+let%test "finalize_stream_acc tool_use missing id fails closed" =
   let acc = create_stream_acc () in
   Hashtbl.replace acc.block_types 0 "tool_use";
   Hashtbl.replace acc.block_tool_names 0 "get_weather";
@@ -1305,19 +1314,12 @@ let%test "finalize_stream_acc tool_use missing id synthesizes stable id" =
     acc.stop_reason_received := true;
     finalize_stream_acc acc
   with
-  | Error err ->
-    let (_ : Types.stream_error) = err in
-    false
-  | Ok result ->
-    (match result.content with
-     | [ Types.ToolUse { id; name = "get_weather"; input = `Assoc [] } ] ->
-       String.starts_with ~prefix:"call_get_weather_" id
-     | unexpected ->
-       let (_ : Types.content_block list) = unexpected in
-       false)
+  | Error (Types.Stream_parse_failed { reason; raw }) ->
+    reason = "malformed_tool_use:index:0:missing_id" && raw = ""
+  | Error (Types.Stream_provider_error _ | Types.Stream_unknown_event _) | Ok _ -> false
 ;;
 
-let%test "finalize_stream_acc tool_use blank id synthesizes stable id" =
+let%test "finalize_stream_acc tool_use blank id fails closed" =
   let acc = create_stream_acc () in
   Hashtbl.replace acc.block_types 0 "tool_use";
   Hashtbl.replace acc.block_tool_ids 0 " ";
@@ -1329,16 +1331,9 @@ let%test "finalize_stream_acc tool_use blank id synthesizes stable id" =
     acc.stop_reason_received := true;
     finalize_stream_acc acc
   with
-  | Error err ->
-    let (_ : Types.stream_error) = err in
-    false
-  | Ok result ->
-    (match result.content with
-     | [ Types.ToolUse { id; name = "get_weather"; input = `Assoc [] } ] ->
-       String.starts_with ~prefix:"call_get_weather_" id
-     | unexpected ->
-       let (_ : Types.content_block list) = unexpected in
-       false)
+  | Error (Types.Stream_parse_failed { reason; raw }) ->
+    reason = "malformed_tool_use:index:0:missing_id" && raw = ""
+  | Error (Types.Stream_provider_error _ | Types.Stream_unknown_event _) | Ok _ -> false
 ;;
 
 let%test "finalize_stream_acc assembles tool_result block" =
@@ -1363,6 +1358,21 @@ let%test "finalize_stream_acc assembles tool_result block" =
            }
        ] -> true
      | _ -> false)
+;;
+
+let%test "finalize_stream_acc tool_result missing id fails closed" =
+  let acc = create_stream_acc () in
+  Hashtbl.replace acc.block_types 0 "tool_result";
+  let buf = Buffer.create 16 in
+  Buffer.add_string buf "done";
+  Hashtbl.replace acc.block_texts 0 buf;
+  match
+    acc.stop_reason_received := true;
+    finalize_stream_acc acc
+  with
+  | Error (Types.Stream_parse_failed { reason; raw }) ->
+    reason = "malformed_tool_result:index:0:missing_id" && raw = ""
+  | Error (Types.Stream_provider_error _ | Types.Stream_unknown_event _) | Ok _ -> false
 ;;
 
 let%test "finalize_stream_acc assembles a streamed image block" =

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -1408,11 +1408,7 @@ let responses_ensure_text_block state emit ~output_index =
   state.text_block_index
 ;;
 
-let responses_tool_id_of_item item =
-  match responses_member_string_opt "call_id" item with
-  | Some id when String.trim id <> "" -> Some id
-  | Some _ | None -> responses_member_string_opt "id" item
-;;
+let responses_tool_id_of_item item = responses_member_string_opt "call_id" item
 
 let responses_ensure_tool_block state emit ~output_index ~tool_id ~tool_name =
   let resolution, start =
@@ -1551,11 +1547,10 @@ let responses_sse_to_events (state : openai_stream_state) event_type data_str
                 state
                 emit
                 ~output_index
-                  (* [item_id] identifies the Responses output item, not the
-                   function call.  Routing is structural by [output_index];
-                   treating [item_id] as a call identity would conflict with
-                   the authoritative [call_id] from [output_item.added]. *)
-                ~tool_id:None
+                  (* [call_id] is the function-call identity on every official
+                   arguments event. [item_id] identifies only the output item
+                   and is never substituted for it. *)
+                ~tool_id:(responses_member_string_opt "call_id" json)
                 ~tool_name:None
             in
             (match index with

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -57,7 +57,23 @@ let parse_sse_event event_type data_str =
         | _ -> cb |> member "id" |> to_string_option
       in
       let tool_name = cb |> member "name" |> to_string_option in
-      Some (ContentBlockStart { index; content_type; tool_id; tool_name })
+      let non_blank_tool_id =
+        match tool_id with
+        | Some id when not (Api_common.string_is_blank id) -> Some id
+        | Some _ | None -> None
+      in
+      (match content_type, non_blank_tool_id with
+       | "tool_use", None ->
+         Some
+           (SSEParseFailed
+              { raw = Printf.sprintf "anthropic tool_use index %d" index
+              ; reason =
+                  Printf.sprintf "malformed_tool_use:index:%d:missing_provider_id" index
+              })
+       | "tool_use", Some tool_id ->
+         Some
+           (ContentBlockStart { index; content_type; tool_id = Some tool_id; tool_name })
+       | _, _ -> Some (ContentBlockStart { index; content_type; tool_id; tool_name }))
     | "content_block_delta" ->
       let index = json |> member "index" |> to_int in
       let delta_json = json |> member "delta" in
@@ -610,22 +626,32 @@ type tool_index_route =
   | Tool_index_single of int
   | Tool_index_ambiguous of int list
 
+type tool_identity_origin =
+  | Provider_supplied
+  | Oas_allocated
+
+type tool_block_identity =
+  { id : string
+  ; origin : tool_identity_origin
+  }
+
 type openai_stream_state =
   { mutable thinking_block_started : bool
   ; mutable thinking_block_index : int
   ; mutable text_block_started : bool
   ; mutable text_block_index : int
   ; tool_blocks_by_id : (string, int) Hashtbl.t
-    (** tool_call id -> block index. Primary identity: a distinct id always gets
-        a distinct block, even when a provider reuses the wire index across
-        parallel calls (minimax-m3 on Ollama Cloud stamps every parallel call
-        index:0). *)
+    (** Secondary lookup index from tool identity to normalized block index.
+        [tool_block_identities] remains the identity authority. *)
   ; tool_block_indices : (int, tool_index_route) Hashtbl.t
     (** tool_call wire index -> routing state. Id-less continuation fragments
         can route only while the wire index maps to one known block. Once more
         than one id has used the same wire index, id-less fragments are
         ambiguous and must fail loud rather than silently picking the last
         writer. *)
+  ; tool_block_identities : (int, tool_block_identity) Hashtbl.t
+    (** Normalized block index -> the identity emitted at block start.  This is
+        the sole identity authority for an open tool block. *)
   ; mutable next_block_index : int
   ; mutable thinking_state : thinking_state
   ; provider : string
@@ -639,16 +665,12 @@ let create_openai_stream_state ?(provider = "") ?(model = "") () =
   ; text_block_index = -1
   ; tool_blocks_by_id = Hashtbl.create 4
   ; tool_block_indices = Hashtbl.create 4
+  ; tool_block_identities = Hashtbl.create 4
   ; next_block_index = 0
   ; thinking_state = Not_thinking
   ; provider
   ; model
   }
-;;
-
-let tool_index_route_indices = function
-  | Tool_index_single index -> [ index ]
-  | Tool_index_ambiguous indices -> indices
 ;;
 
 let tool_index_route_add_block route block_index =
@@ -669,10 +691,166 @@ let record_tool_index_route table tool_index block_index =
   Hashtbl.replace table tool_index route
 ;;
 
-let find_single_tool_index_route table tool_index =
-  match Hashtbl.find_opt table tool_index with
-  | Some (Tool_index_single block_index) -> Some block_index
-  | Some (Tool_index_ambiguous _) | None -> None
+type tool_block_index_policy =
+  | Next_available
+  | Next_after_carrier
+  | Wire_index
+
+type idless_tool_semantics =
+  (* Argument fragments continue the one call selected by the wire index. *)
+  | Continue_by_wire_index
+  (* Each complete provider item is a new call occurrence.  Identical
+      name/arguments must not collapse into one identity. *)
+  | Complete_occurrence
+
+type tool_route_failure =
+  | Ambiguous_idless_continuation
+  | Late_provider_identity
+  | Provider_identity_route_conflict
+  | Identity_index_conflict
+  | Block_index_collision
+  | Missing_block_identity
+
+type tool_block_resolution =
+  | Tool_block_resolved of
+      { block_index : int
+      ; identity : tool_block_identity
+      }
+  | Tool_block_rejected of sse_event
+
+let non_blank_provider_tool_id = function
+  | Some id when not (Api_common.string_is_blank id) -> Some id
+  | Some _ | None -> None
+;;
+
+let tool_route_failure_reason = function
+  | Ambiguous_idless_continuation ->
+    "ambiguous_tool_call_index: id-less continuation follows multiple tool identities"
+  | Late_provider_identity ->
+    "late_provider_tool_call_id: provider identity arrived after an OAS identity was \
+     emitted"
+  | Provider_identity_route_conflict ->
+    "provider_tool_call_id_route_conflict: one provider identity used multiple wire \
+     routes"
+  | Identity_index_conflict ->
+    "tool_identity_index_conflict: identity lookup and block authority disagree"
+  | Block_index_collision ->
+    "tool_block_index_collision: distinct tool identities require the same normalized \
+     block"
+  | Missing_block_identity ->
+    "missing_tool_block_identity: tool route references a block without identity state"
+;;
+
+let reject_tool_block ~protocol ~wire_index failure =
+  Tool_block_rejected
+    (SSEParseFailed
+       { raw = Printf.sprintf "%s tool_call index %d" protocol wire_index
+       ; reason = tool_route_failure_reason failure
+       })
+;;
+
+let register_tool_block_identity state ~block_index identity =
+  Hashtbl.replace state.tool_blocks_by_id identity.id block_index;
+  Hashtbl.replace state.tool_block_identities block_index identity
+;;
+
+let open_tool_block state ~protocol ~wire_index ~provider_tool_id ~tool_name ~index_policy
+  =
+  let block_index =
+    match index_policy with
+    | Next_available -> state.next_block_index
+    | Next_after_carrier -> state.next_block_index + 1
+    | Wire_index -> wire_index
+  in
+  if Hashtbl.mem state.tool_block_identities block_index
+  then reject_tool_block ~protocol ~wire_index Block_index_collision, None
+  else (
+    let identity =
+      match non_blank_provider_tool_id provider_tool_id with
+      | Some id -> { id; origin = Provider_supplied }
+      | None -> { id = Api_common.fresh_tool_use_id (); origin = Oas_allocated }
+    in
+    register_tool_block_identity state ~block_index identity;
+    state.next_block_index <- max state.next_block_index (block_index + 1);
+    ( Tool_block_resolved { block_index; identity }
+    , Some
+        (ContentBlockStart
+           { index = block_index
+           ; content_type = "tool_use"
+           ; tool_id = Some identity.id
+           ; tool_name
+           }) ))
+;;
+
+let resolve_tool_block
+      state
+      ~protocol
+      ~wire_index
+      ~provider_tool_id
+      ~tool_name
+      ~index_policy
+      ~idless_semantics
+  =
+  let reject failure = reject_tool_block ~protocol ~wire_index failure, None in
+  let open_and_record () =
+    let resolution, start =
+      open_tool_block
+        state
+        ~protocol
+        ~wire_index
+        ~provider_tool_id
+        ~tool_name
+        ~index_policy
+    in
+    (match resolution with
+     | Tool_block_resolved { block_index; _ } ->
+       record_tool_index_route state.tool_block_indices wire_index block_index
+     | Tool_block_rejected _ -> ());
+    resolution, start
+  in
+  let route_contains_block route block_index =
+    match route with
+    | Tool_index_single routed -> routed = block_index
+    | Tool_index_ambiguous routed -> List.mem block_index routed
+  in
+  match non_blank_provider_tool_id provider_tool_id with
+  | Some id ->
+    (match Hashtbl.find_opt state.tool_blocks_by_id id with
+     | Some block_index ->
+       (match Hashtbl.find_opt state.tool_block_indices wire_index with
+        | Some route when route_contains_block route block_index ->
+          (match Hashtbl.find_opt state.tool_block_identities block_index with
+           | Some identity when String.equal identity.id id ->
+             Tool_block_resolved { block_index; identity }, None
+           | Some _ -> reject Identity_index_conflict
+           | None -> reject Missing_block_identity)
+        | Some _ | None -> reject Provider_identity_route_conflict)
+     | None ->
+       (match Hashtbl.find_opt state.tool_block_indices wire_index with
+        | Some (Tool_index_single block_index) ->
+          (match Hashtbl.find_opt state.tool_block_identities block_index with
+           | Some { origin = Oas_allocated; _ } -> reject Late_provider_identity
+           | Some { origin = Provider_supplied; _ } ->
+             (match index_policy with
+              | Next_available | Next_after_carrier -> open_and_record ()
+              | Wire_index -> reject Block_index_collision)
+           | None -> reject Missing_block_identity)
+        | Some (Tool_index_ambiguous _) ->
+          (match index_policy with
+           | Next_available | Next_after_carrier -> open_and_record ()
+           | Wire_index -> reject Block_index_collision)
+        | None -> open_and_record ()))
+  | None ->
+    (match idless_semantics with
+     | Complete_occurrence -> open_and_record ()
+     | Continue_by_wire_index ->
+       (match Hashtbl.find_opt state.tool_block_indices wire_index with
+        | Some (Tool_index_single block_index) ->
+          (match Hashtbl.find_opt state.tool_block_identities block_index with
+           | Some identity -> Tool_block_resolved { block_index; identity }, None
+           | None -> reject Missing_block_identity)
+        | Some (Tool_index_ambiguous _) -> reject Ambiguous_idless_continuation
+        | None -> open_and_record ()))
 ;;
 
 (* OpenAI-compatible streams carry no wire [content_block_stop] event (unlike
@@ -690,12 +868,8 @@ let openai_open_block_stops (state : openai_stream_state) : sse_event list =
     (if state.thinking_block_started then [ state.thinking_block_index ] else [])
     @ (if state.text_block_started then [ state.text_block_index ] else [])
     @ Hashtbl.fold
-        (fun _tc_index route acc -> tool_index_route_indices route @ acc)
-        state.tool_block_indices
-        []
-    @ Hashtbl.fold
-        (fun _tool_id block_index acc -> block_index :: acc)
-        state.tool_blocks_by_id
+        (fun block_index _identity acc -> block_index :: acc)
+        state.tool_block_identities
         []
   in
   indices |> List.sort_uniq compare |> List.map (fun index -> ContentBlockStop { index })
@@ -806,71 +980,28 @@ let openai_chunk_to_events (state : openai_stream_state) (chunk : openai_chunk)
     (* Tool call deltas *)
     List.iter
       (fun (tc : openai_tool_call_delta) ->
-         let open_block () =
-           let idx = state.next_block_index in
+         let resolution, start =
+           resolve_tool_block
+             state
+             ~protocol:"openai"
+             ~wire_index:tc.tc_index
+             ~provider_tool_id:tc.tc_id
+             ~tool_name:tc.tc_name
+             ~index_policy:Next_available
+             ~idless_semantics:Continue_by_wire_index
+         in
+         Option.iter emit start;
+         match resolution, tc.tc_arguments with
+         | Tool_block_resolved { block_index; _ }, Some (Args_fragment args)
+           when args <> "" ->
+           emit (ContentBlockDelta { index = block_index; delta = InputJsonDelta args })
+         | Tool_block_resolved { block_index; _ }, Some (Args_complete args)
+           when args <> "" ->
            emit
-             (ContentBlockStart
-                { index = idx
-                ; content_type = "tool_use"
-                ; tool_id = tc.tc_id
-                ; tool_name = tc.tc_name
-                });
-           state.next_block_index <- state.next_block_index + 1;
-           idx
-         in
-         let ambiguous_idless_tool_call_error tc_index =
-           SSEParseFailed
-             { raw = Printf.sprintf "openai tool_call index %d" tc_index
-             ; reason =
-                 "ambiguous_tool_call_index: id-less tool_call continuation cannot be \
-                  routed after multiple ids used the same wire index"
-             }
-         in
-         let block_idx =
-           match tc.tc_id with
-           | Some id ->
-             (* A tool_call delta carrying an id identifies a distinct call. Key
-                its block on the stable id, not the wire index: some
-                OpenAI-compatible providers (minimax-m3 on Ollama Cloud) stamp
-                every parallel tool call index:0, so keying on tc_index alone
-                collapsed distinct calls into one block and concatenated their
-                arguments into invalid JSON ([malformed_tool_use_arguments]).
-                Record index -> block too so an id-less continuation fragment
-                (OpenAI sends id only on a call's first chunk) routes back here. *)
-             let idx =
-               match Hashtbl.find_opt state.tool_blocks_by_id id with
-               | Some idx -> idx
-               | None ->
-                 let idx = open_block () in
-                 Hashtbl.replace state.tool_blocks_by_id id idx;
-                 idx
-             in
-             record_tool_index_route state.tool_block_indices tc.tc_index idx;
-             Some idx
-           | None ->
-             (* Continuation fragment with no id: route by the wire index to the
-                call opened at that index. If none was opened (a provider that
-                never sends an id), fall back to index-keyed allocation so the
-                call is surfaced rather than dropped. *)
-             (match Hashtbl.find_opt state.tool_block_indices tc.tc_index with
-              | Some (Tool_index_single idx) -> Some idx
-              | Some (Tool_index_ambiguous _) ->
-                emit (ambiguous_idless_tool_call_error tc.tc_index);
-                None
-              | None ->
-                let idx = open_block () in
-                Hashtbl.replace
-                  state.tool_block_indices
-                  tc.tc_index
-                  (Tool_index_single idx);
-                Some idx)
-         in
-         match block_idx, tc.tc_arguments with
-         | Some block_idx, Some (Args_fragment args) when args <> "" ->
-           emit (ContentBlockDelta { index = block_idx; delta = InputJsonDelta args })
-         | Some block_idx, Some (Args_complete args) when args <> "" ->
-           emit (ContentBlockDelta { index = block_idx; delta = InputJsonSnapshot args })
-         | Some _, Some (Args_fragment _ | Args_complete _) | Some _, None | None, _ -> ())
+             (ContentBlockDelta { index = block_index; delta = InputJsonSnapshot args })
+         | Tool_block_resolved _, Some (Args_fragment _ | Args_complete _)
+         | Tool_block_resolved _, None -> ()
+         | Tool_block_rejected error, _ -> emit error)
       chunk.delta_tool_calls;
     (* Finish reason -> MessageDelta *)
     (match chunk.finish_reason with
@@ -1130,8 +1261,8 @@ let%test "openai_chunk_to_events: id-less continuation on ambiguous index fails 
   | [ SSEParseFailed { raw; reason } ] ->
     raw = "openai tool_call index 0"
     && reason
-       = "ambiguous_tool_call_index: id-less tool_call continuation cannot be routed \
-          after multiple ids used the same wire index"
+       = "ambiguous_tool_call_index: id-less continuation follows multiple tool \
+          identities"
   | unexpected_events ->
     let (_ : sse_event list) = unexpected_events in
     false
@@ -1284,15 +1415,22 @@ let responses_tool_id_of_item item =
 ;;
 
 let responses_ensure_tool_block state emit ~output_index ~tool_id ~tool_name =
-  match find_single_tool_index_route state.tool_block_indices output_index with
-  | Some idx -> idx
-  | None ->
-    let idx = output_index in
-    Hashtbl.replace state.tool_block_indices output_index (Tool_index_single idx);
-    emit
-      (ContentBlockStart { index = idx; content_type = "tool_use"; tool_id; tool_name });
-    responses_advance_next_block_index state idx;
-    idx
+  let resolution, start =
+    resolve_tool_block
+      state
+      ~protocol:"openai_responses"
+      ~wire_index:output_index
+      ~provider_tool_id:tool_id
+      ~tool_name
+      ~index_policy:Wire_index
+      ~idless_semantics:Continue_by_wire_index
+  in
+  Option.iter emit start;
+  match resolution with
+  | Tool_block_resolved { block_index; _ } -> Some block_index
+  | Tool_block_rejected error ->
+    emit error;
+    None
 ;;
 
 let responses_emit_redacted_reasoning_outputs state emit response =
@@ -1394,7 +1532,7 @@ let responses_sse_to_events (state : openai_stream_state) event_type data_str
          let item = json |> member "item" in
          (match responses_member_string_opt "type" item with
           | Some ("function_call" | "custom_tool_call") ->
-            let _idx =
+            let (_ : int option) =
               responses_ensure_tool_block
                 state
                 emit
@@ -1408,16 +1546,22 @@ let responses_sse_to_events (state : openai_stream_state) event_type data_str
          (match responses_member_string_opt "delta" json with
           | Some delta when delta <> "" ->
             let output_index = responses_member_int_default "output_index" json in
-            let item_id = responses_member_string_opt "item_id" json in
             let index =
               responses_ensure_tool_block
                 state
                 emit
                 ~output_index
-                ~tool_id:item_id
+                  (* [item_id] identifies the Responses output item, not the
+                   function call.  Routing is structural by [output_index];
+                   treating [item_id] as a call identity would conflict with
+                   the authoritative [call_id] from [output_item.added]. *)
+                ~tool_id:None
                 ~tool_name:None
             in
-            emit (ContentBlockDelta { index; delta = InputJsonDelta delta })
+            (match index with
+             | Some index ->
+               emit (ContentBlockDelta { index; delta = InputJsonDelta delta })
+             | None -> ())
           | Some _ | None -> ())
        | "response.completed" | "response.incomplete" ->
          let response = json |> member "response" in
@@ -1537,46 +1681,60 @@ let gemini_chunk_to_events (state : openai_stream_state) (chunk : gemini_chunk)
           (Telemetry_event.Thinking_complete
              { provider = state.provider; model = state.model; thinking_duration_ms })
    | Not_thinking, false | Thinking_done, false | Thinking_started _, true -> ());
-  List.iter
-    (fun part ->
+  List.iteri
+    (fun part_index part ->
        let is_thought = Cli_common_json.member_bool "thought" part in
        let emit_function_call_delta () =
          match part |> member "functionCall" with
          | `Assoc _ as fc ->
            let name = Cli_common_json.member_str "name" fc in
            let args = fc |> member "args" in
-           let id = Api_common.synthesize_tool_use_id ~name args in
-           (match part |> member "thoughtSignature" |> to_string_option with
-            | Some thought_signature
-              when not (Api_common.string_is_blank thought_signature) ->
-              let idx = state.next_block_index in
-              let payload =
-                Backend_gemini.gemini_thought_signature_payload
-                  ~tool_use_id:id
-                  ~thought_signature
-              in
+           let provider_tool_id = fc |> member "id" |> to_string_option in
+           let thought_signature =
+             match part |> member "thoughtSignature" |> to_string_option with
+             | Some signature when not (Api_common.string_is_blank signature) ->
+               Some signature
+             | Some _ | None -> None
+           in
+           let resolution, start =
+             resolve_tool_block
+               state
+               ~protocol:"gemini"
+               ~wire_index:part_index
+               ~provider_tool_id
+               ~tool_name:(Some name)
+               ~index_policy:
+                 (match thought_signature with
+                  | Some _ -> Next_after_carrier
+                  | None -> Next_available)
+               ~idless_semantics:Complete_occurrence
+           in
+           (match resolution with
+            | Tool_block_rejected error -> emit error
+            | Tool_block_resolved { block_index = idx; identity } ->
+              (match start with
+               | Some start ->
+                 (match thought_signature with
+                  | Some thought_signature ->
+                    let payload =
+                      Backend_gemini.gemini_thought_signature_payload
+                        ~tool_use_id:identity.id
+                        ~thought_signature
+                    in
+                    let carrier_index = idx - 1 in
+                    emit
+                      (ContentBlockStart
+                         { index = carrier_index
+                         ; content_type = "redacted_thinking"
+                         ; tool_id = Some payload
+                         ; tool_name = None
+                         })
+                  | None -> ());
+                 emit start
+               | None -> ());
               emit
-                (ContentBlockStart
-                   { index = idx
-                   ; content_type = "redacted_thinking"
-                   ; tool_id = Some payload
-                   ; tool_name = None
-                   });
-              state.next_block_index <- state.next_block_index + 1
-            | Some _ | None -> ());
-           let idx = state.next_block_index in
-           Hashtbl.replace state.tool_block_indices idx (Tool_index_single idx);
-           emit
-             (ContentBlockStart
-                { index = idx
-                ; content_type = "tool_use"
-                ; tool_id = Some id
-                ; tool_name = Some name
-                });
-           state.next_block_index <- state.next_block_index + 1;
-           emit
-             (ContentBlockDelta
-                { index = idx; delta = InputJsonSnapshot (Yojson.Safe.to_string args) })
+                (ContentBlockDelta
+                   { index = idx; delta = InputJsonSnapshot (Yojson.Safe.to_string args) }))
          | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ -> ()
        in
        match part |> member "text" |> to_string_option with
@@ -1865,31 +2023,26 @@ let ollama_chunk_to_events (state : openai_stream_state) (chunk : ollama_chunk)
   List.iter
     (fun (tc : ollama_tool_call_delta) ->
        let block_idx =
-         match find_single_tool_index_route state.tool_block_indices tc.oll_tc_index with
-         | Some idx -> idx
-         | None ->
-           let idx = state.next_block_index in
-           Hashtbl.replace
-             state.tool_block_indices
-             tc.oll_tc_index
-             (Tool_index_single idx);
-           emit
-             (ContentBlockStart
-                { index = idx
-                ; content_type = "tool_use"
-                ; tool_id = tc.oll_tc_id
-                ; tool_name = tc.oll_tc_name
-                });
-           state.next_block_index <- state.next_block_index + 1;
-           idx
+         resolve_tool_block
+           state
+           ~protocol:"ollama"
+           ~wire_index:tc.oll_tc_index
+           ~provider_tool_id:tc.oll_tc_id
+           ~tool_name:tc.oll_tc_name
+           ~index_policy:Next_available
+           ~idless_semantics:Continue_by_wire_index
        in
-       match tc.oll_tc_arguments with
-       | Some (Args_fragment args) when args <> "" ->
-         emit (ContentBlockDelta { index = block_idx; delta = InputJsonDelta args })
-       | Some (Args_complete args) when args <> "" ->
-         emit (ContentBlockDelta { index = block_idx; delta = InputJsonSnapshot args })
-       | Some (Args_fragment _ | Args_complete _) -> ()
-       | None -> ())
+       let resolution, start = block_idx in
+       Option.iter emit start;
+       match resolution, tc.oll_tc_arguments with
+       | Tool_block_resolved { block_index; _ }, Some (Args_fragment args) when args <> ""
+         -> emit (ContentBlockDelta { index = block_index; delta = InputJsonDelta args })
+       | Tool_block_resolved { block_index; _ }, Some (Args_complete args) when args <> ""
+         ->
+         emit (ContentBlockDelta { index = block_index; delta = InputJsonSnapshot args })
+       | Tool_block_resolved _, Some (Args_fragment _ | Args_complete _)
+       | Tool_block_resolved _, None -> ()
+       | Tool_block_rejected error, _ -> emit error)
     chunk.oll_tool_calls;
   (* Terminal chunk: emit MessageDelta with stop_reason + usage. *)
   if chunk.oll_is_done
@@ -2129,10 +2282,14 @@ let%test "ollama_chunk_to_events: tool_calls emit Start+InputJsonSnapshot" =
   let events, _tel = ollama_chunk_to_events state chunk in
   match events with
   | [ ContentBlockStart
-        { index = 0; content_type = "tool_use"; tool_name = Some "search"; _ }
+        { index = 0
+        ; content_type = "tool_use"
+        ; tool_id = Some tool_id
+        ; tool_name = Some "search"
+        }
     ; ContentBlockDelta { index = 0; delta = InputJsonSnapshot args }
     ; MessageDelta { stop_reason = Some StopToolUse; _ }
-    ] -> args = {|{"q":"hello"}|}
+    ] -> String.starts_with ~prefix:"call_oas_" tool_id && args = {|{"q":"hello"}|}
   | unexpected_events ->
     let (_ : sse_event list) = unexpected_events in
     false

--- a/lib/llm_provider/streaming.mli
+++ b/lib/llm_provider/streaming.mli
@@ -81,27 +81,9 @@ type openai_chunk =
   ; chunk_parse_error : openai_chunk_parse_error option
   }
 
-type thinking_state =
-  | Not_thinking
-  | Thinking_started of float
-  | Thinking_done
-
-type tool_index_route =
-  | Tool_index_single of int
-  | Tool_index_ambiguous of int list
-
-type openai_stream_state =
-  { mutable thinking_block_started : bool
-  ; mutable thinking_block_index : int
-  ; mutable text_block_started : bool
-  ; mutable text_block_index : int
-  ; tool_blocks_by_id : (string, int) Hashtbl.t
-  ; tool_block_indices : (int, tool_index_route) Hashtbl.t
-  ; mutable next_block_index : int
-  ; mutable thinking_state : thinking_state
-  ; provider : string
-  ; model : string
-  }
+(** Mutable normalization state.  Its representation is private so callers
+    cannot bypass tool identity and block-routing invariants. *)
+type openai_stream_state
 
 val parse_openai_sse_chunk
   :  ?streaming_reasoning:Reasoning_dialect.streaming_reasoning

--- a/test/test_backend_gemini.ml
+++ b/test/test_backend_gemini.ml
@@ -259,8 +259,14 @@ let test_tool_result () =
   let parts = third |> member "parts" |> to_list in
   let fr = List.hd parts |> member "functionResponse" in
   check bool "has functionResponse" true (fr <> `Null);
+  check string "function response id" "call_123" (fr |> member "id" |> to_string);
   (* Name should be resolved from tool_use_id to tool name *)
-  check string "function name" "get_weather" (fr |> member "name" |> to_string)
+  check string "function name" "get_weather" (fr |> member "name" |> to_string);
+  let assistant = List.nth contents 1 in
+  let function_call =
+    assistant |> member "parts" |> to_list |> List.hd |> member "functionCall"
+  in
+  check string "function call id" "call_123" (function_call |> member "id" |> to_string)
 ;;
 
 let test_dangling_tool_use_closed_before_request () =
@@ -433,7 +439,8 @@ let test_parse_function_call () =
   let resp = Backend_gemini.parse_response json in
   check int "one content block" 1 (List.length resp.content);
   (match List.hd resp.content with
-   | Types.ToolUse { name; input; _ } ->
+   | Types.ToolUse { id; name; input } ->
+     check bool "allocated id" true (String.starts_with ~prefix:"call_oas_" id);
      check string "name" "get_weather" name;
      check
        string
@@ -444,6 +451,17 @@ let test_parse_function_call () =
   match resp.stop_reason with
   | Types.StopToolUse -> ()
   | _ -> fail "expected StopToolUse"
+;;
+
+let test_parse_function_call_preserves_native_id () =
+  let json =
+    Yojson.Safe.from_string
+      {|{"candidates":[{"content":{"parts":[{"functionCall":{"id":"gemini-call-1","name":"lookup","args":{}}}]},"finishReason":"STOP"}]}|}
+  in
+  match (Backend_gemini.parse_response json).content with
+  | [ Types.ToolUse { id; name = "lookup"; _ } ] ->
+    check string "native Gemini function call id" "gemini-call-1" id
+  | _ -> fail "expected one Gemini ToolUse"
 ;;
 
 let function_call_with_thought_signature_json () =
@@ -725,7 +743,7 @@ let test_gemini_stream_function_call () =
     "candidates": [{
       "content": {
         "parts": [{
-          "functionCall": {"name": "search", "args": {"q": "test"}}
+          "functionCall": {"id": "gemini-stream-call-1", "name": "search", "args": {"q": "test"}}
         }],
         "role": "model"
       }
@@ -736,15 +754,32 @@ let test_gemini_stream_function_call () =
   | Some chunk ->
     let state = Streaming.create_openai_stream_state () in
     let events, _tel = Streaming.gemini_chunk_to_events state chunk in
-    let has_tool =
-      List.exists
-        (function
-          | Types.ContentBlockStart { content_type = "tool_use"; _ } -> true
-          | _ -> false)
-        events
-    in
-    check bool "has tool_use block" true has_tool
+    (match events with
+     | [ Types.ContentBlockStart { content_type = "tool_use"; tool_id = Some id; _ }
+       ; Types.ContentBlockDelta _
+       ] -> check string "native stream id" "gemini-stream-call-1" id
+     | _ -> fail "expected identified tool start and arguments")
   | None -> fail "expected Some chunk"
+;;
+
+let test_gemini_stream_repeated_idless_calls_stay_distinct () =
+  let chunk =
+    match
+      Streaming.parse_gemini_sse_chunk
+        {|{"candidates":[{"content":{"parts":[{"functionCall":{"name":"lookup","args":{"q":"same"}}}]}}]}|}
+    with
+    | Some chunk -> chunk
+    | None -> fail "expected id-less Gemini chunk"
+  in
+  let state = Streaming.create_openai_stream_state () in
+  let start_id () =
+    match fst (Streaming.gemini_chunk_to_events state chunk) with
+    | ContentBlockStart { content_type = "tool_use"; tool_id = Some id; _ } :: _ -> id
+    | _ -> fail "expected identified Gemini tool start"
+  in
+  let first = start_id () in
+  let second = start_id () in
+  check bool "complete id-less occurrences stay distinct" true (first <> second)
 ;;
 
 let test_gemini_stream_finish () =
@@ -1217,6 +1252,10 @@ let () =
         ; test_case "thinking parts" `Quick test_parse_thinking_response
         ; test_case "function call" `Quick test_parse_function_call
         ; test_case
+            "function call native id"
+            `Quick
+            test_parse_function_call_preserves_native_id
+        ; test_case
             "function call thought signature"
             `Quick
             test_parse_function_call_preserves_thought_signature
@@ -1233,6 +1272,10 @@ let () =
       , [ test_case "text chunk" `Quick test_gemini_stream_text
         ; test_case "thinking chunk" `Quick test_gemini_stream_thinking
         ; test_case "function call chunk" `Quick test_gemini_stream_function_call
+        ; test_case
+            "repeated id-less calls stay distinct"
+            `Quick
+            test_gemini_stream_repeated_idless_calls_stay_distinct
         ; test_case "finish reason" `Quick test_gemini_stream_finish
         ; test_case
             "thinking delta index (#332)"

--- a/test/test_gemini_edge_cases.ml
+++ b/test/test_gemini_edge_cases.ml
@@ -134,9 +134,9 @@ let test_sse_function_call () =
   | None -> check "parsed chunk" false
 ;;
 
-(* ── 5. tool_use_id synthesis + roundtrip ── *)
+(* ── 5. OAS-allocated tool_use_id + roundtrip ── *)
 let test_tool_use_id_roundtrip () =
-  Printf.printf "=== tool_use_id synthesis roundtrip ===\n";
+  Printf.printf "=== allocated tool_use_id roundtrip ===\n";
   let response_json =
     Yojson.Safe.from_string
       {|{
@@ -152,11 +152,11 @@ let test_tool_use_id_roundtrip () =
     | Types.ToolUse { id; name; input } -> id, name, input
     | _ -> failwith "expected ToolUse"
   in
-  Printf.printf "  synthesized id: %s\n" tu_id;
+  Printf.printf "  allocated id: %s\n" tu_id;
   Printf.printf "  name: %s\n" tu_name;
   check "id is non-empty" (tu_id <> "");
   check "name is get_weather" (tu_name = "get_weather");
-  (* Build next turn with ToolResult using this synthesized id *)
+  (* Build next turn with ToolResult using this allocated id. *)
   let config =
     Provider_config.make
       ~kind:Gemini
@@ -197,9 +197,10 @@ let test_tool_use_id_roundtrip () =
   let parts = third |> member "parts" |> to_list in
   let fr = List.hd parts |> member "functionResponse" in
   check "functionResponse present" (fr <> `Null);
+  check "functionResponse.id preserved" (fr |> member "id" |> to_string = tu_id);
   let fr_name = fr |> member "name" |> to_string in
   check "functionResponse.name = get_weather (resolved from id)" (fr_name = "get_weather");
-  Printf.printf "  functionResponse.name: %s (resolved from synthesized id)\n" fr_name
+  Printf.printf "  functionResponse.name: %s (resolved from allocated id)\n" fr_name
 ;;
 
 let () =

--- a/test/test_llm_provider_cov.ml
+++ b/test/test_llm_provider_cov.ml
@@ -246,24 +246,28 @@ let test_max_stdio_buffer () =
   Alcotest.(check int) "16 MB" (16 * 1024 * 1024) Api_common.max_stdio_buffer
 ;;
 
-let test_synthesize_tool_use_id () =
-  let id1 =
-    Api_common.synthesize_tool_use_id ~name:"my_tool" (`Assoc [ "key", `String "val" ])
-  in
-  let id2 =
-    Api_common.synthesize_tool_use_id ~name:"my_tool" (`Assoc [ "key", `String "val" ])
-  in
-  Alcotest.(check string) "deterministic" id1 id2;
+let test_fresh_tool_use_id () =
+  let id1 = Api_common.fresh_tool_use_id () in
+  let id2 = Api_common.fresh_tool_use_id () in
+  Alcotest.(check bool) "distinct allocations" true (id1 <> id2);
   Alcotest.(check bool)
-    "starts with call_"
+    "starts with OAS namespace"
     true
-    (String.length id1 > 5 && String.sub id1 0 5 = "call_")
+    (String.starts_with ~prefix:"call_oas_" id1)
 ;;
 
-let test_synthesize_tool_use_id_different_args () =
-  let id1 = Api_common.synthesize_tool_use_id ~name:"tool" (`Assoc [ "a", `Int 1 ]) in
-  let id2 = Api_common.synthesize_tool_use_id ~name:"tool" (`Assoc [ "a", `Int 2 ]) in
-  Alcotest.(check bool) "different args -> different id" true (id1 <> id2)
+let test_fresh_tool_use_id_domain_safe () =
+  let domains =
+    Array.init 4 (fun _ ->
+      Domain.spawn (fun () -> List.init 64 (fun _ -> Api_common.fresh_tool_use_id ())))
+  in
+  let ids = domains |> Array.to_list |> List.concat_map Domain.join in
+  let unique = Hashtbl.create (List.length ids) in
+  List.iter (fun id -> Hashtbl.replace unique id ()) ids;
+  Alcotest.(check int)
+    "all domain allocations unique"
+    (List.length ids)
+    (Hashtbl.length unique)
 ;;
 
 let test_string_is_blank () =
@@ -1932,11 +1936,11 @@ let () =
         ; Alcotest.test_case "max_stdio_buffer" `Quick test_max_stdio_buffer
         ] )
     ; ( "api_common.helpers"
-      , [ Alcotest.test_case "synthesize_tool_use_id" `Quick test_synthesize_tool_use_id
+      , [ Alcotest.test_case "fresh_tool_use_id" `Quick test_fresh_tool_use_id
         ; Alcotest.test_case
-            "synthesize_tool_use_id different"
+            "fresh_tool_use_id domain-safe"
             `Quick
-            test_synthesize_tool_use_id_different_args
+            test_fresh_tool_use_id_domain_safe
         ; Alcotest.test_case "string_is_blank" `Quick test_string_is_blank
         ; Alcotest.test_case "text_blocks_to_string" `Quick test_text_blocks_to_string
         ; Alcotest.test_case

--- a/test/test_snapshot_provider_serialization.ml
+++ b/test/test_snapshot_provider_serialization.ml
@@ -667,7 +667,7 @@ let test_anthropic_nudged_tool_turn_merges_followup_text () =
 (* ── Gemini ─────────────────────────────────────────── *)
 
 let gemini_any_expected =
-  {|{"toolConfig":{"functionCallingConfig":{"mode":"ANY"}},"tools":[{"functionDeclarations":[{"name":"get_weather","description":"Get weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}]}],"generationConfig":{"temperature":0.7,"maxOutputTokens":1024},"contents":[{"role":"user","parts":[{"text":"What's the weather in Seoul?"}]},{"role":"model","parts":[{"functionCall":{"name":"get_weather","args":{"city":"Seoul"}}}]},{"role":"user","parts":[{"functionResponse":{"name":"get_weather","response":{"result":"Sunny, 25C"}}}]}]}|}
+  {|{"toolConfig":{"functionCallingConfig":{"mode":"ANY"}},"tools":[{"functionDeclarations":[{"name":"get_weather","description":"Get weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}]}],"generationConfig":{"temperature":0.7,"maxOutputTokens":1024},"contents":[{"role":"user","parts":[{"text":"What's the weather in Seoul?"}]},{"role":"model","parts":[{"functionCall":{"id":"call_1","name":"get_weather","args":{"city":"Seoul"}}}]},{"role":"user","parts":[{"functionResponse":{"id":"call_1","name":"get_weather","response":{"result":"Sunny, 25C"}}}]}]}|}
 ;;
 
 let test_gemini_any () =

--- a/test/test_streaming_coverage.ml
+++ b/test/test_streaming_coverage.ml
@@ -436,7 +436,7 @@ let test_finalize_tool_use_missing_name () =
     Alcotest.fail "expected missing tool name to fail closed"
 ;;
 
-let test_finalize_tool_use_missing_id_synthesizes () =
+let test_finalize_tool_use_missing_id_fails_closed () =
   let acc = Streaming.create_stream_acc () in
   Streaming.accumulate_event
     acc
@@ -445,22 +445,15 @@ let test_finalize_tool_use_missing_id_synthesizes () =
   Streaming.accumulate_event
     acc
     (ContentBlockDelta { index = 0; delta = InputJsonDelta {|{"ok": true}|} });
-  let resp = finalize_ok acc in
-  match resp.content with
-  | [ ToolUse { id; name; input } ] ->
-    check_bool "synthetic id prefix" true (String.starts_with ~prefix:"call_lookup_" id);
-    check_string "tool_name" "lookup" name;
-    let input_ok =
-      match input with
-      | `Assoc [ ("ok", `Bool true) ] -> true
-      | unexpected ->
-        let (_ : Yojson.Safe.t) = unexpected in
-        false
-    in
-    check_bool "input ok" true input_ok
-  | unexpected ->
-    let (_ : content_block list) = unexpected in
-    Alcotest.fail "expected ToolUse with synthetic id"
+  Streaming.accumulate_event
+    acc
+    (MessageDelta { stop_reason = Some StopToolUse; usage = None });
+  match Streaming.finalize_stream_acc acc with
+  | Error (Stream_parse_failed { reason; raw }) ->
+    check_string "missing id reason" "malformed_tool_use:index:0:missing_id" reason;
+    check_string "raw omitted" "" raw
+  | Error err -> fail_unexpected_stream_error err
+  | Ok _ -> Alcotest.fail "expected missing tool id to fail closed"
 ;;
 
 (* ── finalize: text block with no delta (empty text) ────────────── *)
@@ -813,12 +806,15 @@ let test_acc_partial_tool_metadata () =
   Streaming.accumulate_event
     acc
     (ContentBlockDelta { index = 0; delta = InputJsonDelta {|{}|} });
-  let resp = finalize_ok acc in
-  match resp.content with
-  | [ ToolUse { id; name; _ } ] ->
-    check_bool "synthetic id" true (String.starts_with ~prefix:"call_partial_" id);
-    check_string "partial name" "partial" name
-  | _ -> Alcotest.fail "expected ToolUse with partial metadata"
+  Streaming.accumulate_event
+    acc
+    (MessageDelta { stop_reason = Some StopToolUse; usage = None });
+  match Streaming.finalize_stream_acc acc with
+  | Error (Stream_parse_failed { reason; raw }) ->
+    check_string "missing id reason" "malformed_tool_use:index:0:missing_id" reason;
+    check_string "raw omitted" "" raw
+  | Error err -> fail_unexpected_stream_error err
+  | Ok _ -> Alcotest.fail "expected partial tool metadata to fail closed"
 ;;
 
 (* ── finalize: block with buffer but no text (empty buffer) ─────── *)
@@ -951,9 +947,9 @@ let () =
             `Quick
             test_finalize_tool_use_missing_name
         ; Alcotest.test_case
-            "tool_use missing id synthesizes"
+            "tool_use missing id fails closed"
             `Quick
-            test_finalize_tool_use_missing_id_synthesizes
+            test_finalize_tool_use_missing_id_fails_closed
         ; Alcotest.test_case
             "text block no delta"
             `Quick

--- a/test/test_streaming_edge_cases.ml
+++ b/test/test_streaming_edge_cases.ml
@@ -282,7 +282,6 @@ let test_openai_event_edge_branches () =
      check string "provider" "p" r.provider;
      check string "model" "m" r.model
    | _ -> fail "expected thinking completion telemetry");
-  state.thinking_state <- S.Thinking_done;
   let repeat_reasoning_events, _ =
     S.openai_chunk_to_events state (openai_chunk ~delta_reasoning:"again" ())
   in
@@ -363,7 +362,6 @@ let test_gemini_event_edge_branches () =
    | Some (Llm_provider.Telemetry_event.Thinking_complete r) ->
      check string "provider" "gemini" r.provider
    | _ -> fail "expected gemini thinking completion telemetry");
-  state.thinking_state <- S.Thinking_done;
   let restarted_events, _ =
     S.gemini_chunk_to_events state (gemini_chunk ~parts:[ thought_part ] ())
   in
@@ -466,8 +464,11 @@ let test_ollama_event_edge_branches () =
    | Some (Llm_provider.Telemetry_event.Thinking_complete r) ->
      check string "provider" "ollama" r.provider
    | _ -> fail "expected empty-thinking telemetry");
-  state.thinking_state <- S.Thinking_started 0.0;
-  let none_thinking_events, none_tel = S.ollama_chunk_to_events state (ollama_chunk ()) in
+  let none_state = S.create_openai_stream_state ~provider:"ollama" ~model:"m" () in
+  ignore (S.ollama_chunk_to_events none_state (ollama_chunk ~delta_thinking:"start" ()));
+  let none_thinking_events, none_tel =
+    S.ollama_chunk_to_events none_state (ollama_chunk ())
+  in
   check_event_count "missing thinking closes telemetry only" 0 none_thinking_events;
   (match none_tel with
    | Some (Llm_provider.Telemetry_event.Thinking_complete _) -> ()

--- a/test/test_streaming_openai.ml
+++ b/test/test_streaming_openai.ml
@@ -199,6 +199,138 @@ let test_events_tool_call () =
   | _ -> Alcotest.fail "expected InputJsonDelta"
 ;;
 
+let idless_openai_tool_start () =
+  let state = S.create_openai_stream_state () in
+  let events, _ =
+    S.openai_chunk_to_events
+      state
+      { chunk_id = "same-provider-chunk"
+      ; chunk_model = "model"
+      ; delta_content = None
+      ; delta_reasoning = None
+      ; delta_reasoning_details = None
+      ; delta_tool_calls =
+          [ { S.tc_index = 0
+            ; tc_id = None
+            ; tc_name = Some "lookup"
+            ; tc_arguments = Some (S.Args_fragment {|{"q":"same"}|})
+            }
+          ]
+      ; finish_reason = None
+      ; chunk_usage = None
+      ; chunk_parse_error = None
+      }
+  in
+  match events with
+  | [ ContentBlockStart { index = 0; content_type = "tool_use"; tool_id = Some id; _ }
+    ; ContentBlockDelta { index = 0; delta = InputJsonDelta _ }
+    ] -> id, state, events
+  | _ -> Alcotest.fail "expected id-less call to receive one identity at block start"
+;;
+
+let test_events_idless_tool_identity_matches_final_response () =
+  let start_id, state, events = idless_openai_tool_start () in
+  let acc = Acc.create_stream_acc () in
+  Acc.accumulate_event
+    acc
+    (MessageStart { id = "response"; model = "model"; usage = None });
+  List.iter (Acc.accumulate_event acc) events;
+  let terminal, _ =
+    S.openai_chunk_to_events
+      state
+      { chunk_id = "same-provider-chunk"
+      ; chunk_model = "model"
+      ; delta_content = None
+      ; delta_reasoning = None
+      ; delta_reasoning_details = None
+      ; delta_tool_calls = []
+      ; finish_reason = Some "tool_calls"
+      ; chunk_usage = None
+      ; chunk_parse_error = None
+      }
+  in
+  List.iter (Acc.accumulate_event acc) terminal;
+  match Acc.finalize_stream_acc acc with
+  | Ok { content = [ ToolUse { id; name = "lookup"; _ } ]; _ } ->
+    Alcotest.(check string) "start and final identity" start_id id
+  | Ok _ -> Alcotest.fail "expected one finalized ToolUse"
+  | Error _ -> Alcotest.fail "expected id-less normalized stream to finalize"
+;;
+
+let test_events_idless_tool_ids_are_unique_across_streams () =
+  let first, _, _ = idless_openai_tool_start () in
+  let second, _, _ = idless_openai_tool_start () in
+  Alcotest.(check bool) "separate streams allocate distinct ids" true (first <> second)
+;;
+
+let test_events_parallel_idless_tool_ids_are_distinct () =
+  let state = S.create_openai_stream_state () in
+  let call tc_index =
+    { S.tc_index
+    ; tc_id = None
+    ; tc_name = Some "lookup"
+    ; tc_arguments = Some (S.Args_fragment {|{"q":"same"}|})
+    }
+  in
+  let events, _ =
+    S.openai_chunk_to_events
+      state
+      { chunk_id = "chunk"
+      ; chunk_model = "model"
+      ; delta_content = None
+      ; delta_reasoning = None
+      ; delta_reasoning_details = None
+      ; delta_tool_calls = [ call 0; call 1 ]
+      ; finish_reason = None
+      ; chunk_usage = None
+      ; chunk_parse_error = None
+      }
+  in
+  let ids =
+    List.filter_map
+      (function
+        | ContentBlockStart { content_type = "tool_use"; tool_id = Some id; _ } -> Some id
+        | _ -> None)
+      events
+  in
+  match ids with
+  | [ first; second ] ->
+    Alcotest.(check bool) "parallel identical calls stay distinct" true (first <> second)
+  | _ -> Alcotest.fail "expected two identified tool starts"
+;;
+
+let test_events_late_provider_tool_id_fails_closed () =
+  let _, state, _ = idless_openai_tool_start () in
+  let events, _ =
+    S.openai_chunk_to_events
+      state
+      { chunk_id = "same-provider-chunk"
+      ; chunk_model = "model"
+      ; delta_content = None
+      ; delta_reasoning = None
+      ; delta_reasoning_details = None
+      ; delta_tool_calls =
+          [ { S.tc_index = 0
+            ; tc_id = Some "provider-late-id"
+            ; tc_name = None
+            ; tc_arguments = Some (S.Args_fragment "}")
+            }
+          ]
+      ; finish_reason = None
+      ; chunk_usage = None
+      ; chunk_parse_error = None
+      }
+  in
+  match events with
+  | [ SSEParseFailed { reason; _ } ] ->
+    Alcotest.(check string)
+      "late provider identity is explicit"
+      "late_provider_tool_call_id: provider identity arrived after an OAS identity was \
+       emitted"
+      reason
+  | _ -> Alcotest.fail "expected a typed late-provider-identity failure"
+;;
+
 let test_events_finish_reason () =
   let state = S.create_openai_stream_state () in
   let events, _tel =
@@ -715,7 +847,6 @@ let test_events_multi_tool_then_text () =
       ; chunk_parse_error = None
       }
   in
-  Alcotest.(check int) "next_block_index after 2 tools" 2 state.next_block_index;
   (* Text must get index 2 *)
   let text_events, _tel =
     S.openai_chunk_to_events
@@ -759,7 +890,6 @@ let test_events_thinking_tool_text () =
       ; chunk_parse_error = None
       }
   in
-  Alcotest.(check int) "next after thinking" 1 state.next_block_index;
   (* Tool call: gets index 1 *)
   let tc : S.openai_tool_call_delta =
     { tc_index = 0
@@ -782,7 +912,6 @@ let test_events_thinking_tool_text () =
       ; chunk_parse_error = None
       }
   in
-  Alcotest.(check int) "next after tool" 2 state.next_block_index;
   (* Text: must get index 2 *)
   let text_events, _tel =
     S.openai_chunk_to_events
@@ -939,6 +1068,49 @@ let test_responses_stream_reasoning_tool_and_terminal () =
     Alcotest.(check int) "output tokens" 8 usage.output_tokens;
     Alcotest.(check int) "cache read" 2 usage.cache_read_input_tokens
   | _ -> Alcotest.fail "expected redacted reasoning carrier and terminal StopToolUse"
+;;
+
+let test_responses_stream_idless_tool_identity_matches_final_response () =
+  let state =
+    S.create_openai_stream_state ~provider:"openai_compat" ~model:"responses-model" ()
+  in
+  let acc = Acc.create_stream_acc () in
+  let feed event_type data =
+    let events, _ = S.responses_sse_to_events state (Some event_type) data in
+    List.iter (Acc.accumulate_event acc) events;
+    events
+  in
+  let _ =
+    feed
+      "response.created"
+      {|{"type":"response.created","response":{"id":"resp","model":"responses-model","status":"in_progress","usage":null}}|}
+  in
+  let added =
+    feed
+      "response.output_item.added"
+      {|{"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","name":"lookup","arguments":""}}|}
+  in
+  let start_id =
+    match added with
+    | [ ContentBlockStart { index = 0; content_type = "tool_use"; tool_id = Some id; _ } ]
+      -> id
+    | _ -> Alcotest.fail "expected an OAS identity on the Responses tool start"
+  in
+  let _ =
+    feed
+      "response.function_call_arguments.delta"
+      {|{"type":"response.function_call_arguments.delta","output_index":0,"delta":"{\"q\":\"weather\"}"}|}
+  in
+  let _ =
+    feed
+      "response.completed"
+      {|{"type":"response.completed","response":{"id":"resp","model":"responses-model","status":"completed","output":[{"type":"function_call","name":"lookup","arguments":"{\"q\":\"weather\"}"}],"usage":{"input_tokens":1,"output_tokens":1}}}|}
+  in
+  match Acc.finalize_stream_acc acc with
+  | Ok { content = [ ToolUse { id; name = "lookup"; _ } ]; _ } ->
+    Alcotest.(check string) "Responses start and final identity" start_id id
+  | Ok _ -> Alcotest.fail "expected one Responses ToolUse"
+  | Error _ -> Alcotest.fail "expected id-less Responses tool stream to finalize"
 ;;
 
 let test_responses_stream_hidden_reasoning_before_tool () =
@@ -1273,6 +1445,28 @@ let test_ollama_native_interleaved_thinking_tool_text_finalizes () =
        Alcotest.fail "expected thinking, visible text, and tool use to stay separated")
 ;;
 
+let test_ollama_idless_tool_identity_matches_final_response () =
+  let state = S.create_openai_stream_state ~provider:"ollama" ~model:"qwen" () in
+  let chunk =
+    parse_ollama_line_exn
+      {|{"model":"qwen","message":{"role":"assistant","tool_calls":[{"function":{"name":"lookup","arguments":{"city":"Seoul"}}}]},"done":true,"done_reason":"tool_calls"}|}
+  in
+  let events, _ = S.ollama_chunk_to_events state chunk in
+  let start_id =
+    match events with
+    | ContentBlockStart { content_type = "tool_use"; tool_id = Some id; _ } :: _ -> id
+    | _ -> Alcotest.fail "expected Ollama id-less tool start to receive an identity"
+  in
+  let acc = Acc.create_stream_acc () in
+  Acc.accumulate_event acc (MessageStart { id = "ollama"; model = "qwen"; usage = None });
+  List.iter (Acc.accumulate_event acc) events;
+  match Acc.finalize_stream_acc acc with
+  | Ok { content = [ ToolUse { id; name = "lookup"; _ } ]; _ } ->
+    Alcotest.(check string) "Ollama start and final identity" start_id id
+  | Ok _ -> Alcotest.fail "expected one Ollama ToolUse"
+  | Error _ -> Alcotest.fail "expected Ollama id-less tool stream to finalize"
+;;
+
 let () =
   let open Alcotest in
   run
@@ -1324,6 +1518,22 @@ let () =
       , [ test_case "text first chunk" `Quick test_events_text_first_chunk
         ; test_case "text subsequent" `Quick test_events_text_subsequent
         ; test_case "tool_call" `Quick test_events_tool_call
+        ; test_case
+            "id-less start identity equals finalized ToolUse"
+            `Quick
+            test_events_idless_tool_identity_matches_final_response
+        ; test_case
+            "id-less identities differ across streams"
+            `Quick
+            test_events_idless_tool_ids_are_unique_across_streams
+        ; test_case
+            "parallel id-less identities stay distinct"
+            `Quick
+            test_events_parallel_idless_tool_ids_are_distinct
+        ; test_case
+            "late provider identity fails closed"
+            `Quick
+            test_events_late_provider_tool_id_fails_closed
         ; test_case "finish stop" `Quick test_events_finish_reason
         ; test_case "finish tool_calls" `Quick test_events_tool_calls_finish
         ; test_case
@@ -1354,6 +1564,10 @@ let () =
             "hidden reasoning before tool"
             `Quick
             test_responses_stream_hidden_reasoning_before_tool
+        ; test_case
+            "id-less start identity equals finalized ToolUse"
+            `Quick
+            test_responses_stream_idless_tool_identity_matches_final_response
         ; test_case
             "interleaved reasoning/tool/text finalizes"
             `Quick
@@ -1386,6 +1600,10 @@ let () =
             "native interleaved thinking/tool/text finalizes"
             `Quick
             test_ollama_native_interleaved_thinking_tool_text_finalizes
+        ; test_case
+            "id-less start identity equals finalized ToolUse"
+            `Quick
+            test_ollama_idless_tool_identity_matches_final_response
         ] )
     ]
 ;;

--- a/test/test_streaming_openai.ml
+++ b/test/test_streaming_openai.ml
@@ -1113,6 +1113,49 @@ let test_responses_stream_idless_tool_identity_matches_final_response () =
   | Error _ -> Alcotest.fail "expected id-less Responses tool stream to finalize"
 ;;
 
+let test_responses_stream_item_id_is_not_tool_identity () =
+  let state = S.create_openai_stream_state () in
+  let events, _ =
+    S.responses_sse_to_events
+      state
+      (Some "response.output_item.added")
+      {|{"type":"response.output_item.added","output_index":0,"item":{"id":"fc_item_only","type":"function_call","name":"lookup","arguments":""}}|}
+  in
+  match events with
+  | [ ContentBlockStart
+        { index = 0; content_type = "tool_use"; tool_id = Some tool_id; _ }
+    ] ->
+    Alcotest.(check bool)
+      "output item id is not reused as call identity"
+      true
+      (not (String.equal tool_id "fc_item_only"));
+    Alcotest.(check bool)
+      "id-less call receives OAS identity"
+      true
+      (String.starts_with ~prefix:"call_oas_" tool_id)
+  | _ -> Alcotest.fail "expected one identified Responses tool start"
+;;
+
+let test_responses_stream_arguments_delta_preserves_call_id () =
+  let state = S.create_openai_stream_state () in
+  let events, _ =
+    S.responses_sse_to_events
+      state
+      (Some "response.function_call_arguments.delta")
+      {|{"type":"response.function_call_arguments.delta","output_index":0,"item_id":"fc_item","call_id":"call_native","delta":"{}"}|}
+  in
+  match events with
+  | [ ContentBlockStart
+        { index = 0
+        ; content_type = "tool_use"
+        ; tool_id = Some "call_native"
+        ; tool_name = None
+        }
+    ; ContentBlockDelta { index = 0; delta = InputJsonDelta "{}" }
+    ] -> ()
+  | _ -> Alcotest.fail "expected delta call_id to identify its tool block"
+;;
+
 let test_responses_stream_hidden_reasoning_before_tool () =
   let state =
     S.create_openai_stream_state ~provider:"openai_compat" ~model:"gpt-5.5" ()
@@ -1568,6 +1611,14 @@ let () =
             "id-less start identity equals finalized ToolUse"
             `Quick
             test_responses_stream_idless_tool_identity_matches_final_response
+        ; test_case
+            "item id is not tool identity"
+            `Quick
+            test_responses_stream_item_id_is_not_tool_identity
+        ; test_case
+            "arguments delta preserves call id"
+            `Quick
+            test_responses_stream_arguments_delta_preserves_call_id
         ; test_case
             "interleaved reasoning/tool/text finalizes"
             `Quick


### PR DESCRIPTION
## Problem

Some OpenAI-compatible, Ollama, Gemini, and Responses streams begin a tool call without a provider call ID. OAS previously emitted `ContentBlockStart.tool_id = None`, then synthesized a different content-derived ID only after the arguments were complete. Repeated identical calls could collide across streams, while dashboards could not correlate the start, deltas, final `ToolUse`, and result.

Closes jeong-sik/oas#2528.

## Invariants implemented

- Preserve every non-blank provider call ID byte-for-byte.
- Allocate one opaque OAS ID before an id-less tool block start; never derive identity from tool name or arguments.
- Carry the exact start ID through argument deltas and finalized `ToolUse`.
- Keep identical parallel/repeated call occurrences distinct.
- Fail explicitly on late provider IDs, ambiguous id-less continuations, route conflicts, and accumulator tool blocks without IDs.
- Keep stream normalization state abstract so consumers cannot bypass the routing/identity authority.
- Use an OCaml 5 `Atomic.fetch_and_add` sequence under a process namespace; domain-concurrency coverage asserts unique allocation.

## Provider coverage

- OpenAI-compatible Chat Completions
- OpenAI Responses (`call_id` stays authoritative; `item_id` is routing metadata only)
- Ollama native NDJSON
- Gemini native and streaming
  - preserves optional native `FunctionCall.id`
  - round-trips the same ID as `FunctionResponse.id`
  - id-less complete parts are distinct occurrences
  - thought-signature carrier remains immediately before its identified `ToolUse`
- Anthropic malformed tool starts without the required provider ID fail closed

Gemini ID fields were verified against the official v1beta schema:
https://github.com/googleapis/googleapis/blob/master/google/ai/generativelanguage/v1beta/content.proto

## Verification

- `ocamlformat --check` on every changed `.ml`/`.mli`: pass
- `git diff --check`: pass
- Local Dune build/test intentionally not run; OCaml 5.4/5.5 build and test authority is PR CI.

## Follow-up found during review

- jeong-sik/masc#27901 tracks the separate Gemini lowering bug where a compacted/missing `ToolUse` currently falls back to using the opaque ID as `functionResponse.name`.
