### PR TITLE
fix(provider): make registry startup-safe

### DIFF
--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -158,11 +158,11 @@ type provider_impl =
   }
 
 let registry : (string, provider_impl) Hashtbl.t = Hashtbl.create 8
-let registry_mu = Eio.Mutex.create ()
+let registry_mu = Mutex.create ()
+let with_registry_lock f = Mutex.protect registry_mu f
 
 let register_provider impl =
-  Eio.Mutex.use_rw ~protect:true registry_mu (fun () ->
-    Hashtbl.replace registry impl.name impl)
+  with_registry_lock (fun () -> Hashtbl.replace registry impl.name impl)
 ;;
 
 let find_builtin_provider name = function
@@ -249,12 +249,12 @@ let builtin_provider_impls = [ kimi_provider_impl ]
 let find_provider name =
   match find_builtin_provider name builtin_provider_impls with
   | Some impl -> Some impl
-  | None -> Eio.Mutex.use_ro registry_mu (fun () -> Hashtbl.find_opt registry name)
+  | None -> with_registry_lock (fun () -> Hashtbl.find_opt registry name)
 ;;
 
 let registered_providers () =
   let dynamic =
-    Eio.Mutex.use_ro registry_mu (fun () ->
+    with_registry_lock (fun () ->
       Hashtbl.fold (fun name _ acc -> name :: acc) registry [])
   in
   builtin_provider_impls

--- a/test/test_custom_provider.ml
+++ b/test/test_custom_provider.ml
@@ -1,5 +1,6 @@
 (** Tests for Custom_registered provider variant and registry integration.
-    Registry uses Eio.Mutex, so all registry tests run inside Eio_main.run. *)
+    The registry itself is safe to use without an Eio runtime. Integration tests
+    that exercise provider request paths retain their Eio wrapper. *)
 
 open Agent_sdk
 
@@ -35,7 +36,7 @@ let make_test_impl ?(name = "test-provider") ?(request_path = "/v1/test") ()
   }
 ;;
 
-(* Wrap a test body in Eio_main.run to provide the Eio effect handler *)
+(* Provide the Eio effect handler for provider request-path integration tests. *)
 let with_eio f () = Eio_main.run @@ fun _env -> f ()
 
 let task_testable =
@@ -244,16 +245,13 @@ let () =
   Alcotest.run
     "Custom Provider"
     [ ( "registry"
-      , [ Alcotest.test_case "register and find" `Quick (with_eio test_register_and_find)
-        ; Alcotest.test_case "find unregistered" `Quick (with_eio test_find_unregistered)
+      , [ Alcotest.test_case "register and find" `Quick test_register_and_find
+        ; Alcotest.test_case "find unregistered" `Quick test_find_unregistered
         ; Alcotest.test_case
             "registered_providers listing"
             `Quick
-            (with_eio test_registered_providers_listing)
-        ; Alcotest.test_case
-            "register overwrites"
-            `Quick
-            (with_eio test_register_overwrites)
+            test_registered_providers_listing
+        ; Alcotest.test_case "register overwrites" `Quick test_register_overwrites
         ] )
     ; ( "config"
       , [ Alcotest.test_case "custom_provider default" `Quick test_custom_provider_config


### PR DESCRIPTION
## Summary

- protect the process-global custom provider registry with OCaml `Mutex`
- keep register/find/list serialized without requiring an Eio scheduler
- run registry CRUD tests directly; retain `Eio_main.run` only for request-path integration tests

## Extraction scope

This is the registry synchronization subproblem extracted from closed jeong-sik/oas#2526. It deliberately does not close or claim jeong-sik/masc#27905 or jeong-sik/masc#27903; those broader telemetry and request-artifact scopes remain separate.

## Why

`Provider.register_provider`, `find_provider`, and `registered_providers` are public startup/configuration APIs and receive no Eio runtime capability. Protecting their process-global table with `Eio.Mutex` made otherwise synchronous calls raise an unhandled Eio cancellation-context effect before `Eio_main.run`.

This keeps the existing registry SSOT and changes only its synchronization boundary; request execution remains Eio-based.

## Validation

- `ocamlformat --check lib/provider.ml test/test_custom_provider.ml`
- parser checks for both changed files
- `git diff --check`
- `scripts/dune-local.sh build test/test_custom_provider.exe`
- focused executable: 15/15 passing, including four registry cases outside `Eio_main.run`
- full build/test remains PR CI authority

[근거] OCaml 5.4 `Mutex.protect` API (https://ocaml.org/manual/5.4/api/Mutex.html), 확인 2026-07-11, 신뢰도 High.
