### PR TITLE
feat(agent): preserve typed tool failure provenance

### DIFF
--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -32,7 +32,7 @@ type api_strategy = Pipeline.api_strategy =
 (** Run a single turn via the 6-stage pipeline.
     Converts Pipeline.turn_outcome to the polymorphic variant interface
     expected by run_loop and the public API. *)
-let run_turn_core ~sw ?clock ~api_strategy ?raw_trace_run agent =
+let run_turn_core ~sw ?clock ~api_strategy ?raw_trace_run ?recovery_context agent =
   Tracing.with_span
     agent.options.tracer
     { kind = Agent_run
@@ -52,10 +52,17 @@ let run_turn_core ~sw ?clock ~api_strategy ?raw_trace_run agent =
          | Stream { on_event; on_telemetry } -> Pipeline.Stream { on_event; on_telemetry }
        in
        match
-         Pipeline.run_turn ~sw ?clock ~api_strategy:api_strat ?raw_trace_run agent
+         Pipeline.run_turn
+           ~sw
+           ?clock
+           ~api_strategy:api_strat
+           ?raw_trace_run
+           ?recovery_context
+           agent
        with
        | Ok (Pipeline.Complete response) -> Ok (`Complete response)
-       | Ok Pipeline.ToolsExecuted -> Ok `ToolsExecuted
+       | Ok (Pipeline.ToolsExecuted completed_round) ->
+         Ok (`ToolsExecuted completed_round)
        | Ok Pipeline.IdleSkipped ->
          Ok
            (`Complete
@@ -78,6 +85,7 @@ let run_turn_with_trace ~sw ?clock ?raw_trace_run agent =
 ;;
 
 let provide_input agent request response =
+  set_recovery_state agent empty_recovery_state;
   Agent_elicitation.apply_response agent request response
 ;;
 
@@ -100,7 +108,8 @@ let check_loop_guard agent =
            (Error.MaxTurnsExceeded
               { turns = agent.state.turn_count; limit = agent.state.config.max_turns }))
     else if
-      agent.consecutive_idle_turns >= agent.options.max_idle_turns
+      Option.is_none agent.tool_failure_judge
+      && agent.consecutive_idle_turns >= agent.options.max_idle_turns
       && agent.options.max_idle_turns > 0
     then
       Some
@@ -182,6 +191,7 @@ let append_user_input agent user_blocks =
   in
   update_state agent (fun s ->
     { s with messages = Util.snoc (base_messages agent) user_msg });
+  set_recovery_state agent empty_recovery_state;
   user_msg.content
 ;;
 
@@ -226,6 +236,249 @@ let log_turn ~run_start ~turn_start ~turn_index ~max_turns ~model ~stop =
     ]
 ;;
 
+let recovery_failure stage detail =
+  Error.Agent (Error.ToolFailureRecoveryFailed { stage; detail })
+;;
+
+let ( let* ) = Result.bind
+
+let publish_recovery_event agent payload =
+  match agent.options.event_bus with
+  | None -> ()
+  | Some bus ->
+    Pipeline_common.safe_publish
+      ~log:_log
+      bus
+      { Event_bus.meta = Pipeline_common.event_envelope agent; payload }
+;;
+
+let recovery_timestamp = function
+  | Some clock -> Eio.Time.now clock
+  | None -> Unix.gettimeofday ()
+;;
+
+let apply_recovery_receipt_outcome agent receipt =
+  match Tool_failure_recovery.receipt_decision receipt with
+  | Tool_failure_recovery.Retry_modified _ | Tool_failure_recovery.Replan _ -> Ok ()
+  | Tool_failure_recovery.Ask_user { question; schema } ->
+    let request : Hooks.elicitation_request = { question; schema; timeout_s = None } in
+    let input_required =
+      Agent_elicitation.input_required_of_request
+        ~agent_name:agent.state.config.name
+        ~turn:agent.state.turn_count
+        ~created_at:(Tool_failure_recovery.receipt_decided_at receipt)
+        request
+    in
+    Error (Error.Agent (Error.InputRequired input_required))
+  | Tool_failure_recovery.Defer { reason } ->
+    Error
+      (Error.Agent
+         (Error.ToolFailureRecoveryDeferred
+            { reason; tool_names = Tool_failure_recovery.receipt_tool_names receipt }))
+;;
+
+let persist_recovery_decision ?clock agent ~episodes decision =
+  let receipt =
+    Tool_failure_recovery.make_receipt
+      ~resume_turn:agent.state.turn_count
+      ~decided_at:(recovery_timestamp clock)
+      ~episodes
+      ~decision
+  in
+  let* messages =
+    match
+      Tool_failure_recovery.attach_receipt
+        ~messages:agent.state.messages
+        ~episodes
+        ~receipt
+    with
+    | Ok messages -> Ok messages
+    | Error error ->
+      Error
+        (recovery_failure
+           Error.Decision_persistence
+           (Tool_failure_recovery.show_receipt_error error))
+  in
+  let candidate_state = { agent.state with messages } in
+  let* () =
+    Pipeline.persist_turn_checkpoint_for_state
+      agent
+      After_retry_feedback_appended
+      candidate_state
+  in
+  set_state agent candidate_state;
+  update_recovery_state agent (fun state ->
+    { state with pending_episodes = None; pending_receipt = Some receipt });
+  publish_recovery_event
+    agent
+    (Event_bus.ToolFailureRecoveryDecided
+       { agent_name = agent.state.config.name; turn = agent.state.turn_count; decision });
+  Log.info
+    _log
+    "typed tool failure recovery decided"
+    [ Log.S ("agent", agent.state.config.name)
+    ; Log.I ("turn", agent.state.turn_count)
+    ; Log.S ("decision", Tool_failure_recovery.show_decision decision)
+    ];
+  Ok receipt
+;;
+
+let invoke_recovery_judge ~sw ?clock agent episodes =
+  match agent.tool_failure_judge with
+  | None ->
+    update_recovery_state agent (fun state ->
+      { state with pending_episodes = None; pending_receipt = None });
+    Ok ()
+  | Some judge ->
+    (match
+       Tool_failure_recovery.decide
+         ~sw
+         ~agent_name:agent.state.config.name
+         ~turn:agent.state.turn_count
+         ~episodes
+         judge
+     with
+     | Error (Tool_failure_recovery.Completion_failed error) ->
+       let detail =
+         Tool_failure_recovery.judge_error_to_string
+           (Tool_failure_recovery.Completion_failed error)
+       in
+       publish_recovery_event
+         agent
+         (Event_bus.ToolFailureRecoveryJudgeFailed
+            { agent_name = agent.state.config.name
+            ; turn = agent.state.turn_count
+            ; detail
+            });
+       Error error
+     | Error error ->
+       let detail = Tool_failure_recovery.judge_error_to_string error in
+       publish_recovery_event
+         agent
+         (Event_bus.ToolFailureRecoveryJudgeFailed
+            { agent_name = agent.state.config.name
+            ; turn = agent.state.turn_count
+            ; detail
+            });
+       Error (recovery_failure Error.Judge_response detail)
+     | Ok decision ->
+       let* receipt = persist_recovery_decision ?clock agent ~episodes decision in
+       apply_recovery_receipt_outcome agent receipt)
+;;
+
+let resolve_pending_recovery ~sw ?clock agent =
+  let state = recovery_state agent in
+  match state.restore_error with
+  | Some error -> Error error
+  | None ->
+    (match state.pending_episodes with
+     | None ->
+       (match state.pending_receipt with
+        | Some receipt
+          when Tool_failure_recovery.receipt_resume_turn receipt = agent.state.turn_count
+          -> apply_recovery_receipt_outcome agent receipt
+        | Some receipt
+          when Tool_failure_recovery.receipt_resume_turn receipt > agent.state.turn_count
+          ->
+          Error
+            (recovery_failure
+               Error.Resume_restore
+               "recovery receipt targets a future turn")
+        | Some _ ->
+          update_recovery_state agent (fun current ->
+            { current with pending_receipt = None });
+          Ok ()
+        | None -> Ok ())
+     | Some episodes ->
+       (match state.pending_receipt with
+        | Some receipt
+          when Tool_failure_recovery.receipt_resume_turn receipt = agent.state.turn_count
+          ->
+          let* () =
+            match Tool_failure_recovery.validate_receipt ~episodes receipt with
+            | Ok () -> Ok ()
+            | Error error ->
+              Error
+                (recovery_failure
+                   Error.Resume_restore
+                   (Tool_failure_recovery.show_receipt_error error))
+          in
+          update_recovery_state agent (fun current ->
+            { current with pending_episodes = None });
+          apply_recovery_receipt_outcome agent receipt
+        | Some receipt
+          when Tool_failure_recovery.receipt_resume_turn receipt > agent.state.turn_count
+          ->
+          Error
+            (recovery_failure
+               Error.Resume_restore
+               "recovery receipt targets a future turn")
+        | Some _ ->
+          update_recovery_state agent (fun current ->
+            { current with pending_receipt = None });
+          invoke_recovery_judge ~sw ?clock agent episodes
+        | None -> invoke_recovery_judge ~sw ?clock agent episodes))
+;;
+
+let register_completed_tool_round agent current =
+  let state = recovery_state agent in
+  let detection =
+    match state.last_completed_round with
+    | None -> Ok []
+    | Some previous -> Tool_failure_episode.detect ~previous ~current
+  in
+  match detection with
+  | Error error ->
+    update_recovery_state agent (fun state ->
+      { state with last_completed_round = Some current });
+    Error
+      (recovery_failure Error.Episode_detection (Tool_failure_episode.show_error error))
+  | Ok episodes ->
+    update_recovery_state agent (fun state ->
+      { state with
+        last_completed_round = Some current
+      ; pending_episodes = (if episodes = [] then None else Some episodes)
+      ; pending_receipt = None
+      });
+    if episodes <> []
+    then
+      publish_recovery_event
+        agent
+        (Event_bus.ToolFailureEpisodeDetected
+           { agent_name = agent.state.config.name
+           ; turn = agent.state.turn_count
+           ; episodes
+           });
+    Ok ()
+;;
+
+let recovery_context_for_turn agent =
+  let state = recovery_state agent in
+  match state.restore_error with
+  | Some error -> Error error
+  | None ->
+    (match state.pending_receipt with
+     | None -> Ok None
+     | Some receipt ->
+       let resume_turn = Tool_failure_recovery.receipt_resume_turn receipt in
+       if resume_turn = agent.state.turn_count
+       then Ok (Tool_failure_recovery.system_context receipt)
+       else if resume_turn < agent.state.turn_count
+       then (
+         update_recovery_state agent (fun current ->
+           { current with pending_receipt = None });
+         Ok None)
+       else
+         Error
+           (recovery_failure
+              Error.Resume_restore
+              "recovery receipt targets a future turn"))
+;;
+
+type provider_lease =
+  | Held
+  | Released
+
 let run_loop ~sw ?clock ~api_strategy ?on_yield ?on_resume ?on_activity agent user_blocks =
   let bump_activity () =
     match on_activity with
@@ -237,33 +490,23 @@ let run_loop ~sw ?clock ~api_strategy ?on_yield ?on_resume ?on_activity agent us
   with_raw_trace_run agent trace_prompt
   @@ fun raw_trace_run ->
   let yield_enabled = agent.state.config.yield_on_tool in
-  let do_yield () =
-    match on_yield with
-    | Some f -> f ()
-    | None -> ()
+  let release_lease = function
+    | Released -> Released
+    | Held when yield_enabled ->
+      Option.iter (fun callback -> callback ()) on_yield;
+      Released
+    | Held -> Held
   in
-  let do_resume () =
-    match on_resume with
-    | Some f -> f ()
-    | None -> ()
+  let acquire_lease = function
+    | Held -> Held
+    | Released when yield_enabled ->
+      Option.iter (fun callback -> callback ()) on_resume;
+      Held
+    | Released -> Held
   in
-  (* Per-turn timing snapshot: capture when the run started so each turn
-     log line carries both per-turn duration and the cumulative elapsed
-     time against the agent's OAS budget.  Diagnosing wall-clock
-     timeouts requires knowing whether the budget was spent on many
-     moderate turns or a single slow one. *)
   let run_start = Unix.gettimeofday () in
-  (* Convergence turn for [ensure_final_text]: the run's contract is to produce
-     a user-facing answer, but the model ended with tool activity and no visible
-     text (downstream renders this as "Tool-only turn ended without a final
-     reply"). We run exactly ONE more model turn with the tool set withheld
-     ([Tool_set.empty] — the same swap {!run_with_handoffs_blocks} uses). With no
-     tools the model cannot emit a tool call, so it must author a textual final
-     answer: the answer is LLM-authored, not synthesized, and this adds no
-     turn/token cap. This is a single [run_turn_core] call — never a recursion
-     into [loop] — so it runs at most once and cannot itself trigger another
-     final-answer turn. *)
-  let run_final_answer_turn () =
+  let run_final_answer_turn lease =
+    let _lease = acquire_lease lease in
     let tool_withheld_agent = { agent with tools = Tool_set.empty } in
     let turn_index = agent.state.turn_count + 1 in
     let max_turns = agent.state.config.max_turns in
@@ -280,82 +523,87 @@ let run_loop ~sw ?clock ~api_strategy ?on_yield ?on_resume ?on_activity agent us
       ~stop:"ensure_final_text";
     result
   in
-  (* First turn: caller already holds slot, no resume needed *)
-  let rec loop ~is_first_turn =
-    match check_loop_guard agent with
-    | Some (Error.Agent (Error.MaxTurnsExceeded _) as err)
-      when agent.state.config.ensure_final_text ->
-      (* Hit the turn limit after a tool turn with no final text. Converge with
-         one tool-withheld answer turn before surfacing the limit error. If that
-         turn does not yield a [`Complete] response (degenerate [`ToolsExecuted],
-         or a hard error), fall back to the original MaxTurnsExceeded error. *)
-      (match run_final_answer_turn () with
-       | Ok (`Complete final_response) -> Ok final_response
-       | Ok `ToolsExecuted | Error _ -> Error err)
-    | Some err -> Error err
-    | None ->
-      (* Resume slot before LLM turn (skip on first turn) *)
-      if yield_enabled && not is_first_turn then do_resume ();
-      (* Snapshot turn_count BEFORE run_turn_core — Pipeline.stage_collect
-         increments it (pipeline.ml:299) before returning, so reading
-         agent.state.turn_count afterwards would yield the NEXT turn's
-         index, not the one that just finished.  We display as 1-based
-         ("turn 1/15" = the 1st of 15) for human readability. *)
-      let turn_index = agent.state.turn_count + 1 in
-      let max_turns = agent.state.config.max_turns in
-      let turn_start = Unix.gettimeofday () in
-      let result = run_turn_core ~sw ?clock ~api_strategy ?raw_trace_run agent in
-      (* A completed turn is execution progress: bump the idle watchdog
-         so a multi-turn run (especially non-streaming, where there are no
-         token-level [on_event] signals) is not flagged as stalled between
-         turns. Streaming turns also bump per token via the wrapped
-         [on_event] in [run_stream]. *)
-      bump_activity ();
-      (match result with
-       | Error e ->
-         log_turn
-           ~run_start
-           ~turn_start
-           ~turn_index
-           ~max_turns
-           ~model:agent.state.config.model
-           ~stop:("error:" ^ Error.to_string e);
-         Error e
-       | Ok (`Complete response) ->
-         log_turn
-           ~run_start
-           ~turn_start
-           ~turn_index
-           ~max_turns
-           ~model:response.model
-           ~stop:(stop_reason_label response.stop_reason);
-         if
-           agent.state.config.ensure_final_text
-           && Option.is_none (final_text_of_response response)
-         then (
-           (* Terminal turn carried no visible text: converge with one
-              tool-withheld answer turn. Return whatever it yields and do NOT
-              retry — a [`Complete] result is returned even if it is still
-              text-free; a degenerate [`ToolsExecuted] falls back to the
-              original response; a hard error is surfaced honestly. *)
-           match run_final_answer_turn () with
-           | Ok (`Complete final_response) -> Ok final_response
-           | Ok `ToolsExecuted -> Ok response
-           | Error e -> Error e)
-         else Ok response
-       | Ok `ToolsExecuted ->
-         log_turn
-           ~run_start
-           ~turn_start
-           ~turn_index
-           ~max_turns
-           ~model:agent.state.config.model
-           ~stop:"tools_executed";
-         (* Yield slot during tool execution gap *)
-         if yield_enabled then do_yield ();
-         loop ~is_first_turn:false)
+  let rec loop lease =
+    (* A failed-tool judge runs only after the main provider lease has been
+       released. [on_resume] is reserved for the next main provider call. *)
+    let lease =
+      match (recovery_state agent).pending_episodes with
+      | Some _ -> release_lease lease
+      | None -> lease
+    in
+    match resolve_pending_recovery ~sw ?clock agent with
+    | Error error -> Error error
+    | Ok () ->
+      (match check_loop_guard agent with
+       | Some (Error.Agent (Error.MaxTurnsExceeded _) as err)
+         when agent.state.config.ensure_final_text ->
+         (match run_final_answer_turn lease with
+          | Ok (`Complete final_response) -> Ok final_response
+          | Ok (`ToolsExecuted _) | Error _ -> Error err)
+       | Some err -> Error err
+       | None ->
+         (match recovery_context_for_turn agent with
+          | Error error -> Error error
+          | Ok recovery_context ->
+            let lease = acquire_lease lease in
+            let turn_index = agent.state.turn_count + 1 in
+            let max_turns = agent.state.config.max_turns in
+            let turn_start = Unix.gettimeofday () in
+            let result =
+              run_turn_core
+                ~sw
+                ?clock
+                ~api_strategy
+                ?raw_trace_run
+                ?recovery_context
+                agent
+            in
+            bump_activity ();
+            (match result with
+             | Error e ->
+               log_turn
+                 ~run_start
+                 ~turn_start
+                 ~turn_index
+                 ~max_turns
+                 ~model:agent.state.config.model
+                 ~stop:("error:" ^ Error.to_string e);
+               Error e
+             | Ok (`Complete response) ->
+               log_turn
+                 ~run_start
+                 ~turn_start
+                 ~turn_index
+                 ~max_turns
+                 ~model:response.model
+                 ~stop:(stop_reason_label response.stop_reason);
+               if
+                 agent.state.config.ensure_final_text
+                 && Option.is_none (final_text_of_response response)
+               then (
+                 match run_final_answer_turn lease with
+                 | Ok (`Complete final_response) -> Ok final_response
+                 | Ok (`ToolsExecuted _) -> Ok response
+                 | Error e -> Error e)
+               else Ok response
+             | Ok (`ToolsExecuted completed_round) ->
+               log_turn
+                 ~run_start
+                 ~turn_start
+                 ~turn_index
+                 ~max_turns
+                 ~model:agent.state.config.model
+                 ~stop:"tools_executed";
+               let registered =
+                 match completed_round with
+                 | None -> Ok ()
+                 | Some current -> register_completed_tool_round agent current
+               in
+               (match registered with
+                | Error error -> Error error
+                | Ok () -> loop (release_lease lease)))))
   in
-  loop ~is_first_turn:true
+  loop Held
 ;;
 
 (* Start periodic callback fibers, return a stop function *)
@@ -644,22 +892,46 @@ let with_periodic_callbacks ~sw:_ ?clock ~last_activity agent f =
         raise exn)
 ;;
 
+let validate_run_recovery_config agent ~on_yield ~on_resume =
+  match on_yield, on_resume with
+  | Some _, None | None, Some _ ->
+    Error
+      (Error.Config
+         (Error.InvalidConfig
+            { field = "on_yield/on_resume"
+            ; detail = "callbacks must be supplied together or both omitted"
+            }))
+  | Some _, Some _ | None, None ->
+    if Option.is_some agent.tool_failure_judge && not agent.state.config.yield_on_tool
+    then
+      Error
+        (Error.Config
+           (Error.InvalidConfig
+              { field = "yield_on_tool"
+              ; detail = "tool_failure_judge requires yield_on_tool = true"
+              }))
+    else Ok ()
+;;
+
 let run_blocks ~sw ?clock ?on_yield ?on_resume agent user_blocks =
   match validate_user_input_blocks user_blocks with
   | Error _ as err -> err
   | Ok () ->
-    let last_activity = ref (now_or_zero clock) in
-    let on_activity () = last_activity := now_or_zero clock in
-    with_periodic_callbacks ~sw ?clock ~last_activity agent (fun ~sw ->
-      run_loop
-        ~sw
-        ?clock
-        ~api_strategy:Sync
-        ?on_yield
-        ?on_resume
-        ~on_activity
-        agent
-        user_blocks)
+    (match validate_run_recovery_config agent ~on_yield ~on_resume with
+     | Error _ as error -> error
+     | Ok () ->
+       let last_activity = ref (now_or_zero clock) in
+       let on_activity () = last_activity := now_or_zero clock in
+       with_periodic_callbacks ~sw ?clock ~last_activity agent (fun ~sw ->
+         run_loop
+           ~sw
+           ?clock
+           ~api_strategy:Sync
+           ?on_yield
+           ?on_resume
+           ~on_activity
+           agent
+           user_blocks))
 ;;
 
 let run ~sw ?clock ?on_yield ?on_resume agent user_prompt =
@@ -670,35 +942,38 @@ let run_stream_blocks ~sw ?clock ~on_event ?on_yield ?on_resume agent user_block
   match validate_user_input_blocks user_blocks with
   | Error _ as err -> err
   | Ok () ->
-    let on_telemetry =
-      Option.map
-        (fun bus -> Telemetry_bus.publish (Telemetry_bus.of_event_bus bus))
-        agent.options.event_bus
-    in
-    let last_activity = ref (now_or_zero clock) in
-    let on_activity () = last_activity := now_or_zero clock in
-    (* Every streamed event — including reasoning/thinking deltas, which
+    (match validate_run_recovery_config agent ~on_yield ~on_resume with
+     | Error _ as error -> error
+     | Ok () ->
+       let on_telemetry =
+         Option.map
+           (fun bus -> Telemetry_bus.publish (Telemetry_bus.of_event_bus bus))
+           agent.options.event_bus
+       in
+       let last_activity = ref (now_or_zero clock) in
+       let on_activity () = last_activity := now_or_zero clock in
+       (* Every streamed event — including reasoning/thinking deltas, which
        reach [on_event] as [ContentBlockDelta { delta = ThinkingDelta _ }]
        (see Llm_provider.Streaming.openai_chunk_to_events) — counts as
        progress, so a long reasoning burst keeps the idle watchdog from
        firing. [caller_on_event] is the original callback (bound under a
        distinct name so the wrapper is not misread as self-recursion); it
        runs after the activity bump. *)
-    let caller_on_event = on_event in
-    let on_event ev =
-      on_activity ();
-      protect_stream_callback caller_on_event ev
-    in
-    with_periodic_callbacks ~sw ?clock ~last_activity agent (fun ~sw ->
-      run_loop
-        ~sw
-        ?clock
-        ~api_strategy:(Stream { on_event; on_telemetry })
-        ?on_yield
-        ?on_resume
-        ~on_activity
-        agent
-        user_blocks)
+       let caller_on_event = on_event in
+       let on_event ev =
+         on_activity ();
+         protect_stream_callback caller_on_event ev
+       in
+       with_periodic_callbacks ~sw ?clock ~last_activity agent (fun ~sw ->
+         run_loop
+           ~sw
+           ?clock
+           ~api_strategy:(Stream { on_event; on_telemetry })
+           ?on_yield
+           ?on_resume
+           ~on_activity
+           agent
+           user_blocks))
 ;;
 
 let run_stream ~sw ?clock ~on_event ?on_yield ?on_resume agent user_prompt =
@@ -722,105 +997,42 @@ let run_with_handoffs_blocks ~sw ?clock agent ~targets user_blocks =
     with_raw_trace_run agent_with_handoffs trace_prompt
     @@ fun raw_trace_run ->
     let rec loop () =
-      match check_loop_guard agent_with_handoffs with
-      | Some err -> Error err
-      | None ->
-        (match run_turn_with_trace ~sw ?clock ?raw_trace_run agent_with_handoffs with
-         | Error e -> Error e
-         | Ok (`Complete response) -> Ok response
-         | Ok `ToolsExecuted ->
-           (match find_handoff_in_messages agent_with_handoffs.state.messages with
-            | Some (tool_id, target_name, prompt) ->
-              let target_opt =
-                List.find_opt
-                  (fun (t : Handoff.handoff_target) -> t.name = target_name)
-                  targets
+      match resolve_pending_recovery ~sw ?clock agent_with_handoffs with
+      | Error error -> Error error
+      | Ok () ->
+        (match check_loop_guard agent_with_handoffs with
+         | Some err -> Error err
+         | None ->
+           let* recovery_context = recovery_context_for_turn agent_with_handoffs in
+           (match
+              run_turn_core
+                ~sw
+                ?clock
+                ~api_strategy:Sync
+                ?raw_trace_run
+                ?recovery_context
+                agent_with_handoffs
+            with
+            | Error e -> Error e
+            | Ok (`Complete response) -> Ok response
+            | Ok (`ToolsExecuted completed_round) ->
+              let* () =
+                match completed_round with
+                | None -> Ok ()
+                | Some current ->
+                  register_completed_tool_round agent_with_handoffs current
               in
-              (match target_opt with
-               | None ->
-                 let err_msg = Printf.sprintf "Unknown handoff target: %s" target_name in
-                 update_state agent_with_handoffs (fun s ->
-                   { s with
-                     messages =
-                       replace_tool_result
-                         s.messages
-                         ~tool_id
-                         ~content:err_msg
-                         ~is_error:true
-                   });
-                 loop ()
-               | Some target ->
-                 let from_name = agent_with_handoffs.state.config.name in
-                 (* HandoffRequested: capture the run_id so HandoffCompleted
-                    can record it as [caused_by], preserving the
-                    request -> completion causation chain (#877). *)
-                 let handoff_requested_run_id =
-                   match agent_with_handoffs.options.event_bus with
-                   | Some bus ->
-                     let run_id = Event_bus.fresh_id () in
-                     (try
-                        Event_bus.publish
-                          bus
-                          (Event_bus.mk_event
-                             ~run_id
-                             (HandoffRequested
-                                { from_agent = from_name
-                                ; to_agent = target.name
-                                ; reason = prompt
-                                }))
-                      with
-                      | Eio.Cancel.Cancelled _ as exn -> raise exn
-                      | exn ->
-                        Log.warn
-                          _log
-                          "Event_bus.publish failed (HandoffRequested)"
-                          [ Log.S ("error", Printexc.to_string exn) ]);
-                     Some run_id
-                   | None -> None
+              (match find_handoff_in_messages agent_with_handoffs.state.messages with
+               | Some (tool_id, target_name, prompt) ->
+                 let target_opt =
+                   List.find_opt
+                     (fun (t : Handoff.handoff_target) -> t.name = target_name)
+                     targets
                  in
-                 let handoff_t0 = Unix.gettimeofday () in
-                 let sub =
-                   create
-                     ~net:agent.net
-                     ~config:target.config
-                     ~tools:target.tools
-                     ~options:
-                       { default_options with
-                         base_url = agent.options.base_url
-                       ; provider = agent.options.provider
-                       ; policy_channel = agent.options.policy_channel
-                       }
-                     ()
-                 in
-                 let sub_result = run ~sw ?clock sub prompt in
-                 let handoff_elapsed = Unix.gettimeofday () -. handoff_t0 in
-                 (match agent_with_handoffs.options.event_bus with
-                  | Some bus ->
-                    (try
-                       Event_bus.publish
-                         bus
-                         (Event_bus.mk_event
-                            ?caused_by:handoff_requested_run_id
-                            (HandoffCompleted
-                               { from_agent = from_name
-                               ; to_agent = target.name
-                               ; elapsed = handoff_elapsed
-                               }))
-                     with
-                     | Eio.Cancel.Cancelled _ as exn -> raise exn
-                     | exn ->
-                       Log.warn
-                         _log
-                         "Event_bus.publish failed (HandoffCompleted)"
-                         [ Log.S ("error", Printexc.to_string exn) ])
-                  | None -> ());
-                 (match sub_result with
-                  | Error e ->
+                 (match target_opt with
+                  | None ->
                     let err_msg =
-                      Printf.sprintf
-                        "Handoff to %s failed: %s"
-                        target_name
-                        (Error.to_string e)
+                      Printf.sprintf "Unknown handoff target: %s" target_name
                     in
                     update_state agent_with_handoffs (fun s ->
                       { s with
@@ -832,27 +1044,110 @@ let run_with_handoffs_blocks ~sw ?clock agent ~targets user_blocks =
                             ~is_error:true
                       });
                     loop ()
-                  | Ok sub_response ->
-                    let text =
-                      List.fold_left
-                        (fun acc block ->
-                           match block with
-                           | Text s -> if acc = "" then s else acc ^ "\n" ^ s
-                           | _ -> acc)
-                        ""
-                        sub_response.content
+                  | Some target ->
+                    let from_name = agent_with_handoffs.state.config.name in
+                    (* HandoffRequested: capture the run_id so HandoffCompleted
+                    can record it as [caused_by], preserving the
+                    request -> completion causation chain (#877). *)
+                    let handoff_requested_run_id =
+                      match agent_with_handoffs.options.event_bus with
+                      | Some bus ->
+                        let run_id = Event_bus.fresh_id () in
+                        (try
+                           Event_bus.publish
+                             bus
+                             (Event_bus.mk_event
+                                ~run_id
+                                (HandoffRequested
+                                   { from_agent = from_name
+                                   ; to_agent = target.name
+                                   ; reason = prompt
+                                   }))
+                         with
+                         | Eio.Cancel.Cancelled _ as exn -> raise exn
+                         | exn ->
+                           Log.warn
+                             _log
+                             "Event_bus.publish failed (HandoffRequested)"
+                             [ Log.S ("error", Printexc.to_string exn) ]);
+                        Some run_id
+                      | None -> None
                     in
-                    update_state agent_with_handoffs (fun s ->
-                      { s with
-                        messages =
-                          replace_tool_result
-                            s.messages
-                            ~tool_id
-                            ~content:text
-                            ~is_error:false
-                      });
-                    loop ()))
-            | None -> loop ()))
+                    let handoff_t0 = Unix.gettimeofday () in
+                    let sub =
+                      create
+                        ~net:agent.net
+                        ~config:target.config
+                        ~tools:target.tools
+                        ~options:
+                          { default_options with
+                            base_url = agent.options.base_url
+                          ; provider = agent.options.provider
+                          ; policy_channel = agent.options.policy_channel
+                          }
+                        ()
+                    in
+                    let sub_result = run ~sw ?clock sub prompt in
+                    let handoff_elapsed = Unix.gettimeofday () -. handoff_t0 in
+                    (match agent_with_handoffs.options.event_bus with
+                     | Some bus ->
+                       (try
+                          Event_bus.publish
+                            bus
+                            (Event_bus.mk_event
+                               ?caused_by:handoff_requested_run_id
+                               (HandoffCompleted
+                                  { from_agent = from_name
+                                  ; to_agent = target.name
+                                  ; elapsed = handoff_elapsed
+                                  }))
+                        with
+                        | Eio.Cancel.Cancelled _ as exn -> raise exn
+                        | exn ->
+                          Log.warn
+                            _log
+                            "Event_bus.publish failed (HandoffCompleted)"
+                            [ Log.S ("error", Printexc.to_string exn) ])
+                     | None -> ());
+                    (match sub_result with
+                     | Error e ->
+                       let err_msg =
+                         Printf.sprintf
+                           "Handoff to %s failed: %s"
+                           target_name
+                           (Error.to_string e)
+                       in
+                       update_state agent_with_handoffs (fun s ->
+                         { s with
+                           messages =
+                             replace_tool_result
+                               s.messages
+                               ~tool_id
+                               ~content:err_msg
+                               ~is_error:true
+                         });
+                       loop ()
+                     | Ok sub_response ->
+                       let text =
+                         List.fold_left
+                           (fun acc block ->
+                              match block with
+                              | Text s -> if acc = "" then s else acc ^ "\n" ^ s
+                              | _ -> acc)
+                           ""
+                           sub_response.content
+                       in
+                       update_state agent_with_handoffs (fun s ->
+                         { s with
+                           messages =
+                             replace_tool_result
+                               s.messages
+                               ~tool_id
+                               ~content:text
+                               ~is_error:false
+                         });
+                       loop ()))
+               | None -> loop ())))
     in
     loop ()
 ;;
@@ -863,6 +1158,62 @@ let run_with_handoffs ~sw ?clock agent ~targets user_prompt =
 
 (* ── Checkpoint / Resume ─────────────────────────────────────── *)
 
+let restore_tool_failure_recovery messages =
+  let fail detail =
+    { empty_recovery_state with
+      restore_error = Some (recovery_failure Error.Resume_restore detail)
+    }
+  in
+  let project exchange =
+    Tool_failure_episode.project
+      ~tool_uses:exchange.Llm_provider.Tool_message_pairs.tool_uses
+      ~tool_results:exchange.tool_results
+  in
+  let exchanges =
+    Llm_provider.Tool_message_pairs.latest_tool_exchanges ~count:2 messages
+  in
+  match exchanges with
+  | [] ->
+    (match Tool_failure_recovery.latest_receipt messages with
+     | Ok None -> empty_recovery_state
+     | Ok (Some _) -> fail "recovery receipt exists without a tool exchange"
+     | Error error -> fail (Tool_failure_recovery.show_receipt_error error))
+  | current_exchange :: rest ->
+    (match project current_exchange with
+     | Error error -> fail (Tool_failure_episode.show_error error)
+     | Ok current ->
+       let episodes =
+         match rest with
+         | [] -> Ok []
+         | previous_exchange :: _ ->
+           (match project previous_exchange with
+            | Error error -> Error (Tool_failure_episode.show_error error)
+            | Ok previous ->
+              (match Tool_failure_episode.detect ~previous ~current with
+               | Ok episodes -> Ok episodes
+               | Error error -> Error (Tool_failure_episode.show_error error)))
+       in
+       (match episodes with
+        | Error detail -> fail detail
+        | Ok episodes ->
+          (match Tool_failure_recovery.latest_receipt messages with
+           | Error error -> fail (Tool_failure_recovery.show_receipt_error error)
+           | Ok receipt ->
+             let validation =
+               match receipt with
+               | None -> Ok ()
+               | Some receipt -> Tool_failure_recovery.validate_receipt ~episodes receipt
+             in
+             (match validation with
+              | Error error -> fail (Tool_failure_recovery.show_receipt_error error)
+              | Ok () ->
+                { last_completed_round = Some current
+                ; pending_episodes = (if episodes = [] then None else Some episodes)
+                ; pending_receipt = receipt
+                ; restore_error = None
+                }))))
+;;
+
 let resume
       ~net
       ~(checkpoint : Checkpoint.t)
@@ -870,6 +1221,7 @@ let resume
       ?context
       ?(options = default_options)
       ?checkpoint_sink
+      ?tool_failure_judge
       ?config
       ?(auto_context_overflow_retry = true)
       ()
@@ -903,6 +1255,11 @@ let resume
   ; context = ctx
   ; options
   ; checkpoint_sink
+  ; tool_failure_judge
+  ; recovery_state =
+      (match tool_failure_judge with
+       | None -> empty_recovery_state
+       | Some _ -> restore_tool_failure_recovery state.messages)
   }
 ;;
 
@@ -933,7 +1290,25 @@ let run_turn_stream ~sw ?clock ~on_event ?on_telemetry agent =
     protect_stream_callback caller_on_event ev
   in
   with_optional_timeout ?clock ~last_activity agent (fun ~sw ->
-    run_turn_core ~sw ?clock ~api_strategy:(Stream { on_event; on_telemetry }) agent)
+    let* () = resolve_pending_recovery ~sw ?clock agent in
+    let* recovery_context = recovery_context_for_turn agent in
+    match
+      run_turn_core
+        ~sw
+        ?clock
+        ~api_strategy:(Stream { on_event; on_telemetry })
+        ?recovery_context
+        agent
+    with
+    | Ok (`Complete response) -> Ok (`Complete response)
+    | Error error -> Error error
+    | Ok (`ToolsExecuted completed_round) ->
+      let* () =
+        match completed_round with
+        | None -> Ok ()
+        | Some current -> register_completed_tool_round agent current
+      in
+      Ok `ToolsExecuted)
 ;;
 
 let save_journal agent path =

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -115,7 +115,11 @@ val sdk_version : string
     live agent state and emitting completion/journal transitions, then
     commits the same turn delta after the sink succeeds.  The sink is
     passed here rather than through {!options} so callers that construct
-    options records remain source-compatible. *)
+    options records remain source-compatible.
+
+    [tool_failure_judge] installs the LLM boundary used after two adjacent
+    typed failed-tool rounds. It is attached outside [options] for the same
+    record-compatibility reason and must be reattached on {!resume}. *)
 val create
   :  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> ?config:Types.agent_config
@@ -124,6 +128,7 @@ val create
   -> ?options:options
   -> ?auto_context_overflow_retry:bool
   -> ?checkpoint_sink:checkpoint_sink
+  -> ?tool_failure_judge:Tool_failure_recovery.judge
   -> unit
   -> t
 
@@ -240,6 +245,7 @@ val resume
   -> ?context:Context.t
   -> ?options:options
   -> ?checkpoint_sink:checkpoint_sink
+  -> ?tool_failure_judge:Tool_failure_recovery.judge
   -> ?config:Types.agent_config
   -> ?auto_context_overflow_retry:bool
   -> unit

--- a/lib/agent/agent_handoff.ml
+++ b/lib/agent/agent_handoff.ml
@@ -47,7 +47,14 @@ let replace_tool_result messages ~tool_id ~content ~is_error =
       (function
         | ToolResult { tool_use_id = id; _ } when id = tool_id ->
           ToolResult
-            { tool_use_id = id; content; is_error; json = None; content_blocks = None }
+            { tool_use_id = id
+            ; content
+            ; is_error
+            ; failure_kind = None
+            ; error_class = None
+            ; json = None
+            ; content_blocks = None
+            }
         | block -> block)
       blocks
   in
@@ -63,6 +70,8 @@ let replace_tool_result messages ~tool_id ~content ~is_error =
                 { tool_use_id = tool_id
                 ; content
                 ; is_error
+                ; failure_kind = None
+                ; error_class = None
                 ; json = None
                 ; content_blocks = None
                 }

--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -7,7 +7,7 @@ open Types
 
 let _log = Log.create ~module_name:"agent_tools" ()
 
-type tool_failure_kind =
+type tool_failure_kind = Types.tool_failure_kind =
   | Validation_error
   | Recoverable_tool_error
   | Non_retryable_tool_error

--- a/lib/agent/agent_tools.mli
+++ b/lib/agent/agent_tools.mli
@@ -44,7 +44,7 @@ val build_index : Tool.t list -> tool_index
     context cannot be applied to a tool the caller didn't actually name. *)
 val find_in_index : tool_index -> string -> Tool.t option
 
-type tool_failure_kind =
+type tool_failure_kind = Types.tool_failure_kind =
   | Validation_error
   | Recoverable_tool_error
   | Non_retryable_tool_error

--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -612,6 +612,8 @@ let make_tool_results
            { tool_use_id = result.tool_use_id
            ; content
            ; is_error = result.is_error
+           ; failure_kind = result.failure_kind
+           ; error_class = result.error_class
            ; json = None
            ; content_blocks = None
            })
@@ -635,7 +637,7 @@ let make_tool_results
                | Some r -> r.preview
                | None -> sanitized
              in
-             result.tool_use_id, content, result.is_error, false)
+             result, content, false)
            else if
              cfg.threshold_chars > 0 && String.length sanitized > cfg.threshold_chars
            then (
@@ -672,16 +674,16 @@ let make_tool_results
                    result.tool_use_id;
                  sanitized
              in
-             result.tool_use_id, content, result.is_error, false)
+             result, content, false)
            else
              (* Below threshold — fresh, needs aggregate budget check *)
-             result.tool_use_id, sanitized, result.is_error, true)
+             result, sanitized, true)
         results
     in
     (* Phase 2: aggregate budget enforcement for fresh results *)
     let total_fresh_chars =
       List.fold_left
-        (fun acc (_, content, _, is_fresh) ->
+        (fun acc (_, content, is_fresh) ->
            if is_fresh then acc + String.length content else acc)
         0
         phase1
@@ -692,8 +694,10 @@ let make_tool_results
         (* Collect fresh results with sizes *)
         let fresh_entries =
           List.filter_map
-            (fun (tid, content, _, is_fresh) ->
-               if is_fresh then Some (tid, String.length content, content) else None)
+            (fun (result, content, is_fresh) ->
+               if is_fresh
+               then Some (result.tool_use_id, String.length content, content)
+               else None)
             phase1
         in
         (* Sort by size descending — persist largest first *)
@@ -720,7 +724,8 @@ let make_tool_results
     in
     (* Phase 3: apply aggregate decisions, record CRS, truncate *)
     List.map
-      (fun (tid, content, is_error, is_fresh) ->
+      (fun (result, content, is_fresh) ->
+         let tid = result.tool_use_id in
          let content =
            if is_fresh
            then
@@ -765,7 +770,14 @@ let make_tool_results
            else content
          in
          ToolResult
-           { tool_use_id = tid; content; is_error; json = None; content_blocks = None })
+           { tool_use_id = tid
+           ; content
+           ; is_error = result.is_error
+           ; failure_kind = result.failure_kind
+           ; error_class = result.error_class
+           ; json = None
+           ; content_blocks = None
+           })
       phase1
 ;;
 
@@ -782,7 +794,7 @@ let mock_result ?(is_error = false) ~id content : Agent_tools.tool_execution_res
 ;;
 
 let single_tool_result = function
-  | [ ToolResult { tool_use_id; content; is_error; json = _ } ] ->
+  | [ ToolResult { tool_use_id; content; is_error; _ } ] ->
     Some (tool_use_id, content, is_error)
   | []
   | [ Text _ ]

--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -694,7 +694,7 @@ let make_tool_results
         (* Collect fresh results with sizes *)
         let fresh_entries =
           List.filter_map
-            (fun (result, content, is_fresh) ->
+            (fun ((result : Agent_tools.tool_execution_result), content, is_fresh) ->
                if is_fresh
                then Some (result.tool_use_id, String.length content, content)
                else None)
@@ -724,7 +724,7 @@ let make_tool_results
     in
     (* Phase 3: apply aggregate decisions, record CRS, truncate *)
     List.map
-      (fun (result, content, is_fresh) ->
+      (fun ((result : Agent_tools.tool_execution_result), content, is_fresh) ->
          let tid = result.tool_use_id in
          let content =
            if is_fresh

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -27,6 +27,21 @@ type checkpoint_snapshot =
 
 type checkpoint_sink = checkpoint_snapshot -> (unit, string) result
 
+type recovery_state =
+  { last_completed_round : Tool_failure_episode.completed_round option
+  ; pending_episodes : Tool_failure_episode.t list option
+  ; pending_receipt : Tool_failure_recovery.receipt option
+  ; restore_error : Error.sdk_error option
+  }
+
+let empty_recovery_state =
+  { last_completed_round = None
+  ; pending_episodes = None
+  ; pending_receipt = None
+  ; restore_error = None
+  }
+;;
+
 type options =
   { base_url : string
   ; provider : Provider.config option
@@ -206,6 +221,8 @@ type t =
   ; context : Context.t
   ; options : options
   ; checkpoint_sink : checkpoint_sink option
+  ; tool_failure_judge : Tool_failure_recovery.judge option
+  ; mutable recovery_state : recovery_state
   }
 
 (* Public accessors — .mli exposes Agent.t as abstract *)
@@ -227,6 +244,16 @@ let set_state t s = Eio.Mutex.use_rw ~protect:true t.mu (fun () -> t.state <- s)
     inside a single critical section so no concurrent update is lost. *)
 let update_state t f =
   Eio.Mutex.use_rw ~protect:true t.mu (fun () -> t.state <- f t.state)
+;;
+
+let recovery_state t = Eio.Mutex.use_ro t.mu (fun () -> t.recovery_state)
+
+let set_recovery_state t recovery_state =
+  Eio.Mutex.use_rw ~protect:true t.mu (fun () -> t.recovery_state <- recovery_state)
+;;
+
+let update_recovery_state t f =
+  Eio.Mutex.use_rw ~protect:true t.mu (fun () -> t.recovery_state <- f t.recovery_state)
 ;;
 
 let set_consecutive_idle_turns t n =
@@ -357,6 +384,7 @@ let create
       ?(options = default_options)
       ?(auto_context_overflow_retry = true)
       ?checkpoint_sink
+      ?tool_failure_judge
       ()
   =
   let mcp_tools =
@@ -382,6 +410,8 @@ let create
   ; context = ctx
   ; options
   ; checkpoint_sink
+  ; tool_failure_judge
+  ; recovery_state = empty_recovery_state
   }
 ;;
 
@@ -405,6 +435,8 @@ let clone ?(copy_context = false) agent =
   ; context = ctx
   ; options = agent.options
   ; checkpoint_sink = agent.checkpoint_sink
+  ; tool_failure_judge = agent.tool_failure_judge
+  ; recovery_state = agent.recovery_state
   }
 ;;
 

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -30,6 +30,15 @@ type checkpoint_snapshot =
 
 type checkpoint_sink = checkpoint_snapshot -> (unit, string) result
 
+type recovery_state =
+  { last_completed_round : Tool_failure_episode.completed_round option
+  ; pending_episodes : Tool_failure_episode.t list option
+  ; pending_receipt : Tool_failure_recovery.receipt option
+  ; restore_error : Error.sdk_error option
+  }
+
+val empty_recovery_state : recovery_state
+
 type options =
   { base_url : string
   ; provider : Provider.config option
@@ -250,6 +259,8 @@ type t =
   ; context : Context.t
   ; options : options
   ; checkpoint_sink : checkpoint_sink option
+  ; tool_failure_judge : Tool_failure_recovery.judge option
+  ; mutable recovery_state : recovery_state
   }
 
 (** {1 Defaults} *)
@@ -266,6 +277,9 @@ val options : t -> options
 val net : t -> [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
 val set_state : t -> Types.agent_state -> unit
 val update_state : t -> (Types.agent_state -> Types.agent_state) -> unit
+val recovery_state : t -> recovery_state
+val set_recovery_state : t -> recovery_state -> unit
+val update_recovery_state : t -> (recovery_state -> recovery_state) -> unit
 val set_consecutive_idle_turns : t -> int -> unit
 val get_consecutive_idle_turns : t -> int
 
@@ -296,6 +310,7 @@ val create
   -> ?options:options
   -> ?auto_context_overflow_retry:bool
   -> ?checkpoint_sink:checkpoint_sink
+  -> ?tool_failure_judge:Tool_failure_recovery.judge
   -> unit
   -> t
 

--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -71,6 +71,7 @@ type t =
   ; tool_result_relocation : (Tool_result_store.t * Content_replacement_state.t) option
   ; journal : Durable_event.journal option
   ; checkpoint_sink : Agent.checkpoint_sink option
+  ; tool_failure_judge : Tool_failure_recovery.judge option
   ; policy_channel : Policy_channel.t option
   ; summarizer : (Types.message list -> string) option
   ; transport : Llm_provider.Llm_transport.t option
@@ -151,6 +152,7 @@ let create ~net ~model =
   ; tool_result_relocation = None
   ; journal = None
   ; checkpoint_sink = None
+  ; tool_failure_judge = None
   ; policy_channel = None
   ; summarizer = None
   ; transport = None
@@ -166,6 +168,10 @@ let with_journal journal b = { b with journal = Some journal }
 
 let with_checkpoint_sink checkpoint_sink b =
   { b with checkpoint_sink = Some checkpoint_sink }
+;;
+
+let with_tool_failure_judge tool_failure_judge b =
+  { b with tool_failure_judge = Some tool_failure_judge }
 ;;
 
 (** Override the Budget_strategy Emergency-phase summarizer with a
@@ -471,6 +477,7 @@ let build b =
     ~options
     ~auto_context_overflow_retry:b.auto_context_overflow_retry
     ?checkpoint_sink:b.checkpoint_sink
+    ?tool_failure_judge:b.tool_failure_judge
     ()
 ;;
 

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -354,6 +354,11 @@ val with_journal : Durable_event.journal -> t -> t
     @since 0.193.9 *)
 val with_checkpoint_sink : Agent.checkpoint_sink -> t -> t
 
+(** Install the LLM judge used for adjacent typed failed-tool recovery.
+    [with_yield_on_tool true] is required so the main provider lease is not held
+    while the judge completion is waiting. *)
+val with_tool_failure_judge : Tool_failure_recovery.judge -> t -> t
+
 (** Override the Budget_strategy Emergency-phase summarizer with a
     domain-aware function.  Routed into [Agent.options.summarizer] and
     forwarded to {!Budget_strategy.reduce_for_budget} when compaction

--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -98,6 +98,8 @@ module Agent_lifecycle = Agent_lifecycle
 module Agent_turn = Agent_turn
 module Agent_handoff = Agent_handoff
 module Agent_tools = Agent_tools
+module Tool_failure_episode = Tool_failure_episode
+module Tool_failure_recovery = Tool_failure_recovery
 module Agent_tool_name_alias = Agent_tool_name_alias
 module Agent_checkpoint = Agent_checkpoint
 module Agent_turn_budget = Agent_turn_budget
@@ -193,6 +195,7 @@ let create_agent
       ?cache_system_prompt
       ?provider
       ?raw_trace
+      ?tool_failure_judge
       ()
   =
   let open Types in
@@ -236,7 +239,7 @@ let create_agent
     | Some p, Some trace ->
       { Agent.default_options with provider = Some p; raw_trace = Some trace }
   in
-  Agent.create ~net ~config ~options ()
+  Agent.create ~net ~config ~options ?tool_failure_judge ()
 ;;
 
 (* runtime_query/query removed — CLI Runtime purge *)

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -70,6 +70,8 @@ module Agent_lifecycle = Agent_lifecycle
 module Agent_turn = Agent_turn
 module Agent_handoff = Agent_handoff
 module Agent_tools = Agent_tools
+module Tool_failure_episode = Tool_failure_episode
+module Tool_failure_recovery = Tool_failure_recovery
 module Agent_tool_name_alias = Agent_tool_name_alias
 module Agent_checkpoint = Agent_checkpoint
 module Agent_turn_budget = Agent_turn_budget
@@ -168,6 +170,7 @@ val create_agent
   -> ?cache_system_prompt:bool
   -> ?provider:Provider.config
   -> ?raw_trace:Raw_trace.t
+  -> ?tool_failure_judge:Tool_failure_recovery.judge
   -> unit
   -> Agent.t
 

--- a/lib/agent_tool.ml
+++ b/lib/agent_tool.ml
@@ -85,7 +85,7 @@ let content_block_to_json = function
       ; "name", `String name
       ; "input", input
       ]
-  | ToolResult { tool_use_id; content; is_error; json } ->
+  | ToolResult { tool_use_id; content; is_error; json; _ } ->
     `Assoc
       [ "type", `String "tool_result"
       ; "tool_use_id", `String tool_use_id

--- a/lib/agent_typed.ml
+++ b/lib/agent_typed.ml
@@ -12,8 +12,17 @@ type completed
    OCaml's type system enforces state transitions at compile time. *)
 type _ t = T : Agent.t -> _ t
 
-let create ~net ?config ?tools ?context ?options ?checkpoint_sink () =
-  T (Agent.create ~net ?config ?tools ?context ?options ?checkpoint_sink ())
+let create ~net ?config ?tools ?context ?options ?checkpoint_sink ?tool_failure_judge () =
+  T
+    (Agent.create
+       ~net
+       ?config
+       ?tools
+       ?context
+       ?options
+       ?checkpoint_sink
+       ?tool_failure_judge
+       ())
 ;;
 
 let run ~sw ?clock (T agent) prompt =

--- a/lib/agent_typed.mli
+++ b/lib/agent_typed.mli
@@ -39,6 +39,7 @@ val create
   -> ?context:Context.t
   -> ?options:Agent.options
   -> ?checkpoint_sink:Agent.checkpoint_sink
+  -> ?tool_failure_judge:Tool_failure_recovery.judge
   -> unit
   -> created t
 

--- a/lib/base/error.ml
+++ b/lib/base/error.ml
@@ -26,6 +26,13 @@ type input_required =
   ; created_at : float
   }
 
+type tool_failure_recovery_stage =
+  | Round_projection
+  | Episode_detection
+  | Judge_response
+  | Decision_persistence
+  | Resume_restore
+
 (** Agent runtime errors. *)
 type agent_error =
   | MaxTurnsExceeded of
@@ -64,6 +71,14 @@ type agent_error =
       ; reason : string
       }
   | InputRequired of input_required
+  | ToolFailureRecoveryFailed of
+      { stage : tool_failure_recovery_stage
+      ; detail : string
+      }
+  | ToolFailureRecoveryDeferred of
+      { reason : string
+      ; tool_names : string list
+      }
   | ExitConditionMet of { turn : int }
 
 (** MCP client errors. *)
@@ -172,6 +187,22 @@ let agent_error_to_string = function
        | None -> "")
       r.question
       r.request_id
+  | ToolFailureRecoveryFailed r ->
+    let stage =
+      match r.stage with
+      | Round_projection -> "round_projection"
+      | Episode_detection -> "episode_detection"
+      | Judge_response -> "judge_response"
+      | Decision_persistence -> "decision_persistence"
+      | Resume_restore -> "resume_restore"
+    in
+    Printf.sprintf "Tool failure recovery failed at %s: %s" stage r.detail
+  | ToolFailureRecoveryDeferred r ->
+    let tools = String.concat ", " r.tool_names in
+    Printf.sprintf
+      "Tool failure recovery deferred%s: %s"
+      (if String.equal tools "" then "" else Printf.sprintf " for %s" tools)
+      r.reason
   | ExitConditionMet r -> Printf.sprintf "Exit condition met at turn %d" r.turn
 ;;
 

--- a/lib/base/error.mli
+++ b/lib/base/error.mli
@@ -26,6 +26,13 @@ type input_required =
   ; created_at : float
   }
 
+type tool_failure_recovery_stage =
+  | Round_projection
+  | Episode_detection
+  | Judge_response
+  | Decision_persistence
+  | Resume_restore
+
 type agent_error =
   | MaxTurnsExceeded of
       { turns : int
@@ -63,6 +70,14 @@ type agent_error =
       ; reason : string
       }
   | InputRequired of input_required
+  | ToolFailureRecoveryFailed of
+      { stage : tool_failure_recovery_stage
+      ; detail : string
+      }
+  | ToolFailureRecoveryDeferred of
+      { reason : string
+      ; tool_names : string list
+      }
   | ExitConditionMet of { turn : int }
 
 type mcp_error =

--- a/lib/checkpoint_codec.ml
+++ b/lib/checkpoint_codec.ml
@@ -74,9 +74,80 @@ let result_all items =
   |> Result.map List.rev
 ;;
 
+let checkpoint_content_block_to_json block =
+  let wire_json = Api.content_block_to_json block in
+  match block, wire_json with
+  | ToolResult { failure_kind; error_class; _ }, `Assoc fields ->
+    let provenance =
+      (match failure_kind with
+       | Some kind -> [ "failure_kind", Types.tool_failure_kind_to_yojson kind ]
+       | None -> [])
+      @
+      match error_class with
+      | Some error_class ->
+        [ "error_class", Types.tool_error_class_to_yojson error_class ]
+      | None -> []
+    in
+    `Assoc (fields @ provenance)
+  | ( ( Text _
+      | Thinking _
+      | ReasoningDetails _
+      | RedactedThinking _
+      | ToolUse _
+      | Image _
+      | Document _
+      | Audio _ )
+    , _ ) -> wire_json
+;;
+
+let optional_typed_field ~field ~type_name ~decode json =
+  let open Yojson.Safe.Util in
+  match json |> member field with
+  | `Null -> Ok None
+  | value ->
+    decode value
+    |> Result.map Option.some
+    |> Result.map_error (fun detail ->
+      Error.Serialization
+        (JsonParseError
+           { detail =
+               Printf.sprintf
+                 "Checkpoint ToolResult field %s has invalid %s: %s"
+                 field
+                 type_name
+                 detail
+           }))
+;;
+
 let content_block_of_json_strict json =
   try
     match Api.content_block_of_json json with
+    | Some
+        (ToolResult
+           { tool_use_id; content; is_error; json = parsed_json; content_blocks; _ }) ->
+      let* failure_kind =
+        optional_typed_field
+          ~field:"failure_kind"
+          ~type_name:"tool_failure_kind"
+          ~decode:Types.tool_failure_kind_of_yojson
+          json
+      and* error_class =
+        optional_typed_field
+          ~field:"error_class"
+          ~type_name:"tool_error_class"
+          ~decode:Types.tool_error_class_of_yojson
+          json
+      in
+      Ok
+        (ToolResult
+           { tool_use_id
+           ; content
+           ; is_error
+           ; failure_kind
+           ; error_class
+           ; json = parsed_json
+           ; content_blocks
+           })
     | Some block -> Ok block
     | None ->
       let open Yojson.Safe.Util in
@@ -121,7 +192,7 @@ let metadata_of_json json =
 let message_to_json (msg : Types.message) =
   let base_fields =
     [ "role", `String (Types.role_to_string msg.role)
-    ; "content", `List (List.map Api.content_block_to_json msg.content)
+    ; "content", `List (List.map checkpoint_content_block_to_json msg.content)
     ]
   in
   let optional_fields =
@@ -444,6 +515,7 @@ let of_json json =
     let version = json |> member "version" |> to_int in
     if
       version <> checkpoint_version
+      && version <> 5
       && version <> 4
       && version <> 3
       && version <> 2

--- a/lib/checkpoint_codec.ml
+++ b/lib/checkpoint_codec.ml
@@ -98,6 +98,10 @@ let checkpoint_content_block_to_json block =
       | Document _
       | Audio _ )
     , _ ) -> wire_json
+  (* ToolResult serializes to `Assoc via Api.content_block_to_json. If a
+     non-`Assoc wire form ever appears we cannot merge provenance fields, so
+     pass the wire form through unchanged. Closes the exhaustiveness gap. *)
+  | ToolResult _, wire_json -> wire_json
 ;;
 
 let optional_typed_field ~field ~type_name ~decode json =

--- a/lib/checkpoint_codec.ml
+++ b/lib/checkpoint_codec.ml
@@ -98,10 +98,11 @@ let checkpoint_content_block_to_json block =
       | Document _
       | Audio _ )
     , _ ) -> wire_json
-  (* ToolResult serializes to `Assoc via Api.content_block_to_json. If a
-     non-`Assoc wire form ever appears we cannot merge provenance fields, so
-     pass the wire form through unchanged. Closes the exhaustiveness gap. *)
-  | ToolResult _, wire_json -> wire_json
+  | ToolResult _, non_object ->
+    invalid_arg
+      (Printf.sprintf
+         "Checkpoint ToolResult serializer invariant failed: expected object, got %s"
+         (Yojson.Safe.to_string non_object))
 ;;
 
 let optional_typed_field ~field ~type_name ~decode json =

--- a/lib/checkpoint_types.ml
+++ b/lib/checkpoint_types.ml
@@ -1,6 +1,6 @@
 open Types
 
-let checkpoint_version = 5
+let checkpoint_version = 6
 
 type t =
   { version : int

--- a/lib/content_replacement_state.ml
+++ b/lib/content_replacement_state.ml
@@ -111,7 +111,7 @@ let apply_frozen t blocks =
       List.map
         (fun block ->
            match block with
-           | ToolResult { tool_use_id; is_error; json; _ } ->
+           | ToolResult { tool_use_id; is_error; failure_kind; error_class; json; _ } ->
              if Hashtbl.mem t.seen_ids tool_use_id
              then (
                (* Frozen: apply cached replacement or keep *)
@@ -121,6 +121,8 @@ let apply_frozen t blocks =
                    { tool_use_id
                    ; content = r.preview
                    ; is_error
+                   ; failure_kind
+                   ; error_class
                    ; json
                    ; content_blocks = None
                    }
@@ -270,6 +272,8 @@ let%test "apply_frozen: replaces frozen, collects fresh" =
         { tool_use_id = "t1"
         ; content = "long content"
         ; is_error = false
+        ; failure_kind = None
+        ; error_class = None
         ; json = None
         ; content_blocks = None
         }
@@ -277,6 +281,8 @@ let%test "apply_frozen: replaces frozen, collects fresh" =
         { tool_use_id = "t2"
         ; content = "kept content"
         ; is_error = false
+        ; failure_kind = None
+        ; error_class = None
         ; json = None
         ; content_blocks = None
         }
@@ -284,6 +290,8 @@ let%test "apply_frozen: replaces frozen, collects fresh" =
         { tool_use_id = "t3"
         ; content = "new content"
         ; is_error = false
+        ; failure_kind = None
+        ; error_class = None
         ; json = None
         ; content_blocks = None
         }
@@ -312,6 +320,8 @@ let%test "apply_frozen: idempotent" =
         { tool_use_id = "t1"
         ; content = "original"
         ; is_error = false
+        ; failure_kind = None
+        ; error_class = None
         ; json = None
         ; content_blocks = None
         }

--- a/lib/context_reducer.ml
+++ b/lib/context_reducer.ml
@@ -440,6 +440,8 @@ let%test "cap_message_tokens: oversized message with Text blocks is truncated" =
           { tool_use_id = "keep"
           ; content = "r"
           ; is_error = false
+          ; failure_kind = None
+          ; error_class = None
           ; json = None
           ; content_blocks = None
           }
@@ -473,6 +475,8 @@ let%test "cap_message_tokens: truncation marker present when text dropped" =
           { tool_use_id = "t0"
           ; content = "r"
           ; is_error = false
+          ; failure_kind = None
+          ; error_class = None
           ; json = None
           ; content_blocks = None
           }
@@ -517,6 +521,8 @@ let%test
         { tool_use_id = Printf.sprintf "t%d" i
         ; content = String.make 400 'x'
         ; is_error = false
+        ; failure_kind = None
+        ; error_class = None
         ; json = None
         ; content_blocks = None
         })
@@ -536,6 +542,8 @@ let%test "cap_message_tokens: recent turns are not modified" =
         { tool_use_id = Printf.sprintf "t%d" i
         ; content = String.make 400 'x'
         ; is_error = false
+        ; failure_kind = None
+        ; error_class = None
         ; json = None
         ; content_blocks = None
         })
@@ -558,6 +566,8 @@ let%test "cap_message_tokens: monotonicity — never increases tokens" =
           { tool_use_id = Printf.sprintf "t%d" i
           ; content = String.make 500 'x'
           ; is_error = false
+          ; failure_kind = None
+          ; error_class = None
           ; json = None
           ; content_blocks = None
           })
@@ -670,6 +680,8 @@ let%test "estimate_block_tokens ToolResult uses CJK-aware estimation" =
       { tool_use_id = "t1"
       ; content = "\xEA\xB2\xB0\xEA\xB3\xBC\xEC\x9E\x85\xEB\x8B\x88\xEB\x8B\xA4"
       ; is_error = false
+      ; failure_kind = None
+      ; error_class = None
       ; json = None
       ; content_blocks = None
       }

--- a/lib/context_reducer_apply.ml
+++ b/lib/context_reducer_apply.ml
@@ -11,7 +11,8 @@ let apply_prune_tool_outputs ~max_output_len messages =
          List.map
            (fun block ->
               match block with
-              | ToolResult { tool_use_id; content; is_error; _ }
+              | ToolResult
+                  { tool_use_id; content; is_error; failure_kind; error_class; _ }
                 when String.length content > max_output_len ->
                 let truncated = String.sub content 0 max_output_len in
                 let marker =
@@ -21,6 +22,8 @@ let apply_prune_tool_outputs ~max_output_len messages =
                   { tool_use_id
                   ; content = truncated ^ marker
                   ; is_error
+                  ; failure_kind
+                  ; error_class
                   ; json = None
                   ; content_blocks = None
                   }
@@ -136,6 +139,8 @@ let synthetic_tool_result_message id =
               "OAS context reducer synthesized this error result because the original \
                tool call had no matching ToolResult."
           ; is_error = true
+          ; failure_kind = None
+          ; error_class = None
           ; json = None
           ; content_blocks = None
           }
@@ -357,7 +362,8 @@ let apply_clear_tool_results ~keep_recent messages =
                List.map
                  (fun block ->
                     match block with
-                    | ToolResult { tool_use_id; content; is_error; _ }
+                    | ToolResult
+                        { tool_use_id; content; is_error; failure_kind; error_class; _ }
                       when String.length content > 50 ->
                       let summary =
                         if is_error
@@ -371,6 +377,8 @@ let apply_clear_tool_results ~keep_recent messages =
                         { tool_use_id
                         ; content = summary
                         ; is_error
+                        ; failure_kind
+                        ; error_class
                         ; json = None
                         ; content_blocks = None
                         }
@@ -415,7 +423,8 @@ let apply_stub_tool_results ~keep_recent messages =
                List.map
                  (fun block ->
                     match block with
-                    | ToolResult { tool_use_id; content; is_error; _ }
+                    | ToolResult
+                        { tool_use_id; content; is_error; failure_kind; error_class; _ }
                       when String.length content > 50 ->
                       let tool_name =
                         match Hashtbl.find_opt tool_names tool_use_id with
@@ -441,6 +450,8 @@ let apply_stub_tool_results ~keep_recent messages =
                         { tool_use_id
                         ; content = stub
                         ; is_error
+                        ; failure_kind
+                        ; error_class
                         ; json = None
                         ; content_blocks = None
                         }

--- a/lib/error_domain.ml
+++ b/lib/error_domain.ml
@@ -3,6 +3,13 @@
 module Retry = Llm_provider.Retry
 module Http_client = Llm_provider.Http_client
 
+type tool_failure_recovery_stage = Error.tool_failure_recovery_stage =
+  | Round_projection
+  | Episode_detection
+  | Judge_response
+  | Decision_persistence
+  | Resume_restore
+
 type provider_error =
   [ `Rate_limited of float option
   | `Auth_error of string
@@ -31,6 +38,8 @@ type agent_error =
   | `Guardrail_violation of string * string
   | `Tripwire_violation of string * string
   | `Input_required of string * string
+  | `Tool_failure_recovery_failed of tool_failure_recovery_stage * string
+  | `Tool_failure_recovery_deferred of string * string list
   | `Unrecognized_stop_reason of string
   | `Exit_condition_met of int
   ]
@@ -138,6 +147,10 @@ let of_sdk_error (err : Error.sdk_error) : sdk_error_poly =
   | Error.Agent (GuardrailViolation r) -> `Guardrail_violation (r.validator, r.reason)
   | Error.Agent (TripwireViolation r) -> `Tripwire_violation (r.tripwire, r.reason)
   | Error.Agent (InputRequired r) -> `Input_required (r.request_id, r.question)
+  | Error.Agent (ToolFailureRecoveryFailed r) ->
+    `Tool_failure_recovery_failed (r.stage, r.detail)
+  | Error.Agent (ToolFailureRecoveryDeferred r) ->
+    `Tool_failure_recovery_deferred (r.reason, r.tool_names)
   | Error.Agent (UnrecognizedStopReason r) -> `Unrecognized_stop_reason r.reason
   | Error.Agent (ExitConditionMet r) -> `Exit_condition_met r.turn
   | Error.Config (MissingEnvVar r) -> `Missing_env_var r.var_name
@@ -204,6 +217,10 @@ let to_sdk_error (err : sdk_error_poly) : Error.sdk_error =
          ; timeout_s = None
          ; created_at = Unix.gettimeofday ()
          })
+  | `Tool_failure_recovery_failed (stage, detail) ->
+    Error.Agent (ToolFailureRecoveryFailed { stage; detail })
+  | `Tool_failure_recovery_deferred (reason, tool_names) ->
+    Error.Agent (ToolFailureRecoveryDeferred { reason; tool_names })
   | `Unrecognized_stop_reason reason -> Error.Agent (UnrecognizedStopReason { reason })
   | `Exit_condition_met turn -> Error.Agent (ExitConditionMet { turn })
   | `Missing_env_var var -> Error.Config (MissingEnvVar { var_name = var })
@@ -279,6 +296,8 @@ let is_retryable (err : [< sdk_error_poly ]) : bool =
   | `Guardrail_violation _
   | `Tripwire_violation _
   | `Input_required _
+  | `Tool_failure_recovery_failed _
+  | `Tool_failure_recovery_deferred _
   | `Unrecognized_stop_reason _
   | `Exit_condition_met _
   | `Missing_env_var _

--- a/lib/error_domain.mli
+++ b/lib/error_domain.mli
@@ -47,6 +47,13 @@ type tool_error =
 
 (** {1 Agent errors} *)
 
+type tool_failure_recovery_stage = Error.tool_failure_recovery_stage =
+  | Round_projection
+  | Episode_detection
+  | Judge_response
+  | Decision_persistence
+  | Resume_restore
+
 type agent_error =
   [ `Max_turns_exceeded of int * int (** turns, limit *)
   | `Idle_detected of int (** consecutive_idle_turns *)
@@ -57,6 +64,8 @@ type agent_error =
   | `Guardrail_violation of string * string (** validator, reason *)
   | `Tripwire_violation of string * string (** tripwire, reason *)
   | `Input_required of string * string (** request_id, question *)
+  | `Tool_failure_recovery_failed of tool_failure_recovery_stage * string
+  | `Tool_failure_recovery_deferred of string * string list
   | `Unrecognized_stop_reason of string
   | `Exit_condition_met of int (** turn at which exit condition triggered *)
   ]

--- a/lib/eval_collector.ml
+++ b/lib/eval_collector.ml
@@ -82,6 +82,9 @@ let process_events t =
        (* Lifecycle events — observed but not metered here.
        Downstream consumers can subscribe for richer metrics. *)
        | AgentStarted _
+       | ToolFailureEpisodeDetected _
+       | ToolFailureRecoveryDecided _
+       | ToolFailureRecoveryJudgeFailed _
        | TurnReady _
        | TurnCompleted _
        | HandoffRequested _

--- a/lib/event_bus.ml
+++ b/lib/event_bus.ml
@@ -58,6 +58,21 @@ type payload =
       ; output : Types.tool_result
       ; turn : int
       }
+  | ToolFailureEpisodeDetected of
+      { agent_name : string
+      ; turn : int
+      ; episodes : Tool_failure_episode.t list
+      }
+  | ToolFailureRecoveryDecided of
+      { agent_name : string
+      ; turn : int
+      ; decision : Tool_failure_recovery.decision
+      }
+  | ToolFailureRecoveryJudgeFailed of
+      { agent_name : string
+      ; turn : int
+      ; detail : string
+      }
   | TurnStarted of
       { agent_name : string
       ; turn : int
@@ -153,6 +168,9 @@ let payload_kind = function
   | AgentFailed _ -> "agent_failed"
   | ToolCalled _ -> "tool_called"
   | ToolCompleted _ -> "tool_completed"
+  | ToolFailureEpisodeDetected _ -> "tool_failure_episode_detected"
+  | ToolFailureRecoveryDecided _ -> "tool_failure_recovery_decided"
+  | ToolFailureRecoveryJudgeFailed _ -> "tool_failure_recovery_judge_failed"
   | TurnStarted _ -> "turn_started"
   | TurnReady _ -> "turn_ready"
   | TurnCompleted _ -> "turn_completed"
@@ -287,6 +305,9 @@ let filter_agent name : filter =
   | AgentFailed r -> r.agent_name = name
   | ToolCalled r -> r.agent_name = name
   | ToolCompleted r -> r.agent_name = name
+  | ToolFailureEpisodeDetected r -> r.agent_name = name
+  | ToolFailureRecoveryDecided r -> r.agent_name = name
+  | ToolFailureRecoveryJudgeFailed r -> r.agent_name = name
   | TurnStarted r -> r.agent_name = name
   | TurnReady r -> r.agent_name = name
   | TurnCompleted r -> r.agent_name = name
@@ -305,7 +326,11 @@ let filter_agent name : filter =
 let filter_tools_only : filter =
   fun event ->
   match event.payload with
-  | ToolCalled _ | ToolCompleted _ -> true
+  | ToolCalled _
+  | ToolCompleted _
+  | ToolFailureEpisodeDetected _
+  | ToolFailureRecoveryDecided _
+  | ToolFailureRecoveryJudgeFailed _ -> true
   | _ -> false
 ;;
 

--- a/lib/event_bus.mli
+++ b/lib/event_bus.mli
@@ -93,6 +93,21 @@ type payload =
         (** Same turn index as the matching [ToolCalled]. See its doc.
             @since 0.207.0 (#SSOT-DRIFT-REMEDIATION) *)
       }
+  | ToolFailureEpisodeDetected of
+      { agent_name : string
+      ; turn : int
+      ; episodes : Tool_failure_episode.t list
+      }
+  | ToolFailureRecoveryDecided of
+      { agent_name : string
+      ; turn : int
+      ; decision : Tool_failure_recovery.decision
+      }
+  | ToolFailureRecoveryJudgeFailed of
+      { agent_name : string
+      ; turn : int
+      ; detail : string
+      }
   | TurnStarted of
       { agent_name : string
       ; turn : int

--- a/lib/event_forward.ml
+++ b/lib/event_forward.ml
@@ -58,6 +58,9 @@ let event_type_name (event : Event_bus.event) : string =
   | AgentFailed _ -> "agent.failed"
   | ToolCalled _ -> "tool.called"
   | ToolCompleted _ -> "tool.completed"
+  | ToolFailureEpisodeDetected _ -> "tool_failure.episode_detected"
+  | ToolFailureRecoveryDecided _ -> "tool_failure.recovery_decided"
+  | ToolFailureRecoveryJudgeFailed _ -> "tool_failure.recovery_judge_failed"
   | TurnStarted _ -> "turn.started"
   | TurnReady _ -> "turn.ready"
   | TurnCompleted _ -> "turn.completed"
@@ -80,6 +83,9 @@ let agent_name_of_payload : Event_bus.payload -> string option = function
   | AgentFailed r -> Some r.agent_name
   | ToolCalled r -> Some r.agent_name
   | ToolCompleted r -> Some r.agent_name
+  | ToolFailureEpisodeDetected r -> Some r.agent_name
+  | ToolFailureRecoveryDecided r -> Some r.agent_name
+  | ToolFailureRecoveryJudgeFailed r -> Some r.agent_name
   | TurnStarted r -> Some r.agent_name
   | TurnReady r -> Some r.agent_name
   | TurnCompleted r -> Some r.agent_name
@@ -135,6 +141,24 @@ let event_to_payload (event : Event_bus.event) : event_payload =
         ; "tool_use_id", `String r.tool_use_id
         ; "success", `Bool (Result.is_ok r.output)
         ; "turn", `Int r.turn
+        ]
+    | ToolFailureEpisodeDetected r ->
+      `Assoc
+        [ "agent_name", `String r.agent_name
+        ; "turn", `Int r.turn
+        ; "episodes", `List (List.map Tool_failure_episode.to_yojson r.episodes)
+        ]
+    | ToolFailureRecoveryDecided r ->
+      `Assoc
+        [ "agent_name", `String r.agent_name
+        ; "turn", `Int r.turn
+        ; "decision", Tool_failure_recovery.decision_to_yojson r.decision
+        ]
+    | ToolFailureRecoveryJudgeFailed r ->
+      `Assoc
+        [ "agent_name", `String r.agent_name
+        ; "turn", `Int r.turn
+        ; "detail", `String r.detail
         ]
     | TurnStarted r -> `Assoc [ "agent_name", `String r.agent_name; "turn", `Int r.turn ]
     | TurnReady r ->

--- a/lib/llm_provider/api_common.ml
+++ b/lib/llm_provider/api_common.ml
@@ -293,7 +293,16 @@ let rec content_block_of_json_result json =
     in
     let is_error = Cli_common_json.member_bool "is_error" json in
     let json = Types.try_parse_json content in
-    Ok (ToolResult { tool_use_id; content; is_error; json; content_blocks })
+    Ok
+      (ToolResult
+         { tool_use_id
+         ; content
+         ; is_error
+         ; failure_kind = None
+         ; error_class = None
+         ; json
+         ; content_blocks
+         })
   | Some "image" ->
     parse_media_block
       ~block_type:"image"

--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -428,6 +428,8 @@ let%test "openai_messages_of_message user with tool_result" =
             { tool_use_id = "tc1"
             ; content = "result"
             ; is_error = false
+            ; failure_kind = None
+            ; error_class = None
             ; json = None
             ; content_blocks = None
             }
@@ -463,6 +465,8 @@ let%test "build_request strips orphaned tool results from wire messages" =
               { tool_use_id = "orphan-id"
               ; content = "stale"
               ; is_error = false
+              ; failure_kind = None
+              ; error_class = None
               ; json = None
               ; content_blocks = None
               }
@@ -643,6 +647,8 @@ let%test "openai_messages_of_message Tool role with ToolResult" =
             { tool_use_id = "tc1"
             ; content = "result data"
             ; is_error = false
+            ; failure_kind = None
+            ; error_class = None
             ; json = None
             ; content_blocks = None
             }
@@ -1135,6 +1141,8 @@ let%test "openai_content_parts_of_blocks tool_result filtered" =
         { tool_use_id = "t1"
         ; content = "result"
         ; is_error = false
+        ; failure_kind = None
+        ; error_class = None
         ; json = None
         ; content_blocks = None
         }

--- a/lib/llm_provider/canonical_tool.ml
+++ b/lib/llm_provider/canonical_tool.ml
@@ -158,7 +158,7 @@ let tool_calls_of_response (response : Types.api_response) : provider_tool_call 
 
 let tool_result_of_block (block : Types.content_block) : provider_tool_result option =
   match block with
-  | Types.ToolResult { tool_use_id; content; is_error; json; content_blocks } ->
+  | Types.ToolResult { tool_use_id; content; is_error; json; content_blocks; _ } ->
     Some
       { call_id = tool_use_id
       ; content

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -375,6 +375,8 @@ let finalize_stream_acc (acc : stream_acc) =
                 { tool_use_id
                 ; content = text
                 ; is_error
+                ; failure_kind = None
+                ; error_class = None
                 ; json = (if is_error then None else Types.try_parse_json text)
                 ; content_blocks = None
                 }))

--- a/lib/llm_provider/tool_message_pairs.ml
+++ b/lib/llm_provider/tool_message_pairs.ml
@@ -174,6 +174,8 @@ let synthetic_tool_result_message (id, _name) =
               "OAS synthesized this error tool result because provider request history \
                contained a tool call without an adjacent result."
           ; is_error = true
+          ; failure_kind = None
+          ; error_class = None
           ; json = None
           ; content_blocks = None
           }

--- a/lib/llm_provider/tool_message_pairs.ml
+++ b/lib/llm_provider/tool_message_pairs.ml
@@ -14,6 +14,11 @@ type repair_report =
   ; synthesized_tool_result_ids : string list
   }
 
+type tool_exchange =
+  { tool_uses : content_block list
+  ; tool_results : content_block list
+  }
+
 let empty_repair_report = { dropped_tool_results = []; synthesized_tool_result_ids = [] }
 
 let normalize_report report =
@@ -82,6 +87,35 @@ let split_tool_result_span messages =
     | rest -> List.rev span, rest
   in
   loop [] messages
+;;
+
+let latest_tool_exchanges ~count messages =
+  if count < 0 then invalid_arg "latest_tool_exchanges: count must be >= 0";
+  let keep_latest exchanges =
+    let rec take remaining acc = function
+      | _ when remaining = 0 -> List.rev acc
+      | [] -> List.rev acc
+      | exchange :: rest -> take (remaining - 1) (exchange :: acc) rest
+    in
+    take count [] exchanges
+  in
+  let rec collect latest = function
+    | [] -> latest
+    | (message : message) :: rest ->
+      let uses = if message.role = Assistant then tool_uses message else [] in
+      if uses = []
+      then collect latest rest
+      else (
+        let result_span, tail = split_tool_result_span rest in
+        let exchange =
+          { tool_uses = message.content
+          ; tool_results =
+              List.concat_map (fun (result : message) -> result.content) result_span
+          }
+        in
+        collect (keep_latest (exchange :: latest)) tail)
+  in
+  collect [] messages
 ;;
 
 let strip_orphaned_tool_results_with_report (messages : message list)

--- a/lib/llm_provider/tool_message_pairs.mli
+++ b/lib/llm_provider/tool_message_pairs.mli
@@ -20,6 +20,21 @@ type repair_report =
   }
 
 val empty_repair_report : repair_report
+
+type tool_exchange =
+  { tool_uses : Types.content_block list
+  ; tool_results : Types.content_block list
+  }
+
+(** Return up to [count] latest assistant tool-use/result-span exchanges,
+    newest first. Result spans use the same immediate multi-message boundary as
+    provider pairing repair. An incomplete latest exchange is returned with an
+    empty [tool_results] list so callers can fail explicitly.
+
+    This is intended for one-time checkpoint restoration; live agent loops
+    should retain the typed completed-round projection incrementally. *)
+val latest_tool_exchanges : count:int -> Types.message list -> tool_exchange list
+
 val strip_orphaned_tool_results : Types.message list -> Types.message list
 
 val strip_orphaned_tool_results_with_report

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -69,6 +69,12 @@ type tool_error_class =
   | Unknown
 [@@deriving yojson, show]
 
+type tool_failure_kind =
+  | Validation_error
+  | Recoverable_tool_error
+  | Non_retryable_tool_error
+[@@deriving yojson, show]
+
 type tool_error =
   { message : string
   ; recoverable : bool
@@ -276,6 +282,8 @@ type content_block =
       { tool_use_id : string
       ; content : string
       ; is_error : bool
+      ; failure_kind : tool_failure_kind option
+      ; error_class : tool_error_class option
       ; json : Yojson.Safe.t option
         (** Parsed JSON payload when available. Consumers
                         should prefer [json] over [content] for structured access.
@@ -643,7 +651,15 @@ let try_parse_json (s : string) : Yojson.Safe.t option =
 (** Create a tool result message.
     When [json] is not provided, attempts to parse [content] as JSON
     so downstream consumers can access structured data without re-parsing. *)
-let tool_result_msg ~tool_use_id ~content ?(is_error = false) ?json () =
+let tool_result_msg
+      ~tool_use_id
+      ~content
+      ?(is_error = false)
+      ?failure_kind
+      ?error_class
+      ?json
+      ()
+  =
   let json =
     match json with
     | Some _ -> json
@@ -652,7 +668,16 @@ let tool_result_msg ~tool_use_id ~content ?(is_error = false) ?json () =
   make_message
     ~tool_call_id:tool_use_id
     ~role:Tool
-    [ ToolResult { tool_use_id; content; is_error; json; content_blocks = None } ]
+    [ ToolResult
+        { tool_use_id
+        ; content
+        ; is_error
+        ; failure_kind
+        ; error_class
+        ; json
+        ; content_blocks = None
+        }
+    ]
 ;;
 
 (** {1 Tool Result Validation}

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -50,6 +50,15 @@ type tool_error_class =
   | Unknown
 [@@deriving yojson, show]
 
+(** Provider-neutral classification of a failed tool execution. The class is
+    produced by the execution boundary and survives agent history/checkpoint
+    projection; provider wire serializers deliberately omit it. *)
+type tool_failure_kind =
+  | Validation_error
+  | Recoverable_tool_error
+  | Non_retryable_tool_error
+[@@deriving yojson, show]
+
 type tool_error =
   { message : string
   ; recoverable : bool
@@ -146,6 +155,10 @@ type content_block =
       { tool_use_id : string
       ; content : string
       ; is_error : bool
+      ; failure_kind : tool_failure_kind option
+        (** Execution classification, when the result originated inside OAS. *)
+      ; error_class : tool_error_class option
+        (** Provider-neutral error class supplied by the tool boundary. *)
       ; json : Yojson.Safe.t option (** Structured payload when parseable. *)
       ; content_blocks : content_block list option
         (** Structured multi-block result (e.g. text + image). When [Some],
@@ -439,6 +452,8 @@ val tool_result_msg
   :  tool_use_id:string
   -> content:string
   -> ?is_error:bool
+  -> ?failure_kind:tool_failure_kind
+  -> ?error_class:tool_error_class
   -> ?json:Yojson.Safe.t
   -> unit
   -> message

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -92,47 +92,8 @@ type api_strategy =
 
 type turn_outcome =
   | Complete of Types.api_response
-  | ToolsExecuted
+  | ToolsExecuted of Tool_failure_episode.completed_round option
   | IdleSkipped
-
-let all_validation_error_results = function
-  | [] -> false
-  | results ->
-    List.for_all
-      (fun (result : Agent_tools.tool_execution_result) ->
-         result.is_error
-         &&
-         match result.failure_kind with
-         | Some Agent_tools.Validation_error -> true
-         | Some Agent_tools.Recoverable_tool_error
-         | Some Agent_tools.Non_retryable_tool_error
-         | None -> false)
-      results
-;;
-
-let validation_loop_blocked_text ~consecutive_idle_turns results =
-  let tool_names =
-    results
-    |> List.map (fun (result : Agent_tools.tool_execution_result) -> result.tool_name)
-    |> List.sort_uniq String.compare
-    |> String.concat ", "
-  in
-  let tool_names = if tool_names = "" then "(unknown)" else tool_names in
-  let last_error =
-    results
-    |> List.find_map (fun (result : Agent_tools.tool_execution_result) ->
-      if result.is_error then Some result.content else None)
-    |> Option.value ~default:"validation error"
-    |> fun s -> Util.clip s 700
-  in
-  Printf.sprintf
-    "I stopped the tool loop because the same invalid tool call was repeated after \
-     validation feedback. Tool(s): %s. Repeated invalid turn count: %d. Last validation \
-     error: %s"
-    tool_names
-    consecutive_idle_turns
-    last_error
-;;
 
 let persist_turn_checkpoint_for_state agent stage state =
   match agent.checkpoint_sink with
@@ -570,37 +531,13 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails ~response tool_uses
             update_state agent (fun s ->
               { s with messages = Util.snoc s.messages (make_message ~role:User content) });
             let* () = persist_turn_checkpoint agent After_tool_results_appended in
-            Ok ToolsExecuted
+            Ok (ToolsExecuted None)
           | false ->
             let results =
               try Ok (execute_tools_with_trace agent raw_trace_run tool_uses) with
               | Raw_trace.Trace_error err -> Error err
             in
             let* results = results in
-            let uses_default_idle_policy =
-              Option.is_none agent.options.hooks.on_idle
-              && Option.is_none agent.options.hooks.on_idle_escalated
-            in
-            let repeated_validation_loop_blocked =
-              idle_result.is_idle
-              && uses_default_idle_policy
-              && all_validation_error_results results
-            in
-            let validation_loop_blocked_response =
-              if repeated_validation_loop_blocked
-              then
-                Some
-                  { response with
-                    stop_reason = EndTurn
-                  ; content =
-                      [ Text
-                          (validation_loop_blocked_text
-                             ~consecutive_idle_turns:agent.consecutive_idle_turns
-                             results)
-                      ]
-                  }
-              else None
-            in
             let tool_result_event_envelope = Pipeline_common.event_envelope agent in
             let tool_results =
               Agent_turn.make_tool_results
@@ -610,92 +547,65 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails ~response tool_uses
                 ?relocation:agent.options.tool_result_relocation
                 results
             in
+            let completed_round =
+              match agent.tool_failure_judge with
+              | None -> Ok None
+              | Some _ ->
+                (match Tool_failure_episode.project ~tool_uses ~tool_results with
+                 | Ok round -> Ok (Some round)
+                 | Error error ->
+                   Error
+                     (Error.Agent
+                        (Error.ToolFailureRecoveryFailed
+                           { stage = Error.Round_projection
+                           ; detail = Tool_failure_episode.show_error error
+                           })))
+            in
             (* Persist CRS to context after tool result processing so that
             checkpoint captures the current replacement decisions. *)
             (match agent.options.tool_result_relocation with
              | Some (_, crs) ->
                Content_replacement_state.persist_to_context agent.context crs
              | None -> ());
-            (* Tool-call validation / recoverable errors usually flow back to
-              the model as is_error tool_results so it can self-correct on a
-              subsequent turn. A repeated identical validation-only tool call
-              under the default idle policy is terminalized below: it has
-              already received schema feedback and another provider round would
-              replay the same large context without executing useful work. *)
-            let tool_feedback = tool_results in
-            let followup_text =
-              match validation_loop_blocked_response, !pending_nudge with
-              | Some _, _ -> None
-              | None, Some nudge -> Some nudge
-              | None, None when idle_result.is_idle && not !idle_handled ->
-                Some
-                  (Printf.sprintf
-                     "[Idle warning: You called the same tool(s) with identical \
-                      arguments %d time(s) in a row. Try a different tool or change your \
-                      arguments to make progress.]"
-                     agent.consecutive_idle_turns)
-              | None, None -> None
-            in
-            update_state agent (fun s ->
+            let checkpoint_state =
+              let s = agent.state in
               let messages =
-                match tool_feedback with
+                match tool_results with
                 | [] -> s.messages
-                | _ -> Util.snoc s.messages (make_message ~role:Tool tool_feedback)
+                | _ -> Util.snoc s.messages (make_message ~role:Tool tool_results)
               in
               let messages =
-                match followup_text with
+                match !pending_nudge with
                 | None -> messages
                 | Some text -> Util.snoc messages (make_message ~role:User [ Text text ])
               in
-              { s with messages });
-            (match agent.options.context_injector with
-             | None -> ()
-             | Some injector ->
-               let new_messages =
-                 Agent_turn.apply_context_injection
-                   ~context:agent.context
-                   ~messages:agent.state.messages
-                   ~injector
-                   ~tool_uses
-                   ~results
-               in
-               update_state agent (fun s -> { s with messages = new_messages }));
-            (match validation_loop_blocked_response with
-             | None -> ()
-             | Some blocked_response ->
-               update_state agent (fun s ->
-                 { s with
-                   messages =
-                     Util.snoc
-                       s.messages
-                       (make_message ~role:Assistant blocked_response.content)
-                 }));
-            let* () = persist_turn_checkpoint agent After_tool_results_appended in
-            (* The idle nudge (and the fallback anti-repetition hint) is appended
-              as a separate role:User message after the role:Tool result message.
-              This keeps OpenAI-compatible serializers from placing user text
-              before the required tool replies, which strict providers reject. *)
+              let messages =
+                match agent.options.context_injector with
+                | None -> messages
+                | Some injector ->
+                  Agent_turn.apply_context_injection
+                    ~context:agent.context
+                    ~messages
+                    ~injector
+                    ~tool_uses
+                    ~results
+              in
+              { s with messages }
+            in
+            let* () =
+              persist_turn_checkpoint_for_state
+                agent
+                After_tool_results_appended
+                checkpoint_state
+            in
+            set_state agent checkpoint_state;
+            (* A caller-installed idle nudge remains an explicit policy hook and
+               is appended after ToolResult. The former default repeat-count
+               User warning and canned Assistant terminal response are removed;
+               typed recovery owns repeated failed-tool judgment. *)
             ignore idle_handled;
-            (* suppress unused warning after dedup *)
-            (match validation_loop_blocked_response with
-             | Some blocked_response ->
-               Agent_types.reset_idle_state agent;
-               Ok (Complete blocked_response)
-             | None ->
-               (* In-memory message hygiene after each tool execution round.
-            Without this, agent.state.messages grows unbounded across turns —
-            context_reducer only trims before API calls, not in the stored state.
-
-            Two-step pruning (Claude Code Tier 1 pattern):
-            1. Stub old tool results: keep 2 most recent in full, replace older
-               with short stubs. Tool results are the largest allocation source.
-            2. Hard message cap: keep last 100 messages. Prevents unbounded growth
-               in long-running agents (600+ turns). *)
-               (* Tool-result stubbing and message cap are now applied at call-time
-            in Agent_turn.prepare_messages, not here.  Keeping stored messages
-            unmodified preserves the byte-identical conversation prefix that
-            local LLM KV-cache (Ollama/llama.cpp) depends on for reuse. *)
-               Ok ToolsExecuted)))
+            let* completed_round = completed_round in
+            Ok (ToolsExecuted completed_round)))
 ;;
 
 (* ── Stage 6: Output ─────────────────────────────────────── *)
@@ -1035,7 +945,7 @@ let tag_error stage result =
     Error e
 ;;
 
-let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
+let run_turn ~sw ?clock ~api_strategy ?raw_trace_run ?recovery_context agent =
   (* Stage 1: Input *)
   let* () =
     Tracing.with_span
@@ -1060,7 +970,8 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
       ; extra = []
       ; links = []
       }
-      (fun _tracer -> stage_parse ?raw_trace_run ?clock agent |> tag_error "parse")
+      (fun _tracer ->
+         stage_parse ?raw_trace_run ?clock ?recovery_context agent |> tag_error "parse")
   in
   let context_window = proactive_context_window_tokens agent in
   let est_tokens = total_prompt_tokens_for_agent agent agent.state.messages in
@@ -1148,7 +1059,7 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
         then (
           update_state agent (fun s -> { s with config = original_config });
           let* prep', _, _ =
-            stage_parse ?raw_trace_run ?clock agent |> tag_error "parse"
+            stage_parse ?raw_trace_run ?clock ?recovery_context agent |> tag_error "parse"
           in
           Ok prep')
         else Ok prep
@@ -1223,7 +1134,7 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
         else (
           update_state agent (fun s -> { s with config = original_config });
           let* prep', _, _ =
-            stage_parse ?raw_trace_run ?clock agent |> tag_error "parse"
+            stage_parse ?raw_trace_run ?clock ?recovery_context agent |> tag_error "parse"
           in
           attempt_route ~prep:prep' ~compact_attempts:(compact_attempts + 1))
       | other -> other

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -1303,6 +1303,8 @@ let%test "last_tool_results_from finds tool results in last tool message" =
               { tool_use_id = "t1"
               ; content = "result1"
               ; is_error = false
+              ; failure_kind = None
+              ; error_class = None
               ; json = None
               ; content_blocks = None
               }
@@ -1310,6 +1312,8 @@ let%test "last_tool_results_from finds tool results in last tool message" =
               { tool_use_id = "t2"
               ; content = "error msg"
               ; is_error = true
+              ; failure_kind = None
+              ; error_class = None
               ; json = None
               ; content_blocks = None
               }
@@ -1335,6 +1339,8 @@ let%test "last_tool_results_from skips non-tool user messages" =
               { tool_use_id = "t1"
               ; content = "first"
               ; is_error = false
+              ; failure_kind = None
+              ; error_class = None
               ; json = None
               ; content_blocks = None
               }
@@ -1405,6 +1411,8 @@ let%test "last_tool_results_from picks last tool-result message" =
               { tool_use_id = "t1"
               ; content = "first"
               ; is_error = false
+              ; failure_kind = None
+              ; error_class = None
               ; json = None
               ; content_blocks = None
               }
@@ -1425,6 +1433,8 @@ let%test "last_tool_results_from picks last tool-result message" =
               { tool_use_id = "t2"
               ; content = "second"
               ; is_error = false
+              ; failure_kind = None
+              ; error_class = None
               ; json = None
               ; content_blocks = None
               }
@@ -1449,6 +1459,8 @@ let%test "last_tool_results_from mixed content in user message" =
               { tool_use_id = "t1"
               ; content = "ok"
               ; is_error = false
+              ; failure_kind = None
+              ; error_class = None
               ; json = None
               ; content_blocks = None
               }
@@ -1473,6 +1485,8 @@ let%test "last_tool_results_from error tool result" =
               { tool_use_id = "t1"
               ; content = "fail msg"
               ; is_error = true
+              ; failure_kind = None
+              ; error_class = None
               ; json = None
               ; content_blocks = None
               }
@@ -1533,6 +1547,8 @@ let%test "last_tool_results_from multiple tool results in one message" =
               { tool_use_id = "t1"
               ; content = "r1"
               ; is_error = false
+              ; failure_kind = None
+              ; error_class = None
               ; json = None
               ; content_blocks = None
               }
@@ -1540,6 +1556,8 @@ let%test "last_tool_results_from multiple tool results in one message" =
               { tool_use_id = "t2"
               ; content = "r2"
               ; is_error = false
+              ; failure_kind = None
+              ; error_class = None
               ; json = None
               ; content_blocks = None
               }
@@ -1547,6 +1565,8 @@ let%test "last_tool_results_from multiple tool results in one message" =
               { tool_use_id = "t3"
               ; content = "r3"
               ; is_error = true
+              ; failure_kind = None
+              ; error_class = None
               ; json = None
               ; content_blocks = None
               }

--- a/lib/pipeline/pipeline.mli
+++ b/lib/pipeline/pipeline.mli
@@ -19,8 +19,16 @@ type api_strategy =
 
 type turn_outcome =
   | Complete of Types.api_response
-  | ToolsExecuted
+  | ToolsExecuted of Tool_failure_episode.completed_round option
   | IdleSkipped (** on_idle hook returned Skip — agent should stop gracefully. *)
+
+(** Persist [state] using the same pre-commit checkpoint transaction as turn
+    collection. The live agent state is not changed by this function. *)
+val persist_turn_checkpoint_for_state
+  :  Agent_types.t
+  -> Agent_types.checkpoint_stage
+  -> Types.agent_state
+  -> (unit, Error.sdk_error) result
 
 (** Run a single agent turn through the 6-stage pipeline.
     Equivalent to the previous [run_turn_core]. *)
@@ -29,5 +37,6 @@ val run_turn
   -> ?clock:_ Eio.Time.clock
   -> api_strategy:api_strategy
   -> ?raw_trace_run:Raw_trace.active_run
+  -> ?recovery_context:string
   -> Agent_types.t
   -> (turn_outcome, Error.sdk_error) result

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -284,7 +284,7 @@ let%test "runtime MCP policy is narrowed by AllowList guardrails" =
   narrowed.allowed_tool_names = [ "status_tool"; "ledger_tool" ]
 ;;
 
-let stage_parse ?raw_trace_run ?clock agent =
+let stage_parse ?raw_trace_run ?clock ?recovery_context agent =
   let* turn_params =
     match agent.options.hooks.before_turn_params with
     | None -> Ok Hooks.default_turn_params
@@ -345,10 +345,20 @@ let stage_parse ?raw_trace_run ?clock agent =
          | Some _ as t -> t
          | None -> original_config.tool_choice)
     ; system_prompt =
-        (match turn_params.system_prompt_override with
-         | Some _ as s -> s
-         | None -> original_config.system_prompt)
-        |> Option.map Llm_provider.Utf8_sanitize.sanitize
+        (let base =
+           match turn_params.system_prompt_override with
+           | Some _ as prompt -> prompt
+           | None -> original_config.system_prompt
+         in
+         let base = Option.map Llm_provider.Utf8_sanitize.sanitize base in
+         match recovery_context with
+         | None -> base
+         | Some context ->
+           let context = Llm_provider.Utf8_sanitize.sanitize context in
+           Some
+             (match base with
+              | None -> context
+              | Some prompt -> prompt ^ "\n\n" ^ context))
     }
   in
   update_state agent (fun s -> { s with config = new_config });

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -152,6 +152,8 @@ let%test "last_tool_results_from routes through canonical projection (with json)
               { tool_use_id = "t1"
               ; content = "ok payload"
               ; is_error = false
+              ; failure_kind = None
+              ; error_class = None
               ; json = Some (`Assoc [ "rows", `Int 2 ])
               ; content_blocks = None
               }
@@ -159,6 +161,8 @@ let%test "last_tool_results_from routes through canonical projection (with json)
               { tool_use_id = "t2"
               ; content = "boom"
               ; is_error = true
+              ; failure_kind = None
+              ; error_class = None
               ; json = None
               ; content_blocks = None
               }

--- a/lib/succession.ml
+++ b/lib/succession.ml
@@ -274,6 +274,8 @@ let normalize_for_model (msgs : message list) ~(target_model : string) : message
                        ; content =
                            Printf.sprintf "[truncated: %s result unavailable]" name
                        ; is_error = true
+                       ; failure_kind = None
+                       ; error_class = None
                        ; json = None
                        ; content_blocks = None
                        }

--- a/lib/tool_failure_episode.ml
+++ b/lib/tool_failure_episode.ml
@@ -1,0 +1,226 @@
+open Types
+
+type failed_attempt =
+  { tool_use_id : string
+  ; tool_name : string
+  ; input : Yojson.Safe.t
+  ; failure_kind : tool_failure_kind
+  ; error_class : tool_error_class option
+  ; error : string
+  }
+[@@deriving yojson, show]
+
+type t =
+  { previous : failed_attempt
+  ; current : failed_attempt
+  }
+[@@deriving yojson, show]
+
+type paired_attempt =
+  { tool_use_id : string
+  ; tool_name : string
+  ; input : Yojson.Safe.t
+  ; failure : (tool_failure_kind * tool_error_class option * string) option
+  }
+
+type completed_round = paired_attempt list
+
+type error =
+  | Empty_tool_use_round
+  | Blank_tool_use_id
+  | Blank_tool_result_id
+  | Blank_tool_name of { tool_use_id : string }
+  | Duplicate_tool_use_id of { tool_use_id : string }
+  | Duplicate_tool_result_id of { tool_use_id : string }
+  | Missing_tool_result of { tool_use_id : string }
+  | Unmatched_tool_result of { tool_use_id : string }
+  | Failure_metadata_on_success of { tool_use_id : string }
+  | Failure_kind_missing of { tool_use_id : string }
+  | Ambiguous_failure_signature of
+      { tool_name : string
+      ; failure_kind : tool_failure_kind
+      ; error_class : tool_error_class option
+      ; previous_count : int
+      ; current_count : int
+      }
+[@@deriving show]
+
+module String_set = Set.Make (String)
+
+module Failure_key = struct
+  type t = string * tool_failure_kind * tool_error_class option
+
+  let compare = Stdlib.compare
+end
+
+module Failure_map = Map.Make (Failure_key)
+
+let ( let* ) = Result.bind
+let string_is_blank value = String.equal (String.trim value) ""
+
+let tool_uses blocks =
+  List.filter_map
+    (function
+      | ToolUse { id; name; input } -> Some (id, name, input)
+      | Text _
+      | Thinking _
+      | ReasoningDetails _
+      | RedactedThinking _
+      | ToolResult _
+      | Image _
+      | Document _
+      | Audio _ -> None)
+    blocks
+;;
+
+let tool_results blocks =
+  List.filter_map
+    (function
+      | ToolResult { tool_use_id; content; is_error; failure_kind; error_class; _ } ->
+        Some (tool_use_id, content, is_error, failure_kind, error_class)
+      | Text _
+      | Thinking _
+      | ReasoningDetails _
+      | RedactedThinking _
+      | ToolUse _
+      | Image _
+      | Document _
+      | Audio _ -> None)
+    blocks
+;;
+
+let first_duplicate project values =
+  let rec loop seen = function
+    | [] -> None
+    | value :: rest ->
+      let key = project value in
+      if String_set.mem key seen then Some key else loop (String_set.add key seen) rest
+  in
+  loop String_set.empty values
+;;
+
+let failure_of_result ~tool_use_id ~content ~is_error ~failure_kind ~error_class =
+  match is_error, failure_kind, error_class with
+  | false, None, None -> Ok None
+  | false, _, _ -> Error (Failure_metadata_on_success { tool_use_id })
+  | true, None, _ -> Error (Failure_kind_missing { tool_use_id })
+  | true, Some kind, error_class -> Ok (Some (kind, error_class, content))
+;;
+
+let project ~tool_uses:use_blocks ~tool_results:result_blocks =
+  let uses = tool_uses use_blocks in
+  let results = tool_results result_blocks in
+  let* () = if uses = [] then Error Empty_tool_use_round else Ok () in
+  let* () =
+    match List.find_opt (fun (id, _, _) -> string_is_blank id) uses with
+    | Some _ -> Error Blank_tool_use_id
+    | None -> Ok ()
+  in
+  let* () =
+    match List.find_opt (fun (_, name, _) -> string_is_blank name) uses with
+    | Some (tool_use_id, _, _) -> Error (Blank_tool_name { tool_use_id })
+    | None -> Ok ()
+  in
+  let* () =
+    match List.find_opt (fun (id, _, _, _, _) -> string_is_blank id) results with
+    | Some _ -> Error Blank_tool_result_id
+    | None -> Ok ()
+  in
+  let* () =
+    match first_duplicate (fun (id, _, _) -> id) uses with
+    | Some tool_use_id -> Error (Duplicate_tool_use_id { tool_use_id })
+    | None -> Ok ()
+  in
+  let* () =
+    match first_duplicate (fun (id, _, _, _, _) -> id) results with
+    | Some tool_use_id -> Error (Duplicate_tool_result_id { tool_use_id })
+    | None -> Ok ()
+  in
+  let result_for id =
+    List.find_opt (fun (result_id, _, _, _, _) -> String.equal result_id id) results
+  in
+  let* paired =
+    let rec loop acc = function
+      | [] -> Ok (List.rev acc)
+      | (tool_use_id, tool_name, input) :: rest ->
+        (match result_for tool_use_id with
+         | None -> Error (Missing_tool_result { tool_use_id })
+         | Some (_, content, is_error, failure_kind, error_class) ->
+           let* failure =
+             failure_of_result ~tool_use_id ~content ~is_error ~failure_kind ~error_class
+           in
+           loop ({ tool_use_id; tool_name; input; failure } :: acc) rest)
+    in
+    loop [] uses
+  in
+  let use_ids =
+    List.fold_left
+      (fun ids (tool_use_id, _, _) -> String_set.add tool_use_id ids)
+      String_set.empty
+      uses
+  in
+  match
+    List.find_opt (fun (id, _, _, _, _) -> not (String_set.mem id use_ids)) results
+  with
+  | Some (tool_use_id, _, _, _, _) -> Error (Unmatched_tool_result { tool_use_id })
+  | None -> Ok paired
+;;
+
+let failed_attempt = function
+  | { tool_use_id; tool_name; input; failure = Some (failure_kind, error_class, error) }
+    -> Some { tool_use_id; tool_name; input; failure_kind; error_class; error }
+  | { failure = None; _ } -> None
+;;
+
+let failure_key (attempt : failed_attempt) =
+  attempt.tool_name, attempt.failure_kind, attempt.error_class
+;;
+
+let failure_groups round =
+  List.fold_left
+    (fun groups attempt ->
+       match failed_attempt attempt with
+       | None -> groups
+       | Some failure ->
+         Failure_map.update
+           (failure_key failure)
+           (function
+             | None -> Some [ failure ]
+             | Some failures -> Some (failure :: failures))
+           groups)
+    Failure_map.empty
+    round
+;;
+
+let detect ~previous ~current =
+  let previous_groups = failure_groups previous in
+  let current_groups = failure_groups current in
+  let* () =
+    Failure_map.fold
+      (fun ((tool_name, failure_kind, error_class) as key) current_attempts result ->
+         let* () = result in
+         match Failure_map.find_opt key previous_groups with
+         | None -> Ok ()
+         | Some previous_attempts ->
+           let previous_count = List.length previous_attempts in
+           let current_count = List.length current_attempts in
+           if previous_count = 1 && current_count = 1
+           then Ok ()
+           else
+             Error
+               (Ambiguous_failure_signature
+                  { tool_name; failure_kind; error_class; previous_count; current_count }))
+      current_groups
+      (Ok ())
+  in
+  let episodes =
+    current
+    |> List.filter_map failed_attempt
+    |> List.filter_map (fun current_failure ->
+      match Failure_map.find_opt (failure_key current_failure) previous_groups with
+      | Some [ previous_failure ] ->
+        Some { previous = previous_failure; current = current_failure }
+      | None | Some [] | Some (_ :: _ :: _) -> None)
+  in
+  Ok episodes
+;;

--- a/lib/tool_failure_episode.mli
+++ b/lib/tool_failure_episode.mli
@@ -1,0 +1,69 @@
+(** Provider-neutral detection of adjacent failed tool attempts.
+
+    Callers project each completed execution boundary exactly once and retain
+    only the immediately preceding projection. Detection therefore does not
+    reverse-scan an unbounded transcript, guess across injected messages, or
+    inspect error prose and tool arguments.
+
+    @stability Evolving
+    @since 0.212.0 *)
+
+type failed_attempt =
+  { tool_use_id : string
+  ; tool_name : string
+  ; input : Yojson.Safe.t
+  ; failure_kind : Types.tool_failure_kind
+  ; error_class : Types.tool_error_class option
+  ; error : string
+  }
+[@@deriving yojson, show]
+
+type t =
+  { previous : failed_attempt
+  ; current : failed_attempt
+  }
+[@@deriving yojson, show]
+
+(** An immutable, fully paired execution boundary. *)
+type completed_round
+
+type error =
+  | Empty_tool_use_round
+  | Blank_tool_use_id
+  | Blank_tool_result_id
+  | Blank_tool_name of { tool_use_id : string }
+  | Duplicate_tool_use_id of { tool_use_id : string }
+  | Duplicate_tool_result_id of { tool_use_id : string }
+  | Missing_tool_result of { tool_use_id : string }
+  | Unmatched_tool_result of { tool_use_id : string }
+  | Failure_metadata_on_success of { tool_use_id : string }
+  | Failure_kind_missing of { tool_use_id : string }
+  | Ambiguous_failure_signature of
+      { tool_name : string
+      ; failure_kind : Types.tool_failure_kind
+      ; error_class : Types.tool_error_class option
+      ; previous_count : int
+      ; current_count : int
+      }
+[@@deriving show]
+
+(** [project ~tool_uses ~tool_results] pairs a provider response's [ToolUse]
+    blocks with the canonical [ToolResult] blocks produced by execution.
+
+    Non-tool blocks are ignored. Missing, duplicate, unmatched, blank, or
+    incompletely typed failures are explicit [Error] values. In particular,
+    [is_error = true] always requires [failure_kind = Some _]. *)
+val project
+  :  tool_uses:Types.content_block list
+  -> tool_results:Types.content_block list
+  -> (completed_round, error) result
+
+(** [detect ~previous ~current] returns one episode for each failure signature
+    that occurs exactly once in each adjacent completed round. A signature is
+    [(tool_name, failure_kind, error_class)]; argument and error-text changes do
+    not prevent detection.
+
+    Multiple different signatures for the same tool name remain independent.
+    A signature occurring more than once in either round cannot be paired
+    without guessing and returns [Ambiguous_failure_signature]. *)
+val detect : previous:completed_round -> current:completed_round -> (t list, error) result

--- a/lib/tool_failure_recovery.ml
+++ b/lib/tool_failure_recovery.ml
@@ -1,0 +1,602 @@
+type revised_call =
+  { current_tool_use_id : string
+  ; tool_name : string
+  ; revised_input : Yojson.Safe.t
+  }
+[@@deriving show]
+
+type decision =
+  | Retry_modified of revised_call list
+  | Replan of { instruction : string }
+  | Ask_user of
+      { question : string
+      ; schema : Yojson.Safe.t option
+      }
+  | Defer of { reason : string }
+[@@deriving show]
+
+type model_request =
+  { system_prompt : string
+  ; user_prompt : string
+  ; output_schema : Yojson.Safe.t
+  }
+
+type completion = sw:Eio.Switch.t -> model_request -> (string, Error.sdk_error) result
+type judge = { complete : completion }
+
+let create ~complete = { complete }
+
+type decision_error =
+  | Empty_revised_calls
+  | Duplicate_revised_call of { current_tool_use_id : string }
+  | Missing_revised_call of { current_tool_use_id : string }
+  | Unexpected_revised_call of { current_tool_use_id : string }
+  | Revised_tool_name_mismatch of
+      { current_tool_use_id : string
+      ; expected : string
+      ; got : string
+      }
+  | Unchanged_revised_input of { current_tool_use_id : string }
+  | Blank_replan_instruction
+  | Blank_question
+  | Blank_defer_reason
+[@@deriving show]
+
+type response_error =
+  | Invalid_json of string
+  | Expected_object
+  | Missing_field of string
+  | Invalid_field of string
+  | Unsupported_action of string
+  | Invalid_decision of decision_error
+[@@deriving show]
+
+type judge_error =
+  | Completion_failed of Error.sdk_error
+  | Completion_raised of string
+  | Invalid_response of response_error
+
+let judge_error_to_string = function
+  | Completion_failed error ->
+    Printf.sprintf "tool failure recovery LLM call failed: %s" (Error.to_string error)
+  | Completion_raised detail ->
+    Printf.sprintf "tool failure recovery LLM callback raised: %s" detail
+  | Invalid_response error ->
+    Printf.sprintf
+      "tool failure recovery LLM response invalid: %s"
+      (show_response_error error)
+;;
+
+module String_set = Set.Make (String)
+
+let ( let* ) = Result.bind
+let is_blank value = String.equal (String.trim value) ""
+
+let required_field name fields =
+  match List.assoc_opt name fields with
+  | Some value -> Ok value
+  | None -> Error (Missing_field name)
+;;
+
+let required_string name fields =
+  let* value = required_field name fields in
+  match value with
+  | `String value -> Ok value
+  | _ -> Error (Invalid_field name)
+;;
+
+let optional_json name fields =
+  match List.assoc_opt name fields with
+  | None | Some `Null -> None
+  | Some value -> Some value
+;;
+
+let parse_revised_call = function
+  | `Assoc fields ->
+    let* current_tool_use_id = required_string "current_tool_use_id" fields in
+    let* tool_name = required_string "tool_name" fields in
+    let* revised_input = required_field "revised_input" fields in
+    Ok { current_tool_use_id; tool_name; revised_input }
+  | _ -> Error (Invalid_field "revised_calls")
+;;
+
+let parse_revised_calls fields =
+  let* value = required_field "revised_calls" fields in
+  match value with
+  | `List values ->
+    List.fold_right
+      (fun value result ->
+         let* calls = result in
+         let* call = parse_revised_call value in
+         Ok (call :: calls))
+      values
+      (Ok [])
+  | _ -> Error (Invalid_field "revised_calls")
+;;
+
+let parse_decision_json = function
+  | `Assoc fields ->
+    let* action = required_string "action" fields in
+    (match action with
+     | "retry_modified" ->
+       let* calls = parse_revised_calls fields in
+       Ok (Retry_modified calls)
+     | "replan" ->
+       let* instruction = required_string "instruction" fields in
+       Ok (Replan { instruction })
+     | "ask_user" ->
+       let* question = required_string "question" fields in
+       Ok (Ask_user { question; schema = optional_json "schema" fields })
+     | "defer" ->
+       let* reason = required_string "reason" fields in
+       Ok (Defer { reason })
+     | action -> Error (Unsupported_action action))
+  | _ -> Error Expected_object
+;;
+
+let validate_retry episodes calls =
+  let* () = if calls = [] then Error Empty_revised_calls else Ok () in
+  let* () =
+    let rec loop seen = function
+      | [] -> Ok ()
+      | call :: rest ->
+        if String_set.mem call.current_tool_use_id seen
+        then
+          Error
+            (Duplicate_revised_call { current_tool_use_id = call.current_tool_use_id })
+        else loop (String_set.add call.current_tool_use_id seen) rest
+    in
+    loop String_set.empty calls
+  in
+  let episode_for id =
+    List.find_opt
+      (fun (episode : Tool_failure_episode.t) ->
+         String.equal episode.current.tool_use_id id)
+      episodes
+  in
+  let call_for id =
+    List.find_opt (fun call -> String.equal call.current_tool_use_id id) calls
+  in
+  let* () =
+    let rec validate_episodes = function
+      | [] -> Ok ()
+      | (episode : Tool_failure_episode.t) :: rest ->
+        (match call_for episode.current.tool_use_id with
+         | None ->
+           Error
+             (Missing_revised_call { current_tool_use_id = episode.current.tool_use_id })
+         | Some call when not (String.equal call.tool_name episode.current.tool_name) ->
+           Error
+             (Revised_tool_name_mismatch
+                { current_tool_use_id = call.current_tool_use_id
+                ; expected = episode.current.tool_name
+                ; got = call.tool_name
+                })
+         | Some call when Yojson.Safe.equal call.revised_input episode.current.input ->
+           Error
+             (Unchanged_revised_input { current_tool_use_id = call.current_tool_use_id })
+         | Some _ -> validate_episodes rest)
+    in
+    validate_episodes episodes
+  in
+  match
+    List.find_opt
+      (fun call -> Option.is_none (episode_for call.current_tool_use_id))
+      calls
+  with
+  | Some call ->
+    Error (Unexpected_revised_call { current_tool_use_id = call.current_tool_use_id })
+  | None -> Ok ()
+;;
+
+let validate_decision ~episodes = function
+  | Retry_modified calls -> validate_retry episodes calls
+  | Replan { instruction } ->
+    if is_blank instruction then Error Blank_replan_instruction else Ok ()
+  | Ask_user { question; _ } -> if is_blank question then Error Blank_question else Ok ()
+  | Defer { reason } -> if is_blank reason then Error Blank_defer_reason else Ok ()
+;;
+
+let failure_kind_json kind = Types.tool_failure_kind_to_yojson kind
+
+let error_class_json = function
+  | None -> `Null
+  | Some error_class -> Types.tool_error_class_to_yojson error_class
+;;
+
+let attempt_json (attempt : Tool_failure_episode.failed_attempt) =
+  `Assoc
+    [ "tool_use_id", `String attempt.tool_use_id
+    ; "tool_name", `String attempt.tool_name
+    ; "input", attempt.input
+    ; "failure_kind", failure_kind_json attempt.failure_kind
+    ; "error_class", error_class_json attempt.error_class
+    ; "error", `String attempt.error
+    ]
+;;
+
+let episode_json (episode : Tool_failure_episode.t) =
+  `Assoc
+    [ "previous", attempt_json episode.previous; "current", attempt_json episode.current ]
+;;
+
+let output_schema =
+  `Assoc
+    [ "type", `String "object"
+    ; ( "oneOf"
+      , `List
+          [ `Assoc
+              [ ( "properties"
+                , `Assoc
+                    [ "action", `Assoc [ "const", `String "retry_modified" ]
+                    ; ( "revised_calls"
+                      , `Assoc
+                          [ "type", `String "array"
+                          ; "minItems", `Int 1
+                          ; ( "items"
+                            , `Assoc
+                                [ "type", `String "object"
+                                ; ( "required"
+                                  , `List
+                                      [ `String "current_tool_use_id"
+                                      ; `String "tool_name"
+                                      ; `String "revised_input"
+                                      ] )
+                                ] )
+                          ] )
+                    ] )
+              ; "required", `List [ `String "action"; `String "revised_calls" ]
+              ]
+          ; `Assoc
+              [ ( "properties"
+                , `Assoc
+                    [ "action", `Assoc [ "const", `String "replan" ]
+                    ; "instruction", `Assoc [ "type", `String "string" ]
+                    ] )
+              ; "required", `List [ `String "action"; `String "instruction" ]
+              ]
+          ; `Assoc
+              [ ( "properties"
+                , `Assoc
+                    [ "action", `Assoc [ "const", `String "ask_user" ]
+                    ; "question", `Assoc [ "type", `String "string" ]
+                    ] )
+              ; "required", `List [ `String "action"; `String "question" ]
+              ]
+          ; `Assoc
+              [ ( "properties"
+                , `Assoc
+                    [ "action", `Assoc [ "const", `String "defer" ]
+                    ; "reason", `Assoc [ "type", `String "string" ]
+                    ] )
+              ; "required", `List [ `String "action"; `String "reason" ]
+              ]
+          ] )
+    ]
+;;
+
+let system_prompt =
+  "You are the tool-failure recovery judge for a long-lived agent. Choose exactly one "
+  ^ "action from the supplied JSON schema. Base the decision only on the typed adjacent "
+  ^ "failure episodes. retry_modified must provide one materially changed input for \
+     every "
+  ^ "current failed call. replan must give a concrete next-turn instruction. ask_user is "
+  ^ "for missing human-owned information. defer is for work that should resume after an "
+  ^ "external state change. Return only the JSON object."
+;;
+
+let decide ~sw ~agent_name ~turn ~episodes judge =
+  if episodes = []
+  then Error (Invalid_response (Invalid_decision Empty_revised_calls))
+  else (
+    let user_prompt =
+      `Assoc
+        [ "agent_name", `String agent_name
+        ; "turn", `Int turn
+        ; "episodes", `List (List.map episode_json episodes)
+        ]
+      |> Yojson.Safe.to_string
+    in
+    let request = { system_prompt; user_prompt; output_schema } in
+    let completion =
+      try `Returned (judge.complete ~sw request) with
+      | exn ->
+        Llm_provider.Reserved_exn.reraise_if_reserved exn;
+        `Raised (Printexc.to_string exn)
+    in
+    match completion with
+    | `Raised detail -> Error (Completion_raised detail)
+    | `Returned (Error error) -> Error (Completion_failed error)
+    | `Returned (Ok text) ->
+      let parsed =
+        try Ok (Yojson.Safe.from_string text) with
+        | Yojson.Json_error detail -> Error (Invalid_json detail)
+      in
+      (match parsed with
+       | Error error -> Error (Invalid_response error)
+       | Ok json ->
+         (match parse_decision_json json with
+          | Error error -> Error (Invalid_response error)
+          | Ok decision ->
+            (match validate_decision ~episodes decision with
+             | Ok () -> Ok decision
+             | Error error -> Error (Invalid_response (Invalid_decision error))))))
+;;
+
+type episode_ref =
+  { previous_tool_use_id : string
+  ; current_tool_use_id : string
+  ; tool_name : string
+  ; failure_kind : Types.tool_failure_kind
+  ; error_class : Types.tool_error_class option
+  }
+
+type receipt =
+  { resume_turn : int
+  ; decided_at : float
+  ; episodes : episode_ref list
+  ; decision : decision
+  }
+
+let episode_ref (episode : Tool_failure_episode.t) =
+  { previous_tool_use_id = episode.previous.tool_use_id
+  ; current_tool_use_id = episode.current.tool_use_id
+  ; tool_name = episode.current.tool_name
+  ; failure_kind = episode.current.failure_kind
+  ; error_class = episode.current.error_class
+  }
+;;
+
+let make_receipt ~resume_turn ~decided_at ~episodes ~decision =
+  { resume_turn; decided_at; episodes = List.map episode_ref episodes; decision }
+;;
+
+let receipt_resume_turn receipt = receipt.resume_turn
+let receipt_decided_at receipt = receipt.decided_at
+let receipt_decision receipt = receipt.decision
+
+let receipt_tool_names receipt =
+  receipt.episodes
+  |> List.map (fun episode -> episode.tool_name)
+  |> List.sort_uniq String.compare
+;;
+
+type receipt_error =
+  | Result_message_not_found
+  | Duplicate_receipt_metadata
+  | Invalid_receipt_metadata of string
+  | Receipt_episode_mismatch
+  | Receipt_decision_invalid of decision_error
+[@@deriving show]
+
+let metadata_key = "oas.tool_failure_recovery.v1"
+
+let revised_call_json call =
+  `Assoc
+    [ "current_tool_use_id", `String call.current_tool_use_id
+    ; "tool_name", `String call.tool_name
+    ; "revised_input", call.revised_input
+    ]
+;;
+
+let decision_json = function
+  | Retry_modified calls ->
+    `Assoc
+      [ "action", `String "retry_modified"
+      ; "revised_calls", `List (List.map revised_call_json calls)
+      ]
+  | Replan { instruction } ->
+    `Assoc [ "action", `String "replan"; "instruction", `String instruction ]
+  | Ask_user { question; schema } ->
+    `Assoc
+      ([ "action", `String "ask_user"; "question", `String question ]
+       @
+       match schema with
+       | None -> []
+       | Some schema -> [ "schema", schema ])
+  | Defer { reason } -> `Assoc [ "action", `String "defer"; "reason", `String reason ]
+;;
+
+let decision_to_yojson = decision_json
+
+let episode_ref_json episode =
+  `Assoc
+    [ "previous_tool_use_id", `String episode.previous_tool_use_id
+    ; "current_tool_use_id", `String episode.current_tool_use_id
+    ; "tool_name", `String episode.tool_name
+    ; "failure_kind", failure_kind_json episode.failure_kind
+    ; "error_class", error_class_json episode.error_class
+    ]
+;;
+
+let receipt_json receipt =
+  `Assoc
+    [ "version", `Int 1
+    ; "resume_turn", `Int receipt.resume_turn
+    ; "decided_at", `Float receipt.decided_at
+    ; "episodes", `List (List.map episode_ref_json receipt.episodes)
+    ; "decision", decision_json receipt.decision
+    ]
+;;
+
+let tool_result_ids message =
+  List.filter_map
+    (function
+      | Types.ToolResult { tool_use_id; _ } -> Some tool_use_id
+      | Types.Text _
+      | Types.Thinking _
+      | Types.ReasoningDetails _
+      | Types.RedactedThinking _
+      | Types.ToolUse _
+      | Types.Image _
+      | Types.Document _
+      | Types.Audio _ -> None)
+    message.Types.content
+;;
+
+let attach_receipt ~messages ~episodes ~receipt =
+  let expected_ids =
+    List.map (fun episode -> episode.Tool_failure_episode.current.tool_use_id) episodes
+  in
+  let contains_expected message =
+    let actual_ids = tool_result_ids message in
+    expected_ids <> []
+    && List.for_all (fun expected -> List.mem expected actual_ids) expected_ids
+  in
+  let rec update = function
+    | [] -> Error Result_message_not_found
+    | message :: rest when contains_expected message ->
+      if List.mem_assoc metadata_key message.Types.metadata
+      then Error Duplicate_receipt_metadata
+      else
+        Ok
+          ({ message with
+             metadata = (metadata_key, receipt_json receipt) :: message.metadata
+           }
+           :: rest)
+    | message :: rest ->
+      let* rest = update rest in
+      Ok (message :: rest)
+  in
+  let* reversed = update (List.rev messages) in
+  Ok (List.rev reversed)
+;;
+
+let parse_int name fields =
+  match List.assoc_opt name fields with
+  | Some (`Int value) -> Ok value
+  | _ -> Error (Invalid_receipt_metadata name)
+;;
+
+let parse_float name fields =
+  match List.assoc_opt name fields with
+  | Some (`Float value) -> Ok value
+  | Some (`Int value) -> Ok (float_of_int value)
+  | _ -> Error (Invalid_receipt_metadata name)
+;;
+
+let parse_string_receipt name fields =
+  match List.assoc_opt name fields with
+  | Some (`String value) -> Ok value
+  | _ -> Error (Invalid_receipt_metadata name)
+;;
+
+let parse_failure_kind fields =
+  match List.assoc_opt "failure_kind" fields with
+  | None -> Error (Invalid_receipt_metadata "failure_kind")
+  | Some value ->
+    (match Types.tool_failure_kind_of_yojson value with
+     | Ok kind -> Ok kind
+     | Error detail -> Error (Invalid_receipt_metadata detail))
+;;
+
+let parse_error_class fields =
+  match List.assoc_opt "error_class" fields with
+  | None | Some `Null -> Ok None
+  | Some value ->
+    (match Types.tool_error_class_of_yojson value with
+     | Ok error_class -> Ok (Some error_class)
+     | Error detail -> Error (Invalid_receipt_metadata detail))
+;;
+
+let parse_episode_ref = function
+  | `Assoc fields ->
+    let* previous_tool_use_id = parse_string_receipt "previous_tool_use_id" fields in
+    let* current_tool_use_id = parse_string_receipt "current_tool_use_id" fields in
+    let* tool_name = parse_string_receipt "tool_name" fields in
+    let* failure_kind = parse_failure_kind fields in
+    let* error_class = parse_error_class fields in
+    Ok { previous_tool_use_id; current_tool_use_id; tool_name; failure_kind; error_class }
+  | _ -> Error (Invalid_receipt_metadata "episodes")
+;;
+
+let parse_episode_refs fields =
+  match List.assoc_opt "episodes" fields with
+  | Some (`List values) ->
+    List.fold_right
+      (fun value result ->
+         let* refs = result in
+         let* episode = parse_episode_ref value in
+         Ok (episode :: refs))
+      values
+      (Ok [])
+  | _ -> Error (Invalid_receipt_metadata "episodes")
+;;
+
+let parse_receipt = function
+  | `Assoc fields ->
+    let* version = parse_int "version" fields in
+    let* () = if version = 1 then Ok () else Error (Invalid_receipt_metadata "version") in
+    let* resume_turn = parse_int "resume_turn" fields in
+    let* decided_at = parse_float "decided_at" fields in
+    let* episodes = parse_episode_refs fields in
+    let* decision_json =
+      match List.assoc_opt "decision" fields with
+      | Some value -> Ok value
+      | None -> Error (Invalid_receipt_metadata "decision")
+    in
+    let* decision =
+      match parse_decision_json decision_json with
+      | Ok decision -> Ok decision
+      | Error error -> Error (Invalid_receipt_metadata (show_response_error error))
+    in
+    Ok { resume_turn; decided_at; episodes; decision }
+  | _ -> Error (Invalid_receipt_metadata metadata_key)
+;;
+
+let latest_receipt messages =
+  let rec find = function
+    | [] -> Ok None
+    | message :: rest ->
+      if tool_result_ids message = []
+      then find rest
+      else (
+        let values =
+          List.filter_map
+            (fun (key, value) ->
+               if String.equal key metadata_key then Some value else None)
+            message.Types.metadata
+        in
+        match values with
+        | [] -> Ok None
+        | [ value ] ->
+          let* receipt = parse_receipt value in
+          Ok (Some receipt)
+        | _ :: _ :: _ -> Error Duplicate_receipt_metadata)
+  in
+  find (List.rev messages)
+;;
+
+let same_episode_ref left right =
+  String.equal left.previous_tool_use_id right.previous_tool_use_id
+  && String.equal left.current_tool_use_id right.current_tool_use_id
+  && String.equal left.tool_name right.tool_name
+  && left.failure_kind = right.failure_kind
+  && left.error_class = right.error_class
+;;
+
+let validate_receipt ~episodes receipt =
+  let actual = List.map episode_ref episodes in
+  let refs_match =
+    List.length actual = List.length receipt.episodes
+    && List.for_all
+         (fun expected -> List.exists (same_episode_ref expected) receipt.episodes)
+         actual
+  in
+  if not refs_match
+  then Error Receipt_episode_mismatch
+  else (
+    match validate_decision ~episodes receipt.decision with
+    | Ok () -> Ok ()
+    | Error error -> Error (Receipt_decision_invalid error))
+;;
+
+let system_context receipt =
+  match receipt.decision with
+  | Ask_user _ | Defer _ -> None
+  | Retry_modified _ | Replan _ ->
+    Some
+      ("OAS one-turn typed tool-failure recovery control. Follow this control for the "
+       ^ "next main-agent turn; do not reproduce it as user speech: "
+       ^ Yojson.Safe.to_string (decision_json receipt.decision))
+;;

--- a/lib/tool_failure_recovery.mli
+++ b/lib/tool_failure_recovery.mli
@@ -1,0 +1,136 @@
+(** LLM judgment boundary for repeated typed tool failures.
+
+    The main agent loop supplies only structural failure episodes to the judge:
+    no hidden reasoning, repeated narration, provider name, or model name is
+    replayed. The judge returns a closed decision that is validated against the
+    episodes before it can affect execution.
+
+    @stability Evolving
+    @since 0.212.0 *)
+
+type revised_call =
+  { current_tool_use_id : string
+  ; tool_name : string
+  ; revised_input : Yojson.Safe.t
+  }
+[@@deriving show]
+
+type decision = private
+  | Retry_modified of revised_call list
+  | Replan of { instruction : string }
+  | Ask_user of
+      { question : string
+      ; schema : Yojson.Safe.t option
+      }
+  | Defer of { reason : string }
+[@@deriving show]
+
+(** Observation-only JSON projection. Parsing remains private so external code
+    cannot bypass episode validation to construct a [decision]. *)
+val decision_to_yojson : decision -> Yojson.Safe.t
+
+type model_request =
+  { system_prompt : string
+  ; user_prompt : string
+  ; output_schema : Yojson.Safe.t
+  }
+
+(** A caller-owned LLM completion boundary. Coordinators may implement this
+    with their runtime catalog and provider fallback without coupling OAS to
+    that coordinator. The callback must return only the model's response text;
+    OAS owns schema parsing and decision validation. *)
+type completion = sw:Eio.Switch.t -> model_request -> (string, Error.sdk_error) result
+
+type judge
+
+val create : complete:completion -> judge
+
+type decision_error =
+  | Empty_revised_calls
+  | Duplicate_revised_call of { current_tool_use_id : string }
+  | Missing_revised_call of { current_tool_use_id : string }
+  | Unexpected_revised_call of { current_tool_use_id : string }
+  | Revised_tool_name_mismatch of
+      { current_tool_use_id : string
+      ; expected : string
+      ; got : string
+      }
+  | Unchanged_revised_input of { current_tool_use_id : string }
+  | Blank_replan_instruction
+  | Blank_question
+  | Blank_defer_reason
+[@@deriving show]
+
+type response_error =
+  | Invalid_json of string
+  | Expected_object
+  | Missing_field of string
+  | Invalid_field of string
+  | Unsupported_action of string
+  | Invalid_decision of decision_error
+[@@deriving show]
+
+type judge_error =
+  | Completion_failed of Error.sdk_error
+  | Completion_raised of string
+  | Invalid_response of response_error
+
+val judge_error_to_string : judge_error -> string
+
+(** Invoke the configured LLM once, parse its exact JSON object, and validate
+    the closed decision against every supplied episode. Empty episode lists are
+    rejected before the callback is invoked. *)
+val decide
+  :  sw:Eio.Switch.t
+  -> agent_name:string
+  -> turn:int
+  -> episodes:Tool_failure_episode.t list
+  -> judge
+  -> (decision, judge_error) result
+
+(** Durable receipt stored only in OAS message metadata/checkpoints. Provider
+    request serializers do not forward generic message metadata. *)
+type receipt
+
+val make_receipt
+  :  resume_turn:int
+  -> decided_at:float
+  -> episodes:Tool_failure_episode.t list
+  -> decision:decision
+  -> receipt
+
+val receipt_resume_turn : receipt -> int
+val receipt_decided_at : receipt -> float
+val receipt_decision : receipt -> decision
+val receipt_tool_names : receipt -> string list
+
+type receipt_error =
+  | Result_message_not_found
+  | Duplicate_receipt_metadata
+  | Invalid_receipt_metadata of string
+  | Receipt_episode_mismatch
+  | Receipt_decision_invalid of decision_error
+[@@deriving show]
+
+(** Add a versioned receipt to the latest result message containing every
+    current episode id. Existing metadata is preserved; a duplicate receipt is
+    an explicit error. *)
+val attach_receipt
+  :  messages:Types.message list
+  -> episodes:Tool_failure_episode.t list
+  -> receipt:receipt
+  -> (Types.message list, receipt_error) result
+
+(** Read a receipt only from the latest message containing a [ToolResult]. An
+    older receipt is never reused after a newer tool boundary. *)
+val latest_receipt : Types.message list -> (receipt option, receipt_error) result
+
+(** Validate a restored receipt against reconstructed adjacent episodes. *)
+val validate_receipt
+  :  episodes:Tool_failure_episode.t list
+  -> receipt
+  -> (unit, receipt_error) result
+
+(** Render a one-turn system-prompt suffix. [Ask_user] and [Defer] are
+    terminal control decisions and therefore have no continuation context. *)
+val system_context : receipt -> string option

--- a/lib/tool_middleware.ml
+++ b/lib/tool_middleware.ml
@@ -213,6 +213,8 @@ let heal_tool_call
                            (max_retries + 1)
                            enriched_message
                      ; is_error = true
+                     ; failure_kind = Some Validation_error
+                     ; error_class = Some Deterministic
                      ; json = None
                      ; content_blocks = None
                      }

--- a/test/dune
+++ b/test/dune
@@ -196,6 +196,8 @@
   test_swiss_verdict_json
   test_tool
   test_tool_disclosure
+  test_tool_failure_episode
+  test_tool_failure_recovery
   test_tool_index
   test_tool_input_validation
   test_tool_middleware
@@ -400,6 +402,8 @@
   test_swiss_verdict_json
   test_tool
   test_tool_disclosure
+  test_tool_failure_episode
+  test_tool_failure_recovery
   test_tool_index
   test_tool_input_validation
   test_tool_middleware

--- a/test/test_agent.ml
+++ b/test/test_agent.ml
@@ -146,6 +146,8 @@ let test_replace_existing () =
               { tool_use_id = "t1"
               ; content = "old result"
               ; is_error = false
+              ; failure_kind = None
+              ; error_class = None
               ; json = None
               ; content_blocks = None
               }
@@ -208,6 +210,8 @@ let test_replace_preserves_other_results () =
               { tool_use_id = "t1"
               ; content = "keep"
               ; is_error = false
+              ; failure_kind = None
+              ; error_class = None
               ; json = None
               ; content_blocks = None
               }
@@ -215,6 +219,8 @@ let test_replace_preserves_other_results () =
               { tool_use_id = "t2"
               ; content = "replace me"
               ; is_error = false
+              ; failure_kind = None
+              ; error_class = None
               ; json = None
               ; content_blocks = None
               }

--- a/test/test_agent_pipeline.ml
+++ b/test/test_agent_pipeline.ml
@@ -582,6 +582,8 @@ let test_agent_run_context_overflow_auto_retry_can_be_disabled () =
                 { tool_use_id = "tool_1"
                 ; content = String.make 2000 'x'
                 ; is_error = false
+                ; failure_kind = None
+                ; error_class = None
                 ; json = None
                 ; content_blocks = None
                 }
@@ -631,6 +633,8 @@ let big_tool_history () =
             { tool_use_id = "tool_1"
             ; content = String.make 20000 'x'
             ; is_error = false
+            ; failure_kind = None
+            ; error_class = None
             ; json = None
             ; content_blocks = None
             }

--- a/test/test_agent_tool.ml
+++ b/test/test_agent_tool.ml
@@ -41,6 +41,8 @@ let structured_runner prompt : (Types.api_response, Error.sdk_error) result =
             { tool_use_id = "toolu-child"
             ; content = {|{"ok":true}|}
             ; is_error = false
+            ; failure_kind = None
+            ; error_class = None
             ; json = Some (`Assoc [ "ok", `Bool true ])
             ; content_blocks = None
             }

--- a/test/test_agent_turn.ml
+++ b/test/test_agent_turn.ml
@@ -587,7 +587,7 @@ let test_make_tool_results () =
       ; content = "error msg"
       ; is_error = true
       ; failure_kind = Some Agent_tools.Recoverable_tool_error
-      ; error_class = None
+      ; error_class = Some Types.Deterministic
       }
     ]
   in
@@ -596,7 +596,18 @@ let test_make_tool_results () =
   match List.hd blocks with
   | Types.ToolResult { tool_use_id; is_error; _ } ->
     Alcotest.(check string) "id" "t1" tool_use_id;
-    Alcotest.(check bool) "not error" false is_error
+    Alcotest.(check bool) "not error" false is_error;
+    (match List.nth blocks 1 with
+     | Types.ToolResult { failure_kind; error_class; _ } ->
+       Alcotest.(check bool)
+         "failure kind preserved"
+         true
+         (failure_kind = Some Types.Recoverable_tool_error);
+       Alcotest.(check bool)
+         "error class preserved"
+         true
+         (error_class = Some Types.Deterministic)
+     | _ -> Alcotest.fail "expected second ToolResult")
   | _ -> Alcotest.fail "expected ToolResult"
 ;;
 

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -198,6 +198,8 @@ let test_tool_result_round_trip () =
       { tool_use_id = "tu_001"
       ; content = "4"
       ; is_error = false
+      ; failure_kind = None
+      ; error_class = None
       ; json = Types.try_parse_json "4"
       ; content_blocks = None
       }
@@ -214,6 +216,8 @@ let test_tool_result_error_round_trip () =
       { tool_use_id = "tu_002"
       ; content = "failed"
       ; is_error = true
+      ; failure_kind = None
+      ; error_class = None
       ; json = None
       ; content_blocks = None
       }
@@ -274,6 +278,8 @@ let test_kimi_message_to_json_tool_result_uses_text_blocks () =
             { tool_use_id = "tu_001"
             ; content = "5"
             ; is_error = false
+            ; failure_kind = None
+            ; error_class = None
             ; json = Some (`Int 5)
             ; content_blocks = None
             }
@@ -2412,6 +2418,8 @@ let test_text_blocks_to_string () =
         { tool_use_id = "t"
         ; content = "ok"
         ; is_error = false
+        ; failure_kind = None
+        ; error_class = None
         ; json = None
         ; content_blocks = None
         }

--- a/test/test_backend_gemini.ml
+++ b/test/test_backend_gemini.ml
@@ -240,6 +240,8 @@ let test_tool_result () =
               { tool_use_id = "call_123"
               ; content = "Sunny, 25C"
               ; is_error = false
+              ; failure_kind = None
+              ; error_class = None
               ; json = None
               ; content_blocks = None
               }
@@ -519,6 +521,8 @@ let test_thought_signature_roundtrip_request () =
               { tool_use_id
               ; content = "found"
               ; is_error = false
+              ; failure_kind = None
+              ; error_class = None
               ; json = None
               ; content_blocks = None
               }

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -106,6 +106,8 @@ let block_of_fixture json =
       { tool_use_id = require_string "block" "tool_use_id" json
       ; content = require_string "block" "content" json
       ; is_error = optional_bool ~default:false "block" "is_error" json
+      ; failure_kind = None
+      ; error_class = None
       ; json = None
       ; content_blocks = None
       }
@@ -551,6 +553,8 @@ let test_openai_user_messages_text_tool_and_empty () =
           { tool_use_id = "call-1"
           ; content = "42"
           ; is_error = false
+          ; failure_kind = None
+          ; error_class = None
           ; json = None
           ; content_blocks = None
           }
@@ -587,6 +591,8 @@ let test_wire_adjacency_nudged_tool_turn () =
             { tool_use_id = "call-9"
             ; content = "ok"
             ; is_error = false
+            ; failure_kind = None
+            ; error_class = None
             ; json = None
             ; content_blocks = None
             }
@@ -771,6 +777,8 @@ let test_system_and_tool_role_messages () =
              { tool_use_id = "call-2"
              ; content = "ok"
              ; is_error = false
+             ; failure_kind = None
+             ; error_class = None
              ; json = None
              ; content_blocks = None
              }
@@ -800,6 +808,8 @@ let test_strip_orphaned_tool_results_dedupes_and_drops_empty () =
             { tool_use_id = "call-1"
             ; content = "first"
             ; is_error = false
+            ; failure_kind = None
+            ; error_class = None
             ; json = None
             ; content_blocks = None
             }
@@ -807,6 +817,8 @@ let test_strip_orphaned_tool_results_dedupes_and_drops_empty () =
             { tool_use_id = "call-1"
             ; content = "dupe"
             ; is_error = false
+            ; failure_kind = None
+            ; error_class = None
             ; json = None
             ; content_blocks = None
             }
@@ -814,6 +826,8 @@ let test_strip_orphaned_tool_results_dedupes_and_drops_empty () =
             { tool_use_id = "orphan"
             ; content = "bad"
             ; is_error = true
+            ; failure_kind = None
+            ; error_class = None
             ; json = None
             ; content_blocks = None
             }
@@ -825,6 +839,8 @@ let test_strip_orphaned_tool_results_dedupes_and_drops_empty () =
             { tool_use_id = "orphan-2"
             ; content = "drop"
             ; is_error = false
+            ; failure_kind = None
+            ; error_class = None
             ; json = None
             ; content_blocks = None
             }
@@ -854,6 +870,8 @@ let test_close_tool_message_pairs_repairs_dangling_and_late_results () =
             { tool_use_id = "call-1"
             ; content = "late result"
             ; is_error = false
+            ; failure_kind = None
+            ; error_class = None
             ; json = None
             ; content_blocks = None
             }
@@ -994,6 +1012,8 @@ let test_kimi_replay_trace_preserves_all_historical_reasoning () =
             { tool_use_id = "call-k"
             ; content = "ok"
             ; is_error = false
+            ; failure_kind = None
+            ; error_class = None
             ; json = None
             ; content_blocks = None
             }
@@ -1140,6 +1160,8 @@ let ignored_blocks : content_block list =
       { tool_use_id = "call-x"
       ; content = "ignored"
       ; is_error = false
+      ; failure_kind = None
+      ; error_class = None
       ; json = None
       ; content_blocks = None
       }
@@ -1225,6 +1247,8 @@ let test_strip_helpers_cover_non_tool_variants () =
               { tool_use_id = "call"
               ; content = "ok"
               ; is_error = false
+              ; failure_kind = None
+              ; error_class = None
               ; json = None
               ; content_blocks = None
               }
@@ -1897,6 +1921,8 @@ let test_responses_preserves_encrypted_reasoning_item_for_replay () =
                   { tool_use_id = "call_weather"
                   ; content = {|{"temp_c":12}|}
                   ; is_error = false
+                  ; failure_kind = None
+                  ; error_class = None
                   ; json = Some (`Assoc [ "temp_c", `Int 12 ])
                   ; content_blocks = None
                   }
@@ -1968,6 +1994,8 @@ let test_responses_build_request_round_trips_tool_result_items () =
                 { tool_use_id = "call_weather"
                 ; content = {|{"temp_c":12}|}
                 ; is_error = false
+                ; failure_kind = None
+                ; error_class = None
                 ; json = Some (`Assoc [ "temp_c", `Int 12 ])
                 ; content_blocks = None
                 }
@@ -2035,6 +2063,8 @@ let test_responses_build_request_preserves_multiturn_reasoning_tool_order () =
       { tool_use_id = id
       ; content
       ; is_error = false
+      ; failure_kind = None
+      ; error_class = None
       ; json = Some (`Assoc [ "content", `String content ])
       ; content_blocks = None
       }

--- a/test/test_backend_tool_call_harness.ml
+++ b/test/test_backend_tool_call_harness.ml
@@ -132,6 +132,8 @@ let test_validate_response_flags_unknown_tool_and_stop_reason () =
           { tool_use_id = "call-2"
           ; content = "ok"
           ; is_error = false
+          ; failure_kind = None
+          ; error_class = None
           ; json = None
           ; content_blocks = None
           }

--- a/test/test_budget_strategy.ml
+++ b/test/test_budget_strategy.ml
@@ -40,6 +40,8 @@ let tool_result_msg id content =
             { tool_use_id = id
             ; content
             ; is_error = false
+            ; failure_kind = None
+            ; error_class = None
             ; json = None
             ; content_blocks = None
             }

--- a/test/test_bug_hunt.ml
+++ b/test/test_bug_hunt.ml
@@ -94,6 +94,8 @@ let test_b3_injection_role_validation () =
                 { tool_use_id = "t1"
                 ; content = "42"
                 ; is_error = false
+                ; failure_kind = None
+                ; error_class = None
                 ; json = None
                 ; content_blocks = None
                 }

--- a/test/test_canonical_tool.ml
+++ b/test/test_canonical_tool.ml
@@ -245,6 +245,8 @@ let test_tool_call_none_for_non_tooluse () =
         { tool_use_id = "call_x"
         ; content = "ok"
         ; is_error = false
+        ; failure_kind = None
+        ; error_class = None
         ; json = None
         ; content_blocks = None
         }
@@ -271,6 +273,8 @@ let test_result_roundtrip_preserves_fields () =
       { tool_use_id = "call_abc"
       ; content = "3 rows"
       ; is_error = false
+      ; failure_kind = None
+      ; error_class = None
       ; json = Some json
       ; content_blocks = Some blocks
       }
@@ -295,6 +299,8 @@ let test_result_preserves_is_error () =
       { tool_use_id = "call_err"
       ; content = "boom"
       ; is_error = true
+      ; failure_kind = None
+      ; error_class = None
       ; json = None
       ; content_blocks = None
       }

--- a/test/test_checkpoint.ml
+++ b/test/test_checkpoint.ml
@@ -98,13 +98,13 @@ let () =
   run
     "Checkpoint"
     [ ( "version"
-      , [ test_case "checkpoint_version is 5" `Quick (fun () ->
-            check int "version" 5 Checkpoint.checkpoint_version)
+      , [ test_case "checkpoint_version is 6" `Quick (fun () ->
+            check int "version" 6 Checkpoint.checkpoint_version)
         ; test_case "version field in to_json" `Quick (fun () ->
             let cp = make_checkpoint () in
             let json = Checkpoint.to_json cp in
             let v = Yojson.Safe.Util.(json |> member "version" |> to_int) in
-            check int "version" 5 v)
+            check int "version" 6 v)
         ; test_case "wrong version returns Error" `Quick (fun () ->
             let cp = make_checkpoint () in
             let json = Checkpoint.to_json cp in
@@ -245,6 +245,8 @@ let () =
                         { tool_use_id = "id1"
                         ; content = "Sunny 22C"
                         ; is_error = false
+                        ; failure_kind = None
+                        ; error_class = None
                         ; json = None
                         ; content_blocks = None
                         }
@@ -264,6 +266,75 @@ let () =
               check string "content" "Sunny 22C" content;
               check bool "is_error" false is_error
             | _ -> fail "expected ToolResult")
+        ; test_case
+            "typed failed ToolResult survives execution projection and checkpoint"
+            `Quick
+            (fun () ->
+               let execution_result : Agent_tools.tool_execution_result =
+                 { tool_use_id = "failed-1"
+                 ; tool_name = "Execute"
+                 ; content = "working directory is unavailable"
+                 ; is_error = true
+                 ; failure_kind = Some Agent_tools.Validation_error
+                 ; error_class = Some Types.Deterministic
+                 }
+               in
+               let content = Agent_turn.make_tool_results [ execution_result ] in
+               let block = List.hd content in
+               let wire_json = Api.content_block_to_json block in
+               let open Yojson.Safe.Util in
+               check
+                 bool
+                 "provider wire omits failure_kind"
+                 true
+                 (wire_json |> member "failure_kind" = `Null);
+               check
+                 bool
+                 "provider wire omits error_class"
+                 true
+                 (wire_json |> member "error_class" = `Null);
+               let messages =
+                 [ { Types.role = Types.Tool
+                   ; content
+                   ; name = None
+                   ; tool_call_id = Some "failed-1"
+                   ; metadata = []
+                   }
+                 ]
+               in
+               let checkpoint = make_checkpoint ~messages () in
+               let checkpoint_json = Checkpoint.to_json checkpoint in
+               let stored_block =
+                 checkpoint_json
+                 |> member "messages"
+                 |> index 0
+                 |> member "content"
+                 |> index 0
+               in
+               check
+                 bool
+                 "checkpoint stores failure_kind"
+                 true
+                 (stored_block |> member "failure_kind" <> `Null);
+               check
+                 bool
+                 "checkpoint stores error_class"
+                 true
+                 (stored_block |> member "error_class" <> `Null);
+               let restored = Result.get_ok (Checkpoint.of_json checkpoint_json) in
+               match (List.hd restored.messages).content with
+               | [ Types.ToolResult { failure_kind; error_class; _ } ] ->
+                 check
+                   bool
+                   "failure_kind roundtrip"
+                   true
+                   (failure_kind = Some Types.Validation_error);
+                 check
+                   bool
+                   "error_class roundtrip"
+                   true
+                   (error_class = Some Types.Deterministic)
+               | _ -> fail "expected typed ToolResult")
         ; test_case "empty messages roundtrip" `Quick (fun () ->
             let cp = make_checkpoint ~messages:[] () in
             let cp2 = Result.get_ok (Checkpoint.of_json (Checkpoint.to_json cp)) in
@@ -289,6 +360,8 @@ let () =
                         { tool_use_id = "t1"
                         ; content = "found it"
                         ; is_error = false
+                        ; failure_kind = None
+                        ; error_class = None
                         ; json = None
                         ; content_blocks = None
                         }
@@ -1083,7 +1156,11 @@ let () =
               | other -> other
             in
             let cp2 = Result.get_ok (Checkpoint.of_json v1_json) in
-            check int "version upgraded to 5" 5 cp2.version;
+            check
+              int
+              "version upgraded to current"
+              Checkpoint.checkpoint_version
+              cp2.version;
             check int "mcp_sessions empty" 0 (List.length cp2.mcp_sessions))
         ; test_case "version 1 with null mcp_sessions" `Quick (fun () ->
             let cp = make_checkpoint () in

--- a/test/test_context_reducer.ml
+++ b/test/test_context_reducer.ml
@@ -38,14 +38,16 @@ let tool_use_msg id name =
     }
 ;;
 
-let tool_result_msg id content =
+let tool_result_msg ?(is_error = false) ?failure_kind ?error_class id content =
   Types.
     { role = User
     ; content =
         [ ToolResult
             { tool_use_id = id
             ; content
-            ; is_error = false
+            ; is_error
+            ; failure_kind
+            ; error_class
             ; json = None
             ; content_blocks = None
             }
@@ -230,6 +232,8 @@ let test_estimate_tool_result () =
               { tool_use_id = "id1"
               ; content = "result text"
               ; is_error = false
+              ; failure_kind = None
+              ; error_class = None
               ; json = None
               ; content_blocks = None
               }
@@ -506,6 +510,8 @@ let test_cap_preserves_tool_result () =
         { tool_use_id = "call_keep"
         ; content = "r"
         ; is_error = false
+        ; failure_kind = None
+        ; error_class = None
         ; json = None
         ; content_blocks = None
         }
@@ -693,6 +699,28 @@ let test_prune_long_outputs () =
   in
   Alcotest.(check bool) "truncated" true (String.length tool_content < 200);
   Alcotest.(check bool) "has marker" true (String.length tool_content > 50)
+;;
+
+let test_prune_preserves_failure_provenance () =
+  let result =
+    Context_reducer.reduce
+      (Context_reducer.prune_tool_outputs ~max_output_len:10)
+      [ tool_result_msg
+          ~is_error:true
+          ~failure_kind:Types.Recoverable_tool_error
+          ~error_class:Types.Transient
+          "t1"
+          (String.make 100 'x')
+      ]
+  in
+  match result with
+  | [ { Types.content = [ Types.ToolResult { failure_kind; error_class; _ } ]; _ } ] ->
+    Alcotest.(check bool)
+      "failure kind preserved"
+      true
+      (failure_kind = Some Types.Recoverable_tool_error);
+    Alcotest.(check bool) "error class preserved" true (error_class = Some Types.Transient)
+  | _ -> Alcotest.fail "expected one pruned ToolResult"
 ;;
 
 (* --- merge_contiguous --- *)
@@ -1226,6 +1254,8 @@ let test_clear_tool_results_error_marker () =
                 { tool_use_id = "t1"
                 ; content = String.make 100 'E'
                 ; is_error = true
+                ; failure_kind = None
+                ; error_class = None
                 ; json = None
                 ; content_blocks = None
                 }
@@ -1562,6 +1592,8 @@ let test_orphaned_results_mixed () =
                 { tool_use_id = "t1"
                 ; content = "ok"
                 ; is_error = false
+                ; failure_kind = None
+                ; error_class = None
                 ; json = None
                 ; content_blocks = None
                 }
@@ -1569,6 +1601,8 @@ let test_orphaned_results_mixed () =
                 { tool_use_id = "t2"
                 ; content = "orphan"
                 ; is_error = false
+                ; failure_kind = None
+                ; error_class = None
                 ; json = None
                 ; content_blocks = None
                 }
@@ -1696,6 +1730,10 @@ let () =
     ; ( "prune_tool_outputs"
       , [ Alcotest.test_case "short outputs unchanged" `Quick test_prune_short_outputs
         ; Alcotest.test_case "long outputs truncated" `Quick test_prune_long_outputs
+        ; Alcotest.test_case
+            "failure provenance preserved"
+            `Quick
+            test_prune_preserves_failure_provenance
         ] )
     ; ( "merge_contiguous"
       , [ Alcotest.test_case "same role merged" `Quick test_merge_same_role

--- a/test/test_gemini_edge_cases.ml
+++ b/test/test_gemini_edge_cases.ml
@@ -178,6 +178,8 @@ let test_tool_use_id_roundtrip () =
               { tool_use_id = tu_id
               ; content = "Sunny 25C"
               ; is_error = false
+              ; failure_kind = None
+              ; error_class = None
               ; json = None
               ; content_blocks = None
               }

--- a/test/test_http_client.ml
+++ b/test/test_http_client.ml
@@ -398,6 +398,8 @@ let test_api_common_content_block_roundtrip () =
           { tool_use_id = "t1"
           ; content = "result"
           ; is_error = false
+          ; failure_kind = None
+          ; error_class = None
           ; json = None
           ; content_blocks = None
           }

--- a/test/test_llm_cache.ml
+++ b/test/test_llm_cache.ml
@@ -188,6 +188,8 @@ let test_roundtrip_tool_result () =
           { tool_use_id = "tu_1"
           ; content = "result data"
           ; is_error = false
+          ; failure_kind = None
+          ; error_class = None
           ; json = None
           ; content_blocks = None
           }
@@ -212,6 +214,8 @@ let test_roundtrip_tool_result_error () =
           { tool_use_id = "tu_2"
           ; content = "failed"
           ; is_error = true
+          ; failure_kind = None
+          ; error_class = None
           ; json = None
           ; content_blocks = None
           }
@@ -238,6 +242,8 @@ let test_roundtrip_tool_result_content_blocks () =
           { tool_use_id = "tu_blocks"
           ; content = "preview"
           ; is_error = false
+          ; failure_kind = None
+          ; error_class = None
           ; json = None
           ; content_blocks = Some blocks
           }

--- a/test/test_llm_provider_cov.ml
+++ b/test/test_llm_provider_cov.ml
@@ -395,13 +395,23 @@ let test_content_block_to_json_tool_result () =
          { tool_use_id = "tu1"
          ; content = "done"
          ; is_error = true
+         ; failure_kind = Some Validation_error
+         ; error_class = Some Deterministic
          ; json = None
          ; content_blocks = None
          })
   in
   let open Yojson.Safe.Util in
   Alcotest.(check string) "type" "tool_result" (json |> member "type" |> to_string);
-  Alcotest.(check bool) "is_error" true (json |> member "is_error" |> to_bool)
+  Alcotest.(check bool) "is_error" true (json |> member "is_error" |> to_bool);
+  Alcotest.(check bool)
+    "failure_kind is SDK-only"
+    true
+    (json |> member "failure_kind" = `Null);
+  Alcotest.(check bool)
+    "error_class is SDK-only"
+    true
+    (json |> member "error_class" = `Null)
 ;;
 
 let test_content_block_to_json_image () =
@@ -658,6 +668,8 @@ let test_contents_of_messages_tool_use () =
               { tool_use_id = "tu1"
               ; content = "result42"
               ; is_error = false
+              ; failure_kind = None
+              ; error_class = None
               ; json = None
               ; content_blocks = None
               }

--- a/test/test_multimodal.ml
+++ b/test/test_multimodal.ml
@@ -280,6 +280,8 @@ let test_agent_run_with_handoffs_blocks_rejects_internal_blocks () =
         { tool_use_id = "call-1"
         ; content = "internal result"
         ; is_error = false
+        ; failure_kind = None
+        ; error_class = None
         ; json = None
         ; content_blocks = None
         }
@@ -341,6 +343,8 @@ let test_tool_result_content_blocks_serialize () =
       { tool_use_id = "t1"
       ; content = "plain"
       ; is_error = false
+      ; failure_kind = None
+      ; error_class = None
       ; json = None
       ; content_blocks = None
       }
@@ -355,6 +359,8 @@ let test_tool_result_content_blocks_serialize () =
       { tool_use_id = "t2"
       ; content = "fallback"
       ; is_error = false
+      ; failure_kind = None
+      ; error_class = None
       ; json = None
       ; content_blocks =
           Some

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -308,7 +308,7 @@ let test_pipeline_output_resets_idle_on_end_turn () =
   (match Internal_pipeline.run_turn ~sw ~api_strategy:Internal_pipeline.Sync agent with
    | Ok (Internal_pipeline.Complete response) ->
      Alcotest.(check bool) "completed" true (response.stop_reason = EndTurn)
-   | Ok Internal_pipeline.ToolsExecuted ->
+   | Ok (Internal_pipeline.ToolsExecuted _) ->
      Alcotest.fail "expected Complete, got ToolsExecuted"
    | Ok Internal_pipeline.IdleSkipped ->
      Alcotest.fail "expected Complete, got IdleSkipped"
@@ -348,7 +348,7 @@ let test_pipeline_output_completes_repetition_truncation () =
        "documented provider terminal reason is preserved"
        true
        (response.stop_reason = RepetitionTruncation)
-   | Ok Internal_pipeline.ToolsExecuted ->
+   | Ok (Internal_pipeline.ToolsExecuted _) ->
      Alcotest.fail "expected Complete, got ToolsExecuted"
    | Ok Internal_pipeline.IdleSkipped ->
      Alcotest.fail "expected Complete, got IdleSkipped"
@@ -387,7 +387,7 @@ let test_pipeline_tool_recovery_allows_glm_provider () =
   in
   let agent = make_tool_recovery_test_agent ~net ~provider in
   match Internal_pipeline.run_turn ~sw ~api_strategy:Internal_pipeline.Sync agent with
-  | Ok Internal_pipeline.ToolsExecuted -> ()
+  | Ok (Internal_pipeline.ToolsExecuted _) -> ()
   | Ok (Internal_pipeline.Complete _) ->
     Alcotest.fail "expected tool recovery to execute a tool"
   | Ok Internal_pipeline.IdleSkipped -> Alcotest.fail "expected ToolsExecuted"
@@ -407,7 +407,7 @@ let test_pipeline_tool_recovery_rejects_openai_compat_provider () =
     (match response.content with
      | [ Text _ ] -> ()
      | _ -> Alcotest.fail "expected text to remain unpromoted")
-  | Ok Internal_pipeline.ToolsExecuted ->
+  | Ok (Internal_pipeline.ToolsExecuted _) ->
     Alcotest.fail "expected OpenAI-compatible text tool intent to fail closed"
   | Ok Internal_pipeline.IdleSkipped -> Alcotest.fail "expected Complete"
   | Error err -> Alcotest.failf "unexpected run error: %s" (Error.to_string err)

--- a/test/test_pipeline_deep.ml
+++ b/test/test_pipeline_deep.ml
@@ -338,6 +338,8 @@ let test_resolve_params_with_tool_results () =
               { tool_use_id = "tu_1"
               ; content = "found it"
               ; is_error = false
+              ; failure_kind = None
+              ; error_class = None
               ; json = None
               ; content_blocks = None
               }
@@ -396,6 +398,8 @@ let test_resolve_params_error_tool_results () =
               { tool_use_id = "tu_e"
               ; content = "permission denied"
               ; is_error = true
+              ; failure_kind = None
+              ; error_class = None
               ; json = None
               ; content_blocks = None
               }

--- a/test/test_property_advanced.ml
+++ b/test/test_property_advanced.ml
@@ -27,6 +27,8 @@ let content_block_gen =
              { tool_use_id = id
              ; content
              ; is_error
+             ; failure_kind = None
+             ; error_class = None
              ; json = Types.try_parse_json content
              ; content_blocks = None
              })

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -242,6 +242,8 @@ let test_anthropic_build_request_preserves_multiturn_thinking_tool_order () =
       { tool_use_id = id
       ; content
       ; is_error = false
+      ; failure_kind = None
+      ; error_class = None
       ; json = Some (`Assoc [ "content", `String content ])
       ; content_blocks = None
       }
@@ -870,6 +872,8 @@ let test_kimi_direct_tool_result_uses_text_blocks () =
               { tool_use_id = "tool_1"
               ; content = "5"
               ; is_error = false
+              ; failure_kind = None
+              ; error_class = None
               ; json = Some (`Int 5)
               ; content_blocks = None
               }
@@ -936,6 +940,8 @@ let test_glm_preserved_reasoning_replay_and_preserves_auto_tool_choice () =
               { tool_use_id = "call_1"
               ; content = "{\"value\":4}"
               ; is_error = false
+              ; failure_kind = None
+              ; error_class = None
               ; json = Some (`Assoc [ "value", `Int 4 ])
               ; content_blocks = None
               }

--- a/test/test_raw_trace.ml
+++ b/test/test_raw_trace.ml
@@ -933,6 +933,8 @@ let test_tool_result_assistant_block_summary () =
           { tool_use_id = "tool-1"
           ; content = "ok"
           ; is_error = false
+          ; failure_kind = None
+          ; error_class = None
           ; json = None
           ; content_blocks = None
           }));

--- a/test/test_snapshot_provider_serialization.ml
+++ b/test/test_snapshot_provider_serialization.ml
@@ -63,6 +63,8 @@ let messages =
           { tool_use_id = "call_1"
           ; content = "Sunny, 25C"
           ; is_error = false
+          ; failure_kind = None
+          ; error_class = None
           ; json = None
           ; content_blocks = None
           }
@@ -86,6 +88,8 @@ let nudged_messages =
           { tool_use_id = "call_1"
           ; content = "Sunny, 25C"
           ; is_error = false
+          ; failure_kind = None
+          ; error_class = None
           ; json = None
           ; content_blocks = None
           }

--- a/test/test_streaming_edge_cases.ml
+++ b/test/test_streaming_edge_cases.ml
@@ -190,6 +190,8 @@ let test_synthetic_events_media_blocks () =
             { tool_use_id = "call-1"
             ; content = "ok"
             ; is_error = false
+            ; failure_kind = None
+            ; error_class = None
             ; json = None
             ; content_blocks = None
             }

--- a/test/test_structured.ml
+++ b/test/test_structured.ml
@@ -338,6 +338,8 @@ let test_extract_ignores_tool_result () =
         { tool_use_id = "old"
         ; content = "previous result"
         ; is_error = false
+        ; failure_kind = None
+        ; error_class = None
         ; json = None
         ; content_blocks = None
         }
@@ -537,6 +539,8 @@ let test_retry_message_construction () =
               { tool_use_id
               ; content = error_msg
               ; is_error = true
+              ; failure_kind = None
+              ; error_class = None
               ; json = None
               ; content_blocks = None
               }

--- a/test/test_structured_coverage.ml
+++ b/test/test_structured_coverage.ml
@@ -350,6 +350,8 @@ let test_extract_mixed_blocks () =
         { tool_use_id = "old"
         ; content = "old result"
         ; is_error = false
+        ; failure_kind = None
+        ; error_class = None
         ; json = None
         ; content_blocks = None
         }

--- a/test/test_succession.ml
+++ b/test/test_succession.ml
@@ -306,6 +306,8 @@ let test_normalize_preserves_matched_tool_calls () =
               { tool_use_id = "t1"
               ; content = "result"
               ; is_error = false
+              ; failure_kind = None
+              ; error_class = None
               ; json = None
               ; content_blocks = None
               }

--- a/test/test_tool_failure_episode.ml
+++ b/test/test_tool_failure_episode.ml
@@ -1,0 +1,234 @@
+open Agent_sdk
+
+let call id name input = Types.ToolUse { id; name; input }
+
+let result ?failure_kind ?error_class ?(is_error = true) id error =
+  Types.ToolResult
+    { tool_use_id = id
+    ; content = error
+    ; is_error
+    ; failure_kind
+    ; error_class
+    ; json = None
+    ; content_blocks = None
+    }
+;;
+
+let typed_failure ?(error_class = Some Types.Deterministic) id error =
+  result ~failure_kind:Types.Validation_error ?error_class id error
+;;
+
+let project calls results =
+  match Tool_failure_episode.project ~tool_uses:calls ~tool_results:results with
+  | Ok round -> round
+  | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
+;;
+
+let detect previous current = Tool_failure_episode.detect ~previous ~current
+
+let test_changed_input_and_error_text_detected () =
+  let previous =
+    project
+      [ call "p1" "Execute" (`Assoc [ "cmd", `String "gh pr list" ]) ]
+      [ typed_failure "p1" "working directory missing" ]
+  in
+  let current =
+    project
+      [ call
+          "c1"
+          "Execute"
+          (`Assoc [ "cmd", `String "gh pr list"; "cwd", `String "/repo" ])
+      ]
+      [ typed_failure "c1" "repository was not found" ]
+  in
+  match detect previous current with
+  | Ok [ episode ] ->
+    Alcotest.(check string) "previous id" "p1" episode.previous.tool_use_id;
+    Alcotest.(check string) "current id" "c1" episode.current.tool_use_id;
+    Alcotest.(check bool)
+      "input changed"
+      false
+      (Yojson.Safe.equal episode.previous.input episode.current.input)
+  | Ok episodes -> Alcotest.failf "expected one episode, got %d" (List.length episodes)
+  | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
+;;
+
+let test_different_failure_kind_not_detected () =
+  let previous = project [ call "p1" "Execute" `Null ] [ typed_failure "p1" "first" ] in
+  let current =
+    project
+      [ call "c1" "Execute" `Null ]
+      [ result
+          ~failure_kind:Types.Recoverable_tool_error
+          ~error_class:Types.Deterministic
+          "c1"
+          "second"
+      ]
+  in
+  Alcotest.(check bool) "no episode" true (detect previous current = Ok [])
+;;
+
+let test_different_error_class_not_detected () =
+  let previous = project [ call "p1" "Execute" `Null ] [ typed_failure "p1" "first" ] in
+  let current =
+    project
+      [ call "c1" "Execute" `Null ]
+      [ typed_failure ~error_class:(Some Types.Transient) "c1" "second" ]
+  in
+  Alcotest.(check bool) "no episode" true (detect previous current = Ok [])
+;;
+
+let test_successful_intervening_round_breaks_adjacency () =
+  let success =
+    project [ call "s1" "Execute" `Null ] [ result ~is_error:false "s1" "ok" ]
+  in
+  let failed = project [ call "c1" "Execute" `Null ] [ typed_failure "c1" "second" ] in
+  Alcotest.(check bool)
+    "caller advances the adjacent boundary"
+    true
+    (detect success failed = Ok [])
+;;
+
+let test_parallel_failures_preserved () =
+  let previous =
+    project
+      [ call "p1" "Execute" `Null; call "p2" "Read" `Null ]
+      [ typed_failure "p1" "first-a"; typed_failure "p2" "first-b" ]
+  in
+  let current =
+    project
+      [ call "c1" "Execute" (`String "changed"); call "c2" "Read" `Null ]
+      [ typed_failure "c1" "second-a"; typed_failure "c2" "second-b" ]
+  in
+  match detect previous current with
+  | Ok episodes -> Alcotest.(check int) "both episodes" 2 (List.length episodes)
+  | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
+;;
+
+let test_same_name_distinct_signatures_are_independent () =
+  let recoverable id text =
+    result
+      ~failure_kind:Types.Recoverable_tool_error
+      ~error_class:Types.Deterministic
+      id
+      text
+  in
+  let previous =
+    project
+      [ call "p1" "Execute" `Null; call "p2" "Execute" (`String "other") ]
+      [ typed_failure "p1" "validation"; recoverable "p2" "recoverable" ]
+  in
+  let current =
+    project
+      [ call "c1" "Execute" `Null; call "c2" "Execute" (`String "changed") ]
+      [ typed_failure "c1" "validation changed"; recoverable "c2" "recoverable changed" ]
+  in
+  match detect previous current with
+  | Ok episodes -> Alcotest.(check int) "two signatures" 2 (List.length episodes)
+  | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
+;;
+
+let test_success_and_matching_failure_same_name_are_unambiguous () =
+  let previous =
+    project
+      [ call "p1" "Execute" `Null; call "p2" "Execute" (`String "other") ]
+      [ result ~is_error:false "p1" "ok"; typed_failure "p2" "failed" ]
+  in
+  let current = project [ call "c1" "Execute" `Null ] [ typed_failure "c1" "again" ] in
+  match detect previous current with
+  | Ok [ _ ] -> ()
+  | Ok episodes -> Alcotest.failf "expected one episode, got %d" (List.length episodes)
+  | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
+;;
+
+let test_duplicate_failure_signature_is_explicit () =
+  let previous =
+    project
+      [ call "p1" "Execute" `Null; call "p2" "Execute" (`String "other") ]
+      [ typed_failure "p1" "first-a"; typed_failure "p2" "first-b" ]
+  in
+  let current = project [ call "c1" "Execute" `Null ] [ typed_failure "c1" "second" ] in
+  match detect previous current with
+  | Error
+      (Tool_failure_episode.Ambiguous_failure_signature
+         { previous_count = 2; current_count = 1; _ }) -> ()
+  | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
+  | Ok _ -> Alcotest.fail "expected typed ambiguity"
+;;
+
+let test_missing_failure_kind_is_explicit () =
+  match
+    Tool_failure_episode.project
+      ~tool_uses:[ call "c1" "Execute" `Null ]
+      ~tool_results:[ result "c1" "second" ]
+  with
+  | Error (Tool_failure_episode.Failure_kind_missing { tool_use_id = "c1" }) -> ()
+  | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
+  | Ok _ -> Alcotest.fail "expected incomplete metadata error"
+;;
+
+let test_missing_result_is_explicit () =
+  match
+    Tool_failure_episode.project ~tool_uses:[ call "c1" "Execute" `Null ] ~tool_results:[]
+  with
+  | Error (Tool_failure_episode.Missing_tool_result { tool_use_id = "c1" }) -> ()
+  | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
+  | Ok _ -> Alcotest.fail "expected missing result error"
+;;
+
+let test_unmatched_result_is_explicit () =
+  match
+    Tool_failure_episode.project
+      ~tool_uses:[ call "c1" "Execute" `Null ]
+      ~tool_results:[ typed_failure "c1" "matched"; typed_failure "other" "orphan" ]
+  with
+  | Error (Tool_failure_episode.Unmatched_tool_result { tool_use_id = "other" }) -> ()
+  | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
+  | Ok _ -> Alcotest.fail "expected unmatched result error"
+;;
+
+let () =
+  Alcotest.run
+    "tool_failure_episode"
+    [ ( "completed_rounds"
+      , [ Alcotest.test_case
+            "changed input and error text"
+            `Quick
+            test_changed_input_and_error_text_detected
+        ; Alcotest.test_case
+            "different failure kind"
+            `Quick
+            test_different_failure_kind_not_detected
+        ; Alcotest.test_case
+            "different error class"
+            `Quick
+            test_different_error_class_not_detected
+        ; Alcotest.test_case
+            "successful intervening round"
+            `Quick
+            test_successful_intervening_round_breaks_adjacency
+        ; Alcotest.test_case
+            "parallel failures preserved"
+            `Quick
+            test_parallel_failures_preserved
+        ; Alcotest.test_case
+            "same name distinct signatures"
+            `Quick
+            test_same_name_distinct_signatures_are_independent
+        ; Alcotest.test_case
+            "success plus matching failure"
+            `Quick
+            test_success_and_matching_failure_same_name_are_unambiguous
+        ; Alcotest.test_case
+            "duplicate failure signature"
+            `Quick
+            test_duplicate_failure_signature_is_explicit
+        ; Alcotest.test_case
+            "missing failure kind"
+            `Quick
+            test_missing_failure_kind_is_explicit
+        ; Alcotest.test_case "missing result" `Quick test_missing_result_is_explicit
+        ; Alcotest.test_case "unmatched result" `Quick test_unmatched_result_is_explicit
+        ] )
+    ]
+;;

--- a/test/test_tool_failure_recovery.ml
+++ b/test/test_tool_failure_recovery.ml
@@ -1,0 +1,313 @@
+open Agent_sdk
+
+let provider =
+  { Provider.provider = Provider.Local { base_url = "http://mock.local" }
+  ; model_id = "mock-model"
+  ; api_key_env = ""
+  }
+;;
+
+let tool_response id input : Types.api_response =
+  { id = "response-" ^ id
+  ; model = "mock-model"
+  ; stop_reason = StopToolUse
+  ; content = [ ToolUse { id; name = "Execute"; input } ]
+  ; usage = None
+  ; telemetry = None
+  }
+;;
+
+let final_response : Types.api_response =
+  { id = "response-final"
+  ; model = "mock-model"
+  ; stop_reason = EndTurn
+  ; content = [ Text "finished" ]
+  ; usage = None
+  ; telemetry = None
+  }
+;;
+
+let append events event = events := !events @ [ event ]
+
+let failing_tool events =
+  let parameters : Types.tool_param list =
+    [ { name = "cmd"; description = "command"; param_type = String; required = true }
+    ; { name = "cwd"
+      ; description = "working directory"
+      ; param_type = String
+      ; required = false
+      }
+    ]
+  in
+  Tool.create ~name:"Execute" ~description:"execute a command" ~parameters (fun _ ->
+    append events "tool";
+    Error
+      { Types.message = "working directory is required"
+      ; recoverable = true
+      ; error_class = Some Deterministic
+      })
+;;
+
+type scenario =
+  { result : (Types.api_response, Error.sdk_error) result
+  ; events : string list
+  ; requests : Llm_provider.Llm_transport.completion_request list
+  ; agent : Agent.t
+  }
+
+let run_scenario env ~judge_json ?(fail_recovery_checkpoint = false) () =
+  Eio.Switch.run
+  @@ fun sw ->
+  let events = ref [] in
+  let requests = ref [] in
+  let responses =
+    ref
+      [ tool_response "p1" (`Assoc [ "cmd", `String "gh pr list" ])
+      ; tool_response "c1" (`Assoc [ "cmd", `String "gh pr list" ])
+      ; final_response
+      ]
+  in
+  let next_response request =
+    requests := !requests @ [ request ];
+    append events (Printf.sprintf "provider%d" (List.length !requests));
+    match !responses with
+    | response :: rest ->
+      responses := rest;
+      response
+    | [] -> Alcotest.fail "unexpected additional provider call"
+  in
+  let transport : Llm_provider.Llm_transport.t =
+    { complete_sync =
+        (fun request ->
+          { Llm_provider.Llm_transport.response = Ok (next_response request)
+          ; latency_ms = Some 0
+          })
+    ; complete_stream =
+        (fun ?on_telemetry:_ ~on_event:_ request -> Ok (next_response request))
+    }
+  in
+  let judge =
+    Tool_failure_recovery.create ~complete:(fun ~sw:_ request ->
+      append events "judge";
+      Alcotest.(check bool)
+        "judge receives structured schema"
+        true
+        (request.Tool_failure_recovery.output_schema <> `Null);
+      Ok judge_json)
+  in
+  let checkpoint_sink (snapshot : Agent.checkpoint_snapshot) =
+    match snapshot.stage with
+    | After_retry_feedback_appended ->
+      append events "decision_checkpoint";
+      if fail_recovery_checkpoint then Error "recovery checkpoint rejected" else Ok ()
+    | After_assistant_collected | After_tool_results_appended -> Ok ()
+  in
+  let options =
+    { Agent.default_options with
+      transport = Some transport
+    ; provider = Some provider
+    ; guardrails = Guardrails.permissive
+    }
+  in
+  let config =
+    { Types.default_config with
+      name = "recovery-test"
+    ; model = "mock-model"
+    ; system_prompt = Some "base system"
+    ; max_turns = 0
+    ; yield_on_tool = true
+    }
+  in
+  let agent =
+    Agent.create
+      ~net:env#net
+      ~config
+      ~tools:[ failing_tool events ]
+      ~options
+      ~checkpoint_sink
+      ~tool_failure_judge:judge
+      ()
+  in
+  let result =
+    Agent.run
+      ~sw
+      ~on_yield:(fun () -> append events "yield")
+      ~on_resume:(fun () -> append events "resume")
+      agent
+      "review the pull request"
+  in
+  { result; events = !events; requests = !requests; agent }
+;;
+
+let retry_modified_json =
+  {|{"action":"retry_modified","revised_calls":[{"current_tool_use_id":"c1","tool_name":"Execute","revised_input":{"cmd":"gh pr list","cwd":"/repo"}}]}|}
+;;
+
+let test_judge_runs_between_yield_and_resume () =
+  Eio_main.run
+  @@ fun env ->
+  let scenario = run_scenario env ~judge_json:retry_modified_json () in
+  (match scenario.result with
+   | Ok response ->
+     Alcotest.(check string) "final text" "finished" (Types.text_of_response response)
+   | Error error -> Alcotest.fail (Error.to_string error));
+  Alcotest.(check (list string))
+    "lease-safe order"
+    [ "provider1"
+    ; "tool"
+    ; "yield"
+    ; "resume"
+    ; "provider2"
+    ; "tool"
+    ; "yield"
+    ; "judge"
+    ; "decision_checkpoint"
+    ; "resume"
+    ; "provider3"
+    ]
+    scenario.events;
+  let third = List.nth scenario.requests 2 in
+  let system_prompt = Option.value third.config.system_prompt ~default:"" in
+  Alcotest.(check bool)
+    "recovery is a system suffix"
+    true
+    (String.starts_with ~prefix:"base system\n\nOAS one-turn typed" system_prompt);
+  let user_messages =
+    List.filter (fun (message : Types.message) -> message.role = User) third.messages
+  in
+  Alcotest.(check int) "no synthetic recovery User message" 1 (List.length user_messages)
+;;
+
+let test_ask_user_stops_without_resume_or_third_call () =
+  Eio_main.run
+  @@ fun env ->
+  let scenario =
+    run_scenario
+      env
+      ~judge_json:
+        {|{"action":"ask_user","question":"Which repository should I inspect?"}|}
+      ()
+  in
+  (match scenario.result with
+   | Error (Error.Agent (Error.InputRequired request)) ->
+     Alcotest.(check string)
+       "question"
+       "Which repository should I inspect?"
+       request.question
+   | Error error -> Alcotest.fail (Error.to_string error)
+   | Ok _ -> Alcotest.fail "expected InputRequired");
+  Alcotest.(check int) "two main calls" 2 (List.length scenario.requests);
+  Alcotest.(check (list string))
+    "terminal judge does not reacquire"
+    [ "provider1"
+    ; "tool"
+    ; "yield"
+    ; "resume"
+    ; "provider2"
+    ; "tool"
+    ; "yield"
+    ; "judge"
+    ; "decision_checkpoint"
+    ]
+    scenario.events
+;;
+
+let test_checkpoint_failure_does_not_commit_receipt () =
+  Eio_main.run
+  @@ fun env ->
+  let scenario =
+    run_scenario env ~judge_json:retry_modified_json ~fail_recovery_checkpoint:true ()
+  in
+  (match scenario.result with
+   | Error (Error.Internal detail) ->
+     Alcotest.(check bool) "checkpoint failure surfaced" true (String.length detail > 0)
+   | Error error -> Alcotest.fail (Error.to_string error)
+   | Ok _ -> Alcotest.fail "expected checkpoint failure");
+  (match Tool_failure_recovery.latest_receipt (Agent.state scenario.agent).messages with
+   | Ok None -> ()
+   | Ok (Some _) -> Alcotest.fail "failed checkpoint decision leaked into live state"
+   | Error error -> Alcotest.fail (Tool_failure_recovery.show_receipt_error error));
+  Alcotest.(check int) "no third main call" 2 (List.length scenario.requests)
+;;
+
+let project calls results =
+  match Tool_failure_episode.project ~tool_uses:calls ~tool_results:results with
+  | Ok round -> round
+  | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
+;;
+
+let failed_result id =
+  ToolResult
+    { tool_use_id = id
+    ; content = "failed"
+    ; is_error = true
+    ; failure_kind = Some Recoverable_tool_error
+    ; error_class = Some Deterministic
+    ; json = None
+    ; content_blocks = None
+    }
+;;
+
+let test_retry_modified_requires_changed_input () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let previous =
+    project
+      [ ToolUse { id = "p1"; name = "Execute"; input = `Assoc [ "cmd", `String "x" ] } ]
+      [ failed_result "p1" ]
+  in
+  let current =
+    project
+      [ ToolUse { id = "c1"; name = "Execute"; input = `Assoc [ "cmd", `String "x" ] } ]
+      [ failed_result "c1" ]
+  in
+  let episodes =
+    match Tool_failure_episode.detect ~previous ~current with
+    | Ok episodes -> episodes
+    | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
+  in
+  let judge =
+    Tool_failure_recovery.create ~complete:(fun ~sw:_ _ ->
+      Ok
+        {|{"action":"retry_modified","revised_calls":[{"current_tool_use_id":"c1","tool_name":"Execute","revised_input":{"cmd":"x"}}]}|})
+  in
+  match Tool_failure_recovery.decide ~sw ~agent_name:"test" ~turn:2 ~episodes judge with
+  | Error
+      (Tool_failure_recovery.Invalid_response
+         (Tool_failure_recovery.Invalid_decision
+            (Tool_failure_recovery.Unchanged_revised_input { current_tool_use_id = "c1" })))
+    -> ()
+  | Error error -> Alcotest.fail (Tool_failure_recovery.judge_error_to_string error)
+  | Ok decision ->
+    Alcotest.fail
+      ("expected unchanged-input rejection, got "
+       ^ Tool_failure_recovery.show_decision decision)
+;;
+
+let () =
+  Alcotest.run
+    "tool_failure_recovery"
+    [ ( "agent_loop"
+      , [ Alcotest.test_case
+            "judge between yield and resume"
+            `Quick
+            test_judge_runs_between_yield_and_resume
+        ; Alcotest.test_case
+            "ask user is terminal"
+            `Quick
+            test_ask_user_stops_without_resume_or_third_call
+        ; Alcotest.test_case
+            "checkpoint failure is transactional"
+            `Quick
+            test_checkpoint_failure_does_not_commit_receipt
+        ] )
+    ; ( "decision_validation"
+      , [ Alcotest.test_case
+            "retry input must change"
+            `Quick
+            test_retry_modified_requires_changed_input
+        ] )
+    ]
+;;

--- a/test/test_tool_middleware.ml
+++ b/test/test_tool_middleware.ml
@@ -502,6 +502,8 @@ let test_strip_no_orphans () =
             { tool_use_id = "t1"
             ; content = "ok"
             ; is_error = false
+            ; failure_kind = None
+            ; error_class = None
             ; json = None
             ; content_blocks = None
             }
@@ -524,6 +526,8 @@ let test_strip_removes_orphan () =
             { tool_use_id = "orphan-id"
             ; content = "stale"
             ; is_error = false
+            ; failure_kind = None
+            ; error_class = None
             ; json = None
             ; content_blocks = None
             }
@@ -547,6 +551,8 @@ let test_strip_report_names_orphaned_and_duplicate_results () =
             { tool_use_id = "t1"
             ; content = "ok"
             ; is_error = false
+            ; failure_kind = None
+            ; error_class = None
             ; json = None
             ; content_blocks = None
             }
@@ -554,6 +560,8 @@ let test_strip_report_names_orphaned_and_duplicate_results () =
             { tool_use_id = "t1"
             ; content = "duplicate"
             ; is_error = false
+            ; failure_kind = None
+            ; error_class = None
             ; json = None
             ; content_blocks = None
             }
@@ -561,6 +569,8 @@ let test_strip_report_names_orphaned_and_duplicate_results () =
             { tool_use_id = "orphan-id"
             ; content = "stale"
             ; is_error = true
+            ; failure_kind = None
+            ; error_class = None
             ; json = None
             ; content_blocks = None
             }
@@ -590,6 +600,8 @@ let test_strip_preserves_matched () =
             { tool_use_id = "t1"
             ; content = "ok"
             ; is_error = false
+            ; failure_kind = None
+            ; error_class = None
             ; json = None
             ; content_blocks = None
             }
@@ -597,6 +609,8 @@ let test_strip_preserves_matched () =
             { tool_use_id = "orphan"
             ; content = "bad"
             ; is_error = true
+            ; failure_kind = None
+            ; error_class = None
             ; json = None
             ; content_blocks = None
             }
@@ -604,6 +618,8 @@ let test_strip_preserves_matched () =
             { tool_use_id = "t2"
             ; content = "ok2"
             ; is_error = false
+            ; failure_kind = None
+            ; error_class = None
             ; json = None
             ; content_blocks = None
             }
@@ -636,6 +652,8 @@ let test_strip_drops_results_after_interleaved_text () =
             { tool_use_id = "t1"
             ; content = "ok"
             ; is_error = false
+            ; failure_kind = None
+            ; error_class = None
             ; json = None
             ; content_blocks = None
             }
@@ -658,6 +676,8 @@ let test_strip_keeps_tool_role_results_before_nudge_text () =
             { tool_use_id = "t1"
             ; content = "ok"
             ; is_error = false
+            ; failure_kind = None
+            ; error_class = None
             ; json = None
             ; content_blocks = None
             }
@@ -685,6 +705,8 @@ let test_close_report_names_dropped_result_and_synthetic_repair () =
             { tool_use_id = "t1"
             ; content = "late"
             ; is_error = false
+            ; failure_kind = None
+            ; error_class = None
             ; json = None
             ; content_blocks = None
             }

--- a/test/test_tool_result_relocation.ml
+++ b/test/test_tool_result_relocation.ml
@@ -38,7 +38,14 @@ let rm_rf dir =
 
 let tool_result ?(is_error = false) id content : Types.content_block =
   Types.ToolResult
-    { tool_use_id = id; content; is_error; json = None; content_blocks = None }
+    { tool_use_id = id
+    ; content
+    ; is_error
+    ; failure_kind = None
+    ; error_class = None
+    ; json = None
+    ; content_blocks = None
+    }
 ;;
 
 let asst_msg text : Types.message =

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -347,6 +347,8 @@ let test_show_content_block_variants () =
         { tool_use_id = "tu1"
         ; content = "ok"
         ; is_error = false
+        ; failure_kind = None
+        ; error_class = None
         ; json = None
         ; content_blocks = None
         }
@@ -770,6 +772,8 @@ let test_text_of_content_tool_result () =
         { tool_use_id = "tu1"
         ; content = "result text"
         ; is_error = false
+        ; failure_kind = None
+        ; error_class = None
         ; json = None
         ; content_blocks = None
         }
@@ -791,6 +795,8 @@ let test_visible_text_of_content_excludes_non_answer_blocks () =
         { tool_use_id = "tu1"
         ; content = "tool payload"
         ; is_error = false
+        ; failure_kind = None
+        ; error_class = None
         ; json = Some (`Assoc [ "ok", `Bool true ])
         ; content_blocks = Some [ Types.Text "structured tool payload" ]
         }
@@ -882,6 +888,8 @@ let test_text_of_response_and_usage_helpers () =
             { tool_use_id = "tu"
             ; content = "tool text"
             ; is_error = false
+            ; failure_kind = None
+            ; error_class = None
             ; json = None
             ; content_blocks = None
             }
@@ -912,6 +920,8 @@ let test_validate_tool_result_shape () =
       { tool_use_id = "obj"
       ; content = {|{"ok":true}|}
       ; is_error = false
+      ; failure_kind = None
+      ; error_class = None
       ; json = Some (`Assoc [ "ok", `Bool true ])
       ; content_blocks = None
       }
@@ -921,6 +931,8 @@ let test_validate_tool_result_shape () =
       { tool_use_id = "arr"
       ; content = "[1,2]"
       ; is_error = false
+      ; failure_kind = None
+      ; error_class = None
       ; json = Some (`List [ `Int 1; `Int 2 ])
       ; content_blocks = None
       }
@@ -930,6 +942,8 @@ let test_validate_tool_result_shape () =
       { tool_use_id = "bad"
       ; content = "not-json"
       ; is_error = false
+      ; failure_kind = None
+      ; error_class = None
       ; json = None
       ; content_blocks = None
       }
@@ -939,6 +953,8 @@ let test_validate_tool_result_shape () =
       { tool_use_id = "empty"
       ; content = " "
       ; is_error = false
+      ; failure_kind = None
+      ; error_class = None
       ; json = None
       ; content_blocks = None
       }


### PR DESCRIPTION
## Summary

- move `tool_failure_kind` to the canonical provider-neutral type boundary
- preserve `failure_kind` and `error_class` from tool execution through `Types.ToolResult`, relocation, and context reduction
- persist the typed fields in checkpoint v6 while continuing to load v1-v5
- keep SDK-only provenance out of provider wire serialization

## Boundary

This is the durable provenance foundation for #2530. It intentionally does not add repeated-episode detection or a recovery judge yet, and it adds no model/provider-name branch.

The broad fixture diff is mechanical exhaustiveness from widening the closed `ToolResult` record; pre-existing constructors explicitly use `None` rather than inventing classifications.

## Verification

- `ocamlformat --check` on all changed OCaml files
- `git diff --check`
- focused tests cover execution projection, context pruning, checkpoint round-trip, and provider-wire omission
- local Dune build/test not run; GitHub CI is the build authority

Refs #2530