### PR TITLE
fix(provider): align Kimi with Anthropic Messages codec

### DIFF
--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -456,14 +456,12 @@ let complete_stream_http
            })
     else (
       let config = apply_sampling_defaults config in
-      let uses_responses_api =
-        Provider_config.request_path_targets_responses_api config.request_path
-      in
+      let http_codec = Provider_http_codec.of_config config in
       let body_str =
-        match config.kind with
-        | Provider_config.Anthropic ->
+        match http_codec with
+        | Provider_http_codec.Anthropic_messages ->
           Backend_anthropic.build_request ~stream:true ~config ~messages ~tools ()
-        | Provider_config.Ollama ->
+        | Provider_http_codec.Ollama_chat ->
           (* Native /api/chat + NDJSON. The Backend_openai detour was a
            deferred work-around (#849) that dropped Ollama's
            prompt_eval_count / eval_count / *_duration fields and
@@ -471,13 +469,13 @@ let complete_stream_http
            for every streaming caller. NDJSON parser is now in
            Streaming.parse_ollama_ndjson_chunk. *)
           Backend_ollama.build_request ~stream:true ~config ~messages ~tools ()
-        | Provider_config.OpenAI_compat when uses_responses_api ->
+        | Provider_http_codec.Openai_responses ->
           Backend_openai_responses.build_request ~stream:true ~config ~messages ~tools ()
-        | Provider_config.OpenAI_compat | Provider_config.DashScope | Provider_config.Kimi
-          -> Backend_openai.build_request ~stream:true ~config ~messages ~tools ()
-        | Provider_config.Gemini ->
+        | Provider_http_codec.Openai_chat ->
+          Backend_openai.build_request ~stream:true ~config ~messages ~tools ()
+        | Provider_http_codec.Gemini_generate_content ->
           Backend_gemini.build_request ~stream:true ~config ~messages ~tools ()
-        | Provider_config.Glm ->
+        | Provider_http_codec.Glm_chat ->
           Backend_glm.build_request ~stream:true ~config ~messages ~tools ()
       in
       let url =
@@ -487,11 +485,12 @@ let complete_stream_http
           config.base_url ^ config.request_path
       in
       let body_with_stream =
-        match config.kind with
-        | Provider_config.Gemini -> body_str
-        | Anthropic | Ollama -> Http_client.inject_stream_param body_str
-        | OpenAI_compat when uses_responses_api -> body_str
-        | OpenAI_compat | Kimi | Glm | DashScope ->
+        match http_codec with
+        | Provider_http_codec.Gemini_generate_content
+        | Provider_http_codec.Openai_responses -> body_str
+        | Provider_http_codec.Anthropic_messages | Provider_http_codec.Ollama_chat ->
+          Http_client.inject_stream_param body_str
+        | Provider_http_codec.Openai_chat | Provider_http_codec.Glm_chat ->
           (* OpenAI-compatible streaming returns token usage only when the
              request also sets stream_options.include_usage. Anthropic and
              Ollama carry usage natively (message_start/message_delta and the
@@ -784,8 +783,8 @@ let complete_stream_http
                 in
                 let stream_read_result =
                   try
-                    (match config.kind with
-                     | Provider_config.Ollama ->
+                    (match http_codec with
+                     | Provider_http_codec.Ollama_chat ->
                        Http_client.read_ndjson
                          ?clock
                          ?idle_timeout:stream_idle_timeout_s
@@ -819,19 +818,17 @@ let complete_stream_http
                          ~on_data:(fun ~event_type data ->
                            wire_sink data;
                            let events =
-                             match config.kind with
-                             | Provider_config.Anthropic ->
+                             match http_codec with
+                             | Provider_http_codec.Anthropic_messages ->
                                (match Streaming.parse_sse_event event_type data with
                                 | Some evt -> [ evt ], None
                                 | None -> [], None)
-                             | Provider_config.OpenAI_compat when uses_responses_api ->
+                             | Provider_http_codec.Openai_responses ->
                                Streaming.responses_sse_to_events
                                  (get_state ())
                                  event_type
                                  data
-                             | Provider_config.OpenAI_compat
-                             | Provider_config.DashScope
-                             | Provider_config.Kimi ->
+                             | Provider_http_codec.Openai_chat ->
                                (match
                                   Streaming.parse_openai_sse_chunk
                                     ~streaming_reasoning
@@ -848,7 +845,7 @@ let complete_stream_http
                                    completion) and an error object to a typed
                                    [SSEError]; everything else yields no events. *)
                                   Streaming.openai_compat_terminal_events data, None)
-                             | Provider_config.Gemini ->
+                             | Provider_http_codec.Gemini_generate_content ->
                                (match Streaming.parse_gemini_sse_chunk data with
                                 | Some chunk ->
                                   Streaming.gemini_chunk_to_events (get_state ()) chunk
@@ -859,7 +856,7 @@ let complete_stream_http
                                         }
                                     ]
                                   , None ))
-                             | Provider_config.Glm ->
+                             | Provider_http_codec.Glm_chat ->
                                (match Backend_glm.parse_stream_chunk data with
                                 | Some chunk ->
                                   Streaming.openai_chunk_to_events (get_state ()) chunk
@@ -868,7 +865,7 @@ let complete_stream_http
                                    branch: [DONE] -> [MessageStop], error object
                                    -> [SSEError], else no events. *)
                                   Streaming.openai_compat_terminal_events data, None)
-                             | Provider_config.Ollama ->
+                             | Provider_http_codec.Ollama_chat ->
                                [], None (* unreachable: handled above *)
                            in
                            dispatch events)

--- a/lib/llm_provider/complete_sync.ml
+++ b/lib/llm_provider/complete_sync.ml
@@ -68,22 +68,21 @@ let complete_http
              { kind = Http_client.Provider_parse_error { parser }; message })
       in
       let config = apply_sampling_defaults config in
-      let uses_responses_api =
-        Provider_config.request_path_targets_responses_api config.request_path
-      in
+      let http_codec = Provider_http_codec.of_config config in
       let body_str =
-        match config.kind with
-        | Provider_config.Anthropic ->
+        match http_codec with
+        | Provider_http_codec.Anthropic_messages ->
           Backend_anthropic.build_request ~config ~messages ~tools ()
-        | Provider_config.Ollama ->
+        | Provider_http_codec.Ollama_chat ->
           Backend_ollama.build_request ~config ~messages ~tools ()
-        | Provider_config.OpenAI_compat when uses_responses_api ->
+        | Provider_http_codec.Openai_responses ->
           Backend_openai_responses.build_request ~config ~messages ~tools ()
-        | Provider_config.OpenAI_compat | Provider_config.DashScope | Provider_config.Kimi
-          -> Backend_openai.build_request ~config ~messages ~tools ()
-        | Provider_config.Gemini ->
+        | Provider_http_codec.Openai_chat ->
+          Backend_openai.build_request ~config ~messages ~tools ()
+        | Provider_http_codec.Gemini_generate_content ->
           Backend_gemini.build_request ~config ~messages ~tools ()
-        | Provider_config.Glm -> Backend_glm.build_request ~config ~messages ~tools ()
+        | Provider_http_codec.Glm_chat ->
+          Backend_glm.build_request ~config ~messages ~tools ()
       in
       let url =
         match config.kind with
@@ -221,22 +220,18 @@ let complete_http
             if code >= 200 && code < 300
             then (
               try
-                match config.kind with
-                | Provider_config.Anthropic ->
+                match http_codec with
+                | Provider_http_codec.Anthropic_messages ->
                   Ok (Backend_anthropic.parse_response (Yojson.Safe.from_string body))
-                | Provider_config.Ollama ->
+                | Provider_http_codec.Ollama_chat ->
                   (match Backend_ollama.parse_ollama_response body with
                    | Ok resp -> Ok resp
                    | Error msg -> Error (Http_client.HttpError { code = 400; body = msg }))
-                | Provider_config.OpenAI_compat
-                  when Provider_config.request_path_targets_responses_api
-                         config.request_path ->
+                | Provider_http_codec.Openai_responses ->
                   (match Backend_openai_responses.parse_response_result body with
                    | Ok resp -> Ok resp
                    | Error msg -> Error (Http_client.HttpError { code = 400; body = msg }))
-                | Provider_config.OpenAI_compat
-                | Provider_config.DashScope
-                | Provider_config.Kimi ->
+                | Provider_http_codec.Openai_chat ->
                   (match Backend_openai_parse.parse_openai_response_result body with
                    | Ok resp -> Ok resp
                    | Error (Backend_openai_parse.Provider_error msg) ->
@@ -246,9 +241,9 @@ let complete_http
                         fact as streaming. Policy remains downstream of the
                         preserved [stop_reason]. *)
                      Error (Http_client.empty_completion_error ~stop_reason:e.stop_reason))
-                | Provider_config.Gemini ->
+                | Provider_http_codec.Gemini_generate_content ->
                   Ok (Backend_gemini.parse_response (Yojson.Safe.from_string body))
-                | Provider_config.Glm -> Ok (Backend_glm.parse_response body)
+                | Provider_http_codec.Glm_chat -> Ok (Backend_glm.parse_response body)
               with
               | Yojson.Json_error msg ->
                 Diag.error "complete" "JSON parse error: %s" msg;

--- a/lib/llm_provider/dune
+++ b/lib/llm_provider/dune
@@ -3,6 +3,7 @@
 (library
  (name llm_provider)
  (public_name agent_sdk.llm_provider)
+ (private_modules provider_http_codec)
  (libraries
   yojson
   otoml

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -20,7 +20,7 @@ type provider_kind = Provider_kind.t =
     it does not dispatch over an HTTP path. *)
 let request_path_default_for_kind = function
   | Anthropic -> "/v1/messages"
-  | Kimi -> "/v1/chat/completions"
+  | Kimi -> "/v1/messages"
   | OpenAI_compat -> "/v1/chat/completions"
   | Ollama -> "/api/chat"
   | Gemini -> ""

--- a/lib/llm_provider/provider_http_codec.ml
+++ b/lib/llm_provider/provider_http_codec.ml
@@ -1,0 +1,53 @@
+type t =
+  | Anthropic_messages
+  | Openai_chat
+  | Openai_responses
+  | Ollama_chat
+  | Gemini_generate_content
+  | Glm_chat
+
+let of_config (config : Provider_config.t) =
+  (* [kind] owns the wire contract. In particular, Kimi remains Anthropic
+     Messages through custom proxy paths; callers targeting Kimi's OpenAI-
+     compatible endpoint must declare [OpenAI_compat]. The only path-selected
+     sub-protocol is the validated OpenAI Responses endpoint. *)
+  match config.kind with
+  | Provider_config.Anthropic | Provider_config.Kimi -> Anthropic_messages
+  | Provider_config.OpenAI_compat
+    when Provider_config.request_path_targets_responses_api config.request_path ->
+    Openai_responses
+  | Provider_config.OpenAI_compat | Provider_config.DashScope -> Openai_chat
+  | Provider_config.Ollama -> Ollama_chat
+  | Provider_config.Gemini -> Gemini_generate_content
+  | Provider_config.Glm -> Glm_chat
+;;
+
+let%test "kind owns codec; path and model strings do not infer it" =
+  let codec ?request_path ~kind ~model_id () =
+    Provider_config.make ?request_path ~kind ~model_id ~base_url:"https://example.test" ()
+    |> of_config
+  in
+  let cases =
+    [ codec ~kind:Provider_config.Anthropic ~model_id:"model" (), Anthropic_messages
+    ; ( codec
+          ~request_path:"/v1/chat/completions"
+          ~kind:Provider_config.Kimi
+          ~model_id:"kimi-for-coding"
+          ()
+      , Anthropic_messages )
+    ; ( codec ~kind:Provider_config.OpenAI_compat ~model_id:"kimi-for-coding" ()
+      , Openai_chat )
+    ; ( codec
+          ~request_path:"/v1/responses"
+          ~kind:Provider_config.OpenAI_compat
+          ~model_id:"model"
+          ()
+      , Openai_responses )
+    ; codec ~kind:Provider_config.Ollama ~model_id:"model" (), Ollama_chat
+    ; codec ~kind:Provider_config.Gemini ~model_id:"model" (), Gemini_generate_content
+    ; codec ~kind:Provider_config.Glm ~model_id:"model" (), Glm_chat
+    ; codec ~kind:Provider_config.DashScope ~model_id:"model" (), Openai_chat
+    ]
+  in
+  List.for_all (fun (actual, expected) -> actual = expected) cases
+;;

--- a/lib/llm_provider/provider_http_codec.mli
+++ b/lib/llm_provider/provider_http_codec.mli
@@ -1,0 +1,20 @@
+(** Private HTTP wire-codec projection used by Complete sync and stream paths.
+
+    The Dune library marks this module private, so external OAS consumers keep
+    using [Provider_config] and [Complete] without a codec-selection API. *)
+
+type t = private
+  | Anthropic_messages
+  | Openai_chat
+  | Openai_responses
+  | Ollama_chat
+  | Gemini_generate_content
+  | Glm_chat
+
+(** Project one validated provider config to its serializer/parser contract.
+
+    [Kimi] always selects Anthropic Messages, including through a custom proxy
+    path. Kimi's OpenAI-compatible endpoint must be declared as
+    [Provider_config.OpenAI_compat]. Model and provider-name strings never
+    select the codec. *)
+val of_config : Provider_config.t -> t

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -84,14 +84,18 @@ let start_mock_server
       ?(delay_sec = 0.0)
       ?clock
       ?capture_body
+      ?capture_path
       ?on_request
       response_body
   =
   let port = fresh_port () in
-  let handler _conn _req body =
+  let handler _conn req body =
     let request_body = Eio.Buf_read.(of_flow ~max_size:max_int body |> take_all) in
     (match capture_body with
      | Some seen -> seen := Some request_body
+     | None -> ());
+    (match capture_path with
+     | Some seen -> seen := Some (Cohttp.Request.uri req |> Uri.path)
      | None -> ());
     (match on_request with
      | Some f -> f ()
@@ -160,6 +164,18 @@ let make_openai_config base_url =
     ~model_id:"gpt-4"
     ~base_url
     ~request_path:"/v1/chat/completions"
+    ~temperature:0.0
+    ~max_tokens:100
+    ()
+;;
+
+let make_kimi_config ?request_path base_url =
+  Provider_config.make
+    ~kind:Provider_config.Kimi
+    ~model_id:"kimi-for-coding"
+    ~base_url
+    ?request_path
+    ~system_prompt:"Kimi system"
     ~temperature:0.0
     ~max_tokens:100
     ()
@@ -1257,10 +1273,16 @@ let start_raw_sse_server ~sw ~net ~clock delayed_frames =
   Printf.sprintf "http://127.0.0.1:%d" port
 ;;
 
-let start_sse_server ~sw ~net response_body =
+let start_sse_server ~sw ~net ?capture_body ?capture_path response_body =
   let port = fresh_port () in
-  let handler _conn _req body =
-    let _ = Eio.Buf_read.(of_flow ~max_size:max_int body |> take_all) in
+  let handler _conn req body =
+    let request_body = Eio.Buf_read.(of_flow ~max_size:max_int body |> take_all) in
+    (match capture_body with
+     | Some seen -> seen := Some request_body
+     | None -> ());
+    (match capture_path with
+     | Some seen -> seen := Some (Cohttp.Request.uri req |> Uri.path)
+     | None -> ());
     let headers = Cohttp.Header.of_list [ "content-type", "text/event-stream" ] in
     Cohttp_eio.Server.respond_string ~status:`OK ~headers ~body:response_body ()
   in
@@ -1285,6 +1307,152 @@ let text_of_response (resp : Types.api_response) =
       | _ -> None)
     resp.content
   |> String.concat ""
+;;
+
+let check_kimi_anthropic_request ~expected_path ~stream ~captured_body ~captured_path =
+  (match captured_path with
+   | Some path -> check string "Kimi request path" expected_path path
+   | None -> fail "server did not capture Kimi request path");
+  match captured_body with
+  | Some body ->
+    let json = Yojson.Safe.from_string body in
+    let open Yojson.Safe.Util in
+    check string "Kimi model" "kimi-for-coding" (json |> member "model" |> to_string);
+    check
+      string
+      "Anthropic top-level system"
+      "Kimi system"
+      (json |> member "system" |> to_string);
+    check bool "stream flag" stream (json |> member "stream" |> to_bool);
+    (match json |> member "stream_options" with
+     | `Null -> ()
+     | _ -> fail "Anthropic Messages request must not carry OpenAI stream_options")
+  | None -> fail "server did not capture Kimi request body"
+;;
+
+let test_complete_kimi_path_override_stays_anthropic_codec () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let captured_body = ref None in
+    let captured_path = ref None in
+    let url =
+      start_mock_server
+        ~sw
+        ~net:env#net
+        ~capture_body:captured_body
+        ~capture_path:captured_path
+        (anthropic_response "kimi sync")
+    in
+    let request_path = "/v1/chat/completions" in
+    (match
+       Complete.complete
+         ~sw
+         ~net:env#net
+         ~config:(make_kimi_config ~request_path url)
+         ~messages
+         ()
+     with
+     | Ok resp -> check string "Kimi sync text" "kimi sync" (text_of_response resp)
+     | Error _ -> fail "expected Kimi sync Anthropic Messages response to parse");
+    check_kimi_anthropic_request
+      ~expected_path:request_path
+      ~stream:false
+      ~captured_body:!captured_body
+      ~captured_path:!captured_path;
+    Eio.Switch.fail sw Exit
+  with
+  | Exit -> ()
+;;
+
+let test_complete_kimi_anthropic_stream_codec () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let captured_body = ref None in
+    let captured_path = ref None in
+    let url =
+      start_sse_server
+        ~sw
+        ~net:env#net
+        ~capture_body:captured_body
+        ~capture_path:captured_path
+        (anthropic_sse_response "kimi stream")
+    in
+    (match
+       Complete.complete_stream
+         ~sw
+         ~net:env#net
+         ~config:(make_kimi_config url)
+         ~messages
+         ~on_event:(fun _ -> ())
+         ()
+     with
+     | Ok resp -> check string "Kimi stream text" "kimi stream" (text_of_response resp)
+     | Error _ -> fail "expected Kimi Anthropic Messages SSE response to parse");
+    check_kimi_anthropic_request
+      ~expected_path:"/v1/messages"
+      ~stream:true
+      ~captured_body:!captured_body
+      ~captured_path:!captured_path;
+    Eio.Switch.fail sw Exit
+  with
+  | Exit -> ()
+;;
+
+let test_complete_openai_compatible_kimi_uses_openai_codec () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let captured_body = ref None in
+    let captured_path = ref None in
+    let url =
+      start_mock_server
+        ~sw
+        ~net:env#net
+        ~capture_body:captured_body
+        ~capture_path:captured_path
+        (openai_response "kimi openai")
+    in
+    let config =
+      Provider_config.make
+        ~kind:Provider_config.OpenAI_compat
+        ~model_id:"kimi-for-coding"
+        ~base_url:url
+        ~request_path:"/v1/chat/completions"
+        ~system_prompt:"Kimi OpenAI system"
+        ~max_tokens:100
+        ()
+    in
+    (match Complete.complete ~sw ~net:env#net ~config ~messages () with
+     | Ok resp -> check string "Kimi OpenAI text" "kimi openai" (text_of_response resp)
+     | Error _ -> fail "expected OpenAI-compatible Kimi response to parse");
+    (match !captured_path with
+     | Some path -> check string "Kimi OpenAI path" "/v1/chat/completions" path
+     | None -> fail "server did not capture OpenAI-compatible Kimi path");
+    (match !captured_body with
+     | Some body ->
+       let json = Yojson.Safe.from_string body in
+       let open Yojson.Safe.Util in
+       check bool "no Anthropic top-level system" true (json |> member "system" = `Null);
+       (match json |> member "messages" |> to_list with
+        | first_message :: _ ->
+          check
+            string
+            "OpenAI system message"
+            "system"
+            (first_message |> member "role" |> to_string)
+        | [] -> fail "OpenAI-compatible request omitted messages")
+     | None -> fail "server did not capture OpenAI-compatible Kimi body");
+    Eio.Switch.fail sw Exit
+  with
+  | Exit -> ()
 ;;
 
 let test_complete_stream_ok () =
@@ -1840,6 +2008,14 @@ let () =
     [ ( "complete"
       , [ test_case "anthropic ok" `Quick test_complete_anthropic_ok
         ; test_case
+            "Kimi path override stays Anthropic"
+            `Quick
+            test_complete_kimi_path_override_stays_anthropic_codec
+        ; test_case
+            "OpenAI-compatible Kimi uses OpenAI codec"
+            `Quick
+            test_complete_openai_compatible_kimi_uses_openai_codec
+        ; test_case
             "HTTP rejects typed empty completion"
             `Quick
             test_complete_http_rejects_typed_empty_completion
@@ -1908,6 +2084,10 @@ let () =
     ; "retry", [ test_case "first try ok" `Quick test_retry_first_try ]
     ; ( "stream"
       , [ test_case "sse ok" `Quick test_complete_stream_ok
+        ; test_case
+            "Kimi Anthropic Messages SSE codec"
+            `Quick
+            test_complete_kimi_anthropic_stream_codec
         ; test_case
             "HTTP stream rejects typed empty completion"
             `Quick

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -1018,7 +1018,7 @@ let test_config_default_paths () =
   let anth = PC.make ~kind:Anthropic ~model_id:"m" ~base_url:"" () in
   Alcotest.(check string) "anthropic path" "/v1/messages" anth.request_path;
   let kimi = PC.make ~kind:Kimi ~model_id:"m" ~base_url:"" () in
-  Alcotest.(check string) "kimi path" "/v1/chat/completions" kimi.request_path;
+  Alcotest.(check string) "kimi path" "/v1/messages" kimi.request_path;
   let oai = PC.make ~kind:OpenAI_compat ~model_id:"m" ~base_url:"" () in
   Alcotest.(check string) "openai path" "/v1/chat/completions" oai.request_path
 ;;

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -51,7 +51,7 @@ let test_request_path_anthropic () =
 
 let test_request_path_provider_c () =
   let cfg = Provider_config.make ~kind:Kimi ~model_id:"m" ~base_url:"" () in
-  check_string "kimi path" "/v1/chat/completions" cfg.request_path
+  check_string "kimi path" "/v1/messages" cfg.request_path
 ;;
 
 let test_request_path_openai () =


### PR DESCRIPTION
## Summary

- align `Provider_config.Kimi` with the already-declared Anthropic-compatible `/v1/messages` contract
- select request serializer, response parser, stream injection, and stream parser from one closed typed projection
- keep that projection completely internal with Dune `private_modules`; external OAS APIs are unchanged
- add HTTP-level regressions for Kimi sync, Anthropic SSE, custom-path behavior, and OpenAI-compatible Kimi routing

## Root cause

The built-in Kimi provider and provider registry already declared Anthropic Messages and `/v1/messages`, but `Provider_config.Kimi` defaulted to `/v1/chat/completions` and both Complete HTTP paths dispatched Kimi through OpenAI request/response codecs. Path, serializer, parser, and streaming framing therefore disagreed across OAS boundaries.

## Design

`Provider_http_codec` is a Dune-private module. It projects a validated `Provider_config.t` to one closed codec variant consumed by both sync and stream implementations. Provider kind owns the wire contract:

- `Kimi` always means Anthropic Messages, including custom Anthropic-compatible proxy paths
- Kimi through an OpenAI-compatible endpoint uses `Provider_config.OpenAI_compat`
- model/provider-name strings do not select a codec
- only the already-validated OpenAI Responses request path selects the Responses sub-protocol

Kimi reuses the existing Anthropic serializer, response parser, stream parameter behavior, and SSE parser. No Kimi-specific event constants or string classifiers were added.

## Official Kimi evidence

- [근거] Kimi Code Overview documents Anthropic-compatible base `https://api.kimi.com/coding/` and full endpoint `https://api.kimi.com/coding/v1/messages`: https://www.kimi.com/code/docs/en/ — 확인일시 2026-07-11 21:22:40 KST — 신뢰도 High
- [근거] Kimi Code changelog 0.20.2 states that Kimi Code supports the Anthropic-compatible protocol and routes that protocol through the Messages API: https://www.kimi.com/code/docs/en/kimi-code-cli/release-notes/changelog.html — 확인일시 2026-07-11 21:22:40 KST — 신뢰도 High
- [근거] Kimi's official third-party guide connects unmodified Claude Code with `ANTHROPIC_BASE_URL=https://api.kimi.com/coding/`: https://www.kimi.com/code/docs/third-party-tools/other-coding-agents.html — 확인일시 2026-07-11 21:22:40 KST — 신뢰도 High

The Kimi docs do not enumerate every Anthropic SSE event name. Treating the streaming response as Anthropic Messages framing is an inference from the documented Anthropic-compatible protocol plus official unmodified Claude Code integration. The implementation deliberately reuses OAS's existing Anthropic SSE codec instead of inventing Kimi-specific framing.

## Validation

- OCaml parser checks for all eight changed/new `.ml` and `.mli` files
- `ocamlformat --check` for all changed/new OCaml files
- `git diff --check`
- transport truth, reasoning-effort SSOT, core/CDAL boundary, code-smell ratchet, hardening ratchet, and SDK-independence gates
- adversarial self-review: P0/P1/P2/P3 = 0
- local Dune build/test intentionally not run; PR CI is the build authority

## Scope

This is the Kimi HTTP codec/path subproblem extracted from closed jeong-sik/oas#2526. It does not close or claim jeong-sik/masc#27905 or jeong-sik/masc#27903. Output-token receipt/artifact code and provider registry code are intentionally untouched.

## Merge gate

Draft and do-not-merge until exact-head CI and independent review are complete.
