### PR TITLE
feat(agent): judge repeated typed tool failures

### DIFF
--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -32,7 +32,7 @@ type api_strategy = Pipeline.api_strategy =
 (** Run a single turn via the 6-stage pipeline.
     Converts Pipeline.turn_outcome to the polymorphic variant interface
     expected by run_loop and the public API. *)
-let run_turn_core ~sw ?clock ~api_strategy ?raw_trace_run agent =
+let run_turn_core ~sw ?clock ~api_strategy ?raw_trace_run ?recovery_context agent =
   Tracing.with_span
     agent.options.tracer
     { kind = Agent_run
@@ -52,10 +52,17 @@ let run_turn_core ~sw ?clock ~api_strategy ?raw_trace_run agent =
          | Stream { on_event; on_telemetry } -> Pipeline.Stream { on_event; on_telemetry }
        in
        match
-         Pipeline.run_turn ~sw ?clock ~api_strategy:api_strat ?raw_trace_run agent
+         Pipeline.run_turn
+           ~sw
+           ?clock
+           ~api_strategy:api_strat
+           ?raw_trace_run
+           ?recovery_context
+           agent
        with
        | Ok (Pipeline.Complete response) -> Ok (`Complete response)
-       | Ok Pipeline.ToolsExecuted -> Ok `ToolsExecuted
+       | Ok (Pipeline.ToolsExecuted completed_round) ->
+         Ok (`ToolsExecuted completed_round)
        | Ok Pipeline.IdleSkipped ->
          Ok
            (`Complete
@@ -78,6 +85,7 @@ let run_turn_with_trace ~sw ?clock ?raw_trace_run agent =
 ;;
 
 let provide_input agent request response =
+  set_recovery_state agent empty_recovery_state;
   Agent_elicitation.apply_response agent request response
 ;;
 
@@ -100,7 +108,8 @@ let check_loop_guard agent =
            (Error.MaxTurnsExceeded
               { turns = agent.state.turn_count; limit = agent.state.config.max_turns }))
     else if
-      agent.consecutive_idle_turns >= agent.options.max_idle_turns
+      Option.is_none agent.tool_failure_judge
+      && agent.consecutive_idle_turns >= agent.options.max_idle_turns
       && agent.options.max_idle_turns > 0
     then
       Some
@@ -182,6 +191,7 @@ let append_user_input agent user_blocks =
   in
   update_state agent (fun s ->
     { s with messages = Util.snoc (base_messages agent) user_msg });
+  set_recovery_state agent empty_recovery_state;
   user_msg.content
 ;;
 
@@ -226,6 +236,249 @@ let log_turn ~run_start ~turn_start ~turn_index ~max_turns ~model ~stop =
     ]
 ;;
 
+let recovery_failure stage detail =
+  Error.Agent (Error.ToolFailureRecoveryFailed { stage; detail })
+;;
+
+let ( let* ) = Result.bind
+
+let publish_recovery_event agent payload =
+  match agent.options.event_bus with
+  | None -> ()
+  | Some bus ->
+    Pipeline_common.safe_publish
+      ~log:_log
+      bus
+      { Event_bus.meta = Pipeline_common.event_envelope agent; payload }
+;;
+
+let recovery_timestamp = function
+  | Some clock -> Eio.Time.now clock
+  | None -> Unix.gettimeofday ()
+;;
+
+let apply_recovery_receipt_outcome agent receipt =
+  match Tool_failure_recovery.receipt_decision receipt with
+  | Tool_failure_recovery.Retry_modified _ | Tool_failure_recovery.Replan _ -> Ok ()
+  | Tool_failure_recovery.Ask_user { question; schema } ->
+    let request : Hooks.elicitation_request = { question; schema; timeout_s = None } in
+    let input_required =
+      Agent_elicitation.input_required_of_request
+        ~agent_name:agent.state.config.name
+        ~turn:agent.state.turn_count
+        ~created_at:(Tool_failure_recovery.receipt_decided_at receipt)
+        request
+    in
+    Error (Error.Agent (Error.InputRequired input_required))
+  | Tool_failure_recovery.Defer { reason } ->
+    Error
+      (Error.Agent
+         (Error.ToolFailureRecoveryDeferred
+            { reason; tool_names = Tool_failure_recovery.receipt_tool_names receipt }))
+;;
+
+let persist_recovery_decision ?clock agent ~episodes decision =
+  let receipt =
+    Tool_failure_recovery.make_receipt
+      ~resume_turn:agent.state.turn_count
+      ~decided_at:(recovery_timestamp clock)
+      ~episodes
+      ~decision
+  in
+  let* messages =
+    match
+      Tool_failure_recovery.attach_receipt
+        ~messages:agent.state.messages
+        ~episodes
+        ~receipt
+    with
+    | Ok messages -> Ok messages
+    | Error error ->
+      Error
+        (recovery_failure
+           Error.Decision_persistence
+           (Tool_failure_recovery.show_receipt_error error))
+  in
+  let candidate_state = { agent.state with messages } in
+  let* () =
+    Pipeline.persist_turn_checkpoint_for_state
+      agent
+      After_retry_feedback_appended
+      candidate_state
+  in
+  set_state agent candidate_state;
+  update_recovery_state agent (fun state ->
+    { state with pending_episodes = None; pending_receipt = Some receipt });
+  publish_recovery_event
+    agent
+    (Event_bus.ToolFailureRecoveryDecided
+       { agent_name = agent.state.config.name; turn = agent.state.turn_count; decision });
+  Log.info
+    _log
+    "typed tool failure recovery decided"
+    [ Log.S ("agent", agent.state.config.name)
+    ; Log.I ("turn", agent.state.turn_count)
+    ; Log.S ("decision", Tool_failure_recovery.show_decision decision)
+    ];
+  Ok receipt
+;;
+
+let invoke_recovery_judge ~sw ?clock agent episodes =
+  match agent.tool_failure_judge with
+  | None ->
+    update_recovery_state agent (fun state ->
+      { state with pending_episodes = None; pending_receipt = None });
+    Ok ()
+  | Some judge ->
+    (match
+       Tool_failure_recovery.decide
+         ~sw
+         ~agent_name:agent.state.config.name
+         ~turn:agent.state.turn_count
+         ~episodes
+         judge
+     with
+     | Error (Tool_failure_recovery.Completion_failed error) ->
+       let detail =
+         Tool_failure_recovery.judge_error_to_string
+           (Tool_failure_recovery.Completion_failed error)
+       in
+       publish_recovery_event
+         agent
+         (Event_bus.ToolFailureRecoveryJudgeFailed
+            { agent_name = agent.state.config.name
+            ; turn = agent.state.turn_count
+            ; detail
+            });
+       Error error
+     | Error error ->
+       let detail = Tool_failure_recovery.judge_error_to_string error in
+       publish_recovery_event
+         agent
+         (Event_bus.ToolFailureRecoveryJudgeFailed
+            { agent_name = agent.state.config.name
+            ; turn = agent.state.turn_count
+            ; detail
+            });
+       Error (recovery_failure Error.Judge_response detail)
+     | Ok decision ->
+       let* receipt = persist_recovery_decision ?clock agent ~episodes decision in
+       apply_recovery_receipt_outcome agent receipt)
+;;
+
+let resolve_pending_recovery ~sw ?clock agent =
+  let state = recovery_state agent in
+  match state.restore_error with
+  | Some error -> Error error
+  | None ->
+    (match state.pending_episodes with
+     | None ->
+       (match state.pending_receipt with
+        | Some receipt
+          when Tool_failure_recovery.receipt_resume_turn receipt = agent.state.turn_count
+          -> apply_recovery_receipt_outcome agent receipt
+        | Some receipt
+          when Tool_failure_recovery.receipt_resume_turn receipt > agent.state.turn_count
+          ->
+          Error
+            (recovery_failure
+               Error.Resume_restore
+               "recovery receipt targets a future turn")
+        | Some _ ->
+          update_recovery_state agent (fun current ->
+            { current with pending_receipt = None });
+          Ok ()
+        | None -> Ok ())
+     | Some episodes ->
+       (match state.pending_receipt with
+        | Some receipt
+          when Tool_failure_recovery.receipt_resume_turn receipt = agent.state.turn_count
+          ->
+          let* () =
+            match Tool_failure_recovery.validate_receipt ~episodes receipt with
+            | Ok () -> Ok ()
+            | Error error ->
+              Error
+                (recovery_failure
+                   Error.Resume_restore
+                   (Tool_failure_recovery.show_receipt_error error))
+          in
+          update_recovery_state agent (fun current ->
+            { current with pending_episodes = None });
+          apply_recovery_receipt_outcome agent receipt
+        | Some receipt
+          when Tool_failure_recovery.receipt_resume_turn receipt > agent.state.turn_count
+          ->
+          Error
+            (recovery_failure
+               Error.Resume_restore
+               "recovery receipt targets a future turn")
+        | Some _ ->
+          update_recovery_state agent (fun current ->
+            { current with pending_receipt = None });
+          invoke_recovery_judge ~sw ?clock agent episodes
+        | None -> invoke_recovery_judge ~sw ?clock agent episodes))
+;;
+
+let register_completed_tool_round agent current =
+  let state = recovery_state agent in
+  let detection =
+    match state.last_completed_round with
+    | None -> Ok []
+    | Some previous -> Tool_failure_episode.detect ~previous ~current
+  in
+  match detection with
+  | Error error ->
+    update_recovery_state agent (fun state ->
+      { state with last_completed_round = Some current });
+    Error
+      (recovery_failure Error.Episode_detection (Tool_failure_episode.show_error error))
+  | Ok episodes ->
+    update_recovery_state agent (fun state ->
+      { state with
+        last_completed_round = Some current
+      ; pending_episodes = (if episodes = [] then None else Some episodes)
+      ; pending_receipt = None
+      });
+    if episodes <> []
+    then
+      publish_recovery_event
+        agent
+        (Event_bus.ToolFailureEpisodeDetected
+           { agent_name = agent.state.config.name
+           ; turn = agent.state.turn_count
+           ; episodes
+           });
+    Ok ()
+;;
+
+let recovery_context_for_turn agent =
+  let state = recovery_state agent in
+  match state.restore_error with
+  | Some error -> Error error
+  | None ->
+    (match state.pending_receipt with
+     | None -> Ok None
+     | Some receipt ->
+       let resume_turn = Tool_failure_recovery.receipt_resume_turn receipt in
+       if resume_turn = agent.state.turn_count
+       then Ok (Tool_failure_recovery.system_context receipt)
+       else if resume_turn < agent.state.turn_count
+       then (
+         update_recovery_state agent (fun current ->
+           { current with pending_receipt = None });
+         Ok None)
+       else
+         Error
+           (recovery_failure
+              Error.Resume_restore
+              "recovery receipt targets a future turn"))
+;;
+
+type provider_lease =
+  | Held
+  | Released
+
 let run_loop ~sw ?clock ~api_strategy ?on_yield ?on_resume ?on_activity agent user_blocks =
   let bump_activity () =
     match on_activity with
@@ -237,33 +490,23 @@ let run_loop ~sw ?clock ~api_strategy ?on_yield ?on_resume ?on_activity agent us
   with_raw_trace_run agent trace_prompt
   @@ fun raw_trace_run ->
   let yield_enabled = agent.state.config.yield_on_tool in
-  let do_yield () =
-    match on_yield with
-    | Some f -> f ()
-    | None -> ()
+  let release_lease = function
+    | Released -> Released
+    | Held when yield_enabled ->
+      Option.iter (fun callback -> callback ()) on_yield;
+      Released
+    | Held -> Held
   in
-  let do_resume () =
-    match on_resume with
-    | Some f -> f ()
-    | None -> ()
+  let acquire_lease = function
+    | Held -> Held
+    | Released when yield_enabled ->
+      Option.iter (fun callback -> callback ()) on_resume;
+      Held
+    | Released -> Held
   in
-  (* Per-turn timing snapshot: capture when the run started so each turn
-     log line carries both per-turn duration and the cumulative elapsed
-     time against the agent's OAS budget.  Diagnosing wall-clock
-     timeouts requires knowing whether the budget was spent on many
-     moderate turns or a single slow one. *)
   let run_start = Unix.gettimeofday () in
-  (* Convergence turn for [ensure_final_text]: the run's contract is to produce
-     a user-facing answer, but the model ended with tool activity and no visible
-     text (downstream renders this as "Tool-only turn ended without a final
-     reply"). We run exactly ONE more model turn with the tool set withheld
-     ([Tool_set.empty] — the same swap {!run_with_handoffs_blocks} uses). With no
-     tools the model cannot emit a tool call, so it must author a textual final
-     answer: the answer is LLM-authored, not synthesized, and this adds no
-     turn/token cap. This is a single [run_turn_core] call — never a recursion
-     into [loop] — so it runs at most once and cannot itself trigger another
-     final-answer turn. *)
-  let run_final_answer_turn () =
+  let run_final_answer_turn lease =
+    let _lease = acquire_lease lease in
     let tool_withheld_agent = { agent with tools = Tool_set.empty } in
     let turn_index = agent.state.turn_count + 1 in
     let max_turns = agent.state.config.max_turns in
@@ -280,82 +523,87 @@ let run_loop ~sw ?clock ~api_strategy ?on_yield ?on_resume ?on_activity agent us
       ~stop:"ensure_final_text";
     result
   in
-  (* First turn: caller already holds slot, no resume needed *)
-  let rec loop ~is_first_turn =
-    match check_loop_guard agent with
-    | Some (Error.Agent (Error.MaxTurnsExceeded _) as err)
-      when agent.state.config.ensure_final_text ->
-      (* Hit the turn limit after a tool turn with no final text. Converge with
-         one tool-withheld answer turn before surfacing the limit error. If that
-         turn does not yield a [`Complete] response (degenerate [`ToolsExecuted],
-         or a hard error), fall back to the original MaxTurnsExceeded error. *)
-      (match run_final_answer_turn () with
-       | Ok (`Complete final_response) -> Ok final_response
-       | Ok `ToolsExecuted | Error _ -> Error err)
-    | Some err -> Error err
-    | None ->
-      (* Resume slot before LLM turn (skip on first turn) *)
-      if yield_enabled && not is_first_turn then do_resume ();
-      (* Snapshot turn_count BEFORE run_turn_core — Pipeline.stage_collect
-         increments it (pipeline.ml:299) before returning, so reading
-         agent.state.turn_count afterwards would yield the NEXT turn's
-         index, not the one that just finished.  We display as 1-based
-         ("turn 1/15" = the 1st of 15) for human readability. *)
-      let turn_index = agent.state.turn_count + 1 in
-      let max_turns = agent.state.config.max_turns in
-      let turn_start = Unix.gettimeofday () in
-      let result = run_turn_core ~sw ?clock ~api_strategy ?raw_trace_run agent in
-      (* A completed turn is execution progress: bump the idle watchdog
-         so a multi-turn run (especially non-streaming, where there are no
-         token-level [on_event] signals) is not flagged as stalled between
-         turns. Streaming turns also bump per token via the wrapped
-         [on_event] in [run_stream]. *)
-      bump_activity ();
-      (match result with
-       | Error e ->
-         log_turn
-           ~run_start
-           ~turn_start
-           ~turn_index
-           ~max_turns
-           ~model:agent.state.config.model
-           ~stop:("error:" ^ Error.to_string e);
-         Error e
-       | Ok (`Complete response) ->
-         log_turn
-           ~run_start
-           ~turn_start
-           ~turn_index
-           ~max_turns
-           ~model:response.model
-           ~stop:(stop_reason_label response.stop_reason);
-         if
-           agent.state.config.ensure_final_text
-           && Option.is_none (final_text_of_response response)
-         then (
-           (* Terminal turn carried no visible text: converge with one
-              tool-withheld answer turn. Return whatever it yields and do NOT
-              retry — a [`Complete] result is returned even if it is still
-              text-free; a degenerate [`ToolsExecuted] falls back to the
-              original response; a hard error is surfaced honestly. *)
-           match run_final_answer_turn () with
-           | Ok (`Complete final_response) -> Ok final_response
-           | Ok `ToolsExecuted -> Ok response
-           | Error e -> Error e)
-         else Ok response
-       | Ok `ToolsExecuted ->
-         log_turn
-           ~run_start
-           ~turn_start
-           ~turn_index
-           ~max_turns
-           ~model:agent.state.config.model
-           ~stop:"tools_executed";
-         (* Yield slot during tool execution gap *)
-         if yield_enabled then do_yield ();
-         loop ~is_first_turn:false)
+  let rec loop lease =
+    (* A failed-tool judge runs only after the main provider lease has been
+       released. [on_resume] is reserved for the next main provider call. *)
+    let lease =
+      match (recovery_state agent).pending_episodes with
+      | Some _ -> release_lease lease
+      | None -> lease
+    in
+    match resolve_pending_recovery ~sw ?clock agent with
+    | Error error -> Error error
+    | Ok () ->
+      (match check_loop_guard agent with
+       | Some (Error.Agent (Error.MaxTurnsExceeded _) as err)
+         when agent.state.config.ensure_final_text ->
+         (match run_final_answer_turn lease with
+          | Ok (`Complete final_response) -> Ok final_response
+          | Ok (`ToolsExecuted _) | Error _ -> Error err)
+       | Some err -> Error err
+       | None ->
+         (match recovery_context_for_turn agent with
+          | Error error -> Error error
+          | Ok recovery_context ->
+            let lease = acquire_lease lease in
+            let turn_index = agent.state.turn_count + 1 in
+            let max_turns = agent.state.config.max_turns in
+            let turn_start = Unix.gettimeofday () in
+            let result =
+              run_turn_core
+                ~sw
+                ?clock
+                ~api_strategy
+                ?raw_trace_run
+                ?recovery_context
+                agent
+            in
+            bump_activity ();
+            (match result with
+             | Error e ->
+               log_turn
+                 ~run_start
+                 ~turn_start
+                 ~turn_index
+                 ~max_turns
+                 ~model:agent.state.config.model
+                 ~stop:("error:" ^ Error.to_string e);
+               Error e
+             | Ok (`Complete response) ->
+               log_turn
+                 ~run_start
+                 ~turn_start
+                 ~turn_index
+                 ~max_turns
+                 ~model:response.model
+                 ~stop:(stop_reason_label response.stop_reason);
+               if
+                 agent.state.config.ensure_final_text
+                 && Option.is_none (final_text_of_response response)
+               then (
+                 match run_final_answer_turn lease with
+                 | Ok (`Complete final_response) -> Ok final_response
+                 | Ok (`ToolsExecuted _) -> Ok response
+                 | Error e -> Error e)
+               else Ok response
+             | Ok (`ToolsExecuted completed_round) ->
+               log_turn
+                 ~run_start
+                 ~turn_start
+                 ~turn_index
+                 ~max_turns
+                 ~model:agent.state.config.model
+                 ~stop:"tools_executed";
+               let registered =
+                 match completed_round with
+                 | None -> Ok ()
+                 | Some current -> register_completed_tool_round agent current
+               in
+               (match registered with
+                | Error error -> Error error
+                | Ok () -> loop (release_lease lease)))))
   in
-  loop ~is_first_turn:true
+  loop Held
 ;;
 
 (* Start periodic callback fibers, return a stop function *)
@@ -644,22 +892,46 @@ let with_periodic_callbacks ~sw:_ ?clock ~last_activity agent f =
         raise exn)
 ;;
 
+let validate_run_recovery_config agent ~on_yield ~on_resume =
+  match on_yield, on_resume with
+  | Some _, None | None, Some _ ->
+    Error
+      (Error.Config
+         (Error.InvalidConfig
+            { field = "on_yield/on_resume"
+            ; detail = "callbacks must be supplied together or both omitted"
+            }))
+  | Some _, Some _ | None, None ->
+    if Option.is_some agent.tool_failure_judge && not agent.state.config.yield_on_tool
+    then
+      Error
+        (Error.Config
+           (Error.InvalidConfig
+              { field = "yield_on_tool"
+              ; detail = "tool_failure_judge requires yield_on_tool = true"
+              }))
+    else Ok ()
+;;
+
 let run_blocks ~sw ?clock ?on_yield ?on_resume agent user_blocks =
   match validate_user_input_blocks user_blocks with
   | Error _ as err -> err
   | Ok () ->
-    let last_activity = ref (now_or_zero clock) in
-    let on_activity () = last_activity := now_or_zero clock in
-    with_periodic_callbacks ~sw ?clock ~last_activity agent (fun ~sw ->
-      run_loop
-        ~sw
-        ?clock
-        ~api_strategy:Sync
-        ?on_yield
-        ?on_resume
-        ~on_activity
-        agent
-        user_blocks)
+    (match validate_run_recovery_config agent ~on_yield ~on_resume with
+     | Error _ as error -> error
+     | Ok () ->
+       let last_activity = ref (now_or_zero clock) in
+       let on_activity () = last_activity := now_or_zero clock in
+       with_periodic_callbacks ~sw ?clock ~last_activity agent (fun ~sw ->
+         run_loop
+           ~sw
+           ?clock
+           ~api_strategy:Sync
+           ?on_yield
+           ?on_resume
+           ~on_activity
+           agent
+           user_blocks))
 ;;
 
 let run ~sw ?clock ?on_yield ?on_resume agent user_prompt =
@@ -670,35 +942,38 @@ let run_stream_blocks ~sw ?clock ~on_event ?on_yield ?on_resume agent user_block
   match validate_user_input_blocks user_blocks with
   | Error _ as err -> err
   | Ok () ->
-    let on_telemetry =
-      Option.map
-        (fun bus -> Telemetry_bus.publish (Telemetry_bus.of_event_bus bus))
-        agent.options.event_bus
-    in
-    let last_activity = ref (now_or_zero clock) in
-    let on_activity () = last_activity := now_or_zero clock in
-    (* Every streamed event — including reasoning/thinking deltas, which
+    (match validate_run_recovery_config agent ~on_yield ~on_resume with
+     | Error _ as error -> error
+     | Ok () ->
+       let on_telemetry =
+         Option.map
+           (fun bus -> Telemetry_bus.publish (Telemetry_bus.of_event_bus bus))
+           agent.options.event_bus
+       in
+       let last_activity = ref (now_or_zero clock) in
+       let on_activity () = last_activity := now_or_zero clock in
+       (* Every streamed event — including reasoning/thinking deltas, which
        reach [on_event] as [ContentBlockDelta { delta = ThinkingDelta _ }]
        (see Llm_provider.Streaming.openai_chunk_to_events) — counts as
        progress, so a long reasoning burst keeps the idle watchdog from
        firing. [caller_on_event] is the original callback (bound under a
        distinct name so the wrapper is not misread as self-recursion); it
        runs after the activity bump. *)
-    let caller_on_event = on_event in
-    let on_event ev =
-      on_activity ();
-      protect_stream_callback caller_on_event ev
-    in
-    with_periodic_callbacks ~sw ?clock ~last_activity agent (fun ~sw ->
-      run_loop
-        ~sw
-        ?clock
-        ~api_strategy:(Stream { on_event; on_telemetry })
-        ?on_yield
-        ?on_resume
-        ~on_activity
-        agent
-        user_blocks)
+       let caller_on_event = on_event in
+       let on_event ev =
+         on_activity ();
+         protect_stream_callback caller_on_event ev
+       in
+       with_periodic_callbacks ~sw ?clock ~last_activity agent (fun ~sw ->
+         run_loop
+           ~sw
+           ?clock
+           ~api_strategy:(Stream { on_event; on_telemetry })
+           ?on_yield
+           ?on_resume
+           ~on_activity
+           agent
+           user_blocks))
 ;;
 
 let run_stream ~sw ?clock ~on_event ?on_yield ?on_resume agent user_prompt =
@@ -722,105 +997,42 @@ let run_with_handoffs_blocks ~sw ?clock agent ~targets user_blocks =
     with_raw_trace_run agent_with_handoffs trace_prompt
     @@ fun raw_trace_run ->
     let rec loop () =
-      match check_loop_guard agent_with_handoffs with
-      | Some err -> Error err
-      | None ->
-        (match run_turn_with_trace ~sw ?clock ?raw_trace_run agent_with_handoffs with
-         | Error e -> Error e
-         | Ok (`Complete response) -> Ok response
-         | Ok `ToolsExecuted ->
-           (match find_handoff_in_messages agent_with_handoffs.state.messages with
-            | Some (tool_id, target_name, prompt) ->
-              let target_opt =
-                List.find_opt
-                  (fun (t : Handoff.handoff_target) -> t.name = target_name)
-                  targets
+      match resolve_pending_recovery ~sw ?clock agent_with_handoffs with
+      | Error error -> Error error
+      | Ok () ->
+        (match check_loop_guard agent_with_handoffs with
+         | Some err -> Error err
+         | None ->
+           let* recovery_context = recovery_context_for_turn agent_with_handoffs in
+           (match
+              run_turn_core
+                ~sw
+                ?clock
+                ~api_strategy:Sync
+                ?raw_trace_run
+                ?recovery_context
+                agent_with_handoffs
+            with
+            | Error e -> Error e
+            | Ok (`Complete response) -> Ok response
+            | Ok (`ToolsExecuted completed_round) ->
+              let* () =
+                match completed_round with
+                | None -> Ok ()
+                | Some current ->
+                  register_completed_tool_round agent_with_handoffs current
               in
-              (match target_opt with
-               | None ->
-                 let err_msg = Printf.sprintf "Unknown handoff target: %s" target_name in
-                 update_state agent_with_handoffs (fun s ->
-                   { s with
-                     messages =
-                       replace_tool_result
-                         s.messages
-                         ~tool_id
-                         ~content:err_msg
-                         ~is_error:true
-                   });
-                 loop ()
-               | Some target ->
-                 let from_name = agent_with_handoffs.state.config.name in
-                 (* HandoffRequested: capture the run_id so HandoffCompleted
-                    can record it as [caused_by], preserving the
-                    request -> completion causation chain (#877). *)
-                 let handoff_requested_run_id =
-                   match agent_with_handoffs.options.event_bus with
-                   | Some bus ->
-                     let run_id = Event_bus.fresh_id () in
-                     (try
-                        Event_bus.publish
-                          bus
-                          (Event_bus.mk_event
-                             ~run_id
-                             (HandoffRequested
-                                { from_agent = from_name
-                                ; to_agent = target.name
-                                ; reason = prompt
-                                }))
-                      with
-                      | Eio.Cancel.Cancelled _ as exn -> raise exn
-                      | exn ->
-                        Log.warn
-                          _log
-                          "Event_bus.publish failed (HandoffRequested)"
-                          [ Log.S ("error", Printexc.to_string exn) ]);
-                     Some run_id
-                   | None -> None
+              (match find_handoff_in_messages agent_with_handoffs.state.messages with
+               | Some (tool_id, target_name, prompt) ->
+                 let target_opt =
+                   List.find_opt
+                     (fun (t : Handoff.handoff_target) -> t.name = target_name)
+                     targets
                  in
-                 let handoff_t0 = Unix.gettimeofday () in
-                 let sub =
-                   create
-                     ~net:agent.net
-                     ~config:target.config
-                     ~tools:target.tools
-                     ~options:
-                       { default_options with
-                         base_url = agent.options.base_url
-                       ; provider = agent.options.provider
-                       ; policy_channel = agent.options.policy_channel
-                       }
-                     ()
-                 in
-                 let sub_result = run ~sw ?clock sub prompt in
-                 let handoff_elapsed = Unix.gettimeofday () -. handoff_t0 in
-                 (match agent_with_handoffs.options.event_bus with
-                  | Some bus ->
-                    (try
-                       Event_bus.publish
-                         bus
-                         (Event_bus.mk_event
-                            ?caused_by:handoff_requested_run_id
-                            (HandoffCompleted
-                               { from_agent = from_name
-                               ; to_agent = target.name
-                               ; elapsed = handoff_elapsed
-                               }))
-                     with
-                     | Eio.Cancel.Cancelled _ as exn -> raise exn
-                     | exn ->
-                       Log.warn
-                         _log
-                         "Event_bus.publish failed (HandoffCompleted)"
-                         [ Log.S ("error", Printexc.to_string exn) ])
-                  | None -> ());
-                 (match sub_result with
-                  | Error e ->
+                 (match target_opt with
+                  | None ->
                     let err_msg =
-                      Printf.sprintf
-                        "Handoff to %s failed: %s"
-                        target_name
-                        (Error.to_string e)
+                      Printf.sprintf "Unknown handoff target: %s" target_name
                     in
                     update_state agent_with_handoffs (fun s ->
                       { s with
@@ -832,27 +1044,110 @@ let run_with_handoffs_blocks ~sw ?clock agent ~targets user_blocks =
                             ~is_error:true
                       });
                     loop ()
-                  | Ok sub_response ->
-                    let text =
-                      List.fold_left
-                        (fun acc block ->
-                           match block with
-                           | Text s -> if acc = "" then s else acc ^ "\n" ^ s
-                           | _ -> acc)
-                        ""
-                        sub_response.content
+                  | Some target ->
+                    let from_name = agent_with_handoffs.state.config.name in
+                    (* HandoffRequested: capture the run_id so HandoffCompleted
+                    can record it as [caused_by], preserving the
+                    request -> completion causation chain (#877). *)
+                    let handoff_requested_run_id =
+                      match agent_with_handoffs.options.event_bus with
+                      | Some bus ->
+                        let run_id = Event_bus.fresh_id () in
+                        (try
+                           Event_bus.publish
+                             bus
+                             (Event_bus.mk_event
+                                ~run_id
+                                (HandoffRequested
+                                   { from_agent = from_name
+                                   ; to_agent = target.name
+                                   ; reason = prompt
+                                   }))
+                         with
+                         | Eio.Cancel.Cancelled _ as exn -> raise exn
+                         | exn ->
+                           Log.warn
+                             _log
+                             "Event_bus.publish failed (HandoffRequested)"
+                             [ Log.S ("error", Printexc.to_string exn) ]);
+                        Some run_id
+                      | None -> None
                     in
-                    update_state agent_with_handoffs (fun s ->
-                      { s with
-                        messages =
-                          replace_tool_result
-                            s.messages
-                            ~tool_id
-                            ~content:text
-                            ~is_error:false
-                      });
-                    loop ()))
-            | None -> loop ()))
+                    let handoff_t0 = Unix.gettimeofday () in
+                    let sub =
+                      create
+                        ~net:agent.net
+                        ~config:target.config
+                        ~tools:target.tools
+                        ~options:
+                          { default_options with
+                            base_url = agent.options.base_url
+                          ; provider = agent.options.provider
+                          ; policy_channel = agent.options.policy_channel
+                          }
+                        ()
+                    in
+                    let sub_result = run ~sw ?clock sub prompt in
+                    let handoff_elapsed = Unix.gettimeofday () -. handoff_t0 in
+                    (match agent_with_handoffs.options.event_bus with
+                     | Some bus ->
+                       (try
+                          Event_bus.publish
+                            bus
+                            (Event_bus.mk_event
+                               ?caused_by:handoff_requested_run_id
+                               (HandoffCompleted
+                                  { from_agent = from_name
+                                  ; to_agent = target.name
+                                  ; elapsed = handoff_elapsed
+                                  }))
+                        with
+                        | Eio.Cancel.Cancelled _ as exn -> raise exn
+                        | exn ->
+                          Log.warn
+                            _log
+                            "Event_bus.publish failed (HandoffCompleted)"
+                            [ Log.S ("error", Printexc.to_string exn) ])
+                     | None -> ());
+                    (match sub_result with
+                     | Error e ->
+                       let err_msg =
+                         Printf.sprintf
+                           "Handoff to %s failed: %s"
+                           target_name
+                           (Error.to_string e)
+                       in
+                       update_state agent_with_handoffs (fun s ->
+                         { s with
+                           messages =
+                             replace_tool_result
+                               s.messages
+                               ~tool_id
+                               ~content:err_msg
+                               ~is_error:true
+                         });
+                       loop ()
+                     | Ok sub_response ->
+                       let text =
+                         List.fold_left
+                           (fun acc block ->
+                              match block with
+                              | Text s -> if acc = "" then s else acc ^ "\n" ^ s
+                              | _ -> acc)
+                           ""
+                           sub_response.content
+                       in
+                       update_state agent_with_handoffs (fun s ->
+                         { s with
+                           messages =
+                             replace_tool_result
+                               s.messages
+                               ~tool_id
+                               ~content:text
+                               ~is_error:false
+                         });
+                       loop ()))
+               | None -> loop ())))
     in
     loop ()
 ;;
@@ -863,6 +1158,62 @@ let run_with_handoffs ~sw ?clock agent ~targets user_prompt =
 
 (* ── Checkpoint / Resume ─────────────────────────────────────── *)
 
+let restore_tool_failure_recovery messages =
+  let fail detail =
+    { empty_recovery_state with
+      restore_error = Some (recovery_failure Error.Resume_restore detail)
+    }
+  in
+  let project exchange =
+    Tool_failure_episode.project
+      ~tool_uses:exchange.Llm_provider.Tool_message_pairs.tool_uses
+      ~tool_results:exchange.tool_results
+  in
+  let exchanges =
+    Llm_provider.Tool_message_pairs.latest_tool_exchanges ~count:2 messages
+  in
+  match exchanges with
+  | [] ->
+    (match Tool_failure_recovery.latest_receipt messages with
+     | Ok None -> empty_recovery_state
+     | Ok (Some _) -> fail "recovery receipt exists without a tool exchange"
+     | Error error -> fail (Tool_failure_recovery.show_receipt_error error))
+  | current_exchange :: rest ->
+    (match project current_exchange with
+     | Error error -> fail (Tool_failure_episode.show_error error)
+     | Ok current ->
+       let episodes =
+         match rest with
+         | [] -> Ok []
+         | previous_exchange :: _ ->
+           (match project previous_exchange with
+            | Error error -> Error (Tool_failure_episode.show_error error)
+            | Ok previous ->
+              (match Tool_failure_episode.detect ~previous ~current with
+               | Ok episodes -> Ok episodes
+               | Error error -> Error (Tool_failure_episode.show_error error)))
+       in
+       (match episodes with
+        | Error detail -> fail detail
+        | Ok episodes ->
+          (match Tool_failure_recovery.latest_receipt messages with
+           | Error error -> fail (Tool_failure_recovery.show_receipt_error error)
+           | Ok receipt ->
+             let validation =
+               match receipt with
+               | None -> Ok ()
+               | Some receipt -> Tool_failure_recovery.validate_receipt ~episodes receipt
+             in
+             (match validation with
+              | Error error -> fail (Tool_failure_recovery.show_receipt_error error)
+              | Ok () ->
+                { last_completed_round = Some current
+                ; pending_episodes = (if episodes = [] then None else Some episodes)
+                ; pending_receipt = receipt
+                ; restore_error = None
+                }))))
+;;
+
 let resume
       ~net
       ~(checkpoint : Checkpoint.t)
@@ -870,6 +1221,7 @@ let resume
       ?context
       ?(options = default_options)
       ?checkpoint_sink
+      ?tool_failure_judge
       ?config
       ?(auto_context_overflow_retry = true)
       ()
@@ -903,6 +1255,11 @@ let resume
   ; context = ctx
   ; options
   ; checkpoint_sink
+  ; tool_failure_judge
+  ; recovery_state =
+      (match tool_failure_judge with
+       | None -> empty_recovery_state
+       | Some _ -> restore_tool_failure_recovery state.messages)
   }
 ;;
 
@@ -933,7 +1290,25 @@ let run_turn_stream ~sw ?clock ~on_event ?on_telemetry agent =
     protect_stream_callback caller_on_event ev
   in
   with_optional_timeout ?clock ~last_activity agent (fun ~sw ->
-    run_turn_core ~sw ?clock ~api_strategy:(Stream { on_event; on_telemetry }) agent)
+    let* () = resolve_pending_recovery ~sw ?clock agent in
+    let* recovery_context = recovery_context_for_turn agent in
+    match
+      run_turn_core
+        ~sw
+        ?clock
+        ~api_strategy:(Stream { on_event; on_telemetry })
+        ?recovery_context
+        agent
+    with
+    | Ok (`Complete response) -> Ok (`Complete response)
+    | Error error -> Error error
+    | Ok (`ToolsExecuted completed_round) ->
+      let* () =
+        match completed_round with
+        | None -> Ok ()
+        | Some current -> register_completed_tool_round agent current
+      in
+      Ok `ToolsExecuted)
 ;;
 
 let save_journal agent path =

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -115,7 +115,11 @@ val sdk_version : string
     live agent state and emitting completion/journal transitions, then
     commits the same turn delta after the sink succeeds.  The sink is
     passed here rather than through {!options} so callers that construct
-    options records remain source-compatible. *)
+    options records remain source-compatible.
+
+    [tool_failure_judge] installs the LLM boundary used after two adjacent
+    typed failed-tool rounds. It is attached outside [options] for the same
+    record-compatibility reason and must be reattached on {!resume}. *)
 val create
   :  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> ?config:Types.agent_config
@@ -124,6 +128,7 @@ val create
   -> ?options:options
   -> ?auto_context_overflow_retry:bool
   -> ?checkpoint_sink:checkpoint_sink
+  -> ?tool_failure_judge:Tool_failure_recovery.judge
   -> unit
   -> t
 
@@ -240,6 +245,7 @@ val resume
   -> ?context:Context.t
   -> ?options:options
   -> ?checkpoint_sink:checkpoint_sink
+  -> ?tool_failure_judge:Tool_failure_recovery.judge
   -> ?config:Types.agent_config
   -> ?auto_context_overflow_retry:bool
   -> unit

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -27,6 +27,21 @@ type checkpoint_snapshot =
 
 type checkpoint_sink = checkpoint_snapshot -> (unit, string) result
 
+type recovery_state =
+  { last_completed_round : Tool_failure_episode.completed_round option
+  ; pending_episodes : Tool_failure_episode.t list option
+  ; pending_receipt : Tool_failure_recovery.receipt option
+  ; restore_error : Error.sdk_error option
+  }
+
+let empty_recovery_state =
+  { last_completed_round = None
+  ; pending_episodes = None
+  ; pending_receipt = None
+  ; restore_error = None
+  }
+;;
+
 type options =
   { base_url : string
   ; provider : Provider.config option
@@ -206,6 +221,8 @@ type t =
   ; context : Context.t
   ; options : options
   ; checkpoint_sink : checkpoint_sink option
+  ; tool_failure_judge : Tool_failure_recovery.judge option
+  ; mutable recovery_state : recovery_state
   }
 
 (* Public accessors — .mli exposes Agent.t as abstract *)
@@ -227,6 +244,16 @@ let set_state t s = Eio.Mutex.use_rw ~protect:true t.mu (fun () -> t.state <- s)
     inside a single critical section so no concurrent update is lost. *)
 let update_state t f =
   Eio.Mutex.use_rw ~protect:true t.mu (fun () -> t.state <- f t.state)
+;;
+
+let recovery_state t = Eio.Mutex.use_ro t.mu (fun () -> t.recovery_state)
+
+let set_recovery_state t recovery_state =
+  Eio.Mutex.use_rw ~protect:true t.mu (fun () -> t.recovery_state <- recovery_state)
+;;
+
+let update_recovery_state t f =
+  Eio.Mutex.use_rw ~protect:true t.mu (fun () -> t.recovery_state <- f t.recovery_state)
 ;;
 
 let set_consecutive_idle_turns t n =
@@ -357,6 +384,7 @@ let create
       ?(options = default_options)
       ?(auto_context_overflow_retry = true)
       ?checkpoint_sink
+      ?tool_failure_judge
       ()
   =
   let mcp_tools =
@@ -382,6 +410,8 @@ let create
   ; context = ctx
   ; options
   ; checkpoint_sink
+  ; tool_failure_judge
+  ; recovery_state = empty_recovery_state
   }
 ;;
 
@@ -405,6 +435,8 @@ let clone ?(copy_context = false) agent =
   ; context = ctx
   ; options = agent.options
   ; checkpoint_sink = agent.checkpoint_sink
+  ; tool_failure_judge = agent.tool_failure_judge
+  ; recovery_state = agent.recovery_state
   }
 ;;
 

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -30,6 +30,15 @@ type checkpoint_snapshot =
 
 type checkpoint_sink = checkpoint_snapshot -> (unit, string) result
 
+type recovery_state =
+  { last_completed_round : Tool_failure_episode.completed_round option
+  ; pending_episodes : Tool_failure_episode.t list option
+  ; pending_receipt : Tool_failure_recovery.receipt option
+  ; restore_error : Error.sdk_error option
+  }
+
+val empty_recovery_state : recovery_state
+
 type options =
   { base_url : string
   ; provider : Provider.config option
@@ -250,6 +259,8 @@ type t =
   ; context : Context.t
   ; options : options
   ; checkpoint_sink : checkpoint_sink option
+  ; tool_failure_judge : Tool_failure_recovery.judge option
+  ; mutable recovery_state : recovery_state
   }
 
 (** {1 Defaults} *)
@@ -266,6 +277,9 @@ val options : t -> options
 val net : t -> [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
 val set_state : t -> Types.agent_state -> unit
 val update_state : t -> (Types.agent_state -> Types.agent_state) -> unit
+val recovery_state : t -> recovery_state
+val set_recovery_state : t -> recovery_state -> unit
+val update_recovery_state : t -> (recovery_state -> recovery_state) -> unit
 val set_consecutive_idle_turns : t -> int -> unit
 val get_consecutive_idle_turns : t -> int
 
@@ -296,6 +310,7 @@ val create
   -> ?options:options
   -> ?auto_context_overflow_retry:bool
   -> ?checkpoint_sink:checkpoint_sink
+  -> ?tool_failure_judge:Tool_failure_recovery.judge
   -> unit
   -> t
 

--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -71,6 +71,7 @@ type t =
   ; tool_result_relocation : (Tool_result_store.t * Content_replacement_state.t) option
   ; journal : Durable_event.journal option
   ; checkpoint_sink : Agent.checkpoint_sink option
+  ; tool_failure_judge : Tool_failure_recovery.judge option
   ; policy_channel : Policy_channel.t option
   ; summarizer : (Types.message list -> string) option
   ; transport : Llm_provider.Llm_transport.t option
@@ -151,6 +152,7 @@ let create ~net ~model =
   ; tool_result_relocation = None
   ; journal = None
   ; checkpoint_sink = None
+  ; tool_failure_judge = None
   ; policy_channel = None
   ; summarizer = None
   ; transport = None
@@ -166,6 +168,10 @@ let with_journal journal b = { b with journal = Some journal }
 
 let with_checkpoint_sink checkpoint_sink b =
   { b with checkpoint_sink = Some checkpoint_sink }
+;;
+
+let with_tool_failure_judge tool_failure_judge b =
+  { b with tool_failure_judge = Some tool_failure_judge }
 ;;
 
 (** Override the Budget_strategy Emergency-phase summarizer with a
@@ -471,6 +477,7 @@ let build b =
     ~options
     ~auto_context_overflow_retry:b.auto_context_overflow_retry
     ?checkpoint_sink:b.checkpoint_sink
+    ?tool_failure_judge:b.tool_failure_judge
     ()
 ;;
 

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -354,6 +354,11 @@ val with_journal : Durable_event.journal -> t -> t
     @since 0.193.9 *)
 val with_checkpoint_sink : Agent.checkpoint_sink -> t -> t
 
+(** Install the LLM judge used for adjacent typed failed-tool recovery.
+    [with_yield_on_tool true] is required so the main provider lease is not held
+    while the judge completion is waiting. *)
+val with_tool_failure_judge : Tool_failure_recovery.judge -> t -> t
+
 (** Override the Budget_strategy Emergency-phase summarizer with a
     domain-aware function.  Routed into [Agent.options.summarizer] and
     forwarded to {!Budget_strategy.reduce_for_budget} when compaction

--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -99,6 +99,7 @@ module Agent_turn = Agent_turn
 module Agent_handoff = Agent_handoff
 module Agent_tools = Agent_tools
 module Tool_failure_episode = Tool_failure_episode
+module Tool_failure_recovery = Tool_failure_recovery
 module Agent_tool_name_alias = Agent_tool_name_alias
 module Agent_checkpoint = Agent_checkpoint
 module Agent_turn_budget = Agent_turn_budget
@@ -194,6 +195,7 @@ let create_agent
       ?cache_system_prompt
       ?provider
       ?raw_trace
+      ?tool_failure_judge
       ()
   =
   let open Types in
@@ -237,7 +239,7 @@ let create_agent
     | Some p, Some trace ->
       { Agent.default_options with provider = Some p; raw_trace = Some trace }
   in
-  Agent.create ~net ~config ~options ()
+  Agent.create ~net ~config ~options ?tool_failure_judge ()
 ;;
 
 (* runtime_query/query removed — CLI Runtime purge *)

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -71,6 +71,7 @@ module Agent_turn = Agent_turn
 module Agent_handoff = Agent_handoff
 module Agent_tools = Agent_tools
 module Tool_failure_episode = Tool_failure_episode
+module Tool_failure_recovery = Tool_failure_recovery
 module Agent_tool_name_alias = Agent_tool_name_alias
 module Agent_checkpoint = Agent_checkpoint
 module Agent_turn_budget = Agent_turn_budget
@@ -169,6 +170,7 @@ val create_agent
   -> ?cache_system_prompt:bool
   -> ?provider:Provider.config
   -> ?raw_trace:Raw_trace.t
+  -> ?tool_failure_judge:Tool_failure_recovery.judge
   -> unit
   -> Agent.t
 

--- a/lib/agent_typed.ml
+++ b/lib/agent_typed.ml
@@ -12,8 +12,17 @@ type completed
    OCaml's type system enforces state transitions at compile time. *)
 type _ t = T : Agent.t -> _ t
 
-let create ~net ?config ?tools ?context ?options ?checkpoint_sink () =
-  T (Agent.create ~net ?config ?tools ?context ?options ?checkpoint_sink ())
+let create ~net ?config ?tools ?context ?options ?checkpoint_sink ?tool_failure_judge () =
+  T
+    (Agent.create
+       ~net
+       ?config
+       ?tools
+       ?context
+       ?options
+       ?checkpoint_sink
+       ?tool_failure_judge
+       ())
 ;;
 
 let run ~sw ?clock (T agent) prompt =

--- a/lib/agent_typed.mli
+++ b/lib/agent_typed.mli
@@ -39,6 +39,7 @@ val create
   -> ?context:Context.t
   -> ?options:Agent.options
   -> ?checkpoint_sink:Agent.checkpoint_sink
+  -> ?tool_failure_judge:Tool_failure_recovery.judge
   -> unit
   -> created t
 

--- a/lib/base/error.ml
+++ b/lib/base/error.ml
@@ -26,6 +26,13 @@ type input_required =
   ; created_at : float
   }
 
+type tool_failure_recovery_stage =
+  | Round_projection
+  | Episode_detection
+  | Judge_response
+  | Decision_persistence
+  | Resume_restore
+
 (** Agent runtime errors. *)
 type agent_error =
   | MaxTurnsExceeded of
@@ -64,6 +71,14 @@ type agent_error =
       ; reason : string
       }
   | InputRequired of input_required
+  | ToolFailureRecoveryFailed of
+      { stage : tool_failure_recovery_stage
+      ; detail : string
+      }
+  | ToolFailureRecoveryDeferred of
+      { reason : string
+      ; tool_names : string list
+      }
   | ExitConditionMet of { turn : int }
 
 (** MCP client errors. *)
@@ -172,6 +187,22 @@ let agent_error_to_string = function
        | None -> "")
       r.question
       r.request_id
+  | ToolFailureRecoveryFailed r ->
+    let stage =
+      match r.stage with
+      | Round_projection -> "round_projection"
+      | Episode_detection -> "episode_detection"
+      | Judge_response -> "judge_response"
+      | Decision_persistence -> "decision_persistence"
+      | Resume_restore -> "resume_restore"
+    in
+    Printf.sprintf "Tool failure recovery failed at %s: %s" stage r.detail
+  | ToolFailureRecoveryDeferred r ->
+    let tools = String.concat ", " r.tool_names in
+    Printf.sprintf
+      "Tool failure recovery deferred%s: %s"
+      (if String.equal tools "" then "" else Printf.sprintf " for %s" tools)
+      r.reason
   | ExitConditionMet r -> Printf.sprintf "Exit condition met at turn %d" r.turn
 ;;
 

--- a/lib/base/error.mli
+++ b/lib/base/error.mli
@@ -26,6 +26,13 @@ type input_required =
   ; created_at : float
   }
 
+type tool_failure_recovery_stage =
+  | Round_projection
+  | Episode_detection
+  | Judge_response
+  | Decision_persistence
+  | Resume_restore
+
 type agent_error =
   | MaxTurnsExceeded of
       { turns : int
@@ -63,6 +70,14 @@ type agent_error =
       ; reason : string
       }
   | InputRequired of input_required
+  | ToolFailureRecoveryFailed of
+      { stage : tool_failure_recovery_stage
+      ; detail : string
+      }
+  | ToolFailureRecoveryDeferred of
+      { reason : string
+      ; tool_names : string list
+      }
   | ExitConditionMet of { turn : int }
 
 type mcp_error =

--- a/lib/error_domain.ml
+++ b/lib/error_domain.ml
@@ -3,6 +3,13 @@
 module Retry = Llm_provider.Retry
 module Http_client = Llm_provider.Http_client
 
+type tool_failure_recovery_stage = Error.tool_failure_recovery_stage =
+  | Round_projection
+  | Episode_detection
+  | Judge_response
+  | Decision_persistence
+  | Resume_restore
+
 type provider_error =
   [ `Rate_limited of float option
   | `Auth_error of string
@@ -31,6 +38,8 @@ type agent_error =
   | `Guardrail_violation of string * string
   | `Tripwire_violation of string * string
   | `Input_required of string * string
+  | `Tool_failure_recovery_failed of tool_failure_recovery_stage * string
+  | `Tool_failure_recovery_deferred of string * string list
   | `Unrecognized_stop_reason of string
   | `Exit_condition_met of int
   ]
@@ -138,6 +147,10 @@ let of_sdk_error (err : Error.sdk_error) : sdk_error_poly =
   | Error.Agent (GuardrailViolation r) -> `Guardrail_violation (r.validator, r.reason)
   | Error.Agent (TripwireViolation r) -> `Tripwire_violation (r.tripwire, r.reason)
   | Error.Agent (InputRequired r) -> `Input_required (r.request_id, r.question)
+  | Error.Agent (ToolFailureRecoveryFailed r) ->
+    `Tool_failure_recovery_failed (r.stage, r.detail)
+  | Error.Agent (ToolFailureRecoveryDeferred r) ->
+    `Tool_failure_recovery_deferred (r.reason, r.tool_names)
   | Error.Agent (UnrecognizedStopReason r) -> `Unrecognized_stop_reason r.reason
   | Error.Agent (ExitConditionMet r) -> `Exit_condition_met r.turn
   | Error.Config (MissingEnvVar r) -> `Missing_env_var r.var_name
@@ -204,6 +217,10 @@ let to_sdk_error (err : sdk_error_poly) : Error.sdk_error =
          ; timeout_s = None
          ; created_at = Unix.gettimeofday ()
          })
+  | `Tool_failure_recovery_failed (stage, detail) ->
+    Error.Agent (ToolFailureRecoveryFailed { stage; detail })
+  | `Tool_failure_recovery_deferred (reason, tool_names) ->
+    Error.Agent (ToolFailureRecoveryDeferred { reason; tool_names })
   | `Unrecognized_stop_reason reason -> Error.Agent (UnrecognizedStopReason { reason })
   | `Exit_condition_met turn -> Error.Agent (ExitConditionMet { turn })
   | `Missing_env_var var -> Error.Config (MissingEnvVar { var_name = var })

--- a/lib/error_domain.ml
+++ b/lib/error_domain.ml
@@ -296,6 +296,8 @@ let is_retryable (err : [< sdk_error_poly ]) : bool =
   | `Guardrail_violation _
   | `Tripwire_violation _
   | `Input_required _
+  | `Tool_failure_recovery_failed _
+  | `Tool_failure_recovery_deferred _
   | `Unrecognized_stop_reason _
   | `Exit_condition_met _
   | `Missing_env_var _

--- a/lib/error_domain.mli
+++ b/lib/error_domain.mli
@@ -47,6 +47,13 @@ type tool_error =
 
 (** {1 Agent errors} *)
 
+type tool_failure_recovery_stage = Error.tool_failure_recovery_stage =
+  | Round_projection
+  | Episode_detection
+  | Judge_response
+  | Decision_persistence
+  | Resume_restore
+
 type agent_error =
   [ `Max_turns_exceeded of int * int (** turns, limit *)
   | `Idle_detected of int (** consecutive_idle_turns *)
@@ -57,6 +64,8 @@ type agent_error =
   | `Guardrail_violation of string * string (** validator, reason *)
   | `Tripwire_violation of string * string (** tripwire, reason *)
   | `Input_required of string * string (** request_id, question *)
+  | `Tool_failure_recovery_failed of tool_failure_recovery_stage * string
+  | `Tool_failure_recovery_deferred of string * string list
   | `Unrecognized_stop_reason of string
   | `Exit_condition_met of int (** turn at which exit condition triggered *)
   ]

--- a/lib/eval_collector.ml
+++ b/lib/eval_collector.ml
@@ -82,6 +82,9 @@ let process_events t =
        (* Lifecycle events — observed but not metered here.
        Downstream consumers can subscribe for richer metrics. *)
        | AgentStarted _
+       | ToolFailureEpisodeDetected _
+       | ToolFailureRecoveryDecided _
+       | ToolFailureRecoveryJudgeFailed _
        | TurnReady _
        | TurnCompleted _
        | HandoffRequested _

--- a/lib/event_bus.ml
+++ b/lib/event_bus.ml
@@ -58,6 +58,21 @@ type payload =
       ; output : Types.tool_result
       ; turn : int
       }
+  | ToolFailureEpisodeDetected of
+      { agent_name : string
+      ; turn : int
+      ; episodes : Tool_failure_episode.t list
+      }
+  | ToolFailureRecoveryDecided of
+      { agent_name : string
+      ; turn : int
+      ; decision : Tool_failure_recovery.decision
+      }
+  | ToolFailureRecoveryJudgeFailed of
+      { agent_name : string
+      ; turn : int
+      ; detail : string
+      }
   | TurnStarted of
       { agent_name : string
       ; turn : int
@@ -153,6 +168,9 @@ let payload_kind = function
   | AgentFailed _ -> "agent_failed"
   | ToolCalled _ -> "tool_called"
   | ToolCompleted _ -> "tool_completed"
+  | ToolFailureEpisodeDetected _ -> "tool_failure_episode_detected"
+  | ToolFailureRecoveryDecided _ -> "tool_failure_recovery_decided"
+  | ToolFailureRecoveryJudgeFailed _ -> "tool_failure_recovery_judge_failed"
   | TurnStarted _ -> "turn_started"
   | TurnReady _ -> "turn_ready"
   | TurnCompleted _ -> "turn_completed"
@@ -287,6 +305,9 @@ let filter_agent name : filter =
   | AgentFailed r -> r.agent_name = name
   | ToolCalled r -> r.agent_name = name
   | ToolCompleted r -> r.agent_name = name
+  | ToolFailureEpisodeDetected r -> r.agent_name = name
+  | ToolFailureRecoveryDecided r -> r.agent_name = name
+  | ToolFailureRecoveryJudgeFailed r -> r.agent_name = name
   | TurnStarted r -> r.agent_name = name
   | TurnReady r -> r.agent_name = name
   | TurnCompleted r -> r.agent_name = name
@@ -305,7 +326,11 @@ let filter_agent name : filter =
 let filter_tools_only : filter =
   fun event ->
   match event.payload with
-  | ToolCalled _ | ToolCompleted _ -> true
+  | ToolCalled _
+  | ToolCompleted _
+  | ToolFailureEpisodeDetected _
+  | ToolFailureRecoveryDecided _
+  | ToolFailureRecoveryJudgeFailed _ -> true
   | _ -> false
 ;;
 

--- a/lib/event_bus.mli
+++ b/lib/event_bus.mli
@@ -93,6 +93,21 @@ type payload =
         (** Same turn index as the matching [ToolCalled]. See its doc.
             @since 0.207.0 (#SSOT-DRIFT-REMEDIATION) *)
       }
+  | ToolFailureEpisodeDetected of
+      { agent_name : string
+      ; turn : int
+      ; episodes : Tool_failure_episode.t list
+      }
+  | ToolFailureRecoveryDecided of
+      { agent_name : string
+      ; turn : int
+      ; decision : Tool_failure_recovery.decision
+      }
+  | ToolFailureRecoveryJudgeFailed of
+      { agent_name : string
+      ; turn : int
+      ; detail : string
+      }
   | TurnStarted of
       { agent_name : string
       ; turn : int

--- a/lib/event_forward.ml
+++ b/lib/event_forward.ml
@@ -58,6 +58,9 @@ let event_type_name (event : Event_bus.event) : string =
   | AgentFailed _ -> "agent.failed"
   | ToolCalled _ -> "tool.called"
   | ToolCompleted _ -> "tool.completed"
+  | ToolFailureEpisodeDetected _ -> "tool_failure.episode_detected"
+  | ToolFailureRecoveryDecided _ -> "tool_failure.recovery_decided"
+  | ToolFailureRecoveryJudgeFailed _ -> "tool_failure.recovery_judge_failed"
   | TurnStarted _ -> "turn.started"
   | TurnReady _ -> "turn.ready"
   | TurnCompleted _ -> "turn.completed"
@@ -80,6 +83,9 @@ let agent_name_of_payload : Event_bus.payload -> string option = function
   | AgentFailed r -> Some r.agent_name
   | ToolCalled r -> Some r.agent_name
   | ToolCompleted r -> Some r.agent_name
+  | ToolFailureEpisodeDetected r -> Some r.agent_name
+  | ToolFailureRecoveryDecided r -> Some r.agent_name
+  | ToolFailureRecoveryJudgeFailed r -> Some r.agent_name
   | TurnStarted r -> Some r.agent_name
   | TurnReady r -> Some r.agent_name
   | TurnCompleted r -> Some r.agent_name
@@ -135,6 +141,24 @@ let event_to_payload (event : Event_bus.event) : event_payload =
         ; "tool_use_id", `String r.tool_use_id
         ; "success", `Bool (Result.is_ok r.output)
         ; "turn", `Int r.turn
+        ]
+    | ToolFailureEpisodeDetected r ->
+      `Assoc
+        [ "agent_name", `String r.agent_name
+        ; "turn", `Int r.turn
+        ; "episodes", `List (List.map Tool_failure_episode.to_yojson r.episodes)
+        ]
+    | ToolFailureRecoveryDecided r ->
+      `Assoc
+        [ "agent_name", `String r.agent_name
+        ; "turn", `Int r.turn
+        ; "decision", Tool_failure_recovery.decision_to_yojson r.decision
+        ]
+    | ToolFailureRecoveryJudgeFailed r ->
+      `Assoc
+        [ "agent_name", `String r.agent_name
+        ; "turn", `Int r.turn
+        ; "detail", `String r.detail
         ]
     | TurnStarted r -> `Assoc [ "agent_name", `String r.agent_name; "turn", `Int r.turn ]
     | TurnReady r ->

--- a/lib/llm_provider/tool_message_pairs.ml
+++ b/lib/llm_provider/tool_message_pairs.ml
@@ -14,6 +14,11 @@ type repair_report =
   ; synthesized_tool_result_ids : string list
   }
 
+type tool_exchange =
+  { tool_uses : content_block list
+  ; tool_results : content_block list
+  }
+
 let empty_repair_report = { dropped_tool_results = []; synthesized_tool_result_ids = [] }
 
 let normalize_report report =
@@ -82,6 +87,34 @@ let split_tool_result_span messages =
     | rest -> List.rev span, rest
   in
   loop [] messages
+;;
+
+let latest_tool_exchanges ~count messages =
+  if count < 0 then invalid_arg "latest_tool_exchanges: count must be >= 0";
+  let keep_latest exchanges =
+    let rec take remaining acc = function
+      | _ when remaining = 0 -> List.rev acc
+      | [] -> List.rev acc
+      | exchange :: rest -> take (remaining - 1) (exchange :: acc) rest
+    in
+    take count [] exchanges
+  in
+  let rec collect latest = function
+    | [] -> latest
+    | (message : message) :: rest ->
+      let uses = if message.role = Assistant then tool_uses message else [] in
+      if uses = []
+      then collect latest rest
+      else (
+        let result_span, tail = split_tool_result_span rest in
+        let exchange =
+          { tool_uses = message.content
+          ; tool_results = List.concat_map (fun result -> result.content) result_span
+          }
+        in
+        collect (keep_latest (exchange :: latest)) tail)
+  in
+  collect [] messages
 ;;
 
 let strip_orphaned_tool_results_with_report (messages : message list)

--- a/lib/llm_provider/tool_message_pairs.ml
+++ b/lib/llm_provider/tool_message_pairs.ml
@@ -109,7 +109,8 @@ let latest_tool_exchanges ~count messages =
         let result_span, tail = split_tool_result_span rest in
         let exchange =
           { tool_uses = message.content
-          ; tool_results = List.concat_map (fun result -> result.content) result_span
+          ; tool_results =
+              List.concat_map (fun (result : message) -> result.content) result_span
           }
         in
         collect (keep_latest (exchange :: latest)) tail)

--- a/lib/llm_provider/tool_message_pairs.mli
+++ b/lib/llm_provider/tool_message_pairs.mli
@@ -20,6 +20,21 @@ type repair_report =
   }
 
 val empty_repair_report : repair_report
+
+type tool_exchange =
+  { tool_uses : Types.content_block list
+  ; tool_results : Types.content_block list
+  }
+
+(** Return up to [count] latest assistant tool-use/result-span exchanges,
+    newest first. Result spans use the same immediate multi-message boundary as
+    provider pairing repair. An incomplete latest exchange is returned with an
+    empty [tool_results] list so callers can fail explicitly.
+
+    This is intended for one-time checkpoint restoration; live agent loops
+    should retain the typed completed-round projection incrementally. *)
+val latest_tool_exchanges : count:int -> Types.message list -> tool_exchange list
+
 val strip_orphaned_tool_results : Types.message list -> Types.message list
 
 val strip_orphaned_tool_results_with_report

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -92,47 +92,8 @@ type api_strategy =
 
 type turn_outcome =
   | Complete of Types.api_response
-  | ToolsExecuted
+  | ToolsExecuted of Tool_failure_episode.completed_round option
   | IdleSkipped
-
-let all_validation_error_results = function
-  | [] -> false
-  | results ->
-    List.for_all
-      (fun (result : Agent_tools.tool_execution_result) ->
-         result.is_error
-         &&
-         match result.failure_kind with
-         | Some Agent_tools.Validation_error -> true
-         | Some Agent_tools.Recoverable_tool_error
-         | Some Agent_tools.Non_retryable_tool_error
-         | None -> false)
-      results
-;;
-
-let validation_loop_blocked_text ~consecutive_idle_turns results =
-  let tool_names =
-    results
-    |> List.map (fun (result : Agent_tools.tool_execution_result) -> result.tool_name)
-    |> List.sort_uniq String.compare
-    |> String.concat ", "
-  in
-  let tool_names = if tool_names = "" then "(unknown)" else tool_names in
-  let last_error =
-    results
-    |> List.find_map (fun (result : Agent_tools.tool_execution_result) ->
-      if result.is_error then Some result.content else None)
-    |> Option.value ~default:"validation error"
-    |> fun s -> Util.clip s 700
-  in
-  Printf.sprintf
-    "I stopped the tool loop because the same invalid tool call was repeated after \
-     validation feedback. Tool(s): %s. Repeated invalid turn count: %d. Last validation \
-     error: %s"
-    tool_names
-    consecutive_idle_turns
-    last_error
-;;
 
 let persist_turn_checkpoint_for_state agent stage state =
   match agent.checkpoint_sink with
@@ -570,37 +531,13 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails ~response tool_uses
             update_state agent (fun s ->
               { s with messages = Util.snoc s.messages (make_message ~role:User content) });
             let* () = persist_turn_checkpoint agent After_tool_results_appended in
-            Ok ToolsExecuted
+            Ok (ToolsExecuted None)
           | false ->
             let results =
               try Ok (execute_tools_with_trace agent raw_trace_run tool_uses) with
               | Raw_trace.Trace_error err -> Error err
             in
             let* results = results in
-            let uses_default_idle_policy =
-              Option.is_none agent.options.hooks.on_idle
-              && Option.is_none agent.options.hooks.on_idle_escalated
-            in
-            let repeated_validation_loop_blocked =
-              idle_result.is_idle
-              && uses_default_idle_policy
-              && all_validation_error_results results
-            in
-            let validation_loop_blocked_response =
-              if repeated_validation_loop_blocked
-              then
-                Some
-                  { response with
-                    stop_reason = EndTurn
-                  ; content =
-                      [ Text
-                          (validation_loop_blocked_text
-                             ~consecutive_idle_turns:agent.consecutive_idle_turns
-                             results)
-                      ]
-                  }
-              else None
-            in
             let tool_result_event_envelope = Pipeline_common.event_envelope agent in
             let tool_results =
               Agent_turn.make_tool_results
@@ -610,92 +547,65 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails ~response tool_uses
                 ?relocation:agent.options.tool_result_relocation
                 results
             in
+            let completed_round =
+              match agent.tool_failure_judge with
+              | None -> Ok None
+              | Some _ ->
+                (match Tool_failure_episode.project ~tool_uses ~tool_results with
+                 | Ok round -> Ok (Some round)
+                 | Error error ->
+                   Error
+                     (Error.Agent
+                        (Error.ToolFailureRecoveryFailed
+                           { stage = Error.Round_projection
+                           ; detail = Tool_failure_episode.show_error error
+                           })))
+            in
             (* Persist CRS to context after tool result processing so that
             checkpoint captures the current replacement decisions. *)
             (match agent.options.tool_result_relocation with
              | Some (_, crs) ->
                Content_replacement_state.persist_to_context agent.context crs
              | None -> ());
-            (* Tool-call validation / recoverable errors usually flow back to
-              the model as is_error tool_results so it can self-correct on a
-              subsequent turn. A repeated identical validation-only tool call
-              under the default idle policy is terminalized below: it has
-              already received schema feedback and another provider round would
-              replay the same large context without executing useful work. *)
-            let tool_feedback = tool_results in
-            let followup_text =
-              match validation_loop_blocked_response, !pending_nudge with
-              | Some _, _ -> None
-              | None, Some nudge -> Some nudge
-              | None, None when idle_result.is_idle && not !idle_handled ->
-                Some
-                  (Printf.sprintf
-                     "[Idle warning: You called the same tool(s) with identical \
-                      arguments %d time(s) in a row. Try a different tool or change your \
-                      arguments to make progress.]"
-                     agent.consecutive_idle_turns)
-              | None, None -> None
-            in
-            update_state agent (fun s ->
+            let checkpoint_state =
+              let s = agent.state in
               let messages =
-                match tool_feedback with
+                match tool_results with
                 | [] -> s.messages
-                | _ -> Util.snoc s.messages (make_message ~role:Tool tool_feedback)
+                | _ -> Util.snoc s.messages (make_message ~role:Tool tool_results)
               in
               let messages =
-                match followup_text with
+                match !pending_nudge with
                 | None -> messages
                 | Some text -> Util.snoc messages (make_message ~role:User [ Text text ])
               in
-              { s with messages });
-            (match agent.options.context_injector with
-             | None -> ()
-             | Some injector ->
-               let new_messages =
-                 Agent_turn.apply_context_injection
-                   ~context:agent.context
-                   ~messages:agent.state.messages
-                   ~injector
-                   ~tool_uses
-                   ~results
-               in
-               update_state agent (fun s -> { s with messages = new_messages }));
-            (match validation_loop_blocked_response with
-             | None -> ()
-             | Some blocked_response ->
-               update_state agent (fun s ->
-                 { s with
-                   messages =
-                     Util.snoc
-                       s.messages
-                       (make_message ~role:Assistant blocked_response.content)
-                 }));
-            let* () = persist_turn_checkpoint agent After_tool_results_appended in
-            (* The idle nudge (and the fallback anti-repetition hint) is appended
-              as a separate role:User message after the role:Tool result message.
-              This keeps OpenAI-compatible serializers from placing user text
-              before the required tool replies, which strict providers reject. *)
+              let messages =
+                match agent.options.context_injector with
+                | None -> messages
+                | Some injector ->
+                  Agent_turn.apply_context_injection
+                    ~context:agent.context
+                    ~messages
+                    ~injector
+                    ~tool_uses
+                    ~results
+              in
+              { s with messages }
+            in
+            let* () =
+              persist_turn_checkpoint_for_state
+                agent
+                After_tool_results_appended
+                checkpoint_state
+            in
+            set_state agent checkpoint_state;
+            (* A caller-installed idle nudge remains an explicit policy hook and
+               is appended after ToolResult. The former default repeat-count
+               User warning and canned Assistant terminal response are removed;
+               typed recovery owns repeated failed-tool judgment. *)
             ignore idle_handled;
-            (* suppress unused warning after dedup *)
-            (match validation_loop_blocked_response with
-             | Some blocked_response ->
-               Agent_types.reset_idle_state agent;
-               Ok (Complete blocked_response)
-             | None ->
-               (* In-memory message hygiene after each tool execution round.
-            Without this, agent.state.messages grows unbounded across turns —
-            context_reducer only trims before API calls, not in the stored state.
-
-            Two-step pruning (Claude Code Tier 1 pattern):
-            1. Stub old tool results: keep 2 most recent in full, replace older
-               with short stubs. Tool results are the largest allocation source.
-            2. Hard message cap: keep last 100 messages. Prevents unbounded growth
-               in long-running agents (600+ turns). *)
-               (* Tool-result stubbing and message cap are now applied at call-time
-            in Agent_turn.prepare_messages, not here.  Keeping stored messages
-            unmodified preserves the byte-identical conversation prefix that
-            local LLM KV-cache (Ollama/llama.cpp) depends on for reuse. *)
-               Ok ToolsExecuted)))
+            let* completed_round = completed_round in
+            Ok (ToolsExecuted completed_round)))
 ;;
 
 (* ── Stage 6: Output ─────────────────────────────────────── *)
@@ -1035,7 +945,7 @@ let tag_error stage result =
     Error e
 ;;
 
-let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
+let run_turn ~sw ?clock ~api_strategy ?raw_trace_run ?recovery_context agent =
   (* Stage 1: Input *)
   let* () =
     Tracing.with_span
@@ -1060,7 +970,8 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
       ; extra = []
       ; links = []
       }
-      (fun _tracer -> stage_parse ?raw_trace_run ?clock agent |> tag_error "parse")
+      (fun _tracer ->
+         stage_parse ?raw_trace_run ?clock ?recovery_context agent |> tag_error "parse")
   in
   let context_window = proactive_context_window_tokens agent in
   let est_tokens = total_prompt_tokens_for_agent agent agent.state.messages in
@@ -1148,7 +1059,7 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
         then (
           update_state agent (fun s -> { s with config = original_config });
           let* prep', _, _ =
-            stage_parse ?raw_trace_run ?clock agent |> tag_error "parse"
+            stage_parse ?raw_trace_run ?clock ?recovery_context agent |> tag_error "parse"
           in
           Ok prep')
         else Ok prep
@@ -1223,7 +1134,7 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run agent =
         else (
           update_state agent (fun s -> { s with config = original_config });
           let* prep', _, _ =
-            stage_parse ?raw_trace_run ?clock agent |> tag_error "parse"
+            stage_parse ?raw_trace_run ?clock ?recovery_context agent |> tag_error "parse"
           in
           attempt_route ~prep:prep' ~compact_attempts:(compact_attempts + 1))
       | other -> other

--- a/lib/pipeline/pipeline.mli
+++ b/lib/pipeline/pipeline.mli
@@ -19,8 +19,16 @@ type api_strategy =
 
 type turn_outcome =
   | Complete of Types.api_response
-  | ToolsExecuted
+  | ToolsExecuted of Tool_failure_episode.completed_round option
   | IdleSkipped (** on_idle hook returned Skip — agent should stop gracefully. *)
+
+(** Persist [state] using the same pre-commit checkpoint transaction as turn
+    collection. The live agent state is not changed by this function. *)
+val persist_turn_checkpoint_for_state
+  :  Agent_types.t
+  -> Agent_types.checkpoint_stage
+  -> Types.agent_state
+  -> (unit, Error.sdk_error) result
 
 (** Run a single agent turn through the 6-stage pipeline.
     Equivalent to the previous [run_turn_core]. *)
@@ -29,5 +37,6 @@ val run_turn
   -> ?clock:_ Eio.Time.clock
   -> api_strategy:api_strategy
   -> ?raw_trace_run:Raw_trace.active_run
+  -> ?recovery_context:string
   -> Agent_types.t
   -> (turn_outcome, Error.sdk_error) result

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -284,7 +284,7 @@ let%test "runtime MCP policy is narrowed by AllowList guardrails" =
   narrowed.allowed_tool_names = [ "status_tool"; "ledger_tool" ]
 ;;
 
-let stage_parse ?raw_trace_run ?clock agent =
+let stage_parse ?raw_trace_run ?clock ?recovery_context agent =
   let* turn_params =
     match agent.options.hooks.before_turn_params with
     | None -> Ok Hooks.default_turn_params
@@ -345,10 +345,20 @@ let stage_parse ?raw_trace_run ?clock agent =
          | Some _ as t -> t
          | None -> original_config.tool_choice)
     ; system_prompt =
-        (match turn_params.system_prompt_override with
-         | Some _ as s -> s
-         | None -> original_config.system_prompt)
-        |> Option.map Llm_provider.Utf8_sanitize.sanitize
+        (let base =
+           match turn_params.system_prompt_override with
+           | Some _ as prompt -> prompt
+           | None -> original_config.system_prompt
+         in
+         let base = Option.map Llm_provider.Utf8_sanitize.sanitize base in
+         match recovery_context with
+         | None -> base
+         | Some context ->
+           let context = Llm_provider.Utf8_sanitize.sanitize context in
+           Some
+             (match base with
+              | None -> context
+              | Some prompt -> prompt ^ "\n\n" ^ context))
     }
   in
   update_state agent (fun s -> { s with config = new_config });

--- a/lib/tool_failure_episode.ml
+++ b/lib/tool_failure_episode.ml
@@ -8,13 +8,13 @@ type failed_attempt =
   ; error_class : tool_error_class option
   ; error : string
   }
-[@@deriving show]
+[@@deriving yojson, show]
 
 type t =
   { previous : failed_attempt
   ; current : failed_attempt
   }
-[@@deriving show]
+[@@deriving yojson, show]
 
 type paired_attempt =
   { tool_use_id : string

--- a/lib/tool_failure_episode.mli
+++ b/lib/tool_failure_episode.mli
@@ -16,13 +16,13 @@ type failed_attempt =
   ; error_class : Types.tool_error_class option
   ; error : string
   }
-[@@deriving show]
+[@@deriving yojson, show]
 
 type t =
   { previous : failed_attempt
   ; current : failed_attempt
   }
-[@@deriving show]
+[@@deriving yojson, show]
 
 (** An immutable, fully paired execution boundary. *)
 type completed_round

--- a/lib/tool_failure_recovery.ml
+++ b/lib/tool_failure_recovery.ml
@@ -1,0 +1,600 @@
+type revised_call =
+  { current_tool_use_id : string
+  ; tool_name : string
+  ; revised_input : Yojson.Safe.t
+  }
+[@@deriving show]
+
+type decision =
+  | Retry_modified of revised_call list
+  | Replan of { instruction : string }
+  | Ask_user of
+      { question : string
+      ; schema : Yojson.Safe.t option
+      }
+  | Defer of { reason : string }
+[@@deriving show]
+
+type model_request =
+  { system_prompt : string
+  ; user_prompt : string
+  ; output_schema : Yojson.Safe.t
+  }
+
+type completion = sw:Eio.Switch.t -> model_request -> (string, Error.sdk_error) result
+type judge = { complete : completion }
+
+let create ~complete = { complete }
+
+type decision_error =
+  | Empty_revised_calls
+  | Duplicate_revised_call of { current_tool_use_id : string }
+  | Missing_revised_call of { current_tool_use_id : string }
+  | Unexpected_revised_call of { current_tool_use_id : string }
+  | Revised_tool_name_mismatch of
+      { current_tool_use_id : string
+      ; expected : string
+      ; got : string
+      }
+  | Unchanged_revised_input of { current_tool_use_id : string }
+  | Blank_replan_instruction
+  | Blank_question
+  | Blank_defer_reason
+[@@deriving show]
+
+type response_error =
+  | Invalid_json of string
+  | Expected_object
+  | Missing_field of string
+  | Invalid_field of string
+  | Unsupported_action of string
+  | Invalid_decision of decision_error
+[@@deriving show]
+
+type judge_error =
+  | Completion_failed of Error.sdk_error
+  | Completion_raised of string
+  | Invalid_response of response_error
+
+let judge_error_to_string = function
+  | Completion_failed error ->
+    Printf.sprintf "tool failure recovery LLM call failed: %s" (Error.to_string error)
+  | Completion_raised detail ->
+    Printf.sprintf "tool failure recovery LLM callback raised: %s" detail
+  | Invalid_response error ->
+    Printf.sprintf
+      "tool failure recovery LLM response invalid: %s"
+      (show_response_error error)
+;;
+
+module String_set = Set.Make (String)
+
+let ( let* ) = Result.bind
+let is_blank value = String.equal (String.trim value) ""
+
+let required_field name fields =
+  match List.assoc_opt name fields with
+  | Some value -> Ok value
+  | None -> Error (Missing_field name)
+;;
+
+let required_string name fields =
+  let* value = required_field name fields in
+  match value with
+  | `String value -> Ok value
+  | _ -> Error (Invalid_field name)
+;;
+
+let optional_json name fields =
+  match List.assoc_opt name fields with
+  | None | Some `Null -> None
+  | Some value -> Some value
+;;
+
+let parse_revised_call = function
+  | `Assoc fields ->
+    let* current_tool_use_id = required_string "current_tool_use_id" fields in
+    let* tool_name = required_string "tool_name" fields in
+    let* revised_input = required_field "revised_input" fields in
+    Ok { current_tool_use_id; tool_name; revised_input }
+  | _ -> Error (Invalid_field "revised_calls")
+;;
+
+let parse_revised_calls fields =
+  let* value = required_field "revised_calls" fields in
+  match value with
+  | `List values ->
+    List.fold_right
+      (fun value result ->
+         let* calls = result in
+         let* call = parse_revised_call value in
+         Ok (call :: calls))
+      values
+      (Ok [])
+  | _ -> Error (Invalid_field "revised_calls")
+;;
+
+let parse_decision_json = function
+  | `Assoc fields ->
+    let* action = required_string "action" fields in
+    (match action with
+     | "retry_modified" ->
+       let* calls = parse_revised_calls fields in
+       Ok (Retry_modified calls)
+     | "replan" ->
+       let* instruction = required_string "instruction" fields in
+       Ok (Replan { instruction })
+     | "ask_user" ->
+       let* question = required_string "question" fields in
+       Ok (Ask_user { question; schema = optional_json "schema" fields })
+     | "defer" ->
+       let* reason = required_string "reason" fields in
+       Ok (Defer { reason })
+     | action -> Error (Unsupported_action action))
+  | _ -> Error Expected_object
+;;
+
+let validate_retry episodes calls =
+  let* () = if calls = [] then Error Empty_revised_calls else Ok () in
+  let* () =
+    let rec loop seen = function
+      | [] -> Ok ()
+      | call :: rest ->
+        if String_set.mem call.current_tool_use_id seen
+        then
+          Error
+            (Duplicate_revised_call { current_tool_use_id = call.current_tool_use_id })
+        else loop (String_set.add call.current_tool_use_id seen) rest
+    in
+    loop String_set.empty calls
+  in
+  let episode_for id =
+    List.find_opt
+      (fun (episode : Tool_failure_episode.t) ->
+         String.equal episode.current.tool_use_id id)
+      episodes
+  in
+  let call_for id =
+    List.find_opt (fun call -> String.equal call.current_tool_use_id id) calls
+  in
+  let* () =
+    let rec validate_episodes = function
+      | [] -> Ok ()
+      | (episode : Tool_failure_episode.t) :: rest ->
+        (match call_for episode.current.tool_use_id with
+         | None ->
+           Error
+             (Missing_revised_call { current_tool_use_id = episode.current.tool_use_id })
+         | Some call when not (String.equal call.tool_name episode.current.tool_name) ->
+           Error
+             (Revised_tool_name_mismatch
+                { current_tool_use_id = call.current_tool_use_id
+                ; expected = episode.current.tool_name
+                ; got = call.tool_name
+                })
+         | Some call when Yojson.Safe.equal call.revised_input episode.current.input ->
+           Error
+             (Unchanged_revised_input { current_tool_use_id = call.current_tool_use_id })
+         | Some _ -> validate_episodes rest)
+    in
+    validate_episodes episodes
+  in
+  match
+    List.find_opt
+      (fun call -> Option.is_none (episode_for call.current_tool_use_id))
+      calls
+  with
+  | Some call ->
+    Error (Unexpected_revised_call { current_tool_use_id = call.current_tool_use_id })
+  | None -> Ok ()
+;;
+
+let validate_decision ~episodes = function
+  | Retry_modified calls -> validate_retry episodes calls
+  | Replan { instruction } ->
+    if is_blank instruction then Error Blank_replan_instruction else Ok ()
+  | Ask_user { question; _ } -> if is_blank question then Error Blank_question else Ok ()
+  | Defer { reason } -> if is_blank reason then Error Blank_defer_reason else Ok ()
+;;
+
+let failure_kind_json kind = Types.tool_failure_kind_to_yojson kind
+
+let error_class_json = function
+  | None -> `Null
+  | Some error_class -> Types.tool_error_class_to_yojson error_class
+;;
+
+let attempt_json (attempt : Tool_failure_episode.failed_attempt) =
+  `Assoc
+    [ "tool_use_id", `String attempt.tool_use_id
+    ; "tool_name", `String attempt.tool_name
+    ; "input", attempt.input
+    ; "failure_kind", failure_kind_json attempt.failure_kind
+    ; "error_class", error_class_json attempt.error_class
+    ; "error", `String attempt.error
+    ]
+;;
+
+let episode_json (episode : Tool_failure_episode.t) =
+  `Assoc
+    [ "previous", attempt_json episode.previous; "current", attempt_json episode.current ]
+;;
+
+let output_schema =
+  `Assoc
+    [ "type", `String "object"
+    ; ( "oneOf"
+      , `List
+          [ `Assoc
+              [ ( "properties"
+                , `Assoc
+                    [ "action", `Assoc [ "const", `String "retry_modified" ]
+                    ; ( "revised_calls"
+                      , `Assoc
+                          [ "type", `String "array"
+                          ; "minItems", `Int 1
+                          ; ( "items"
+                            , `Assoc
+                                [ "type", `String "object"
+                                ; ( "required"
+                                  , `List
+                                      [ `String "current_tool_use_id"
+                                      ; `String "tool_name"
+                                      ; `String "revised_input"
+                                      ] )
+                                ] )
+                          ] )
+                    ] )
+              ; "required", `List [ `String "action"; `String "revised_calls" ]
+              ]
+          ; `Assoc
+              [ ( "properties"
+                , `Assoc
+                    [ "action", `Assoc [ "const", `String "replan" ]
+                    ; "instruction", `Assoc [ "type", `String "string" ]
+                    ] )
+              ; "required", `List [ `String "action"; `String "instruction" ]
+              ]
+          ; `Assoc
+              [ ( "properties"
+                , `Assoc
+                    [ "action", `Assoc [ "const", `String "ask_user" ]
+                    ; "question", `Assoc [ "type", `String "string" ]
+                    ] )
+              ; "required", `List [ `String "action"; `String "question" ]
+              ]
+          ; `Assoc
+              [ ( "properties"
+                , `Assoc
+                    [ "action", `Assoc [ "const", `String "defer" ]
+                    ; "reason", `Assoc [ "type", `String "string" ]
+                    ] )
+              ; "required", `List [ `String "action"; `String "reason" ]
+              ]
+          ] )
+    ]
+;;
+
+let system_prompt =
+  "You are the tool-failure recovery judge for a long-lived agent. Choose exactly one "
+  ^ "action from the supplied JSON schema. Base the decision only on the typed adjacent "
+  ^ "failure episodes. retry_modified must provide one materially changed input for \
+     every "
+  ^ "current failed call. replan must give a concrete next-turn instruction. ask_user is "
+  ^ "for missing human-owned information. defer is for work that should resume after an "
+  ^ "external state change. Return only the JSON object."
+;;
+
+let decide ~sw ~agent_name ~turn ~episodes judge =
+  if episodes = []
+  then Error (Invalid_response (Invalid_decision Empty_revised_calls))
+  else (
+    let user_prompt =
+      `Assoc
+        [ "agent_name", `String agent_name
+        ; "turn", `Int turn
+        ; "episodes", `List (List.map episode_json episodes)
+        ]
+      |> Yojson.Safe.to_string
+    in
+    let request = { system_prompt; user_prompt; output_schema } in
+    let completion =
+      try `Returned (judge.complete ~sw request) with
+      | exn ->
+        Llm_provider.Reserved_exn.reraise_if_reserved exn;
+        `Raised (Printexc.to_string exn)
+    in
+    match completion with
+    | `Raised detail -> Error (Completion_raised detail)
+    | `Returned (Error error) -> Error (Completion_failed error)
+    | `Returned (Ok text) ->
+      let parsed =
+        try Ok (Yojson.Safe.from_string text) with
+        | Yojson.Json_error detail -> Error (Invalid_json detail)
+      in
+      (match parsed with
+       | Error error -> Error (Invalid_response error)
+       | Ok json ->
+         (match parse_decision_json json with
+          | Error error -> Error (Invalid_response error)
+          | Ok decision ->
+            (match validate_decision ~episodes decision with
+             | Ok () -> Ok decision
+             | Error error -> Error (Invalid_response (Invalid_decision error))))))
+;;
+
+type episode_ref =
+  { previous_tool_use_id : string
+  ; current_tool_use_id : string
+  ; tool_name : string
+  ; failure_kind : Types.tool_failure_kind
+  ; error_class : Types.tool_error_class option
+  }
+
+type receipt =
+  { resume_turn : int
+  ; decided_at : float
+  ; episodes : episode_ref list
+  ; decision : decision
+  }
+
+let episode_ref (episode : Tool_failure_episode.t) =
+  { previous_tool_use_id = episode.previous.tool_use_id
+  ; current_tool_use_id = episode.current.tool_use_id
+  ; tool_name = episode.current.tool_name
+  ; failure_kind = episode.current.failure_kind
+  ; error_class = episode.current.error_class
+  }
+;;
+
+let make_receipt ~resume_turn ~decided_at ~episodes ~decision =
+  { resume_turn; decided_at; episodes = List.map episode_ref episodes; decision }
+;;
+
+let receipt_resume_turn receipt = receipt.resume_turn
+let receipt_decided_at receipt = receipt.decided_at
+let receipt_decision receipt = receipt.decision
+
+let receipt_tool_names receipt =
+  receipt.episodes
+  |> List.map (fun episode -> episode.tool_name)
+  |> List.sort_uniq String.compare
+;;
+
+type receipt_error =
+  | Result_message_not_found
+  | Duplicate_receipt_metadata
+  | Invalid_receipt_metadata of string
+  | Receipt_episode_mismatch
+  | Receipt_decision_invalid of decision_error
+[@@deriving show]
+
+let metadata_key = "oas.tool_failure_recovery.v1"
+
+let revised_call_json call =
+  `Assoc
+    [ "current_tool_use_id", `String call.current_tool_use_id
+    ; "tool_name", `String call.tool_name
+    ; "revised_input", call.revised_input
+    ]
+;;
+
+let decision_json = function
+  | Retry_modified calls ->
+    `Assoc
+      [ "action", `String "retry_modified"
+      ; "revised_calls", `List (List.map revised_call_json calls)
+      ]
+  | Replan { instruction } ->
+    `Assoc [ "action", `String "replan"; "instruction", `String instruction ]
+  | Ask_user { question; schema } ->
+    `Assoc
+      ([ "action", `String "ask_user"; "question", `String question ]
+       @
+       match schema with
+       | None -> []
+       | Some schema -> [ "schema", schema ])
+  | Defer { reason } -> `Assoc [ "action", `String "defer"; "reason", `String reason ]
+;;
+
+let episode_ref_json episode =
+  `Assoc
+    [ "previous_tool_use_id", `String episode.previous_tool_use_id
+    ; "current_tool_use_id", `String episode.current_tool_use_id
+    ; "tool_name", `String episode.tool_name
+    ; "failure_kind", failure_kind_json episode.failure_kind
+    ; "error_class", error_class_json episode.error_class
+    ]
+;;
+
+let receipt_json receipt =
+  `Assoc
+    [ "version", `Int 1
+    ; "resume_turn", `Int receipt.resume_turn
+    ; "decided_at", `Float receipt.decided_at
+    ; "episodes", `List (List.map episode_ref_json receipt.episodes)
+    ; "decision", decision_json receipt.decision
+    ]
+;;
+
+let tool_result_ids message =
+  List.filter_map
+    (function
+      | Types.ToolResult { tool_use_id; _ } -> Some tool_use_id
+      | Types.Text _
+      | Types.Thinking _
+      | Types.ReasoningDetails _
+      | Types.RedactedThinking _
+      | Types.ToolUse _
+      | Types.Image _
+      | Types.Document _
+      | Types.Audio _ -> None)
+    message.Types.content
+;;
+
+let attach_receipt ~messages ~episodes ~receipt =
+  let expected_ids =
+    List.map (fun episode -> episode.Tool_failure_episode.current.tool_use_id) episodes
+  in
+  let contains_expected message =
+    let actual_ids = tool_result_ids message in
+    expected_ids <> []
+    && List.for_all (fun expected -> List.mem expected actual_ids) expected_ids
+  in
+  let rec update = function
+    | [] -> Error Result_message_not_found
+    | message :: rest when contains_expected message ->
+      if List.mem_assoc metadata_key message.Types.metadata
+      then Error Duplicate_receipt_metadata
+      else
+        Ok
+          ({ message with
+             metadata = (metadata_key, receipt_json receipt) :: message.metadata
+           }
+           :: rest)
+    | message :: rest ->
+      let* rest = update rest in
+      Ok (message :: rest)
+  in
+  let* reversed = update (List.rev messages) in
+  Ok (List.rev reversed)
+;;
+
+let parse_int name fields =
+  match List.assoc_opt name fields with
+  | Some (`Int value) -> Ok value
+  | _ -> Error (Invalid_receipt_metadata name)
+;;
+
+let parse_float name fields =
+  match List.assoc_opt name fields with
+  | Some (`Float value) -> Ok value
+  | Some (`Int value) -> Ok (float_of_int value)
+  | _ -> Error (Invalid_receipt_metadata name)
+;;
+
+let parse_string_receipt name fields =
+  match List.assoc_opt name fields with
+  | Some (`String value) -> Ok value
+  | _ -> Error (Invalid_receipt_metadata name)
+;;
+
+let parse_failure_kind fields =
+  match List.assoc_opt "failure_kind" fields with
+  | None -> Error (Invalid_receipt_metadata "failure_kind")
+  | Some value ->
+    (match Types.tool_failure_kind_of_yojson value with
+     | Ok kind -> Ok kind
+     | Error detail -> Error (Invalid_receipt_metadata detail))
+;;
+
+let parse_error_class fields =
+  match List.assoc_opt "error_class" fields with
+  | None | Some `Null -> Ok None
+  | Some value ->
+    (match Types.tool_error_class_of_yojson value with
+     | Ok error_class -> Ok (Some error_class)
+     | Error detail -> Error (Invalid_receipt_metadata detail))
+;;
+
+let parse_episode_ref = function
+  | `Assoc fields ->
+    let* previous_tool_use_id = parse_string_receipt "previous_tool_use_id" fields in
+    let* current_tool_use_id = parse_string_receipt "current_tool_use_id" fields in
+    let* tool_name = parse_string_receipt "tool_name" fields in
+    let* failure_kind = parse_failure_kind fields in
+    let* error_class = parse_error_class fields in
+    Ok { previous_tool_use_id; current_tool_use_id; tool_name; failure_kind; error_class }
+  | _ -> Error (Invalid_receipt_metadata "episodes")
+;;
+
+let parse_episode_refs fields =
+  match List.assoc_opt "episodes" fields with
+  | Some (`List values) ->
+    List.fold_right
+      (fun value result ->
+         let* refs = result in
+         let* episode = parse_episode_ref value in
+         Ok (episode :: refs))
+      values
+      (Ok [])
+  | _ -> Error (Invalid_receipt_metadata "episodes")
+;;
+
+let parse_receipt = function
+  | `Assoc fields ->
+    let* version = parse_int "version" fields in
+    let* () = if version = 1 then Ok () else Error (Invalid_receipt_metadata "version") in
+    let* resume_turn = parse_int "resume_turn" fields in
+    let* decided_at = parse_float "decided_at" fields in
+    let* episodes = parse_episode_refs fields in
+    let* decision_json =
+      match List.assoc_opt "decision" fields with
+      | Some value -> Ok value
+      | None -> Error (Invalid_receipt_metadata "decision")
+    in
+    let* decision =
+      match parse_decision_json decision_json with
+      | Ok decision -> Ok decision
+      | Error error -> Error (Invalid_receipt_metadata (show_response_error error))
+    in
+    Ok { resume_turn; decided_at; episodes; decision }
+  | _ -> Error (Invalid_receipt_metadata metadata_key)
+;;
+
+let latest_receipt messages =
+  let rec find = function
+    | [] -> Ok None
+    | message :: rest ->
+      if tool_result_ids message = []
+      then find rest
+      else (
+        let values =
+          List.filter_map
+            (fun (key, value) ->
+               if String.equal key metadata_key then Some value else None)
+            message.Types.metadata
+        in
+        match values with
+        | [] -> Ok None
+        | [ value ] ->
+          let* receipt = parse_receipt value in
+          Ok (Some receipt)
+        | _ :: _ :: _ -> Error Duplicate_receipt_metadata)
+  in
+  find (List.rev messages)
+;;
+
+let same_episode_ref left right =
+  String.equal left.previous_tool_use_id right.previous_tool_use_id
+  && String.equal left.current_tool_use_id right.current_tool_use_id
+  && String.equal left.tool_name right.tool_name
+  && left.failure_kind = right.failure_kind
+  && left.error_class = right.error_class
+;;
+
+let validate_receipt ~episodes receipt =
+  let actual = List.map episode_ref episodes in
+  let refs_match =
+    List.length actual = List.length receipt.episodes
+    && List.for_all
+         (fun expected -> List.exists (same_episode_ref expected) receipt.episodes)
+         actual
+  in
+  if not refs_match
+  then Error Receipt_episode_mismatch
+  else (
+    match validate_decision ~episodes receipt.decision with
+    | Ok () -> Ok ()
+    | Error error -> Error (Receipt_decision_invalid error))
+;;
+
+let system_context receipt =
+  match receipt.decision with
+  | Ask_user _ | Defer _ -> None
+  | Retry_modified _ | Replan _ ->
+    Some
+      ("OAS one-turn typed tool-failure recovery control. Follow this control for the "
+       ^ "next main-agent turn; do not reproduce it as user speech: "
+       ^ Yojson.Safe.to_string (decision_json receipt.decision))
+;;

--- a/lib/tool_failure_recovery.ml
+++ b/lib/tool_failure_recovery.ml
@@ -3,7 +3,7 @@ type revised_call =
   ; tool_name : string
   ; revised_input : Yojson.Safe.t
   }
-[@@deriving show]
+[@@deriving yojson, show]
 
 type decision =
   | Retry_modified of revised_call list
@@ -13,7 +13,7 @@ type decision =
       ; schema : Yojson.Safe.t option
       }
   | Defer of { reason : string }
-[@@deriving show]
+[@@deriving yojson, show]
 
 type model_request =
   { system_prompt : string

--- a/lib/tool_failure_recovery.ml
+++ b/lib/tool_failure_recovery.ml
@@ -3,7 +3,7 @@ type revised_call =
   ; tool_name : string
   ; revised_input : Yojson.Safe.t
   }
-[@@deriving yojson, show]
+[@@deriving show]
 
 type decision =
   | Retry_modified of revised_call list
@@ -13,7 +13,7 @@ type decision =
       ; schema : Yojson.Safe.t option
       }
   | Defer of { reason : string }
-[@@deriving yojson, show]
+[@@deriving show]
 
 type model_request =
   { system_prompt : string
@@ -396,6 +396,8 @@ let decision_json = function
        | Some schema -> [ "schema", schema ])
   | Defer { reason } -> `Assoc [ "action", `String "defer"; "reason", `String reason ]
 ;;
+
+let decision_to_yojson = decision_json
 
 let episode_ref_json episode =
   `Assoc

--- a/lib/tool_failure_recovery.mli
+++ b/lib/tool_failure_recovery.mli
@@ -13,7 +13,7 @@ type revised_call =
   ; tool_name : string
   ; revised_input : Yojson.Safe.t
   }
-[@@deriving yojson, show]
+[@@deriving show]
 
 type decision = private
   | Retry_modified of revised_call list
@@ -23,7 +23,11 @@ type decision = private
       ; schema : Yojson.Safe.t option
       }
   | Defer of { reason : string }
-[@@deriving yojson, show]
+[@@deriving show]
+
+(** Observation-only JSON projection. Parsing remains private so external code
+    cannot bypass episode validation to construct a [decision]. *)
+val decision_to_yojson : decision -> Yojson.Safe.t
 
 type model_request =
   { system_prompt : string

--- a/lib/tool_failure_recovery.mli
+++ b/lib/tool_failure_recovery.mli
@@ -1,0 +1,132 @@
+(** LLM judgment boundary for repeated typed tool failures.
+
+    The main agent loop supplies only structural failure episodes to the judge:
+    no hidden reasoning, repeated narration, provider name, or model name is
+    replayed. The judge returns a closed decision that is validated against the
+    episodes before it can affect execution.
+
+    @stability Evolving
+    @since 0.212.0 *)
+
+type revised_call =
+  { current_tool_use_id : string
+  ; tool_name : string
+  ; revised_input : Yojson.Safe.t
+  }
+[@@deriving show]
+
+type decision = private
+  | Retry_modified of revised_call list
+  | Replan of { instruction : string }
+  | Ask_user of
+      { question : string
+      ; schema : Yojson.Safe.t option
+      }
+  | Defer of { reason : string }
+[@@deriving show]
+
+type model_request =
+  { system_prompt : string
+  ; user_prompt : string
+  ; output_schema : Yojson.Safe.t
+  }
+
+(** A caller-owned LLM completion boundary. Coordinators may implement this
+    with their runtime catalog and provider fallback without coupling OAS to
+    that coordinator. The callback must return only the model's response text;
+    OAS owns schema parsing and decision validation. *)
+type completion = sw:Eio.Switch.t -> model_request -> (string, Error.sdk_error) result
+
+type judge
+
+val create : complete:completion -> judge
+
+type decision_error =
+  | Empty_revised_calls
+  | Duplicate_revised_call of { current_tool_use_id : string }
+  | Missing_revised_call of { current_tool_use_id : string }
+  | Unexpected_revised_call of { current_tool_use_id : string }
+  | Revised_tool_name_mismatch of
+      { current_tool_use_id : string
+      ; expected : string
+      ; got : string
+      }
+  | Unchanged_revised_input of { current_tool_use_id : string }
+  | Blank_replan_instruction
+  | Blank_question
+  | Blank_defer_reason
+[@@deriving show]
+
+type response_error =
+  | Invalid_json of string
+  | Expected_object
+  | Missing_field of string
+  | Invalid_field of string
+  | Unsupported_action of string
+  | Invalid_decision of decision_error
+[@@deriving show]
+
+type judge_error =
+  | Completion_failed of Error.sdk_error
+  | Completion_raised of string
+  | Invalid_response of response_error
+
+val judge_error_to_string : judge_error -> string
+
+(** Invoke the configured LLM once, parse its exact JSON object, and validate
+    the closed decision against every supplied episode. Empty episode lists are
+    rejected before the callback is invoked. *)
+val decide
+  :  sw:Eio.Switch.t
+  -> agent_name:string
+  -> turn:int
+  -> episodes:Tool_failure_episode.t list
+  -> judge
+  -> (decision, judge_error) result
+
+(** Durable receipt stored only in OAS message metadata/checkpoints. Provider
+    request serializers do not forward generic message metadata. *)
+type receipt
+
+val make_receipt
+  :  resume_turn:int
+  -> decided_at:float
+  -> episodes:Tool_failure_episode.t list
+  -> decision:decision
+  -> receipt
+
+val receipt_resume_turn : receipt -> int
+val receipt_decided_at : receipt -> float
+val receipt_decision : receipt -> decision
+val receipt_tool_names : receipt -> string list
+
+type receipt_error =
+  | Result_message_not_found
+  | Duplicate_receipt_metadata
+  | Invalid_receipt_metadata of string
+  | Receipt_episode_mismatch
+  | Receipt_decision_invalid of decision_error
+[@@deriving show]
+
+(** Add a versioned receipt to the latest result message containing every
+    current episode id. Existing metadata is preserved; a duplicate receipt is
+    an explicit error. *)
+val attach_receipt
+  :  messages:Types.message list
+  -> episodes:Tool_failure_episode.t list
+  -> receipt:receipt
+  -> (Types.message list, receipt_error) result
+
+(** Read a receipt only from the latest message containing a [ToolResult]. An
+    older receipt is never reused after a newer tool boundary. *)
+val latest_receipt : Types.message list -> (receipt option, receipt_error) result
+
+(** Validate a restored receipt against reconstructed adjacent episodes. *)
+val validate_receipt
+  :  episodes:Tool_failure_episode.t list
+  -> receipt
+  -> (unit, receipt_error) result
+
+(** Render a one-turn system-prompt suffix. [Ask_user] and [Defer] are
+    terminal control decisions and therefore have no continuation context. *)
+val system_context : receipt -> string option

--- a/lib/tool_failure_recovery.mli
+++ b/lib/tool_failure_recovery.mli
@@ -13,7 +13,7 @@ type revised_call =
   ; tool_name : string
   ; revised_input : Yojson.Safe.t
   }
-[@@deriving show]
+[@@deriving yojson, show]
 
 type decision = private
   | Retry_modified of revised_call list
@@ -23,7 +23,7 @@ type decision = private
       ; schema : Yojson.Safe.t option
       }
   | Defer of { reason : string }
-[@@deriving show]
+[@@deriving yojson, show]
 
 type model_request =
   { system_prompt : string

--- a/test/dune
+++ b/test/dune
@@ -197,6 +197,7 @@
   test_tool
   test_tool_disclosure
   test_tool_failure_episode
+  test_tool_failure_recovery
   test_tool_index
   test_tool_input_validation
   test_tool_middleware
@@ -402,6 +403,7 @@
   test_tool
   test_tool_disclosure
   test_tool_failure_episode
+  test_tool_failure_recovery
   test_tool_index
   test_tool_input_validation
   test_tool_middleware

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -308,7 +308,7 @@ let test_pipeline_output_resets_idle_on_end_turn () =
   (match Internal_pipeline.run_turn ~sw ~api_strategy:Internal_pipeline.Sync agent with
    | Ok (Internal_pipeline.Complete response) ->
      Alcotest.(check bool) "completed" true (response.stop_reason = EndTurn)
-   | Ok Internal_pipeline.ToolsExecuted ->
+   | Ok (Internal_pipeline.ToolsExecuted _) ->
      Alcotest.fail "expected Complete, got ToolsExecuted"
    | Ok Internal_pipeline.IdleSkipped ->
      Alcotest.fail "expected Complete, got IdleSkipped"
@@ -348,7 +348,7 @@ let test_pipeline_output_completes_repetition_truncation () =
        "documented provider terminal reason is preserved"
        true
        (response.stop_reason = RepetitionTruncation)
-   | Ok Internal_pipeline.ToolsExecuted ->
+   | Ok (Internal_pipeline.ToolsExecuted _) ->
      Alcotest.fail "expected Complete, got ToolsExecuted"
    | Ok Internal_pipeline.IdleSkipped ->
      Alcotest.fail "expected Complete, got IdleSkipped"
@@ -387,7 +387,7 @@ let test_pipeline_tool_recovery_allows_glm_provider () =
   in
   let agent = make_tool_recovery_test_agent ~net ~provider in
   match Internal_pipeline.run_turn ~sw ~api_strategy:Internal_pipeline.Sync agent with
-  | Ok Internal_pipeline.ToolsExecuted -> ()
+  | Ok (Internal_pipeline.ToolsExecuted _) -> ()
   | Ok (Internal_pipeline.Complete _) ->
     Alcotest.fail "expected tool recovery to execute a tool"
   | Ok Internal_pipeline.IdleSkipped -> Alcotest.fail "expected ToolsExecuted"
@@ -407,7 +407,7 @@ let test_pipeline_tool_recovery_rejects_openai_compat_provider () =
     (match response.content with
      | [ Text _ ] -> ()
      | _ -> Alcotest.fail "expected text to remain unpromoted")
-  | Ok Internal_pipeline.ToolsExecuted ->
+  | Ok (Internal_pipeline.ToolsExecuted _) ->
     Alcotest.fail "expected OpenAI-compatible text tool intent to fail closed"
   | Ok Internal_pipeline.IdleSkipped -> Alcotest.fail "expected Complete"
   | Error err -> Alcotest.failf "unexpected run error: %s" (Error.to_string err)

--- a/test/test_tool_failure_recovery.ml
+++ b/test/test_tool_failure_recovery.ml
@@ -1,0 +1,313 @@
+open Agent_sdk
+
+let provider =
+  { Provider.provider = Provider.Local { base_url = "http://mock.local" }
+  ; model_id = "mock-model"
+  ; api_key_env = ""
+  }
+;;
+
+let tool_response id input : Types.api_response =
+  { id = "response-" ^ id
+  ; model = "mock-model"
+  ; stop_reason = StopToolUse
+  ; content = [ ToolUse { id; name = "Execute"; input } ]
+  ; usage = None
+  ; telemetry = None
+  }
+;;
+
+let final_response : Types.api_response =
+  { id = "response-final"
+  ; model = "mock-model"
+  ; stop_reason = EndTurn
+  ; content = [ Text "finished" ]
+  ; usage = None
+  ; telemetry = None
+  }
+;;
+
+let append events event = events := !events @ [ event ]
+
+let failing_tool events =
+  let parameters : Types.tool_param list =
+    [ { name = "cmd"; description = "command"; param_type = String; required = true }
+    ; { name = "cwd"
+      ; description = "working directory"
+      ; param_type = String
+      ; required = false
+      }
+    ]
+  in
+  Tool.create ~name:"Execute" ~description:"execute a command" ~parameters (fun _ ->
+    append events "tool";
+    Error
+      { Types.message = "working directory is required"
+      ; recoverable = true
+      ; error_class = Some Deterministic
+      })
+;;
+
+type scenario =
+  { result : (Types.api_response, Error.sdk_error) result
+  ; events : string list
+  ; requests : Llm_provider.Llm_transport.completion_request list
+  ; agent : Agent.t
+  }
+
+let run_scenario env ~judge_json ?(fail_recovery_checkpoint = false) () =
+  Eio.Switch.run
+  @@ fun sw ->
+  let events = ref [] in
+  let requests = ref [] in
+  let responses =
+    ref
+      [ tool_response "p1" (`Assoc [ "cmd", `String "gh pr list" ])
+      ; tool_response "c1" (`Assoc [ "cmd", `String "gh pr list" ])
+      ; final_response
+      ]
+  in
+  let next_response request =
+    requests := !requests @ [ request ];
+    append events (Printf.sprintf "provider%d" (List.length !requests));
+    match !responses with
+    | response :: rest ->
+      responses := rest;
+      response
+    | [] -> Alcotest.fail "unexpected additional provider call"
+  in
+  let transport : Llm_provider.Llm_transport.t =
+    { complete_sync =
+        (fun request ->
+          { Llm_provider.Llm_transport.response = Ok (next_response request)
+          ; latency_ms = Some 0
+          })
+    ; complete_stream =
+        (fun ?on_telemetry:_ ~on_event:_ request -> Ok (next_response request))
+    }
+  in
+  let judge =
+    Tool_failure_recovery.create ~complete:(fun ~sw:_ request ->
+      append events "judge";
+      Alcotest.(check bool)
+        "judge receives structured schema"
+        true
+        (request.Tool_failure_recovery.output_schema <> `Null);
+      Ok judge_json)
+  in
+  let checkpoint_sink (snapshot : Agent.checkpoint_snapshot) =
+    match snapshot.stage with
+    | After_retry_feedback_appended ->
+      append events "decision_checkpoint";
+      if fail_recovery_checkpoint then Error "recovery checkpoint rejected" else Ok ()
+    | After_assistant_collected | After_tool_results_appended -> Ok ()
+  in
+  let options =
+    { Agent.default_options with
+      transport = Some transport
+    ; provider = Some provider
+    ; guardrails = Guardrails.permissive
+    }
+  in
+  let config =
+    { Types.default_config with
+      name = "recovery-test"
+    ; model = "mock-model"
+    ; system_prompt = Some "base system"
+    ; max_turns = 0
+    ; yield_on_tool = true
+    }
+  in
+  let agent =
+    Agent.create
+      ~net:env#net
+      ~config
+      ~tools:[ failing_tool events ]
+      ~options
+      ~checkpoint_sink
+      ~tool_failure_judge:judge
+      ()
+  in
+  let result =
+    Agent.run
+      ~sw
+      ~on_yield:(fun () -> append events "yield")
+      ~on_resume:(fun () -> append events "resume")
+      agent
+      "review the pull request"
+  in
+  { result; events = !events; requests = !requests; agent }
+;;
+
+let retry_modified_json =
+  {|{"action":"retry_modified","revised_calls":[{"current_tool_use_id":"c1","tool_name":"Execute","revised_input":{"cmd":"gh pr list","cwd":"/repo"}}]}|}
+;;
+
+let test_judge_runs_between_yield_and_resume () =
+  Eio_main.run
+  @@ fun env ->
+  let scenario = run_scenario env ~judge_json:retry_modified_json () in
+  (match scenario.result with
+   | Ok response ->
+     Alcotest.(check string) "final text" "finished" (Types.text_of_response response)
+   | Error error -> Alcotest.fail (Error.to_string error));
+  Alcotest.(check (list string))
+    "lease-safe order"
+    [ "provider1"
+    ; "tool"
+    ; "yield"
+    ; "resume"
+    ; "provider2"
+    ; "tool"
+    ; "yield"
+    ; "judge"
+    ; "decision_checkpoint"
+    ; "resume"
+    ; "provider3"
+    ]
+    scenario.events;
+  let third = List.nth scenario.requests 2 in
+  let system_prompt = Option.value third.config.system_prompt ~default:"" in
+  Alcotest.(check bool)
+    "recovery is a system suffix"
+    true
+    (String.starts_with ~prefix:"base system\n\nOAS one-turn typed" system_prompt);
+  let user_messages =
+    List.filter (fun (message : Types.message) -> message.role = User) third.messages
+  in
+  Alcotest.(check int) "no synthetic recovery User message" 1 (List.length user_messages)
+;;
+
+let test_ask_user_stops_without_resume_or_third_call () =
+  Eio_main.run
+  @@ fun env ->
+  let scenario =
+    run_scenario
+      env
+      ~judge_json:
+        {|{"action":"ask_user","question":"Which repository should I inspect?"}|}
+      ()
+  in
+  (match scenario.result with
+   | Error (Error.Agent (Error.InputRequired request)) ->
+     Alcotest.(check string)
+       "question"
+       "Which repository should I inspect?"
+       request.question
+   | Error error -> Alcotest.fail (Error.to_string error)
+   | Ok _ -> Alcotest.fail "expected InputRequired");
+  Alcotest.(check int) "two main calls" 2 (List.length scenario.requests);
+  Alcotest.(check (list string))
+    "terminal judge does not reacquire"
+    [ "provider1"
+    ; "tool"
+    ; "yield"
+    ; "resume"
+    ; "provider2"
+    ; "tool"
+    ; "yield"
+    ; "judge"
+    ; "decision_checkpoint"
+    ]
+    scenario.events
+;;
+
+let test_checkpoint_failure_does_not_commit_receipt () =
+  Eio_main.run
+  @@ fun env ->
+  let scenario =
+    run_scenario env ~judge_json:retry_modified_json ~fail_recovery_checkpoint:true ()
+  in
+  (match scenario.result with
+   | Error (Error.Internal detail) ->
+     Alcotest.(check bool) "checkpoint failure surfaced" true (String.length detail > 0)
+   | Error error -> Alcotest.fail (Error.to_string error)
+   | Ok _ -> Alcotest.fail "expected checkpoint failure");
+  (match Tool_failure_recovery.latest_receipt (Agent.state scenario.agent).messages with
+   | Ok None -> ()
+   | Ok (Some _) -> Alcotest.fail "failed checkpoint decision leaked into live state"
+   | Error error -> Alcotest.fail (Tool_failure_recovery.show_receipt_error error));
+  Alcotest.(check int) "no third main call" 2 (List.length scenario.requests)
+;;
+
+let project calls results =
+  match Tool_failure_episode.project ~tool_uses:calls ~tool_results:results with
+  | Ok round -> round
+  | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
+;;
+
+let failed_result id =
+  ToolResult
+    { tool_use_id = id
+    ; content = "failed"
+    ; is_error = true
+    ; failure_kind = Some Recoverable_tool_error
+    ; error_class = Some Deterministic
+    ; json = None
+    ; content_blocks = None
+    }
+;;
+
+let test_retry_modified_requires_changed_input () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let previous =
+    project
+      [ ToolUse { id = "p1"; name = "Execute"; input = `Assoc [ "cmd", `String "x" ] } ]
+      [ failed_result "p1" ]
+  in
+  let current =
+    project
+      [ ToolUse { id = "c1"; name = "Execute"; input = `Assoc [ "cmd", `String "x" ] } ]
+      [ failed_result "c1" ]
+  in
+  let episodes =
+    match Tool_failure_episode.detect ~previous ~current with
+    | Ok episodes -> episodes
+    | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
+  in
+  let judge =
+    Tool_failure_recovery.create ~complete:(fun ~sw:_ _ ->
+      Ok
+        {|{"action":"retry_modified","revised_calls":[{"current_tool_use_id":"c1","tool_name":"Execute","revised_input":{"cmd":"x"}}]}|})
+  in
+  match Tool_failure_recovery.decide ~sw ~agent_name:"test" ~turn:2 ~episodes judge with
+  | Error
+      (Tool_failure_recovery.Invalid_response
+         (Tool_failure_recovery.Invalid_decision
+            (Tool_failure_recovery.Unchanged_revised_input { current_tool_use_id = "c1" })))
+    -> ()
+  | Error error -> Alcotest.fail (Tool_failure_recovery.judge_error_to_string error)
+  | Ok decision ->
+    Alcotest.fail
+      ("expected unchanged-input rejection, got "
+       ^ Tool_failure_recovery.show_decision decision)
+;;
+
+let () =
+  Alcotest.run
+    "tool_failure_recovery"
+    [ ( "agent_loop"
+      , [ Alcotest.test_case
+            "judge between yield and resume"
+            `Quick
+            test_judge_runs_between_yield_and_resume
+        ; Alcotest.test_case
+            "ask user is terminal"
+            `Quick
+            test_ask_user_stops_without_resume_or_third_call
+        ; Alcotest.test_case
+            "checkpoint failure is transactional"
+            `Quick
+            test_checkpoint_failure_does_not_commit_receipt
+        ] )
+    ; ( "decision_validation"
+      , [ Alcotest.test_case
+            "retry input must change"
+            `Quick
+            test_retry_modified_requires_changed_input
+        ] )
+    ]
+;;


### PR DESCRIPTION
Stacked on #2541 (and transitively #2539).

Implements the provider/model-neutral recovery boundary for adjacent typed failed-tool rounds:

- project completed tool rounds at the execution boundary
- persist ToolResult before releasing the main provider lease
- invoke a caller-owned LLM completion judge while the main lease is released
- validate closed Retry_modified/Replan/Ask_user/Defer decisions
- persist a versioned decision receipt before continuation
- inject retry/replan control only as a one-turn system-prompt suffix
- remove canned validation-loop Assistant replies and default repeat-count User warnings
- expose typed events and explicit recovery/defer failures
- reconstruct pending recovery from checkpoint history

No model-name/provider-name branches. No local Dune build; CI is the build authority.