### PR TITLE
feat(llm_provider): bind output-token receipts to request artifacts

### DIFF
--- a/lib/llm_provider/backend_anthropic.ml
+++ b/lib/llm_provider/backend_anthropic.ml
@@ -6,6 +6,11 @@
 
 open Types
 
+type request_artifact = string Request_artifact_internal.t
+
+let request_payload = Request_artifact_internal.payload
+let request_output_token_receipt = Request_artifact_internal.output_token_receipt
+
 (** Parse Anthropic API response JSON into {!api_response}. *)
 let parse_response json =
   let open Yojson.Safe.Util in
@@ -158,34 +163,49 @@ let effective_max_output_tokens = Backend_openai_request.effective_max_output_to
    resolver above:
    - caller [Some n] -> clamped to the catalog ceiling with a one-shot
      WARN (shared clamp semantics via [effective_max_output_tokens]).
-   - caller [None] -> the catalog-declared model maximum. This is OAS's
-     explicit required-envelope fallback, not a claim that the provider
-     supplies that value as its default. Reusing the declared maximum keeps
-     known-model calls simple without inventing a second numeric policy;
+   - caller [None] -> the model-catalog maximum or the caller's declared
+     capability-override maximum. This is OAS's explicit required-envelope
+     fallback, not a claim that the provider supplies that value as its
+     default. The receipt preserves which declaration supplied the value;
      callers that need a smaller request bound can still pass one explicitly.
    - neither declared -> fail loudly naming the model; an invented
      constant is shared by thinking and answer and silently truncates
      long reasoning. *)
-let required_max_output_tokens (config : Provider_config.t) =
-  match effective_max_output_tokens config with
-  | Some n -> n
+let required_output_token_receipt (config : Provider_config.t) =
+  Backend_openai_request.output_token_receipt
+    ~envelope:Types.Anthropic_messages_max_tokens
+    config
+  |> Types.required_output_token_receipt
+;;
+
+let required_output_token_error_message (config : Provider_config.t) = function
+  | Types.Required_output_token_ceiling_missing ->
+    Printf.sprintf
+      "Backend_anthropic.required_max_output_tokens: model %s declares no \
+       max_output_tokens and the caller passed none; the Anthropic Messages API requires \
+       max_tokens — declare max_output_tokens in the model catalog, provide an explicit \
+       capability override, or pass ~max_tokens"
+      config.model_id
+;;
+
+let required_output_token_value receipt =
+  match Types.output_token_receipt_effective receipt with
+  | Some value -> value
   | None ->
-    let caps = Backend_openai_request.capabilities_of_config config in
-    (match caps.max_output_tokens with
-     | Some cap -> cap
-     | None ->
-       invalid_arg
-         (Printf.sprintf
-            "Backend_anthropic.required_max_output_tokens: model %s declares no \
-             max_output_tokens and the caller passed none; the Anthropic Messages API \
-             requires max_tokens — declare max_output_tokens in the model catalog or \
-             pass ~max_tokens"
-            config.model_id))
+    invalid_arg
+      "Backend_anthropic: required output-token receipt has no effective wire value"
+;;
+
+let required_max_output_tokens config =
+  match required_output_token_receipt config with
+  | Ok receipt -> required_output_token_value receipt
+  | Error error -> invalid_arg (required_output_token_error_message config error)
 ;;
 
 (** Build Anthropic Messages API request body from {!Provider_config.t}.
     Returns a JSON string ready for HTTP POST. *)
-let build_request
+let build_request_artifact_from_receipt
+      ~output_token_receipt
       ?(stream = false)
       ~(config : Provider_config.t)
       ~(messages : message list)
@@ -259,7 +279,7 @@ let build_request
   let msgs_json = List.map message_to_json messages in
   let body =
     [ "model", `String config.model_id
-    ; "max_tokens", `Int (required_max_output_tokens config)
+    ; "max_tokens", `Int (required_output_token_value output_token_receipt)
     ; "messages", `List msgs_json
     ; "stream", `Bool stream
     ]
@@ -370,5 +390,27 @@ let build_request
         ("tool_choice", tc) :: body)
       else body
   in
-  Yojson.Safe.to_string (`Assoc body)
+  Request_artifact_internal.create
+    ~payload:(Yojson.Safe.to_string (`Assoc body))
+    ~output_token_receipt
+;;
+
+let build_request_artifact ?stream ~config ~messages ?tools () =
+  match required_output_token_receipt config with
+  | Error _ as error -> error
+  | Ok output_token_receipt ->
+    Ok
+      (build_request_artifact_from_receipt
+         ~output_token_receipt
+         ?stream
+         ~config
+         ~messages
+         ?tools
+         ())
+;;
+
+let build_request ?stream ~config ~messages ?tools () =
+  match build_request_artifact ?stream ~config ~messages ?tools () with
+  | Ok artifact -> request_payload artifact
+  | Error error -> invalid_arg (required_output_token_error_message config error)
 ;;

--- a/lib/llm_provider/backend_anthropic.mli
+++ b/lib/llm_provider/backend_anthropic.mli
@@ -7,6 +7,11 @@
 
 val parse_response : Yojson.Safe.t -> Types.api_response
 
+type request_artifact
+
+val request_payload : request_artifact -> string
+val request_output_token_receipt : request_artifact -> Types.output_token_receipt
+
 (** Provider-correct Claude thinking request field for a model family.
     Exposed so the legacy Agent SDK Anthropic builder can share the same
     manual-budget vs adaptive-thinking dispatch as this backend. *)
@@ -28,13 +33,29 @@ val output_config_for_config
     [None] — the ceiling is never injected as a request value. *)
 val effective_max_output_tokens : Provider_config.t -> int option
 
-(** The Messages API requires [max_tokens] on every request, so this
-    envelope carries an explicit OAS required-envelope policy: caller
-    override clamped to the catalog ceiling; caller [None] falls back to the
-    catalog-declared model maximum (this is not a provider default); raises
-    [Invalid_argument] naming the model when neither the caller nor the
-    catalog declares a value — no second numeric policy is invented. *)
+(** Resolve the Messages required [max_tokens] decision. Caller [None] falls
+    back to a model-catalog ceiling or an explicit capability-override ceiling,
+    preserving the source in the resulting receipt. *)
+val required_output_token_receipt
+  :  Provider_config.t
+  -> (Types.output_token_receipt, Types.required_output_token_error) result
+
+(** Compatibility projection of {!required_output_token_receipt}. Raises
+    [Invalid_argument] naming the model when no explicit value, catalog
+    ceiling, or capability-override ceiling exists. *)
 val required_max_output_tokens : Provider_config.t -> int
+
+(** Build one immutable Messages request artifact. Missing required
+    [max_tokens] metadata is returned as a typed error before any HTTP payload
+    can be observed. Other pre-existing request validation failures retain
+    their explicit [Invalid_argument] contract. *)
+val build_request_artifact
+  :  ?stream:bool
+  -> config:Provider_config.t
+  -> messages:Types.message list
+  -> ?tools:Yojson.Safe.t list
+  -> unit
+  -> (request_artifact, Types.required_output_token_error) result
 
 val build_request
   :  ?stream:bool

--- a/lib/llm_provider/backend_gemini.ml
+++ b/lib/llm_provider/backend_gemini.ml
@@ -7,6 +7,11 @@
 
 open Types
 
+type request_artifact = string Request_artifact_internal.t
+
+let request_payload = Request_artifact_internal.payload
+let request_output_token_receipt = Request_artifact_internal.output_token_receipt
+
 exception Gemini_api_error of string
 
 (* ── Helpers ────────────────────────────────────────── *)
@@ -291,7 +296,7 @@ let build_function_declaration = function
 
 (* ── Build request body ─────────────────────────────── *)
 
-let build_request
+let build_request_artifact
       ?(stream = false)
       ~(config : Provider_config.t)
       ~(messages : message list)
@@ -300,6 +305,11 @@ let build_request
   =
   ignore stream;
   (* Gemini streaming is URL-based, not body-based *)
+  let output_token_receipt =
+    Backend_openai_request.output_token_receipt
+      ~envelope:Types.Gemini_generation_config_max_output_tokens
+      config
+  in
   let contents, system_instruction = contents_of_messages messages in
   (* Prepend system_prompt from config if present *)
   let system_instruction =
@@ -330,7 +340,7 @@ let build_request
      omitted when both are unknown) — [maxOutputTokens] is optional on
      generateContent, and omission lets Gemini apply the model's own
      limit instead of an invented 16384. *)
-  (match Backend_openai_request.effective_max_output_tokens config with
+  (match Types.output_token_receipt_effective output_token_receipt with
    | Some mt -> gen_config := ("maxOutputTokens", `Int mt) :: !gen_config
    | None -> ());
   (match config.temperature with
@@ -414,7 +424,13 @@ let build_request
       :: body
     | None -> body
   in
-  Yojson.Safe.to_string (`Assoc body)
+  Request_artifact_internal.create
+    ~payload:(Yojson.Safe.to_string (`Assoc body))
+    ~output_token_receipt
+;;
+
+let build_request ?stream ~config ~messages ?tools () =
+  build_request_artifact ?stream ~config ~messages ?tools () |> request_payload
 ;;
 
 (* ── Parse response ─────────────────────────────────── *)

--- a/lib/llm_provider/backend_gemini.mli
+++ b/lib/llm_provider/backend_gemini.mli
@@ -13,6 +13,19 @@
 
 exception Gemini_api_error of string
 
+type request_artifact
+
+val request_payload : request_artifact -> string
+val request_output_token_receipt : request_artifact -> Types.output_token_receipt
+
+val build_request_artifact
+  :  ?stream:bool
+  -> config:Provider_config.t
+  -> messages:Types.message list
+  -> ?tools:Yojson.Safe.t list
+  -> unit
+  -> request_artifact
+
 (** Build a Gemini [generateContent] request body from {!Provider_config.t}.
     Returns a JSON string.  URL construction (including [?key=]) is handled
     by {!Complete}; this function only produces the body. *)

--- a/lib/llm_provider/backend_glm.ml
+++ b/lib/llm_provider/backend_glm.ml
@@ -12,6 +12,11 @@
 
 open Types
 
+type request_artifact = string Request_artifact_internal.t
+
+let request_payload = Request_artifact_internal.payload
+let request_output_token_receipt = Request_artifact_internal.output_token_receipt
+
 type glm_error_class =
   | Glm_quota_exceeded
   | Glm_rate_limited
@@ -110,7 +115,7 @@ let normalize_tool_choice_fields ~(tool_choice : Types.tool_choice option) field
   | Some (Tool _ | None_) | None -> without_field "tool_choice" fields
 ;;
 
-let build_request
+let build_request_artifact
       ?(stream = false)
       ~(config : Provider_config.t)
       ~(messages : message list)
@@ -121,30 +126,45 @@ let build_request
      serializing then parsing the whole message body back — removes one full
      [Yojson.Safe.to_string] (OpenAI) + one [Yojson.Safe.from_string] (here)
      per GLM turn. Byte-identical: [from_string (to_string assoc) = assoc]. *)
-  let base_assoc =
-    Backend_openai.build_request_assoc ~stream ~config ~messages ~tools ()
+  let base_artifact =
+    Backend_openai_request.build_request_assoc_artifact
+      ~stream
+      ~config
+      ~messages
+      ~tools
+      ()
   in
-  match base_assoc with
-  | `Assoc fields ->
-    (* GLM thinking-control fields are emitted by the shared
+  let payload =
+    match Backend_openai_request.request_assoc_payload base_artifact with
+    | `Assoc fields ->
+      (* GLM thinking-control fields are emitted by the shared
        [Reasoning_dialect.request_control_fields] path inside the OpenAI
        request builder. Keep Backend_glm limited to GLM-only post-processing
        that is not a thinking builder: Z.AI's [tool_choice=auto] normalization
        and [tool_stream]. *)
-    let fields = normalize_tool_choice_fields ~tool_choice:config.tool_choice fields in
-    let fields =
-      (* GLM streams tool-call arguments incrementally only when both
+      let fields = normalize_tool_choice_fields ~tool_choice:config.tool_choice fields in
+      let fields =
+        (* GLM streams tool-call arguments incrementally only when both
          [stream] and [tool_stream] are set; [config.tool_stream] defaults
          false, so a streaming request carrying tools would otherwise buffer
          tool args. Default [tool_stream] on when tools are present
          (RFC-OAS-023). *)
-      if stream && (config.tool_stream || tools <> [])
-      then ("tool_stream", `Bool true) :: fields
-      else fields
-    in
-    Yojson.Safe.to_string (`Assoc fields)
-  | (`List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null) as other ->
-    Yojson.Safe.to_string other
+        if stream && (config.tool_stream || tools <> [])
+        then ("tool_stream", `Bool true) :: fields
+        else fields
+      in
+      Yojson.Safe.to_string (`Assoc fields)
+    | (`List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null) as other ->
+      Yojson.Safe.to_string other
+  in
+  Request_artifact_internal.create
+    ~payload
+    ~output_token_receipt:
+      (Backend_openai_request.request_assoc_output_token_receipt base_artifact)
+;;
+
+let build_request ?stream ~config ~messages ?tools () =
+  build_request_artifact ?stream ~config ~messages ?tools () |> request_payload
 ;;
 
 (* ── Response parsing ────────────────────────────── *)

--- a/lib/llm_provider/backend_glm.mli
+++ b/lib/llm_provider/backend_glm.mli
@@ -35,6 +35,11 @@ type glm_error =
 
 exception Glm_api_error of glm_error
 
+type request_artifact
+
+val request_payload : request_artifact -> string
+val request_output_token_receipt : request_artifact -> Types.output_token_receipt
+
 (** Classify a Glm error code + message into a semantic class.
     Code-based classification takes priority; message keywords are fallback. *)
 val classify_glm_error : code:string -> message:string -> glm_error_class * bool
@@ -54,6 +59,14 @@ val build_request
   -> ?tools:Yojson.Safe.t list
   -> unit
   -> string
+
+val build_request_artifact
+  :  ?stream:bool
+  -> config:Provider_config.t
+  -> messages:message list
+  -> ?tools:Yojson.Safe.t list
+  -> unit
+  -> request_artifact
 
 (** Parse a Glm chat completion response.
     Handles Glm-specific string error codes and extracts

--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -9,6 +9,10 @@
 
 open Types
 
+type request_artifact = string Request_artifact_internal.t
+
+let request_payload = Request_artifact_internal.payload
+let request_output_token_receipt = Request_artifact_internal.output_token_receipt
 let ( let* ) = Result.bind
 let keep_alive_env_var = "OAS_OLLAMA_KEEP_ALIVE"
 
@@ -22,7 +26,7 @@ let keep_alive_env_var = "OAS_OLLAMA_KEEP_ALIVE"
     - Sampling params go inside [options] object
     - [num_predict] instead of [max_tokens]
     - No [tool_choice] support *)
-let build_request
+let build_request_artifact
       ?(stream = false)
       ~(config : Provider_config.t)
       ~(messages : message list)
@@ -38,6 +42,11 @@ let build_request
     match Provider_config.capabilities_for_config_model config with
     | Some c -> c
     | None -> Capabilities.ollama_capabilities
+  in
+  let output_token_receipt =
+    Backend_openai_request.output_token_receipt
+      ~envelope:Types.Ollama_options_num_predict
+      config
   in
   (* The chat-template token injection is shared with the OpenAI-compat request
      builder ([Backend_openai_serialize]) so the same catalog row cannot be
@@ -164,7 +173,7 @@ let build_request
      omitted when both are unknown) — Ollama's [num_predict] is optional,
      and omission lets the server apply the model's own limit. Previously
      this arm bypassed the capability catalog and invented 16384. *)
-  (match Backend_openai_request.effective_max_output_tokens config with
+  (match Types.output_token_receipt_effective output_token_receipt with
    | Some mt -> options := ("num_predict", `Int mt) :: !options
    | None -> ());
   (match config.temperature with
@@ -191,7 +200,13 @@ let build_request
    | Some n when n > 0 -> options := ("num_ctx", `Int n) :: !options
    | _ -> ());
   let body = ("options", `Assoc !options) :: body in
-  Yojson.Safe.to_string (`Assoc body)
+  Request_artifact_internal.create
+    ~payload:(Yojson.Safe.to_string (`Assoc body))
+    ~output_token_receipt
+;;
+
+let build_request ?stream ~config ~messages ?tools () =
+  build_request_artifact ?stream ~config ~messages ?tools () |> request_payload
 ;;
 
 (* ── Response parsing ────────────────────────────────── *)

--- a/lib/llm_provider/backend_ollama.mli
+++ b/lib/llm_provider/backend_ollama.mli
@@ -5,6 +5,19 @@
 
     @since 0.113.0 *)
 
+type request_artifact
+
+val request_payload : request_artifact -> string
+val request_output_token_receipt : request_artifact -> Types.output_token_receipt
+
+val build_request_artifact
+  :  ?stream:bool
+  -> config:Provider_config.t
+  -> messages:Types.message list
+  -> ?tools:Yojson.Safe.t list
+  -> unit
+  -> request_artifact
+
 val build_request
   :  ?stream:bool
   -> config:Provider_config.t

--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -44,8 +44,30 @@ let structured_schema_of_config = Backend_openai_request.structured_schema_of_co
 let openai_json_schema_payload = Backend_openai_request.openai_json_schema_payload
 let response_format_to_openai_json = Backend_openai_request.response_format_to_openai_json
 let response_format_of_config = Backend_openai_request.response_format_of_config
-let build_request = Backend_openai_request.build_request
-let build_request_assoc = Backend_openai_request.build_request_assoc
+
+type request_artifact =
+  | Openai_request_artifact of Backend_openai_request.request_artifact
+
+let request_payload (Openai_request_artifact artifact) =
+  Backend_openai_request.request_payload artifact
+;;
+
+let request_output_token_receipt (Openai_request_artifact artifact) =
+  Backend_openai_request.request_output_token_receipt artifact
+;;
+
+let build_request_assoc ?stream ~config ~messages ?tools () =
+  Backend_openai_request.build_request_assoc ?stream ~config ~messages ?tools ()
+;;
+
+let build_request_artifact ?stream ~config ~messages ?tools () =
+  Openai_request_artifact
+    (Backend_openai_request.build_request_artifact ?stream ~config ~messages ?tools ())
+;;
+
+let build_request ?stream ~config ~messages ?tools () =
+  build_request_artifact ?stream ~config ~messages ?tools () |> request_payload
+;;
 
 [@@@coverage off]
 (* === Inline tests === *)

--- a/lib/llm_provider/backend_openai.mli
+++ b/lib/llm_provider/backend_openai.mli
@@ -24,6 +24,11 @@ val parse_openai_response_result
 
 val usage_of_openai_json : Yojson.Safe.t -> Types.api_usage option
 
+type request_artifact
+
+val request_payload : request_artifact -> string
+val request_output_token_receipt : request_artifact -> Types.output_token_receipt
+
 val build_request_assoc
   :  ?stream:bool
   -> config:Provider_config.t
@@ -39,6 +44,14 @@ val build_request
   -> ?tools:Yojson.Safe.t list
   -> unit
   -> string
+
+val build_request_artifact
+  :  ?stream:bool
+  -> config:Provider_config.t
+  -> messages:Types.message list
+  -> ?tools:Yojson.Safe.t list
+  -> unit
+  -> request_artifact
 
 (** Emit a one-shot stderr WARN the first time a capability-gated
     sampling field is dropped for a given [(model_id, field)] pair.

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -6,6 +6,14 @@
 
 open Types
 
+type request_assoc_artifact = Yojson.Safe.t Request_artifact_internal.t
+type request_artifact = string Request_artifact_internal.t
+
+let request_assoc_payload = Request_artifact_internal.payload
+let request_assoc_output_token_receipt = Request_artifact_internal.output_token_receipt
+let request_payload = Request_artifact_internal.payload
+let request_output_token_receipt = Request_artifact_internal.output_token_receipt
+
 (* ── Capability-drop WARN dedup ────────────────────────── *)
 
 (** One-shot stderr WARN table, keyed by ([model_id], [field_name]).
@@ -181,14 +189,45 @@ let capabilities_of_config (config : Provider_config.t) =
    which applies an explicit OAS required-envelope fallback (the
    catalog-declared model maximum, not a provider default) and fails loudly
    when no value is declared anywhere — no invented constants. *)
+let output_token_ceiling (config : Provider_config.t) =
+  (* [model_capabilities_override] is the typed declaration boundary documented
+     by [Provider_config.t]: it includes caller declarations and provider/runtime
+     catalog binding declarations.  It is intentionally distinct from the model
+     catalog lookup below.  Do not infer provenance by comparing capability
+     records or model/provider strings. *)
+  match config.model_capabilities_override with
+  | Some caps ->
+    Option.map
+      (fun value ->
+         Types.output_token_ceiling ~value ~source:Types.Declared_capability_override)
+      caps.max_output_tokens
+  | None ->
+    Option.bind (Provider_config.capabilities_for_config_model config) (fun caps ->
+      Option.map
+        (fun value -> Types.output_token_ceiling ~value ~source:Types.Catalog_model)
+        caps.max_output_tokens)
+;;
+
+let output_token_receipt ~envelope (config : Provider_config.t) =
+  let receipt =
+    Types.optional_output_token_receipt
+      ~envelope
+      ~requested:config.max_tokens
+      ~ceiling:(output_token_ceiling config)
+  in
+  (match Types.output_token_receipt_policy receipt with
+   | Types.Explicit_clamped ->
+     warn_capability_drop ~model_id:config.model_id ~field:"max_tokens:clamp"
+   | Omitted
+   | Explicit
+   | Required_catalog_fallback
+   | Required_capability_override_fallback -> ());
+  receipt
+;;
+
 let effective_max_output_tokens (config : Provider_config.t) =
-  let caps = capabilities_of_config config in
-  match config.max_tokens, caps.max_output_tokens with
-  | None, _ -> None
-  | Some n, Some cap when n > cap ->
-    warn_capability_drop ~model_id:config.model_id ~field:"max_tokens:clamp";
-    Some cap
-  | (Some _ as n), _ -> n
+  output_token_receipt ~envelope:Types.Openai_chat_max_tokens config
+  |> Types.output_token_receipt_effective
 ;;
 
 (* Shared tool_choice emission gate for the Chat and Responses envelopes.
@@ -215,7 +254,7 @@ let is_zai_glm_request = Provider_config.is_zai_glm_config
 
 (** Build Openai Chat Completions request body from {!Provider_config.t}.
     Returns a JSON string ready for HTTP POST. *)
-let build_request_assoc
+let build_request_assoc_artifact
       ?(stream = false)
       ~(config : Provider_config.t)
       ~(messages : message list)
@@ -228,6 +267,9 @@ let build_request_assoc
   in
   let dialect = Reasoning_dialect.for_provider_config config in
   let caps = capabilities_of_config config in
+  let output_token_receipt =
+    output_token_receipt ~envelope:Types.Openai_chat_max_tokens config
+  in
   let assistant_tool_content_format = caps.Capabilities.assistant_tool_content_format in
   let provider_messages =
     (* RFC-OAS-029 S3.1: reasoning replay is decided by the typed dialect
@@ -277,7 +319,7 @@ let build_request_assoc
      neither caller nor catalog declares a value. *)
   let body = [ "model", `String config.model_id; "messages", `List provider_messages ] in
   let body =
-    match effective_max_output_tokens config with
+    match Types.output_token_receipt_effective output_token_receipt with
     | Some mt -> body @ [ "max_tokens", `Int mt ]
     | None -> body
   in
@@ -388,7 +430,12 @@ let build_request_assoc
       ("seed", `Int seed) :: body)
     else body
   in
-  `Assoc body
+  Request_artifact_internal.create ~payload:(`Assoc body) ~output_token_receipt
+;;
+
+let build_request_assoc ?stream ~config ~messages ?tools () =
+  build_request_assoc_artifact ?stream ~config ~messages ?tools ()
+  |> request_assoc_payload
 ;;
 
 (** [build_request] serializes [build_request_assoc] to a JSON string.
@@ -396,12 +443,19 @@ let build_request_assoc
     {!Backend_glm}) mutate the request Assoc directly instead of parsing the
     serialized string back — one fewer full [Yojson.Safe.from_string] +
     [Yojson.Safe.to_string] of the message body per turn. *)
-let build_request
+let build_request_artifact
       ?(stream = false)
       ~(config : Provider_config.t)
       ~(messages : message list)
       ?(tools : Yojson.Safe.t list = [])
       ()
   =
-  build_request_assoc ~stream ~config ~messages ~tools () |> Yojson.Safe.to_string
+  let assoc_artifact = build_request_assoc_artifact ~stream ~config ~messages ~tools () in
+  Request_artifact_internal.create
+    ~payload:(Yojson.Safe.to_string (request_assoc_payload assoc_artifact))
+    ~output_token_receipt:(request_assoc_output_token_receipt assoc_artifact)
+;;
+
+let build_request ?stream ~config ~messages ?tools () =
+  build_request_artifact ?stream ~config ~messages ?tools () |> request_payload
 ;;

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -202,10 +202,14 @@ let output_token_ceiling (config : Provider_config.t) =
          Types.output_token_ceiling ~value ~source:Types.Declared_capability_override)
       caps.max_output_tokens
   | None ->
-    Option.bind (Provider_config.capabilities_for_config_model config) (fun caps ->
-      Option.map
-        (fun value -> Types.output_token_ceiling ~value ~source:Types.Catalog_model)
-        caps.max_output_tokens)
+    let caps, source =
+      match Provider_config.capabilities_for_config_model config with
+      | Some caps -> caps, Types.Catalog_model
+      | None -> capabilities_of_config config, Types.Provider_default
+    in
+    Option.map
+      (fun value -> Types.output_token_ceiling ~value ~source)
+      caps.max_output_tokens
 ;;
 
 let output_token_receipt ~envelope (config : Provider_config.t) =

--- a/lib/llm_provider/backend_openai_request.mli
+++ b/lib/llm_provider/backend_openai_request.mli
@@ -39,7 +39,8 @@ val capabilities_of_config : Provider_config.t -> Capabilities.capabilities
 val effective_max_output_tokens : Provider_config.t -> int option
 
 (** Resolve the optional output-token decision once, preserving whether its
-    ceiling came from the model catalog or an explicit capability override. *)
+    ceiling came from the model catalog, an explicit capability override, or
+    the typed provider default used by {!capabilities_of_config}. *)
 val output_token_receipt
   :  envelope:Types.output_token_envelope
   -> Provider_config.t

--- a/lib/llm_provider/backend_openai_request.mli
+++ b/lib/llm_provider/backend_openai_request.mli
@@ -7,6 +7,17 @@
 
     @stability Internal *)
 
+type request_assoc_artifact
+type request_artifact
+
+val request_assoc_payload : request_assoc_artifact -> Yojson.Safe.t
+
+val request_assoc_output_token_receipt
+  :  request_assoc_artifact
+  -> Types.output_token_receipt
+
+val request_payload : request_artifact -> string
+val request_output_token_receipt : request_artifact -> Types.output_token_receipt
 val warn_capability_drop : model_id:string -> field:string -> unit
 val effective_tool_choice : Provider_config.t -> Yojson.Safe.t option
 val effective_tools : Provider_config.t -> Yojson.Safe.t list -> Yojson.Safe.t list
@@ -26,6 +37,13 @@ val capabilities_of_config : Provider_config.t -> Capabilities.capabilities
     required Anthropic envelope uses
     [Backend_anthropic.required_max_output_tokens] instead. *)
 val effective_max_output_tokens : Provider_config.t -> int option
+
+(** Resolve the optional output-token decision once, preserving whether its
+    ceiling came from the model catalog or an explicit capability override. *)
+val output_token_receipt
+  :  envelope:Types.output_token_envelope
+  -> Provider_config.t
+  -> Types.output_token_receipt
 
 (** Prepend the sampling [(field, value)] to [body] unless the reasoning
     dialect suppresses that parameter, in which case the field is dropped with a
@@ -60,6 +78,14 @@ val build_request_assoc
   -> unit
   -> Yojson.Safe.t
 
+val build_request_assoc_artifact
+  :  ?stream:bool
+  -> config:Provider_config.t
+  -> messages:Types.message list
+  -> ?tools:Yojson.Safe.t list
+  -> unit
+  -> request_assoc_artifact
+
 val build_request
   :  ?stream:bool
   -> config:Provider_config.t
@@ -67,3 +93,11 @@ val build_request
   -> ?tools:Yojson.Safe.t list
   -> unit
   -> string
+
+val build_request_artifact
+  :  ?stream:bool
+  -> config:Provider_config.t
+  -> messages:Types.message list
+  -> ?tools:Yojson.Safe.t list
+  -> unit
+  -> request_artifact

--- a/lib/llm_provider/backend_openai_responses.ml
+++ b/lib/llm_provider/backend_openai_responses.ml
@@ -7,6 +7,10 @@
 
 open Types
 
+type request_artifact = string Request_artifact_internal.t
+
+let request_payload = Request_artifact_internal.payload
+let request_output_token_receipt = Request_artifact_internal.output_token_receipt
 let ( let* ) = Result.bind
 
 let json_assoc_opt key = function
@@ -350,10 +354,9 @@ let capabilities_of_config = Backend_openai_request.capabilities_of_config
    (dialect WARN included) are single-sourced with the Chat Completions
    builder; Responses only renames the budget wire field to
    [max_output_tokens]. *)
-let effective_max_output_tokens = Backend_openai_request.effective_max_output_tokens
 let add_sampling_field = Backend_openai_request.add_sampling_field
 
-let build_request
+let build_request_artifact
       ?(stream = false)
       ~(config : Provider_config.t)
       ~(messages : message list)
@@ -365,6 +368,11 @@ let build_request
     Backend_openai_serialize.close_tool_message_pairs_for_request messages
   in
   let dialect = Reasoning_dialect.for_provider_config config in
+  let output_token_receipt =
+    Backend_openai_request.output_token_receipt
+      ~envelope:Types.Openai_responses_max_output_tokens
+      config
+  in
   let reasoning_effort =
     (match Provider_config.validate_reasoning_effort_request config with
      | Ok () -> ()
@@ -384,7 +392,7 @@ let build_request
     ]
   in
   let body =
-    match effective_max_output_tokens config with
+    match Types.output_token_receipt_effective output_token_receipt with
     | Some mt -> body @ [ "max_output_tokens", `Int mt ]
     | None -> body
   in
@@ -460,7 +468,13 @@ let build_request
     @ body
   in
   let body = if stream then ("stream", `Bool true) :: body else body in
-  Yojson.Safe.to_string (`Assoc body)
+  Request_artifact_internal.create
+    ~payload:(Yojson.Safe.to_string (`Assoc body))
+    ~output_token_receipt
+;;
+
+let build_request ?stream ~config ~messages ?tools () =
+  build_request_artifact ?stream ~config ~messages ?tools () |> request_payload
 ;;
 
 let output_text_of_content = function

--- a/lib/llm_provider/backend_openai_responses.mli
+++ b/lib/llm_provider/backend_openai_responses.mli
@@ -17,6 +17,19 @@ type response_phase =
 val response_phase_metadata : response_phase -> string * Yojson.Safe.t
 val responses_tool_json : Yojson.Safe.t -> Yojson.Safe.t
 
+type request_artifact
+
+val request_payload : request_artifact -> string
+val request_output_token_receipt : request_artifact -> Types.output_token_receipt
+
+val build_request_artifact
+  :  ?stream:bool
+  -> config:Provider_config.t
+  -> messages:Types.message list
+  -> ?tools:Yojson.Safe.t list
+  -> unit
+  -> request_artifact
+
 val build_request
   :  ?stream:bool
   -> config:Provider_config.t

--- a/lib/llm_provider/dune
+++ b/lib/llm_provider/dune
@@ -3,7 +3,10 @@
 (library
  (name llm_provider)
  (public_name agent_sdk.llm_provider)
- (private_modules provider_http_codec)
+ (private_modules
+  provider_http_codec
+  output_token_wire_internal
+  request_artifact_internal)
  (libraries
   yojson
   otoml

--- a/lib/llm_provider/output_token_wire_internal.ml
+++ b/lib/llm_provider/output_token_wire_internal.ml
@@ -17,6 +17,7 @@ type policy =
 type ceiling_source =
   | Catalog_model
   | Declared_capability_override
+  | Provider_default
 [@@deriving show, eq]
 
 let envelope_wire_name = function
@@ -77,6 +78,7 @@ let policy_of_yojson = function
 let ceiling_source_wire_name = function
   | Catalog_model -> "catalog_model"
   | Declared_capability_override -> "declared_capability_override"
+  | Provider_default -> "provider_default"
 ;;
 
 let ceiling_source_to_yojson source = `String (ceiling_source_wire_name source)
@@ -87,7 +89,215 @@ let ceiling_source_of_yojson = function
   | `String value
     when String.equal value (ceiling_source_wire_name Declared_capability_override) ->
     Ok Declared_capability_override
+  | `String value when String.equal value (ceiling_source_wire_name Provider_default) ->
+    Ok Provider_default
   | `String value ->
     Error (Printf.sprintf "unknown output-token ceiling source: %S" value)
   | _ -> Error "output-token ceiling source must be a string"
+;;
+
+type ceiling =
+  { value : int
+  ; source : ceiling_source
+  }
+[@@deriving show, eq]
+
+let ceiling ~value ~source =
+  if value <= 0
+  then invalid_arg "output_token_ceiling: value must be positive"
+  else { value; source }
+;;
+
+type required_fallback_source =
+  | Required_catalog_source
+  | Required_capability_override_source
+[@@deriving show, eq]
+
+type resolution =
+  | Omitted_resolution of { ceiling : ceiling option }
+  | Explicit_resolution of
+      { value : int
+      ; ceiling : ceiling option
+      }
+  | Explicit_clamped_resolution of
+      { requested : int
+      ; ceiling : ceiling
+      }
+  | Required_fallback_resolution of
+      { ceiling : ceiling
+      ; source : required_fallback_source
+      }
+[@@deriving show, eq]
+
+type receipt =
+  { envelope : envelope
+  ; resolution : resolution
+  }
+[@@deriving show, eq]
+
+type required_error = Required_output_token_ceiling_missing [@@deriving show, eq]
+
+let receipt_envelope receipt = receipt.envelope
+
+let receipt_requested receipt =
+  match receipt.resolution with
+  | Omitted_resolution _ | Required_fallback_resolution _ -> None
+  | Explicit_resolution { value; _ } -> Some value
+  | Explicit_clamped_resolution { requested; _ } -> Some requested
+;;
+
+let receipt_effective receipt =
+  match receipt.resolution with
+  | Omitted_resolution _ -> None
+  | Explicit_resolution { value; _ } -> Some value
+  | Explicit_clamped_resolution { ceiling; _ } | Required_fallback_resolution { ceiling }
+    -> Some ceiling.value
+;;
+
+let receipt_policy receipt =
+  match receipt.resolution with
+  | Omitted_resolution _ -> Omitted
+  | Explicit_resolution _ -> Explicit
+  | Explicit_clamped_resolution _ -> Explicit_clamped
+  | Required_fallback_resolution { source = Required_catalog_source; _ } ->
+    Required_catalog_fallback
+  | Required_fallback_resolution { source = Required_capability_override_source; _ } ->
+    Required_capability_override_fallback
+;;
+
+let receipt_ceiling_value receipt =
+  match receipt.resolution with
+  | Omitted_resolution { ceiling } | Explicit_resolution { ceiling; _ } -> ceiling
+  | Explicit_clamped_resolution { ceiling; _ } | Required_fallback_resolution { ceiling }
+    -> Some ceiling
+;;
+
+let receipt_ceiling receipt =
+  Option.map (fun ceiling -> ceiling.value) (receipt_ceiling_value receipt)
+;;
+
+let receipt_ceiling_source receipt =
+  Option.map (fun ceiling -> ceiling.source) (receipt_ceiling_value receipt)
+;;
+
+let optional_receipt ~envelope ~requested ~ceiling =
+  (match requested with
+   | Some value when value < 0 ->
+     invalid_arg "optional_output_token_receipt: requested value must be non-negative"
+   | None | Some _ -> ());
+  let resolution =
+    match requested, ceiling with
+    | None, ceiling -> Omitted_resolution { ceiling }
+    | Some requested, Some ceiling when requested > ceiling.value ->
+      Explicit_clamped_resolution { requested; ceiling }
+    | Some value, ceiling -> Explicit_resolution { value; ceiling }
+  in
+  { envelope; resolution }
+;;
+
+let required_receipt receipt =
+  match receipt.resolution with
+  | Omitted_resolution { ceiling = Some ({ source = Catalog_model; _ } as ceiling) } ->
+    Ok
+      { receipt with
+        resolution =
+          Required_fallback_resolution { ceiling; source = Required_catalog_source }
+      }
+  | Omitted_resolution
+      { ceiling = Some ({ source = Declared_capability_override; _ } as ceiling) } ->
+    Ok
+      { receipt with
+        resolution =
+          Required_fallback_resolution
+            { ceiling; source = Required_capability_override_source }
+      }
+  | Omitted_resolution { ceiling = None | Some { source = Provider_default; _ } } ->
+    Error Required_output_token_ceiling_missing
+  | Explicit_resolution _ | Explicit_clamped_resolution _ | Required_fallback_resolution _
+    -> Ok receipt
+;;
+
+let receipt_to_yojson receipt =
+  let option_int_to_yojson = function
+    | Some value -> `Int value
+    | None -> `Null
+  in
+  `Assoc
+    [ "requested", option_int_to_yojson (receipt_requested receipt)
+    ; "effective", option_int_to_yojson (receipt_effective receipt)
+    ; "policy", policy_to_yojson (receipt_policy receipt)
+    ; "ceiling", option_int_to_yojson (receipt_ceiling receipt)
+    ; ( "ceiling_source"
+      , match receipt_ceiling_source receipt with
+        | Some source -> ceiling_source_to_yojson source
+        | None -> `Null )
+    ; "envelope", envelope_to_yojson receipt.envelope
+    ]
+;;
+
+let receipt_of_yojson json =
+  let open Yojson.Safe.Util in
+  let token_value_option = function
+    | `Null -> Ok None
+    | `Int value when value >= 0 -> Ok (Some value)
+    | `Int _ -> Error "output_token_receipt: token values must be non-negative"
+    | _ -> Error "output_token_receipt: expected integer or null"
+  in
+  let ceiling_option = function
+    | `Null -> Ok None
+    | `Int value when value > 0 -> Ok (Some value)
+    | `Int _ -> Error "output_token_receipt: ceiling must be positive"
+    | _ -> Error "output_token_receipt: expected integer or null"
+  in
+  let ( let* ) result f = Result.bind result f in
+  try
+    let* requested = token_value_option (member "requested" json) in
+    let* effective = token_value_option (member "effective" json) in
+    let* ceiling_value = ceiling_option (member "ceiling" json) in
+    let* ceiling_source =
+      match member "ceiling_source" json with
+      | `Null -> Ok None
+      | source_json ->
+        Result.map (fun source -> Some source) (ceiling_source_of_yojson source_json)
+    in
+    let* ceiling =
+      match ceiling_value, ceiling_source with
+      | None, None -> Ok None
+      | Some value, Some source -> Ok (Some (ceiling ~value ~source))
+      | Some _, None | None, Some _ ->
+        Error "output_token_receipt: ceiling and ceiling_source must appear together"
+    in
+    let* policy = policy_of_yojson (member "policy" json) in
+    let* envelope = envelope_of_yojson (member "envelope" json) in
+    match policy, requested, effective, ceiling with
+    | Omitted, None, None, ceiling ->
+      Ok { envelope; resolution = Omitted_resolution { ceiling } }
+    | Explicit, Some requested, Some effective, ceiling
+      when requested = effective
+           &&
+           match ceiling with
+           | Some cap -> effective <= cap.value
+           | None -> true ->
+      Ok { envelope; resolution = Explicit_resolution { value = effective; ceiling } }
+    | Explicit_clamped, Some requested, Some effective, Some ceiling
+      when effective = ceiling.value && requested > ceiling.value ->
+      Ok { envelope; resolution = Explicit_clamped_resolution { requested; ceiling } }
+    | Required_catalog_fallback, None, Some effective, Some ceiling
+      when ceiling.source = Catalog_model && effective = ceiling.value ->
+      Ok
+        { envelope
+        ; resolution =
+            Required_fallback_resolution { ceiling; source = Required_catalog_source }
+        }
+    | Required_capability_override_fallback, None, Some effective, Some ceiling
+      when ceiling.source = Declared_capability_override && effective = ceiling.value ->
+      Ok
+        { envelope
+        ; resolution =
+            Required_fallback_resolution
+              { ceiling; source = Required_capability_override_source }
+        }
+    | _ -> Error "output_token_receipt: inconsistent requested/effective policy fields"
+  with
+  | Yojson.Safe.Util.Type_error (message, _) -> Error message
 ;;

--- a/lib/llm_provider/output_token_wire_internal.ml
+++ b/lib/llm_provider/output_token_wire_internal.ml
@@ -1,0 +1,93 @@
+type envelope =
+  | Openai_chat_max_tokens
+  | Openai_responses_max_output_tokens
+  | Anthropic_messages_max_tokens
+  | Gemini_generation_config_max_output_tokens
+  | Ollama_options_num_predict
+[@@deriving show, eq]
+
+type policy =
+  | Omitted
+  | Explicit
+  | Explicit_clamped
+  | Required_catalog_fallback
+  | Required_capability_override_fallback
+[@@deriving show, eq]
+
+type ceiling_source =
+  | Catalog_model
+  | Declared_capability_override
+[@@deriving show, eq]
+
+let envelope_wire_name = function
+  | Openai_chat_max_tokens -> "openai_chat_max_tokens"
+  | Openai_responses_max_output_tokens -> "openai_responses_max_output_tokens"
+  | Anthropic_messages_max_tokens -> "anthropic_messages_max_tokens"
+  | Gemini_generation_config_max_output_tokens ->
+    "gemini_generation_config_max_output_tokens"
+  | Ollama_options_num_predict -> "ollama_options_num_predict"
+;;
+
+let envelope_to_yojson envelope = `String (envelope_wire_name envelope)
+
+let envelope_of_yojson = function
+  | `String value when String.equal value (envelope_wire_name Openai_chat_max_tokens) ->
+    Ok Openai_chat_max_tokens
+  | `String value
+    when String.equal value (envelope_wire_name Openai_responses_max_output_tokens) ->
+    Ok Openai_responses_max_output_tokens
+  | `String value
+    when String.equal value (envelope_wire_name Anthropic_messages_max_tokens) ->
+    Ok Anthropic_messages_max_tokens
+  | `String value
+    when String.equal
+           value
+           (envelope_wire_name Gemini_generation_config_max_output_tokens) ->
+    Ok Gemini_generation_config_max_output_tokens
+  | `String value when String.equal value (envelope_wire_name Ollama_options_num_predict)
+    -> Ok Ollama_options_num_predict
+  | `String value -> Error (Printf.sprintf "unknown output-token envelope: %S" value)
+  | _ -> Error "output-token envelope must be a string"
+;;
+
+let policy_wire_name = function
+  | Omitted -> "omitted"
+  | Explicit -> "explicit"
+  | Explicit_clamped -> "explicit_clamped"
+  | Required_catalog_fallback -> "required_catalog_fallback"
+  | Required_capability_override_fallback -> "required_capability_override_fallback"
+;;
+
+let policy_to_yojson policy = `String (policy_wire_name policy)
+
+let policy_of_yojson = function
+  | `String value when String.equal value (policy_wire_name Omitted) -> Ok Omitted
+  | `String value when String.equal value (policy_wire_name Explicit) -> Ok Explicit
+  | `String value when String.equal value (policy_wire_name Explicit_clamped) ->
+    Ok Explicit_clamped
+  | `String value when String.equal value (policy_wire_name Required_catalog_fallback) ->
+    Ok Required_catalog_fallback
+  | `String value
+    when String.equal value (policy_wire_name Required_capability_override_fallback) ->
+    Ok Required_capability_override_fallback
+  | `String value -> Error (Printf.sprintf "unknown output-token policy: %S" value)
+  | _ -> Error "output-token policy must be a string"
+;;
+
+let ceiling_source_wire_name = function
+  | Catalog_model -> "catalog_model"
+  | Declared_capability_override -> "declared_capability_override"
+;;
+
+let ceiling_source_to_yojson source = `String (ceiling_source_wire_name source)
+
+let ceiling_source_of_yojson = function
+  | `String value when String.equal value (ceiling_source_wire_name Catalog_model) ->
+    Ok Catalog_model
+  | `String value
+    when String.equal value (ceiling_source_wire_name Declared_capability_override) ->
+    Ok Declared_capability_override
+  | `String value ->
+    Error (Printf.sprintf "unknown output-token ceiling source: %S" value)
+  | _ -> Error "output-token ceiling source must be a string"
+;;

--- a/lib/llm_provider/output_token_wire_internal.mli
+++ b/lib/llm_provider/output_token_wire_internal.mli
@@ -1,4 +1,5 @@
-(** Dune-private stable JSON vocabulary for output-token receipt enums. *)
+(** Dune-private implementation and stable JSON vocabulary for output-token
+    receipts.  {!Types} re-exports the public surface. *)
 
 type envelope =
   | Openai_chat_max_tokens
@@ -19,6 +20,7 @@ type policy =
 type ceiling_source =
   | Catalog_model
   | Declared_capability_override
+  | Provider_default
 [@@deriving show, eq]
 
 val envelope_to_yojson : envelope -> Yojson.Safe.t
@@ -27,3 +29,33 @@ val policy_to_yojson : policy -> Yojson.Safe.t
 val policy_of_yojson : Yojson.Safe.t -> (policy, string) result
 val ceiling_source_to_yojson : ceiling_source -> Yojson.Safe.t
 val ceiling_source_of_yojson : Yojson.Safe.t -> (ceiling_source, string) result
+
+type ceiling =
+  { value : int
+  ; source : ceiling_source
+  }
+[@@deriving show, eq]
+
+val ceiling : value:int -> source:ceiling_source -> ceiling
+
+type receipt
+type required_error = Required_output_token_ceiling_missing [@@deriving show, eq]
+
+val optional_receipt
+  :  envelope:envelope
+  -> requested:int option
+  -> ceiling:ceiling option
+  -> receipt
+
+val required_receipt : receipt -> (receipt, required_error) result
+val receipt_envelope : receipt -> envelope
+val receipt_requested : receipt -> int option
+val receipt_effective : receipt -> int option
+val receipt_policy : receipt -> policy
+val receipt_ceiling : receipt -> int option
+val receipt_ceiling_source : receipt -> ceiling_source option
+val receipt_to_yojson : receipt -> Yojson.Safe.t
+val receipt_of_yojson : Yojson.Safe.t -> (receipt, string) result
+val equal_receipt : receipt -> receipt -> bool
+val pp_receipt : Format.formatter -> receipt -> unit
+val show_receipt : receipt -> string

--- a/lib/llm_provider/output_token_wire_internal.mli
+++ b/lib/llm_provider/output_token_wire_internal.mli
@@ -1,0 +1,29 @@
+(** Dune-private stable JSON vocabulary for output-token receipt enums. *)
+
+type envelope =
+  | Openai_chat_max_tokens
+  | Openai_responses_max_output_tokens
+  | Anthropic_messages_max_tokens
+  | Gemini_generation_config_max_output_tokens
+  | Ollama_options_num_predict
+[@@deriving show, eq]
+
+type policy =
+  | Omitted
+  | Explicit
+  | Explicit_clamped
+  | Required_catalog_fallback
+  | Required_capability_override_fallback
+[@@deriving show, eq]
+
+type ceiling_source =
+  | Catalog_model
+  | Declared_capability_override
+[@@deriving show, eq]
+
+val envelope_to_yojson : envelope -> Yojson.Safe.t
+val envelope_of_yojson : Yojson.Safe.t -> (envelope, string) result
+val policy_to_yojson : policy -> Yojson.Safe.t
+val policy_of_yojson : Yojson.Safe.t -> (policy, string) result
+val ceiling_source_to_yojson : ceiling_source -> Yojson.Safe.t
+val ceiling_source_of_yojson : Yojson.Safe.t -> (ceiling_source, string) result

--- a/lib/llm_provider/request_artifact_internal.ml
+++ b/lib/llm_provider/request_artifact_internal.ml
@@ -1,0 +1,8 @@
+type 'payload t =
+  { payload : 'payload
+  ; output_token_receipt : Types.output_token_receipt
+  }
+
+let create ~payload ~output_token_receipt = { payload; output_token_receipt }
+let payload artifact = artifact.payload
+let output_token_receipt artifact = artifact.output_token_receipt

--- a/lib/llm_provider/request_artifact_internal.mli
+++ b/lib/llm_provider/request_artifact_internal.mli
@@ -1,0 +1,13 @@
+(** Dune-private immutable storage for a provider-built request and the exact
+    output-token decision used to build it.  Public backends expose only their
+    own abstract artifact types and read-only projections. *)
+
+type 'payload t
+
+val create
+  :  payload:'payload
+  -> output_token_receipt:Types.output_token_receipt
+  -> 'payload t
+
+val payload : 'payload t -> 'payload
+val output_token_receipt : 'payload t -> Types.output_token_receipt

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -465,6 +465,7 @@ type output_token_policy = Output_token_wire_internal.policy =
 type output_token_ceiling_source = Output_token_wire_internal.ceiling_source =
   | Catalog_model
   | Declared_capability_override
+  | Provider_default
 
 let pp_output_token_envelope = Output_token_wire_internal.pp_envelope
 let show_output_token_envelope = Output_token_wire_internal.show_envelope
@@ -488,189 +489,37 @@ let output_token_ceiling_source_of_yojson =
   Output_token_wire_internal.ceiling_source_of_yojson
 ;;
 
-type output_token_ceiling =
+type output_token_ceiling = Output_token_wire_internal.ceiling =
   { value : int
   ; source : output_token_ceiling_source
   }
 [@@deriving show, eq]
 
-let output_token_ceiling ~value ~source =
-  if value <= 0
-  then invalid_arg "output_token_ceiling: value must be positive"
-  else { value; source }
-;;
+let output_token_ceiling = Output_token_wire_internal.ceiling
 
-type output_token_resolution =
-  | Omitted_resolution of { ceiling : output_token_ceiling option }
-  | Explicit_resolution of
-      { value : int
-      ; ceiling : output_token_ceiling option
-      }
-  | Explicit_clamped_resolution of
-      { requested : int
-      ; ceiling : output_token_ceiling
-      }
-  | Required_fallback_resolution of { ceiling : output_token_ceiling }
+type output_token_receipt = Output_token_wire_internal.receipt
+
+type required_output_token_error = Output_token_wire_internal.required_error =
+  | Required_output_token_ceiling_missing
 [@@deriving show, eq]
 
-(** Invariant-checked observation of an output-token decision.  The internal
-    sum prevents impossible combinations such as a clamped policy without a
-    ceiling; opaque backend artifacts separately establish exact payload
-    provenance. *)
-type output_token_receipt =
-  { envelope : output_token_envelope
-  ; resolution : output_token_resolution
-  }
-[@@deriving show, eq]
+let optional_output_token_receipt = Output_token_wire_internal.optional_receipt
+let required_output_token_receipt = Output_token_wire_internal.required_receipt
+let output_token_receipt_envelope = Output_token_wire_internal.receipt_envelope
+let output_token_receipt_requested = Output_token_wire_internal.receipt_requested
+let output_token_receipt_effective = Output_token_wire_internal.receipt_effective
+let output_token_receipt_policy = Output_token_wire_internal.receipt_policy
+let output_token_receipt_ceiling = Output_token_wire_internal.receipt_ceiling
 
-type required_output_token_error = Required_output_token_ceiling_missing
-[@@deriving show, eq]
-
-let output_token_receipt_envelope receipt = receipt.envelope
-
-let output_token_receipt_requested receipt =
-  match receipt.resolution with
-  | Omitted_resolution _ | Required_fallback_resolution _ -> None
-  | Explicit_resolution { value; _ } -> Some value
-  | Explicit_clamped_resolution { requested; _ } -> Some requested
+let output_token_receipt_ceiling_source =
+  Output_token_wire_internal.receipt_ceiling_source
 ;;
 
-let output_token_receipt_effective receipt =
-  match receipt.resolution with
-  | Omitted_resolution _ -> None
-  | Explicit_resolution { value; _ } -> Some value
-  | Explicit_clamped_resolution { ceiling; _ } | Required_fallback_resolution { ceiling }
-    -> Some ceiling.value
-;;
-
-let output_token_receipt_policy receipt =
-  match receipt.resolution with
-  | Omitted_resolution _ -> Omitted
-  | Explicit_resolution _ -> Explicit
-  | Explicit_clamped_resolution _ -> Explicit_clamped
-  | Required_fallback_resolution { ceiling = { source = Catalog_model; _ } } ->
-    Required_catalog_fallback
-  | Required_fallback_resolution
-      { ceiling = { source = Declared_capability_override; _ } } ->
-    Required_capability_override_fallback
-;;
-
-let receipt_ceiling receipt =
-  match receipt.resolution with
-  | Omitted_resolution { ceiling } | Explicit_resolution { ceiling; _ } -> ceiling
-  | Explicit_clamped_resolution { ceiling; _ } | Required_fallback_resolution { ceiling }
-    -> Some ceiling
-;;
-
-let output_token_receipt_ceiling receipt =
-  Option.map (fun ceiling -> ceiling.value) (receipt_ceiling receipt)
-;;
-
-let output_token_receipt_ceiling_source receipt =
-  Option.map (fun ceiling -> ceiling.source) (receipt_ceiling receipt)
-;;
-
-let optional_output_token_receipt ~envelope ~requested ~ceiling =
-  (match requested with
-   | Some value when value < 0 ->
-     invalid_arg "optional_output_token_receipt: requested value must be non-negative"
-   | None | Some _ -> ());
-  let resolution =
-    match requested, ceiling with
-    | None, ceiling -> Omitted_resolution { ceiling }
-    | Some requested, Some ceiling when requested > ceiling.value ->
-      Explicit_clamped_resolution { requested; ceiling }
-    | Some value, ceiling -> Explicit_resolution { value; ceiling }
-  in
-  { envelope; resolution }
-;;
-
-let required_output_token_receipt receipt =
-  match receipt.resolution with
-  | Omitted_resolution { ceiling = Some ceiling } ->
-    Ok { receipt with resolution = Required_fallback_resolution { ceiling } }
-  | Omitted_resolution { ceiling = None } -> Error Required_output_token_ceiling_missing
-  | Explicit_resolution _ | Explicit_clamped_resolution _ | Required_fallback_resolution _
-    -> Ok receipt
-;;
-
-let output_token_receipt_to_yojson receipt =
-  let option_int_to_yojson = function
-    | Some value -> `Int value
-    | None -> `Null
-  in
-  `Assoc
-    [ "requested", option_int_to_yojson (output_token_receipt_requested receipt)
-    ; "effective", option_int_to_yojson (output_token_receipt_effective receipt)
-    ; "policy", output_token_policy_to_yojson (output_token_receipt_policy receipt)
-    ; "ceiling", option_int_to_yojson (output_token_receipt_ceiling receipt)
-    ; ( "ceiling_source"
-      , match output_token_receipt_ceiling_source receipt with
-        | Some source -> output_token_ceiling_source_to_yojson source
-        | None -> `Null )
-    ; "envelope", output_token_envelope_to_yojson receipt.envelope
-    ]
-;;
-
-let output_token_receipt_of_yojson json =
-  let open Yojson.Safe.Util in
-  let token_value_option = function
-    | `Null -> Ok None
-    | `Int value when value >= 0 -> Ok (Some value)
-    | `Int _ -> Error "output_token_receipt: token values must be non-negative"
-    | _ -> Error "output_token_receipt: expected integer or null"
-  in
-  let ceiling_option = function
-    | `Null -> Ok None
-    | `Int value when value > 0 -> Ok (Some value)
-    | `Int _ -> Error "output_token_receipt: ceiling must be positive"
-    | _ -> Error "output_token_receipt: expected integer or null"
-  in
-  let ( let* ) result f = Result.bind result f in
-  try
-    let* requested = token_value_option (member "requested" json) in
-    let* effective = token_value_option (member "effective" json) in
-    let* ceiling = ceiling_option (member "ceiling" json) in
-    let* ceiling_source =
-      match member "ceiling_source" json with
-      | `Null -> Ok None
-      | source_json ->
-        Result.map
-          (fun source -> Some source)
-          (output_token_ceiling_source_of_yojson source_json)
-    in
-    let* ceiling =
-      match ceiling, ceiling_source with
-      | None, None -> Ok None
-      | Some value, Some source -> Ok (Some (output_token_ceiling ~value ~source))
-      | Some _, None | None, Some _ ->
-        Error "output_token_receipt: ceiling and ceiling_source must appear together"
-    in
-    let* policy = output_token_policy_of_yojson (member "policy" json) in
-    let* envelope = output_token_envelope_of_yojson (member "envelope" json) in
-    match policy, requested, effective, ceiling with
-    | Omitted, None, None, ceiling ->
-      Ok { envelope; resolution = Omitted_resolution { ceiling } }
-    | Explicit, Some requested, Some effective, ceiling
-      when requested = effective
-           &&
-           match ceiling with
-           | Some cap -> effective <= cap.value
-           | None -> true ->
-      Ok { envelope; resolution = Explicit_resolution { value = effective; ceiling } }
-    | Explicit_clamped, Some requested, Some effective, Some ceiling
-      when effective = ceiling.value && requested > ceiling.value ->
-      Ok { envelope; resolution = Explicit_clamped_resolution { requested; ceiling } }
-    | Required_catalog_fallback, None, Some effective, Some ceiling
-      when ceiling.source = Catalog_model && effective = ceiling.value ->
-      Ok { envelope; resolution = Required_fallback_resolution { ceiling } }
-    | Required_capability_override_fallback, None, Some effective, Some ceiling
-      when ceiling.source = Declared_capability_override && effective = ceiling.value ->
-      Ok { envelope; resolution = Required_fallback_resolution { ceiling } }
-    | _ -> Error "output_token_receipt: inconsistent requested/effective policy fields"
-  with
-  | Yojson.Safe.Util.Type_error (message, _) -> Error message
-;;
+let output_token_receipt_to_yojson = Output_token_wire_internal.receipt_to_yojson
+let output_token_receipt_of_yojson = Output_token_wire_internal.receipt_of_yojson
+let equal_output_token_receipt = Output_token_wire_internal.equal_receipt
+let pp_output_token_receipt = Output_token_wire_internal.pp_receipt
+let show_output_token_receipt = Output_token_wire_internal.show_receipt
 
 (** Per-call inference telemetry.
     Parsed from the raw API response; never computed by downstream. *)

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -445,6 +445,233 @@ type inference_timings =
   }
 [@@deriving show, yojson]
 
+(** The provider wire field that carries one output-token decision.  This is an
+    envelope identity, not a provider brand: providers using an
+    OpenAI-compatible endpoint share the matching OpenAI envelope. *)
+type output_token_envelope = Output_token_wire_internal.envelope =
+  | Openai_chat_max_tokens
+  | Openai_responses_max_output_tokens
+  | Anthropic_messages_max_tokens
+  | Gemini_generation_config_max_output_tokens
+  | Ollama_options_num_predict
+
+type output_token_policy = Output_token_wire_internal.policy =
+  | Omitted
+  | Explicit
+  | Explicit_clamped
+  | Required_catalog_fallback
+  | Required_capability_override_fallback
+
+type output_token_ceiling_source = Output_token_wire_internal.ceiling_source =
+  | Catalog_model
+  | Declared_capability_override
+
+let pp_output_token_envelope = Output_token_wire_internal.pp_envelope
+let show_output_token_envelope = Output_token_wire_internal.show_envelope
+let equal_output_token_envelope = Output_token_wire_internal.equal_envelope
+let pp_output_token_policy = Output_token_wire_internal.pp_policy
+let show_output_token_policy = Output_token_wire_internal.show_policy
+let equal_output_token_policy = Output_token_wire_internal.equal_policy
+let pp_output_token_ceiling_source = Output_token_wire_internal.pp_ceiling_source
+let show_output_token_ceiling_source = Output_token_wire_internal.show_ceiling_source
+let equal_output_token_ceiling_source = Output_token_wire_internal.equal_ceiling_source
+let output_token_envelope_to_yojson = Output_token_wire_internal.envelope_to_yojson
+let output_token_envelope_of_yojson = Output_token_wire_internal.envelope_of_yojson
+let output_token_policy_to_yojson = Output_token_wire_internal.policy_to_yojson
+let output_token_policy_of_yojson = Output_token_wire_internal.policy_of_yojson
+
+let output_token_ceiling_source_to_yojson =
+  Output_token_wire_internal.ceiling_source_to_yojson
+;;
+
+let output_token_ceiling_source_of_yojson =
+  Output_token_wire_internal.ceiling_source_of_yojson
+;;
+
+type output_token_ceiling =
+  { value : int
+  ; source : output_token_ceiling_source
+  }
+[@@deriving show, eq]
+
+let output_token_ceiling ~value ~source =
+  if value <= 0
+  then invalid_arg "output_token_ceiling: value must be positive"
+  else { value; source }
+;;
+
+type output_token_resolution =
+  | Omitted_resolution of { ceiling : output_token_ceiling option }
+  | Explicit_resolution of
+      { value : int
+      ; ceiling : output_token_ceiling option
+      }
+  | Explicit_clamped_resolution of
+      { requested : int
+      ; ceiling : output_token_ceiling
+      }
+  | Required_fallback_resolution of { ceiling : output_token_ceiling }
+[@@deriving show, eq]
+
+(** Invariant-checked observation of an output-token decision.  The internal
+    sum prevents impossible combinations such as a clamped policy without a
+    ceiling; opaque backend artifacts separately establish exact payload
+    provenance. *)
+type output_token_receipt =
+  { envelope : output_token_envelope
+  ; resolution : output_token_resolution
+  }
+[@@deriving show, eq]
+
+type required_output_token_error = Required_output_token_ceiling_missing
+[@@deriving show, eq]
+
+let output_token_receipt_envelope receipt = receipt.envelope
+
+let output_token_receipt_requested receipt =
+  match receipt.resolution with
+  | Omitted_resolution _ | Required_fallback_resolution _ -> None
+  | Explicit_resolution { value; _ } -> Some value
+  | Explicit_clamped_resolution { requested; _ } -> Some requested
+;;
+
+let output_token_receipt_effective receipt =
+  match receipt.resolution with
+  | Omitted_resolution _ -> None
+  | Explicit_resolution { value; _ } -> Some value
+  | Explicit_clamped_resolution { ceiling; _ } | Required_fallback_resolution { ceiling }
+    -> Some ceiling.value
+;;
+
+let output_token_receipt_policy receipt =
+  match receipt.resolution with
+  | Omitted_resolution _ -> Omitted
+  | Explicit_resolution _ -> Explicit
+  | Explicit_clamped_resolution _ -> Explicit_clamped
+  | Required_fallback_resolution { ceiling = { source = Catalog_model; _ } } ->
+    Required_catalog_fallback
+  | Required_fallback_resolution
+      { ceiling = { source = Declared_capability_override; _ } } ->
+    Required_capability_override_fallback
+;;
+
+let receipt_ceiling receipt =
+  match receipt.resolution with
+  | Omitted_resolution { ceiling } | Explicit_resolution { ceiling; _ } -> ceiling
+  | Explicit_clamped_resolution { ceiling; _ } | Required_fallback_resolution { ceiling }
+    -> Some ceiling
+;;
+
+let output_token_receipt_ceiling receipt =
+  Option.map (fun ceiling -> ceiling.value) (receipt_ceiling receipt)
+;;
+
+let output_token_receipt_ceiling_source receipt =
+  Option.map (fun ceiling -> ceiling.source) (receipt_ceiling receipt)
+;;
+
+let optional_output_token_receipt ~envelope ~requested ~ceiling =
+  (match requested with
+   | Some value when value < 0 ->
+     invalid_arg "optional_output_token_receipt: requested value must be non-negative"
+   | None | Some _ -> ());
+  let resolution =
+    match requested, ceiling with
+    | None, ceiling -> Omitted_resolution { ceiling }
+    | Some requested, Some ceiling when requested > ceiling.value ->
+      Explicit_clamped_resolution { requested; ceiling }
+    | Some value, ceiling -> Explicit_resolution { value; ceiling }
+  in
+  { envelope; resolution }
+;;
+
+let required_output_token_receipt receipt =
+  match receipt.resolution with
+  | Omitted_resolution { ceiling = Some ceiling } ->
+    Ok { receipt with resolution = Required_fallback_resolution { ceiling } }
+  | Omitted_resolution { ceiling = None } -> Error Required_output_token_ceiling_missing
+  | Explicit_resolution _ | Explicit_clamped_resolution _ | Required_fallback_resolution _
+    -> Ok receipt
+;;
+
+let output_token_receipt_to_yojson receipt =
+  let option_int_to_yojson = function
+    | Some value -> `Int value
+    | None -> `Null
+  in
+  `Assoc
+    [ "requested", option_int_to_yojson (output_token_receipt_requested receipt)
+    ; "effective", option_int_to_yojson (output_token_receipt_effective receipt)
+    ; "policy", output_token_policy_to_yojson (output_token_receipt_policy receipt)
+    ; "ceiling", option_int_to_yojson (output_token_receipt_ceiling receipt)
+    ; ( "ceiling_source"
+      , match output_token_receipt_ceiling_source receipt with
+        | Some source -> output_token_ceiling_source_to_yojson source
+        | None -> `Null )
+    ; "envelope", output_token_envelope_to_yojson receipt.envelope
+    ]
+;;
+
+let output_token_receipt_of_yojson json =
+  let open Yojson.Safe.Util in
+  let token_value_option = function
+    | `Null -> Ok None
+    | `Int value when value >= 0 -> Ok (Some value)
+    | `Int _ -> Error "output_token_receipt: token values must be non-negative"
+    | _ -> Error "output_token_receipt: expected integer or null"
+  in
+  let ceiling_option = function
+    | `Null -> Ok None
+    | `Int value when value > 0 -> Ok (Some value)
+    | `Int _ -> Error "output_token_receipt: ceiling must be positive"
+    | _ -> Error "output_token_receipt: expected integer or null"
+  in
+  let ( let* ) result f = Result.bind result f in
+  try
+    let* requested = token_value_option (member "requested" json) in
+    let* effective = token_value_option (member "effective" json) in
+    let* ceiling = ceiling_option (member "ceiling" json) in
+    let* ceiling_source =
+      match member "ceiling_source" json with
+      | `Null -> Ok None
+      | source_json ->
+        Result.map
+          (fun source -> Some source)
+          (output_token_ceiling_source_of_yojson source_json)
+    in
+    let* ceiling =
+      match ceiling, ceiling_source with
+      | None, None -> Ok None
+      | Some value, Some source -> Ok (Some (output_token_ceiling ~value ~source))
+      | Some _, None | None, Some _ ->
+        Error "output_token_receipt: ceiling and ceiling_source must appear together"
+    in
+    let* policy = output_token_policy_of_yojson (member "policy" json) in
+    let* envelope = output_token_envelope_of_yojson (member "envelope" json) in
+    match policy, requested, effective, ceiling with
+    | Omitted, None, None, ceiling ->
+      Ok { envelope; resolution = Omitted_resolution { ceiling } }
+    | Explicit, Some requested, Some effective, ceiling
+      when requested = effective
+           &&
+           match ceiling with
+           | Some cap -> effective <= cap.value
+           | None -> true ->
+      Ok { envelope; resolution = Explicit_resolution { value = effective; ceiling } }
+    | Explicit_clamped, Some requested, Some effective, Some ceiling
+      when effective = ceiling.value && requested > ceiling.value ->
+      Ok { envelope; resolution = Explicit_clamped_resolution { requested; ceiling } }
+    | Required_catalog_fallback, None, Some effective, Some ceiling
+      when ceiling.source = Catalog_model && effective = ceiling.value ->
+      Ok { envelope; resolution = Required_fallback_resolution { ceiling } }
+    | Required_capability_override_fallback, None, Some effective, Some ceiling
+      when ceiling.source = Declared_capability_override && effective = ceiling.value ->
+      Ok { envelope; resolution = Required_fallback_resolution { ceiling } }
+    | _ -> Error "output_token_receipt: inconsistent requested/effective policy fields"
+  with
+  | Yojson.Safe.Util.Type_error (message, _) -> Error message
+;;
+
 (** Per-call inference telemetry.
     Parsed from the raw API response; never computed by downstream. *)
 type inference_telemetry =

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -307,9 +307,14 @@ type output_token_policy =
 val output_token_policy_to_yojson : output_token_policy -> Yojson.Safe.t
 val output_token_policy_of_yojson : Yojson.Safe.t -> (output_token_policy, string) result
 
+(** Typed provenance of the validation ceiling consulted for the receipt.
+    [Provider_default] is the provider-config fallback used only when neither a
+    capability override nor a model-catalog entry resolves.  Required request
+    envelopes do not inject that validation fallback as a request value. *)
 type output_token_ceiling_source =
   | Catalog_model
   | Declared_capability_override
+  | Provider_default
 [@@deriving show, eq]
 
 val output_token_ceiling_source_to_yojson : output_token_ceiling_source -> Yojson.Safe.t

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -282,6 +282,91 @@ type inference_telemetry =
   }
 [@@deriving show, yojson]
 
+type output_token_envelope =
+  | Openai_chat_max_tokens
+  | Openai_responses_max_output_tokens
+  | Anthropic_messages_max_tokens
+  | Gemini_generation_config_max_output_tokens
+  | Ollama_options_num_predict
+[@@deriving show, eq]
+
+val output_token_envelope_to_yojson : output_token_envelope -> Yojson.Safe.t
+
+val output_token_envelope_of_yojson
+  :  Yojson.Safe.t
+  -> (output_token_envelope, string) result
+
+type output_token_policy =
+  | Omitted
+  | Explicit
+  | Explicit_clamped
+  | Required_catalog_fallback
+  | Required_capability_override_fallback
+[@@deriving show, eq]
+
+val output_token_policy_to_yojson : output_token_policy -> Yojson.Safe.t
+val output_token_policy_of_yojson : Yojson.Safe.t -> (output_token_policy, string) result
+
+type output_token_ceiling_source =
+  | Catalog_model
+  | Declared_capability_override
+[@@deriving show, eq]
+
+val output_token_ceiling_source_to_yojson : output_token_ceiling_source -> Yojson.Safe.t
+
+val output_token_ceiling_source_of_yojson
+  :  Yojson.Safe.t
+  -> (output_token_ceiling_source, string) result
+
+type output_token_ceiling = private
+  { value : int
+  ; source : output_token_ceiling_source
+  }
+
+val output_token_ceiling
+  :  value:int
+  -> source:output_token_ceiling_source
+  -> output_token_ceiling
+
+(** An invariant-checked observation of one output-token decision.  Exact
+    payload/receipt provenance is established only by the opaque request
+    artifact returned by a backend; a receipt value by itself is a read
+    projection, not proof that a particular payload was built or sent. *)
+type output_token_receipt
+
+type required_output_token_error = Required_output_token_ceiling_missing
+[@@deriving show, eq]
+
+val optional_output_token_receipt
+  :  envelope:output_token_envelope
+  -> requested:int option
+  -> ceiling:output_token_ceiling option
+  -> output_token_receipt
+
+val required_output_token_receipt
+  :  output_token_receipt
+  -> (output_token_receipt, required_output_token_error) result
+
+val output_token_receipt_envelope : output_token_receipt -> output_token_envelope
+val output_token_receipt_requested : output_token_receipt -> int option
+val output_token_receipt_effective : output_token_receipt -> int option
+val output_token_receipt_policy : output_token_receipt -> output_token_policy
+val output_token_receipt_ceiling : output_token_receipt -> int option
+
+val output_token_receipt_ceiling_source
+  :  output_token_receipt
+  -> output_token_ceiling_source option
+
+val output_token_receipt_to_yojson : output_token_receipt -> Yojson.Safe.t
+
+val output_token_receipt_of_yojson
+  :  Yojson.Safe.t
+  -> (output_token_receipt, string) result
+
+val equal_output_token_receipt : output_token_receipt -> output_token_receipt -> bool
+val pp_output_token_receipt : Format.formatter -> output_token_receipt -> unit
+val show_output_token_receipt : output_token_receipt -> string
+
 (** Default/zero inference telemetry value owned by the telemetry type module.
     Callers should record-update this value instead of duplicating every field. *)
 val default_inference_telemetry : inference_telemetry

--- a/test/dune
+++ b/test/dune
@@ -468,6 +468,12 @@
  (libraries agent_sdk llm_provider alcotest eio_main))
 
 (test
+ (name test_output_token_receipt)
+ (modules test_output_token_receipt)
+ (deps ../models.toml)
+ (libraries llm_provider alcotest))
+
+(test
  (name test_complete_http)
  (modules test_complete_http)
  (libraries agent_sdk llm_provider alcotest eio_main eio.mock))

--- a/test/test_output_token_receipt.ml
+++ b/test/test_output_token_receipt.ml
@@ -453,6 +453,11 @@ let test_anthropic_missing_required_ceiling_is_typed () =
 ;;
 
 let test_anthropic_zero_is_explicit () =
+  let provider_default_ceiling =
+    match Capabilities.anthropic_capabilities.max_output_tokens with
+    | Some value -> value
+    | None -> Alcotest.fail "Anthropic provider default must declare an output ceiling"
+  in
   let config =
     PC.make
       ~kind:Anthropic
@@ -472,8 +477,8 @@ let test_anthropic_zero_is_explicit () =
     ~requested:(Some 0)
     ~effective:(Some 0)
     ~policy:Explicit
-    ~ceiling:None
-    ~ceiling_source:None
+    ~ceiling:(Some provider_default_ceiling)
+    ~ceiling_source:(Some Provider_default)
     (Anthropic.request_output_token_receipt artifact)
 ;;
 

--- a/test/test_output_token_receipt.ml
+++ b/test/test_output_token_receipt.ml
@@ -1,0 +1,469 @@
+open Llm_provider
+open Types
+module PC = Provider_config
+module Anthropic = Backend_anthropic
+module Gemini = Backend_gemini
+module Glm = Backend_glm
+module Ollama = Backend_ollama
+module Openai = Backend_openai
+module Responses = Backend_openai_responses
+
+let () =
+  match Model_catalog.load_default () with
+  | Ok catalog -> Model_catalog.set_global catalog
+  | Error message -> Alcotest.failf "failed to load the default model catalog: %s" message
+;;
+
+let declared_capabilities ceiling =
+  { Capabilities.default_capabilities with max_output_tokens = Some ceiling }
+;;
+
+let check_receipt ~envelope ~requested ~effective ~policy ~ceiling ~ceiling_source receipt
+  =
+  Alcotest.(check bool)
+    "receipt envelope"
+    true
+    (equal_output_token_envelope envelope (output_token_receipt_envelope receipt));
+  Alcotest.(check (option int))
+    "receipt requested"
+    requested
+    (output_token_receipt_requested receipt);
+  Alcotest.(check (option int))
+    "receipt effective"
+    effective
+    (output_token_receipt_effective receipt);
+  Alcotest.(check bool)
+    "receipt policy"
+    true
+    (equal_output_token_policy policy (output_token_receipt_policy receipt));
+  Alcotest.(check (option int))
+    "receipt ceiling"
+    ceiling
+    (output_token_receipt_ceiling receipt);
+  Alcotest.(check bool)
+    "receipt ceiling source"
+    true
+    (output_token_receipt_ceiling_source receipt = ceiling_source);
+  let json = output_token_receipt_to_yojson receipt in
+  let decoded =
+    match output_token_receipt_of_yojson json with
+    | Ok decoded -> decoded
+    | Error message -> Alcotest.fail message
+  in
+  Alcotest.(check bool)
+    "receipt JSON round trip"
+    true
+    (equal_output_token_receipt receipt decoded)
+;;
+
+let wire_int payload path =
+  List.fold_left
+    (fun json key -> Yojson.Safe.Util.member key json)
+    (Yojson.Safe.from_string payload)
+    path
+  |> Yojson.Safe.Util.to_int
+;;
+
+let top_level_field_absent payload field =
+  match Yojson.Safe.from_string payload with
+  | `Assoc fields -> not (List.mem_assoc field fields)
+  | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> false
+;;
+
+let check_scalar_codec label to_yojson fixtures =
+  List.iter
+    (fun (value, expected) ->
+       Alcotest.(check string) label expected (Yojson.Safe.to_string (to_yojson value)))
+    fixtures
+;;
+
+let test_stable_scalar_wire_vocabulary () =
+  check_scalar_codec
+    "envelope wire name"
+    output_token_envelope_to_yojson
+    [ Openai_chat_max_tokens, {|"openai_chat_max_tokens"|}
+    ; Openai_responses_max_output_tokens, {|"openai_responses_max_output_tokens"|}
+    ; Anthropic_messages_max_tokens, {|"anthropic_messages_max_tokens"|}
+    ; ( Gemini_generation_config_max_output_tokens
+      , {|"gemini_generation_config_max_output_tokens"|} )
+    ; Ollama_options_num_predict, {|"ollama_options_num_predict"|}
+    ];
+  check_scalar_codec
+    "policy wire name"
+    output_token_policy_to_yojson
+    [ Omitted, {|"omitted"|}
+    ; Explicit, {|"explicit"|}
+    ; Explicit_clamped, {|"explicit_clamped"|}
+    ; Required_catalog_fallback, {|"required_catalog_fallback"|}
+    ; Required_capability_override_fallback, {|"required_capability_override_fallback"|}
+    ];
+  check_scalar_codec
+    "ceiling-source wire name"
+    output_token_ceiling_source_to_yojson
+    [ Catalog_model, {|"catalog_model"|}
+    ; Declared_capability_override, {|"declared_capability_override"|}
+    ];
+  Alcotest.(check bool)
+    "legacy ppx array encoding is rejected"
+    true
+    (Result.is_error (output_token_policy_of_yojson (`List [ `String "Explicit" ])))
+;;
+
+let test_exact_receipt_json_fixture () =
+  let receipt =
+    optional_output_token_receipt
+      ~envelope:Gemini_generation_config_max_output_tokens
+      ~requested:(Some 200)
+      ~ceiling:
+        (Some (output_token_ceiling ~value:100 ~source:Declared_capability_override))
+  in
+  Alcotest.(check string)
+    "exact flat receipt JSON"
+    {|{"requested":200,"effective":100,"policy":"explicit_clamped","ceiling":100,"ceiling_source":"declared_capability_override","envelope":"gemini_generation_config_max_output_tokens"}|}
+    (Yojson.Safe.to_string (output_token_receipt_to_yojson receipt))
+;;
+
+let test_openai_chat_omission () =
+  let config =
+    PC.make
+      ~kind:OpenAI_compat
+      ~model_id:"receipt-openai-omission"
+      ~base_url:""
+      ~model_capabilities_override:(declared_capabilities 100)
+      ()
+  in
+  let artifact = Openai.build_request_artifact ~config ~messages:[ user_msg "hi" ] () in
+  let payload = Openai.request_payload artifact in
+  Alcotest.(check string)
+    "legacy payload projection"
+    payload
+    (Openai.build_request ~config ~messages:[ user_msg "hi" ] ());
+  Alcotest.(check bool)
+    "optional field omitted"
+    true
+    (top_level_field_absent payload "max_tokens");
+  check_receipt
+    ~envelope:Openai_chat_max_tokens
+    ~requested:None
+    ~effective:None
+    ~policy:Omitted
+    ~ceiling:(Some 100)
+    ~ceiling_source:(Some Declared_capability_override)
+    (Openai.request_output_token_receipt artifact)
+;;
+
+let test_openai_responses_exact () =
+  let config =
+    PC.make
+      ~kind:OpenAI_compat
+      ~model_id:"receipt-responses-exact"
+      ~base_url:""
+      ~max_tokens:80
+      ~model_capabilities_override:(declared_capabilities 100)
+      ()
+  in
+  let artifact =
+    Responses.build_request_artifact ~config ~messages:[ user_msg "hi" ] ()
+  in
+  let payload = Responses.request_payload artifact in
+  Alcotest.(check string)
+    "legacy payload projection"
+    payload
+    (Responses.build_request ~config ~messages:[ user_msg "hi" ] ());
+  Alcotest.(check int)
+    "Responses max_output_tokens"
+    80
+    (wire_int payload [ "max_output_tokens" ]);
+  check_receipt
+    ~envelope:Openai_responses_max_output_tokens
+    ~requested:(Some 80)
+    ~effective:(Some 80)
+    ~policy:Explicit
+    ~ceiling:(Some 100)
+    ~ceiling_source:(Some Declared_capability_override)
+    (Responses.request_output_token_receipt artifact)
+;;
+
+let test_gemini_clamp () =
+  let config =
+    PC.make
+      ~kind:Gemini
+      ~model_id:"receipt-gemini-clamp"
+      ~base_url:""
+      ~max_tokens:200
+      ~model_capabilities_override:(declared_capabilities 100)
+      ()
+  in
+  let artifact = Gemini.build_request_artifact ~config ~messages:[ user_msg "hi" ] () in
+  let payload = Gemini.request_payload artifact in
+  Alcotest.(check string)
+    "legacy payload projection"
+    payload
+    (Gemini.build_request ~config ~messages:[ user_msg "hi" ] ());
+  Alcotest.(check int)
+    "Gemini generationConfig.maxOutputTokens"
+    100
+    (wire_int payload [ "generationConfig"; "maxOutputTokens" ]);
+  check_receipt
+    ~envelope:Gemini_generation_config_max_output_tokens
+    ~requested:(Some 200)
+    ~effective:(Some 100)
+    ~policy:Explicit_clamped
+    ~ceiling:(Some 100)
+    ~ceiling_source:(Some Declared_capability_override)
+    (Gemini.request_output_token_receipt artifact)
+;;
+
+let test_ollama_exact () =
+  let config =
+    PC.make
+      ~kind:Ollama
+      ~model_id:"receipt-ollama-exact"
+      ~base_url:""
+      ~max_tokens:60
+      ~model_capabilities_override:(declared_capabilities 100)
+      ~keep_alive:"-1"
+      ()
+  in
+  let artifact = Ollama.build_request_artifact ~config ~messages:[ user_msg "hi" ] () in
+  let payload = Ollama.request_payload artifact in
+  Alcotest.(check string)
+    "legacy payload projection"
+    payload
+    (Ollama.build_request ~config ~messages:[ user_msg "hi" ] ());
+  Alcotest.(check int)
+    "Ollama options.num_predict"
+    60
+    (wire_int payload [ "options"; "num_predict" ]);
+  check_receipt
+    ~envelope:Ollama_options_num_predict
+    ~requested:(Some 60)
+    ~effective:(Some 60)
+    ~policy:Explicit
+    ~ceiling:(Some 100)
+    ~ceiling_source:(Some Declared_capability_override)
+    (Ollama.request_output_token_receipt artifact)
+;;
+
+let check_openai_chat_compatible_artifact ~label ~requested ~payload ~receipt =
+  Alcotest.(check int) label requested (wire_int payload [ "max_tokens" ]);
+  check_receipt
+    ~envelope:Openai_chat_max_tokens
+    ~requested:(Some requested)
+    ~effective:(Some requested)
+    ~policy:Explicit
+    ~ceiling:(Some 100)
+    ~ceiling_source:(Some Declared_capability_override)
+    receipt
+;;
+
+let test_glm_and_dashscope_chat_envelopes () =
+  let glm_config =
+    PC.make
+      ~kind:Glm
+      ~model_id:"receipt-glm-chat"
+      ~base_url:""
+      ~max_tokens:70
+      ~model_capabilities_override:(declared_capabilities 100)
+      ()
+  in
+  let glm_artifact = Glm.build_request_artifact ~config:glm_config ~messages:[] () in
+  let glm_payload = Glm.request_payload glm_artifact in
+  Alcotest.(check string)
+    "GLM legacy payload projection"
+    glm_payload
+    (Glm.build_request ~config:glm_config ~messages:[] ());
+  check_openai_chat_compatible_artifact
+    ~label:"GLM max_tokens"
+    ~requested:70
+    ~payload:glm_payload
+    ~receipt:(Glm.request_output_token_receipt glm_artifact);
+  let dashscope_config =
+    PC.make
+      ~kind:DashScope
+      ~model_id:"receipt-dashscope-chat"
+      ~base_url:""
+      ~max_tokens:60
+      ~model_capabilities_override:(declared_capabilities 100)
+      ()
+  in
+  let dashscope_artifact =
+    Openai.build_request_artifact ~config:dashscope_config ~messages:[] ()
+  in
+  let dashscope_payload = Openai.request_payload dashscope_artifact in
+  Alcotest.(check string)
+    "DashScope legacy payload projection"
+    dashscope_payload
+    (Openai.build_request ~config:dashscope_config ~messages:[] ());
+  check_openai_chat_compatible_artifact
+    ~label:"DashScope max_tokens"
+    ~requested:60
+    ~payload:dashscope_payload
+    ~receipt:(Openai.request_output_token_receipt dashscope_artifact)
+;;
+
+let require_anthropic_artifact = function
+  | Ok artifact -> artifact
+  | Error Required_output_token_ceiling_missing ->
+    Alcotest.fail "expected a required Messages output-token decision"
+;;
+
+let test_anthropic_catalog_fallback () =
+  let model_id = "claude-sonnet-4-6" in
+  let ceiling =
+    match Capabilities.for_model_id model_id with
+    | Some capabilities ->
+      (match capabilities.max_output_tokens with
+       | Some value -> value
+       | None -> Alcotest.fail "catalog model must declare max_output_tokens")
+    | None -> Alcotest.fail "catalog model must exist"
+  in
+  let config = PC.make ~kind:Anthropic ~model_id ~base_url:"" () in
+  let artifact =
+    Anthropic.build_request_artifact ~config ~messages:[ user_msg "hi" ] ()
+    |> require_anthropic_artifact
+  in
+  let payload = Anthropic.request_payload artifact in
+  Alcotest.(check string)
+    "legacy payload projection"
+    payload
+    (Anthropic.build_request ~config ~messages:[ user_msg "hi" ] ());
+  Alcotest.(check int)
+    "Anthropic required max_tokens"
+    ceiling
+    (wire_int payload [ "max_tokens" ]);
+  check_receipt
+    ~envelope:Anthropic_messages_max_tokens
+    ~requested:None
+    ~effective:(Some ceiling)
+    ~policy:Required_catalog_fallback
+    ~ceiling:(Some ceiling)
+    ~ceiling_source:(Some Catalog_model)
+    (Anthropic.request_output_token_receipt artifact)
+;;
+
+let check_messages_override_fallback ~kind ~model_id =
+  let config =
+    PC.make
+      ~kind
+      ~model_id
+      ~base_url:""
+      ~model_capabilities_override:(declared_capabilities 321)
+      ()
+  in
+  let artifact =
+    Anthropic.build_request_artifact ~config ~messages:[ user_msg "hi" ] ()
+    |> require_anthropic_artifact
+  in
+  let payload = Anthropic.request_payload artifact in
+  Alcotest.(check string)
+    "legacy payload projection"
+    payload
+    (Anthropic.build_request ~config ~messages:[ user_msg "hi" ] ());
+  Alcotest.(check int)
+    "Messages required max_tokens"
+    321
+    (wire_int payload [ "max_tokens" ]);
+  check_receipt
+    ~envelope:Anthropic_messages_max_tokens
+    ~requested:None
+    ~effective:(Some 321)
+    ~policy:Required_capability_override_fallback
+    ~ceiling:(Some 321)
+    ~ceiling_source:(Some Declared_capability_override)
+    (Anthropic.request_output_token_receipt artifact)
+;;
+
+let test_anthropic_and_kimi_override_fallbacks () =
+  check_messages_override_fallback ~kind:Anthropic ~model_id:"receipt-anthropic-override";
+  check_messages_override_fallback ~kind:Kimi ~model_id:"receipt-kimi-messages-override"
+;;
+
+let test_anthropic_missing_required_ceiling_is_typed () =
+  let config =
+    PC.make ~kind:Anthropic ~model_id:"receipt-required-missing" ~base_url:"" ()
+  in
+  Alcotest.(check bool)
+    "receipt resolver returns typed missing-ceiling error"
+    true
+    (Anthropic.required_output_token_receipt config
+     = Error Required_output_token_ceiling_missing);
+  Alcotest.(check bool)
+    "artifact builder returns typed missing-ceiling error"
+    true
+    (match Anthropic.build_request_artifact ~config ~messages:[ user_msg "hi" ] () with
+     | Error Required_output_token_ceiling_missing -> true
+     | Ok _ -> false);
+  Alcotest.(check bool)
+    "legacy payload projection fails loudly"
+    true
+    (match Anthropic.build_request ~config ~messages:[ user_msg "hi" ] () with
+     | exception Invalid_argument _ -> true
+     | _ -> false)
+;;
+
+let test_anthropic_zero_is_explicit () =
+  let config =
+    PC.make
+      ~kind:Anthropic
+      ~model_id:"receipt-explicit-zero"
+      ~base_url:""
+      ~max_tokens:0
+      ()
+  in
+  let artifact =
+    Anthropic.build_request_artifact ~config ~messages:[ user_msg "prewarm" ] ()
+    |> require_anthropic_artifact
+  in
+  let payload = Anthropic.request_payload artifact in
+  Alcotest.(check int) "explicit zero on wire" 0 (wire_int payload [ "max_tokens" ]);
+  check_receipt
+    ~envelope:Anthropic_messages_max_tokens
+    ~requested:(Some 0)
+    ~effective:(Some 0)
+    ~policy:Explicit
+    ~ceiling:None
+    ~ceiling_source:None
+    (Anthropic.request_output_token_receipt artifact)
+;;
+
+let () =
+  Alcotest.run
+    "output_token_receipt"
+    [ ( "wire_codec"
+      , [ Alcotest.test_case
+            "stable scalar vocabulary"
+            `Quick
+            test_stable_scalar_wire_vocabulary
+        ; Alcotest.test_case "exact receipt JSON" `Quick test_exact_receipt_json_fixture
+        ] )
+    ; ( "optional_envelopes"
+      , [ Alcotest.test_case "OpenAI Chat omission" `Quick test_openai_chat_omission
+        ; Alcotest.test_case "OpenAI Responses exact" `Quick test_openai_responses_exact
+        ; Alcotest.test_case "Gemini clamp" `Quick test_gemini_clamp
+        ; Alcotest.test_case "Ollama exact" `Quick test_ollama_exact
+        ; Alcotest.test_case
+            "GLM and DashScope Chat envelopes"
+            `Quick
+            test_glm_and_dashscope_chat_envelopes
+        ] )
+    ; ( "required_messages_envelope"
+      , [ Alcotest.test_case
+            "Anthropic catalog fallback"
+            `Quick
+            test_anthropic_catalog_fallback
+        ; Alcotest.test_case
+            "Anthropic and Kimi override fallbacks"
+            `Quick
+            test_anthropic_and_kimi_override_fallbacks
+        ; Alcotest.test_case
+            "missing required ceiling is typed"
+            `Quick
+            test_anthropic_missing_required_ceiling_is_typed
+        ; Alcotest.test_case
+            "explicit zero remains explicit"
+            `Quick
+            test_anthropic_zero_is_explicit
+        ] )
+    ]
+;;

--- a/test/test_output_token_receipt.ml
+++ b/test/test_output_token_receipt.ml
@@ -102,6 +102,7 @@ let test_stable_scalar_wire_vocabulary () =
     output_token_ceiling_source_to_yojson
     [ Catalog_model, {|"catalog_model"|}
     ; Declared_capability_override, {|"declared_capability_override"|}
+    ; Provider_default, {|"provider_default"|}
     ];
   Alcotest.(check bool)
     "legacy ppx array encoding is rejected"
@@ -302,6 +303,55 @@ let test_glm_and_dashscope_chat_envelopes () =
     ~receipt:(Openai.request_output_token_receipt dashscope_artifact)
 ;;
 
+let test_glm_provider_default_clamp () =
+  let model_id = "receipt-uncatalogued-glm-provider-default" in
+  let provider_default_ceiling =
+    match Capabilities.glm_capabilities.max_output_tokens with
+    | Some value -> value
+    | None -> Alcotest.fail "GLM provider default must declare max_output_tokens"
+  in
+  let requested = provider_default_ceiling + 1 in
+  let config = PC.make ~kind:Glm ~model_id ~base_url:"" ~max_tokens:requested () in
+  Alcotest.(check bool)
+    "regression precondition: no model-catalog capabilities"
+    true
+    (Option.is_none (PC.capabilities_for_config_model config));
+  let drops = ref [] in
+  let previous_metrics = Metrics.get_global () in
+  let artifact =
+    Fun.protect
+      ~finally:(fun () -> Metrics.set_global previous_metrics)
+      (fun () ->
+         Metrics.set_global
+           { Metrics.noop with
+             on_capability_drop =
+               (fun ~model_id ~field -> drops := (model_id, field) :: !drops)
+           };
+         Glm.build_request_artifact ~config ~messages:[] ())
+  in
+  let payload = Glm.request_payload artifact in
+  Alcotest.(check int)
+    "GLM provider-default ceiling clamps the wire value"
+    provider_default_ceiling
+    (wire_int payload [ "max_tokens" ]);
+  check_receipt
+    ~envelope:Openai_chat_max_tokens
+    ~requested:(Some requested)
+    ~effective:(Some provider_default_ceiling)
+    ~policy:Explicit_clamped
+    ~ceiling:(Some provider_default_ceiling)
+    ~ceiling_source:(Some Provider_default)
+    (Glm.request_output_token_receipt artifact);
+  match !drops with
+  | [ (dropped_model_id, field) ] ->
+    Alcotest.(check string) "clamp warning model" model_id dropped_model_id;
+    Alcotest.(check string) "clamp warning field" "max_tokens:clamp" field
+  | drops ->
+    Alcotest.failf
+      "expected one provider-default clamp warning, received %d"
+      (List.length drops)
+;;
+
 let require_anthropic_artifact = function
   | Ok artifact -> artifact
   | Error Required_output_token_ceiling_missing ->
@@ -446,6 +496,10 @@ let () =
             "GLM and DashScope Chat envelopes"
             `Quick
             test_glm_and_dashscope_chat_envelopes
+        ; Alcotest.test_case
+            "GLM provider-default clamp"
+            `Quick
+            test_glm_provider_default_clamp
         ] )
     ; ( "required_messages_envelope"
       , [ Alcotest.test_case

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -170,7 +170,7 @@ let test_anthropic_thinking_forced_tool_choice_rejected_before_request () =
 ;;
 
 let test_anthropic_stream_flag () =
-  let config = PC.make ~kind:Anthropic ~model_id:"m" ~base_url:"" () in
+  let config = PC.make ~kind:Anthropic ~model_id:"m" ~base_url:"" ~max_tokens:128 () in
   let body = BA.build_request ~stream:true ~config ~messages:[ user_msg "hi" ] () in
   let json = Yojson.Safe.from_string body in
   let open Yojson.Safe.Util in
@@ -1376,6 +1376,7 @@ let test_cache_short_prompt_preserves_opt_in () =
       ~kind:Anthropic
       ~model_id:"m"
       ~base_url:""
+      ~max_tokens:128
       ~system_prompt:"Short."
       ~cache_system_prompt:true
       ()
@@ -1399,6 +1400,7 @@ let test_cache_no_system_no_cache () =
       ~kind:Anthropic
       ~model_id:"m"
       ~base_url:""
+      ~max_tokens:128
       ~system_prompt:"Hello."
       ~cache_system_prompt:false
       ()
@@ -1415,7 +1417,13 @@ let test_cache_no_system_no_cache () =
 
 let test_cache_tools () =
   let config =
-    PC.make ~kind:Anthropic ~model_id:"m" ~base_url:"" ~cache_system_prompt:true ()
+    PC.make
+      ~kind:Anthropic
+      ~model_id:"m"
+      ~base_url:""
+      ~max_tokens:128
+      ~cache_system_prompt:true
+      ()
   in
   let tool1 = `Assoc [ "name", `String "a"; "description", `String "tool a" ] in
   let tool2 = `Assoc [ "name", `String "b"; "description", `String "tool b" ] in


### PR DESCRIPTION
## Summary

Build one immutable backend-owned request artifact that projects both the exact HTTP payload and its output-token wire receipt.

This is the production-safe core boundary for jeong-sik/masc#27905 and jeong-sik/masc#27903. It does **not** claim either issue complete: `Complete` sync/stream delivery results and transport-failure provenance are intentionally deferred to the next slice.

## Boundary

- OAS remains MASC-agnostic.
- Existing simple `build_request` APIs remain source-compatible payload projections.
- OpenAI Chat, OpenAI Responses, Anthropic Messages, Gemini, Ollama, and GLM expose backend-specific opaque `request_artifact` values.
- Payload and receipt can only be projected from the same artifact; the generic constructor is Dune-private.
- Kimi reuses the Anthropic Messages envelope and GLM/DashScope reuse OpenAI Chat by typed backend/codec selection, never provider/model string matching.
- The public `Complete` APIs are unchanged in this slice.

## Semantics

The receipt preserves:

- exact provider wire envelope;
- requested and effective token values;
- omitted, explicit, clamped, catalog-required fallback, and capability-override-required fallback policies;
- catalog-model vs declared-capability-override ceiling provenance;
- a typed error when a required Anthropic/Kimi ceiling is absent.

No default token budget is invented. No payload is emitted from the typed Anthropic artifact builder when its required ceiling cannot be established.

## Verification

- changed/new OCaml parser sweep: green
- `ocamlformat --check`: green
- `git diff --check`: green
- transport truth gate: green
- reasoning SSOT gate: green
- core/CDAL boundary gate: green
- code-smell and hardening ratchets: green
- SDK independence gate: green
- local Dune build/test: not run; PR CI is the build authority

Focused tests bind the payload field and receipt projection for OpenAI Chat, Responses, Gemini clamp, Ollama `options.num_predict`, GLM/DashScope, Anthropic catalog fallback, Anthropic/Kimi capability-override fallback, and missing-required-ceiling typed failure.

## Non-goals

- no `Complete` sync/stream result change;
- no observer/delivery callback;
- no network-error-after-artifact receipt propagation yet;
- no MASC integration;
- no changes to provider/model catalog policy.

Next slice: integrate with the green Kimi codec split (#2540), then expose `Not_emitted | Delivered | Delivery_failed` on a detailed completion API while preserving the simple external call path.
