### PR TITLE
fix(agent): compile typed failure recovery

### DIFF
--- a/lib/tool_failure_recovery.ml
+++ b/lib/tool_failure_recovery.ml
@@ -371,7 +371,7 @@ type receipt_error =
 
 let metadata_key = "oas.tool_failure_recovery.v1"
 
-let revised_call_json call =
+let revised_call_json (call : revised_call) =
   `Assoc
     [ "current_tool_use_id", `String call.current_tool_use_id
     ; "tool_name", `String call.tool_name

--- a/test/test_tool_failure_recovery.ml
+++ b/test/test_tool_failure_recovery.ml
@@ -237,7 +237,7 @@ let project calls results =
 ;;
 
 let failed_result id =
-  ToolResult
+  Types.ToolResult
     { tool_use_id = id
     ; content = "failed"
     ; is_error = true


### PR DESCRIPTION
## Summary
- disambiguate revised_call JSON projection after the typed recovery records landed
- qualify the ToolResult constructor in the focused recovery test

## Evidence
- reproduces the exact OCaml 5.4.1 and 5.5.0 CI compiler failures from run 29154872823
- ocamlformat checks pass locally
- full Dune build/test delegated to PR CI per repository policy