### PR TITLE
fix(agent): harden typed failure recovery resume

### DIFF
--- a/docs/EVENT-CATALOG.md
+++ b/docs/EVENT-CATALOG.md
@@ -7,7 +7,7 @@ relate, and the contracts downstream consumers can rely on.
 **Scope**: `agent_sdk` library (`lib/`).
 **Status**: Stable catalog; entries marked *Evolving* may change with
 deprecation notice.
-**Last updated**: v0.184.0.
+**Last updated**: v0.212.0.
 
 ---
 
@@ -81,12 +81,21 @@ Pattern-matchable OCaml sum type. **Stable across every provider.**
 | `ContentReplacementReplaced` / `ContentReplacementKept` | `content_replacement_event_bridge.ml` | Tool-result content replacement decision froze |
 | `SlotSchedulerObserved` | `slot_scheduler_event_bridge.ml` | Queue/slot snapshot of the provider scheduler |
 | `InferenceTelemetry` | `pipeline/pipeline_collect.ml` | Per-turn provider timing/token telemetry when reported by the backend |
+| `ToolFailureEpisodeDetected` | `agent/agent.ml` | Two adjacent completed tool rounds contain the same typed failure signature; carries the exact structural episodes selected for recovery judgment |
+| `ToolFailureRecoveryDecided` | `agent/agent.ml` | The recovery judge returned a closed decision that passed episode validation and was durably checkpointed |
+| `ToolFailureRecoveryJudgeFailed` | `agent/agent.ml` | The recovery completion, JSON parse, or decision validation boundary failed explicitly |
 | `Custom (name, json)` | anywhere | Extension point — see §2.3 |
 
 **Invariants**:
 - **I1 Provider-agnostic**: every native payload field is meaningful regardless of which provider serves the underlying LLM.
 - **I2 Stable envelope**: envelope field set is identical across providers.
 - **I6 Multi-vendor**: a native variant is only added if its semantic exists in ≥2 vendor SDKs.
+
+The three tool-failure recovery variants are OAS orchestration semantics, not
+provider wire events. They are derived only from canonical `ToolUse` and typed
+`ToolResult` records, so their shape and meaning do not vary by provider or
+model. Hidden reasoning and assistant narration are never inputs to episode
+detection.
 
 ### 2.3 Custom namespaces (reserved)
 

--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -86,7 +86,11 @@ let run_turn_with_trace ~sw ?clock ?raw_trace_run agent =
 
 let provide_input agent request response =
   set_recovery_state agent empty_recovery_state;
-  Agent_elicitation.apply_response agent request response
+  Agent_elicitation.apply_response
+    ~metadata:(recovery_run_boundary_metadata agent)
+    agent
+    request
+    response
 ;;
 
 (* ── Shared loop guard (finite max_turns + idle) ─────────── *)
@@ -186,7 +190,7 @@ let append_user_input agent user_blocks =
     ; content = sanitize_user_input_blocks user_blocks
     ; name = None
     ; tool_call_id = None
-    ; metadata = []
+    ; metadata = recovery_run_boundary_metadata agent
     }
   in
   update_state agent (fun s ->
@@ -350,7 +354,7 @@ let invoke_recovery_judge ~sw ?clock agent episodes =
             ; turn = agent.state.turn_count
             ; detail
             });
-       Error error
+       Error (recovery_failure Error.Judge_response detail)
      | Error error ->
        let detail = Tool_failure_recovery.judge_error_to_string error in
        publish_recovery_event
@@ -1164,54 +1168,88 @@ let restore_tool_failure_recovery messages =
       restore_error = Some (recovery_failure Error.Resume_restore detail)
     }
   in
-  let project exchange =
+  let project (exchange : Llm_provider.Tool_message_pairs.tool_exchange) =
     Tool_failure_episode.project
-      ~tool_uses:exchange.Llm_provider.Tool_message_pairs.tool_uses
+      ~tool_uses:exchange.tool_uses
       ~tool_results:exchange.tool_results
   in
-  let exchanges =
-    Llm_provider.Tool_message_pairs.latest_tool_exchanges ~count:2 messages
+  let rec current_run_messages suffix = function
+    | [] -> Ok (`Legacy messages)
+    | (message : Types.message) :: rest ->
+      (match Types.Conversation_metadata.classify_run_boundary message.metadata with
+       | Types.Conversation_metadata.Present -> Ok (`Marked suffix)
+       | Types.Conversation_metadata.Absent ->
+         current_run_messages (message :: suffix) rest
+       | Types.Conversation_metadata.Malformed ->
+         Error "malformed or duplicate OAS agent run-boundary metadata")
   in
-  match exchanges with
-  | [] ->
-    (match Tool_failure_recovery.latest_receipt messages with
-     | Ok None -> empty_recovery_state
-     | Ok (Some _) -> fail "recovery receipt exists without a tool exchange"
-     | Error error -> fail (Tool_failure_recovery.show_receipt_error error))
-  | current_exchange :: rest ->
-    (match project current_exchange with
-     | Error error -> fail (Tool_failure_episode.show_error error)
-     | Ok current ->
-       let episodes =
-         match rest with
-         | [] -> Ok []
-         | previous_exchange :: _ ->
-           (match project previous_exchange with
-            | Error error -> Error (Tool_failure_episode.show_error error)
-            | Ok previous ->
-              (match Tool_failure_episode.detect ~previous ~current with
-               | Ok episodes -> Ok episodes
-               | Error error -> Error (Tool_failure_episode.show_error error)))
-       in
-       (match episodes with
-        | Error detail -> fail detail
-        | Ok episodes ->
-          (match Tool_failure_recovery.latest_receipt messages with
-           | Error error -> fail (Tool_failure_recovery.show_receipt_error error)
-           | Ok receipt ->
-             let validation =
-               match receipt with
-               | None -> Ok ()
-               | Some receipt -> Tool_failure_recovery.validate_receipt ~episodes receipt
-             in
-             (match validation with
-              | Error error -> fail (Tool_failure_recovery.show_receipt_error error)
-              | Ok () ->
-                { last_completed_round = Some current
-                ; pending_episodes = (if episodes = [] then None else Some episodes)
-                ; pending_receipt = receipt
-                ; restore_error = None
-                }))))
+  let restore_marked run_messages =
+    let exchanges =
+      Llm_provider.Tool_message_pairs.latest_tool_exchanges ~count:2 run_messages
+    in
+    match exchanges with
+    | [] ->
+      (match Tool_failure_recovery.latest_receipt run_messages with
+       | Ok None -> empty_recovery_state
+       | Ok (Some _) -> fail "recovery receipt exists without a tool exchange"
+       | Error error -> fail (Tool_failure_recovery.show_receipt_error error))
+    | current_exchange :: rest ->
+      (match project current_exchange with
+       | Error error -> fail (Tool_failure_episode.show_error error)
+       | Ok current ->
+         let episodes =
+           match rest with
+           | [] -> Ok []
+           | previous_exchange :: _ ->
+             (match project previous_exchange with
+              | Error error -> Error (Tool_failure_episode.show_error error)
+              | Ok previous ->
+                (match Tool_failure_episode.detect ~previous ~current with
+                 | Ok episodes -> Ok episodes
+                 | Error error -> Error (Tool_failure_episode.show_error error)))
+         in
+         (match episodes with
+          | Error detail -> fail detail
+          | Ok episodes ->
+            (match Tool_failure_recovery.latest_receipt run_messages with
+             | Error error -> fail (Tool_failure_recovery.show_receipt_error error)
+             | Ok receipt ->
+               let validation =
+                 match receipt with
+                 | None -> Ok ()
+                 | Some receipt ->
+                   Tool_failure_recovery.validate_receipt ~episodes receipt
+               in
+               (match validation with
+                | Error error -> fail (Tool_failure_recovery.show_receipt_error error)
+                | Ok () ->
+                  { last_completed_round = Some current
+                  ; pending_episodes = (if episodes = [] then None else Some episodes)
+                  ; pending_receipt = receipt
+                  ; restore_error = None
+                  }))))
+  in
+  match current_run_messages [] (List.rev messages) with
+  | Error detail -> fail detail
+  | Ok (`Marked run_messages) -> restore_marked run_messages
+  | Ok (`Legacy legacy_messages) ->
+    (match Tool_failure_recovery.latest_receipt legacy_messages with
+     | Error error -> fail (Tool_failure_recovery.show_receipt_error error)
+     | Ok (Some _) -> fail "recovery receipt exists without an OAS run boundary"
+     | Ok None ->
+       (* Checkpoints written before run-boundary metadata cannot prove that
+          two historical exchanges belong to the same external user run. Keep
+          only the latest completed round so the next live failure can form a
+          typed episode without correlating across a user boundary. *)
+       (match
+          Llm_provider.Tool_message_pairs.latest_tool_exchanges ~count:1 legacy_messages
+        with
+        | [] -> empty_recovery_state
+        | current_exchange :: _ ->
+          (match project current_exchange with
+           | Error error -> fail (Tool_failure_episode.show_error error)
+           | Ok current ->
+             { empty_recovery_state with last_completed_round = Some current })))
 ;;
 
 let resume

--- a/lib/agent/agent_elicitation.ml
+++ b/lib/agent/agent_elicitation.ml
@@ -44,23 +44,18 @@ let runtime_response_to_hooks = function
   | Runtime.Input_timeout -> Hooks.Timeout
 ;;
 
-let message_of_response ~question = function
+let message_of_response ?(metadata = []) ~question = function
   | Hooks.Answer json ->
     let text =
       Printf.sprintf "[User input] %s: %s" question (Yojson.Safe.to_string json)
     in
     Some
-      { role = User
-      ; content = [ Text text ]
-      ; name = None
-      ; tool_call_id = None
-      ; metadata = []
-      }
+      { role = User; content = [ Text text ]; name = None; tool_call_id = None; metadata }
   | Hooks.Declined | Hooks.Timeout -> None
 ;;
 
-let apply_response agent (req : Error.input_required) response =
-  match message_of_response ~question:req.question response with
+let apply_response ?metadata agent (req : Error.input_required) response =
+  match message_of_response ?metadata ~question:req.question response with
   | None -> ()
   | Some message ->
     update_state agent (fun state ->

--- a/lib/agent/agent_elicitation.mli
+++ b/lib/agent/agent_elicitation.mli
@@ -18,12 +18,14 @@ val runtime_input_request_of_input_required
 val runtime_response_to_hooks : Runtime.input_response -> Hooks.elicitation_response
 
 val message_of_response
-  :  question:string
+  :  ?metadata:Types.metadata
+  -> question:string
   -> Hooks.elicitation_response
   -> Types.message option
 
 val apply_response
-  :  Agent_types.t
+  :  ?metadata:Types.metadata
+  -> Agent_types.t
   -> Error.input_required
   -> Hooks.elicitation_response
   -> unit

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -256,6 +256,12 @@ let update_recovery_state t f =
   Eio.Mutex.use_rw ~protect:true t.mu (fun () -> t.recovery_state <- f t.recovery_state)
 ;;
 
+let recovery_run_boundary_metadata t =
+  if Option.is_some t.tool_failure_judge
+  then Types.Conversation_metadata.run_boundary
+  else []
+;;
+
 let set_consecutive_idle_turns t n =
   Eio.Mutex.use_rw ~protect:true t.mu (fun () -> t.consecutive_idle_turns <- n)
 ;;

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -280,6 +280,7 @@ val update_state : t -> (Types.agent_state -> Types.agent_state) -> unit
 val recovery_state : t -> recovery_state
 val set_recovery_state : t -> recovery_state -> unit
 val update_recovery_state : t -> (recovery_state -> recovery_state) -> unit
+val recovery_run_boundary_metadata : t -> Types.metadata
 val set_consecutive_idle_turns : t -> int -> unit
 val get_consecutive_idle_turns : t -> int
 

--- a/lib/base/error.ml
+++ b/lib/base/error.ml
@@ -33,6 +33,14 @@ type tool_failure_recovery_stage =
   | Decision_persistence
   | Resume_restore
 
+let tool_failure_recovery_stage_to_string = function
+  | Round_projection -> "round_projection"
+  | Episode_detection -> "episode_detection"
+  | Judge_response -> "judge_response"
+  | Decision_persistence -> "decision_persistence"
+  | Resume_restore -> "resume_restore"
+;;
+
 (** Agent runtime errors. *)
 type agent_error =
   | MaxTurnsExceeded of
@@ -188,15 +196,10 @@ let agent_error_to_string = function
       r.question
       r.request_id
   | ToolFailureRecoveryFailed r ->
-    let stage =
-      match r.stage with
-      | Round_projection -> "round_projection"
-      | Episode_detection -> "episode_detection"
-      | Judge_response -> "judge_response"
-      | Decision_persistence -> "decision_persistence"
-      | Resume_restore -> "resume_restore"
-    in
-    Printf.sprintf "Tool failure recovery failed at %s: %s" stage r.detail
+    Printf.sprintf
+      "Tool failure recovery failed at %s: %s"
+      (tool_failure_recovery_stage_to_string r.stage)
+      r.detail
   | ToolFailureRecoveryDeferred r ->
     let tools = String.concat ", " r.tool_names in
     Printf.sprintf

--- a/lib/base/error.mli
+++ b/lib/base/error.mli
@@ -33,6 +33,8 @@ type tool_failure_recovery_stage =
   | Decision_persistence
   | Resume_restore
 
+val tool_failure_recovery_stage_to_string : tool_failure_recovery_stage -> string
+
 type agent_error =
   | MaxTurnsExceeded of
       { turns : int

--- a/lib/llm_provider/api_common.ml
+++ b/lib/llm_provider/api_common.ml
@@ -373,7 +373,10 @@ let message_has_tool_result (msg : message) =
 
 let merge_tool_result_followup_user_messages messages =
   let mergeable_followup (msg : message) =
-    msg.role = User && msg.name = None && msg.tool_call_id = None && msg.metadata = []
+    msg.role = User
+    && msg.name = None
+    && msg.tool_call_id = None
+    && Conversation_metadata.is_mergeable_followup msg.metadata
   in
   let rec aux acc = function
     | ({ role = Tool; _ } as tool_msg) :: (followup : message) :: rest

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -329,6 +329,34 @@ let reasoning_details_text
     Keys are caller-defined strings; values are JSON payloads. *)
 type metadata = (string * Yojson.Safe.t) list [@@deriving show]
 
+module Conversation_metadata = struct
+  type run_boundary =
+    | Absent
+    | Present
+    | Malformed
+
+  let run_boundary_key = "oas.agent_run_boundary.v1"
+  let run_boundary = [ run_boundary_key, `Bool true ]
+
+  let classify_run_boundary metadata =
+    let values =
+      List.filter_map
+        (fun (key, value) ->
+           if String.equal key run_boundary_key then Some value else None)
+        metadata
+    in
+    match values with
+    | [] -> Absent
+    | [ `Bool true ] -> Present
+    | _ -> Malformed
+  ;;
+
+  let is_mergeable_followup = function
+    | [] -> true
+    | metadata -> classify_run_boundary metadata = Present && List.length metadata = 1
+  ;;
+end
+
 (** A single message in the conversation.
     [name] identifies the speaker (e.g. tool result source).
     [tool_call_id] links a tool result back to its tool_use request. *)

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -195,6 +195,23 @@ val reasoning_details_text
 (** Message metadata: extensible typed key-value pairs attached to a message. *)
 type metadata = (string * Yojson.Safe.t) list [@@deriving show]
 
+(** Checkpoint-only conversation metadata owned by OAS. The run boundary is
+    deliberately absent from provider payloads; it lets crash recovery avoid
+    correlating tool failures across distinct external user runs. *)
+module Conversation_metadata : sig
+  type run_boundary =
+    | Absent
+    | Present
+    | Malformed
+
+  val run_boundary : metadata
+  val classify_run_boundary : metadata -> run_boundary
+
+  (** Whether a follow-up User message may be folded into the preceding Tool
+      message for providers that require a single user-role span. *)
+  val is_mergeable_followup : metadata -> bool
+end
+
 type message =
   { role : role
   ; content : content_block list

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -54,9 +54,15 @@ let stage_input ?raw_trace_run ?clock agent =
                   ; response
                   }))
         | None -> ());
-       (match Agent_elicitation.message_of_response ~question:req.question response with
+       (match
+          Agent_elicitation.message_of_response
+            ~metadata:(Agent_types.recovery_run_boundary_metadata agent)
+            ~question:req.question
+            response
+        with
         | Some message ->
-          update_state agent (fun s -> { s with messages = Util.snoc s.messages message })
+          update_state agent (fun s -> { s with messages = Util.snoc s.messages message });
+          Agent_types.set_recovery_state agent Agent_types.empty_recovery_state
         | None -> ());
        Ok ()
      | None ->

--- a/lib/tool_failure_recovery.ml
+++ b/lib/tool_failure_recovery.ml
@@ -47,6 +47,8 @@ type response_error =
   | Expected_object
   | Missing_field of string
   | Invalid_field of string
+  | Duplicate_field of string
+  | Unexpected_field of string
   | Unsupported_action of string
   | Invalid_decision of decision_error
 [@@deriving show]
@@ -72,6 +74,25 @@ module String_set = Set.Make (String)
 let ( let* ) = Result.bind
 let is_blank value = String.equal (String.trim value) ""
 
+let validate_unique_fields fields =
+  let rec loop seen = function
+    | [] -> Ok ()
+    | (name, _) :: rest ->
+      if String_set.mem name seen
+      then Error (Duplicate_field name)
+      else loop (String_set.add name seen) rest
+  in
+  loop String_set.empty fields
+;;
+
+let validate_fields ~allowed fields =
+  let* () = validate_unique_fields fields in
+  let allowed = List.fold_right String_set.add allowed String_set.empty in
+  match List.find_opt (fun (name, _) -> not (String_set.mem name allowed)) fields with
+  | Some (name, _) -> Error (Unexpected_field name)
+  | None -> Ok ()
+;;
+
 let required_field name fields =
   match List.assoc_opt name fields with
   | Some value -> Ok value
@@ -93,9 +114,19 @@ let optional_json name fields =
 
 let parse_revised_call = function
   | `Assoc fields ->
+    let* () =
+      validate_fields
+        ~allowed:[ "current_tool_use_id"; "tool_name"; "revised_input" ]
+        fields
+    in
     let* current_tool_use_id = required_string "current_tool_use_id" fields in
     let* tool_name = required_string "tool_name" fields in
-    let* revised_input = required_field "revised_input" fields in
+    let* revised_input_value = required_field "revised_input" fields in
+    let* revised_input =
+      match revised_input_value with
+      | `Assoc _ -> Ok revised_input_value
+      | _ -> Error (Invalid_field "revised_input")
+    in
     Ok { current_tool_use_id; tool_name; revised_input }
   | _ -> Error (Invalid_field "revised_calls")
 ;;
@@ -116,18 +147,23 @@ let parse_revised_calls fields =
 
 let parse_decision_json = function
   | `Assoc fields ->
+    let* () = validate_unique_fields fields in
     let* action = required_string "action" fields in
     (match action with
      | "retry_modified" ->
+       let* () = validate_fields ~allowed:[ "action"; "revised_calls" ] fields in
        let* calls = parse_revised_calls fields in
        Ok (Retry_modified calls)
      | "replan" ->
+       let* () = validate_fields ~allowed:[ "action"; "instruction" ] fields in
        let* instruction = required_string "instruction" fields in
        Ok (Replan { instruction })
      | "ask_user" ->
+       let* () = validate_fields ~allowed:[ "action"; "question"; "schema" ] fields in
        let* question = required_string "question" fields in
        Ok (Ask_user { question; schema = optional_json "schema" fields })
      | "defer" ->
+       let* () = validate_fields ~allowed:[ "action"; "reason" ] fields in
        let* reason = required_string "reason" fields in
        Ok (Defer { reason })
      | action -> Error (Unsupported_action action))
@@ -220,57 +256,56 @@ let episode_json (episode : Tool_failure_episode.t) =
     [ "previous", attempt_json episode.previous; "current", attempt_json episode.current ]
 ;;
 
+let non_blank_string_schema = `Assoc [ "type", `String "string"; "minLength", `Int 1 ]
+
+let closed_object_schema ~properties ~required =
+  `Assoc
+    [ "type", `String "object"
+    ; "properties", `Assoc properties
+    ; "required", `List (List.map (fun name -> `String name) required)
+    ; "additionalProperties", `Bool false
+    ]
+;;
+
+let action_schema action properties required =
+  closed_object_schema
+    ~properties:(("action", `Assoc [ "const", `String action ]) :: properties)
+    ~required:("action" :: required)
+;;
+
 let output_schema =
+  let revised_call_schema =
+    closed_object_schema
+      ~properties:
+        [ "current_tool_use_id", non_blank_string_schema
+        ; "tool_name", non_blank_string_schema
+        ; "revised_input", `Assoc [ "type", `String "object" ]
+        ]
+      ~required:[ "current_tool_use_id"; "tool_name"; "revised_input" ]
+  in
   `Assoc
     [ "type", `String "object"
     ; ( "oneOf"
       , `List
-          [ `Assoc
-              [ ( "properties"
+          [ action_schema
+              "retry_modified"
+              [ ( "revised_calls"
                 , `Assoc
-                    [ "action", `Assoc [ "const", `String "retry_modified" ]
-                    ; ( "revised_calls"
-                      , `Assoc
-                          [ "type", `String "array"
-                          ; "minItems", `Int 1
-                          ; ( "items"
-                            , `Assoc
-                                [ "type", `String "object"
-                                ; ( "required"
-                                  , `List
-                                      [ `String "current_tool_use_id"
-                                      ; `String "tool_name"
-                                      ; `String "revised_input"
-                                      ] )
-                                ] )
-                          ] )
+                    [ "type", `String "array"
+                    ; "minItems", `Int 1
+                    ; "items", revised_call_schema
                     ] )
-              ; "required", `List [ `String "action"; `String "revised_calls" ]
               ]
-          ; `Assoc
-              [ ( "properties"
-                , `Assoc
-                    [ "action", `Assoc [ "const", `String "replan" ]
-                    ; "instruction", `Assoc [ "type", `String "string" ]
-                    ] )
-              ; "required", `List [ `String "action"; `String "instruction" ]
-              ]
-          ; `Assoc
-              [ ( "properties"
-                , `Assoc
-                    [ "action", `Assoc [ "const", `String "ask_user" ]
-                    ; "question", `Assoc [ "type", `String "string" ]
-                    ] )
-              ; "required", `List [ `String "action"; `String "question" ]
-              ]
-          ; `Assoc
-              [ ( "properties"
-                , `Assoc
-                    [ "action", `Assoc [ "const", `String "defer" ]
-                    ; "reason", `Assoc [ "type", `String "string" ]
-                    ] )
-              ; "required", `List [ `String "action"; `String "reason" ]
-              ]
+              [ "revised_calls" ]
+          ; action_schema
+              "replan"
+              [ "instruction", non_blank_string_schema ]
+              [ "instruction" ]
+          ; action_schema
+              "ask_user"
+              [ "question", non_blank_string_schema; "schema", `Assoc [] ]
+              [ "question" ]
+          ; action_schema "defer" [ "reason", non_blank_string_schema ] [ "reason" ]
           ] )
     ]
 ;;

--- a/lib/tool_failure_recovery.ml
+++ b/lib/tool_failure_recovery.ml
@@ -419,7 +419,7 @@ let receipt_json receipt =
     ]
 ;;
 
-let tool_result_ids message =
+let tool_result_ids (message : Types.message) =
   List.filter_map
     (function
       | Types.ToolResult { tool_use_id; _ } -> Some tool_use_id

--- a/lib/tool_failure_recovery.ml
+++ b/lib/tool_failure_recovery.ml
@@ -438,14 +438,14 @@ let attach_receipt ~messages ~episodes ~receipt =
   let expected_ids =
     List.map (fun episode -> episode.Tool_failure_episode.current.tool_use_id) episodes
   in
-  let contains_expected message =
+  let contains_expected (message : Types.message) =
     let actual_ids = tool_result_ids message in
     expected_ids <> []
     && List.for_all (fun expected -> List.mem expected actual_ids) expected_ids
   in
   let rec update = function
     | [] -> Error Result_message_not_found
-    | message :: rest when contains_expected message ->
+    | (message : Types.message) :: rest when contains_expected message ->
       if List.mem_assoc metadata_key message.Types.metadata
       then Error Duplicate_receipt_metadata
       else
@@ -454,7 +454,7 @@ let attach_receipt ~messages ~episodes ~receipt =
              metadata = (metadata_key, receipt_json receipt) :: message.metadata
            }
            :: rest)
-    | message :: rest ->
+    | (message : Types.message) :: rest ->
       let* rest = update rest in
       Ok (message :: rest)
   in

--- a/lib/tool_failure_recovery.mli
+++ b/lib/tool_failure_recovery.mli
@@ -66,6 +66,8 @@ type response_error =
   | Expected_object
   | Missing_field of string
   | Invalid_field of string
+  | Duplicate_field of string
+  | Unexpected_field of string
   | Unsupported_action of string
   | Invalid_decision of decision_error
 [@@deriving show]

--- a/test/test_tool_failure_recovery.ml
+++ b/test/test_tool_failure_recovery.ml
@@ -53,6 +53,7 @@ type scenario =
   ; events : string list
   ; requests : Llm_provider.Llm_transport.completion_request list
   ; agent : Agent.t
+  ; decision_checkpoint : Checkpoint.t option
   }
 
 let run_scenario env ~judge_json ?(fail_recovery_checkpoint = false) () =
@@ -60,6 +61,7 @@ let run_scenario env ~judge_json ?(fail_recovery_checkpoint = false) () =
   @@ fun sw ->
   let events = ref [] in
   let requests = ref [] in
+  let decision_checkpoint = ref None in
   let responses =
     ref
       [ tool_response "p1" (`Assoc [ "cmd", `String "gh pr list" ])
@@ -99,6 +101,7 @@ let run_scenario env ~judge_json ?(fail_recovery_checkpoint = false) () =
     match snapshot.stage with
     | After_retry_feedback_appended ->
       append events "decision_checkpoint";
+      decision_checkpoint := Some snapshot.checkpoint;
       if fail_recovery_checkpoint then Error "recovery checkpoint rejected" else Ok ()
     | After_assistant_collected | After_tool_results_appended -> Ok ()
   in
@@ -136,7 +139,12 @@ let run_scenario env ~judge_json ?(fail_recovery_checkpoint = false) () =
       agent
       "review the pull request"
   in
-  { result; events = !events; requests = !requests; agent }
+  { result
+  ; events = !events
+  ; requests = !requests
+  ; agent
+  ; decision_checkpoint = !decision_checkpoint
+  }
 ;;
 
 let retry_modified_json =
@@ -248,11 +256,7 @@ let failed_result id =
     }
 ;;
 
-let test_retry_modified_requires_changed_input () =
-  Eio_main.run
-  @@ fun env ->
-  Eio.Switch.run
-  @@ fun sw ->
+let sample_episodes () =
   let previous =
     project
       [ ToolUse { id = "p1"; name = "Execute"; input = `Assoc [ "cmd", `String "x" ] } ]
@@ -263,11 +267,161 @@ let test_retry_modified_requires_changed_input () =
       [ ToolUse { id = "c1"; name = "Execute"; input = `Assoc [ "cmd", `String "x" ] } ]
       [ failed_result "c1" ]
   in
-  let episodes =
-    match Tool_failure_episode.detect ~previous ~current with
-    | Ok episodes -> episodes
-    | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
+  match Tool_failure_episode.detect ~previous ~current with
+  | Ok episodes -> episodes
+  | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
+;;
+
+let resumed_final_run env ~checkpoint ~judge =
+  Eio.Switch.run
+  @@ fun sw ->
+  let requests = ref [] in
+  let record request =
+    requests := !requests @ [ request ];
+    final_response
   in
+  let transport : Llm_provider.Llm_transport.t =
+    { complete_sync =
+        (fun request ->
+          { Llm_provider.Llm_transport.response = Ok (record request)
+          ; latency_ms = Some 0
+          })
+    ; complete_stream = (fun ?on_telemetry:_ ~on_event:_ request -> Ok (record request))
+    }
+  in
+  let options =
+    { Agent.default_options with
+      transport = Some transport
+    ; provider = Some provider
+    ; guardrails = Guardrails.permissive
+    }
+  in
+  let events = ref [] in
+  let agent =
+    Agent.resume
+      ~net:env#net
+      ~checkpoint
+      ~tools:[ failing_tool events ]
+      ~options
+      ~tool_failure_judge:judge
+      ()
+  in
+  let result = Agent.run_turn_stream ~sw ~on_event:(fun _ -> ()) agent in
+  result, !requests
+;;
+
+let test_decision_checkpoint_resumes_without_rejudging () =
+  Eio_main.run
+  @@ fun env ->
+  let scenario = run_scenario env ~judge_json:retry_modified_json () in
+  let checkpoint =
+    match scenario.decision_checkpoint with
+    | Some checkpoint -> checkpoint
+    | None -> Alcotest.fail "missing recovery decision checkpoint"
+  in
+  let judge_calls = ref 0 in
+  let judge =
+    Tool_failure_recovery.create ~complete:(fun ~sw:_ _ ->
+      incr judge_calls;
+      Ok {|{"action":"replan","instruction":"must not run"}|})
+  in
+  let result, requests = resumed_final_run env ~checkpoint ~judge in
+  (match result with
+   | Ok (`Complete response) ->
+     Alcotest.(check string)
+       "resumed final text"
+       "finished"
+       (Types.text_of_response response)
+   | Ok `ToolsExecuted -> Alcotest.fail "unexpected resumed tool execution"
+   | Error error -> Alcotest.fail (Error.to_string error));
+  Alcotest.(check int) "persisted receipt skips judge" 0 !judge_calls;
+  Alcotest.(check int) "one resumed provider call" 1 (List.length requests);
+  let request = List.hd requests in
+  let system_prompt = Option.value request.config.system_prompt ~default:"" in
+  Alcotest.(check bool)
+    "persisted control restored"
+    true
+    (String.starts_with ~prefix:"base system\n\nOAS one-turn typed" system_prompt)
+;;
+
+let message ~role ~content ~metadata : Types.message =
+  { role; content; name = None; tool_call_id = None; metadata }
+;;
+
+let test_resume_does_not_correlate_across_external_user_runs () =
+  Eio_main.run
+  @@ fun env ->
+  let seed =
+    Agent.create
+      ~net:env#net
+      ~config:
+        { Types.default_config with
+          name = "boundary-test"
+        ; model = "mock-model"
+        ; system_prompt = Some "base system"
+        ; max_turns = 0
+        ; yield_on_tool = true
+        }
+      ()
+  in
+  let boundary = Types.Conversation_metadata.run_boundary in
+  let call id =
+    ToolUse { id; name = "Execute"; input = `Assoc [ "cmd", `String "gh pr list" ] }
+  in
+  let checkpoint =
+    { (Agent.checkpoint seed) with
+      turn_count = 2
+    ; messages =
+        [ message ~role:User ~content:[ Text "first request" ] ~metadata:boundary
+        ; message ~role:Assistant ~content:[ call "p1" ] ~metadata:[]
+        ; message ~role:Tool ~content:[ failed_result "p1" ] ~metadata:[]
+        ; message ~role:User ~content:[ Text "second request" ] ~metadata:boundary
+        ; message ~role:Assistant ~content:[ call "c1" ] ~metadata:[]
+        ; message ~role:Tool ~content:[ failed_result "c1" ] ~metadata:[]
+        ]
+    }
+  in
+  let judge_calls = ref 0 in
+  let judge =
+    Tool_failure_recovery.create ~complete:(fun ~sw:_ _ ->
+      incr judge_calls;
+      Ok {|{"action":"replan","instruction":"must not run"}|})
+  in
+  let result, requests = resumed_final_run env ~checkpoint ~judge in
+  (match result with
+   | Ok (`Complete _) -> ()
+   | Ok `ToolsExecuted -> Alcotest.fail "unexpected resumed tool execution"
+   | Error error -> Alcotest.fail (Error.to_string error));
+  Alcotest.(check int) "no cross-user judge call" 0 !judge_calls;
+  Alcotest.(check int) "main provider still runs" 1 (List.length requests)
+;;
+
+let test_run_boundary_metadata_remains_provider_mergeable () =
+  let messages =
+    [ message ~role:Tool ~content:[ failed_result "c1" ] ~metadata:[]
+    ; message
+        ~role:User
+        ~content:[ Text "next external request" ]
+        ~metadata:Types.Conversation_metadata.run_boundary
+    ]
+  in
+  match Llm_provider.Api_common.merge_tool_result_followup_user_messages messages with
+  | [ merged ] ->
+    Alcotest.(check int)
+      "tool result and external follow-up share one provider user span"
+      2
+      (List.length merged.Types.content)
+  | merged ->
+    Alcotest.fail
+      (Printf.sprintf "expected one provider message, got %d" (List.length merged))
+;;
+
+let test_retry_modified_requires_changed_input () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let episodes = sample_episodes () in
   let judge =
     Tool_failure_recovery.create ~complete:(fun ~sw:_ _ ->
       Ok
@@ -283,6 +437,56 @@ let test_retry_modified_requires_changed_input () =
   | Ok decision ->
     Alcotest.fail
       ("expected unchanged-input rejection, got "
+       ^ Tool_failure_recovery.show_decision decision)
+;;
+
+let decide_fixture sw text =
+  let judge = Tool_failure_recovery.create ~complete:(fun ~sw:_ _ -> Ok text) in
+  Tool_failure_recovery.decide
+    ~sw
+    ~agent_name:"test"
+    ~turn:2
+    ~episodes:(sample_episodes ())
+    judge
+;;
+
+let test_response_rejects_unexpected_field () =
+  Eio_main.run
+  @@ fun _env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  match
+    decide_fixture
+      sw
+      {|{"action":"replan","instruction":"use repository cwd","reason":"ignored"}|}
+  with
+  | Error
+      (Tool_failure_recovery.Invalid_response
+         (Tool_failure_recovery.Unexpected_field "reason")) -> ()
+  | Error error -> Alcotest.fail (Tool_failure_recovery.judge_error_to_string error)
+  | Ok decision ->
+    Alcotest.fail
+      ("expected unexpected-field rejection, got "
+       ^ Tool_failure_recovery.show_decision decision)
+;;
+
+let test_response_rejects_duplicate_field () =
+  Eio_main.run
+  @@ fun _env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  match
+    decide_fixture
+      sw
+      {|{"action":"replan","action":"defer","instruction":"use cwd","reason":"wait"}|}
+  with
+  | Error
+      (Tool_failure_recovery.Invalid_response
+         (Tool_failure_recovery.Duplicate_field "action")) -> ()
+  | Error error -> Alcotest.fail (Tool_failure_recovery.judge_error_to_string error)
+  | Ok decision ->
+    Alcotest.fail
+      ("expected duplicate-field rejection, got "
        ^ Tool_failure_recovery.show_decision decision)
 ;;
 
@@ -302,12 +506,32 @@ let () =
             "checkpoint failure is transactional"
             `Quick
             test_checkpoint_failure_does_not_commit_receipt
+        ; Alcotest.test_case
+            "decision checkpoint resumes without rejudging"
+            `Quick
+            test_decision_checkpoint_resumes_without_rejudging
+        ; Alcotest.test_case
+            "resume respects external user run boundary"
+            `Quick
+            test_resume_does_not_correlate_across_external_user_runs
+        ; Alcotest.test_case
+            "run boundary metadata is provider-mergeable"
+            `Quick
+            test_run_boundary_metadata_remains_provider_mergeable
         ] )
     ; ( "decision_validation"
       , [ Alcotest.test_case
             "retry input must change"
             `Quick
             test_retry_modified_requires_changed_input
+        ; Alcotest.test_case
+            "unexpected response field is rejected"
+            `Quick
+            test_response_rejects_unexpected_field
+        ; Alcotest.test_case
+            "duplicate response field is rejected"
+            `Quick
+            test_response_rejects_duplicate_field
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- persist a versioned external-user run boundary in checkpoint-only message metadata
- reconstruct recovery episodes only inside that boundary; legacy checkpoints carry one latest round without cross-user inference
- restore persisted recovery decisions without calling the judge twice
- keep boundary metadata out of provider semantics while preserving required Tool plus User folding
- reject duplicate, unknown, and structurally invalid recovery JSON fields
- classify judge completion failures as typed recovery failures
- document the provider-neutral recovery events

## Invariants
- no hidden reasoning, narration, provider name, or model name participates in detection
- no textual error matching or input similarity heuristic
- decision checkpoint commits before live state and before provider reacquisition
- new user or HITL input resets the recovery episode boundary

## Verification
- focused crash-resume, cross-user boundary, provider folding, and closed-parser tests added
- ocamlformat and whitespace checks pass
- full OCaml 5.4 and 5.5 proof delegated to stacked PR CI