### PR TITLE
fix(test): type recovery boundary fixture

### DIFF
--- a/test/test_tool_failure_recovery.ml
+++ b/test/test_tool_failure_recovery.ml
@@ -365,8 +365,8 @@ let test_resume_does_not_correlate_across_external_user_runs () =
       ()
   in
   let boundary = Types.Conversation_metadata.run_boundary in
-  let call id =
-    ToolUse { id; name = "Execute"; input = `Assoc [ "cmd", `String "gh pr list" ] }
+  let call id : Types.content_block =
+    Types.ToolUse { id; name = "Execute"; input = `Assoc [ "cmd", `String "gh pr list" ] }
   in
   let checkpoint =
     { (Agent.checkpoint seed) with


### PR DESCRIPTION
## Why

OAS main merged recovery resume hardening before its CI build completed. The build then failed because a fixture helper constructed ToolUse without an expected content_block type.

## Change

- annotate the helper result as Types.content_block
- qualify the constructor as Types.ToolUse

## Verification

- ocamlformat applied
- git diff --check passed
- full Dune build/test delegated to PR CI per repository policy

Observed failing run: https://github.com/jeong-sik/oas/actions/runs/29157427051