### PR TITLE
fix(agent): make typed recovery opt-in and authoritative

### DIFF
--- a/examples/error_handling.ml
+++ b/examples/error_handling.ml
@@ -72,8 +72,11 @@ let () =
     List.iter
       (function
         | Text t -> Printf.printf "  %s\n" t
-        | ToolResult { content; is_error; _ } ->
-          Printf.printf "  [tool_result error=%b] %s\n" is_error content
+        | ToolResult { content; outcome; _ } ->
+          Printf.printf
+            "  [tool_result error=%b] %s\n"
+            (tool_result_outcome_is_error outcome)
+            content
         | _ -> ())
       resp.content
   | Error e ->

--- a/examples/tool_use.ml
+++ b/examples/tool_use.ml
@@ -152,8 +152,11 @@ let () =
       (function
         | Text t -> Printf.printf "%s\n" t
         | ToolUse { id; name; _ } -> Printf.printf "[tool_use] %s (id=%s)\n" name id
-        | ToolResult { content; is_error; _ } ->
-          Printf.printf "[tool_result] %s (error=%b)\n" content is_error
+        | ToolResult { content; outcome; _ } ->
+          Printf.printf
+            "[tool_result] %s (error=%b)\n"
+            content
+            (tool_result_outcome_is_error outcome)
         | _ -> ())
       response.content
   | Error e -> Printf.eprintf "Error: %s\n" (Error.to_string e)

--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -85,12 +85,13 @@ let run_turn_with_trace ~sw ?clock ?raw_trace_run agent =
 ;;
 
 let provide_input agent request response =
-  set_recovery_state agent empty_recovery_state;
-  Agent_elicitation.apply_response
-    ~metadata:(recovery_run_boundary_metadata agent)
-    agent
-    request
-    response
+  if
+    Agent_elicitation.apply_response
+      ~metadata:(recovery_run_boundary_metadata agent)
+      agent
+      request
+      response
+  then set_recovery_state agent empty_recovery_state
 ;;
 
 (* ── Shared loop guard (finite max_turns + idle) ─────────── *)

--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -897,7 +897,7 @@ let with_periodic_callbacks ~sw:_ ?clock ~last_activity agent f =
         raise exn)
 ;;
 
-let validate_run_recovery_config agent ~on_yield ~on_resume =
+let validate_run_callbacks ~on_yield ~on_resume =
   match on_yield, on_resume with
   | Some _, None | None, Some _ ->
     Error
@@ -906,23 +906,14 @@ let validate_run_recovery_config agent ~on_yield ~on_resume =
             { field = "on_yield/on_resume"
             ; detail = "callbacks must be supplied together or both omitted"
             }))
-  | Some _, Some _ | None, None ->
-    if Option.is_some agent.tool_failure_judge && not agent.state.config.yield_on_tool
-    then
-      Error
-        (Error.Config
-           (Error.InvalidConfig
-              { field = "yield_on_tool"
-              ; detail = "tool_failure_judge requires yield_on_tool = true"
-              }))
-    else Ok ()
+  | Some _, Some _ | None, None -> Ok ()
 ;;
 
 let run_blocks ~sw ?clock ?on_yield ?on_resume agent user_blocks =
   match validate_user_input_blocks user_blocks with
   | Error _ as err -> err
   | Ok () ->
-    (match validate_run_recovery_config agent ~on_yield ~on_resume with
+    (match validate_run_callbacks ~on_yield ~on_resume with
      | Error _ as error -> error
      | Ok () ->
        let last_activity = ref (now_or_zero clock) in
@@ -947,7 +938,7 @@ let run_stream_blocks ~sw ?clock ~on_event ?on_yield ?on_resume agent user_block
   match validate_user_input_blocks user_blocks with
   | Error _ as err -> err
   | Ok () ->
-    (match validate_run_recovery_config agent ~on_yield ~on_resume with
+    (match validate_run_callbacks ~on_yield ~on_resume with
      | Error _ as error -> error
      | Ok () ->
        let on_telemetry =
@@ -1177,88 +1168,38 @@ let restore_tool_failure_recovery messages =
       restore_error = Some (recovery_failure Error.Resume_restore detail)
     }
   in
-  let project (exchange : Llm_provider.Tool_message_pairs.tool_exchange) =
-    Tool_failure_episode.project
-      ~tool_uses:exchange.tool_uses
-      ~tool_results:exchange.tool_results
-  in
-  let rec current_run_messages suffix = function
-    | [] -> Ok (`Legacy messages)
-    | (message : Types.message) :: rest ->
-      (match Types.Conversation_metadata.classify_run_boundary message.metadata with
-       | Types.Conversation_metadata.Present -> Ok (`Marked suffix)
-       | Types.Conversation_metadata.Absent ->
-         current_run_messages (message :: suffix) rest
-       | Types.Conversation_metadata.Malformed ->
-         Error "malformed or duplicate OAS agent run-boundary metadata")
-  in
-  let restore_marked run_messages =
-    let exchanges =
-      Llm_provider.Tool_message_pairs.latest_tool_exchanges ~count:2 run_messages
+  match Tool_failure_episode.latest_completed_rounds ~count:2 messages with
+  | Error error -> fail (Tool_failure_episode.show_error error)
+  | Ok [] ->
+    (match Tool_failure_recovery.latest_receipt messages with
+     | Ok None -> empty_recovery_state
+     | Ok (Some _) -> fail "recovery receipt exists without a completed tool round"
+     | Error error -> fail (Tool_failure_recovery.show_receipt_error error))
+  | Ok (current :: rest) ->
+    let episodes =
+      match rest with
+      | [] -> Ok []
+      | previous :: _ -> Tool_failure_episode.detect ~previous ~current
     in
-    match exchanges with
-    | [] ->
-      (match Tool_failure_recovery.latest_receipt run_messages with
-       | Ok None -> empty_recovery_state
-       | Ok (Some _) -> fail "recovery receipt exists without a tool exchange"
-       | Error error -> fail (Tool_failure_recovery.show_receipt_error error))
-    | current_exchange :: rest ->
-      (match project current_exchange with
-       | Error error -> fail (Tool_failure_episode.show_error error)
-       | Ok current ->
-         let episodes =
-           match rest with
-           | [] -> Ok []
-           | previous_exchange :: _ ->
-             (match project previous_exchange with
-              | Error error -> Error (Tool_failure_episode.show_error error)
-              | Ok previous ->
-                (match Tool_failure_episode.detect ~previous ~current with
-                 | Ok episodes -> Ok episodes
-                 | Error error -> Error (Tool_failure_episode.show_error error)))
-         in
-         (match episodes with
-          | Error detail -> fail detail
-          | Ok episodes ->
-            (match Tool_failure_recovery.latest_receipt run_messages with
-             | Error error -> fail (Tool_failure_recovery.show_receipt_error error)
-             | Ok receipt ->
-               let validation =
-                 match receipt with
-                 | None -> Ok ()
-                 | Some receipt ->
-                   Tool_failure_recovery.validate_receipt ~episodes receipt
-               in
-               (match validation with
-                | Error error -> fail (Tool_failure_recovery.show_receipt_error error)
-                | Ok () ->
-                  { last_completed_round = Some current
-                  ; pending_episodes = (if episodes = [] then None else Some episodes)
-                  ; pending_receipt = receipt
-                  ; restore_error = None
-                  }))))
-  in
-  match current_run_messages [] (List.rev messages) with
-  | Error detail -> fail detail
-  | Ok (`Marked run_messages) -> restore_marked run_messages
-  | Ok (`Legacy legacy_messages) ->
-    (match Tool_failure_recovery.latest_receipt legacy_messages with
-     | Error error -> fail (Tool_failure_recovery.show_receipt_error error)
-     | Ok (Some _) -> fail "recovery receipt exists without an OAS run boundary"
-     | Ok None ->
-       (* Checkpoints written before run-boundary metadata cannot prove that
-          two historical exchanges belong to the same external user run. Keep
-          only the latest completed round so the next live failure can form a
-          typed episode without correlating across a user boundary. *)
-       (match
-          Llm_provider.Tool_message_pairs.latest_tool_exchanges ~count:1 legacy_messages
-        with
-        | [] -> empty_recovery_state
-        | current_exchange :: _ ->
-          (match project current_exchange with
-           | Error error -> fail (Tool_failure_episode.show_error error)
-           | Ok current ->
-             { empty_recovery_state with last_completed_round = Some current })))
+    (match episodes with
+     | Error error -> fail (Tool_failure_episode.show_error error)
+     | Ok episodes ->
+       (match Tool_failure_recovery.latest_receipt messages with
+        | Error error -> fail (Tool_failure_recovery.show_receipt_error error)
+        | Ok receipt ->
+          let validation =
+            match receipt with
+            | None -> Ok ()
+            | Some receipt -> Tool_failure_recovery.validate_receipt ~episodes receipt
+          in
+          (match validation with
+           | Error error -> fail (Tool_failure_recovery.show_receipt_error error)
+           | Ok () ->
+             { last_completed_round = Some current
+             ; pending_episodes = (if episodes = [] then None else Some episodes)
+             ; pending_receipt = receipt
+             ; restore_error = None
+             })))
 ;;
 
 let resume
@@ -1281,6 +1222,9 @@ let resume
     match options.priority with
     | Some p -> { state with config = { state.config with priority = Some p } }
     | None -> state
+  in
+  let state =
+    { state with config = config_with_tool_failure_judge state.config tool_failure_judge }
   in
   let options =
     match options.tool_result_relocation with

--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -1046,7 +1046,11 @@ let run_with_handoffs_blocks ~sw ?clock agent ~targets user_blocks =
                             s.messages
                             ~tool_id
                             ~content:err_msg
-                            ~is_error:true
+                            ~outcome:
+                              (Tool_failed
+                                 { failure_kind = Non_retryable_tool_error
+                                 ; error_class = Some Deterministic
+                                 })
                       });
                     loop ()
                   | Some target ->
@@ -1129,7 +1133,11 @@ let run_with_handoffs_blocks ~sw ?clock agent ~targets user_blocks =
                                s.messages
                                ~tool_id
                                ~content:err_msg
-                               ~is_error:true
+                               ~outcome:
+                                 (Tool_failed
+                                    { failure_kind = Non_retryable_tool_error
+                                    ; error_class = Some Unknown
+                                    })
                          });
                        loop ()
                      | Ok sub_response ->
@@ -1149,7 +1157,7 @@ let run_with_handoffs_blocks ~sw ?clock agent ~targets user_blocks =
                                s.messages
                                ~tool_id
                                ~content:text
-                               ~is_error:false
+                               ~outcome:Tool_succeeded
                          });
                        loop ()))
                | None -> loop ())))

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -118,10 +118,9 @@ val sdk_version : string
     options records remain source-compatible.
 
     [tool_failure_judge] installs the LLM boundary used after two adjacent
-    typed failed-tool rounds. Without one, the run fails explicitly with
-    [ToolFailureRecoveryFailed] before another provider call. It is attached
-    outside [options] for the same record-compatibility reason and must be
-    reattached on {!resume}. *)
+    typed failed-tool rounds. It is attached outside [options] for the same
+    record-compatibility reason and must be reattached on {!resume}. Installing
+    it enables tool-boundary yielding automatically. *)
 val create
   :  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> ?config:Types.agent_config

--- a/lib/agent/agent_elicitation.ml
+++ b/lib/agent/agent_elicitation.ml
@@ -56,8 +56,9 @@ let message_of_response ?(metadata = []) ~question = function
 
 let apply_response ?metadata agent (req : Error.input_required) response =
   match message_of_response ?metadata ~question:req.question response with
-  | None -> ()
+  | None -> false
   | Some message ->
     update_state agent (fun state ->
-      { state with messages = Util.snoc state.messages message })
+      { state with messages = Util.snoc state.messages message });
+    true
 ;;

--- a/lib/agent/agent_elicitation.mli
+++ b/lib/agent/agent_elicitation.mli
@@ -23,9 +23,10 @@ val message_of_response
   -> Hooks.elicitation_response
   -> Types.message option
 
+(** [true] only when an external User message was appended. *)
 val apply_response
   :  ?metadata:Types.metadata
   -> Agent_types.t
   -> Error.input_required
   -> Hooks.elicitation_response
-  -> unit
+  -> bool

--- a/lib/agent/agent_handoff.ml
+++ b/lib/agent/agent_handoff.ml
@@ -41,20 +41,13 @@ let find_handoff_in_messages messages =
 (** Replace the tool result emitted for a specific ToolUse id in the most recent
     tool-result message. This lets handoff interception overwrite the
     sentinel handler output with the delegated agent response. *)
-let replace_tool_result messages ~tool_id ~content ~is_error =
+let replace_tool_result messages ~tool_id ~content ~outcome =
   let replace_in_content blocks =
     List.map
       (function
         | ToolResult { tool_use_id = id; _ } when id = tool_id ->
           ToolResult
-            { tool_use_id = id
-            ; content
-            ; is_error
-            ; failure_kind = None
-            ; error_class = None
-            ; json = None
-            ; content_blocks = None
-            }
+            { tool_use_id = id; content; outcome; json = None; content_blocks = None }
         | block -> block)
       blocks
   in
@@ -69,9 +62,7 @@ let replace_tool_result messages ~tool_id ~content ~is_error =
             [ ToolResult
                 { tool_use_id = tool_id
                 ; content
-                ; is_error
-                ; failure_kind = None
-                ; error_class = None
+                ; outcome
                 ; json = None
                 ; content_blocks = None
                 }

--- a/lib/agent/agent_handoff.mli
+++ b/lib/agent/agent_handoff.mli
@@ -22,5 +22,5 @@ val replace_tool_result
   :  Types.message list
   -> tool_id:string
   -> content:string
-  -> is_error:bool
+  -> outcome:Types.tool_result_outcome
   -> Types.message list

--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -16,9 +16,7 @@ type tool_execution_result =
   { tool_use_id : string
   ; tool_name : string
   ; content : string
-  ; is_error : bool
-  ; failure_kind : tool_failure_kind option
-  ; error_class : Types.tool_error_class option
+  ; outcome : Types.tool_result_outcome
   }
 
 type scheduled_tool_use =
@@ -98,11 +96,6 @@ let concurrency_class_of_tool tool =
   | None -> Tool.Sequential_workspace
 ;;
 
-let recoverable_of_failure_kind = function
-  | Some Validation_error | Some Recoverable_tool_error -> true
-  | Some Non_retryable_tool_error | None -> false
-;;
-
 let json_object_keys_for_log = function
   | `Assoc fields ->
     fields |> List.map fst |> List.sort_uniq String.compare |> String.concat ","
@@ -137,7 +130,7 @@ let preview_tool_names ?(limit = 12) names =
 let unknown_tool_failure ~requested ~available =
   let available_preview = preview_tool_names available in
   let failure_kind =
-    if available = [] then Some Non_retryable_tool_error else Some Validation_error
+    if available = [] then Non_retryable_tool_error else Validation_error
   in
   ( Printf.sprintf "Tool not found: %s. Available tools: %s" requested available_preview
   , failure_kind )
@@ -159,9 +152,9 @@ let tool_failure_result ~id ~name ~content ~error_class =
   { tool_use_id = id
   ; tool_name = name
   ; content
-  ; is_error = true
-  ; failure_kind = Some Non_retryable_tool_error
-  ; error_class = Some error_class
+  ; outcome =
+      Tool_failed
+        { failure_kind = Non_retryable_tool_error; error_class = Some error_class }
   }
 ;;
 
@@ -337,9 +330,11 @@ let find_and_execute_tool_with_index
           { tool_use_id = id
           ; tool_name = name
           ; content = message
-          ; is_error = true
-          ; failure_kind = Some Validation_error
-          ; error_class = None
+          ; outcome =
+              Tool_failed
+                { failure_kind = Validation_error
+                ; error_class = Some Types.Deterministic
+                }
           }
         in
         let emit_post_tool_use_failure ~input message =
@@ -507,25 +502,18 @@ let find_and_execute_tool_with_index
                       (Hooks.OnToolError { tool_name = name; error = message })
                     : Hooks.hook_decision)
                | Ok _ -> ());
-              let content, is_error, failure_kind, error_class =
+              let content, outcome =
                 match result with
-                | Ok { content; _meta = _ } -> content, false, None, None
+                | Ok { content; _meta = _ } -> content, Tool_succeeded
                 | Error { message; recoverable; error_class } ->
                   let failure_kind =
-                    Some
-                      (if recoverable
-                       then Recoverable_tool_error
-                       else Non_retryable_tool_error)
+                    if recoverable
+                    then Recoverable_tool_error
+                    else Non_retryable_tool_error
                   in
-                  message, true, failure_kind, error_class
+                  message, Tool_failed { failure_kind; error_class }
               in
-              { tool_use_id = id
-              ; tool_name = name
-              ; content
-              ; is_error
-              ; failure_kind
-              ; error_class
-              }))
+              { tool_use_id = id; tool_name = name; content; outcome }))
         (* Tool_middleware validation match *)
       | None ->
         (* Tool dispatch failure (the LLM asked for a tool that isn't
@@ -559,9 +547,7 @@ let find_and_execute_tool_with_index
         { tool_use_id = id
         ; tool_name = requested_name
         ; content = message
-        ; is_error = true
-        ; failure_kind
-        ; error_class = Some Types.Deterministic
+        ; outcome = Tool_failed { failure_kind; error_class = Some Types.Deterministic }
         }
     with
     | Out_of_memory -> raise Out_of_memory
@@ -574,17 +560,7 @@ let find_and_execute_tool_with_index
   (match event_bus with
    | Some bus ->
      let output_content = result.content in
-     let is_error = result.is_error in
-     let output : Types.tool_result =
-       if is_error
-       then
-         Error
-           { message = output_content
-           ; recoverable = recoverable_of_failure_kind result.failure_kind
-           ; error_class = result.error_class
-           }
-       else Ok { content = output_content; _meta = None }
-     in
+     let output = Types.tool_result_of_outcome ~content:output_content result.outcome in
      (try
         Event_bus.publish
           bus
@@ -712,17 +688,13 @@ let execute_scheduled_tool
              { tool_use_id = id
              ; tool_name = name
              ; content = "Tool execution skipped by hook"
-             ; is_error = false
-             ; failure_kind = None
-             ; error_class = None
+             ; outcome = Tool_succeeded
              }
            | Hooks.Override value ->
              { tool_use_id = id
              ; tool_name = name
              ; content = value
-             ; is_error = false
-             ; failure_kind = None
-             ; error_class = None
+             ; outcome = Tool_succeeded
              }
            | Hooks.ApprovalRequired ->
              (match approval with
@@ -865,9 +837,11 @@ let execute_scheduled_tool
            { tool_use_id = id
            ; tool_name = name
            ; content = msg
-           ; is_error = true
-           ; failure_kind = Some Non_retryable_tool_error
-           ; error_class = Some Types.Unknown
+           ; outcome =
+               Tool_failed
+                 { failure_kind = Non_retryable_tool_error
+                 ; error_class = Some Types.Unknown
+                 }
            })
   in
   let duration_ms_tool = (Unix.gettimeofday () -. t0_tool) *. 1000.0 in
@@ -880,7 +854,7 @@ let execute_scheduled_tool
           ; tool_name = name
           ; idempotency_key = idem_key
           ; output_json = `String triple.content
-          ; is_error = triple.is_error
+          ; is_error = Types.tool_result_outcome_is_error triple.outcome
           ; duration_ms = duration_ms_tool
           ; timestamp = Unix.gettimeofday ()
           })
@@ -892,7 +866,7 @@ let execute_scheduled_tool
          ~tool_use_id:id
          ~tool_name:name
          ~content:triple.content
-         ~is_error:triple.is_error)
+         ~is_error:(Types.tool_result_outcome_is_error triple.outcome))
    | None -> ());
   index, triple
 ;;

--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -15,6 +15,7 @@ type tool_failure_kind = Types.tool_failure_kind =
 type tool_execution_result =
   { tool_use_id : string
   ; tool_name : string
+  ; input : Yojson.Safe.t
   ; content : string
   ; outcome : Types.tool_result_outcome
   }
@@ -148,9 +149,10 @@ let resolve_tool_call tool_index name input =
      | None -> name, input, None, None)
 ;;
 
-let tool_failure_result ~id ~name ~content ~error_class =
+let tool_failure_result ~id ~name ~input ~content ~error_class =
   { tool_use_id = id
   ; tool_name = name
+  ; input
   ; content
   ; outcome =
       Tool_failed
@@ -158,13 +160,13 @@ let tool_failure_result ~id ~name ~content ~error_class =
   }
 ;;
 
-let blocked_tool_result ~id ~name ~content =
-  tool_failure_result ~id ~name ~content ~error_class:Types.Deterministic
+let blocked_tool_result ~id ~name ~input ~content =
+  tool_failure_result ~id ~name ~input ~content ~error_class:Types.Deterministic
 ;;
 
-let tool_exception_result ~id ~name exn =
+let tool_exception_result ~id ~name ~input exn =
   let content = Printf.sprintf "Tool '%s' raised: %s" name (Printexc.to_string exn) in
-  tool_failure_result ~id ~name ~content ~error_class:Types.Unknown
+  tool_failure_result ~id ~name ~input ~content ~error_class:Types.Unknown
 ;;
 
 let protect_tool_lifecycle_callback ~tool_name ~callback_name f =
@@ -183,9 +185,9 @@ let protect_tool_lifecycle_callback ~tool_name ~callback_name f =
       ]
 ;;
 
-let approval_required_without_callback_result ~id ~name =
+let approval_required_without_callback_result ~id ~name ~input =
   let reason = "approval required but no approval callback is registered" in
-  blocked_tool_result ~id ~name ~content:("Tool rejected: " ^ reason)
+  blocked_tool_result ~id ~name ~input ~content:("Tool rejected: " ^ reason)
 ;;
 
 let schedule_tool_use ~tool_index index (id, name, input) =
@@ -326,9 +328,10 @@ let find_and_execute_tool_with_index
     try
       match tool_opt with
       | Some tool ->
-        let validation_error_result message =
+        let validation_error_result ~input message =
           { tool_use_id = id
           ; tool_name = name
+          ; input
           ; content = message
           ; outcome =
               Tool_failed
@@ -406,7 +409,7 @@ let find_and_execute_tool_with_index
                 ; Log.S ("changed_fields", changed_fields)
                 ]);
             Ok corrected
-          | Correction_pipeline.Still_invalid { errors; attempted } ->
+          | Correction_pipeline.Still_invalid { corrected; errors; attempted } ->
             Log.warn
               _log
               "correction_pipeline still invalid after deterministic fixes"
@@ -419,15 +422,16 @@ let find_and_execute_tool_with_index
             let message =
               Correction_pipeline.build_nondet_feedback
                 ~tool_name:name
-                ~args:input
+                ~args:corrected
                 ~still_invalid:errors
                 ~attempted
             in
-            emit_post_tool_use_failure ~input message;
-            Error message
+            emit_post_tool_use_failure ~input:corrected message;
+            Error (corrected, message)
         in
         (match validated_input with
-         | Error msg -> validation_error_result msg
+         | Error (corrected_input, msg) ->
+           validation_error_result ~input:corrected_input msg
          | Ok coerced_input ->
            let shell_constraint_result =
              match Tool.descriptor tool with
@@ -441,7 +445,7 @@ let find_and_execute_tool_with_index
            (match shell_constraint_result with
             | Tool_middleware.Reject { message; _ } ->
               emit_post_tool_use_failure ~input:coerced_input message;
-              validation_error_result message
+              validation_error_result ~input:coerced_input message
             | Tool_middleware.Pass | Tool_middleware.Proceed _ ->
               let t0 = Unix.gettimeofday () in
               let result = Tool.execute ~context tool coerced_input in
@@ -513,7 +517,12 @@ let find_and_execute_tool_with_index
                   in
                   message, Tool_failed { failure_kind; error_class }
               in
-              { tool_use_id = id; tool_name = name; content; outcome }))
+              { tool_use_id = id
+              ; tool_name = name
+              ; input = coerced_input
+              ; content
+              ; outcome
+              }))
         (* Tool_middleware validation match *)
       | None ->
         (* Tool dispatch failure (the LLM asked for a tool that isn't
@@ -546,6 +555,7 @@ let find_and_execute_tool_with_index
            : Hooks.hook_decision);
         { tool_use_id = id
         ; tool_name = requested_name
+        ; input
         ; content = message
         ; outcome = Tool_failed { failure_kind; error_class = Some Types.Deterministic }
         }
@@ -554,7 +564,7 @@ let find_and_execute_tool_with_index
     | Stack_overflow -> raise Stack_overflow
     | Sys.Break -> raise Sys.Break
     | Eio.Cancel.Cancelled _ as ex -> raise ex
-    | exn -> tool_exception_result ~id ~name exn
+    | exn -> tool_exception_result ~id ~name ~input exn
   in
   (* ToolCompleted event *)
   (match event_bus with
@@ -687,12 +697,14 @@ let execute_scheduled_tool
            | Hooks.Skip ->
              { tool_use_id = id
              ; tool_name = name
+             ; input
              ; content = "Tool execution skipped by hook"
              ; outcome = Tool_succeeded
              }
            | Hooks.Override value ->
              { tool_use_id = id
              ; tool_name = name
+             ; input
              ; content = value
              ; outcome = Tool_succeeded
              }
@@ -725,7 +737,7 @@ let execute_scheduled_tool
                      _log
                      "ApprovalRequired but no approval callback — rejecting"
                      [ Log.S ("tool", name); Log.S ("agent", agent_name) ];
-                   approval_required_without_callback_result ~id ~name)
+                   approval_required_without_callback_result ~id ~name ~input)
               | Some approve_fn ->
                 (match approve_fn ~tool_name:name ~input with
                  | Hooks.Approve ->
@@ -745,7 +757,11 @@ let execute_scheduled_tool
                      input
                      id
                  | Hooks.Reject reason ->
-                   blocked_tool_result ~id ~name ~content:("Tool rejected: " ^ reason)
+                   blocked_tool_result
+                     ~id
+                     ~name
+                     ~input
+                     ~content:("Tool rejected: " ^ reason)
                  | Hooks.Edit new_input ->
                    find_and_execute_tool_with_index
                      ~context
@@ -814,6 +830,7 @@ let execute_scheduled_tool
              blocked_tool_result
                ~id
                ~name
+               ~input
                ~content:
                  (Printf.sprintf
                     "Tool execution blocked: hook pre_tool_use failed at %s: %s"
@@ -824,7 +841,7 @@ let execute_scheduled_tool
                 executes no tool; the reason string becomes the tool result
                 content verbatim. Distinct from [Hooks.Override] (soft nudge,
                 is_error=false) and [Hooks.HookFailed] (infra failure). *)
-             blocked_tool_result ~id ~name ~content:reason
+             blocked_tool_result ~id ~name ~input ~content:reason
          with
          | Out_of_memory -> raise Out_of_memory
          | Stack_overflow -> raise Stack_overflow
@@ -836,6 +853,7 @@ let execute_scheduled_tool
            in
            { tool_use_id = id
            ; tool_name = name
+           ; input
            ; content = msg
            ; outcome =
                Tool_failed

--- a/lib/agent/agent_tools.mli
+++ b/lib/agent/agent_tools.mli
@@ -53,9 +53,7 @@ type tool_execution_result =
   { tool_use_id : string
   ; tool_name : string
   ; content : string
-  ; is_error : bool
-  ; failure_kind : tool_failure_kind option
-  ; error_class : Types.tool_error_class option
+  ; outcome : Types.tool_result_outcome
   }
 
 (** Find a tool by name and execute it, invoking [PostToolUse] (and

--- a/lib/agent/agent_tools.mli
+++ b/lib/agent/agent_tools.mli
@@ -52,6 +52,11 @@ type tool_failure_kind = Types.tool_failure_kind =
 type tool_execution_result =
   { tool_use_id : string
   ; tool_name : string
+  ; input : Yojson.Safe.t
+    (** Effective input at the deepest execution boundary reached. Successful
+        dispatches record the exact handler input; validation failures retain
+        the final deterministic candidate; pre-dispatch rejections retain the
+        exact rejected request. *)
   ; content : string
   ; outcome : Types.tool_result_outcome
   }

--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -355,14 +355,8 @@ let resolve_turn_params ~hooks ~messages ~max_turns ~turn ~invoke_hook =
             let results =
               List.filter_map
                 (function
-                  | ToolResult { content; is_error; _ } ->
-                    if is_error
-                    then
-                      Some
-                        (Error
-                           { message = content; recoverable = true; error_class = None }
-                         : tool_result)
-                    else Some (Ok { content; _meta = None } : tool_result)
+                  | ToolResult { content; outcome; _ } ->
+                    Some (Types.tool_result_of_outcome ~content outcome)
                   | Text _
                   | Thinking _
                   | ReasoningDetails _
@@ -426,26 +420,14 @@ let filter_valid_messages ~messages extra_messages =
     filter_valid last_role extra_messages
 ;;
 
-let recoverable_of_failure_kind = function
-  | Some Agent_tools.Validation_error | Some Agent_tools.Recoverable_tool_error -> true
-  | Some Agent_tools.Non_retryable_tool_error | None -> false
-;;
-
 let apply_context_injection ~context ~messages ~injector ~tool_uses ~results =
   let current_messages = ref messages in
   List.iter2
     (fun block (result : Agent_tools.tool_execution_result) ->
        match block with
        | ToolUse { name; input; _ } ->
-         let output : tool_result =
-           if result.is_error
-           then
-             Error
-               { message = result.content
-               ; recoverable = recoverable_of_failure_kind result.failure_kind
-               ; error_class = result.error_class
-               }
-           else Ok { content = result.content; _meta = None }
+         let output =
+           Types.tool_result_of_outcome ~content:result.content result.outcome
          in
          (try
             match injector ~tool_name:name ~input ~output with
@@ -611,9 +593,7 @@ let make_tool_results
          ToolResult
            { tool_use_id = result.tool_use_id
            ; content
-           ; is_error = result.is_error
-           ; failure_kind = result.failure_kind
-           ; error_class = result.error_class
+           ; outcome = result.outcome
            ; json = None
            ; content_blocks = None
            })
@@ -772,9 +752,7 @@ let make_tool_results
          ToolResult
            { tool_use_id = tid
            ; content
-           ; is_error = result.is_error
-           ; failure_kind = result.failure_kind
-           ; error_class = result.error_class
+           ; outcome = result.outcome
            ; json = None
            ; content_blocks = None
            })
@@ -787,15 +765,20 @@ let mock_result ?(is_error = false) ~id content : Agent_tools.tool_execution_res
   { tool_use_id = id
   ; tool_name = "test"
   ; content
-  ; is_error
-  ; failure_kind = None
-  ; error_class = None
+  ; outcome =
+      (if is_error
+       then
+         Tool_failed
+           { failure_kind = Agent_tools.Non_retryable_tool_error
+           ; error_class = Some Types.Unknown
+           }
+       else Tool_succeeded)
   }
 ;;
 
 let single_tool_result = function
-  | [ ToolResult { tool_use_id; content; is_error; _ } ] ->
-    Some (tool_use_id, content, is_error)
+  | [ ToolResult { tool_use_id; content; outcome; _ } ] ->
+    Some (tool_use_id, content, Types.tool_result_outcome_is_error outcome)
   | []
   | [ Text _ ]
   | [ Thinking _ ]

--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -764,6 +764,7 @@ let make_tool_results
 let mock_result ?(is_error = false) ~id content : Agent_tools.tool_execution_result =
   { tool_use_id = id
   ; tool_name = "test"
+  ; input = `Null
   ; content
   ; outcome =
       (if is_error

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -382,6 +382,11 @@ let set_lifecycle
               status))
 ;;
 
+let config_with_tool_failure_judge config = function
+  | None -> config
+  | Some _ -> { config with yield_on_tool = true }
+;;
+
 let create
       ~net
       ?(config = default_config)
@@ -393,6 +398,7 @@ let create
       ?tool_failure_judge
       ()
   =
+  let config = config_with_tool_failure_judge config tool_failure_judge in
   let mcp_tools =
     List.concat_map (fun (m : Mcp.managed) -> m.tools) options.mcp_clients
   in

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -303,6 +303,11 @@ val sdk_version : string
 
 (** {1 Construction} *)
 
+val config_with_tool_failure_judge
+  :  Types.agent_config
+  -> Tool_failure_recovery.judge option
+  -> Types.agent_config
+
 val create
   :  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> ?config:Types.agent_config

--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -171,7 +171,7 @@ let with_checkpoint_sink checkpoint_sink b =
 ;;
 
 let with_tool_failure_judge tool_failure_judge b =
-  { b with tool_failure_judge = Some tool_failure_judge }
+  { b with tool_failure_judge = Some tool_failure_judge; yield_on_tool = true }
 ;;
 
 (** Override the Budget_strategy Emergency-phase summarizer with a

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -355,8 +355,8 @@ val with_journal : Durable_event.journal -> t -> t
 val with_checkpoint_sink : Agent.checkpoint_sink -> t -> t
 
 (** Install the LLM judge used for adjacent typed failed-tool recovery.
-    [with_yield_on_tool true] is required so the main provider lease is not held
-    while the judge completion is waiting. *)
+    This also enables tool-boundary yielding so the main provider lease is not
+    held while the judge completion is waiting. *)
 val with_tool_failure_judge : Tool_failure_recovery.judge -> t -> t
 
 (** Override the Budget_strategy Emergency-phase summarizer with a

--- a/lib/agent_tool.ml
+++ b/lib/agent_tool.ml
@@ -85,12 +85,12 @@ let content_block_to_json = function
       ; "name", `String name
       ; "input", input
       ]
-  | ToolResult { tool_use_id; content; is_error; json; _ } ->
+  | ToolResult { tool_use_id; content; outcome; json; _ } ->
     `Assoc
       [ "type", `String "tool_result"
       ; "tool_use_id", `String tool_use_id
       ; "content", `String content
-      ; "is_error", `Bool is_error
+      ; "is_error", `Bool (tool_result_outcome_is_error outcome)
       ; "json", Option.value ~default:`Null json
       ]
   | Image { media_type; data; source_type } ->

--- a/lib/checkpoint_codec.ml
+++ b/lib/checkpoint_codec.ml
@@ -77,16 +77,17 @@ let result_all items =
 let checkpoint_content_block_to_json block =
   let wire_json = Api.content_block_to_json block in
   match block, wire_json with
-  | ToolResult { failure_kind; error_class; _ }, `Assoc fields ->
+  | ToolResult { outcome; _ }, `Assoc fields ->
     let provenance =
-      (match failure_kind with
-       | Some kind -> [ "failure_kind", Types.tool_failure_kind_to_yojson kind ]
-       | None -> [])
-      @
-      match error_class with
-      | Some error_class ->
-        [ "error_class", Types.tool_error_class_to_yojson error_class ]
-      | None -> []
+      match outcome with
+      | Tool_succeeded | Legacy_unclassified_failure -> []
+      | Tool_failed { failure_kind; error_class } ->
+        [ "failure_kind", Types.tool_failure_kind_to_yojson failure_kind ]
+        @
+          (match error_class with
+          | Some error_class ->
+            [ "error_class", Types.tool_error_class_to_yojson error_class ]
+          | None -> [])
     in
     `Assoc (fields @ provenance)
   | ( ( Text _
@@ -129,7 +130,12 @@ let content_block_of_json_strict json =
     match Api.content_block_of_json json with
     | Some
         (ToolResult
-           { tool_use_id; content; is_error; json = parsed_json; content_blocks; _ }) ->
+           { tool_use_id
+           ; content
+           ; outcome = wire_outcome
+           ; json = parsed_json
+           ; content_blocks
+           }) ->
       let* failure_kind =
         optional_typed_field
           ~field:"failure_kind"
@@ -143,16 +149,30 @@ let content_block_of_json_strict json =
           ~decode:Types.tool_error_class_of_yojson
           json
       in
+      let* outcome =
+        match wire_outcome, failure_kind, error_class with
+        | Tool_succeeded, None, None -> Ok Tool_succeeded
+        | Tool_succeeded, _, _ ->
+          Error
+            (Error.Serialization
+               (JsonParseError
+                  { detail =
+                      "Checkpoint ToolResult marks success but contains failure \
+                       provenance"
+                  }))
+        | (Legacy_unclassified_failure | Tool_failed _), Some failure_kind, error_class ->
+          Ok (Tool_failed { failure_kind; error_class })
+        | (Legacy_unclassified_failure | Tool_failed _), None, None ->
+          Ok Legacy_unclassified_failure
+        | (Legacy_unclassified_failure | Tool_failed _), None, Some _ ->
+          Error
+            (Error.Serialization
+               (JsonParseError
+                  { detail = "Checkpoint ToolResult has error_class without failure_kind"
+                  }))
+      in
       Ok
-        (ToolResult
-           { tool_use_id
-           ; content
-           ; is_error
-           ; failure_kind
-           ; error_class
-           ; json = parsed_json
-           ; content_blocks
-           })
+        (ToolResult { tool_use_id; content; outcome; json = parsed_json; content_blocks })
     | Some block -> Ok block
     | None ->
       let open Yojson.Safe.Util in

--- a/lib/content_replacement_state.ml
+++ b/lib/content_replacement_state.ml
@@ -111,7 +111,7 @@ let apply_frozen t blocks =
       List.map
         (fun block ->
            match block with
-           | ToolResult { tool_use_id; is_error; failure_kind; error_class; json; _ } ->
+           | ToolResult { tool_use_id; outcome; json; _ } ->
              if Hashtbl.mem t.seen_ids tool_use_id
              then (
                (* Frozen: apply cached replacement or keep *)
@@ -120,9 +120,7 @@ let apply_frozen t blocks =
                  ToolResult
                    { tool_use_id
                    ; content = r.preview
-                   ; is_error
-                   ; failure_kind
-                   ; error_class
+                   ; outcome
                    ; json
                    ; content_blocks = None
                    }
@@ -271,27 +269,21 @@ let%test "apply_frozen: replaces frozen, collects fresh" =
     [ ToolResult
         { tool_use_id = "t1"
         ; content = "long content"
-        ; is_error = false
-        ; failure_kind = None
-        ; error_class = None
+        ; outcome = Tool_succeeded
         ; json = None
         ; content_blocks = None
         }
     ; ToolResult
         { tool_use_id = "t2"
         ; content = "kept content"
-        ; is_error = false
-        ; failure_kind = None
-        ; error_class = None
+        ; outcome = Tool_succeeded
         ; json = None
         ; content_blocks = None
         }
     ; ToolResult
         { tool_use_id = "t3"
         ; content = "new content"
-        ; is_error = false
-        ; failure_kind = None
-        ; error_class = None
+        ; outcome = Tool_succeeded
         ; json = None
         ; content_blocks = None
         }
@@ -319,9 +311,7 @@ let%test "apply_frozen: idempotent" =
     [ ToolResult
         { tool_use_id = "t1"
         ; content = "original"
-        ; is_error = false
-        ; failure_kind = None
-        ; error_class = None
+        ; outcome = Tool_succeeded
         ; json = None
         ; content_blocks = None
         }

--- a/lib/context_reducer.ml
+++ b/lib/context_reducer.ml
@@ -439,9 +439,7 @@ let%test "cap_message_tokens: oversized message with Text blocks is truncated" =
     @ [ ToolResult
           { tool_use_id = "keep"
           ; content = "r"
-          ; is_error = false
-          ; failure_kind = None
-          ; error_class = None
+          ; outcome = Tool_succeeded
           ; json = None
           ; content_blocks = None
           }
@@ -474,9 +472,7 @@ let%test "cap_message_tokens: truncation marker present when text dropped" =
     @ [ ToolResult
           { tool_use_id = "t0"
           ; content = "r"
-          ; is_error = false
-          ; failure_kind = None
-          ; error_class = None
+          ; outcome = Tool_succeeded
           ; json = None
           ; content_blocks = None
           }
@@ -520,9 +516,7 @@ let%test
       ToolResult
         { tool_use_id = Printf.sprintf "t%d" i
         ; content = String.make 400 'x'
-        ; is_error = false
-        ; failure_kind = None
-        ; error_class = None
+        ; outcome = Tool_succeeded
         ; json = None
         ; content_blocks = None
         })
@@ -541,9 +535,7 @@ let%test "cap_message_tokens: recent turns are not modified" =
       ToolResult
         { tool_use_id = Printf.sprintf "t%d" i
         ; content = String.make 400 'x'
-        ; is_error = false
-        ; failure_kind = None
-        ; error_class = None
+        ; outcome = Tool_succeeded
         ; json = None
         ; content_blocks = None
         })
@@ -565,9 +557,7 @@ let%test "cap_message_tokens: monotonicity — never increases tokens" =
         ToolResult
           { tool_use_id = Printf.sprintf "t%d" i
           ; content = String.make 500 'x'
-          ; is_error = false
-          ; failure_kind = None
-          ; error_class = None
+          ; outcome = Tool_succeeded
           ; json = None
           ; content_blocks = None
           })
@@ -679,9 +669,7 @@ let%test "estimate_block_tokens ToolResult uses CJK-aware estimation" =
     ToolResult
       { tool_use_id = "t1"
       ; content = "\xEA\xB2\xB0\xEA\xB3\xBC\xEC\x9E\x85\xEB\x8B\x88\xEB\x8B\xA4"
-      ; is_error = false
-      ; failure_kind = None
-      ; error_class = None
+      ; outcome = Tool_succeeded
       ; json = None
       ; content_blocks = None
       }

--- a/lib/context_reducer_apply.ml
+++ b/lib/context_reducer_apply.ml
@@ -11,8 +11,7 @@ let apply_prune_tool_outputs ~max_output_len messages =
          List.map
            (fun block ->
               match block with
-              | ToolResult
-                  { tool_use_id; content; is_error; failure_kind; error_class; _ }
+              | ToolResult { tool_use_id; content; outcome; _ }
                 when String.length content > max_output_len ->
                 let truncated = String.sub content 0 max_output_len in
                 let marker =
@@ -21,9 +20,7 @@ let apply_prune_tool_outputs ~max_output_len messages =
                 ToolResult
                   { tool_use_id
                   ; content = truncated ^ marker
-                  ; is_error
-                  ; failure_kind
-                  ; error_class
+                  ; outcome
                   ; json = None
                   ; content_blocks = None
                   }
@@ -138,9 +135,11 @@ let synthetic_tool_result_message id =
           ; content =
               "OAS context reducer synthesized this error result because the original \
                tool call had no matching ToolResult."
-          ; is_error = true
-          ; failure_kind = None
-          ; error_class = None
+          ; outcome =
+              Tool_failed
+                { failure_kind = Non_retryable_tool_error
+                ; error_class = Some Deterministic
+                }
           ; json = None
           ; content_blocks = None
           }
@@ -362,11 +361,10 @@ let apply_clear_tool_results ~keep_recent messages =
                List.map
                  (fun block ->
                     match block with
-                    | ToolResult
-                        { tool_use_id; content; is_error; failure_kind; error_class; _ }
+                    | ToolResult { tool_use_id; content; outcome; _ }
                       when String.length content > 50 ->
                       let summary =
-                        if is_error
+                        if tool_result_outcome_is_error outcome
                         then "[tool error result cleared]"
                         else
                           Printf.sprintf
@@ -376,9 +374,7 @@ let apply_clear_tool_results ~keep_recent messages =
                       ToolResult
                         { tool_use_id
                         ; content = summary
-                        ; is_error
-                        ; failure_kind
-                        ; error_class
+                        ; outcome
                         ; json = None
                         ; content_blocks = None
                         }
@@ -423,8 +419,7 @@ let apply_stub_tool_results ~keep_recent messages =
                List.map
                  (fun block ->
                     match block with
-                    | ToolResult
-                        { tool_use_id; content; is_error; failure_kind; error_class; _ }
+                    | ToolResult { tool_use_id; content; outcome; _ }
                       when String.length content > 50 ->
                       let tool_name =
                         match Hashtbl.find_opt tool_names tool_use_id with
@@ -438,7 +433,9 @@ let apply_stub_tool_results ~keep_recent messages =
                             0
                             content
                       in
-                      let status = if is_error then "error" else "ok" in
+                      let status =
+                        if tool_result_outcome_is_error outcome then "error" else "ok"
+                      in
                       let stub =
                         Printf.sprintf
                           "[tool: %s, %d lines, %s]"
@@ -449,9 +446,7 @@ let apply_stub_tool_results ~keep_recent messages =
                       ToolResult
                         { tool_use_id
                         ; content = stub
-                        ; is_error
-                        ; failure_kind
-                        ; error_class
+                        ; outcome
                         ; json = None
                         ; content_blocks = None
                         }

--- a/lib/correction_pipeline.ml
+++ b/lib/correction_pipeline.ml
@@ -17,7 +17,8 @@ type det_result =
       ; corrections : correction list
       }
   | Still_invalid of
-      { errors : Tool_input_validation.field_error list
+      { corrected : Yojson.Safe.t
+      ; errors : Tool_input_validation.field_error list
       ; attempted : correction list
       }
 
@@ -186,7 +187,7 @@ let run ~schema ?(stages = default_stages) input =
   | Tool_input_validation.Valid final ->
     Fixed { corrected = final; corrections = all_corrections }
   | Tool_input_validation.Invalid errors ->
-    Still_invalid { errors; attempted = all_corrections }
+    Still_invalid { corrected; errors; attempted = all_corrections }
 ;;
 
 (* ── Det/NonDet boundary ────────────────────────────────── *)

--- a/lib/correction_pipeline.mli
+++ b/lib/correction_pipeline.mli
@@ -37,9 +37,13 @@ type det_result =
       ; corrections : correction list
       } (** All validation errors resolved by deterministic stages. *)
   | Still_invalid of
-      { errors : Tool_input_validation.field_error list
+      { corrected : Yojson.Safe.t
+      ; errors : Tool_input_validation.field_error list
       ; attempted : correction list
-      } (** Some errors remain after all stages exhausted. *)
+      }
+  (** Some errors remain after all stages exhausted. [corrected] is the
+          exact final deterministic candidate, retained for execution
+          provenance and LLM recovery. *)
 
 (** {1 Stages} *)
 

--- a/lib/llm_provider/api_common.ml
+++ b/lib/llm_provider/api_common.ml
@@ -131,7 +131,7 @@ let rec content_block_to_json_with
       ; "name", `String name
       ; "input", input
       ]
-  | ToolResult { tool_use_id; content; is_error; content_blocks; _ } ->
+  | ToolResult { tool_use_id; content; outcome; content_blocks; _ } ->
     let content_json =
       match content_blocks with
       | Some blocks ->
@@ -153,7 +153,7 @@ let rec content_block_to_json_with
       [ "type", `String "tool_result"
       ; "tool_use_id", `String tool_use_id
       ; "content", content_json
-      ; "is_error", `Bool is_error
+      ; "is_error", `Bool (tool_result_outcome_is_error outcome)
       ]
   | Image { media_type; data; source_type } ->
     `Assoc
@@ -306,18 +306,13 @@ let rec content_block_of_json_result json =
         Ok (text_blocks_to_string blocks, Some blocks)
       | other -> Ok (Yojson.Safe.to_string other, None)
     in
-    let is_error = Cli_common_json.member_bool "is_error" json in
+    let outcome =
+      if Cli_common_json.member_bool "is_error" json
+      then Legacy_unclassified_failure
+      else Tool_succeeded
+    in
     let json = Types.try_parse_json content in
-    Ok
-      (ToolResult
-         { tool_use_id
-         ; content
-         ; is_error
-         ; failure_kind = None
-         ; error_class = None
-         ; json
-         ; content_blocks
-         })
+    Ok (ToolResult { tool_use_id; content; outcome; json; content_blocks })
   | Some "image" ->
     parse_media_block
       ~block_type:"image"

--- a/lib/llm_provider/api_common.ml
+++ b/lib/llm_provider/api_common.ml
@@ -376,7 +376,12 @@ let merge_tool_result_followup_user_messages messages =
   let rec aux acc = function
     | ({ role = Tool; _ } as tool_msg) :: (followup : message) :: rest
       when message_has_tool_result tool_msg && mergeable_followup followup ->
-      let merged = { tool_msg with content = tool_msg.content @ followup.content } in
+      let merged =
+        { tool_msg with
+          content = tool_msg.content @ followup.content
+        ; metadata = tool_msg.metadata @ followup.metadata
+        }
+      in
       aux (merged :: acc) rest
     | msg :: rest -> aux (msg :: acc) rest
     | [] -> List.rev acc

--- a/lib/llm_provider/api_common.mli
+++ b/lib/llm_provider/api_common.mli
@@ -74,6 +74,10 @@ val content_block_of_json_result
   -> (Types.content_block, content_block_decode_error) result
 
 val content_block_of_json : Yojson.Safe.t -> Types.content_block option
+
+(* Internal metadata is retained while projecting an immediate ToolResult plus
+   plain User follow-up into one provider user turn; metadata is not wire
+   content. *)
 val merge_tool_result_followup_user_messages : Types.message list -> Types.message list
 val message_to_json : Types.message -> Yojson.Safe.t
 val kimi_message_to_json : Types.message -> Yojson.Safe.t

--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -427,9 +427,7 @@ let%test "openai_messages_of_message user with tool_result" =
         ; ToolResult
             { tool_use_id = "tc1"
             ; content = "result"
-            ; is_error = false
-            ; failure_kind = None
-            ; error_class = None
+            ; outcome = Tool_succeeded
             ; json = None
             ; content_blocks = None
             }
@@ -464,9 +462,7 @@ let%test "build_request strips orphaned tool results from wire messages" =
           ; ToolResult
               { tool_use_id = "orphan-id"
               ; content = "stale"
-              ; is_error = false
-              ; failure_kind = None
-              ; error_class = None
+              ; outcome = Tool_succeeded
               ; json = None
               ; content_blocks = None
               }
@@ -646,9 +642,7 @@ let%test "openai_messages_of_message Tool role with ToolResult" =
         [ ToolResult
             { tool_use_id = "tc1"
             ; content = "result data"
-            ; is_error = false
-            ; failure_kind = None
-            ; error_class = None
+            ; outcome = Tool_succeeded
             ; json = None
             ; content_blocks = None
             }
@@ -1140,9 +1134,7 @@ let%test "openai_content_parts_of_blocks tool_result filtered" =
     [ ToolResult
         { tool_use_id = "t1"
         ; content = "result"
-        ; is_error = false
-        ; failure_kind = None
-        ; error_class = None
+        ; outcome = Tool_succeeded
         ; json = None
         ; content_blocks = None
         }

--- a/lib/llm_provider/canonical_tool.ml
+++ b/lib/llm_provider/canonical_tool.ml
@@ -47,7 +47,7 @@ type provider_tool_result =
   ; structured_content : Yojson.Safe.t option
     (** Projection of [ToolResult.json] (WP4 parsed payload), verbatim — not a
         fresh parse, and not [provider_config.output_schema] (RFC-OAS-024 D7). *)
-  ; is_error : bool
+  ; outcome : Types.tool_result_outcome
   }
 
 let provider_kind_of_response (response : Types.api_response) =
@@ -158,13 +158,13 @@ let tool_calls_of_response (response : Types.api_response) : provider_tool_call 
 
 let tool_result_of_block (block : Types.content_block) : provider_tool_result option =
   match block with
-  | Types.ToolResult { tool_use_id; content; is_error; json; content_blocks; _ } ->
+  | Types.ToolResult { tool_use_id; content; outcome; json; content_blocks; _ } ->
     Some
       { call_id = tool_use_id
       ; content
       ; content_blocks
       ; structured_content = json
-      ; is_error
+      ; outcome
       }
   | Types.Text _
   | Types.Thinking _

--- a/lib/llm_provider/canonical_tool.mli
+++ b/lib/llm_provider/canonical_tool.mli
@@ -95,7 +95,7 @@ type provider_tool_result =
     (** Projection of [ToolResult.json] (WP4 parsed payload), verbatim. Not a
           fresh parse, and {b not} [provider_config.output_schema] which is a
           request-level concern (RFC-OAS-024 D7). *)
-  ; is_error : bool
+  ; outcome : Types.tool_result_outcome
   }
 
 (** Project a single content block into a tool result. Returns [None] for any

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -383,9 +383,10 @@ let finalize_stream_acc (acc : stream_acc) =
              (Types.ToolResult
                 { tool_use_id
                 ; content = text
-                ; is_error
-                ; failure_kind = None
-                ; error_class = None
+                ; outcome =
+                    (if is_error
+                     then Types.Legacy_unclassified_failure
+                     else Types.Tool_succeeded)
                 ; json = (if is_error then None else Types.try_parse_json text)
                 ; content_blocks = None
                 }))

--- a/lib/llm_provider/tool_message_pairs.ml
+++ b/lib/llm_provider/tool_message_pairs.ml
@@ -207,9 +207,11 @@ let synthetic_tool_result_message (id, _name) =
           ; content =
               "OAS synthesized this error tool result because provider request history \
                contained a tool call without an adjacent result."
-          ; is_error = true
-          ; failure_kind = None
-          ; error_class = None
+          ; outcome =
+              Tool_failed
+                { failure_kind = Non_retryable_tool_error
+                ; error_class = Some Deterministic
+                }
           ; json = None
           ; content_blocks = None
           }

--- a/lib/llm_provider/tool_message_pairs.ml
+++ b/lib/llm_provider/tool_message_pairs.ml
@@ -14,11 +14,6 @@ type repair_report =
   ; synthesized_tool_result_ids : string list
   }
 
-type tool_exchange =
-  { tool_uses : content_block list
-  ; tool_results : content_block list
-  }
-
 let empty_repair_report = { dropped_tool_results = []; synthesized_tool_result_ids = [] }
 
 let normalize_report report =
@@ -87,35 +82,6 @@ let split_tool_result_span messages =
     | rest -> List.rev span, rest
   in
   loop [] messages
-;;
-
-let latest_tool_exchanges ~count messages =
-  if count < 0 then invalid_arg "latest_tool_exchanges: count must be >= 0";
-  let keep_latest exchanges =
-    let rec take remaining acc = function
-      | _ when remaining = 0 -> List.rev acc
-      | [] -> List.rev acc
-      | exchange :: rest -> take (remaining - 1) (exchange :: acc) rest
-    in
-    take count [] exchanges
-  in
-  let rec collect latest = function
-    | [] -> latest
-    | (message : message) :: rest ->
-      let uses = if message.role = Assistant then tool_uses message else [] in
-      if uses = []
-      then collect latest rest
-      else (
-        let result_span, tail = split_tool_result_span rest in
-        let exchange =
-          { tool_uses = message.content
-          ; tool_results =
-              List.concat_map (fun (result : message) -> result.content) result_span
-          }
-        in
-        collect (keep_latest (exchange :: latest)) tail)
-  in
-  collect [] messages
 ;;
 
 let strip_orphaned_tool_results_with_report (messages : message list)

--- a/lib/llm_provider/tool_message_pairs.mli
+++ b/lib/llm_provider/tool_message_pairs.mli
@@ -20,21 +20,6 @@ type repair_report =
   }
 
 val empty_repair_report : repair_report
-
-type tool_exchange =
-  { tool_uses : Types.content_block list
-  ; tool_results : Types.content_block list
-  }
-
-(** Return up to [count] latest assistant tool-use/result-span exchanges,
-    newest first. Result spans use the same immediate multi-message boundary as
-    provider pairing repair. An incomplete latest exchange is returned with an
-    empty [tool_results] list so callers can fail explicitly.
-
-    This is intended for one-time checkpoint restoration; live agent loops
-    should retain the typed completed-round projection incrementally. *)
-val latest_tool_exchanges : count:int -> Types.message list -> tool_exchange list
-
 val strip_orphaned_tool_results : Types.message list -> Types.message list
 
 val strip_orphaned_tool_results_with_report

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -75,6 +75,28 @@ type tool_failure_kind =
   | Non_retryable_tool_error
 [@@deriving yojson, show]
 
+type tool_failure_provenance =
+  { failure_kind : tool_failure_kind
+  ; error_class : tool_error_class option
+  }
+[@@deriving show]
+
+type tool_result_outcome =
+  | Tool_succeeded
+  | Tool_failed of tool_failure_provenance
+  | Legacy_unclassified_failure
+[@@deriving show]
+
+let tool_failure_kind_is_recoverable = function
+  | Validation_error | Recoverable_tool_error -> true
+  | Non_retryable_tool_error -> false
+;;
+
+let tool_result_outcome_is_error = function
+  | Tool_succeeded -> false
+  | Tool_failed _ | Legacy_unclassified_failure -> true
+;;
+
 type tool_error =
   { message : string
   ; recoverable : bool
@@ -82,6 +104,18 @@ type tool_error =
   }
 
 type tool_result = (tool_output, tool_error) result
+
+let tool_result_of_outcome ~content = function
+  | Tool_succeeded -> Ok { content; _meta = None }
+  | Tool_failed { failure_kind; error_class } ->
+    Error
+      { message = content
+      ; recoverable = tool_failure_kind_is_recoverable failure_kind
+      ; error_class
+      }
+  | Legacy_unclassified_failure ->
+    Error { message = content; recoverable = false; error_class = None }
+;;
 
 type tool_param =
   { name : string
@@ -281,9 +315,7 @@ type content_block =
   | ToolResult of
       { tool_use_id : string
       ; content : string
-      ; is_error : bool
-      ; failure_kind : tool_failure_kind option
-      ; error_class : tool_error_class option
+      ; outcome : tool_result_outcome
       ; json : Yojson.Safe.t option
         (** Parsed JSON payload when available. Consumers
                         should prefer [json] over [content] for structured access.
@@ -679,15 +711,7 @@ let try_parse_json (s : string) : Yojson.Safe.t option =
 (** Create a tool result message.
     When [json] is not provided, attempts to parse [content] as JSON
     so downstream consumers can access structured data without re-parsing. *)
-let tool_result_msg
-      ~tool_use_id
-      ~content
-      ?(is_error = false)
-      ?failure_kind
-      ?error_class
-      ?json
-      ()
-  =
+let tool_result_msg ~tool_use_id ~content ?(outcome = Tool_succeeded) ?json () =
   let json =
     match json with
     | Some _ -> json
@@ -696,16 +720,7 @@ let tool_result_msg
   make_message
     ~tool_call_id:tool_use_id
     ~role:Tool
-    [ ToolResult
-        { tool_use_id
-        ; content
-        ; is_error
-        ; failure_kind
-        ; error_class
-        ; json
-        ; content_blocks = None
-        }
-    ]
+    [ ToolResult { tool_use_id; content; outcome; json; content_blocks = None } ]
 ;;
 
 (** {1 Tool Result Validation}

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -365,10 +365,12 @@ module Conversation_metadata = struct
   type run_boundary =
     | Absent
     | Present
-    | Malformed
+    | Invalid
+    | Duplicate
 
   let run_boundary_key = "oas.agent_run_boundary.v1"
-  let run_boundary = [ run_boundary_key, `Bool true ]
+  let run_boundary_entry = run_boundary_key, `Bool true
+  let run_boundary = [ run_boundary_entry ]
 
   let classify_run_boundary metadata =
     let values =
@@ -380,7 +382,8 @@ module Conversation_metadata = struct
     match values with
     | [] -> Absent
     | [ `Bool true ] -> Present
-    | _ -> Malformed
+    | [ _ ] -> Invalid
+    | _ -> Duplicate
   ;;
 
   let is_mergeable_followup = function

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -59,6 +59,24 @@ type tool_failure_kind =
   | Non_retryable_tool_error
 [@@deriving yojson, show]
 
+type tool_failure_provenance =
+  { failure_kind : tool_failure_kind
+  ; error_class : tool_error_class option
+  }
+[@@deriving show]
+
+(** A tool result has one authoritative outcome. Provider serializers derive
+    their wire-level [is_error] flag from this value. The legacy case exists
+    only for failed provider/checkpoint rows that predate typed provenance. *)
+type tool_result_outcome =
+  | Tool_succeeded
+  | Tool_failed of tool_failure_provenance
+  | Legacy_unclassified_failure
+[@@deriving show]
+
+val tool_failure_kind_is_recoverable : tool_failure_kind -> bool
+val tool_result_outcome_is_error : tool_result_outcome -> bool
+
 type tool_error =
   { message : string
   ; recoverable : bool
@@ -66,6 +84,10 @@ type tool_error =
   }
 
 type tool_result = (tool_output, tool_error) result
+
+(** Lower an authoritative outcome to the hook/event-facing tool result.
+    Unclassified legacy failures are conservatively non-recoverable. *)
+val tool_result_of_outcome : content:string -> tool_result_outcome -> tool_result
 
 type tool_param =
   { name : string
@@ -154,11 +176,7 @@ type content_block =
   | ToolResult of
       { tool_use_id : string
       ; content : string
-      ; is_error : bool
-      ; failure_kind : tool_failure_kind option
-        (** Execution classification, when the result originated inside OAS. *)
-      ; error_class : tool_error_class option
-        (** Provider-neutral error class supplied by the tool boundary. *)
+      ; outcome : tool_result_outcome
       ; json : Yojson.Safe.t option (** Structured payload when parseable. *)
       ; content_blocks : content_block list option
         (** Structured multi-block result (e.g. text + image). When [Some],
@@ -468,9 +486,7 @@ val try_parse_json : string -> Yojson.Safe.t option
 val tool_result_msg
   :  tool_use_id:string
   -> content:string
-  -> ?is_error:bool
-  -> ?failure_kind:tool_failure_kind
-  -> ?error_class:tool_error_class
+  -> ?outcome:tool_result_outcome
   -> ?json:Yojson.Safe.t
   -> unit
   -> message

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -220,8 +220,10 @@ module Conversation_metadata : sig
   type run_boundary =
     | Absent
     | Present
-    | Malformed
+    | Invalid
+    | Duplicate
 
+  val run_boundary_entry : string * Yojson.Safe.t
   val run_boundary : metadata
   val classify_run_boundary : metadata -> run_boundary
 

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -1210,18 +1210,14 @@ let%test "last_tool_results_from finds tool results in last tool message" =
           [ ToolResult
               { tool_use_id = "t1"
               ; content = "result1"
-              ; is_error = false
-              ; failure_kind = None
-              ; error_class = None
+              ; outcome = Tool_succeeded
               ; json = None
               ; content_blocks = None
               }
           ; ToolResult
               { tool_use_id = "t2"
               ; content = "error msg"
-              ; is_error = true
-              ; failure_kind = None
-              ; error_class = None
+              ; outcome = Legacy_unclassified_failure
               ; json = None
               ; content_blocks = None
               }
@@ -1234,7 +1230,7 @@ let%test "last_tool_results_from finds tool results in last tool message" =
   in
   match last_tool_results_from msgs with
   | [ Ok { content = "result1"; _meta = _ }
-    ; Error { message = "error msg"; recoverable = true; error_class = None }
+    ; Error { message = "error msg"; recoverable = false; error_class = None }
     ] -> true
   | _ -> false
 ;;
@@ -1246,9 +1242,7 @@ let%test "last_tool_results_from skips non-tool user messages" =
           [ ToolResult
               { tool_use_id = "t1"
               ; content = "first"
-              ; is_error = false
-              ; failure_kind = None
-              ; error_class = None
+              ; outcome = Tool_succeeded
               ; json = None
               ; content_blocks = None
               }
@@ -1318,9 +1312,7 @@ let%test "last_tool_results_from picks last tool-result message" =
           [ ToolResult
               { tool_use_id = "t1"
               ; content = "first"
-              ; is_error = false
-              ; failure_kind = None
-              ; error_class = None
+              ; outcome = Tool_succeeded
               ; json = None
               ; content_blocks = None
               }
@@ -1340,9 +1332,7 @@ let%test "last_tool_results_from picks last tool-result message" =
           [ ToolResult
               { tool_use_id = "t2"
               ; content = "second"
-              ; is_error = false
-              ; failure_kind = None
-              ; error_class = None
+              ; outcome = Tool_succeeded
               ; json = None
               ; content_blocks = None
               }
@@ -1366,9 +1356,7 @@ let%test "last_tool_results_from mixed content in user message" =
           ; ToolResult
               { tool_use_id = "t1"
               ; content = "ok"
-              ; is_error = false
-              ; failure_kind = None
-              ; error_class = None
+              ; outcome = Tool_succeeded
               ; json = None
               ; content_blocks = None
               }
@@ -1392,9 +1380,7 @@ let%test "last_tool_results_from error tool result" =
           [ ToolResult
               { tool_use_id = "t1"
               ; content = "fail msg"
-              ; is_error = true
-              ; failure_kind = None
-              ; error_class = None
+              ; outcome = Legacy_unclassified_failure
               ; json = None
               ; content_blocks = None
               }
@@ -1406,7 +1392,7 @@ let%test "last_tool_results_from error tool result" =
     ]
   in
   match last_tool_results_from msgs with
-  | [ Error { message = "fail msg"; recoverable = true; error_class = None } ] -> true
+  | [ Error { message = "fail msg"; recoverable = false; error_class = None } ] -> true
   | _ -> false
 ;;
 
@@ -1454,27 +1440,21 @@ let%test "last_tool_results_from multiple tool results in one message" =
           [ ToolResult
               { tool_use_id = "t1"
               ; content = "r1"
-              ; is_error = false
-              ; failure_kind = None
-              ; error_class = None
+              ; outcome = Tool_succeeded
               ; json = None
               ; content_blocks = None
               }
           ; ToolResult
               { tool_use_id = "t2"
               ; content = "r2"
-              ; is_error = false
-              ; failure_kind = None
-              ; error_class = None
+              ; outcome = Tool_succeeded
               ; json = None
               ; content_blocks = None
               }
           ; ToolResult
               { tool_use_id = "t3"
               ; content = "r3"
-              ; is_error = true
-              ; failure_kind = None
-              ; error_class = None
+              ; outcome = Legacy_unclassified_failure
               ; json = None
               ; content_blocks = None
               }

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -547,16 +547,31 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails ~response tool_uses
                 ?relocation:agent.options.tool_result_relocation
                 results
             in
-            let completed_round =
-              match Tool_failure_episode.project ~tool_uses ~tool_results with
-              | Ok round -> Ok (Some round)
-              | Error error ->
-                Error
-                  (Error.Agent
-                     (Error.ToolFailureRecoveryFailed
-                        { stage = Error.Round_projection
-                        ; detail = Tool_failure_episode.show_error error
-                        }))
+            let* completed_round, completed_round_metadata =
+              match agent.tool_failure_judge with
+              | None -> Ok (None, [])
+              | Some _ ->
+                let executions =
+                  List.map
+                    (fun (result : Agent_tools.tool_execution_result) ->
+                       { Tool_failure_episode.tool_use_id = result.tool_use_id
+                       ; tool_name = result.tool_name
+                       ; input = result.input
+                       })
+                    results
+                in
+                (match Tool_failure_episode.project ~executions ~tool_results with
+                 | Ok round ->
+                   Ok
+                     ( Some round
+                     , [ Tool_failure_episode.completed_round_metadata executions ] )
+                 | Error error ->
+                   Error
+                     (Error.Agent
+                        (Error.ToolFailureRecoveryFailed
+                           { stage = Error.Round_projection
+                           ; detail = Tool_failure_episode.show_error error
+                           })))
             in
             (* Persist CRS to context after tool result processing so that
             checkpoint captures the current replacement decisions. *)
@@ -569,7 +584,13 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails ~response tool_uses
               let messages =
                 match tool_results with
                 | [] -> s.messages
-                | _ -> Util.snoc s.messages (make_message ~role:Tool tool_results)
+                | _ ->
+                  Util.snoc
+                    s.messages
+                    (make_message
+                       ~metadata:completed_round_metadata
+                       ~role:Tool
+                       tool_results)
               in
               let messages =
                 match !pending_nudge with
@@ -601,7 +622,6 @@ let stage_execute ?raw_trace_run agent ~effective_guardrails ~response tool_uses
                User warning and canned Assistant terminal response are removed;
                typed recovery owns repeated failed-tool judgment. *)
             ignore idle_handled;
-            let* completed_round = completed_round in
             Ok (ToolsExecuted completed_round)))
 ;;
 

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -106,7 +106,7 @@ let stage_input ?raw_trace_run ?clock agent =
 ;;
 
 (* Lower a canonical tool-result projection to the [Types.tool_result] the
-   [before_turn_params] hook and disclosure resolver consume. [is_error]
+   [before_turn_params] hook and disclosure resolver consume. [outcome]
    selects the Error/Ok branch; [content] is the canonical string payload.
    [structured_content]/[content_blocks] from the projection are not needed by
    these local consumers but are surfaced by the projection for a downstream
@@ -114,9 +114,7 @@ let stage_input ?raw_trace_run ?clock agent =
 let tool_result_of_projection (proj : Llm_provider.Canonical_tool.provider_tool_result)
   : Types.tool_result
   =
-  if proj.is_error
-  then Error { Types.message = proj.content; recoverable = true; error_class = None }
-  else Ok { Types.content = proj.content; _meta = None }
+  Types.tool_result_of_outcome ~content:proj.content proj.outcome
 ;;
 
 let role_can_carry_tool_results = function
@@ -157,18 +155,14 @@ let%test "last_tool_results_from routes through canonical projection (with json)
           [ ToolResult
               { tool_use_id = "t1"
               ; content = "ok payload"
-              ; is_error = false
-              ; failure_kind = None
-              ; error_class = None
+              ; outcome = Tool_succeeded
               ; json = Some (`Assoc [ "rows", `Int 2 ])
               ; content_blocks = None
               }
           ; ToolResult
               { tool_use_id = "t2"
               ; content = "boom"
-              ; is_error = true
-              ; failure_kind = None
-              ; error_class = None
+              ; outcome = Legacy_unclassified_failure
               ; json = None
               ; content_blocks = None
               }

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -175,7 +175,7 @@ let%test "last_tool_results_from routes through canonical projection (with json)
   in
   match last_tool_results_from msgs with
   | [ Ok { content = "ok payload"; _meta = _ }
-    ; Error { message = "boom"; recoverable = true; error_class = None }
+    ; Error { message = "boom"; recoverable = false; error_class = None }
     ] -> true
   | _ -> false
 ;;

--- a/lib/succession.ml
+++ b/lib/succession.ml
@@ -273,9 +273,11 @@ let normalize_for_model (msgs : message list) ~(target_model : string) : message
                        { tool_use_id = id
                        ; content =
                            Printf.sprintf "[truncated: %s result unavailable]" name
-                       ; is_error = true
-                       ; failure_kind = None
-                       ; error_class = None
+                       ; outcome =
+                           Tool_failed
+                             { failure_kind = Non_retryable_tool_error
+                             ; error_class = Some Deterministic
+                             }
                        ; json = None
                        ; content_blocks = None
                        }

--- a/lib/tool_failure_episode.ml
+++ b/lib/tool_failure_episode.ml
@@ -16,6 +16,13 @@ type t =
   }
 [@@deriving yojson, show]
 
+type executed_call =
+  { tool_use_id : string
+  ; tool_name : string
+  ; input : Yojson.Safe.t
+  }
+[@@deriving yojson, show]
+
 type paired_attempt =
   { tool_use_id : string
   ; tool_name : string
@@ -34,8 +41,12 @@ type error =
   | Duplicate_tool_result_id of { tool_use_id : string }
   | Missing_tool_result of { tool_use_id : string }
   | Unmatched_tool_result of { tool_use_id : string }
-  | Failure_metadata_on_success of { tool_use_id : string }
-  | Failure_kind_missing of { tool_use_id : string }
+  | Unclassified_failure of { tool_use_id : string }
+  | Missing_completed_round_metadata of { tool_use_ids : string list }
+  | Duplicate_completed_round_metadata
+  | Invalid_completed_round_metadata of string
+  | Duplicate_run_boundary_metadata
+  | Invalid_run_boundary_metadata
   | Ambiguous_failure_signature of
       { tool_name : string
       ; failure_kind : tool_failure_kind
@@ -58,26 +69,11 @@ module Failure_map = Map.Make (Failure_key)
 let ( let* ) = Result.bind
 let string_is_blank value = String.equal (String.trim value) ""
 
-let tool_uses blocks =
-  List.filter_map
-    (function
-      | ToolUse { id; name; input } -> Some (id, name, input)
-      | Text _
-      | Thinking _
-      | ReasoningDetails _
-      | RedactedThinking _
-      | ToolResult _
-      | Image _
-      | Document _
-      | Audio _ -> None)
-    blocks
-;;
-
 let tool_results blocks =
   List.filter_map
     (function
-      | ToolResult { tool_use_id; content; is_error; failure_kind; error_class; _ } ->
-        Some (tool_use_id, content, is_error, failure_kind, error_class)
+      | ToolResult { tool_use_id; content; outcome; _ } ->
+        Some (tool_use_id, content, outcome)
       | Text _
       | Thinking _
       | ReasoningDetails _
@@ -99,71 +95,151 @@ let first_duplicate project values =
   loop String_set.empty values
 ;;
 
-let failure_of_result ~tool_use_id ~content ~is_error ~failure_kind ~error_class =
-  match is_error, failure_kind, error_class with
-  | false, None, None -> Ok None
-  | false, _, _ -> Error (Failure_metadata_on_success { tool_use_id })
-  | true, None, _ -> Error (Failure_kind_missing { tool_use_id })
-  | true, Some kind, error_class -> Ok (Some (kind, error_class, content))
+let failure_of_result ~tool_use_id ~content = function
+  | Tool_succeeded -> Ok None
+  | Tool_failed { failure_kind; error_class } ->
+    Ok (Some (failure_kind, error_class, content))
+  | Legacy_unclassified_failure -> Error (Unclassified_failure { tool_use_id })
 ;;
 
-let project ~tool_uses:use_blocks ~tool_results:result_blocks =
-  let uses = tool_uses use_blocks in
+let project ~executions ~tool_results:result_blocks =
   let results = tool_results result_blocks in
-  let* () = if uses = [] then Error Empty_tool_use_round else Ok () in
+  let* () = if executions = [] then Error Empty_tool_use_round else Ok () in
   let* () =
-    match List.find_opt (fun (id, _, _) -> string_is_blank id) uses with
+    match
+      List.find_opt
+        (fun (call : executed_call) -> string_is_blank call.tool_use_id)
+        executions
+    with
     | Some _ -> Error Blank_tool_use_id
     | None -> Ok ()
   in
   let* () =
-    match List.find_opt (fun (_, name, _) -> string_is_blank name) uses with
-    | Some (tool_use_id, _, _) -> Error (Blank_tool_name { tool_use_id })
+    match
+      List.find_opt
+        (fun (call : executed_call) -> string_is_blank call.tool_name)
+        executions
+    with
+    | Some call -> Error (Blank_tool_name { tool_use_id = call.tool_use_id })
     | None -> Ok ()
   in
   let* () =
-    match List.find_opt (fun (id, _, _, _, _) -> string_is_blank id) results with
+    match List.find_opt (fun (id, _, _) -> string_is_blank id) results with
     | Some _ -> Error Blank_tool_result_id
     | None -> Ok ()
   in
   let* () =
-    match first_duplicate (fun (id, _, _) -> id) uses with
+    match first_duplicate (fun (call : executed_call) -> call.tool_use_id) executions with
     | Some tool_use_id -> Error (Duplicate_tool_use_id { tool_use_id })
     | None -> Ok ()
   in
   let* () =
-    match first_duplicate (fun (id, _, _, _, _) -> id) results with
+    match first_duplicate (fun (id, _, _) -> id) results with
     | Some tool_use_id -> Error (Duplicate_tool_result_id { tool_use_id })
     | None -> Ok ()
   in
   let result_for id =
-    List.find_opt (fun (result_id, _, _, _, _) -> String.equal result_id id) results
+    List.find_opt (fun (result_id, _, _) -> String.equal result_id id) results
   in
   let* paired =
     let rec loop acc = function
       | [] -> Ok (List.rev acc)
-      | (tool_use_id, tool_name, input) :: rest ->
-        (match result_for tool_use_id with
-         | None -> Error (Missing_tool_result { tool_use_id })
-         | Some (_, content, is_error, failure_kind, error_class) ->
+      | (call : executed_call) :: rest ->
+        (match result_for call.tool_use_id with
+         | None -> Error (Missing_tool_result { tool_use_id = call.tool_use_id })
+         | Some (_, content, outcome) ->
            let* failure =
-             failure_of_result ~tool_use_id ~content ~is_error ~failure_kind ~error_class
+             failure_of_result ~tool_use_id:call.tool_use_id ~content outcome
            in
-           loop ({ tool_use_id; tool_name; input; failure } :: acc) rest)
+           loop
+             ({ tool_use_id = call.tool_use_id
+              ; tool_name = call.tool_name
+              ; input = call.input
+              ; failure
+              }
+              :: acc)
+             rest)
     in
-    loop [] uses
+    loop [] executions
   in
   let use_ids =
     List.fold_left
-      (fun ids (tool_use_id, _, _) -> String_set.add tool_use_id ids)
+      (fun ids (call : executed_call) -> String_set.add call.tool_use_id ids)
       String_set.empty
-      uses
+      executions
   in
-  match
-    List.find_opt (fun (id, _, _, _, _) -> not (String_set.mem id use_ids)) results
-  with
-  | Some (tool_use_id, _, _, _, _) -> Error (Unmatched_tool_result { tool_use_id })
+  match List.find_opt (fun (id, _, _) -> not (String_set.mem id use_ids)) results with
+  | Some (tool_use_id, _, _) -> Error (Unmatched_tool_result { tool_use_id })
   | None -> Ok paired
+;;
+
+let metadata_key = "oas.tool_failure_episode.completed_round.v1"
+let executions_to_yojson executions = `List (List.map executed_call_to_yojson executions)
+
+let executions_of_yojson = function
+  | `List values ->
+    List.fold_right
+      (fun value result ->
+         let* executions = result in
+         let* execution = executed_call_of_yojson value in
+         Ok (execution :: executions))
+      values
+      (Ok [])
+  | _ -> Error "completed-round execution metadata must be a list"
+;;
+
+let completed_round_metadata executions = metadata_key, executions_to_yojson executions
+
+let is_run_boundary (message : message) =
+  match Conversation_metadata.classify_run_boundary message.metadata with
+  | Conversation_metadata.Absent -> Ok false
+  | Conversation_metadata.Present -> Ok true
+  | Conversation_metadata.Invalid -> Error Invalid_run_boundary_metadata
+  | Conversation_metadata.Duplicate -> Error Duplicate_run_boundary_metadata
+;;
+
+let latest_run_messages messages =
+  let rec collect acc = function
+    | [] -> Ok acc
+    | message :: rest ->
+      let* boundary = is_run_boundary message in
+      if boundary then Ok acc else collect (message :: acc) rest
+  in
+  collect [] (List.rev messages)
+;;
+
+let completed_round_of_message (message : message) =
+  match List.filter (fun (key, _) -> String.equal key metadata_key) message.metadata with
+  | [] ->
+    let tool_use_ids =
+      List.map (fun (tool_use_id, _, _) -> tool_use_id) (tool_results message.content)
+    in
+    if tool_use_ids = []
+    then Ok None
+    else Error (Missing_completed_round_metadata { tool_use_ids })
+  | [ (_, json) ] ->
+    let* executions =
+      executions_of_yojson json
+      |> Result.map_error (fun detail -> Invalid_completed_round_metadata detail)
+    in
+    let* round = project ~executions ~tool_results:message.content in
+    Ok (Some round)
+  | _ -> Error Duplicate_completed_round_metadata
+;;
+
+let latest_completed_rounds ~count messages =
+  if count < 0 then invalid_arg "latest_completed_rounds: count must be >= 0";
+  let* messages = latest_run_messages messages in
+  let rec collect remaining acc = function
+    | _ when remaining = 0 -> Ok (List.rev acc)
+    | [] -> Ok (List.rev acc)
+    | message :: rest ->
+      let* round = completed_round_of_message message in
+      (match round with
+       | None -> collect remaining acc rest
+       | Some round -> collect (remaining - 1) (round :: acc) rest)
+  in
+  collect count [] (List.rev messages)
 ;;
 
 let failed_attempt = function

--- a/lib/tool_failure_episode.ml
+++ b/lib/tool_failure_episode.ml
@@ -176,12 +176,31 @@ let project ~executions ~tool_results:result_blocks =
 let metadata_key = "oas.tool_failure_episode.completed_round.v1"
 let executions_to_yojson executions = `List (List.map executed_call_to_yojson executions)
 
+let execution_of_metadata_yojson = function
+  | `Assoc fields as json ->
+    let rec validate_fields seen = function
+      | [] -> Ok ()
+      | (name, _) :: rest when String_set.mem name seen ->
+        Error (Printf.sprintf "duplicate executed-call field: %s" name)
+      | (name, _) :: rest ->
+        if
+          String.equal name "tool_use_id"
+          || String.equal name "tool_name"
+          || String.equal name "input"
+        then validate_fields (String_set.add name seen) rest
+        else Error (Printf.sprintf "unexpected executed-call field: %s" name)
+    in
+    let* () = validate_fields String_set.empty fields in
+    executed_call_of_yojson json
+  | _ -> Error "completed-round execution entry must be an object"
+;;
+
 let executions_of_yojson = function
   | `List values ->
     List.fold_right
       (fun value result ->
          let* executions = result in
-         let* execution = executed_call_of_yojson value in
+         let* execution = execution_of_metadata_yojson value in
          Ok (execution :: executions))
       values
       (Ok [])

--- a/lib/tool_failure_episode.mli
+++ b/lib/tool_failure_episode.mli
@@ -24,6 +24,18 @@ type t =
   }
 [@@deriving yojson, show]
 
+(** Identity and effective input emitted by the OAS execution boundary.
+    Successful dispatches and post-resolution failures use the resolved tool
+    and final deterministic candidate; pre-dispatch rejections preserve the
+    exact rejected request. It is never reconstructed from a later mutable
+    registry. *)
+type executed_call =
+  { tool_use_id : string
+  ; tool_name : string
+  ; input : Yojson.Safe.t
+  }
+[@@deriving yojson, show]
+
 (** An immutable, fully paired execution boundary. *)
 type completed_round
 
@@ -36,8 +48,12 @@ type error =
   | Duplicate_tool_result_id of { tool_use_id : string }
   | Missing_tool_result of { tool_use_id : string }
   | Unmatched_tool_result of { tool_use_id : string }
-  | Failure_metadata_on_success of { tool_use_id : string }
-  | Failure_kind_missing of { tool_use_id : string }
+  | Unclassified_failure of { tool_use_id : string }
+  | Missing_completed_round_metadata of { tool_use_ids : string list }
+  | Duplicate_completed_round_metadata
+  | Invalid_completed_round_metadata of string
+  | Duplicate_run_boundary_metadata
+  | Invalid_run_boundary_metadata
   | Ambiguous_failure_signature of
       { tool_name : string
       ; failure_kind : Types.tool_failure_kind
@@ -47,16 +63,33 @@ type error =
       }
 [@@deriving show]
 
-(** [project ~tool_uses ~tool_results] pairs a provider response's [ToolUse]
-    blocks with the canonical [ToolResult] blocks produced by execution.
+(** [project ~executions ~tool_results] pairs canonical executed calls with
+    the bounded [ToolResult] blocks persisted in agent history.
 
-    Non-tool blocks are ignored. Missing, duplicate, unmatched, blank, or
-    incompletely typed failures are explicit [Error] values. In particular,
-    [is_error = true] always requires [failure_kind = Some _]. *)
+    Non-result blocks are ignored. Missing, duplicate, unmatched, blank, or
+    unclassified failures are explicit [Error] values. A successful outcome
+    cannot carry failure provenance by construction. *)
 val project
-  :  tool_uses:Types.content_block list
+  :  executions:executed_call list
   -> tool_results:Types.content_block list
   -> (completed_round, error) result
+
+(** Metadata entry for checkpointing only the execution identity absent from a
+    [ToolResult]. Failure outcome and content remain authoritative in the
+    [ToolResult] and are re-projected during restore. Generic provider request
+    serializers do not forward message metadata. *)
+val completed_round_metadata : executed_call list -> string * Yojson.Safe.t
+
+(** Chronological messages after the latest run boundary. Malformed or
+    duplicate boundary metadata is an explicit error. *)
+val latest_run_messages : Types.message list -> (Types.message list, error) result
+
+(** Read up to [count] newest durable rounds, newest first. Missing, duplicate,
+    malformed, or result-inconsistent round metadata is an explicit error. *)
+val latest_completed_rounds
+  :  count:int
+  -> Types.message list
+  -> (completed_round list, error) result
 
 (** [detect ~previous ~current] returns one episode for each failure signature
     that occurs exactly once in each adjacent completed round. A signature is

--- a/lib/tool_failure_recovery.ml
+++ b/lib/tool_failure_recovery.ml
@@ -400,6 +400,7 @@ type receipt_error =
   | Result_message_not_found
   | Duplicate_receipt_metadata
   | Invalid_receipt_metadata of string
+  | Run_boundary_error of Tool_failure_episode.error
   | Receipt_episode_mismatch
   | Receipt_decision_invalid of decision_error
 [@@deriving show]
@@ -493,8 +494,22 @@ let attach_receipt ~messages ~episodes ~receipt =
       let* rest = update rest in
       Ok (message :: rest)
   in
-  let* reversed = update (List.rev messages) in
-  Ok (List.rev reversed)
+  let* run_messages =
+    Tool_failure_episode.latest_run_messages messages
+    |> Result.map_error (fun error -> Run_boundary_error error)
+  in
+  let prefix_length = List.length messages - List.length run_messages in
+  let rec split_prefix remaining prefix rest =
+    if remaining = 0
+    then List.rev prefix, rest
+    else (
+      match rest with
+      | [] -> invalid_arg "attach_receipt: latest-run prefix exceeds message history"
+      | message :: tail -> split_prefix (remaining - 1) (message :: prefix) tail)
+  in
+  let prefix, _ = split_prefix prefix_length [] messages in
+  let* reversed = update (List.rev run_messages) in
+  Ok (prefix @ List.rev reversed)
 ;;
 
 let parse_int name fields =
@@ -599,7 +614,11 @@ let latest_receipt messages =
           Ok (Some receipt)
         | _ :: _ :: _ -> Error Duplicate_receipt_metadata)
   in
-  find (List.rev messages)
+  let* run_messages =
+    Tool_failure_episode.latest_run_messages messages
+    |> Result.map_error (fun error -> Run_boundary_error error)
+  in
+  find (List.rev run_messages)
 ;;
 
 let same_episode_ref left right =

--- a/lib/tool_failure_recovery.ml
+++ b/lib/tool_failure_recovery.ml
@@ -405,6 +405,7 @@ type receipt_error =
   | Receipt_decision_invalid of decision_error
 [@@deriving show]
 
+let receipt_version = 1
 let metadata_key = "oas.tool_failure_recovery.v1"
 
 let revised_call_json (call : revised_call) =
@@ -447,7 +448,7 @@ let episode_ref_json episode =
 
 let receipt_json receipt =
   `Assoc
-    [ "version", `Int 1
+    [ "version", `Int receipt_version
     ; "resume_turn", `Int receipt.resume_turn
     ; "decided_at", `Float receipt.decided_at
     ; "episodes", `List (List.map episode_ref_json receipt.episodes)
@@ -531,6 +532,11 @@ let parse_string_receipt name fields =
   | _ -> Error (Invalid_receipt_metadata name)
 ;;
 
+let validate_receipt_fields ~allowed fields =
+  validate_fields ~allowed fields
+  |> Result.map_error (fun error -> Invalid_receipt_metadata (show_response_error error))
+;;
+
 let parse_failure_kind fields =
   match List.assoc_opt "failure_kind" fields with
   | None -> Error (Invalid_receipt_metadata "failure_kind")
@@ -542,7 +548,8 @@ let parse_failure_kind fields =
 
 let parse_error_class fields =
   match List.assoc_opt "error_class" fields with
-  | None | Some `Null -> Ok None
+  | None -> Error (Invalid_receipt_metadata "error_class")
+  | Some `Null -> Ok None
   | Some value ->
     (match Types.tool_error_class_of_yojson value with
      | Ok error_class -> Ok (Some error_class)
@@ -551,6 +558,17 @@ let parse_error_class fields =
 
 let parse_episode_ref = function
   | `Assoc fields ->
+    let* () =
+      validate_receipt_fields
+        ~allowed:
+          [ "previous_tool_use_id"
+          ; "current_tool_use_id"
+          ; "tool_name"
+          ; "failure_kind"
+          ; "error_class"
+          ]
+        fields
+    in
     let* previous_tool_use_id = parse_string_receipt "previous_tool_use_id" fields in
     let* current_tool_use_id = parse_string_receipt "current_tool_use_id" fields in
     let* tool_name = parse_string_receipt "tool_name" fields in
@@ -575,8 +593,17 @@ let parse_episode_refs fields =
 
 let parse_receipt = function
   | `Assoc fields ->
+    let* () =
+      validate_receipt_fields
+        ~allowed:[ "version"; "resume_turn"; "decided_at"; "episodes"; "decision" ]
+        fields
+    in
     let* version = parse_int "version" fields in
-    let* () = if version = 1 then Ok () else Error (Invalid_receipt_metadata "version") in
+    let* () =
+      if version = receipt_version
+      then Ok ()
+      else Error (Invalid_receipt_metadata "version")
+    in
     let* resume_turn = parse_int "resume_turn" fields in
     let* decided_at = parse_float "decided_at" fields in
     let* episodes = parse_episode_refs fields in

--- a/lib/tool_failure_recovery.mli
+++ b/lib/tool_failure_recovery.mli
@@ -110,11 +110,12 @@ type receipt_error =
   | Result_message_not_found
   | Duplicate_receipt_metadata
   | Invalid_receipt_metadata of string
+  | Run_boundary_error of Tool_failure_episode.error
   | Receipt_episode_mismatch
   | Receipt_decision_invalid of decision_error
 [@@deriving show]
 
-(** Add a versioned receipt to the latest result message containing every
+(** Add a versioned receipt to the latest-run result message containing every
     current episode id. Existing metadata is preserved; a duplicate receipt is
     an explicit error. *)
 val attach_receipt
@@ -123,8 +124,8 @@ val attach_receipt
   -> receipt:receipt
   -> (Types.message list, receipt_error) result
 
-(** Read a receipt only from the latest message containing a [ToolResult]. An
-    older receipt is never reused after a newer tool boundary. *)
+(** Read a receipt only from the latest-run message containing a [ToolResult].
+    An older receipt is never reused after a run or tool boundary. *)
 val latest_receipt : Types.message list -> (receipt option, receipt_error) result
 
 (** Validate a restored receipt against reconstructed adjacent episodes. *)

--- a/lib/tool_input_validation.mli
+++ b/lib/tool_input_validation.mli
@@ -34,7 +34,7 @@ type validation_result =
 val validate : Types.tool_schema -> Yojson.Safe.t -> validation_result
 
 (** Format field errors as a structured, LLM-readable feedback string.
-    Designed for [ToolResult] with [is_error=true]. *)
+    Designed for a failed [ToolResult] outcome. *)
 val format_errors : tool_name:string -> field_error list -> string
 
 (** Samchon-style inline error feedback: shows the LLM's original JSON

--- a/lib/tool_middleware.ml
+++ b/lib/tool_middleware.ml
@@ -174,7 +174,7 @@ let heal_tool_call
         ; attempts = attempt + 1
         ; healed = attempt > 0 || corrections <> []
         }
-    | Correction_pipeline.Still_invalid { errors = _; attempted = _ } ->
+    | Correction_pipeline.Still_invalid _ ->
       (match validate_and_coerce ~tool_name ~schema current_args with
        | Pass -> Ok { value = current_args; attempts = attempt + 1; healed = attempt > 0 }
        | Proceed coerced -> Ok { value = coerced; attempts = attempt + 1; healed = true }
@@ -191,7 +191,7 @@ let heal_tool_call
            (* Reuse det_result from above — no duplicate pipeline run *)
            let enriched_message =
              match det_result with
-             | Correction_pipeline.Still_invalid { errors; attempted } ->
+             | Correction_pipeline.Still_invalid { errors; attempted; _ } ->
                Correction_pipeline.build_nondet_feedback
                  ~tool_name
                  ~args:current_args

--- a/lib/tool_middleware.ml
+++ b/lib/tool_middleware.ml
@@ -212,9 +212,11 @@ let heal_tool_call
                            (attempt + 1)
                            (max_retries + 1)
                            enriched_message
-                     ; is_error = true
-                     ; failure_kind = Some Validation_error
-                     ; error_class = Some Deterministic
+                     ; outcome =
+                         Tool_failed
+                           { failure_kind = Validation_error
+                           ; error_class = Some Deterministic
+                           }
                      ; json = None
                      ; content_blocks = None
                      }

--- a/test/test_agent.ml
+++ b/test/test_agent.ml
@@ -145,9 +145,7 @@ let test_replace_existing () =
           [ ToolResult
               { tool_use_id = "t1"
               ; content = "old result"
-              ; is_error = false
-              ; failure_kind = None
-              ; error_class = None
+              ; outcome = Tool_succeeded
               ; json = None
               ; content_blocks = None
               }
@@ -163,15 +161,15 @@ let test_replace_existing () =
       msgs
       ~tool_id:"t1"
       ~content:"new result"
-      ~is_error:false
+      ~outcome:Tool_succeeded
   in
   let last = List.nth updated (List.length updated - 1) in
   Alcotest.(check bool) "legacy role preserved" true (last.role = User);
   match last.content with
-  | [ ToolResult { tool_use_id; content; is_error; _ } ] ->
+  | [ ToolResult { tool_use_id; content; outcome; _ } ] ->
     Alcotest.(check string) "id preserved" "t1" tool_use_id;
     Alcotest.(check string) "content replaced" "new result" content;
-    Alcotest.(check bool) "not error" false is_error
+    Alcotest.(check bool) "not error" false (tool_result_outcome_is_error outcome)
   | _ -> Alcotest.fail "expected single ToolResult"
 ;;
 
@@ -190,15 +188,17 @@ let test_replace_missing_appends () =
       msgs
       ~tool_id:"t99"
       ~content:"injected"
-      ~is_error:true
+      ~outcome:
+        (Tool_failed
+           { failure_kind = Non_retryable_tool_error; error_class = Some Unknown })
   in
   let last = List.nth updated (List.length updated - 1) in
   Alcotest.(check bool) "fallback role" true (last.role = Tool);
   match last.content with
-  | [ ToolResult { tool_use_id; content; is_error; _ } ] ->
+  | [ ToolResult { tool_use_id; content; outcome; _ } ] ->
     Alcotest.(check string) "id" "t99" tool_use_id;
     Alcotest.(check string) "content" "injected" content;
-    Alcotest.(check bool) "is error" true is_error
+    Alcotest.(check bool) "is error" true (tool_result_outcome_is_error outcome)
   | _ -> Alcotest.fail "expected appended ToolResult"
 ;;
 
@@ -209,18 +209,14 @@ let test_replace_preserves_other_results () =
           [ ToolResult
               { tool_use_id = "t1"
               ; content = "keep"
-              ; is_error = false
-              ; failure_kind = None
-              ; error_class = None
+              ; outcome = Tool_succeeded
               ; json = None
               ; content_blocks = None
               }
           ; ToolResult
               { tool_use_id = "t2"
               ; content = "replace me"
-              ; is_error = false
-              ; failure_kind = None
-              ; error_class = None
+              ; outcome = Tool_succeeded
               ; json = None
               ; content_blocks = None
               }
@@ -236,17 +232,19 @@ let test_replace_preserves_other_results () =
       msgs
       ~tool_id:"t2"
       ~content:"replaced"
-      ~is_error:true
+      ~outcome:
+        (Tool_failed
+           { failure_kind = Non_retryable_tool_error; error_class = Some Unknown })
   in
   let last = List.nth updated (List.length updated - 1) in
   match last.content with
-  | [ ToolResult { tool_use_id = "t1"; content = c1; is_error = e1; _ }
-    ; ToolResult { tool_use_id = "t2"; content = c2; is_error = e2; _ }
+  | [ ToolResult { tool_use_id = "t1"; content = c1; outcome = o1; _ }
+    ; ToolResult { tool_use_id = "t2"; content = c2; outcome = o2; _ }
     ] ->
     Alcotest.(check string) "t1 unchanged" "keep" c1;
-    Alcotest.(check bool) "t1 no error" false e1;
+    Alcotest.(check bool) "t1 no error" false (tool_result_outcome_is_error o1);
     Alcotest.(check string) "t2 replaced" "replaced" c2;
-    Alcotest.(check bool) "t2 error" true e2
+    Alcotest.(check bool) "t2 error" true (tool_result_outcome_is_error o2)
   | other ->
     Alcotest.fail (Printf.sprintf "unexpected content: %d blocks" (List.length other))
 ;;

--- a/test/test_agent_pipeline.ml
+++ b/test/test_agent_pipeline.ml
@@ -581,9 +581,7 @@ let test_agent_run_context_overflow_auto_retry_can_be_disabled () =
             [ ToolResult
                 { tool_use_id = "tool_1"
                 ; content = String.make 2000 'x'
-                ; is_error = false
-                ; failure_kind = None
-                ; error_class = None
+                ; outcome = Tool_succeeded
                 ; json = None
                 ; content_blocks = None
                 }
@@ -632,9 +630,7 @@ let big_tool_history () =
         [ ToolResult
             { tool_use_id = "tool_1"
             ; content = String.make 20000 'x'
-            ; is_error = false
-            ; failure_kind = None
-            ; error_class = None
+            ; outcome = Tool_succeeded
             ; json = None
             ; content_blocks = None
             }

--- a/test/test_agent_tool.ml
+++ b/test/test_agent_tool.ml
@@ -40,9 +40,7 @@ let structured_runner prompt : (Types.api_response, Error.sdk_error) result =
         ; ToolResult
             { tool_use_id = "toolu-child"
             ; content = {|{"ok":true}|}
-            ; is_error = false
-            ; failure_kind = None
-            ; error_class = None
+            ; outcome = Tool_succeeded
             ; json = Some (`Assoc [ "ok", `Bool true ])
             ; content_blocks = None
             }

--- a/test/test_agent_turn.ml
+++ b/test/test_agent_turn.ml
@@ -577,11 +577,13 @@ let test_make_tool_results () =
   let results =
     [ { Agent_tools.tool_use_id = "t1"
       ; tool_name = "tool-1"
+      ; input = `Null
       ; content = "success output"
       ; outcome = Tool_succeeded
       }
     ; { tool_use_id = "t2"
       ; tool_name = "tool-2"
+      ; input = `Null
       ; content = "error msg"
       ; outcome =
           Tool_failed
@@ -832,6 +834,7 @@ let test_apply_context_injection_no_injector () =
   let results =
     [ { Agent_tools.tool_use_id = "t1"
       ; tool_name = "search"
+      ; input = `Assoc [ "q", `String "test" ]
       ; content = "result"
       ; outcome = Tool_succeeded
       }
@@ -859,6 +862,7 @@ let test_apply_context_injection_with_context_update () =
   let results =
     [ { Agent_tools.tool_use_id = "t1"
       ; tool_name = "search"
+      ; input = `Assoc [ "q", `String "test" ]
       ; content = "found it"
       ; outcome = Tool_succeeded
       }
@@ -894,6 +898,7 @@ let test_apply_context_injection_with_extra_messages () =
   let results =
     [ { Agent_tools.tool_use_id = "t1"
       ; tool_name = "search"
+      ; input = `Assoc [ "q", `String "test" ]
       ; content = "result"
       ; outcome = Tool_succeeded
       }
@@ -933,6 +938,7 @@ let test_apply_context_injection_exception_handled () =
   let results =
     [ { Agent_tools.tool_use_id = "t1"
       ; tool_name = "search"
+      ; input = `Assoc [ "q", `String "test" ]
       ; content = "result"
       ; outcome = Tool_succeeded
       }
@@ -962,6 +968,7 @@ let test_apply_context_injection_preserves_non_retryable_error () =
   let results =
     [ { Agent_tools.tool_use_id = "t1"
       ; tool_name = "search"
+      ; input = `Assoc [ "q", `String "test" ]
       ; content = "fatal"
       ; outcome =
           Tool_failed

--- a/test/test_agent_turn.ml
+++ b/test/test_agent_turn.ml
@@ -578,35 +578,34 @@ let test_make_tool_results () =
     [ { Agent_tools.tool_use_id = "t1"
       ; tool_name = "tool-1"
       ; content = "success output"
-      ; is_error = false
-      ; failure_kind = None
-      ; error_class = None
+      ; outcome = Tool_succeeded
       }
     ; { tool_use_id = "t2"
       ; tool_name = "tool-2"
       ; content = "error msg"
-      ; is_error = true
-      ; failure_kind = Some Agent_tools.Recoverable_tool_error
-      ; error_class = Some Types.Deterministic
+      ; outcome =
+          Tool_failed
+            { failure_kind = Agent_tools.Recoverable_tool_error
+            ; error_class = Some Types.Deterministic
+            }
       }
     ]
   in
   let blocks = Agent_turn.make_tool_results results in
   Alcotest.(check int) "2 results" 2 (List.length blocks);
   match List.hd blocks with
-  | Types.ToolResult { tool_use_id; is_error; _ } ->
+  | Types.ToolResult { tool_use_id; outcome; _ } ->
     Alcotest.(check string) "id" "t1" tool_use_id;
-    Alcotest.(check bool) "not error" false is_error;
+    Alcotest.(check bool) "not error" false (Types.tool_result_outcome_is_error outcome);
     (match List.nth blocks 1 with
-     | Types.ToolResult { failure_kind; error_class; _ } ->
-       Alcotest.(check bool)
-         "failure kind preserved"
-         true
-         (failure_kind = Some Types.Recoverable_tool_error);
-       Alcotest.(check bool)
-         "error class preserved"
-         true
-         (error_class = Some Types.Deterministic)
+     | Types.ToolResult
+         { outcome =
+             Tool_failed
+               { failure_kind = Types.Recoverable_tool_error
+               ; error_class = Some Types.Deterministic
+               }
+         ; _
+         } -> ()
      | _ -> Alcotest.fail "expected second ToolResult")
   | _ -> Alcotest.fail "expected ToolResult"
 ;;
@@ -834,9 +833,7 @@ let test_apply_context_injection_no_injector () =
     [ { Agent_tools.tool_use_id = "t1"
       ; tool_name = "search"
       ; content = "result"
-      ; is_error = false
-      ; failure_kind = None
-      ; error_class = None
+      ; outcome = Tool_succeeded
       }
     ]
   in
@@ -863,9 +860,7 @@ let test_apply_context_injection_with_context_update () =
     [ { Agent_tools.tool_use_id = "t1"
       ; tool_name = "search"
       ; content = "found it"
-      ; is_error = false
-      ; failure_kind = None
-      ; error_class = None
+      ; outcome = Tool_succeeded
       }
     ]
   in
@@ -900,9 +895,7 @@ let test_apply_context_injection_with_extra_messages () =
     [ { Agent_tools.tool_use_id = "t1"
       ; tool_name = "search"
       ; content = "result"
-      ; is_error = false
-      ; failure_kind = None
-      ; error_class = None
+      ; outcome = Tool_succeeded
       }
     ]
   in
@@ -941,9 +934,7 @@ let test_apply_context_injection_exception_handled () =
     [ { Agent_tools.tool_use_id = "t1"
       ; tool_name = "search"
       ; content = "result"
-      ; is_error = false
-      ; failure_kind = None
-      ; error_class = None
+      ; outcome = Tool_succeeded
       }
     ]
   in
@@ -972,9 +963,11 @@ let test_apply_context_injection_preserves_non_retryable_error () =
     [ { Agent_tools.tool_use_id = "t1"
       ; tool_name = "search"
       ; content = "fatal"
-      ; is_error = true
-      ; failure_kind = Some Agent_tools.Non_retryable_tool_error
-      ; error_class = Some Types.Deterministic
+      ; outcome =
+          Tool_failed
+            { failure_kind = Agent_tools.Non_retryable_tool_error
+            ; error_class = Some Types.Deterministic
+            }
       }
     ]
   in

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -197,9 +197,7 @@ let test_tool_result_round_trip () =
     Types.ToolResult
       { tool_use_id = "tu_001"
       ; content = "4"
-      ; is_error = false
-      ; failure_kind = None
-      ; error_class = None
+      ; outcome = Tool_succeeded
       ; json = Types.try_parse_json "4"
       ; content_blocks = None
       }
@@ -215,9 +213,7 @@ let test_tool_result_error_round_trip () =
     Types.ToolResult
       { tool_use_id = "tu_002"
       ; content = "failed"
-      ; is_error = true
-      ; failure_kind = None
-      ; error_class = None
+      ; outcome = Legacy_unclassified_failure
       ; json = None
       ; content_blocks = None
       }
@@ -277,9 +273,7 @@ let test_kimi_message_to_json_tool_result_uses_text_blocks () =
         [ Types.ToolResult
             { tool_use_id = "tu_001"
             ; content = "5"
-            ; is_error = false
-            ; failure_kind = None
-            ; error_class = None
+            ; outcome = Tool_succeeded
             ; json = Some (`Int 5)
             ; content_blocks = None
             }
@@ -2417,9 +2411,7 @@ let test_text_blocks_to_string () =
     ; Types.ToolResult
         { tool_use_id = "t"
         ; content = "ok"
-        ; is_error = false
-        ; failure_kind = None
-        ; error_class = None
+        ; outcome = Tool_succeeded
         ; json = None
         ; content_blocks = None
         }

--- a/test/test_approval.ml
+++ b/test/test_approval.ml
@@ -142,7 +142,7 @@ let test_approval_required_no_callback () =
   | [ result ] ->
     check string "id" "t1" result.tool_use_id;
     check string "content" {|"hello"|} result.content;
-    check bool "no error" false result.is_error
+    check bool "no error" false (tool_result_outcome_is_error result.outcome)
   | _ -> fail "expected exactly one result"
 ;;
 
@@ -171,7 +171,7 @@ let test_tool_lifecycle_callback_exceptions_are_nonfatal () =
     check int "finished callback called" 1 !finished_calls;
     check string "id" "t1" result.tool_use_id;
     check string "content" {|{"x":1}|} result.content;
-    check bool "no error" false result.is_error
+    check bool "no error" false (tool_result_outcome_is_error result.outcome)
   | _ -> fail "expected exactly one result"
 ;;
 
@@ -193,13 +193,13 @@ let test_approval_required_no_callback_fail_closed () =
       "content"
       "Tool rejected: approval required but no approval callback is registered"
       result.content;
-    check bool "is error" true result.is_error;
-    (match result.failure_kind with
-     | Some Agent_tools.Non_retryable_tool_error -> ()
-     | _ -> fail "expected non-retryable tool error");
-    (match result.error_class with
-     | Some Types.Deterministic -> ()
-     | _ -> fail "expected deterministic error class")
+    check bool "is error" true (tool_result_outcome_is_error result.outcome);
+    (match result.outcome with
+     | Tool_failed
+         { failure_kind = Agent_tools.Non_retryable_tool_error
+         ; error_class = Some Types.Deterministic
+         } -> ()
+     | _ -> fail "expected deterministic non-retryable tool error")
   | _ -> fail "expected exactly one result"
 ;;
 
@@ -218,7 +218,7 @@ let test_approval_approve () =
   | [ result ] ->
     check string "id" "t1" result.tool_use_id;
     check string "content" {|"data"|} result.content;
-    check bool "no error" false result.is_error
+    check bool "no error" false (tool_result_outcome_is_error result.outcome)
   | _ -> fail "expected exactly one result"
 ;;
 
@@ -237,7 +237,7 @@ let test_approval_reject () =
   | [ result ] ->
     check string "id" "t1" result.tool_use_id;
     check string "content" "Tool rejected: too dangerous" result.content;
-    check bool "is error" true result.is_error
+    check bool "is error" true (tool_result_outcome_is_error result.outcome)
   | _ -> fail "expected exactly one result"
 ;;
 
@@ -254,13 +254,13 @@ let test_block_is_deterministic_failure () =
   | [ result ] ->
     check string "id" "t1" result.tool_use_id;
     check string "reason is verbatim" "policy denied" result.content;
-    check bool "is error" true result.is_error;
-    (match result.failure_kind with
-     | Some Agent_tools.Non_retryable_tool_error -> ()
-     | _ -> fail "expected non-retryable tool error");
-    (match result.error_class with
-     | Some Types.Deterministic -> ()
-     | _ -> fail "expected deterministic error class")
+    check bool "is error" true (tool_result_outcome_is_error result.outcome);
+    (match result.outcome with
+     | Tool_failed
+         { failure_kind = Agent_tools.Non_retryable_tool_error
+         ; error_class = Some Types.Deterministic
+         } -> ()
+     | _ -> fail "expected deterministic non-retryable tool error")
   | _ -> fail "expected exactly one result"
 ;;
 
@@ -280,7 +280,7 @@ let test_approval_edit () =
   | [ result ] ->
     check string "id" "t1" result.tool_use_id;
     check string "content uses edited input" {|"sanitized"|} result.content;
-    check bool "no error" false result.is_error
+    check bool "no error" false (tool_result_outcome_is_error result.outcome)
   | _ -> fail "expected exactly one result"
 ;;
 
@@ -316,10 +316,10 @@ let test_selective_approval () =
   | [ safe; dangerous ] ->
     check string "safe id" "t1" safe.tool_use_id;
     check string "safe executed" {|"ok"|} safe.content;
-    check bool "safe no error" false safe.is_error;
+    check bool "safe no error" false (tool_result_outcome_is_error safe.outcome);
     check string "dangerous id" "t2" dangerous.tool_use_id;
     check string "dangerous rejected" "Tool rejected: blocked" dangerous.content;
-    check bool "dangerous is error" true dangerous.is_error
+    check bool "dangerous is error" true (tool_result_outcome_is_error dangerous.outcome)
   | _ -> fail "expected exactly two results"
 ;;
 
@@ -358,10 +358,10 @@ let test_skip_override_unaffected () =
   | [ skip; override ] ->
     check string "skip id" "t1" skip.tool_use_id;
     check string "skipped" "Tool execution skipped by hook" skip.content;
-    check bool "skip not error" false skip.is_error;
+    check bool "skip not error" false (tool_result_outcome_is_error skip.outcome);
     check string "override id" "t2" override.tool_use_id;
     check string "overridden" "overridden" override.content;
-    check bool "override not error" false override.is_error
+    check bool "override not error" false (tool_result_outcome_is_error override.outcome)
   | _ -> fail "expected exactly two results"
 ;;
 
@@ -436,7 +436,9 @@ let test_parallel_read_tools_share_batch () =
       ]
   in
   match results with
-  | [ first; second ] when (not first.is_error) && not second.is_error -> ()
+  | [ first; second ]
+    when (not (tool_result_outcome_is_error first.outcome))
+         && not (tool_result_outcome_is_error second.outcome) -> ()
   | _ -> fail "parallel read batch should allow both tools to start"
 ;;
 
@@ -476,9 +478,9 @@ let test_workspace_tools_run_sequentially () =
   match results with
   | [ first; second ]
     when first.content = "write_a"
-         && (not first.is_error)
+         && (not (tool_result_outcome_is_error first.outcome))
          && second.content = "write_b"
-         && not second.is_error -> ()
+         && not (tool_result_outcome_is_error second.outcome) -> ()
   | _ -> fail "workspace tools should execute sequentially"
 ;;
 
@@ -513,9 +515,9 @@ let test_undeclared_tools_default_to_sequential () =
   match results with
   | [ first; second ]
     when first.content = "implicit_a"
-         && (not first.is_error)
+         && (not (tool_result_outcome_is_error first.outcome))
          && second.content = "implicit_b"
-         && not second.is_error -> ()
+         && not (tool_result_outcome_is_error second.outcome) -> ()
   | _ -> fail "undeclared tools should stay sequential by default"
 ;;
 
@@ -579,11 +581,11 @@ let test_workspace_barrier_splits_parallel_read_batches () =
   match results with
   | [ first; second; third ]
     when first.content = "read_before"
-         && (not first.is_error)
+         && (not (tool_result_outcome_is_error first.outcome))
          && second.content = "write_mid"
-         && (not second.is_error)
+         && (not (tool_result_outcome_is_error second.outcome))
          && third.content = "read_after"
-         && not third.is_error -> ()
+         && not (tool_result_outcome_is_error third.outcome) -> ()
   | _ -> fail "workspace tool should form a sequential barrier between read batches"
 ;;
 
@@ -672,10 +674,10 @@ let test_exclusive_external_barrier_isolation () =
       ]
   in
   match results with
-  | [ { Agent_tools.tool_name = "read_first"; is_error = false; _ }
-    ; { tool_name = "write_mid"; is_error = false; _ }
-    ; { tool_name = "ext_call"; is_error = false; _ }
-    ; { tool_name = "read_last"; is_error = false; _ }
+  | [ { Agent_tools.tool_name = "read_first"; outcome = Tool_succeeded; _ }
+    ; { tool_name = "write_mid"; outcome = Tool_succeeded; _ }
+    ; { tool_name = "ext_call"; outcome = Tool_succeeded; _ }
+    ; { tool_name = "read_last"; outcome = Tool_succeeded; _ }
     ] -> ()
   | _ -> fail "exclusive external tool must run in complete isolation"
 ;;
@@ -766,7 +768,7 @@ let test_shell_descriptor_constraint_blocks_execution () =
   in
   match results with
   | [ result ] ->
-    check bool "blocked" true result.is_error;
+    check bool "blocked" true (tool_result_outcome_is_error result.outcome);
     check bool "handler not called" false !handler_called;
     check
       bool
@@ -795,7 +797,7 @@ let test_tool_exception_still_publishes_tool_completed () =
   in
   (match results with
    | [ result ] ->
-     check bool "tool result is error" true result.is_error;
+     check bool "tool result is error" true (tool_result_outcome_is_error result.outcome);
      check
        bool
        "tool result reports exception"

--- a/test/test_backend_gemini.ml
+++ b/test/test_backend_gemini.ml
@@ -239,9 +239,7 @@ let test_tool_result () =
           [ ToolResult
               { tool_use_id = "call_123"
               ; content = "Sunny, 25C"
-              ; is_error = false
-              ; failure_kind = None
-              ; error_class = None
+              ; outcome = Tool_succeeded
               ; json = None
               ; content_blocks = None
               }
@@ -538,9 +536,7 @@ let test_thought_signature_roundtrip_request () =
           [ ToolResult
               { tool_use_id
               ; content = "found"
-              ; is_error = false
-              ; failure_kind = None
-              ; error_class = None
+              ; outcome = Tool_succeeded
               ; json = None
               ; content_blocks = None
               }

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -102,12 +102,15 @@ let block_of_fixture json =
       ; input = require_field "block" "input" json
       }
   | "tool_result" ->
+    let outcome =
+      if optional_bool ~default:false "block" "is_error" json
+      then Legacy_unclassified_failure
+      else Tool_succeeded
+    in
     ToolResult
       { tool_use_id = require_string "block" "tool_use_id" json
       ; content = require_string "block" "content" json
-      ; is_error = optional_bool ~default:false "block" "is_error" json
-      ; failure_kind = None
-      ; error_class = None
+      ; outcome
       ; json = None
       ; content_blocks = None
       }
@@ -552,9 +555,7 @@ let test_openai_user_messages_text_tool_and_empty () =
       ; ToolResult
           { tool_use_id = "call-1"
           ; content = "42"
-          ; is_error = false
-          ; failure_kind = None
-          ; error_class = None
+          ; outcome = Tool_succeeded
           ; json = None
           ; content_blocks = None
           }
@@ -590,9 +591,7 @@ let test_wire_adjacency_nudged_tool_turn () =
         [ ToolResult
             { tool_use_id = "call-9"
             ; content = "ok"
-            ; is_error = false
-            ; failure_kind = None
-            ; error_class = None
+            ; outcome = Tool_succeeded
             ; json = None
             ; content_blocks = None
             }
@@ -776,9 +775,7 @@ let test_system_and_tool_role_messages () =
          [ ToolResult
              { tool_use_id = "call-2"
              ; content = "ok"
-             ; is_error = false
-             ; failure_kind = None
-             ; error_class = None
+             ; outcome = Tool_succeeded
              ; json = None
              ; content_blocks = None
              }
@@ -807,27 +804,21 @@ let test_strip_orphaned_tool_results_dedupes_and_drops_empty () =
         [ ToolResult
             { tool_use_id = "call-1"
             ; content = "first"
-            ; is_error = false
-            ; failure_kind = None
-            ; error_class = None
+            ; outcome = Tool_succeeded
             ; json = None
             ; content_blocks = None
             }
         ; ToolResult
             { tool_use_id = "call-1"
             ; content = "dupe"
-            ; is_error = false
-            ; failure_kind = None
-            ; error_class = None
+            ; outcome = Tool_succeeded
             ; json = None
             ; content_blocks = None
             }
         ; ToolResult
             { tool_use_id = "orphan"
             ; content = "bad"
-            ; is_error = true
-            ; failure_kind = None
-            ; error_class = None
+            ; outcome = Legacy_unclassified_failure
             ; json = None
             ; content_blocks = None
             }
@@ -838,9 +829,7 @@ let test_strip_orphaned_tool_results_dedupes_and_drops_empty () =
         [ ToolResult
             { tool_use_id = "orphan-2"
             ; content = "drop"
-            ; is_error = false
-            ; failure_kind = None
-            ; error_class = None
+            ; outcome = Tool_succeeded
             ; json = None
             ; content_blocks = None
             }
@@ -869,9 +858,7 @@ let test_close_tool_message_pairs_repairs_dangling_and_late_results () =
         [ ToolResult
             { tool_use_id = "call-1"
             ; content = "late result"
-            ; is_error = false
-            ; failure_kind = None
-            ; error_class = None
+            ; outcome = Tool_succeeded
             ; json = None
             ; content_blocks = None
             }
@@ -882,12 +869,12 @@ let test_close_tool_message_pairs_repairs_dangling_and_late_results () =
   check_int "synthetic inserted and late result dropped" 3 (List.length closed);
   (match List.nth closed 1 with
    | { role = Tool
-     ; content = [ ToolResult { tool_use_id; content; is_error; _ } ]
+     ; content = [ ToolResult { tool_use_id; content; outcome; _ } ]
      ; metadata
      ; _
      } ->
      check_string "synthetic id" "call-1" tool_use_id;
-     check_bool "synthetic is error" true is_error;
+     check_bool "synthetic is error" true (tool_result_outcome_is_error outcome);
      check_bool
        "synthetic content"
        true
@@ -1011,9 +998,7 @@ let test_kimi_replay_trace_preserves_all_historical_reasoning () =
         [ ToolResult
             { tool_use_id = "call-k"
             ; content = "ok"
-            ; is_error = false
-            ; failure_kind = None
-            ; error_class = None
+            ; outcome = Tool_succeeded
             ; json = None
             ; content_blocks = None
             }
@@ -1159,9 +1144,7 @@ let ignored_blocks : content_block list =
   ; ToolResult
       { tool_use_id = "call-x"
       ; content = "ignored"
-      ; is_error = false
-      ; failure_kind = None
-      ; error_class = None
+      ; outcome = Tool_succeeded
       ; json = None
       ; content_blocks = None
       }
@@ -1246,9 +1229,7 @@ let test_strip_helpers_cover_non_tool_variants () =
           ; ToolResult
               { tool_use_id = "call"
               ; content = "ok"
-              ; is_error = false
-              ; failure_kind = None
-              ; error_class = None
+              ; outcome = Tool_succeeded
               ; json = None
               ; content_blocks = None
               }
@@ -1920,9 +1901,7 @@ let test_responses_preserves_encrypted_reasoning_item_for_replay () =
               [ ToolResult
                   { tool_use_id = "call_weather"
                   ; content = {|{"temp_c":12}|}
-                  ; is_error = false
-                  ; failure_kind = None
-                  ; error_class = None
+                  ; outcome = Tool_succeeded
                   ; json = Some (`Assoc [ "temp_c", `Int 12 ])
                   ; content_blocks = None
                   }
@@ -1993,9 +1972,7 @@ let test_responses_build_request_round_trips_tool_result_items () =
             [ ToolResult
                 { tool_use_id = "call_weather"
                 ; content = {|{"temp_c":12}|}
-                ; is_error = false
-                ; failure_kind = None
-                ; error_class = None
+                ; outcome = Tool_succeeded
                 ; json = Some (`Assoc [ "temp_c", `Int 12 ])
                 ; content_blocks = None
                 }
@@ -2062,9 +2039,7 @@ let test_responses_build_request_preserves_multiturn_reasoning_tool_order () =
     ToolResult
       { tool_use_id = id
       ; content
-      ; is_error = false
-      ; failure_kind = None
-      ; error_class = None
+      ; outcome = Tool_succeeded
       ; json = Some (`Assoc [ "content", `String content ])
       ; content_blocks = None
       }

--- a/test/test_backend_tool_call_harness.ml
+++ b/test/test_backend_tool_call_harness.ml
@@ -131,9 +131,7 @@ let test_validate_response_flags_unknown_tool_and_stop_reason () =
       ; T.ToolResult
           { tool_use_id = "call-2"
           ; content = "ok"
-          ; is_error = false
-          ; failure_kind = None
-          ; error_class = None
+          ; outcome = Tool_succeeded
           ; json = None
           ; content_blocks = None
           }

--- a/test/test_budget_strategy.ml
+++ b/test/test_budget_strategy.ml
@@ -39,9 +39,7 @@ let tool_result_msg id content =
         [ ToolResult
             { tool_use_id = id
             ; content
-            ; is_error = false
-            ; failure_kind = None
-            ; error_class = None
+            ; outcome = Tool_succeeded
             ; json = None
             ; content_blocks = None
             }

--- a/test/test_bug_hunt.ml
+++ b/test/test_bug_hunt.ml
@@ -93,9 +93,7 @@ let test_b3_injection_role_validation () =
             [ ToolResult
                 { tool_use_id = "t1"
                 ; content = "42"
-                ; is_error = false
-                ; failure_kind = None
-                ; error_class = None
+                ; outcome = Tool_succeeded
                 ; json = None
                 ; content_blocks = None
                 }

--- a/test/test_canonical_tool.ml
+++ b/test/test_canonical_tool.ml
@@ -244,9 +244,7 @@ let test_tool_call_none_for_non_tooluse () =
     ; Types.ToolResult
         { tool_use_id = "call_x"
         ; content = "ok"
-        ; is_error = false
-        ; failure_kind = None
-        ; error_class = None
+        ; outcome = Tool_succeeded
         ; json = None
         ; content_blocks = None
         }
@@ -272,9 +270,7 @@ let test_result_roundtrip_preserves_fields () =
     Types.ToolResult
       { tool_use_id = "call_abc"
       ; content = "3 rows"
-      ; is_error = false
-      ; failure_kind = None
-      ; error_class = None
+      ; outcome = Tool_succeeded
       ; json = Some json
       ; content_blocks = Some blocks
       }
@@ -284,7 +280,7 @@ let test_result_roundtrip_preserves_fields () =
   | Some proj ->
     Alcotest.(check string) "call_id" "call_abc" proj.call_id;
     Alcotest.(check string) "content" "3 rows" proj.content;
-    Alcotest.(check bool) "is_error" false proj.is_error;
+    Alcotest.(check bool) "succeeded" true (proj.outcome = Types.Tool_succeeded);
     (match proj.structured_content with
      | Some j -> Alcotest.check json_eq "structured_content == json" json j
      | None -> Alcotest.fail "structured_content dropped");
@@ -293,21 +289,22 @@ let test_result_roundtrip_preserves_fields () =
      | None -> Alcotest.fail "content_blocks dropped")
 ;;
 
-let test_result_preserves_is_error () =
+let test_result_preserves_failure_outcome () =
   let block =
     Types.ToolResult
       { tool_use_id = "call_err"
       ; content = "boom"
-      ; is_error = true
-      ; failure_kind = None
-      ; error_class = None
+      ; outcome = Legacy_unclassified_failure
       ; json = None
       ; content_blocks = None
       }
   in
   match Ct.tool_result_of_block block with
   | Some proj ->
-    Alcotest.(check bool) "is_error preserved" true proj.is_error;
+    Alcotest.(check bool)
+      "failure outcome preserved"
+      true
+      (proj.outcome = Types.Legacy_unclassified_failure);
     Alcotest.(check (option json_eq))
       "structured_content None when json None"
       None
@@ -379,9 +376,9 @@ let () =
             `Quick
             test_result_roundtrip_preserves_fields
         ; Alcotest.test_case
-            "preserves is_error / None json"
+            "preserves failure outcome / None json"
             `Quick
-            test_result_preserves_is_error
+            test_result_preserves_failure_outcome
         ; Alcotest.test_case
             "None for non-ToolResult"
             `Quick

--- a/test/test_checkpoint.ml
+++ b/test/test_checkpoint.ml
@@ -298,6 +298,7 @@ let () =
                let execution_result : Agent_tools.tool_execution_result =
                  { tool_use_id = "failed-1"
                  ; tool_name = "Execute"
+                 ; input = `Assoc [ "cwd", `String "/missing" ]
                  ; content = "working directory is unavailable"
                  ; outcome =
                      Tool_failed

--- a/test/test_checkpoint.ml
+++ b/test/test_checkpoint.ml
@@ -57,6 +57,33 @@ let make_checkpoint
   }
 ;;
 
+let checkpoint_json_with_tool_result ?(extra_fields = []) outcome =
+  let block =
+    Types.ToolResult
+      { tool_use_id = "tool-result-outcome"
+      ; content = "result"
+      ; outcome
+      ; json = None
+      ; content_blocks = None
+      }
+    |> Api.content_block_to_json
+    |> function
+    | `Assoc fields -> `Assoc (fields @ extra_fields)
+    | json ->
+      Alcotest.failf
+        "provider ToolResult must serialize to an object, got %s"
+        (Yojson.Safe.to_string json)
+  in
+  match Checkpoint.to_json (make_checkpoint ()) with
+  | `Assoc fields ->
+    let message = `Assoc [ "role", `String "tool"; "content", `List [ block ] ] in
+    `Assoc (("messages", `List [ message ]) :: List.remove_assoc "messages" fields)
+  | json ->
+    Alcotest.failf
+      "checkpoint must serialize to an object, got %s"
+      (Yojson.Safe.to_string json)
+;;
+
 (* Helper: a sample tool_schema *)
 let sample_tool_schema : Types.tool_schema =
   { name = "get_weather"
@@ -244,9 +271,7 @@ let () =
                     [ Types.ToolResult
                         { tool_use_id = "id1"
                         ; content = "Sunny 22C"
-                        ; is_error = false
-                        ; failure_kind = None
-                        ; error_class = None
+                        ; outcome = Tool_succeeded
                         ; json = None
                         ; content_blocks = None
                         }
@@ -261,10 +286,10 @@ let () =
             let cp2 = Result.get_ok (Checkpoint.of_json (Checkpoint.to_json cp)) in
             check bool "tool role" true ((List.hd cp2.messages).role = Types.Tool);
             match (List.hd cp2.messages).content with
-            | [ Types.ToolResult { tool_use_id; content; is_error; _ } ] ->
+            | [ Types.ToolResult { tool_use_id; content; outcome; _ } ] ->
               check string "id" "id1" tool_use_id;
               check string "content" "Sunny 22C" content;
-              check bool "is_error" false is_error
+              check bool "is_error" false (Types.tool_result_outcome_is_error outcome)
             | _ -> fail "expected ToolResult")
         ; test_case
             "typed failed ToolResult survives execution projection and checkpoint"
@@ -274,9 +299,11 @@ let () =
                  { tool_use_id = "failed-1"
                  ; tool_name = "Execute"
                  ; content = "working directory is unavailable"
-                 ; is_error = true
-                 ; failure_kind = Some Agent_tools.Validation_error
-                 ; error_class = Some Types.Deterministic
+                 ; outcome =
+                     Tool_failed
+                       { failure_kind = Agent_tools.Validation_error
+                       ; error_class = Some Types.Deterministic
+                       }
                  }
                in
                let content = Agent_turn.make_tool_results [ execution_result ] in
@@ -323,18 +350,50 @@ let () =
                  (stored_block |> member "error_class" <> `Null);
                let restored = Result.get_ok (Checkpoint.of_json checkpoint_json) in
                match (List.hd restored.messages).content with
-               | [ Types.ToolResult { failure_kind; error_class; _ } ] ->
-                 check
-                   bool
-                   "failure_kind roundtrip"
-                   true
-                   (failure_kind = Some Types.Validation_error);
-                 check
-                   bool
-                   "error_class roundtrip"
-                   true
-                   (error_class = Some Types.Deterministic)
+               | [ Types.ToolResult
+                     { outcome =
+                         Tool_failed
+                           { failure_kind = Types.Validation_error
+                           ; error_class = Some Types.Deterministic
+                           }
+                     ; _
+                     }
+                 ] -> ()
                | _ -> fail "expected typed ToolResult")
+        ; test_case "legacy failed ToolResult remains explicit" `Quick (fun () ->
+            let checkpoint_json =
+              checkpoint_json_with_tool_result Types.Legacy_unclassified_failure
+            in
+            let restored = Result.get_ok (Checkpoint.of_json checkpoint_json) in
+            match (List.hd restored.messages).content with
+            | [ Types.ToolResult { outcome = Legacy_unclassified_failure; _ } ] -> ()
+            | _ -> fail "expected explicit legacy failure outcome")
+        ; test_case "success with failure provenance is rejected" `Quick (fun () ->
+            let checkpoint_json =
+              checkpoint_json_with_tool_result
+                ~extra_fields:
+                  [ ( "failure_kind"
+                    , Types.tool_failure_kind_to_yojson Types.Validation_error )
+                  ]
+                Types.Tool_succeeded
+            in
+            check
+              bool
+              "rejected"
+              true
+              (Result.is_error (Checkpoint.of_json checkpoint_json)))
+        ; test_case "error_class without failure_kind is rejected" `Quick (fun () ->
+            let checkpoint_json =
+              checkpoint_json_with_tool_result
+                ~extra_fields:
+                  [ "error_class", Types.tool_error_class_to_yojson Types.Deterministic ]
+                Types.Legacy_unclassified_failure
+            in
+            check
+              bool
+              "rejected"
+              true
+              (Result.is_error (Checkpoint.of_json checkpoint_json)))
         ; test_case "empty messages roundtrip" `Quick (fun () ->
             let cp = make_checkpoint ~messages:[] () in
             let cp2 = Result.get_ok (Checkpoint.of_json (Checkpoint.to_json cp)) in
@@ -359,9 +418,7 @@ let () =
                     [ Types.ToolResult
                         { tool_use_id = "t1"
                         ; content = "found it"
-                        ; is_error = false
-                        ; failure_kind = None
-                        ; error_class = None
+                        ; outcome = Tool_succeeded
                         ; json = None
                         ; content_blocks = None
                         }

--- a/test/test_context_reducer.ml
+++ b/test/test_context_reducer.ml
@@ -38,19 +38,12 @@ let tool_use_msg id name =
     }
 ;;
 
-let tool_result_msg ?(is_error = false) ?failure_kind ?error_class id content =
+let tool_result_msg ?(outcome = Types.Tool_succeeded) id content =
   Types.
     { role = User
     ; content =
         [ ToolResult
-            { tool_use_id = id
-            ; content
-            ; is_error
-            ; failure_kind
-            ; error_class
-            ; json = None
-            ; content_blocks = None
-            }
+            { tool_use_id = id; content; outcome; json = None; content_blocks = None }
         ]
     ; name = None
     ; tool_call_id = None
@@ -231,9 +224,7 @@ let test_estimate_tool_result () =
           [ ToolResult
               { tool_use_id = "id1"
               ; content = "result text"
-              ; is_error = false
-              ; failure_kind = None
-              ; error_class = None
+              ; outcome = Tool_succeeded
               ; json = None
               ; content_blocks = None
               }
@@ -509,9 +500,7 @@ let test_cap_preserves_tool_result () =
     ; Types.ToolResult
         { tool_use_id = "call_keep"
         ; content = "r"
-        ; is_error = false
-        ; failure_kind = None
-        ; error_class = None
+        ; outcome = Tool_succeeded
         ; json = None
         ; content_blocks = None
         }
@@ -706,20 +695,29 @@ let test_prune_preserves_failure_provenance () =
     Context_reducer.reduce
       (Context_reducer.prune_tool_outputs ~max_output_len:10)
       [ tool_result_msg
-          ~is_error:true
-          ~failure_kind:Types.Recoverable_tool_error
-          ~error_class:Types.Transient
+          ~outcome:
+            (Types.Tool_failed
+               { failure_kind = Types.Recoverable_tool_error
+               ; error_class = Some Types.Transient
+               })
           "t1"
           (String.make 100 'x')
       ]
   in
   match result with
-  | [ { Types.content = [ Types.ToolResult { failure_kind; error_class; _ } ]; _ } ] ->
-    Alcotest.(check bool)
-      "failure kind preserved"
-      true
-      (failure_kind = Some Types.Recoverable_tool_error);
-    Alcotest.(check bool) "error class preserved" true (error_class = Some Types.Transient)
+  | [ { Types.content =
+          [ Types.ToolResult
+              { outcome =
+                  Tool_failed
+                    { failure_kind = Types.Recoverable_tool_error
+                    ; error_class = Some Types.Transient
+                    }
+              ; _
+              }
+          ]
+      ; _
+      }
+    ] -> ()
   | _ -> Alcotest.fail "expected one pruned ToolResult"
 ;;
 
@@ -1253,9 +1251,7 @@ let test_clear_tool_results_error_marker () =
             [ ToolResult
                 { tool_use_id = "t1"
                 ; content = String.make 100 'E'
-                ; is_error = true
-                ; failure_kind = None
-                ; error_class = None
+                ; outcome = Legacy_unclassified_failure
                 ; json = None
                 ; content_blocks = None
                 }
@@ -1438,11 +1434,11 @@ let test_repair_single_orphan () =
   (* The inserted message should be a Tool message with ToolResult *)
   match List.nth result 2 with
   | { Types.role = Types.Tool
-    ; content = [ Types.ToolResult { tool_use_id; is_error; _ } ]
+    ; content = [ Types.ToolResult { tool_use_id; outcome; _ } ]
     ; _
     } ->
     Alcotest.(check string) "matches id" "t1" tool_use_id;
-    Alcotest.(check bool) "is_error" true is_error
+    Alcotest.(check bool) "is_error" true (Types.tool_result_outcome_is_error outcome)
   | _ -> Alcotest.fail "expected synthetic tool result"
 ;;
 
@@ -1522,9 +1518,12 @@ let test_repair_late_result_is_not_pairing () =
   let result = Context_reducer.reduce Context_reducer.repair_dangling_tool_calls msgs in
   Alcotest.(check int) "late result does not satisfy adjacency" 6 (List.length result);
   match List.nth result 2 with
-  | { Types.content = [ Types.ToolResult { tool_use_id; is_error; _ } ]; _ } ->
+  | { Types.content = [ Types.ToolResult { tool_use_id; outcome; _ } ]; _ } ->
     Alcotest.(check string) "synthetic id" "t1" tool_use_id;
-    Alcotest.(check bool) "synthetic error" true is_error
+    Alcotest.(check bool)
+      "synthetic error"
+      true
+      (Types.tool_result_outcome_is_error outcome)
   | _ -> Alcotest.fail "expected synthetic adjacent tool result"
 ;;
 
@@ -1591,18 +1590,14 @@ let test_orphaned_results_mixed () =
             [ ToolResult
                 { tool_use_id = "t1"
                 ; content = "ok"
-                ; is_error = false
-                ; failure_kind = None
-                ; error_class = None
+                ; outcome = Tool_succeeded
                 ; json = None
                 ; content_blocks = None
                 }
             ; ToolResult
                 { tool_use_id = "t2"
                 ; content = "orphan"
-                ; is_error = false
-                ; failure_kind = None
-                ; error_class = None
+                ; outcome = Tool_succeeded
                 ; json = None
                 ; content_blocks = None
                 }
@@ -1666,9 +1661,12 @@ let test_default_tool_contract_repairs_late_result () =
   let result = Context_reducer.reduce Defaults.default_context_reducer msgs in
   Alcotest.(check int) "synthetic inserted and late result removed" 5 (List.length result);
   (match List.nth result 2 with
-   | { Types.content = [ Types.ToolResult { tool_use_id; is_error; _ } ]; _ } ->
+   | { Types.content = [ Types.ToolResult { tool_use_id; outcome; _ } ]; _ } ->
      Alcotest.(check string) "synthetic id" "t1" tool_use_id;
-     Alcotest.(check bool) "synthetic error" true is_error
+     Alcotest.(check bool)
+       "synthetic error"
+       true
+       (Types.tool_result_outcome_is_error outcome)
    | _ -> Alcotest.fail "expected synthetic adjacent tool result");
   match List.nth result 3 with
   | { Types.content = [ Types.Text text ]; _ } ->

--- a/test/test_correction_pipeline.ml
+++ b/test/test_correction_pipeline.ml
@@ -67,6 +67,22 @@ let test_coercion_impossible () =
     Alcotest.(check bool) "has errors" true (List.length errors > 0)
 ;;
 
+let test_partial_correction_is_retained_on_failure () =
+  let schema = make_schema [ int_param "count" true; str_param "name" true ] in
+  let input = `Assoc [ "count", `String "42" ] in
+  match Correction_pipeline.run ~schema input with
+  | Fixed _ -> Alcotest.fail "expected missing name to remain invalid"
+  | Still_invalid { corrected; errors; _ } ->
+    Alcotest.(check int)
+      "coerced candidate"
+      42
+      Yojson.Safe.Util.(corrected |> member "count" |> to_int);
+    Alcotest.(check bool)
+      "missing field retained"
+      true
+      (List.exists (fun error -> error.Tool_input_validation.path = "/name") errors)
+;;
+
 (* ── Stage 2: Default Injection ─────────────────────────── *)
 
 let test_default_missing_optional () =
@@ -259,6 +275,10 @@ let () =
       , [ Alcotest.test_case "string to int" `Quick test_coercion_string_to_int
         ; Alcotest.test_case "string to bool" `Quick test_coercion_string_to_bool
         ; Alcotest.test_case "impossible coercion" `Quick test_coercion_impossible
+        ; Alcotest.test_case
+            "partial correction retained"
+            `Quick
+            test_partial_correction_is_retained_on_failure
         ] )
     ; ( "default_injection"
       , [ Alcotest.test_case "missing optional" `Quick test_default_missing_optional

--- a/test/test_elicitation.ml
+++ b/test/test_elicitation.ml
@@ -198,6 +198,39 @@ let test_agent_elicit_input_without_callback_pauses () =
   | Ok _ -> Alcotest.fail "expected InputRequired"
 ;;
 
+let test_provide_input_marks_only_appended_answers () =
+  Eio_main.run
+  @@ fun env ->
+  let judge =
+    Tool_failure_recovery.create ~complete:(fun ~sw:_ _ ->
+      Ok {|{"action":"defer","reason":"unused"}|})
+  in
+  let agent = Agent.create ~net:env#net ~tool_failure_judge:judge () in
+  let request : Hooks.elicitation_request =
+    { question = "Which environment?"; schema = None; timeout_s = None }
+  in
+  let input =
+    Agent_elicitation.input_required_of_request
+      ~agent_name:"human-reviewer"
+      ~turn:0
+      request
+  in
+  Agent.provide_input agent input Hooks.Declined;
+  Alcotest.(check int)
+    "decline appends nothing"
+    0
+    (List.length (Agent.state agent).messages);
+  Agent.provide_input agent input (Hooks.Answer (`String "prod"));
+  match List.rev (Agent.state agent).messages with
+  | message :: _ ->
+    Alcotest.(check bool)
+      "answer starts a durable recovery run"
+      true
+      (Types.Conversation_metadata.classify_run_boundary message.metadata
+       = Types.Conversation_metadata.Present)
+  | [] -> Alcotest.fail "expected appended answer"
+;;
+
 let () =
   let open Alcotest in
   run
@@ -228,6 +261,10 @@ let () =
             "ElicitInput without callback returns InputRequired"
             `Quick
             test_agent_elicit_input_without_callback_pauses
+        ; test_case
+            "provide_input marks appended answers"
+            `Quick
+            test_provide_input_marks_only_appended_answers
         ] )
     ]
 ;;

--- a/test/test_elicitation.ml
+++ b/test/test_elicitation.ml
@@ -209,11 +209,14 @@ let test_provide_input_marks_only_appended_answers () =
   let request : Hooks.elicitation_request =
     { question = "Which environment?"; schema = None; timeout_s = None }
   in
-  let input =
-    Agent_elicitation.input_required_of_request
-      ~agent_name:"human-reviewer"
-      ~turn:0
-      request
+  let input : Error.input_required =
+    { request_id = "input-1"
+    ; participant_name = Some "human-reviewer"
+    ; question = request.question
+    ; schema = request.schema
+    ; timeout_s = request.timeout_s
+    ; created_at = 0.0
+    }
   in
   Agent.provide_input agent input Hooks.Declined;
   Alcotest.(check int)

--- a/test/test_event_bus.ml
+++ b/test/test_event_bus.ml
@@ -944,6 +944,11 @@ let test_registered_execute_alias_preserves_input () =
     (Types.tool_result_outcome_is_error result.outcome);
   check string "result uses visible tool name" "Execute" result.tool_name;
   check string "execute content" "execute-ok" result.content;
+  check
+    bool
+    "result preserves canonical handler input"
+    true
+    (Yojson.Safe.equal result.input !captured_input);
   match !captured_input with
   | `Assoc fields ->
     check
@@ -963,6 +968,60 @@ let test_registered_execute_alias_preserves_input () =
     check bool "executable not synthesized" false (List.mem_assoc "executable" fields);
     check bool "argv not synthesized" false (List.mem_assoc "argv" fields)
   | _ -> fail "expected object input"
+;;
+
+let test_execution_result_preserves_corrected_input () =
+  Eio_main.run
+  @@ fun _env ->
+  let context = Context.create_sync () in
+  let handler_input = ref `Null in
+  let tool =
+    Tool.create
+      ~name:"Count"
+      ~description:"Count"
+      ~parameters:
+        [ { Types.name = "count"
+          ; description = "count"
+          ; param_type = Integer
+          ; required = true
+          }
+        ]
+      (fun input ->
+         handler_input := input;
+         Ok { Types.content = "ok"; _meta = None })
+  in
+  let schedule : Hooks.tool_schedule =
+    { planned_index = 0
+    ; batch_index = 0
+    ; batch_size = 1
+    ; concurrency_class = "sequential_workspace"
+    ; batch_kind = "sequential"
+    }
+  in
+  let result =
+    Agent_tools.find_and_execute_tool
+      ~context
+      ~tools:[ tool ]
+      ~hooks:Hooks.empty
+      ~event_bus:None
+      ~tracer:Tracing.null
+      ~agent_name:"agent"
+      ~turn_count:0
+      ~schedule
+      "Count"
+      (`Assoc [ "count", `String "42" ])
+      "tool-corrected-input"
+  in
+  check
+    bool
+    "result equals handler input"
+    true
+    (Yojson.Safe.equal result.input !handler_input);
+  check
+    int
+    "coerced integer preserved"
+    42
+    Yojson.Safe.Util.(result.input |> member "count" |> to_int)
 ;;
 
 let test_on_error_silent_on_successful_dispatch () =
@@ -1327,6 +1386,10 @@ let () =
             "registered execute_command alias preserves input"
             `Quick
             test_registered_execute_alias_preserves_input
+        ; test_case
+            "execution result preserves corrected input"
+            `Quick
+            test_execution_result_preserves_corrected_input
         ; test_case
             "on_error silent on successful dispatch"
             `Quick

--- a/test/test_event_bus.ml
+++ b/test/test_event_bus.ml
@@ -695,17 +695,23 @@ let test_unknown_tool_reports_available_tools_and_retries () =
       (`Assoc [])
       "tool-unknown"
   in
-  check bool "unknown call is an error" true result.is_error;
+  check
+    bool
+    "unknown call is an error"
+    true
+    (Types.tool_result_outcome_is_error result.outcome);
   check
     (option string)
     "unknown call is retryable validation"
     (Some "validation")
-    (Option.map
-       (function
-         | Agent_tools.Validation_error -> "validation"
-         | Agent_tools.Recoverable_tool_error -> "recoverable"
-         | Agent_tools.Non_retryable_tool_error -> "non_retryable")
-       result.failure_kind);
+    (match result.outcome with
+     | Types.Tool_failed { failure_kind = Agent_tools.Validation_error; _ } ->
+       Some "validation"
+     | Types.Tool_failed { failure_kind = Agent_tools.Recoverable_tool_error; _ } ->
+       Some "recoverable"
+     | Types.Tool_failed { failure_kind = Agent_tools.Non_retryable_tool_error; _ } ->
+       Some "non_retryable"
+     | Types.Tool_succeeded | Types.Legacy_unclassified_failure -> None);
   check
     bool
     "content names missing tool"
@@ -782,7 +788,11 @@ let test_registered_read_alias_dispatches_to_read_file_when_visible () =
       (`Assoc [ "path", `String "README.md" ])
       "tool-name-alias-read"
   in
-  check bool "registered read alias succeeds" false result.is_error;
+  check
+    bool
+    "registered read alias succeeds"
+    false
+    (Types.tool_result_outcome_is_error result.outcome);
   check string "result uses visible tool name" "ReadFile" result.tool_name;
   check string "read content" "read-ok" result.content;
   check bool "on_error not called" false !on_error_called;
@@ -860,7 +870,11 @@ let test_registered_search_alias_dispatches_to_search_files_when_visible () =
       (`Assoc [ "query", `String "tool_returned_error_result"; "path", `String "logs" ])
       "tool-name-alias-search"
   in
-  check bool "registered search alias succeeds" false result.is_error;
+  check
+    bool
+    "registered search alias succeeds"
+    false
+    (Types.tool_result_outcome_is_error result.outcome);
   check string "result uses visible tool name" "SearchFiles" result.tool_name;
   check string "search content" "search-ok" result.content;
   check bool "on_error not called" false !on_error_called;
@@ -923,7 +937,11 @@ let test_registered_execute_alias_preserves_input () =
       (`Assoc [ "command", `String "git status --short"; "cwd", `String "/tmp/workspace" ])
       "tool-name-alias-execute"
   in
-  check bool "registered execute alias succeeds" false result.is_error;
+  check
+    bool
+    "registered execute alias succeeds"
+    false
+    (Types.tool_result_outcome_is_error result.outcome);
   check string "result uses visible tool name" "Execute" result.tool_name;
   check string "execute content" "execute-ok" result.content;
   match !captured_input with

--- a/test/test_gemini_edge_cases.ml
+++ b/test/test_gemini_edge_cases.ml
@@ -177,9 +177,7 @@ let test_tool_use_id_roundtrip () =
           [ Types.ToolResult
               { tool_use_id = tu_id
               ; content = "Sunny 25C"
-              ; is_error = false
-              ; failure_kind = None
-              ; error_class = None
+              ; outcome = Tool_succeeded
               ; json = None
               ; content_blocks = None
               }

--- a/test/test_http_client.ml
+++ b/test/test_http_client.ml
@@ -397,9 +397,7 @@ let test_api_common_content_block_roundtrip () =
       ; ToolResult
           { tool_use_id = "t1"
           ; content = "result"
-          ; is_error = false
-          ; failure_kind = None
-          ; error_class = None
+          ; outcome = Tool_succeeded
           ; json = None
           ; content_blocks = None
           }

--- a/test/test_llm_cache.ml
+++ b/test/test_llm_cache.ml
@@ -187,9 +187,7 @@ let test_roundtrip_tool_result () =
       [ ToolResult
           { tool_use_id = "tu_1"
           ; content = "result data"
-          ; is_error = false
-          ; failure_kind = None
-          ; error_class = None
+          ; outcome = Tool_succeeded
           ; json = None
           ; content_blocks = None
           }
@@ -199,10 +197,10 @@ let test_roundtrip_tool_result () =
   match Cache.response_of_json json with
   | Some r ->
     (match r.content with
-     | [ ToolResult { tool_use_id; content; is_error; _ } ] ->
+     | [ ToolResult { tool_use_id; content; outcome; _ } ] ->
        Alcotest.(check string) "tool_use_id" "tu_1" tool_use_id;
        Alcotest.(check string) "content" "result data" content;
-       Alcotest.(check bool) "not error" false is_error
+       Alcotest.(check bool) "not error" false (tool_result_outcome_is_error outcome)
      | _ -> Alcotest.fail "expected single ToolResult block")
   | None -> Alcotest.fail "roundtrip failed"
 ;;
@@ -213,9 +211,7 @@ let test_roundtrip_tool_result_error () =
       [ ToolResult
           { tool_use_id = "tu_2"
           ; content = "failed"
-          ; is_error = true
-          ; failure_kind = None
-          ; error_class = None
+          ; outcome = Legacy_unclassified_failure
           ; json = None
           ; content_blocks = None
           }
@@ -225,7 +221,8 @@ let test_roundtrip_tool_result_error () =
   match Cache.response_of_json json with
   | Some r ->
     (match r.content with
-     | [ ToolResult { is_error; _ } ] -> Alcotest.(check bool) "is error" true is_error
+     | [ ToolResult { outcome; _ } ] ->
+       Alcotest.(check bool) "is error" true (tool_result_outcome_is_error outcome)
      | _ -> Alcotest.fail "expected ToolResult block")
   | None -> Alcotest.fail "roundtrip failed"
 ;;
@@ -241,9 +238,7 @@ let test_roundtrip_tool_result_content_blocks () =
       [ ToolResult
           { tool_use_id = "tu_blocks"
           ; content = "preview"
-          ; is_error = false
-          ; failure_kind = None
-          ; error_class = None
+          ; outcome = Tool_succeeded
           ; json = None
           ; content_blocks = Some blocks
           }

--- a/test/test_llm_provider_cov.ml
+++ b/test/test_llm_provider_cov.ml
@@ -658,7 +658,7 @@ let test_tool_result_followup_merge_preserves_internal_metadata () =
       true
       (List.exists
          (function
-           | ToolResult { tool_use_id = "tu1"; _ } -> true
+           | Types.ToolResult { tool_use_id = "tu1"; _ } -> true
            | _ -> false)
          merged.content);
     Alcotest.(check bool)
@@ -666,7 +666,7 @@ let test_tool_result_followup_merge_preserves_internal_metadata () =
       true
       (List.exists
          (function
-           | Text "continue" -> true
+           | Types.Text "continue" -> true
            | _ -> false)
          merged.content);
     Alcotest.(check bool)

--- a/test/test_llm_provider_cov.ml
+++ b/test/test_llm_provider_cov.ml
@@ -398,9 +398,9 @@ let test_content_block_to_json_tool_result () =
       (ToolResult
          { tool_use_id = "tu1"
          ; content = "done"
-         ; is_error = true
-         ; failure_kind = Some Validation_error
-         ; error_class = Some Deterministic
+         ; outcome =
+             Tool_failed
+               { failure_kind = Validation_error; error_class = Some Deterministic }
          ; json = None
          ; content_blocks = None
          })
@@ -503,7 +503,9 @@ let test_content_block_of_json_tool_result () =
       ]
   in
   match Api_common.content_block_of_json json with
-  | Some (ToolResult { tool_use_id = "tu1"; content = "done"; is_error = false; _ }) -> ()
+  | Some
+      (ToolResult { tool_use_id = "tu1"; content = "done"; outcome = Tool_succeeded; _ })
+    -> ()
   | _ -> Alcotest.fail "tool_result roundtrip"
 ;;
 
@@ -516,7 +518,7 @@ let test_content_block_of_json_tool_result_no_is_error () =
       ]
   in
   match Api_common.content_block_of_json json with
-  | Some (ToolResult { is_error = false; _ }) -> ()
+  | Some (ToolResult { outcome = Tool_succeeded; _ }) -> ()
   | _ -> Alcotest.fail "tool_result default is_error"
 ;;
 
@@ -671,9 +673,7 @@ let test_contents_of_messages_tool_use () =
           [ ToolResult
               { tool_use_id = "tu1"
               ; content = "result42"
-              ; is_error = false
-              ; failure_kind = None
-              ; error_class = None
+              ; outcome = Tool_succeeded
               ; json = None
               ; content_blocks = None
               }

--- a/test/test_llm_provider_cov.ml
+++ b/test/test_llm_provider_cov.ml
@@ -630,6 +630,53 @@ let test_message_to_json_tool () =
   Alcotest.(check string) "tool -> user" "user" (json |> member "role" |> to_string)
 ;;
 
+let test_tool_result_followup_merge_preserves_internal_metadata () =
+  let tool_result =
+    Types.make_message
+      ~role:Tool
+      [ ToolResult
+          { tool_use_id = "tu1"
+          ; content = "failed"
+          ; outcome =
+              Tool_failed
+                { failure_kind = Recoverable_tool_error
+                ; error_class = Some Deterministic
+                }
+          ; json = None
+          ; content_blocks = None
+          }
+      ]
+  in
+  let boundary = Types.Conversation_metadata.run_boundary_entry in
+  let followup =
+    Types.make_message ~metadata:[ boundary ] ~role:User [ Text "continue" ]
+  in
+  match Api_common.merge_tool_result_followup_user_messages [ tool_result; followup ] with
+  | [ merged ] ->
+    Alcotest.(check bool)
+      "tool result retained"
+      true
+      (List.exists
+         (function
+           | ToolResult { tool_use_id = "tu1"; _ } -> true
+           | _ -> false)
+         merged.content);
+    Alcotest.(check bool)
+      "follow-up retained"
+      true
+      (List.exists
+         (function
+           | Text "continue" -> true
+           | _ -> false)
+         merged.content);
+    Alcotest.(check bool)
+      "internal metadata retained"
+      true
+      (List.mem boundary merged.metadata)
+  | messages ->
+    Alcotest.failf "expected one merged provider message, got %d" (List.length messages)
+;;
+
 (* ═══════════════════════════════════════════════════
    4. Backend_gemini — build_request, parse_response,
       contents_of_messages
@@ -2012,6 +2059,10 @@ let () =
         ; Alcotest.test_case "assistant" `Quick test_message_to_json_assistant
         ; Alcotest.test_case "system" `Quick test_message_to_json_system
         ; Alcotest.test_case "tool" `Quick test_message_to_json_tool
+        ; Alcotest.test_case
+            "tool follow-up internal metadata"
+            `Quick
+            test_tool_result_followup_merge_preserves_internal_metadata
         ] )
     ; ( "backend_gemini.contents_of_messages"
       , [ Alcotest.test_case "user" `Quick test_contents_of_messages_user

--- a/test/test_multimodal.ml
+++ b/test/test_multimodal.ml
@@ -279,9 +279,7 @@ let test_agent_run_with_handoffs_blocks_rejects_internal_blocks () =
     [ Types.ToolResult
         { tool_use_id = "call-1"
         ; content = "internal result"
-        ; is_error = false
-        ; failure_kind = None
-        ; error_class = None
+        ; outcome = Tool_succeeded
         ; json = None
         ; content_blocks = None
         }
@@ -342,9 +340,7 @@ let test_tool_result_content_blocks_serialize () =
     Types.ToolResult
       { tool_use_id = "t1"
       ; content = "plain"
-      ; is_error = false
-      ; failure_kind = None
-      ; error_class = None
+      ; outcome = Tool_succeeded
       ; json = None
       ; content_blocks = None
       }
@@ -358,9 +354,7 @@ let test_tool_result_content_blocks_serialize () =
     Types.ToolResult
       { tool_use_id = "t2"
       ; content = "fallback"
-      ; is_error = false
-      ; failure_kind = None
-      ; error_class = None
+      ; outcome = Tool_succeeded
       ; json = None
       ; content_blocks =
           Some

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -812,16 +812,12 @@ let test_make_tool_results_ok () =
     [ { Agent_tools.tool_use_id = "tu1"
       ; tool_name = "tool-1"
       ; content = "result1"
-      ; is_error = false
-      ; failure_kind = None
-      ; error_class = None
+      ; outcome = Tool_succeeded
       }
     ; { tool_use_id = "tu2"
       ; tool_name = "tool-2"
       ; content = "result2"
-      ; is_error = false
-      ; failure_kind = None
-      ; error_class = None
+      ; outcome = Tool_succeeded
       }
     ]
   in
@@ -830,8 +826,11 @@ let test_make_tool_results_ok () =
   List.iter
     (fun block ->
        match block with
-       | Types.ToolResult { is_error; _ } ->
-         Alcotest.(check bool) "not error" false is_error
+       | Types.ToolResult { outcome; _ } ->
+         Alcotest.(check bool)
+           "not error"
+           false
+           (Types.tool_result_outcome_is_error outcome)
        | _ -> Alcotest.fail "expected ToolResult")
     tool_results
 ;;
@@ -841,16 +840,16 @@ let test_make_tool_results_error () =
     [ { Agent_tools.tool_use_id = "tu1"
       ; tool_name = "tool-1"
       ; content = "failed"
-      ; is_error = true
-      ; failure_kind = Some Agent_tools.Recoverable_tool_error
-      ; error_class = None
+      ; outcome =
+          Tool_failed
+            { failure_kind = Agent_tools.Recoverable_tool_error; error_class = None }
       }
     ]
   in
   let tool_results = Agent_turn.make_tool_results results in
   Alcotest.(check int) "1 tool result" 1 (List.length tool_results);
   match List.hd tool_results with
-  | Types.ToolResult { is_error = true; content; _ } ->
+  | Types.ToolResult { outcome = Tool_failed _; content; _ } ->
     Alcotest.(check bool) "error content" true (String.length content > 0)
   | _ -> Alcotest.fail "expected error ToolResult"
 ;;
@@ -860,16 +859,14 @@ let test_make_tool_results_mixed () =
     [ { Agent_tools.tool_use_id = "tu1"
       ; tool_name = "tool-1"
       ; content = "good"
-      ; is_error = false
-      ; failure_kind = None
-      ; error_class = None
+      ; outcome = Tool_succeeded
       }
     ; { tool_use_id = "tu2"
       ; tool_name = "tool-2"
       ; content = "bad"
-      ; is_error = true
-      ; failure_kind = Some Agent_tools.Recoverable_tool_error
-      ; error_class = None
+      ; outcome =
+          Tool_failed
+            { failure_kind = Agent_tools.Recoverable_tool_error; error_class = None }
       }
     ]
   in

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -423,7 +423,7 @@ let repeated_invalid_tool_response id : Types.api_response =
   }
 ;;
 
-let test_repeated_validation_error_loop_blocks_without_third_provider_call () =
+let test_repeated_validation_error_without_judge_continues_to_provider () =
   Eio_main.run
   @@ fun env ->
   Eio.Switch.run
@@ -435,7 +435,15 @@ let test_repeated_validation_error_loop_blocks_without_third_provider_call () =
     match !provider_calls with
     | 1 | 2 ->
       repeated_invalid_tool_response (Printf.sprintf "invalid-%d" !provider_calls)
-    | _ -> Alcotest.fail "unexpected third provider call"
+    | 3 ->
+      { Types.id = "validation-replanned"
+      ; model = "mock-model"
+      ; stop_reason = EndTurn
+      ; content = [ Text "provider replanned" ]
+      ; usage = None
+      ; telemetry = None
+      }
+    | _ -> Alcotest.fail "unexpected fourth provider call"
   in
   let transport : Llm_provider.Llm_transport.t =
     { complete_sync =
@@ -478,25 +486,18 @@ let test_repeated_validation_error_loop_blocks_without_third_provider_call () =
       ()
   in
   match Agent.run ~sw agent "call my_tool" with
-  | Error
-      (Error.Agent
-         (Error.ToolFailureRecoveryFailed { stage = Error.Judge_response; detail })) ->
-    Alcotest.(check int) "provider calls" 2 !provider_calls;
-    Alcotest.(check int) "tool handler not executed" 0 !executed;
-    Alcotest.(check bool) "missing judge is explicit" true (String.length detail > 0);
-    (match List.rev (Agent.state agent).messages with
-     | { Types.role = Tool
-       ; content =
-           [ ToolResult { is_error = true; failure_kind = Some Validation_error; _ } ]
-       ; _
-       }
-       :: _ -> ()
-     | _ -> Alcotest.fail "expected persisted typed validation result")
-  | Error err -> Alcotest.failf "unexpected run error: %s" (Error.to_string err)
   | Ok response ->
-    Alcotest.failf
-      "expected explicit missing-judge failure, got: %s"
+    Alcotest.(check int) "provider calls" 3 !provider_calls;
+    Alcotest.(check int) "tool handler not executed" 0 !executed;
+    Alcotest.(check string)
+      "provider controls terminal response"
+      "validation-replanned"
+      response.id;
+    Alcotest.(check string)
+      "provider final text"
+      "provider replanned"
       (Types.text_of_response response)
+  | Error err -> Alcotest.failf "unexpected run error: %s" (Error.to_string err)
 ;;
 
 (* ── Provider_mock: additional coverage ─────────────────── *)
@@ -811,11 +812,13 @@ let test_make_tool_results_ok () =
   let results =
     [ { Agent_tools.tool_use_id = "tu1"
       ; tool_name = "tool-1"
+      ; input = `Null
       ; content = "result1"
       ; outcome = Tool_succeeded
       }
     ; { tool_use_id = "tu2"
       ; tool_name = "tool-2"
+      ; input = `Null
       ; content = "result2"
       ; outcome = Tool_succeeded
       }
@@ -839,6 +842,7 @@ let test_make_tool_results_error () =
   let results =
     [ { Agent_tools.tool_use_id = "tu1"
       ; tool_name = "tool-1"
+      ; input = `Null
       ; content = "failed"
       ; outcome =
           Tool_failed
@@ -858,11 +862,13 @@ let test_make_tool_results_mixed () =
   let results =
     [ { Agent_tools.tool_use_id = "tu1"
       ; tool_name = "tool-1"
+      ; input = `Null
       ; content = "good"
       ; outcome = Tool_succeeded
       }
     ; { tool_use_id = "tu2"
       ; tool_name = "tool-2"
+      ; input = `Null
       ; content = "bad"
       ; outcome =
           Tool_failed
@@ -1323,9 +1329,9 @@ let () =
             `Quick
             test_pipeline_tool_recovery_rejects_openai_compat_provider
         ; Alcotest.test_case
-            "repeated validation error loop blocks"
+            "repeated validation error without judge continues"
             `Quick
-            test_repeated_validation_error_loop_blocks_without_third_provider_call
+            test_repeated_validation_error_without_judge_continues_to_provider
         ; Alcotest.test_case "extra system context" `Quick test_prepare_turn_extra_context
         ; Alcotest.test_case
             "tool filter override"

--- a/test/test_pipeline_deep.ml
+++ b/test/test_pipeline_deep.ml
@@ -485,6 +485,7 @@ let test_context_injection_sets_values () =
   let results =
     [ { Agent_tools.tool_use_id = "tu_1"
       ; tool_name = "search"
+      ; input = `Assoc []
       ; content = "result text"
       ; outcome = Tool_succeeded
       }
@@ -524,6 +525,7 @@ let test_context_injection_none () =
   let results =
     [ { Agent_tools.tool_use_id = "tu_n"
       ; tool_name = "tool"
+      ; input = `Assoc []
       ; content = "ok"
       ; outcome = Tool_succeeded
       }
@@ -571,6 +573,7 @@ let test_context_injection_extra_messages () =
   let results =
     [ { Agent_tools.tool_use_id = "tu_m"
       ; tool_name = "tool"
+      ; input = `Assoc []
       ; content = "ok"
       ; outcome = Tool_succeeded
       }
@@ -604,6 +607,7 @@ let test_context_injection_error_result () =
   let results =
     [ { Agent_tools.tool_use_id = "tu_err"
       ; tool_name = "tool"
+      ; input = `Assoc []
       ; content = "something went wrong"
       ; outcome =
           Tool_failed
@@ -639,6 +643,7 @@ let test_context_injection_raises () =
   let results =
     [ { Agent_tools.tool_use_id = "tu_ex"
       ; tool_name = "tool"
+      ; input = `Assoc []
       ; content = "ok"
       ; outcome = Tool_succeeded
       }

--- a/test/test_pipeline_deep.ml
+++ b/test/test_pipeline_deep.ml
@@ -337,9 +337,7 @@ let test_resolve_params_with_tool_results () =
           [ ToolResult
               { tool_use_id = "tu_1"
               ; content = "found it"
-              ; is_error = false
-              ; failure_kind = None
-              ; error_class = None
+              ; outcome = Tool_succeeded
               ; json = None
               ; content_blocks = None
               }
@@ -397,9 +395,11 @@ let test_resolve_params_error_tool_results () =
           [ ToolResult
               { tool_use_id = "tu_e"
               ; content = "permission denied"
-              ; is_error = true
-              ; failure_kind = None
-              ; error_class = None
+              ; outcome =
+                  Tool_failed
+                    { failure_kind = Recoverable_tool_error
+                    ; error_class = Some Deterministic
+                    }
               ; json = None
               ; content_blocks = None
               }
@@ -420,9 +420,10 @@ let test_resolve_params_error_tool_results () =
   in
   Alcotest.(check int) "1 error result" 1 (List.length !captured_results);
   match List.hd !captured_results with
-  | Error { message; recoverable; _ } ->
+  | Error { message; recoverable; error_class } ->
     Alcotest.(check string) "error message" "permission denied" message;
-    Alcotest.(check bool) "recoverable" true recoverable
+    Alcotest.(check bool) "recoverable" true recoverable;
+    Alcotest.(check bool) "error class" true (error_class = Some Types.Deterministic)
   | Ok _ -> Alcotest.fail "expected Error result"
 ;;
 
@@ -485,9 +486,7 @@ let test_context_injection_sets_values () =
     [ { Agent_tools.tool_use_id = "tu_1"
       ; tool_name = "search"
       ; content = "result text"
-      ; is_error = false
-      ; failure_kind = None
-      ; error_class = None
+      ; outcome = Tool_succeeded
       }
     ]
   in
@@ -526,9 +525,7 @@ let test_context_injection_none () =
     [ { Agent_tools.tool_use_id = "tu_n"
       ; tool_name = "tool"
       ; content = "ok"
-      ; is_error = false
-      ; failure_kind = None
-      ; error_class = None
+      ; outcome = Tool_succeeded
       }
     ]
   in
@@ -575,9 +572,7 @@ let test_context_injection_extra_messages () =
     [ { Agent_tools.tool_use_id = "tu_m"
       ; tool_name = "tool"
       ; content = "ok"
-      ; is_error = false
-      ; failure_kind = None
-      ; error_class = None
+      ; outcome = Tool_succeeded
       }
     ]
   in
@@ -610,9 +605,9 @@ let test_context_injection_error_result () =
     [ { Agent_tools.tool_use_id = "tu_err"
       ; tool_name = "tool"
       ; content = "something went wrong"
-      ; is_error = true
-      ; failure_kind = Some Agent_tools.Recoverable_tool_error
-      ; error_class = None
+      ; outcome =
+          Tool_failed
+            { failure_kind = Agent_tools.Recoverable_tool_error; error_class = None }
       }
     ]
   in
@@ -645,9 +640,7 @@ let test_context_injection_raises () =
     [ { Agent_tools.tool_use_id = "tu_ex"
       ; tool_name = "tool"
       ; content = "ok"
-      ; is_error = false
-      ; failure_kind = None
-      ; error_class = None
+      ; outcome = Tool_succeeded
       }
     ]
   in

--- a/test/test_property_advanced.ml
+++ b/test/test_property_advanced.ml
@@ -26,9 +26,8 @@ let content_block_gen =
            ToolResult
              { tool_use_id = id
              ; content
-             ; is_error
-             ; failure_kind = None
-             ; error_class = None
+             ; outcome =
+                 (if is_error then Legacy_unclassified_failure else Tool_succeeded)
              ; json = Types.try_parse_json content
              ; content_blocks = None
              })

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -241,9 +241,7 @@ let test_anthropic_build_request_preserves_multiturn_thinking_tool_order () =
     ToolResult
       { tool_use_id = id
       ; content
-      ; is_error = false
-      ; failure_kind = None
-      ; error_class = None
+      ; outcome = Tool_succeeded
       ; json = Some (`Assoc [ "content", `String content ])
       ; content_blocks = None
       }
@@ -871,9 +869,7 @@ let test_kimi_direct_tool_result_uses_text_blocks () =
           [ ToolResult
               { tool_use_id = "tool_1"
               ; content = "5"
-              ; is_error = false
-              ; failure_kind = None
-              ; error_class = None
+              ; outcome = Tool_succeeded
               ; json = Some (`Int 5)
               ; content_blocks = None
               }
@@ -939,9 +935,7 @@ let test_glm_preserved_reasoning_replay_and_preserves_auto_tool_choice () =
           [ ToolResult
               { tool_use_id = "call_1"
               ; content = "{\"value\":4}"
-              ; is_error = false
-              ; failure_kind = None
-              ; error_class = None
+              ; outcome = Tool_succeeded
               ; json = Some (`Assoc [ "value", `Int 4 ])
               ; content_blocks = None
               }

--- a/test/test_raw_trace.ml
+++ b/test/test_raw_trace.ml
@@ -932,9 +932,7 @@ let test_tool_result_assistant_block_summary () =
        (Types.ToolResult
           { tool_use_id = "tool-1"
           ; content = "ok"
-          ; is_error = false
-          ; failure_kind = None
-          ; error_class = None
+          ; outcome = Tool_succeeded
           ; json = None
           ; content_blocks = None
           }));

--- a/test/test_snapshot_provider_serialization.ml
+++ b/test/test_snapshot_provider_serialization.ml
@@ -62,9 +62,7 @@ let messages =
       [ ToolResult
           { tool_use_id = "call_1"
           ; content = "Sunny, 25C"
-          ; is_error = false
-          ; failure_kind = None
-          ; error_class = None
+          ; outcome = Tool_succeeded
           ; json = None
           ; content_blocks = None
           }
@@ -87,9 +85,7 @@ let nudged_messages =
       [ ToolResult
           { tool_use_id = "call_1"
           ; content = "Sunny, 25C"
-          ; is_error = false
-          ; failure_kind = None
-          ; error_class = None
+          ; outcome = Tool_succeeded
           ; json = None
           ; content_blocks = None
           }

--- a/test/test_streaming_edge_cases.ml
+++ b/test/test_streaming_edge_cases.ml
@@ -189,9 +189,7 @@ let test_synthetic_events_media_blocks () =
         ; ToolResult
             { tool_use_id = "call-1"
             ; content = "ok"
-            ; is_error = false
-            ; failure_kind = None
-            ; error_class = None
+            ; outcome = Tool_succeeded
             ; json = None
             ; content_blocks = None
             }

--- a/test/test_structured.ml
+++ b/test/test_structured.ml
@@ -337,9 +337,7 @@ let test_extract_ignores_tool_result () =
     [ ToolResult
         { tool_use_id = "old"
         ; content = "previous result"
-        ; is_error = false
-        ; failure_kind = None
-        ; error_class = None
+        ; outcome = Tool_succeeded
         ; json = None
         ; content_blocks = None
         }
@@ -538,9 +536,7 @@ let test_retry_message_construction () =
           [ ToolResult
               { tool_use_id
               ; content = error_msg
-              ; is_error = true
-              ; failure_kind = None
-              ; error_class = None
+              ; outcome = Legacy_unclassified_failure
               ; json = None
               ; content_blocks = None
               }
@@ -559,8 +555,15 @@ let test_retry_message_construction () =
     let has_error_result =
       List.exists
         (function
-          | ToolResult { is_error = true; _ } -> true
-          | _ -> false)
+          | ToolResult { outcome; _ } -> tool_result_outcome_is_error outcome
+          | Text _
+          | Thinking _
+          | ReasoningDetails _
+          | RedactedThinking _
+          | ToolUse _
+          | Image _
+          | Document _
+          | Audio _ -> false)
         retry_msg.content
     in
     Alcotest.(check bool) "has error tool_result" true has_error_result

--- a/test/test_structured_coverage.ml
+++ b/test/test_structured_coverage.ml
@@ -349,9 +349,7 @@ let test_extract_mixed_blocks () =
     ; ToolResult
         { tool_use_id = "old"
         ; content = "old result"
-        ; is_error = false
-        ; failure_kind = None
-        ; error_class = None
+        ; outcome = Tool_succeeded
         ; json = None
         ; content_blocks = None
         }

--- a/test/test_succession.ml
+++ b/test/test_succession.ml
@@ -305,9 +305,7 @@ let test_normalize_preserves_matched_tool_calls () =
           [ Types.ToolResult
               { tool_use_id = "t1"
               ; content = "result"
-              ; is_error = false
-              ; failure_kind = None
-              ; error_class = None
+              ; outcome = Tool_succeeded
               ; json = None
               ; content_blocks = None
               }

--- a/test/test_tool_failure_episode.ml
+++ b/test/test_tool_failure_episode.ml
@@ -1,25 +1,27 @@
 open Agent_sdk
 
-let call id name input = Types.ToolUse { id; name; input }
+let call id tool_name input : Tool_failure_episode.executed_call =
+  { tool_use_id = id; tool_name; input }
+;;
 
-let result ?failure_kind ?error_class ?(is_error = true) id error =
+let result outcome id content =
   Types.ToolResult
-    { tool_use_id = id
-    ; content = error
-    ; is_error
-    ; failure_kind
-    ; error_class
-    ; json = None
-    ; content_blocks = None
-    }
+    { tool_use_id = id; content; outcome; json = None; content_blocks = None }
 ;;
 
-let typed_failure ?(error_class = Some Types.Deterministic) id error =
-  result ~failure_kind:Types.Validation_error ?error_class id error
+let typed_failure
+      ?(failure_kind = Types.Validation_error)
+      ?(error_class = Some Types.Deterministic)
+      id
+      error
+  =
+  result (Types.Tool_failed { failure_kind; error_class }) id error
 ;;
+
+let successful_result id content = result Types.Tool_succeeded id content
 
 let project calls results =
-  match Tool_failure_episode.project ~tool_uses:calls ~tool_results:results with
+  match Tool_failure_episode.project ~executions:calls ~tool_results:results with
   | Ok round -> round
   | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
 ;;
@@ -58,12 +60,7 @@ let test_different_failure_kind_not_detected () =
   let current =
     project
       [ call "c1" "Execute" `Null ]
-      [ result
-          ~failure_kind:Types.Recoverable_tool_error
-          ~error_class:Types.Deterministic
-          "c1"
-          "second"
-      ]
+      [ typed_failure ~failure_kind:Types.Recoverable_tool_error "c1" "second" ]
   in
   Alcotest.(check bool) "no episode" true (detect previous current = Ok [])
 ;;
@@ -79,9 +76,7 @@ let test_different_error_class_not_detected () =
 ;;
 
 let test_successful_intervening_round_breaks_adjacency () =
-  let success =
-    project [ call "s1" "Execute" `Null ] [ result ~is_error:false "s1" "ok" ]
-  in
+  let success = project [ call "s1" "Execute" `Null ] [ successful_result "s1" "ok" ] in
   let failed = project [ call "c1" "Execute" `Null ] [ typed_failure "c1" "second" ] in
   Alcotest.(check bool)
     "caller advances the adjacent boundary"
@@ -107,11 +102,7 @@ let test_parallel_failures_preserved () =
 
 let test_same_name_distinct_signatures_are_independent () =
   let recoverable id text =
-    result
-      ~failure_kind:Types.Recoverable_tool_error
-      ~error_class:Types.Deterministic
-      id
-      text
+    typed_failure ~failure_kind:Types.Recoverable_tool_error id text
   in
   let previous =
     project
@@ -132,7 +123,7 @@ let test_success_and_matching_failure_same_name_are_unambiguous () =
   let previous =
     project
       [ call "p1" "Execute" `Null; call "p2" "Execute" (`String "other") ]
-      [ result ~is_error:false "p1" "ok"; typed_failure "p2" "failed" ]
+      [ successful_result "p1" "ok"; typed_failure "p2" "failed" ]
   in
   let current = project [ call "c1" "Execute" `Null ] [ typed_failure "c1" "again" ] in
   match detect previous current with
@@ -156,20 +147,22 @@ let test_duplicate_failure_signature_is_explicit () =
   | Ok _ -> Alcotest.fail "expected typed ambiguity"
 ;;
 
-let test_missing_failure_kind_is_explicit () =
+let test_unclassified_failure_is_explicit () =
   match
     Tool_failure_episode.project
-      ~tool_uses:[ call "c1" "Execute" `Null ]
-      ~tool_results:[ result "c1" "second" ]
+      ~executions:[ call "c1" "Execute" `Null ]
+      ~tool_results:[ result Types.Legacy_unclassified_failure "c1" "second" ]
   with
-  | Error (Tool_failure_episode.Failure_kind_missing { tool_use_id = "c1" }) -> ()
+  | Error (Tool_failure_episode.Unclassified_failure { tool_use_id = "c1" }) -> ()
   | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
-  | Ok _ -> Alcotest.fail "expected incomplete metadata error"
+  | Ok _ -> Alcotest.fail "expected unclassified failure error"
 ;;
 
 let test_missing_result_is_explicit () =
   match
-    Tool_failure_episode.project ~tool_uses:[ call "c1" "Execute" `Null ] ~tool_results:[]
+    Tool_failure_episode.project
+      ~executions:[ call "c1" "Execute" `Null ]
+      ~tool_results:[]
   with
   | Error (Tool_failure_episode.Missing_tool_result { tool_use_id = "c1" }) -> ()
   | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
@@ -179,12 +172,170 @@ let test_missing_result_is_explicit () =
 let test_unmatched_result_is_explicit () =
   match
     Tool_failure_episode.project
-      ~tool_uses:[ call "c1" "Execute" `Null ]
+      ~executions:[ call "c1" "Execute" `Null ]
       ~tool_results:[ typed_failure "c1" "matched"; typed_failure "other" "orphan" ]
   with
   | Error (Tool_failure_episode.Unmatched_tool_result { tool_use_id = "other" }) -> ()
   | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
   | Ok _ -> Alcotest.fail "expected unmatched result error"
+;;
+
+let test_completed_round_metadata_preserves_canonical_execution () =
+  let input = `Assoc [ "command", `String "git status"; "cwd", `String "/repo" ] in
+  let tool_result = typed_failure "c1" "failed" in
+  let message =
+    Types.make_message
+      ~metadata:
+        [ Tool_failure_episode.completed_round_metadata [ call "c1" "Execute" input ] ]
+      ~role:Types.Tool
+      [ tool_result ]
+  in
+  match Tool_failure_episode.latest_completed_rounds ~count:1 [ message ] with
+  | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
+  | Ok [ restored ] ->
+    (match detect restored restored with
+     | Ok [ episode ] ->
+       Alcotest.(check string) "canonical tool" "Execute" episode.current.tool_name;
+       Alcotest.(check bool)
+         "canonical input"
+         true
+         (Yojson.Safe.equal input episode.current.input)
+     | Ok episodes ->
+       Alcotest.failf "expected one restored episode, got %d" (List.length episodes)
+     | Error error -> Alcotest.fail (Tool_failure_episode.show_error error))
+  | Ok rounds -> Alcotest.failf "expected one restored round, got %d" (List.length rounds)
+;;
+
+let test_duplicate_completed_round_metadata_is_explicit () =
+  let tool_result = typed_failure "c1" "failed" in
+  let metadata =
+    Tool_failure_episode.completed_round_metadata [ call "c1" "Execute" `Null ]
+  in
+  let message =
+    Types.make_message ~metadata:[ metadata; metadata ] ~role:Types.Tool [ tool_result ]
+  in
+  match Tool_failure_episode.latest_completed_rounds ~count:1 [ message ] with
+  | Error Tool_failure_episode.Duplicate_completed_round_metadata -> ()
+  | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
+  | Ok _ -> Alcotest.fail "expected duplicate completed-round metadata error"
+;;
+
+let test_missing_completed_round_metadata_is_explicit () =
+  let tool_result = typed_failure "c1" "failed" in
+  let message = Types.make_message ~role:Types.Tool [ tool_result ] in
+  match Tool_failure_episode.latest_completed_rounds ~count:1 [ message ] with
+  | Error
+      (Tool_failure_episode.Missing_completed_round_metadata { tool_use_ids = [ "c1" ] })
+    -> ()
+  | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
+  | Ok _ -> Alcotest.fail "expected missing completed-round metadata error"
+;;
+
+let test_invalid_completed_round_metadata_is_explicit () =
+  let key, _ =
+    Tool_failure_episode.completed_round_metadata [ call "c1" "Execute" `Null ]
+  in
+  let message =
+    Types.make_message
+      ~metadata:[ key, `Assoc [] ]
+      ~role:Types.Tool
+      [ typed_failure "c1" "failed" ]
+  in
+  match Tool_failure_episode.latest_completed_rounds ~count:1 [ message ] with
+  | Error (Tool_failure_episode.Invalid_completed_round_metadata _) -> ()
+  | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
+  | Ok _ -> Alcotest.fail "expected invalid completed-round metadata error"
+;;
+
+let test_tool_result_outcome_is_restore_ssot () =
+  let execution = call "c1" "Execute" (`Assoc [ "cmd", `String "status" ]) in
+  let metadata = Tool_failure_episode.completed_round_metadata [ execution ] in
+  let restored_with result =
+    let message = Types.make_message ~metadata:[ metadata ] ~role:Types.Tool [ result ] in
+    match Tool_failure_episode.latest_completed_rounds ~count:1 [ message ] with
+    | Ok [ round ] -> round
+    | Ok rounds ->
+      Alcotest.failf "expected one restored round, got %d" (List.length rounds)
+    | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
+  in
+  let failed = restored_with (typed_failure "c1" "failed") in
+  let succeeded = restored_with (successful_result "c1" "ok") in
+  (match detect failed failed with
+   | Ok [ _ ] -> ()
+   | Ok episodes ->
+     Alcotest.failf "expected one failed episode, got %d" (List.length episodes)
+   | Error error -> Alcotest.fail (Tool_failure_episode.show_error error));
+  match detect succeeded succeeded with
+  | Ok [] -> ()
+  | Ok episodes ->
+    Alcotest.failf
+      "metadata overrode successful outcome (%d episodes)"
+      (List.length episodes)
+  | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
+;;
+
+let test_invalid_run_boundary_is_explicit () =
+  let key, _ = Types.Conversation_metadata.run_boundary_entry in
+  let boundary =
+    Types.make_message
+      ~metadata:[ key, `Bool false ]
+      ~role:Types.User
+      [ Types.Text "new" ]
+  in
+  match Tool_failure_episode.latest_completed_rounds ~count:1 [ boundary ] with
+  | Error Tool_failure_episode.Invalid_run_boundary_metadata -> ()
+  | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
+  | Ok _ -> Alcotest.fail "expected invalid run-boundary metadata error"
+;;
+
+let test_duplicate_run_boundary_is_explicit () =
+  let boundary = Types.Conversation_metadata.run_boundary_entry in
+  let message =
+    Types.make_message
+      ~metadata:[ boundary; boundary ]
+      ~role:Types.User
+      [ Types.Text "new" ]
+  in
+  match Tool_failure_episode.latest_completed_rounds ~count:1 [ message ] with
+  | Error Tool_failure_episode.Duplicate_run_boundary_metadata -> ()
+  | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
+  | Ok _ -> Alcotest.fail "expected duplicate run-boundary metadata error"
+;;
+
+let test_run_boundary_prevents_cross_request_pairing () =
+  let old_result = typed_failure "old" "old failure" in
+  let old_message =
+    Types.make_message
+      ~metadata:
+        [ Tool_failure_episode.completed_round_metadata [ call "old" "Execute" `Null ] ]
+      ~role:Types.Tool
+      [ old_result ]
+  in
+  let boundary =
+    Types.make_message
+      ~metadata:Types.Conversation_metadata.run_boundary
+      ~role:Types.User
+      [ Types.Text "new request" ]
+  in
+  let current_result = typed_failure "current" "current failure" in
+  let current_message =
+    Types.make_message
+      ~metadata:
+        [ Tool_failure_episode.completed_round_metadata
+            [ call "current" "Execute" (`String "new") ]
+        ]
+      ~role:Types.Tool
+      [ current_result ]
+  in
+  match
+    Tool_failure_episode.latest_completed_rounds
+      ~count:2
+      [ old_message; boundary; current_message ]
+  with
+  | Ok [ _ ] -> ()
+  | Ok rounds ->
+    Alcotest.failf "expected only the current request round, got %d" (List.length rounds)
+  | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
 ;;
 
 let () =
@@ -224,11 +375,45 @@ let () =
             `Quick
             test_duplicate_failure_signature_is_explicit
         ; Alcotest.test_case
-            "missing failure kind"
+            "unclassified failure"
             `Quick
-            test_missing_failure_kind_is_explicit
+            test_unclassified_failure_is_explicit
         ; Alcotest.test_case "missing result" `Quick test_missing_result_is_explicit
         ; Alcotest.test_case "unmatched result" `Quick test_unmatched_result_is_explicit
+        ] )
+    ; ( "durability"
+      , [ Alcotest.test_case
+            "canonical execution metadata"
+            `Quick
+            test_completed_round_metadata_preserves_canonical_execution
+        ; Alcotest.test_case
+            "duplicate metadata"
+            `Quick
+            test_duplicate_completed_round_metadata_is_explicit
+        ; Alcotest.test_case
+            "missing metadata"
+            `Quick
+            test_missing_completed_round_metadata_is_explicit
+        ; Alcotest.test_case
+            "invalid metadata"
+            `Quick
+            test_invalid_completed_round_metadata_is_explicit
+        ; Alcotest.test_case
+            "tool result outcome SSOT"
+            `Quick
+            test_tool_result_outcome_is_restore_ssot
+        ; Alcotest.test_case
+            "run boundary"
+            `Quick
+            test_run_boundary_prevents_cross_request_pairing
+        ; Alcotest.test_case
+            "invalid run boundary"
+            `Quick
+            test_invalid_run_boundary_is_explicit
+        ; Alcotest.test_case
+            "duplicate run boundary"
+            `Quick
+            test_duplicate_run_boundary_is_explicit
         ] )
     ]
 ;;

--- a/test/test_tool_failure_episode.ml
+++ b/test/test_tool_failure_episode.ml
@@ -247,6 +247,49 @@ let test_invalid_completed_round_metadata_is_explicit () =
   | Ok _ -> Alcotest.fail "expected invalid completed-round metadata error"
 ;;
 
+let test_unexpected_execution_metadata_field_is_explicit () =
+  let key, json =
+    Tool_failure_episode.completed_round_metadata [ call "c1" "Execute" `Null ]
+  in
+  let json =
+    match json with
+    | `List [ `Assoc fields ] -> `List [ `Assoc (("unexpected", `Bool true) :: fields) ]
+    | _ -> Alcotest.fail "expected one executed-call metadata object"
+  in
+  let message =
+    Types.make_message
+      ~metadata:[ key, json ]
+      ~role:Types.Tool
+      [ typed_failure "c1" "failed" ]
+  in
+  match Tool_failure_episode.latest_completed_rounds ~count:1 [ message ] with
+  | Error (Tool_failure_episode.Invalid_completed_round_metadata _) -> ()
+  | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
+  | Ok _ -> Alcotest.fail "expected unexpected executed-call field error"
+;;
+
+let test_duplicate_execution_metadata_field_is_explicit () =
+  let key, json =
+    Tool_failure_episode.completed_round_metadata [ call "c1" "Execute" `Null ]
+  in
+  let json =
+    match json with
+    | `List [ `Assoc fields ] ->
+      `List [ `Assoc (("tool_use_id", `String "duplicate") :: fields) ]
+    | _ -> Alcotest.fail "expected one executed-call metadata object"
+  in
+  let message =
+    Types.make_message
+      ~metadata:[ key, json ]
+      ~role:Types.Tool
+      [ typed_failure "c1" "failed" ]
+  in
+  match Tool_failure_episode.latest_completed_rounds ~count:1 [ message ] with
+  | Error (Tool_failure_episode.Invalid_completed_round_metadata _) -> ()
+  | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
+  | Ok _ -> Alcotest.fail "expected duplicate executed-call field error"
+;;
+
 let test_tool_result_outcome_is_restore_ssot () =
   let execution = call "c1" "Execute" (`Assoc [ "cmd", `String "status" ]) in
   let metadata = Tool_failure_episode.completed_round_metadata [ execution ] in
@@ -398,6 +441,14 @@ let () =
             "invalid metadata"
             `Quick
             test_invalid_completed_round_metadata_is_explicit
+        ; Alcotest.test_case
+            "unexpected execution metadata field"
+            `Quick
+            test_unexpected_execution_metadata_field_is_explicit
+        ; Alcotest.test_case
+            "duplicate execution metadata field"
+            `Quick
+            test_duplicate_execution_metadata_field_is_explicit
         ; Alcotest.test_case
             "tool result outcome SSOT"
             `Quick

--- a/test/test_tool_failure_recovery.ml
+++ b/test/test_tool_failure_recovery.ml
@@ -344,6 +344,50 @@ let test_attach_receipt_does_not_cross_new_run_boundary () =
   | Ok _ -> Alcotest.fail "receipt crossed the new run boundary"
 ;;
 
+let mutate_receipt_fields messages mutate =
+  let changed = ref false in
+  let messages =
+    List.map
+      (fun (message : Types.message) ->
+         let metadata =
+           List.map
+             (fun (key, json) ->
+                match !changed, json with
+                | false, `Assoc fields when List.mem_assoc "version" fields ->
+                  changed := true;
+                  key, `Assoc (mutate fields)
+                | _ -> key, json)
+             message.metadata
+         in
+         { message with metadata })
+      messages
+  in
+  if not !changed then Alcotest.fail "recovery receipt metadata not found";
+  messages
+;;
+
+let test_receipt_record_is_closed () =
+  Eio_main.run
+  @@ fun env ->
+  let scenario =
+    run_scenario
+      env
+      ~judge_json:{|{"action":"ask_user","question":"Which repository?"}|}
+      ()
+  in
+  let messages = (Agent.state scenario.agent).messages in
+  let check_invalid label mutate =
+    let messages = mutate_receipt_fields messages mutate in
+    match Tool_failure_recovery.latest_receipt messages with
+    | Error (Tool_failure_recovery.Invalid_receipt_metadata _) -> ()
+    | Error error ->
+      Alcotest.failf "%s: %s" label (Tool_failure_recovery.show_receipt_error error)
+    | Ok _ -> Alcotest.failf "%s: expected invalid receipt metadata" label
+  in
+  check_invalid "duplicate field" (fun fields -> ("version", `Int 1) :: fields);
+  check_invalid "unexpected field" (fun fields -> ("unexpected", `Null) :: fields)
+;;
+
 let project calls results =
   let executions =
     List.map
@@ -525,6 +569,56 @@ let test_resume_does_not_correlate_across_external_user_runs () =
   Alcotest.(check int) "main provider still runs" 1 (List.length requests)
 ;;
 
+let test_resume_rejects_result_without_execution_metadata () =
+  Eio_main.run
+  @@ fun env ->
+  let seed =
+    Agent.create
+      ~net:env#net
+      ~config:
+        { Types.default_config with
+          name = "missing-execution-metadata-test"
+        ; model = "mock-model"
+        ; system_prompt = Some "base system"
+        ; max_turns = 0
+        }
+      ()
+  in
+  let input = `Assoc [ "cmd", `String "gh pr list" ] in
+  let checkpoint =
+    { (Agent.checkpoint seed) with
+      turn_count = 1
+    ; messages =
+        [ message
+            ~role:User
+            ~content:[ Text "request" ]
+            ~metadata:Types.Conversation_metadata.run_boundary
+        ; message
+            ~role:Assistant
+            ~content:[ ToolUse { id = "c1"; name = "Execute"; input } ]
+            ~metadata:[]
+        ; message ~role:Tool ~content:[ failed_result "c1" ] ~metadata:[]
+        ]
+    }
+  in
+  let judge_calls = ref 0 in
+  let judge =
+    Tool_failure_recovery.create ~complete:(fun ~sw:_ _ ->
+      incr judge_calls;
+      Ok {|{"action":"replan","instruction":"must not run"}|})
+  in
+  let result, requests = resumed_final_run env ~checkpoint ~judge in
+  (match result with
+   | Error
+       (Error.Agent
+          (Error.ToolFailureRecoveryFailed { stage = Error.Resume_restore; detail })) ->
+     Alcotest.(check bool) "explicit restore detail" true (String.length detail > 0)
+   | Error error -> Alcotest.fail (Error.to_string error)
+   | Ok _ -> Alcotest.fail "expected explicit recovery restore error");
+  Alcotest.(check int) "judge not called" 0 !judge_calls;
+  Alcotest.(check int) "provider not called" 0 (List.length requests)
+;;
+
 let test_run_boundary_metadata_remains_provider_mergeable () =
   let messages =
     [ message ~role:Tool ~content:[ failed_result "c1" ] ~metadata:[]
@@ -644,6 +738,10 @@ let () =
             `Quick
             test_resume_does_not_correlate_across_external_user_runs
         ; Alcotest.test_case
+            "resume requires execution metadata"
+            `Quick
+            test_resume_rejects_result_without_execution_metadata
+        ; Alcotest.test_case
             "run boundary metadata is provider-mergeable"
             `Quick
             test_run_boundary_metadata_remains_provider_mergeable
@@ -659,6 +757,10 @@ let () =
             "receipt attachment respects new run"
             `Quick
             test_attach_receipt_does_not_cross_new_run_boundary
+        ; Alcotest.test_case
+            "receipt record is closed"
+            `Quick
+            test_receipt_record_is_closed
         ] )
     ; ( "decision_validation"
       , [ Alcotest.test_case

--- a/test/test_tool_failure_recovery.ml
+++ b/test/test_tool_failure_recovery.ml
@@ -118,7 +118,6 @@ let run_scenario env ~judge_json ?(fail_recovery_checkpoint = false) () =
     ; model = "mock-model"
     ; system_prompt = Some "base system"
     ; max_turns = 0
-    ; yield_on_tool = true
     }
   in
   let agent =
@@ -131,6 +130,10 @@ let run_scenario env ~judge_json ?(fail_recovery_checkpoint = false) () =
       ~tool_failure_judge:judge
       ()
   in
+  Alcotest.(check bool)
+    "judge enables tool yielding"
+    true
+    (Agent.state agent).config.yield_on_tool;
   let result =
     Agent.run
       ~sw
@@ -238,19 +241,133 @@ let test_checkpoint_failure_does_not_commit_receipt () =
   Alcotest.(check int) "no third main call" 2 (List.length scenario.requests)
 ;;
 
+let test_checkpoint_roundtrip_preserves_canonical_rounds () =
+  Eio_main.run
+  @@ fun env ->
+  let scenario =
+    run_scenario
+      env
+      ~judge_json:{|{"action":"ask_user","question":"Which repository?"}|}
+      ()
+  in
+  let checkpoint = Agent.checkpoint ~session_id:"typed-recovery" scenario.agent in
+  let restored = Result.get_ok (Checkpoint.of_json (Checkpoint.to_json checkpoint)) in
+  match Tool_failure_episode.latest_completed_rounds ~count:2 restored.messages with
+  | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
+  | Ok [ current; previous ] ->
+    (match Tool_failure_episode.detect ~previous ~current with
+     | Ok [ episode ] ->
+       Alcotest.(check string) "canonical tool" "Execute" episode.current.tool_name;
+       Alcotest.(check bool)
+         "failure kind"
+         true
+         (episode.current.failure_kind = Types.Recoverable_tool_error);
+       Alcotest.(check bool)
+         "error class"
+         true
+         (episode.current.error_class = Some Types.Deterministic);
+       Alcotest.(check bool)
+         "executed input"
+         true
+         (Yojson.Safe.equal
+            episode.current.input
+            (`Assoc [ "cmd", `String "gh pr list" ]))
+     | Ok episodes ->
+       Alcotest.failf "expected one restored episode, got %d" (List.length episodes)
+     | Error error -> Alcotest.fail (Tool_failure_episode.show_error error))
+  | Ok rounds ->
+    Alcotest.failf "expected two restored rounds, got %d" (List.length rounds)
+;;
+
+let test_new_run_boundary_hides_old_receipt () =
+  Eio_main.run
+  @@ fun env ->
+  let scenario =
+    run_scenario
+      env
+      ~judge_json:{|{"action":"ask_user","question":"Which repository?"}|}
+      ()
+  in
+  let boundary =
+    Types.make_message
+      ~metadata:Types.Conversation_metadata.run_boundary
+      ~role:Types.User
+      [ Types.Text "new request" ]
+  in
+  let messages = (Agent.state scenario.agent).messages @ [ boundary ] in
+  match Tool_failure_recovery.latest_receipt messages with
+  | Ok None -> ()
+  | Ok (Some _) -> Alcotest.fail "receipt crossed the new run boundary"
+  | Error error -> Alcotest.fail (Tool_failure_recovery.show_receipt_error error)
+;;
+
+let test_attach_receipt_does_not_cross_new_run_boundary () =
+  Eio_main.run
+  @@ fun env ->
+  let scenario =
+    run_scenario
+      env
+      ~judge_json:{|{"action":"ask_user","question":"Which repository?"}|}
+      ()
+  in
+  let messages = (Agent.state scenario.agent).messages in
+  let episodes =
+    match Tool_failure_episode.latest_completed_rounds ~count:2 messages with
+    | Ok [ current; previous ] ->
+      (match Tool_failure_episode.detect ~previous ~current with
+       | Ok episodes -> episodes
+       | Error error -> Alcotest.fail (Tool_failure_episode.show_error error))
+    | Ok rounds ->
+      Alcotest.failf "expected two completed rounds, got %d" (List.length rounds)
+    | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
+  in
+  let receipt =
+    match Tool_failure_recovery.latest_receipt messages with
+    | Ok (Some receipt) -> receipt
+    | Ok None -> Alcotest.fail "expected recovery receipt"
+    | Error error -> Alcotest.fail (Tool_failure_recovery.show_receipt_error error)
+  in
+  let boundary =
+    Types.make_message
+      ~metadata:Types.Conversation_metadata.run_boundary
+      ~role:Types.User
+      [ Types.Text "new request" ]
+  in
+  match
+    Tool_failure_recovery.attach_receipt
+      ~messages:(messages @ [ boundary ])
+      ~episodes
+      ~receipt
+  with
+  | Error Tool_failure_recovery.Result_message_not_found -> ()
+  | Error error -> Alcotest.fail (Tool_failure_recovery.show_receipt_error error)
+  | Ok _ -> Alcotest.fail "receipt crossed the new run boundary"
+;;
+
 let project calls results =
-  match Tool_failure_episode.project ~tool_uses:calls ~tool_results:results with
+  let executions =
+    List.map
+      (function
+        | Types.ToolUse { id; name; input } ->
+          ({ tool_use_id = id; tool_name = name; input }
+           : Tool_failure_episode.executed_call)
+        | _ -> Alcotest.fail "expected ToolUse fixture")
+      calls
+  in
+  match Tool_failure_episode.project ~executions ~tool_results:results with
   | Ok round -> round
   | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
 ;;
 
-let failed_result id =
+let failed_result id : Types.content_block =
   Types.ToolResult
     { tool_use_id = id
     ; content = "failed"
-    ; is_error = true
-    ; failure_kind = Some Recoverable_tool_error
-    ; error_class = Some Deterministic
+    ; outcome =
+        Types.Tool_failed
+          { failure_kind = Types.Recoverable_tool_error
+          ; error_class = Some Types.Deterministic
+          }
     ; json = None
     ; content_blocks = None
     }
@@ -365,8 +482,14 @@ let test_resume_does_not_correlate_across_external_user_runs () =
       ()
   in
   let boundary = Types.Conversation_metadata.run_boundary in
-  let call id : Types.content_block =
-    Types.ToolUse { id; name = "Execute"; input = `Assoc [ "cmd", `String "gh pr list" ] }
+  let input = `Assoc [ "cmd", `String "gh pr list" ] in
+  let call id : Types.content_block = Types.ToolUse { id; name = "Execute"; input } in
+  let round_metadata id =
+    [ Tool_failure_episode.completed_round_metadata
+        [ ({ tool_use_id = id; tool_name = "Execute"; input }
+           : Tool_failure_episode.executed_call)
+        ]
+    ]
   in
   let checkpoint =
     { (Agent.checkpoint seed) with
@@ -374,10 +497,16 @@ let test_resume_does_not_correlate_across_external_user_runs () =
     ; messages =
         [ message ~role:User ~content:[ Text "first request" ] ~metadata:boundary
         ; message ~role:Assistant ~content:[ call "p1" ] ~metadata:[]
-        ; message ~role:Tool ~content:[ failed_result "p1" ] ~metadata:[]
+        ; message
+            ~role:Tool
+            ~content:[ failed_result "p1" ]
+            ~metadata:(round_metadata "p1")
         ; message ~role:User ~content:[ Text "second request" ] ~metadata:boundary
         ; message ~role:Assistant ~content:[ call "c1" ] ~metadata:[]
-        ; message ~role:Tool ~content:[ failed_result "c1" ] ~metadata:[]
+        ; message
+            ~role:Tool
+            ~content:[ failed_result "c1" ]
+            ~metadata:(round_metadata "c1")
         ]
     }
   in
@@ -518,6 +647,18 @@ let () =
             "run boundary metadata is provider-mergeable"
             `Quick
             test_run_boundary_metadata_remains_provider_mergeable
+        ; Alcotest.test_case
+            "checkpoint preserves canonical rounds"
+            `Quick
+            test_checkpoint_roundtrip_preserves_canonical_rounds
+        ; Alcotest.test_case
+            "new run hides old receipt"
+            `Quick
+            test_new_run_boundary_hides_old_receipt
+        ; Alcotest.test_case
+            "receipt attachment respects new run"
+            `Quick
+            test_attach_receipt_does_not_cross_new_run_boundary
         ] )
     ; ( "decision_validation"
       , [ Alcotest.test_case

--- a/test/test_tool_middleware.ml
+++ b/test/test_tool_middleware.ml
@@ -501,9 +501,7 @@ let test_strip_no_orphans () =
         [ ToolResult
             { tool_use_id = "t1"
             ; content = "ok"
-            ; is_error = false
-            ; failure_kind = None
-            ; error_class = None
+            ; outcome = Tool_succeeded
             ; json = None
             ; content_blocks = None
             }
@@ -525,9 +523,7 @@ let test_strip_removes_orphan () =
         ; ToolResult
             { tool_use_id = "orphan-id"
             ; content = "stale"
-            ; is_error = false
-            ; failure_kind = None
-            ; error_class = None
+            ; outcome = Tool_succeeded
             ; json = None
             ; content_blocks = None
             }
@@ -550,27 +546,21 @@ let test_strip_report_names_orphaned_and_duplicate_results () =
         [ ToolResult
             { tool_use_id = "t1"
             ; content = "ok"
-            ; is_error = false
-            ; failure_kind = None
-            ; error_class = None
+            ; outcome = Tool_succeeded
             ; json = None
             ; content_blocks = None
             }
         ; ToolResult
             { tool_use_id = "t1"
             ; content = "duplicate"
-            ; is_error = false
-            ; failure_kind = None
-            ; error_class = None
+            ; outcome = Tool_succeeded
             ; json = None
             ; content_blocks = None
             }
         ; ToolResult
             { tool_use_id = "orphan-id"
             ; content = "stale"
-            ; is_error = true
-            ; failure_kind = None
-            ; error_class = None
+            ; outcome = Legacy_unclassified_failure
             ; json = None
             ; content_blocks = None
             }
@@ -599,27 +589,21 @@ let test_strip_preserves_matched () =
         [ ToolResult
             { tool_use_id = "t1"
             ; content = "ok"
-            ; is_error = false
-            ; failure_kind = None
-            ; error_class = None
+            ; outcome = Tool_succeeded
             ; json = None
             ; content_blocks = None
             }
         ; ToolResult
             { tool_use_id = "orphan"
             ; content = "bad"
-            ; is_error = true
-            ; failure_kind = None
-            ; error_class = None
+            ; outcome = Legacy_unclassified_failure
             ; json = None
             ; content_blocks = None
             }
         ; ToolResult
             { tool_use_id = "t2"
             ; content = "ok2"
-            ; is_error = false
-            ; failure_kind = None
-            ; error_class = None
+            ; outcome = Tool_succeeded
             ; json = None
             ; content_blocks = None
             }
@@ -651,9 +635,7 @@ let test_strip_drops_results_after_interleaved_text () =
         [ ToolResult
             { tool_use_id = "t1"
             ; content = "ok"
-            ; is_error = false
-            ; failure_kind = None
-            ; error_class = None
+            ; outcome = Tool_succeeded
             ; json = None
             ; content_blocks = None
             }
@@ -675,9 +657,7 @@ let test_strip_keeps_tool_role_results_before_nudge_text () =
         [ ToolResult
             { tool_use_id = "t1"
             ; content = "ok"
-            ; is_error = false
-            ; failure_kind = None
-            ; error_class = None
+            ; outcome = Tool_succeeded
             ; json = None
             ; content_blocks = None
             }
@@ -704,9 +684,7 @@ let test_close_report_names_dropped_result_and_synthetic_repair () =
         [ ToolResult
             { tool_use_id = "t1"
             ; content = "late"
-            ; is_error = false
-            ; failure_kind = None
-            ; error_class = None
+            ; outcome = Tool_succeeded
             ; json = None
             ; content_blocks = None
             }
@@ -716,9 +694,12 @@ let test_close_report_names_dropped_result_and_synthetic_repair () =
   let result, report = Serialize.close_tool_message_pairs_for_request_with_report msgs in
   Alcotest.(check int) "closed length" 3 (List.length result);
   (match List.nth result 1 with
-   | { Types.metadata; content = [ ToolResult { tool_use_id; is_error; _ } ]; _ } ->
+   | { Types.metadata; content = [ ToolResult { tool_use_id; outcome; _ } ]; _ } ->
      Alcotest.(check string) "synthetic id" "t1" tool_use_id;
-     Alcotest.(check bool) "synthetic error" true is_error;
+     Alcotest.(check bool)
+       "synthetic error"
+       true
+       (Types.tool_result_outcome_is_error outcome);
      Alcotest.(check (option bool))
        "synthetic metadata"
        (Some true)

--- a/test/test_tool_result_relocation.ml
+++ b/test/test_tool_result_relocation.ml
@@ -211,11 +211,13 @@ let test_make_tool_results_with_relocation () =
   let mock_results : Agent_tools.tool_execution_result list =
     [ { tool_use_id = "t1"
       ; tool_name = "read"
+      ; input = `Null
       ; content = String.make 200 'x'
       ; outcome = Tool_succeeded
       }
     ; { tool_use_id = "t2"
       ; tool_name = "echo"
+      ; input = `Null
       ; content = "small"
       ; outcome = Tool_succeeded
       }
@@ -268,6 +270,7 @@ let test_make_tool_results_persist_failure_freezes_kept () =
   let mock_results : Agent_tools.tool_execution_result list =
     [ { tool_use_id = "..."
       ; tool_name = "read"
+      ; input = `Null
       ; content = original
       ; outcome = Tool_succeeded
       }
@@ -311,11 +314,13 @@ let test_make_tool_results_publishes_content_replacement_events () =
   let mock_results : Agent_tools.tool_execution_result list =
     [ { tool_use_id = "big"
       ; tool_name = "read"
+      ; input = `Null
       ; content = String.make 40 'x'
       ; outcome = Tool_succeeded
       }
     ; { tool_use_id = "small"
       ; tool_name = "echo"
+      ; input = `Null
       ; content = "ok"
       ; outcome = Tool_succeeded
       }
@@ -493,16 +498,19 @@ let test_aggregate_budget_persists_largest () =
   let mock_results : Agent_tools.tool_execution_result list =
     [ { tool_use_id = "t1"
       ; tool_name = "a"
+      ; input = `Null
       ; content = String.make 8000 'a'
       ; outcome = Tool_succeeded
       }
     ; { tool_use_id = "t2"
       ; tool_name = "b"
+      ; input = `Null
       ; content = String.make 5000 'b'
       ; outcome = Tool_succeeded
       }
     ; { tool_use_id = "t3"
       ; tool_name = "c"
+      ; input = `Null
       ; content = String.make 4000 'c'
       ; outcome = Tool_succeeded
       }
@@ -561,6 +569,7 @@ let test_aggregate_budget_disabled () =
   let mock_results : Agent_tools.tool_execution_result list =
     [ { tool_use_id = "t1"
       ; tool_name = "a"
+      ; input = `Null
       ; content = String.make 8000 'x'
       ; outcome = Tool_succeeded
       }

--- a/test/test_tool_result_relocation.ml
+++ b/test/test_tool_result_relocation.ml
@@ -36,16 +36,9 @@ let rm_rf dir =
   | _ -> ()
 ;;
 
-let tool_result ?(is_error = false) id content : Types.content_block =
+let tool_result ?(outcome = Types.Tool_succeeded) id content : Types.content_block =
   Types.ToolResult
-    { tool_use_id = id
-    ; content
-    ; is_error
-    ; failure_kind = None
-    ; error_class = None
-    ; json = None
-    ; content_blocks = None
-    }
+    { tool_use_id = id; content; outcome; json = None; content_blocks = None }
 ;;
 
 let asst_msg text : Types.message =
@@ -219,16 +212,12 @@ let test_make_tool_results_with_relocation () =
     [ { tool_use_id = "t1"
       ; tool_name = "read"
       ; content = String.make 200 'x'
-      ; is_error = false
-      ; failure_kind = None
-      ; error_class = None
+      ; outcome = Tool_succeeded
       }
     ; { tool_use_id = "t2"
       ; tool_name = "echo"
       ; content = "small"
-      ; is_error = false
-      ; failure_kind = None
-      ; error_class = None
+      ; outcome = Tool_succeeded
       }
     ]
   in
@@ -280,9 +269,7 @@ let test_make_tool_results_persist_failure_freezes_kept () =
     [ { tool_use_id = "..."
       ; tool_name = "read"
       ; content = original
-      ; is_error = false
-      ; failure_kind = None
-      ; error_class = None
+      ; outcome = Tool_succeeded
       }
     ]
   in
@@ -325,16 +312,12 @@ let test_make_tool_results_publishes_content_replacement_events () =
     [ { tool_use_id = "big"
       ; tool_name = "read"
       ; content = String.make 40 'x'
-      ; is_error = false
-      ; failure_kind = None
-      ; error_class = None
+      ; outcome = Tool_succeeded
       }
     ; { tool_use_id = "small"
       ; tool_name = "echo"
       ; content = "ok"
-      ; is_error = false
-      ; failure_kind = None
-      ; error_class = None
+      ; outcome = Tool_succeeded
       }
     ]
   in
@@ -511,23 +494,17 @@ let test_aggregate_budget_persists_largest () =
     [ { tool_use_id = "t1"
       ; tool_name = "a"
       ; content = String.make 8000 'a'
-      ; is_error = false
-      ; failure_kind = None
-      ; error_class = None
+      ; outcome = Tool_succeeded
       }
     ; { tool_use_id = "t2"
       ; tool_name = "b"
       ; content = String.make 5000 'b'
-      ; is_error = false
-      ; failure_kind = None
-      ; error_class = None
+      ; outcome = Tool_succeeded
       }
     ; { tool_use_id = "t3"
       ; tool_name = "c"
       ; content = String.make 4000 'c'
-      ; is_error = false
-      ; failure_kind = None
-      ; error_class = None
+      ; outcome = Tool_succeeded
       }
     ]
   in
@@ -585,9 +562,7 @@ let test_aggregate_budget_disabled () =
     [ { tool_use_id = "t1"
       ; tool_name = "a"
       ; content = String.make 8000 'x'
-      ; is_error = false
-      ; failure_kind = None
-      ; error_class = None
+      ; outcome = Tool_succeeded
       }
     ]
   in

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -346,9 +346,7 @@ let test_show_content_block_variants () =
     ; Types.ToolResult
         { tool_use_id = "tu1"
         ; content = "ok"
-        ; is_error = false
-        ; failure_kind = None
-        ; error_class = None
+        ; outcome = Tool_succeeded
         ; json = None
         ; content_blocks = None
         }
@@ -718,15 +716,22 @@ let test_tool_result_msg () =
   let m = Types.tool_result_msg ~tool_use_id:"tu1" ~content:"result" () in
   Alcotest.(check string) "role" "tool" (Types.role_to_string m.role);
   match m.content with
-  | [ Types.ToolResult { tool_use_id = "tu1"; content = "result"; is_error = false; _ } ]
-    -> ()
+  | [ Types.ToolResult
+        { tool_use_id = "tu1"; content = "result"; outcome = Tool_succeeded; _ }
+    ] -> ()
   | _ -> Alcotest.fail "expected ToolResult"
 ;;
 
 let test_tool_result_msg_error () =
-  let m = Types.tool_result_msg ~tool_use_id:"tu2" ~content:"err" ~is_error:true () in
+  let outcome =
+    Types.Tool_failed
+      { failure_kind = Types.Non_retryable_tool_error
+      ; error_class = Some Types.Deterministic
+      }
+  in
+  let m = Types.tool_result_msg ~tool_use_id:"tu2" ~content:"err" ~outcome () in
   match m.content with
-  | [ Types.ToolResult { is_error = true; _ } ] -> ()
+  | [ Types.ToolResult { outcome = Tool_failed _; _ } ] -> ()
   | _ -> Alcotest.fail "expected error ToolResult"
 ;;
 
@@ -771,9 +776,7 @@ let test_text_of_content_tool_result () =
     [ Types.ToolResult
         { tool_use_id = "tu1"
         ; content = "result text"
-        ; is_error = false
-        ; failure_kind = None
-        ; error_class = None
+        ; outcome = Tool_succeeded
         ; json = None
         ; content_blocks = None
         }
@@ -794,9 +797,7 @@ let test_visible_text_of_content_excludes_non_answer_blocks () =
     ; Types.ToolResult
         { tool_use_id = "tu1"
         ; content = "tool payload"
-        ; is_error = false
-        ; failure_kind = None
-        ; error_class = None
+        ; outcome = Tool_succeeded
         ; json = Some (`Assoc [ "ok", `Bool true ])
         ; content_blocks = Some [ Types.Text "structured tool payload" ]
         }
@@ -887,9 +888,7 @@ let test_text_of_response_and_usage_helpers () =
         ; Types.ToolResult
             { tool_use_id = "tu"
             ; content = "tool text"
-            ; is_error = false
-            ; failure_kind = None
-            ; error_class = None
+            ; outcome = Tool_succeeded
             ; json = None
             ; content_blocks = None
             }
@@ -919,9 +918,7 @@ let test_validate_tool_result_shape () =
     Types.ToolResult
       { tool_use_id = "obj"
       ; content = {|{"ok":true}|}
-      ; is_error = false
-      ; failure_kind = None
-      ; error_class = None
+      ; outcome = Tool_succeeded
       ; json = Some (`Assoc [ "ok", `Bool true ])
       ; content_blocks = None
       }
@@ -930,9 +927,7 @@ let test_validate_tool_result_shape () =
     Types.ToolResult
       { tool_use_id = "arr"
       ; content = "[1,2]"
-      ; is_error = false
-      ; failure_kind = None
-      ; error_class = None
+      ; outcome = Tool_succeeded
       ; json = Some (`List [ `Int 1; `Int 2 ])
       ; content_blocks = None
       }
@@ -941,9 +936,7 @@ let test_validate_tool_result_shape () =
     Types.ToolResult
       { tool_use_id = "bad"
       ; content = "not-json"
-      ; is_error = false
-      ; failure_kind = None
-      ; error_class = None
+      ; outcome = Tool_succeeded
       ; json = None
       ; content_blocks = None
       }
@@ -952,9 +945,7 @@ let test_validate_tool_result_shape () =
     Types.ToolResult
       { tool_use_id = "empty"
       ; content = " "
-      ; is_error = false
-      ; failure_kind = None
-      ; error_class = None
+      ; outcome = Tool_succeeded
       ; json = None
       ; content_blocks = None
       }


### PR DESCRIPTION
## Summary

Follow-up to merged #2539, #2541, #2546, and #2547.

- replace independent ToolResult error fields with one closed authoritative outcome
- persist canonical executed tool identity and re-project failure truth from ToolResult on restore
- scope durable rounds and recovery receipts to the current agent run boundary
- keep the recovery judge optional; installing one automatically enables tool-boundary yielding
- let agents without a judge continue to the main provider instead of forcing a canned stop or missing-judge failure
- keep OAS provider-neutral and free of MASC dependencies

Fixes #2530

## Why

The merged recovery path still allowed execution identity to be reconstructed from raw provider history and changed default Agent behavior when no judge was configured. That violated the durable SSOT and made the optional OAS feature mandatory in practice.

This change makes ToolResult the only failure-outcome authority. Checkpoint metadata stores only identity absent from ToolResult, uses closed strict decoders, and fails explicitly on malformed, duplicate, missing, or inconsistent recovery records.

## Focused local validation

- focused build of lib/agent_sdk.cmxa and all 37 changed test executables: pass
- all 37 changed test executables: pass
- model-catalog suites executed with the repository models.toml, matching CI catalog injection
- ocamlformat check for every changed ML and MLI file: pass
- git diff --check and new stub/TODO/Obj.magic, hardcoded workspace path, MASC reverse dependency, removed API residue scans: pass

Full Dune build and OCaml 5.4/5.5 matrix remain CI authority.