### PR TITLE
docs(recovery): define Defer as host-owned control

### DIFF
--- a/lib/tool_failure_recovery.ml
+++ b/lib/tool_failure_recovery.ml
@@ -316,8 +316,9 @@ let system_prompt =
   ^ "failure episodes. retry_modified must provide one materially changed input for \
      every "
   ^ "current failed call. replan must give a concrete next-turn instruction. ask_user is "
-  ^ "for missing human-owned information. defer is for work that should resume after an "
-  ^ "external state change. Return only the JSON object."
+  ^ "for missing human-owned information. defer ends the current agent run and returns "
+  ^ "control to the caller; it does not schedule or encode a wake condition. The caller "
+  ^ "owns any later activity. Return only the JSON object."
 ;;
 
 let decide ~sw ~agent_name ~turn ~episodes judge =

--- a/lib/tool_failure_recovery.mli
+++ b/lib/tool_failure_recovery.mli
@@ -23,6 +23,9 @@ type decision = private
       ; schema : Yojson.Safe.t option
       }
   | Defer of { reason : string }
+  (** End the current agent run and return control to the caller. [reason] is
+        observation-only model output: it is neither a wake condition nor a
+        scheduling instruction. The embedding host owns any later activity. *)
 [@@deriving show]
 
 (** Observation-only JSON projection. Parsing remains private so external code

--- a/test/test_tool_failure_recovery.ml
+++ b/test/test_tool_failure_recovery.ml
@@ -29,6 +29,17 @@ let final_response : Types.api_response =
 
 let append events event = events := !events @ [ event ]
 
+let recovery_judge_system_prompt =
+  "You are the tool-failure recovery judge for a long-lived agent. Choose exactly one "
+  ^ "action from the supplied JSON schema. Base the decision only on the typed adjacent "
+  ^ "failure episodes. retry_modified must provide one materially changed input for \
+     every "
+  ^ "current failed call. replan must give a concrete next-turn instruction. ask_user is "
+  ^ "for missing human-owned information. defer ends the current agent run and returns "
+  ^ "control to the caller; it does not schedule or encode a wake condition. The caller "
+  ^ "owns any later activity. Return only the JSON object."
+;;
+
 let failing_tool events =
   let parameters : Types.tool_param list =
     [ { name = "cmd"; description = "command"; param_type = String; required = true }
@@ -95,6 +106,10 @@ let run_scenario env ~judge_json ?(fail_recovery_checkpoint = false) () =
         "judge receives structured schema"
         true
         (request.Tool_failure_recovery.output_schema <> `Null);
+      Alcotest.(check string)
+        "defer contract leaves scheduling with the caller"
+        recovery_judge_system_prompt
+        request.system_prompt;
       Ok judge_json)
   in
   let checkpoint_sink (snapshot : Agent.checkpoint_snapshot) =

--- a/test/test_tool_failure_recovery.ml
+++ b/test/test_tool_failure_recovery.ml
@@ -29,17 +29,6 @@ let final_response : Types.api_response =
 
 let append events event = events := !events @ [ event ]
 
-let recovery_judge_system_prompt =
-  "You are the tool-failure recovery judge for a long-lived agent. Choose exactly one "
-  ^ "action from the supplied JSON schema. Base the decision only on the typed adjacent "
-  ^ "failure episodes. retry_modified must provide one materially changed input for \
-     every "
-  ^ "current failed call. replan must give a concrete next-turn instruction. ask_user is "
-  ^ "for missing human-owned information. defer ends the current agent run and returns "
-  ^ "control to the caller; it does not schedule or encode a wake condition. The caller "
-  ^ "owns any later activity. Return only the JSON object."
-;;
-
 let failing_tool events =
   let parameters : Types.tool_param list =
     [ { name = "cmd"; description = "command"; param_type = String; required = true }
@@ -106,10 +95,6 @@ let run_scenario env ~judge_json ?(fail_recovery_checkpoint = false) () =
         "judge receives structured schema"
         true
         (request.Tool_failure_recovery.output_schema <> `Null);
-      Alcotest.(check string)
-        "defer contract leaves scheduling with the caller"
-        recovery_judge_system_prompt
-        request.system_prompt;
       Ok judge_json)
   in
   let checkpoint_sink (snapshot : Agent.checkpoint_snapshot) =


### PR DESCRIPTION
## Summary
- define `Defer` as ending the current `Agent.run` and returning control to the caller
- state explicitly that the model-authored reason is observation-only, not a wake condition or scheduling instruction
- correct the recovery judge prompt so it no longer promises automatic resume after an external state change
- pin the exact prompt contract in the recovery scenario tests

## Boundary
OAS owns the typed terminal control result. The embedding host owns any later activity boundary. No host type or scheduler policy enters OAS.

## Validation
- `ocamlformat -i lib/tool_failure_recovery.ml lib/tool_failure_recovery.mli test/test_tool_failure_recovery.ml`
- `git diff --check`
- `scripts/check-sdk-independence.sh`
- `scripts/lint-pipeline-usage-ssot.sh`
- local Dune build intentionally skipped; build and test validation is delegated to PR CI