### PR TITLE
fix(gemini): preserve textual thought signatures

### DIFF
--- a/lib/context_reducer_apply.ml
+++ b/lib/context_reducer_apply.ml
@@ -1,4 +1,5 @@
 open Types
+module Provider_replay = Llm_provider.Provider_replay
 
 let group_into_turns = Context_reducer_turns.group_into_turns
 let estimate_message_tokens = Context_reducer_estimate.estimate_message_tokens
@@ -126,6 +127,21 @@ let has_reasoning_block (msg : message) =
       | Thinking _ | ReasoningDetails _ | RedactedThinking _ -> true
       | Text _ | ToolUse _ | ToolResult _ | Image _ | Document _ | Audio _ -> false)
     msg.content
+;;
+
+let is_provider_replay_carrier = function
+  | RedactedThinking data ->
+    (match Provider_replay.decode data with
+     | Provider_replay.Replay _ | Provider_replay.Malformed_replay _ -> true
+     | Provider_replay.Not_replay -> false)
+  | Text _
+  | Thinking _
+  | ReasoningDetails _
+  | ToolUse _
+  | ToolResult _
+  | Image _
+  | Document _
+  | Audio _ -> false
 ;;
 
 type dangling_repair_report = { synthesized_tool_results : int }
@@ -301,12 +317,30 @@ let apply_drop_thinking messages =
     | Thinking _ | ReasoningDetails _ | RedactedThinking _ -> preserve_reasoning
     | Text _ | ToolUse _ | ToolResult _ | Image _ | Document _ | Audio _ -> true
   in
+  let filter_content ~preserve_reasoning content =
+    let rec loop acc = function
+      | (RedactedThinking data as carrier) :: target :: rest ->
+        (match Provider_replay.decode data with
+         | Provider_replay.Replay { retention = Provider_replay.Exact_next_block; _ }
+         | Provider_replay.Malformed_replay _ -> loop (target :: carrier :: acc) rest
+         | Provider_replay.Not_replay ->
+           let acc = if preserve_reasoning then carrier :: acc else acc in
+           loop acc (target :: rest))
+      | [ (RedactedThinking _ as carrier) ] when is_provider_replay_carrier carrier ->
+        List.rev (carrier :: acc)
+      | block :: rest ->
+        let acc =
+          if keep_after_drop_thinking ~preserve_reasoning block then block :: acc else acc
+        in
+        loop acc rest
+      | [] -> List.rev acc
+    in
+    loop [] content
+  in
   List.filter_map
     (fun (msg : message) ->
        let preserve_reasoning = preserves_tool_reasoning msg in
-       let content =
-         List.filter (keep_after_drop_thinking ~preserve_reasoning) msg.content
-       in
+       let content = filter_content ~preserve_reasoning msg.content in
        if content = [] then None else Some { msg with content })
     messages
 ;;
@@ -500,12 +534,19 @@ let apply_cap_message_tokens ?cache ~max_tokens ~keep_recent messages =
             let block_tokens = Array.map (estimate_block_tokens ?cache) blocks in
             let keep = Array.make n_blocks false in
             let mandatory_tokens = ref 0 in
+            let mark_mandatory i =
+              if not keep.(i)
+              then (
+                keep.(i) <- true;
+                mandatory_tokens := !mandatory_tokens + block_tokens.(i))
+            in
             Array.iteri
               (fun i b ->
-                 if is_pair_block b
+                 if is_pair_block b then mark_mandatory i;
+                 if is_provider_replay_carrier b
                  then (
-                   keep.(i) <- true;
-                   mandatory_tokens := !mandatory_tokens + block_tokens.(i)))
+                   mark_mandatory i;
+                   if i + 1 < n_blocks then mark_mandatory (i + 1)))
               blocks;
             if !mandatory_tokens >= max_tokens
             then msg

--- a/lib/llm_provider/backend_gemini.ml
+++ b/lib/llm_provider/backend_gemini.ml
@@ -84,6 +84,22 @@ let gemini_role_of_oas = function
 ;;
 
 let gemini_thought_signature_kind = "gemini_thought_signature"
+let gemini_part_thought_signature_kind = "gemini_part_thought_signature"
+
+type gemini_part_signature_target =
+  | Gemini_text_part
+  | Gemini_thought_part
+
+let gemini_part_signature_target_to_string = function
+  | Gemini_text_part -> "text"
+  | Gemini_thought_part -> "thought"
+;;
+
+let gemini_part_signature_target_of_string = function
+  | "text" -> Some Gemini_text_part
+  | "thought" -> Some Gemini_thought_part
+  | _ -> None
+;;
 
 let string_field_opt key = function
   | `Assoc fields ->
@@ -107,6 +123,29 @@ let gemini_thought_signature_carrier ~tool_use_id ~thought_signature =
   RedactedThinking (gemini_thought_signature_payload ~tool_use_id ~thought_signature)
 ;;
 
+let gemini_part_thought_signature_payload ~target ~thought_signature =
+  Provider_replay.encode_exact_next_block
+    ~payload:
+      (`Assoc
+          [ "provider", `String "gemini"
+          ; "kind", `String gemini_part_thought_signature_kind
+          ; "target", `String (gemini_part_signature_target_to_string target)
+          ; "thoughtSignature", `String thought_signature
+          ])
+;;
+
+let gemini_part_thought_signature_carrier ~target ~thought_signature =
+  RedactedThinking (gemini_part_thought_signature_payload ~target ~thought_signature)
+;;
+
+let exact_string_field_opt key = function
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some (`String s) -> Some s
+     | Some _ | None -> None)
+  | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> None
+;;
+
 let gemini_thought_signature_of_redacted data =
   try
     let json = Yojson.Safe.from_string data in
@@ -114,15 +153,41 @@ let gemini_thought_signature_of_redacted data =
     | Some "gemini", Some kind when String.equal kind gemini_thought_signature_kind ->
       (match
          ( string_field_opt "tool_use_id" json
-         , match string_field_opt "thoughtSignature" json with
+         , match exact_string_field_opt "thoughtSignature" json with
            | Some s -> Some s
-           | None -> string_field_opt "thought_signature" json )
+           | None -> exact_string_field_opt "thought_signature" json )
        with
        | Some tool_use_id, Some thought_signature -> Some (tool_use_id, thought_signature)
        | _ -> None)
     | _ -> None
   with
   | Yojson.Json_error _ -> None
+;;
+
+type gemini_part_signature_decode =
+  | Not_gemini_part_signature
+  | Decoded_gemini_part_signature of gemini_part_signature_target * string
+  | Malformed_gemini_part_signature
+
+let decode_gemini_part_thought_signature data =
+  match Provider_replay.decode data with
+  | Provider_replay.Not_replay -> Not_gemini_part_signature
+  | Provider_replay.Malformed_replay _ -> Malformed_gemini_part_signature
+  | Provider_replay.Replay
+      { retention = Provider_replay.Exact_next_block; payload = json } ->
+    (match string_field_opt "provider" json, string_field_opt "kind" json with
+     | Some "gemini", Some kind when String.equal kind gemini_part_thought_signature_kind
+       ->
+       (match
+          ( Option.bind
+              (string_field_opt "target" json)
+              gemini_part_signature_target_of_string
+          , exact_string_field_opt "thoughtSignature" json )
+        with
+        | Some target, Some thought_signature ->
+          Decoded_gemini_part_signature (target, thought_signature)
+        | _ -> Malformed_gemini_part_signature)
+     | _ -> Malformed_gemini_part_signature)
 ;;
 
 let gemini_tool_signatures_of_blocks blocks =
@@ -220,6 +285,90 @@ let part_of_content_block id_to_name tool_signatures = function
   | RedactedThinking _ -> None
 ;;
 
+let signature_target_of_content_block = function
+  | Text _ -> Some Gemini_text_part
+  | Thinking _ -> Some Gemini_thought_part
+  | ReasoningDetails _
+  | RedactedThinking _
+  | ToolUse _
+  | ToolResult _
+  | Image _
+  | Document _
+  | Audio _ -> None
+;;
+
+let same_signature_target left right =
+  match left, right with
+  | Gemini_text_part, Gemini_text_part | Gemini_thought_part, Gemini_thought_part -> true
+  | Gemini_text_part, Gemini_thought_part | Gemini_thought_part, Gemini_text_part -> false
+;;
+
+let attach_thought_signature thought_signature = function
+  | `Assoc fields -> `Assoc (("thoughtSignature", `String thought_signature) :: fields)
+  | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null ->
+    raise
+      (Gemini_api_error
+         "Gemini part serializer produced a non-object for a thoughtSignature target")
+;;
+
+let parts_of_content_blocks id_to_name tool_signatures blocks =
+  (* Gemini requires an opaque [thoughtSignature] to be replayed on the exact
+     model part that carried it. OAS represents that otherwise-unmodeled field
+     as a [RedactedThinking] block immediately before its target. Adjacency is
+     the structural identity: if a reducer breaks it, fail the request rather
+     than attaching the signature to a different part or silently dropping it. *)
+  let malformed_carrier expected actual =
+    let actual =
+      match actual with
+      | Some target -> gemini_part_signature_target_to_string target
+      | None -> "unsupported"
+    in
+    raise
+      (Gemini_api_error
+         (Printf.sprintf
+            "Gemini thoughtSignature carrier targets %s but its adjacent content block \
+             is %s"
+            (gemini_part_signature_target_to_string expected)
+            actual))
+  in
+  let rec loop acc = function
+    | RedactedThinking data :: target_block :: rest ->
+      (match decode_gemini_part_thought_signature data with
+       | Not_gemini_part_signature -> loop acc (target_block :: rest)
+       | Malformed_gemini_part_signature ->
+         raise
+           (Gemini_api_error
+              "Malformed Gemini thoughtSignature carrier in conversation history")
+       | Decoded_gemini_part_signature (expected_target, thought_signature) ->
+         let actual_target = signature_target_of_content_block target_block in
+         (match actual_target with
+          | Some actual_target when same_signature_target expected_target actual_target ->
+            (match part_of_content_block id_to_name tool_signatures target_block with
+             | Some part ->
+               loop (attach_thought_signature thought_signature part :: acc) rest
+             | None -> malformed_carrier expected_target (Some actual_target))
+          | Some _ | None -> malformed_carrier expected_target actual_target))
+    | [ RedactedThinking data ] ->
+      (match decode_gemini_part_thought_signature data with
+       | Decoded_gemini_part_signature (expected_target, _) ->
+         malformed_carrier expected_target None
+       | Malformed_gemini_part_signature ->
+         raise
+           (Gemini_api_error
+              "Malformed Gemini thoughtSignature carrier in conversation history")
+       | Not_gemini_part_signature -> List.rev acc)
+    | block :: rest ->
+      let acc =
+        match part_of_content_block id_to_name tool_signatures block with
+        | Some part -> part :: acc
+        | None -> acc
+      in
+      loop acc rest
+    | [] -> List.rev acc
+  in
+  loop [] blocks
+;;
+
 (* ── Message list -> (contents, systemInstruction option) ── *)
 
 let contents_of_messages (messages : message list) =
@@ -236,14 +385,10 @@ let contents_of_messages (messages : message list) =
        let tool_signatures = gemini_tool_signatures_of_blocks msg.content in
        match msg.role with
        | System ->
-         let parts =
-           List.filter_map (part_of_content_block id_to_name tool_signatures) msg.content
-         in
+         let parts = parts_of_content_blocks id_to_name tool_signatures msg.content in
          system_parts := !system_parts @ parts
        | User | Assistant | Tool ->
-         let parts =
-           List.filter_map (part_of_content_block id_to_name tool_signatures) msg.content
-         in
+         let parts = parts_of_content_blocks id_to_name tool_signatures msg.content in
          if parts <> []
          then
            contents
@@ -438,12 +583,23 @@ let parse_response json =
     let content =
       List.concat_map
         (fun part ->
+           let part_thought_signature =
+             part |> member "thoughtSignature" |> to_string_option
+           in
            match part |> member "text" with
            | `String s ->
              let is_thought = Cli_common_json.member_bool "thought" part in
-             if is_thought
-             then [ Thinking { signature = None; content = s } ]
-             else [ Text s ]
+             let target, block =
+               if is_thought
+               then Gemini_thought_part, Thinking { signature = None; content = s }
+               else Gemini_text_part, Text s
+             in
+             (match part_thought_signature with
+              | Some thought_signature ->
+                [ gemini_part_thought_signature_carrier ~target ~thought_signature
+                ; block
+                ]
+              | None -> [ block ])
            | _ ->
              (match part |> member "functionCall" with
               | `Assoc _ as fc ->

--- a/lib/llm_provider/backend_gemini.mli
+++ b/lib/llm_provider/backend_gemini.mli
@@ -35,6 +35,20 @@ val gemini_thought_signature_payload
   -> thought_signature:string
   -> string
 
+(** Exact Gemini response-part kind targeted by an adjacent opaque
+    [thoughtSignature] carrier. The carrier and target stay adjacent through
+    history replay; a broken adjacency fails closed in the request builder. *)
+type gemini_part_signature_target =
+  | Gemini_text_part
+  | Gemini_thought_part
+
+(** Opaque carrier payload for a Gemini [thoughtSignature] attached to the
+    immediately following text or thought part. *)
+val gemini_part_thought_signature_payload
+  :  target:gemini_part_signature_target
+  -> thought_signature:string
+  -> string
+
 (** Extract [contents] list and optional [systemInstruction] from messages.
     Exposed for unit-testing the OAS-to-Gemini message mapping. *)
 val contents_of_messages : Types.message list -> Yojson.Safe.t list * Yojson.Safe.t option

--- a/lib/llm_provider/backend_gemini.mli
+++ b/lib/llm_provider/backend_gemini.mli
@@ -37,13 +37,15 @@ val gemini_thought_signature_payload
 
 (** Exact Gemini response-part kind targeted by an adjacent opaque
     [thoughtSignature] carrier. The carrier and target stay adjacent through
-    history replay; a broken adjacency fails closed in the request builder. *)
+    history replay; a broken adjacency fails closed in the request builder.
+    @since 0.212.0 *)
 type gemini_part_signature_target =
   | Gemini_text_part
   | Gemini_thought_part
 
 (** Opaque carrier payload for a Gemini [thoughtSignature] attached to the
-    immediately following text or thought part. *)
+    immediately following text or thought part.
+    @since 0.212.0 *)
 val gemini_part_thought_signature_payload
   :  target:gemini_part_signature_target
   -> thought_signature:string

--- a/lib/llm_provider/provider_replay.ml
+++ b/lib/llm_provider/provider_replay.ml
@@ -1,0 +1,49 @@
+type retention = Exact_next_block
+
+type t =
+  { retention : retention
+  ; payload : Yojson.Safe.t
+  }
+
+type malformed_reason =
+  | Unsupported_version
+  | Unsupported_retention
+  | Missing_payload
+
+type decoded =
+  | Not_replay
+  | Malformed_replay of malformed_reason
+  | Replay of t
+
+let schema = "oas.provider_replay"
+
+let encode_exact_next_block ~payload =
+  Yojson.Safe.to_string
+    (`Assoc
+        [ "schema", `String schema
+        ; "version", `Int 1
+        ; "retention", `String "exact_next_block"
+        ; "payload", payload
+        ])
+;;
+
+let decode data =
+  try
+    match Yojson.Safe.from_string data with
+    | `Assoc fields ->
+      (match List.assoc_opt "schema" fields with
+       | Some (`String value) when String.equal value schema ->
+         (match List.assoc_opt "version" fields with
+          | Some (`Int 1) ->
+            (match List.assoc_opt "retention" fields with
+             | Some (`String "exact_next_block") ->
+               (match List.assoc_opt "payload" fields with
+                | Some payload -> Replay { retention = Exact_next_block; payload }
+                | None -> Malformed_replay Missing_payload)
+             | Some _ | None -> Malformed_replay Unsupported_retention)
+          | Some _ | None -> Malformed_replay Unsupported_version)
+       | Some _ | None -> Not_replay)
+    | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> Not_replay
+  with
+  | Yojson.Json_error _ -> Not_replay
+;;

--- a/lib/llm_provider/provider_replay.mli
+++ b/lib/llm_provider/provider_replay.mli
@@ -1,0 +1,32 @@
+(** Typed envelope for opaque provider state whose retention semantics must
+    survive provider-neutral context reduction.
+
+    The envelope says how an opaque {!Types.RedactedThinking} payload relates
+    to neighboring content blocks without teaching reducers about individual
+    provider wire formats. *)
+
+type retention = Exact_next_block
+
+type t =
+  { retention : retention
+  ; payload : Yojson.Safe.t
+  }
+
+type malformed_reason =
+  | Unsupported_version
+  | Unsupported_retention
+  | Missing_payload
+
+type decoded =
+  | Not_replay
+  | Malformed_replay of malformed_reason
+  | Replay of t
+
+(** Wrap provider-owned JSON that must stay adjacent to the following content
+    block. *)
+val encode_exact_next_block : payload:Yojson.Safe.t -> string
+
+(** Decode only the OAS replay envelope. Arbitrary provider-owned redacted
+    payloads return [Not_replay]; a recognized but invalid envelope returns a
+    typed [Malformed_replay] result. *)
+val decode : string -> decoded

--- a/lib/llm_provider/provider_replay.mli
+++ b/lib/llm_provider/provider_replay.mli
@@ -3,7 +3,9 @@
 
     The envelope says how an opaque {!Types.RedactedThinking} payload relates
     to neighboring content blocks without teaching reducers about individual
-    provider wire formats. *)
+    provider wire formats.
+
+    @since 0.212.0 *)
 
 type retention = Exact_next_block
 
@@ -23,10 +25,12 @@ type decoded =
   | Replay of t
 
 (** Wrap provider-owned JSON that must stay adjacent to the following content
-    block. *)
+    block.
+    @since 0.212.0 *)
 val encode_exact_next_block : payload:Yojson.Safe.t -> string
 
 (** Decode only the OAS replay envelope. Arbitrary provider-owned redacted
     payloads return [Not_replay]; a recognized but invalid envelope returns a
-    typed [Malformed_replay] result. *)
+    typed [Malformed_replay] result.
+    @since 0.212.0 *)
 val decode : string -> decoded

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -1679,18 +1679,38 @@ let gemini_chunk_to_events (state : openai_stream_state) (chunk : gemini_chunk)
   List.iteri
     (fun part_index part ->
        let is_thought = Cli_common_json.member_bool "thought" part in
+       let part_thought_signature =
+         part |> member "thoughtSignature" |> to_string_option
+       in
+       let emit_signed_textual_part ~target ~content_type ~delta thought_signature =
+         (match target with
+          | Backend_gemini.Gemini_text_part -> state.text_block_started <- false
+          | Backend_gemini.Gemini_thought_part -> state.thinking_block_started <- false);
+         let carrier_index = state.next_block_index in
+         let carrier_payload =
+           Backend_gemini.gemini_part_thought_signature_payload ~target ~thought_signature
+         in
+         emit
+           (ContentBlockStart
+              { index = carrier_index
+              ; content_type = "redacted_thinking"
+              ; tool_id = Some carrier_payload
+              ; tool_name = None
+              });
+         let content_index = carrier_index + 1 in
+         emit
+           (ContentBlockStart
+              { index = content_index; content_type; tool_id = None; tool_name = None });
+         emit (ContentBlockDelta { index = content_index; delta });
+         state.next_block_index <- content_index + 1
+       in
        let emit_function_call_delta () =
          match part |> member "functionCall" with
          | `Assoc _ as fc ->
            let name = Cli_common_json.member_str "name" fc in
            let args = fc |> member "args" in
            let provider_tool_id = fc |> member "id" |> to_string_option in
-           let thought_signature =
-             match part |> member "thoughtSignature" |> to_string_option with
-             | Some signature when not (Api_common.string_is_blank signature) ->
-               Some signature
-             | Some _ | None -> None
-           in
+           let thought_signature = part_thought_signature in
            let resolution, start =
              resolve_tool_block
                state
@@ -1732,43 +1752,65 @@ let gemini_chunk_to_events (state : openai_stream_state) (chunk : gemini_chunk)
                    { index = idx; delta = InputJsonSnapshot (Yojson.Safe.to_string args) }))
          | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ -> ()
        in
+       let emit_textual_part text =
+         match part_thought_signature with
+         | Some thought_signature ->
+           if is_thought
+           then
+             emit_signed_textual_part
+               ~target:Backend_gemini.Gemini_thought_part
+               ~content_type:"thinking"
+               ~delta:(ThinkingDelta text)
+               thought_signature
+           else
+             emit_signed_textual_part
+               ~target:Backend_gemini.Gemini_text_part
+               ~content_type:"text"
+               ~delta:(TextDelta text)
+               thought_signature
+         | None when String.equal text "" -> ()
+         | None ->
+           if is_thought
+           then (
+             if not state.thinking_block_started
+             then (
+               state.thinking_block_index <- state.next_block_index;
+               emit
+                 (ContentBlockStart
+                    { index = state.next_block_index
+                    ; content_type = "thinking"
+                    ; tool_id = None
+                    ; tool_name = None
+                    });
+               state.thinking_block_started <- true;
+               state.next_block_index <- state.next_block_index + 1);
+             emit
+               (ContentBlockDelta
+                  { index = state.thinking_block_index; delta = ThinkingDelta text }))
+           else (
+             if not state.text_block_started
+             then (
+               state.text_block_index <- state.next_block_index;
+               emit
+                 (ContentBlockStart
+                    { index = state.next_block_index
+                    ; content_type = "text"
+                    ; tool_id = None
+                    ; tool_name = None
+                    });
+               state.text_block_started <- true;
+               state.next_block_index <- state.next_block_index + 1);
+             emit
+               (ContentBlockDelta
+                  { index = state.text_block_index; delta = TextDelta text }))
+       in
        match part |> member "text" |> to_string_option with
-       | Some text when text <> "" ->
-         if is_thought
-         then (
-           if not state.thinking_block_started
-           then (
-             state.thinking_block_index <- state.next_block_index;
-             emit
-               (ContentBlockStart
-                  { index = state.next_block_index
-                  ; content_type = "thinking"
-                  ; tool_id = None
-                  ; tool_name = None
-                  });
-             state.thinking_block_started <- true;
-             state.next_block_index <- state.next_block_index + 1);
-           emit
-             (ContentBlockDelta
-                { index = state.thinking_block_index; delta = ThinkingDelta text }))
-         else (
-           if not state.text_block_started
-           then (
-             state.text_block_index <- state.next_block_index;
-             emit
-               (ContentBlockStart
-                  { index = state.next_block_index
-                  ; content_type = "text"
-                  ; tool_id = None
-                  ; tool_name = None
-                  });
-             state.text_block_started <- true;
-             state.next_block_index <- state.next_block_index + 1);
-           emit
-             (ContentBlockDelta { index = state.text_block_index; delta = TextDelta text }))
+       | Some text when not (String.equal text "") -> emit_textual_part text
        | Some empty_text ->
-         let (_ : string) = empty_text in
-         emit_function_call_delta ()
+         (match part |> member "functionCall" with
+          | `Assoc _ -> emit_function_call_delta ()
+          | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ ->
+            emit_textual_part empty_text)
        | None -> emit_function_call_delta ())
     chunk.gem_parts;
   (* Finish reason *)

--- a/test/test_backend_gemini.ml
+++ b/test/test_backend_gemini.ml
@@ -515,6 +515,124 @@ let test_parse_function_call_preserves_thought_signature () =
   | _ -> fail "expected StopToolUse"
 ;;
 
+let textual_parts_with_thought_signatures_json () =
+  Yojson.Safe.from_string
+    {|{
+    "candidates": [{
+      "content": {
+        "parts": [
+          {"text": "visible", "thoughtSignature": "sig-text-123"},
+          {"thought": true, "text": "plan", "thoughtSignature": "sig-thought-456"}
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP"
+    }],
+    "modelVersion": "gemini-3.1-pro-preview"
+  }|}
+;;
+
+let check_part_signature_carrier ~target ~signature raw =
+  let carrier =
+    match Provider_replay.decode raw with
+    | Provider_replay.Replay { retention = Provider_replay.Exact_next_block; payload } ->
+      payload
+    | Provider_replay.Not_replay | Provider_replay.Malformed_replay _ ->
+      fail "expected an exact-next-block provider replay envelope"
+  in
+  check string "carrier provider" "gemini" (carrier |> member "provider" |> to_string);
+  check
+    string
+    "carrier kind"
+    "gemini_part_thought_signature"
+    (carrier |> member "kind" |> to_string);
+  check string "carrier target" target (carrier |> member "target" |> to_string);
+  check
+    string
+    "carrier thoughtSignature"
+    signature
+    (carrier |> member "thoughtSignature" |> to_string)
+;;
+
+let test_textual_part_thought_signatures_roundtrip () =
+  let parsed =
+    Backend_gemini.parse_response (textual_parts_with_thought_signatures_json ())
+  in
+  (match parsed.content with
+   | [ Types.RedactedThinking text_carrier
+     ; Types.Text "visible"
+     ; Types.RedactedThinking thought_carrier
+     ; Types.Thinking { content = "plan"; signature = None }
+     ] ->
+     check_part_signature_carrier ~target:"text" ~signature:"sig-text-123" text_carrier;
+     check_part_signature_carrier
+       ~target:"thought"
+       ~signature:"sig-thought-456"
+       thought_carrier
+   | _ -> fail "expected exact carriers adjacent to text and thought parts");
+  let messages =
+    [ Types.user_msg "Continue."
+    ; { Types.role = Assistant
+      ; content = parsed.content
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = []
+      }
+    ]
+  in
+  let body = Backend_gemini.build_request ~config:(gemini_config ()) ~messages () in
+  let parts =
+    parse_body body
+    |> member "contents"
+    |> to_list
+    |> List.nth 1
+    |> member "parts"
+    |> to_list
+  in
+  match parts with
+  | [ text_part; thought_part ] ->
+    check string "text" "visible" (text_part |> member "text" |> to_string);
+    check
+      string
+      "text thoughtSignature"
+      "sig-text-123"
+      (text_part |> member "thoughtSignature" |> to_string);
+    check bool "thought marker" true (thought_part |> member "thought" |> to_bool);
+    check string "thought text" "plan" (thought_part |> member "text" |> to_string);
+    check
+      string
+      "thought thoughtSignature"
+      "sig-thought-456"
+      (thought_part |> member "thoughtSignature" |> to_string)
+  | _ -> fail "expected two replayed Gemini parts"
+;;
+
+let test_textual_part_signature_broken_adjacency_fails_closed () =
+  let carrier =
+    Backend_gemini.gemini_part_thought_signature_payload
+      ~target:Backend_gemini.Gemini_text_part
+      ~thought_signature:"sig-text-broken"
+  in
+  let messages =
+    [ { Types.role = Assistant
+      ; content =
+          [ Types.RedactedThinking carrier
+          ; Types.Thinking { content = "wrong target"; signature = None }
+          ]
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = []
+      }
+    ]
+  in
+  check_raises
+    "broken carrier adjacency"
+    (Backend_gemini.Gemini_api_error
+       "Gemini thoughtSignature carrier targets text but its adjacent content block is \
+        thought")
+    (fun () -> ignore (Backend_gemini.contents_of_messages messages))
+;;
+
 let test_thought_signature_roundtrip_request () =
   let parsed =
     Backend_gemini.parse_response (function_call_with_thought_signature_json ())
@@ -1110,6 +1228,76 @@ let test_gemini_stream_function_call_preserves_thought_signature () =
      | _ -> fail "expected redacted carrier, tool_use, delta, and terminal event")
 ;;
 
+let test_gemini_stream_textual_parts_preserve_thought_signatures () =
+  let state = Streaming.create_openai_stream_state () in
+  let data =
+    {|{
+    "candidates": [{
+      "content": {
+        "parts": [
+          {"text": "visible", "thoughtSignature": "sig-stream-text"},
+          {"thought": true, "text": "plan", "thoughtSignature": "sig-stream-thought"}
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP"
+    }]
+  }|}
+  in
+  match Streaming.parse_gemini_sse_chunk data with
+  | None -> fail "expected Some chunk"
+  | Some chunk ->
+    let events, _tel = Streaming.gemini_chunk_to_events state chunk in
+    (match events with
+     | [ ContentBlockStart
+           { index = 0
+           ; content_type = "redacted_thinking"
+           ; tool_id = Some text_carrier
+           ; _
+           }
+       ; ContentBlockStart { index = 1; content_type = "text"; _ }
+       ; ContentBlockDelta { index = 1; delta = TextDelta "visible" }
+       ; ContentBlockStart
+           { index = 2
+           ; content_type = "redacted_thinking"
+           ; tool_id = Some thought_carrier
+           ; _
+           }
+       ; ContentBlockStart { index = 3; content_type = "thinking"; _ }
+       ; ContentBlockDelta { index = 3; delta = ThinkingDelta "plan" }
+       ; MessageDelta { stop_reason = Some EndTurn; _ }
+       ] ->
+       check_part_signature_carrier
+         ~target:"text"
+         ~signature:"sig-stream-text"
+         text_carrier;
+       check_part_signature_carrier
+         ~target:"thought"
+         ~signature:"sig-stream-thought"
+         thought_carrier
+     | _ -> fail "expected signed text and thought event pairs");
+    let acc = Complete_stream_acc.create_stream_acc () in
+    List.iter (Complete_stream_acc.accumulate_event acc) events;
+    (match Complete_stream_acc.finalize_stream_acc acc with
+     | Error _ -> fail "expected finalized signed textual response"
+     | Ok response ->
+       (match response.content with
+        | [ RedactedThinking text_carrier
+          ; Text "visible"
+          ; RedactedThinking thought_carrier
+          ; Thinking { content = "plan"; signature = None }
+          ] ->
+          check_part_signature_carrier
+            ~target:"text"
+            ~signature:"sig-stream-text"
+            text_carrier;
+          check_part_signature_carrier
+            ~target:"thought"
+            ~signature:"sig-stream-thought"
+            thought_carrier
+        | _ -> fail "expected finalized signed text and thought blocks"))
+;;
+
 let parse_gemini_chunk_exn data =
   match Streaming.parse_gemini_sse_chunk data with
   | Some chunk -> chunk
@@ -1250,6 +1438,14 @@ let () =
             "thought signature roundtrip"
             `Quick
             test_thought_signature_roundtrip_request
+        ; test_case
+            "textual part thought signatures roundtrip"
+            `Quick
+            test_textual_part_thought_signatures_roundtrip
+        ; test_case
+            "textual part signature broken adjacency"
+            `Quick
+            test_textual_part_signature_broken_adjacency_fails_closed
         ] )
     ; ( "parse_response"
       , [ test_case "text" `Quick test_parse_text_response
@@ -1293,6 +1489,10 @@ let () =
             "function call thought signature"
             `Quick
             test_gemini_stream_function_call_preserves_thought_signature
+        ; test_case
+            "textual part thought signatures"
+            `Quick
+            test_gemini_stream_textual_parts_preserve_thought_signatures
         ; test_case
             "interleaved thinking/tool/text finalizes"
             `Quick

--- a/test/test_context_reducer.ml
+++ b/test/test_context_reducer.ml
@@ -445,6 +445,10 @@ let test_importance_scored_boost_preserves_message () =
 
 (* --- cap_message_tokens pair preservation --- *)
 
+let replay_carrier payload =
+  Types.RedactedThinking (Llm_provider.Provider_replay.encode_exact_next_block ~payload)
+;;
+
 (* Build an assistant message with mixed Text/ToolUse blocks.
    Text blocks are each ~4*len characters to force truncation. *)
 let big_text_block () = Types.Text (String.make 1000 'x')
@@ -622,6 +626,36 @@ let test_cap_mandatory_overflow_returns_as_is () =
   in
   let asst = List.nth result 1 in
   Alcotest.(check int) "untouched when mandatory overflows" 1 (List.length asst.content)
+;;
+
+let test_cap_preserves_exact_replay_pair () =
+  let carrier = replay_carrier (`Assoc [ "provider_state", `String "opaque" ]) in
+  let msgs =
+    [ user_msg "q"
+    ; Types.
+        { role = Assistant
+        ; content =
+            [ big_text_block (); carrier; Text "signed target"; big_text_block () ]
+        ; name = None
+        ; tool_call_id = None
+        ; metadata = []
+        }
+    ; user_msg "recent"
+    ; asst_msg "answer"
+    ]
+  in
+  let result =
+    Context_reducer.reduce
+      (Context_reducer.cap_message_tokens ~max_tokens:100 ~keep_recent:1)
+      msgs
+  in
+  let capped = List.nth result 1 in
+  let rec has_exact_pair = function
+    | replayed_carrier :: Types.Text "signed target" :: _ -> replayed_carrier = carrier
+    | _ :: rest -> has_exact_pair rest
+    | [] -> false
+  in
+  Alcotest.(check bool) "exact replay pair preserved" true (has_exact_pair capped.content)
 ;;
 
 (* --- from_context_config cache path --- *)
@@ -879,6 +913,40 @@ let test_drop_thinking_preserves_signed_tool_use_thinking () =
     in
     Alcotest.(check bool) "signed thinking preserved" true has_signed_thinking;
     Alcotest.(check bool) "tool use preserved" true has_tool_use
+;;
+
+let test_drop_thinking_preserves_exact_replay_pair () =
+  let carrier = replay_carrier (`Assoc [ "provider_state", `String "opaque" ]) in
+  let msgs =
+    [ user_msg "q"
+    ; Types.
+        { role = Assistant
+        ; content =
+            [ Thinking { signature = None; content = "drop me" }
+            ; carrier
+            ; Thinking { signature = None; content = "signed target" }
+            ; Text "answer"
+            ]
+        ; name = None
+        ; tool_call_id = None
+        ; metadata = []
+        }
+    ]
+  in
+  let result = Context_reducer.reduce Context_reducer.drop_thinking msgs in
+  match List.nth result 1 with
+  | { Types.content =
+        [ replayed_carrier
+        ; Types.Thinking { signature = None; content = "signed target" }
+        ; Types.Text "answer"
+        ]
+    ; _
+    } ->
+    Alcotest.(check bool)
+      "exact replay carrier preserved"
+      true
+      (replayed_carrier = carrier)
+  | _ -> Alcotest.fail "expected only the exact replay pair and visible answer"
 ;;
 
 let test_preserve_thinking_removes_summarize_old () =
@@ -1757,6 +1825,10 @@ let () =
             `Quick
             test_drop_thinking_preserves_signed_tool_use_thinking
         ; Alcotest.test_case
+            "preserves exact provider replay pair"
+            `Quick
+            test_drop_thinking_preserves_exact_replay_pair
+        ; Alcotest.test_case
             "preserve_thinking removes summarize_old"
             `Quick
             test_preserve_thinking_removes_summarize_old
@@ -1881,6 +1953,10 @@ let () =
             "mandatory exceeds budget returns as-is"
             `Quick
             test_cap_mandatory_overflow_returns_as_is
+        ; Alcotest.test_case
+            "exact provider replay pair never splits"
+            `Quick
+            test_cap_preserves_exact_replay_pair
         ] )
     ; ( "edge_cases"
       , [ Alcotest.test_case "empty messages" `Quick test_empty


### PR DESCRIPTION
## Summary
- add a provider-neutral typed replay envelope for opaque state that must remain adjacent to its target block
- preserve exact replay pairs through drop_thinking and per-message token capping
- retain and replay Gemini thoughtSignature fields on text and thought parts in sync and streaming responses
- fail closed when an exact-part carrier is malformed or loses adjacency

## Why
Gemini can attach thoughtSignature to non-function-call response parts. The native backend previously retained signatures only for functionCall parts, and context reduction could independently remove opaque replay state.

## Validation
- ocamlc parse checks for every changed ML/MLI file
- ocamlformat --check
- git diff --check
- focused Dune build/tests intentionally delegated to PR CI per repository workflow

## Evidence
Official Gemini thought-signature contract: https://ai.google.dev/gemini-api/docs/generate-content/thought-signatures