### PR TITLE
fix(events): redact recovery control payloads

### DIFF
--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -354,6 +354,9 @@ let invoke_recovery_judge ~sw ?clock agent episodes =
          (Event_bus.ToolFailureRecoveryJudgeFailed
             { agent_name = agent.state.config.name
             ; turn = agent.state.turn_count
+            ; kind =
+                Tool_failure_recovery.judge_error_kind
+                  (Tool_failure_recovery.Completion_failed error)
             ; detail
             });
        Error (recovery_failure Error.Judge_response detail)
@@ -364,6 +367,7 @@ let invoke_recovery_judge ~sw ?clock agent episodes =
          (Event_bus.ToolFailureRecoveryJudgeFailed
             { agent_name = agent.state.config.name
             ; turn = agent.state.turn_count
+            ; kind = Tool_failure_recovery.judge_error_kind error
             ; detail
             });
        Error (recovery_failure Error.Judge_response detail)

--- a/lib/event_bus.ml
+++ b/lib/event_bus.ml
@@ -71,6 +71,7 @@ type payload =
   | ToolFailureRecoveryJudgeFailed of
       { agent_name : string
       ; turn : int
+      ; kind : Tool_failure_recovery.judge_error_kind
       ; detail : string
       }
   | TurnStarted of

--- a/lib/event_bus.mli
+++ b/lib/event_bus.mli
@@ -106,6 +106,7 @@ type payload =
   | ToolFailureRecoveryJudgeFailed of
       { agent_name : string
       ; turn : int
+      ; kind : Tool_failure_recovery.judge_error_kind
       ; detail : string
       }
   | TurnStarted of

--- a/lib/event_forward.ml
+++ b/lib/event_forward.ml
@@ -159,6 +159,8 @@ let event_to_payload (event : Event_bus.event) : event_payload =
       `Assoc
         [ "agent_name", `String r.agent_name
         ; "turn", `Int r.turn
+        ; ( "failure_kind"
+          , `String (Tool_failure_recovery.judge_error_kind_to_string r.kind) )
         ; "detail_redacted", `Bool true
         ]
     | TurnStarted r -> `Assoc [ "agent_name", `String r.agent_name; "turn", `Int r.turn ]

--- a/lib/event_forward.ml
+++ b/lib/event_forward.ml
@@ -146,19 +146,20 @@ let event_to_payload (event : Event_bus.event) : event_payload =
       `Assoc
         [ "agent_name", `String r.agent_name
         ; "turn", `Int r.turn
-        ; "episodes", `List (List.map Tool_failure_episode.to_yojson r.episodes)
+        ; ( "episodes"
+          , `List (List.map Tool_failure_episode.observation_to_yojson r.episodes) )
         ]
     | ToolFailureRecoveryDecided r ->
       `Assoc
         [ "agent_name", `String r.agent_name
         ; "turn", `Int r.turn
-        ; "decision", Tool_failure_recovery.decision_to_yojson r.decision
+        ; "decision", Tool_failure_recovery.decision_observation_to_yojson r.decision
         ]
     | ToolFailureRecoveryJudgeFailed r ->
       `Assoc
         [ "agent_name", `String r.agent_name
         ; "turn", `Int r.turn
-        ; "detail", `String r.detail
+        ; "detail_redacted", `Bool true
         ]
     | TurnStarted r -> `Assoc [ "agent_name", `String r.agent_name; "turn", `Int r.turn ]
     | TurnReady r ->

--- a/lib/tool_failure_episode.ml
+++ b/lib/tool_failure_episode.ml
@@ -271,6 +271,21 @@ let failure_key (attempt : failed_attempt) =
   attempt.tool_name, attempt.failure_kind, attempt.error_class
 ;;
 
+let observation_to_yojson (episode : t) =
+  let error_class =
+    match episode.current.error_class with
+    | Some value -> tool_error_class_to_yojson value
+    | None -> `Null
+  in
+  `Assoc
+    [ "previous_tool_use_id", `String episode.previous.tool_use_id
+    ; "current_tool_use_id", `String episode.current.tool_use_id
+    ; "tool_name", `String episode.current.tool_name
+    ; "failure_kind", tool_failure_kind_to_yojson episode.current.failure_kind
+    ; "error_class", error_class
+    ]
+;;
+
 let failure_groups round =
   List.fold_left
     (fun groups attempt ->

--- a/lib/tool_failure_episode.mli
+++ b/lib/tool_failure_episode.mli
@@ -100,3 +100,8 @@ val latest_completed_rounds
     A signature occurring more than once in either round cannot be paired
     without guessing and returns [Ambiguous_failure_signature]. *)
 val detect : previous:completed_round -> current:completed_round -> (t list, error) result
+
+(** External-observability projection. Includes stable tool identities and
+    typed failure classification, but never tool inputs or error text.
+    @since 0.212.0 *)
+val observation_to_yojson : t -> Yojson.Safe.t

--- a/lib/tool_failure_recovery.ml
+++ b/lib/tool_failure_recovery.ml
@@ -441,7 +441,7 @@ let decision_observation_to_yojson = function
   | Retry_modified calls ->
     let tool_names =
       calls
-      |> List.map (fun call -> call.tool_name)
+      |> List.map (fun (call : revised_call) -> call.tool_name)
       |> List.sort_uniq String.compare
       |> List.map (fun tool_name -> `String tool_name)
     in

--- a/lib/tool_failure_recovery.ml
+++ b/lib/tool_failure_recovery.ml
@@ -58,6 +58,23 @@ type judge_error =
   | Completion_raised of string
   | Invalid_response of response_error
 
+type judge_error_kind =
+  | Provider_call_failed
+  | Callback_raised
+  | Invalid_judge_response
+
+let judge_error_kind = function
+  | Completion_failed _ -> Provider_call_failed
+  | Completion_raised _ -> Callback_raised
+  | Invalid_response _ -> Invalid_judge_response
+;;
+
+let judge_error_kind_to_string = function
+  | Provider_call_failed -> "provider_call_failed"
+  | Callback_raised -> "callback_raised"
+  | Invalid_judge_response -> "invalid_judge_response"
+;;
+
 let judge_error_to_string = function
   | Completion_failed error ->
     Printf.sprintf "tool failure recovery LLM call failed: %s" (Error.to_string error)

--- a/lib/tool_failure_recovery.ml
+++ b/lib/tool_failure_recovery.ml
@@ -437,6 +437,24 @@ let decision_json = function
 
 let decision_to_yojson = decision_json
 
+let decision_observation_to_yojson = function
+  | Retry_modified calls ->
+    let tool_names =
+      calls
+      |> List.map (fun call -> call.tool_name)
+      |> List.sort_uniq String.compare
+      |> List.map (fun tool_name -> `String tool_name)
+    in
+    `Assoc
+      [ "action", `String "retry_modified"
+      ; "call_count", `Int (List.length calls)
+      ; "tool_names", `List tool_names
+      ]
+  | Replan _ -> `Assoc [ "action", `String "replan" ]
+  | Ask_user _ -> `Assoc [ "action", `String "ask_user" ]
+  | Defer _ -> `Assoc [ "action", `String "defer" ]
+;;
+
 let episode_ref_json episode =
   `Assoc
     [ "previous_tool_use_id", `String episode.previous_tool_use_id

--- a/lib/tool_failure_recovery.mli
+++ b/lib/tool_failure_recovery.mli
@@ -32,6 +32,12 @@ type decision = private
     cannot bypass episode validation to construct a [decision]. *)
 val decision_to_yojson : decision -> Yojson.Safe.t
 
+(** External-observability projection of a decision. Reports only the closed
+    action and non-sensitive cardinality/tool-name metadata; revised inputs,
+    instructions, questions, schemas, and defer reasons remain internal.
+    @since 0.212.0 *)
+val decision_observation_to_yojson : decision -> Yojson.Safe.t
+
 type model_request =
   { system_prompt : string
   ; user_prompt : string

--- a/lib/tool_failure_recovery.mli
+++ b/lib/tool_failure_recovery.mli
@@ -86,6 +86,13 @@ type judge_error =
   | Completion_raised of string
   | Invalid_response of response_error
 
+type judge_error_kind =
+  | Provider_call_failed
+  | Callback_raised
+  | Invalid_judge_response
+
+val judge_error_kind : judge_error -> judge_error_kind
+val judge_error_kind_to_string : judge_error_kind -> string
 val judge_error_to_string : judge_error -> string
 
 (** Invoke the configured LLM once, parse its exact JSON object, and validate

--- a/test/test_event_forward.ml
+++ b/test/test_event_forward.ml
@@ -332,17 +332,18 @@ let test_recovery_episode_payload_omits_input_and_error () =
          (Event_bus.ToolFailureEpisodeDetected
             { agent_name = "keeper"; turn = 3; episodes = [ episode ] }))
   in
-  let rendered = Yojson.Safe.to_string payload.data in
-  Alcotest.(check bool)
-    "tool input omitted"
-    false
-    (Util.string_contains ~needle:secret rendered);
-  Alcotest.(check bool)
-    "error text omitted"
-    false
-    (Util.string_contains ~needle:error_secret rendered);
   let open Yojson.Safe.Util in
   let observation = payload.data |> member "episodes" |> to_list |> List.hd in
+  let field_names = observation |> to_assoc |> List.map fst |> List.sort String.compare in
+  Alcotest.(check (list string))
+    "only the closed observation fields are forwarded"
+    [ "current_tool_use_id"
+    ; "error_class"
+    ; "failure_kind"
+    ; "previous_tool_use_id"
+    ; "tool_name"
+    ]
+    field_names;
   Alcotest.(check string)
     "typed tool name retained"
     "Execute"
@@ -355,13 +356,24 @@ let test_recovery_judge_failure_payload_redacts_detail () =
     Event_forward.event_to_payload
       (ev
          (Event_bus.ToolFailureRecoveryJudgeFailed
-            { agent_name = "keeper"; turn = 3; detail = secret }))
+            { agent_name = "keeper"
+            ; turn = 3
+            ; kind = Tool_failure_recovery.Callback_raised
+            ; detail = secret
+            }))
   in
-  let rendered = Yojson.Safe.to_string payload.data in
-  Alcotest.(check bool)
-    "judge detail omitted"
-    false
-    (Util.string_contains ~needle:secret rendered);
+  let open Yojson.Safe.Util in
+  let field_names =
+    payload.data |> to_assoc |> List.map fst |> List.sort String.compare
+  in
+  Alcotest.(check (list string))
+    "judge detail is absent while typed classification remains"
+    [ "agent_name"; "detail_redacted"; "failure_kind"; "turn" ]
+    field_names;
+  Alcotest.(check string)
+    "typed failure kind"
+    "callback_raised"
+    (payload.data |> member "failure_kind" |> to_string);
   Alcotest.(check bool)
     "redaction explicit"
     true

--- a/test/test_event_forward.ml
+++ b/test/test_event_forward.ml
@@ -300,6 +300,74 @@ let test_tool_events_payload () =
     (p2.data |> member "tool_use_id" |> to_string)
 ;;
 
+let failed_attempt ~tool_use_id ~input ~error : Tool_failure_episode.failed_attempt =
+  { tool_use_id
+  ; tool_name = "Execute"
+  ; input
+  ; failure_kind = Recoverable_tool_error
+  ; error_class = Some Deterministic
+  ; error
+  }
+;;
+
+let test_recovery_episode_payload_omits_input_and_error () =
+  let secret = "secret-tool-argument" in
+  let error_secret = "secret-provider-error" in
+  let episode : Tool_failure_episode.t =
+    { previous =
+        failed_attempt
+          ~tool_use_id:"previous-call"
+          ~input:(`Assoc [ "token", `String secret ])
+          ~error:error_secret
+    ; current =
+        failed_attempt
+          ~tool_use_id:"current-call"
+          ~input:(`Assoc [ "token", `String secret ])
+          ~error:error_secret
+    }
+  in
+  let payload =
+    Event_forward.event_to_payload
+      (ev
+         (Event_bus.ToolFailureEpisodeDetected
+            { agent_name = "keeper"; turn = 3; episodes = [ episode ] }))
+  in
+  let rendered = Yojson.Safe.to_string payload.data in
+  Alcotest.(check bool)
+    "tool input omitted"
+    false
+    (Util.string_contains ~needle:secret rendered);
+  Alcotest.(check bool)
+    "error text omitted"
+    false
+    (Util.string_contains ~needle:error_secret rendered);
+  let open Yojson.Safe.Util in
+  let observation = payload.data |> member "episodes" |> to_list |> List.hd in
+  Alcotest.(check string)
+    "typed tool name retained"
+    "Execute"
+    (observation |> member "tool_name" |> to_string)
+;;
+
+let test_recovery_judge_failure_payload_redacts_detail () =
+  let secret = "secret-judge-error" in
+  let payload =
+    Event_forward.event_to_payload
+      (ev
+         (Event_bus.ToolFailureRecoveryJudgeFailed
+            { agent_name = "keeper"; turn = 3; detail = secret }))
+  in
+  let rendered = Yojson.Safe.to_string payload.data in
+  Alcotest.(check bool)
+    "judge detail omitted"
+    false
+    (Util.string_contains ~needle:secret rendered);
+  Alcotest.(check bool)
+    "redaction explicit"
+    true
+    Yojson.Safe.Util.(payload.data |> member "detail_redacted" |> to_bool)
+;;
+
 let test_native_telemetry_payloads () =
   let replacement =
     ev
@@ -597,6 +665,14 @@ let () =
         ; Alcotest.test_case "payload_to_json" `Quick test_payload_to_json
         ; Alcotest.test_case "agent_completed" `Quick test_agent_completed_payload
         ; Alcotest.test_case "tool events" `Quick test_tool_events_payload
+        ; Alcotest.test_case
+            "recovery episode safe projection"
+            `Quick
+            test_recovery_episode_payload_omits_input_and_error
+        ; Alcotest.test_case
+            "recovery judge failure safe projection"
+            `Quick
+            test_recovery_judge_failure_payload_redacts_detail
         ; Alcotest.test_case "native telemetry" `Quick test_native_telemetry_payloads
         ; Alcotest.test_case
             "inference_telemetry full"

--- a/test/test_tool_failure_recovery.ml
+++ b/test/test_tool_failure_recovery.ml
@@ -718,23 +718,22 @@ let test_decision_observation_omits_revised_input () =
   @@ fun _env ->
   Eio.Switch.run
   @@ fun sw ->
-  let secret = "secret-revised-input" in
   match
     decide_fixture
       sw
-      (Printf.sprintf
-         {|{"action":"retry_modified","revised_calls":[{"current_tool_use_id":"c1","tool_name":"Execute","revised_input":{"cmd":"%s"}}]}|}
-         secret)
+      {|{"action":"retry_modified","revised_calls":[{"current_tool_use_id":"c1","tool_name":"Execute","revised_input":{"cmd":"private"}}]}|}
   with
   | Error error -> Alcotest.fail (Tool_failure_recovery.judge_error_to_string error)
   | Ok decision ->
     let observation = Tool_failure_recovery.decision_observation_to_yojson decision in
-    let rendered = Yojson.Safe.to_string observation in
-    Alcotest.(check bool)
-      "revised input omitted"
-      false
-      (Util.string_contains ~needle:secret rendered);
     let open Yojson.Safe.Util in
+    let field_names =
+      observation |> to_assoc |> List.map fst |> List.sort String.compare
+    in
+    Alcotest.(check (list string))
+      "only the closed decision observation fields are emitted"
+      [ "action"; "call_count"; "tool_names" ]
+      field_names;
     Alcotest.(check string)
       "action retained"
       "retry_modified"

--- a/test/test_tool_failure_recovery.ml
+++ b/test/test_tool_failure_recovery.ml
@@ -713,6 +713,38 @@ let test_response_rejects_duplicate_field () =
        ^ Tool_failure_recovery.show_decision decision)
 ;;
 
+let test_decision_observation_omits_revised_input () =
+  Eio_main.run
+  @@ fun _env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let secret = "secret-revised-input" in
+  match
+    decide_fixture
+      sw
+      (Printf.sprintf
+         {|{"action":"retry_modified","revised_calls":[{"current_tool_use_id":"c1","tool_name":"Execute","revised_input":{"cmd":"%s"}}]}|}
+         secret)
+  with
+  | Error error -> Alcotest.fail (Tool_failure_recovery.judge_error_to_string error)
+  | Ok decision ->
+    let observation = Tool_failure_recovery.decision_observation_to_yojson decision in
+    let rendered = Yojson.Safe.to_string observation in
+    Alcotest.(check bool)
+      "revised input omitted"
+      false
+      (Util.string_contains ~needle:secret rendered);
+    let open Yojson.Safe.Util in
+    Alcotest.(check string)
+      "action retained"
+      "retry_modified"
+      (observation |> member "action" |> to_string);
+    Alcotest.(check int)
+      "call count retained"
+      1
+      (observation |> member "call_count" |> to_int)
+;;
+
 let () =
   Alcotest.run
     "tool_failure_recovery"
@@ -775,6 +807,10 @@ let () =
             "duplicate response field is rejected"
             `Quick
             test_response_rejects_duplicate_field
+        ; Alcotest.test_case
+            "decision observation omits revised input"
+            `Quick
+            test_decision_observation_omits_revised_input
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- project repeated-failure episodes to typed tool identity/classification fields without tool input or error text
- project recovery decisions to action/count/tool-name metadata without revised inputs, instructions, questions, schemas, or defer reasons
- keep judge failure detail on the internal event bus while making external redaction explicit

## Boundary
Internal OAS events retain diagnostic data. Event_forward targets receive only the stable observability projection.

## Validation
- OCaml parser checks for changed ML/MLI and tests
- ocamlformat --check
- git diff --check
- focused Dune build/tests delegated to PR CI per repository workflow