### PR TITLE
fix(test): repair main-red gemini List.nth compile error

### DIFF
--- a/test/test_backend_gemini.ml
+++ b/test/test_backend_gemini.ml
@@ -579,14 +579,8 @@ let test_textual_part_thought_signatures_roundtrip () =
     ]
   in
   let body = Backend_gemini.build_request ~config:(gemini_config ()) ~messages () in
-  let parts =
-    parse_body body
-    |> member "contents"
-    |> to_list
-    |> List.nth 1
-    |> member "parts"
-    |> to_list
-  in
+  let contents = parse_body body |> member "contents" |> to_list in
+  let parts = List.nth contents 1 |> member "parts" |> to_list in
   match parts with
   | [ text_part; thought_part ] ->
     check string "text" "visible" (text_part |> member "text" |> to_string);


### PR DESCRIPTION
## 요약

`main`(`e7518197f`)이 red 상태예용. #2554가 CI FAILURE인 채로 auto-merge되면서 `test/test_backend_gemini.ml:586`의 컴파일 에러가 그대로 들어왔어용.

## 근본 원인

```ocaml
|> to_list
|> List.nth 1   (* xs |> List.nth 1  ==  List.nth 1 xs → 1이 list 인자로 바인딩 *)
```

`List.nth : 'a list -> int -> 'a`. 파이프가 리스트를 첫 인자로 넣는데 그 자리에 이미 `1`이 있어서, 상수 `1`이 list 타입으로 검사돼용. `warn-error +a`라 빌드가 깨져용.

## 수정

파일의 지배적 관례(`List.nth contents 1`, 260/267/676행)에 맞춰 contents를 먼저 바인딩하고 올바른 인자 순서로 인덱싱해용. 동작은 동일 — index 1(assistant 메시지)의 parts를 검증.

## 검증

- 로컬 dune 빌드 대신 CI(Build & Test 5.4.1 / 5.5.0)로 확인해용.

## 우선순위

- **P0**: main 빌드 복구. green 확인 후 즉시 머지 필요.
- 재발 방지(별건): 공유 계정 auto-merge가 CI green을 기다리지 않아 red PR이 머지됨 — process 결함.
