### PR TITLE
fix(agent): reject duplicate checkpoint provenance

### DIFF
--- a/lib/checkpoint_codec.ml
+++ b/lib/checkpoint_codec.ml
@@ -106,11 +106,22 @@ let checkpoint_content_block_to_json block =
          (Yojson.Safe.to_string non_object))
 ;;
 
-let optional_typed_field ~field ~type_name ~decode json =
-  let open Yojson.Safe.Util in
-  match json |> member field with
-  | `Null -> Ok None
-  | value ->
+let unique_optional_field ~field fields =
+  match List.filter_map (fun (name, value) -> if String.equal name field then Some value else None) fields with
+  | [] -> Ok None
+  | [ value ] -> Ok (Some value)
+  | _ ->
+    Error
+      (Error.Serialization
+         (JsonParseError
+            { detail = Printf.sprintf "Checkpoint ToolResult duplicates field %s" field }))
+;;
+
+let optional_typed_field ~field ~type_name ~decode fields =
+  let* value = unique_optional_field ~field fields in
+  match value with
+  | None -> Ok None
+  | Some value ->
     decode value
     |> Result.map Option.some
     |> Result.map_error (fun detail ->
@@ -125,6 +136,20 @@ let optional_typed_field ~field ~type_name ~decode json =
            }))
 ;;
 
+let tool_result_fields json =
+  match json with
+  | `Assoc fields -> Ok fields
+  | non_object ->
+    Error
+      (Error.Serialization
+         (JsonParseError
+            { detail =
+                Printf.sprintf
+                  "Checkpoint ToolResult must be an object, got %s"
+                  (Yojson.Safe.to_string non_object)
+            }))
+;;
+
 let content_block_of_json_strict json =
   try
     match Api.content_block_of_json json with
@@ -136,18 +161,19 @@ let content_block_of_json_strict json =
            ; json = parsed_json
            ; content_blocks
            }) ->
+      let* fields = tool_result_fields json in
       let* failure_kind =
         optional_typed_field
           ~field:"failure_kind"
           ~type_name:"tool_failure_kind"
           ~decode:Types.tool_failure_kind_of_yojson
-          json
+          fields
       and* error_class =
         optional_typed_field
           ~field:"error_class"
           ~type_name:"tool_error_class"
           ~decode:Types.tool_error_class_of_yojson
-          json
+          fields
       in
       let* outcome =
         match wire_outcome, failure_kind, error_class with

--- a/test/test_checkpoint.ml
+++ b/test/test_checkpoint.ml
@@ -395,6 +395,32 @@ let () =
               "rejected"
               true
               (Result.is_error (Checkpoint.of_json checkpoint_json)))
+        ; test_case "duplicate failure_kind is rejected" `Quick (fun () ->
+            let checkpoint_json =
+              checkpoint_json_with_tool_result
+                ~extra_fields:
+                  [ ( "failure_kind"
+                    , Types.tool_failure_kind_to_yojson Types.Validation_error )
+                  ; ( "failure_kind"
+                    , Types.tool_failure_kind_to_yojson Types.Recoverable_tool_error )
+                  ]
+                Types.Legacy_unclassified_failure
+            in
+            check bool "rejected" true (Result.is_error (Checkpoint.of_json checkpoint_json)))
+        ; test_case "duplicate error_class is rejected" `Quick (fun () ->
+            let checkpoint_json =
+              checkpoint_json_with_tool_result
+                ~extra_fields:
+                  [ ( "failure_kind"
+                    , Types.tool_failure_kind_to_yojson Types.Validation_error )
+                  ; ( "error_class"
+                    , Types.tool_error_class_to_yojson Types.Deterministic )
+                  ; ( "error_class"
+                    , Types.tool_error_class_to_yojson Types.Transient )
+                  ]
+                Types.Legacy_unclassified_failure
+            in
+            check bool "rejected" true (Result.is_error (Checkpoint.of_json checkpoint_json)))
         ; test_case "empty messages roundtrip" `Quick (fun () ->
             let cp = make_checkpoint ~messages:[] () in
             let cp2 = Result.get_ok (Checkpoint.of_json (Checkpoint.to_json cp)) in


### PR DESCRIPTION
## 변경

checkpoint ToolResult의 `failure_kind`와 `error_class` 중복 키를 fail-closed로 거부해용.

- 중복 provenance는 typed `JsonParseError`로 반환해용.
- 상충하는 중복 failure kind와 error class 회귀 테스트를 추가했어용.

기존 #2551은 GitHub가 삭제됐던 head ref의 이전 SHA를 계속 고정해 새 커밋을 받지 못해, 이 PR로 CI 검증을 이어가요.