### PR TITLE
fix(gemini): harden thought-signature replay boundaries

### DIFF
--- a/lib/llm_provider/backend_gemini.ml
+++ b/lib/llm_provider/backend_gemini.ml
@@ -151,6 +151,18 @@ let exact_string_field_opt key = function
   | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> None
 ;;
 
+let thought_signature_of_part = function
+  | `Assoc fields ->
+    (match List.assoc_opt "thoughtSignature" fields with
+     | None | Some `Null -> None
+     | Some (`String value) when not (Api_common.string_is_blank value) -> Some value
+     | Some (`String _) ->
+       raise (Gemini_api_error "Gemini response contains a blank thoughtSignature")
+     | Some _ ->
+       raise (Gemini_api_error "Gemini response contains a non-string thoughtSignature"))
+  | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> None
+;;
+
 let gemini_thought_signature_of_redacted data =
   try
     let json = Yojson.Safe.from_string data in
@@ -189,10 +201,14 @@ let decode_gemini_part_thought_signature data =
               gemini_part_signature_target_of_string
           , exact_string_field_opt "thoughtSignature" json )
         with
-        | Some target, Some thought_signature ->
+        | Some target, Some thought_signature
+          when not (Api_common.string_is_blank thought_signature) ->
           Decoded_gemini_part_signature (target, thought_signature)
         | _ -> Malformed_gemini_part_signature)
-     | _ -> Malformed_gemini_part_signature)
+     | Some "gemini", _ -> Malformed_gemini_part_signature
+     | _, Some kind when String.equal kind gemini_part_thought_signature_kind ->
+       Malformed_gemini_part_signature
+     | _ -> Not_gemini_part_signature)
 ;;
 
 let gemini_tool_signatures_of_blocks blocks =
@@ -316,7 +332,7 @@ let attach_thought_signature thought_signature = function
          "Gemini part serializer produced a non-object for a thoughtSignature target")
 ;;
 
-let parts_of_content_blocks id_to_name tool_signatures blocks =
+let parts_of_content_blocks ~role id_to_name tool_signatures blocks =
   (* Gemini requires an opaque [thoughtSignature] to be replayed on the exact
      model part that carried it. OAS represents that otherwise-unmodeled field
      as a [RedactedThinking] block immediately before its target. Adjacency is
@@ -345,6 +361,13 @@ let parts_of_content_blocks id_to_name tool_signatures blocks =
            (Gemini_api_error
               "Malformed Gemini thoughtSignature carrier in conversation history")
        | Decoded_gemini_part_signature (expected_target, thought_signature) ->
+         (match role with
+          | Assistant -> ()
+          | User | System | Tool ->
+            raise
+              (Gemini_api_error
+                 "Gemini thoughtSignature carrier is only valid on an assistant/model \
+                  +                  message"));
          let actual_target = signature_target_of_content_block target_block in
          (match actual_target with
           | Some actual_target when same_signature_target expected_target actual_target ->
@@ -390,10 +413,14 @@ let contents_of_messages (messages : message list) =
        let tool_signatures = gemini_tool_signatures_of_blocks msg.content in
        match msg.role with
        | System ->
-         let parts = parts_of_content_blocks id_to_name tool_signatures msg.content in
+         let parts =
+           parts_of_content_blocks ~role:msg.role id_to_name tool_signatures msg.content
+         in
          system_parts := !system_parts @ parts
        | User | Assistant | Tool ->
-         let parts = parts_of_content_blocks id_to_name tool_signatures msg.content in
+         let parts =
+           parts_of_content_blocks ~role:msg.role id_to_name tool_signatures msg.content
+         in
          if parts <> []
          then
            contents
@@ -599,9 +626,7 @@ let parse_response json =
     let content =
       List.concat_map
         (fun part ->
-           let part_thought_signature =
-             part |> member "thoughtSignature" |> to_string_option
-           in
+           let part_thought_signature = thought_signature_of_part part in
            match part |> member "text" with
            | `String s ->
              let is_thought = Cli_common_json.member_bool "thought" part in
@@ -627,13 +652,12 @@ let parse_response json =
                   | None -> Api_common.fresh_tool_use_id ()
                 in
                 let tool_use = ToolUse { id; name; input = args } in
-                (match part |> member "thoughtSignature" |> to_string_option with
-                 | Some thought_signature
-                   when not (Api_common.string_is_blank thought_signature) ->
+                (match part_thought_signature with
+                 | Some thought_signature ->
                    [ gemini_thought_signature_carrier ~tool_use_id:id ~thought_signature
                    ; tool_use
                    ]
-                 | Some _ | None -> [ tool_use ])
+                 | None -> [ tool_use ])
               | _ -> []))
         parts
     in

--- a/lib/llm_provider/backend_gemini.ml
+++ b/lib/llm_provider/backend_gemini.ml
@@ -94,15 +94,24 @@ let gemini_part_thought_signature_kind = "gemini_part_thought_signature"
 type gemini_part_signature_target =
   | Gemini_text_part
   | Gemini_thought_part
+  | Gemini_image_part
+  | Gemini_audio_part
+  | Gemini_document_part
 
 let gemini_part_signature_target_to_string = function
   | Gemini_text_part -> "text"
   | Gemini_thought_part -> "thought"
+  | Gemini_image_part -> "image"
+  | Gemini_audio_part -> "audio"
+  | Gemini_document_part -> "document"
 ;;
 
 let gemini_part_signature_target_of_string = function
   | "text" -> Some Gemini_text_part
   | "thought" -> Some Gemini_thought_part
+  | "image" -> Some Gemini_image_part
+  | "audio" -> Some Gemini_audio_part
+  | "document" -> Some Gemini_document_part
   | _ -> None
 ;;
 
@@ -256,6 +265,48 @@ let inline_data_part ~block ~media_type ~data source_type =
         [ "inlineData", `Assoc [ "mimeType", `String media_type; "data", `String data ] ])
 ;;
 
+let media_content_block_of_inline_data = function
+  | `Assoc fields ->
+    let required_non_blank name =
+      match List.assoc_opt name fields with
+      | Some (`String value) when not (Api_common.string_is_blank value) -> value
+      | Some (`String _) ->
+        raise
+          (Gemini_api_error (Printf.sprintf "Gemini inlineData contains a blank %s" name))
+      | Some _ | None ->
+        raise
+          (Gemini_api_error
+             (Printf.sprintf "Gemini inlineData is missing string field %s" name))
+    in
+    let media_type = required_non_blank "mimeType" in
+    let data = required_non_blank "data" in
+    let top_level =
+      match String.split_on_char '/' media_type with
+      | top_level :: subtype_parts
+        when (not (Api_common.string_is_blank top_level))
+             && subtype_parts <> []
+             && List.for_all
+                  (fun part -> not (Api_common.string_is_blank part))
+                  subtype_parts -> String.lowercase_ascii top_level
+      | _ ->
+        raise
+          (Gemini_api_error
+             (Printf.sprintf "Gemini inlineData has invalid MIME type %S" media_type))
+    in
+    (match top_level with
+     | "image" -> Gemini_image_part, Image { media_type; data; source_type = Base64 }
+     | "audio" -> Gemini_audio_part, Audio { media_type; data; source_type = Base64 }
+     | _ -> Gemini_document_part, Document { media_type; data; source_type = Base64 })
+  | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null ->
+    raise (Gemini_api_error "Gemini inlineData must be an object")
+;;
+
+let blocks_with_part_signature ~target ~block = function
+  | Some thought_signature ->
+    [ gemini_part_thought_signature_carrier ~target ~thought_signature; block ]
+  | None -> [ block ]
+;;
+
 let part_of_content_block id_to_name tool_signatures = function
   | Text s -> Some (`Assoc [ "text", `String (Utf8_sanitize.sanitize s) ])
   | Thinking { content; _ } ->
@@ -309,19 +360,39 @@ let part_of_content_block id_to_name tool_signatures = function
 let signature_target_of_content_block = function
   | Text _ -> Some Gemini_text_part
   | Thinking _ -> Some Gemini_thought_part
-  | ReasoningDetails _
-  | RedactedThinking _
-  | ToolUse _
-  | ToolResult _
-  | Image _
-  | Document _
-  | Audio _ -> None
+  | Image _ -> Some Gemini_image_part
+  | Audio _ -> Some Gemini_audio_part
+  | Document _ -> Some Gemini_document_part
+  | ReasoningDetails _ | RedactedThinking _ | ToolUse _ | ToolResult _ -> None
 ;;
 
 let same_signature_target left right =
-  match left, right with
-  | Gemini_text_part, Gemini_text_part | Gemini_thought_part, Gemini_thought_part -> true
-  | Gemini_text_part, Gemini_thought_part | Gemini_thought_part, Gemini_text_part -> false
+  match left with
+  | Gemini_text_part ->
+    (match right with
+     | Gemini_text_part -> true
+     | Gemini_thought_part | Gemini_image_part | Gemini_audio_part | Gemini_document_part
+       -> false)
+  | Gemini_thought_part ->
+    (match right with
+     | Gemini_thought_part -> true
+     | Gemini_text_part | Gemini_image_part | Gemini_audio_part | Gemini_document_part ->
+       false)
+  | Gemini_image_part ->
+    (match right with
+     | Gemini_image_part -> true
+     | Gemini_text_part | Gemini_thought_part | Gemini_audio_part | Gemini_document_part
+       -> false)
+  | Gemini_audio_part ->
+    (match right with
+     | Gemini_audio_part -> true
+     | Gemini_text_part | Gemini_thought_part | Gemini_image_part | Gemini_document_part
+       -> false)
+  | Gemini_document_part ->
+    (match right with
+     | Gemini_document_part -> true
+     | Gemini_text_part | Gemini_thought_part | Gemini_image_part | Gemini_audio_part ->
+       false)
 ;;
 
 let attach_thought_signature thought_signature = function
@@ -635,12 +706,7 @@ let parse_response json =
                then Gemini_thought_part, Thinking { signature = None; content = s }
                else Gemini_text_part, Text s
              in
-             (match part_thought_signature with
-              | Some thought_signature ->
-                [ gemini_part_thought_signature_carrier ~target ~thought_signature
-                ; block
-                ]
-              | None -> [ block ])
+             blocks_with_part_signature ~target ~block part_thought_signature
            | _ ->
              (match part |> member "functionCall" with
               | `Assoc _ as fc ->
@@ -658,7 +724,19 @@ let parse_response json =
                    ; tool_use
                    ]
                  | None -> [ tool_use ])
-              | _ -> []))
+              | _ ->
+                (match part |> member "inlineData" with
+                 | `Assoc _ as inline_data ->
+                   let target, block = media_content_block_of_inline_data inline_data in
+                   blocks_with_part_signature ~target ~block part_thought_signature
+                 | `Null ->
+                   (match part_thought_signature with
+                    | Some _ ->
+                      raise
+                        (Gemini_api_error
+                           "Gemini thoughtSignature is attached to an unsupported Part")
+                    | None -> [])
+                 | _ -> raise (Gemini_api_error "Gemini inlineData must be an object"))))
         parts
     in
     let finish_reason =

--- a/lib/llm_provider/backend_gemini.mli
+++ b/lib/llm_provider/backend_gemini.mli
@@ -55,6 +55,9 @@ val gemini_thought_signature_payload
 type gemini_part_signature_target =
   | Gemini_text_part
   | Gemini_thought_part
+  | Gemini_image_part
+  | Gemini_audio_part
+  | Gemini_document_part
 
 (** Opaque carrier payload for a Gemini [thoughtSignature] attached to the
     immediately following text or thought part.
@@ -69,6 +72,14 @@ val gemini_part_thought_signature_payload
     Shared by synchronous and streaming response paths.
     @since 0.212.0 *)
 val thought_signature_of_part : Yojson.Safe.t -> string option
+
+(** Decode a Gemini [inlineData] object to its closed replay target and OAS
+    media block. Missing/blank fields and malformed MIME types fail closed.
+    Shared by synchronous and streaming response paths.
+    @since 0.212.0 *)
+val media_content_block_of_inline_data
+  :  Yojson.Safe.t
+  -> gemini_part_signature_target * Types.content_block
 
 (** Extract [contents] list and optional [systemInstruction] from messages.
     Exposed for unit-testing the OAS-to-Gemini message mapping. *)

--- a/lib/llm_provider/backend_gemini.mli
+++ b/lib/llm_provider/backend_gemini.mli
@@ -64,6 +64,12 @@ val gemini_part_thought_signature_payload
   -> thought_signature:string
   -> string
 
+(** Decode an optional Gemini wire [thoughtSignature]. Missing/null returns
+    [None]; blank or non-string values fail closed with {!Gemini_api_error}.
+    Shared by synchronous and streaming response paths.
+    @since 0.212.0 *)
+val thought_signature_of_part : Yojson.Safe.t -> string option
+
 (** Extract [contents] list and optional [systemInstruction] from messages.
     Exposed for unit-testing the OAS-to-Gemini message mapping. *)
 val contents_of_messages : Types.message list -> Yojson.Safe.t list * Yojson.Safe.t option

--- a/lib/llm_provider/provider_replay.ml
+++ b/lib/llm_provider/provider_replay.ml
@@ -6,6 +6,11 @@ type t =
   }
 
 type malformed_reason =
+  | Invalid_json
+  | Expected_object
+  | Duplicate_field of string
+  | Unexpected_field of string
+  | Unsupported_schema
   | Unsupported_version
   | Unsupported_retention
   | Missing_payload
@@ -16,34 +21,67 @@ type decoded =
   | Replay of t
 
 let schema = "oas.provider_replay"
+let wire_prefix = schema ^ ".v1:"
+
+let first_duplicate fields =
+  let rec loop seen = function
+    | [] -> None
+    | (name, _) :: rest ->
+      if List.mem name seen then Some name else loop (name :: seen) rest
+  in
+  loop [] fields
+;;
+
+let first_unexpected fields =
+  let allowed = [ "schema"; "version"; "retention"; "payload" ] in
+  fields
+  |> List.find_map (fun (name, _) -> if List.mem name allowed then None else Some name)
+;;
 
 let encode_exact_next_block ~payload =
-  Yojson.Safe.to_string
-    (`Assoc
-        [ "schema", `String schema
-        ; "version", `Int 1
-        ; "retention", `String "exact_next_block"
-        ; "payload", payload
-        ])
+  wire_prefix
+  ^ Yojson.Safe.to_string
+      (`Assoc
+          [ "schema", `String schema
+          ; "version", `Int 1
+          ; "retention", `String "exact_next_block"
+          ; "payload", payload
+          ])
 ;;
 
 let decode data =
-  try
-    match Yojson.Safe.from_string data with
-    | `Assoc fields ->
-      (match List.assoc_opt "schema" fields with
-       | Some (`String value) when String.equal value schema ->
-         (match List.assoc_opt "version" fields with
-          | Some (`Int 1) ->
-            (match List.assoc_opt "retention" fields with
-             | Some (`String "exact_next_block") ->
-               (match List.assoc_opt "payload" fields with
-                | Some payload -> Replay { retention = Exact_next_block; payload }
-                | None -> Malformed_replay Missing_payload)
-             | Some _ | None -> Malformed_replay Unsupported_retention)
-          | Some _ | None -> Malformed_replay Unsupported_version)
-       | Some _ | None -> Not_replay)
-    | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> Not_replay
-  with
-  | Yojson.Json_error _ -> Not_replay
+  if not (String.starts_with ~prefix:wire_prefix data)
+  then Not_replay
+  else (
+    let encoded =
+      String.sub
+        data
+        (String.length wire_prefix)
+        (String.length data - String.length wire_prefix)
+    in
+    try
+      match Yojson.Safe.from_string encoded with
+      | `Assoc fields ->
+        (match first_duplicate fields with
+         | Some name -> Malformed_replay (Duplicate_field name)
+         | None ->
+           (match first_unexpected fields with
+            | Some name -> Malformed_replay (Unexpected_field name)
+            | None ->
+              (match List.assoc_opt "schema" fields with
+               | Some (`String value) when String.equal value schema ->
+                 (match List.assoc_opt "version" fields with
+                  | Some (`Int 1) ->
+                    (match List.assoc_opt "retention" fields with
+                     | Some (`String "exact_next_block") ->
+                       (match List.assoc_opt "payload" fields with
+                        | Some payload -> Replay { retention = Exact_next_block; payload }
+                        | None -> Malformed_replay Missing_payload)
+                     | Some _ | None -> Malformed_replay Unsupported_retention)
+                  | Some _ | None -> Malformed_replay Unsupported_version)
+               | Some _ | None -> Malformed_replay Unsupported_schema)))
+      | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null ->
+        Malformed_replay Expected_object
+    with
+    | Yojson.Json_error _ -> Malformed_replay Invalid_json)
 ;;

--- a/lib/llm_provider/provider_replay.mli
+++ b/lib/llm_provider/provider_replay.mli
@@ -15,6 +15,11 @@ type t =
   }
 
 type malformed_reason =
+  | Invalid_json
+  | Expected_object
+  | Duplicate_field of string
+  | Unexpected_field of string
+  | Unsupported_schema
   | Unsupported_version
   | Unsupported_retention
   | Missing_payload

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -1680,10 +1680,13 @@ let gemini_chunk_to_events (state : openai_stream_state) (chunk : gemini_chunk)
     (fun part_index part ->
        let is_thought = Cli_common_json.member_bool "thought" part in
        let part_thought_signature = Backend_gemini.thought_signature_of_part part in
-       let emit_signed_textual_part ~target ~content_type ~delta thought_signature =
+       let emit_signed_part ~target ~content_type ~delta thought_signature =
          (match target with
           | Backend_gemini.Gemini_text_part -> state.text_block_started <- false
-          | Backend_gemini.Gemini_thought_part -> state.thinking_block_started <- false);
+          | Backend_gemini.Gemini_thought_part -> state.thinking_block_started <- false
+          | Backend_gemini.Gemini_image_part
+          | Backend_gemini.Gemini_audio_part
+          | Backend_gemini.Gemini_document_part -> ());
          let carrier_index = state.next_block_index in
          let carrier_payload =
            Backend_gemini.gemini_part_thought_signature_payload ~target ~thought_signature
@@ -1755,13 +1758,13 @@ let gemini_chunk_to_events (state : openai_stream_state) (chunk : gemini_chunk)
          | Some thought_signature ->
            if is_thought
            then
-             emit_signed_textual_part
+             emit_signed_part
                ~target:Backend_gemini.Gemini_thought_part
                ~content_type:"thinking"
                ~delta:(ThinkingDelta text)
                thought_signature
            else
-             emit_signed_textual_part
+             emit_signed_part
                ~target:Backend_gemini.Gemini_text_part
                ~content_type:"text"
                ~delta:(TextDelta text)
@@ -1802,14 +1805,68 @@ let gemini_chunk_to_events (state : openai_stream_state) (chunk : gemini_chunk)
                (ContentBlockDelta
                   { index = state.text_block_index; delta = TextDelta text }))
        in
+       let emit_media_part inline_data =
+         let target, block =
+           Backend_gemini.media_content_block_of_inline_data inline_data
+         in
+         let content_type, delta =
+           match block with
+           | Image { media_type; source_type; data } ->
+             "image", MediaDelta { media_type; source_type; data }
+           | Audio { media_type; source_type; data } ->
+             "audio", MediaDelta { media_type; source_type; data }
+           | Document { media_type; source_type; data } ->
+             "document", MediaDelta { media_type; source_type; data }
+           | Text _
+           | Thinking _
+           | ReasoningDetails _
+           | RedactedThinking _
+           | ToolUse _
+           | ToolResult _ ->
+             raise
+               (Backend_gemini.Gemini_api_error
+                  "Gemini inlineData decoder produced a non-media content block")
+         in
+         match part_thought_signature with
+         | Some thought_signature ->
+           emit_signed_part ~target ~content_type ~delta thought_signature
+         | None ->
+           let index = state.next_block_index in
+           emit
+             (ContentBlockStart { index; content_type; tool_id = None; tool_name = None });
+           emit (ContentBlockDelta { index; delta });
+           state.next_block_index <- index + 1
+       in
+       let emit_non_text_part () =
+         match part |> member "functionCall" with
+         | `Assoc _ -> emit_function_call_delta ()
+         | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ ->
+           (match part |> member "inlineData" with
+            | `Assoc _ as inline_data -> emit_media_part inline_data
+            | `Null ->
+              (match part_thought_signature with
+               | Some _ ->
+                 raise
+                   (Backend_gemini.Gemini_api_error
+                      "Gemini thoughtSignature is attached to an unsupported Part")
+               | None -> ())
+            | _ ->
+              raise
+                (Backend_gemini.Gemini_api_error "Gemini inlineData must be an object"))
+       in
        match part |> member "text" |> to_string_option with
        | Some text when not (String.equal text "") -> emit_textual_part text
        | Some empty_text ->
          (match part |> member "functionCall" with
           | `Assoc _ -> emit_function_call_delta ()
           | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ ->
-            emit_textual_part empty_text)
-       | None -> emit_function_call_delta ())
+            (match part |> member "inlineData" with
+             | `Assoc _ as inline_data -> emit_media_part inline_data
+             | `Null -> emit_textual_part empty_text
+             | _ ->
+               raise
+                 (Backend_gemini.Gemini_api_error "Gemini inlineData must be an object")))
+       | None -> emit_non_text_part ())
     chunk.gem_parts;
   (* Finish reason *)
   (match chunk.gem_finish_reason with

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -1679,9 +1679,7 @@ let gemini_chunk_to_events (state : openai_stream_state) (chunk : gemini_chunk)
   List.iteri
     (fun part_index part ->
        let is_thought = Cli_common_json.member_bool "thought" part in
-       let part_thought_signature =
-         part |> member "thoughtSignature" |> to_string_option
-       in
+       let part_thought_signature = Backend_gemini.thought_signature_of_part part in
        let emit_signed_textual_part ~target ~content_type ~delta thought_signature =
          (match target with
           | Backend_gemini.Gemini_text_part -> state.text_block_started <- false

--- a/test/test_backend_gemini.ml
+++ b/test/test_backend_gemini.ml
@@ -625,6 +625,86 @@ let test_textual_part_signature_broken_adjacency_fails_closed () =
     (fun () -> ignore (Backend_gemini.contents_of_messages messages))
 ;;
 
+let message_with_blocks role content : Types.message =
+  { role; content; name = None; tool_call_id = None; metadata = [] }
+;;
+
+let test_textual_part_signature_non_assistant_fails_closed () =
+  let carrier =
+    Backend_gemini.gemini_part_thought_signature_payload
+      ~target:Backend_gemini.Gemini_text_part
+      ~thought_signature:"sig-user-injection"
+  in
+  let messages = [ message_with_blocks User [ RedactedThinking carrier; Text "user" ] ] in
+  check_raises
+    "model signature on user role"
+    (Backend_gemini.Gemini_api_error
+       "Gemini thoughtSignature carrier is only valid on an assistant/model message")
+    (fun () -> ignore (Backend_gemini.contents_of_messages messages))
+;;
+
+let test_other_provider_replay_is_not_a_gemini_signature () =
+  let carrier =
+    Provider_replay.encode_exact_next_block
+      ~payload:
+        (`Assoc
+            [ "provider", `String "another-provider"
+            ; "kind", `String "opaque-state"
+            ; "value", `String "opaque"
+            ])
+  in
+  let contents, _ =
+    Backend_gemini.contents_of_messages
+      [ message_with_blocks Assistant [ RedactedThinking carrier; Text "visible" ] ]
+  in
+  match contents with
+  | [ content ] ->
+    (match content |> member "parts" |> to_list with
+     | [ part ] ->
+       check string "target survives" "visible" (part |> member "text" |> to_string);
+       check
+         bool
+         "foreign signature omitted"
+         true
+         (part |> member "thoughtSignature" = `Null)
+     | _ -> fail "expected one visible Gemini part")
+  | _ -> fail "expected one assistant content"
+;;
+
+let test_malformed_provider_replay_fails_closed () =
+  let carrier =
+    Backend_gemini.gemini_part_thought_signature_payload
+      ~target:Backend_gemini.Gemini_text_part
+      ~thought_signature:"sig-truncated"
+  in
+  let carrier = String.sub carrier 0 (String.length carrier - 1) in
+  (match Provider_replay.decode carrier with
+   | Provider_replay.Malformed_replay Provider_replay.Invalid_json -> ()
+   | Provider_replay.Not_replay
+   | Provider_replay.Replay _
+   | Provider_replay.Malformed_replay _ ->
+     fail "expected truncated OAS replay envelope to remain recognizably malformed");
+  check_raises
+    "malformed replay carrier"
+    (Backend_gemini.Gemini_api_error
+       "Malformed Gemini thoughtSignature carrier in conversation history")
+    (fun () ->
+       ignore
+         (Backend_gemini.contents_of_messages
+            [ message_with_blocks Assistant [ RedactedThinking carrier; Text "visible" ] ]))
+;;
+
+let test_blank_part_thought_signature_fails_closed () =
+  let response =
+    Yojson.Safe.from_string
+      {|{"candidates":[{"content":{"parts":[{"text":"visible","thoughtSignature":" "}]},"finishReason":"STOP"}]}|}
+  in
+  check_raises
+    "blank response signature"
+    (Backend_gemini.Gemini_api_error "Gemini response contains a blank thoughtSignature")
+    (fun () -> ignore (Backend_gemini.parse_response response))
+;;
+
 let test_thought_signature_roundtrip_request () =
   let parsed =
     Backend_gemini.parse_response (function_call_with_thought_signature_json ())
@@ -1436,6 +1516,18 @@ let () =
             "textual part signature broken adjacency"
             `Quick
             test_textual_part_signature_broken_adjacency_fails_closed
+        ; test_case
+            "textual part signature requires assistant role"
+            `Quick
+            test_textual_part_signature_non_assistant_fails_closed
+        ; test_case
+            "foreign replay is not a Gemini signature"
+            `Quick
+            test_other_provider_replay_is_not_a_gemini_signature
+        ; test_case
+            "malformed replay fails closed"
+            `Quick
+            test_malformed_provider_replay_fails_closed
         ] )
     ; ( "parse_response"
       , [ test_case "text" `Quick test_parse_text_response
@@ -1449,6 +1541,10 @@ let () =
             "function call thought signature"
             `Quick
             test_parse_function_call_preserves_thought_signature
+        ; test_case
+            "blank part thought signature"
+            `Quick
+            test_blank_part_thought_signature_fails_closed
         ; test_case "usage" `Quick test_parse_usage
         ; test_case "stop reasons" `Quick test_parse_stop_reasons
         ; test_case "error" `Quick test_parse_error

--- a/test/test_backend_gemini.ml
+++ b/test/test_backend_gemini.ml
@@ -705,6 +705,47 @@ let test_blank_part_thought_signature_fails_closed () =
     (fun () -> ignore (Backend_gemini.parse_response response))
 ;;
 
+let test_signed_inline_image_roundtrip () =
+  let response =
+    Yojson.Safe.from_string
+      {|{"candidates":[{"content":{"role":"model","parts":[{"inlineData":{"mimeType":"image/png","data":"iVBORw0KGgo="},"thoughtSignature":"sig-image"}]},"finishReason":"STOP"}]}|}
+  in
+  let parsed = Backend_gemini.parse_response response in
+  (match parsed.content with
+   | [ RedactedThinking carrier
+     ; Image { media_type = "image/png"; data = "iVBORw0KGgo="; source_type = Base64 }
+     ] -> check_part_signature_carrier ~target:"image" ~signature:"sig-image" carrier
+   | _ -> fail "expected signed inline image response pair");
+  let body =
+    Backend_gemini.build_request
+      ~config:(gemini_config ())
+      ~messages:
+        [ Types.user_msg "Continue editing."
+        ; message_with_blocks Assistant parsed.content
+        ]
+      ()
+  in
+  let parts =
+    parse_body body
+    |> member "contents"
+    |> to_list
+    |> fun contents -> List.nth contents 1 |> member "parts" |> to_list
+  in
+  match parts with
+  | [ part ] ->
+    check
+      string
+      "image signature"
+      "sig-image"
+      (part |> member "thoughtSignature" |> to_string);
+    check
+      string
+      "image MIME"
+      "image/png"
+      (part |> member "inlineData" |> member "mimeType" |> to_string)
+  | _ -> fail "expected one replayed image part"
+;;
+
 let test_thought_signature_roundtrip_request () =
   let parsed =
     Backend_gemini.parse_response (function_call_with_thought_signature_json ())
@@ -1368,6 +1409,44 @@ let test_gemini_stream_textual_parts_preserve_thought_signatures () =
         | _ -> fail "expected finalized signed text and thought blocks"))
 ;;
 
+let test_gemini_stream_signed_inline_image () =
+  let state = Streaming.create_openai_stream_state () in
+  let data =
+    {|{"candidates":[{"content":{"role":"model","parts":[{"inlineData":{"mimeType":"image/png","data":"iVBORw0KGgo="},"thoughtSignature":"sig-stream-image"}]},"finishReason":"STOP"}]}|}
+  in
+  match Streaming.parse_gemini_sse_chunk data with
+  | None -> fail "expected signed image chunk"
+  | Some chunk ->
+    let events, _ = Streaming.gemini_chunk_to_events state chunk in
+    (match events with
+     | [ ContentBlockStart
+           { index = 0; content_type = "redacted_thinking"; tool_id = Some carrier; _ }
+       ; ContentBlockStart { index = 1; content_type = "image"; _ }
+       ; ContentBlockDelta
+           { index = 1
+           ; delta =
+               MediaDelta
+                 { media_type = "image/png"; source_type = Base64; data = "iVBORw0KGgo=" }
+           }
+       ; MessageDelta { stop_reason = Some EndTurn; _ }
+       ] ->
+       check_part_signature_carrier ~target:"image" ~signature:"sig-stream-image" carrier
+     | _ -> fail "expected signed image carrier and media delta");
+    let acc = Complete_stream_acc.create_stream_acc () in
+    List.iter (Complete_stream_acc.accumulate_event acc) events;
+    (match Complete_stream_acc.finalize_stream_acc acc with
+     | Ok
+         { content =
+             [ RedactedThinking carrier
+             ; Image
+                 { media_type = "image/png"; source_type = Base64; data = "iVBORw0KGgo=" }
+             ]
+         ; _
+         } ->
+       check_part_signature_carrier ~target:"image" ~signature:"sig-stream-image" carrier
+     | Ok _ | Error _ -> fail "expected finalized signed image response")
+;;
+
 let parse_gemini_chunk_exn data =
   match Streaming.parse_gemini_sse_chunk data with
   | Some chunk -> chunk
@@ -1545,6 +1624,10 @@ let () =
             "blank part thought signature"
             `Quick
             test_blank_part_thought_signature_fails_closed
+        ; test_case
+            "signed inline image roundtrip"
+            `Quick
+            test_signed_inline_image_roundtrip
         ; test_case "usage" `Quick test_parse_usage
         ; test_case "stop reasons" `Quick test_parse_stop_reasons
         ; test_case "error" `Quick test_parse_error
@@ -1579,6 +1662,7 @@ let () =
             "textual part thought signatures"
             `Quick
             test_gemini_stream_textual_parts_preserve_thought_signatures
+        ; test_case "signed inline image" `Quick test_gemini_stream_signed_inline_image
         ; test_case
             "interleaved thinking/tool/text finalizes"
             `Quick


### PR DESCRIPTION
## 요약

#2554의 textual `thoughtSignature` replay를 현재 Google 계약에 맞게 fail-closed로 보강했어용.

- versioned replay prefix와 exact-field decode로 잘린 JSON, 중복/미지 필드를 typed malformed로 유지
- 다른 provider의 replay envelope를 Gemini 오류로 오인하지 않음
- Gemini signature는 assistant/model message의 정확한 다음 Part에만 부착
- blank/non-string signature를 sync/stream 공통 decoder에서 명시적으로 거부
- signed `inlineData`를 MIME top-level로 Image/Audio/Document에 typed decode하고 sync/stream에서 exact Part로 replay
- malformed adjacency, role injection, foreign-provider replay, blank signature 회귀 테스트 추가

## P0/P1/P2/P3

- P0: 없음
- P1 해결: malformed carrier가 일반 redacted block으로 조용히 탈락하던 경로 제거
- P1 해결: foreign-provider carrier 차단, user/system signature 주입, 빈 signature 재전송 제거
- P2 해결: 공식 문서의 signed final `inlineData`도 Image/Audio/Document closed target으로 보존하고 stream accumulator까지 검증
- P3: 없음

## 검증

- exact base: `a317895d5`
- exact head: `8adc727ba`
- OCaml parse checks, `ocamlformat --check`, `git diff --check` 통과
- `scripts/check-sdk-independence.sh` 통과
- focused Dune과 OCaml 5.4.1/5.5.0 전체 검증은 CI에서 확인

[근거] Google 공식 Thought Signatures 문서: https://ai.google.dev/gemini-api/docs/generate-content/thought-signatures — 확인일시 2026-07-12 KST — 신뢰도 High. Signature는 원래 Part 그대로 재전송하고 signed/unsigned Part를 합치지 않아야 함.

후속: #2554, #2556
