### PR TITLE
fix(checkpoint): reject duplicate recovery provenance

### DIFF
--- a/lib/checkpoint_codec.ml
+++ b/lib/checkpoint_codec.ml
@@ -107,7 +107,11 @@ let checkpoint_content_block_to_json block =
 ;;
 
 let unique_optional_field ~field fields =
-  match List.filter_map (fun (name, value) -> if String.equal name field then Some value else None) fields with
+  match
+    List.filter_map
+      (fun (name, value) -> if String.equal name field then Some value else None)
+      fields
+  with
   | [] -> Ok None
   | [ value ] -> Ok (Some value)
   | _ ->

--- a/test/test_checkpoint.ml
+++ b/test/test_checkpoint.ml
@@ -406,21 +406,27 @@ let () =
                   ]
                 Types.Legacy_unclassified_failure
             in
-            check bool "rejected" true (Result.is_error (Checkpoint.of_json checkpoint_json)))
+            check
+              bool
+              "rejected"
+              true
+              (Result.is_error (Checkpoint.of_json checkpoint_json)))
         ; test_case "duplicate error_class is rejected" `Quick (fun () ->
             let checkpoint_json =
               checkpoint_json_with_tool_result
                 ~extra_fields:
                   [ ( "failure_kind"
                     , Types.tool_failure_kind_to_yojson Types.Validation_error )
-                  ; ( "error_class"
-                    , Types.tool_error_class_to_yojson Types.Deterministic )
-                  ; ( "error_class"
-                    , Types.tool_error_class_to_yojson Types.Transient )
+                  ; "error_class", Types.tool_error_class_to_yojson Types.Deterministic
+                  ; "error_class", Types.tool_error_class_to_yojson Types.Transient
                   ]
                 Types.Legacy_unclassified_failure
             in
-            check bool "rejected" true (Result.is_error (Checkpoint.of_json checkpoint_json)))
+            check
+              bool
+              "rejected"
+              true
+              (Result.is_error (Checkpoint.of_json checkpoint_json)))
         ; test_case "empty messages roundtrip" `Quick (fun () ->
             let cp = make_checkpoint ~messages:[] () in
             let cp2 = Result.get_ok (Checkpoint.of_json (Checkpoint.to_json cp)) in


### PR DESCRIPTION
## 변경

checkpoint ToolResult의 중복 `failure_kind`/`error_class`를 fail-closed로 거부해용.

- 중복 provenance는 typed `JsonParseError`로 처리해용.
- 상충 키 회귀 테스트를 추가했어용.
- 최신 main과 CI OCamlformat 0.29 형식에 맞췄어용.

#2551과 #2558은 GitHub가 삭제된 이전 head를 고정해 새 커밋을 반영하지 않아 병합 차단으로 남겨요.