### PR TITLE
fix(fmt): restore main formatting gate

### DIFF
--- a/lib/checkpoint_codec.ml
+++ b/lib/checkpoint_codec.ml
@@ -107,7 +107,11 @@ let checkpoint_content_block_to_json block =
 ;;
 
 let unique_optional_field ~field fields =
-  match List.filter_map (fun (name, value) -> if String.equal name field then Some value else None) fields with
+  match
+    List.filter_map
+      (fun (name, value) -> if String.equal name field then Some value else None)
+      fields
+  with
   | [] -> Ok None
   | [ value ] -> Ok (Some value)
   | _ ->

--- a/test/test_checkpoint.ml
+++ b/test/test_checkpoint.ml
@@ -406,21 +406,27 @@ let () =
                   ]
                 Types.Legacy_unclassified_failure
             in
-            check bool "rejected" true (Result.is_error (Checkpoint.of_json checkpoint_json)))
+            check
+              bool
+              "rejected"
+              true
+              (Result.is_error (Checkpoint.of_json checkpoint_json)))
         ; test_case "duplicate error_class is rejected" `Quick (fun () ->
             let checkpoint_json =
               checkpoint_json_with_tool_result
                 ~extra_fields:
                   [ ( "failure_kind"
                     , Types.tool_failure_kind_to_yojson Types.Validation_error )
-                  ; ( "error_class"
-                    , Types.tool_error_class_to_yojson Types.Deterministic )
-                  ; ( "error_class"
-                    , Types.tool_error_class_to_yojson Types.Transient )
+                  ; "error_class", Types.tool_error_class_to_yojson Types.Deterministic
+                  ; "error_class", Types.tool_error_class_to_yojson Types.Transient
                   ]
                 Types.Legacy_unclassified_failure
             in
-            check bool "rejected" true (Result.is_error (Checkpoint.of_json checkpoint_json)))
+            check
+              bool
+              "rejected"
+              true
+              (Result.is_error (Checkpoint.of_json checkpoint_json)))
         ; test_case "empty messages roundtrip" `Quick (fun () ->
             let cp = make_checkpoint ~messages:[] () in
             let cp2 = Result.get_ok (Checkpoint.of_json (Checkpoint.to_json cp)) in


### PR DESCRIPTION
## Summary

- apply the repository ocamlformat contract to the two files reported by main CI
- restore the format gate so OCaml 5.4/5.5 jobs can run instead of being cancelled

## Evidence

- `ocamlformat -i lib/checkpoint_codec.ml test/test_checkpoint.ml`
- `ocamlc -stop-after parsing lib/checkpoint_codec.ml`
- `ocamlc -stop-after parsing test/test_checkpoint.ml`
- `git diff --check`

Upstream failure: main CI run 29176279080, job 86605947837.