### PR TITLE
fix(gemini): restore signature role error message

### DIFF
--- a/lib/llm_provider/backend_gemini.ml
+++ b/lib/llm_provider/backend_gemini.ml
@@ -438,7 +438,7 @@ let parts_of_content_blocks ~role id_to_name tool_signatures blocks =
             raise
               (Gemini_api_error
                  "Gemini thoughtSignature carrier is only valid on an assistant/model \
-                  +                  message"));
+                  message"));
          let actual_target = signature_target_of_content_block target_block in
          (match actual_target with
           | Some actual_target when same_signature_target expected_target actual_target ->


### PR DESCRIPTION
## 원인

- 병합된 `#2559`의 `8adc727ba`가 오류 문자열에 patch 잔여 `+`를 포함해 OCaml 5.4/5.5 테스트를 각각 실패시켰어용.

## 수정

- 최신 `origin/main` (`bbdd8eaac`)에서 오류 문자열 한 줄만 복구했어용.
- head: `a85186f18`

## 검증

- focused build: `test/test_backend_gemini.exe` 통과
- 직접 실행: 50/50 통과
- `ocamlformat --check`, parse, `git diff --check` 통과
- 전체 Dune은 PR CI에서 확인해용.

[근거] [실패한 CI run](https://github.com/jeong-sik/oas/actions/runs/29176261410) + `gh run view 29176261410 --log-failed` + 확인일시 2026-07-12 11:21 KST + 신뢰도 High
