### PR TITLE
fix(gemini): validate exact replay payload schema

### DIFF
--- a/lib/llm_provider/backend_gemini.ml
+++ b/lib/llm_provider/backend_gemini.ml
@@ -195,29 +195,51 @@ type gemini_part_signature_decode =
   | Decoded_gemini_part_signature of gemini_part_signature_target * string
   | Malformed_gemini_part_signature
 
+let gemini_part_signature_payload_mentions_gemini = function
+  | `Assoc fields ->
+    List.exists
+      (function
+        | "provider", `String "gemini" -> true
+        | "kind", `String kind -> String.equal kind gemini_part_thought_signature_kind
+        | _ -> false)
+      fields
+  | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> false
+;;
+
 let decode_gemini_part_thought_signature data =
   match Provider_replay.decode data with
   | Provider_replay.Not_replay -> Not_gemini_part_signature
   | Provider_replay.Malformed_replay _ -> Malformed_gemini_part_signature
   | Provider_replay.Replay
       { retention = Provider_replay.Exact_next_block; payload = json } ->
-    (match string_field_opt "provider" json, string_field_opt "kind" json with
-     | Some "gemini", Some kind when String.equal kind gemini_part_thought_signature_kind
-       ->
-       (match
-          ( Option.bind
-              (string_field_opt "target" json)
-              gemini_part_signature_target_of_string
-          , exact_string_field_opt "thoughtSignature" json )
-        with
-        | Some target, Some thought_signature
-          when not (Api_common.string_is_blank thought_signature) ->
-          Decoded_gemini_part_signature (target, thought_signature)
-        | _ -> Malformed_gemini_part_signature)
-     | Some "gemini", _ -> Malformed_gemini_part_signature
-     | _, Some kind when String.equal kind gemini_part_thought_signature_kind ->
-       Malformed_gemini_part_signature
-     | _ -> Not_gemini_part_signature)
+    if not (gemini_part_signature_payload_mentions_gemini json)
+    then Not_gemini_part_signature
+    else (
+      match
+        Provider_replay.exact_object_fields
+          ~allowed:[ "provider"; "kind"; "target"; "thoughtSignature" ]
+          json
+      with
+      | Error _ -> Malformed_gemini_part_signature
+      | Ok fields ->
+        let json = `Assoc fields in
+        (match string_field_opt "provider" json, string_field_opt "kind" json with
+         | Some "gemini", Some kind
+           when String.equal kind gemini_part_thought_signature_kind ->
+           (match
+              ( Option.bind
+                  (string_field_opt "target" json)
+                  gemini_part_signature_target_of_string
+              , exact_string_field_opt "thoughtSignature" json )
+            with
+            | Some target, Some thought_signature
+              when not (Api_common.string_is_blank thought_signature) ->
+              Decoded_gemini_part_signature (target, thought_signature)
+            | _ -> Malformed_gemini_part_signature)
+         | Some "gemini", _ -> Malformed_gemini_part_signature
+         | _, Some kind when String.equal kind gemini_part_thought_signature_kind ->
+           Malformed_gemini_part_signature
+         | _ -> Not_gemini_part_signature))
 ;;
 
 let gemini_tool_signatures_of_blocks blocks =

--- a/lib/llm_provider/provider_replay.ml
+++ b/lib/llm_provider/provider_replay.ml
@@ -32,10 +32,21 @@ let first_duplicate fields =
   loop [] fields
 ;;
 
-let first_unexpected fields =
-  let allowed = [ "schema"; "version"; "retention"; "payload" ] in
+let first_unexpected ~allowed fields =
   fields
   |> List.find_map (fun (name, _) -> if List.mem name allowed then None else Some name)
+;;
+
+let exact_object_fields ~allowed = function
+  | `Assoc fields ->
+    (match first_duplicate fields with
+     | Some name -> Error (Duplicate_field name)
+     | None ->
+       (match first_unexpected ~allowed fields with
+        | Some name -> Error (Unexpected_field name)
+        | None -> Ok fields))
+  | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null ->
+    Error Expected_object
 ;;
 
 let encode_exact_next_block ~payload =
@@ -60,28 +71,24 @@ let decode data =
         (String.length data - String.length wire_prefix)
     in
     try
-      match Yojson.Safe.from_string encoded with
-      | `Assoc fields ->
-        (match first_duplicate fields with
-         | Some name -> Malformed_replay (Duplicate_field name)
-         | None ->
-           (match first_unexpected fields with
-            | Some name -> Malformed_replay (Unexpected_field name)
-            | None ->
-              (match List.assoc_opt "schema" fields with
-               | Some (`String value) when String.equal value schema ->
-                 (match List.assoc_opt "version" fields with
-                  | Some (`Int 1) ->
-                    (match List.assoc_opt "retention" fields with
-                     | Some (`String "exact_next_block") ->
-                       (match List.assoc_opt "payload" fields with
-                        | Some payload -> Replay { retention = Exact_next_block; payload }
-                        | None -> Malformed_replay Missing_payload)
-                     | Some _ | None -> Malformed_replay Unsupported_retention)
-                  | Some _ | None -> Malformed_replay Unsupported_version)
-               | Some _ | None -> Malformed_replay Unsupported_schema)))
-      | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null ->
-        Malformed_replay Expected_object
+      match
+        Yojson.Safe.from_string encoded
+        |> exact_object_fields ~allowed:[ "schema"; "version"; "retention"; "payload" ]
+      with
+      | Error reason -> Malformed_replay reason
+      | Ok fields ->
+        (match List.assoc_opt "schema" fields with
+         | Some (`String value) when String.equal value schema ->
+           (match List.assoc_opt "version" fields with
+            | Some (`Int 1) ->
+              (match List.assoc_opt "retention" fields with
+               | Some (`String "exact_next_block") ->
+                 (match List.assoc_opt "payload" fields with
+                  | Some payload -> Replay { retention = Exact_next_block; payload }
+                  | None -> Malformed_replay Missing_payload)
+               | Some _ | None -> Malformed_replay Unsupported_retention)
+            | Some _ | None -> Malformed_replay Unsupported_version)
+         | Some _ | None -> Malformed_replay Unsupported_schema)
     with
     | Yojson.Json_error _ -> Malformed_replay Invalid_json)
 ;;

--- a/lib/llm_provider/provider_replay.mli
+++ b/lib/llm_provider/provider_replay.mli
@@ -29,6 +29,15 @@ type decoded =
   | Malformed_replay of malformed_reason
   | Replay of t
 
+(** Validate one exact JSON object schema before any field lookup. Duplicate
+    and unexpected keys retain their typed malformed reason so provider-owned
+    payload decoders can share the envelope's cardinality contract.
+    @since 0.212.0 *)
+val exact_object_fields
+  :  allowed:string list
+  -> Yojson.Safe.t
+  -> ((string * Yojson.Safe.t) list, malformed_reason) result
+
 (** Wrap provider-owned JSON that must stay adjacent to the following content
     block.
     @since 0.212.0 *)

--- a/test/test_backend_gemini.ml
+++ b/test/test_backend_gemini.ml
@@ -671,6 +671,54 @@ let test_other_provider_replay_is_not_a_gemini_signature () =
   | _ -> fail "expected one assistant content"
 ;;
 
+let check_gemini_replay_payload_rejected label payload =
+  let carrier = Provider_replay.encode_exact_next_block ~payload in
+  check_raises
+    label
+    (Backend_gemini.Gemini_api_error
+       "Malformed Gemini thoughtSignature carrier in conversation history")
+    (fun () ->
+       ignore
+         (Backend_gemini.contents_of_messages
+            [ message_with_blocks Assistant [ RedactedThinking carrier; Text "visible" ] ]))
+;;
+
+let canonical_gemini_replay_payload_fields () =
+  let carrier =
+    Backend_gemini.gemini_part_thought_signature_payload
+      ~target:Backend_gemini.Gemini_text_part
+      ~thought_signature:"sig-a"
+  in
+  match Provider_replay.decode carrier with
+  | Provider_replay.Replay
+      { retention = Provider_replay.Exact_next_block; payload = `Assoc fields } -> fields
+  | Provider_replay.Not_replay | Provider_replay.Malformed_replay _
+  | Provider_replay.Replay
+      { payload = `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null
+      ; _
+      } -> fail "canonical Gemini replay encoder did not produce an object payload"
+;;
+
+let test_duplicate_gemini_replay_payload_fields_fail_closed () =
+  let fields = canonical_gemini_replay_payload_fields () in
+  [ "provider", `String "another-provider"
+  ; "kind", `String "opaque-state"
+  ; "target", `String "thought"
+  ; "thoughtSignature", `String "sig-b"
+  ]
+  |> List.iter (fun (field, conflicting_value) ->
+    check_gemini_replay_payload_rejected
+      ("duplicate " ^ field)
+      (`Assoc (fields @ [ field, conflicting_value ])))
+;;
+
+let test_unexpected_gemini_replay_payload_field_fails_closed () =
+  let fields = canonical_gemini_replay_payload_fields () in
+  check_gemini_replay_payload_rejected
+    "unexpected Gemini replay field"
+    (`Assoc (fields @ [ "unexpected", `Bool true ]))
+;;
+
 let test_malformed_provider_replay_fails_closed () =
   let carrier =
     Backend_gemini.gemini_part_thought_signature_payload
@@ -1603,6 +1651,14 @@ let () =
             "foreign replay is not a Gemini signature"
             `Quick
             test_other_provider_replay_is_not_a_gemini_signature
+        ; test_case
+            "duplicate Gemini replay fields fail closed"
+            `Quick
+            test_duplicate_gemini_replay_payload_fields_fail_closed
+        ; test_case
+            "unexpected Gemini replay field fails closed"
+            `Quick
+            test_unexpected_gemini_replay_payload_field_fails_closed
         ; test_case
             "malformed replay fails closed"
             `Quick


### PR DESCRIPTION
## 문제\n\n#2559는 provider replay outer envelope의 duplicate/unexpected field는 거부하지만, inner Gemini payload의 provider/kind/target/thoughtSignature는 List.assoc_opt first-match로 읽었어요. valid outer envelope 안의 상충 signature와 unknown field가 typed malformed가 아니라 replay될 수 있었어요.\n\n## 변경\n\n- Provider_replay에 exact_object_fields를 추가해 outer envelope과 provider payload가 같은 duplicate/unexpected cardinality 계약을 공유해요.\n- exact Gemini discriminator가 실제 등장한 payload만 strict schema로 검사해요.\n- provider/kind/target/thoughtSignature duplicate와 unknown inner field를 Malformed_gemini_part_signature로 fail-closed 처리해요.\n- foreign provider의 opaque payload와 extra fields는 기존처럼 Gemini signature로 해석하지 않아요.\n- 회귀 fixture는 production encoder가 만든 canonical payload에서 파생해 protocol literal SSOT를 복제하지 않아요.\n\n## 검증\n\n- exact base: 492de3248908a4a9701ad239cea3f55e8af16bab\n- exact head: 68efbab61d3c95ea6461903b34d1c909bccbe4ab\n- scripts/dune-local.sh build test/test_backend_gemini.exe: PASS\n- scripts/dune-local.sh exec test/test_backend_gemini.exe: 52/52 PASS\n- opam exec -- ocamlformat --check touched files: PASS\n- scripts/check-sdk-independence.sh: PASS\n- git diff --check: PASS\n- 전체 OCaml 5.4/5.5 검증은 PR CI에서 확인해요.\n\n## P0/P1/P2/P3\n\n- P0: 없음\n- P1 해결: inner replay payload duplicate/unknown first-match 제거\n- P2/P3: 없음\n- mergeability: Draft + P1 + do-not-merge로 시작하고 exact-head CI green 뒤 재검토\n\nCloses #2563\n\n[근거] current main 492de32489, focused wrapper/build/test/format/SDK gate 실행 결과, 확인일시 2026-07-12 KST, 신뢰도 High.