### PR TITLE
ci: reject same-tree no-op PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,8 +226,10 @@ jobs:
         env:
           OAS_PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           OAS_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          OAS_PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          git fetch --no-tags --depth=1 origin "$OAS_PR_BASE_SHA" "$OAS_PR_HEAD_SHA"
+          git fetch --no-tags --depth=1 origin "$OAS_PR_BASE_SHA" \
+            "+refs/pull/${OAS_PR_NUMBER}/head:refs/remotes/pull/${OAS_PR_NUMBER}/head"
           bash scripts/check-pr-tree-identity.sh "$OAS_PR_BASE_SHA" "$OAS_PR_HEAD_SHA"
 
       - name: Setup OCaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Test PR tree identity gate
+        run: bash scripts/test-check-pr-tree-identity.sh
+
+      - name: Reject same-tree no-op PRs
+        if: github.event_name == 'pull_request'
+        env:
+          OAS_PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          OAS_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          git fetch --no-tags --depth=1 origin "$OAS_PR_BASE_SHA" "$OAS_PR_HEAD_SHA"
+          bash scripts/check-pr-tree-identity.sh "$OAS_PR_BASE_SHA" "$OAS_PR_HEAD_SHA"
+
       - name: Setup OCaml
         uses: ocaml/setup-ocaml@v3
         with:

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -38,8 +38,10 @@ jobs:
       - name: Fetch exact PR commits
         env:
           OAS_PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          OAS_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: git fetch --no-tags --depth=1 origin "$OAS_PR_BASE_SHA" "$OAS_PR_HEAD_SHA"
+          OAS_PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          git fetch --no-tags --depth=1 origin "$OAS_PR_BASE_SHA" \
+            "+refs/pull/${OAS_PR_NUMBER}/head:refs/remotes/pull/${OAS_PR_NUMBER}/head"
 
       - name: Reject same-tree no-op PRs
         env:

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -22,6 +22,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  pr-tree-identity:
+    name: PR Tree Identity Gate
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.state != 'closed' }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout trusted base workflow tree
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 1
+
+      - name: Fetch exact PR commits
+        env:
+          OAS_PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          OAS_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: git fetch --no-tags --depth=1 origin "$OAS_PR_BASE_SHA" "$OAS_PR_HEAD_SHA"
+
+      - name: Reject same-tree no-op PRs
+        env:
+          OAS_PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          OAS_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: bash scripts/check-pr-tree-identity.sh "$OAS_PR_BASE_SHA" "$OAS_PR_HEAD_SHA"
+
   draft-automerge-guard:
     name: Draft Auto-Merge Guard
     runs-on: ubuntu-latest

--- a/scripts/check-pr-tree-identity.sh
+++ b/scripts/check-pr-tree-identity.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 <base-commit> <head-commit>" >&2
+  exit 2
+fi
+
+base_ref=$1
+head_ref=$2
+
+if ! base_tree=$(git rev-parse --verify --end-of-options "${base_ref}^{tree}" 2>/dev/null); then
+  echo "::error title=PR tree identity gate::cannot resolve base commit tree: ${base_ref}" >&2
+  exit 2
+fi
+
+if ! head_tree=$(git rev-parse --verify --end-of-options "${head_ref}^{tree}" 2>/dev/null); then
+  echo "::error title=PR tree identity gate::cannot resolve head commit tree: ${head_ref}" >&2
+  exit 2
+fi
+
+echo "base_commit=${base_ref} base_tree=${base_tree}"
+echo "head_commit=${head_ref} head_tree=${head_tree}"
+
+if [ "$base_tree" = "$head_tree" ]; then
+  echo "::error title=Same-tree no-op PR::base and head resolve to the same Git tree ${head_tree}; close this superseded PR instead of creating a no-op main commit" >&2
+  exit 1
+fi
+
+echo "PR tree identity gate passed: base and head trees differ"

--- a/scripts/test-check-pr-tree-identity.sh
+++ b/scripts/test-check-pr-tree-identity.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+gate="${script_dir}/check-pr-tree-identity.sh"
+fixture=$(mktemp -d)
+trap 'rm -rf "$fixture"' EXIT
+
+git -C "$fixture" init --quiet --initial-branch=fixture
+mkdir -p "${fixture}/hooks-disabled"
+git -C "$fixture" config core.hooksPath "${fixture}/hooks-disabled"
+git -C "$fixture" config user.name "tree-gate-test"
+git -C "$fixture" config user.email "tree-gate-test@example.invalid"
+
+printf 'base\n' >"${fixture}/value.txt"
+git -C "$fixture" add value.txt
+git -C "$fixture" commit --quiet -m base
+base_commit=$(git -C "$fixture" rev-parse HEAD)
+
+git -C "$fixture" commit --quiet --allow-empty -m same-tree
+same_tree_commit=$(git -C "$fixture" rev-parse HEAD)
+if (cd "$fixture" && bash "$gate" "$base_commit" "$same_tree_commit") >/dev/null 2>&1; then
+  echo "expected same-tree commits to fail" >&2
+  exit 1
+fi
+
+printf 'changed\n' >"${fixture}/value.txt"
+git -C "$fixture" add value.txt
+git -C "$fixture" commit --quiet -m changed-tree
+changed_tree_commit=$(git -C "$fixture" rev-parse HEAD)
+(cd "$fixture" && bash "$gate" "$same_tree_commit" "$changed_tree_commit") >/dev/null
+
+if (cd "$fixture" && bash "$gate" missing-ref "$changed_tree_commit") >/dev/null 2>&1; then
+  echo "expected an unresolved commit to fail closed" >&2
+  exit 1
+fi
+
+echo "PR tree identity gate tests passed"


### PR DESCRIPTION
## Summary

- compare exact base/head Git tree OIDs through one shell SSOT
- run the gate in the existing required `Lint` context and a base-trusted `pull_request_target` job
- fail closed for unresolved commits and same-tree PRs without title, body, or path heuristics
- add isolated regressions for same-tree, changed-tree, and unresolved-ref cases

## Verification

- `bash scripts/test-check-pr-tree-identity.sh`
- `actionlint .github/workflows/ci.yml .github/workflows/pr-automation.yml`
- `shellcheck scripts/check-pr-tree-identity.sh scripts/test-check-pr-tree-identity.sh`
- historical #2564: base `38882255` and head `ce7a66a9` resolve to tree `1eda2326` and the gate rejects them
- normal #2569: base `492de324` and head `68efbab6` resolve to different trees and the gate passes
- `git diff --check`

Refs #2565. Repository-level `enforce_admins=false` is not changed by this PR and remains a separate control-plane decision.