### PR TITLE
fix(api): preserve legacy error projections with typed evidence

### DIFF
--- a/lib/api.ml
+++ b/lib/api.ml
@@ -331,9 +331,7 @@ let create_message_detailed
        live site in [Llm_provider.Complete] — see
        lib/llm_provider/complete.ml:271,274. *)
             | Failure msg ->
-              Error
-                (Retry_error
-                   (Retry.NetworkError { message = msg; kind = Unknown }))
+              Error (Retry_error (Retry.NetworkError { message = msg; kind = Unknown }))
             | Yojson.Json_error msg ->
               Error
                 (Retry_error

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -7,18 +7,60 @@ type response_accept = Types.api_response -> (unit, string) result
 
 type create_message_error =
   | Retry_error of Retry.api_error
+  | Attributed_retry_error of
+      { retry_error : Retry.api_error
+      ; http_error : Llm_provider.Http_client.http_error
+      }
   | Completion_error of Llm_provider.Http_client.http_error
 
-let create_message_error_of_http_error err = Completion_error err
+let attributed_retry_error http_error retry_error =
+  Attributed_retry_error { retry_error; http_error }
+;;
+
+let create_message_error_of_http_error = function
+  | Llm_provider.Http_client.HttpError { code; body } as http_error ->
+    attributed_retry_error http_error (Retry.classify_error ~status:code ~body)
+  | Llm_provider.Http_client.NetworkError
+      { message; kind = Llm_provider.Http_client.Timeout } as http_error ->
+    attributed_retry_error http_error (Retry.Timeout { message; phase = None })
+  | Llm_provider.Http_client.NetworkError { message; kind } as http_error ->
+    attributed_retry_error http_error (Retry.NetworkError { message; kind })
+  | Llm_provider.Http_client.TimeoutError { message; phase } as http_error ->
+    attributed_retry_error http_error (Retry.Timeout { message; phase = Some phase })
+  | Llm_provider.Http_client.AcceptRejected { reason } as http_error ->
+    attributed_retry_error
+      http_error
+      (Retry.InvalidRequest
+         { message = "Response rejected: " ^ reason; reason = Unknown_invalid_request })
+  | Llm_provider.Http_client.ProviderTerminal { message; _ } as http_error ->
+    attributed_retry_error
+      http_error
+      (Retry.InvalidRequest { message; reason = Unknown_invalid_request })
+  | Llm_provider.Http_client.ProviderFailure
+      { kind = Llm_provider.Http_client.Empty_completion _; _ } as http_error ->
+    Completion_error http_error
+  | Llm_provider.Http_client.ProviderFailure { kind; message } as http_error ->
+    attributed_retry_error
+      http_error
+      (Retry.InvalidRequest
+         { message = Llm_provider.Http_client.provider_failure_to_string ~kind ~message
+         ; reason = Unknown_invalid_request
+         })
+;;
 
 let retry_error_of_create_message_error = function
   | Retry_error err -> Some err
+  | Attributed_retry_error { retry_error; _ } -> Some retry_error
   | Completion_error err -> Llm_provider.Retry_classify.classify_retry_error err
 ;;
 
 let detailed_error_of_create_message_error ~binding = function
   | Retry_error err ->
     Provider_failure_attribution.of_response_parse_error ~binding (Error.Api err)
+  | Attributed_retry_error { retry_error; http_error } ->
+    { (Provider_failure_attribution.of_http_error ~binding http_error) with
+      error = Error.Api retry_error
+    }
   | Completion_error err -> Provider_failure_attribution.of_http_error ~binding err
 ;;
 
@@ -252,28 +294,32 @@ let create_message_detailed
                   raw_resp_result
               | `HttpError (code, body_str) ->
                 Error
-                  (Completion_error
+                  (create_message_error_of_http_error
                      (Llm_provider.Http_client.HttpError { code; body = body_str }))
               | `TransportError err -> Error err
             with
             | Eio.Time.Timeout ->
+              let message =
+                Printf.sprintf
+                  "HTTP request exceeded %.1fs wall-clock timeout"
+                  request_timeout_s
+              in
+              let http_error =
+                Llm_provider.Http_client.TimeoutError
+                  { message; phase = Llm_provider.Http_client.Wall_clock }
+              in
               Error
-                (Completion_error
-                   (Llm_provider.Http_client.TimeoutError
-                      { message =
-                          Printf.sprintf
-                            "HTTP request exceeded %.1fs wall-clock timeout"
-                            request_timeout_s
-                      ; phase = Llm_provider.Http_client.Wall_clock
-                      }))
+                (attributed_retry_error
+                   http_error
+                   (Retry.Timeout { message; phase = None }))
             | Eio.Io _ as exn ->
               Error
-                (Completion_error
+                (create_message_error_of_http_error
                    (Llm_provider.Http_client.NetworkError
                       { message = Printexc.to_string exn; kind = Unknown }))
             | Unix.Unix_error _ as exn ->
               Error
-                (Completion_error
+                (create_message_error_of_http_error
                    (Llm_provider.Http_client.NetworkError
                       { message = Printexc.to_string exn; kind = Unknown }))
             (* Backend_gemini.Gemini_api_error and Backend_glm.Glm_api_error
@@ -287,10 +333,7 @@ let create_message_detailed
             | Failure msg ->
               Error
                 (Retry_error
-                   (Retry.InvalidRequest
-                      { message = "Response parser failure: " ^ msg
-                      ; reason = Retry.Json_parse_error
-                      }))
+                   (Retry.NetworkError { message = msg; kind = Unknown }))
             | Yojson.Json_error msg ->
               Error
                 (Retry_error

--- a/test/test_api_http_client.ml
+++ b/test/test_api_http_client.ml
@@ -79,8 +79,7 @@ let register_failing_custom_provider ~name ~base_url parse_response =
     ; capabilities = Provider.default_capabilities
     ; build_body = (fun ~config:_ ~messages:_ ?tools:_ () -> "{}")
     ; parse_response
-    ; resolve =
-        (fun _ -> Ok (base_url, "", [ "Content-Type", "application/json" ]))
+    ; resolve = (fun _ -> Ok (base_url, "", [ "Content-Type", "application/json" ]))
     }
   in
   Provider.register_provider impl;
@@ -255,8 +254,8 @@ let test_custom_parser_failure_preserves_legacy_error_and_parse_evidence () =
     (match detailed.Provider_failure_attribution.error with
      | Error.Api
          (Llm_provider.Retry.NetworkError
-            { message = "custom parser failed"; kind = Llm_provider.Http_client.Unknown }) ->
-       ()
+            { message = "custom parser failed"; kind = Llm_provider.Http_client.Unknown })
+       -> ()
      | error ->
        Alcotest.failf
          "expected legacy parser NetworkError, got %s"

--- a/test/test_api_http_client.ml
+++ b/test/test_api_http_client.ml
@@ -71,6 +71,33 @@ let state_and_messages (provider : Provider.config) =
   state, messages
 ;;
 
+let register_failing_custom_provider ~name ~base_url parse_response =
+  let impl : Provider.provider_impl =
+    { name
+    ; request_kind = Provider.Custom name
+    ; request_path = "/v1/custom"
+    ; capabilities = Provider.default_capabilities
+    ; build_body = (fun ~config:_ ~messages:_ ?tools:_ () -> "{}")
+    ; parse_response
+    ; resolve =
+        (fun _ -> Ok (base_url, "", [ "Content-Type", "application/json" ]))
+    }
+  in
+  Provider.register_provider impl;
+  Provider.custom_provider ~name ~model_id:"mock" ()
+;;
+
+let require_detailed_error = function
+  | Error detailed -> detailed
+  | Ok _ -> Alcotest.fail "expected detailed error, got Ok"
+;;
+
+let require_attribution detailed =
+  match detailed.Provider_failure_attribution.provider_failure with
+  | Some attribution -> attribution
+  | None -> Alcotest.fail "expected provider failure attribution"
+;;
+
 let expect_provider_unavailable = function
   | Error (Error.Provider (Llm_provider.Error.ProviderUnavailable _)) -> ()
   | Error err ->
@@ -208,6 +235,67 @@ let test_custom_stream_fallback_empty_maps_to_provider_unavailable () =
     [ Llm_provider.Types.EndTurn; Llm_provider.Types.MaxTokens ]
 ;;
 
+let test_custom_parser_failure_preserves_legacy_error_and_parse_evidence () =
+  let handler _conn _req body =
+    ignore (Eio.Buf_read.(of_flow ~max_size:(1024 * 1024) body |> take_all) : string);
+    Cohttp_eio.Server.respond_string ~status:`OK ~body:"malformed" ()
+  in
+  with_mock_server handler (fun ~sw ~net ~clock:_ ~base_url ->
+    let provider =
+      register_failing_custom_provider
+        ~name:"api-custom-parser-failure"
+        ~base_url
+        (fun _ -> failwith "custom parser failed")
+    in
+    let config, messages = state_and_messages provider in
+    let detailed =
+      Api.create_message_detailed ~sw ~net ~provider ~config ~messages ()
+      |> require_detailed_error
+    in
+    (match detailed.Provider_failure_attribution.error with
+     | Error.Api
+         (Llm_provider.Retry.NetworkError
+            { message = "custom parser failed"; kind = Llm_provider.Http_client.Unknown }) ->
+       ()
+     | error ->
+       Alcotest.failf
+         "expected legacy parser NetworkError, got %s"
+         (Error.to_string error));
+    let attribution = require_attribution detailed in
+    match attribution.Provider_failure_attribution.evidence with
+    | Provider_failure_attribution.Response_parse -> ()
+    | _ -> Alcotest.fail "expected typed response-parse evidence")
+;;
+
+let test_wall_clock_timeout_preserves_legacy_error_and_typed_evidence () =
+  let handler _conn _req body =
+    ignore (Eio.Buf_read.(of_flow ~max_size:(1024 * 1024) body |> take_all) : string);
+    Cohttp_eio.Server.respond_string ~status:`OK ~body:"slow" ()
+  in
+  with_mock_server handler (fun ~sw ~net ~clock:_ ~base_url ->
+    let provider =
+      register_failing_custom_provider
+        ~name:"api-custom-wall-clock-timeout"
+        ~base_url
+        (fun _ -> raise Eio.Time.Timeout)
+    in
+    let config, messages = state_and_messages provider in
+    let detailed =
+      Api.create_message_detailed ~sw ~net ~provider ~config ~messages ()
+      |> require_detailed_error
+    in
+    (match detailed.Provider_failure_attribution.error with
+     | Error.Api (Llm_provider.Retry.Timeout { phase = None; _ }) -> ()
+     | error ->
+       Alcotest.failf
+         "expected legacy timeout with no phase, got %s"
+         (Error.to_string error));
+    let attribution = require_attribution detailed in
+    match attribution.Provider_failure_attribution.evidence with
+    | Provider_failure_attribution.Timeout Llm_provider.Http_client.Wall_clock -> ()
+    | _ -> Alcotest.fail "expected typed wall-clock timeout evidence")
+;;
+
 let () =
   Alcotest.run
     "Api_http_client"
@@ -224,6 +312,14 @@ let () =
             "custom stream fallback maps empty to provider unavailable"
             `Quick
             test_custom_stream_fallback_empty_maps_to_provider_unavailable
+        ; Alcotest.test_case
+            "custom parser failure preserves legacy error and parse evidence"
+            `Quick
+            test_custom_parser_failure_preserves_legacy_error_and_parse_evidence
+        ; Alcotest.test_case
+            "wall-clock timeout preserves legacy error and typed evidence"
+            `Quick
+            test_wall_clock_timeout_preserves_legacy_error_and_typed_evidence
         ] )
     ]
 ;;


### PR DESCRIPTION
## What

- restore the pre-#2572 Retry.api_error mapping for HTTP, network, timeout, accept-rejection, provider-terminal, and provider-failure paths
- retain the new typed provider attribution by carrying the original HTTP error alongside the legacy retry projection
- restore custom parser Failure to the legacy NetworkError Unknown projection
- keep wall-clock timeout phase=None in the public error while exposing typed Wall_clock evidence

## Why

#2572 promised that detailed errors preserve the exact legacy .error projection, but the API boundary changed timeout and parser failures and widened the same regression across several transport constructors.

## Verification

- scripts/dune-local.sh build test/test_api_http_client.exe
- scripts/dune-local.sh exec test/test_api_http_client.exe (5/5)
- scripts/dune-local.sh build test/test_provider_intf.exe
- scripts/dune-local.sh exec test/test_provider_intf.exe (17/17)
- scripts/dune-local.sh build @fmt
- git diff --check
- exact-head b519c5b72: OCaml 5.4.1/5.5.0 Build & Test, Lint, OCaml Format, Tree Identity Gate, and all applicable checks terminal green

Closes #2575
Follow-up to #2572.