### PR TITLE
style(provider): remove redundant unclassified status arms

### DIFF
--- a/lib/provider_failure_attribution.ml
+++ b/lib/provider_failure_attribution.ml
@@ -129,7 +129,7 @@ let ownership_of_http_status ~binding code =
   (* A generic server status does not identify whether the fault belongs to
      this binding, endpoint, region, or provider.  Only richer typed provider
      evidence may widen it beyond [Unclassified]. *)
-  | 403 | 429 | _ -> Unclassified
+  | _ -> Unclassified
 ;;
 
 let ownership_of_network = function


### PR DESCRIPTION
## Summary

Follow-up to merged #2572 and its exact-head P3 review.

- remove the dead `403 | 429` alternatives that returned the same `Unclassified` value as the exhaustive fallback
- keep 403/429 behavior locked by the existing closed ownership acceptance matrix
- make no provider attribution or credential ownership semantic change

## Boundary

OAS-only cleanup. No MASC dependency or knowledge is introduced.

## Validation

- `ocamlformat --check lib/provider_failure_attribution.ml`
- `git diff --check origin/main...HEAD`
- focused wrapper was attempted but deferred by the machine-wide Dune lock; PR CI is the build authority

Ref: #2572 review P3.