### PR TITLE
fix(agent): preserve idle guard with recovery judge

### DIFF
--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -138,8 +138,7 @@ let check_loop_guard agent =
            (Error.MaxTurnsExceeded
               { turns = agent.state.turn_count; limit = agent.state.config.max_turns }))
     else if
-      Option.is_none agent.tool_failure_judge
-      && agent.consecutive_idle_turns >= agent.options.max_idle_turns
+      agent.consecutive_idle_turns >= agent.options.max_idle_turns
       && agent.options.max_idle_turns > 0
     then
       Some

--- a/test/test_agent_race.ml
+++ b/test/test_agent_race.ml
@@ -8,13 +8,13 @@ open Agent_sdk
 
 (* ── Helpers ──────────────────────────────────────────────── *)
 
-let make_agent env =
+let make_agent ?tool_failure_judge env =
   let tools =
     [ Tool.create ~name:"echo" ~description:"echo" ~parameters:[] (fun input ->
         Ok { Types.content = Yojson.Safe.to_string input; _meta = None })
     ]
   in
-  Agent.create ~net:(Eio.Stdenv.net env) ~tools ()
+  Agent.create ~net:(Eio.Stdenv.net env) ~tools ?tool_failure_judge ()
 ;;
 
 let with_log_capture f =
@@ -145,6 +145,24 @@ let test_set_consecutive_idle_protected () =
   | _ -> Alcotest.fail "expected IdleDetected after setting consecutive_idle_turns=5"
 ;;
 
+let test_tool_failure_judge_preserves_idle_guard () =
+  Eio_main.run
+  @@ fun env ->
+  let tool_failure_judge =
+    Tool_failure_recovery.create ~complete:(fun ~sw:_ _request ->
+      Error (Error.Internal "judge must not run from the loop guard"))
+  in
+  let agent = make_agent ~tool_failure_judge env in
+  Agent.set_consecutive_idle_turns agent 5;
+  match Agent.check_loop_guard agent with
+  | Some (Error.Agent (Error.IdleDetected { consecutive_idle_turns = 5 })) -> ()
+  | Some error ->
+    Alcotest.failf "expected IdleDetected, got %s" (Error.to_string error)
+  | None ->
+    Alcotest.fail
+      "tool-failure judge disabled the generic repeated-tool idle guard"
+;;
+
 (* ── Test: lifecycle transitions are ordered ────────────── *)
 
 let test_lifecycle_transition_order () =
@@ -219,6 +237,10 @@ let () =
             "set_consecutive_idle protected"
             `Quick
             test_set_consecutive_idle_protected
+        ; Alcotest.test_case
+            "tool-failure judge preserves idle guard"
+            `Quick
+            test_tool_failure_judge_preserves_idle_guard
         ; Alcotest.test_case
             "lifecycle transition order"
             `Quick

--- a/test/test_agent_race.ml
+++ b/test/test_agent_race.ml
@@ -156,11 +156,9 @@ let test_tool_failure_judge_preserves_idle_guard () =
   Agent.set_consecutive_idle_turns agent 5;
   match Agent.check_loop_guard agent with
   | Some (Error.Agent (Error.IdleDetected { consecutive_idle_turns = 5 })) -> ()
-  | Some error ->
-    Alcotest.failf "expected IdleDetected, got %s" (Error.to_string error)
+  | Some error -> Alcotest.failf "expected IdleDetected, got %s" (Error.to_string error)
   | None ->
-    Alcotest.fail
-      "tool-failure judge disabled the generic repeated-tool idle guard"
+    Alcotest.fail "tool-failure judge disabled the generic repeated-tool idle guard"
 ;;
 
 (* ── Test: lifecycle transitions are ordered ────────────── *)


### PR DESCRIPTION
## Summary

- keep the generic repeated-tool idle guard active when a typed tool-failure judge is installed
- add a regression test proving the judge is not invoked by the loop guard and cannot disable IdleDetected

## Why

MASC installs the recovery judge on every Keeper run. The prior condition disabled max_idle_turns whenever that judge existed, leaving successful no-op repetition and non-matching failure loops to run until the outer dispatch watchdog.

## Verification

- scripts/dune-local.sh build test/test_agent_race.exe
- scripts/dune-local.sh exec test/test_agent_race.exe (9/9)
- scripts/dune-local.sh build @fmt
- git diff --check