### PR TITLE
fix(release): reconcile API availability versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,6 +282,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Install ripgrep
+        run: sudo apt-get install -y ripgrep
+
       - name: Verify version strings match
         run: |
           # Tolerant of trailing release-please annotations:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,6 +300,13 @@ jobs:
 
           echo "Version consistency check passed: $DUNE_VER"
 
+      - name: Test release availability gate
+        run: bash scripts/test-check-since-version.sh
+
+      - name: Reject future API availability claims in release candidates
+        if: ${{ startsWith(github.head_ref, 'release-please--branches--') || startsWith(github.ref_name, 'release-please--branches--') }}
+        run: bash scripts/check-since-version.sh
+
   transport-drift:
     name: Transport Drift Gate
     # Run on drafts: catching drift at draft time prevents main from going

--- a/docs/EVENT-CATALOG.md
+++ b/docs/EVENT-CATALOG.md
@@ -7,7 +7,7 @@ relate, and the contracts downstream consumers can rely on.
 **Scope**: `agent_sdk` library (`lib/`).
 **Status**: Stable catalog; entries marked *Evolving* may change with
 deprecation notice.
-**Last updated**: v0.212.0.
+**Last updated**: v0.211.3.
 
 ---
 

--- a/lib/binding_identity.mli
+++ b/lib/binding_identity.mli
@@ -4,7 +4,7 @@
     OAS-owned catalog facts.  Embedding runtimes may compare/hash it, but cannot
     reconstruct it from display strings or inspect credential material.
 
-    @since 0.212.0 *)
+    @since 0.211.7 *)
 
 type transport =
   | Http

--- a/lib/durable_event.mli
+++ b/lib/durable_event.mli
@@ -21,7 +21,7 @@
 
 (** Canonical envelope type for adapters that project durable journal events
     across runtimes. Journal variants remain unchanged for compatibility.
-    @since truth-layer-evidence *)
+    @since 0.170.5 *)
 type envelope_v2 = Event_envelope.t
 
 val mk_envelope_v2

--- a/lib/event_bus.mli
+++ b/lib/event_bus.mli
@@ -30,7 +30,7 @@ type envelope =
 (** Richer, cross-runtime envelope with explicit event IDs, observation time,
     and sequence/parent metadata. Existing {!envelope} remains the event bus
     compatibility shape; new adapters should prefer [envelope_v2].
-    @since truth-layer-evidence *)
+    @since 0.170.5 *)
 type envelope_v2 = Event_envelope.t
 
 (** {2 Payload types} *)

--- a/lib/llm_provider/backend_gemini.mli
+++ b/lib/llm_provider/backend_gemini.mli
@@ -51,7 +51,7 @@ val gemini_thought_signature_payload
 (** Exact Gemini response-part kind targeted by an adjacent opaque
     [thoughtSignature] carrier. The carrier and target stay adjacent through
     history replay; a broken adjacency fails closed in the request builder.
-    @since 0.212.0 *)
+    @since 0.211.3 *)
 type gemini_part_signature_target =
   | Gemini_text_part
   | Gemini_thought_part
@@ -61,7 +61,7 @@ type gemini_part_signature_target =
 
 (** Opaque carrier payload for a Gemini [thoughtSignature] attached to the
     immediately following text or thought part.
-    @since 0.212.0 *)
+    @since 0.211.3 *)
 val gemini_part_thought_signature_payload
   :  target:gemini_part_signature_target
   -> thought_signature:string
@@ -70,13 +70,13 @@ val gemini_part_thought_signature_payload
 (** Decode an optional Gemini wire [thoughtSignature]. Missing/null returns
     [None]; blank or non-string values fail closed with {!Gemini_api_error}.
     Shared by synchronous and streaming response paths.
-    @since 0.212.0 *)
+    @since 0.211.4 *)
 val thought_signature_of_part : Yojson.Safe.t -> string option
 
 (** Decode a Gemini [inlineData] object to its closed replay target and OAS
     media block. Missing/blank fields and malformed MIME types fail closed.
     Shared by synchronous and streaming response paths.
-    @since 0.212.0 *)
+    @since 0.211.4 *)
 val media_content_block_of_inline_data
   :  Yojson.Safe.t
   -> gemini_part_signature_target * Types.content_block

--- a/lib/llm_provider/provider_replay.mli
+++ b/lib/llm_provider/provider_replay.mli
@@ -5,7 +5,7 @@
     to neighboring content blocks without teaching reducers about individual
     provider wire formats.
 
-    @since 0.212.0 *)
+    @since 0.211.3 *)
 
 type retention = Exact_next_block
 
@@ -32,7 +32,7 @@ type decoded =
 (** Validate one exact JSON object schema before any field lookup. Duplicate
     and unexpected keys retain their typed malformed reason so provider-owned
     payload decoders can share the envelope's cardinality contract.
-    @since 0.212.0 *)
+    @since 0.211.6 *)
 val exact_object_fields
   :  allowed:string list
   -> Yojson.Safe.t
@@ -40,11 +40,11 @@ val exact_object_fields
 
 (** Wrap provider-owned JSON that must stay adjacent to the following content
     block.
-    @since 0.212.0 *)
+    @since 0.211.3 *)
 val encode_exact_next_block : payload:Yojson.Safe.t -> string
 
 (** Decode only the OAS replay envelope. Arbitrary provider-owned redacted
     payloads return [Not_replay]; a recognized but invalid envelope returns a
     typed [Malformed_replay] result.
-    @since 0.212.0 *)
+    @since 0.211.3 *)
 val decode : string -> decoded

--- a/lib/llm_provider/wire_capture.mli
+++ b/lib/llm_provider/wire_capture.mli
@@ -21,7 +21,7 @@
     JSON line larger than the cap is skipped with a warning instead of exceeding
     the bound.
 
-    @since introduced for the agent output repetition investigation (Phase O). *)
+    @since 0.208.13 *)
 
 (** A per-chunk capture function. Call with each raw pre-parse chunk. *)
 type sink = string -> unit

--- a/lib/provider_failure_attribution.mli
+++ b/lib/provider_failure_attribution.mli
@@ -5,7 +5,7 @@
     projection and whose optional attribution is constructed before typed
     transport evidence is discarded.
 
-    @since 0.212.0 *)
+    @since 0.211.7 *)
 
 type failure_ownership =
   | Attempt_local

--- a/lib/tool_failure_episode.mli
+++ b/lib/tool_failure_episode.mli
@@ -6,7 +6,7 @@
     inspect error prose and tool arguments.
 
     @stability Evolving
-    @since 0.212.0 *)
+    @since 0.211.2 *)
 
 type failed_attempt =
   { tool_use_id : string
@@ -103,5 +103,5 @@ val detect : previous:completed_round -> current:completed_round -> (t list, err
 
 (** External-observability projection. Includes stable tool identities and
     typed failure classification, but never tool inputs or error text.
-    @since 0.212.0 *)
+    @since 0.211.4 *)
 val observation_to_yojson : t -> Yojson.Safe.t

--- a/lib/tool_failure_recovery.mli
+++ b/lib/tool_failure_recovery.mli
@@ -6,7 +6,7 @@
     episodes before it can affect execution.
 
     @stability Evolving
-    @since 0.212.0 *)
+    @since 0.211.2 *)
 
 type revised_call =
   { current_tool_use_id : string
@@ -35,7 +35,7 @@ val decision_to_yojson : decision -> Yojson.Safe.t
 (** External-observability projection of a decision. Reports only the closed
     action and non-sensitive cardinality/tool-name metadata; revised inputs,
     instructions, questions, schemas, and defer reasons remain internal.
-    @since 0.212.0 *)
+    @since 0.211.4 *)
 val decision_observation_to_yojson : decision -> Yojson.Safe.t
 
 type model_request =

--- a/scripts/check-since-version.sh
+++ b/scripts/check-since-version.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "${repo_root}/scripts/release-version-lib.sh"
+
+release_version="${1:-$(release_extract_dune_project_version "${repo_root}/dune-project")}"
+scan_root="${2:-${repo_root}/lib}"
+
+if [[ ! "$release_version" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+  echo "ERROR: release version is not strict SemVer: ${release_version}" >&2
+  exit 1
+fi
+
+version_gt() {
+  local lhs="$1"
+  local rhs="$2"
+  local lhs_major lhs_minor lhs_patch
+  local rhs_major rhs_minor rhs_patch
+
+  IFS=. read -r lhs_major lhs_minor lhs_patch <<< "$lhs"
+  IFS=. read -r rhs_major rhs_minor rhs_patch <<< "$rhs"
+
+  (( 10#$lhs_major > 10#$rhs_major )) && return 0
+  (( 10#$lhs_major < 10#$rhs_major )) && return 1
+  (( 10#$lhs_minor > 10#$rhs_minor )) && return 0
+  (( 10#$lhs_minor < 10#$rhs_minor )) && return 1
+  (( 10#$lhs_patch > 10#$rhs_patch ))
+}
+
+annotations=0
+violations=0
+while IFS=: read -r path line annotation; do
+  [[ -n "$annotation" ]] || continue
+  read -r _ since <<< "$annotation"
+  annotations=$((annotations + 1))
+
+  if [[ ! "$since" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+    echo "ERROR: ${path}:${line}: invalid @since version '${since}'" >&2
+    violations=$((violations + 1))
+  elif version_gt "$since" "$release_version"; then
+    echo "ERROR: ${path}:${line}: @since ${since} exceeds release ${release_version}" >&2
+    violations=$((violations + 1))
+  fi
+done < <(
+  rg --with-filename --line-number --only-matching \
+    '@since[[:space:]]+[^[:space:]*]+' "$scan_root" -g '*.mli' || true
+)
+
+if (( annotations == 0 )); then
+  echo "ERROR: no @since annotations found under ${scan_root}" >&2
+  exit 1
+fi
+
+if (( violations > 0 )); then
+  echo "Release availability check failed with ${violations} violation(s)." >&2
+  exit 1
+fi
+
+echo "Release availability check passed: ${annotations} @since annotation(s) <= ${release_version}"

--- a/scripts/test-check-since-version.sh
+++ b/scripts/test-check-since-version.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+checker="${repo_root}/scripts/check-since-version.sh"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+mkdir -p "$tmpdir/valid" "$tmpdir/future" "$tmpdir/invalid"
+printf '(** @since 0.211.3 *)\n(** @since 0.211.8 *)\n' > "$tmpdir/valid/api.mli"
+printf '(** @since 0.211.9 *)\n' > "$tmpdir/future/api.mli"
+printf '(** @since next *)\n' > "$tmpdir/invalid/api.mli"
+
+bash "$checker" 0.211.8 "$tmpdir/valid" >/dev/null
+
+if bash "$checker" 0.211.8 "$tmpdir/future" >/dev/null 2>&1; then
+  echo "FAIL: future @since annotation was accepted" >&2
+  exit 1
+fi
+
+if bash "$checker" 0.211.8 "$tmpdir/invalid" >/dev/null 2>&1; then
+  echo "FAIL: invalid @since annotation was accepted" >&2
+  exit 1
+fi
+
+echo "release availability gate fixtures passed"


### PR DESCRIPTION
## Summary

- replace future/non-semver `@since` claims with each public symbol's first containing release tag
- correct the event catalog's last-updated release from its latest content commit
- add a release-candidate gate that rejects invalid or future API availability annotations

## Why

`v0.211.7` shipped public APIs documented as `@since 0.212.0`, while older surfaces still used prose in `@since`. The release candidate must not claim a version newer than the artifact being published.

## Verification

- `bash scripts/test-check-since-version.sh`
- `bash scripts/check-since-version.sh` (468 annotations <= 0.211.7)
- `bash scripts/test-release-version-extraction.sh`
- `shellcheck -x scripts/check-since-version.sh scripts/test-check-since-version.sh`
- `actionlint .github/workflows/ci.yml`
- `ocamlformat --check` on all changed `.mli` files
- `git diff --check`

Closes #2574