### PR TITLE
fix(agent): recover repeated failure groups without guessing

### DIFF
--- a/lib/tool_failure_episode.ml
+++ b/lib/tool_failure_episode.ml
@@ -11,7 +11,7 @@ type failed_attempt =
 [@@deriving yojson, show]
 
 type t =
-  { previous : failed_attempt
+  { previous : failed_attempt list
   ; current : failed_attempt
   }
 [@@deriving yojson, show]
@@ -47,13 +47,6 @@ type error =
   | Invalid_completed_round_metadata of string
   | Duplicate_run_boundary_metadata
   | Invalid_run_boundary_metadata
-  | Ambiguous_failure_signature of
-      { tool_name : string
-      ; failure_kind : tool_failure_kind
-      ; error_class : tool_error_class option
-      ; previous_count : int
-      ; current_count : int
-      }
 [@@deriving show]
 
 module String_set = Set.Make (String)
@@ -278,7 +271,12 @@ let observation_to_yojson (episode : t) =
     | None -> `Null
   in
   `Assoc
-    [ "previous_tool_use_id", `String episode.previous.tool_use_id
+    [ ( "previous_tool_use_ids"
+      , `List
+          (List.map
+             (fun (attempt : failed_attempt) -> `String attempt.tool_use_id)
+             episode.previous) )
+    ; "previous_count", `Int (List.length episode.previous)
     ; "current_tool_use_id", `String episode.current.tool_use_id
     ; "tool_name", `String episode.current.tool_name
     ; "failure_kind", tool_failure_kind_to_yojson episode.current.failure_kind
@@ -304,33 +302,14 @@ let failure_groups round =
 
 let detect ~previous ~current =
   let previous_groups = failure_groups previous in
-  let current_groups = failure_groups current in
-  let* () =
-    Failure_map.fold
-      (fun ((tool_name, failure_kind, error_class) as key) current_attempts result ->
-         let* () = result in
-         match Failure_map.find_opt key previous_groups with
-         | None -> Ok ()
-         | Some previous_attempts ->
-           let previous_count = List.length previous_attempts in
-           let current_count = List.length current_attempts in
-           if previous_count = 1 && current_count = 1
-           then Ok ()
-           else
-             Error
-               (Ambiguous_failure_signature
-                  { tool_name; failure_kind; error_class; previous_count; current_count }))
-      current_groups
-      (Ok ())
-  in
   let episodes =
     current
     |> List.filter_map failed_attempt
     |> List.filter_map (fun current_failure ->
       match Failure_map.find_opt (failure_key current_failure) previous_groups with
-      | Some [ previous_failure ] ->
-        Some { previous = previous_failure; current = current_failure }
-      | None | Some [] | Some (_ :: _ :: _) -> None)
+      | Some (_ :: _ as previous_failures) ->
+        Some { previous = List.rev previous_failures; current = current_failure }
+      | None | Some [] -> None)
   in
   Ok episodes
 ;;

--- a/lib/tool_failure_episode.mli
+++ b/lib/tool_failure_episode.mli
@@ -19,7 +19,7 @@ type failed_attempt =
 [@@deriving yojson, show]
 
 type t =
-  { previous : failed_attempt
+  { previous : failed_attempt list
   ; current : failed_attempt
   }
 [@@deriving yojson, show]
@@ -54,13 +54,6 @@ type error =
   | Invalid_completed_round_metadata of string
   | Duplicate_run_boundary_metadata
   | Invalid_run_boundary_metadata
-  | Ambiguous_failure_signature of
-      { tool_name : string
-      ; failure_kind : Types.tool_failure_kind
-      ; error_class : Types.tool_error_class option
-      ; previous_count : int
-      ; current_count : int
-      }
 [@@deriving show]
 
 (** [project ~executions ~tool_results] pairs canonical executed calls with
@@ -91,14 +84,14 @@ val latest_completed_rounds
   -> Types.message list
   -> (completed_round list, error) result
 
-(** [detect ~previous ~current] returns one episode for each failure signature
-    that occurs exactly once in each adjacent completed round. A signature is
+(** [detect ~previous ~current] returns one episode for every current failed
+    call whose typed signature also occurred in the immediately preceding
+    completed round. A signature is
     [(tool_name, failure_kind, error_class)]; argument and error-text changes do
-    not prevent detection.
-
-    Multiple different signatures for the same tool name remain independent.
-    A signature occurring more than once in either round cannot be paired
-    without guessing and returns [Ambiguous_failure_signature]. *)
+    not prevent detection. [previous] retains the complete matching group in
+    execution order, so repeated parallel calls are represented without
+    guessing an individual pair. Multiple signatures for one tool remain
+    independent. *)
 val detect : previous:completed_round -> current:completed_round -> (t list, error) result
 
 (** External-observability projection. Includes stable tool identities and

--- a/lib/tool_failure_recovery.ml
+++ b/lib/tool_failure_recovery.ml
@@ -270,7 +270,9 @@ let attempt_json (attempt : Tool_failure_episode.failed_attempt) =
 
 let episode_json (episode : Tool_failure_episode.t) =
   `Assoc
-    [ "previous", attempt_json episode.previous; "current", attempt_json episode.current ]
+    [ "previous", `List (List.map attempt_json episode.previous)
+    ; "current", attempt_json episode.current
+    ]
 ;;
 
 let non_blank_string_schema = `Assoc [ "type", `String "string"; "minLength", `Int 1 ]
@@ -377,7 +379,7 @@ let decide ~sw ~agent_name ~turn ~episodes judge =
 ;;
 
 type episode_ref =
-  { previous_tool_use_id : string
+  { previous_tool_use_ids : string list
   ; current_tool_use_id : string
   ; tool_name : string
   ; failure_kind : Types.tool_failure_kind
@@ -392,7 +394,10 @@ type receipt =
   }
 
 let episode_ref (episode : Tool_failure_episode.t) =
-  { previous_tool_use_id = episode.previous.tool_use_id
+  { previous_tool_use_ids =
+      List.map
+        (fun (attempt : Tool_failure_episode.failed_attempt) -> attempt.tool_use_id)
+        episode.previous
   ; current_tool_use_id = episode.current.tool_use_id
   ; tool_name = episode.current.tool_name
   ; failure_kind = episode.current.failure_kind
@@ -423,8 +428,8 @@ type receipt_error =
   | Receipt_decision_invalid of decision_error
 [@@deriving show]
 
-let receipt_version = 1
-let metadata_key = "oas.tool_failure_recovery.v1"
+let receipt_version = 2
+let metadata_key = "oas.tool_failure_recovery.v2"
 
 let revised_call_json (call : revised_call) =
   `Assoc
@@ -474,7 +479,8 @@ let decision_observation_to_yojson = function
 
 let episode_ref_json episode =
   `Assoc
-    [ "previous_tool_use_id", `String episode.previous_tool_use_id
+    [ ( "previous_tool_use_ids"
+      , `List (List.map (fun id -> `String id) episode.previous_tool_use_ids) )
     ; "current_tool_use_id", `String episode.current_tool_use_id
     ; "tool_name", `String episode.tool_name
     ; "failure_kind", failure_kind_json episode.failure_kind
@@ -568,6 +574,19 @@ let parse_string_receipt name fields =
   | _ -> Error (Invalid_receipt_metadata name)
 ;;
 
+let parse_string_list_receipt name fields =
+  match List.assoc_opt name fields with
+  | Some (`List values) ->
+    let rec loop acc = function
+      | [] -> Ok (List.rev acc)
+      | `String value :: rest when not (String.equal (String.trim value) "") ->
+        loop (value :: acc) rest
+      | `String _ :: _ | _ :: _ -> Error (Invalid_receipt_metadata name)
+    in
+    loop [] values
+  | _ -> Error (Invalid_receipt_metadata name)
+;;
+
 let validate_receipt_fields ~allowed fields =
   validate_fields ~allowed fields
   |> Result.map_error (fun error -> Invalid_receipt_metadata (show_response_error error))
@@ -597,7 +616,7 @@ let parse_episode_ref = function
     let* () =
       validate_receipt_fields
         ~allowed:
-          [ "previous_tool_use_id"
+          [ "previous_tool_use_ids"
           ; "current_tool_use_id"
           ; "tool_name"
           ; "failure_kind"
@@ -605,12 +624,20 @@ let parse_episode_ref = function
           ]
         fields
     in
-    let* previous_tool_use_id = parse_string_receipt "previous_tool_use_id" fields in
+    let* previous_tool_use_ids =
+      parse_string_list_receipt "previous_tool_use_ids" fields
+    in
+    let* () =
+      if previous_tool_use_ids = []
+      then Error (Invalid_receipt_metadata "previous_tool_use_ids")
+      else Ok ()
+    in
     let* current_tool_use_id = parse_string_receipt "current_tool_use_id" fields in
     let* tool_name = parse_string_receipt "tool_name" fields in
     let* failure_kind = parse_failure_kind fields in
     let* error_class = parse_error_class fields in
-    Ok { previous_tool_use_id; current_tool_use_id; tool_name; failure_kind; error_class }
+    Ok
+      { previous_tool_use_ids; current_tool_use_id; tool_name; failure_kind; error_class }
   | _ -> Error (Invalid_receipt_metadata "episodes")
 ;;
 
@@ -685,7 +712,7 @@ let latest_receipt messages =
 ;;
 
 let same_episode_ref left right =
-  String.equal left.previous_tool_use_id right.previous_tool_use_id
+  left.previous_tool_use_ids = right.previous_tool_use_ids
   && String.equal left.current_tool_use_id right.current_tool_use_id
   && String.equal left.tool_name right.tool_name
   && left.failure_kind = right.failure_kind

--- a/test/test_event_forward.ml
+++ b/test/test_event_forward.ml
@@ -315,10 +315,11 @@ let test_recovery_episode_payload_omits_input_and_error () =
   let error_secret = "secret-provider-error" in
   let episode : Tool_failure_episode.t =
     { previous =
-        failed_attempt
-          ~tool_use_id:"previous-call"
-          ~input:(`Assoc [ "token", `String secret ])
-          ~error:error_secret
+        [ failed_attempt
+            ~tool_use_id:"previous-call"
+            ~input:(`Assoc [ "token", `String secret ])
+            ~error:error_secret
+        ]
     ; current =
         failed_attempt
           ~tool_use_id:"current-call"
@@ -340,7 +341,8 @@ let test_recovery_episode_payload_omits_input_and_error () =
     [ "current_tool_use_id"
     ; "error_class"
     ; "failure_kind"
-    ; "previous_tool_use_id"
+    ; "previous_count"
+    ; "previous_tool_use_ids"
     ; "tool_name"
     ]
     field_names;

--- a/test/test_tool_failure_episode.ml
+++ b/test/test_tool_failure_episode.ml
@@ -45,12 +45,19 @@ let test_changed_input_and_error_text_detected () =
   in
   match detect previous current with
   | Ok [ episode ] ->
-    Alcotest.(check string) "previous id" "p1" episode.previous.tool_use_id;
+    Alcotest.(check (list string))
+      "previous ids"
+      [ "p1" ]
+      (List.map
+         (fun (attempt : Tool_failure_episode.failed_attempt) -> attempt.tool_use_id)
+         episode.previous);
     Alcotest.(check string) "current id" "c1" episode.current.tool_use_id;
     Alcotest.(check bool)
       "input changed"
       false
-      (Yojson.Safe.equal episode.previous.input episode.current.input)
+      (match episode.previous with
+       | [ previous ] -> Yojson.Safe.equal previous.input episode.current.input
+       | _ -> true)
   | Ok episodes -> Alcotest.failf "expected one episode, got %d" (List.length episodes)
   | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
 ;;
@@ -132,7 +139,7 @@ let test_success_and_matching_failure_same_name_are_unambiguous () =
   | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
 ;;
 
-let test_duplicate_failure_signature_is_explicit () =
+let test_repeated_failure_signature_preserves_previous_group () =
   let previous =
     project
       [ call "p1" "Execute" `Null; call "p2" "Execute" (`String "other") ]
@@ -140,11 +147,46 @@ let test_duplicate_failure_signature_is_explicit () =
   in
   let current = project [ call "c1" "Execute" `Null ] [ typed_failure "c1" "second" ] in
   match detect previous current with
-  | Error
-      (Tool_failure_episode.Ambiguous_failure_signature
-         { previous_count = 2; current_count = 1; _ }) -> ()
+  | Ok [ episode ] ->
+    Alcotest.(check (list string))
+      "complete previous group"
+      [ "p1"; "p2" ]
+      (List.map
+         (fun (attempt : Tool_failure_episode.failed_attempt) -> attempt.tool_use_id)
+         episode.previous);
+    Alcotest.(check string) "current id" "c1" episode.current.tool_use_id
+  | Ok episodes ->
+    Alcotest.failf "expected one grouped episode, got %d" (List.length episodes)
   | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
-  | Ok _ -> Alcotest.fail "expected typed ambiguity"
+;;
+
+let test_repeated_current_calls_each_receive_the_group () =
+  let previous =
+    project
+      [ call "p1" "Execute" `Null; call "p2" "Execute" (`String "other") ]
+      [ typed_failure "p1" "first-a"; typed_failure "p2" "first-b" ]
+  in
+  let current =
+    project
+      [ call "c1" "Execute" `Null; call "c2" "Execute" (`String "changed") ]
+      [ typed_failure "c1" "second-a"; typed_failure "c2" "second-b" ]
+  in
+  match detect previous current with
+  | Ok episodes ->
+    Alcotest.(check (list string))
+      "every current failed call remains independently addressable"
+      [ "c1"; "c2" ]
+      (List.map
+         (fun (episode : Tool_failure_episode.t) -> episode.current.tool_use_id)
+         episodes);
+    List.iter
+      (fun (episode : Tool_failure_episode.t) ->
+         Alcotest.(check int)
+           "complete previous group on each episode"
+           2
+           (List.length episode.previous))
+      episodes
+  | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
 ;;
 
 let test_unclassified_failure_is_explicit () =
@@ -414,9 +456,13 @@ let () =
             `Quick
             test_success_and_matching_failure_same_name_are_unambiguous
         ; Alcotest.test_case
-            "duplicate failure signature"
+            "repeated failure signature preserves previous group"
             `Quick
-            test_duplicate_failure_signature_is_explicit
+            test_repeated_failure_signature_preserves_previous_group
+        ; Alcotest.test_case
+            "repeated current calls each receive the group"
+            `Quick
+            test_repeated_current_calls_each_receive_the_group
         ; Alcotest.test_case
             "unclassified failure"
             `Quick


### PR DESCRIPTION
## Summary
- retain every previous attempt for a repeated typed failure signature
- create one recovery episode per current failed call without positional pairing
- version recovery receipts around grouped previous-call identity

## Why
Repeated parallel calls with the same typed failure signature previously returned `Ambiguous_failure_signature`, disabling the recovery judge exactly when a model was perseverating.

## Verification
- `scripts/dune-local.sh build test/test_tool_failure_episode.exe test/test_tool_failure_recovery.exe test/test_event_forward.exe @fmt`
- 22 tool-failure episode tests
- 15 recovery tests
- 29 event-forward tests
