### PR TITLE
fix(recovery): resume legacy failure receipts

### DIFF
--- a/lib/tool_failure_recovery.ml
+++ b/lib/tool_failure_recovery.ml
@@ -428,8 +428,19 @@ type receipt_error =
   | Receipt_decision_invalid of decision_error
 [@@deriving show]
 
-let receipt_version = 2
-let metadata_key = "oas.tool_failure_recovery.v2"
+type receipt_wire_version =
+  | Legacy_v1
+  | Current_v2
+
+let receipt_wire_version_number = function
+  | Legacy_v1 -> 1
+  | Current_v2 -> 2
+;;
+
+let receipt_metadata_key = function
+  | Legacy_v1 -> "oas.tool_failure_recovery.v1"
+  | Current_v2 -> "oas.tool_failure_recovery.v2"
+;;
 
 let revised_call_json (call : revised_call) =
   `Assoc
@@ -490,12 +501,24 @@ let episode_ref_json episode =
 
 let receipt_json receipt =
   `Assoc
-    [ "version", `Int receipt_version
+    [ "version", `Int (receipt_wire_version_number Current_v2)
     ; "resume_turn", `Int receipt.resume_turn
     ; "decided_at", `Float receipt.decided_at
     ; "episodes", `List (List.map episode_ref_json receipt.episodes)
     ; "decision", decision_json receipt.decision
     ]
+;;
+
+let receipt_metadata_values metadata =
+  List.fold_left
+    (fun (v1_values, v2_values) (key, value) ->
+       if String.equal key (receipt_metadata_key Legacy_v1)
+       then value :: v1_values, v2_values
+       else if String.equal key (receipt_metadata_key Current_v2)
+       then v1_values, value :: v2_values
+       else v1_values, v2_values)
+    ([], [])
+    metadata
 ;;
 
 let tool_result_ids (message : Types.message) =
@@ -525,14 +548,16 @@ let attach_receipt ~messages ~episodes ~receipt =
   let rec update = function
     | [] -> Error Result_message_not_found
     | (message : Types.message) :: rest when contains_expected message ->
-      if List.mem_assoc metadata_key message.Types.metadata
-      then Error Duplicate_receipt_metadata
-      else
-        Ok
-          ({ message with
-             metadata = (metadata_key, receipt_json receipt) :: message.metadata
-           }
-           :: rest)
+      (match receipt_metadata_values message.Types.metadata with
+       | _ :: _, _ | _, _ :: _ -> Error Duplicate_receipt_metadata
+       | [], [] ->
+         Ok
+           ({ message with
+              metadata =
+                (receipt_metadata_key Current_v2, receipt_json receipt)
+                :: message.metadata
+            }
+            :: rest))
     | (message : Types.message) :: rest ->
       let* rest = update rest in
       Ok (message :: rest)
@@ -611,50 +636,66 @@ let parse_error_class fields =
      | Error detail -> Error (Invalid_receipt_metadata detail))
 ;;
 
-let parse_episode_ref = function
+let parse_episode_ref_fields ~previous_field ~parse_previous_tool_use_ids fields =
+  let* () =
+    validate_receipt_fields
+      ~allowed:
+        [ previous_field
+        ; "current_tool_use_id"
+        ; "tool_name"
+        ; "failure_kind"
+        ; "error_class"
+        ]
+      fields
+  in
+  let* previous_tool_use_ids = parse_previous_tool_use_ids fields in
+  let* current_tool_use_id = parse_string_receipt "current_tool_use_id" fields in
+  let* tool_name = parse_string_receipt "tool_name" fields in
+  let* failure_kind = parse_failure_kind fields in
+  let* error_class = parse_error_class fields in
+  Ok { previous_tool_use_ids; current_tool_use_id; tool_name; failure_kind; error_class }
+;;
+
+let parse_episode_ref ~wire_version = function
   | `Assoc fields ->
-    let* () =
-      validate_receipt_fields
-        ~allowed:
-          [ "previous_tool_use_ids"
-          ; "current_tool_use_id"
-          ; "tool_name"
-          ; "failure_kind"
-          ; "error_class"
-          ]
-        fields
-    in
-    let* previous_tool_use_ids =
-      parse_string_list_receipt "previous_tool_use_ids" fields
-    in
-    let* () =
-      if previous_tool_use_ids = []
-      then Error (Invalid_receipt_metadata "previous_tool_use_ids")
-      else Ok ()
-    in
-    let* current_tool_use_id = parse_string_receipt "current_tool_use_id" fields in
-    let* tool_name = parse_string_receipt "tool_name" fields in
-    let* failure_kind = parse_failure_kind fields in
-    let* error_class = parse_error_class fields in
-    Ok
-      { previous_tool_use_ids; current_tool_use_id; tool_name; failure_kind; error_class }
+    (match wire_version with
+     | Legacy_v1 ->
+       parse_episode_ref_fields
+         ~previous_field:"previous_tool_use_id"
+         ~parse_previous_tool_use_ids:(fun fields ->
+           let* previous_tool_use_id =
+             parse_string_receipt "previous_tool_use_id" fields
+           in
+           Ok [ previous_tool_use_id ])
+         fields
+     | Current_v2 ->
+       parse_episode_ref_fields
+         ~previous_field:"previous_tool_use_ids"
+         ~parse_previous_tool_use_ids:(fun fields ->
+           let* previous_tool_use_ids =
+             parse_string_list_receipt "previous_tool_use_ids" fields
+           in
+           if previous_tool_use_ids = []
+           then Error (Invalid_receipt_metadata "previous_tool_use_ids")
+           else Ok previous_tool_use_ids)
+         fields)
   | _ -> Error (Invalid_receipt_metadata "episodes")
 ;;
 
-let parse_episode_refs fields =
+let parse_episode_refs ~wire_version fields =
   match List.assoc_opt "episodes" fields with
   | Some (`List values) ->
     List.fold_right
       (fun value result ->
          let* refs = result in
-         let* episode = parse_episode_ref value in
+         let* episode = parse_episode_ref ~wire_version value in
          Ok (episode :: refs))
       values
       (Ok [])
   | _ -> Error (Invalid_receipt_metadata "episodes")
 ;;
 
-let parse_receipt = function
+let parse_receipt ~wire_version = function
   | `Assoc fields ->
     let* () =
       validate_receipt_fields
@@ -663,13 +704,13 @@ let parse_receipt = function
     in
     let* version = parse_int "version" fields in
     let* () =
-      if version = receipt_version
+      if version = receipt_wire_version_number wire_version
       then Ok ()
       else Error (Invalid_receipt_metadata "version")
     in
     let* resume_turn = parse_int "resume_turn" fields in
     let* decided_at = parse_float "decided_at" fields in
-    let* episodes = parse_episode_refs fields in
+    let* episodes = parse_episode_refs ~wire_version fields in
     let* decision_json =
       match List.assoc_opt "decision" fields with
       | Some value -> Ok value
@@ -681,7 +722,20 @@ let parse_receipt = function
       | Error error -> Error (Invalid_receipt_metadata (show_response_error error))
     in
     Ok { resume_turn; decided_at; episodes; decision }
-  | _ -> Error (Invalid_receipt_metadata metadata_key)
+  | _ -> Error (Invalid_receipt_metadata (receipt_metadata_key wire_version))
+;;
+
+type selected_receipt_metadata =
+  | Selected_v1 of Yojson.Safe.t
+  | Selected_v2 of Yojson.Safe.t
+
+let select_receipt_metadata metadata =
+  let v1_values, v2_values = receipt_metadata_values metadata in
+  match v1_values, v2_values with
+  | [], [] -> Ok None
+  | [ value ], [] -> Ok (Some (Selected_v1 value))
+  | [], [ value ] -> Ok (Some (Selected_v2 value))
+  | _ -> Error Duplicate_receipt_metadata
 ;;
 
 let latest_receipt messages =
@@ -690,19 +744,16 @@ let latest_receipt messages =
     | message :: rest ->
       if tool_result_ids message = []
       then find rest
-      else (
-        let values =
-          List.filter_map
-            (fun (key, value) ->
-               if String.equal key metadata_key then Some value else None)
-            message.Types.metadata
-        in
-        match values with
-        | [] -> Ok None
-        | [ value ] ->
-          let* receipt = parse_receipt value in
-          Ok (Some receipt)
-        | _ :: _ :: _ -> Error Duplicate_receipt_metadata)
+      else
+        let* selected = select_receipt_metadata message.Types.metadata in
+        (match selected with
+         | None -> Ok None
+         | Some (Selected_v1 value) ->
+           let* receipt = parse_receipt ~wire_version:Legacy_v1 value in
+           Ok (Some receipt)
+         | Some (Selected_v2 value) ->
+           let* receipt = parse_receipt ~wire_version:Current_v2 value in
+           Ok (Some receipt))
   in
   let* run_messages =
     Tool_failure_episode.latest_run_messages messages

--- a/lib/tool_failure_recovery.mli
+++ b/lib/tool_failure_recovery.mli
@@ -131,9 +131,9 @@ type receipt_error =
   | Receipt_decision_invalid of decision_error
 [@@deriving show]
 
-(** Add a versioned receipt to the latest-run result message containing every
-    current episode id. Existing metadata is preserved; a duplicate receipt is
-    an explicit error. *)
+(** Add the current v2 receipt to the latest-run result message containing every
+    current episode id. Existing metadata is preserved; any existing recovery
+    receipt is an explicit error. *)
 val attach_receipt
   :  messages:Types.message list
   -> episodes:Tool_failure_episode.t list
@@ -141,7 +141,11 @@ val attach_receipt
   -> (Types.message list, receipt_error) result
 
 (** Read a receipt only from the latest-run message containing a [ToolResult].
-    An older receipt is never reused after a run or tool boundary. *)
+    Current v2 is the sole write format. Exact legacy v1 receipts are read
+    compatibly by lifting their singular previous tool-use id into a singleton
+    group. Multiple recovery receipts on one message are rejected as
+    [Duplicate_receipt_metadata], including a v1/v2 pair. An older receipt is
+    never reused after a run or tool boundary. *)
 val latest_receipt : Types.message list -> (receipt option, receipt_error) result
 
 (** Validate a restored receipt against reconstructed adjacent episodes. *)

--- a/test/test_tool_failure_recovery.ml
+++ b/test/test_tool_failure_recovery.ml
@@ -433,6 +433,231 @@ let sample_episodes () =
   | Error error -> Alcotest.fail (Tool_failure_episode.show_error error)
 ;;
 
+let legacy_receipt_key = "oas.tool_failure_recovery.v1"
+let current_receipt_key = "oas.tool_failure_recovery.v2"
+
+(* Frozen from agent_sdk v0.211.8 (677a7eed6) rather than derived from the
+   current v2 serializer. *)
+let legacy_receipt_v02118_golden =
+  Yojson.Safe.from_string
+    {|{"version":1,"resume_turn":2,"decided_at":42.5,"episodes":[{"previous_tool_use_id":"p1","current_tool_use_id":"c1","tool_name":"Execute","failure_kind":["Recoverable_tool_error"],"error_class":["Deterministic"]}],"decision":{"action":"retry_modified","revised_calls":[{"current_tool_use_id":"c1","tool_name":"Execute","revised_input":{"cmd":"gh pr list","cwd":"/repo"}}]}}|}
+;;
+
+let replace_current_receipt ~key ~value messages =
+  let replacements = ref 0 in
+  let messages =
+    List.map
+      (fun (message : Types.message) ->
+         let metadata =
+           List.map
+             (fun ((existing_key, _) as entry) ->
+                if String.equal existing_key current_receipt_key
+                then (
+                  incr replacements;
+                  key, value)
+                else entry)
+             message.metadata
+         in
+         { message with metadata })
+      messages
+  in
+  Alcotest.(check int) "one current receipt replaced" 1 !replacements;
+  messages
+;;
+
+let rewrite_current_receipt_as_legacy messages =
+  replace_current_receipt
+    ~key:legacy_receipt_key
+    ~value:legacy_receipt_v02118_golden
+    messages
+;;
+
+let add_legacy_receipt_beside_current messages =
+  let added = ref 0 in
+  let messages =
+    List.map
+      (fun (message : Types.message) ->
+         let metadata =
+           List.fold_right
+             (fun ((key, _) as entry) acc ->
+                if String.equal key current_receipt_key
+                then (
+                  incr added;
+                  (legacy_receipt_key, legacy_receipt_v02118_golden) :: entry :: acc)
+                else entry :: acc)
+             message.metadata
+             []
+         in
+         { message with metadata })
+      messages
+  in
+  Alcotest.(check int) "one legacy receipt added" 1 !added;
+  messages
+;;
+
+let duplicate_receipt_metadata ~key messages =
+  let duplicated = ref 0 in
+  let messages =
+    List.map
+      (fun (message : Types.message) ->
+         let metadata =
+           List.fold_right
+             (fun ((existing_key, _) as entry) acc ->
+                if String.equal existing_key key
+                then (
+                  incr duplicated;
+                  entry :: entry :: acc)
+                else entry :: acc)
+             message.metadata
+             []
+         in
+         { message with metadata })
+      messages
+  in
+  Alcotest.(check int) "one receipt duplicated" 1 !duplicated;
+  messages
+;;
+
+let map_receipt_fields map = function
+  | `Assoc fields -> `Assoc (map fields)
+  | _ -> Alcotest.fail "frozen receipt fixture is not an object"
+;;
+
+let replace_receipt_version version =
+  map_receipt_fields
+    (List.map (fun (name, value) ->
+       if String.equal name "version" then name, `Int version else name, value))
+;;
+
+let pluralize_legacy_previous_id =
+  map_receipt_fields
+    (List.map (fun (name, value) ->
+       if String.equal name "episodes"
+       then
+         ( name
+         , match value with
+           | `List episodes ->
+             `List
+               (List.map
+                  (function
+                    | `Assoc fields ->
+                      `Assoc
+                        (List.map
+                           (fun (field, value) ->
+                              if String.equal field "previous_tool_use_id"
+                              then "previous_tool_use_ids", `List [ value ]
+                              else field, value)
+                           fields)
+                    | _ -> Alcotest.fail "frozen episode fixture is not an object")
+                  episodes)
+           | _ -> Alcotest.fail "frozen receipt episodes are not a list" )
+       else name, value))
+;;
+
+let test_legacy_receipt_reads_as_singleton_group () =
+  Eio_main.run
+  @@ fun env ->
+  let scenario = run_scenario env ~judge_json:retry_modified_json () in
+  let messages =
+    rewrite_current_receipt_as_legacy (Agent.state scenario.agent).messages
+  in
+  match Tool_failure_recovery.latest_receipt messages with
+  | Ok (Some receipt) ->
+    (match
+       Tool_failure_recovery.validate_receipt ~episodes:(sample_episodes ()) receipt
+     with
+     | Ok () -> ()
+     | Error error -> Alcotest.fail (Tool_failure_recovery.show_receipt_error error));
+    Alcotest.(check string)
+      "legacy decision preserved"
+      retry_modified_json
+      (Tool_failure_recovery.receipt_decision receipt
+       |> Tool_failure_recovery.decision_to_yojson
+       |> Yojson.Safe.to_string)
+  | Ok None -> Alcotest.fail "expected legacy recovery receipt"
+  | Error error -> Alcotest.fail (Tool_failure_recovery.show_receipt_error error)
+;;
+
+let test_duplicate_receipt_metadata_is_explicit () =
+  Eio_main.run
+  @@ fun env ->
+  let scenario = run_scenario env ~judge_json:retry_modified_json () in
+  let current_messages = (Agent.state scenario.agent).messages in
+  let receipt =
+    match Tool_failure_recovery.latest_receipt current_messages with
+    | Ok (Some receipt) -> receipt
+    | Ok None -> Alcotest.fail "expected current recovery receipt"
+    | Error error -> Alcotest.fail (Tool_failure_recovery.show_receipt_error error)
+  in
+  let assert_duplicate label messages =
+    match Tool_failure_recovery.latest_receipt messages with
+    | Error Tool_failure_recovery.Duplicate_receipt_metadata -> ()
+    | Error error ->
+      Alcotest.failf "%s: %s" label (Tool_failure_recovery.show_receipt_error error)
+    | Ok _ -> Alcotest.failf "%s: expected duplicate receipt metadata" label
+  in
+  let mixed_versions = add_legacy_receipt_beside_current current_messages in
+  let duplicate_current =
+    duplicate_receipt_metadata ~key:current_receipt_key current_messages
+  in
+  let duplicate_legacy =
+    current_messages
+    |> rewrite_current_receipt_as_legacy
+    |> duplicate_receipt_metadata ~key:legacy_receipt_key
+  in
+  assert_duplicate "mixed v1/v2" mixed_versions;
+  assert_duplicate "duplicate v2" duplicate_current;
+  assert_duplicate "duplicate v1" duplicate_legacy;
+  match
+    Tool_failure_recovery.attach_receipt
+      ~messages:mixed_versions
+      ~episodes:(sample_episodes ())
+      ~receipt
+  with
+  | Error Tool_failure_recovery.Duplicate_receipt_metadata -> ()
+  | Error error -> Alcotest.fail (Tool_failure_recovery.show_receipt_error error)
+  | Ok _ -> Alcotest.fail "writer accepted duplicate receipt metadata"
+;;
+
+let test_legacy_receipt_schema_mismatches_are_rejected () =
+  Eio_main.run
+  @@ fun env ->
+  let scenario = run_scenario env ~judge_json:retry_modified_json () in
+  let current_messages = (Agent.state scenario.agent).messages in
+  let assert_version_mismatch label ~key value =
+    let messages = replace_current_receipt ~key ~value current_messages in
+    match Tool_failure_recovery.latest_receipt messages with
+    | Error (Tool_failure_recovery.Invalid_receipt_metadata "version") -> ()
+    | Error error ->
+      Alcotest.failf "%s: %s" label (Tool_failure_recovery.show_receipt_error error)
+    | Ok _ -> Alcotest.failf "%s: expected key/version mismatch" label
+  in
+  let assert_schema_mismatch label ~key value =
+    let messages = replace_current_receipt ~key ~value current_messages in
+    match Tool_failure_recovery.latest_receipt messages with
+    | Error (Tool_failure_recovery.Invalid_receipt_metadata _) -> ()
+    | Error error ->
+      Alcotest.failf "%s: %s" label (Tool_failure_recovery.show_receipt_error error)
+    | Ok _ -> Alcotest.failf "%s: expected receipt schema mismatch" label
+  in
+  assert_version_mismatch
+    "v1 key with v2 version"
+    ~key:legacy_receipt_key
+    (replace_receipt_version 2 legacy_receipt_v02118_golden);
+  assert_version_mismatch
+    "v2 key with v1 version"
+    ~key:current_receipt_key
+    legacy_receipt_v02118_golden;
+  assert_schema_mismatch
+    "v1 key with plural previous ids"
+    ~key:legacy_receipt_key
+    (pluralize_legacy_previous_id legacy_receipt_v02118_golden);
+  assert_schema_mismatch
+    "v2 key with singular previous id"
+    ~key:current_receipt_key
+    (replace_receipt_version 2 legacy_receipt_v02118_golden)
+;;
+
 let resumed_final_run env ~checkpoint ~judge =
   Eio.Switch.run
   @@ fun sw ->
@@ -501,6 +726,42 @@ let test_decision_checkpoint_resumes_without_rejudging () =
   let system_prompt = Option.value request.config.system_prompt ~default:"" in
   Alcotest.(check bool)
     "persisted control restored"
+    true
+    (String.starts_with ~prefix:"base system\n\nOAS one-turn typed" system_prompt)
+;;
+
+let test_legacy_decision_checkpoint_resumes_without_rejudging () =
+  Eio_main.run
+  @@ fun env ->
+  let scenario = run_scenario env ~judge_json:retry_modified_json () in
+  let checkpoint =
+    match scenario.decision_checkpoint with
+    | Some checkpoint ->
+      { checkpoint with messages = rewrite_current_receipt_as_legacy checkpoint.messages }
+    | None -> Alcotest.fail "missing recovery decision checkpoint"
+  in
+  let checkpoint = Checkpoint.to_json checkpoint |> Checkpoint.of_json |> Result.get_ok in
+  let judge_calls = ref 0 in
+  let judge =
+    Tool_failure_recovery.create ~complete:(fun ~sw:_ _ ->
+      incr judge_calls;
+      Ok {|{"action":"replan","instruction":"must not run"}|})
+  in
+  let result, requests = resumed_final_run env ~checkpoint ~judge in
+  (match result with
+   | Ok (`Complete response) ->
+     Alcotest.(check string)
+       "legacy resumed final text"
+       "finished"
+       (Types.text_of_response response)
+   | Ok `ToolsExecuted -> Alcotest.fail "unexpected resumed tool execution"
+   | Error error -> Alcotest.fail (Error.to_string error));
+  Alcotest.(check int) "legacy receipt skips judge" 0 !judge_calls;
+  Alcotest.(check int) "one resumed provider call" 1 (List.length requests);
+  let request = List.hd requests in
+  let system_prompt = Option.value request.config.system_prompt ~default:"" in
+  Alcotest.(check bool)
+    "legacy control restored"
     true
     (String.starts_with ~prefix:"base system\n\nOAS one-turn typed" system_prompt)
 ;;
@@ -765,6 +1026,10 @@ let () =
             `Quick
             test_decision_checkpoint_resumes_without_rejudging
         ; Alcotest.test_case
+            "legacy decision checkpoint resumes without rejudging"
+            `Quick
+            test_legacy_decision_checkpoint_resumes_without_rejudging
+        ; Alcotest.test_case
             "resume respects external user run boundary"
             `Quick
             test_resume_does_not_correlate_across_external_user_runs
@@ -792,6 +1057,18 @@ let () =
             "receipt record is closed"
             `Quick
             test_receipt_record_is_closed
+        ; Alcotest.test_case
+            "legacy receipt reads as singleton group"
+            `Quick
+            test_legacy_receipt_reads_as_singleton_group
+        ; Alcotest.test_case
+            "duplicate receipt metadata is explicit"
+            `Quick
+            test_duplicate_receipt_metadata_is_explicit
+        ; Alcotest.test_case
+            "legacy receipt schema mismatches are rejected"
+            `Quick
+            test_legacy_receipt_schema_mismatches_are_rejected
         ] )
     ; ( "decision_validation"
       , [ Alcotest.test_case


### PR DESCRIPTION
## Summary

- read exact `oas.tool_failure_recovery.v1` receipts from pre-0.211.9 checkpoints
- project the singular predecessor into the current singleton failure group without re-running the judge
- keep v2 as the only write format and fail explicitly on duplicate or mixed receipt metadata
- reuse the existing public typed duplicate error so the 0.211.x patch API remains compatible

Follow-up to the merged review finding in #2582: https://github.com/jeong-sik/oas/pull/2582#discussion_r3566031835

## Correctness

- frozen v0.211.8 wire golden is independent of the v2 serializer
- key/version and singular/plural schema mismatches fail closed
- checkpoint JSON round-trip resumes with zero judge calls and exactly one continuation provider call
- no provider/model/tool-text heuristics and no silent fallback

## Verification

- `scripts/dune-local.sh build test/test_tool_failure_recovery.exe`
- `_build/default/test/test_tool_failure_recovery.exe` — 19/19 passed
- `ocamlformat --check`
- `git diff --check`
- `scripts/check-since-version.sh`

## Performance

The compatibility scan runs only while restoring or attaching recovery metadata and preserves the existing O(metadata entries) complexity. It does not add work to the normal provider/tool hot path.
