### PR TITLE
fix: treat typed media responses as deliverable

### DIFF
--- a/lib/llm_provider/response_shape.ml
+++ b/lib/llm_provider/response_shape.ml
@@ -95,6 +95,7 @@ let summarize_blocks (content : Types.content_block list) =
 ;;
 
 let summarize (response : Types.api_response) = summarize_blocks response.content
+
 let has_deliverable_content shape =
   shape.text_chars > 0
   || shape.tool_use_count > 0

--- a/lib/llm_provider/response_shape.ml
+++ b/lib/llm_provider/response_shape.ml
@@ -95,11 +95,24 @@ let summarize_blocks (content : Types.content_block list) =
 ;;
 
 let summarize (response : Types.api_response) = summarize_blocks response.content
-let has_deliverable_content shape = shape.text_chars > 0 || shape.tool_use_count > 0
+let has_deliverable_content shape =
+  shape.text_chars > 0
+  || shape.tool_use_count > 0
+  || shape.image_count > 0
+  || shape.document_count > 0
+  || shape.audio_count > 0
+;;
 
 let content_shape (response : Types.api_response) shape =
   match response.content with
   | [] -> Empty
+  | _
+    when shape.image_count + shape.document_count + shape.audio_count > 0
+         && shape.text_chars = 0
+         && shape.tool_use_count = 0
+         && shape.tool_result_count = 0
+         && shape.thinking_blocks = 0
+         && shape.redacted_thinking_blocks = 0 -> Media_only
   | _ when has_deliverable_content shape -> Has_deliverable_content
   | _
     when shape.thinking_blocks + shape.redacted_thinking_blocks > 0
@@ -128,13 +141,6 @@ let content_shape (response : Types.api_response) shape =
          && shape.image_count = 0
          && shape.document_count = 0
          && shape.audio_count = 0 -> Tool_result_only
-  | _
-    when shape.image_count + shape.document_count + shape.audio_count > 0
-         && shape.text_chars = 0
-         && shape.tool_use_count = 0
-         && shape.tool_result_count = 0
-         && shape.thinking_blocks = 0
-         && shape.redacted_thinking_blocks = 0 -> Media_only
   | _ -> Mixed_without_deliverable_content
 ;;
 

--- a/lib/llm_provider/response_shape.mli
+++ b/lib/llm_provider/response_shape.mli
@@ -38,8 +38,8 @@ val content_shape : Types.api_response -> t -> content_shape
 val content_shape_to_string : content_shape -> string
 
 (** [true] when the response carries downstream-visible progress: non-blank
-    text or a tool call. Hidden thinking, tool results, and media-only blocks
-    are not deliverable progress by themselves. *)
+    text, a tool call, or an image/document/audio block. Hidden thinking and
+    tool results are not deliverable progress by themselves. *)
 val has_deliverable_content : t -> bool
 
 (** [true] when the provider response ended normally without downstream-visible

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -1163,10 +1163,7 @@ let test_response_shape_media_only_is_deliverable () =
       , response
           ~content:
             [ Types.Image
-                { media_type = "image/png"
-                ; data = "AAAA"
-                ; source_type = Types.Base64
-                }
+                { media_type = "image/png"; data = "AAAA"; source_type = Types.Base64 }
             ]
           () )
     ; ( "document"
@@ -1183,10 +1180,7 @@ let test_response_shape_media_only_is_deliverable () =
       , response
           ~content:
             [ Types.Audio
-                { media_type = "audio/wav"
-                ; data = "AAAA"
-                ; source_type = Types.Base64
-                }
+                { media_type = "audio/wav"; data = "AAAA"; source_type = Types.Base64 }
             ]
           () )
     ]

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -1157,6 +1157,59 @@ let test_response_shape_thinking_plus_text_is_deliverable () =
     (Response_shape.content_shape_to_string (Response_shape.content_shape response shape))
 ;;
 
+let test_response_shape_media_only_is_deliverable () =
+  let responses =
+    [ ( "image"
+      , response
+          ~content:
+            [ Types.Image
+                { media_type = "image/png"
+                ; data = "AAAA"
+                ; source_type = Types.Base64
+                }
+            ]
+          () )
+    ; ( "document"
+      , response
+          ~content:
+            [ Types.Document
+                { media_type = "application/pdf"
+                ; data = "AAAA"
+                ; source_type = Types.Base64
+                }
+            ]
+          () )
+    ; ( "audio"
+      , response
+          ~content:
+            [ Types.Audio
+                { media_type = "audio/wav"
+                ; data = "AAAA"
+                ; source_type = Types.Base64
+                }
+            ]
+          () )
+    ]
+  in
+  List.iter
+    (fun (label, response) ->
+       let shape = Response_shape.summarize response in
+       Alcotest.(check bool)
+         (label ^ " is deliverable")
+         true
+         (Response_shape.has_deliverable_content shape);
+       Alcotest.(check bool)
+         (label ^ " is not an empty completion")
+         false
+         (Response_shape.ended_without_deliverable_content response);
+       Alcotest.(check string)
+         (label ^ " retains the typed media-only diagnostic")
+         "media_only"
+         (Response_shape.content_shape_to_string
+            (Response_shape.content_shape response shape)))
+    responses
+;;
+
 let test_response_shape_thinking_plus_tool_use_is_deliverable () =
   let response =
     response
@@ -1224,6 +1277,10 @@ let () =
             "thinking plus text is deliverable"
             `Quick
             test_response_shape_thinking_plus_text_is_deliverable
+        ; Alcotest.test_case
+            "media-only is deliverable"
+            `Quick
+            test_response_shape_media_only_is_deliverable
         ; Alcotest.test_case
             "thinking plus tool use is deliverable"
             `Quick


### PR DESCRIPTION
## Summary
- classify canonical Image, Document, and Audio response blocks as downstream-deliverable
- retain the exact `media_only` diagnostic shape
- keep hidden thinking and tool-result-only responses non-deliverable

This is an OAS response-contract fix only. It contains no MASC, Keeper, tool-name, provider-name, or product-specific policy.

## Verification
- `env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_types.exe`
- `./_build/default/test/test_types.exe` (62 passed)
- `git diff --check`