### PR TITLE
refactor(catalog)!: embed the OAS model catalog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,6 @@ jobs:
           - ocaml-compiler: '5.5.0'
             experimental: true
       fail-fast: false
-    env:
-      OAS_MODEL_CATALOG: ${{ github.workspace }}/models.toml
-
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -44,6 +41,9 @@ jobs:
 
       - name: Build
         run: opam exec -- dune build @all
+
+      - name: Standalone embedded model catalog smoke
+        run: opam exec -- bash scripts/check-model-catalog-embedded.sh
 
       - name: Test
         env:

--- a/agent_sdk.opam
+++ b/agent_sdk.opam
@@ -12,7 +12,6 @@ bug-reports: "https://github.com/jeong-sik/agent-sdk/issues"
 depends: [
   "ocaml" {>= "5.1"}
   "dune" {>= "3.22" & >= "3.22"}
-  "dune-site" {>= "3.22"}
   "eio_main" {>= "1.3"}
   "cohttp-eio" {>= "6.2.0"}
   "tls" {>= "2.0.0"}

--- a/docs/capability-manifest.md
+++ b/docs/capability-manifest.md
@@ -19,7 +19,7 @@ catalog row for the same model prefix.
 ## Priority
 
 ```
-Model catalog row (OAS_MODEL_CATALOG, prefix match)
+Model catalog row (explicit OAS_MODEL_CATALOG or embedded OAS default, prefix match)
     ↓ miss
 Manifest entry (OAS_CAPABILITY_MANIFEST, prefix match)
     ↓ miss

--- a/docs/provider-catalog.md
+++ b/docs/provider-catalog.md
@@ -28,11 +28,12 @@ Resolution order:
 2. `OAS_PROVIDER_CATALOG`
 3. Built-in provider seed data
 
-The packaged `models.toml` can also carry shareable provider identity rows under
-`[[providers]]`. Those rows are data, not OCaml vendor branches: OAS uses them
-to register default provider entries and to resolve exact endpoint identity
-without hardcoded host lists. External products can read the same TOML file and
-project the same provider/model catalog into their runtime config.
+The OAS-owned `models.toml` also carries shareable provider identity rows under
+`[[providers]]`. Those rows are data, not OCaml vendor branches: OAS embeds that
+file at build time and uses it to register default provider entries and resolve
+exact endpoint identity without hardcoded host lists. Linked applications need
+no catalog file beside their executable. An operator who deliberately supplies
+`OAS_MODEL_CATALOG` replaces the embedded default with that explicit file.
 
 Catalog entries overwrite built-in provider ids when ids collide. Aliases are
 registered as additional lookup keys for the same entry.

--- a/dune
+++ b/dune
@@ -1,7 +1,0 @@
-(install
- (section
-  (site
-   (agent_sdk model_catalog)))
- (package agent_sdk)
- (files
-  (models.toml as models.toml)))

--- a/dune-project
+++ b/dune-project
@@ -1,9 +1,6 @@
 (lang dune 3.22)
-(using dune_site 0.1)
 (name agent_sdk)
 (version 0.211.10) ; x-release-please-version
 
 (package
- (name agent_sdk)
- (sites
-  (share model_catalog)))
+ (name agent_sdk))

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -1203,8 +1203,8 @@ let apply_catalog_entry (entry : Model_catalog.model_entry) : capabilities =
 
     The catalog itself is resolved by {!Model_catalog.global}, in order:
     runtime override installed via {!Model_catalog.set_global}, then the
-    [OAS_MODEL_CATALOG] environment variable, then the packaged default
-    [models.toml]. Ambient discovery is cached after first load; embedding
+    [OAS_MODEL_CATALOG] environment variable, then the build-time embedded
+    OAS [models.toml]. Ambient discovery is cached after first load; embedding
     hosts and test harnesses can call [Model_catalog.preload_global], inject
     [OAS_MODEL_CATALOG] during bootstrap, or install an explicit runtime
     override.
@@ -1515,9 +1515,9 @@ let%test "for_model_id glm-4.5-flash has GLM-4.5 thinking limits" =
 (* [for_model_id_catalog] tests below install an explicit catalog through
    [Model_catalog.set_global] and restore the override afterwards, so they
    are insulated from BOTH ambient manifest overrides
-   ([OAS_CAPABILITY_MANIFEST]) and ambient catalog discovery
-   ([OAS_MODEL_CATALOG]). CI injects the repository [models.toml] through
-   [OAS_MODEL_CATALOG] for inline tests that exercise the production catalog.
+   ([OAS_CAPABILITY_MANIFEST]) and the explicit catalog override
+   ([OAS_MODEL_CATALOG]). Inline tests that exercise the production catalog use
+   the default generated directly from the OAS-owned [models.toml].
 
    [test_catalog_entry] fills every field with [None]; each fixture entry
    then sets only the capability-relevant fields, mirroring the

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -238,8 +238,8 @@ val gemini_thinking_control_of_id : string -> gemini_thinking_control
 
     The catalog is resolved by {!Model_catalog.global}, in order: runtime
     override installed via {!Model_catalog.set_global}, the
-    [OAS_MODEL_CATALOG] environment variable, then the packaged default
-    [models.toml]. Ambient discovery is cached after first load; embedding
+    [OAS_MODEL_CATALOG] environment variable, then the build-time embedded
+    OAS [models.toml]. Ambient discovery is cached after first load; embedding
     hosts and test harnesses can call [Model_catalog.preload_global], inject
     [OAS_MODEL_CATALOG] during bootstrap, or install an explicit runtime
     override.

--- a/lib/llm_provider/dune
+++ b/lib/llm_provider/dune
@@ -35,4 +35,6 @@
  (action
   (with-stdout-to
    %{target}
-   (run model_catalog_embed_gen/model_catalog_embed_gen.exe %{dep:../../models.toml}))))
+   (run
+    model_catalog_embed_gen/model_catalog_embed_gen.exe
+    %{dep:../../models.toml}))))

--- a/lib/llm_provider/dune
+++ b/lib/llm_provider/dune
@@ -4,13 +4,13 @@
  (name llm_provider)
  (public_name agent_sdk.llm_provider)
  (private_modules
+  model_catalog_embedded
   provider_http_codec
   output_token_wire_internal
   request_artifact_internal)
  (libraries
   yojson
   otoml
-  dune-site
   ppx_deriving_yojson.runtime
   eio
   eio.unix
@@ -29,7 +29,10 @@
  (instrumentation
   (backend bisect_ppx)))
 
-(generate_sites_module
- (module model_catalog_sites)
- (sourceroot)
- (sites agent_sdk))
+(rule
+ (target model_catalog_embedded.ml)
+ (deps ../../models.toml)
+ (action
+  (with-stdout-to
+   %{target}
+   (run model_catalog_embed_gen/model_catalog_embed_gen.exe %{dep:../../models.toml}))))

--- a/lib/llm_provider/model_catalog.ml
+++ b/lib/llm_provider/model_catalog.ml
@@ -74,7 +74,6 @@ let empty = { models = []; providers = [] }
 let of_model_entries models = { empty with models }
 let model_entries t = t.models
 let provider_entries t = t.providers
-let default_catalog_filename = "models.toml"
 
 let find_string_opt toml path =
   match Otoml.find_opt toml Otoml.get_string path with
@@ -679,25 +678,31 @@ let parse_table_array toml key parse =
            results)
 ;;
 
-let load_file path =
+let catalog_of_toml toml =
+  match parse_table_array toml "models" parse_entry with
+  | Error _ as e -> e
+  | Ok models ->
+    (match parse_table_array toml "providers" Model_provider_catalog.parse_entry with
+     | Error _ as e -> e
+     | Ok providers -> Ok { models; providers })
+;;
+
+let parse_catalog ~source parse =
   let parse_res =
-    try Ok (Otoml.Parser.from_file path) with
-    | Sys_error msg -> Error (Printf.sprintf "cannot read model catalog %s: %s" path msg)
+    try Ok (parse ()) with
+    | Sys_error msg ->
+      Error (Printf.sprintf "cannot read model catalog %s: %s" source msg)
     | Otoml.Parse_error (_pos, msg) ->
-      Error (Printf.sprintf "model catalog TOML parse error in %s: %s" path msg)
+      Error (Printf.sprintf "model catalog TOML parse error in %s: %s" source msg)
     | Failure msg ->
-      Error (Printf.sprintf "model catalog TOML failure in %s: %s" path msg)
+      Error (Printf.sprintf "model catalog TOML failure in %s: %s" source msg)
   in
   match parse_res with
   | Error _ as e -> e
-  | Ok toml ->
-    (match parse_table_array toml "models" parse_entry with
-     | Error _ as e -> e
-     | Ok models ->
-       (match parse_table_array toml "providers" Model_provider_catalog.parse_entry with
-        | Error _ as e -> e
-        | Ok providers -> Ok { models; providers }))
+  | Ok toml -> catalog_of_toml toml
 ;;
+
+let load_file path = parse_catalog ~source:path (fun () -> Otoml.Parser.from_file path)
 
 let load_runtime_file path =
   match load_file path with
@@ -714,52 +719,9 @@ let load_runtime_file path =
     None
 ;;
 
-let is_existing_file path =
-  try Sys.file_exists path && not (Sys.is_directory path) with
-  | Sys_error _ -> false
-;;
-
-let dedupe_paths paths =
-  List.fold_left
-    (fun seen path -> if List.mem path seen then seen else path :: seen)
-    []
-    paths
-  |> List.rev
-;;
-
-let default_catalog_paths () =
-  let site_paths =
-    List.map
-      (fun dir -> Filename.concat dir default_catalog_filename)
-      Model_catalog_sites.Sites.model_catalog
-  in
-  let source_paths =
-    match Model_catalog_sites.sourceroot with
-    | None -> []
-    | Some root -> [ Filename.concat root default_catalog_filename ]
-  in
-  site_paths @ source_paths |> dedupe_paths
-;;
-
 let load_default () =
-  match default_catalog_paths () with
-  | [] -> Error "default model catalog has no Dune site or source-root candidate paths"
-  | paths ->
-    let rec first_loaded errors = function
-      | [] ->
-        Error
-          (Printf.sprintf
-             "default model catalog failed to load from candidate path(s): %s"
-             (String.concat "; " (List.rev errors)))
-      | path :: rest ->
-        let load_result =
-          if is_existing_file path then load_file path else Error "file not found"
-        in
-        (match load_result with
-         | Ok catalog -> Ok catalog
-         | Error msg -> first_loaded (Printf.sprintf "%s: %s" path msg :: errors) rest)
-    in
-    first_loaded [] paths
+  parse_catalog ~source:"embedded default model catalog" (fun () ->
+    Otoml.Parser.from_string Model_catalog_embedded.contents)
 ;;
 
 let dot_qualified_aliases model_id =
@@ -832,14 +794,14 @@ let load_ambient_catalog () =
      | Ok catalog ->
        Diag.info
          "model_catalog"
-         "loaded %d default model entries and %d provider entries from packaged catalog"
+         "loaded %d default model entries and %d provider entries from embedded catalog"
          (List.length catalog.models)
          (List.length catalog.providers);
        Some catalog
      | Error msg ->
        Diag.warn
          "model_catalog"
-         "failed to load packaged default model catalog: %s; set OAS_MODEL_CATALOG to an \
+         "failed to load embedded default model catalog: %s; set OAS_MODEL_CATALOG to an \
           explicit catalog path to override"
          msg;
        None)

--- a/lib/llm_provider/model_catalog.mli
+++ b/lib/llm_provider/model_catalog.mli
@@ -87,18 +87,14 @@ val provider_entries : t -> provider_entry list
 val load_file : string -> (t, string) result
 val load_runtime_file : string -> t option
 
-(** Candidate locations for the packaged default [models.toml].
+(** Load the build-time embedded default [models.toml].
 
-    The paths come from Dune's site metadata and, for uninstalled development
-    builds, Dune's source-root metadata. The list preserves missing candidates
-    so {!load_default} can report exactly what it tried. *)
-val default_catalog_paths : unit -> string list
-
-(** Load the packaged default [models.toml].
-
-    Returns [Error] when the default catalog cannot be found or parsed; callers
-    that require catalog-backed capability decisions should propagate that error
-    rather than falling back silently. *)
+    The embedded value is generated directly from the OAS-owned root
+    [models.toml], so linked consumers do not depend on a working directory,
+    installation prefix, or host filesystem layout. Returns [Error] when the
+    embedded TOML cannot be parsed; callers that require catalog-backed
+    capability decisions should propagate that error rather than falling back
+    silently. *)
 val load_default : unit -> (t, string) result
 
 (** Longest-prefix lookup for catalog model IDs.
@@ -143,9 +139,7 @@ val provider_label_for_endpoint
     Resolution order:
     - runtime override installed with {!set_global}
     - [OAS_MODEL_CATALOG], when set to a non-empty path
-    - packaged default [models.toml] installed through the agent_sdk
-      [model_catalog] Dune site, or the source-root [models.toml] when running
-      from an uninstalled Dune build
+    - build-time embedded OAS [models.toml]
 
     The ambient result is cached after the first load. {!clear_global} clears
     the runtime override and the ambient cache. *)

--- a/lib/llm_provider/model_catalog_embed_gen/dune
+++ b/lib/llm_provider/model_catalog_embed_gen/dune
@@ -1,0 +1,2 @@
+(executable
+ (name model_catalog_embed_gen))

--- a/lib/llm_provider/model_catalog_embed_gen/model_catalog_embed_gen.ml
+++ b/lib/llm_provider/model_catalog_embed_gen/model_catalog_embed_gen.ml
@@ -1,0 +1,19 @@
+let read_file path =
+  let input = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in input)
+    (fun () -> really_input_string input (in_channel_length input))
+;;
+
+let () =
+  match Array.to_list Sys.argv with
+  | [ _; path ] ->
+    Printf.printf
+      "(* Generated from the OAS-owned models.toml. Do not edit. *)\nlet contents = %S\n"
+      (read_file path)
+  | argv ->
+    Printf.eprintf
+      "model_catalog_embed_gen: expected exactly one models.toml path, received %d\n"
+      (List.length argv - 1);
+    exit 64
+;;

--- a/scripts/check-model-catalog-embedded.sh
+++ b/scripts/check-model-catalog-embedded.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+case "${DUNE_BUILD_DIR:-}" in
+  "") build_root="${repo_root}/_build" ;;
+  /*) build_root="${DUNE_BUILD_DIR}" ;;
+  *) build_root="${repo_root}/${DUNE_BUILD_DIR}" ;;
+esac
+probe_source="${build_root}/default/test/model_catalog_standalone_probe.exe"
+isolated_dir="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "${isolated_dir}"
+}
+trap cleanup EXIT
+
+"${repo_root}/scripts/dune-local.sh" build test/model_catalog_standalone_probe.exe
+install -m 0755 "${probe_source}" "${isolated_dir}/model-catalog-probe"
+
+cd "${isolated_dir}"
+env -u OAS_MODEL_CATALOG ./model-catalog-probe

--- a/test/dune
+++ b/test/dune
@@ -3,6 +3,11 @@
  (modules test_local_llm)
  (libraries agent_sdk eio eio_main yojson))
 
+(executable
+ (name model_catalog_standalone_probe)
+ (modules model_catalog_standalone_probe)
+ (libraries agent_sdk.llm_provider))
+
 ; --- AUTO-WIRED ORPHANS (fix/test-dune-orphans) ---
 ; ---- (1) compile failures — not wired until bodies are fixed ----
 ; The following files are NOT wired here because they fail to compile

--- a/test/model_catalog_standalone_probe.ml
+++ b/test/model_catalog_standalone_probe.ml
@@ -1,0 +1,25 @@
+module Model_catalog = Llm_provider.Model_catalog
+
+let fail message =
+  Printf.eprintf "model_catalog_standalone_probe: %s\n" message;
+  exit 1
+;;
+
+let () =
+  (match Sys.getenv_opt "OAS_MODEL_CATALOG" with
+   | None | Some "" -> ()
+   | Some _ -> fail "OAS_MODEL_CATALOG must be unset for the standalone smoke test");
+  Model_catalog.clear_global ();
+  match Model_catalog.global () with
+  | None -> fail "embedded default catalog was unavailable"
+  | Some catalog ->
+    let model_count = List.length (Model_catalog.model_entries catalog) in
+    let provider_count = List.length (Model_catalog.provider_entries catalog) in
+    if model_count = 0
+    then fail "embedded default catalog contained no model entries"
+    else
+      Printf.printf
+        "embedded model catalog: %d models, %d providers\n"
+        model_count
+        provider_count
+;;

--- a/test/test_model_catalog_default.ml
+++ b/test/test_model_catalog_default.ml
@@ -2,12 +2,6 @@ open Alcotest
 module Capabilities = Llm_provider.Capabilities
 module Model_catalog = Llm_provider.Model_catalog
 
-let id_prefixes catalog =
-  catalog
-  |> Model_catalog.model_entries
-  |> List.map (fun (entry : Model_catalog.model_entry) -> entry.id_prefix)
-;;
-
 let first_id_prefix ~suite catalog =
   match Model_catalog.model_entries catalog with
   | [] -> failf "%s: repo model catalog should not be empty" suite
@@ -35,10 +29,12 @@ let test_load_default_catalog () =
   | Error msg -> failf "default model catalog should load: %s" msg
   | Ok catalog ->
     check
-      (list string)
-      "default catalog id_prefixes match repo catalog"
-      (id_prefixes expected)
-      (id_prefixes catalog)
+      bool
+      "embedded default is exactly the OAS models.toml catalog"
+      true
+      (Model_catalog.model_entries expected = Model_catalog.model_entries catalog
+       && Model_catalog.provider_entries expected = Model_catalog.provider_entries catalog
+      )
 ;;
 
 let test_global_loads_default_catalog_for_capabilities () =
@@ -62,10 +58,10 @@ let test_global_loads_default_catalog_for_capabilities () =
 let () =
   run
     "model catalog default"
-    [ ( "packaged catalog"
+    [ ( "embedded catalog"
       , [ test_case "load_default" `Quick test_load_default_catalog
         ; test_case
-            "global uses packaged default"
+            "global uses embedded default"
             `Quick
             test_global_loads_default_catalog_for_capabilities
         ] )


### PR DESCRIPTION
## What changed

- generate a private OCaml module directly from the OAS-owned `models.toml`
- load the default catalog from that linked value instead of Dune site or source-root paths
- retain only the explicit `OAS_MODEL_CATALOG` override boundary
- remove the Dune-site package dependency and CI ambient catalog injection
- add a copied-binary standalone smoke test with no catalog sidecar

## Root cause

The previous default loader searched Dune-site and source-root paths at runtime. A downstream standalone binary or Docker image could therefore link OAS successfully but start without the catalog unless it also copied a matching external file. MASC had compensated by vendoring its own projection, which created real SSOT drift.

The OAS root `models.toml` now remains the only source artifact. Dune regenerates the linked module whenever that file changes.

## Impact

Linked users need no cwd convention, environment setup, installation-prefix lookup, or catalog sidecar. An explicitly configured `OAS_MODEL_CATALOG` still replaces the embedded default and fails observably if invalid.

The downstream MASC vendored-catalog purge must depend on a released OAS version containing this change; it must not restore a MASC-owned fallback.

## Validation

- focused `llm_provider.cmxa` and package-mode build
- `test_model_catalog_default.exe`: 2/2 passed, full catalog equality
- standalone copied-binary smoke: 170 models and 1 provider loaded without a sidecar
- OCamlformat, ShellCheck, `bash -n`, `opam lint`, and `git diff --check` passed

Full Dune build and test remain CI authority.