### PR TITLE
fix: preserve exact provider and pricing contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,21 @@ original tag dates. `0.100.4` was never tagged or released.
   Agent pipeline now perform exactly one provider attempt and return the typed
   result unchanged; callers own any later asynchronous attempt or runtime
   rotation.
+* **agent provider configuration:** remove the lossy
+  `Provider.config_of_provider_config` adapter and its orphan
+  `Provider.default_api_key_env_of_kind` helper. `Builder.with_provider_config`
+  now carries the exact typed provider identity, wire kind, endpoint,
+  credential, headers, request path, and capability overrides through Agent
+  dispatch without catalog, URL, model-name, or environment reinterpretation.
+  `Builder.with_provider` and `Builder.with_provider_config` replace one another;
+  the last setter selects the active provider representation.
+* **pricing observation:** preserve absent cache multipliers as `float option`
+  and make `Provider.estimate_cost`/`Llm_provider.Pricing.estimate_cost` return
+  `Estimated | Incomplete` instead of inventing a multiplier. Pricing lookup
+  accepts an optional exact provider identity, and `Agent_turn.accumulate_usage`
+  now receives the typed provider config and returned model identity explicitly.
+  These values remain telemetry only and never gate execution. See the
+  [0.212 provider/pricing migration guide](docs/migrations/0.212-explicit-provider-pricing.md).
 * **implicit recovery:** remove `Lenient_json`, `Correction_pipeline`,
   `Tool_use_recovery`, `Tool_failure_episode`, `Tool_failure_recovery`, and
   `Reflexion`. OAS no longer repairs malformed model JSON/tool calls, detects

--- a/docs/migrations/0.212-explicit-provider-pricing.md
+++ b/docs/migrations/0.212-explicit-provider-pricing.md
@@ -1,0 +1,67 @@
+# 0.212 explicit provider and pricing migration
+
+OAS 0.212 removes the lossy conversion from `Provider_config.t` to the legacy
+`Provider.config` and makes incomplete catalog pricing explicit. These are
+source-breaking changes to the Stable `Builder` and `Provider` facades.
+
+## Typed provider configuration
+
+Before:
+
+```ocaml
+let provider = Provider.config_of_provider_config provider_config in
+
+Builder.create ~net ~model:provider.model_id
+|> Builder.with_provider provider
+|> Builder.build
+```
+
+After:
+
+```ocaml
+Builder.create ~net ~model:provider_config.model_id
+|> Builder.with_provider_config provider_config
+|> Builder.build
+```
+
+The typed Builder path preserves the declared provider identity, wire kind,
+endpoint, credential, headers, request path, and capability overrides. Later
+Builder turn-control setters still replace their corresponding request fields.
+`with_provider` and `with_provider_config` replace one another; the last setter
+selects the active representation.
+
+Do not recreate the removed adapter by inspecting URLs, model names, or
+credentials. Callers that still use a legacy `Provider.config` must construct
+that legacy value explicitly. Environment-backed credential selection, when
+needed, belongs at the caller's configuration/bootstrap boundary.
+
+## Pricing observation
+
+Cache multipliers are now optional and `estimate_cost` reports whether the
+observed usage can be priced exactly:
+
+```ocaml
+match Provider.pricing_for_model_opt ?provider_id model_id with
+| None -> `Pricing_unavailable
+| Some pricing ->
+  (match
+     Provider.estimate_cost
+       ~pricing
+       ~input_tokens
+       ~output_tokens
+       ~cache_creation_input_tokens
+       ~cache_read_input_tokens
+       ()
+   with
+   | Provider.Estimated cost_usd -> `Estimated cost_usd
+   | Provider.Incomplete missing -> `Pricing_incomplete missing)
+```
+
+`provider_id`, when supplied, is an exact catalog identity. The exact
+provider/model row wins; a provider-independent row is considered only when no
+exact row exists. Missing cache multipliers are required only when the
+corresponding cache-token count is non-zero. Never replace a missing multiplier
+with `1.0` or `0.0`.
+
+Pricing and token totals are observations. `None` and `Incomplete` must remain
+visible to telemetry and must not stop, pause, reject, or retry an agent turn.

--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -518,7 +518,9 @@ let run_handoff_target ~sw ?clock agent (target : Handoff.handoff_target) prompt
         { default_options with
           base_url = agent.options.base_url
         ; provider = agent.options.provider
+        ; transport = agent.options.transport
         }
+      ?provider_config:agent.provider_config
       ()
   in
   let result = run ~sw ?clock sub prompt in
@@ -581,10 +583,16 @@ let resume
       ?(tools = [])
       ?context
       ?(options = default_options)
+      ?provider_config
       ?checkpoint_sink
       ?config
       ()
   =
+  let options =
+    match provider_config with
+    | Some _ -> { options with provider = None }
+    | None -> options
+  in
   let { Agent_checkpoint.state; context = ctx } =
     Agent_checkpoint.build_resume ~checkpoint ~eio_context:true ?config ?context ()
   in
@@ -595,6 +603,7 @@ let resume
   ; net
   ; context = ctx
   ; options
+  ; provider_config
   ; checkpoint_sink
   }
 ;;

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -74,6 +74,7 @@ val lifecycle : t -> lifecycle_snapshot option
 val tools : t -> Tool_set.t
 val context : t -> Context.t
 val options : t -> options
+val provider_config : t -> Llm_provider.Provider_config.t option
 val net : t -> [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
 val description : t -> string option
 
@@ -90,13 +91,18 @@ val sdk_version : string
     after successful context injection. A sink failure is returned before the
     pipeline advances to the next mutation stage. The sink is passed here
     rather than through {!options} so callers that construct options records
-    remain source-compatible. *)
+    remain source-compatible.
+
+    [provider_config] is the exact typed provider carrier. When supplied it
+    replaces [options.provider]; endpoint, credential, request path, headers,
+    and capability overrides are not reconstructed from the legacy option. *)
 val create
   :  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> config:Types.agent_config
   -> ?tools:Tool.t list
   -> ?context:Context.t
   -> ?options:options
+  -> ?provider_config:Llm_provider.Provider_config.t
   -> ?checkpoint_sink:checkpoint_sink
   -> unit
   -> t
@@ -300,13 +306,15 @@ val run_with_handoffs_blocks_detailed
     non-persisted runtime fields use those defaults. The optional sink is the same caller-owned
     turn-boundary checkpoint sink used by {!create}. It is not stored in
     {!options}; pass it explicitly when resumed turns should continue emitting
-    crash-recovery checkpoints. *)
+    crash-recovery checkpoints. An explicit [provider_config] replaces
+    [options.provider] under the same exact-carrier contract as {!create}. *)
 val resume
   :  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> checkpoint:Checkpoint.t
   -> ?tools:Tool.t list
   -> ?context:Context.t
   -> ?options:options
+  -> ?provider_config:Llm_provider.Provider_config.t
   -> ?checkpoint_sink:checkpoint_sink
   -> ?config:Types.agent_config
   -> unit

--- a/lib/agent/agent_lifecycle.ml
+++ b/lib/agent/agent_lifecycle.ml
@@ -80,6 +80,10 @@ let provider_runtime_name (cfg : Provider.config option) =
   | Some cfg -> Some (Provider_runtime_binding.provider_id_of_config cfg)
 ;;
 
+let typed_provider_runtime_name (cfg : Llm_provider.Provider_config.t option) =
+  Option.map Provider_runtime_binding.provider_id_of_provider_config cfg
+;;
+
 let hook_decision_to_string = function
   | Hooks.Continue -> "continue"
   | Hooks.AdjustParams _ -> "adjust_params"
@@ -95,6 +99,7 @@ let build_snapshot
       ~agent_name
       ~(provider : Provider.config option)
       ~(model : Types.model)
+      ?provider_config
       ?previous
       ?current_run_id
       ?worker_id
@@ -110,6 +115,11 @@ let build_snapshot
   =
   let pick fallback next = Util.first_some next fallback in
   let default_actor = Some agent_name in
+  let requested_provider =
+    match typed_provider_runtime_name provider_config with
+    | Some _ as exact -> exact
+    | None -> provider_runtime_name provider
+  in
   { current_run_id =
       pick (Option.bind previous (fun s -> s.current_run_id)) current_run_id
   ; agent_name
@@ -120,13 +130,14 @@ let build_snapshot
         (Option.bind previous (fun s -> s.runtime_actor))
         (pick default_actor runtime_actor)
   ; status
-  ; requested_provider = provider_runtime_name provider
+  ; requested_provider
   ; requested_model = Some (Types.model_to_string model)
-  ; resolved_provider = provider_runtime_name provider
+  ; resolved_provider = requested_provider
   ; resolved_model =
-      (match provider with
-       | Some cfg -> Some cfg.model_id
-       | None -> Some (Types.model_to_string model))
+      (match provider_config, provider with
+       | Some _, _ -> Some (Types.model_to_string model)
+       | None, Some cfg -> Some cfg.model_id
+       | None, None -> Some (Types.model_to_string model))
   ; last_error = pick (Option.bind previous (fun s -> s.last_error)) last_error
   ; accepted_at = pick (Option.bind previous (fun s -> s.accepted_at)) accepted_at
   ; ready_at = pick (Option.bind previous (fun s -> s.ready_at)) ready_at

--- a/lib/agent/agent_lifecycle.mli
+++ b/lib/agent/agent_lifecycle.mli
@@ -92,6 +92,7 @@ val build_snapshot
   :  agent_name:string
   -> provider:Provider.config option
   -> model:Types.model
+  -> ?provider_config:Llm_provider.Provider_config.t
   -> ?previous:lifecycle_snapshot
   -> ?current_run_id:string
   -> ?worker_id:string

--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -56,41 +56,70 @@ let prepare_turn ~tools ~messages ~turn_params () =
 
 (* ── Usage accumulation ───────────────────────────────────────── *)
 
-let accumulate_usage ~current_usage ~provider ~response_usage =
+let pricing_identity ~provider ~provider_config ~response_model =
+  let provider_id, configured_model =
+    match provider_config with
+    | Some config ->
+      ( config.Llm_provider.Provider_config.provider_id
+      , Util.trim_non_empty_opt (Some config.Llm_provider.Provider_config.model_id) )
+    | None ->
+      (match provider with
+       | Some (config : Provider.config) ->
+         ( Some (Provider_runtime_binding.provider_id_of_config config)
+         , Util.trim_non_empty_opt (Some config.model_id) )
+       | None -> None, None)
+  in
+  let response_model = Util.trim_non_empty_opt response_model in
+  provider_id, Util.first_some response_model configured_model
+;;
+
+let with_pricing_gap usage model_id =
+  match usage.pricing_gap with
+  | Some _ -> usage
+  | None ->
+    { usage with
+      pricing_gap =
+        Some
+          (match model_id with
+           | Some model_id -> Pricing_unavailable model_id
+           | None -> Model_identity_unavailable)
+    }
+;;
+
+let accumulate_usage
+      ~current_usage
+      ~provider_config
+      ~provider
+      ~response_model
+      ~response_usage
+  =
   match response_usage with
   | Some u ->
     let base = add_usage current_usage u in
     (match u.cost_usd with
      | Some cost -> { base with estimated_cost_usd = base.estimated_cost_usd +. cost }
      | None ->
-       let model_id =
-         match provider with
-         | Some (cfg : Provider.config) when cfg.model_id <> "" -> Some cfg.model_id
-         | Some _ | None -> None
+       let provider_id, model_id =
+         pricing_identity ~provider ~provider_config ~response_model
        in
-       (match Option.bind model_id Provider.pricing_for_model_opt with
-        | Some pricing ->
-          let turn_cost =
-            Provider.estimate_cost
-              ~pricing
-              ~input_tokens:u.input_tokens
-              ~output_tokens:u.output_tokens
-              ~cache_creation_input_tokens:u.cache_creation_input_tokens
-              ~cache_read_input_tokens:u.cache_read_input_tokens
-              ()
-          in
-          { base with estimated_cost_usd = base.estimated_cost_usd +. turn_cost }
-        | None ->
-          let pricing_gap =
-            match base.pricing_gap with
-            | Some _ as already -> already
-            | None ->
-              Some
-                (match model_id with
-                 | Some model_id -> Pricing_unavailable model_id
-                 | None -> Model_identity_unavailable)
-          in
-          { base with pricing_gap }))
+       (match model_id with
+        | None -> with_pricing_gap base None
+        | Some model_id ->
+          (match Provider.pricing_for_model_opt ?provider_id model_id with
+           | None -> with_pricing_gap base (Some model_id)
+           | Some pricing ->
+             (match
+                Provider.estimate_cost
+                  ~pricing
+                  ~input_tokens:u.input_tokens
+                  ~output_tokens:u.output_tokens
+                  ~cache_creation_input_tokens:u.cache_creation_input_tokens
+                  ~cache_read_input_tokens:u.cache_read_input_tokens
+                  ()
+              with
+              | Provider.Estimated turn_cost ->
+                { base with estimated_cost_usd = base.estimated_cost_usd +. turn_cost }
+              | Provider.Incomplete _ -> with_pricing_gap base (Some model_id)))))
   | None -> { current_usage with api_calls = current_usage.api_calls + 1 }
 ;;
 

--- a/lib/agent/agent_turn.mli
+++ b/lib/agent/agent_turn.mli
@@ -56,10 +56,16 @@ val prepare_turn
 
 (** {1 Usage accumulation} *)
 
-(** Accumulate response usage into running totals, including cost estimation. *)
+(** Accumulate response usage into running totals, including observational cost
+    estimation. [provider_config] and [provider] are alternative identity
+    carriers; the exact non-empty [response_model] takes precedence over the
+    configured request model. Missing or incomplete pricing records a gap and
+    never blocks the turn. *)
 val accumulate_usage
   :  current_usage:Types.usage_stats
+  -> provider_config:Llm_provider.Provider_config.t option
   -> provider:Provider.config option
+  -> response_model:string option
   -> response_usage:Types.api_usage option
   -> Types.usage_stats
 

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -131,6 +131,7 @@ type t =
   ; net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   ; context : Context.t
   ; options : options
+  ; provider_config : Llm_provider.Provider_config.t option
   ; checkpoint_sink : checkpoint_sink option
   }
 
@@ -140,6 +141,7 @@ let lifecycle t = t.lifecycle
 let tools t = t.tools
 let context t = t.context
 let options t = t.options
+let provider_config t = t.provider_config
 let net t = t.net
 
 (** Mutex-protected write to [state].  All mutations of [t.state] should
@@ -166,11 +168,16 @@ let provider_name (cfg : Provider.config) =
   | Provider.Custom_registered { name } -> name
 ;;
 
+let typed_provider_name (cfg : Llm_provider.Provider_config.t) =
+  Provider_runtime_binding.provider_id_of_provider_config cfg
+;;
+
 let card t =
   let supported_providers =
-    match t.options.provider with
-    | Some p -> [ provider_name p ]
-    | None -> [ "anthropic" ]
+    match t.provider_config, t.options.provider with
+    | Some config, _ -> [ typed_provider_name config ]
+    | None, Some provider -> [ provider_name provider ]
+    | None, None -> [ "anthropic" ]
   in
   let skills =
     match t.options.skill_registry with
@@ -241,6 +248,7 @@ let set_lifecycle
               ~agent_name:agent.state.config.name
               ~provider:agent.options.provider
               ~model:agent.state.config.model
+              ?provider_config:agent.provider_config
               ?previous:agent.lifecycle
               ?current_run_id
               ?worker_id
@@ -261,9 +269,15 @@ let create
       ?(tools = [])
       ?context
       ?(options = default_options)
+      ?provider_config
       ?checkpoint_sink
       ()
   =
+  let options =
+    match provider_config with
+    | Some _ -> { options with provider = None }
+    | None -> options
+  in
   let mcp_tools =
     List.concat_map (fun (m : Mcp.managed) -> m.tools) options.mcp_clients
   in
@@ -283,6 +297,7 @@ let create
   ; net
   ; context = ctx
   ; options
+  ; provider_config
   ; checkpoint_sink
   }
 ;;
@@ -303,6 +318,7 @@ let clone ?(copy_context = false) agent =
   ; net = agent.net
   ; context = ctx
   ; options = agent.options
+  ; provider_config = agent.provider_config
   ; checkpoint_sink = agent.checkpoint_sink
   }
 ;;

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -145,6 +145,7 @@ type t =
   ; net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   ; context : Context.t
   ; options : options
+  ; provider_config : Llm_provider.Provider_config.t option
   ; checkpoint_sink : checkpoint_sink option
   }
 
@@ -159,6 +160,7 @@ val lifecycle : t -> lifecycle_snapshot option
 val tools : t -> Tool_set.t
 val context : t -> Context.t
 val options : t -> options
+val provider_config : t -> Llm_provider.Provider_config.t option
 val net : t -> [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
 val set_state : t -> Types.agent_state -> unit
 val update_state : t -> (Types.agent_state -> Types.agent_state) -> unit
@@ -176,6 +178,7 @@ val create
   -> ?tools:Tool.t list
   -> ?context:Context.t
   -> ?options:options
+  -> ?provider_config:Llm_provider.Provider_config.t
   -> ?checkpoint_sink:checkpoint_sink
   -> unit
   -> t

--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -29,6 +29,7 @@ type t =
   ; context : Context.t option
   ; base_url : string
   ; provider : Provider.config option
+  ; provider_config : Llm_provider.Provider_config.t option
   ; stream_idle_timeout_s : float option
   ; body_timeout_s : float option
   ; hooks : Hooks.hooks
@@ -77,6 +78,7 @@ let create ~net ~model =
   ; context = None
   ; base_url = Api.default_base_url
   ; provider = None
+  ; provider_config = None
   ; stream_idle_timeout_s = None
   ; body_timeout_s = None
   ; hooks = Hooks.empty
@@ -153,8 +155,30 @@ let with_tracer tracer b = { b with tracer }
 let with_trace_link trace_link b = { b with trace_link }
 let with_raw_trace raw_trace b = { b with raw_trace = Some raw_trace }
 let with_context ctx b = { b with context = Some ctx }
-let with_provider provider b = { b with provider = Some provider }
-let with_provider_config pc b = with_provider (Provider.config_of_provider_config pc) b
+let with_provider provider b = { b with provider = Some provider; provider_config = None }
+
+let with_provider_config (pc : Llm_provider.Provider_config.t) b =
+  { b with
+    model = pc.model_id
+  ; system_prompt = pc.system_prompt
+  ; max_tokens = pc.max_tokens
+  ; temperature = pc.temperature
+  ; top_p = pc.top_p
+  ; top_k = pc.top_k
+  ; min_p = pc.min_p
+  ; enable_thinking = pc.enable_thinking
+  ; preserve_thinking = pc.preserve_thinking
+  ; response_format = pc.response_format
+  ; thinking_budget = pc.thinking_budget
+  ; reasoning_effort = pc.reasoning_effort
+  ; tool_choice = pc.tool_choice
+  ; disable_parallel_tool_use = pc.disable_parallel_tool_use
+  ; cache_system_prompt = pc.cache_system_prompt
+  ; provider = None
+  ; provider_config = Some pc
+  }
+;;
+
 let with_base_url url b = { b with base_url = url }
 let with_mcp_clients clients b = { b with mcp_clients = clients }
 let with_guardrails_async guardrails_async b = { b with guardrails_async }
@@ -259,6 +283,7 @@ let build b =
     ~tools:(Tool_set.to_list tools)
     ?context
     ~options
+    ?provider_config:b.provider_config
     ?checkpoint_sink:b.checkpoint_sink
     ()
 ;;

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -101,7 +101,15 @@ val with_periodic_callbacks : Agent.periodic_callback list -> t -> t
 (** {2 Provider} *)
 
 val with_provider : Provider.config -> t -> t
+
+(** Select an exact typed provider configuration. The Builder carries provider
+    identity, wire kind, endpoint, credential, headers, request path, and
+    capability overrides unchanged to dispatch. Generic turn fields seed the
+    Builder and may be replaced by later [with_*] calls. Calling
+    {!with_provider} later replaces this selection; calling this function after
+    {!with_provider} replaces the legacy selection. *)
 val with_provider_config : Llm_provider.Provider_config.t -> t -> t
+
 val with_base_url : string -> t -> t
 
 (** Inject an {!Llm_provider.Llm_transport.t} for non-HTTP providers.

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -185,6 +185,7 @@ let create_message_detailed
        Error (Provider_failure_attribution.of_provider_configuration_error error)
      | Ok (base_url, api_key, header_list) ->
        let provider_cfg = provider in
+       let provider_id = Provider_runtime_binding.provider_id_of_config provider_cfg in
        let model_spec = Provider.model_spec_of_config provider_cfg in
        let binding =
          Binding_identity.of_resolved_provider
@@ -342,7 +343,7 @@ let create_message_detailed
                    in
                    Result.map
                      (fun resp ->
-                        Llm_provider.Pricing.annotate_response_cost resp
+                        Llm_provider.Pricing.annotate_response_cost ~provider_id resp
                         |> fun response ->
                         Llm_provider.Complete_common.patch_telemetry
                           response

--- a/lib/cost_tracker.ml
+++ b/lib/cost_tracker.ml
@@ -65,5 +65,5 @@ let report_to_string (r : cost_report) : string =
   | Some Types.Model_identity_unavailable ->
     summary ^ " | Pricing incomplete: model identity unavailable"
   | Some (Types.Pricing_unavailable model_id) ->
-    summary ^ Printf.sprintf " | Pricing incomplete: no catalog entry for %s" model_id
+    summary ^ Printf.sprintf " | Pricing incomplete for model %s" model_id
 ;;

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -145,7 +145,9 @@ let complete
        let result = ensure_nonempty_completion result in
        (match result with
         | Ok resp ->
-          let resp = Pricing.annotate_response_cost resp in
+          let resp =
+            Pricing.annotate_response_cost ?provider_id:config.provider_id resp
+          in
           let resp = patch_telemetry resp ~config latency_ms in
           m.on_request_end ~model_id ~latency_ms;
           emit_tool_call_metrics
@@ -296,7 +298,7 @@ let complete_stream
     Result.map
       (fun resp ->
          let latency_ms = latency_ms_int latency_counter in
-         let resp = Pricing.annotate_response_cost resp in
+         let resp = Pricing.annotate_response_cost ?provider_id:config.provider_id resp in
          let existing_telemetry = resp.telemetry in
          let ttfrc_ms = Option.bind existing_telemetry (fun t -> t.ttfrc_ms) in
          let prefill_ms = Option.bind existing_telemetry (fun t -> t.prefill_ms) in

--- a/lib/llm_provider/pricing.ml
+++ b/lib/llm_provider/pricing.ml
@@ -7,35 +7,48 @@
 type pricing =
   { input_per_million : float
   ; output_per_million : float
-  ; cache_write_multiplier : float
-  ; cache_read_multiplier : float
+  ; cache_write_multiplier : float option
+  ; cache_read_multiplier : float option
   }
 
+type cache_price_component =
+  | Cache_creation
+  | Cache_read
+
+type cost_estimate =
+  | Estimated of float
+  | Incomplete of cache_price_component list
+
 let pricing_of_catalog_entry (entry : Model_catalog.model_entry) =
-  match
-    ( entry.input_per_million
-    , entry.output_per_million
-    , entry.cache_write_multiplier
-    , entry.cache_read_multiplier )
-  with
-  | ( Some input_per_million
-    , Some output_per_million
-    , Some cache_write_multiplier
-    , Some cache_read_multiplier ) ->
+  match entry.input_per_million, entry.output_per_million with
+  | Some input_per_million, Some output_per_million ->
     Some
       { input_per_million
       ; output_per_million
-      ; cache_write_multiplier
-      ; cache_read_multiplier
+      ; cache_write_multiplier = entry.cache_write_multiplier
+      ; cache_read_multiplier = entry.cache_read_multiplier
       }
-  | None, _, _, _ | _, None, _, _ | _, _, None, _ | _, _, _, None -> None
+  | None, _ | _, None -> None
 ;;
 
-let pricing_for_model_opt model_id =
+let catalog_entry_for_model catalog ?provider_id model_id =
+  match provider_id with
+  | None -> Model_catalog.lookup catalog model_id
+  | Some provider_id ->
+    (match
+       Model_catalog.lookup_for_provider catalog ~provider_name:provider_id ~model_id
+     with
+     | Some _ as exact -> exact
+     | None -> Model_catalog.lookup catalog model_id)
+;;
+
+let pricing_for_model_opt ?provider_id model_id =
   match Model_catalog.global () with
   | None -> None
   | Some catalog ->
-    Option.bind (Model_catalog.lookup catalog model_id) pricing_of_catalog_entry
+    Option.bind
+      (catalog_entry_for_model catalog ?provider_id model_id)
+      pricing_of_catalog_entry
 ;;
 
 let estimate_cost
@@ -49,54 +62,82 @@ let estimate_cost
   let regular_input =
     max 0 (input_tokens - cache_creation_input_tokens - cache_read_input_tokens)
   in
-  let rate = pricing.input_per_million /. 1_000_000.0 in
-  let input_cost = Float.of_int regular_input *. rate in
-  let cache_write_cost =
-    Float.of_int cache_creation_input_tokens *. rate *. pricing.cache_write_multiplier
+  let missing_cache_components =
+    let creation =
+      if cache_creation_input_tokens > 0 && Option.is_none pricing.cache_write_multiplier
+      then [ Cache_creation ]
+      else []
+    in
+    let read =
+      if cache_read_input_tokens > 0 && Option.is_none pricing.cache_read_multiplier
+      then [ Cache_read ]
+      else []
+    in
+    creation @ read
   in
-  let cache_read_cost =
-    Float.of_int cache_read_input_tokens *. rate *. pricing.cache_read_multiplier
-  in
-  let output_cost =
-    Float.of_int output_tokens *. pricing.output_per_million /. 1_000_000.0
-  in
-  input_cost +. cache_write_cost +. cache_read_cost +. output_cost
+  match missing_cache_components with
+  | _ :: _ as missing -> Incomplete missing
+  | [] ->
+    let rate = pricing.input_per_million /. 1_000_000.0 in
+    let input_cost = Float.of_int regular_input *. rate in
+    let cache_cost token_count = function
+      | Some multiplier -> Float.of_int token_count *. rate *. multiplier
+      | None -> 0.0
+    in
+    let cache_write_cost =
+      cache_cost cache_creation_input_tokens pricing.cache_write_multiplier
+    in
+    let cache_read_cost =
+      cache_cost cache_read_input_tokens pricing.cache_read_multiplier
+    in
+    let output_cost =
+      Float.of_int output_tokens *. pricing.output_per_million /. 1_000_000.0
+    in
+    Estimated (input_cost +. cache_write_cost +. cache_read_cost +. output_cost)
 ;;
 
-let annotate_usage_cost ~model_id (usage : Types.api_usage) =
+let annotate_usage_cost ?provider_id ~model_id (usage : Types.api_usage) =
   match usage.cost_usd with
   | Some _ -> usage
   | None ->
-    (match pricing_for_model_opt model_id with
+    (match pricing_for_model_opt ?provider_id model_id with
      | None -> usage
      | Some pricing ->
-       let cost_usd =
-         estimate_cost
-           ~pricing
-           ~input_tokens:usage.input_tokens
-           ~output_tokens:usage.output_tokens
-           ~cache_creation_input_tokens:usage.cache_creation_input_tokens
-           ~cache_read_input_tokens:usage.cache_read_input_tokens
-           ()
-       in
-       { usage with cost_usd = Some cost_usd })
+       (match
+          estimate_cost
+            ~pricing
+            ~input_tokens:usage.input_tokens
+            ~output_tokens:usage.output_tokens
+            ~cache_creation_input_tokens:usage.cache_creation_input_tokens
+            ~cache_read_input_tokens:usage.cache_read_input_tokens
+            ()
+        with
+        | Estimated cost_usd -> { usage with cost_usd = Some cost_usd }
+        | Incomplete _ -> usage))
 ;;
 
-let annotate_response_cost (response : Types.api_response) =
+let annotate_response_cost ?provider_id (response : Types.api_response) =
   match response.usage with
   | None -> response
   | Some usage ->
-    { response with usage = Some (annotate_usage_cost ~model_id:response.model usage) }
+    { response with
+      usage = Some (annotate_usage_cost ?provider_id ~model_id:response.model usage)
+    }
 ;;
 
 [@@@coverage off]
 
 let close_enough a b = Float.abs (a -. b) < 1e-9
 
-let test_catalog_entry ?input ?output ?cache_write ?cache_read id_prefix =
+let option_close_enough expected = function
+  | Some actual -> close_enough expected actual
+  | None -> false
+;;
+
+let test_catalog_entry ?provider_name ?input ?output ?cache_write ?cache_read id_prefix =
   { Model_catalog.id_prefix
   ; base_label = None
-  ; provider_name = None
+  ; provider_name
   ; max_context_tokens = None
   ; max_output_tokens = None
   ; supports_tools = None
@@ -166,8 +207,8 @@ let%test "catalog-declared pricing is returned" =
        | Some pricing ->
          close_enough pricing.input_per_million 3.0
          && close_enough pricing.output_per_million 15.0
-         && close_enough pricing.cache_write_multiplier 1.25
-         && close_enough pricing.cache_read_multiplier 0.1)
+         && option_close_enough 1.25 pricing.cache_write_multiplier
+         && option_close_enough 0.1 pricing.cache_read_multiplier)
 ;;
 
 let%test "catalog miss remains absent" =
@@ -182,10 +223,73 @@ let%test "partial catalog pricing remains absent" =
     (fun () -> pricing_for_model_opt "partial-model" = None)
 ;;
 
-let%test "catalog pricing with absent cache multipliers remains absent" =
+let%test "catalog pricing preserves absent cache multipliers" =
   with_catalog
     [ test_catalog_entry ~input:1.0 ~output:2.0 "partial-cache-pricing" ]
-    (fun () -> pricing_for_model_opt "partial-cache-pricing" = None)
+    (fun () ->
+       match pricing_for_model_opt "partial-cache-pricing" with
+       | Some
+           { input_per_million = 1.0
+           ; output_per_million = 2.0
+           ; cache_write_multiplier = None
+           ; cache_read_multiplier = None
+           } -> true
+       | Some _ | None -> false)
+;;
+
+let%test "exact provider pricing precedes provider-independent pricing" =
+  with_catalog
+    [ test_catalog_entry
+        ~input:9.0
+        ~output:90.0
+        ~cache_write:1.0
+        ~cache_read:1.0
+        "shared-model"
+    ; test_catalog_entry
+        ~provider_name:"deepseek"
+        ~input:1.0
+        ~output:2.0
+        ~cache_write:1.0
+        ~cache_read:0.1
+        "shared-model"
+    ]
+    (fun () ->
+       match
+         ( pricing_for_model_opt "shared-model"
+         , pricing_for_model_opt ~provider_id:"deepseek" "shared-model" )
+       with
+       | Some generic, Some exact ->
+         close_enough generic.input_per_million 9.0
+         && close_enough exact.input_per_million 1.0
+       | None, _ | _, None -> false)
+;;
+
+let%test "an exact incomplete provider row does not fall through to generic pricing" =
+  with_catalog
+    [ test_catalog_entry
+        ~input:9.0
+        ~output:90.0
+        ~cache_write:1.0
+        ~cache_read:1.0
+        "shared-model"
+    ; test_catalog_entry ~provider_name:"ollama_cloud" ~input:0.0 "shared-model"
+    ]
+    (fun () -> pricing_for_model_opt ~provider_id:"ollama_cloud" "shared-model" = None)
+;;
+
+let%test "unknown provider can use provider-independent pricing" =
+  with_catalog
+    [ test_catalog_entry
+        ~input:9.0
+        ~output:90.0
+        ~cache_write:1.0
+        ~cache_read:1.0
+        "shared-model"
+    ]
+    (fun () ->
+       match pricing_for_model_opt ~provider_id:"unknown" "shared-model" with
+       | Some pricing -> close_enough pricing.input_per_million 9.0
+       | None -> false)
 ;;
 
 let%test "explicit catalog zero is distinguishable from absence" =
@@ -209,13 +313,47 @@ let%test "estimate_cost uses declared rates" =
   let pricing =
     { input_per_million = 3.0
     ; output_per_million = 15.0
-    ; cache_write_multiplier = 1.25
-    ; cache_read_multiplier = 0.1
+    ; cache_write_multiplier = Some 1.25
+    ; cache_read_multiplier = Some 0.1
     }
   in
-  close_enough
-    (estimate_cost ~pricing ~input_tokens:1_000_000 ~output_tokens:100_000 ())
-    4.5
+  match estimate_cost ~pricing ~input_tokens:1_000_000 ~output_tokens:100_000 () with
+  | Estimated cost -> close_enough cost 4.5
+  | Incomplete _ -> false
+;;
+
+let%test "absent cache prices do not block a non-cache estimate" =
+  let pricing =
+    { input_per_million = 3.0
+    ; output_per_million = 15.0
+    ; cache_write_multiplier = None
+    ; cache_read_multiplier = None
+    }
+  in
+  match estimate_cost ~pricing ~input_tokens:1_000_000 ~output_tokens:100_000 () with
+  | Estimated cost -> close_enough cost 4.5
+  | Incomplete _ -> false
+;;
+
+let%test "observed cache tokens expose every missing cache price" =
+  let pricing =
+    { input_per_million = 3.0
+    ; output_per_million = 15.0
+    ; cache_write_multiplier = None
+    ; cache_read_multiplier = None
+    }
+  in
+  match
+    estimate_cost
+      ~pricing
+      ~input_tokens:100
+      ~output_tokens:10
+      ~cache_creation_input_tokens:20
+      ~cache_read_input_tokens:30
+      ()
+  with
+  | Incomplete [ Cache_creation; Cache_read ] -> true
+  | Estimated _ | Incomplete _ -> false
 ;;
 
 [@@@coverage on]

--- a/lib/llm_provider/pricing.mli
+++ b/lib/llm_provider/pricing.mli
@@ -1,22 +1,39 @@
 (** Catalog-backed cost observation.
 
     Pricing is sourced exclusively from {!Model_catalog}.  Unknown models and
-    catalog rows with incomplete pricing remain explicit [None]; they are never
-    classified as free. *)
+    catalog rows without both input and output rates remain explicit [None];
+    they are never classified as free. *)
 
 type pricing =
   { input_per_million : float
   ; output_per_million : float
-  ; cache_write_multiplier : float
-  ; cache_read_multiplier : float
+  ; cache_write_multiplier : float option
+  ; cache_read_multiplier : float option
   }
 
-(** Return the complete price declared by the active model catalog. Missing
-    input, output, or cache rates remain [None]; the SDK does not synthesize
-    cache multipliers. *)
-val pricing_for_model_opt : string -> pricing option
+(** Cache-price components that are required by observed usage but absent from
+    the selected catalog row. *)
+type cache_price_component =
+  | Cache_creation
+  | Cache_read
 
-(** Estimate USD cost from an explicit pricing value and provider token usage. *)
+(** A cost observation is either exact for the supplied usage or explicitly
+    incomplete.  Missing cache multipliers matter only when the corresponding
+    observed token count is non-zero. *)
+type cost_estimate =
+  | Estimated of float
+  | Incomplete of cache_price_component list
+
+(** Return the price declared by the active model catalog.
+
+    When [provider_id] is present, an exact provider/model row takes
+    precedence.  A provider-independent row is consulted only when no exact
+    provider row exists.  Provider identity is never inferred from the model
+    id or endpoint.  Missing cache multipliers remain [None]. *)
+val pricing_for_model_opt : ?provider_id:string -> string -> pricing option
+
+(** Estimate USD cost from an explicit pricing value and provider token usage.
+    This function never synthesizes a missing cache multiplier. *)
 val estimate_cost
   :  pricing:pricing
   -> input_tokens:int
@@ -24,11 +41,18 @@ val estimate_cost
   -> ?cache_creation_input_tokens:int
   -> ?cache_read_input_tokens:int
   -> unit
-  -> float
+  -> cost_estimate
 
-(** Fill [usage.cost_usd] only when both catalog pricing and provider usage are
-    available.  An absent price remains absent. *)
-val annotate_usage_cost : model_id:string -> Types.api_usage -> Types.api_usage
+(** Fill [usage.cost_usd] only when catalog pricing is available and exact for
+    the observed usage.  An absent or incomplete price remains absent. *)
+val annotate_usage_cost
+  :  ?provider_id:string
+  -> model_id:string
+  -> Types.api_usage
+  -> Types.api_usage
 
 (** Apply {!annotate_usage_cost} to a response usage record. *)
-val annotate_response_cost : Types.api_response -> Types.api_response
+val annotate_response_cost
+  :  ?provider_id:string
+  -> Types.api_response
+  -> Types.api_response

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -215,7 +215,9 @@ let stage_collect ?raw_trace_run ?clock agent response =
        let usage =
          Agent_turn.accumulate_usage
            ~current_usage:agent.state.usage
+           ~provider_config:agent.provider_config
            ~provider:agent.options.provider
+           ~response_model:(Some response.model)
            ~response_usage:response.usage
        in
        let after_decision =

--- a/lib/pipeline/pipeline_stage_route.ml
+++ b/lib/pipeline/pipeline_stage_route.ml
@@ -13,6 +13,17 @@ let binding_identity_for_call agent provider_config =
   Binding_identity.of_provider_config ~transport provider_config
 ;;
 
+let provider_config_for_turn ~turn_config agent =
+  match agent.provider_config with
+  | Some provider_config ->
+    Ok (Provider.provider_config_with_agent_config ~config:turn_config provider_config)
+  | None ->
+    Provider.provider_config_of_agent
+      ~state:{ agent.state with config = turn_config }
+      ~base_url:agent.options.base_url
+      agent.options.provider
+;;
+
 let dispatch_sync
       ~sw
       ?clock
@@ -23,12 +34,7 @@ let dispatch_sync
       (prep : Agent_turn.turn_preparation)
   =
   let tools = Option.value prep.Agent_turn.tools_json ~default:[] in
-  match
-    Provider.provider_config_of_agent
-      ~state:{ agent.state with config = turn_config }
-      ~base_url:agent.options.base_url
-      agent.options.provider
-  with
+  match provider_config_for_turn ~turn_config agent with
   | Error error ->
     let detailed = Provider_failure_attribution.of_provider_configuration_error error in
     notify_attribution on_provider_failure detailed.provider_failure;
@@ -72,12 +78,7 @@ let dispatch_stream
       ()
   =
   let tools = Option.value prep.Agent_turn.tools_json ~default:[] in
-  match
-    Provider.provider_config_of_agent
-      ~state:{ agent.state with config = turn_config }
-      ~base_url:agent.options.base_url
-      agent.options.provider
-  with
+  match provider_config_for_turn ~turn_config agent with
   | Error error ->
     let detailed = Provider_failure_attribution.of_provider_configuration_error error in
     notify_attribution on_provider_failure detailed.provider_failure;

--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -393,9 +393,17 @@ let openrouter ~model_id () =
 type pricing = Llm_provider.Pricing.pricing =
   { input_per_million : float
   ; output_per_million : float
-  ; cache_write_multiplier : float
-  ; cache_read_multiplier : float
+  ; cache_write_multiplier : float option
+  ; cache_read_multiplier : float option
   }
+
+type cache_price_component = Llm_provider.Pricing.cache_price_component =
+  | Cache_creation
+  | Cache_read
+
+type cost_estimate = Llm_provider.Pricing.cost_estimate =
+  | Estimated of float
+  | Incomplete of cache_price_component list
 
 let pricing_for_model_opt = Llm_provider.Pricing.pricing_for_model_opt
 let estimate_cost = Llm_provider.Pricing.estimate_cost
@@ -404,19 +412,6 @@ let estimate_cost = Llm_provider.Pricing.estimate_cost
 
 let custom_provider ~name ~model_id ?(api_key_env = "") () =
   { provider = Custom_registered { name }; model_id; api_key_env }
-;;
-
-(** Well-known env var names per provider kind.
-    Used as fallback when [Provider_config.t.api_key] is empty.
-    Delegates to {!Llm_provider.Provider_kind.default_api_key_env}
-    — the sum type owns this convention so adding a new variant
-    updates both call sites from one edit. *)
-let default_api_key_env_of_kind (kind : Llm_provider.Provider_config.provider_kind)
-  : string
-  =
-  match Llm_provider.Provider_kind.default_api_key_env kind with
-  | Some env -> env
-  | None -> ""
 ;;
 
 let api_key_from_declared_env env_name =
@@ -463,51 +458,6 @@ let auth_headers_only_for_kind
      | Anthropic | Kimi -> [ "x-api-key", key ]
      | Gemini -> [ "x-goog-api-key", key ]
      | OpenAI_compat | Ollama | Glm | DashScope -> [ "Authorization", "Bearer " ^ key ])
-;;
-
-(** Convert a [Llm_provider.Provider_config.t] into a
-    [Provider.config] (for Agent Builder).  Keeps the conversion
-    internal to OAS so consumers don't need their own adapters.
-
-    When [api_key] is empty, falls back to the well-known env var
-    name for the provider kind (e.g. [ANTHROPIC_API_KEY]). *)
-let config_of_provider_config (pc : Llm_provider.Provider_config.t) : config =
-  (* When pc.api_key is non-empty it is the *resolved* API key value
-     (not an env var name).  Pass it via static_token + auth_header
-     so that resolve() includes it in the Authorization header without
-     a second Sys.getenv_opt lookup (which would fail because the
-     value is not an env var name).  When pc.api_key is empty, fall
-     back to api_key_env so resolve() can look up the env var. *)
-  let has_key = not (Llm_provider.Secret.is_empty pc.api_key) in
-  let auth_header = if has_key then Some "Authorization" else None in
-  let static_token =
-    if has_key then Some (Llm_provider.Secret.header_value pc.api_key) else None
-  in
-  let provider =
-    match pc.provider_id with
-    | Some name -> Custom_registered { name }
-    | None ->
-      (match pc.kind with
-       | Anthropic -> Anthropic
-       | Kimi | Ollama | Gemini | Glm | DashScope ->
-         Custom_registered
-           { name = Llm_provider.Provider_config.string_of_provider_kind pc.kind }
-       | OpenAI_compat ->
-         OpenAICompat
-           { base_url = pc.base_url; auth_header; path = pc.request_path; static_token })
-  in
-  let api_key_env =
-    match provider with
-    | Custom_registered { name } ->
-      (match
-         Llm_provider.Provider_registry.default ()
-         |> fun registry -> Llm_provider.Provider_registry.find registry name
-       with
-       | Some entry -> entry.defaults.api_key_env
-       | None -> default_api_key_env_of_kind pc.kind)
-    | Local _ | Anthropic | OpenAICompat _ -> default_api_key_env_of_kind pc.kind
-  in
-  { provider; model_id = pc.model_id; api_key_env }
 ;;
 
 (** Forward adapter: build a {!Llm_provider.Provider_config.t} from an
@@ -736,4 +686,34 @@ let provider_config_of_agent
             { field = "provider"
             ; detail = "An explicit provider configuration is required"
             }))
+;;
+
+let provider_config_with_agent_config
+      ~(config : Types.agent_config)
+      (provider_config : Llm_provider.Provider_config.t)
+  =
+  let response_format = config.response_format in
+  let output_schema =
+    if response_format = provider_config.response_format
+    then provider_config.output_schema
+    else Llm_provider.Provider_config.output_schema_of_response_format response_format
+  in
+  { provider_config with
+    model_id = Types.model_to_string config.model
+  ; max_tokens = config.max_tokens
+  ; temperature = config.temperature
+  ; top_p = config.top_p
+  ; top_k = config.top_k
+  ; min_p = config.min_p
+  ; system_prompt = config.system_prompt
+  ; enable_thinking = config.enable_thinking
+  ; preserve_thinking = config.preserve_thinking
+  ; thinking_budget = config.thinking_budget
+  ; reasoning_effort = config.reasoning_effort
+  ; tool_choice = config.tool_choice
+  ; disable_parallel_tool_use = config.disable_parallel_tool_use
+  ; response_format
+  ; output_schema
+  ; cache_system_prompt = config.cache_system_prompt
+  }
 ;;

--- a/lib/provider.mli
+++ b/lib/provider.mli
@@ -226,12 +226,26 @@ val openrouter : model_id:string -> unit -> config
 type pricing = Llm_provider.Pricing.pricing =
   { input_per_million : float
   ; output_per_million : float
-  ; cache_write_multiplier : float
-  ; cache_read_multiplier : float
+  ; cache_write_multiplier : float option
+  ; cache_read_multiplier : float option
   }
 
-val pricing_for_model_opt : string -> pricing option
+type cache_price_component = Llm_provider.Pricing.cache_price_component =
+  | Cache_creation
+  | Cache_read
 
+type cost_estimate = Llm_provider.Pricing.cost_estimate =
+  | Estimated of float
+  | Incomplete of cache_price_component list
+
+(** Return catalog pricing for a model. When [provider_id] is supplied, the
+    exact provider/model row wins; a provider-independent row is used only when
+    that exact row is absent. Provider identity is never inferred from endpoint
+    or model syntax. *)
+val pricing_for_model_opt : ?provider_id:string -> string -> pricing option
+
+(** Compute an exact cost or report the cache price components required by the
+    observed usage but absent from the selected catalog row. *)
 val estimate_cost
   :  pricing:pricing
   -> input_tokens:int
@@ -239,7 +253,7 @@ val estimate_cost
   -> ?cache_creation_input_tokens:int
   -> ?cache_read_input_tokens:int
   -> unit
-  -> float
+  -> cost_estimate
 
 (** {2 Custom Provider Registry} *)
 
@@ -270,19 +284,6 @@ val custom_provider
   -> unit
   -> config
 
-(** Well-known env var name for a provider kind.
-    Returns empty string for providers that don't need auth
-    (Local and the CLI transports).
-    @since 0.87.0 *)
-val default_api_key_env_of_kind : Llm_provider.Provider_config.provider_kind -> string
-
-(** Convert a {!Llm_provider.Provider_config.t} into a {!config}.
-    Falls back to {!default_api_key_env_of_kind} when [api_key] is
-    empty.
-    @since 0.84.0
-    @since 0.87.0 — env var fallback *)
-val config_of_provider_config : Llm_provider.Provider_config.t -> config
-
 (** Forward adapter: build a {!Llm_provider.Provider_config.t} from an
     agent state and optional {!config}. Sampling params, tool_choice,
     thinking controls come from [state.config]; provider kind,
@@ -310,3 +311,15 @@ val provider_config_of_agent
   -> base_url:string
   -> config option
   -> (Llm_provider.Provider_config.t, Error.sdk_error) result
+
+(** Project the caller-owned agent turn controls onto an exact provider
+    configuration. Provider identity, wire kind, endpoint, credential, headers,
+    request path, and capability overrides remain unchanged. Fields that only
+    exist on {!Llm_provider.Provider_config.t} also remain unchanged.
+
+    This is the typed Builder/Agent path; it never consults a provider catalog,
+    endpoint URL, model syntax, or process environment. *)
+val provider_config_with_agent_config
+  :  config:Types.agent_config
+  -> Llm_provider.Provider_config.t
+  -> Llm_provider.Provider_config.t

--- a/lib/runtime_server.ml
+++ b/lib/runtime_server.ml
@@ -1166,9 +1166,7 @@ let handle_request ~sw state request =
       else (
         match Util.trim_non_empty_opt detail.provider with
         | None -> Ok ()
-        | Some provider ->
-          let* _resolved = resolve_provider ~provider ?model:detail.model () in
-          Ok ())
+        | Some provider -> validate_provider_identity ~provider)
     in
     let* _initialized = initialize state detail in
     Ok

--- a/lib/runtime_server_resolve.ml
+++ b/lib/runtime_server_resolve.ml
@@ -27,6 +27,23 @@ let required_provider_error () =
           }))
 ;;
 
+let unknown_provider_error selector =
+  unsupported_provider
+    (Printf.sprintf
+       "unknown provider %S; catalog/registry selectors: %s"
+       selector
+       (valid_provider_detail ()))
+;;
+
+let validate_provider_identity ~provider =
+  match Util.trim_non_empty_opt (Some provider) with
+  | None -> required_provider_error ()
+  | Some selector ->
+    (match Provider_runtime_binding.find selector with
+     | Some _binding -> Ok ()
+     | None -> unknown_provider_error selector)
+;;
+
 let resolve_provider ?provider ?model () =
   match Util.trim_non_empty_opt provider with
   | None -> required_provider_error ()
@@ -34,12 +51,7 @@ let resolve_provider ?provider ?model () =
     (match Provider_runtime_binding.resolve ?model selector with
      | Some (Ok (_binding, cfg)) -> Ok cfg
      | Some (Error _ as error) -> error
-     | None ->
-       unsupported_provider
-         (Printf.sprintf
-            "unknown provider %S; catalog/registry selectors: %s"
-            selector
-            (valid_provider_detail ())))
+     | None -> unknown_provider_error selector)
 ;;
 
 let resolve_execution (session : session) (detail : spawn_agent_request) =
@@ -56,12 +68,7 @@ let resolve_execution (session : session) (detail : spawn_agent_request) =
   | None -> required_provider_error ()
   | Some selector ->
     (match Provider_runtime_binding.resolve ?model:requested_model selector with
-     | None ->
-       unsupported_provider
-         (Printf.sprintf
-            "unknown provider %S; catalog/registry selectors: %s"
-            selector
-            (valid_provider_detail ()))
+     | None -> unknown_provider_error selector
      | Some (Error _ as error) -> error
      | Some (Ok (binding, provider_cfg)) ->
        Ok

--- a/lib/runtime_server_resolve.mli
+++ b/lib/runtime_server_resolve.mli
@@ -15,6 +15,11 @@ type execution_resolution =
   ; provider_cfg : Provider.config
   }
 
+(** Validate only the exact runtime provider identity. This deliberately does
+    not require a model: initialization and session settings are defaults, and
+    the exact model may be supplied by a later session or participant request. *)
+val validate_provider_identity : provider:string -> (unit, Error.sdk_error) result
+
 val resolve_provider
   :  ?provider:string
   -> ?model:string

--- a/lib/streaming.ml
+++ b/lib/streaming.ml
@@ -55,7 +55,7 @@ let map_stream_finalize_result = function
      | Error err -> Error (map_http_error err))
 ;;
 
-let map_stream_finalize_result_detailed ~binding ~provider_config = function
+let map_stream_finalize_result_detailed ~binding ~provider_id ~provider_config = function
   | Error error -> Error (Provider_failure_attribution.of_http_error ~binding error)
   | Ok result ->
     let result =
@@ -65,7 +65,7 @@ let map_stream_finalize_result_detailed ~binding ~provider_config = function
     (match result with
      | Ok response ->
        Ok
-         (Llm_provider.Pricing.annotate_response_cost response
+         (Llm_provider.Pricing.annotate_response_cost ~provider_id response
           |> fun response ->
           Llm_provider.Complete_common.patch_telemetry
             response
@@ -126,6 +126,7 @@ let create_message_stream_detailed
     Error (Provider_failure_attribution.of_provider_configuration_error error)
   | Ok (base_url, api_key, resolved_headers) ->
     let provider_cfg = provider in
+    let provider_id = Provider_runtime_binding.provider_id_of_config provider_cfg in
     let model_spec = Provider.model_spec_of_config provider_cfg in
     let binding =
       Binding_identity.of_resolved_provider
@@ -209,6 +210,7 @@ let create_message_stream_detailed
                ()
              |> map_stream_finalize_result_detailed
                   ~binding
+                  ~provider_id
                   ~provider_config:response_provider_config)
         | Provider.Openai_chat_completions ->
           (* OpenAI-compatible SSE streaming. *)
@@ -297,6 +299,7 @@ let create_message_stream_detailed
                ()
              |> map_stream_finalize_result_detailed
                   ~binding
+                  ~provider_id
                   ~provider_config:response_provider_config)
         | Provider.Custom name ->
           let error =

--- a/test/test_agent_turn.ml
+++ b/test/test_agent_turn.ml
@@ -241,7 +241,9 @@ let test_accumulate_usage_with_response () =
   let result =
     Agent_turn.accumulate_usage
       ~current_usage:current
+      ~provider_config:None
       ~provider:(Some provider_cfg)
+      ~response_model:(Some "claude-sonnet-4-6")
       ~response_usage:(Some response_usage)
   in
   Alcotest.(check int) "input tokens" 100 result.total_input_tokens;
@@ -252,7 +254,12 @@ let test_accumulate_usage_with_response () =
 let test_accumulate_usage_none_response () =
   let current = { Types.empty_usage with api_calls = 2 } in
   let result =
-    Agent_turn.accumulate_usage ~current_usage:current ~provider:None ~response_usage:None
+    Agent_turn.accumulate_usage
+      ~current_usage:current
+      ~provider_config:None
+      ~provider:None
+      ~response_model:None
+      ~response_usage:None
   in
   Alcotest.(check int) "api_calls incremented" 3 result.api_calls
 ;;
@@ -276,7 +283,9 @@ let test_accumulate_usage_local_pricing () =
   let result =
     Agent_turn.accumulate_usage
       ~current_usage:current
+      ~provider_config:None
       ~provider:(Some provider_cfg)
+      ~response_model:(Some "dashscope-3.5")
       ~response_usage:(Some response_usage)
   in
   Alcotest.(check (float 0.001)) "local is free" 0.0 result.estimated_cost_usd
@@ -298,10 +307,75 @@ let test_accumulate_usage_prefers_response_cost () =
   let result =
     Agent_turn.accumulate_usage
       ~current_usage:current
+      ~provider_config:None
       ~provider:(Some provider_cfg)
+      ~response_model:(Some "claude-sonnet-4-6")
       ~response_usage:(Some response_usage)
   in
   Alcotest.(check (float 0.0001)) "uses response cost" 0.4321 result.estimated_cost_usd
+;;
+
+let test_accumulate_usage_uses_typed_provider_and_response_model () =
+  let provider_config =
+    Llm_provider.Provider_config.make
+      ~kind:OpenAI_compat
+      ~provider_id:"deepseek"
+      ~model_id:"configured-model-before-provider-rotation"
+      ~base_url:"https://api.deepseek.com"
+      ()
+  in
+  let response_usage : Types.api_usage =
+    { input_tokens = 1_000_000
+    ; output_tokens = 1_000_000
+    ; cache_creation_input_tokens = 0
+    ; cache_read_input_tokens = 0
+    ; cost_usd = None
+    }
+  in
+  let result =
+    Agent_turn.accumulate_usage
+      ~current_usage:Types.empty_usage
+      ~provider_config:(Some provider_config)
+      ~provider:None
+      ~response_model:(Some "deepseek-v4-pro")
+      ~response_usage:(Some response_usage)
+  in
+  Alcotest.(check (float 0.0001))
+    "exact provider and returned model price"
+    1.305
+    result.estimated_cost_usd;
+  Alcotest.(check (option reject)) "no pricing gap" None result.pricing_gap
+;;
+
+let test_accumulate_usage_records_incomplete_cache_pricing () =
+  let provider_config =
+    Llm_provider.Provider_config.make
+      ~kind:DashScope
+      ~model_id:"dashscope-3.5"
+      ~base_url:"https://dashscope.invalid"
+      ()
+  in
+  let response_usage : Types.api_usage =
+    { input_tokens = 100
+    ; output_tokens = 10
+    ; cache_creation_input_tokens = 0
+    ; cache_read_input_tokens = 50
+    ; cost_usd = None
+    }
+  in
+  let result =
+    Agent_turn.accumulate_usage
+      ~current_usage:Types.empty_usage
+      ~provider_config:(Some provider_config)
+      ~provider:None
+      ~response_model:(Some "dashscope-3.5")
+      ~response_usage:(Some response_usage)
+  in
+  Alcotest.(check (float 0.0001)) "no invented cost" 0.0 result.estimated_cost_usd;
+  match result.pricing_gap with
+  | Some (Types.Pricing_unavailable "dashscope-3.5") -> ()
+  | Some gap -> Alcotest.failf "unexpected pricing gap: %s" (Types.show_pricing_gap gap)
+  | None -> Alcotest.fail "missing explicit pricing gap"
 ;;
 
 (* ── make_tool_results tests ─────────────────────────────── *)
@@ -360,7 +434,9 @@ let test_accumulate_usage_no_provider () =
   let result =
     Agent_turn.accumulate_usage
       ~current_usage:current
+      ~provider_config:None
       ~provider:None
+      ~response_model:None
       ~response_usage:(Some response_usage)
   in
   Alcotest.(check int) "input" 200 result.total_input_tokens;
@@ -390,7 +466,9 @@ let test_accumulate_usage_cumulative () =
   let result =
     Agent_turn.accumulate_usage
       ~current_usage:current
+      ~provider_config:None
       ~provider:None
+      ~response_model:None
       ~response_usage:(Some response_usage)
   in
   Alcotest.(check int) "cumulative input" 300 result.total_input_tokens;
@@ -669,6 +747,14 @@ let () =
             "prefers response cost"
             `Quick
             test_accumulate_usage_prefers_response_cost
+        ; Alcotest.test_case
+            "typed provider and response model"
+            `Quick
+            test_accumulate_usage_uses_typed_provider_and_response_model
+        ; Alcotest.test_case
+            "incomplete cache pricing"
+            `Quick
+            test_accumulate_usage_records_incomplete_cache_pricing
         ; Alcotest.test_case "no provider" `Quick test_accumulate_usage_no_provider
         ; Alcotest.test_case "cumulative" `Quick test_accumulate_usage_cumulative
         ] )

--- a/test/test_api_dispatch.ml
+++ b/test/test_api_dispatch.ml
@@ -47,6 +47,11 @@ let declared_pricing model_id =
   | None -> failf "expected catalog pricing for %S" model_id
 ;;
 
+let require_estimated_cost = function
+  | Provider.Estimated cost -> cost
+  | Provider.Incomplete _ -> fail "expected an exact cost estimate"
+;;
+
 (* ── Anthropic body shape ────────────────────────────────────── *)
 
 let test_anthropic_body_shape () =
@@ -126,10 +131,10 @@ let test_openai_body_shape () =
   let json = Yojson.Safe.from_string body_str in
   check bool "has model" true (json_has_key "model" json);
   check bool "has messages" true (json_has_key "messages" json);
-  (* The resolved provider config owns the request model identity. *)
+  (* The dispatched request is bound to the exact provider configuration. *)
   match json_get "model" json with
   | Some (`String "gpt") -> ()
-  | _ -> fail "model should come from the resolved provider config"
+  | _ -> fail "model should come from provider_config"
 ;;
 
 let test_openai_parse_response () =
@@ -201,9 +206,16 @@ let test_pricing_known_models () =
   check (float 0.01) "mini input" 0.15 p_mini.input_per_million;
   check
     bool
-    "partial catalog pricing is not treated as free"
+    "catalog zero remains declared despite absent cache multipliers"
     true
-    (Option.is_none (Provider.pricing_for_model_opt "dashscope-3.5-35b"));
+    (match Provider.pricing_for_model_opt "dashscope-3.5-35b" with
+     | Some
+         { input_per_million = 0.0
+         ; output_per_million = 0.0
+         ; cache_write_multiplier = None
+         ; cache_read_multiplier = None
+         } -> true
+     | Some _ | None -> false);
   check
     bool
     "undeclared local model remains unpriced"
@@ -215,12 +227,13 @@ let test_pricing_cost_estimation () =
   let pricing =
     { Provider.input_per_million = 3.0
     ; output_per_million = 15.0
-    ; cache_write_multiplier = 1.25
-    ; cache_read_multiplier = 0.1
+    ; cache_write_multiplier = Some 1.25
+    ; cache_read_multiplier = Some 0.1
     }
   in
   let cost =
     Provider.estimate_cost ~pricing ~input_tokens:1_000_000 ~output_tokens:100_000 ()
+    |> require_estimated_cost
   in
   check (float 0.01) "cost" 4.5 cost
 ;;
@@ -300,6 +313,7 @@ let test_cache_cost_calculation () =
       ~cache_creation_input_tokens:500_000
       ~cache_read_input_tokens:300_000
       ()
+    |> require_estimated_cost
   in
   (* regular = 1M - 500K - 300K = 200K -> 200K * 3.0/1M = 0.6
      cache_write = 500K * 3.0/1M * 1.25 = 1.875
@@ -312,6 +326,7 @@ let test_cache_cost_no_cache_tokens () =
   let pricing = declared_pricing "claude-sonnet-4-6" in
   let cost_with =
     Provider.estimate_cost ~pricing ~input_tokens:1_000_000 ~output_tokens:100_000 ()
+    |> require_estimated_cost
   in
   let cost_explicit =
     Provider.estimate_cost
@@ -321,6 +336,7 @@ let test_cache_cost_no_cache_tokens () =
       ~cache_creation_input_tokens:0
       ~cache_read_input_tokens:0
       ()
+    |> require_estimated_cost
   in
   check (float 0.0001) "zero cache same as default" cost_with cost_explicit
 ;;
@@ -328,8 +344,16 @@ let test_cache_cost_no_cache_tokens () =
 let test_cache_multipliers_for_non_anthropic () =
   let pricing = declared_pricing "gpt" in
   (* Openai: no cache pricing, multipliers are 1.0 *)
-  check (float 0.001) "no cache write discount" 1.0 pricing.cache_write_multiplier;
-  check (float 0.001) "no cache read discount" 1.0 pricing.cache_read_multiplier
+  check
+    (option (float 0.001))
+    "no cache write discount"
+    (Some 1.0)
+    pricing.cache_write_multiplier;
+  check
+    (option (float 0.001))
+    "no cache read discount"
+    (Some 1.0)
+    pricing.cache_read_multiplier
 ;;
 
 (* ── Test runner ─────────────────────────────────────────────── *)

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -101,6 +101,12 @@ let to_string json = Yojson.Safe.Util.to_string json
 let to_int json = Yojson.Safe.Util.to_int json
 let to_list json = Yojson.Safe.Util.to_list json
 
+let require_model_capabilities model_id =
+  match Capabilities.for_model_id model_id with
+  | Some capabilities -> capabilities
+  | None -> Alcotest.failf "missing declared capabilities for %S" model_id
+;;
+
 let rec find_repo_root dir =
   if Sys.file_exists (Filename.concat dir "dune-project")
   then dir
@@ -1714,6 +1720,7 @@ let test_responses_build_request_round_trips_tool_result_items () =
       ~request_path:"/v1/responses"
       ~enable_thinking:true
       ~max_tokens:128
+      ~model_capabilities_override:(require_model_capabilities "gpt-5.5")
       ()
   in
   let tool =

--- a/test/test_builder.ml
+++ b/test/test_builder.ml
@@ -283,6 +283,302 @@ let test_with_provider () =
     (Option.is_some (Agent.options agent).provider)
 ;;
 
+let exact_provider_config () =
+  let schema = `Assoc [ "type", `String "object" ] in
+  let capabilities =
+    { Llm_provider.Capabilities.openai_compat_chat_capabilities with
+      supports_tools = true
+    ; supports_structured_output = true
+    }
+  in
+  Llm_provider.Provider_config.make
+    ~kind:Llm_provider.Provider_config.Ollama
+    ~provider_id:"ollama"
+    ~model_id:"builder-exact-model"
+    ~base_url:"https://builder-exact.invalid/api"
+    ~api_key:"builder-exact-secret"
+    ~headers:[ "Content-Type", "application/json"; "x-builder-tenant", "exact" ]
+    ~request_path:"/exact/chat"
+    ~max_tokens:111
+    ~max_context:65536
+    ~temperature:0.75
+    ~top_p:0.8
+    ~top_k:32
+    ~min_p:0.05
+    ~system_prompt:"exact provider prompt"
+    ~enable_thinking:true
+    ~preserve_thinking:true
+    ~thinking_budget:4096
+    ~clear_thinking:false
+    ~tool_stream:true
+    ~tool_choice:Types.Auto
+    ~response_format:(Types.JsonSchema schema)
+    ~cache_system_prompt:true
+    ~supports_tool_choice_override:true
+    ~supports_structured_output_override:true
+    ~model_capabilities_override:capabilities
+    ~keep_alive:"-1"
+    ~num_ctx:32768
+    ~seed:2590
+    ~previous_response_id:"response-before-builder"
+    ~connect_timeout_s:12.5
+    ()
+;;
+
+let test_with_provider_config_reaches_dispatch_losslessly () =
+  with_net
+  @@ fun net ->
+  let observed = ref None in
+  let response : Types.api_response =
+    { id = "builder-exact-response"
+    ; model = "builder-exact-model"
+    ; stop_reason = Types.EndTurn
+    ; content = [ Types.Text "ok" ]
+    ; usage = None
+    ; telemetry = None
+    }
+  in
+  let transport : Llm_provider.Llm_transport.t =
+    { complete_sync =
+        (fun request ->
+          observed := Some request.Llm_provider.Llm_transport.config;
+          { response = Ok response; latency_ms = Some 0 })
+    ; complete_stream = (fun ?on_telemetry:_ ~on_event:_ _request -> Ok response)
+    }
+  in
+  let provider_config = exact_provider_config () in
+  let legacy =
+    Provider.local_llm ~base_url:"http://legacy.invalid" ~model_id:"legacy" ()
+  in
+  let agent =
+    Builder.create ~net ~model:"initial-model"
+    |> Builder.with_provider legacy
+    |> Builder.with_provider_config provider_config
+    |> Builder.with_max_tokens 777
+    |> Builder.with_temperature 0.25
+    |> Builder.with_response_format Types.JsonMode
+    |> Builder.with_transport transport
+    |> Builder.build_safe
+    |> Result.get_ok
+  in
+  Alcotest.(check bool)
+    "typed selection clears legacy provider"
+    true
+    (Option.is_none (Agent.options agent).provider);
+  Alcotest.(check bool)
+    "exact carrier retained"
+    true
+    (Option.is_some (Agent.provider_config agent));
+  Alcotest.(check (list string))
+    "agent card observes canonical provider identity"
+    [ "ollama" ]
+    (Agent.card agent).supported_providers;
+  let result = Eio.Switch.run (fun sw -> Agent.run ~sw agent "hello") in
+  (match result with
+   | Ok _ -> ()
+   | Error error -> Alcotest.fail (Error.to_string error));
+  (match Agent.lifecycle agent with
+   | Some snapshot ->
+     Alcotest.(check (option string))
+       "lifecycle observes canonical provider identity"
+       (Some "ollama")
+       snapshot.requested_provider
+   | None -> Alcotest.fail "completed agent has no lifecycle snapshot");
+  let dispatched =
+    match !observed with
+    | Some config -> config
+    | None -> Alcotest.fail "transport did not observe a provider config"
+  in
+  Alcotest.(check bool) "wire kind" true (dispatched.kind = provider_config.kind);
+  Alcotest.(check (option string))
+    "provider identity"
+    provider_config.provider_id
+    dispatched.provider_id;
+  Alcotest.(check string) "endpoint" provider_config.base_url dispatched.base_url;
+  Alcotest.(check string)
+    "request path"
+    provider_config.request_path
+    dispatched.request_path;
+  Alcotest.(check string)
+    "credential"
+    (provider_config.api_key :> string)
+    (dispatched.api_key :> string);
+  Alcotest.(check (list (pair string string)))
+    "headers"
+    provider_config.headers
+    dispatched.headers;
+  Alcotest.(check (option bool))
+    "tool choice override"
+    provider_config.supports_tool_choice_override
+    dispatched.supports_tool_choice_override;
+  Alcotest.(check (option bool))
+    "structured output override"
+    provider_config.supports_structured_output_override
+    dispatched.supports_structured_output_override;
+  Alcotest.(check bool)
+    "capability override"
+    true
+    (match dispatched.model_capabilities_override with
+     | Some capabilities ->
+       capabilities.supports_tools && capabilities.supports_structured_output
+     | None -> false);
+  Alcotest.(check (option string)) "keep alive" (Some "-1") dispatched.keep_alive;
+  Alcotest.(check (option int)) "num ctx" (Some 32768) dispatched.num_ctx;
+  Alcotest.(check (option int)) "seed" (Some 2590) dispatched.seed;
+  Alcotest.(check (option string))
+    "previous response id"
+    (Some "response-before-builder")
+    dispatched.previous_response_id;
+  Alcotest.(check (option (float 0.001)))
+    "connect timeout"
+    (Some 12.5)
+    dispatched.connect_timeout_s;
+  Alcotest.(check string)
+    "model seeded from exact config"
+    "builder-exact-model"
+    dispatched.model_id;
+  Alcotest.(check (option int))
+    "later max_tokens setter wins"
+    (Some 777)
+    dispatched.max_tokens;
+  Alcotest.(check (option (float 0.001)))
+    "later temperature setter wins"
+    (Some 0.25)
+    dispatched.temperature;
+  Alcotest.(check string)
+    "later response format setter wins"
+    (Types.show_response_format Types.JsonMode)
+    (Types.show_response_format dispatched.response_format);
+  Alcotest.(check bool)
+    "changed response format clears stale output schema"
+    true
+    (Option.is_none dispatched.output_schema)
+;;
+
+let test_handoff_inherits_injected_transport () =
+  with_net
+  @@ fun net ->
+  let response ~id ~stop_reason content : Types.api_response =
+    { id
+    ; model = "builder-exact-model"
+    ; stop_reason
+    ; content
+    ; usage = None
+    ; telemetry = None
+    }
+  in
+  let responses =
+    ref
+      [ response
+          ~id:"parent-handoff"
+          ~stop_reason:Types.StopToolUse
+          [ Types.ToolUse
+              { id = "handoff-tool"
+              ; name = "researcher"
+              ; input = `Assoc [ "prompt", `String "inspect" ]
+              }
+          ]
+      ; response
+          ~id:"subagent-complete"
+          ~stop_reason:Types.EndTurn
+          [ Types.Text "sub ok" ]
+      ; response
+          ~id:"parent-complete"
+          ~stop_reason:Types.EndTurn
+          [ Types.Text "parent done" ]
+      ]
+  in
+  let calls = ref 0 in
+  let transport_error () =
+    Llm_provider.Http_client.NetworkError
+      { message = "scripted transport exhausted"; kind = Unknown }
+  in
+  let transport : Llm_provider.Llm_transport.t =
+    { complete_sync =
+        (fun _request ->
+          incr calls;
+          match !responses with
+          | next :: rest ->
+            responses := rest;
+            { response = Ok next; latency_ms = Some 0 }
+          | [] -> { response = Error (transport_error ()); latency_ms = Some 0 })
+    ; complete_stream =
+        (fun ?on_telemetry:_ ~on_event:_ _request -> Error (transport_error ()))
+    }
+  in
+  let target =
+    Subagent.to_handoff_target
+      ~parent_config:(Types.default_config ~model:"parent-model")
+      ~base_tools:[]
+      (Subagent.of_markdown
+         "---\n\
+          name: researcher\n\
+          description: Inspect the requested subject\n\
+          model: subagent-model\n\
+          ---\n\
+          Inspect the request.")
+  in
+  let agent =
+    Builder.create ~net ~model:"parent-model"
+    |> Builder.with_provider_config (exact_provider_config ())
+    |> Builder.with_transport transport
+    |> Builder.build_safe
+    |> Result.get_ok
+  in
+  let result =
+    Eio.Switch.run (fun sw ->
+      Agent.run_with_handoffs ~sw agent ~targets:[ target ] "delegate")
+  in
+  (match result with
+   | Ok response ->
+     Alcotest.(check string)
+       "parent completes"
+       "parent done"
+       (Types.visible_text_of_response response)
+   | Error error -> Alcotest.fail (Error.to_string error));
+  Alcotest.(check int) "parent and subagent use one transport" 3 !calls;
+  Alcotest.(check int) "all scripted responses consumed" 0 (List.length !responses)
+;;
+
+let test_provider_selection_last_setter_wins () =
+  with_net
+  @@ fun net ->
+  let exact = exact_provider_config () in
+  let legacy =
+    Provider.local_llm ~base_url:"http://legacy.invalid" ~model_id:"legacy" ()
+  in
+  let legacy_last =
+    Builder.create ~net ~model:"initial"
+    |> Builder.with_provider_config exact
+    |> Builder.with_provider legacy
+    |> Builder.build_safe
+    |> Result.get_ok
+  in
+  Alcotest.(check bool)
+    "legacy selection clears exact carrier"
+    true
+    (Option.is_none (Agent.provider_config legacy_last));
+  Alcotest.(check bool)
+    "legacy selection retained"
+    true
+    (Option.is_some (Agent.options legacy_last).provider);
+  let exact_last =
+    Builder.create ~net ~model:"initial"
+    |> Builder.with_provider legacy
+    |> Builder.with_provider_config exact
+    |> Builder.build_safe
+    |> Result.get_ok
+  in
+  Alcotest.(check bool)
+    "exact selection clears legacy provider"
+    true
+    (Option.is_none (Agent.options exact_last).provider);
+  Alcotest.(check bool)
+    "exact selection retained"
+    true
+    (Option.is_some (Agent.provider_config exact_last))
+;;
+
 (* --- 15. with_base_url --- *)
 
 let test_with_base_url () =
@@ -654,6 +950,18 @@ let () =
         ; Alcotest.test_case "transport" `Quick test_with_transport
         ; Alcotest.test_case "context" `Quick test_with_context
         ; Alcotest.test_case "provider" `Quick test_with_provider
+        ; Alcotest.test_case
+            "exact provider config reaches dispatch losslessly"
+            `Quick
+            test_with_provider_config_reaches_dispatch_losslessly
+        ; Alcotest.test_case
+            "handoff inherits injected transport"
+            `Quick
+            test_handoff_inherits_injected_transport
+        ; Alcotest.test_case
+            "provider selection last setter wins"
+            `Quick
+            test_provider_selection_last_setter_wins
         ; Alcotest.test_case "base_url" `Quick test_with_base_url
         ; Alcotest.test_case "mcp_clients" `Quick test_with_mcp_clients
         ; Alcotest.test_case

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -867,7 +867,9 @@ let test_accumulate_usage_with_response () =
   let result =
     Agent_turn.accumulate_usage
       ~current_usage:current
+      ~provider_config:None
       ~provider:None
+      ~response_model:None
       ~response_usage:resp_usage
   in
   Alcotest.(check int) "input tokens" 100 result.total_input_tokens;
@@ -884,7 +886,12 @@ let test_accumulate_usage_no_response () =
     }
   in
   let result =
-    Agent_turn.accumulate_usage ~current_usage:current ~provider:None ~response_usage:None
+    Agent_turn.accumulate_usage
+      ~current_usage:current
+      ~provider_config:None
+      ~provider:None
+      ~response_model:None
+      ~response_usage:None
   in
   Alcotest.(check int) "api_calls incremented" 3 result.api_calls;
   Alcotest.(check int) "input tokens preserved" 500 result.total_input_tokens;
@@ -913,11 +920,18 @@ let test_accumulate_usage_cumulative () =
   let after1 =
     Agent_turn.accumulate_usage
       ~current_usage:Types.empty_usage
+      ~provider_config:None
       ~provider:None
+      ~response_model:None
       ~response_usage:u1
   in
   let after2 =
-    Agent_turn.accumulate_usage ~current_usage:after1 ~provider:None ~response_usage:u2
+    Agent_turn.accumulate_usage
+      ~current_usage:after1
+      ~provider_config:None
+      ~provider:None
+      ~response_model:None
+      ~response_usage:u2
   in
   Alcotest.(check int) "cumulative input" 80 after2.total_input_tokens;
   Alcotest.(check int) "cumulative output" 30 after2.total_output_tokens;

--- a/test/test_property_advanced.ml
+++ b/test/test_property_advanced.ml
@@ -214,11 +214,13 @@ let test_cost_estimation_non_negative =
        let pricing =
          { Provider.input_per_million = rate
          ; output_per_million = rate
-         ; cache_write_multiplier = 1.25
-         ; cache_read_multiplier = 0.1
+         ; cache_write_multiplier = Some 1.25
+         ; cache_read_multiplier = Some 0.1
          }
        in
-       Provider.estimate_cost ~pricing ~input_tokens ~output_tokens () >= 0.0)
+       match Provider.estimate_cost ~pricing ~input_tokens ~output_tokens () with
+       | Provider.Estimated cost -> cost >= 0.0
+       | Provider.Incomplete _ -> false)
 ;;
 
 let test_cost_scales_with_tokens =
@@ -232,15 +234,17 @@ let test_cost_scales_with_tokens =
        let pricing =
          { Provider.input_per_million = 3.0
          ; output_per_million = 15.0
-         ; cache_write_multiplier = 1.25
-         ; cache_read_multiplier = 0.1
+         ; cache_write_multiplier = Some 1.25
+         ; cache_read_multiplier = Some 0.1
          }
        in
        let cost_a = Provider.estimate_cost ~pricing ~input_tokens:a ~output_tokens:0 () in
        let cost_b =
          Provider.estimate_cost ~pricing ~input_tokens:(a + b) ~output_tokens:0 ()
        in
-       cost_b >= cost_a)
+       match cost_a, cost_b with
+       | Provider.Estimated cost_a, Provider.Estimated cost_b -> cost_b >= cost_a
+       | Provider.Incomplete _, _ | _, Provider.Incomplete _ -> false)
 ;;
 
 (* ── Provider Resolve Properties ──────────────────────────────── *)

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -51,6 +51,11 @@ let declared_pricing model_id =
   | None -> Alcotest.failf "expected catalog pricing for %S" model_id
 ;;
 
+let require_estimated_cost = function
+  | Provider.Estimated cost -> cost
+  | Provider.Incomplete _ -> Alcotest.fail "expected an exact cost estimate"
+;;
+
 let with_empty_capability_sources f =
   let original_catalog = Llm_provider.Model_catalog.global () in
   let original_manifest = Llm_provider.Capability_manifest.global () in
@@ -656,23 +661,36 @@ let test_pricing_sonnet () =
   let p = declared_pricing "claude-sonnet-4-6-20250514" in
   Alcotest.(check (float 0.001)) "input/M" 3.0 p.input_per_million;
   Alcotest.(check (float 0.001)) "output/M" 15.0 p.output_per_million;
-  Alcotest.(check (float 0.001)) "cache_write" 1.25 p.cache_write_multiplier;
-  Alcotest.(check (float 0.001)) "cache_read" 0.1 p.cache_read_multiplier
+  Alcotest.(check (option (float 0.001)))
+    "cache_write"
+    (Some 1.25)
+    p.cache_write_multiplier;
+  Alcotest.(check (option (float 0.001))) "cache_read" (Some 0.1) p.cache_read_multiplier
 ;;
 
 let test_pricing_gpt55 () =
   let p = declared_pricing "gpt-5.5" in
   Alcotest.(check (float 0.001)) "input/M" 5.0 p.input_per_million;
   Alcotest.(check (float 0.001)) "output/M" 30.0 p.output_per_million;
-  Alcotest.(check (float 0.001)) "cache_write" 1.0 p.cache_write_multiplier;
-  Alcotest.(check (float 0.001)) "cache_read" 0.1 p.cache_read_multiplier
+  Alcotest.(check (option (float 0.001)))
+    "cache_write"
+    (Some 1.0)
+    p.cache_write_multiplier;
+  Alcotest.(check (option (float 0.001))) "cache_read" (Some 0.1) p.cache_read_multiplier
 ;;
 
-let test_incomplete_catalog_pricing_remains_absent () =
+let test_incomplete_cache_pricing_remains_declared () =
   Alcotest.(check bool)
-    "cache multipliers are not invented"
+    "base price remains observable without inventing cache multipliers"
     true
-    (Option.is_none (Provider.pricing_for_model_opt "dashscope-3.5-35b-a3b"))
+    (match Provider.pricing_for_model_opt "dashscope-3.5-35b-a3b" with
+     | Some
+         { input_per_million = 0.0
+         ; output_per_million = 0.0
+         ; cache_write_multiplier = None
+         ; cache_read_multiplier = None
+         } -> true
+     | Some _ | None -> false)
 ;;
 
 let test_pricing_unknown () =
@@ -692,90 +710,9 @@ let test_estimate_cost () =
       ~cache_creation_input_tokens:100_000
       ~cache_read_input_tokens:200_000
       ()
+    |> require_estimated_cost
   in
   Alcotest.(check bool) "cost > 0" true (cost > 0.0)
-;;
-
-let test_config_of_provider_config_localhost_boundary () =
-  let cfg =
-    Llm_provider.Provider_config.make
-      ~kind:Llm_provider.Provider_config.OpenAI_compat
-      ~model_id:"test-model"
-      ~base_url:"http://localhostevil.com:8080"
-      ()
-  in
-  match Provider.config_of_provider_config cfg with
-  | { provider = Provider.OpenAICompat _; _ } -> ()
-  | { provider = Provider.Local _; _ } ->
-    Alcotest.fail "localhostevil.com must not be treated as local"
-  | _ -> Alcotest.fail "unexpected provider kind"
-;;
-
-let test_config_of_provider_config_typed_ollama_is_not_inferred_local () =
-  let cfg =
-    Llm_provider.Provider_config.make
-      ~kind:Llm_provider.Provider_config.Ollama
-      ~model_id:"test-model"
-      ~base_url:"http://localhost:11434"
-      ()
-  in
-  match Provider.config_of_provider_config cfg with
-  | { provider = Provider.Custom_registered { name }; _ } ->
-    Alcotest.(check string) "typed provider identity" "ollama" name
-  | { provider = Provider.Local _; _ } ->
-    Alcotest.fail "localhost URL must not replace the typed Ollama identity"
-  | _ -> Alcotest.fail "expected typed Ollama identity to be preserved"
-;;
-
-let test_config_of_provider_config_explicit_id_is_not_inferred_local () =
-  let cfg =
-    Llm_provider.Provider_config.make
-      ~kind:Llm_provider.Provider_config.OpenAI_compat
-      ~provider_id:"Explicit-Localhost-Provider"
-      ~model_id:"test-model"
-      ~base_url:"  HTTP://LOCALHOST:11434/v1  "
-      ()
-  in
-  match Provider.config_of_provider_config cfg with
-  | { provider = Provider.Custom_registered { name }; _ } ->
-    Alcotest.(check string)
-      "explicit provider identity"
-      "explicit-localhost-provider"
-      name
-  | { provider = Provider.Local _; _ } ->
-    Alcotest.fail "localhost URL must not replace the explicit provider identity"
-  | _ -> Alcotest.fail "expected explicit provider identity to be preserved"
-;;
-
-let test_config_of_provider_config_openai_compat_is_not_inferred_local () =
-  let cfg =
-    Llm_provider.Provider_config.make
-      ~kind:Llm_provider.Provider_config.OpenAI_compat
-      ~model_id:"test-model"
-      ~base_url:"http://localhost?foo=bar"
-      ()
-  in
-  match Provider.config_of_provider_config cfg with
-  | { provider = Provider.OpenAICompat { base_url; _ }; _ } ->
-    Alcotest.(check string) "base_url preserved" "http://localhost?foo=bar" base_url
-  | { provider = Provider.Local _; _ } ->
-    Alcotest.fail "localhost URL must not replace the typed OpenAI-compatible identity"
-  | _ -> Alcotest.fail "expected OpenAI-compatible identity to be preserved"
-;;
-
-let test_config_of_provider_config_kimi_uses_custom_provider () =
-  let cfg =
-    Llm_provider.Provider_config.make
-      ~kind:Llm_provider.Provider_config.Kimi
-      ~model_id:"kimi-for-coding"
-      ~base_url:"https://api.kimi.com/coding"
-      ()
-  in
-  match Provider.config_of_provider_config cfg with
-  | { provider = Provider.Custom_registered { name }; api_key_env; _ } ->
-    Alcotest.(check string) "provider name" "kimi" name;
-    Alcotest.(check string) "api_key_env" "KIMI_API_KEY" api_key_env
-  | _ -> Alcotest.fail "expected kimi config to round-trip through Custom_registered"
 ;;
 
 let test_openai_compat_static_token () =
@@ -1582,31 +1519,11 @@ let () =
       , [ Alcotest.test_case "sonnet pricing" `Quick test_pricing_sonnet
         ; Alcotest.test_case "gpt-5.5 pricing" `Quick test_pricing_gpt55
         ; Alcotest.test_case
-            "incomplete catalog pricing remains absent"
+            "incomplete cache pricing remains declared"
             `Quick
-            test_incomplete_catalog_pricing_remains_absent
+            test_incomplete_cache_pricing_remains_declared
         ; Alcotest.test_case "unknown model" `Quick test_pricing_unknown
         ; Alcotest.test_case "estimate cost" `Quick test_estimate_cost
-        ; Alcotest.test_case
-            "provider_config localhost boundary"
-            `Quick
-            test_config_of_provider_config_localhost_boundary
-        ; Alcotest.test_case
-            "provider_config typed ollama is not URL-local"
-            `Quick
-            test_config_of_provider_config_typed_ollama_is_not_inferred_local
-        ; Alcotest.test_case
-            "provider_config explicit id is not URL-local"
-            `Quick
-            test_config_of_provider_config_explicit_id_is_not_inferred_local
-        ; Alcotest.test_case
-            "provider_config OpenAI compatibility is not URL-local"
-            `Quick
-            test_config_of_provider_config_openai_compat_is_not_inferred_local
-        ; Alcotest.test_case
-            "provider_config kimi custom"
-            `Quick
-            test_config_of_provider_config_kimi_uses_custom_provider
         ] )
     ; ( "openai_compat"
       , [ Alcotest.test_case "static token" `Quick test_openai_compat_static_token

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -1090,6 +1090,24 @@ let fake_transport response : Llm_provider.Llm_transport.t =
   }
 ;;
 
+let with_model_catalog_toml contents f =
+  let original = Llm_provider.Model_catalog.global () in
+  match
+    Llm_provider.Model_catalog.of_toml_string
+      ~source:"test_provider_complete provider pricing"
+      contents
+  with
+  | Error message -> Alcotest.fail message
+  | Ok catalog ->
+    Llm_provider.Model_catalog.set_global catalog;
+    Fun.protect
+      ~finally:(fun () ->
+        match original with
+        | Some catalog -> Llm_provider.Model_catalog.set_global catalog
+        | None -> Llm_provider.Model_catalog.clear_global ())
+      f
+;;
+
 let complete_with_captured_diag ~config ~response =
   let entries = ref [] in
   let run () =
@@ -1264,6 +1282,85 @@ let test_annotate_response_cost_gpt55 () =
   | { usage = Some { cost_usd = Some cost; _ }; _ } ->
     Alcotest.(check (float 0.001)) "gpt-5.5 cost" 35.0 cost
   | _ -> Alcotest.fail "expected gpt-5.5 annotated response cost"
+;;
+
+let test_complete_propagates_exact_provider_to_cost_annotation () =
+  let catalog =
+    {|
+[[models]]
+id_prefix = "shared-priced-model"
+base = "openai_chat"
+input_per_million = 9.0
+output_per_million = 90.0
+cache_write_multiplier = 1.0
+cache_read_multiplier = 1.0
+
+[[models]]
+id_prefix = "shared-priced-model"
+provider_name = "pricing-provider"
+base = "openai_chat"
+input_per_million = 1.0
+output_per_million = 2.0
+cache_write_multiplier = 1.0
+cache_read_multiplier = 1.0
+|}
+  in
+  let response : api_response =
+    { id = "provider-priced-response"
+    ; model = "shared-priced-model"
+    ; stop_reason = EndTurn
+    ; content = [ Text "ok" ]
+    ; usage =
+        Some
+          { input_tokens = 1_000_000
+          ; output_tokens = 1_000_000
+          ; cache_creation_input_tokens = 0
+          ; cache_read_input_tokens = 0
+          ; cost_usd = None
+          }
+    ; telemetry = None
+    }
+  in
+  let config =
+    PC.make
+      ~kind:OpenAI_compat
+      ~provider_id:"pricing-provider"
+      ~model_id:"shared-priced-model"
+      ~base_url:"https://example.invalid/v1"
+      ()
+  in
+  let check_cost label = function
+    | Ok { usage = Some { cost_usd = Some cost; _ }; _ } ->
+      Alcotest.(check (float 0.001)) label 3.0 cost
+    | Ok _ -> Alcotest.failf "%s: expected annotated cost" label
+    | Error _ -> Alcotest.failf "%s: fake completion should succeed" label
+  in
+  with_model_catalog_toml catalog (fun () ->
+    Eio_main.run
+    @@ fun env ->
+    Eio.Switch.run
+    @@ fun sw ->
+    let net = Eio.Stdenv.net env in
+    let transport = fake_transport response in
+    check_cost
+      "sync exact provider price"
+      (Llm_provider.Complete.complete
+         ~sw
+         ~net
+         ~transport
+         ~config
+         ~messages:[ user_msg "hi" ]
+         ());
+    check_cost
+      "stream exact provider price"
+      (Llm_provider.Complete.complete_stream
+         ~sw
+         ~net
+         ~transport
+         ~config
+         ~messages:[ user_msg "hi" ]
+         ~on_event:(fun _ -> ())
+         ()))
 ;;
 
 (* ── Stream accumulator ──────────────────────────────── *)
@@ -1586,6 +1683,10 @@ let () =
             "annotate gpt-5.5 response cost"
             `Quick
             test_annotate_response_cost_gpt55
+        ; test_case
+            "complete propagates exact provider to cost annotation"
+            `Quick
+            test_complete_propagates_exact_provider_to_cost_annotation
         ] )
     ; ( "stream_acc"
       , [ test_case "text events" `Quick test_stream_acc_text

--- a/test/test_runtime_server_coverage.ml
+++ b/test/test_runtime_server_coverage.ml
@@ -177,6 +177,100 @@ let test_handle_initialize_status_events_report_prove_shutdown () =
   | Error err -> Alcotest.fail (Error.to_string err)
 ;;
 
+let test_initialize_provider_then_start_session_model () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_store
+  @@ fun root _store ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let state = Runtime_server_types.create ~net:(Eio.Stdenv.net env) () in
+  let provider =
+    match Provider_runtime_binding.find "claude" with
+    | Some provider -> provider
+    | None -> Alcotest.fail "expected builtin claude provider identity"
+  in
+  Alcotest.(check (option string))
+    "provider has no invented default model"
+    None
+    provider.default_model;
+  let init : Runtime.init_request =
+    { session_root = Some root
+    ; provider = Some "claude"
+    ; model = None
+    ; include_partial_messages = false
+    ; setting_sources = []
+    ; resume_session = None
+    ; cwd = None
+    }
+  in
+  (match Runtime_server.handle_request ~sw state (Runtime.Initialize init) with
+   | Ok (Runtime.Initialized _) -> ()
+   | Ok _ -> Alcotest.fail "expected Initialized"
+   | Error err -> Alcotest.fail (Error.to_string err));
+  let start : Runtime.start_request =
+    { session_id = Some "rt-session-model"
+    ; goal = "use a session-level exact model"
+    ; participants = [ "worker" ]
+    ; provider = None
+    ; model = Some "claude-exact-session-model"
+    ; system_prompt = None
+    ; workdir = None
+    }
+  in
+  match Runtime_server.handle_request ~sw state (Runtime.Start_session start) with
+  | Ok (Runtime.Session_started_response session) ->
+    Alcotest.(check (option string)) "inherited provider" (Some "claude") session.provider;
+    Alcotest.(check (option string))
+      "session model"
+      (Some "claude-exact-session-model")
+      session.model;
+    let spawn : Runtime.spawn_agent_request =
+      { participant_name = "worker"
+      ; role = None
+      ; prompt = "work"
+      ; provider = None
+      ; model = None
+      ; system_prompt = None
+      }
+    in
+    (match Runtime_server_resolve.resolve_execution session spawn with
+     | Ok resolution ->
+       Alcotest.(check (option string))
+         "resolved model"
+         (Some "claude-exact-session-model")
+         resolution.resolved_model
+     | Error err -> Alcotest.fail (Error.to_string err))
+  | Ok _ -> Alcotest.fail "expected Session_started_response"
+  | Error err -> Alcotest.fail (Error.to_string err)
+;;
+
+let test_initialize_unknown_provider_remains_uninitialized () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let state = Runtime_server_types.create ~net:(Eio.Stdenv.net env) () in
+  let init : Runtime.init_request =
+    { session_root = None
+    ; provider = Some "unknown-runtime-provider"
+    ; model = None
+    ; include_partial_messages = false
+    ; setting_sources = []
+    ; resume_session = None
+    ; cwd = None
+    }
+  in
+  (match Runtime_server.handle_request ~sw state (Runtime.Initialize init) with
+   | Error (Error.Config (UnsupportedProvider _)) -> ()
+   | Error err -> Alcotest.failf "unexpected error: %s" (Error.to_string err)
+   | Ok _ -> Alcotest.fail "unknown provider must fail initialization");
+  Alcotest.(check bool)
+    "state remains uninitialized"
+    false
+    (Runtime_server_types.is_initialized state)
+;;
+
 let test_apply_command_public_paths_and_errors () =
   Eio_main.run
   @@ fun env ->
@@ -477,6 +571,14 @@ let () =
             "initialize status events report prove shutdown"
             `Quick
             test_handle_initialize_status_events_report_prove_shutdown
+        ; Alcotest.test_case
+            "provider at initialize and model at session start"
+            `Quick
+            test_initialize_provider_then_start_session_model
+        ; Alcotest.test_case
+            "unknown provider leaves runtime uninitialized"
+            `Quick
+            test_initialize_unknown_provider_remains_uninitialized
         ; Alcotest.test_case
             "shutdown waits for participant lanes"
             `Quick

--- a/test/test_runtime_server_resolve.ml
+++ b/test/test_runtime_server_resolve.ml
@@ -25,6 +25,14 @@ let with_provider_catalog f =
           "auth": {"type": "none"},
           "default_model": "runtime-b-model",
           "capabilities_base": "openai_chat"
+        },
+        {
+          "id": "runtime-no-default",
+          "kind": "openai_compat",
+          "base_url": "https://runtime-no-default.invalid",
+          "request_path": "/v1/chat/completions",
+          "auth": {"type": "none"},
+          "capabilities_base": "openai_chat"
         }
       ]
     }|}
@@ -100,6 +108,23 @@ let test_explicit_model_is_preserved () =
     | Error err -> Alcotest.fail (Error.to_string err))
 ;;
 
+let test_provider_identity_does_not_require_model () =
+  with_provider_catalog (fun () ->
+    match
+      Runtime_server_resolve.validate_provider_identity ~provider:"runtime-no-default"
+    with
+    | Ok () -> ()
+    | Error err -> Alcotest.fail (Error.to_string err))
+;;
+
+let test_provider_resolution_still_requires_model () =
+  with_provider_catalog (fun () ->
+    match Runtime_server_resolve.resolve_provider ~provider:"runtime-no-default" () with
+    | Error (Error.Config (InvalidConfig { field = "model"; _ })) -> ()
+    | Error err -> Alcotest.failf "unexpected error: %s" (Error.to_string err)
+    | Ok _ -> Alcotest.fail "execution resolution must require an exact model")
+;;
+
 let test_missing_provider_is_explicit_error () =
   match Runtime_server_resolve.resolve_provider () with
   | Error (Error.Config (InvalidConfig { field = "provider"; _ })) -> ()
@@ -169,6 +194,14 @@ let () =
       , [ Alcotest.test_case "exact provider" `Quick test_exact_catalog_provider
         ; Alcotest.test_case "catalog alias" `Quick test_catalog_alias
         ; Alcotest.test_case "explicit model" `Quick test_explicit_model_is_preserved
+        ; Alcotest.test_case
+            "provider identity does not require model"
+            `Quick
+            test_provider_identity_does_not_require_model
+        ; Alcotest.test_case
+            "execution resolution requires model"
+            `Quick
+            test_provider_resolution_still_requires_model
         ; Alcotest.test_case
             "missing provider"
             `Quick


### PR DESCRIPTION
## Summary

Follow-up to merged #2590 and review #4691256774.

- make Runtime `Initialize` validate exact provider identity without requiring a model before execution
- carry `Provider_config.t` losslessly through Builder, clone, resume, handoff, lifecycle, and dispatch
- preserve an injected transport across handoff sub-agents
- make provider-scoped pricing and missing cache multipliers explicit instead of inventing defaults
- keep pricing/cost strictly observational; incomplete pricing never gates execution
- remove the lossy `Provider.config_of_provider_config` adapter and obsolete tests
- document the source-breaking 0.212 migration

## Root cause

The legacy adapter collapsed typed provider configuration into a smaller provider value and later reconstructed endpoint, credential, headers, and capability state. Pricing also treated absent cache multipliers as if a complete price existed. That made exact identity lossy and allowed telemetry to report invented costs.

The merged #2590 head advanced with the typed whole-history reasoning replay work before these review fixes were pushed. This PR is rebased onto the merged `main` and preserves that reasoning/telemetry structure while adding exact provider-aware pricing.

## Impact

Callers can use `Builder.with_provider_config` directly. Exact provider identity and wire configuration survive execution boundaries. Missing pricing data remains visible as `Incomplete` and does not pause, reject, retry, or stop an agent.

## Validation

- `ocamlformat --check` for every changed OCaml interface/source
- focused `scripts/dune-local.sh build` for 12 affected test executables
- executed and passed: Builder, Agent_turn, Pipeline, Provider, Provider_complete, API dispatch, OpenAI codec, provider catalog coverage, Runtime resolve/coverage, property advanced, and streaming coverage
- adversarial final review: P0=0, P1=0
