### PR TITLE
feat(agent): add typed cooperative tool-boundary yield

### DIFF
--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -40,7 +40,14 @@ let project_detailed_error result =
 (** Run a single turn via the 6-stage pipeline.
     Converts Pipeline.turn_outcome to the polymorphic variant interface
     expected by run_loop and the public API. *)
-let run_turn_core_detailed ~sw ?clock ~api_strategy ?raw_trace_run agent =
+let run_turn_core_detailed
+      ~sw
+      ?clock
+      ~api_strategy
+      ?raw_trace_run
+      ?before_tool_execution
+      agent
+  =
   let provider_failure = ref None in
   Tracing.with_span
     agent.options.tracer
@@ -66,6 +73,7 @@ let run_turn_core_detailed ~sw ?clock ~api_strategy ?raw_trace_run agent =
            ?clock
            ~api_strategy:api_strat
            ?raw_trace_run
+           ?before_tool_execution
            ~on_provider_failure:(fun attribution -> provider_failure := attribution)
            agent
        with
@@ -212,12 +220,15 @@ type provider_lease =
   | Held
   | Released
 
-let release_provider_lease ~yield_enabled ~on_yield = function
-  | Released -> Released
-  | Held when yield_enabled ->
-    Option.iter (fun callback -> callback ()) on_yield;
-    Released
-  | Held -> Held
+type provider_lease_release =
+  { after : provider_lease
+  ; before_tool_execution : (unit -> unit) option
+  }
+
+let plan_provider_lease_release ~yield_enabled ~on_yield = function
+  | Released -> { after = Released; before_tool_execution = None }
+  | Held when yield_enabled -> { after = Released; before_tool_execution = on_yield }
+  | Held -> { after = Held; before_tool_execution = None }
 ;;
 
 let acquire_provider_lease ~yield_enabled ~on_resume = function
@@ -241,9 +252,18 @@ let run_loop_detailed ~sw ?clock ~api_strategy ?on_yield ?on_resume agent user_b
   let run_start = Unix.gettimeofday () in
   let rec loop lease =
     let lease = acquire_provider_lease ~yield_enabled ~on_resume lease in
+    let release = plan_provider_lease_release ~yield_enabled ~on_yield lease in
     let turn_index = agent.state.turn_count + 1 in
     let turn_start = Unix.gettimeofday () in
-    let result = run_turn_core_detailed ~sw ?clock ~api_strategy ?raw_trace_run agent in
+    let result =
+      run_turn_core_detailed
+        ~sw
+        ?clock
+        ~api_strategy
+        ?raw_trace_run
+        ?before_tool_execution:release.before_tool_execution
+        agent
+    in
     match result with
     | Error e ->
       log_turn
@@ -268,7 +288,7 @@ let run_loop_detailed ~sw ?clock ~api_strategy ?on_yield ?on_resume agent user_b
         ~turn_index
         ~model:agent.state.config.model
         ~stop:"tools_executed";
-      loop (release_provider_lease ~yield_enabled ~on_yield lease)
+      loop release.after
   in
   loop Held
 ;;
@@ -680,9 +700,18 @@ module Advanced = struct
     let run_start = Unix.gettimeofday () in
     let rec loop lease =
       let lease = acquire_provider_lease ~yield_enabled ~on_resume lease in
+      let release = plan_provider_lease_release ~yield_enabled ~on_yield lease in
       let turn_index = agent.state.turn_count + 1 in
       let turn_start = Unix.gettimeofday () in
-      match run_turn_core_detailed ~sw ?clock ~api_strategy ?raw_trace_run agent with
+      match
+        run_turn_core_detailed
+          ~sw
+          ?clock
+          ~api_strategy
+          ?raw_trace_run
+          ?before_tool_execution:release.before_tool_execution
+          agent
+      with
       | Error error ->
         log_turn
           ~run_start
@@ -706,10 +735,9 @@ module Advanced = struct
           ~turn_index
           ~model:agent.state.config.model
           ~stop:"tools_executed";
-        let lease = release_provider_lease ~yield_enabled ~on_yield lease in
         let boundary = completed_tool_boundary agent checkpoint_stage in
         (match on_tool_boundary boundary with
-         | Continue -> loop lease
+         | Continue -> loop release.after
          | Yield ->
            let checkpoint = checkpoint agent in
            Ok

--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -70,7 +70,8 @@ let run_turn_core_detailed ~sw ?clock ~api_strategy ?raw_trace_run agent =
            agent
        with
        | Ok (Pipeline.Complete response) -> Ok (`Complete response)
-       | Ok Pipeline.ToolsExecuted -> Ok `ToolsExecuted
+       | Ok (Pipeline.ToolsExecuted checkpoint_stage) ->
+         Ok (`ToolsExecuted checkpoint_stage)
        | Error error -> Error { error; provider_failure = !provider_failure })
 ;;
 
@@ -258,7 +259,7 @@ let run_loop_detailed ~sw ?clock ~api_strategy ?on_yield ?on_resume agent user_b
         ~model:response.model
         ~stop:(stop_reason_label response.stop_reason);
       Ok response
-    | Ok `ToolsExecuted ->
+    | Ok (`ToolsExecuted _) ->
       log_turn
         ~run_start
         ~turn_start
@@ -619,12 +620,117 @@ let checkpoint ?(session_id = "") ?working_context agent =
     ()
 ;;
 
+module Advanced = struct
+  type tool_boundary =
+    { turn : int
+    ; checkpoint_stage : checkpoint_stage
+    }
+
+  type boundary_decision =
+    | Continue
+    | Yield
+
+  type yielded =
+    { turn : int
+    ; checkpoint_stage : checkpoint_stage
+    ; checkpoint : Checkpoint.t
+    }
+
+  type run_outcome =
+    | Completed of Types.api_response
+    | Yielded of yielded
+
+  let raw_trace_yield_stop_reason = "cooperative_tool_boundary_yield"
+
+  let completed_tool_boundary agent checkpoint_stage =
+    { turn = agent.state.turn_count; checkpoint_stage }
+  ;;
+
+  let classify_trace_success = function
+    | Completed response ->
+      Run_completed
+        { final_text = final_text_of_response response
+        ; stop_reason = Some (Types.show_stop_reason response.stop_reason)
+        }
+    | Yielded _ -> Run_yielded { stop_reason = raw_trace_yield_stop_reason }
+  ;;
+
+  let run_loop_detailed ~sw ?clock ~api_strategy ~on_tool_boundary agent user_blocks =
+    let user_blocks = append_user_input agent user_blocks in
+    let trace_prompt = trace_prompt_of_blocks user_blocks in
+    with_raw_trace_run_classified_result
+      ~of_sdk_error:detailed_error_of_sdk_error
+      ~error_to_string:(fun detailed -> Error.to_string detailed.error)
+      ~classify_success:classify_trace_success
+      agent
+      trace_prompt
+    @@ fun raw_trace_run ->
+    let run_start = Unix.gettimeofday () in
+    let rec loop () =
+      let turn_index = agent.state.turn_count + 1 in
+      let turn_start = Unix.gettimeofday () in
+      match run_turn_core_detailed ~sw ?clock ~api_strategy ?raw_trace_run agent with
+      | Error error ->
+        log_turn
+          ~run_start
+          ~turn_start
+          ~turn_index
+          ~model:agent.state.config.model
+          ~stop:("error:" ^ Error.to_string error.error);
+        Error error
+      | Ok (`Complete response) ->
+        log_turn
+          ~run_start
+          ~turn_start
+          ~turn_index
+          ~model:response.model
+          ~stop:(stop_reason_label response.stop_reason);
+        Ok (Completed response)
+      | Ok (`ToolsExecuted checkpoint_stage) ->
+        log_turn
+          ~run_start
+          ~turn_start
+          ~turn_index
+          ~model:agent.state.config.model
+          ~stop:"tools_executed";
+        let boundary = completed_tool_boundary agent checkpoint_stage in
+        (match on_tool_boundary boundary with
+         | Continue -> loop ()
+         | Yield ->
+           let checkpoint = checkpoint agent in
+           Ok
+             (Yielded
+                { turn = boundary.turn
+                ; checkpoint_stage = boundary.checkpoint_stage
+                ; checkpoint
+                }))
+    in
+    loop ()
+  ;;
+
+  let run_blocks_detailed ~sw ?clock ~api_strategy ~on_tool_boundary agent user_blocks =
+    match validate_user_input_blocks user_blocks with
+    | Error error -> Error (detailed_error_of_sdk_error error)
+    | Ok () ->
+      with_periodic_callbacks ~sw ?clock agent (fun ~sw ->
+        run_loop_detailed ~sw ?clock ~api_strategy ~on_tool_boundary agent user_blocks)
+  ;;
+
+  let run_blocks ~sw ?clock ~api_strategy ~on_tool_boundary agent user_blocks =
+    run_blocks_detailed ~sw ?clock ~api_strategy ~on_tool_boundary agent user_blocks
+    |> project_detailed_error
+  ;;
+end
+
 let run_turn_stream_detailed ~sw ?clock ~on_event ?on_telemetry agent =
   run_turn_core_detailed
     ~sw
     ?clock
     ~api_strategy:(Stream { on_event; on_telemetry })
     agent
+  |> Result.map (function
+    | `Complete response -> `Complete response
+    | `ToolsExecuted _ -> `ToolsExecuted)
 ;;
 
 let run_turn_stream ~sw ?clock ~on_event ?on_telemetry agent =

--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -212,6 +212,22 @@ type provider_lease =
   | Held
   | Released
 
+let release_provider_lease ~yield_enabled ~on_yield = function
+  | Released -> Released
+  | Held when yield_enabled ->
+    Option.iter (fun callback -> callback ()) on_yield;
+    Released
+  | Held -> Held
+;;
+
+let acquire_provider_lease ~yield_enabled ~on_resume = function
+  | Held -> Held
+  | Released when yield_enabled ->
+    Option.iter (fun callback -> callback ()) on_resume;
+    Held
+  | Released -> Held
+;;
+
 let run_loop_detailed ~sw ?clock ~api_strategy ?on_yield ?on_resume agent user_blocks =
   let user_blocks = append_user_input agent user_blocks in
   let trace_prompt = trace_prompt_of_blocks user_blocks in
@@ -222,23 +238,9 @@ let run_loop_detailed ~sw ?clock ~api_strategy ?on_yield ?on_resume agent user_b
     trace_prompt
   @@ fun raw_trace_run ->
   let yield_enabled = agent.state.config.yield_on_tool in
-  let release_lease = function
-    | Released -> Released
-    | Held when yield_enabled ->
-      Option.iter (fun callback -> callback ()) on_yield;
-      Released
-    | Held -> Held
-  in
-  let acquire_lease = function
-    | Held -> Held
-    | Released when yield_enabled ->
-      Option.iter (fun callback -> callback ()) on_resume;
-      Held
-    | Released -> Held
-  in
   let run_start = Unix.gettimeofday () in
   let rec loop lease =
-    let lease = acquire_lease lease in
+    let lease = acquire_provider_lease ~yield_enabled ~on_resume lease in
     let turn_index = agent.state.turn_count + 1 in
     let turn_start = Unix.gettimeofday () in
     let result = run_turn_core_detailed ~sw ?clock ~api_strategy ?raw_trace_run agent in
@@ -266,7 +268,7 @@ let run_loop_detailed ~sw ?clock ~api_strategy ?on_yield ?on_resume agent user_b
         ~turn_index
         ~model:agent.state.config.model
         ~stop:"tools_executed";
-      loop (release_lease lease)
+      loop (release_provider_lease ~yield_enabled ~on_yield lease)
   in
   loop Held
 ;;
@@ -655,7 +657,16 @@ module Advanced = struct
     | Yielded _ -> Run_yielded { stop_reason = raw_trace_yield_stop_reason }
   ;;
 
-  let run_loop_detailed ~sw ?clock ~api_strategy ~on_tool_boundary agent user_blocks =
+  let run_loop_detailed
+        ~sw
+        ?clock
+        ~api_strategy
+        ?on_yield
+        ?on_resume
+        ~on_tool_boundary
+        agent
+        user_blocks
+    =
     let user_blocks = append_user_input agent user_blocks in
     let trace_prompt = trace_prompt_of_blocks user_blocks in
     with_raw_trace_run_classified_result
@@ -665,8 +676,10 @@ module Advanced = struct
       agent
       trace_prompt
     @@ fun raw_trace_run ->
+    let yield_enabled = agent.state.config.yield_on_tool in
     let run_start = Unix.gettimeofday () in
-    let rec loop () =
+    let rec loop lease =
+      let lease = acquire_provider_lease ~yield_enabled ~on_resume lease in
       let turn_index = agent.state.turn_count + 1 in
       let turn_start = Unix.gettimeofday () in
       match run_turn_core_detailed ~sw ?clock ~api_strategy ?raw_trace_run agent with
@@ -693,9 +706,10 @@ module Advanced = struct
           ~turn_index
           ~model:agent.state.config.model
           ~stop:"tools_executed";
+        let lease = release_provider_lease ~yield_enabled ~on_yield lease in
         let boundary = completed_tool_boundary agent checkpoint_stage in
         (match on_tool_boundary boundary with
-         | Continue -> loop ()
+         | Continue -> loop lease
          | Yield ->
            let checkpoint = checkpoint agent in
            Ok
@@ -705,19 +719,56 @@ module Advanced = struct
                 ; checkpoint
                 }))
     in
-    loop ()
+    loop Held
   ;;
 
-  let run_blocks_detailed ~sw ?clock ~api_strategy ~on_tool_boundary agent user_blocks =
+  let run_blocks_detailed
+        ~sw
+        ?clock
+        ?on_yield
+        ?on_resume
+        ~api_strategy
+        ~on_tool_boundary
+        agent
+        user_blocks
+    =
     match validate_user_input_blocks user_blocks with
     | Error error -> Error (detailed_error_of_sdk_error error)
     | Ok () ->
-      with_periodic_callbacks ~sw ?clock agent (fun ~sw ->
-        run_loop_detailed ~sw ?clock ~api_strategy ~on_tool_boundary agent user_blocks)
+      (match validate_run_callbacks ~on_yield ~on_resume with
+       | Error error -> Error (detailed_error_of_sdk_error error)
+       | Ok () ->
+         with_periodic_callbacks ~sw ?clock agent (fun ~sw ->
+           run_loop_detailed
+             ~sw
+             ?clock
+             ~api_strategy
+             ?on_yield
+             ?on_resume
+             ~on_tool_boundary
+             agent
+             user_blocks))
   ;;
 
-  let run_blocks ~sw ?clock ~api_strategy ~on_tool_boundary agent user_blocks =
-    run_blocks_detailed ~sw ?clock ~api_strategy ~on_tool_boundary agent user_blocks
+  let run_blocks
+        ~sw
+        ?clock
+        ?on_yield
+        ?on_resume
+        ~api_strategy
+        ~on_tool_boundary
+        agent
+        user_blocks
+    =
+    run_blocks_detailed
+      ~sw
+      ?clock
+      ?on_yield
+      ?on_resume
+      ~api_strategy
+      ~on_tool_boundary
+      agent
+      user_blocks
     |> project_detailed_error
   ;;
 end

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -164,6 +164,13 @@ module Advanced : sig
       host state and return a decision; blocking work belongs after a [Yielded]
       return.
 
+      [on_yield] and [on_resume] preserve the regular run API's provider-lease
+      callbacks and must be supplied together or both omitted.  When
+      [agent_config.yield_on_tool] is enabled, [on_yield] runs after the typed
+      tool boundary has succeeded and before [on_tool_boundary].  [Continue]
+      invokes [on_resume] before the next provider turn; [Yield] returns with
+      the lease released and does not invoke [on_resume] in this call.
+
       [Yielded] is a successful host outcome: it is not an SDK error, does not
       consume or enforce a turn/time/cost budget, and leaves the agent lifecycle
       [Ready].  Its [checkpoint] is captured only after the callback chooses
@@ -171,6 +178,8 @@ module Advanced : sig
   val run_blocks_detailed
     :  sw:Eio.Switch.t
     -> ?clock:_ Eio.Time.clock
+    -> ?on_yield:(unit -> unit)
+    -> ?on_resume:(unit -> unit)
     -> api_strategy:api_strategy
     -> on_tool_boundary:(tool_boundary -> boundary_decision)
     -> t
@@ -181,6 +190,8 @@ module Advanced : sig
   val run_blocks
     :  sw:Eio.Switch.t
     -> ?clock:_ Eio.Time.clock
+    -> ?on_yield:(unit -> unit)
+    -> ?on_resume:(unit -> unit)
     -> api_strategy:api_strategy
     -> on_tool_boundary:(tool_boundary -> boundary_decision)
     -> t

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -166,10 +166,12 @@ module Advanced : sig
 
       [on_yield] and [on_resume] preserve the regular run API's provider-lease
       callbacks and must be supplied together or both omitted.  When
-      [agent_config.yield_on_tool] is enabled, [on_yield] runs after the typed
-      tool boundary has succeeded and before [on_tool_boundary].  [Continue]
-      invokes [on_resume] before the next provider turn; [Yield] returns with
-      the lease released and does not invoke [on_resume] in this call.
+      [agent_config.yield_on_tool] is enabled, [on_yield] runs after assistant
+      collection and its checkpoint have succeeded but before tool execution.
+      [on_tool_boundary] remains after tool execution, optional context
+      injection, and the final checkpoint sink. [Continue] invokes [on_resume]
+      before the next provider turn; [Yield] returns with the lease released
+      and does not invoke [on_resume] in this call.
 
       [Yielded] is a successful host outcome: it is not an SDK error, does not
       consume or enforce a turn/time/cost budget, and leaves the agent lifecycle
@@ -223,9 +225,11 @@ val run_detailed
     Caller-initiated [Eio.Cancel.Cancelled] propagates and is not converted into
     an agent result.
 
-    [on_yield] is called when the agent enters tool execution and [on_resume]
-    before the next LLM turn, allowing callers to release/re-acquire provider
-    capacity. They are invoked only when
+    [on_yield] is called after a non-empty tool batch and the collected
+    assistant checkpoint have been validated, immediately before the first
+    tool hook or implementation starts. [on_resume] is called before the next
+    LLM turn, allowing callers to release/re-acquire provider capacity. They
+    must be supplied together or both omitted and are invoked only when
     [agent_config.yield_on_tool = true].
     @since 0.100.0 *)
 val run

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -129,6 +129,65 @@ type detailed_error = Provider_failure_attribution.detailed_error =
   ; provider_failure : Provider_failure_attribution.t option
   }
 
+(** Advanced host-driven execution.  The regular {!run}, {!run_blocks}, and
+    streaming entry points remain the simple run-to-completion API. *)
+module Advanced : sig
+  type tool_boundary =
+    { turn : int
+    ; checkpoint_stage : checkpoint_stage
+    }
+
+  type boundary_decision =
+    | Continue
+    | Yield
+
+  type yielded =
+    { turn : int
+    ; checkpoint_stage : checkpoint_stage
+    ; checkpoint : Checkpoint.t
+    }
+
+  type run_outcome =
+    | Completed of Types.api_response
+    | Yielded of yielded
+
+  (** Run from one caller-authored input until terminal completion or until
+      [on_tool_boundary] requests a cooperative yield.
+
+      The callback is evaluated only after all tool executions for the turn,
+      optional context injection, and the final configured checkpoint-sink
+      call have succeeded.  [checkpoint_stage] identifies that typed boundary.
+      When no checkpoint sink is configured, crossing the stage is an in-memory
+      boundary and does not claim durable persistence.
+
+      The callback runs synchronously on the agent fiber and should only inspect
+      host state and return a decision; blocking work belongs after a [Yielded]
+      return.
+
+      [Yielded] is a successful host outcome: it is not an SDK error, does not
+      consume or enforce a turn/time/cost budget, and leaves the agent lifecycle
+      [Ready].  Its [checkpoint] is captured only after the callback chooses
+      [Yield], avoiding checkpoint-copy overhead on [Continue]. *)
+  val run_blocks_detailed
+    :  sw:Eio.Switch.t
+    -> ?clock:_ Eio.Time.clock
+    -> api_strategy:api_strategy
+    -> on_tool_boundary:(tool_boundary -> boundary_decision)
+    -> t
+    -> Types.content_block list
+    -> (run_outcome, detailed_error) result
+
+  (** Exact error projection of {!run_blocks_detailed}. *)
+  val run_blocks
+    :  sw:Eio.Switch.t
+    -> ?clock:_ Eio.Time.clock
+    -> api_strategy:api_strategy
+    -> on_tool_boundary:(tool_boundary -> boundary_decision)
+    -> t
+    -> Types.content_block list
+    -> (run_outcome, Error.sdk_error) result
+end
+
 (** Detailed counterpart of {!run}. *)
 val run_detailed
   :  sw:Eio.Switch.t

--- a/lib/agent/agent_trace.ml
+++ b/lib/agent/agent_trace.ml
@@ -154,6 +154,13 @@ let final_text_of_response response =
   if String.trim text = "" then None else Some text
 ;;
 
+type trace_success =
+  | Run_completed of
+      { final_text : string option
+      ; stop_reason : string option
+      }
+  | Run_yielded of { stop_reason : string }
+
 let%test "raw trace final_text excludes thinking blocks" =
   let response =
     { Types.id = "resp"
@@ -183,10 +190,39 @@ let%test "raw trace final_text is absent for thinking-only responses" =
   final_text_of_response response = None
 ;;
 
-let with_raw_trace_run_result ~of_sdk_error ~error_to_string agent user_prompt f =
+let with_raw_trace_run_classified_result
+      ~of_sdk_error
+      ~error_to_string
+      ~classify_success
+      agent
+      user_prompt
+      f
+  =
   (* Reset lifecycle so each run() starts fresh — allows agent reuse
      after Completed/Failed without hitting invalid transition. *)
   Eio.Mutex.use_rw ~protect:true agent.mu (fun () -> agent.lifecycle <- None);
+  let set_lifecycle_for_result result =
+    match result with
+    | Error err ->
+      set_lifecycle
+        agent
+        ~finished_at:(Unix.gettimeofday ())
+        ~last_error:(error_to_string err)
+        Failed
+    | Ok value ->
+      (match classify_success value with
+       | Run_completed _ ->
+         set_lifecycle agent ~finished_at:(Unix.gettimeofday ()) Completed
+       | Run_yielded _ -> set_lifecycle agent ~ready_at:(Unix.gettimeofday ()) Ready)
+  in
+  let invoke_completion_for_result result =
+    match result with
+    | Error _ -> invoke_on_run_complete agent ~ok:false
+    | Ok value ->
+      (match classify_success value with
+       | Run_completed _ -> invoke_on_run_complete agent ~ok:true
+       | Run_yielded _ -> ())
+  in
   match agent.options.raw_trace with
   | None ->
     let ts = Unix.gettimeofday () in
@@ -196,11 +232,11 @@ let with_raw_trace_run_result ~of_sdk_error ~error_to_string agent user_prompt f
        updated, so completion hooks observe the pre-terminal run state.
        Reserved exceptions (e.g. Eio.Cancel.Cancelled) still propagate, but the
        terminal lifecycle transition must not be skipped. *)
-    (try invoke_on_run_complete agent ~ok:(Result.is_ok result) with
+    (try invoke_completion_for_result result with
      | exn ->
-       set_terminal_lifecycle ~error_to_string agent result;
+       set_lifecycle_for_result result;
        raise exn);
-    set_terminal_lifecycle ~error_to_string agent result;
+    set_lifecycle_for_result result;
     result
   | Some sink ->
     (match
@@ -231,10 +267,10 @@ let with_raw_trace_run_result ~of_sdk_error ~error_to_string agent user_prompt f
        let finalize result =
          let final_text, stop_reason, error =
            match result with
-           | Ok response ->
-             ( final_text_of_response response
-             , Some (Types.show_stop_reason response.stop_reason)
-             , None )
+           | Ok value ->
+             (match classify_success value with
+              | Run_completed { final_text; stop_reason } -> final_text, stop_reason, None
+              | Run_yielded { stop_reason } -> None, Some stop_reason, None)
            | Error err -> None, None, Some (error_to_string err)
          in
          (* Raw trace is finished first (so a reserved exception re-raised from the
@@ -242,11 +278,11 @@ let with_raw_trace_run_result ~of_sdk_error ~error_to_string agent user_prompt f
          the lifecycle transition per the agent_types.mli contract. *)
          match Raw_trace.finish_run active ~final_text ~stop_reason ~error with
          | Ok _ ->
-           (try invoke_on_run_complete agent ~ok:(Result.is_ok result) with
+           (try invoke_completion_for_result result with
             | exn ->
-              set_terminal_lifecycle ~error_to_string agent result;
+              set_lifecycle_for_result result;
               raise exn);
-           set_terminal_lifecycle ~error_to_string agent result;
+           set_lifecycle_for_result result;
            result
          | Error err ->
            let trace_error = Error (of_sdk_error err) in
@@ -286,6 +322,20 @@ let with_raw_trace_run_result ~of_sdk_error ~error_to_string agent user_prompt f
             ~last_error:error_msg
             Failed;
           Printexc.raise_with_backtrace exn backtrace))
+;;
+
+let with_raw_trace_run_result ~of_sdk_error ~error_to_string agent user_prompt f =
+  with_raw_trace_run_classified_result
+    ~of_sdk_error
+    ~error_to_string
+    ~classify_success:(fun response ->
+      Run_completed
+        { final_text = final_text_of_response response
+        ; stop_reason = Some (Types.show_stop_reason response.stop_reason)
+        })
+    agent
+    user_prompt
+    f
 ;;
 
 let with_raw_trace_run agent user_prompt f =

--- a/lib/agent/agent_trace.mli
+++ b/lib/agent/agent_trace.mli
@@ -57,6 +57,27 @@ val final_text_of_response : Types.api_response -> string option
 
 (** {1 Run lifecycle} *)
 
+type trace_success =
+  | Run_completed of
+      { final_text : string option
+      ; stop_reason : string option
+      }
+  | Run_yielded of { stop_reason : string }
+
+(** Outcome-aware form of {!with_raw_trace_run_result}.  [classify_success]
+    distinguishes a terminal completion from a cooperative yield without
+    encoding either as an error.  A yielded run segment is finalized with no
+    raw-trace error, leaves the agent lifecycle [Ready], and does not invoke
+    [on_run_complete]. *)
+val with_raw_trace_run_classified_result
+  :  of_sdk_error:(Error.sdk_error -> 'error)
+  -> error_to_string:('error -> string)
+  -> classify_success:('value -> trace_success)
+  -> t
+  -> string
+  -> (Raw_trace.active_run option -> ('value, 'error) result)
+  -> ('value, 'error) result
+
 (** Execute [f] within a raw-trace run, handling start/finish recording
     and lifecycle status updates.  [f] receives [Some active_run] when
     raw-trace is configured, [None] otherwise. *)

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -31,12 +31,13 @@ val with_response_format_json : bool -> t -> t
 val with_cache_system_prompt : bool -> t -> t
 val with_cache_extended_ttl : bool -> t -> t
 
-(** Enable or disable yielding when the agent is about to call a tool.
+(** Enable or disable provider-lease release before tool execution.
 
-    When [true], the agent yields before invoking a tool, triggering
-    any [on_yield] hooks and requiring a corresponding [on_resume] to
-    continue execution. Only affects [on_yield]/[on_resume] hook
-    behavior; does not change model or tool semantics.
+    When [true], a run invokes [on_yield] after assistant collection succeeds
+    and immediately before the first tool hook or implementation. A continuing
+    run invokes [on_resume] before its next provider turn. Only affects
+    [on_yield]/[on_resume] callback behavior; it does not change model or tool
+    semantics.
 
     @since 0.99.7 *)
 val with_yield_on_tool : bool -> t -> t

--- a/lib/base/types.mli
+++ b/lib/base/types.mli
@@ -56,7 +56,8 @@ type agent_config =
       for long-running agents that go idle 5+ minutes between turns.
       @since 0.151.0 *)
   ; initial_messages : message list
-  ; yield_on_tool : bool (** Release LLM slot during tool execution. @since 0.100.0 *)
+  ; yield_on_tool : bool
+    (** Release provider capacity before tool execution. @since 0.100.0 *)
   }
 [@@deriving show]
 

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -40,7 +40,7 @@ type api_strategy =
 
 type turn_outcome =
   | Complete of Types.api_response
-  | ToolsExecuted
+  | ToolsExecuted of checkpoint_stage
 
 let persist_turn_checkpoint_for_state agent stage state =
   match agent.checkpoint_sink with
@@ -407,7 +407,7 @@ let stage_execute ?raw_trace_run agent tool_uses_nonempty =
          Printexc.raise_with_backtrace exception_ backtrace
        | None ->
          (match agent.options.context_injector with
-          | None -> Ok ToolsExecuted
+          | None -> Ok (ToolsExecuted After_tool_results_appended)
           | Some injector ->
             let* messages =
               Agent_turn.apply_context_injection
@@ -433,7 +433,7 @@ let stage_execute ?raw_trace_run agent tool_uses_nonempty =
                 After_context_injection
                 injected_state
             in
-            Ok ToolsExecuted))
+            Ok (ToolsExecuted After_context_injection)))
 ;;
 
 (* ── Stage 6: Output ─────────────────────────────────────── *)

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -352,7 +352,7 @@ let stage_collect ?raw_trace_run ?clock agent response =
 (* ── Stage 5: Execute ────────────────────────────────────── *)
 
 (** Handle tool execution and context injection. *)
-let stage_execute ?raw_trace_run agent tool_uses_nonempty =
+let stage_execute ?raw_trace_run ?before_tool_execution agent tool_uses_nonempty =
   (* The caller (stage_output) proves the tool-call set is non-empty: a
      StopToolUse turn that carried no tool block is rejected before this stage
      (Stop_reason_wire.reconcile downgrades it to Unknown at parse time).
@@ -369,6 +369,7 @@ let stage_execute ?raw_trace_run agent tool_uses_nonempty =
     ; links = []
     }
     (fun _tracer ->
+       Option.iter (fun callback -> callback ()) before_tool_execution;
        let results, failure =
          match execute_tools_with_trace agent raw_trace_run tool_uses with
          | Ok results -> results, None
@@ -439,7 +440,7 @@ let stage_execute ?raw_trace_run agent tool_uses_nonempty =
 (* ── Stage 6: Output ─────────────────────────────────────── *)
 
 (** Map stop_reason to turn_outcome. *)
-let stage_output ?raw_trace_run agent response =
+let stage_output ?raw_trace_run ?before_tool_execution agent response =
   Tracing.with_span
     agent.options.tracer
     { kind = Hook_invoke
@@ -480,7 +481,7 @@ let stage_output ?raw_trace_run agent response =
                  (UnrecognizedStopReason
                     { reason = "StopToolUse turn carried no tool block" }))
           | Some tool_uses_nonempty ->
-            stage_execute ?raw_trace_run agent tool_uses_nonempty)
+            stage_execute ?raw_trace_run ?before_tool_execution agent tool_uses_nonempty)
        | UnmatchedToolCalls ->
          (* The wire boundary has already classified this response shape as
             malformed. Keep rejecting it; arbitrary provider terminal reasons
@@ -543,7 +544,15 @@ let tag_error stage result =
     Error e
 ;;
 
-let run_turn ~sw ?clock ~api_strategy ?raw_trace_run ?on_provider_failure agent =
+let run_turn
+      ~sw
+      ?clock
+      ~api_strategy
+      ?raw_trace_run
+      ?on_provider_failure
+      ?before_tool_execution
+      agent
+  =
   (* Stage 1: Input *)
   let* () =
     Tracing.with_span
@@ -651,7 +660,8 @@ let run_turn ~sw ?clock ~api_strategy ?raw_trace_run ?on_provider_failure agent 
           let* () =
             stage_collect ?raw_trace_run ?clock agent response |> tag_error "collect"
           in
-          stage_output ?raw_trace_run agent response |> tag_error "output"))
+          stage_output ?raw_trace_run ?before_tool_execution agent response
+          |> tag_error "output"))
 ;;
 
 [@@@coverage off]

--- a/lib/pipeline/pipeline.mli
+++ b/lib/pipeline/pipeline.mli
@@ -19,7 +19,7 @@ type api_strategy =
 
 type turn_outcome =
   | Complete of Types.api_response
-  | ToolsExecuted
+  | ToolsExecuted of Agent_types.checkpoint_stage
 
 (** Persist [state] using the same pre-commit checkpoint transaction as turn
     collection. The live agent state is not changed by this function. *)

--- a/lib/pipeline/pipeline.mli
+++ b/lib/pipeline/pipeline.mli
@@ -30,12 +30,18 @@ val persist_turn_checkpoint_for_state
   -> (unit, Error.sdk_error) result
 
 (** Run a single agent turn through the 6-stage pipeline.
-    Equivalent to the previous [run_turn_core]. *)
+    Equivalent to the previous [run_turn_core].
+
+    [before_tool_execution], when present, runs exactly once for a non-empty
+    tool batch after assistant collection has committed successfully and before
+    the first tool hook or implementation starts.  Exceptions propagate and
+    prevent tool execution. *)
 val run_turn
   :  sw:Eio.Switch.t
   -> ?clock:_ Eio.Time.clock
   -> api_strategy:api_strategy
   -> ?raw_trace_run:Raw_trace.active_run
   -> ?on_provider_failure:(Provider_failure_attribution.t option -> unit)
+  -> ?before_tool_execution:(unit -> unit)
   -> Agent_types.t
   -> (turn_outcome, Error.sdk_error) result

--- a/test/dune
+++ b/test/dune
@@ -432,6 +432,11 @@
  (libraries agent_sdk llm_provider alcotest eio_main))
 
 (test
+ (name test_agent_advanced)
+ (modules test_agent_advanced)
+ (libraries agent_sdk llm_provider alcotest eio_main))
+
+(test
  (name test_api)
  (modules test_api)
  (libraries agent_sdk alcotest))

--- a/test/test_agent_advanced.ml
+++ b/test/test_agent_advanced.ml
@@ -1,0 +1,360 @@
+(** Typed cooperative tool-boundary execution tests. *)
+
+open Agent_sdk
+
+let mock_provider : Provider.config =
+  { provider = Provider.Local { base_url = "http://mock.local" }
+  ; model_id = "mock-model"
+  ; api_key_env = ""
+  }
+;;
+
+let text_response text : Types.api_response =
+  { id = "advanced-text"
+  ; model = "mock-model"
+  ; stop_reason = Types.EndTurn
+  ; content = [ Types.Text text ]
+  ; usage = None
+  ; telemetry = None
+  }
+;;
+
+let tool_use_response : Types.api_response =
+  { id = "advanced-tool"
+  ; model = "mock-model"
+  ; stop_reason = Types.StopToolUse
+  ; content =
+      [ Types.ToolUse
+          { id = "call_1"
+          ; name = "get_time"
+          ; input = `Assoc [ "timezone", `String "UTC" ]
+          }
+      ]
+  ; usage = None
+  ; telemetry = None
+  }
+;;
+
+let sequence_transport responses =
+  let remaining = ref responses in
+  let call_count = ref 0 in
+  let next () =
+    incr call_count;
+    match !remaining with
+    | response :: rest ->
+      remaining := rest;
+      response
+    | [] -> Alcotest.fail "mock transport exhausted"
+  in
+  let transport : Llm_provider.Llm_transport.t =
+    { complete_sync =
+        (fun _request ->
+          { Llm_provider.Llm_transport.response = Ok (next ()); latency_ms = Some 0 })
+    ; complete_stream = (fun ?on_telemetry:_ ~on_event:_ _request -> Ok (next ()))
+    }
+  in
+  transport, call_count
+;;
+
+let make_agent
+      ~net
+      ~transport
+      ~raw_trace
+      ~checkpoint_sink
+      ~context_injector
+      ~on_run_complete
+      ~tool
+  =
+  let options =
+    { Agent.default_options with
+      provider = Some mock_provider
+    ; transport = Some transport
+    ; raw_trace = Some raw_trace
+    ; context_injector
+    ; on_run_complete
+    }
+  in
+  let config =
+    { (Types.default_config ~model:"mock-model") with name = "advanced-boundary-test" }
+  in
+  Agent.create ~net ~config ~tools:[ tool ] ~options ~checkpoint_sink ()
+;;
+
+let time_tool on_execute =
+  Tool.create
+    ~name:"get_time"
+    ~description:"Get current time"
+    ~parameters:
+      [ { Types.name = "timezone"
+        ; param_type = Types.String
+        ; description = "timezone"
+        ; required = true
+        }
+      ]
+    (fun _input ->
+       on_execute ();
+       Ok { Types.content = "12:00 UTC"; _meta = None })
+;;
+
+let messages_contain_text expected messages =
+  List.exists
+    (fun (message : Types.message) ->
+       List.exists
+         (function
+           | Types.Text text -> String.equal expected text
+           | Types.Thinking _
+           | Types.ReasoningDetails _
+           | Types.RedactedThinking _
+           | Types.ToolUse _
+           | Types.ToolResult _
+           | Types.Image _
+           | Types.Document _
+           | Types.Audio _ -> false)
+         message.content)
+    messages
+;;
+
+let last_record path =
+  match Raw_trace.read_all ~path () with
+  | Error error -> Alcotest.fail (Error.to_string error)
+  | Ok records ->
+    (match List.rev records with
+     | record :: _ -> record
+     | [] -> Alcotest.fail "raw trace is empty")
+;;
+
+let with_temp_trace f =
+  let path = Filename.temp_file "oas-agent-advanced" ".jsonl" in
+  Fun.protect
+    ~finally:(fun () -> if Sys.file_exists path then Sys.remove path)
+    (fun () -> f path)
+;;
+
+let test_yield_after_context_checkpoint () =
+  with_temp_trace
+  @@ fun trace_path ->
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let trace = Raw_trace.create ~path:trace_path () |> Result.get_ok in
+  let persisted = ref [] in
+  let checkpoint_sink snapshot =
+    persisted := snapshot :: !persisted;
+    Ok ()
+  in
+  let tool_executed = ref false in
+  let context_injected = ref false in
+  let context_injector ~tool_name:_ ~input:_ ~output:_ =
+    context_injected := true;
+    Some
+      { Hooks.context_updates = []
+      ; extra_messages =
+          [ Types.make_message ~role:Types.User [ Types.Text "projected context" ] ]
+      }
+  in
+  let completions = ref [] in
+  let transport, call_count = sequence_transport [ tool_use_response ] in
+  let agent =
+    make_agent
+      ~net:env#net
+      ~transport
+      ~raw_trace:trace
+      ~checkpoint_sink
+      ~context_injector:(Some context_injector)
+      ~on_run_complete:(Some (fun completed -> completions := completed :: !completions))
+      ~tool:(time_tool (fun () -> tool_executed := true))
+  in
+  let callback_count = ref 0 in
+  let on_tool_boundary (boundary : Agent.Advanced.tool_boundary) =
+    incr callback_count;
+    Alcotest.(check bool) "tool completed before callback" true !tool_executed;
+    Alcotest.(check bool) "context injected before callback" true !context_injected;
+    (match !persisted with
+     | latest :: _ ->
+       Alcotest.(check bool)
+         "context checkpoint persisted before callback"
+         true
+         (latest.Agent.stage = Agent.After_context_injection)
+     | [] -> Alcotest.fail "callback ran without a successful checkpoint");
+    Alcotest.(check int) "boundary turn" 1 boundary.turn;
+    Alcotest.(check bool)
+      "boundary stage"
+      true
+      (boundary.checkpoint_stage = Agent.After_context_injection);
+    Agent.Advanced.Yield
+  in
+  (match
+     Agent.Advanced.run_blocks
+       ~sw
+       ~api_strategy:Agent.Sync
+       ~on_tool_boundary
+       agent
+       [ Types.Text "what time is it?" ]
+   with
+   | Error error -> Alcotest.fail (Error.to_string error)
+   | Ok (Agent.Advanced.Completed _) -> Alcotest.fail "expected cooperative yield"
+   | Ok (Agent.Advanced.Yielded yielded) ->
+     Alcotest.(check int) "yielded turn" 1 yielded.turn;
+     Alcotest.(check int) "checkpoint turn" 1 yielded.checkpoint.turn_count;
+     Alcotest.(check bool)
+       "yielded checkpoint stage"
+       true
+       (yielded.checkpoint_stage = Agent.After_context_injection);
+     Alcotest.(check bool)
+       "yielded checkpoint includes projected context"
+       true
+       (messages_contain_text "projected context" yielded.checkpoint.messages));
+  Alcotest.(check int) "callback count" 1 !callback_count;
+  Alcotest.(check int) "provider call count" 1 !call_count;
+  Alcotest.(check (list bool)) "not terminal-complete" [] !completions;
+  (match Agent.lifecycle agent with
+   | Some snapshot ->
+     Alcotest.(check bool) "lifecycle ready" true (snapshot.status = Agent.Ready);
+     Alcotest.(check (option string)) "no lifecycle error" None snapshot.last_error
+   | None -> Alcotest.fail "missing lifecycle snapshot");
+  let record = last_record trace_path in
+  Alcotest.(check bool) "trace finished" true (record.record_type = Raw_trace.Run_finished);
+  Alcotest.(check (option string)) "trace error" None record.error;
+  Alcotest.(check (option string))
+    "trace yield outcome"
+    (Some "cooperative_tool_boundary_yield")
+    record.stop_reason
+;;
+
+let test_continue_reaches_terminal_completion () =
+  with_temp_trace
+  @@ fun trace_path ->
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let trace = Raw_trace.create ~path:trace_path () |> Result.get_ok in
+  let checkpoint_sink _snapshot = Ok () in
+  let completions = ref [] in
+  let transport, call_count =
+    sequence_transport [ tool_use_response; text_response "done" ]
+  in
+  let agent =
+    make_agent
+      ~net:env#net
+      ~transport
+      ~raw_trace:trace
+      ~checkpoint_sink
+      ~context_injector:None
+      ~on_run_complete:(Some (fun completed -> completions := completed :: !completions))
+      ~tool:(time_tool ignore)
+  in
+  let callback_count = ref 0 in
+  let on_tool_boundary (boundary : Agent.Advanced.tool_boundary) =
+    incr callback_count;
+    Alcotest.(check bool)
+      "base tool-result checkpoint boundary"
+      true
+      (boundary.checkpoint_stage = Agent.After_tool_results_appended);
+    Agent.Advanced.Continue
+  in
+  (match
+     Agent.Advanced.run_blocks
+       ~sw
+       ~api_strategy:Agent.Sync
+       ~on_tool_boundary
+       agent
+       [ Types.Text "what time is it?" ]
+   with
+   | Error error -> Alcotest.fail (Error.to_string error)
+   | Ok (Agent.Advanced.Yielded _) -> Alcotest.fail "expected terminal completion"
+   | Ok (Agent.Advanced.Completed response) ->
+     Alcotest.(check string)
+       "visible response"
+       "done"
+       (Types.visible_text_of_response response));
+  Alcotest.(check int) "callback count" 1 !callback_count;
+  Alcotest.(check int) "provider call count" 2 !call_count;
+  Alcotest.(check (list bool)) "terminal callback" [ true ] !completions;
+  (match Agent.lifecycle agent with
+   | Some snapshot ->
+     Alcotest.(check bool) "lifecycle completed" true (snapshot.status = Agent.Completed)
+   | None -> Alcotest.fail "missing lifecycle snapshot");
+  let record = last_record trace_path in
+  Alcotest.(check (option string)) "trace error" None record.error;
+  Alcotest.(check (option string))
+    "terminal stop reason"
+    (Some (Types.show_stop_reason Types.EndTurn))
+    record.stop_reason
+;;
+
+let test_checkpoint_failure_prevents_callback () =
+  with_temp_trace
+  @@ fun trace_path ->
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let trace = Raw_trace.create ~path:trace_path () |> Result.get_ok in
+  let checkpoint_sink (snapshot : Agent.checkpoint_snapshot) =
+    match snapshot.stage with
+    | Agent.After_context_injection -> Error "durable sink rejected boundary"
+    | Agent.After_assistant_collected | Agent.After_tool_results_appended -> Ok ()
+  in
+  let context_injector ~tool_name:_ ~input:_ ~output:_ =
+    Some { Hooks.context_updates = []; extra_messages = [] }
+  in
+  let transport, _call_count = sequence_transport [ tool_use_response ] in
+  let agent =
+    make_agent
+      ~net:env#net
+      ~transport
+      ~raw_trace:trace
+      ~checkpoint_sink
+      ~context_injector:(Some context_injector)
+      ~on_run_complete:None
+      ~tool:(time_tool ignore)
+  in
+  let callback_count = ref 0 in
+  let outcome =
+    Agent.Advanced.run_blocks
+      ~sw
+      ~api_strategy:Agent.Sync
+      ~on_tool_boundary:(fun _boundary ->
+        incr callback_count;
+        Agent.Advanced.Yield)
+      agent
+      [ Types.Text "what time is it?" ]
+  in
+  (match outcome with
+   | Error (Error.Internal _) -> ()
+   | Error error -> Alcotest.fail ("unexpected error: " ^ Error.to_string error)
+   | Ok _ -> Alcotest.fail "expected checkpoint failure");
+  Alcotest.(check int) "callback suppressed" 0 !callback_count;
+  (match Agent.lifecycle agent with
+   | Some snapshot ->
+     Alcotest.(check bool) "lifecycle failed" true (snapshot.status = Agent.Failed)
+   | None -> Alcotest.fail "missing lifecycle snapshot");
+  let record = last_record trace_path in
+  Alcotest.(check bool)
+    "trace has typed failure detail"
+    true
+    (Option.is_some record.error);
+  Alcotest.(check (option string)) "no yield stop reason" None record.stop_reason
+;;
+
+let () =
+  Alcotest.run
+    "Agent advanced cooperative execution"
+    [ ( "tool boundary"
+      , [ Alcotest.test_case
+            "yield after context checkpoint"
+            `Quick
+            test_yield_after_context_checkpoint
+        ; Alcotest.test_case
+            "continue reaches terminal completion"
+            `Quick
+            test_continue_reaches_terminal_completion
+        ; Alcotest.test_case
+            "checkpoint failure prevents callback"
+            `Quick
+            test_checkpoint_failure_prevents_callback
+        ] )
+    ]
+;;

--- a/test/test_agent_advanced.ml
+++ b/test/test_agent_advanced.ml
@@ -35,10 +35,11 @@ let tool_use_response : Types.api_response =
   }
 ;;
 
-let sequence_transport responses =
+let sequence_transport ?(on_call = ignore) responses =
   let remaining = ref responses in
   let call_count = ref 0 in
   let next () =
+    on_call ();
     incr call_count;
     match !remaining with
     | response :: rest ->
@@ -75,7 +76,10 @@ let make_agent
     }
   in
   let config =
-    { (Types.default_config ~model:"mock-model") with name = "advanced-boundary-test" }
+    { (Types.default_config ~model:"mock-model") with
+      name = "advanced-boundary-test"
+    ; yield_on_tool = true
+    }
   in
   Agent.create ~net ~config ~tools:[ tool ] ~options ~checkpoint_sink ()
 ;;
@@ -154,7 +158,12 @@ let test_yield_after_context_checkpoint () =
       }
   in
   let completions = ref [] in
-  let transport, call_count = sequence_transport [ tool_use_response ] in
+  let lease_events = ref [] in
+  let transport, call_count =
+    sequence_transport
+      ~on_call:(fun () -> lease_events := "provider" :: !lease_events)
+      [ tool_use_response ]
+  in
   let agent =
     make_agent
       ~net:env#net
@@ -167,6 +176,7 @@ let test_yield_after_context_checkpoint () =
   in
   let callback_count = ref 0 in
   let on_tool_boundary (boundary : Agent.Advanced.tool_boundary) =
+    lease_events := "boundary" :: !lease_events;
     incr callback_count;
     Alcotest.(check bool) "tool completed before callback" true !tool_executed;
     Alcotest.(check bool) "context injected before callback" true !context_injected;
@@ -184,9 +194,18 @@ let test_yield_after_context_checkpoint () =
       (boundary.checkpoint_stage = Agent.After_context_injection);
     Agent.Advanced.Yield
   in
+  let on_yield () =
+    Alcotest.(check bool)
+      "checkpoint persisted before provider lease release"
+      true
+      (not (List.is_empty !persisted));
+    lease_events := "yield" :: !lease_events
+  in
   (match
      Agent.Advanced.run_blocks
        ~sw
+       ~on_yield
+       ~on_resume:(fun () -> lease_events := "resume" :: !lease_events)
        ~api_strategy:Agent.Sync
        ~on_tool_boundary
        agent
@@ -206,6 +225,10 @@ let test_yield_after_context_checkpoint () =
        true
        (messages_contain_text "projected context" yielded.checkpoint.messages));
   Alcotest.(check int) "callback count" 1 !callback_count;
+  Alcotest.(check (list string))
+    "yield releases before boundary and does not resume"
+    [ "provider"; "yield"; "boundary" ]
+    (List.rev !lease_events);
   Alcotest.(check int) "provider call count" 1 !call_count;
   Alcotest.(check (list bool)) "not terminal-complete" [] !completions;
   (match Agent.lifecycle agent with
@@ -232,8 +255,11 @@ let test_continue_reaches_terminal_completion () =
   let trace = Raw_trace.create ~path:trace_path () |> Result.get_ok in
   let checkpoint_sink _snapshot = Ok () in
   let completions = ref [] in
+  let lease_events = ref [] in
   let transport, call_count =
-    sequence_transport [ tool_use_response; text_response "done" ]
+    sequence_transport
+      ~on_call:(fun () -> lease_events := "provider" :: !lease_events)
+      [ tool_use_response; text_response "done" ]
   in
   let agent =
     make_agent
@@ -247,6 +273,7 @@ let test_continue_reaches_terminal_completion () =
   in
   let callback_count = ref 0 in
   let on_tool_boundary (boundary : Agent.Advanced.tool_boundary) =
+    lease_events := "boundary" :: !lease_events;
     incr callback_count;
     Alcotest.(check bool)
       "base tool-result checkpoint boundary"
@@ -257,6 +284,8 @@ let test_continue_reaches_terminal_completion () =
   (match
      Agent.Advanced.run_blocks
        ~sw
+       ~on_yield:(fun () -> lease_events := "yield" :: !lease_events)
+       ~on_resume:(fun () -> lease_events := "resume" :: !lease_events)
        ~api_strategy:Agent.Sync
        ~on_tool_boundary
        agent
@@ -270,6 +299,10 @@ let test_continue_reaches_terminal_completion () =
        "done"
        (Types.visible_text_of_response response));
   Alcotest.(check int) "callback count" 1 !callback_count;
+  Alcotest.(check (list string))
+    "continue release-boundary-resume ordering"
+    [ "provider"; "yield"; "boundary"; "resume"; "provider" ]
+    (List.rev !lease_events);
   Alcotest.(check int) "provider call count" 2 !call_count;
   Alcotest.(check (list bool)) "terminal callback" [ true ] !completions;
   (match Agent.lifecycle agent with
@@ -339,6 +372,41 @@ let test_checkpoint_failure_prevents_callback () =
   Alcotest.(check (option string)) "no yield stop reason" None record.stop_reason
 ;;
 
+let test_unpaired_lease_callback_is_rejected () =
+  with_temp_trace
+  @@ fun trace_path ->
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let trace = Raw_trace.create ~path:trace_path () |> Result.get_ok in
+  let transport, call_count = sequence_transport [ text_response "unused" ] in
+  let agent =
+    make_agent
+      ~net:env#net
+      ~transport
+      ~raw_trace:trace
+      ~checkpoint_sink:(fun _snapshot -> Ok ())
+      ~context_injector:None
+      ~on_run_complete:None
+      ~tool:(time_tool ignore)
+  in
+  (match
+     Agent.Advanced.run_blocks
+       ~sw
+       ~on_yield:ignore
+       ~api_strategy:Agent.Sync
+       ~on_tool_boundary:(fun _boundary -> Agent.Advanced.Continue)
+       agent
+       [ Types.Text "must not reach provider" ]
+   with
+   | Error (Error.Config (Error.InvalidConfig { field; _ })) ->
+     Alcotest.(check string) "callback pair field" "on_yield/on_resume" field
+   | Error error -> Alcotest.fail ("unexpected error: " ^ Error.to_string error)
+   | Ok _ -> Alcotest.fail "expected unpaired callback validation error");
+  Alcotest.(check int) "provider not called" 0 !call_count
+;;
+
 let () =
   Alcotest.run
     "Agent advanced cooperative execution"
@@ -355,6 +423,10 @@ let () =
             "checkpoint failure prevents callback"
             `Quick
             test_checkpoint_failure_prevents_callback
+        ; Alcotest.test_case
+            "unpaired provider lease callback is rejected"
+            `Quick
+            test_unpaired_lease_callback_is_rejected
         ] )
     ]
 ;;

--- a/test/test_agent_advanced.ml
+++ b/test/test_agent_advanced.ml
@@ -172,7 +172,10 @@ let test_yield_after_context_checkpoint () =
       ~checkpoint_sink
       ~context_injector:(Some context_injector)
       ~on_run_complete:(Some (fun completed -> completions := completed :: !completions))
-      ~tool:(time_tool (fun () -> tool_executed := true))
+      ~tool:
+        (time_tool (fun () ->
+           tool_executed := true;
+           lease_events := "tool" :: !lease_events))
   in
   let callback_count = ref 0 in
   let on_tool_boundary (boundary : Agent.Advanced.tool_boundary) =
@@ -195,10 +198,14 @@ let test_yield_after_context_checkpoint () =
     Agent.Advanced.Yield
   in
   let on_yield () =
-    Alcotest.(check bool)
-      "checkpoint persisted before provider lease release"
-      true
-      (not (List.is_empty !persisted));
+    Alcotest.(check bool) "tool not started at lease release" false !tool_executed;
+    (match !persisted with
+     | latest :: _ ->
+       Alcotest.(check bool)
+         "assistant checkpoint persisted before provider lease release"
+         true
+         (latest.Agent.stage = Agent.After_assistant_collected)
+     | [] -> Alcotest.fail "lease released before assistant checkpoint");
     lease_events := "yield" :: !lease_events
   in
   (match
@@ -227,7 +234,7 @@ let test_yield_after_context_checkpoint () =
   Alcotest.(check int) "callback count" 1 !callback_count;
   Alcotest.(check (list string))
     "yield releases before boundary and does not resume"
-    [ "provider"; "yield"; "boundary" ]
+    [ "provider"; "yield"; "tool"; "boundary" ]
     (List.rev !lease_events);
   Alcotest.(check int) "provider call count" 1 !call_count;
   Alcotest.(check (list bool)) "not terminal-complete" [] !completions;
@@ -269,7 +276,7 @@ let test_continue_reaches_terminal_completion () =
       ~checkpoint_sink
       ~context_injector:None
       ~on_run_complete:(Some (fun completed -> completions := completed :: !completions))
-      ~tool:(time_tool ignore)
+      ~tool:(time_tool (fun () -> lease_events := "tool" :: !lease_events))
   in
   let callback_count = ref 0 in
   let on_tool_boundary (boundary : Agent.Advanced.tool_boundary) =
@@ -301,7 +308,7 @@ let test_continue_reaches_terminal_completion () =
   Alcotest.(check int) "callback count" 1 !callback_count;
   Alcotest.(check (list string))
     "continue release-boundary-resume ordering"
-    [ "provider"; "yield"; "boundary"; "resume"; "provider" ]
+    [ "provider"; "yield"; "tool"; "boundary"; "resume"; "provider" ]
     (List.rev !lease_events);
   Alcotest.(check int) "provider call count" 2 !call_count;
   Alcotest.(check (list bool)) "terminal callback" [ true ] !completions;
@@ -317,7 +324,7 @@ let test_continue_reaches_terminal_completion () =
     record.stop_reason
 ;;
 
-let test_checkpoint_failure_prevents_callback () =
+let test_context_checkpoint_failure_prevents_boundary_and_resume () =
   with_temp_trace
   @@ fun trace_path ->
   Eio_main.run
@@ -333,7 +340,13 @@ let test_checkpoint_failure_prevents_callback () =
   let context_injector ~tool_name:_ ~input:_ ~output:_ =
     Some { Hooks.context_updates = []; extra_messages = [] }
   in
-  let transport, _call_count = sequence_transport [ tool_use_response ] in
+  let lease_events = ref [] in
+  let tool_executed = ref false in
+  let transport, _call_count =
+    sequence_transport
+      ~on_call:(fun () -> lease_events := "provider" :: !lease_events)
+      [ tool_use_response ]
+  in
   let agent =
     make_agent
       ~net:env#net
@@ -342,12 +355,17 @@ let test_checkpoint_failure_prevents_callback () =
       ~checkpoint_sink
       ~context_injector:(Some context_injector)
       ~on_run_complete:None
-      ~tool:(time_tool ignore)
+      ~tool:
+        (time_tool (fun () ->
+           tool_executed := true;
+           lease_events := "tool" :: !lease_events))
   in
   let callback_count = ref 0 in
   let outcome =
     Agent.Advanced.run_blocks
       ~sw
+      ~on_yield:(fun () -> lease_events := "yield" :: !lease_events)
+      ~on_resume:(fun () -> lease_events := "resume" :: !lease_events)
       ~api_strategy:Agent.Sync
       ~on_tool_boundary:(fun _boundary ->
         incr callback_count;
@@ -360,6 +378,11 @@ let test_checkpoint_failure_prevents_callback () =
    | Error error -> Alcotest.fail ("unexpected error: " ^ Error.to_string error)
    | Ok _ -> Alcotest.fail "expected checkpoint failure");
   Alcotest.(check int) "callback suppressed" 0 !callback_count;
+  Alcotest.(check bool) "tool ran after lease release" true !tool_executed;
+  Alcotest.(check (list string))
+    "context checkpoint failure does not reacquire provider lease"
+    [ "provider"; "yield"; "tool" ]
+    (List.rev !lease_events);
   (match Agent.lifecycle agent with
    | Some snapshot ->
      Alcotest.(check bool) "lifecycle failed" true (snapshot.status = Agent.Failed)
@@ -370,6 +393,161 @@ let test_checkpoint_failure_prevents_callback () =
     true
     (Option.is_some record.error);
   Alcotest.(check (option string)) "no yield stop reason" None record.stop_reason
+;;
+
+let test_assistant_checkpoint_failure_suppresses_release_and_tool () =
+  with_temp_trace
+  @@ fun trace_path ->
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let trace = Raw_trace.create ~path:trace_path () |> Result.get_ok in
+  let checkpoint_sink (snapshot : Agent.checkpoint_snapshot) =
+    match snapshot.stage with
+    | Agent.After_assistant_collected -> Error "assistant checkpoint rejected"
+    | Agent.After_tool_results_appended | Agent.After_context_injection -> Ok ()
+  in
+  let lease_events = ref [] in
+  let tool_executed = ref false in
+  let transport, call_count =
+    sequence_transport
+      ~on_call:(fun () -> lease_events := "provider" :: !lease_events)
+      [ tool_use_response ]
+  in
+  let agent =
+    make_agent
+      ~net:env#net
+      ~transport
+      ~raw_trace:trace
+      ~checkpoint_sink
+      ~context_injector:None
+      ~on_run_complete:None
+      ~tool:(time_tool (fun () -> tool_executed := true))
+  in
+  let boundary_count = ref 0 in
+  let outcome =
+    Agent.Advanced.run_blocks
+      ~sw
+      ~on_yield:(fun () -> lease_events := "yield" :: !lease_events)
+      ~on_resume:(fun () -> lease_events := "resume" :: !lease_events)
+      ~api_strategy:Agent.Sync
+      ~on_tool_boundary:(fun _boundary ->
+        incr boundary_count;
+        Agent.Advanced.Continue)
+      agent
+      [ Types.Text "what time is it?" ]
+  in
+  (match outcome with
+   | Error (Error.Internal _) -> ()
+   | Error error -> Alcotest.fail ("unexpected error: " ^ Error.to_string error)
+   | Ok _ -> Alcotest.fail "expected assistant checkpoint failure");
+  Alcotest.(check int) "one provider call" 1 !call_count;
+  Alcotest.(check int) "boundary suppressed" 0 !boundary_count;
+  Alcotest.(check bool) "tool suppressed" false !tool_executed;
+  Alcotest.(check (list string))
+    "lease release suppressed"
+    [ "provider" ]
+    (List.rev !lease_events)
+;;
+
+let test_release_callback_failure_prevents_tool_execution () =
+  with_temp_trace
+  @@ fun trace_path ->
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let trace = Raw_trace.create ~path:trace_path () |> Result.get_ok in
+  let tool_executed = ref false in
+  let boundary_count = ref 0 in
+  let resume_count = ref 0 in
+  let transport, _call_count = sequence_transport [ tool_use_response ] in
+  let agent =
+    make_agent
+      ~net:env#net
+      ~transport
+      ~raw_trace:trace
+      ~checkpoint_sink:(fun _snapshot -> Ok ())
+      ~context_injector:None
+      ~on_run_complete:None
+      ~tool:(time_tool (fun () -> tool_executed := true))
+  in
+  let callback_failed =
+    match
+      Agent.Advanced.run_blocks
+        ~sw
+        ~on_yield:(fun () -> raise (Failure "provider lease release failed"))
+        ~on_resume:(fun () -> incr resume_count)
+        ~api_strategy:Agent.Sync
+        ~on_tool_boundary:(fun _boundary ->
+          incr boundary_count;
+          Agent.Advanced.Continue)
+        agent
+        [ Types.Text "what time is it?" ]
+    with
+    | Ok _ | Error _ -> false
+    | exception Failure _ -> true
+  in
+  Alcotest.(check bool) "release callback failure propagated" true callback_failed;
+  Alcotest.(check bool) "tool did not start" false !tool_executed;
+  Alcotest.(check int) "boundary did not run" 0 !boundary_count;
+  Alcotest.(check int) "lease was not reacquired" 0 !resume_count;
+  match Agent.lifecycle agent with
+  | Some snapshot ->
+    Alcotest.(check bool) "lifecycle failed" true (snapshot.status = Agent.Failed)
+  | None -> Alcotest.fail "missing lifecycle snapshot"
+;;
+
+let test_regular_run_releases_before_tool_execution () =
+  with_temp_trace
+  @@ fun trace_path ->
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let trace = Raw_trace.create ~path:trace_path () |> Result.get_ok in
+  let lease_events = ref [] in
+  let tool_executed = ref false in
+  let transport, call_count =
+    sequence_transport
+      ~on_call:(fun () -> lease_events := "provider" :: !lease_events)
+      [ tool_use_response; text_response "done" ]
+  in
+  let agent =
+    make_agent
+      ~net:env#net
+      ~transport
+      ~raw_trace:trace
+      ~checkpoint_sink:(fun _snapshot -> Ok ())
+      ~context_injector:None
+      ~on_run_complete:None
+      ~tool:
+        (time_tool (fun () ->
+           tool_executed := true;
+           lease_events := "tool" :: !lease_events))
+  in
+  (match
+     Agent.run_blocks
+       ~sw
+       ~on_yield:(fun () ->
+         Alcotest.(check bool) "tool not started" false !tool_executed;
+         lease_events := "yield" :: !lease_events)
+       ~on_resume:(fun () -> lease_events := "resume" :: !lease_events)
+       agent
+       [ Types.Text "what time is it?" ]
+   with
+   | Error error -> Alcotest.fail (Error.to_string error)
+   | Ok response ->
+     Alcotest.(check string)
+       "visible response"
+       "done"
+       (Types.visible_text_of_response response));
+  Alcotest.(check int) "two provider calls" 2 !call_count;
+  Alcotest.(check (list string))
+    "regular run release-tool-resume ordering"
+    [ "provider"; "yield"; "tool"; "resume"; "provider" ]
+    (List.rev !lease_events)
 ;;
 
 let test_unpaired_lease_callback_is_rejected () =
@@ -420,9 +598,21 @@ let () =
             `Quick
             test_continue_reaches_terminal_completion
         ; Alcotest.test_case
-            "checkpoint failure prevents callback"
+            "context checkpoint failure prevents boundary and resume"
             `Quick
-            test_checkpoint_failure_prevents_callback
+            test_context_checkpoint_failure_prevents_boundary_and_resume
+        ; Alcotest.test_case
+            "assistant checkpoint failure suppresses release and tool"
+            `Quick
+            test_assistant_checkpoint_failure_suppresses_release_and_tool
+        ; Alcotest.test_case
+            "release callback failure prevents tool execution"
+            `Quick
+            test_release_callback_failure_prevents_tool_execution
+        ; Alcotest.test_case
+            "regular run releases before tool execution"
+            `Quick
+            test_regular_run_releases_before_tool_execution
         ; Alcotest.test_case
             "unpaired provider lease callback is rejected"
             `Quick

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -269,7 +269,7 @@ let test_pipeline_sends_exact_supplied_tools () =
     { (Internal_agent.state agent) with messages = [ Types.user_msg "hello" ] };
   (match Internal_pipeline.run_turn ~sw ~api_strategy:Internal_pipeline.Sync agent with
    | Ok (Internal_pipeline.Complete _) -> ()
-   | Ok Internal_pipeline.ToolsExecuted -> Alcotest.fail "expected terminal response"
+   | Ok (Internal_pipeline.ToolsExecuted _) -> Alcotest.fail "expected terminal response"
    | Error error -> Alcotest.fail (Error.to_string error));
   Alcotest.(check bool)
     "provider receives exact caller tool schemas"
@@ -341,7 +341,7 @@ let test_stream_route_carries_exact_raw_trace_run_id () =
             agent
         with
         | Ok (Internal_pipeline.Complete _) -> ()
-        | Ok Internal_pipeline.ToolsExecuted ->
+        | Ok (Internal_pipeline.ToolsExecuted _) ->
           Alcotest.fail "expected a completed streaming turn"
         | Error error -> Alcotest.fail (Error.to_string error));
        Alcotest.(check (option string))
@@ -404,7 +404,7 @@ let test_pipeline_output_completes_on_end_turn () =
   match Internal_pipeline.run_turn ~sw ~api_strategy:Internal_pipeline.Sync agent with
   | Ok (Internal_pipeline.Complete response) ->
     Alcotest.(check bool) "completed" true (response.stop_reason = EndTurn)
-  | Ok Internal_pipeline.ToolsExecuted ->
+  | Ok (Internal_pipeline.ToolsExecuted _) ->
     Alcotest.fail "expected Complete, got ToolsExecuted"
   | Error err -> Alcotest.failf "unexpected run error: %s" (Error.to_string err)
 ;;
@@ -440,7 +440,7 @@ let test_pipeline_output_completes_repetition_truncation () =
       "documented provider terminal reason is preserved"
       true
       (response.stop_reason = RepetitionTruncation)
-  | Ok Internal_pipeline.ToolsExecuted ->
+  | Ok (Internal_pipeline.ToolsExecuted _) ->
     Alcotest.fail "expected Complete, got ToolsExecuted"
   | Error err -> Alcotest.failf "unexpected run error: %s" (Error.to_string err)
 ;;
@@ -474,7 +474,7 @@ let test_pipeline_text_tool_intent_remains_text () =
     (match response.content with
      | [ Text _ ] -> ()
      | _ -> Alcotest.fail "expected text to remain unpromoted")
-  | Ok Internal_pipeline.ToolsExecuted ->
+  | Ok (Internal_pipeline.ToolsExecuted _) ->
     Alcotest.fail "text content must not be promoted into a tool call"
   | Error err -> Alcotest.failf "unexpected run error: %s" (Error.to_string err)
 ;;


### PR DESCRIPTION
## 목적

호스트가 도구 실행 완료 뒤의 안전한 typed boundary에서 에이전트 lane을 정상적으로 양보할 수 있게 하면서, 기존 provider lease는 실제 tool 작업이 시작되기 전에 반환합니다. 취소 예외, 실행 시간, turn 수, cost/token budget을 정상 제어 흐름으로 사용하지 않습니다.

## API

- 기존 `Agent.run*` simple API signature는 변경하지 않음
- 새 `Agent.Advanced.run_blocks(_detailed)`만 추가
- boundary 입력: `{ turn; checkpoint_stage }`
- boundary 결정: `Continue | Yield`
- 결과: `Completed response | Yielded { turn; checkpoint_stage; checkpoint }`
- sync/stream은 기존 typed `api_strategy`로 선택
- 기존 provider-lease/progress 관측 계약과 같은 optional `on_yield`/`on_resume` pair를 보존

## 경계 및 lease 정당성

- Pipeline이 실제 통과한 `After_tool_results_appended` 또는 `After_context_injection` stage를 typed outcome에 직접 전달합니다. context 설정으로 stage를 재추론하지 않습니다.
- `Pipeline.run_turn`의 typed `before_tool_execution` callback은 `StopToolUse`의 non-empty tool batch에서만, `After_assistant_collected` checkpoint 성공 뒤 첫 tool hook/implementation 직전에 정확히 한 번 실행됩니다.
- `yield_on_tool=true`이면 이 경계에서 `on_yield`를 호출하므로 provider capacity를 tool/approval/context 작업 동안 점유하지 않습니다.
- tool execution, optional context injection, final configured checkpoint sink가 성공한 뒤에만 Advanced `on_tool_boundary`를 평가합니다.
- `Continue`는 `on_resume` 뒤 다음 provider turn을 실행합니다. `Yield`는 이 호출에서 `on_resume` 없이 반환합니다.
- `on_yield`/`on_resume`은 둘 다 제공하거나 둘 다 생략해야 하며 기존 `validate_run_callbacks`를 그대로 사용합니다.
- callback 예외는 삼키지 않으며 tool 실행 전에 fail-closed로 전파합니다. tool/context 실패로 run이 끝나면 불필요한 provider reacquire를 수행하지 않습니다.
- checkpoint sink가 없으면 durable persistence를 주장하지 않고 in-memory boundary로 문서화합니다.
- `Yielded`는 raw trace `error=None`, lifecycle `Ready`이며 `on_run_complete`를 호출하지 않습니다.
- `Switch.fail`이나 cancellation을 normal yield로 사용하지 않습니다.
- #2595의 live-state/checkpoint ordering 변경은 포함하지 않았습니다.
- provider/reasoning 파일은 변경하지 않았습니다.

## 검증

- `scripts/dune-local.sh build lib/agent_sdk.cmxa test/test_agent_advanced.exe test/test_pipeline.exe`
- `scripts/dune-local.sh exec ./test/test_agent_advanced.exe` — 7/7 green
  - Advanced Yield: provider → `on_yield` → tool → boundary, `on_resume` 없음
  - Advanced Continue: provider → `on_yield` → tool → boundary → `on_resume` → provider
  - regular `Agent.run_blocks`: provider → `on_yield` → tool → `on_resume` → provider
  - assistant checkpoint failure는 lease release/tool/boundary를 모두 억제
  - context checkpoint failure는 tool 뒤 boundary/reacquire를 억제
  - release callback exception은 tool 실행 전에 전파
  - unpaired lease callback은 provider 호출 전에 typed config error
- `scripts/dune-local.sh exec ./test/test_pipeline.exe` — 37/37 green
- `scripts/ci-code-smell-ratchet.sh --check` — pass
- `scripts/hardening-ratchet.sh --check` — pass
- `git diff --check` — pass

[근거] OCaml 5.4 manual parallel programming: https://ocaml.org/manual/5.4/parallelism.html — 확인 2026-07-14 KST — 신뢰도 High

[근거] Eio 1.3 Switch docs: https://ocaml.org/p/eio/latest/doc/eio/Eio/Switch/index.html — Switch.fail은 switch failure와 cancellation을 유발하고 run에서 재발생하므로 정상 yield에 부적합 — 확인 2026-07-14 KST — 신뢰도 High
