### PR TITLE
fix(agent-tool): align declared and consumed inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ original tag dates. `0.100.4` was never tagged or released.
 
 ### Breaking Changes
 
+* **agent-as-tool inputs:** remove `Agent_tool.config.input_parameters` and
+  scalar-string invocation. The advertised and consumed input contract is now
+  exactly one required object field, `prompt`; see the
+  [0.213 migration guide](docs/migrations/0.213-agent-tool-input.md).
 * **HTTP deadlines:** remove the implicit 60-second request/connect deadline
   and 30-second response-drain deadline. `timeout_s` and
   `connect_timeout_s` are enforced only when explicitly supplied, and a

--- a/docs/migrations/0.213-agent-tool-input.md
+++ b/docs/migrations/0.213-agent-tool-input.md
@@ -1,0 +1,24 @@
+# Agent-as-tool input contract (0.213)
+
+`Agent_tool` now advertises and consumes one exact input shape:
+
+```json
+{"prompt": "..."}
+```
+
+Remove `input_parameters` from `Agent_tool.config`. Those fields were exposed
+to the model but never consumed by `agent_runner`, so they could not affect the
+child invocation. Put child context in `prompt`, or define a separate typed
+tool whose parser and handler consume every declared field.
+
+Scalar string calls are no longer accepted. Replace:
+
+```ocaml
+Tool.execute tool (`String prompt)
+```
+
+with:
+
+```ocaml
+Tool.execute tool (`Assoc [ "prompt", `String prompt ])
+```

--- a/lib/agent_tool.ml
+++ b/lib/agent_tool.ml
@@ -21,7 +21,6 @@ type config =
   ; description : string
   ; runner : agent_runner
   ; output_summarizer : (string -> string) option
-  ; input_parameters : tool_param list
   }
 
 (* ── Text extraction ─────────────────────────────────────────── *)
@@ -139,7 +138,7 @@ let prompt_param =
   }
 ;;
 
-let parameters config = prompt_param :: config.input_parameters
+let parameters = [ prompt_param ]
 
 let prompt_of_input = function
   | `Assoc fields ->
@@ -147,9 +146,7 @@ let prompt_of_input = function
      | Some (`String s) -> Ok s
      | Some _ -> Error "Agent_tool prompt must be a string"
      | None -> Error "Agent_tool input requires a prompt field")
-  | `String s -> Ok s
-  | json ->
-    Error ("Agent_tool input must be an object or string: " ^ Yojson.Safe.to_string json)
+  | json -> Error ("Agent_tool input must be an object: " ^ Yojson.Safe.to_string json)
 ;;
 
 let make_handler config : Tool.tool_handler =
@@ -198,7 +195,7 @@ let create config =
   Tool.create
     ~name:config.name
     ~description:config.description
-    ~parameters:(parameters config)
+    ~parameters
     (make_handler config)
 ;;
 
@@ -206,7 +203,7 @@ let create_typed config =
   Typed_tool.create
     ~name:config.name
     ~description:config.description
-    ~params:(parameters config)
+    ~params:parameters
     ~parse:parse_child_invocation
     ~handler:(make_typed_handler config)
     ~encode:child_output_to_json
@@ -216,7 +213,7 @@ let create_typed config =
 let create_typed_untyped config = config |> create_typed |> Typed_tool.to_untyped
 
 let create_simple ~name ~description runner =
-  create { name; description; runner; output_summarizer = None; input_parameters = [] }
+  create { name; description; runner; output_summarizer = None }
 ;;
 
 [@@@coverage off]
@@ -252,11 +249,11 @@ let%test "handler returns agent text" =
   | Error _ -> false
 ;;
 
-let%test "handler with string input" =
+let%test "handler rejects string input outside its schema" =
   let tool = create_simple ~name:"t" ~description:"d" (mock_runner "ok") in
   match Tool.execute tool (`String "direct prompt") with
-  | Ok { content; _meta = _ } -> content = "ok"
-  | Error _ -> false
+  | Error _ -> true
+  | Ok _ -> false
 ;;
 
 let%test "handler propagates error" =
@@ -273,7 +270,6 @@ let%test "output_summarizer applied" =
       ; description = "d"
       ; runner = mock_runner "long output text here"
       ; output_summarizer = Some (fun s -> String.sub s 0 4)
-      ; input_parameters = []
       }
   in
   match Tool.execute tool (`Assoc [ "prompt", `String "q" ]) with
@@ -281,21 +277,14 @@ let%test "output_summarizer applied" =
   | Error _ -> false
 ;;
 
-let%test "extra input_parameters included" =
+let%test "declared inputs exactly match the consumed prompt" =
   let tool =
     create
       { name = "t"
       ; description = "d"
       ; runner = mock_runner "ok"
       ; output_summarizer = None
-      ; input_parameters =
-          [ { name = "context"
-            ; description = "extra"
-            ; param_type = String
-            ; required = false
-            }
-          ]
       }
   in
-  List.length tool.schema.parameters = 2
+  tool.schema.parameters = [ prompt_param ]
 ;;

--- a/lib/agent_tool.mli
+++ b/lib/agent_tool.mli
@@ -36,8 +36,6 @@ type config =
   ; runner : agent_runner (** Closure that captures the child agent and runs it. *)
   ; output_summarizer : (string -> string) option
     (** Optional post-processing of agent output before returning. *)
-  ; input_parameters : Types.tool_param list
-    (** Extra structured parameters beyond the default "prompt". *)
   }
 
 (** {1 Construction} *)

--- a/test/test_agent_tool.ml
+++ b/test/test_agent_tool.ml
@@ -88,9 +88,12 @@ let test_execute_with_prompt () =
 let test_execute_with_string_input () =
   let tool = Agent_tool.create_simple ~name:"echo" ~description:"d" echo_runner in
   match Tool.execute tool (`String "direct string") with
-  | Ok { content; _meta = _ } ->
-    Alcotest.(check string) "echo" "echo: direct string" content
-  | Error { message; _ } -> Alcotest.failf "error: %s" message
+  | Error { message; _ } ->
+    Alcotest.(check string)
+      "object contract"
+      {|Agent_tool input must be an object: "direct string"|}
+      message
+  | Ok _ -> Alcotest.fail "string input is outside the declared tool schema"
 ;;
 
 let test_execute_error_propagation () =
@@ -134,7 +137,6 @@ let test_output_summarizer () =
       ; runner = mock_runner "this is a very long response from the agent"
       ; output_summarizer =
           Some (fun s -> if String.length s > 10 then String.sub s 0 10 ^ "..." else s)
-      ; input_parameters = []
       }
   in
   match Tool.execute tool (`Assoc [ "prompt", `String "q" ]) with
@@ -143,31 +145,19 @@ let test_output_summarizer () =
   | Error { message; _ } -> Alcotest.failf "error: %s" message
 ;;
 
-(* ── Extra parameters ────────────────────────────────────────── *)
+(* ── Schema/parser SSOT ──────────────────────────────────────── *)
 
-let test_extra_parameters () =
+let test_declared_inputs_match_parser () =
   let tool =
     Agent_tool.create
       { name = "t"
       ; description = "d"
       ; runner = mock_runner "ok"
       ; output_summarizer = None
-      ; input_parameters =
-          [ { name = "style"
-            ; description = "Output style"
-            ; param_type = Types.String
-            ; required = false
-            }
-          ; { name = "max_length"
-            ; description = "Max chars"
-            ; param_type = Types.Integer
-            ; required = false
-            }
-          ]
       }
   in
-  (* prompt + 2 extra = 3 params *)
-  Alcotest.(check int) "3 params" 3 (List.length tool.schema.parameters)
+  Alcotest.(check int) "one consumed input" 1 (List.length tool.schema.parameters);
+  Alcotest.(check string) "prompt" "prompt" (List.hd tool.schema.parameters).name
 ;;
 
 (* ── Multi-content response ──────────────────────────────────── *)
@@ -197,7 +187,6 @@ let typed_config runner =
   ; description = "Typed child agent"
   ; runner
   ; output_summarizer = None
-  ; input_parameters = []
   }
 ;;
 
@@ -289,7 +278,9 @@ let () =
             test_execute_untyped_malformed_input_errors
         ] )
     ; "summarizer", [ Alcotest.test_case "truncate" `Quick test_output_summarizer ]
-    ; "params", [ Alcotest.test_case "extra" `Quick test_extra_parameters ]
+    ; ( "params"
+      , [ Alcotest.test_case "schema parser SSOT" `Quick test_declared_inputs_match_parser
+        ] )
     ; "multi_content", [ Alcotest.test_case "joined" `Quick test_multi_content ]
     ; ( "typed_child"
       , [ Alcotest.test_case "schema" `Quick test_create_typed_schema


### PR DESCRIPTION
## What
- Remove Agent_tool.config.input_parameters.
- Accept only the declared object shape with one required prompt field.
- Replace scalar-string and extra-parameter tests with schema/parser contract regressions.
- Add the 0.213 hard-cut migration note.

## Why
Agent_tool advertised arbitrary extra fields that its runner never consumed, while its parser also accepted scalar strings that the tool schema did not advertise. The declared schema and execution boundary could therefore disagree, making model correction non-convergent.

## Validation
- scripts/dune-local.sh build test/test_agent_tool.exe
- _build/default/test/test_agent_tool.exe (13/13)
- ocamlformat --check on changed OCaml files
- git diff --check

## Scope
5 files, 51 insertions, 45 deletions. No checkpoint, provider, budget, model routing, or compatibility shim changes.