### PR TITLE
feat(catalog): deployment overlay merge + alias-canonicalized provider lookup (RFC-OAS-036)

### DIFF
--- a/docs/rfc/RFC-OAS-036-model-catalog-overlay.md
+++ b/docs/rfc/RFC-OAS-036-model-catalog-overlay.md
@@ -1,0 +1,70 @@
+# RFC-OAS-036: Model catalog overlay and alias-canonicalized provider lookup
+
+- Status: Implemented (this PR)
+- Date: 2026-07-15
+- Related: RFC-OAS-034 (endpoint/capability boundary), masc RFC-0342 (D1), masc#24528
+
+## Problem
+
+`Model_catalog` supported exactly two catalog sources: the build-time embedded
+`models.toml`, and a whole-catalog replacement installed with `set_global`.
+A deployment that needs even one extra row — a provider-scoped row for a
+locally-served model, a coding-plan endpoint alias — had to fork the entire
+catalog and re-install it, which:
+
+- masks every upstream row behind a copy that goes stale on every release
+  (observed 2026-07-15: a 103-row fork from three schema generations back
+  shadowed the current 171-row embedded catalog and took a whole fleet's boot
+  gate down),
+- pushes deployment-specific rows upstream instead (`provider_name =
+  "runpod_rtxa6000"` in the shared `models.toml`), violating RFC-OAS-034's
+  serving-contract namespace rule from the other direction.
+
+Separately, capability lookup had two alias semantics. The binding-registry
+path (`Provider_runtime_binding.provider_id_of_provider_config`) resolves a
+provider label through declared aliases before use; the capability path
+(`Provider_config.capabilities_for_config_model` →
+`Model_catalog.lookup_for_provider`) compared the raw label only. The same
+config could resolve capabilities on one path and miss on the other.
+
+## Change
+
+1. **`Model_catalog.merge ~base ~overlay`** — row-level merge. Identity is
+   what lookup keys on: `(provider_name, id_prefix)` for model rows (a bare
+   row and a provider-scoped row with the same `id_prefix` are distinct),
+   `id` for provider entries, compared with lookup normalization
+   (trim + ASCII case-fold). Overlay rows replace same-identity base rows;
+   rows unique to either side are kept.
+
+2. **`Model_catalog.set_global_overlay`** — installs a deployment overlay.
+   `global ()` now resolves: `set_global` replacement (unchanged, still wins
+   outright — tests and explicit full-catalog callers keep their semantics) →
+   embedded ⊕ overlay (cached, invalidated on overlay change) → embedded.
+   `clear_global` also drops the overlay and the merged cache.
+
+3. **Alias-canonicalized `lookup_for_provider`** — when no row matches the
+   requested provider name verbatim, the name is canonicalized once through
+   the catalog's own `[[providers]]` entries (`id` or `aliases` containing the
+   requested name) and the exact lookup is retried with that entry's `id`.
+   A verbatim row always wins. This closes the two-path asymmetry and lets an
+   overlay express a deployment alias as data: a provider entry
+   `id = "vllm-qwen3-mtp"` with `aliases = ["runpod_mtp"]` routes the
+   deployment label to the upstream serving-contract rows without duplicating
+   capability data.
+
+No lookup behavior changes for names that already resolved: the alias pass
+only runs where the previous implementation returned `None`.
+
+## Consumer wiring (out of scope here)
+
+Downstream runtimes (masc) resolve an overlay file (e.g. config-root
+`oas-models-overlay.toml`) and call `set_global_overlay` during bootstrap,
+replacing their full-file `oas-models.toml` pickup. Tracked in masc RFC-0342
+(D1 landing plan and the deployment-fork removal target).
+
+## Tests
+
+`test/test_model_catalog_overlay.ml`: merge precedence per key kind, bare vs
+provider-scoped key distinctness, provider-entry replacement, embedded ⊕
+overlay composition through `global ()`, `set_global` precedence,
+`clear_global` reset, alias resolution, and verbatim-over-alias precedence.

--- a/docs/rfc/RFC-OAS-036-model-catalog-overlay.md
+++ b/docs/rfc/RFC-OAS-036-model-catalog-overlay.md
@@ -48,9 +48,17 @@ config could resolve capabilities on one path and miss on the other.
    requested name) and the exact lookup is retried with that entry's `id`.
    A verbatim row always wins. This closes the two-path asymmetry and lets an
    overlay express a deployment alias as data: a provider entry
-   `id = "vllm-qwen3-mtp"` with `aliases = ["runpod_mtp"]` routes the
-   deployment label to the upstream serving-contract rows without duplicating
-   capability data.
+   `id = "vllm-qwen3-mtp"` with `aliases = ["runpod_mtp"]` and
+   `capabilities_base = "openai_compat"` routes the deployment label to the
+   upstream serving-contract rows without duplicating capability data.
+   `capabilities_base` is required in practice for deployment-only ids:
+   `Provider_registry.default` resolves an absent `capabilities_base` to the
+   entry `id` (`lib/llm_provider/provider_registry.ml`), and a label unknown
+   to `Capabilities.capabilities_for_provider_label` raises `Invalid_argument`
+   at registry construction — before any request is served. Overlay authors
+   must pick a label the capability table already resolves (a
+   `Provider_kind.to_string` value or a declared alias such as
+   `"openai_chat"`).
 
 No lookup behavior changes for names that already resolved: the alias pass
 only runs where the previous implementation returned `None`.

--- a/lib/llm_provider/model_catalog.ml
+++ b/lib/llm_provider/model_catalog.ml
@@ -735,24 +735,36 @@ let lookup t model_id =
 
 let normalize_label value = String.lowercase_ascii (String.trim value)
 
+(* Wire-kind labels ("openai_compat", "gemini", ...) are what
+   [capability_provider_label] synthesizes when a config declares no
+   [provider_id]. They stay opaque to alias canonicalization: letting a
+   catalog entry claim one as an alias would route every anonymous config of
+   that wire kind onto that provider's scoped capabilities/pricing. *)
+let wire_kind_labels =
+  List.map (fun kind -> Provider_kind.to_string kind) Provider_kind.all
+;;
+
 (* Canonical provider label per the catalog's own [[providers]] alias data.
    This applies the alias-to-canonical-id policy the binding registry already
    uses ([Provider_runtime_binding.provider_id_of_provider_config]); the
    capability path previously compared the raw label only, so the same config
    could resolve capabilities on one path and miss on the other. The first
    declaring entry wins and resolution is single-step (a canonical id is
-   never re-resolved). *)
+   never re-resolved). Wire-kind labels are never canonicalized. *)
 let canonical_provider_name t provider_name =
   let provider_name = normalize_label provider_name in
-  let matches (entry : provider_entry) =
-    String.equal provider_name (normalize_label entry.id)
-    || List.exists
-         (fun alias -> String.equal provider_name (normalize_label alias))
-         entry.aliases
-  in
-  match List.find_opt matches t.providers with
-  | Some entry -> normalize_label entry.id
-  | None -> provider_name
+  if List.mem provider_name wire_kind_labels
+  then provider_name
+  else (
+    let matches (entry : provider_entry) =
+      String.equal provider_name (normalize_label entry.id)
+      || List.exists
+           (fun alias -> String.equal provider_name (normalize_label alias))
+           entry.aliases
+    in
+    match List.find_opt matches t.providers with
+    | Some entry -> normalize_label entry.id
+    | None -> provider_name)
 ;;
 
 let lookup_for_provider t ~provider_name ~model_id =
@@ -801,8 +813,14 @@ let merge ~base ~overlay =
       (fun entry -> not (List.mem (provider_entry_key entry) overlay_provider_keys))
       base.providers
   in
-  { models = kept_models @ overlay.models
-  ; providers = kept_providers @ overlay.providers
+  (* Overlay rows come first: provider-entry consumers such as
+     [provider_label_for_base_url]/[provider_label_for_endpoint] scan in
+     declaration order, so a deployment entry whose endpoint identity is also
+     covered by an embedded entry must win. Model-row lookups are
+     order-independent (exact key or longest-prefix), so the same ordering is
+     applied there purely for consistency. *)
+  { models = overlay.models @ kept_models
+  ; providers = overlay.providers @ kept_providers
   }
 ;;
 
@@ -860,7 +878,14 @@ let runtime_override : t option Atomic.t = Atomic.make None
    OAS_MODEL_CATALOG-style callers) still wins outright, and so the merged
    result can be cached and invalidated independently. *)
 let overlay_catalog : t option Atomic.t = Atomic.make None
-let merged_cache : t option Atomic.t = Atomic.make None
+
+(* The cache pairs the merged result with the exact overlay value it was
+   derived from. Readers accept a hit only when the cached overlay is
+   physically the current one, so a racing writer that publishes a merge of a
+   just-replaced overlay can never pin stale capabilities: the identity check
+   fails and the next call recomputes from the fresh overlay. The worst case
+   under contention is a redundant pure merge, never a stale read. *)
+let merged_cache : (t * t) option Atomic.t = Atomic.make None
 let set_global t = Atomic.set runtime_override (Some t)
 
 let set_global_overlay t =
@@ -887,12 +912,9 @@ let global () =
         | None -> Some embedded_value
         | Some overlay ->
           (match Atomic.get merged_cache with
-           | Some merged -> Some merged
-           | None ->
-             (* A concurrent [set_global_overlay] may race this merge; the
-                worst case is one redundant pure merge, and the cache is
-                re-derived from the freshest overlay on the next call. *)
+           | Some (cached_overlay, merged) when cached_overlay == overlay -> Some merged
+           | Some _ | None ->
              let merged = merge ~base:embedded_value ~overlay in
-             Atomic.set merged_cache (Some merged);
+             Atomic.set merged_cache (Some (overlay, merged));
              Some merged)))
 ;;

--- a/lib/llm_provider/model_catalog.ml
+++ b/lib/llm_provider/model_catalog.ml
@@ -733,17 +733,77 @@ let lookup t model_id =
   |> fun entries -> lookup_entries entries model_id
 ;;
 
+let normalize_label value = String.lowercase_ascii (String.trim value)
+
+(* Canonical provider label per the catalog's own [[providers]] alias data.
+   This applies the alias-to-canonical-id policy the binding registry already
+   uses ([Provider_runtime_binding.provider_id_of_provider_config]); the
+   capability path previously compared the raw label only, so the same config
+   could resolve capabilities on one path and miss on the other. The first
+   declaring entry wins and resolution is single-step (a canonical id is
+   never re-resolved). *)
+let canonical_provider_name t provider_name =
+  let provider_name = normalize_label provider_name in
+  let matches (entry : provider_entry) =
+    String.equal provider_name (normalize_label entry.id)
+    || List.exists
+         (fun alias -> String.equal provider_name (normalize_label alias))
+         entry.aliases
+  in
+  match List.find_opt matches t.providers with
+  | Some entry -> normalize_label entry.id
+  | None -> provider_name
+;;
+
 let lookup_for_provider t ~provider_name ~model_id =
-  let provider_name = String.lowercase_ascii (String.trim provider_name) in
-  let model_id = String.lowercase_ascii (String.trim model_id) in
-  List.find_opt
-    (fun entry ->
-       match entry.provider_name with
-       | None -> false
-       | Some declared ->
-         String.equal provider_name (String.lowercase_ascii (String.trim declared))
-         && String.equal model_id (String.lowercase_ascii (String.trim entry.id_prefix)))
-    t.models
+  let model_id = normalize_label model_id in
+  let find_exact label =
+    List.find_opt
+      (fun entry ->
+         match entry.provider_name with
+         | None -> false
+         | Some declared ->
+           String.equal label (normalize_label declared)
+           && String.equal model_id (normalize_label entry.id_prefix))
+      t.models
+  in
+  let requested = normalize_label provider_name in
+  match find_exact requested with
+  | Some _ as hit -> hit
+  | None ->
+    let canonical = canonical_provider_name t requested in
+    if String.equal canonical requested then None else find_exact canonical
+;;
+
+(* Row-level catalog merge (RFC-OAS-036). Identity is what lookup keys on:
+   [(provider_name, id_prefix)] for model rows — a bare row and a
+   provider-scoped row with the same [id_prefix] are distinct rows — and [id]
+   for provider entries, all compared with lookup's normalization. Overlay
+   rows replace same-identity base rows; everything else is kept from both
+   sides. This is the deployment-delta alternative to forking the whole
+   catalog through [set_global]. *)
+let model_row_key (entry : model_entry) =
+  Option.map normalize_label entry.provider_name, normalize_label entry.id_prefix
+;;
+
+let provider_entry_key (entry : provider_entry) = normalize_label entry.id
+
+let merge ~base ~overlay =
+  let overlay_model_keys = List.map model_row_key overlay.models in
+  let overlay_provider_keys = List.map provider_entry_key overlay.providers in
+  let kept_models =
+    List.filter
+      (fun entry -> not (List.mem (model_row_key entry) overlay_model_keys))
+      base.models
+  in
+  let kept_providers =
+    List.filter
+      (fun entry -> not (List.mem (provider_entry_key entry) overlay_provider_keys))
+      base.providers
+  in
+  { models = kept_models @ overlay.models
+  ; providers = kept_providers @ overlay.providers
+  }
 ;;
 
 let provider_label_for_base_url ?getenv t ~kind ~base_url =
@@ -794,10 +854,24 @@ let load_embedded_once () =
 ;;
 
 let runtime_override : t option Atomic.t = Atomic.make None
+
+(* Deployment overlay merged onto the embedded catalog by [global]. Kept
+   separate from [runtime_override] so a full replacement (tests, explicit
+   OAS_MODEL_CATALOG-style callers) still wins outright, and so the merged
+   result can be cached and invalidated independently. *)
+let overlay_catalog : t option Atomic.t = Atomic.make None
+let merged_cache : t option Atomic.t = Atomic.make None
 let set_global t = Atomic.set runtime_override (Some t)
+
+let set_global_overlay t =
+  Atomic.set overlay_catalog (Some t);
+  Atomic.set merged_cache None
+;;
 
 let clear_global () =
   Atomic.set runtime_override None;
+  Atomic.set overlay_catalog None;
+  Atomic.set merged_cache None;
   Atomic.set embedded_catalog Unloaded
 ;;
 
@@ -808,5 +882,17 @@ let global () =
     let embedded_value = load_embedded_once () in
     (match Atomic.get runtime_override with
      | Some _ as o -> o
-     | None -> Some embedded_value)
+     | None ->
+       (match Atomic.get overlay_catalog with
+        | None -> Some embedded_value
+        | Some overlay ->
+          (match Atomic.get merged_cache with
+           | Some merged -> Some merged
+           | None ->
+             (* A concurrent [set_global_overlay] may race this merge; the
+                worst case is one redundant pure merge, and the cache is
+                re-derived from the freshest overlay on the next call. *)
+             let merged = merge ~base:embedded_value ~overlay in
+             Atomic.set merged_cache (Some merged);
+             Some merged)))
 ;;

--- a/lib/llm_provider/model_catalog.mli
+++ b/lib/llm_provider/model_catalog.mli
@@ -119,12 +119,29 @@ val lookup : t -> string -> model_entry option
     provider and model remain separate values; OAS never synthesizes slash,
     colon, or dot-qualified model ids.
 
+    When no row matches the requested [provider_name] verbatim, the name is
+    canonicalized once through the catalog's own [[providers]] alias data (the
+    first entry whose [id] or [aliases] contains the requested name, in
+    declaration order) and the exact lookup is retried with that entry's [id].
+    This applies the same alias-to-canonical-id policy the binding registry
+    uses for its own catalog, so both capability paths answer alike. A
+    verbatim row always wins over an alias-resolved one, and resolution is
+    single-step (a canonical id is never re-resolved).
+
     Provider-independent family matching remains exclusively in {!lookup}. *)
 val lookup_for_provider
   :  t
   -> provider_name:string
   -> model_id:string
   -> model_entry option
+
+(** Row-level overlay merge (RFC-OAS-036). Rows in [overlay] replace rows in
+    [base] with the same identity — [(provider_name, id_prefix)] for model
+    rows (a bare row and a provider-scoped row with the same [id_prefix] are
+    distinct), [id] for provider entries, compared with lookup normalization —
+    and rows unique to either side are kept. This lets a deployment carry only
+    its delta rows instead of forking the entire catalog. *)
+val merge : base:t -> overlay:t -> t
 
 (** Return the catalog-declared provider identity for a concrete endpoint.
 
@@ -152,17 +169,28 @@ val provider_label_for_endpoint
 (** Return the active model catalog.
 
     Resolution order:
-    - runtime override installed with {!set_global}
-    - build-time embedded OAS [models.toml]
+    - runtime override installed with {!set_global} (full replacement)
+    - build-time embedded OAS [models.toml], merged with the deployment
+      overlay installed with {!set_global_overlay} when one is present
 
-    The embedded result is cached after the first load. Invalid generated data
-    raises {!Invalid_embedded_catalog}; it never becomes [None] or an empty
-    catalog. OAS does not inspect an environment variable for an alternate
-    catalog. Callers that need a custom catalog must call {!load_file} and
-    {!set_global} explicitly.
+    The embedded result and the merged result are cached after first
+    computation. Invalid generated data raises {!Invalid_embedded_catalog}; it
+    never becomes [None] or an empty catalog. OAS does not inspect an
+    environment variable for an alternate catalog. Callers that need a custom
+    catalog must call {!load_file} and {!set_global} or {!set_global_overlay}
+    explicitly.
 
-    {!clear_global} clears the runtime override and embedded cache. *)
+    {!clear_global} clears the runtime override, the overlay, and both
+    caches. *)
 val global : unit -> t option
 
 val set_global : t -> unit
+
+(** Install a deployment overlay {!merge}d onto the embedded default catalog
+    by {!global}. Unlike {!set_global}, embedded rows not shadowed by the
+    overlay stay visible, so the overlay carries only deployment-local deltas
+    (RFC-OAS-036). A full {!set_global} override, when installed, takes
+    precedence over the overlay. *)
+val set_global_overlay : t -> unit
+
 val clear_global : unit -> unit

--- a/lib/llm_provider/model_catalog.mli
+++ b/lib/llm_provider/model_catalog.mli
@@ -126,7 +126,11 @@ val lookup : t -> string -> model_entry option
     This applies the same alias-to-canonical-id policy the binding registry
     uses for its own catalog, so both capability paths answer alike. A
     verbatim row always wins over an alias-resolved one, and resolution is
-    single-step (a canonical id is never re-resolved).
+    single-step (a canonical id is never re-resolved). Wire-kind labels
+    ({!Provider_kind.to_string} values such as ["openai_compat"]) are never
+    canonicalized: they are what configs without an explicit provider id
+    synthesize, and an alias claiming one would capture every anonymous
+    config of that wire kind.
 
     Provider-independent family matching remains exclusively in {!lookup}. *)
 val lookup_for_provider
@@ -139,8 +143,12 @@ val lookup_for_provider
     [base] with the same identity — [(provider_name, id_prefix)] for model
     rows (a bare row and a provider-scoped row with the same [id_prefix] are
     distinct), [id] for provider entries, compared with lookup normalization —
-    and rows unique to either side are kept. This lets a deployment carry only
-    its delta rows instead of forking the entire catalog. *)
+    and rows unique to either side are kept. Overlay rows precede base rows in
+    the result, so order-sensitive provider-entry consumers
+    ({!provider_label_for_base_url}, {!provider_label_for_endpoint}) prefer a
+    deployment entry whose endpoint identity is also covered by an embedded
+    entry. This lets a deployment carry only its delta rows instead of forking
+    the entire catalog. *)
 val merge : base:t -> overlay:t -> t
 
 (** Return the catalog-declared provider identity for a concrete endpoint.

--- a/test/dune
+++ b/test/dune
@@ -116,6 +116,7 @@
   test_metric_contract
   test_metrics
   test_model_catalog_default
+  test_model_catalog_overlay
   test_module_check
   test_multimodal
   test_multivendor_events
@@ -280,6 +281,7 @@
   test_metric_contract
   test_metrics
   test_model_catalog_default
+  test_model_catalog_overlay
   test_module_check
   test_multimodal
   test_multivendor_events

--- a/test/test_model_catalog_overlay.ml
+++ b/test/test_model_catalog_overlay.ml
@@ -1,0 +1,346 @@
+open Alcotest
+module Model_catalog = Llm_provider.Model_catalog
+
+let catalog_of ~suite toml =
+  match Model_catalog.of_toml_string ~source:(suite ^ " inline catalog") toml with
+  | Ok catalog -> catalog
+  | Error msg -> failf "%s: inline catalog should parse: %s" suite msg
+;;
+
+let with_clean_model_catalog_override f =
+  Model_catalog.clear_global ();
+  Fun.protect ~finally:Model_catalog.clear_global f
+;;
+
+let scoped_row ?(extra = "") ~provider ~model ~max_context () =
+  Printf.sprintf
+    "[[models]]\nid_prefix = %S\nprovider_name = %S\nmax_context_tokens = %d\n%s"
+    model
+    provider
+    max_context
+    extra
+;;
+
+let bare_row ~model ~max_context =
+  Printf.sprintf "[[models]]\nid_prefix = %S\nmax_context_tokens = %d\n" model max_context
+;;
+
+let provider_entry ?(aliases = []) ~id ~base_url () =
+  let aliases =
+    match aliases with
+    | [] -> ""
+    | aliases ->
+      Printf.sprintf
+        "aliases = [%s]\n"
+        (String.concat ", " (List.map (Printf.sprintf "%S") aliases))
+  in
+  Printf.sprintf
+    "[[providers]]\n\
+     id = %S\n\
+     %skind = \"openai_compat\"\n\
+     base_url = %S\n\
+     request_path = \"/v1/chat/completions\"\n\
+     api_key_env = \"\"\n\
+     capabilities_base = \"openai_chat\"\n"
+    id
+    aliases
+    base_url
+;;
+
+let max_context ~suite ~what = function
+  | None -> failf "%s: expected %s row" suite what
+  | Some (entry : Model_catalog.model_entry) -> entry.max_context_tokens
+;;
+
+(* --- merge --- *)
+
+let test_merge_overlay_row_replaces_same_key () =
+  let suite = "merge same key" in
+  let base =
+    catalog_of
+      ~suite
+      (scoped_row ~provider:"prov-a" ~model:"model-1" ~max_context:100 ()
+       ^ scoped_row ~provider:"prov-a" ~model:"model-2" ~max_context:300 ())
+  in
+  let overlay =
+    catalog_of ~suite (scoped_row ~provider:"prov-a" ~model:"model-1" ~max_context:200 ())
+  in
+  let merged = Model_catalog.merge ~base ~overlay in
+  check
+    (option int)
+    "overlay row wins on the shared (provider_name, id_prefix) key"
+    (Some 200)
+    (max_context
+       ~suite
+       ~what:"overridden"
+       (Model_catalog.lookup_for_provider
+          merged
+          ~provider_name:"prov-a"
+          ~model_id:"model-1"));
+  check
+    (option int)
+    "base row with a different key survives"
+    (Some 300)
+    (max_context
+       ~suite
+       ~what:"untouched"
+       (Model_catalog.lookup_for_provider
+          merged
+          ~provider_name:"prov-a"
+          ~model_id:"model-2"));
+  check
+    int
+    "no duplicate rows for the shared key"
+    2
+    (List.length (Model_catalog.model_entries merged))
+;;
+
+let test_merge_keeps_bare_and_scoped_rows_distinct () =
+  let suite = "merge bare vs scoped" in
+  let base = catalog_of ~suite (bare_row ~model:"model-1" ~max_context:100) in
+  let overlay =
+    catalog_of ~suite (scoped_row ~provider:"prov-a" ~model:"model-1" ~max_context:200 ())
+  in
+  let merged = Model_catalog.merge ~base ~overlay in
+  check
+    (option int)
+    "bare row remains reachable through the bare lookup"
+    (Some 100)
+    (max_context ~suite ~what:"bare" (Model_catalog.lookup merged "model-1"));
+  check
+    (option int)
+    "scoped overlay row is reachable through the provider lookup"
+    (Some 200)
+    (max_context
+       ~suite
+       ~what:"scoped"
+       (Model_catalog.lookup_for_provider
+          merged
+          ~provider_name:"prov-a"
+          ~model_id:"model-1"))
+;;
+
+let test_merge_provider_entries_replace_by_id () =
+  let suite = "merge provider entries" in
+  let base =
+    catalog_of
+      ~suite
+      (provider_entry ~id:"prov-a" ~base_url:"https://base.example" ()
+       ^ provider_entry ~id:"prov-b" ~base_url:"https://other.example" ())
+  in
+  let overlay =
+    catalog_of ~suite (provider_entry ~id:"prov-a" ~base_url:"https://overlay.example" ())
+  in
+  let merged = Model_catalog.merge ~base ~overlay in
+  check
+    int
+    "one entry per provider id"
+    2
+    (List.length (Model_catalog.provider_entries merged));
+  let prov_a =
+    List.find_opt
+      (fun (entry : Model_catalog.provider_entry) -> String.equal entry.id "prov-a")
+      (Model_catalog.provider_entries merged)
+  in
+  match prov_a with
+  | None -> failf "%s: merged catalog should keep prov-a" suite
+  | Some entry ->
+    check string "overlay provider entry wins" "https://overlay.example" entry.base_url
+;;
+
+(* --- global composition --- *)
+
+let overlay_only_row_provider = "overlay-only-provider"
+let overlay_only_row_model = "overlay-only-model"
+
+let tiny_overlay ~suite =
+  catalog_of
+    ~suite
+    (scoped_row
+       ~provider:overlay_only_row_provider
+       ~model:overlay_only_row_model
+       ~max_context:4242
+       ())
+;;
+
+let test_global_overlay_composes_with_embedded () =
+  let suite = "global overlay" in
+  with_clean_model_catalog_override
+  @@ fun () ->
+  let embedded =
+    match Model_catalog.load_default () with
+    | Ok catalog -> catalog
+    | Error msg -> failf "%s: embedded catalog should load: %s" suite msg
+  in
+  Model_catalog.set_global_overlay (tiny_overlay ~suite);
+  match Model_catalog.global () with
+  | None -> failf "%s: global catalog should be available" suite
+  | Some merged ->
+    check
+      (option int)
+      "overlay delta row resolves through the global catalog"
+      (Some 4242)
+      (max_context
+         ~suite
+         ~what:"overlay"
+         (Model_catalog.lookup_for_provider
+            merged
+            ~provider_name:overlay_only_row_provider
+            ~model_id:overlay_only_row_model));
+    check
+      int
+      "every embedded row stays visible next to the delta"
+      (List.length (Model_catalog.model_entries embedded) + 1)
+      (List.length (Model_catalog.model_entries merged))
+;;
+
+let test_set_global_still_wins_over_overlay () =
+  let suite = "set_global precedence" in
+  with_clean_model_catalog_override
+  @@ fun () ->
+  Model_catalog.set_global_overlay (tiny_overlay ~suite);
+  let replacement =
+    catalog_of ~suite (scoped_row ~provider:"prov-a" ~model:"model-1" ~max_context:7 ())
+  in
+  Model_catalog.set_global replacement;
+  match Model_catalog.global () with
+  | None -> failf "%s: global catalog should be available" suite
+  | Some catalog ->
+    check
+      int
+      "full replacement hides both embedded and overlay rows"
+      1
+      (List.length (Model_catalog.model_entries catalog));
+    check
+      bool
+      "overlay delta row is not reachable through a full replacement"
+      true
+      (Option.is_none
+         (Model_catalog.lookup_for_provider
+            catalog
+            ~provider_name:overlay_only_row_provider
+            ~model_id:overlay_only_row_model))
+;;
+
+let test_clear_global_drops_overlay () =
+  let suite = "clear_global overlay" in
+  with_clean_model_catalog_override
+  @@ fun () ->
+  Model_catalog.set_global_overlay (tiny_overlay ~suite);
+  Model_catalog.clear_global ();
+  match Model_catalog.global () with
+  | None -> failf "%s: global catalog should be available" suite
+  | Some catalog ->
+    check
+      bool
+      "overlay delta row is gone after clear_global"
+      true
+      (Option.is_none
+         (Model_catalog.lookup_for_provider
+            catalog
+            ~provider_name:overlay_only_row_provider
+            ~model_id:overlay_only_row_model))
+;;
+
+(* --- alias-canonicalized provider lookup --- *)
+
+let test_lookup_for_provider_resolves_declared_alias () =
+  let suite = "alias lookup" in
+  let catalog =
+    catalog_of
+      ~suite
+      (provider_entry
+         ~id:"serving-contract"
+         ~aliases:[ "deployment-alias" ]
+         ~base_url:"https://serving.example"
+         ()
+       ^ scoped_row ~provider:"serving-contract" ~model:"model-1" ~max_context:111 ())
+  in
+  check
+    (option int)
+    "alias resolves to the serving-contract row"
+    (Some 111)
+    (max_context
+       ~suite
+       ~what:"alias-resolved"
+       (Model_catalog.lookup_for_provider
+          catalog
+          ~provider_name:"deployment-alias"
+          ~model_id:"model-1"));
+  check
+    bool
+    "an undeclared provider name still misses"
+    true
+    (Option.is_none
+       (Model_catalog.lookup_for_provider
+          catalog
+          ~provider_name:"unrelated"
+          ~model_id:"model-1"))
+;;
+
+let test_lookup_for_provider_prefers_verbatim_over_alias () =
+  let suite = "alias precedence" in
+  let catalog =
+    catalog_of
+      ~suite
+      (provider_entry
+         ~id:"serving-contract"
+         ~aliases:[ "deployment-alias" ]
+         ~base_url:"https://serving.example"
+         ()
+       ^ scoped_row ~provider:"serving-contract" ~model:"model-1" ~max_context:222 ()
+       ^ scoped_row ~provider:"deployment-alias" ~model:"model-1" ~max_context:111 ())
+  in
+  check
+    (option int)
+    "a verbatim provider row wins over alias canonicalization"
+    (Some 111)
+    (max_context
+       ~suite
+       ~what:"verbatim"
+       (Model_catalog.lookup_for_provider
+          catalog
+          ~provider_name:"deployment-alias"
+          ~model_id:"model-1"))
+;;
+
+let () =
+  run
+    "model_catalog_overlay"
+    [ ( "merge"
+      , [ test_case
+            "overlay row replaces same key"
+            `Quick
+            test_merge_overlay_row_replaces_same_key
+        ; test_case
+            "bare and scoped rows stay distinct"
+            `Quick
+            test_merge_keeps_bare_and_scoped_rows_distinct
+        ; test_case
+            "provider entries replace by id"
+            `Quick
+            test_merge_provider_entries_replace_by_id
+        ] )
+    ; ( "global"
+      , [ test_case
+            "overlay composes with embedded"
+            `Quick
+            test_global_overlay_composes_with_embedded
+        ; test_case
+            "set_global wins over overlay"
+            `Quick
+            test_set_global_still_wins_over_overlay
+        ; test_case "clear_global drops overlay" `Quick test_clear_global_drops_overlay
+        ] )
+    ; ( "alias"
+      , [ test_case
+            "declared alias resolves to serving contract"
+            `Quick
+            test_lookup_for_provider_resolves_declared_alias
+        ; test_case
+            "verbatim row wins over alias"
+            `Quick
+            test_lookup_for_provider_prefers_verbatim_over_alias
+        ] )
+    ]
+;;

--- a/test/test_model_catalog_overlay.ml
+++ b/test/test_model_catalog_overlay.ml
@@ -304,6 +304,100 @@ let test_lookup_for_provider_prefers_verbatim_over_alias () =
           ~model_id:"model-1"))
 ;;
 
+(* --- review hardening (oas#2604 Codex P2s) --- *)
+
+let test_merge_overlay_provider_wins_endpoint_identity () =
+  let suite = "merge endpoint identity" in
+  let base =
+    catalog_of
+      ~suite
+      (provider_entry ~id:"embedded-prov" ~base_url:"https://shared.example" ())
+  in
+  let overlay =
+    catalog_of
+      ~suite
+      (provider_entry ~id:"deployment-prov" ~base_url:"https://shared.example" ())
+  in
+  let merged = Model_catalog.merge ~base ~overlay in
+  check
+    (option string)
+    "overlay provider entry wins order-sensitive endpoint identity"
+    (Some "deployment-prov")
+    (Model_catalog.provider_label_for_base_url
+       merged
+       ~kind:Llm_provider.Provider_kind.OpenAI_compat
+       ~base_url:"https://shared.example")
+;;
+
+let test_wire_kind_label_is_never_alias_canonicalized () =
+  let suite = "wire-kind alias guard" in
+  let catalog =
+    catalog_of
+      ~suite
+      (provider_entry
+         ~id:"hijack-prov"
+         ~aliases:[ "openai_compat" ]
+         ~base_url:"https://hijack.example"
+         ()
+       ^ scoped_row ~provider:"hijack-prov" ~model:"model-1" ~max_context:333 ())
+  in
+  check
+    bool
+    "an alias claiming a wire-kind label captures nothing"
+    true
+    (Option.is_none
+       (Model_catalog.lookup_for_provider
+          catalog
+          ~provider_name:"openai_compat"
+          ~model_id:"model-1"));
+  check
+    (option int)
+    "the provider's own id still resolves its scoped row"
+    (Some 333)
+    (max_context
+       ~suite
+       ~what:"verbatim"
+       (Model_catalog.lookup_for_provider
+          catalog
+          ~provider_name:"hijack-prov"
+          ~model_id:"model-1"))
+;;
+
+let test_overlay_swap_replaces_merged_cache () =
+  let suite = "overlay swap" in
+  with_clean_model_catalog_override
+  @@ fun () ->
+  let lookup_overlay_row () =
+    match Model_catalog.global () with
+    | None -> failf "%s: global catalog should be available" suite
+    | Some catalog ->
+      max_context
+        ~suite
+        ~what:"overlay"
+        (Model_catalog.lookup_for_provider
+           catalog
+           ~provider_name:overlay_only_row_provider
+           ~model_id:overlay_only_row_model)
+  in
+  Model_catalog.set_global_overlay (tiny_overlay ~suite);
+  check (option int) "first overlay serves its row" (Some 4242) (lookup_overlay_row ());
+  let replacement =
+    catalog_of
+      ~suite
+      (scoped_row
+         ~provider:overlay_only_row_provider
+         ~model:overlay_only_row_model
+         ~max_context:7777
+         ())
+  in
+  Model_catalog.set_global_overlay replacement;
+  check
+    (option int)
+    "swapped overlay replaces the cached merge"
+    (Some 7777)
+    (lookup_overlay_row ())
+;;
+
 let () =
   run
     "model_catalog_overlay"
@@ -320,6 +414,10 @@ let () =
             "provider entries replace by id"
             `Quick
             test_merge_provider_entries_replace_by_id
+        ; test_case
+            "overlay provider wins endpoint identity"
+            `Quick
+            test_merge_overlay_provider_wins_endpoint_identity
         ] )
     ; ( "global"
       , [ test_case
@@ -331,6 +429,10 @@ let () =
             `Quick
             test_set_global_still_wins_over_overlay
         ; test_case "clear_global drops overlay" `Quick test_clear_global_drops_overlay
+        ; test_case
+            "overlay swap replaces merged cache"
+            `Quick
+            test_overlay_swap_replaces_merged_cache
         ] )
     ; ( "alias"
       , [ test_case
@@ -341,6 +443,10 @@ let () =
             "verbatim row wins over alias"
             `Quick
             test_lookup_for_provider_prefers_verbatim_over_alias
+        ; test_case
+            "wire-kind label never canonicalized"
+            `Quick
+            test_wire_kind_label_is_never_alias_canonicalized
         ] )
     ]
 ;;


### PR DESCRIPTION
## 배경

2026-07-15 masc 부팅 전멸 사건(masc RFC-0342, masc#24528)의 구조 원인 중 OAS 소유 부분:

- `Model_catalog`는 임베디드 전체 아니면 `set_global` 전체 교체뿐 — row 하나 추가하려면 전체 fork가 필요하고, fork는 릴리즈마다 썩음 (실측: 3세대 전 스키마의 103-row fork가 171-row 임베디드를 가려 fleet 부팅 게이트 전멸).
- capability 조회의 alias 의미론 이원화: binding registry 경로는 alias resolve, capability 경로(`lookup_for_provider`)는 raw 라벨만 비교 — 같은 config가 경로에 따라 다른 답.

## 변경 (RFC-OAS-036, 문서 포함)

1. `Model_catalog.merge ~base ~overlay` — row-level 병합. 키 = lookup이 쓰는 identity 그대로 (`(provider_name, id_prefix)` model row / `id` provider entry, lookup 정규화로 비교). overlay가 같은 키를 대체, 나머지는 양쪽 보존.
2. `set_global_overlay` — `global ()` 해석 순서: `set_global` 전체 교체(기존 의미 불변, 항상 우선) → embedded ⊕ overlay(캐시) → embedded. `clear_global`이 overlay/캐시도 리셋.
3. `lookup_for_provider` alias 정규화 — verbatim miss일 때만 `[[providers]]`의 id/aliases로 1회 정규화 후 재시도. verbatim row 우선, single-step. **임베디드 카탈로그에 aliases 선언 0건이라 기존 조회 결과 불변.**

## 검증

- 신규 `test/test_model_catalog_overlay.ml` 8 케이스 green (merge 키 의미론, bare/scoped 구분, provider entry 교체, global 조합, set_global 우선, clear 리셋, alias 해석, verbatim 우선).
- 기존 `test_model_catalog_default` 3/3, `test_capabilities` 100/100, `test_capabilities_wiring` 6/6 green.
- fmt clean. dune 빌드 전체는 CI에서 확인 예정.

## Consumer wiring (별도)

masc가 config-root `oas-models-overlay.toml`을 resolve해 `set_global_overlay` 호출하는 배선은 릴리즈+pin bump 후 masc PR (masc RFC-0342 D1). 그때 masc 배포의 full-fork `oas-models.toml`(WORKAROUND 라벨) 제거.

## Self-review 노트 (적대 검사)

- alias 중복 선언 시 선언 순서 첫 항목 승리 — mli에 명시. parse-time 중복 거부는 기존 카탈로그 호환성 확인 후 후속.
- overlay의 provider entry는 field-merge가 아니라 entry 교체 — mli에 명시.
- `set_global_overlay`의 연산 순서(overlay 설정→캐시 무효화)가 stale-cache 레이스 차단 방향.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>