### PR TITLE
test: stamp reasoning provenance on GLM replay fixtures (main red #2599)

### DIFF
--- a/test/test_snapshot_provider_serialization.ml
+++ b/test/test_snapshot_provider_serialization.ml
@@ -455,19 +455,37 @@ let raw_zai_openai_compat_cfg () =
     ()
 ;;
 
-let zai_glm_messages_with_reasoning =
+(* Provenance stamp mirroring the production response path:
+   [Complete_common.patch_telemetry] resolves the source with
+   [Reasoning_dialect.reasoning_source_for_provider_config] and
+   [Types.assistant_message_of_response] moves it onto the stored assistant
+   message metadata. A reasoning-bearing history message without this stamp is
+   unrepresentable through the production path, and
+   [Reasoning_history_projection] drops its reasoning fail-closed
+   (missing_source) before the replay policy is even consulted. *)
+let reasoning_source_metadata config =
+  match Reasoning_dialect.reasoning_source_for_provider_config config with
+  | Ok source -> Reasoning_source.metadata source
+  | Error detail -> Alcotest.fail detail
+;;
+
+let zai_glm_messages_with_reasoning ~config =
   [ msg User [ Text "solve" ]
-  ; msg
-      Assistant
-      [ Text "answer"; Thinking { signature = None; content = "chain of thought" } ]
+  ; { (msg
+         Assistant
+         [ Text "answer"; Thinking { signature = None; content = "chain of thought" } ])
+      with
+      metadata = reasoning_source_metadata config
+    }
   ]
 ;;
 
 let test_raw_openai_compat_does_not_infer_glm_thinking_or_replay () =
+  let config = raw_zai_openai_compat_cfg () in
   let body =
     Backend_openai_request.build_request
-      ~config:(raw_zai_openai_compat_cfg ())
-      ~messages:zai_glm_messages_with_reasoning
+      ~config
+      ~messages:(zai_glm_messages_with_reasoning ~config)
       ()
   in
   check
@@ -503,10 +521,11 @@ let native_glm_cfg ?(enable_thinking = Some true) ?preserve_thinking ?clear_thin
 ;;
 
 let test_native_glm_replays_reasoning_when_preserve_thinking () =
+  let config = native_glm_cfg ~preserve_thinking:true () in
   let body =
     Backend_openai_request.build_request
-      ~config:(native_glm_cfg ~preserve_thinking:true ())
-      ~messages:zai_glm_messages_with_reasoning
+      ~config
+      ~messages:(zai_glm_messages_with_reasoning ~config)
       ()
   in
   check_reasoning_content
@@ -516,10 +535,11 @@ let test_native_glm_replays_reasoning_when_preserve_thinking () =
 ;;
 
 let test_native_glm_drops_reasoning_by_default () =
+  let config = native_glm_cfg () in
   let body =
     Backend_openai_request.build_request
-      ~config:(native_glm_cfg ())
-      ~messages:zai_glm_messages_with_reasoning
+      ~config
+      ~messages:(zai_glm_messages_with_reasoning ~config)
       ()
   in
   check_reasoning_content
@@ -529,10 +549,11 @@ let test_native_glm_drops_reasoning_by_default () =
 ;;
 
 let test_native_glm_drops_reasoning_when_thinking_disabled () =
+  let config = native_glm_cfg ~enable_thinking:(Some false) ~preserve_thinking:true () in
   let body =
     Backend_openai_request.build_request
-      ~config:(native_glm_cfg ~enable_thinking:(Some false) ~preserve_thinking:true ())
-      ~messages:zai_glm_messages_with_reasoning
+      ~config
+      ~messages:(zai_glm_messages_with_reasoning ~config)
       ()
   in
   check_reasoning_content


### PR DESCRIPTION
## 목적

main CI red 해소 (#2599). `6f3648d61`(#2590 hard-cut) 이후 main red는 스냅샷 1건이 아니라 **같은 뿌리의 4건**:

- `test_snapshot_provider_serialization` openai #9 `native-glm replays reasoning when preserve_thinking`
- `backend_glm.ml:388` inline `build_request replays reasoning via typed dialect` (is false)
- `backend_glm.ml:439` inline `preserves ZAI GLM ... replay and tool content shape` (Type_error)
- `backend_openai.ml:1231` inline `glm build_request replays reasoning_content under preserved thinking` (Type_error)

(인라인 3건은 `dune runtest` 전체에서만 실행되어 이슈 #2599 본문에는 스냅샷만 기록되어 있었음)

## SSOT 판정 (#2599가 요구한 결정)

**픽스처가 stale, 카탈로그와 코드는 정확.** 근거 사슬(실측):

1. 4건 모두 실제 drop 사유는 `missing_source` — Thinking 블록은 있는데 `Reasoning_source` provenance metadata가 없는 assistant 메시지. replay policy 판정 **이전** 단계에서 fail-closed 드랍.
2. 이 상태는 production 경로에서 만들어질 수 없음: `Complete_common.patch_telemetry`가 source를 스탬프하고 `Types.assistant_message_of_response`(types.ml:785)는 reasoning이 있는데 source가 없으면 `Error` 반환.
3. GLM replay 게이트는 정상: typed `kind:Glm` + `clear_thinking` 조건으로 `Preserve_always`/`No_replay` 해석(reasoning_dialect.ml:439). substring 매칭 없음.
4. glm-5 카탈로그 row의 `reasoning_replay` 무선언도 올바름 — GLM replay는 request-local(`clear_thinking`) 조건부라 artifact identity에 실을 수 없고 dialect 경계에서 typed로 해석됨. 로그의 `replay_policy=[No_replay]`는 identity 계약 표기이지 실패 원인이 아님.

## 변경 (테스트 픽스처만, production 코드 변경 0)

- `test/test_snapshot_provider_serialization.ml` — 픽스처를 `~config` 함수로 전환, production과 동일한 resolver(`reasoning_source_for_provider_config`)로 provenance 스탬프. 4개 케이스 호출부 갱신.
- `lib/llm_provider/backend_glm.ml` ×2, `lib/llm_provider/backend_openai.ml` ×1 — 인라인 픽스처에 동일 스탬프.
- 부수 강화: 종전 negative 케이스들은 missing_source로 **공허하게** 통과했으나, 이제 replay-policy 게이트(`replay_policy_excluded`) 자체를 검증 (로컬 로그 실측: `replay_policy_excluded:1, missing_source:0`).

이슈의 금지 조건 준수: provider/model substring 매칭 복원 없음, compatibility fallback 없음.

## 검증 (로컬)

- `test_snapshot_provider_serialization` 20/20 (종전 main: openai #9 FAIL 실측 → green)
- `dune runtest lib/llm_provider` 인라인 전체 green (종전 CI: 2/26 + 1/95 FAIL)
- `test_provider_agnostic_reasoning_replay` 8/8, `test_thinking_control_dialects` 43/43
- fmt clean

미검증: full `dune runtest`는 CI에서.

Closes #2599

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
