### PR TITLE
test: stamp reasoning provenance on GLM inline replay fixtures (main red, remainder of #2599)

### DIFF
--- a/lib/llm_provider/backend_glm.ml
+++ b/lib/llm_provider/backend_glm.ml
@@ -398,25 +398,6 @@ let%test
      (clear_thinking=true) must not. Reverting the dialect resolution leaves the
      GLM dialect at the dead [No_replay] default and turns the [preserved] case
      red. *)
-  let messages =
-    [ { role = Assistant
-      ; content =
-          [ Thinking { content = "prior reasoning"; signature = None }; Text "answer" ]
-      ; name = None
-      ; tool_call_id = None
-      ; metadata = []
-      }
-    ]
-  in
-  let replays config =
-    let body = build_request ~config ~messages () in
-    let open Yojson.Safe.Util in
-    Yojson.Safe.from_string body
-    |> member "messages"
-    |> to_list
-    |> List.exists (fun m ->
-      m |> member "reasoning_content" |> to_string_option = Some "prior reasoning")
-  in
   let preserved =
     Provider_config.make
       ~kind:Glm
@@ -433,6 +414,34 @@ let%test
       ~base_url:Zai_catalog.coding_base_url
       ()
   in
+  (* Provenance stamp mirroring the production response path; the projection
+     drops unstamped reasoning fail-closed (missing_source) before the replay
+     policy is consulted. The source identity is request-knob independent, so
+     one stamp is valid for both configs. *)
+  let metadata =
+    match Reasoning_dialect.reasoning_source_for_provider_config preserved with
+    | Ok source -> Reasoning_source.metadata source
+    | Error detail -> failwith detail
+  in
+  let messages =
+    [ { role = Assistant
+      ; content =
+          [ Thinking { content = "prior reasoning"; signature = None }; Text "answer" ]
+      ; name = None
+      ; tool_call_id = None
+      ; metadata
+      }
+    ]
+  in
+  let replays config =
+    let body = build_request ~config ~messages () in
+    let open Yojson.Safe.Util in
+    Yojson.Safe.from_string body
+    |> member "messages"
+    |> to_list
+    |> List.exists (fun m ->
+      m |> member "reasoning_content" |> to_string_option = Some "prior reasoning")
+  in
   replays preserved && not (replays default_config)
 ;;
 
@@ -447,6 +456,11 @@ let%test "build_request preserves ZAI GLM OpenAI-compatible replay and tool cont
       ~preserve_thinking:true
       ()
   in
+  let metadata =
+    match Reasoning_dialect.reasoning_source_for_provider_config config with
+    | Ok source -> Reasoning_source.metadata source
+    | Error detail -> failwith detail
+  in
   let messages =
     [ { role = Assistant
       ; content =
@@ -456,7 +470,7 @@ let%test "build_request preserves ZAI GLM OpenAI-compatible replay and tool cont
           ]
       ; name = None
       ; tool_call_id = None
-      ; metadata = []
+      ; metadata
       }
     ]
   in

--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -1241,6 +1241,11 @@ let%test
       ~preserve_thinking:true
       ()
   in
+  let metadata =
+    match Reasoning_dialect.reasoning_source_for_provider_config config with
+    | Ok source -> Reasoning_source.metadata source
+    | Error detail -> failwith detail
+  in
   let messages =
     [ { role = Assistant
       ; content =
@@ -1250,7 +1255,7 @@ let%test
           ]
       ; name = None
       ; tool_call_id = None
-      ; metadata = []
+      ; metadata
       }
     ]
   in


### PR DESCRIPTION
## 목적

main red **잔여분** 해소. #2605는 4형제 실패 중 스냅샷 1건만 담긴 시점(2253312e2)에 머지되어, 같은 뿌리의 **인라인 테스트 3건**이 main에 남아 있음:

- `backend_glm.ml:388` `build_request replays reasoning via typed dialect` (is false)
- `backend_glm.ml:439` `preserves ZAI GLM ... replay and tool content shape` (Type_error: Expected string, got null)
- `backend_openai.ml:1231` `glm build_request replays reasoning_content under preserved thinking` (Type_error)

이 커밋은 #2605 브랜치에 머지 후 push되어 고아가 된 `eb3d7aaef`의 cherry-pick (fresh main 기준 재발의, 병합된 브랜치 재사용 금지 규칙).

## 원인/판정 (#2605와 동일)

세 픽스처 모두 provenance(`Reasoning_source` metadata) 없는 Thinking 메시지 — production 경로에서 만들어질 수 없는 상태(`assistant_message_of_response` fail-closed). projection이 replay policy 판정 전에 `missing_source`로 드랍. 카탈로그/코드 정상, 픽스처만 stale.

## 변경

인라인 픽스처 3곳에 production과 동일 resolver(`reasoning_source_for_provider_config`)로 스탬프. dialect 테스트의 negative arm은 이제 `replay_policy_excluded`(typed 게이트)를 실검증 (로컬 로그: `replay_policy_excluded:1, missing_source:0`).

## 검증 (로컬)

- `dune runtest lib/llm_provider` green (종전 CI: 2/26 + 1/95 FAIL)
- fmt clean

주의: CI `dune runtest`는 fail-fast라 이 3건 뒤에 가려진 실패가 더 있을 수 있음 — 이 PR의 CI가 첫 전체 노출임.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
