### PR TITLE
fix(provider): keep one sync timeout boundary

### DIFF
--- a/lib/llm_provider/complete.mli
+++ b/lib/llm_provider/complete.mli
@@ -90,8 +90,8 @@ val complete
     (AcceptRejected _)] even when a cached response exists.
 
     With no injected [transport], the built-in HTTP path owns the single
-    deadline around [Http_client.post_sync]; [complete] does not add a second
-    timeout. With an injected [transport], [complete] applies the resolved
+    deadline around [Http_client.post_sync]; [config.connect_timeout_s] is not
+    added as a nested sync deadline. With an injected [transport], [complete] applies the resolved
     deadline around [Llm_transport.t.complete_sync]. On expiry the result is
     [Error (TimeoutError { phase = Non_streaming_body; _ })] with a
     message that identifies the body deadline. The typed failure is returned
@@ -143,17 +143,14 @@ val complete
     [ProviderFailure { kind = Empty_completion { stop_reason } }] for built-in
     HTTP and injected transports alike.
 
-    [clock] and [stream_idle_timeout_s] together bound two streaming
-    stalls on every HTTP streaming path: inter-line idle, and
-    thinking-only generation before the first deliverable text/tool
-    signal. The line-idle deadline covers Ollama native NDJSON
+    [clock] and [stream_idle_timeout_s] bound inter-line stalls on every HTTP
+    streaming path. The idle deadline covers Ollama native NDJSON
     (see {!Http_client.read_ndjson}) and the SSE format used by
     Anthropic, OpenAI-compatible, Gemini, and Glm
     (see {!Http_client.read_sse}). The deadline resets after each
-    successful line. The thinking-only guard does not reset on hidden
-    reasoning deltas; it is cleared by text or tool-call progress.
-    Together these do not cap total stream duration after answer/tool
-    progress has started.
+    successful line. Thinking, answer, tool-call, heartbeat, substrate, and
+    terminal lines are all liveness; there is no thinking-only or total stream
+    wall-clock cutoff.
     SSE keepalive comments reset the deadline like any other line.
     A stalled endpoint surfaces as
     [TimeoutError { phase = Stream_idle state; _ }], where [state]

--- a/lib/llm_provider/complete_sync.ml
+++ b/lib/llm_provider/complete_sync.ml
@@ -151,7 +151,6 @@ let complete_http
             ~url
             ~headers:(config.headers @ Provider_config.auth_headers_for_config config)
             ~body:body_str
-            ?timeout_s:config.connect_timeout_s
             ()
         in
         (* Body-level deadline (since 0.195.0): wraps the entire

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -1211,6 +1211,40 @@ let read_http_request flow =
   if content_length > 0 then ignore (Eio.Buf_read.take content_length reader : string)
 ;;
 
+let start_raw_sync_server ~sw ~net ~clock ~body_delay_sec response_body =
+  let port = fresh_port () in
+  let socket =
+    Eio.Net.listen
+      net
+      ~sw
+      ~backlog:8
+      ~reuse_addr:true
+      (`Tcp (Eio.Net.Ipaddr.V4.loopback, port))
+  in
+  Eio.Fiber.fork ~sw (fun () ->
+    Eio.Net.accept_fork
+      ~sw
+      socket
+      ~on_error:(fun _ -> ())
+      (fun flow _addr ->
+         try
+           read_http_request flow;
+           Eio.Flow.copy_string
+             (Printf.sprintf
+                "HTTP/1.1 200 OK\r\n\
+                 Content-Type: application/json\r\n\
+                 Content-Length: %d\r\n\
+                 Connection: close\r\n\
+                 \r\n"
+                (String.length response_body))
+             flow;
+           Eio.Time.sleep clock body_delay_sec;
+           Eio.Flow.copy_string response_body flow
+         with
+         | _ -> ()));
+  Printf.sprintf "http://127.0.0.1:%d" port
+;;
+
 let start_raw_sse_server ~sw ~net ~clock delayed_frames =
   let port = fresh_port () in
   let socket =
@@ -2109,6 +2143,38 @@ let test_complete_body_timeout_does_not_fire_on_fast_response () =
   | Exit -> ()
 ;;
 
+let test_complete_sync_uses_only_outer_body_timeout () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let url =
+      start_raw_sync_server
+        ~sw
+        ~net:env#net
+        ~clock:env#clock
+        ~body_delay_sec:0.08
+        (anthropic_response "slow body")
+    in
+    let config = { (make_config url) with connect_timeout_s = Some 0.02 } in
+    (match
+       Complete.complete
+         ~sw
+         ~net:env#net
+         ~clock:env#clock
+         ~config
+         ~messages
+         ~body_timeout_s:0.5
+         ()
+     with
+     | Ok response -> check string "body" "slow body" (text_of_response response)
+     | Error _ -> fail "nested connect timeout incorrectly capped sync body");
+    Eio.Switch.fail sw Exit
+  with
+  | Exit -> ()
+;;
+
 let test_complete_body_timeout_without_clock_rejected_before_request () =
   Eio_main.run
   @@ fun env ->
@@ -2617,6 +2683,10 @@ let () =
             "body_timeout_s no-op on fast response"
             `Quick
             test_complete_body_timeout_does_not_fire_on_fast_response
+        ; test_case
+            "sync uses only outer body timeout"
+            `Quick
+            test_complete_sync_uses_only_outer_body_timeout
         ; test_case
             "body_timeout_s without clock rejects before request"
             `Quick


### PR DESCRIPTION
## Summary
- remove the nested sync connect timeout from Complete
- keep body_timeout_s as the single non-streaming Provider deadline
- document streaming thinking/tool/heartbeat events as liveness, not wall-clock cutoff
- add regression coverage for a slow body that outlives connect_timeout_s

## Verification
- OCaml parser check on modified .ml files
- git diff --check
- full Dune build/test delegated to PR CI by operator request