### PR TITLE
fix(reasoning): scope Qwen replay to latest user turn

### DIFF
--- a/docs/capability-manifest.md
+++ b/docs/capability-manifest.md
@@ -109,7 +109,7 @@ for the full JSON Schema (draft-07).
 | `thinking_control_token` | string | absent | Exact chat-template token used when `thinking_control_format = "chat_template_token"`; blank values and leading/trailing whitespace are rejected. |
 | `preserve_thinking_control_format` | string | from base | Historical reasoning replay/preserve wire control. Accepted values: `none`, `thinking_object_keep_all`, `chat_template_kwargs_preserve_thinking`, `top_level_preserve_thinking`, `always_preserved`. |
 | `reasoning_output_format` | string | from base | Request-side reasoning output split control. Accepted values: `none`, `split_reasoning_fields`. |
-| `reasoning_replay` | string | `default` | Optional multi-turn reasoning replay override. Accepted values: `default`, `no_replay`, `drop_without_tool`, `preserve_always`. |
+| `reasoning_replay` | string | `default` | Optional multi-turn reasoning replay override. Accepted values: `default`, `no_replay`, `drop_without_tool`, `latest_user_turn_tool_calls`, `preserve_always`. |
 
 Unknown fields and unknown enum values are rejected. Additive schema changes
 must update the parser and this schema together.

--- a/docs/schemas/capability-manifest-v1.json
+++ b/docs/schemas/capability-manifest-v1.json
@@ -231,6 +231,7 @@
             "default",
             "no_replay",
             "drop_without_tool",
+            "latest_user_turn_tool_calls",
             "preserve_always"
           ]
         }

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -52,6 +52,8 @@ type reasoning_replay_override = Capability_vocab.reasoning_replay_override =
   | Default_reasoning_replay
   | Force_no_replay
   | Force_drop_without_tool_preserve_with_tool
+  | Force_latest_user_turn_tool_calls
+  (** Replay tool-call reasoning only inside the structurally latest user turn. *)
   | Force_preserve_always
 
 type assistant_tool_content_format = Capability_vocab.assistant_tool_content_format =
@@ -1080,6 +1082,8 @@ let%test "reasoning_replay_override_of_catalog_string parses vocabulary" =
   = Some Force_preserve_always
   && reasoning_replay_override_of_catalog_string "drop_without_tool"
      = Some Force_drop_without_tool_preserve_with_tool
+  && reasoning_replay_override_of_catalog_string "latest_user_turn_tool_calls"
+     = Some Force_latest_user_turn_tool_calls
   && reasoning_replay_override_of_catalog_string "no_replay" = Some Force_no_replay
   && reasoning_replay_override_of_catalog_string "" = Some Default_reasoning_replay
   && reasoning_replay_override_of_catalog_string "bogus" = None

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -34,6 +34,8 @@ type reasoning_replay_override = Capability_vocab.reasoning_replay_override =
   | Default_reasoning_replay
   | Force_no_replay
   | Force_drop_without_tool_preserve_with_tool
+  | Force_latest_user_turn_tool_calls
+  (** Replay tool-call reasoning only inside the structurally latest user turn. *)
   | Force_preserve_always
 
 type assistant_tool_content_format = Capability_vocab.assistant_tool_content_format =

--- a/lib/llm_provider/capability_vocab.ml
+++ b/lib/llm_provider/capability_vocab.ml
@@ -32,6 +32,7 @@ type reasoning_replay_override =
   | Default_reasoning_replay
   | Force_no_replay
   | Force_drop_without_tool_preserve_with_tool
+  | Force_latest_user_turn_tool_calls
   | Force_preserve_always
 
 type assistant_tool_content_format =
@@ -301,6 +302,7 @@ let reasoning_replay_table =
   ; "no_replay", Force_no_replay
   ; "drop_without_tool", Force_drop_without_tool_preserve_with_tool
   ; "drop_without_tool_preserve_with_tool", Force_drop_without_tool_preserve_with_tool
+  ; "latest_user_turn_tool_calls", Force_latest_user_turn_tool_calls
   ; "preserve_always", Force_preserve_always
   ]
 ;;

--- a/lib/llm_provider/reasoning_dialect.ml
+++ b/lib/llm_provider/reasoning_dialect.ml
@@ -30,6 +30,7 @@ type sampling_policy =
 type replay_policy =
   | No_replay
   | Drop_without_tool_preserve_with_tool
+  | Latest_user_turn_tool_calls
   | Preserve_always
   | Provider_hidden_replay
 
@@ -190,6 +191,8 @@ let apply_replay_override caps dialect =
   | Force_no_replay -> { dialect with replay_policy = No_replay }
   | Force_drop_without_tool_preserve_with_tool ->
     { dialect with replay_policy = Drop_without_tool_preserve_with_tool }
+  | Force_latest_user_turn_tool_calls ->
+    { dialect with replay_policy = Latest_user_turn_tool_calls }
   | Force_preserve_always -> { dialect with replay_policy = Preserve_always }
 ;;
 
@@ -472,6 +475,7 @@ let replay_contract dialect : Reasoning_replay_contract.t =
     match dialect.replay_policy with
     | No_replay -> Reasoning_replay_contract.No_replay
     | Drop_without_tool_preserve_with_tool -> Tool_call_assistant_messages_all_history
+    | Latest_user_turn_tool_calls -> Tool_call_assistant_messages_latest_user_turn
     | Preserve_always -> All_assistant_messages
     | Provider_hidden_replay -> Provider_opaque_state
   in
@@ -561,7 +565,8 @@ let should_replay_reasoning dialect ~assistant_had_tool_call =
   match dialect.replay_policy with
   | No_replay | Provider_hidden_replay -> false
   | Preserve_always -> true
-  | Drop_without_tool_preserve_with_tool -> assistant_had_tool_call
+  | Drop_without_tool_preserve_with_tool | Latest_user_turn_tool_calls ->
+    assistant_had_tool_call
 ;;
 
 let requires_reasoning_replay_on_tool_call dialect =
@@ -587,6 +592,7 @@ let toggle_wire_to_string = function
 let replay_policy_to_string = function
   | No_replay -> "no_replay"
   | Drop_without_tool_preserve_with_tool -> "drop_without_tool_preserve_with_tool"
+  | Latest_user_turn_tool_calls -> "latest_user_turn_tool_calls"
   | Preserve_always -> "preserve_always"
   | Provider_hidden_replay -> "provider_hidden_replay"
 ;;
@@ -619,6 +625,20 @@ let%test "reasoning_replay_override drop_without_tool replays only on tool turns
   let dialect = of_capabilities caps in
   (not (should_replay_reasoning dialect ~assistant_had_tool_call:false))
   && should_replay_reasoning dialect ~assistant_had_tool_call:true
+;;
+
+let%test "reasoning_replay_override latest_user_turn stays structurally distinct" =
+  let caps =
+    { Capabilities.default_capabilities with
+      supports_reasoning = true
+    ; thinking_control_format = Capabilities.Chat_template_kwargs
+    ; reasoning_replay_override = Capabilities.Force_latest_user_turn_tool_calls
+    }
+  in
+  let dialect = of_capabilities caps in
+  replay_policy_to_string dialect.replay_policy = "latest_user_turn_tool_calls"
+  && should_replay_reasoning dialect ~assistant_had_tool_call:true
+  && not (should_replay_reasoning dialect ~assistant_had_tool_call:false)
 ;;
 
 let%test

--- a/lib/llm_provider/reasoning_dialect.mli
+++ b/lib/llm_provider/reasoning_dialect.mli
@@ -40,6 +40,7 @@ type sampling_policy =
 type replay_policy =
   | No_replay
   | Drop_without_tool_preserve_with_tool
+  | Latest_user_turn_tool_calls
   | Preserve_always
   | Provider_hidden_replay
 
@@ -139,9 +140,11 @@ val sampling_field_ignored_when_thinking
   -> bool
 
 (** Whether an assistant reasoning side-channel should be replayed into a
-    subsequent request. [assistant_had_tool_call] is intentionally explicit:
-    DeepSeek-style thinking requires replay after tool calls but can drop
-    reasoning between plain user turns. *)
+    subsequent request based on message shape. [assistant_had_tool_call] is
+    intentionally explicit: DeepSeek-style thinking requires replay after tool
+    calls but can drop reasoning between plain user turns. Position-sensitive
+    policies are finalized by {!Reasoning_history_projection} from the typed
+    {!replay_contract}; this function reports only shape eligibility. *)
 val should_replay_reasoning : t -> assistant_had_tool_call:bool -> bool
 
 val requires_reasoning_replay_on_tool_call : t -> bool

--- a/lib/llm_provider/reasoning_history_projection.ml
+++ b/lib/llm_provider/reasoning_history_projection.ml
@@ -197,8 +197,8 @@ let replay_selected
     assistant_had_tool_call
     &&
       (match latest_user_message_index with
-       | Some user_message_index -> message_index > user_message_index
-       | None -> false)
+      | Some user_message_index -> message_index > user_message_index
+      | None -> false)
 ;;
 
 let project

--- a/lib/llm_provider/reasoning_history_projection.ml
+++ b/lib/llm_provider/reasoning_history_projection.ml
@@ -173,11 +173,32 @@ let validate_supported_reasoning ~reasoning_block_supported ~message_index conte
     Error (Unsupported_reasoning_block { message_index; block_index; block_kind })
 ;;
 
-let replay_selected replay_policy ~assistant_had_tool_call =
+let find_latest_user_message_index classified_messages =
+  List.fold_left
+    (fun latest (message_index, (message : Types.message), _) ->
+       match message.role with
+       | User -> Some message_index
+       | System | Assistant | Tool -> latest)
+    None
+    classified_messages
+;;
+
+let replay_selected
+      replay_policy
+      ~assistant_had_tool_call
+      ~message_index
+      ~latest_user_message_index
+  =
   match replay_policy with
   | Reasoning_replay_contract.No_replay | Provider_opaque_state -> false
   | All_assistant_messages -> true
   | Tool_call_assistant_messages_all_history -> assistant_had_tool_call
+  | Tool_call_assistant_messages_latest_user_turn ->
+    assistant_had_tool_call
+    &&
+      (match latest_user_message_index with
+       | Some user_message_index -> message_index > user_message_index
+       | None -> false)
 ;;
 
 let project
@@ -190,6 +211,7 @@ let project
   match validate_and_classify messages with
   | Error _ as error -> error
   | Ok classified_messages ->
+    let latest_user_message_index = find_latest_user_message_index classified_messages in
     let rec loop projected replay_drops removed_empty = function
       | [] ->
         Ok
@@ -237,6 +259,8 @@ let project
                  replay_selected
                    replay_policy
                    ~assistant_had_tool_call:(content_has_tool_use message.content)
+                   ~message_index
+                   ~latest_user_message_index
                then
                  Result.map
                    (fun content -> content, None)

--- a/lib/llm_provider/reasoning_replay_contract.ml
+++ b/lib/llm_provider/reasoning_replay_contract.ml
@@ -1,6 +1,7 @@
 type replay_policy =
   | No_replay
   | Tool_call_assistant_messages_all_history
+  | Tool_call_assistant_messages_latest_user_turn
   | All_assistant_messages
   | Provider_opaque_state
 [@@deriving show, eq, yojson]

--- a/lib/llm_provider/reasoning_replay_contract.mli
+++ b/lib/llm_provider/reasoning_replay_contract.mli
@@ -7,6 +7,9 @@
 type replay_policy =
   | No_replay
   | Tool_call_assistant_messages_all_history
+  | Tool_call_assistant_messages_latest_user_turn
+  (** Replay reasoning only from assistant tool-call messages that occur after
+      the structurally latest [User] role. With no [User] role, replay none. *)
   | All_assistant_messages
   | Provider_opaque_state
 [@@deriving show, eq, yojson]

--- a/lib/provider.mli
+++ b/lib/provider.mli
@@ -76,6 +76,7 @@ type reasoning_replay_override = Llm_provider.Capabilities.reasoning_replay_over
   | Default_reasoning_replay
   | Force_no_replay
   | Force_drop_without_tool_preserve_with_tool
+  | Force_latest_user_turn_tool_calls
   | Force_preserve_always
 
 type assistant_tool_content_format =

--- a/models.toml
+++ b/models.toml
@@ -2011,7 +2011,7 @@ supports_extended_thinking = true
 thinking_control_format = "chat_template_kwargs"
 preserve_thinking_control_format = "chat_template_kwargs_preserve_thinking"
 reasoning_streaming_format = "delta:reasoning_content"
-reasoning_replay = "drop_without_tool_preserve_with_tool"
+reasoning_replay = "latest_user_turn_tool_calls"
 supports_response_format_json = true
 supports_structured_output = true
 supports_native_streaming = true
@@ -2040,7 +2040,7 @@ supports_reasoning_budget = true
 thinking_control_format = "chat_template_kwargs"
 preserve_thinking_control_format = "chat_template_kwargs_preserve_thinking"
 reasoning_streaming_format = "delta:reasoning_content"
-reasoning_replay = "drop_without_tool_preserve_with_tool"
+reasoning_replay = "latest_user_turn_tool_calls"
 supports_native_streaming = true
 
 [[models]]
@@ -2056,7 +2056,7 @@ supports_reasoning_budget = true
 thinking_control_format = "chat_template_kwargs"
 preserve_thinking_control_format = "chat_template_kwargs_preserve_thinking"
 reasoning_streaming_format = "delta:reasoning_content"
-reasoning_replay = "drop_without_tool_preserve_with_tool"
+reasoning_replay = "latest_user_turn_tool_calls"
 supports_native_streaming = true
 
 # Llama Models

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -509,9 +509,23 @@ let test_lookup_provider_m_qwen3_mtp_explicit_provider () =
        fail "vllm-qwen3-mtp should stream reasoning_content as a typed delta field");
     check
       string
-      "vllm-qwen3-mtp replays tool-call reasoning by default"
-      "drop_without_tool_preserve_with_tool"
-      (Reasoning_dialect.replay_policy_to_string dialect.replay_policy)
+      "vllm-qwen3-mtp scopes tool-call reasoning to the latest user turn"
+      "latest_user_turn_tool_calls"
+      (Reasoning_dialect.replay_policy_to_string dialect.replay_policy);
+    check
+      bool
+      "catalog resolves the closed latest-user replay policy"
+      true
+      (c.reasoning_replay_override = Capabilities.Force_latest_user_turn_tool_calls);
+    (match Capabilities.for_model_id "qwen36-35b-a3b-mtp" with
+     | Some bare ->
+       check
+         bool
+         "bare runtime row resolves the same latest-user replay policy"
+         true
+         (bare.reasoning_replay_override
+          = Capabilities.Force_latest_user_turn_tool_calls)
+     | None -> fail "bare qwen3.6 runtime row should resolve")
   | None -> fail "explicit provider/model lookup should match qwen3.6 model id"
 ;;
 
@@ -1082,6 +1096,7 @@ type structured_contract =
 type replay_contract =
   | Replay_not_required
   | Replay_tool_turn_only
+  | Replay_latest_user_tool_turn_only
   | Replay_every_turn
 
 type streaming_contract =
@@ -1217,6 +1232,29 @@ let check_frontier_model
          (label ^ " requires replay only on tool call")
          true
          (Reasoning_dialect.requires_reasoning_replay_on_tool_call dialect)
+     | Replay_latest_user_tool_turn_only ->
+       check
+         string
+         (label ^ " replay policy")
+         "latest_user_turn_tool_calls"
+         (Reasoning_dialect.replay_policy_to_string dialect.replay_policy);
+       check
+         bool
+         (label ^ " drops plain-turn reasoning")
+         false
+         (Reasoning_dialect.should_replay_reasoning
+            dialect
+            ~assistant_had_tool_call:false);
+       check
+         bool
+         (label ^ " preserves a selected tool-call reasoning artifact")
+         true
+         (Reasoning_dialect.should_replay_reasoning dialect ~assistant_had_tool_call:true);
+       check
+         bool
+         (label ^ " requires replay only on a selected tool call")
+         true
+         (Reasoning_dialect.requires_reasoning_replay_on_tool_call dialect)
      | Replay_every_turn ->
        check
          string
@@ -1344,7 +1382,7 @@ let test_frontier_grouped_tool_thinking_provider_contracts () =
       , "qwen/qwen3.6-35b-a3b"
       , Extended_thinking
       , Response_format_json_schema
-      , Replay_tool_turn_only
+      , Replay_latest_user_tool_turn_only
       , Delta_stream "reasoning_content" )
     ; ( "Ollama Cloud Qwen3.5"
       , Provider_qualified "ollama_cloud"

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -523,8 +523,7 @@ let test_lookup_provider_m_qwen3_mtp_explicit_provider () =
          bool
          "bare runtime row resolves the same latest-user replay policy"
          true
-         (bare.reasoning_replay_override
-          = Capabilities.Force_latest_user_turn_tool_calls)
+         (bare.reasoning_replay_override = Capabilities.Force_latest_user_turn_tool_calls)
      | None -> fail "bare qwen3.6 runtime row should resolve")
   | None -> fail "explicit provider/model lookup should match qwen3.6 model id"
 ;;

--- a/test/test_provider_agnostic_reasoning_replay.ml
+++ b/test/test_provider_agnostic_reasoning_replay.ml
@@ -58,8 +58,14 @@ let content_has_reasoning =
 let content_has_tool_use =
   List.exists (function
     | ToolUse _ -> true
-    | Text _ | Thinking _ | ReasoningDetails _ | RedactedThinking _ | ToolResult _
-    | Image _ | Document _ | Audio _ -> false)
+    | Text _
+    | Thinking _
+    | ReasoningDetails _
+    | RedactedThinking _
+    | ToolResult _
+    | Image _
+    | Document _
+    | Audio _ -> false)
 ;;
 
 let tool_result tool_use_id =
@@ -183,15 +189,26 @@ let test_latest_user_turn_policy_keeps_only_current_tool_reasoning () =
     ; message Tool [ tool_result "current-call" ]
     ]
   in
-  match project ~target ~policy:Tool_call_assistant_messages_latest_user_turn messages with
+  match
+    project ~target ~policy:Tool_call_assistant_messages_latest_user_turn messages
+  with
   | Error error -> Alcotest.fail (Reasoning_history_projection.error_to_string error)
   | Ok projection ->
-    check_int "message and tool-result history is lossless" 6 (List.length projection.messages);
-    check_int "only the older reasoning artifact is dropped" 1 (List.length projection.reasoning_replay_drops);
+    check_int
+      "message and tool-result history is lossless"
+      6
+      (List.length projection.messages);
+    check_int
+      "only the older reasoning artifact is dropped"
+      1
+      (List.length projection.reasoning_replay_drops);
     let old_assistant = List.nth projection.messages 1 in
     let current_assistant = List.nth projection.messages 4 in
     check_bool "old tool call remains" true (content_has_tool_use old_assistant.content);
-    check_bool "old reasoning is removed" false (content_has_reasoning old_assistant.content);
+    check_bool
+      "old reasoning is removed"
+      false
+      (content_has_reasoning old_assistant.content);
     check_bool
       "current tool reasoning remains"
       true
@@ -210,12 +227,17 @@ let test_latest_user_turn_policy_without_user_replays_none () =
     ; message Tool [ tool_result "call" ]
     ]
   in
-  match project ~target ~policy:Tool_call_assistant_messages_latest_user_turn messages with
+  match
+    project ~target ~policy:Tool_call_assistant_messages_latest_user_turn messages
+  with
   | Error error -> Alcotest.fail (Reasoning_history_projection.error_to_string error)
   | Ok projection ->
     let assistant = List.hd projection.messages in
     check_bool "tool call remains" true (content_has_tool_use assistant.content);
-    check_bool "unscoped reasoning is removed" false (content_has_reasoning assistant.content)
+    check_bool
+      "unscoped reasoning is removed"
+      false
+      (content_has_reasoning assistant.content)
 ;;
 
 let test_selected_unsupported_block_fails_closed () =
@@ -298,8 +320,7 @@ let test_explicit_preserve_promotes_latest_user_policy_to_full_history () =
   check_bool
     "explicit preserve selects all assistant messages"
     true
-    ((Reasoning_dialect.replay_contract dialect).replay_policy
-     = All_assistant_messages);
+    ((Reasoning_dialect.replay_contract dialect).replay_policy = All_assistant_messages);
   let messages =
     [ message User [ Text "first request" ]
     ; with_source

--- a/test/test_provider_agnostic_reasoning_replay.ml
+++ b/test/test_provider_agnostic_reasoning_replay.ml
@@ -55,6 +55,23 @@ let content_has_reasoning =
     | Text _ | ToolUse _ | ToolResult _ | Image _ | Document _ | Audio _ -> false)
 ;;
 
+let content_has_tool_use =
+  List.exists (function
+    | ToolUse _ -> true
+    | Text _ | Thinking _ | ReasoningDetails _ | RedactedThinking _ | ToolResult _
+    | Image _ | Document _ | Audio _ -> false)
+;;
+
+let tool_result tool_use_id =
+  ToolResult
+    { tool_use_id
+    ; content = "ok"
+    ; outcome = Tool_succeeded
+    ; json = None
+    ; content_blocks = None
+    }
+;;
+
 let test_source_exactness_and_classification () =
   let left = source All_assistant_messages in
   let same = source All_assistant_messages in
@@ -145,6 +162,62 @@ let test_tool_call_policy_applies_across_history () =
       (content_has_reasoning last.content)
 ;;
 
+let test_latest_user_turn_policy_keeps_only_current_tool_reasoning () =
+  let target = source Tool_call_assistant_messages_latest_user_turn in
+  let messages =
+    [ message User [ Text "first request" ]
+    ; with_source
+        target
+        Assistant
+        [ Thinking { content = "old tool reasoning"; signature = None }
+        ; ToolUse { id = "old-call"; name = "lookup"; input = `Assoc [] }
+        ]
+    ; message Tool [ tool_result "old-call" ]
+    ; message User [ Text "current request" ]
+    ; with_source
+        target
+        Assistant
+        [ Thinking { content = "current tool reasoning"; signature = None }
+        ; ToolUse { id = "current-call"; name = "inspect"; input = `Assoc [] }
+        ]
+    ; message Tool [ tool_result "current-call" ]
+    ]
+  in
+  match project ~target ~policy:Tool_call_assistant_messages_latest_user_turn messages with
+  | Error error -> Alcotest.fail (Reasoning_history_projection.error_to_string error)
+  | Ok projection ->
+    check_int "message and tool-result history is lossless" 6 (List.length projection.messages);
+    check_int "only the older reasoning artifact is dropped" 1 (List.length projection.reasoning_replay_drops);
+    let old_assistant = List.nth projection.messages 1 in
+    let current_assistant = List.nth projection.messages 4 in
+    check_bool "old tool call remains" true (content_has_tool_use old_assistant.content);
+    check_bool "old reasoning is removed" false (content_has_reasoning old_assistant.content);
+    check_bool
+      "current tool reasoning remains"
+      true
+      (content_has_reasoning current_assistant.content)
+;;
+
+let test_latest_user_turn_policy_without_user_replays_none () =
+  let target = source Tool_call_assistant_messages_latest_user_turn in
+  let messages =
+    [ with_source
+        target
+        Assistant
+        [ Thinking { content = "unscoped reasoning"; signature = None }
+        ; ToolUse { id = "call"; name = "lookup"; input = `Assoc [] }
+        ]
+    ; message Tool [ tool_result "call" ]
+    ]
+  in
+  match project ~target ~policy:Tool_call_assistant_messages_latest_user_turn messages with
+  | Error error -> Alcotest.fail (Reasoning_history_projection.error_to_string error)
+  | Ok projection ->
+    let assistant = List.hd projection.messages in
+    check_bool "tool call remains" true (content_has_tool_use assistant.content);
+    check_bool "unscoped reasoning is removed" false (content_has_reasoning assistant.content)
+;;
+
 let test_selected_unsupported_block_fails_closed () =
   let target = source All_assistant_messages in
   let result =
@@ -195,10 +268,64 @@ let preserving_capabilities =
   }
 ;;
 
+let latest_user_turn_capabilities =
+  { Capabilities.default_capabilities with
+    supports_reasoning = true
+  ; thinking_control_format = Chat_template_kwargs
+  ; preserve_thinking_control_format = Chat_template_kwargs_preserve_thinking
+  ; reasoning_replay_override = Force_latest_user_turn_tool_calls
+  }
+;;
+
 let source_for_config config =
   match Reasoning_dialect.reasoning_source_for_provider_config config with
   | Ok source -> source
   | Error detail -> Alcotest.fail detail
+;;
+
+let test_explicit_preserve_promotes_latest_user_policy_to_full_history () =
+  let config =
+    Provider_config.make
+      ~kind:OpenAI_compat
+      ~model_id:"model-a"
+      ~base_url:"https://provider.example"
+      ~model_capabilities_override:latest_user_turn_capabilities
+      ~preserve_thinking:true
+      ()
+  in
+  let source = source_for_config config in
+  let dialect = Reasoning_dialect.for_provider_config config in
+  check_bool
+    "explicit preserve selects all assistant messages"
+    true
+    ((Reasoning_dialect.replay_contract dialect).replay_policy
+     = All_assistant_messages);
+  let messages =
+    [ message User [ Text "first request" ]
+    ; with_source
+        source
+        Assistant
+        [ Thinking { content = "old tool reasoning"; signature = None }
+        ; ToolUse { id = "old-call"; name = "lookup"; input = `Assoc [] }
+        ]
+    ; message Tool [ tool_result "old-call" ]
+    ; message User [ Text "current request" ]
+    ]
+  in
+  match
+    Reasoning_history_projection.project_for_provider_config
+      ~assistant_has_payload:(fun content -> content <> [])
+      ~reasoning_block_supported:reasoning_supported
+      config
+      messages
+  with
+  | Error error -> Alcotest.fail (Reasoning_history_projection.error_to_string error)
+  | Ok projection ->
+    let old_assistant = List.nth projection.messages 1 in
+    check_bool
+      "explicit preserve retains prior-turn reasoning"
+      true
+      (content_has_reasoning old_assistant.content)
 ;;
 
 let test_openai_chat_request_uses_whole_history_projection () =
@@ -310,7 +437,7 @@ let test_openai_responses_replays_only_opaque_item () =
 let () =
   Alcotest.run
     "provider_agnostic_reasoning_replay"
-    [ ( "typed whole-history replay"
+    [ ( "typed replay projection"
       , [ Alcotest.test_case
             "source exactness"
             `Quick
@@ -323,6 +450,18 @@ let () =
             "tool-call policy"
             `Quick
             test_tool_call_policy_applies_across_history
+        ; Alcotest.test_case
+            "latest user turn policy"
+            `Quick
+            test_latest_user_turn_policy_keeps_only_current_tool_reasoning
+        ; Alcotest.test_case
+            "latest user turn policy requires a user boundary"
+            `Quick
+            test_latest_user_turn_policy_without_user_replays_none
+        ; Alcotest.test_case
+            "explicit preserve promotes latest-user policy"
+            `Quick
+            test_explicit_preserve_promotes_latest_user_policy_to_full_history
         ; Alcotest.test_case
             "unsupported codec fails"
             `Quick

--- a/test/test_thinking_control_dialects.ml
+++ b/test/test_thinking_control_dialects.ml
@@ -146,7 +146,7 @@ let declared_qwen_openai_compat_capabilities =
   ; thinking_control_format = CAP.Chat_template_kwargs
   ; preserve_thinking_control_format = CAP.Chat_template_kwargs_preserve_thinking
   ; reasoning_streaming_format = CAP.Delta_reasoning_field "reasoning_content"
-  ; reasoning_replay_override = CAP.Force_drop_without_tool_preserve_with_tool
+  ; reasoning_replay_override = CAP.Force_latest_user_turn_tool_calls
   }
 ;;
 
@@ -316,7 +316,7 @@ let test_qwen36_reasoning_dialect_without_preserve_keeps_tool_reasoning () =
   check
     string
     "replay policy"
-    "drop_without_tool_preserve_with_tool"
+    "latest_user_turn_tool_calls"
     (RD.replay_policy_to_string dialect.replay_policy);
   check
     bool


### PR DESCRIPTION
## Problem

The Qwen3.6 catalog currently maps tool-call reasoning replay to the generic all-history policy. `Reasoning_history_projection` therefore preserves reasoning from every earlier assistant tool-call message, including tool cycles belonging to older user requests.

That is the wrong feedback boundary for Qwen3.6's default multi-turn behavior. It can feed an old work plan back into a new user turn and is consistent with the observed failure where a new source-inspection request resumed and repeated an earlier PR-review plan. This PR fixes the source contract; it does **not** claim the live MASC/RunPod deployment is repaired until the OAS version is integrated and runtime-smoked.

## Change

- add the closed replay contract `Tool_call_assistant_messages_latest_user_turn`
- add one catalog/dialect capability value, `latest_user_turn_tool_calls`
- find the latest typed `User` role boundary structurally
- preserve reasoning only for assistant tool-call messages after that boundary
- keep all `ToolUse` and `ToolResult` blocks; only out-of-scope reasoning artifacts are removed
- replay no reasoning when no user boundary exists
- keep explicit `preserve_thinking=true` as an intentional promotion to full assistant-history replay
- leave DeepSeek, MiMo, OpenAI, Anthropic, Gemini, and provider-opaque replay policies unchanged
- update the three explicit Qwen3.6 catalog rows; no model-name inference is introduced

There is no repetition counter, content similarity check, substring/model-name branch, turn/cost/token budget gate, or silent fallback.

## Boundary / SSOT

- `models.toml` remains the declaration SSOT for a concrete model endpoint.
- `Capability_vocab` parses the closed manifest value.
- `Reasoning_dialect` maps that capability to the provider-agnostic replay contract.
- `Reasoning_history_projection` applies the typed message-role boundary.
- serializers continue consuming the single projection; no Qwen-only serializer fork is added.
- public `Agent.run` usage is unchanged.

## Official contract evidence

- Qwen3.6 documents that reasoning content is preserved for tool calls in the current user turn by default, while full historical thinking preservation is an explicit mode: [Qwen3.6 model card](https://huggingface.co/Qwen/Qwen3.6-35B-A3B), [Alibaba Model Studio deep-thinking guide](https://www.alibabacloud.com/help/en/model-studio/deep-thinking).
- Qwen's function-calling documentation requires the assistant tool-call message and matching tool result to remain in the multi-turn message sequence: [Qwen function calling](https://qwen.readthedocs.io/en/stable/framework/function_call.html).

[근거] Official Qwen/Alibaba documentation checked 2026-07-16 KST. Contract confidence High. The exact RunPod vLLM parser/config remains deployment-specific and must be verified separately; confidence Medium until live config inspection.

## Verification

- fresh focused build after rebasing on #2611: pass
- provider-agnostic reasoning replay: 11/11 pass
  - old-user-turn reasoning removed
  - current-user-turn tool reasoning retained
  - ToolUse/ToolResult history retained
  - no-User boundary replays none
  - explicit preserve retains prior-turn reasoning
- capabilities/catalog: 100/100 pass
- thinking-control dialects: 43/43 pass
- `git diff --check`: pass
- current commit `7a49038f1` full GitHub CI: pass (OCaml 5.4.1 + 5.5.0, tests, lint, format, boundary/SSOT/TLA+ gates) — https://github.com/jeong-sik/oas/actions/runs/29465658347

Full build/test authority remains GitHub CI.

## Stack and follow-up

This Draft is stacked on #2611 because the lossless execution journal/store is the hierarchy SSOT being used by the runtime hard cut.

This PR removes one confirmed model-feedback cause of cross-turn self-recursion. It does not use a repetition heuristic and it does not replace the remaining required work:

1. lane-local asynchronous durability actor so filesystem barriers cannot block Keeper dispatch
2. durable `Tool_attempt` before effects and exact typed `Tool_receipt` after effects
3. completed streamed tool-call assembly before execution
4. hard removal of the legacy duplicate writer and lossy string ToolResult reconstruction
5. OAS release/MASC pin plus a real RunPod Qwen3.6 multi-turn tool smoke
