### PR TITLE
feat(execution): add lane-local durable journal writer

### DIFF
--- a/docs/capability-manifest.md
+++ b/docs/capability-manifest.md
@@ -109,7 +109,7 @@ for the full JSON Schema (draft-07).
 | `thinking_control_token` | string | absent | Exact chat-template token used when `thinking_control_format = "chat_template_token"`; blank values and leading/trailing whitespace are rejected. |
 | `preserve_thinking_control_format` | string | from base | Historical reasoning replay/preserve wire control. Accepted values: `none`, `thinking_object_keep_all`, `chat_template_kwargs_preserve_thinking`, `top_level_preserve_thinking`, `always_preserved`. |
 | `reasoning_output_format` | string | from base | Request-side reasoning output split control. Accepted values: `none`, `split_reasoning_fields`. |
-| `reasoning_replay` | string | `default` | Optional multi-turn reasoning replay override. Accepted values: `default`, `no_replay`, `drop_without_tool`, `preserve_always`. |
+| `reasoning_replay` | string | `default` | Optional multi-turn reasoning replay override. Accepted values: `default`, `no_replay`, `drop_without_tool`, `latest_user_turn_tool_calls`, `preserve_always`. |
 
 Unknown fields and unknown enum values are rejected. Additive schema changes
 must update the parser and this schema together.

--- a/docs/schemas/capability-manifest-v1.json
+++ b/docs/schemas/capability-manifest-v1.json
@@ -231,6 +231,7 @@
             "default",
             "no_replay",
             "drop_without_tool",
+            "latest_user_turn_tool_calls",
             "preserve_always"
           ]
         }

--- a/lib/dune
+++ b/lib/dune
@@ -11,7 +11,8 @@
   execution_tool_schedule
   execution_event
   execution_event_store
-  execution_journal)
+  execution_journal
+  execution_lane_writer)
  (libraries
   llm_provider
   (re_export agent_sdk_base)

--- a/lib/execution_event_store.ml
+++ b/lib/execution_event_store.ml
@@ -2,6 +2,28 @@ open Result_syntax
 module Event = Execution_event
 module Sha256 = Digestif.SHA256
 
+let reverse_append_cooperatively values tail =
+  let rec loop reversed = function
+    | [] -> reversed
+    | value :: rest ->
+      Eio.Fiber.yield ();
+      loop (value :: reversed) rest
+  in
+  loop tail values
+;;
+
+let reverse_cooperatively values = reverse_append_cooperatively values []
+
+let length_cooperatively values =
+  let rec loop length = function
+    | [] -> length
+    | _ :: rest ->
+      Eio.Fiber.yield ();
+      loop (length + 1) rest
+  in
+  loop 0 values
+;;
+
 module Scope_id = Execution_id.Make (struct
     let value = "execution-scope-"
   end)
@@ -75,6 +97,13 @@ type error =
       }
   | Writer_already_active
   | Store_already_attached
+  | Store_released
+  | Store_release_forbidden
+  | Resource_cleanup_failed of { operations : string list }
+  | Construction_cleanup_failed of
+      { primary : error
+      ; cleanup : error
+      }
   | Store_already_exists
   | Store_not_found
   | Store_initialization_incomplete
@@ -101,13 +130,24 @@ type error =
   | Commit_outcome_unknown of string
 [@@deriving show]
 
-let error_to_string = function
+let rec error_to_string = function
   | Invalid_argument detail -> "invalid execution store argument: " ^ detail
   | Identity_failure detail -> "execution store identity failure: " ^ detail
   | Io_failure { operation; detail } ->
     Printf.sprintf "execution store %s failed: %s" operation detail
   | Writer_already_active -> "execution store already has an active writer"
   | Store_already_attached -> "execution store is already attached to a journal"
+  | Store_released -> "execution store resources have been released"
+  | Store_release_forbidden ->
+    "execution store cannot release resources after journal publication"
+  | Resource_cleanup_failed { operations } ->
+    "execution store resource cleanup failed: " ^ String.concat "; " operations
+  | Construction_cleanup_failed { primary; cleanup } ->
+    "execution store construction failed ("
+    ^ error_to_string primary
+    ^ ") and cleanup also failed ("
+    ^ error_to_string cleanup
+    ^ ")"
   | Store_already_exists -> "execution store already exists"
   | Store_not_found -> "execution store does not exist"
   | Store_initialization_incomplete -> "execution store has an uncommitted initialization"
@@ -337,14 +377,42 @@ let fsync_directory dir =
      | exn -> Error (io_error "sync directory" exn))
 ;;
 
-let release_acquired_resources ?file lock_file claim =
-  Fun.protect
-    ~finally:(fun () -> release_writer_path claim)
-    (fun () ->
-       Fun.protect
-         ~finally:(fun () -> Eio.Resource.close lock_file)
-         (fun () -> Option.iter Eio.Resource.close file))
+let release_acquired_resources ?file lock_file claim claim_hook =
+  let close (operations, reserved) name resource =
+    match Eio.Resource.close resource with
+    | () -> operations, reserved
+    | exception
+        ((Out_of_memory | Stack_overflow | Sys.Break | Eio.Cancel.Cancelled _) as exn) ->
+      let reserved =
+        match reserved with
+        | Some _ -> reserved
+        | None -> Some (exn, Printexc.get_raw_backtrace ())
+      in
+      operations, reserved
+    | exception exn -> (name ^ ": " ^ Printexc.to_string exn) :: operations, reserved
+  in
+  let cleanup =
+    match file with
+    | None -> [], None
+    | Some file -> close ([], None) "close WAL" file
+  in
+  let operations, reserved = close cleanup "close writer lock" lock_file in
+  ignore (Eio.Switch.try_remove_hook claim_hook);
+  release_writer_path claim;
+  match reserved with
+  | Some (exn, backtrace) -> Printexc.raise_with_backtrace exn backtrace
+  | None ->
+    (match List.rev operations with
+     | [] -> Ok ()
+     | operations -> Error (Resource_cleanup_failed { operations }))
 ;;
+
+let combine_cleanup primary = function
+  | Ok () -> Error primary
+  | Error cleanup -> Error (Construction_cleanup_failed { primary; cleanup })
+;;
+
+exception Cleanup_failed_after_exception of exn * error
 
 let acquire_writer_lock ~sw dir =
   let* writer_path =
@@ -363,42 +431,38 @@ let acquire_writer_lock ~sw dir =
   match claim_writer_path writer_path with
   | None -> Error Writer_already_active
   | Some claim ->
-    let lock_file = ref None in
-    let acquired = ref false in
-    Fun.protect
-      ~finally:(fun () ->
-        if not !acquired
-        then (
-          match !lock_file with
-          | Some file -> release_acquired_resources file claim
-          | None -> release_writer_path claim))
-      (fun () ->
-         Eio.Switch.on_release sw (fun () -> release_writer_path claim);
-         match
-           with_io "open writer lock" (fun () ->
-             Eio.Path.open_out ~sw ~create:(`If_missing 0o600) (lock_path dir))
-         with
-         | Error error -> Error error
-         | Ok file ->
-           lock_file := Some file;
-           (match Eio_unix.Resource.fd_opt file with
-            | None ->
-              Error
-                (Io_failure
-                   { operation = "lock writer"
-                   ; detail = "the writer lock is not backed by a Unix file descriptor"
-                   })
-            | Some fd ->
-              (try
-                 Eio_unix.Fd.use_exn "execution store writer lock" fd (fun unix_fd ->
-                   Eio_unix.run_in_systhread ~label:"execution store lockf" (fun () ->
-                     Unix.lockf unix_fd Unix.F_TLOCK 0));
-                 acquired := true;
-                 Ok (file, claim)
-               with
-               | Unix.Unix_error ((Unix.EACCES | Unix.EAGAIN), _, _) ->
-                 Error Writer_already_active
-               | exn -> Error (io_error "lock writer" exn))))
+    let claim_hook =
+      Eio.Switch.on_release_cancellable sw (fun () -> release_writer_path claim)
+    in
+    (match
+       with_io "open writer lock" (fun () ->
+         Eio.Path.open_out ~sw ~create:(`If_missing 0o600) (lock_path dir))
+     with
+     | Error error ->
+       ignore (Eio.Switch.try_remove_hook claim_hook);
+       release_writer_path claim;
+       Error error
+     | Ok file ->
+       let fail primary =
+         combine_cleanup primary (release_acquired_resources file claim claim_hook)
+       in
+       (match Eio_unix.Resource.fd_opt file with
+        | None ->
+          fail
+            (Io_failure
+               { operation = "lock writer"
+               ; detail = "the writer lock is not backed by a Unix file descriptor"
+               })
+        | Some fd ->
+          (try
+             Eio_unix.Fd.use_exn "execution store writer lock" fd (fun unix_fd ->
+               Eio_unix.run_in_systhread ~label:"execution store lockf" (fun () ->
+                 Unix.lockf unix_fd Unix.F_TLOCK 0));
+             Ok (file, claim, claim_hook)
+           with
+           | Unix.Unix_error ((Unix.EACCES | Unix.EAGAIN), _, _) ->
+             fail Writer_already_active
+           | exn -> fail (io_error "lock writer" exn))))
 ;;
 
 type frame_guard =
@@ -425,17 +489,25 @@ type committed_state =
   ; committed_offset : int64
   }
 
+type lifecycle =
+  | Unpublished of writer_claim
+  | Published
+  | Releasing
+  | Released
+
 type t =
   { scope_id : Scope_id.t
   ; correlation_id : Event.Correlation_id.t
   ; dir : Eio.Fs.dir_ty Eio.Path.t
   ; file : Eio.File.rw_ty Eio.Resource.t
   ; lock_file : Eio.File.rw_ty Eio.Resource.t
+  ; mutable claim_hook : Eio.Switch.hook
+  ; mutable lifecycle_hook : Eio.Switch.hook
   ; writer_gate : Eio.Mutex.t
   ; mu : Eio.Mutex.t
   ; mutable committed : committed_state
   ; mutable health : health
-  ; mutable attached : bool
+  ; mutable lifecycle : lifecycle
   }
 
 type writer = { store : t }
@@ -443,7 +515,7 @@ type writer = { store : t }
 let scope_id store = store.scope_id
 let correlation_id store = store.correlation_id
 let with_read store f = Eio.Mutex.use_ro store.mu f
-let with_state_write store f = Eio.Cancel.protect (fun () -> Eio.Mutex.use_ro store.mu f)
+let with_state_write store f = Eio.Mutex.use_rw ~protect:true store.mu f
 let with_writer store f = Eio.Mutex.use_ro store.writer_gate f
 
 let fence_store store error =
@@ -457,17 +529,64 @@ let require_reconciliation store error =
   with_state_write store (fun () -> store.health <- Fenced error)
 ;;
 
-let last_seq store = with_read store (fun () -> store.committed.last_seq)
+let lifecycle_available = function
+  | Unpublished _ | Published -> true
+  | Releasing | Released -> false
+;;
+
+let require_available store =
+  with_read store (fun () ->
+    if lifecycle_available store.lifecycle then Ok () else Error Store_released)
+;;
+
+let last_seq store =
+  with_read store (fun () ->
+    if lifecycle_available store.lifecycle
+    then Ok store.committed.last_seq
+    else Error Store_released)
+;;
+
 let beginning_cursor store = { scope_id = store.scope_id; seq = 0 }
-let current_cursor store = { scope_id = store.scope_id; seq = last_seq store }
+
+let current_cursor store =
+  let+ seq = last_seq store in
+  { scope_id = store.scope_id; seq }
+;;
+
+let release_unpublished store =
+  Eio.Cancel.protect (fun () ->
+    match
+      with_state_write store (fun () ->
+        match store.lifecycle with
+        | Unpublished claim ->
+          store.lifecycle <- Releasing;
+          let claim_hook = store.claim_hook in
+          let lifecycle_hook = store.lifecycle_hook in
+          store.claim_hook <- Eio.Switch.null_hook;
+          store.lifecycle_hook <- Eio.Switch.null_hook;
+          Ok (Some (claim, claim_hook, lifecycle_hook))
+        | Releasing | Released -> Ok None
+        | Published -> Error Store_release_forbidden)
+    with
+    | Error _ as error -> error
+    | Ok None -> Ok ()
+    | Ok (Some (claim, claim_hook, lifecycle_hook)) ->
+      ignore (Eio.Switch.try_remove_hook lifecycle_hook);
+      Fun.protect
+        ~finally:(fun () ->
+          with_state_write store (fun () -> store.lifecycle <- Released))
+        (fun () ->
+           release_acquired_resources ~file:store.file store.lock_file claim claim_hook))
+;;
 
 let attach store =
   with_state_write store (fun () ->
-    if store.attached
-    then Error Store_already_attached
-    else (
-      store.attached <- true;
-      Ok { store }))
+    match store.lifecycle with
+    | Unpublished _ ->
+      store.lifecycle <- Published;
+      Ok { store }
+    | Published -> Error Store_already_attached
+    | Releasing | Released -> Error Store_released)
 ;;
 
 type decoded_frame =
@@ -1061,7 +1180,7 @@ let scan_store file ~file_size =
                 Error
                   (Corrupt_store
                      { offset = event_offset; detail = "batch event digest mismatch" })
-              else Ok (next_offset, expected_last, List.rev locations_rev)
+              else Ok (next_offset, expected_last, reverse_cooperatively locations_rev)
             | Complete_frame _ ->
               Error
                 (Corrupt_store
@@ -1140,6 +1259,8 @@ let make_store
       ~dir
       ~file
       ~lock_file
+      ~claim
+      ~claim_hook
       ~locations
       ~last_seq
       ~committed_offset
@@ -1149,25 +1270,40 @@ let make_store
   ; dir
   ; file
   ; lock_file
+  ; claim_hook
+  ; lifecycle_hook = Eio.Switch.null_hook
   ; writer_gate = Eio.Mutex.create ()
   ; mu = Eio.Mutex.create ()
   ; committed = { locations; last_seq; committed_offset }
   ; health = Writable
-  ; attached = false
+  ; lifecycle = Unpublished claim
   }
 ;;
 
-let protect_store_resources lock_file claim opened_file f =
-  let keep = ref false in
-  Fun.protect
-    ~finally:(fun () ->
-      if not !keep then release_acquired_resources ?file:!opened_file lock_file claim)
-    (fun () ->
-       let result = f () in
-       (match result with
-        | Ok _ -> keep := true
-        | Error _ -> ());
-       result)
+let bind_lifecycle_to_switch ~sw store =
+  store.lifecycle_hook
+  <- Eio.Switch.on_release_cancellable sw (fun () ->
+       with_state_write store (fun () ->
+         store.lifecycle_hook <- Eio.Switch.null_hook;
+         store.lifecycle <- Released));
+  store
+;;
+
+let protect_store_resources lock_file claim claim_hook opened_file f =
+  match f () with
+  | Ok _ as result -> result
+  | Error primary ->
+    combine_cleanup
+      primary
+      (release_acquired_resources ?file:!opened_file lock_file claim claim_hook)
+  | exception primary ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    (match release_acquired_resources ?file:!opened_file lock_file claim claim_hook with
+     | Ok () -> Printexc.raise_with_backtrace primary backtrace
+     | Error cleanup ->
+       Printexc.raise_with_backtrace
+         (Cleanup_failed_after_exception (primary, cleanup))
+         backtrace)
 ;;
 
 let create ~sw ~dir ?correlation_id () =
@@ -1175,9 +1311,9 @@ let create ~sw ~dir ?correlation_id () =
     with_io "check store directory" (fun () -> Eio.Path.is_directory dir)
   in
   let* () = if directory_exists then Ok () else Error Store_not_found in
-  let* lock_file, claim = acquire_writer_lock ~sw dir in
+  let* lock_file, claim, claim_hook = acquire_writer_lock ~sw dir in
   let opened_file = ref None in
-  protect_store_resources lock_file claim opened_file (fun () ->
+  protect_store_resources lock_file claim claim_hook opened_file (fun () ->
     let* wal_exists =
       with_io "check WAL existence" (fun () -> Eio.Path.is_file (wal_path dir))
     in
@@ -1267,15 +1403,19 @@ let create ~sw ~dir ?correlation_id () =
           | result -> result)
       in
       Ok
-        ( make_store
-            ~scope_id
-            ~correlation_id
-            ~dir
-            ~file
-            ~lock_file
-            ~locations:Sequence_map.empty
-            ~last_seq:0
-            ~committed_offset
+        ( bind_lifecycle_to_switch
+            ~sw
+            (make_store
+               ~scope_id
+               ~correlation_id
+               ~dir
+               ~file
+               ~lock_file
+               ~claim
+               ~claim_hook
+               ~locations:Sequence_map.empty
+               ~last_seq:0
+               ~committed_offset)
         , initialization ))
 ;;
 
@@ -1286,9 +1426,9 @@ let open_existing ~sw ~dir =
   if not directory_exists
   then Error Store_not_found
   else
-    let* lock_file, claim = acquire_writer_lock ~sw dir in
+    let* lock_file, claim, claim_hook = acquire_writer_lock ~sw dir in
     let opened_file = ref None in
-    protect_store_resources lock_file claim opened_file (fun () ->
+    protect_store_resources lock_file claim claim_hook opened_file (fun () ->
       let* wal_exists =
         with_io "check WAL existence" (fun () -> Eio.Path.is_file (wal_path dir))
       in
@@ -1412,15 +1552,19 @@ let open_existing ~sw ~dir =
         | actions -> Recovered actions
       in
       Ok
-        ( make_store
-            ~scope_id
-            ~correlation_id
-            ~dir
-            ~file
-            ~lock_file
-            ~locations
-            ~last_seq
-            ~committed_offset
+        ( bind_lifecycle_to_switch
+            ~sw
+            (make_store
+               ~scope_id
+               ~correlation_id
+               ~dir
+               ~file
+               ~lock_file
+               ~claim
+               ~claim_hook
+               ~locations
+               ~last_seq
+               ~committed_offset)
         , recovery ))
 ;;
 
@@ -1431,7 +1575,7 @@ let validate_append (store : t) ~expected_next_seq events =
     match events with
     | [] -> Error (Invalid_argument "append batch must contain at least one event")
     | _ ->
-      let count = List.length events in
+      let count = length_cooperatively events in
       let* () =
         if expected_next_seq > max_int - count + 1
         then
@@ -1463,7 +1607,8 @@ let validate_append (store : t) ~expected_next_seq events =
             | [] -> Ok ()
             | _ -> loop (expected + 1) rest)
       in
-      loop expected_next_seq events)
+      let+ () = loop expected_next_seq events in
+      count)
 ;;
 
 let location_at locations seq = Sequence_map.find seq locations
@@ -1552,7 +1697,7 @@ let read_range store ~committed_offset locations ~first_seq ~count =
   in
   let rec loop seq remaining events_rev =
     if remaining = 0
-    then Ok (List.rev events_rev)
+    then Ok (reverse_cooperatively events_rev)
     else (
       let location = location_at locations seq in
       let* event = read_location_locked store ~file_size:committed_offset location in
@@ -1667,13 +1812,12 @@ let prepare_frame ~file_offset kind payload =
   , payload_digest )
 ;;
 
-let append_new_batch store ~expected_next_seq events =
+let append_new_batch store ~expected_next_seq ~count events =
   let* batch_id =
     match Random_id.create () with
     | Ok value -> Ok value
     | Error detail -> Error (Identity_failure detail)
   in
-  let count = List.length events in
   let last_seq = expected_next_seq + count - 1 in
   let payloads = event_payloads events in
   let digest = events_digest payloads in
@@ -1734,7 +1878,7 @@ let append_new_batch store ~expected_next_seq events =
     let commit_write, committed_offset, _ =
       prepare_frame ~file_offset:commit_offset Batch_commit commit_payload
     in
-    let locations = List.rev locations_rev in
+    let locations = reverse_cooperatively locations_rev in
     let next_locations =
       List.fold_left
         (fun locations location ->
@@ -1753,7 +1897,7 @@ let append_new_batch store ~expected_next_seq events =
         }
     in
     let prepared =
-      { writes = List.rev (commit_write :: writes_rev)
+      { writes = reverse_cooperatively (commit_write :: writes_rev)
       ; committed = next_committed
       ; authority_payload
       }
@@ -1835,8 +1979,8 @@ let append_new_batch store ~expected_next_seq events =
       | Ok outcome -> Ok outcome))
 ;;
 
-let compare_committed store ~expected_next_seq events committed_last =
-  let last_seq = expected_next_seq + List.length events - 1 in
+let compare_committed store ~expected_next_seq ~count events committed_last =
+  let last_seq = expected_next_seq + count - 1 in
   if last_seq > committed_last
   then
     Error (Sequence_conflict { expected_next_seq; actual_next_seq = committed_last + 1 })
@@ -1865,20 +2009,22 @@ let compare_committed store ~expected_next_seq events committed_last =
 let append_batch writer ~expected_next_seq events =
   let store = writer.store in
   Eio.Fiber.check ();
-  let* () = validate_append store ~expected_next_seq events in
+  let* () = require_available store in
+  let* count = validate_append store ~expected_next_seq events in
   with_writer store (fun () ->
     Eio.Fiber.check ();
-    let health, committed_last =
-      with_read store (fun () -> store.health, store.committed.last_seq)
+    let lifecycle, health, committed_last =
+      with_read store (fun () -> store.lifecycle, store.health, store.committed.last_seq)
     in
-    match health with
-    | Fenced error -> Error error
-    | Writable ->
+    match lifecycle, health with
+    | (Releasing | Released), _ -> Error Store_released
+    | (Unpublished _ | Published), Fenced error -> Error error
+    | (Unpublished _ | Published), Writable ->
       let* () = verify_write_fence_locked store in
       if expected_next_seq = committed_last + 1
-      then append_new_batch store ~expected_next_seq events
+      then append_new_batch store ~expected_next_seq ~count events
       else if expected_next_seq <= committed_last
-      then compare_committed store ~expected_next_seq events committed_last
+      then compare_committed store ~expected_next_seq ~count events committed_last
       else
         Error
           (Sequence_conflict { expected_next_seq; actual_next_seq = committed_last + 1 }))
@@ -1893,6 +2039,7 @@ type page =
   }
 
 let read_page (store : t) ~(after : cursor) ?through ~limit () =
+  let* () = require_available store in
   if limit <= 0
   then Error (Invalid_argument "page limit must be positive")
   else if not (Scope_id.equal after.scope_id store.scope_id)
@@ -1905,9 +2052,10 @@ let read_page (store : t) ~(after : cursor) ?through ~limit () =
   else
     let* high, committed_offset, committed_locations, count =
       with_read store (fun () ->
-        match store.health with
-        | Fenced error -> Error error
-        | Writable ->
+        match store.lifecycle, store.health with
+        | (Releasing | Released), _ -> Error Store_released
+        | (Unpublished _ | Published), Fenced error -> Error error
+        | (Unpublished _ | Published), Writable ->
           let committed = store.committed in
           let current = committed.last_seq in
           let high =
@@ -1929,7 +2077,7 @@ let read_page (store : t) ~(after : cursor) ?through ~limit () =
         ~first_seq:(after.seq + 1)
         ~count
     in
-    let next_seq = after.seq + List.length events in
+    let next_seq = after.seq + count in
     Ok
       { events
       ; next_cursor = { scope_id = store.scope_id; seq = next_seq }
@@ -1940,11 +2088,13 @@ let read_page (store : t) ~(after : cursor) ?through ~limit () =
 ;;
 
 let load_all (store : t) =
+  let* () = require_available store in
   let* committed_offset, committed_locations, last_seq =
     with_read store (fun () ->
-      match store.health with
-      | Fenced error -> Error error
-      | Writable ->
+      match store.lifecycle, store.health with
+      | (Releasing | Released), _ -> Error Store_released
+      | (Unpublished _ | Published), Fenced error -> Error error
+      | (Unpublished _ | Published), Writable ->
         let committed = store.committed in
         Ok (committed.committed_offset, committed.locations, committed.last_seq))
   in

--- a/lib/execution_event_store.ml
+++ b/lib/execution_event_store.ml
@@ -377,42 +377,116 @@ let fsync_directory dir =
      | exn -> Error (io_error "sync directory" exn))
 ;;
 
-let release_acquired_resources ?file lock_file claim claim_hook =
-  let close (operations, reserved) name resource =
-    match Eio.Resource.close resource with
-    | () -> operations, reserved
-    | exception
-        ((Out_of_memory | Stack_overflow | Sys.Break | Eio.Cancel.Cancelled _) as exn) ->
-      let reserved =
-        match reserved with
-        | Some _ -> reserved
-        | None -> Some (exn, Printexc.get_raw_backtrace ())
-      in
-      operations, reserved
-    | exception exn -> (name ^ ": " ^ Printexc.to_string exn) :: operations, reserved
-  in
-  let cleanup =
-    match file with
-    | None -> [], None
-    | Some file -> close ([], None) "close WAL" file
-  in
-  let operations, reserved = close cleanup "close writer lock" lock_file in
-  ignore (Eio.Switch.try_remove_hook claim_hook);
-  release_writer_path claim;
-  match reserved with
-  | Some (exn, backtrace) -> Printexc.raise_with_backtrace exn backtrace
-  | None ->
-    (match List.rev operations with
-     | [] -> Ok ()
-     | operations -> Error (Resource_cleanup_failed { operations }))
+type cleanup_operation =
+  | Close_wal
+  | Close_writer_lock
+
+let cleanup_operation_to_string = function
+  | Close_wal -> "close WAL"
+  | Close_writer_lock -> "close writer lock"
 ;;
 
-let combine_cleanup primary = function
+exception Resource_cleanup_operation_raised of cleanup_operation * exn
+exception Construction_cleanup_raised of error * exn
+
+let () =
+  Printexc.register_printer (function
+    | Resource_cleanup_operation_raised (operation, cause) ->
+      Some
+        (cleanup_operation_to_string operation
+         ^ " raised during execution store cleanup: "
+         ^ Printexc.to_string cause)
+    | Construction_cleanup_raised (primary, cleanup) ->
+      Some
+        ("execution store construction failed ("
+         ^ error_to_string primary
+         ^ ") and cleanup raised ("
+         ^ Printexc.to_string cleanup
+         ^ ")")
+    | _ -> None)
+;;
+
+let is_reserved_exception = function
+  | Out_of_memory | Stack_overflow | Sys.Break | Eio.Cancel.Cancelled _ -> true
+  | _ -> false
+;;
+
+let release_acquired_resources ?file lock_file claim claim_hook =
+  let close failures operation resource =
+    match Eio.Resource.close resource with
+    | () -> failures
+    | exception exn -> (operation, exn, Printexc.get_raw_backtrace ()) :: failures
+  in
+  let failures =
+    match file with
+    | None -> []
+    | Some file -> close [] Close_wal file
+  in
+  let failures = close failures Close_writer_lock lock_file |> List.rev in
+  (* A close failure leaves physical ownership uncertain. Keep the in-process
+     claim attached to the switch so another writer cannot be admitted before
+     the owning scope finishes its remaining cleanup. *)
+  match failures with
+  | [] ->
+    ignore (Eio.Switch.try_remove_hook claim_hook);
+    release_writer_path claim;
+    Ok ()
+  | [ (_, cause, backtrace) ] when is_reserved_exception cause ->
+    Printexc.raise_with_backtrace cause backtrace
+  | (first_operation, first_cause, first_backtrace) :: rest
+    when List.exists (fun (_, exn, _) -> is_reserved_exception exn) failures ->
+    let combined, combined_backtrace =
+      List.fold_left
+        (fun combined (operation, cause, backtrace) ->
+           Eio.Exn.combine
+             combined
+             (Resource_cleanup_operation_raised (operation, cause), backtrace))
+        (Resource_cleanup_operation_raised (first_operation, first_cause), first_backtrace)
+        rest
+    in
+    Printexc.raise_with_backtrace combined combined_backtrace
+  | failures ->
+    let operations =
+      List.map
+        (fun (operation, cause, _) ->
+           cleanup_operation_to_string operation ^ ": " ^ Printexc.to_string cause)
+        failures
+    in
+    Error (Resource_cleanup_failed { operations })
+;;
+
+let combine_cleanup primary cleanup =
+  match cleanup () with
   | Ok () -> Error primary
   | Error cleanup -> Error (Construction_cleanup_failed { primary; cleanup })
+  | exception cleanup_exn ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    Printexc.raise_with_backtrace
+      (Construction_cleanup_raised (primary, cleanup_exn))
+      backtrace
 ;;
 
 exception Cleanup_failed_after_exception of exn * error
+exception Cleanup_raised_after_exception of Eio.Exn.with_bt * Eio.Exn.with_bt
+
+let () =
+  Printexc.register_printer (function
+    | Cleanup_failed_after_exception (primary, cleanup) ->
+      Some
+        ("execution store construction raised ("
+         ^ Printexc.to_string primary
+         ^ ") and cleanup failed ("
+         ^ error_to_string cleanup
+         ^ ")")
+    | Cleanup_raised_after_exception ((primary, _), (cleanup, _)) ->
+      Some
+        ("execution store construction raised ("
+         ^ Printexc.to_string primary
+         ^ ") and cleanup also raised ("
+         ^ Printexc.to_string cleanup
+         ^ ")")
+    | _ -> None)
+;;
 
 let acquire_writer_lock ~sw dir =
   let* writer_path =
@@ -444,7 +518,8 @@ let acquire_writer_lock ~sw dir =
        Error error
      | Ok file ->
        let fail primary =
-         combine_cleanup primary (release_acquired_resources file claim claim_hook)
+         combine_cleanup primary (fun () ->
+           release_acquired_resources file claim claim_hook)
        in
        (match Eio_unix.Resource.fd_opt file with
         | None ->
@@ -1293,9 +1368,8 @@ let protect_store_resources lock_file claim claim_hook opened_file f =
   match f () with
   | Ok _ as result -> result
   | Error primary ->
-    combine_cleanup
-      primary
-      (release_acquired_resources ?file:!opened_file lock_file claim claim_hook)
+    combine_cleanup primary (fun () ->
+      release_acquired_resources ?file:!opened_file lock_file claim claim_hook)
   | exception primary ->
     let backtrace = Printexc.get_raw_backtrace () in
     (match release_acquired_resources ?file:!opened_file lock_file claim claim_hook with
@@ -1303,6 +1377,12 @@ let protect_store_resources lock_file claim claim_hook opened_file f =
      | Error cleanup ->
        Printexc.raise_with_backtrace
          (Cleanup_failed_after_exception (primary, cleanup))
+         backtrace
+     | exception cleanup_exn ->
+       let cleanup_backtrace = Printexc.get_raw_backtrace () in
+       Printexc.raise_with_backtrace
+         (Cleanup_raised_after_exception
+            ((primary, backtrace), (cleanup_exn, cleanup_backtrace)))
          backtrace)
 ;;
 

--- a/lib/execution_event_store.mli
+++ b/lib/execution_event_store.mli
@@ -12,7 +12,9 @@
 
     The directory is caller-owned and dedicated to one execution scope. The
     implementation acquires an exclusive writer lock for the lifetime of the
-    supplied {!Eio.Switch.t}. *)
+    supplied {!Eio.Switch.t}. Store and writer capabilities are switch-bound;
+    after release, every operation that depends on live resources returns
+    [Store_released] rather than touching a closed descriptor. *)
 
 module Scope_id : sig
   type t
@@ -66,6 +68,13 @@ type error =
       }
   | Writer_already_active
   | Store_already_attached
+  | Store_released
+  | Store_release_forbidden
+  | Resource_cleanup_failed of { operations : string list }
+  | Construction_cleanup_failed of
+      { primary : error
+      ; cleanup : error
+      }
   | Store_already_exists
   | Store_not_found
   | Store_initialization_incomplete
@@ -122,9 +131,16 @@ val open_existing
 
 val scope_id : t -> Scope_id.t
 val correlation_id : t -> Execution_event.Correlation_id.t
-val last_seq : t -> int
+val last_seq : t -> (int, error) result
 val beginning_cursor : t -> cursor
-val current_cursor : t -> cursor
+val current_cursor : t -> (cursor, error) result
+
+(** Release a store that its construction wrapper failed to publish. This is
+    idempotent with the owning switch's later cleanup and exists only so a
+    higher-level atomic constructor cannot leak the writer claim on replay or
+    semantic initialization failure. Published stores must remain owned by
+    their switch. *)
+val release_unpublished : t -> (unit, error) result
 
 (** Mint the store's sole semantic append capability. A store can be attached
     to exactly one journal for its lifetime. Read projections continue to use

--- a/lib/execution_journal.ml
+++ b/lib/execution_journal.ml
@@ -2,6 +2,37 @@ open Result_syntax
 module Event = Execution_event
 module Store = Execution_event_store
 
+let reverse_append_cooperatively values tail =
+  let rec loop reversed = function
+    | [] -> reversed
+    | value :: rest ->
+      Eio.Fiber.yield ();
+      loop (value :: reversed) rest
+  in
+  loop tail values
+;;
+
+let reverse_cooperatively values = reverse_append_cooperatively values []
+
+let reverse_filter_map_cooperatively f values =
+  let rec loop filtered = function
+    | [] -> filtered
+    | value :: rest ->
+      let filtered =
+        match f value with
+        | None -> filtered
+        | Some value -> value :: filtered
+      in
+      Eio.Fiber.yield ();
+      loop filtered rest
+  in
+  loop [] values
+;;
+
+let append_cooperatively left right =
+  reverse_append_cooperatively (reverse_cooperatively left) right
+;;
+
 module Event_id_set = Set.Make (struct
     type t = Event.Event_id.t
 
@@ -159,6 +190,32 @@ type error =
   | Identity_failure of string
   | Empty_batch
   | Durable_batch_owner_mismatch
+  | Direct_mutation_forbidden
+  | Durable_writer_owner_mismatch
+  | Durable_store_unavailable
+  | Durable_construction_cleanup_failed of
+      { construction_error : error
+      ; cleanup_error : Store.error
+      }
+  | Reconciliation_scope_mismatch
+  | Reconciliation_correlation_mismatch
+  | Reconciliation_content_conflict of
+      { first_seq : int
+      ; last_seq : int
+      }
+  | Reconciliation_conflict of
+      { base_seq : int
+      ; final_seq : int
+      ; current_seq : int
+      }
+  | Reconciliation_store_diverged of
+      { first_seq : int
+      ; last_seq : int
+      }
+  | Projection_index_diverged of
+      { expected_seq : int
+      ; high_watermark : int
+      }
   | Stale_batch of
       { expected_last_seq : int
       ; actual_last_seq : int
@@ -171,13 +228,51 @@ type error =
   | Persistence_failure of Store.error
   | Invariant_violation of invariant_violation
 
-let error_to_string = function
+let rec error_to_string = function
   | Invalid_argument detail -> "invalid execution journal argument: " ^ detail
   | Invalid_event detail -> "invalid execution event: " ^ detail
   | Identity_failure detail -> "execution journal identity allocation failed: " ^ detail
   | Empty_batch -> "execution journal batch contains no semantic mutations"
   | Durable_batch_owner_mismatch ->
     "execution journal durable capability does not own the staged batch"
+  | Direct_mutation_forbidden ->
+    "execution journal direct mutation is forbidden after durable writer claim"
+  | Durable_writer_owner_mismatch ->
+    "execution journal durable writer claim does not own this journal"
+  | Durable_store_unavailable ->
+    "execution journal durable writer has no persistent store"
+  | Durable_construction_cleanup_failed { construction_error; cleanup_error } ->
+    "execution journal durable construction failed with "
+    ^ error_to_string construction_error
+    ^ "; unpublished store cleanup also failed: "
+    ^ Store.error_to_string cleanup_error
+  | Reconciliation_scope_mismatch ->
+    "execution journal batch reconciliation scope does not match"
+  | Reconciliation_correlation_mismatch ->
+    "execution journal batch reconciliation correlation does not match"
+  | Reconciliation_content_conflict { first_seq; last_seq } ->
+    Printf.sprintf
+      "execution journal batch reconciliation content differs at sequence range %d..%d"
+      first_seq
+      last_seq
+  | Reconciliation_conflict { base_seq; final_seq; current_seq } ->
+    Printf.sprintf
+      "execution journal batch reconciliation expected current sequence %d or %d but \
+       found %d"
+      base_seq
+      final_seq
+      current_seq
+  | Reconciliation_store_diverged { first_seq; last_seq } ->
+    Printf.sprintf
+      "execution journal reducer contains sequence range %d..%d absent from its durable \
+       store"
+      first_seq
+      last_seq
+  | Projection_index_diverged { expected_seq; high_watermark } ->
+    Printf.sprintf
+      "execution journal projection index is missing sequence %d below high watermark %d"
+      expected_seq
+      high_watermark
   | Stale_batch { expected_last_seq; actual_last_seq } ->
     Printf.sprintf
       "execution journal batch base is stale: expected last sequence %d but found %d"
@@ -192,6 +287,34 @@ let error_to_string = function
   | Persistence_failure error ->
     "execution journal persistence failed: " ^ Store.error_to_string error
   | Invariant_violation violation -> show_invariant_violation violation
+;;
+
+type commit_error_disposition =
+  | Reconcile_required
+  | Final_failure
+
+let commit_error_disposition = function
+  | Persistence_failure (Store.Commit_outcome_unknown _) -> Reconcile_required
+  | Invalid_argument _
+  | Invalid_event _
+  | Identity_failure _
+  | Empty_batch
+  | Durable_batch_owner_mismatch
+  | Direct_mutation_forbidden
+  | Durable_writer_owner_mismatch
+  | Durable_store_unavailable
+  | Durable_construction_cleanup_failed _
+  | Reconciliation_scope_mismatch
+  | Reconciliation_correlation_mismatch
+  | Reconciliation_content_conflict _
+  | Reconciliation_conflict _
+  | Reconciliation_store_diverged _
+  | Projection_index_diverged _
+  | Stale_batch _
+  | Cursor_scope_mismatch
+  | Cursor_ahead _
+  | Persistence_failure _
+  | Invariant_violation _ -> Final_failure
 ;;
 
 module Reducer = struct
@@ -247,19 +370,26 @@ module Reducer = struct
     | Event.Tool_attempt -> Tool_attempt_state
   ;;
 
-  let node_view state (record : node_record) =
+  let node_view_from_histories state (record : node_record) ~updates ~children =
     { node = record.node
     ; opened = record.opened
     ; status = record.status
-    ; updates = List.rev record.updates_rev
-    ; children = List.rev record.children_rev
+    ; updates
+    ; children
     ; materialized = materialized record
     ; through_seq = state.last_seq
     }
   ;;
 
   let find_node state node_id =
-    Option.map (node_view state) (find_node_record state node_id)
+    Option.map
+      (fun record ->
+         node_view_from_histories
+           state
+           record
+           ~updates:(List.rev record.updates_rev)
+           ~children:(List.rev record.children_rev))
+      (find_node_record state node_id)
   ;;
 
   let find_run_record state run_id = Run_id_map.find_opt run_id state.runs
@@ -275,24 +405,33 @@ module Reducer = struct
   ;;
 
   let open_subtree_postorder state root =
-    let open_children_chronological (record : node_record) =
-      record.children_rev
-      |> List.rev
-      |> List.filter_map (fun child ->
-        let child_id = Event.node_id child.value in
-        if Node_id_set.mem child_id record.open_children then Some child_id else None)
+    let prepend_open_children (record : node_record) tail =
+      let rec loop work = function
+        | [] -> work
+        | child :: rest ->
+          let child_id = Event.node_id child.value in
+          let work =
+            if Node_id_set.mem child_id record.open_children
+            then `Enter child_id :: work
+            else work
+          in
+          Eio.Fiber.yield ();
+          loop work rest
+      in
+      loop tail record.children_rev
     in
     let rec loop work reverse_postorder =
       match work with
-      | [] -> Ok (List.rev reverse_postorder)
-      | `Exit node_id :: rest -> loop rest (node_id :: reverse_postorder)
+      | [] -> Ok (reverse_cooperatively reverse_postorder)
+      | `Exit node_id :: rest ->
+        Eio.Fiber.yield ();
+        loop rest (node_id :: reverse_postorder)
       | `Enter node_id :: rest ->
         (match find_node_record state node_id with
          | None -> Error (Unknown_node node_id)
          | Some record ->
-           let children = open_children_chronological record in
-           let children_rev = List.rev_map (fun child -> `Enter child) children in
-           let work = List.rev_append children_rev (`Exit node_id :: rest) in
+           let work = prepend_open_children record (`Exit node_id :: rest) in
+           Eio.Fiber.yield ();
            loop work reverse_postorder)
     in
     loop [ `Enter root ] []
@@ -801,9 +940,12 @@ module Reducer = struct
   ;;
 end
 
+module Event_seq_map = Map.Make (Int)
+
 type journal_state =
   { reducer : Reducer.t
   ; events_rev : Event.t list
+  ; events_by_seq : Event.t Event_seq_map.t
   }
 
 type snapshot =
@@ -811,27 +953,50 @@ type snapshot =
   ; reducer : Reducer.t
   }
 
+type writer_authority =
+  | Unclaimed_writer
+  | Direct_writer
+  | Claimed_durable_writer of unit ref
+
 type t =
   { scope_id : Store.Scope_id.t
   ; correlation_id : Event.Correlation_id.t
   ; store_writer : Store.writer option
   ; writer_gate : Eio.Mutex.t
   ; mu : Eio.Mutex.t
+  ; mutable writer_authority : writer_authority
   ; mutable state : journal_state
   }
 
-type durable = { journal : t }
+type durable_writer =
+  { journal : t
+  ; claim : unit ref
+  }
 
 let with_read journal f = Eio.Mutex.use_ro journal.mu (fun () -> f journal.state)
-
-let with_state_write journal f =
-  Eio.Cancel.protect (fun () -> Eio.Mutex.use_ro journal.mu f)
-;;
-
+let with_state_write journal f = Eio.Mutex.use_rw ~protect:true journal.mu f
 let with_writer_gate journal f = Eio.Mutex.use_ro journal.writer_gate f
 
-let with_abort_gate journal f =
-  Eio.Cancel.protect (fun () -> Eio.Mutex.use_ro journal.writer_gate f)
+let claim_direct_writer_locked journal =
+  match journal.writer_authority with
+  | Unclaimed_writer ->
+    journal.writer_authority <- Direct_writer;
+    Ok ()
+  | Direct_writer -> Ok ()
+  | Claimed_durable_writer _ -> Error Direct_mutation_forbidden
+;;
+
+let ensure_direct_writer_allowed_locked journal =
+  match journal.writer_authority with
+  | Unclaimed_writer | Direct_writer -> Ok ()
+  | Claimed_durable_writer _ -> Error Direct_mutation_forbidden
+;;
+
+let validate_durable_writer_locked (writer : durable_writer) =
+  match writer.journal.writer_authority with
+  | Claimed_durable_writer claim when claim == writer.claim -> Ok ()
+  | Unclaimed_writer | Direct_writer | Claimed_durable_writer _ ->
+    Error Durable_writer_owner_mismatch
 ;;
 
 let length journal = with_read journal (fun state -> Reducer.last_seq state.reducer)
@@ -839,7 +1004,7 @@ let last_seq journal = with_read journal (fun state -> Reducer.last_seq state.re
 
 let events journal =
   let events_rev = with_read journal (fun state -> state.events_rev) in
-  List.rev events_rev
+  reverse_cooperatively events_rev
 ;;
 
 let make_cursor scope_id seq =
@@ -855,25 +1020,53 @@ let current_cursor journal =
   make_cursor journal.scope_id seq
 ;;
 
-let events_after journal ~(after : cursor) =
-  if not (Store.Scope_id.equal (Store.cursor_scope_id after) journal.scope_id)
+type page =
+  { events : Event.t list
+  ; next_cursor : cursor
+  ; high_watermark : cursor
+  ; has_more : bool
+  }
+
+let read_page journal ~after ?through ~limit () =
+  if limit <= 0
+  then Error (Invalid_argument "page limit must be positive")
+  else if not (Store.Scope_id.equal (Store.cursor_scope_id after) journal.scope_id)
   then Error Cursor_scope_mismatch
-  else if Store.cursor_seq after < 0
-  then Error (Invalid_argument "cursor sequence must be non-negative")
+  else if
+    match through with
+    | Some through ->
+      not (Store.Scope_id.equal (Store.cursor_scope_id through) journal.scope_id)
+    | None -> false
+  then Error Cursor_scope_mismatch
   else (
+    let state = with_read journal Fun.id in
+    let current_seq = Reducer.last_seq state.reducer in
     let after_seq = Store.cursor_seq after in
-    let last_seq, events_rev =
-      with_read journal (fun state -> Reducer.last_seq state.reducer, state.events_rev)
-    in
-    if after_seq > last_seq
-    then Error (Cursor_ahead { after_seq; last_seq })
+    let high_watermark = Option.fold ~none:current_seq ~some:Store.cursor_seq through in
+    if high_watermark > current_seq
+    then Error (Cursor_ahead { after_seq = high_watermark; last_seq = current_seq })
+    else if after_seq > high_watermark
+    then Error (Cursor_ahead { after_seq; last_seq = high_watermark })
     else (
-      let rec collect chronological = function
-        | event :: rest when Event.seq event > after_seq ->
-          collect (event :: chronological) rest
-        | _ -> chronological
+      let page_event_count = min limit (high_watermark - after_seq) in
+      let page_last_seq = after_seq + page_event_count in
+      let rec collect seq events_rev =
+        if seq > page_last_seq
+        then Ok (reverse_cooperatively events_rev)
+        else (
+          match Event_seq_map.find_opt seq state.events_by_seq with
+          | None ->
+            Error (Projection_index_diverged { expected_seq = seq; high_watermark })
+          | Some event ->
+            Eio.Fiber.yield ();
+            collect (seq + 1) (event :: events_rev))
       in
-      Ok (collect [] events_rev, make_cursor journal.scope_id last_seq)))
+      let+ events = collect (after_seq + 1) [] in
+      { events
+      ; next_cursor = make_cursor journal.scope_id page_last_seq
+      ; high_watermark = make_cursor journal.scope_id high_watermark
+      ; has_more = page_last_seq < high_watermark
+      }))
 ;;
 
 let snapshot journal =
@@ -886,7 +1079,12 @@ let snapshot_cursor (snapshot : snapshot) =
 ;;
 
 let snapshot_find_node (snapshot : snapshot) node_id =
-  Reducer.find_node snapshot.reducer node_id
+  match Reducer.find_node_record snapshot.reducer node_id with
+  | None -> None
+  | Some record ->
+    let updates = reverse_cooperatively record.updates_rev in
+    let children = reverse_cooperatively record.children_rev in
+    Some (Reducer.node_view_from_histories snapshot.reducer record ~updates ~children)
 ;;
 
 let snapshot_find_run (snapshot : snapshot) run_id =
@@ -936,7 +1134,12 @@ let append_to_state
     | Ok reducer -> Ok reducer
     | Error violation -> Error (Invariant_violation violation)
   in
-  Ok ({ reducer; events_rev = event :: state.events_rev }, event)
+  Ok
+    ( { reducer
+      ; events_rev = event :: state.events_rev
+      ; events_by_seq = Event_seq_map.add (Event.seq event) event state.events_by_seq
+      }
+    , event )
 ;;
 
 type 'a mutation =
@@ -996,8 +1199,10 @@ let commit_mutation journal (captured_state : journal_state) mutation =
 
 let with_write journal f =
   with_writer_gate journal (fun () ->
+    let* () = ensure_direct_writer_allowed_locked journal in
     let captured_state = with_read journal Fun.id in
     let* mutation = f captured_state in
+    let* () = claim_direct_writer_locked journal in
     commit_mutation journal captured_state mutation)
 ;;
 
@@ -1148,6 +1353,61 @@ let stage_finish_run ?causes journal state ~run terminal =
     payload
 ;;
 
+let stage_abort_run ?causes journal captured_state ~run terminal =
+  match terminal with
+  | Event.Succeeded ->
+    Error (Invalid_argument "abort_run requires a failed or cancelled terminal")
+  | Event.Failed _ | Event.Cancelled _ ->
+    let* terminal = payload_result (Event.validate_terminal terminal) in
+    let* () = validate_run_handle captured_state run in
+    let* order =
+      match Reducer.open_subtree_postorder captured_state.reducer run.root with
+      | Ok order -> Ok order
+      | Error violation -> Error (Invariant_violation violation)
+    in
+    let rec apply_closes state events_rev closed_by_node = function
+      | [] -> Ok (state, events_rev)
+      | node_id :: nodes ->
+        let* event_id = identity_result (Event.Event_id.fresh ()) in
+        let* record = node_record_or_error state node_id in
+        let* parent_event_id = node_last_event state node_id in
+        let payload = Event.close_payload ~node_id terminal in
+        let child_causes =
+          reverse_filter_map_cooperatively
+            (fun (child : Event.node event_record) ->
+               let child_id = Event.node_id child.value in
+               Option.map
+                 (fun event -> Event.Internal_event (Event.event_id event))
+                 (Node_id_map.find_opt child_id closed_by_node))
+            record.children_rev
+        in
+        let event_causes =
+          append_cooperatively (Option.value causes ~default:[]) child_causes
+        in
+        let* next_state, event =
+          append_to_state
+            state
+            ~event_id
+            ~correlation_id:journal.correlation_id
+            ~run_id:(Event.node_run_id record.node)
+            ~parent_event_id:(Some parent_event_id)
+            ~causes:event_causes
+            payload
+        in
+        Eio.Fiber.yield ();
+        apply_closes
+          next_state
+          (event :: events_rev)
+          (Node_id_map.add node_id event closed_by_node)
+          nodes
+    in
+    let+ next_state, events_rev =
+      apply_closes captured_state [] Node_id_map.empty order
+    in
+    let events = reverse_cooperatively events_rev in
+    { next_state; events; value = events }
+;;
+
 let start_run ?parent_invocation ?causes journal ~agent_name =
   with_write journal (fun state ->
     stage_start_run ?parent_invocation ?causes journal state ~agent_name)
@@ -1177,19 +1437,36 @@ type batch =
   ; events_rev : Event.t list
   }
 
+type batch_metadata =
+  { base_cursor : cursor
+  ; final_cursor : cursor
+  ; correlation_id : Event.Correlation_id.t
+  }
+
 let begin_batch journal =
   let base_state = with_read journal Fun.id in
   { journal; base_state; staged_state = base_state; events_rev = [] }
 ;;
 
+let begin_durable_batch (writer : durable_writer) = begin_batch writer.journal
+
 let batch_length batch =
   Reducer.last_seq batch.staged_state.reducer - Reducer.last_seq batch.base_state.reducer
+;;
+
+let batch_metadata batch =
+  { base_cursor =
+      make_cursor batch.journal.scope_id (Reducer.last_seq batch.base_state.reducer)
+  ; final_cursor =
+      make_cursor batch.journal.scope_id (Reducer.last_seq batch.staged_state.reducer)
+  ; correlation_id = batch.journal.correlation_id
+  }
 ;;
 
 let extend_batch batch mutation =
   ( { batch with
       staged_state = mutation.next_state
-    ; events_rev = List.rev_append mutation.events batch.events_rev
+    ; events_rev = reverse_append_cooperatively mutation.events batch.events_rev
     }
   , mutation.value )
 ;;
@@ -1227,6 +1504,12 @@ module Transaction = struct
         ; terminal : Event.terminal
         }
         -> Event.t t
+    | Abort_run :
+        { causes : Event.cause list
+        ; run : run
+        ; terminal : Event.terminal
+        }
+        -> Event.t list t
 
   let start_run ?parent_invocation ?(causes = []) ~agent_name () =
     Start_run { parent_invocation; causes; agent_name }
@@ -1239,6 +1522,7 @@ module Transaction = struct
   let update_node ?(causes = []) ~node update = Update_node { causes; node; update }
   let close_node ?(causes = []) ~node terminal = Close_node { causes; node; terminal }
   let finish_run ?(causes = []) ~run terminal = Finish_run { causes; run; terminal }
+  let abort_run ?(causes = []) ~run terminal = Abort_run { causes; run; terminal }
 end
 
 let stage : type value. batch -> value Transaction.t -> (batch * value, error) result =
@@ -1268,91 +1552,129 @@ let stage : type value. batch -> value Transaction.t -> (batch * value, error) r
   | Transaction.Finish_run { causes; run; terminal } ->
     stage_mutation
       (stage_finish_run ~causes batch.journal batch.staged_state ~run terminal)
+  | Transaction.Abort_run { causes; run; terminal } ->
+    stage_mutation
+      (stage_abort_run ~causes batch.journal batch.staged_state ~run terminal)
+;;
+
+let commit_batch_locked batch =
+  if batch_length batch = 0
+  then Error Empty_batch
+  else (
+    let actual_state = with_read batch.journal Fun.id in
+    if not (actual_state == batch.base_state)
+    then
+      Error
+        (Stale_batch
+           { expected_last_seq = Reducer.last_seq batch.base_state.reducer
+           ; actual_last_seq = Reducer.last_seq actual_state.reducer
+           })
+    else (
+      let events = reverse_cooperatively batch.events_rev in
+      commit_mutation
+        batch.journal
+        batch.base_state
+        { next_state = batch.staged_state; events; value = events }))
 ;;
 
 let commit_batch batch =
-  if batch_length batch = 0
-  then Error Empty_batch
-  else
-    with_writer_gate batch.journal (fun () ->
-      let actual_state = with_read batch.journal Fun.id in
-      if not (actual_state == batch.base_state)
-      then
-        Error
-          (Stale_batch
-             { expected_last_seq = Reducer.last_seq batch.base_state.reducer
-             ; actual_last_seq = Reducer.last_seq actual_state.reducer
-             })
-      else (
-        let events = List.rev batch.events_rev in
-        commit_mutation
-          batch.journal
-          batch.base_state
-          { next_state = batch.staged_state; events; value = events }))
+  with_writer_gate batch.journal (fun () ->
+    let* () = ensure_direct_writer_allowed_locked batch.journal in
+    if batch_length batch = 0
+    then Error Empty_batch
+    else
+      let* () = claim_direct_writer_locked batch.journal in
+      commit_batch_locked batch)
 ;;
 
-let commit_durable_batch (durable : durable) (batch : batch) =
-  if durable.journal != batch.journal
+let commit_durable_batch (writer : durable_writer) (batch : batch) =
+  if writer.journal != batch.journal
   then Error Durable_batch_owner_mismatch
-  else commit_batch batch
+  else
+    with_writer_gate writer.journal (fun () ->
+      let* () = validate_durable_writer_locked writer in
+      commit_batch_locked batch)
+;;
+
+type durable_batch_reconciliation =
+  | Applied of Event.t list
+  | Already_durable of Event.t list
+
+let replay_exact_batch (state : journal_state) events =
+  let rec loop (state : journal_state) = function
+    | [] -> Ok state
+    | event :: rest ->
+      let* reducer =
+        match Reducer.apply state.reducer event with
+        | Ok reducer -> Ok reducer
+        | Error violation -> Error (Invariant_violation violation)
+      in
+      Eio.Fiber.yield ();
+      loop
+        { reducer
+        ; events_rev = event :: state.events_rev
+        ; events_by_seq = Event_seq_map.add (Event.seq event) event state.events_by_seq
+        }
+        rest
+  in
+  loop state events
+;;
+
+let reconcile_durable_batch (writer : durable_writer) (batch : batch) =
+  with_writer_gate writer.journal (fun () ->
+    let* () = validate_durable_writer_locked writer in
+    if batch_length batch = 0
+    then Error Empty_batch
+    else if not (Store.Scope_id.equal writer.journal.scope_id batch.journal.scope_id)
+    then Error Reconciliation_scope_mismatch
+    else if
+      not
+        (Event.Correlation_id.equal
+           writer.journal.correlation_id
+           batch.journal.correlation_id)
+    then Error Reconciliation_correlation_mismatch
+    else (
+      let base_seq = Reducer.last_seq batch.base_state.reducer in
+      let final_seq = Reducer.last_seq batch.staged_state.reducer in
+      let actual_state = with_read writer.journal Fun.id in
+      let current_seq = Reducer.last_seq actual_state.reducer in
+      let events = reverse_cooperatively batch.events_rev in
+      if current_seq = base_seq
+      then
+        let* next_state = replay_exact_batch actual_state events in
+        let+ committed =
+          commit_mutation
+            writer.journal
+            actual_state
+            { next_state; events; value = events }
+        in
+        Applied committed
+      else if current_seq = final_seq
+      then (
+        match writer.journal.store_writer with
+        | None -> Error Durable_store_unavailable
+        | Some store_writer ->
+          (match
+             Store.append_batch store_writer ~expected_next_seq:(base_seq + 1) events
+           with
+           | Ok Store.Already_committed -> Ok (Already_durable events)
+           | Ok Store.Stored ->
+             Error
+               (Reconciliation_store_diverged
+                  { first_seq = base_seq + 1; last_seq = final_seq })
+           | Error (Store.Committed_content_conflict { first_seq; last_seq }) ->
+             Error (Reconciliation_content_conflict { first_seq; last_seq })
+           | Error error -> Error (Persistence_failure error)))
+      else Error (Reconciliation_conflict { base_seq; final_seq; current_seq })))
 ;;
 
 let abort_run ?causes journal ~run terminal =
-  match terminal with
-  | Event.Succeeded ->
-    Error (Invalid_argument "abort_run requires a failed or cancelled terminal")
-  | Event.Failed _ | Event.Cancelled _ ->
-    let* terminal = payload_result (Event.validate_terminal terminal) in
-    with_abort_gate journal (fun () ->
-      let captured_state = with_read journal Fun.id in
-      let* () = validate_run_handle captured_state run in
-      let* order =
-        match Reducer.open_subtree_postorder captured_state.reducer run.root with
-        | Ok order -> Ok order
-        | Error violation -> Error (Invariant_violation violation)
-      in
-      let rec apply_closes state events_rev closed_by_node = function
-        | [] -> Ok (state, events_rev)
-        | node_id :: nodes ->
-          let* event_id = identity_result (Event.Event_id.fresh ()) in
-          let* record = node_record_or_error state node_id in
-          let* parent_event_id = node_last_event state node_id in
-          let payload = Event.close_payload ~node_id terminal in
-          let child_causes =
-            record.children_rev
-            |> List.rev
-            |> List.filter_map (fun (child : Event.node event_record) ->
-              let child_id = Event.node_id child.value in
-              Option.map
-                (fun event -> Event.Internal_event (Event.event_id event))
-                (Node_id_map.find_opt child_id closed_by_node))
-          in
-          let event_causes = Option.value causes ~default:[] @ child_causes in
-          let* next_state, event =
-            append_to_state
-              state
-              ~event_id
-              ~correlation_id:journal.correlation_id
-              ~run_id:(Event.node_run_id record.node)
-              ~parent_event_id:(Some parent_event_id)
-              ~causes:event_causes
-              payload
-          in
-          Eio.Fiber.yield ();
-          apply_closes
-            next_state
-            (event :: events_rev)
-            (Node_id_map.add node_id event closed_by_node)
-            nodes
-      in
-      let* final_state, events_rev =
-        apply_closes captured_state [] Node_id_map.empty order
-      in
-      let events = List.rev events_rev in
-      commit_mutation
-        journal
-        captured_state
-        { next_state = final_state; events; value = events })
+  with_writer_gate journal (fun () ->
+    let* () = ensure_direct_writer_allowed_locked journal in
+    let captured_state = with_read journal Fun.id in
+    let* mutation = stage_abort_run ?causes journal captured_state ~run terminal in
+    let* () = claim_direct_writer_locked journal in
+    commit_mutation journal captured_state mutation)
 ;;
 
 let replay_events events =
@@ -1365,12 +1687,20 @@ let replay_events events =
         | Error violation -> Error (Invariant_violation violation)
       in
       Eio.Fiber.yield ();
-      loop { reducer; events_rev = event :: state.events_rev } rest
+      loop
+        { reducer
+        ; events_rev = event :: state.events_rev
+        ; events_by_seq = Event_seq_map.add (Event.seq event) event state.events_by_seq
+        }
+        rest
   in
-  loop ({ reducer = Reducer.empty; events_rev = [] } : journal_state) events
+  loop
+    ({ reducer = Reducer.empty; events_rev = []; events_by_seq = Event_seq_map.empty }
+     : journal_state)
+    events
 ;;
 
-let create ?correlation_id ?store () =
+let create_internal ?correlation_id store =
   let* scope_id, correlation_id, state, store_writer =
     match store with
     | None ->
@@ -1384,7 +1714,14 @@ let create ?correlation_id ?store () =
         | Some correlation_id -> Ok correlation_id
         | None -> identity_result (Event.Correlation_id.fresh ())
       in
-      Ok (scope_id, correlation_id, { reducer = Reducer.empty; events_rev = [] }, None)
+      Ok
+        ( scope_id
+        , correlation_id
+        , { reducer = Reducer.empty
+          ; events_rev = []
+          ; events_by_seq = Event_seq_map.empty
+          }
+        , None )
     | Some store ->
       let store_correlation = Store.correlation_id store in
       let* () =
@@ -1413,28 +1750,69 @@ let create ?correlation_id ?store () =
     ; store_writer
     ; writer_gate = Eio.Mutex.create ()
     ; mu = Eio.Mutex.create ()
+    ; writer_authority = Unclaimed_writer
     ; state
     }
 ;;
 
-let durable_journal (durable : durable) = durable.journal
+let create ?correlation_id () = create_internal ?correlation_id None
 
-let create_durable ~sw ~dir ?correlation_id () =
+let make_durable_writer journal =
+  let claim = ref () in
+  journal.writer_authority <- Claimed_durable_writer claim;
+  { journal; claim }
+;;
+
+let durable_writer_journal (writer : durable_writer) = writer.journal
+
+exception Unpublished_store_release_failed of Store.error
+
+let () =
+  Printexc.register_printer (function
+    | Unpublished_store_release_failed error ->
+      Some ("unpublished execution store cleanup failed: " ^ Store.error_to_string error)
+    | _ -> None)
+;;
+
+let release_after_construction_error store construction_error =
+  match Store.release_unpublished store with
+  | Ok () -> Error construction_error
+  | Error cleanup_error ->
+    Error (Durable_construction_cleanup_failed { construction_error; cleanup_error })
+;;
+
+let journal_writer_of_store store =
+  match create_internal (Some store) with
+  | Ok journal -> Ok (make_durable_writer journal)
+  | Error construction_error -> release_after_construction_error store construction_error
+  | exception exn ->
+    let bt = Printexc.get_raw_backtrace () in
+    (match Store.release_unpublished store with
+     | Ok () -> Printexc.raise_with_backtrace exn bt
+     | Error cleanup_error ->
+       let cleanup_exn = Unpublished_store_release_failed cleanup_error in
+       let combined, combined_bt =
+         Eio.Exn.combine (exn, bt) (cleanup_exn, Eio.Exn.empty_backtrace)
+       in
+       Printexc.raise_with_backtrace combined combined_bt)
+;;
+
+let create_durable_writer ~sw ~dir ?correlation_id () =
   let* store, initialization =
     match Store.create ~sw ~dir ?correlation_id () with
     | Ok result -> Ok result
     | Error error -> Error (Persistence_failure error)
   in
-  let+ journal = create ~store () in
-  { journal }, initialization
+  let+ writer = journal_writer_of_store store in
+  writer, initialization
 ;;
 
-let open_durable ~sw ~dir =
+let open_durable_writer ~sw ~dir =
   let* store, recovery =
     match Store.open_existing ~sw ~dir with
     | Ok result -> Ok result
     | Error error -> Error (Persistence_failure error)
   in
-  let+ journal = create ~store () in
-  { journal }, recovery
+  let+ writer = journal_writer_of_store store in
+  writer, recovery
 ;;

--- a/lib/execution_journal.ml
+++ b/lib/execution_journal.ml
@@ -1765,12 +1765,33 @@ let make_durable_writer journal =
 
 let durable_writer_journal (writer : durable_writer) = writer.journal
 
-exception Unpublished_store_release_failed of Store.error
+exception Durable_construction_cleanup_raised of error * exn
+exception Journal_construction_cleanup_failed of exn * Store.error
+exception Journal_construction_cleanup_raised of Eio.Exn.with_bt * Eio.Exn.with_bt
 
 let () =
   Printexc.register_printer (function
-    | Unpublished_store_release_failed error ->
-      Some ("unpublished execution store cleanup failed: " ^ Store.error_to_string error)
+    | Durable_construction_cleanup_raised (construction_error, cleanup_exn) ->
+      Some
+        ("durable journal construction failed ("
+         ^ error_to_string construction_error
+         ^ ") and unpublished store cleanup raised ("
+         ^ Printexc.to_string cleanup_exn
+         ^ ")")
+    | Journal_construction_cleanup_failed (construction_exn, cleanup_error) ->
+      Some
+        ("durable journal construction raised ("
+         ^ Printexc.to_string construction_exn
+         ^ ") and unpublished store cleanup failed ("
+         ^ Store.error_to_string cleanup_error
+         ^ ")")
+    | Journal_construction_cleanup_raised ((construction_exn, _), (cleanup_exn, _)) ->
+      Some
+        ("durable journal construction raised ("
+         ^ Printexc.to_string construction_exn
+         ^ ") and unpublished store cleanup also raised ("
+         ^ Printexc.to_string cleanup_exn
+         ^ ")")
     | _ -> None)
 ;;
 
@@ -1779,6 +1800,11 @@ let release_after_construction_error store construction_error =
   | Ok () -> Error construction_error
   | Error cleanup_error ->
     Error (Durable_construction_cleanup_failed { construction_error; cleanup_error })
+  | exception cleanup_exn ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    Printexc.raise_with_backtrace
+      (Durable_construction_cleanup_raised (construction_error, cleanup_exn))
+      backtrace
 ;;
 
 let journal_writer_of_store store =
@@ -1790,11 +1816,14 @@ let journal_writer_of_store store =
     (match Store.release_unpublished store with
      | Ok () -> Printexc.raise_with_backtrace exn bt
      | Error cleanup_error ->
-       let cleanup_exn = Unpublished_store_release_failed cleanup_error in
-       let combined, combined_bt =
-         Eio.Exn.combine (exn, bt) (cleanup_exn, Eio.Exn.empty_backtrace)
-       in
-       Printexc.raise_with_backtrace combined combined_bt)
+       Printexc.raise_with_backtrace
+         (Journal_construction_cleanup_failed (exn, cleanup_error))
+         bt
+     | exception cleanup_exn ->
+       let cleanup_bt = Printexc.get_raw_backtrace () in
+       Printexc.raise_with_backtrace
+         (Journal_construction_cleanup_raised ((exn, bt), (cleanup_exn, cleanup_bt)))
+         bt)
 ;;
 
 let create_durable_writer ~sw ~dir ?correlation_id () =

--- a/lib/execution_journal.ml
+++ b/lib/execution_journal.ml
@@ -157,6 +157,12 @@ type error =
   | Invalid_argument of string
   | Invalid_event of string
   | Identity_failure of string
+  | Empty_batch
+  | Durable_batch_owner_mismatch
+  | Stale_batch of
+      { expected_last_seq : int
+      ; actual_last_seq : int
+      }
   | Cursor_scope_mismatch
   | Cursor_ahead of
       { after_seq : int
@@ -169,6 +175,14 @@ let error_to_string = function
   | Invalid_argument detail -> "invalid execution journal argument: " ^ detail
   | Invalid_event detail -> "invalid execution event: " ^ detail
   | Identity_failure detail -> "execution journal identity allocation failed: " ^ detail
+  | Empty_batch -> "execution journal batch contains no semantic mutations"
+  | Durable_batch_owner_mismatch ->
+    "execution journal durable capability does not own the staged batch"
+  | Stale_batch { expected_last_seq; actual_last_seq } ->
+    Printf.sprintf
+      "execution journal batch base is stale: expected last sequence %d but found %d"
+      expected_last_seq
+      actual_last_seq
   | Cursor_scope_mismatch -> "execution journal cursor belongs to another scope"
   | Cursor_ahead { after_seq; last_seq } ->
     Printf.sprintf
@@ -806,6 +820,8 @@ type t =
   ; mutable state : journal_state
   }
 
+type durable = { journal : t }
+
 let with_read journal f = Eio.Mutex.use_ro journal.mu (fun () -> f journal.state)
 
 let with_state_write journal f =
@@ -997,7 +1013,7 @@ let node_last_event (state : journal_state) node_id =
   | Some event_id -> Ok event_id
 ;;
 
-let start_run ?parent_invocation ?causes journal ~agent_name =
+let stage_start_run ?parent_invocation ?causes journal state ~agent_name =
   let* run_id = identity_result (Event.Run_id.fresh ()) in
   let* root = identity_result (Event.Node_id.fresh ()) in
   let* event_id = identity_result (Event.Event_id.fresh ()) in
@@ -1013,21 +1029,20 @@ let start_run ?parent_invocation ?causes journal ~agent_name =
     | Error detail -> Error (Invalid_argument detail)
   in
   let* payload = payload_result (Event.validate_payload (Event.Node_opened node)) in
-  with_write journal (fun state ->
-    let* parent_event_id =
-      match parent_invocation with
-      | None -> Ok None
-      | Some node_id ->
-        let+ event_id = node_last_event state node_id in
-        Some event_id
-    in
-    let+ mutation =
-      append_one journal state ~event_id ~run_id ~parent_event_id ?causes payload
-    in
-    { next_state = mutation.next_state
-    ; events = mutation.events
-    ; value = { id = run_id; root }, mutation.value
-    })
+  let* parent_event_id =
+    match parent_invocation with
+    | None -> Ok None
+    | Some node_id ->
+      let+ event_id = node_last_event state node_id in
+      Some event_id
+  in
+  let+ mutation =
+    append_one journal state ~event_id ~run_id ~parent_event_id ?causes payload
+  in
+  { next_state = mutation.next_state
+  ; events = mutation.events
+  ; value = { id = run_id; root }, mutation.value
+  }
 ;;
 
 let validate_run_handle (state : journal_state) run =
@@ -1040,7 +1055,7 @@ let validate_run_handle (state : journal_state) run =
   | Some { status = Running; _ } -> Ok ()
 ;;
 
-let open_node ?causes journal ~run ~parent ~kind =
+let stage_open_node ?causes journal state ~run ~parent ~kind =
   match kind with
   | Event.Agent_run _ -> Error (Invariant_violation Agent_run_must_use_start_run)
   | Event.Agent_turn _
@@ -1058,33 +1073,54 @@ let open_node ?causes journal ~run ~parent ~kind =
       | Error detail -> Error (Invalid_argument detail)
     in
     let* payload = payload_result (Event.validate_payload (Event.Node_opened node)) in
-    with_write journal (fun state ->
-      let* () = validate_run_handle state run in
-      let* parent_event_id = node_last_event state parent in
-      let+ mutation =
-        append_one
-          journal
-          state
-          ~event_id
-          ~run_id:run.id
-          ~parent_event_id:(Some parent_event_id)
-          ?causes
-          payload
-      in
-      { next_state = mutation.next_state
-      ; events = mutation.events
-      ; value = node_id, mutation.value
-      })
+    let* () = validate_run_handle state run in
+    let* parent_event_id = node_last_event state parent in
+    let+ mutation =
+      append_one
+        journal
+        state
+        ~event_id
+        ~run_id:run.id
+        ~parent_event_id:(Some parent_event_id)
+        ?causes
+        payload
+    in
+    { next_state = mutation.next_state
+    ; events = mutation.events
+    ; value = node_id, mutation.value
+    }
 ;;
 
-let update_node ?causes journal ~node update =
+let stage_update_node ?causes journal state ~node update =
   let* event_id = identity_result (Event.Event_id.fresh ()) in
   let* payload =
     payload_result
       (Event.validate_payload (Event.Node_updated { node_id = node; update }))
   in
-  with_write journal (fun state ->
-    let* view = node_record_or_error state node in
+  let* view = node_record_or_error state node in
+  let* parent_event_id = node_last_event state node in
+  append_one
+    journal
+    state
+    ~event_id
+    ~run_id:(Event.node_run_id view.node)
+    ~parent_event_id:(Some parent_event_id)
+    ?causes
+    payload
+;;
+
+let stage_close_node ?causes journal state ~node terminal =
+  let* event_id = identity_result (Event.Event_id.fresh ()) in
+  let* terminal = payload_result (Event.validate_terminal terminal) in
+  let payload = Event.close_payload ~node_id:node terminal in
+  let* view = node_record_or_error state node in
+  match Event.node_kind view.node with
+  | Event.Agent_run _ -> Error (Invariant_violation (Root_must_use_finish_run node))
+  | Event.Agent_turn _
+  | Event.Provider_attempt _
+  | Event.Output_block _
+  | Event.Tool_invocation _
+  | Event.Tool_attempt ->
     let* parent_event_id = node_last_event state node in
     append_one
       journal
@@ -1093,48 +1129,172 @@ let update_node ?causes journal ~node update =
       ~run_id:(Event.node_run_id view.node)
       ~parent_event_id:(Some parent_event_id)
       ?causes
-      payload)
+      payload
 ;;
 
-let close_node ?causes journal ~node terminal =
-  let* event_id = identity_result (Event.Event_id.fresh ()) in
-  let* terminal = payload_result (Event.validate_terminal terminal) in
-  let payload = Event.close_payload ~node_id:node terminal in
-  with_write journal (fun state ->
-    let* view = node_record_or_error state node in
-    match Event.node_kind view.node with
-    | Event.Agent_run _ -> Error (Invariant_violation (Root_must_use_finish_run node))
-    | Event.Agent_turn _
-    | Event.Provider_attempt _
-    | Event.Output_block _
-    | Event.Tool_invocation _
-    | Event.Tool_attempt ->
-      let* parent_event_id = node_last_event state node in
-      append_one
-        journal
-        state
-        ~event_id
-        ~run_id:(Event.node_run_id view.node)
-        ~parent_event_id:(Some parent_event_id)
-        ?causes
-        payload)
-;;
-
-let finish_run ?causes journal ~run terminal =
+let stage_finish_run ?causes journal state ~run terminal =
   let* event_id = identity_result (Event.Event_id.fresh ()) in
   let* terminal = payload_result (Event.validate_terminal terminal) in
   let payload = Event.close_payload ~node_id:run.root terminal in
+  let* () = validate_run_handle state run in
+  let* parent_event_id = node_last_event state run.root in
+  append_one
+    journal
+    state
+    ~event_id
+    ~run_id:run.id
+    ~parent_event_id:(Some parent_event_id)
+    ?causes
+    payload
+;;
+
+let start_run ?parent_invocation ?causes journal ~agent_name =
   with_write journal (fun state ->
-    let* () = validate_run_handle state run in
-    let* parent_event_id = node_last_event state run.root in
-    append_one
-      journal
-      state
-      ~event_id
-      ~run_id:run.id
-      ~parent_event_id:(Some parent_event_id)
-      ?causes
-      payload)
+    stage_start_run ?parent_invocation ?causes journal state ~agent_name)
+;;
+
+let open_node ?causes journal ~run ~parent ~kind =
+  with_write journal (fun state ->
+    stage_open_node ?causes journal state ~run ~parent ~kind)
+;;
+
+let update_node ?causes journal ~node update =
+  with_write journal (fun state -> stage_update_node ?causes journal state ~node update)
+;;
+
+let close_node ?causes journal ~node terminal =
+  with_write journal (fun state -> stage_close_node ?causes journal state ~node terminal)
+;;
+
+let finish_run ?causes journal ~run terminal =
+  with_write journal (fun state -> stage_finish_run ?causes journal state ~run terminal)
+;;
+
+type batch =
+  { journal : t
+  ; base_state : journal_state
+  ; staged_state : journal_state
+  ; events_rev : Event.t list
+  }
+
+let begin_batch journal =
+  let base_state = with_read journal Fun.id in
+  { journal; base_state; staged_state = base_state; events_rev = [] }
+;;
+
+let batch_length batch =
+  Reducer.last_seq batch.staged_state.reducer - Reducer.last_seq batch.base_state.reducer
+;;
+
+let extend_batch batch mutation =
+  ( { batch with
+      staged_state = mutation.next_state
+    ; events_rev = List.rev_append mutation.events batch.events_rev
+    }
+  , mutation.value )
+;;
+
+module Transaction = struct
+  type _ t =
+    | Start_run :
+        { parent_invocation : Event.Node_id.t option
+        ; causes : Event.cause list
+        ; agent_name : string
+        }
+        -> (run * Event.t) t
+    | Open_node :
+        { causes : Event.cause list
+        ; run : run
+        ; parent : Event.Node_id.t
+        ; kind : Event.node_kind
+        }
+        -> (Event.Node_id.t * Event.t) t
+    | Update_node :
+        { causes : Event.cause list
+        ; node : Event.Node_id.t
+        ; update : Event.node_update
+        }
+        -> Event.t t
+    | Close_node :
+        { causes : Event.cause list
+        ; node : Event.Node_id.t
+        ; terminal : Event.terminal
+        }
+        -> Event.t t
+    | Finish_run :
+        { causes : Event.cause list
+        ; run : run
+        ; terminal : Event.terminal
+        }
+        -> Event.t t
+
+  let start_run ?parent_invocation ?(causes = []) ~agent_name () =
+    Start_run { parent_invocation; causes; agent_name }
+  ;;
+
+  let open_node ?(causes = []) ~run ~parent ~kind () =
+    Open_node { causes; run; parent; kind }
+  ;;
+
+  let update_node ?(causes = []) ~node update = Update_node { causes; node; update }
+  let close_node ?(causes = []) ~node terminal = Close_node { causes; node; terminal }
+  let finish_run ?(causes = []) ~run terminal = Finish_run { causes; run; terminal }
+end
+
+let stage : type value. batch -> value Transaction.t -> (batch * value, error) result =
+  fun batch transaction ->
+  let stage_mutation result =
+    let+ mutation = result in
+    extend_batch batch mutation
+  in
+  match transaction with
+  | Transaction.Start_run { parent_invocation; causes; agent_name } ->
+    stage_mutation
+      (stage_start_run
+         ?parent_invocation
+         ~causes
+         batch.journal
+         batch.staged_state
+         ~agent_name)
+  | Transaction.Open_node { causes; run; parent; kind } ->
+    stage_mutation
+      (stage_open_node ~causes batch.journal batch.staged_state ~run ~parent ~kind)
+  | Transaction.Update_node { causes; node; update } ->
+    stage_mutation
+      (stage_update_node ~causes batch.journal batch.staged_state ~node update)
+  | Transaction.Close_node { causes; node; terminal } ->
+    stage_mutation
+      (stage_close_node ~causes batch.journal batch.staged_state ~node terminal)
+  | Transaction.Finish_run { causes; run; terminal } ->
+    stage_mutation
+      (stage_finish_run ~causes batch.journal batch.staged_state ~run terminal)
+;;
+
+let commit_batch batch =
+  if batch_length batch = 0
+  then Error Empty_batch
+  else
+    with_writer_gate batch.journal (fun () ->
+      let actual_state = with_read batch.journal Fun.id in
+      if not (actual_state == batch.base_state)
+      then
+        Error
+          (Stale_batch
+             { expected_last_seq = Reducer.last_seq batch.base_state.reducer
+             ; actual_last_seq = Reducer.last_seq actual_state.reducer
+             })
+      else (
+        let events = List.rev batch.events_rev in
+        commit_mutation
+          batch.journal
+          batch.base_state
+          { next_state = batch.staged_state; events; value = events }))
+;;
+
+let commit_durable_batch (durable : durable) (batch : batch) =
+  if durable.journal != batch.journal
+  then Error Durable_batch_owner_mismatch
+  else commit_batch batch
 ;;
 
 let abort_run ?causes journal ~run terminal =
@@ -1255,4 +1415,26 @@ let create ?correlation_id ?store () =
     ; mu = Eio.Mutex.create ()
     ; state
     }
+;;
+
+let durable_journal (durable : durable) = durable.journal
+
+let create_durable ~sw ~dir ?correlation_id () =
+  let* store, initialization =
+    match Store.create ~sw ~dir ?correlation_id () with
+    | Ok result -> Ok result
+    | Error error -> Error (Persistence_failure error)
+  in
+  let+ journal = create ~store () in
+  { journal }, initialization
+;;
+
+let open_durable ~sw ~dir =
+  let* store, recovery =
+    match Store.open_existing ~sw ~dir with
+    | Ok result -> Ok result
+    | Error error -> Error (Persistence_failure error)
+  in
+  let+ journal = create ~store () in
+  { journal }, recovery
 ;;

--- a/lib/execution_journal.mli
+++ b/lib/execution_journal.mli
@@ -136,6 +136,12 @@ type error =
   | Invalid_argument of string
   | Invalid_event of string
   | Identity_failure of string
+  | Empty_batch
+  | Durable_batch_owner_mismatch
+  | Stale_batch of
+      { expected_last_seq : int
+      ; actual_last_seq : int
+      }
   | Cursor_scope_mismatch
   | Cursor_ahead of
       { after_seq : int
@@ -158,6 +164,7 @@ module Reducer : sig
 end
 
 type t
+type durable
 
 (** An immutable, O(1)-captured reducer snapshot. Materializing node histories
     from it does not hold the journal mutex, and every projection shares one
@@ -174,6 +181,22 @@ val create
   -> unit
   -> (t, error) result
 
+(** Explicit durable construction. The directory is caller-owned and dedicated
+    to one execution scope; no path or runtime mode is inferred. The abstract
+    capability is the proof required by a durability-owning writer actor. *)
+val create_durable
+  :  sw:Eio.Switch.t
+  -> dir:Eio.Fs.dir_ty Eio.Path.t
+  -> ?correlation_id:Execution_event.Correlation_id.t
+  -> unit
+  -> (durable * Execution_event_store.initialization, error) result
+
+val open_durable
+  :  sw:Eio.Switch.t
+  -> dir:Eio.Fs.dir_ty Eio.Path.t
+  -> (durable * Execution_event_store.recovery, error) result
+
+val durable_journal : durable -> t
 val length : t -> int
 val last_seq : t -> int
 val events : t -> Execution_event.t list
@@ -190,6 +213,75 @@ val snapshot_find_node : snapshot -> Execution_event.Node_id.t -> node_view opti
 val snapshot_find_run : snapshot -> Execution_event.Run_id.t -> run_view option
 val find_node : t -> Execution_event.Node_id.t -> node_view option
 val find_run : t -> Execution_event.Run_id.t -> run_view option
+
+(** An immutable semantic transaction staged from one exact journal snapshot.
+    Callers can construct only the closed journal mutation set below, never raw
+    events or caller-selected sequence and identity fields. A rejected stage
+    leaves the input [batch] unchanged.
+
+    Event and node identities are allocated while staging and retained by the
+    returned batch. Retrying [commit_batch] therefore submits the exact same
+    canonical events; callers must not rebuild a failed batch to retry durable
+    persistence. *)
+type batch
+
+val begin_batch : t -> batch
+val batch_length : batch -> int
+
+module Transaction : sig
+  type 'a t
+
+  val start_run
+    :  ?parent_invocation:Execution_event.Node_id.t
+    -> ?causes:Execution_event.cause list
+    -> agent_name:string
+    -> unit
+    -> (run * Execution_event.t) t
+
+  val open_node
+    :  ?causes:Execution_event.cause list
+    -> run:run
+    -> parent:Execution_event.Node_id.t
+    -> kind:Execution_event.node_kind
+    -> unit
+    -> (Execution_event.Node_id.t * Execution_event.t) t
+
+  val update_node
+    :  ?causes:Execution_event.cause list
+    -> node:Execution_event.Node_id.t
+    -> Execution_event.node_update
+    -> Execution_event.t t
+
+  val close_node
+    :  ?causes:Execution_event.cause list
+    -> node:Execution_event.Node_id.t
+    -> Execution_event.terminal
+    -> Execution_event.t t
+
+  val finish_run
+    :  ?causes:Execution_event.cause list
+    -> run:run
+    -> Execution_event.terminal
+    -> Execution_event.t t
+end
+
+(** Validate and stage one typed semantic transaction against the batch's
+    current immutable reducer state. The result type is carried by
+    [Transaction.t], allowing a writer actor to pair heterogeneous commands
+    with correctly typed completion tickets. *)
+val stage : batch -> 'a Transaction.t -> (batch * 'a, error) result
+
+(** Commit every staged event with one store append and then publish the final
+    immutable reducer state once. [Stale_batch] is returned before persistence
+    if another mutation has advanced the journal since [begin_batch]. An empty
+    batch is rejected explicitly. [Commit_outcome_unknown] remains a typed
+    {!Persistence_failure}; reconciliation requires reopening the owning store,
+    so this API does not pretend that a live journal can resolve it. *)
+val commit_batch : batch -> (Execution_event.t list, error) result
+
+(** Commit through an explicit durable capability. A batch captured from any
+    other journal is rejected before persistence. *)
+val commit_durable_batch : durable -> batch -> (Execution_event.t list, error) result
 
 (** Start the journal's sole top-level run, or a child run beneath an existing
     open [Tool_invocation]. Once the top-level run has started, the journal can

--- a/lib/execution_journal.mli
+++ b/lib/execution_journal.mli
@@ -4,9 +4,9 @@
     recursively invoked beneath it. It owns one global logical sequence across
     that tree. Timestamps are observations only; ordering uses [seq].
 
-    Events remain in memory for the lifetime of [t]. Durable storage and
-    transport are outside this API boundary; consumers obtain immutable event
-    snapshots through [events] or [events_after]. *)
+    Events remain in memory for the lifetime of [t]. A claimed durable writer
+    hides the physical store behind this semantic boundary; consumers obtain
+    immutable event snapshots through [events] or bounded [read_page] calls. *)
 
 type run
 
@@ -138,6 +138,32 @@ type error =
   | Identity_failure of string
   | Empty_batch
   | Durable_batch_owner_mismatch
+  | Direct_mutation_forbidden
+  | Durable_writer_owner_mismatch
+  | Durable_store_unavailable
+  | Durable_construction_cleanup_failed of
+      { construction_error : error
+      ; cleanup_error : Execution_event_store.error
+      }
+  | Reconciliation_scope_mismatch
+  | Reconciliation_correlation_mismatch
+  | Reconciliation_content_conflict of
+      { first_seq : int
+      ; last_seq : int
+      }
+  | Reconciliation_conflict of
+      { base_seq : int
+      ; final_seq : int
+      ; current_seq : int
+      }
+  | Reconciliation_store_diverged of
+      { first_seq : int
+      ; last_seq : int
+      }
+  | Projection_index_diverged of
+      { expected_seq : int
+      ; high_watermark : int
+      }
   | Stale_batch of
       { expected_last_seq : int
       ; actual_last_seq : int
@@ -152,6 +178,15 @@ type error =
 
 val error_to_string : error -> string
 
+type commit_error_disposition =
+  | Reconcile_required
+  | Final_failure
+
+(** Closed classification for writer actors. This is the only API outside this
+    module that needs to distinguish an authority outcome requiring reopen;
+    callers never inspect store errors or error strings. *)
+val commit_error_disposition : error -> commit_error_disposition
+
 (** Pure immutable reducer used to validate and project the event stream. *)
 module Reducer : sig
   type t
@@ -164,48 +199,61 @@ module Reducer : sig
 end
 
 type t
-type durable
+type durable_writer
 
 (** An immutable, O(1)-captured reducer snapshot. Materializing node histories
     from it does not hold the journal mutex, and every projection shares one
     [through_seq] watermark. *)
 type snapshot
 
-(** Create an execution scope. With [store], all committed store events are
-    replayed through {!Reducer} and every later mutation is durably appended
-    before its immutable in-memory state is published. Without [store], the
-    journal remains explicitly volatile. *)
-val create
-  :  ?correlation_id:Execution_event.Correlation_id.t
-  -> ?store:Execution_event_store.t
-  -> unit
-  -> (t, error) result
+(** Create an explicitly volatile execution scope. Durable scopes are created
+    only through {!create_durable_writer}; no caller can obtain an unclaimed
+    durable journal or bypass its claimed writer authority. *)
+val create : ?correlation_id:Execution_event.Correlation_id.t -> unit -> (t, error) result
 
 (** Explicit durable construction. The directory is caller-owned and dedicated
     to one execution scope; no path or runtime mode is inferred. The abstract
     capability is the proof required by a durability-owning writer actor. *)
-val create_durable
+val create_durable_writer
   :  sw:Eio.Switch.t
   -> dir:Eio.Fs.dir_ty Eio.Path.t
   -> ?correlation_id:Execution_event.Correlation_id.t
   -> unit
-  -> (durable * Execution_event_store.initialization, error) result
+  -> (durable_writer * Execution_event_store.initialization, error) result
 
-val open_durable
+val open_durable_writer
   :  sw:Eio.Switch.t
   -> dir:Eio.Fs.dir_ty Eio.Path.t
-  -> (durable * Execution_event_store.recovery, error) result
+  -> (durable_writer * Execution_event_store.recovery, error) result
 
-val durable_journal : durable -> t
+(** Read/projection access. Direct mutation functions reject this journal with
+    [Direct_mutation_forbidden]; only typed writer transactions can mutate it. *)
+val durable_writer_journal : durable_writer -> t
+
 val length : t -> int
 val last_seq : t -> int
 val events : t -> Execution_event.t list
 val beginning_cursor : t -> cursor
 val current_cursor : t -> cursor
 
-(** Exclusive global cursor query. Returns the immutable event slice and the
-    cursor at the same captured journal state. *)
-val events_after : t -> after:cursor -> (Execution_event.t list * cursor, error) result
+type page = private
+  { events : Execution_event.t list
+  ; next_cursor : cursor
+  ; high_watermark : cursor
+  ; has_more : bool
+  }
+
+(** Read a bounded immutable projection page. Omitting [through] captures the
+    current journal high watermark; passing that cursor on later calls freezes
+    the projection while new events continue to append. [limit] is a transport
+    resource boundary only and never controls execution admission or lifetime. *)
+val read_page
+  :  t
+  -> after:cursor
+  -> ?through:cursor
+  -> limit:int
+  -> unit
+  -> (page, error) result
 
 val snapshot : t -> snapshot
 val snapshot_cursor : snapshot -> cursor
@@ -225,8 +273,19 @@ val find_run : t -> Execution_event.Run_id.t -> run_view option
     persistence. *)
 type batch
 
+type batch_metadata = private
+  { base_cursor : cursor
+  ; final_cursor : cursor
+  ; correlation_id : Execution_event.Correlation_id.t
+  }
+
 val begin_batch : t -> batch
+
+(** Capture the claimed writer's current reducer snapshot. *)
+val begin_durable_batch : durable_writer -> batch
+
 val batch_length : batch -> int
+val batch_metadata : batch -> batch_metadata
 
 module Transaction : sig
   type 'a t
@@ -263,6 +322,12 @@ module Transaction : sig
     -> run:run
     -> Execution_event.terminal
     -> Execution_event.t t
+
+  val abort_run
+    :  ?causes:Execution_event.cause list
+    -> run:run
+    -> Execution_event.terminal
+    -> Execution_event.t list t
 end
 
 (** Validate and stage one typed semantic transaction against the batch's
@@ -279,9 +344,26 @@ val stage : batch -> 'a Transaction.t -> (batch * 'a, error) result
     so this API does not pretend that a live journal can resolve it. *)
 val commit_batch : batch -> (Execution_event.t list, error) result
 
-(** Commit through an explicit durable capability. A batch captured from any
-    other journal is rejected before persistence. *)
-val commit_durable_batch : durable -> batch -> (Execution_event.t list, error) result
+(** Commit through the exclusive durable writer claim. A batch captured from
+    any other live journal is rejected before persistence. *)
+val commit_durable_batch
+  :  durable_writer
+  -> batch
+  -> (Execution_event.t list, error) result
+
+type durable_batch_reconciliation =
+  | Applied of Execution_event.t list
+  | Already_durable of Execution_event.t list
+
+(** Reconcile one immutable pending batch against a newly reopened writer for
+    the same scope and correlation. At the exact base cursor the original
+    events are applied without regenerating identities. At the exact final
+    cursor the committed range is compared byte-for-byte. No other cursor is
+    inferred or retried. *)
+val reconcile_durable_batch
+  :  durable_writer
+  -> batch
+  -> (durable_batch_reconciliation, error) result
 
 (** Start the journal's sole top-level run, or a child run beneath an existing
     open [Tool_invocation]. Once the top-level run has started, the journal can
@@ -331,15 +413,13 @@ val finish_run
 
 (** Atomically close every open descendant of [run] in post-order and then
     close the run root with the same failure or cancellation terminal. The
-    whole cleanup is cancellation-protected. A journal-local writer gate fences
-    concurrent mutations while traversal and validation run outside the state
-    mutex, so readers remain available and abort cannot starve behind a stream
-    of optimistic retries. It yields between semantic nodes without releasing
-    the journal-local writer fence, allowing unrelated fibers and other journal
-    scopes on the same Eio domain to progress. The immutable final state is
-    published only if every terminal event satisfies the reducer. [Succeeded]
-    is rejected: normal completion must use the explicit close/finish
-    lifecycle. *)
+    staging traversal is cancellable and publishes no partial prefix. A
+    journal-local writer gate fences concurrent mutations while traversal and
+    validation run outside the state mutex. It yields between semantic nodes
+    without releasing that fence, allowing unrelated fibers and other journal
+    scopes on the same Eio domain to progress. Once staging completes, the
+    immutable final state is published atomically. [Succeeded] is rejected:
+    normal completion must use the explicit close/finish lifecycle. *)
 val abort_run
   :  ?causes:Execution_event.cause list
   -> t

--- a/lib/execution_lane_writer.ml
+++ b/lib/execution_lane_writer.ml
@@ -1,0 +1,903 @@
+module Event = Execution_event
+module Journal = Execution_journal
+
+type reconciliation_evidence =
+  { first_outcome_unknown : Journal.error
+  ; latest_outcome_unknown : Journal.error
+  ; outcome_count : int
+  }
+
+type reconciliation_wake_source =
+  | Durability_health_changed
+  | Operator_requested
+
+type reconciliation_wake_event =
+  | External_wake of reconciliation_wake_source
+  | Close_requested
+
+type scope_failure =
+  | Initialization_failed of Journal.error
+  | Initialization_reconciliation_failed of
+      { evidence : reconciliation_evidence
+      ; reconciliation_error : Journal.error
+      }
+  | Mutation_writer_failed of Journal.error
+  | Reconciliation_failed of
+      { evidence : reconciliation_evidence
+      ; reconciliation_error : Journal.error
+      }
+  | Reconciliation_interrupted of
+      { evidence : reconciliation_evidence
+      ; interruption : exn
+      }
+  | Reconciliation_unresolved_on_close of { evidence : reconciliation_evidence }
+  | Supervisor_cancelled of exn
+  | Unexpected_exception of exn
+
+exception Callback_failed_after_scope_failure of exn * scope_failure
+
+type submit_error =
+  | Admission_closed
+  | Admission_failed of scope_failure
+
+type ticket_error =
+  | Transaction_rejected of Journal.error
+  | Scope_failed of scope_failure
+
+type ticket_phase =
+  | Queued
+  | Committing
+  | Reconciling
+  | Settled
+
+type admission =
+  | Accepting
+  | Draining
+  | Failed of scope_failure
+  | Closed
+
+type worker_phase =
+  | Starting
+  | Idle
+  | Committing_group
+  | Reconciling_group
+  | Awaiting_reconciliation_wake
+
+type 'a receipt =
+  { value : 'a
+  ; through : Journal.cursor
+  ; group_event_count : int
+  }
+
+type stats =
+  { admission : admission
+  ; worker_phase : worker_phase
+  ; queue_depth : int
+  ; in_flight_commands : int
+  ; accepted : int
+  ; settled : int
+  ; committed_groups : int
+  ; committed_commands : int
+  ; committed_events : int
+  ; reconciliation_unknowns : int
+  ; reconciliation_wakes : int
+  ; current_reconciliation : reconciliation_evidence option
+  ; last_reconciliation_wake : reconciliation_wake_event option
+  }
+
+type read_error =
+  | Journal_not_ready
+  | Journal_reconciling
+  | Journal_unavailable of scope_failure
+  | Journal_read_failed of Journal.error
+
+type page =
+  { events : Event.t list
+  ; next_cursor : Journal.cursor
+  ; high_watermark : Journal.cursor
+  ; has_more : bool
+  }
+
+type 'a ticket =
+  { mu : Eio.Mutex.t
+  ; mutable phase : ticket_phase
+  ; settled : ('a receipt, ticket_error) result Eio.Promise.t
+  ; settle : ('a receipt, ticket_error) result Eio.Promise.u
+  }
+
+type packed_command =
+  | Command :
+      { transaction : 'a Journal.Transaction.t
+      ; ticket : 'a ticket
+      }
+      -> packed_command
+
+type staged_command =
+  | Staged :
+      { ticket : 'a ticket
+      ; value : 'a
+      }
+      -> staged_command
+
+type journal_view =
+  | No_journal
+  | Available of Journal.t
+  | Reconciliation_in_progress
+  | Unavailable of scope_failure
+
+type open_mode =
+  | Create of Event.Correlation_id.t option
+  | Open_existing
+
+type t =
+  { dir : Eio.Fs.dir_ty Eio.Path.t
+  ; initial_mode : open_mode
+  ; mu : Eio.Mutex.t
+  ; changed : Eio.Condition.t
+  ; mutable newest_first : packed_command list
+  ; mutable queue_depth : int
+  ; mutable in_flight : packed_command list
+  ; mutable in_flight_commands : int
+  ; mutable admission : admission
+  ; mutable worker_phase : worker_phase
+  ; mutable journal_view : journal_view
+  ; mutable pending_outcome : reconciliation_evidence option
+  ; mutable reconciliation_wake_token : unit ref
+  ; mutable last_reconciliation_wake : reconciliation_wake_event option
+  ; mutable accepted : int
+  ; mutable settled : int
+  ; mutable committed_groups : int
+  ; mutable committed_commands : int
+  ; mutable committed_events : int
+  ; mutable reconciliation_unknowns : int
+  ; mutable reconciliation_wakes : int
+  ; ready : (unit, scope_failure) result Eio.Promise.t
+  ; resolve_ready : (unit, scope_failure) result Eio.Promise.u
+  ; closed : (unit, scope_failure) result Eio.Promise.t
+  ; resolve_closed : (unit, scope_failure) result Eio.Promise.u
+  }
+
+type pending_group =
+  { batch : Journal.batch
+  ; staged : staged_command list
+  ; command_count : int
+  ; event_count : int
+  ; evidence : reconciliation_evidence
+  }
+
+type pending_reconciliation =
+  | Initialization_outcome_unknown of reconciliation_evidence
+  | Group_outcome_unknown of pending_group
+
+type epoch_result =
+  | Epoch_closed
+  | Epoch_reconcile of pending_reconciliation
+  | Epoch_await_reconciliation_wake of
+      { pending : pending_reconciliation
+      ; observed_wake : unit ref
+      }
+  | Epoch_failed of scope_failure
+
+type group_result =
+  | Continue
+  | Reconcile of pending_group
+  | Await_reconciliation_wake of pending_group
+  | Group_failed of scope_failure
+
+let reconciliation_evidence_to_string evidence =
+  Printf.sprintf
+    "%d unknown outcome(s); first=%s; latest=%s"
+    evidence.outcome_count
+    (Journal.error_to_string evidence.first_outcome_unknown)
+    (Journal.error_to_string evidence.latest_outcome_unknown)
+;;
+
+let scope_failure_to_string = function
+  | Initialization_failed error ->
+    "execution lane writer initialization failed: " ^ Journal.error_to_string error
+  | Initialization_reconciliation_failed { evidence; reconciliation_error } ->
+    "execution lane writer initialization reconciliation failed after "
+    ^ reconciliation_evidence_to_string evidence
+    ^ ": "
+    ^ Journal.error_to_string reconciliation_error
+  | Mutation_writer_failed error ->
+    "execution lane writer mutation failed: " ^ Journal.error_to_string error
+  | Reconciliation_failed { evidence; reconciliation_error } ->
+    "execution lane writer reconciliation failed after "
+    ^ reconciliation_evidence_to_string evidence
+    ^ ": "
+    ^ Journal.error_to_string reconciliation_error
+  | Reconciliation_interrupted { evidence; interruption } ->
+    "execution lane writer reconciliation interrupted after "
+    ^ reconciliation_evidence_to_string evidence
+    ^ ": "
+    ^ Printexc.to_string interruption
+  | Reconciliation_unresolved_on_close { evidence } ->
+    "execution lane writer closed with an unresolved commit outcome after "
+    ^ reconciliation_evidence_to_string evidence
+  | Supervisor_cancelled reason ->
+    "execution lane writer supervisor cancelled: " ^ Printexc.to_string reason
+  | Unexpected_exception exn ->
+    "execution lane writer raised unexpectedly: " ^ Printexc.to_string exn
+;;
+
+let submit_error_to_string = function
+  | Admission_closed -> "execution lane writer admission is closed"
+  | Admission_failed failure -> scope_failure_to_string failure
+;;
+
+let ticket_error_to_string = function
+  | Transaction_rejected error ->
+    "execution transaction rejected: " ^ Journal.error_to_string error
+  | Scope_failed failure -> scope_failure_to_string failure
+;;
+
+let read_error_to_string = function
+  | Journal_not_ready -> "execution journal is not ready"
+  | Journal_reconciling -> "execution journal is reconciling a commit outcome"
+  | Journal_unavailable failure -> scope_failure_to_string failure
+  | Journal_read_failed error -> Journal.error_to_string error
+;;
+
+let with_lock mu f = Eio.Mutex.use_rw ~protect:true mu f
+
+let make_ticket () : _ ticket =
+  let settled, settle = Eio.Promise.create () in
+  { mu = Eio.Mutex.create (); phase = Queued; settled; settle }
+;;
+
+let ticket_phase (ticket : _ ticket) = with_lock ticket.mu (fun () -> ticket.phase)
+
+let set_ticket_phase (ticket : _ ticket) (phase : ticket_phase) =
+  with_lock ticket.mu (fun () ->
+    match ticket.phase with
+    | Settled -> ()
+    | Queued | Committing | Reconciling -> ticket.phase <- phase)
+;;
+
+let settle_ticket (ticket : _ ticket) result =
+  let should_resolve =
+    with_lock ticket.mu (fun () ->
+      match ticket.phase with
+      | Settled -> false
+      | Queued | Committing | Reconciling ->
+        ticket.phase <- Settled;
+        true)
+  in
+  should_resolve && Eio.Promise.try_resolve ticket.settle result
+;;
+
+let await (ticket : _ ticket) = Eio.Promise.await ticket.settled
+
+let settle_command failure (Command { ticket; _ }) =
+  settle_ticket ticket (Error (Scope_failed failure))
+;;
+
+let record_settled writer count =
+  if count > 0
+  then with_lock writer.mu (fun () -> writer.settled <- writer.settled + count)
+;;
+
+let finish_empty_group writer =
+  Eio.Cancel.protect (fun () ->
+    with_lock writer.mu (fun () ->
+      writer.in_flight <- [];
+      writer.in_flight_commands <- 0;
+      writer.worker_phase <- Idle))
+;;
+
+let finish_durable_group writer journal staged command_count event_count =
+  Eio.Cancel.protect (fun () ->
+    let through = Journal.current_cursor journal in
+    let rec settle settled = function
+      | [] -> settled
+      | Staged { ticket; value } :: rest ->
+        let settled =
+          if settle_ticket ticket (Ok { value; through; group_event_count = event_count })
+          then settled + 1
+          else settled
+        in
+        Eio.Fiber.yield ();
+        settle settled rest
+    in
+    let newly_settled = settle 0 staged in
+    with_lock writer.mu (fun () ->
+      writer.journal_view <- Available journal;
+      writer.pending_outcome <- None;
+      writer.in_flight <- [];
+      writer.in_flight_commands <- 0;
+      writer.worker_phase <- Idle;
+      writer.committed_groups <- writer.committed_groups + 1;
+      writer.committed_commands <- writer.committed_commands + command_count;
+      writer.committed_events <- writer.committed_events + event_count;
+      writer.settled <- writer.settled + newly_settled))
+;;
+
+let reject_transaction writer ticket error =
+  Eio.Cancel.protect (fun () ->
+    if settle_ticket ticket (Error (Transaction_rejected error))
+    then record_settled writer 1)
+;;
+
+let rec reverse_staged chronological = function
+  | [] -> chronological
+  | staged :: rest ->
+    Eio.Fiber.yield ();
+    reverse_staged (staged :: chronological) rest
+;;
+
+let rec stage_ready writer batch staged_rev staged_count = function
+  | [] -> batch, reverse_staged [] staged_rev, staged_count
+  | Command { transaction; ticket } :: rest ->
+    let continue batch staged_rev staged_count =
+      Eio.Fiber.yield ();
+      stage_ready writer batch staged_rev staged_count rest
+    in
+    set_ticket_phase ticket Committing;
+    let before = Journal.batch_length batch in
+    (match Journal.stage batch transaction with
+     | Error error ->
+       reject_transaction writer ticket error;
+       continue batch staged_rev staged_count
+     | Ok (next_batch, value) ->
+       if Journal.batch_length next_batch = before
+       then (
+         reject_transaction writer ticket Journal.Empty_batch;
+         continue batch staged_rev staged_count)
+       else continue next_batch (Staged { ticket; value } :: staged_rev) (staged_count + 1))
+;;
+
+let reverse_ready newest_first =
+  let rec loop chronological = function
+    | [] -> chronological
+    | command :: rest ->
+      Eio.Fiber.yield ();
+      loop (command :: chronological) rest
+  in
+  loop [] newest_first
+;;
+
+let initial_reconciliation_evidence error =
+  { first_outcome_unknown = error; latest_outcome_unknown = error; outcome_count = 1 }
+;;
+
+let observe_reconciliation_unknown evidence error =
+  { evidence with
+    latest_outcome_unknown = error
+  ; outcome_count = evidence.outcome_count + 1
+  }
+;;
+
+let unresolved_on_close writer evidence =
+  with_lock writer.mu (fun () ->
+    match writer.admission with
+    | Draining -> Some (Reconciliation_unresolved_on_close { evidence })
+    | Accepting | Failed _ | Closed -> None)
+;;
+
+let mark_reconciling writer staged evidence =
+  Eio.Cancel.protect (fun () ->
+    with_lock writer.mu (fun () ->
+      writer.worker_phase <- Reconciling_group;
+      writer.journal_view <- Reconciliation_in_progress;
+      if Option.is_none writer.pending_outcome
+      then writer.last_reconciliation_wake <- None;
+      writer.pending_outcome <- Some evidence;
+      writer.reconciliation_unknowns <- writer.reconciliation_unknowns + 1);
+    let rec mark = function
+      | [] -> ()
+      | Staged { ticket; _ } :: rest ->
+        set_ticket_phase ticket Reconciling;
+        Eio.Fiber.yield ();
+        mark rest
+    in
+    mark staged)
+;;
+
+let mark_initialization_reconciling writer evidence =
+  Eio.Cancel.protect (fun () ->
+    with_lock writer.mu (fun () ->
+      writer.worker_phase <- Reconciling_group;
+      writer.journal_view <- Reconciliation_in_progress;
+      if Option.is_none writer.pending_outcome
+      then writer.last_reconciliation_wake <- None;
+      writer.pending_outcome <- Some evidence;
+      writer.reconciliation_unknowns <- writer.reconciliation_unknowns + 1))
+;;
+
+let process_ready writer durable_writer journal commands =
+  let batch = Journal.begin_durable_batch durable_writer in
+  let batch, staged, command_count = stage_ready writer batch [] 0 commands in
+  match staged with
+  | [] ->
+    finish_empty_group writer;
+    Continue
+  | _ ->
+    let event_count = Journal.batch_length batch in
+    (match Journal.commit_durable_batch durable_writer batch with
+     | Ok _events ->
+       finish_durable_group writer journal staged command_count event_count;
+       Continue
+     | Error error ->
+       (match Journal.commit_error_disposition error with
+        | Journal.Reconcile_required ->
+          let evidence = initial_reconciliation_evidence error in
+          mark_reconciling writer staged evidence;
+          Reconcile { batch; staged; command_count; event_count; evidence }
+        | Journal.Final_failure -> Group_failed (Mutation_writer_failed error)))
+;;
+
+let detach_ready writer =
+  let rec await () =
+    Eio.Mutex.lock writer.mu;
+    match writer.newest_first, writer.admission with
+    | [], Accepting ->
+      (match Eio.Condition.await writer.changed writer.mu with
+       | () ->
+         Eio.Mutex.unlock writer.mu;
+         await ()
+       | exception exn ->
+         Eio.Mutex.unlock writer.mu;
+         raise exn)
+    | [], (Draining | Failed _ | Closed) ->
+      Eio.Mutex.unlock writer.mu;
+      None
+    | newest_first, _ ->
+      let command_count = writer.queue_depth in
+      writer.newest_first <- [];
+      writer.queue_depth <- 0;
+      writer.in_flight <- newest_first;
+      writer.in_flight_commands <- command_count;
+      writer.worker_phase <- Committing_group;
+      Eio.Mutex.unlock writer.mu;
+      Some (reverse_ready newest_first)
+  in
+  await ()
+;;
+
+let reconciliation_wake_token writer =
+  with_lock writer.mu (fun () -> writer.reconciliation_wake_token)
+;;
+
+let rec run_ready writer durable_writer journal =
+  match detach_ready writer with
+  | None -> Epoch_closed
+  | Some commands ->
+    (match process_ready writer durable_writer journal commands with
+     | Continue ->
+       Eio.Fiber.check ();
+       run_ready writer durable_writer journal
+     | Reconcile pending -> Epoch_reconcile (Group_outcome_unknown pending)
+     | Await_reconciliation_wake pending ->
+       Epoch_await_reconciliation_wake
+         { pending = Group_outcome_unknown pending
+         ; observed_wake = reconciliation_wake_token writer
+         }
+     | Group_failed failure -> Epoch_failed failure)
+;;
+
+let open_writer writer ~sw mode =
+  match mode with
+  | Create correlation_id ->
+    (match Journal.create_durable_writer ~sw ~dir:writer.dir ?correlation_id () with
+     | Error error -> Error error
+     | Ok (durable_writer, _initialization) ->
+       Ok (durable_writer, Journal.durable_writer_journal durable_writer))
+  | Open_existing ->
+    (match Journal.open_durable_writer ~sw ~dir:writer.dir with
+     | Error error -> Error error
+     | Ok (durable_writer, _recovery) ->
+       Ok (durable_writer, Journal.durable_writer_journal durable_writer))
+;;
+
+let publish_open_journal writer journal =
+  Eio.Cancel.protect (fun () ->
+    with_lock writer.mu (fun () ->
+      writer.journal_view <- Available journal;
+      writer.pending_outcome <- None;
+      writer.worker_phase <- Idle);
+    ignore (Eio.Promise.try_resolve writer.resolve_ready (Ok ())))
+;;
+
+let reconcile_pending writer durable_writer journal pending =
+  match Journal.reconcile_durable_batch durable_writer pending.batch with
+  | Ok (Journal.Applied _events | Journal.Already_durable _events) ->
+    finish_durable_group
+      writer
+      journal
+      pending.staged
+      pending.command_count
+      pending.event_count;
+    Continue
+  | Error error ->
+    (match Journal.commit_error_disposition error with
+     | Journal.Reconcile_required ->
+       let evidence = observe_reconciliation_unknown pending.evidence error in
+       mark_reconciling writer pending.staged evidence;
+       (match unresolved_on_close writer evidence with
+        | Some failure -> Group_failed failure
+        | None -> Await_reconciliation_wake { pending with evidence })
+     | Journal.Final_failure ->
+       Group_failed
+         (Reconciliation_failed
+            { evidence = pending.evidence; reconciliation_error = error }))
+;;
+
+let mark_pending_reconciliation writer = function
+  | Initialization_outcome_unknown evidence ->
+    mark_initialization_reconciling writer evidence
+  | Group_outcome_unknown pending ->
+    mark_reconciling writer pending.staged pending.evidence
+;;
+
+let pending_with_unknown pending error =
+  match pending with
+  | Initialization_outcome_unknown evidence ->
+    Initialization_outcome_unknown (observe_reconciliation_unknown evidence error)
+  | Group_outcome_unknown group ->
+    Group_outcome_unknown
+      { group with evidence = observe_reconciliation_unknown group.evidence error }
+;;
+
+let failure_after_reconciliation pending reconciliation_error =
+  match pending with
+  | Initialization_outcome_unknown evidence ->
+    Initialization_reconciliation_failed { evidence; reconciliation_error }
+  | Group_outcome_unknown pending ->
+    Reconciliation_failed { evidence = pending.evidence; reconciliation_error }
+;;
+
+let run_epoch writer mode pending =
+  let observed_wake = reconciliation_wake_token writer in
+  Eio.Switch.run (fun store_sw ->
+    match open_writer writer ~sw:store_sw mode with
+    | Error error ->
+      (match Journal.commit_error_disposition error, pending with
+       | Journal.Reconcile_required, None ->
+         let evidence = initial_reconciliation_evidence error in
+         mark_initialization_reconciling writer evidence;
+         Epoch_reconcile (Initialization_outcome_unknown evidence)
+       | Journal.Reconcile_required, Some pending ->
+         let pending = pending_with_unknown pending error in
+         mark_pending_reconciliation writer pending;
+         let evidence =
+           match pending with
+           | Initialization_outcome_unknown evidence -> evidence
+           | Group_outcome_unknown pending -> pending.evidence
+         in
+         (match unresolved_on_close writer evidence with
+          | Some failure -> Epoch_failed failure
+          | None -> Epoch_await_reconciliation_wake { pending; observed_wake })
+       | Journal.Final_failure, None -> Epoch_failed (Initialization_failed error)
+       | Journal.Final_failure, Some pending ->
+         Epoch_failed (failure_after_reconciliation pending error))
+    | Ok (durable_writer, journal) ->
+      (match pending with
+       | None ->
+         publish_open_journal writer journal;
+         run_ready writer durable_writer journal
+       | Some (Initialization_outcome_unknown _) ->
+         publish_open_journal writer journal;
+         Eio.Fiber.check ();
+         run_ready writer durable_writer journal
+       | Some (Group_outcome_unknown pending) ->
+         (match reconcile_pending writer durable_writer journal pending with
+          | Continue ->
+            Eio.Fiber.check ();
+            run_ready writer durable_writer journal
+          | Reconcile pending -> Epoch_reconcile (Group_outcome_unknown pending)
+          | Await_reconciliation_wake pending ->
+            Epoch_await_reconciliation_wake
+              { pending = Group_outcome_unknown pending; observed_wake }
+          | Group_failed failure -> Epoch_failed failure)))
+;;
+
+let complete_actor writer =
+  Eio.Cancel.protect (fun () ->
+    let transitioned =
+      with_lock writer.mu (fun () ->
+        match writer.admission with
+        | Failed _ | Closed -> false
+        | Accepting | Draining ->
+          writer.admission <- Closed;
+          writer.worker_phase <- Idle;
+          writer.pending_outcome <- None;
+          writer.in_flight <- [];
+          writer.in_flight_commands <- 0;
+          true)
+    in
+    if transitioned
+    then (
+      ignore (Eio.Promise.try_resolve writer.resolve_ready (Ok ()));
+      ignore (Eio.Promise.try_resolve writer.resolve_closed (Ok ()))))
+;;
+
+let fail_actor writer failure =
+  Eio.Cancel.protect (fun () ->
+    let pending =
+      with_lock writer.mu (fun () ->
+        match writer.admission with
+        | Failed _ | Closed -> None
+        | Accepting | Draining ->
+          let failure =
+            match writer.pending_outcome, failure with
+            | Some evidence, Supervisor_cancelled interruption
+            | Some evidence, Unexpected_exception interruption ->
+              Reconciliation_interrupted { evidence; interruption }
+            | None, _
+            | ( Some _
+              , ( Initialization_failed _
+                | Initialization_reconciliation_failed _
+                | Mutation_writer_failed _
+                | Reconciliation_failed _
+                | Reconciliation_interrupted _
+                | Reconciliation_unresolved_on_close _ ) ) -> failure
+          in
+          writer.admission <- Failed failure;
+          writer.worker_phase <- Idle;
+          writer.journal_view <- Unavailable failure;
+          writer.pending_outcome <- None;
+          let in_flight = writer.in_flight in
+          let queued = writer.newest_first in
+          writer.in_flight <- [];
+          writer.in_flight_commands <- 0;
+          writer.newest_first <- [];
+          writer.queue_depth <- 0;
+          Some (failure, in_flight, queued))
+    in
+    match pending with
+    | None -> ()
+    | Some (failure, in_flight, queued) ->
+      ignore (Eio.Promise.try_resolve writer.resolve_ready (Error failure));
+      let rec settle_all count = function
+        | [] -> count
+        | command :: rest ->
+          let count = if settle_command failure command then count + 1 else count in
+          Eio.Fiber.yield ();
+          settle_all count rest
+      in
+      let newly_settled = settle_all (settle_all 0 in_flight) queued in
+      record_settled writer newly_settled;
+      ignore (Eio.Promise.try_resolve writer.resolve_closed (Error failure)))
+;;
+
+let await_reconciliation_wake writer observed_wake =
+  let rec await () =
+    Eio.Mutex.lock writer.mu;
+    if writer.reconciliation_wake_token != observed_wake
+    then (
+      let wake = writer.last_reconciliation_wake in
+      Eio.Mutex.unlock writer.mu;
+      match wake with
+      | Some wake -> wake
+      | None -> invalid_arg "execution lane reconciliation wake has no typed source")
+    else (
+      match writer.admission with
+      | Failed _ | Closed ->
+        Eio.Mutex.unlock writer.mu;
+        invalid_arg "execution lane reconciliation wait outlived its admission"
+      | Draining ->
+        writer.reconciliation_wake_token <- ref ();
+        writer.last_reconciliation_wake <- Some Close_requested;
+        writer.reconciliation_wakes <- writer.reconciliation_wakes + 1;
+        writer.worker_phase <- Reconciling_group;
+        Eio.Mutex.unlock writer.mu;
+        Close_requested
+      | Accepting ->
+        writer.worker_phase <- Awaiting_reconciliation_wake;
+        (match Eio.Condition.await writer.changed writer.mu with
+         | () ->
+           Eio.Mutex.unlock writer.mu;
+           await ()
+         | exception exn ->
+           Eio.Mutex.unlock writer.mu;
+           raise exn))
+  in
+  await ()
+;;
+
+let run_actor writer =
+  let rec epochs mode pending =
+    match run_epoch writer mode pending with
+    | Epoch_closed -> complete_actor writer
+    | Epoch_failed failure -> fail_actor writer failure
+    | Epoch_reconcile next ->
+      Eio.Fiber.yield ();
+      Eio.Fiber.check ();
+      epochs Open_existing (Some next)
+    | Epoch_await_reconciliation_wake { pending; observed_wake } ->
+      let _wake = await_reconciliation_wake writer observed_wake in
+      Eio.Fiber.check ();
+      epochs Open_existing (Some pending)
+  in
+  match epochs writer.initial_mode None with
+  | () -> ()
+  | exception (Eio.Cancel.Cancelled reason as exn) ->
+    let bt = Printexc.get_raw_backtrace () in
+    fail_actor writer (Supervisor_cancelled reason);
+    Printexc.raise_with_backtrace exn bt
+  | exception ((Out_of_memory | Stack_overflow | Sys.Break) as exn) ->
+    let bt = Printexc.get_raw_backtrace () in
+    fail_actor writer (Unexpected_exception exn);
+    Printexc.raise_with_backtrace exn bt
+  | exception exn -> fail_actor writer (Unexpected_exception exn)
+;;
+
+let spawn ~sw ~dir initial_mode =
+  let ready, resolve_ready = Eio.Promise.create () in
+  let closed, resolve_closed = Eio.Promise.create () in
+  let writer =
+    { dir
+    ; initial_mode
+    ; mu = Eio.Mutex.create ()
+    ; changed = Eio.Condition.create ()
+    ; newest_first = []
+    ; queue_depth = 0
+    ; in_flight = []
+    ; in_flight_commands = 0
+    ; admission = Accepting
+    ; worker_phase = Starting
+    ; journal_view = No_journal
+    ; pending_outcome = None
+    ; reconciliation_wake_token = ref ()
+    ; last_reconciliation_wake = None
+    ; accepted = 0
+    ; settled = 0
+    ; committed_groups = 0
+    ; committed_commands = 0
+    ; committed_events = 0
+    ; reconciliation_unknowns = 0
+    ; reconciliation_wakes = 0
+    ; ready
+    ; resolve_ready
+    ; closed
+    ; resolve_closed
+    }
+  in
+  (match Eio.Switch.get_error sw with
+   | Some (Eio.Cancel.Cancelled reason) -> fail_actor writer (Supervisor_cancelled reason)
+   | Some reason -> fail_actor writer (Supervisor_cancelled reason)
+   | None ->
+     Eio.Fiber.fork_daemon ~sw (fun () ->
+       run_actor writer;
+       `Stop_daemon));
+  writer
+;;
+
+let signal_reconciliation_locked writer event =
+  match writer.pending_outcome, writer.journal_view, writer.worker_phase with
+  | Some _, Reconciliation_in_progress, Awaiting_reconciliation_wake ->
+    writer.reconciliation_wake_token <- ref ();
+    writer.last_reconciliation_wake <- Some event;
+    writer.reconciliation_wakes <- writer.reconciliation_wakes + 1;
+    writer.worker_phase <- Reconciling_group;
+    true
+  | None, _, _
+  | Some _, (No_journal | Available _ | Unavailable _), _
+  | ( Some _
+    , Reconciliation_in_progress
+    , (Starting | Idle | Committing_group | Reconciling_group) ) -> false
+;;
+
+let wake_reconciliation writer ~source =
+  let wake =
+    with_lock writer.mu (fun () ->
+      signal_reconciliation_locked writer (External_wake source))
+  in
+  if wake then Eio.Condition.broadcast writer.changed;
+  wake
+;;
+
+let submit writer transaction =
+  let ticket = make_ticket () in
+  let result, wake =
+    with_lock writer.mu (fun () ->
+      match writer.admission with
+      | Failed failure -> Error (Admission_failed failure), false
+      | Draining | Closed -> Error Admission_closed, false
+      | Accepting ->
+        let wake = writer.newest_first = [] in
+        writer.newest_first <- Command { transaction; ticket } :: writer.newest_first;
+        writer.queue_depth <- writer.queue_depth + 1;
+        writer.accepted <- writer.accepted + 1;
+        Ok ticket, wake)
+  in
+  if wake then Eio.Condition.broadcast writer.changed;
+  result
+;;
+
+let close writer =
+  let wake =
+    with_lock writer.mu (fun () ->
+      match writer.admission with
+      | Accepting ->
+        ignore (signal_reconciliation_locked writer Close_requested);
+        writer.admission <- Draining;
+        true
+      | Draining | Failed _ | Closed -> false)
+  in
+  if wake then Eio.Condition.broadcast writer.changed
+;;
+
+let await_closed writer = Eio.Promise.await writer.closed
+let await_ready writer = Eio.Promise.await writer.ready
+
+let close_and_await writer =
+  close writer;
+  await_closed writer
+;;
+
+let run_with_mode ~dir mode f =
+  Eio.Switch.run (fun sw ->
+    let writer = spawn ~sw ~dir mode in
+    match f ~sw writer with
+    | value ->
+      (match close_and_await writer with
+       | Ok () -> Ok value
+       | Error failure -> Error failure)
+    | exception exn ->
+      let backtrace = Printexc.get_raw_backtrace () in
+      let shutdown =
+        match Eio.Cancel.protect (fun () -> close_and_await writer) with
+        | result -> result
+        | exception shutdown_exn ->
+          let shutdown_backtrace = Printexc.get_raw_backtrace () in
+          let combined, combined_backtrace =
+            Eio.Exn.combine (exn, backtrace) (shutdown_exn, shutdown_backtrace)
+          in
+          Printexc.raise_with_backtrace combined combined_backtrace
+      in
+      (match shutdown with
+       | Ok () -> Printexc.raise_with_backtrace exn backtrace
+       | Error failure ->
+         Printexc.raise_with_backtrace
+           (Callback_failed_after_scope_failure (exn, failure))
+           backtrace))
+;;
+
+let run ~dir ?correlation_id f = run_with_mode ~dir (Create correlation_id) f
+let resume ~dir f = run_with_mode ~dir Open_existing f
+
+let read_journal writer f =
+  let journal_view = with_lock writer.mu (fun () -> writer.journal_view) in
+  match journal_view with
+  | No_journal -> Error Journal_not_ready
+  | Reconciliation_in_progress -> Error Journal_reconciling
+  | Unavailable failure -> Error (Journal_unavailable failure)
+  | Available journal -> f journal
+;;
+
+let current_cursor writer =
+  read_journal writer (fun journal -> Ok (Journal.current_cursor journal))
+;;
+
+let read_page writer ~after ?through ~limit () =
+  read_journal writer (fun journal ->
+    match Journal.read_page journal ~after ?through ~limit () with
+    | Ok page ->
+      Ok
+        { events = page.events
+        ; next_cursor = page.next_cursor
+        ; high_watermark = page.high_watermark
+        ; has_more = page.has_more
+        }
+    | Error error -> Error (Journal_read_failed error))
+;;
+
+let stats writer =
+  with_lock writer.mu (fun () ->
+    { admission = writer.admission
+    ; worker_phase = writer.worker_phase
+    ; queue_depth = writer.queue_depth
+    ; in_flight_commands = writer.in_flight_commands
+    ; accepted = writer.accepted
+    ; settled = writer.settled
+    ; committed_groups = writer.committed_groups
+    ; committed_commands = writer.committed_commands
+    ; committed_events = writer.committed_events
+    ; reconciliation_unknowns = writer.reconciliation_unknowns
+    ; reconciliation_wakes = writer.reconciliation_wakes
+    ; current_reconciliation = writer.pending_outcome
+    ; last_reconciliation_wake = writer.last_reconciliation_wake
+    })
+;;

--- a/lib/execution_lane_writer.mli
+++ b/lib/execution_lane_writer.mli
@@ -1,0 +1,181 @@
+(** Lane-local single-writer actor for the recursive execution journal.
+
+    Construction returns before filesystem initialization finishes. Semantic
+    mutations are accepted as typed journal transactions, committed by the
+    actor, and acknowledged only after the journal authority is durable.
+
+    This module is private to OAS. It owns no product policy and exposes no
+    storage primitive or raw-event append path. *)
+
+type t
+type 'a ticket
+
+type reconciliation_evidence = private
+  { first_outcome_unknown : Execution_journal.error
+  ; latest_outcome_unknown : Execution_journal.error
+  ; outcome_count : int
+  }
+
+type reconciliation_wake_source =
+  | Durability_health_changed
+  | Operator_requested
+
+type reconciliation_wake_event =
+  | External_wake of reconciliation_wake_source
+  | Close_requested
+
+type scope_failure =
+  | Initialization_failed of Execution_journal.error
+  | Initialization_reconciliation_failed of
+      { evidence : reconciliation_evidence
+      ; reconciliation_error : Execution_journal.error
+      }
+  | Mutation_writer_failed of Execution_journal.error
+  | Reconciliation_failed of
+      { evidence : reconciliation_evidence
+      ; reconciliation_error : Execution_journal.error
+      }
+  | Reconciliation_interrupted of
+      { evidence : reconciliation_evidence
+      ; interruption : exn
+      }
+  | Reconciliation_unresolved_on_close of { evidence : reconciliation_evidence }
+  | Supervisor_cancelled of exn
+  | Unexpected_exception of exn
+
+(** Both causes are retained when callback failure coincides with a typed
+    durability-scope shutdown failure. *)
+exception Callback_failed_after_scope_failure of exn * scope_failure
+
+type submit_error =
+  | Admission_closed
+  | Admission_failed of scope_failure
+
+type ticket_error =
+  | Transaction_rejected of Execution_journal.error
+  | Scope_failed of scope_failure
+
+type ticket_phase =
+  | Queued
+  | Committing
+  | Reconciling
+  | Settled
+
+type admission =
+  | Accepting
+  | Draining
+  | Failed of scope_failure
+  | Closed
+
+type worker_phase =
+  | Starting
+  | Idle
+  | Committing_group
+  | Reconciling_group
+  | Awaiting_reconciliation_wake
+
+type 'a receipt =
+  { value : 'a
+  ; through : Execution_journal.cursor
+  ; group_event_count : int
+  }
+
+type stats =
+  { admission : admission
+  ; worker_phase : worker_phase
+  ; queue_depth : int
+  ; in_flight_commands : int
+  ; accepted : int
+  ; settled : int
+  ; committed_groups : int
+  ; committed_commands : int
+  ; committed_events : int
+  ; reconciliation_unknowns : int
+  ; reconciliation_wakes : int
+  ; current_reconciliation : reconciliation_evidence option
+  ; last_reconciliation_wake : reconciliation_wake_event option
+  }
+
+type read_error =
+  | Journal_not_ready
+  | Journal_reconciling
+  | Journal_unavailable of scope_failure
+  | Journal_read_failed of Execution_journal.error
+
+type page = private
+  { events : Execution_event.t list
+  ; next_cursor : Execution_journal.cursor
+  ; high_watermark : Execution_journal.cursor
+  ; has_more : bool
+  }
+
+(** Run a fresh durability scope inside an OAS-owned supervisor. The callback
+    may fork work on [sw]. When it returns normally, the wrapper stops
+    admission, drains every accepted command, joins the actor, and only then
+    returns its value. A callback exception also stops admission and lets the
+    actor finish or reconcile every actor-owned durability operation before the
+    original exception is re-raised; the supervisor fiber never settles an
+    in-flight durability group itself. *)
+val run
+  :  dir:Eio.Fs.dir_ty Eio.Path.t
+  -> ?correlation_id:Execution_event.Correlation_id.t
+  -> (sw:Eio.Switch.t -> t -> 'a)
+  -> ('a, scope_failure) result
+
+(** Resume an existing durability scope with the same owned-supervisor
+    lifecycle as {!run}. *)
+val resume
+  :  dir:Eio.Fs.dir_ty Eio.Path.t
+  -> (sw:Eio.Switch.t -> t -> 'a)
+  -> ('a, scope_failure) result
+
+(** Linearized admission. No timer, capacity, event count, token, cost, or turn
+    budget controls acceptance. *)
+val submit : t -> 'a Execution_journal.Transaction.t -> ('a ticket, submit_error) result
+
+(** Await a terminal ticket settlement. Cancelling this waiter never cancels
+    the accepted transaction or the actor. *)
+val await : 'a ticket -> ('a receipt, ticket_error) result
+
+val ticket_phase : 'a ticket -> ticket_phase
+
+(** Await the first usable journal view or its exact terminal initialization
+    failure. This is the deterministic boundary for read-only consumers; it
+    performs no polling and does not submit a synthetic mutation. *)
+val await_ready : t -> (unit, scope_failure) result
+
+(** Stop admission. Every transaction accepted before this call is drained and
+    settled before [await_closed] returns. This operation is idempotent. *)
+val close : t -> unit
+
+val await_closed : t -> (unit, scope_failure) result
+val close_and_await : t -> (unit, scope_failure) result
+
+(** Signal that external durability health or operator state changed while the
+    actor is waiting after a repeated unknown outcome. Returns [true] only when
+    this call atomically claims the next reconciliation cycle; concurrent or
+    early signals return [false] and are never reported as accepted work. The
+    signal carries no retry count or deadline; it is an event, not an execution
+    budget. *)
+val wake_reconciliation : t -> source:reconciliation_wake_source -> bool
+
+(** Lossless projection reads use the journal cursor as their SSOT. A caller
+    may retain its last acknowledged cursor and replay after any wake hint. *)
+val current_cursor : t -> (Execution_journal.cursor, read_error) result
+
+val read_page
+  :  t
+  -> after:Execution_journal.cursor
+  -> ?through:Execution_journal.cursor
+  -> limit:int
+  -> unit
+  -> (page, read_error) result
+
+(** Observations only. None of these values participates in admission,
+    batching, pausing, cancellation, or termination. *)
+val stats : t -> stats
+
+val scope_failure_to_string : scope_failure -> string
+val submit_error_to_string : submit_error -> string
+val ticket_error_to_string : ticket_error -> string
+val read_error_to_string : read_error -> string

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -52,6 +52,8 @@ type reasoning_replay_override = Capability_vocab.reasoning_replay_override =
   | Default_reasoning_replay
   | Force_no_replay
   | Force_drop_without_tool_preserve_with_tool
+  | Force_latest_user_turn_tool_calls
+  (** Replay tool-call reasoning only inside the structurally latest user turn. *)
   | Force_preserve_always
 
 type assistant_tool_content_format = Capability_vocab.assistant_tool_content_format =
@@ -1080,6 +1082,8 @@ let%test "reasoning_replay_override_of_catalog_string parses vocabulary" =
   = Some Force_preserve_always
   && reasoning_replay_override_of_catalog_string "drop_without_tool"
      = Some Force_drop_without_tool_preserve_with_tool
+  && reasoning_replay_override_of_catalog_string "latest_user_turn_tool_calls"
+     = Some Force_latest_user_turn_tool_calls
   && reasoning_replay_override_of_catalog_string "no_replay" = Some Force_no_replay
   && reasoning_replay_override_of_catalog_string "" = Some Default_reasoning_replay
   && reasoning_replay_override_of_catalog_string "bogus" = None

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -34,6 +34,8 @@ type reasoning_replay_override = Capability_vocab.reasoning_replay_override =
   | Default_reasoning_replay
   | Force_no_replay
   | Force_drop_without_tool_preserve_with_tool
+  | Force_latest_user_turn_tool_calls
+  (** Replay tool-call reasoning only inside the structurally latest user turn. *)
   | Force_preserve_always
 
 type assistant_tool_content_format = Capability_vocab.assistant_tool_content_format =

--- a/lib/llm_provider/capability_vocab.ml
+++ b/lib/llm_provider/capability_vocab.ml
@@ -32,6 +32,7 @@ type reasoning_replay_override =
   | Default_reasoning_replay
   | Force_no_replay
   | Force_drop_without_tool_preserve_with_tool
+  | Force_latest_user_turn_tool_calls
   | Force_preserve_always
 
 type assistant_tool_content_format =
@@ -301,6 +302,7 @@ let reasoning_replay_table =
   ; "no_replay", Force_no_replay
   ; "drop_without_tool", Force_drop_without_tool_preserve_with_tool
   ; "drop_without_tool_preserve_with_tool", Force_drop_without_tool_preserve_with_tool
+  ; "latest_user_turn_tool_calls", Force_latest_user_turn_tool_calls
   ; "preserve_always", Force_preserve_always
   ]
 ;;

--- a/lib/llm_provider/reasoning_dialect.ml
+++ b/lib/llm_provider/reasoning_dialect.ml
@@ -30,6 +30,7 @@ type sampling_policy =
 type replay_policy =
   | No_replay
   | Drop_without_tool_preserve_with_tool
+  | Latest_user_turn_tool_calls
   | Preserve_always
   | Provider_hidden_replay
 
@@ -190,6 +191,8 @@ let apply_replay_override caps dialect =
   | Force_no_replay -> { dialect with replay_policy = No_replay }
   | Force_drop_without_tool_preserve_with_tool ->
     { dialect with replay_policy = Drop_without_tool_preserve_with_tool }
+  | Force_latest_user_turn_tool_calls ->
+    { dialect with replay_policy = Latest_user_turn_tool_calls }
   | Force_preserve_always -> { dialect with replay_policy = Preserve_always }
 ;;
 
@@ -472,6 +475,7 @@ let replay_contract dialect : Reasoning_replay_contract.t =
     match dialect.replay_policy with
     | No_replay -> Reasoning_replay_contract.No_replay
     | Drop_without_tool_preserve_with_tool -> Tool_call_assistant_messages_all_history
+    | Latest_user_turn_tool_calls -> Tool_call_assistant_messages_latest_user_turn
     | Preserve_always -> All_assistant_messages
     | Provider_hidden_replay -> Provider_opaque_state
   in
@@ -561,7 +565,8 @@ let should_replay_reasoning dialect ~assistant_had_tool_call =
   match dialect.replay_policy with
   | No_replay | Provider_hidden_replay -> false
   | Preserve_always -> true
-  | Drop_without_tool_preserve_with_tool -> assistant_had_tool_call
+  | Drop_without_tool_preserve_with_tool | Latest_user_turn_tool_calls ->
+    assistant_had_tool_call
 ;;
 
 let requires_reasoning_replay_on_tool_call dialect =
@@ -587,6 +592,7 @@ let toggle_wire_to_string = function
 let replay_policy_to_string = function
   | No_replay -> "no_replay"
   | Drop_without_tool_preserve_with_tool -> "drop_without_tool_preserve_with_tool"
+  | Latest_user_turn_tool_calls -> "latest_user_turn_tool_calls"
   | Preserve_always -> "preserve_always"
   | Provider_hidden_replay -> "provider_hidden_replay"
 ;;
@@ -619,6 +625,20 @@ let%test "reasoning_replay_override drop_without_tool replays only on tool turns
   let dialect = of_capabilities caps in
   (not (should_replay_reasoning dialect ~assistant_had_tool_call:false))
   && should_replay_reasoning dialect ~assistant_had_tool_call:true
+;;
+
+let%test "reasoning_replay_override latest_user_turn stays structurally distinct" =
+  let caps =
+    { Capabilities.default_capabilities with
+      supports_reasoning = true
+    ; thinking_control_format = Capabilities.Chat_template_kwargs
+    ; reasoning_replay_override = Capabilities.Force_latest_user_turn_tool_calls
+    }
+  in
+  let dialect = of_capabilities caps in
+  replay_policy_to_string dialect.replay_policy = "latest_user_turn_tool_calls"
+  && should_replay_reasoning dialect ~assistant_had_tool_call:true
+  && not (should_replay_reasoning dialect ~assistant_had_tool_call:false)
 ;;
 
 let%test

--- a/lib/llm_provider/reasoning_dialect.mli
+++ b/lib/llm_provider/reasoning_dialect.mli
@@ -40,6 +40,7 @@ type sampling_policy =
 type replay_policy =
   | No_replay
   | Drop_without_tool_preserve_with_tool
+  | Latest_user_turn_tool_calls
   | Preserve_always
   | Provider_hidden_replay
 
@@ -139,9 +140,11 @@ val sampling_field_ignored_when_thinking
   -> bool
 
 (** Whether an assistant reasoning side-channel should be replayed into a
-    subsequent request. [assistant_had_tool_call] is intentionally explicit:
-    DeepSeek-style thinking requires replay after tool calls but can drop
-    reasoning between plain user turns. *)
+    subsequent request based on message shape. [assistant_had_tool_call] is
+    intentionally explicit: DeepSeek-style thinking requires replay after tool
+    calls but can drop reasoning between plain user turns. Position-sensitive
+    policies are finalized by {!Reasoning_history_projection} from the typed
+    {!replay_contract}; this function reports only shape eligibility. *)
 val should_replay_reasoning : t -> assistant_had_tool_call:bool -> bool
 
 val requires_reasoning_replay_on_tool_call : t -> bool

--- a/lib/llm_provider/reasoning_history_projection.ml
+++ b/lib/llm_provider/reasoning_history_projection.ml
@@ -197,8 +197,8 @@ let replay_selected
     assistant_had_tool_call
     &&
       (match latest_user_message_index with
-       | Some user_message_index -> message_index > user_message_index
-       | None -> false)
+      | Some user_message_index -> message_index > user_message_index
+      | None -> false)
 ;;
 
 let project

--- a/lib/llm_provider/reasoning_history_projection.ml
+++ b/lib/llm_provider/reasoning_history_projection.ml
@@ -173,11 +173,32 @@ let validate_supported_reasoning ~reasoning_block_supported ~message_index conte
     Error (Unsupported_reasoning_block { message_index; block_index; block_kind })
 ;;
 
-let replay_selected replay_policy ~assistant_had_tool_call =
+let find_latest_user_message_index classified_messages =
+  List.fold_left
+    (fun latest (message_index, (message : Types.message), _) ->
+       match message.role with
+       | User -> Some message_index
+       | System | Assistant | Tool -> latest)
+    None
+    classified_messages
+;;
+
+let replay_selected
+      replay_policy
+      ~assistant_had_tool_call
+      ~message_index
+      ~latest_user_message_index
+  =
   match replay_policy with
   | Reasoning_replay_contract.No_replay | Provider_opaque_state -> false
   | All_assistant_messages -> true
   | Tool_call_assistant_messages_all_history -> assistant_had_tool_call
+  | Tool_call_assistant_messages_latest_user_turn ->
+    assistant_had_tool_call
+    &&
+      (match latest_user_message_index with
+       | Some user_message_index -> message_index > user_message_index
+       | None -> false)
 ;;
 
 let project
@@ -190,6 +211,7 @@ let project
   match validate_and_classify messages with
   | Error _ as error -> error
   | Ok classified_messages ->
+    let latest_user_message_index = find_latest_user_message_index classified_messages in
     let rec loop projected replay_drops removed_empty = function
       | [] ->
         Ok
@@ -237,6 +259,8 @@ let project
                  replay_selected
                    replay_policy
                    ~assistant_had_tool_call:(content_has_tool_use message.content)
+                   ~message_index
+                   ~latest_user_message_index
                then
                  Result.map
                    (fun content -> content, None)

--- a/lib/llm_provider/reasoning_replay_contract.ml
+++ b/lib/llm_provider/reasoning_replay_contract.ml
@@ -1,6 +1,7 @@
 type replay_policy =
   | No_replay
   | Tool_call_assistant_messages_all_history
+  | Tool_call_assistant_messages_latest_user_turn
   | All_assistant_messages
   | Provider_opaque_state
 [@@deriving show, eq, yojson]

--- a/lib/llm_provider/reasoning_replay_contract.mli
+++ b/lib/llm_provider/reasoning_replay_contract.mli
@@ -7,6 +7,9 @@
 type replay_policy =
   | No_replay
   | Tool_call_assistant_messages_all_history
+  | Tool_call_assistant_messages_latest_user_turn
+  (** Replay reasoning only from assistant tool-call messages that occur after
+      the structurally latest [User] role. With no [User] role, replay none. *)
   | All_assistant_messages
   | Provider_opaque_state
 [@@deriving show, eq, yojson]

--- a/lib/provider.mli
+++ b/lib/provider.mli
@@ -76,6 +76,7 @@ type reasoning_replay_override = Llm_provider.Capabilities.reasoning_replay_over
   | Default_reasoning_replay
   | Force_no_replay
   | Force_drop_without_tool_preserve_with_tool
+  | Force_latest_user_turn_tool_calls
   | Force_preserve_always
 
 type assistant_tool_content_format =

--- a/models.toml
+++ b/models.toml
@@ -2011,7 +2011,7 @@ supports_extended_thinking = true
 thinking_control_format = "chat_template_kwargs"
 preserve_thinking_control_format = "chat_template_kwargs_preserve_thinking"
 reasoning_streaming_format = "delta:reasoning_content"
-reasoning_replay = "drop_without_tool_preserve_with_tool"
+reasoning_replay = "latest_user_turn_tool_calls"
 supports_response_format_json = true
 supports_structured_output = true
 supports_native_streaming = true
@@ -2040,7 +2040,7 @@ supports_reasoning_budget = true
 thinking_control_format = "chat_template_kwargs"
 preserve_thinking_control_format = "chat_template_kwargs_preserve_thinking"
 reasoning_streaming_format = "delta:reasoning_content"
-reasoning_replay = "drop_without_tool_preserve_with_tool"
+reasoning_replay = "latest_user_turn_tool_calls"
 supports_native_streaming = true
 
 [[models]]
@@ -2056,7 +2056,7 @@ supports_reasoning_budget = true
 thinking_control_format = "chat_template_kwargs"
 preserve_thinking_control_format = "chat_template_kwargs_preserve_thinking"
 reasoning_streaming_format = "delta:reasoning_content"
-reasoning_replay = "drop_without_tool_preserve_with_tool"
+reasoning_replay = "latest_user_turn_tool_calls"
 supports_native_streaming = true
 
 # Llama Models

--- a/test/dune
+++ b/test/dune
@@ -376,6 +376,16 @@
  (action
   (run %{test})))
 
+(test
+ (name test_execution_lane_writer)
+ (modules test_execution_lane_writer)
+ (libraries agent_sdk agent_sdk.llm_provider alcotest eio_main)
+ (deps ../models.toml)
+ (flags
+  (:standard -open Agent_sdk__))
+ (action
+  (run %{test})))
+
 ; QCheck-based property tests
 
 (tests

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -509,9 +509,23 @@ let test_lookup_provider_m_qwen3_mtp_explicit_provider () =
        fail "vllm-qwen3-mtp should stream reasoning_content as a typed delta field");
     check
       string
-      "vllm-qwen3-mtp replays tool-call reasoning by default"
-      "drop_without_tool_preserve_with_tool"
-      (Reasoning_dialect.replay_policy_to_string dialect.replay_policy)
+      "vllm-qwen3-mtp scopes tool-call reasoning to the latest user turn"
+      "latest_user_turn_tool_calls"
+      (Reasoning_dialect.replay_policy_to_string dialect.replay_policy);
+    check
+      bool
+      "catalog resolves the closed latest-user replay policy"
+      true
+      (c.reasoning_replay_override = Capabilities.Force_latest_user_turn_tool_calls);
+    (match Capabilities.for_model_id "qwen36-35b-a3b-mtp" with
+     | Some bare ->
+       check
+         bool
+         "bare runtime row resolves the same latest-user replay policy"
+         true
+         (bare.reasoning_replay_override
+          = Capabilities.Force_latest_user_turn_tool_calls)
+     | None -> fail "bare qwen3.6 runtime row should resolve")
   | None -> fail "explicit provider/model lookup should match qwen3.6 model id"
 ;;
 
@@ -1082,6 +1096,7 @@ type structured_contract =
 type replay_contract =
   | Replay_not_required
   | Replay_tool_turn_only
+  | Replay_latest_user_tool_turn_only
   | Replay_every_turn
 
 type streaming_contract =
@@ -1217,6 +1232,29 @@ let check_frontier_model
          (label ^ " requires replay only on tool call")
          true
          (Reasoning_dialect.requires_reasoning_replay_on_tool_call dialect)
+     | Replay_latest_user_tool_turn_only ->
+       check
+         string
+         (label ^ " replay policy")
+         "latest_user_turn_tool_calls"
+         (Reasoning_dialect.replay_policy_to_string dialect.replay_policy);
+       check
+         bool
+         (label ^ " drops plain-turn reasoning")
+         false
+         (Reasoning_dialect.should_replay_reasoning
+            dialect
+            ~assistant_had_tool_call:false);
+       check
+         bool
+         (label ^ " preserves a selected tool-call reasoning artifact")
+         true
+         (Reasoning_dialect.should_replay_reasoning dialect ~assistant_had_tool_call:true);
+       check
+         bool
+         (label ^ " requires replay only on a selected tool call")
+         true
+         (Reasoning_dialect.requires_reasoning_replay_on_tool_call dialect)
      | Replay_every_turn ->
        check
          string
@@ -1344,7 +1382,7 @@ let test_frontier_grouped_tool_thinking_provider_contracts () =
       , "qwen/qwen3.6-35b-a3b"
       , Extended_thinking
       , Response_format_json_schema
-      , Replay_tool_turn_only
+      , Replay_latest_user_tool_turn_only
       , Delta_stream "reasoning_content" )
     ; ( "Ollama Cloud Qwen3.5"
       , Provider_qualified "ollama_cloud"

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -523,8 +523,7 @@ let test_lookup_provider_m_qwen3_mtp_explicit_provider () =
          bool
          "bare runtime row resolves the same latest-user replay policy"
          true
-         (bare.reasoning_replay_override
-          = Capabilities.Force_latest_user_turn_tool_calls)
+         (bare.reasoning_replay_override = Capabilities.Force_latest_user_turn_tool_calls)
      | None -> fail "bare qwen3.6 runtime row should resolve")
   | None -> fail "explicit provider/model lookup should match qwen3.6 model id"
 ;;

--- a/test/test_execution_event_store.ml
+++ b/test/test_execution_event_store.ml
@@ -5,6 +5,7 @@ module Journal = Execution_journal
 module Store = Execution_event_store
 
 exception Cancel_before_append
+exception Store_scope_failed
 
 let require_store = function
   | Ok value -> value
@@ -94,6 +95,20 @@ let rewrite_cursor cursor ~scope_id ~seq =
   | _ -> fail "cursor encoder did not produce an object"
 ;;
 
+let rewrite_event_seq event seq =
+  match Event.to_yojson event with
+  | `Assoc fields ->
+    (match List.assoc_opt "envelope" fields with
+     | Some (`Assoc envelope) ->
+       let envelope = ("seq", `Int seq) :: List.remove_assoc "seq" envelope in
+       let json =
+         `Assoc (("envelope", `Assoc envelope) :: List.remove_assoc "envelope" fields)
+       in
+       require_event (Event.of_yojson json)
+     | Some _ | None -> fail "event encoder did not return an envelope object")
+  | _ -> fail "event encoder did not return an object"
+;;
+
 let test_append_reopen_idempotency_and_paging () =
   Eio_main.run
   @@ fun env ->
@@ -155,7 +170,7 @@ let test_append_reopen_idempotency_and_paging () =
       (match recovery with
        | Store.Clean -> ()
        | _ -> fail "clean WAL reported recovery");
-      check int "recovered sequence" 4 (Store.last_seq store);
+      check int "recovered sequence" 4 (require_store (Store.last_seq store));
       check_events "full replay" !expected (require_store (Store.load_all store));
       let after = Option.get !first_cursor in
       let page = require_store (Store.read_page store ~after ~limit:8 ()) in
@@ -547,10 +562,10 @@ let test_uncommitted_initialization_is_explicitly_recovered () =
       (match initialization with
        | Store.Recovered_uncommitted_initialization -> ()
        | Store.Fresh -> fail "orphan initialization recovery was silent");
-      check int "recovered store begins empty" 0 (Store.last_seq store));
+      check int "recovered store begins empty" 0 (require_store (Store.last_seq store)));
     Eio.Switch.run (fun sw ->
       let store, recovery = require_store (open_store ~sw ~dir) in
-      check int "recovered store reopens" 0 (Store.last_seq store);
+      check int "recovered store reopens" 0 (require_store (Store.last_seq store));
       match recovery with
       | Store.Clean -> ()
       | _ -> fail "recovered initialization did not produce a clean WAL"))
@@ -566,7 +581,11 @@ let test_initial_commit_authority_is_rebuilt_explicitly () =
     Eio.Path.rename authority initializing;
     Eio.Switch.run (fun sw ->
       let store, recovery = require_store (open_store ~sw ~dir) in
-      check int "rebuilt authority keeps the empty store" 0 (Store.last_seq store);
+      check
+        int
+        "rebuilt authority keeps the empty store"
+        0
+        (require_store (Store.last_seq store));
       match recovery with
       | Store.Recovered
           [ Store.Discarded_uncommitted_authority; Store.Rebuilt_initial_authority ] -> ()
@@ -597,6 +616,32 @@ let test_failed_create_releases_writer_immediately () =
       | _ -> fail "create did not recover after its prior explicit failure"))
 ;;
 
+let test_failed_journal_replay_releases_store_immediately () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun dir ->
+    Eio.Switch.run (fun sw ->
+      let store = create_store ~sw ~dir in
+      let writer = attach_store store in
+      let invalid = List.nth (make_four_events (Store.correlation_id store)) 1 in
+      let invalid = rewrite_event_seq invalid 1 in
+      match Store.append_batch writer ~expected_next_seq:1 [ invalid ] with
+      | Ok Store.Stored -> ()
+      | Ok Store.Already_committed -> fail "invalid fixture was already committed"
+      | Error error -> fail (Store.error_to_string error));
+    Eio.Switch.run (fun sw ->
+      let expect_semantic_replay_failure () =
+        match Journal.open_durable_writer ~sw ~dir with
+        | Error
+            (Journal.Invariant_violation
+               (Journal.Unknown_parent_event _ | Journal.Unknown_parent_node _)) -> ()
+        | Error error -> fail (Journal.error_to_string error)
+        | Ok _ -> fail "semantically invalid WAL opened as a journal"
+      in
+      expect_semantic_replay_failure ();
+      expect_semantic_replay_failure ()))
+;;
+
 let test_create_unknown_outcome_reconciles_through_open () =
   Eio_main.run
   @@ fun env ->
@@ -611,7 +656,11 @@ let test_create_unknown_outcome_reconciles_through_open () =
     Eio.Path.rmtree ~missing_ok:false blocker;
     Eio.Switch.run (fun sw ->
       let store, recovery = require_store (open_store ~sw ~dir) in
-      check int "reconciled unknown create is empty" 0 (Store.last_seq store);
+      check
+        int
+        "reconciled unknown create is empty"
+        0
+        (require_store (Store.last_seq store));
       match recovery with
       | Store.Recovered [ Store.Rebuilt_initial_authority ] -> ()
       | _ -> fail "unknown create was not reconciled explicitly by open"))
@@ -630,15 +679,19 @@ let test_append_failure_rolls_back_before_authority () =
       (match Store.append_batch writer ~expected_next_seq:1 events with
        | Error (Store.Io_failure _) -> ()
        | _ -> fail "pre-authority append failure did not surface its I/O error");
-      check int "failed append did not advance store" 0 (Store.last_seq store);
+      check
+        int
+        "failed append did not advance store"
+        0
+        (require_store (Store.last_seq store));
       Eio.Path.rmtree ~missing_ok:false blocker;
       (match Store.append_batch writer ~expected_next_seq:1 events with
        | Ok Store.Stored -> ()
        | _ -> fail "append could not retry after proven rollback");
-      check int "retried append committed" 4 (Store.last_seq store));
+      check int "retried append committed" 4 (require_store (Store.last_seq store)));
     Eio.Switch.run (fun sw ->
       let store, recovery = require_store (open_store ~sw ~dir) in
-      check int "retried append reopens" 4 (Store.last_seq store);
+      check int "retried append reopens" 4 (require_store (Store.last_seq store));
       match recovery with
       | Store.Clean -> ()
       | _ -> fail "proven append rollback left recovery residue"))
@@ -666,7 +719,11 @@ let test_cancelled_append_does_not_mutate_store () =
         | exception Eio.Cancel.Cancelled _ -> true
       in
       check bool "append observed pre-existing cancellation" true cancelled;
-      check int "cancelled append did not publish" 0 (Store.last_seq store);
+      check
+        int
+        "cancelled append did not publish"
+        0
+        (require_store (Store.last_seq store));
       check string "cancelled append did not mutate WAL" wal_before (Eio.Path.load wal);
       check
         string
@@ -682,38 +739,61 @@ let test_journal_persists_before_publish_and_replays () =
   Eio_main.run
   @@ fun env ->
   with_temp_dir env (fun dir ->
+    Eio.Path.mkdirs ~exists_ok:false ~perm:0o700 dir;
     let run_handle = ref None in
     let opened_event = ref None in
     Eio.Switch.run (fun sw ->
-      let store = create_store ~sw ~dir in
-      let journal = require_journal (Journal.create ~store ()) in
-      let run, opened =
-        require_journal (Journal.start_run journal ~agent_name:"durable-journal")
+      let writer, initialization =
+        require_journal (Journal.create_durable_writer ~sw ~dir ())
+      in
+      (match initialization with
+       | Store.Fresh -> ()
+       | Store.Recovered_uncommitted_initialization ->
+         fail "new durable journal recovered an unexpected initialization");
+      let journal = Journal.durable_writer_journal writer in
+      let batch, (run, opened) =
+        require_journal
+          (Journal.stage
+             (Journal.begin_durable_batch writer)
+             (Journal.Transaction.start_run ~agent_name:"durable-journal" ()))
       in
       run_handle := Some run;
       opened_event := Some opened;
-      check int "store committed before call returns" 1 (Store.last_seq store);
+      check_events
+        "durable commit returns the staged event"
+        [ opened ]
+        (require_journal (Journal.commit_durable_batch writer batch));
       check int "journal published one event" 1 (Journal.length journal));
     Eio.Switch.run (fun sw ->
-      let store, recovery = require_store (open_store ~sw ~dir) in
+      let writer, recovery = require_journal (Journal.open_durable_writer ~sw ~dir) in
       (match recovery with
        | Store.Clean -> ()
        | _ -> fail "unexpected recovery");
-      let journal = require_journal (Journal.create ~store ()) in
+      let journal = Journal.durable_writer_journal writer in
       check int "journal reducer replayed" 1 (Journal.length journal);
       check_events
         "replayed exact event"
         [ Option.get !opened_event ]
         (Journal.events journal);
-      ignore
-        (require_journal
-           (Journal.finish_run journal ~run:(Option.get !run_handle) Event.Succeeded));
-      check int "finish durably committed" 2 (Store.last_seq store));
+      let batch, _closed =
+        require_journal
+          (Journal.stage
+             (Journal.begin_durable_batch writer)
+             (Journal.Transaction.finish_run
+                ~run:(Option.get !run_handle)
+                Event.Succeeded))
+      in
+      ignore (require_journal (Journal.commit_durable_batch writer batch));
+      check int "finish durably committed" 2 (Journal.last_seq journal));
     Eio.Switch.run (fun sw ->
-      let store, _recovery = require_store (open_store ~sw ~dir) in
-      let journal = require_journal (Journal.create ~store ()) in
+      let writer, _recovery = require_journal (Journal.open_durable_writer ~sw ~dir) in
+      let journal = Journal.durable_writer_journal writer in
       check int "finished scope fully replayed" 2 (Journal.length journal);
-      match Journal.start_run journal ~agent_name:"second-top-level" with
+      match
+        Journal.stage
+          (Journal.begin_durable_batch writer)
+          (Journal.Transaction.start_run ~agent_name:"second-top-level" ())
+      with
       | Error (Journal.Invariant_violation Journal.Top_level_run_already_exists) -> ()
       | _ -> fail "recovered scope admitted a second top-level run"))
 ;;
@@ -725,14 +805,14 @@ let test_durable_journal_batch_commits_one_exact_authority_step () =
     Eio.Path.mkdirs ~exists_ok:false ~perm:0o700 dir;
     let exact_events = ref [] in
     Eio.Switch.run (fun sw ->
-      let durable, initialization =
-        require_journal (Journal.create_durable ~sw ~dir ())
+      let writer, initialization =
+        require_journal (Journal.create_durable_writer ~sw ~dir ())
       in
       (match initialization with
        | Store.Fresh -> ()
        | Store.Recovered_uncommitted_initialization ->
          fail "new durable journal recovered an unexpected initialization");
-      let journal = Journal.durable_journal durable in
+      let journal = Journal.durable_writer_journal writer in
       let volatile = require_journal (Journal.create ()) in
       let foreign_batch, _ =
         require_journal
@@ -740,7 +820,7 @@ let test_durable_journal_batch_commits_one_exact_authority_step () =
              (Journal.begin_batch volatile)
              (Journal.Transaction.start_run ~agent_name:"volatile" ()))
       in
-      (match Journal.commit_durable_batch durable foreign_batch with
+      (match Journal.commit_durable_batch writer foreign_batch with
        | Error Journal.Durable_batch_owner_mismatch -> ()
        | Error error -> fail (Journal.error_to_string error)
        | Ok _ -> fail "durable capability accepted another journal's batch");
@@ -758,7 +838,7 @@ let test_durable_journal_batch_commits_one_exact_authority_step () =
       let batch, (run, opened_run) =
         require_journal
           (Journal.stage
-             (Journal.begin_batch journal)
+             (Journal.begin_durable_batch writer)
              (Journal.Transaction.start_run ~agent_name:"durable-batch" ()))
       in
       let batch, (turn, opened_turn) =
@@ -782,25 +862,25 @@ let test_durable_journal_batch_commits_one_exact_authority_step () =
           (Journal.stage batch (Journal.Transaction.finish_run ~run Event.Succeeded))
       in
       check int "no durable prefix is published before commit" 0 (Journal.length journal);
-      let committed = require_journal (Journal.commit_durable_batch durable batch) in
+      let committed = require_journal (Journal.commit_durable_batch writer batch) in
       let expected = [ opened_run; opened_turn; closed_turn; closed_run ] in
       check_events "durable commit keeps exact staged events" expected committed;
-      let visible, cursor =
-        require_journal (Journal.events_after journal ~after:beginning)
+      let page =
+        require_journal (Journal.read_page journal ~after:beginning ~limit:4 ())
       in
-      check_events "authority exposes the entire semantic batch" expected visible;
+      check_events "authority exposes the entire semantic batch" expected page.events;
       check
         int
         "authority advances from zero through all four events"
         4
-        (Journal.cursor_seq cursor);
+        (Journal.cursor_seq page.next_cursor);
       exact_events := expected);
     Eio.Switch.run (fun sw ->
-      let durable, recovery = require_journal (Journal.open_durable ~sw ~dir) in
+      let writer, recovery = require_journal (Journal.open_durable_writer ~sw ~dir) in
       (match recovery with
        | Store.Clean -> ()
        | Store.Recovered _ -> fail "clean durable batch required recovery");
-      let journal = Journal.durable_journal durable in
+      let journal = Journal.durable_writer_journal writer in
       check int "reopened authority retains final sequence" 4 (Journal.last_seq journal);
       check_events
         "reopen replays the exact atomic batch"
@@ -812,22 +892,35 @@ let test_external_wal_mutation_fails_without_journal_publish () =
   Eio_main.run
   @@ fun env ->
   with_temp_dir env (fun dir ->
+    Eio.Path.mkdirs ~exists_ok:false ~perm:0o700 dir;
     Eio.Switch.run (fun sw ->
-      let store = create_store ~sw ~dir in
-      let journal = require_journal (Journal.create ~store ()) in
-      let run, _opened =
-        require_journal (Journal.start_run journal ~agent_name:"mutation-fence")
+      let writer, _initialization =
+        require_journal (Journal.create_durable_writer ~sw ~dir ())
       in
+      let journal = Journal.durable_writer_journal writer in
+      let batch, (run, _opened) =
+        require_journal
+          (Journal.stage
+             (Journal.begin_durable_batch writer)
+             (Journal.Transaction.start_run ~agent_name:"mutation-fence" ()))
+      in
+      ignore (require_journal (Journal.commit_durable_batch writer batch));
       let before = Journal.events journal in
       let wal = Eio.Path.(dir / "events.v1.wal") in
       Eio.Path.with_open_out ~create:(`Or_truncate 0o600) wal (fun file ->
         Eio.File.sync file);
-      (match Journal.finish_run journal ~run Event.Succeeded with
+      let finish_batch, _closed =
+        require_journal
+          (Journal.stage
+             (Journal.begin_durable_batch writer)
+             (Journal.Transaction.finish_run ~run Event.Succeeded))
+      in
+      (match Journal.commit_durable_batch writer finish_batch with
        | Error (Journal.Persistence_failure (Store.Corrupt_store _)) -> ()
        | _ -> fail "physical WAL drift did not surface as persistence failure");
       check_events "failed persistence did not publish" before (Journal.events journal);
       check int "failed persistence did not advance reducer" 1 (Journal.length journal);
-      match Journal.finish_run journal ~run Event.Succeeded with
+      match Journal.commit_durable_batch writer finish_batch with
       | Error (Journal.Persistence_failure (Store.Store_poisoned _)) -> ()
       | _ -> fail "detected physical WAL drift did not fence later journal writes"))
 ;;
@@ -862,6 +955,322 @@ let test_cursor_scope_and_writer_exclusivity () =
       match Store.read_page store ~after:cursor ~limit:0 () with
       | Error (Store.Invalid_argument _) -> ()
       | _ -> fail "non-positive page size was accepted"))
+;;
+
+let stage_started_batch writer agent_name =
+  Journal.stage
+    (Journal.begin_durable_batch writer)
+    (Journal.Transaction.start_run ~agent_name ())
+  |> require_journal
+;;
+
+let stage_finished_batch writer agent_name =
+  let batch, (run, opened_run) = stage_started_batch writer agent_name in
+  let batch, (turn, opened_turn) =
+    require_journal
+      (Journal.stage
+         batch
+         (Journal.Transaction.open_node
+            ~run
+            ~parent:(Journal.run_root run)
+            ~kind:(Event.Agent_turn { ordinal = 0 })
+            ()))
+  in
+  let batch, closed_turn =
+    require_journal
+      (Journal.stage batch (Journal.Transaction.close_node ~node:turn Event.Succeeded))
+  in
+  let batch, closed_run =
+    require_journal
+      (Journal.stage batch (Journal.Transaction.finish_run ~run Event.Succeeded))
+  in
+  batch, [ opened_run; opened_turn; closed_turn; closed_run ]
+;;
+
+let test_durable_writer_rejects_direct_mutation () =
+  Eio_main.run
+  @@ fun env ->
+  (match
+     Journal.commit_error_disposition
+       (Journal.Persistence_failure (Store.Commit_outcome_unknown "test fence"))
+   with
+   | Journal.Reconcile_required -> ()
+   | Journal.Final_failure ->
+     fail "unknown commit outcome was not routed to reconciliation");
+  (match Journal.commit_error_disposition Journal.Direct_mutation_forbidden with
+   | Journal.Final_failure -> ()
+   | Journal.Reconcile_required ->
+     fail "definite writer conflict requested reconciliation");
+  with_temp_dir env (fun dir ->
+    Eio.Path.mkdirs ~exists_ok:false ~perm:0o700 dir;
+    Eio.Switch.run (fun sw ->
+      let writer, _initialization =
+        require_journal (Journal.create_durable_writer ~sw ~dir ())
+      in
+      let journal = Journal.durable_writer_journal writer in
+      (match Journal.start_run journal ~agent_name:"bypass" with
+       | Error Journal.Direct_mutation_forbidden -> ()
+       | Error error -> fail (Journal.error_to_string error)
+       | Ok _ -> fail "start_run bypassed the durable actor claim");
+      let batch, (run, _opened) = stage_started_batch writer "claimed" in
+      let metadata = Journal.batch_metadata batch in
+      check int "durable batch base cursor" 0 (Journal.cursor_seq metadata.base_cursor);
+      check int "durable batch final cursor" 1 (Journal.cursor_seq metadata.final_cursor);
+      (match Journal.commit_batch batch with
+       | Error Journal.Direct_mutation_forbidden -> ()
+       | Error error -> fail (Journal.error_to_string error)
+       | Ok _ -> fail "commit_batch bypassed the durable actor claim");
+      check int "rejected direct commits do not publish" 0 (Journal.length journal);
+      ignore (require_journal (Journal.commit_durable_batch writer batch));
+      (match Journal.finish_run journal ~run Event.Succeeded with
+       | Error Journal.Direct_mutation_forbidden -> ()
+       | Error error -> fail (Journal.error_to_string error)
+       | Ok _ -> fail "finish_run bypassed the durable actor claim");
+      (match
+         Journal.abort_run
+           journal
+           ~run
+           (Event.Cancelled { reason = Some "bypass"; data = None })
+       with
+       | Error Journal.Direct_mutation_forbidden -> ()
+       | Error error -> fail (Journal.error_to_string error)
+       | Ok _ -> fail "abort_run bypassed the durable actor claim");
+      check int "rejected direct paths do not publish" 1 (Journal.length journal)))
+;;
+
+let test_reopened_writer_reconciles_only_exact_batch () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun root ->
+    Eio.Path.mkdirs ~exists_ok:false ~perm:0o700 root;
+    let applied_dir = Eio.Path.(root / "applied") in
+    let sequence_dir = Eio.Path.(root / "sequence") in
+    let content_dir = Eio.Path.(root / "content") in
+    let foreign_dir = Eio.Path.(root / "foreign") in
+    List.iter
+      (fun dir -> Eio.Path.mkdirs ~exists_ok:false ~perm:0o700 dir)
+      [ applied_dir; sequence_dir; content_dir; foreign_dir ];
+    let applied_batch = ref None in
+    let applied_events = ref [] in
+    Eio.Switch.run (fun sw ->
+      let writer, _ =
+        require_journal (Journal.create_durable_writer ~sw ~dir:applied_dir ())
+      in
+      let batch, (_run, opened) = stage_started_batch writer "reconcile-applied" in
+      applied_batch := Some batch;
+      applied_events := [ opened ]);
+    Eio.Switch.run (fun sw ->
+      let writer, _ =
+        require_journal (Journal.open_durable_writer ~sw ~dir:applied_dir)
+      in
+      match
+        require_journal
+          (Journal.reconcile_durable_batch writer (Option.get !applied_batch))
+      with
+      | Journal.Applied events ->
+        check_events "reconcile applies exact staged events" !applied_events events
+      | Journal.Already_durable _ -> fail "uncommitted batch was reported durable");
+    Eio.Switch.run (fun sw ->
+      let writer, _ =
+        require_journal (Journal.open_durable_writer ~sw ~dir:applied_dir)
+      in
+      match
+        require_journal
+          (Journal.reconcile_durable_batch writer (Option.get !applied_batch))
+      with
+      | Journal.Already_durable events ->
+        check_events "reconcile compares the exact committed range" !applied_events events
+      | Journal.Applied _ -> fail "committed batch was applied twice");
+    let sequence_batch = ref None in
+    Eio.Switch.run (fun sw ->
+      let writer, _ =
+        require_journal (Journal.create_durable_writer ~sw ~dir:sequence_dir ())
+      in
+      sequence_batch := Some (fst (stage_finished_batch writer "four-events"));
+      let winner, _ = stage_started_batch writer "one-event" in
+      ignore (require_journal (Journal.commit_durable_batch writer winner)));
+    Eio.Switch.run (fun sw ->
+      let writer, _ =
+        require_journal (Journal.open_durable_writer ~sw ~dir:sequence_dir)
+      in
+      match Journal.reconcile_durable_batch writer (Option.get !sequence_batch) with
+      | Error
+          (Journal.Reconciliation_conflict
+             { base_seq = 0; final_seq = 4; current_seq = 1 }) -> ()
+      | Error error -> fail (Journal.error_to_string error)
+      | Ok _ -> fail "reconcile guessed across an intermediate sequence");
+    let conflicting_batch = ref None in
+    Eio.Switch.run (fun sw ->
+      let writer, _ =
+        require_journal (Journal.create_durable_writer ~sw ~dir:content_dir ())
+      in
+      conflicting_batch := Some (fst (stage_started_batch writer "candidate"));
+      let winner, _ = stage_started_batch writer "different-bytes" in
+      ignore (require_journal (Journal.commit_durable_batch writer winner)));
+    Eio.Switch.run (fun sw ->
+      let writer, _ =
+        require_journal (Journal.open_durable_writer ~sw ~dir:content_dir)
+      in
+      match Journal.reconcile_durable_batch writer (Option.get !conflicting_batch) with
+      | Error (Journal.Reconciliation_content_conflict { first_seq = 1; last_seq = 1 }) ->
+        ()
+      | Error error -> fail (Journal.error_to_string error)
+      | Ok _ -> fail "reconcile accepted different canonical event bytes");
+    Eio.Switch.run (fun sw ->
+      let writer, _ =
+        require_journal (Journal.create_durable_writer ~sw ~dir:foreign_dir ())
+      in
+      match Journal.reconcile_durable_batch writer (Option.get !applied_batch) with
+      | Error Journal.Reconciliation_scope_mismatch -> ()
+      | Error error -> fail (Journal.error_to_string error)
+      | Ok _ -> fail "reconcile accepted a batch from another scope"))
+;;
+
+let test_store_lifecycle_transition_matrix () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun dir ->
+    Eio.Switch.run (fun sw ->
+      let store = create_store ~sw ~dir in
+      ignore (require_store (Store.release_unpublished store));
+      ignore (require_store (Store.release_unpublished store));
+      (match Store.attach store with
+       | Error Store.Store_released -> ()
+       | Error error -> fail (Store.error_to_string error)
+       | Ok _ -> fail "released unpublished store minted a writer");
+      let reopened, _recovery = require_store (Store.open_existing ~sw ~dir) in
+      let writer = attach_store reopened in
+      (match Store.release_unpublished reopened with
+       | Error Store.Store_release_forbidden -> ()
+       | Error error -> fail (Store.error_to_string error)
+       | Ok () -> fail "published store released switch-owned resources");
+      let events = make_four_events (Store.correlation_id reopened) in
+      ignore (require_store (Store.append_batch writer ~expected_next_seq:1 events));
+      check
+        int
+        "published store remains writable"
+        4
+        (require_store (Store.last_seq reopened))))
+;;
+
+let test_explicit_release_removes_long_lived_switch_hooks () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun dir ->
+    Eio.Switch.run (fun sw ->
+      let release_and_keep_only_weak_reference () =
+        let store = create_store ~sw ~dir in
+        let weak = Weak.create 1 in
+        Weak.set weak 0 (Some store);
+        ignore (require_store (Store.release_unpublished store));
+        weak
+      in
+      let released = release_and_keep_only_weak_reference () in
+      Gc.full_major ();
+      (match Weak.get released 0 with
+       | None -> ()
+       | Some _ -> fail "released store remained retained by a long-lived switch hook");
+      let reopened, _recovery = require_store (Store.open_existing ~sw ~dir) in
+      ignore (require_store (Store.release_unpublished reopened))))
+;;
+
+let test_unpublished_store_is_released_with_switch () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun dir ->
+    let escaped = ref None in
+    Eio.Switch.run (fun sw -> escaped := Some (create_store ~sw ~dir));
+    let store = Option.get !escaped in
+    (match Store.attach store with
+     | Error Store.Store_released -> ()
+     | Error error -> fail (Store.error_to_string error)
+     | Ok _ -> fail "switch-released store minted a writer");
+    (match Store.last_seq store with
+     | Error Store.Store_released -> ()
+     | Error error -> fail (Store.error_to_string error)
+     | Ok _ -> fail "switch-released store exposed a stale sequence");
+    Eio.Switch.run (fun sw ->
+      let reopened, _recovery = require_store (Store.open_existing ~sw ~dir) in
+      ignore (attach_store reopened)))
+;;
+
+let test_unpublished_store_is_released_with_failed_switch () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun dir ->
+    let escaped = ref None in
+    (match
+       Eio.Switch.run (fun sw ->
+         escaped := Some (create_store ~sw ~dir);
+         Eio.Switch.fail sw Store_scope_failed)
+     with
+     | () -> fail "failed switch returned normally"
+     | exception Store_scope_failed -> ()
+     | exception exn -> raise exn);
+    let store = Option.get !escaped in
+    (match Store.last_seq store with
+     | Error Store.Store_released -> ()
+     | Error error -> fail (Store.error_to_string error)
+     | Ok _ -> fail "failed-switch store exposed a stale sequence");
+    Eio.Switch.run (fun sw ->
+      let reopened, _recovery = require_store (Store.open_existing ~sw ~dir) in
+      ignore (attach_store reopened)))
+;;
+
+let test_published_store_rejects_use_after_switch () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun dir ->
+    let escaped_store = ref None in
+    let escaped_writer = ref None in
+    let events = ref [] in
+    Eio.Switch.run (fun sw ->
+      let store = create_store ~sw ~dir in
+      let writer = attach_store store in
+      let committed = make_four_events (Store.correlation_id store) in
+      ignore (require_store (Store.append_batch writer ~expected_next_seq:1 committed));
+      escaped_store := Some store;
+      escaped_writer := Some writer;
+      events := committed);
+    let store = Option.get !escaped_store in
+    let writer = Option.get !escaped_writer in
+    let next_events =
+      List.mapi (fun index event -> rewrite_event_seq event (index + 5)) !events
+    in
+    let expect_released = function
+      | Error Store.Store_released -> ()
+      | Error error -> fail (Store.error_to_string error)
+      | Ok _ -> fail "switch-released store operation succeeded"
+    in
+    expect_released (Store.last_seq store);
+    expect_released (Store.current_cursor store);
+    expect_released (Store.load_all store);
+    expect_released
+      (Store.read_page store ~after:(Store.beginning_cursor store) ~limit:1 ());
+    expect_released (Store.append_batch writer ~expected_next_seq:5 next_events);
+    Eio.Switch.run (fun sw ->
+      let reopened, _recovery = require_store (Store.open_existing ~sw ~dir) in
+      let current_writer = attach_store reopened in
+      check
+        int
+        "new owner sees committed prefix"
+        4
+        (require_store (Store.last_seq reopened));
+      expect_released (Store.append_batch writer ~expected_next_seq:5 next_events);
+      check
+        int
+        "stale writer cannot move the new owner's authority"
+        4
+        (require_store (Store.last_seq reopened));
+      (match Store.append_batch current_writer ~expected_next_seq:5 next_events with
+       | Ok Store.Stored -> ()
+       | Ok Store.Already_committed -> fail "valid next batch was already committed"
+       | Error error -> fail (Store.error_to_string error));
+      check
+        int
+        "new owner commits the valid next batch"
+        8
+        (require_store (Store.last_seq reopened))))
 ;;
 
 let () =
@@ -921,6 +1330,10 @@ let () =
             `Quick
             test_failed_create_releases_writer_immediately
         ; test_case
+            "failed journal replay releases store immediately"
+            `Quick
+            test_failed_journal_replay_releases_store_immediately
+        ; test_case
             "create unknown outcome reconciles through open"
             `Quick
             test_create_unknown_outcome_reconciles_through_open
@@ -948,6 +1361,34 @@ let () =
             "cursor scope and writer exclusivity"
             `Quick
             test_cursor_scope_and_writer_exclusivity
+        ; test_case
+            "durable writer rejects direct mutation"
+            `Quick
+            test_durable_writer_rejects_direct_mutation
+        ; test_case
+            "reopened writer reconciles only an exact batch"
+            `Quick
+            test_reopened_writer_reconciles_only_exact_batch
+        ; test_case
+            "store lifecycle transitions are explicit"
+            `Quick
+            test_store_lifecycle_transition_matrix
+        ; test_case
+            "explicit release removes long-lived switch hooks"
+            `Quick
+            test_explicit_release_removes_long_lived_switch_hooks
+        ; test_case
+            "unpublished store is released with switch"
+            `Quick
+            test_unpublished_store_is_released_with_switch
+        ; test_case
+            "unpublished store is released with failed switch"
+            `Quick
+            test_unpublished_store_is_released_with_failed_switch
+        ; test_case
+            "published store rejects use after switch"
+            `Quick
+            test_published_store_rejects_use_after_switch
         ] )
     ]
 ;;

--- a/test/test_execution_event_store.ml
+++ b/test/test_execution_event_store.ml
@@ -718,6 +718,96 @@ let test_journal_persists_before_publish_and_replays () =
       | _ -> fail "recovered scope admitted a second top-level run"))
 ;;
 
+let test_durable_journal_batch_commits_one_exact_authority_step () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun dir ->
+    Eio.Path.mkdirs ~exists_ok:false ~perm:0o700 dir;
+    let exact_events = ref [] in
+    Eio.Switch.run (fun sw ->
+      let durable, initialization =
+        require_journal (Journal.create_durable ~sw ~dir ())
+      in
+      (match initialization with
+       | Store.Fresh -> ()
+       | Store.Recovered_uncommitted_initialization ->
+         fail "new durable journal recovered an unexpected initialization");
+      let journal = Journal.durable_journal durable in
+      let volatile = require_journal (Journal.create ()) in
+      let foreign_batch, _ =
+        require_journal
+          (Journal.stage
+             (Journal.begin_batch volatile)
+             (Journal.Transaction.start_run ~agent_name:"volatile" ()))
+      in
+      (match Journal.commit_durable_batch durable foreign_batch with
+       | Error Journal.Durable_batch_owner_mismatch -> ()
+       | Error error -> fail (Journal.error_to_string error)
+       | Ok _ -> fail "durable capability accepted another journal's batch");
+      check
+        int
+        "ownership rejection leaves durable journal empty"
+        0
+        (Journal.length journal);
+      check
+        int
+        "ownership rejection leaves volatile batch unpublished"
+        0
+        (Journal.length volatile);
+      let beginning = Journal.beginning_cursor journal in
+      let batch, (run, opened_run) =
+        require_journal
+          (Journal.stage
+             (Journal.begin_batch journal)
+             (Journal.Transaction.start_run ~agent_name:"durable-batch" ()))
+      in
+      let batch, (turn, opened_turn) =
+        require_journal
+          (Journal.stage
+             batch
+             (Journal.Transaction.open_node
+                ~run
+                ~parent:(Journal.run_root run)
+                ~kind:(Event.Agent_turn { ordinal = 0 })
+                ()))
+      in
+      let batch, closed_turn =
+        require_journal
+          (Journal.stage
+             batch
+             (Journal.Transaction.close_node ~node:turn Event.Succeeded))
+      in
+      let batch, closed_run =
+        require_journal
+          (Journal.stage batch (Journal.Transaction.finish_run ~run Event.Succeeded))
+      in
+      check int "no durable prefix is published before commit" 0 (Journal.length journal);
+      let committed = require_journal (Journal.commit_durable_batch durable batch) in
+      let expected = [ opened_run; opened_turn; closed_turn; closed_run ] in
+      check_events "durable commit keeps exact staged events" expected committed;
+      let visible, cursor =
+        require_journal (Journal.events_after journal ~after:beginning)
+      in
+      check_events "authority exposes the entire semantic batch" expected visible;
+      check
+        int
+        "authority advances from zero through all four events"
+        4
+        (Journal.cursor_seq cursor);
+      exact_events := expected);
+    Eio.Switch.run (fun sw ->
+      let durable, recovery = require_journal (Journal.open_durable ~sw ~dir) in
+      (match recovery with
+       | Store.Clean -> ()
+       | Store.Recovered _ -> fail "clean durable batch required recovery");
+      let journal = Journal.durable_journal durable in
+      check int "reopened authority retains final sequence" 4 (Journal.last_seq journal);
+      check_events
+        "reopen replays the exact atomic batch"
+        !exact_events
+        (Journal.events journal)))
+;;
+
 let test_external_wal_mutation_fails_without_journal_publish () =
   Eio_main.run
   @@ fun env ->
@@ -846,6 +936,10 @@ let () =
             "journal persists before publish and replays"
             `Quick
             test_journal_persists_before_publish_and_replays
+        ; test_case
+            "durable journal batch commits one exact authority step"
+            `Quick
+            test_durable_journal_batch_commits_one_exact_authority_step
         ; test_case
             "external WAL mutation fails without publish"
             `Quick

--- a/test/test_execution_journal.ml
+++ b/test/test_execution_journal.ml
@@ -1366,6 +1366,101 @@ let test_concurrent_updates_keep_one_sequence () =
   check_contiguous events
 ;;
 
+let test_batch_stages_immutably_and_publishes_once () =
+  Eio_main.run
+  @@ fun _env ->
+  let journal = require_ok (Journal.create ()) in
+  let empty = Journal.begin_batch journal in
+  check int "empty batch has no events" 0 (Journal.batch_length empty);
+  (match Journal.commit_batch empty with
+   | Error Journal.Empty_batch -> ()
+   | Error error -> fail (Journal.error_to_string error)
+   | Ok _ -> fail "an empty batch was committed");
+  let batch, (run, opened_run) =
+    require_ok
+      (Journal.stage empty (Journal.Transaction.start_run ~agent_name:"batched-run" ()))
+  in
+  let batch, (turn, opened_turn) =
+    require_ok
+      (Journal.stage
+         batch
+         (Journal.Transaction.open_node
+            ~run
+            ~parent:(Journal.run_root run)
+            ~kind:(Event.Agent_turn { ordinal = 0 })
+            ()))
+  in
+  check int "two semantic mutations are staged" 2 (Journal.batch_length batch);
+  (match Journal.stage batch (Journal.Transaction.finish_run ~run Event.Succeeded) with
+   | Error (Journal.Invariant_violation (Journal.Node_has_open_children node_id)) ->
+     check
+       bool
+       "invalid stage reports the exact run root"
+       true
+       (Event.Node_id.equal node_id (Journal.run_root run))
+   | Error error -> fail (Journal.error_to_string error)
+   | Ok _ -> fail "an invalid finish entered the batch");
+  check int "rejected stage leaves input batch unchanged" 2 (Journal.batch_length batch);
+  check int "staging does not publish a prefix" 0 (Journal.length journal);
+  (match Journal.find_run journal (Journal.run_id run) with
+   | None -> ()
+   | Some _ -> fail "a staged run was visible before the batch commit");
+  let batch, closed_turn =
+    require_ok
+      (Journal.stage batch (Journal.Transaction.close_node ~node:turn Event.Succeeded))
+  in
+  let batch, closed_run =
+    require_ok (Journal.stage batch (Journal.Transaction.finish_run ~run Event.Succeeded))
+  in
+  check int "valid replacement extends original batch" 4 (Journal.batch_length batch);
+  let committed = require_ok (Journal.commit_batch batch) in
+  check int "all staged events committed together" 4 (List.length committed);
+  check int "one final reducer snapshot is visible" 4 (Journal.length journal);
+  check_contiguous committed;
+  check
+    bool
+    "commit retains staged event identities and order"
+    true
+    (List.equal
+       Event.equal
+       [ opened_run; opened_turn; closed_turn; closed_run ]
+       committed);
+  match Journal.find_run journal (Journal.run_id run) with
+  | Some { status = Journal.Finished { value = Event.Succeeded; _ }; through_seq; _ } ->
+    check int "published projection uses final batch watermark" 4 through_seq
+  | _ -> fail "committed batch did not publish its finished run projection"
+;;
+
+let test_batch_rejects_a_stale_base_without_rebuilding_events () =
+  Eio_main.run
+  @@ fun _env ->
+  let journal = require_ok (Journal.create ()) in
+  let batch, (_staged_run, staged_event) =
+    require_ok
+      (Journal.stage
+         (Journal.begin_batch journal)
+         (Journal.Transaction.start_run ~agent_name:"staged-before-race" ()))
+  in
+  let _committed_run, committed_event =
+    require_ok (Journal.start_run journal ~agent_name:"concurrent-winner")
+  in
+  let expect_stale () =
+    match Journal.commit_batch batch with
+    | Error (Journal.Stale_batch { expected_last_seq = 0; actual_last_seq = 1 }) -> ()
+    | Error error -> fail (Journal.error_to_string error)
+    | Ok _ -> fail "a batch from a stale reducer snapshot was committed"
+  in
+  expect_stale ();
+  expect_stale ();
+  check int "stale rejection retains the immutable batch" 1 (Journal.batch_length batch);
+  check int "stale commit does not mutate journal" 1 (Journal.length journal);
+  check
+    bool
+    "staged identity was not substituted for committed state"
+    false
+    (Event.Event_id.equal (Event.event_id staged_event) (Event.event_id committed_event))
+;;
+
 let () =
   run
     "Execution journal"
@@ -1406,6 +1501,14 @@ let () =
             "abort is cancellation-protected and serializes writers"
             `Quick
             test_abort_is_cancellation_protected_and_serializes_a_writer
+        ; test_case
+            "immutable batch rejects a stage and publishes once"
+            `Quick
+            test_batch_stages_immutably_and_publishes_once
+        ; test_case
+            "stale batch is rejected without rebuilding events"
+            `Quick
+            test_batch_rejects_a_stale_base_without_rebuilding_events
         ] )
     ; ( "codec"
       , [ test_case

--- a/test/test_execution_journal.ml
+++ b/test/test_execution_journal.ml
@@ -222,16 +222,18 @@ let test_recursive_tree_and_global_sequence () =
      check bool "fan-in causes are distinct" false (Event.Event_id.equal attempt child)
    | _ -> fail "tool result did not retain attempt plus child-run fan-in");
   let after_fifteen = cursor_at (Journal.current_cursor journal) 15 in
-  let tail, next = require_ok (Journal.events_after journal ~after:after_fifteen) in
+  let page = require_ok (Journal.read_page journal ~after:after_fifteen ~limit:10 ()) in
+  let tail = page.events in
+  let next = page.next_cursor in
   check int "exclusive cursor" 10 (List.length tail);
   check bool "cursor order" true (List.for_all (fun event -> Event.seq event > 15) tail);
   check int "returned cursor watermark" 25 (Journal.cursor_seq next);
   let ahead = cursor_at next 26 in
-  (match Journal.events_after journal ~after:ahead with
+  (match Journal.read_page journal ~after:ahead ~limit:1 () with
    | Error (Journal.Cursor_ahead { after_seq = 26; last_seq = 25 }) -> ()
    | _ -> fail "a cursor ahead of the journal was silently accepted");
   let foreign = Journal.beginning_cursor (require_ok (Journal.create ())) in
-  (match Journal.events_after journal ~after:foreign with
+  (match Journal.read_page journal ~after:foreign ~limit:1 () with
    | Error Journal.Cursor_scope_mismatch -> ()
    | _ -> fail "a cursor from another journal was silently accepted");
   let expected_correlation = Event.correlation_id (List.hd events) in
@@ -1276,15 +1278,18 @@ let test_abort_run_handles_deep_recursive_composition_iteratively () =
     "every deep recursive node closed"
     (1 + (4 * deep_chain_depth))
     (List.length closed);
-  let all_events, cursor = require_ok (Journal.events_after journal ~after:beginning) in
+  let page =
+    require_ok
+      (Journal.read_page journal ~after:beginning ~limit:(Journal.length journal) ())
+  in
   check
     int
     "deep journal cursor is exact"
-    (List.length all_events)
-    (Journal.cursor_seq cursor)
+    (List.length page.events)
+    (Journal.cursor_seq page.next_cursor)
 ;;
 
-let test_abort_is_cancellation_protected_and_serializes_a_writer () =
+let test_cancelled_abort_does_not_publish_a_partial_batch () =
   Eio_main.run
   @@ fun _env ->
   let journal = require_ok (Journal.create ()) in
@@ -1299,41 +1304,28 @@ let test_abort_is_cancellation_protected_and_serializes_a_writer () =
          ~kind:(Event.Output_block { ordinal = 0; block_kind = Event.Thinking_block }))
   in
   let terminal = Event.Cancelled { reason = Some "test cancellation"; data = None } in
-  let start, release_start = Eio.Promise.create () in
-  let abort_result, resolve_abort = Eio.Promise.create () in
-  let writer_result, resolve_writer = Eio.Promise.create () in
-  Eio.Switch.run (fun sw ->
-    Eio.Fiber.fork ~sw (fun () ->
-      Eio.Promise.await start;
-      let result =
-        Eio.Cancel.sub (fun cancellation ->
-          Eio.Cancel.cancel cancellation Exit;
-          Journal.abort_run journal ~run terminal)
-      in
-      Eio.Promise.resolve resolve_abort result);
-    Eio.Fiber.fork ~sw (fun () ->
-      Eio.Promise.await start;
-      Eio.Promise.resolve
-        resolve_writer
-        (Journal.update_node
-           journal
-           ~node:output
-           (Event.Output_delta (`String "concurrent"))));
-    Eio.Promise.resolve release_start ());
-  let closed = require_ok (Eio.Promise.await abort_result) in
-  check int "abort closes one four-node provider path" 4 (List.length closed);
-  let writer_committed =
-    match Eio.Promise.await writer_result with
-    | Ok _ -> true
-    | Error (Journal.Invariant_violation (Journal.Node_already_closed node_id))
-      when Event.Node_id.equal node_id output -> false
-    | Error error -> fail (Journal.error_to_string error)
+  let before = Journal.length journal in
+  let cancelled =
+    match
+      Eio.Cancel.sub (fun cancellation ->
+        Eio.Cancel.cancel cancellation Exit;
+        ignore (Journal.abort_run journal ~run terminal);
+        false)
+    with
+    | value -> value
+    | exception Eio.Cancel.Cancelled Exit -> true
+    | exception exn -> raise exn
   in
-  check
-    int
-    "writer observes only one side of the abort batch"
-    (if writer_committed then 9 else 8)
-    (Journal.length journal);
+  check bool "cancelled abort exits" true cancelled;
+  check int "cancelled abort publishes no prefix" before (Journal.length journal);
+  ignore
+    (require_ok
+       (Journal.update_node
+          journal
+          ~node:output
+          (Event.Output_delta (`String "after-cancellation"))));
+  let closed = require_ok (Journal.abort_run journal ~run terminal) in
+  check int "later abort closes one four-node provider path" 4 (List.length closed);
   check_contiguous (Journal.events journal)
 ;;
 
@@ -1461,6 +1453,62 @@ let test_batch_rejects_a_stale_base_without_rebuilding_events () =
     (Event.Event_id.equal (Event.event_id staged_event) (Event.event_id committed_event))
 ;;
 
+let test_closed_abort_transaction_stages_one_batch () =
+  Eio_main.run
+  @@ fun _env ->
+  let journal = require_ok (Journal.create ()) in
+  let terminal = Event.Cancelled { reason = Some "composed abort"; data = None } in
+  let batch, (run, opened_run) =
+    require_ok
+      (Journal.stage
+         (Journal.begin_batch journal)
+         (Journal.Transaction.start_run ~agent_name:"closed-abort" ()))
+  in
+  let batch, (_turn, opened_turn) =
+    require_ok
+      (Journal.stage
+         batch
+         (Journal.Transaction.open_node
+            ~run
+            ~parent:(Journal.run_root run)
+            ~kind:(Event.Agent_turn { ordinal = 0 })
+            ()))
+  in
+  let batch, aborted =
+    require_ok (Journal.stage batch (Journal.Transaction.abort_run ~run terminal))
+  in
+  check
+    int
+    "closed transaction set stages open and terminal events"
+    4
+    (Journal.batch_length batch);
+  (match Journal.stage batch (Journal.Transaction.abort_run ~run terminal) with
+   | Error (Journal.Invariant_violation (Journal.Run_already_finished run_id)) ->
+     check
+       bool
+       "second abort identifies the already-finished run"
+       true
+       (Event.Run_id.equal run_id (Journal.run_id run))
+   | Error error -> fail (Journal.error_to_string error)
+   | Ok _ -> fail "closed abort transaction accepted an already-closed run");
+  check
+    int
+    "rejected abort leaves the staged batch unchanged"
+    4
+    (Journal.batch_length batch);
+  check int "closed transaction is invisible before commit" 0 (Journal.length journal);
+  check int "typed abort closes turn and root" 2 (List.length aborted);
+  let committed = require_ok (Journal.commit_batch batch) in
+  check
+    bool
+    "closed transaction retains exact event identities"
+    true
+    (List.equal Event.equal ([ opened_run; opened_turn ] @ aborted) committed);
+  match Journal.find_run journal (Journal.run_id run) with
+  | Some { status = Journal.Finished { value = Event.Cancelled _; _ }; _ } -> ()
+  | _ -> fail "closed abort transaction did not close its run"
+;;
+
 let () =
   run
     "Execution journal"
@@ -1498,9 +1546,9 @@ let () =
             `Slow
             test_abort_run_handles_deep_recursive_composition_iteratively
         ; test_case
-            "abort is cancellation-protected and serializes writers"
+            "cancelled abort does not publish a partial batch"
             `Quick
-            test_abort_is_cancellation_protected_and_serializes_a_writer
+            test_cancelled_abort_does_not_publish_a_partial_batch
         ; test_case
             "immutable batch rejects a stage and publishes once"
             `Quick
@@ -1509,6 +1557,10 @@ let () =
             "stale batch is rejected without rebuilding events"
             `Quick
             test_batch_rejects_a_stale_base_without_rebuilding_events
+        ; test_case
+            "closed abort transaction stages one batch"
+            `Quick
+            test_closed_abort_transaction_stages_one_batch
         ] )
     ; ( "codec"
       , [ test_case

--- a/test/test_execution_lane_writer.ml
+++ b/test/test_execution_lane_writer.ml
@@ -1,0 +1,1123 @@
+open Alcotest
+open Agent_sdk
+module Event = Execution_event
+module Journal = Execution_journal
+module Store = Execution_event_store
+module Writer = Execution_lane_writer
+module Tx = Journal.Transaction
+
+exception Cancel_waiter
+exception Cancel_scope
+exception Callback_failed
+
+let require_submit = function
+  | Ok ticket -> ticket
+  | Error error -> fail (Writer.submit_error_to_string error)
+;;
+
+let require_ticket = function
+  | Ok receipt -> receipt
+  | Error error -> fail (Writer.ticket_error_to_string error)
+;;
+
+let require_closed = function
+  | Ok () -> ()
+  | Error error -> fail (Writer.scope_failure_to_string error)
+;;
+
+let require_scope = function
+  | Ok value -> value
+  | Error error -> fail (Writer.scope_failure_to_string error)
+;;
+
+let with_fresh dir f = require_scope (Writer.run ~dir (fun ~sw writer -> f sw writer))
+
+let with_existing dir f =
+  require_scope (Writer.resume ~dir (fun ~sw writer -> f sw writer))
+;;
+
+let require_codec = function
+  | Ok value -> value
+  | Error detail -> fail detail
+;;
+
+let with_temp_dir env f =
+  let native_path = Filename.temp_file "oas-execution-lane-writer-" ".dir" in
+  Sys.remove native_path;
+  let dir = Eio.Path.(Eio.Stdenv.fs env / native_path) in
+  Fun.protect ~finally:(fun () -> Eio.Path.rmtree ~missing_ok:true dir) (fun () -> f dir)
+;;
+
+let make_dir dir = Eio.Path.mkdirs ~exists_ok:false ~perm:0o700 dir
+
+let cursor_at cursor seq =
+  match Journal.cursor_to_yojson cursor with
+  | `Assoc fields ->
+    require_codec
+      (Journal.cursor_of_yojson
+         (`Assoc (("seq", `Int seq) :: List.remove_assoc "seq" fields)))
+  | _ -> fail "journal cursor encoder did not return an object"
+;;
+
+let check_cursor message expected actual =
+  check
+    bool
+    message
+    true
+    (Store.Scope_id.equal (Store.cursor_scope_id expected) (Store.cursor_scope_id actual)
+     && Store.cursor_seq expected = Store.cursor_seq actual)
+;;
+
+let read_complete_page writer ~after ~limit =
+  match Writer.read_page writer ~after ~limit () with
+  | Error error -> fail (Writer.read_error_to_string error)
+  | Ok page ->
+    check bool "requested page reaches its frozen watermark" false page.has_more;
+    check
+      int
+      "page cursor reaches its frozen watermark"
+      (Journal.cursor_seq page.high_watermark)
+      (Journal.cursor_seq page.next_cursor);
+    page.events, page.next_cursor
+;;
+
+let provider_attempt ordinal =
+  let config =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_kind.OpenAI_compat
+      ~provider_id:"lane-writer-test"
+      ~model_id:"lane-writer-model"
+      ~base_url:"https://provider.test"
+      ()
+  in
+  let binding =
+    Binding_identity.of_provider_config
+      ~transport:(Binding_identity.transport_for_call ~injected:false)
+      config
+    |> require_codec
+  in
+  require_codec (Event.provider_attempt ~ordinal binding)
+;;
+
+let submit_and_await writer transaction =
+  require_ticket (Writer.await (require_submit (Writer.submit writer transaction)))
+;;
+
+let check_single_event_group (receipt : _ Writer.receipt) =
+  check int "one setup command per durable group" 1 receipt.group_event_count
+;;
+
+let open_output writer =
+  let opened_run_receipt =
+    submit_and_await writer (Tx.start_run ~agent_name:"lane-writer" ())
+  in
+  let run, opened_run = opened_run_receipt.value in
+  let opened_turn_receipt =
+    submit_and_await
+      writer
+      (Tx.open_node
+         ~run
+         ~parent:(Journal.run_root run)
+         ~kind:(Event.Agent_turn { ordinal = 0 })
+         ())
+  in
+  let turn, opened_turn = opened_turn_receipt.value in
+  let opened_attempt_receipt =
+    submit_and_await writer (Tx.open_node ~run ~parent:turn ~kind:(provider_attempt 0) ())
+  in
+  let attempt, opened_attempt = opened_attempt_receipt.value in
+  let opened_output_receipt =
+    submit_and_await
+      writer
+      (Tx.open_node
+         ~run
+         ~parent:attempt
+         ~kind:(Event.Output_block { ordinal = 0; block_kind = Event.Thinking_block })
+         ())
+  in
+  let output, opened_output = opened_output_receipt.value in
+  check_single_event_group opened_run_receipt;
+  check_single_event_group opened_turn_receipt;
+  check_single_event_group opened_attempt_receipt;
+  check_single_event_group opened_output_receipt;
+  ( run
+  , output
+  , opened_output_receipt.through
+  , [ opened_run; opened_turn; opened_attempt; opened_output ] )
+;;
+
+let delta_transaction output index =
+  Tx.update_node ~node:output (Event.Output_delta (`Assoc [ "index", `Int index ]))
+;;
+
+let rec await_reconciliation_phase writer =
+  let observed = Writer.stats writer in
+  match observed.admission, observed.worker_phase with
+  | Writer.Failed failure, _ -> fail (Writer.scope_failure_to_string failure)
+  | Writer.Closed, _ -> fail "writer closed before reconciliation was observed"
+  | ( (Writer.Accepting | Writer.Draining)
+    , (Writer.Reconciling_group | Writer.Awaiting_reconciliation_wake) ) -> ()
+  | ( (Writer.Accepting | Writer.Draining)
+    , (Writer.Starting | Writer.Idle | Writer.Committing_group) ) ->
+    Eio.Fiber.yield ();
+    await_reconciliation_phase writer
+;;
+
+let rec await_reconciliation_wait writer ~outcome_count =
+  let observed = Writer.stats writer in
+  match observed.admission, observed.worker_phase, observed.current_reconciliation with
+  | Writer.Failed failure, _, _ -> fail (Writer.scope_failure_to_string failure)
+  | Writer.Closed, _, _ -> fail "writer closed before reconciliation wait"
+  | ( (Writer.Accepting | Writer.Draining)
+    , Writer.Awaiting_reconciliation_wake
+    , Some evidence )
+    when evidence.outcome_count = outcome_count -> observed
+  | ( (Writer.Accepting | Writer.Draining)
+    , ( Writer.Starting
+      | Writer.Idle
+      | Writer.Committing_group
+      | Writer.Reconciling_group
+      | Writer.Awaiting_reconciliation_wake )
+    , _ ) ->
+    Eio.Fiber.yield ();
+    await_reconciliation_wait writer ~outcome_count
+;;
+
+let test_single_command_commits_and_close_drains () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun dir ->
+    make_dir dir;
+    with_fresh dir (fun _sw writer ->
+      let ticket =
+        require_submit (Writer.submit writer (Tx.start_run ~agent_name:"single" ()))
+      in
+      Writer.close writer;
+      (match Writer.submit writer (Tx.start_run ~agent_name:"late" ()) with
+       | Error Writer.Admission_closed -> ()
+       | Error error -> fail (Writer.submit_error_to_string error)
+       | Ok _ -> fail "closed admission accepted another transaction");
+      let receipt = require_ticket (Writer.await ticket) in
+      check int "single event cursor" 1 (Journal.cursor_seq receipt.through);
+      check int "single event group" 1 receipt.group_event_count;
+      require_closed (Writer.await_closed writer);
+      let observed = Writer.stats writer in
+      (match observed.admission with
+       | Writer.Closed -> ()
+       | Writer.Accepting | Writer.Draining | Writer.Failed _ ->
+         fail "drained actor did not reach closed admission");
+      check int "accepted" 1 observed.accepted;
+      check int "settled" 1 observed.settled;
+      check int "empty queue" 0 observed.queue_depth;
+      Writer.close writer;
+      require_closed (Writer.await_closed writer)))
+;;
+
+let test_ready_set_is_one_fifo_durable_group () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun dir ->
+    make_dir dir;
+    with_fresh dir (fun _sw writer ->
+      let _run, output, setup_through, setup_events = open_output writer in
+      check bool "setup values are exact events" true (List.length setup_events = 4);
+      let tickets : Event.t Writer.ticket list =
+        List.init 32 (fun index ->
+          require_submit (Writer.submit writer (delta_transaction output index)))
+      in
+      let receipts : Event.t Writer.receipt list =
+        List.map (fun ticket -> require_ticket (Writer.await ticket)) tickets
+      in
+      let expected_through = Journal.cursor_seq setup_through + 32 in
+      List.iter
+        (fun (receipt : Event.t Writer.receipt) ->
+           check
+             int
+             "shared group cursor"
+             expected_through
+             (Journal.cursor_seq receipt.Writer.through);
+           check int "shared group size" 32 receipt.Writer.group_event_count)
+        receipts;
+      let events, through = read_complete_page writer ~after:setup_through ~limit:32 in
+      check int "replayed ready set" 32 (List.length events);
+      check int "replayed cursor" expected_through (Journal.cursor_seq through);
+      check
+        bool
+        "FIFO receipts equal durable replay"
+        true
+        (List.equal
+           Event.equal
+           (List.map (fun receipt -> receipt.Writer.value) receipts)
+           events);
+      let observed = Writer.stats writer in
+      check int "five physical groups" 5 observed.committed_groups;
+      check int "all commands observed" 36 observed.committed_commands;
+      check int "all events observed" 36 observed.committed_events;
+      require_closed (Writer.close_and_await writer)))
+;;
+
+let test_semantic_rejection_does_not_poison_ready_group () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun dir ->
+    make_dir dir;
+    with_fresh dir (fun _sw writer ->
+      let run, output, setup_through, _events = open_output writer in
+      let first = require_submit (Writer.submit writer (delta_transaction output 0)) in
+      let rejected =
+        require_submit (Writer.submit writer (Tx.finish_run ~run Event.Succeeded))
+      in
+      let second = require_submit (Writer.submit writer (delta_transaction output 1)) in
+      ignore (require_ticket (Writer.await first));
+      (match Writer.await rejected with
+       | Error
+           (Writer.Transaction_rejected
+              (Journal.Invariant_violation (Journal.Node_has_open_children node_id))) ->
+         check
+           bool
+           "exact rejected root"
+           true
+           (Event.Node_id.equal node_id (Journal.run_root run))
+       | Error error -> fail (Writer.ticket_error_to_string error)
+       | Ok _ -> fail "invalid finish_run entered the durable group");
+      ignore (require_ticket (Writer.await second));
+      let events, through = read_complete_page writer ~after:setup_through ~limit:2 in
+      check int "only valid events committed" 2 (List.length events);
+      check int "cursor excludes rejected event" 6 (Journal.cursor_seq through);
+      let observed = Writer.stats writer in
+      check int "all admitted tickets settled" 7 observed.settled;
+      check int "five physical groups" 5 observed.committed_groups;
+      check int "only valid commands committed" 6 observed.committed_commands;
+      require_closed (Writer.close_and_await writer)))
+;;
+
+let test_concurrent_submit_and_close_linearize_without_loss () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun dir ->
+    make_dir dir;
+    with_fresh dir (fun _sw writer ->
+      let _run, output, setup_through, setup_events = open_output writer in
+      let accepted_before_race =
+        require_submit (Writer.submit writer (delta_transaction output (-1)))
+      in
+      let race_size = 32 in
+      let submissions = Array.make race_size None in
+      let start, release_start = Eio.Promise.create () in
+      Eio.Switch.run (fun race_sw ->
+        Array.iteri
+          (fun index _ ->
+             Eio.Fiber.fork ~sw:race_sw (fun () ->
+               Eio.Promise.await start;
+               submissions.(index)
+               <- Some (Writer.submit writer (delta_transaction output index))))
+          submissions;
+        Eio.Fiber.fork ~sw:race_sw (fun () ->
+          Eio.Promise.await start;
+          Writer.close writer);
+        Eio.Promise.resolve release_start ());
+      require_closed (Writer.await_closed writer);
+      let accepted_tickets : Event.t Writer.ticket list ref =
+        ref [ accepted_before_race ]
+      in
+      let rejected = ref 0 in
+      Array.iter
+        (function
+          | Some (Ok ticket) -> accepted_tickets := ticket :: !accepted_tickets
+          | Some (Error Writer.Admission_closed) -> incr rejected
+          | Some (Error error) -> fail (Writer.submit_error_to_string error)
+          | None -> fail "racing submitter did not publish its linearized result")
+        submissions;
+      check
+        int
+        "every racing submission linearized"
+        race_size
+        (List.length !accepted_tickets - 1 + !rejected);
+      let receipts =
+        List.map (fun ticket -> require_ticket (Writer.await ticket)) !accepted_tickets
+      in
+      let events, through =
+        read_complete_page writer ~after:setup_through ~limit:(List.length receipts)
+      in
+      let receipt_events =
+        List.map (fun receipt -> receipt.Writer.value) receipts
+        |> List.sort (fun left right -> Int.compare (Event.seq left) (Event.seq right))
+      in
+      check
+        bool
+        "every accepted mutation is replayed exactly once"
+        true
+        (List.equal Event.equal receipt_events events);
+      check
+        int
+        "replay cursor covers every accepted mutation"
+        (Journal.cursor_seq setup_through + List.length receipts)
+        (Journal.cursor_seq through);
+      let observed = Writer.stats writer in
+      let expected_accepted = List.length setup_events + List.length receipts in
+      check int "exact accepted command count" expected_accepted observed.accepted;
+      check int "accepted commands all settled" observed.accepted observed.settled;
+      check int "drained queue is empty" 0 observed.queue_depth;
+      check int "drained in-flight set is empty" 0 observed.in_flight_commands;
+      check
+        int
+        "accepted commands are all durable"
+        observed.accepted
+        observed.committed_commands;
+      check
+        int
+        "one event per accepted command"
+        observed.committed_commands
+        observed.committed_events;
+      match Writer.submit writer (Tx.start_run ~agent_name:"after-race" ()) with
+      | Error Writer.Admission_closed -> ()
+      | Error error -> fail (Writer.submit_error_to_string error)
+      | Ok _ -> fail "closed writer accepted a post-linearization transaction"))
+;;
+
+let test_cancelled_waiter_does_not_cancel_ticket () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun dir ->
+    make_dir dir;
+    with_fresh dir (fun _sw writer ->
+      let ticket =
+        require_submit (Writer.submit writer (Tx.start_run ~agent_name:"waiter" ()))
+      in
+      let waiter_cancelled =
+        match
+          Eio.Cancel.sub (fun context ->
+            Eio.Cancel.cancel context Cancel_waiter;
+            ignore (Writer.await ticket);
+            false)
+        with
+        | value -> value
+        | exception Eio.Cancel.Cancelled Cancel_waiter -> true
+        | exception exn -> raise exn
+      in
+      check bool "awaiting fiber was cancelled" true waiter_cancelled;
+      let receipt = require_ticket (Writer.await ticket) in
+      check int "accepted mutation survived waiter" 1 (Journal.cursor_seq receipt.through);
+      require_closed (Writer.close_and_await writer)))
+;;
+
+let test_supervisor_cancellation_settles_accepted_ticket () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun dir ->
+    make_dir dir;
+    let ticket = ref None in
+    (match
+       with_fresh dir (fun sw writer ->
+         ticket
+         := Some
+              (require_submit
+                 (Writer.submit writer (Tx.start_run ~agent_name:"cancelled-scope" ())));
+         Eio.Switch.fail sw Cancel_scope)
+     with
+     | () -> fail "failed supervisor switch returned normally"
+     | exception Cancel_scope -> ()
+     | exception exn -> raise exn);
+    match Writer.await (Option.get !ticket) with
+    | Error (Writer.Scope_failed (Writer.Supervisor_cancelled Cancel_scope)) -> ()
+    | Error error -> fail (Writer.ticket_error_to_string error)
+    | Ok _ -> fail "cancelled supervisor reported a durable ticket")
+;;
+
+let test_initialization_failure_is_scope_local () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun root ->
+    make_dir root;
+    let missing = Eio.Path.(root / "missing" / "scope") in
+    let healthy = Eio.Path.(root / "healthy") in
+    make_dir healthy;
+    let failed, healthy =
+      Eio.Fiber.pair
+        (fun () ->
+           Writer.run ~dir:missing (fun ~sw:_ failed_writer ->
+             match Writer.await_ready failed_writer with
+             | Error (Writer.Initialization_failed _) -> ()
+             | Error error -> fail (Writer.scope_failure_to_string error)
+             | Ok () -> fail "missing durability directory became ready"))
+        (fun () ->
+           Writer.run ~dir:healthy (fun ~sw:_ healthy_writer ->
+             require_scope (Writer.await_ready healthy_writer);
+             Writer.submit healthy_writer (Tx.start_run ~agent_name:"healthy-scope" ())
+             |> require_submit
+             |> Writer.await
+             |> require_ticket))
+    in
+    (match failed with
+     | Error (Writer.Initialization_failed _) -> ()
+     | Error error -> fail (Writer.scope_failure_to_string error)
+     | Ok () -> fail "missing durability directory closed successfully");
+    match healthy with
+    | Error error -> fail (Writer.scope_failure_to_string error)
+    | Ok healthy_receipt ->
+      check
+        int
+        "sibling scope remains durable"
+        1
+        (Journal.cursor_seq healthy_receipt.through))
+;;
+
+let test_clean_reopen_continues_exact_cursor () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun dir ->
+    make_dir dir;
+    let first_receipt = ref None in
+    with_fresh dir (fun _sw writer ->
+      let receipt =
+        require_ticket
+          (Writer.await
+             (require_submit
+                (Writer.submit writer (Tx.start_run ~agent_name:"reopen" ()))))
+      in
+      first_receipt := Some receipt;
+      require_closed (Writer.close_and_await writer));
+    let first = Option.get !first_receipt in
+    with_existing dir (fun _sw writer ->
+      let run, _opened = first.value in
+      let second =
+        require_ticket
+          (Writer.await
+             (require_submit
+                (Writer.submit
+                   writer
+                   (Tx.open_node
+                      ~run
+                      ~parent:(Journal.run_root run)
+                      ~kind:(Event.Agent_turn { ordinal = 0 })
+                      ()))))
+      in
+      check
+        int
+        "reopened cursor advances exactly once"
+        (Journal.cursor_seq first.through + 1)
+        (Journal.cursor_seq second.through);
+      let events, through = read_complete_page writer ~after:first.through ~limit:1 in
+      check int "one post-reopen event" 1 (List.length events);
+      let _node, opened = second.value in
+      check
+        bool
+        "post-reopen identity is exact"
+        true
+        (Event.equal opened (List.hd events));
+      check int "post-reopen replay cursor" 2 (Journal.cursor_seq through);
+      require_closed (Writer.close_and_await writer)))
+;;
+
+let test_abort_transaction_is_one_durable_terminal_group () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun dir ->
+    make_dir dir;
+    with_fresh dir (fun _sw writer ->
+      let run, output, setup_through, _events = open_output writer in
+      let terminal = Event.Cancelled { reason = Some "scope shutdown"; data = None } in
+      let aborted =
+        require_ticket
+          (Writer.await
+             (require_submit (Writer.submit writer (Tx.abort_run ~run terminal))))
+      in
+      check int "entire open subtree closes together" 4 aborted.group_event_count;
+      let events, through = read_complete_page writer ~after:setup_through ~limit:4 in
+      check
+        bool
+        "abort receipt is exact durable tail"
+        true
+        (List.equal Event.equal aborted.value events);
+      check int "terminal watermark" 8 (Journal.cursor_seq through);
+      let rejected = require_submit (Writer.submit writer (delta_transaction output 1)) in
+      (match Writer.await rejected with
+       | Error
+           (Writer.Transaction_rejected
+              (Journal.Invariant_violation (Journal.Node_already_closed node_id))) ->
+         check bool "exact closed node" true (Event.Node_id.equal node_id output)
+       | Error error -> fail (Writer.ticket_error_to_string error)
+       | Ok _ -> fail "closed output accepted another delta");
+      require_closed (Writer.close_and_await writer)))
+;;
+
+let test_repeated_unknown_waits_for_typed_external_wake () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun dir ->
+    make_dir dir;
+    let blocker = Eio.Path.(dir / "events.v1.commit") in
+    Eio.Path.mkdirs ~exists_ok:false ~perm:0o700 blocker;
+    let durable_event = ref None in
+    let durable_through = ref None in
+    with_fresh dir (fun _sw writer ->
+      let first =
+        require_submit
+          (Writer.submit writer (Tx.start_run ~agent_name:"unknown-create" ()))
+      in
+      let waiting = await_reconciliation_wait writer ~outcome_count:2 in
+      check int "repeated unknown does not self-wake" 0 waiting.reconciliation_wakes;
+      check
+        bool
+        "no wake source before an external event"
+        true
+        (Option.is_none waiting.last_reconciliation_wake);
+      let second =
+        require_submit
+          (Writer.submit writer (Tx.start_run ~agent_name:"queued-during-wait" ()))
+      in
+      Eio.Fiber.yield ();
+      let after_submit = Writer.stats writer in
+      check
+        int
+        "submission does not retry filesystem"
+        2
+        after_submit.reconciliation_unknowns;
+      check int "submission is not a durability wake" 0 after_submit.reconciliation_wakes;
+      Eio.Path.rmtree ~missing_ok:false blocker;
+      check
+        bool
+        "unknown outcome accepts typed wake"
+        true
+        (Writer.wake_reconciliation writer ~source:Writer.Durability_health_changed);
+      check
+        bool
+        "a claimed wake cannot be claimed again"
+        false
+        (Writer.wake_reconciliation writer ~source:Writer.Operator_requested);
+      let receipt = require_ticket (Writer.await first) in
+      let _run, opened = receipt.value in
+      durable_event := Some opened;
+      durable_through := Some receipt.through;
+      (match Writer.await second with
+       | Error
+           (Writer.Transaction_rejected
+              (Journal.Invariant_violation Journal.Top_level_run_already_exists)) -> ()
+       | Error error -> fail (Writer.ticket_error_to_string error)
+       | Ok _ -> fail "second top-level run was accepted");
+      check int "reconciled command commits once" 1 (Journal.cursor_seq receipt.through);
+      check int "reconciled command is one durability group" 1 receipt.group_event_count;
+      let observed = Writer.stats writer in
+      check int "both unknown outcomes are observed" 2 observed.reconciliation_unknowns;
+      check int "reconciliation wake is observed" 1 observed.reconciliation_wakes;
+      check
+        bool
+        "typed wake source is retained"
+        true
+        (observed.last_reconciliation_wake
+         = Some (Writer.External_wake Writer.Durability_health_changed));
+      check
+        bool
+        "successful reconciliation clears current evidence"
+        true
+        (Option.is_none observed.current_reconciliation);
+      require_closed (Writer.close_and_await writer));
+    let through = Option.get !durable_through in
+    with_existing dir (fun _sw writer ->
+      require_scope (Writer.await_ready writer);
+      let page =
+        match
+          Writer.read_page writer ~after:(cursor_at through 0) ~through ~limit:1 ()
+        with
+        | Ok page -> page
+        | Error error -> fail (Writer.read_error_to_string error)
+      in
+      check
+        bool
+        "reopen preserves the exact reconciled event"
+        true
+        (List.equal Event.equal [ Option.get !durable_event ] page.events);
+      check_cursor "reopen preserves the reconciled cursor" through page.next_cursor))
+;;
+
+let test_close_terminates_unresolved_reconciliation () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun dir ->
+    make_dir dir;
+    let blocker = Eio.Path.(dir / "events.v1.commit") in
+    Eio.Path.mkdirs ~exists_ok:false ~perm:0o700 blocker;
+    let writer_ref = ref None in
+    let first_waiter = ref None in
+    let second_waiter = ref None in
+    let outcome =
+      Writer.run ~dir (fun ~sw writer ->
+        writer_ref := Some writer;
+        let first =
+          require_submit
+            (Writer.submit writer (Tx.start_run ~agent_name:"close-unknown-1" ()))
+        in
+        let second =
+          require_submit
+            (Writer.submit writer (Tx.start_run ~agent_name:"close-unknown-2" ()))
+        in
+        ignore (await_reconciliation_wait writer ~outcome_count:2);
+        Eio.Fiber.fork ~sw (fun () -> first_waiter := Some (Writer.await first));
+        Eio.Fiber.fork ~sw (fun () -> second_waiter := Some (Writer.await second)))
+    in
+    (match outcome with
+     | Error (Writer.Reconciliation_unresolved_on_close { evidence }) ->
+       check int "close performs one final exact reconciliation" 3 evidence.outcome_count
+     | Error error -> fail (Writer.scope_failure_to_string error)
+     | Ok () -> fail "unresolved reconciliation closed successfully");
+    let check_waiter = function
+      | Error
+          (Writer.Scope_failed (Writer.Reconciliation_unresolved_on_close { evidence }))
+        -> check int "ticket retains close evidence" 3 evidence.outcome_count
+      | Error error -> fail (Writer.ticket_error_to_string error)
+      | Ok _ -> fail "ambiguous ticket reported durable success"
+    in
+    check_waiter (Option.get !first_waiter);
+    check_waiter (Option.get !second_waiter);
+    let observed = Writer.stats (Option.get !writer_ref) in
+    check int "close wake is observed" 1 observed.reconciliation_wakes;
+    check
+      bool
+      "close wake source is typed"
+      true
+      (observed.last_reconciliation_wake = Some Writer.Close_requested);
+    check int "all ambiguous tickets settle" observed.accepted observed.settled;
+    check int "failed close clears queue" 0 observed.queue_depth;
+    check int "failed close clears in-flight" 0 observed.in_flight_commands;
+    Eio.Path.rmtree ~missing_ok:false blocker;
+    require_scope
+      (Writer.resume ~dir (fun ~sw:_ writer ->
+         require_scope (Writer.await_ready writer);
+         match Writer.current_cursor writer with
+         | Ok cursor ->
+           check int "unresolved close publishes no events" 0 (Journal.cursor_seq cursor)
+         | Error error -> fail (Writer.read_error_to_string error))))
+;;
+
+let test_each_external_wake_authorizes_one_reconciliation () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun dir ->
+    make_dir dir;
+    let blocker = Eio.Path.(dir / "events.v1.commit") in
+    Eio.Path.mkdirs ~exists_ok:false ~perm:0o700 blocker;
+    let ticket_ref = ref None in
+    let outcome =
+      Writer.run ~dir (fun ~sw:_ writer ->
+        let ticket =
+          require_submit
+            (Writer.submit writer (Tx.start_run ~agent_name:"operator-wake" ()))
+        in
+        ticket_ref := Some ticket;
+        ignore (await_reconciliation_wait writer ~outcome_count:2);
+        check
+          bool
+          "operator wake is accepted"
+          true
+          (Writer.wake_reconciliation writer ~source:Writer.Operator_requested);
+        let waiting = await_reconciliation_wait writer ~outcome_count:3 in
+        check int "one external wake causes one retry" 1 waiting.reconciliation_wakes;
+        check
+          bool
+          "operator wake source is retained"
+          true
+          (waiting.last_reconciliation_wake
+           = Some (Writer.External_wake Writer.Operator_requested));
+        Eio.Fiber.yield ();
+        let stable = Writer.stats writer in
+        check
+          int
+          "no autonomous retry follows the external attempt"
+          3
+          stable.reconciliation_unknowns)
+    in
+    (match outcome with
+     | Error (Writer.Reconciliation_unresolved_on_close { evidence }) ->
+       check int "close owns the next and final retry" 4 evidence.outcome_count
+     | Error error -> fail (Writer.scope_failure_to_string error)
+     | Ok () -> fail "blocked reconciliation closed successfully");
+    match Writer.await (Option.get !ticket_ref) with
+    | Error (Writer.Scope_failed (Writer.Reconciliation_unresolved_on_close _)) -> ()
+    | Error error -> fail (Writer.ticket_error_to_string error)
+    | Ok _ -> fail "blocked ticket reported durable success")
+;;
+
+let test_owned_supervisor_drains_same_scope_waiter () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun dir ->
+    make_dir dir;
+    let writer = ref None in
+    let ticket = ref None in
+    let waiter = ref None in
+    require_scope
+      (Writer.run ~dir (fun ~sw created ->
+         writer := Some created;
+         let accepted =
+           require_submit
+             (Writer.submit created (Tx.start_run ~agent_name:"owned-scope" ()))
+         in
+         ticket := Some accepted;
+         Eio.Fiber.fork ~sw (fun () -> waiter := Some (Writer.await accepted))));
+    let receipt = require_ticket (Option.get !waiter) in
+    check
+      int
+      "owned supervisor drains accepted ticket"
+      1
+      (Journal.cursor_seq receipt.through);
+    require_closed (Writer.await_closed (Option.get !writer));
+    let observed = Writer.stats (Option.get !writer) in
+    check
+      int
+      "owned supervisor settles accepted ticket"
+      observed.accepted
+      observed.settled;
+    check int "owned supervisor clears queue" 0 observed.queue_depth;
+    check int "owned supervisor clears in-flight" 0 observed.in_flight_commands;
+    ignore (require_ticket (Writer.await (Option.get !ticket))))
+;;
+
+let test_callback_exception_preserves_durable_group_truth () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun dir ->
+    make_dir dir;
+    let writer_ref = ref None in
+    let setup_through_ref = ref None in
+    let first_receipt = ref None in
+    let second_ticket = ref None in
+    (match
+       with_fresh dir (fun _sw writer ->
+         writer_ref := Some writer;
+         let _run, output, setup_through, _events = open_output writer in
+         setup_through_ref := Some setup_through;
+         let first = require_submit (Writer.submit writer (delta_transaction output 1)) in
+         let second =
+           require_submit (Writer.submit writer (delta_transaction output 2))
+         in
+         second_ticket := Some second;
+         first_receipt := Some (require_ticket (Writer.await first));
+         (match Writer.ticket_phase second with
+          | Writer.Committing -> ()
+          | Writer.Queued | Writer.Reconciling | Writer.Settled ->
+            fail "second ticket was not pending inside durable settlement");
+         raise Callback_failed)
+     with
+     | () -> fail "callback failure returned normally"
+     | exception Callback_failed -> ()
+     | exception exn -> raise exn);
+    let first = Option.get !first_receipt in
+    let second = require_ticket (Writer.await (Option.get !second_ticket)) in
+    check_cursor
+      "callback failure keeps one durable group cursor"
+      first.through
+      second.through;
+    check int "callback failure keeps exact durable group size" 2 first.group_event_count;
+    check int "callback failure keeps sibling group size" 2 second.group_event_count;
+    require_closed (Writer.await_closed (Option.get !writer_ref));
+    let observed = Writer.stats (Option.get !writer_ref) in
+    check
+      int
+      "callback failure settles every accepted ticket"
+      observed.accepted
+      observed.settled;
+    check int "callback failure clears queue" 0 observed.queue_depth;
+    check int "callback failure clears in-flight" 0 observed.in_flight_commands;
+    with_existing dir (fun _sw writer ->
+      require_scope (Writer.await_ready writer);
+      let page =
+        match
+          Writer.read_page
+            writer
+            ~after:(Option.get !setup_through_ref)
+            ~through:first.through
+            ~limit:2
+            ()
+        with
+        | Ok page -> page
+        | Error error -> fail (Writer.read_error_to_string error)
+      in
+      check
+        bool
+        "callback failure replays both durable events"
+        true
+        (List.equal Event.equal [ first.value; second.value ] page.events)))
+;;
+
+let test_callback_exception_retains_unresolved_scope_failure () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun dir ->
+    make_dir dir;
+    let blocker = Eio.Path.(dir / "events.v1.commit") in
+    Eio.Path.mkdirs ~exists_ok:false ~perm:0o700 blocker;
+    let ticket_ref = ref None in
+    (match
+       Writer.run ~dir (fun ~sw:_ writer ->
+         let ticket =
+           require_submit
+             (Writer.submit writer (Tx.start_run ~agent_name:"callback-unknown" ()))
+         in
+         ticket_ref := Some ticket;
+         ignore (await_reconciliation_wait writer ~outcome_count:2);
+         raise Callback_failed)
+     with
+     | exception
+         Writer.Callback_failed_after_scope_failure
+           (Callback_failed, Writer.Reconciliation_unresolved_on_close { evidence }) ->
+       check int "callback and close retain exact evidence" 3 evidence.outcome_count
+     | exception exn -> raise exn
+     | Ok _ | Error _ -> fail "callback failure returned as a normal scope result");
+    match Writer.await (Option.get !ticket_ref) with
+    | Error (Writer.Scope_failed (Writer.Reconciliation_unresolved_on_close { evidence }))
+      -> check int "ticket retains the same close evidence" 3 evidence.outcome_count
+    | Error error -> fail (Writer.ticket_error_to_string error)
+    | Ok _ -> fail "ambiguous ticket reported durable success")
+;;
+
+let test_durable_success_settles_group_before_supervisor_cancellation () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun dir ->
+    make_dir dir;
+    let writer_ref = ref None in
+    let output_ref = ref None in
+    let setup_through_ref = ref None in
+    let first_ticket = ref None in
+    let second_ticket = ref None in
+    let first_receipt = ref None in
+    (match
+       with_fresh dir (fun sw writer ->
+         writer_ref := Some writer;
+         let _run, output, setup_through, _events = open_output writer in
+         output_ref := Some output;
+         setup_through_ref := Some setup_through;
+         let first = require_submit (Writer.submit writer (delta_transaction output 1)) in
+         let second =
+           require_submit (Writer.submit writer (delta_transaction output 2))
+         in
+         first_ticket := Some first;
+         second_ticket := Some second;
+         first_receipt := Some (require_ticket (Writer.await first));
+         (match Writer.ticket_phase second with
+          | Writer.Committing -> ()
+          | Writer.Queued | Writer.Reconciling | Writer.Settled ->
+            fail "second ticket was not pending inside durable settlement");
+         Eio.Switch.fail sw Cancel_scope)
+     with
+     | () -> fail "failed supervisor switch returned normally"
+     | exception Cancel_scope -> ()
+     | exception exn -> raise exn);
+    let first = Option.get !first_receipt in
+    let second = require_ticket (Writer.await (Option.get !second_ticket)) in
+    check
+      int
+      "same durable group cursor"
+      (Journal.cursor_seq first.through)
+      (Journal.cursor_seq second.through);
+    check int "same durable group size" first.group_event_count second.group_event_count;
+    check int "both commands committed together" 2 first.group_event_count;
+    (match Writer.await_closed (Option.get !writer_ref) with
+     | Error (Writer.Supervisor_cancelled Cancel_scope) -> ()
+     | Error error -> fail (Writer.scope_failure_to_string error)
+     | Ok () -> fail "cancelled supervisor reported a normal actor close");
+    let observed = Writer.stats (Option.get !writer_ref) in
+    check
+      int
+      "cancelled scope settles every accepted ticket"
+      observed.accepted
+      observed.settled;
+    check int "cancelled scope clears queue" 0 observed.queue_depth;
+    check int "cancelled scope clears in-flight" 0 observed.in_flight_commands;
+    with_existing dir (fun _sw writer ->
+      let output = Option.get !output_ref in
+      ignore (submit_and_await writer (delta_transaction output 3));
+      let page =
+        match
+          Writer.read_page
+            writer
+            ~after:(Option.get !setup_through_ref)
+            ~through:first.through
+            ~limit:2
+            ()
+        with
+        | Ok page -> page
+        | Error error -> fail (Writer.read_error_to_string error)
+      in
+      check
+        bool
+        "reopen replays the exact successful group"
+        true
+        (List.equal Event.equal [ first.value; second.value ] page.events);
+      require_closed (Writer.close_and_await writer)))
+;;
+
+let test_frozen_pages_remain_lossless_after_close () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun dir ->
+    make_dir dir;
+    with_fresh dir (fun _sw writer ->
+      let _run, output, setup_through, _events = open_output writer in
+      let first = require_submit (Writer.submit writer (delta_transaction output 1)) in
+      let second = require_submit (Writer.submit writer (delta_transaction output 2)) in
+      let first_receipt = require_ticket (Writer.await first) in
+      let second_receipt = require_ticket (Writer.await second) in
+      let first_page =
+        match Writer.read_page writer ~after:setup_through ~limit:1 () with
+        | Ok page -> page
+        | Error error -> fail (Writer.read_error_to_string error)
+      in
+      check bool "first frozen page has a remainder" true first_page.has_more;
+      check_cursor
+        "first page freezes the exact current watermark"
+        second_receipt.through
+        first_page.high_watermark;
+      check_cursor
+        "first page advances by the exact first event"
+        (cursor_at setup_through (Journal.cursor_seq setup_through + 1))
+        first_page.next_cursor;
+      let third = submit_and_await writer (delta_transaction output 3) in
+      require_closed (Writer.close_and_await writer);
+      let frozen_tail =
+        match
+          Writer.read_page
+            writer
+            ~after:first_page.next_cursor
+            ~through:first_page.high_watermark
+            ~limit:1
+            ()
+        with
+        | Ok page -> page
+        | Error error -> fail (Writer.read_error_to_string error)
+      in
+      check
+        bool
+        "frozen tail excludes later append"
+        true
+        (List.equal Event.equal [ second_receipt.value ] frozen_tail.events);
+      check bool "frozen tail is complete" false frozen_tail.has_more;
+      check
+        int
+        "frozen tail keeps old watermark"
+        (Journal.cursor_seq second_receipt.through)
+        (Journal.cursor_seq frozen_tail.high_watermark);
+      check_cursor
+        "frozen tail keeps exact old watermark scope"
+        second_receipt.through
+        frozen_tail.high_watermark;
+      check
+        int
+        "frozen tail stops at old watermark"
+        (Journal.cursor_seq second_receipt.through)
+        (Journal.cursor_seq frozen_tail.next_cursor);
+      check_cursor
+        "frozen tail stops at exact old watermark"
+        second_receipt.through
+        frozen_tail.next_cursor;
+      let later =
+        match Writer.read_page writer ~after:first_page.high_watermark ~limit:1 () with
+        | Ok page -> page
+        | Error error -> fail (Writer.read_error_to_string error)
+      in
+      check
+        bool
+        "new watermark retains later append"
+        true
+        (List.equal Event.equal [ third.value ] later.events);
+      check bool "later page is complete" false later.has_more;
+      check
+        int
+        "later page exposes new watermark"
+        (Journal.cursor_seq third.through)
+        (Journal.cursor_seq later.high_watermark);
+      check_cursor
+        "later page exposes exact new watermark"
+        third.through
+        later.high_watermark;
+      check
+        int
+        "later page reaches new watermark"
+        (Journal.cursor_seq third.through)
+        (Journal.cursor_seq later.next_cursor);
+      check_cursor
+        "later page reaches exact new watermark"
+        third.through
+        later.next_cursor;
+      check
+        bool
+        "first receipt remains exact"
+        true
+        (Event.equal first_receipt.value (List.hd first_page.events))))
+;;
+
+let () =
+  run
+    "execution lane writer"
+    [ ( "durability"
+      , [ test_case
+            "single command commits and close drains"
+            `Quick
+            test_single_command_commits_and_close_drains
+        ; test_case
+            "ready set is one FIFO durable group"
+            `Quick
+            test_ready_set_is_one_fifo_durable_group
+        ; test_case
+            "semantic rejection does not poison ready group"
+            `Quick
+            test_semantic_rejection_does_not_poison_ready_group
+        ; test_case
+            "concurrent submit and close linearize without loss"
+            `Quick
+            test_concurrent_submit_and_close_linearize_without_loss
+        ; test_case
+            "cancelled waiter does not cancel ticket"
+            `Quick
+            test_cancelled_waiter_does_not_cancel_ticket
+        ; test_case
+            "supervisor cancellation settles accepted ticket"
+            `Quick
+            test_supervisor_cancellation_settles_accepted_ticket
+        ; test_case
+            "initialization failure is scope local"
+            `Quick
+            test_initialization_failure_is_scope_local
+        ; test_case
+            "clean reopen continues exact cursor"
+            `Quick
+            test_clean_reopen_continues_exact_cursor
+        ; test_case
+            "abort transaction is one durable terminal group"
+            `Quick
+            test_abort_transaction_is_one_durable_terminal_group
+        ; test_case
+            "repeated unknown waits for typed external wake"
+            `Quick
+            test_repeated_unknown_waits_for_typed_external_wake
+        ; test_case
+            "close terminates unresolved reconciliation"
+            `Quick
+            test_close_terminates_unresolved_reconciliation
+        ; test_case
+            "each external wake authorizes one reconciliation"
+            `Quick
+            test_each_external_wake_authorizes_one_reconciliation
+        ; test_case
+            "owned supervisor drains same-scope waiter"
+            `Quick
+            test_owned_supervisor_drains_same_scope_waiter
+        ; test_case
+            "callback exception preserves durable group truth"
+            `Quick
+            test_callback_exception_preserves_durable_group_truth
+        ; test_case
+            "callback exception retains unresolved scope failure"
+            `Quick
+            test_callback_exception_retains_unresolved_scope_failure
+        ; test_case
+            "durable success settles group before supervisor cancellation"
+            `Quick
+            test_durable_success_settles_group_before_supervisor_cancellation
+        ; test_case
+            "frozen pages remain lossless after close"
+            `Quick
+            test_frozen_pages_remain_lossless_after_close
+        ] )
+    ]
+;;

--- a/test/test_provider_agnostic_reasoning_replay.ml
+++ b/test/test_provider_agnostic_reasoning_replay.ml
@@ -58,8 +58,14 @@ let content_has_reasoning =
 let content_has_tool_use =
   List.exists (function
     | ToolUse _ -> true
-    | Text _ | Thinking _ | ReasoningDetails _ | RedactedThinking _ | ToolResult _
-    | Image _ | Document _ | Audio _ -> false)
+    | Text _
+    | Thinking _
+    | ReasoningDetails _
+    | RedactedThinking _
+    | ToolResult _
+    | Image _
+    | Document _
+    | Audio _ -> false)
 ;;
 
 let tool_result tool_use_id =
@@ -183,15 +189,26 @@ let test_latest_user_turn_policy_keeps_only_current_tool_reasoning () =
     ; message Tool [ tool_result "current-call" ]
     ]
   in
-  match project ~target ~policy:Tool_call_assistant_messages_latest_user_turn messages with
+  match
+    project ~target ~policy:Tool_call_assistant_messages_latest_user_turn messages
+  with
   | Error error -> Alcotest.fail (Reasoning_history_projection.error_to_string error)
   | Ok projection ->
-    check_int "message and tool-result history is lossless" 6 (List.length projection.messages);
-    check_int "only the older reasoning artifact is dropped" 1 (List.length projection.reasoning_replay_drops);
+    check_int
+      "message and tool-result history is lossless"
+      6
+      (List.length projection.messages);
+    check_int
+      "only the older reasoning artifact is dropped"
+      1
+      (List.length projection.reasoning_replay_drops);
     let old_assistant = List.nth projection.messages 1 in
     let current_assistant = List.nth projection.messages 4 in
     check_bool "old tool call remains" true (content_has_tool_use old_assistant.content);
-    check_bool "old reasoning is removed" false (content_has_reasoning old_assistant.content);
+    check_bool
+      "old reasoning is removed"
+      false
+      (content_has_reasoning old_assistant.content);
     check_bool
       "current tool reasoning remains"
       true
@@ -210,12 +227,17 @@ let test_latest_user_turn_policy_without_user_replays_none () =
     ; message Tool [ tool_result "call" ]
     ]
   in
-  match project ~target ~policy:Tool_call_assistant_messages_latest_user_turn messages with
+  match
+    project ~target ~policy:Tool_call_assistant_messages_latest_user_turn messages
+  with
   | Error error -> Alcotest.fail (Reasoning_history_projection.error_to_string error)
   | Ok projection ->
     let assistant = List.hd projection.messages in
     check_bool "tool call remains" true (content_has_tool_use assistant.content);
-    check_bool "unscoped reasoning is removed" false (content_has_reasoning assistant.content)
+    check_bool
+      "unscoped reasoning is removed"
+      false
+      (content_has_reasoning assistant.content)
 ;;
 
 let test_selected_unsupported_block_fails_closed () =
@@ -298,8 +320,7 @@ let test_explicit_preserve_promotes_latest_user_policy_to_full_history () =
   check_bool
     "explicit preserve selects all assistant messages"
     true
-    ((Reasoning_dialect.replay_contract dialect).replay_policy
-     = All_assistant_messages);
+    ((Reasoning_dialect.replay_contract dialect).replay_policy = All_assistant_messages);
   let messages =
     [ message User [ Text "first request" ]
     ; with_source

--- a/test/test_provider_agnostic_reasoning_replay.ml
+++ b/test/test_provider_agnostic_reasoning_replay.ml
@@ -55,6 +55,23 @@ let content_has_reasoning =
     | Text _ | ToolUse _ | ToolResult _ | Image _ | Document _ | Audio _ -> false)
 ;;
 
+let content_has_tool_use =
+  List.exists (function
+    | ToolUse _ -> true
+    | Text _ | Thinking _ | ReasoningDetails _ | RedactedThinking _ | ToolResult _
+    | Image _ | Document _ | Audio _ -> false)
+;;
+
+let tool_result tool_use_id =
+  ToolResult
+    { tool_use_id
+    ; content = "ok"
+    ; outcome = Tool_succeeded
+    ; json = None
+    ; content_blocks = None
+    }
+;;
+
 let test_source_exactness_and_classification () =
   let left = source All_assistant_messages in
   let same = source All_assistant_messages in
@@ -145,6 +162,62 @@ let test_tool_call_policy_applies_across_history () =
       (content_has_reasoning last.content)
 ;;
 
+let test_latest_user_turn_policy_keeps_only_current_tool_reasoning () =
+  let target = source Tool_call_assistant_messages_latest_user_turn in
+  let messages =
+    [ message User [ Text "first request" ]
+    ; with_source
+        target
+        Assistant
+        [ Thinking { content = "old tool reasoning"; signature = None }
+        ; ToolUse { id = "old-call"; name = "lookup"; input = `Assoc [] }
+        ]
+    ; message Tool [ tool_result "old-call" ]
+    ; message User [ Text "current request" ]
+    ; with_source
+        target
+        Assistant
+        [ Thinking { content = "current tool reasoning"; signature = None }
+        ; ToolUse { id = "current-call"; name = "inspect"; input = `Assoc [] }
+        ]
+    ; message Tool [ tool_result "current-call" ]
+    ]
+  in
+  match project ~target ~policy:Tool_call_assistant_messages_latest_user_turn messages with
+  | Error error -> Alcotest.fail (Reasoning_history_projection.error_to_string error)
+  | Ok projection ->
+    check_int "message and tool-result history is lossless" 6 (List.length projection.messages);
+    check_int "only the older reasoning artifact is dropped" 1 (List.length projection.reasoning_replay_drops);
+    let old_assistant = List.nth projection.messages 1 in
+    let current_assistant = List.nth projection.messages 4 in
+    check_bool "old tool call remains" true (content_has_tool_use old_assistant.content);
+    check_bool "old reasoning is removed" false (content_has_reasoning old_assistant.content);
+    check_bool
+      "current tool reasoning remains"
+      true
+      (content_has_reasoning current_assistant.content)
+;;
+
+let test_latest_user_turn_policy_without_user_replays_none () =
+  let target = source Tool_call_assistant_messages_latest_user_turn in
+  let messages =
+    [ with_source
+        target
+        Assistant
+        [ Thinking { content = "unscoped reasoning"; signature = None }
+        ; ToolUse { id = "call"; name = "lookup"; input = `Assoc [] }
+        ]
+    ; message Tool [ tool_result "call" ]
+    ]
+  in
+  match project ~target ~policy:Tool_call_assistant_messages_latest_user_turn messages with
+  | Error error -> Alcotest.fail (Reasoning_history_projection.error_to_string error)
+  | Ok projection ->
+    let assistant = List.hd projection.messages in
+    check_bool "tool call remains" true (content_has_tool_use assistant.content);
+    check_bool "unscoped reasoning is removed" false (content_has_reasoning assistant.content)
+;;
+
 let test_selected_unsupported_block_fails_closed () =
   let target = source All_assistant_messages in
   let result =
@@ -195,10 +268,64 @@ let preserving_capabilities =
   }
 ;;
 
+let latest_user_turn_capabilities =
+  { Capabilities.default_capabilities with
+    supports_reasoning = true
+  ; thinking_control_format = Chat_template_kwargs
+  ; preserve_thinking_control_format = Chat_template_kwargs_preserve_thinking
+  ; reasoning_replay_override = Force_latest_user_turn_tool_calls
+  }
+;;
+
 let source_for_config config =
   match Reasoning_dialect.reasoning_source_for_provider_config config with
   | Ok source -> source
   | Error detail -> Alcotest.fail detail
+;;
+
+let test_explicit_preserve_promotes_latest_user_policy_to_full_history () =
+  let config =
+    Provider_config.make
+      ~kind:OpenAI_compat
+      ~model_id:"model-a"
+      ~base_url:"https://provider.example"
+      ~model_capabilities_override:latest_user_turn_capabilities
+      ~preserve_thinking:true
+      ()
+  in
+  let source = source_for_config config in
+  let dialect = Reasoning_dialect.for_provider_config config in
+  check_bool
+    "explicit preserve selects all assistant messages"
+    true
+    ((Reasoning_dialect.replay_contract dialect).replay_policy
+     = All_assistant_messages);
+  let messages =
+    [ message User [ Text "first request" ]
+    ; with_source
+        source
+        Assistant
+        [ Thinking { content = "old tool reasoning"; signature = None }
+        ; ToolUse { id = "old-call"; name = "lookup"; input = `Assoc [] }
+        ]
+    ; message Tool [ tool_result "old-call" ]
+    ; message User [ Text "current request" ]
+    ]
+  in
+  match
+    Reasoning_history_projection.project_for_provider_config
+      ~assistant_has_payload:(fun content -> content <> [])
+      ~reasoning_block_supported:reasoning_supported
+      config
+      messages
+  with
+  | Error error -> Alcotest.fail (Reasoning_history_projection.error_to_string error)
+  | Ok projection ->
+    let old_assistant = List.nth projection.messages 1 in
+    check_bool
+      "explicit preserve retains prior-turn reasoning"
+      true
+      (content_has_reasoning old_assistant.content)
 ;;
 
 let test_openai_chat_request_uses_whole_history_projection () =
@@ -310,7 +437,7 @@ let test_openai_responses_replays_only_opaque_item () =
 let () =
   Alcotest.run
     "provider_agnostic_reasoning_replay"
-    [ ( "typed whole-history replay"
+    [ ( "typed replay projection"
       , [ Alcotest.test_case
             "source exactness"
             `Quick
@@ -323,6 +450,18 @@ let () =
             "tool-call policy"
             `Quick
             test_tool_call_policy_applies_across_history
+        ; Alcotest.test_case
+            "latest user turn policy"
+            `Quick
+            test_latest_user_turn_policy_keeps_only_current_tool_reasoning
+        ; Alcotest.test_case
+            "latest user turn policy requires a user boundary"
+            `Quick
+            test_latest_user_turn_policy_without_user_replays_none
+        ; Alcotest.test_case
+            "explicit preserve promotes latest-user policy"
+            `Quick
+            test_explicit_preserve_promotes_latest_user_policy_to_full_history
         ; Alcotest.test_case
             "unsupported codec fails"
             `Quick

--- a/test/test_thinking_control_dialects.ml
+++ b/test/test_thinking_control_dialects.ml
@@ -146,7 +146,7 @@ let declared_qwen_openai_compat_capabilities =
   ; thinking_control_format = CAP.Chat_template_kwargs
   ; preserve_thinking_control_format = CAP.Chat_template_kwargs_preserve_thinking
   ; reasoning_streaming_format = CAP.Delta_reasoning_field "reasoning_content"
-  ; reasoning_replay_override = CAP.Force_drop_without_tool_preserve_with_tool
+  ; reasoning_replay_override = CAP.Force_latest_user_turn_tool_calls
   }
 ;;
 
@@ -316,7 +316,7 @@ let test_qwen36_reasoning_dialect_without_preserve_keeps_tool_reasoning () =
   check
     string
     "replay policy"
-    "drop_without_tool_preserve_with_tool"
+    "latest_user_turn_tool_calls"
     (RD.replay_policy_to_string dialect.replay_policy);
   check
     bool


### PR DESCRIPTION
## Goal

Turn the private recursive execution journal into a real lane-local durability primitive. A request/Keeper fiber submits a typed semantic transaction and receives a receipt only after the journal authority proves the exact event group durable. Filesystem uncertainty never causes regenerated IDs, repeated Tool effects, or silent volatile fallback.

This Draft is stacked on #2617. It contains the durability actor and the hard-cut Store/Journal contracts required by that actor; it does not yet claim the live MASC/RunPod Keeper path is fixed.

## What this PR implements

### One semantic and physical authority

- `Execution_journal.Reducer` remains the sole topology, lifecycle, and recursive hierarchy authority.
- `Execution_event_store` remains the sole WAL/offset/commit-authority owner and is imported only by Journal in production.
- `Execution_lane_writer` accepts only the closed `Execution_journal.Transaction.'a t` GADT. It cannot append raw events, choose sequence values, reconstruct events from strings, or inspect WAL errors.
- durable construction is atomic: callers obtain only a claimed `durable_writer`; direct mutation through the projected journal is typed-rejected.
- one immutable staged group is either published exactly once or reconciled byte-for-byte against the same scope, correlation, base cursor, final cursor, and original events.

### Lane-local actor lifecycle

- O(1) reverse-list inbox under the mutex; reversal, semantic staging, WAL work, reconciliation, and ticket settlement happen outside the admission critical section.
- every command ready at the detach boundary forms one durability group. There is no timer, count threshold, capacity rule, token/cost/turn limit, or other execution budget gate.
- typed ticket phases: `Queued -> Committing -> Reconciling -> Settled`.
- cancelling a waiter does not cancel accepted work.
- `run` / `resume` own the supervisor switch, stop admission, drain all accepted commands, and join the actor before returning.
- `await_ready` is the deterministic read-only initialization boundary; no readiness polling or synthetic mutation is required.
- callback exceptions cannot settle actor-owned in-flight work. The actor first completes or reconciles durability, then the original callback exception is re-raised.
- if callback failure and durability-scope shutdown failure coincide, `Callback_failed_after_scope_failure` retains both typed causes.

### Exact reconciliation without a retry loop

- only `Commit_outcome_unknown` enters reconciliation; every other error is terminal and typed.
- the first automatic reopen is part of the same commit attempt. A repeated unknown then waits for an explicit typed external event.
- an external wake is one atomic claim for one reconciliation cycle. Early/concurrent signals return `false`; submission is not a durability wake.
- close is a latched typed event. It performs one final exact reconciliation even when close races the transition into the wait state, then returns `Reconciliation_unresolved_on_close` with first/latest/count evidence if authority is still unknowable.
- no retry count, backoff duration, deadline, watchdog, substring match, model family, `cwd`, or provider-specific branch participates in correctness.

### Lossless projection and recursive work-block support

- bounded pages carry an exact scope-bearing `next_cursor` and frozen `high_watermark`.
- a consumer can keep the last acknowledged cursor, receive any level-triggered wake hint, and replay the exact missing range.
- physical commit groups do not define dashboard hierarchy. Typed `Node_id`, parent edges, run/tool/attempt/output kinds, and ordered sequence remain the recursive work-block SSOT.
- closed abort is one typed transaction that stages the complete open subtree in post-order and publishes no partial prefix on cancellation.

### Resource and server-performance safety

- Store lifecycle is explicit: `Unpublished -> Published` or `Unpublished -> Releasing -> Released`; stale Store/writer capabilities return `Store_released` instead of touching closed descriptors.
- unpublished construction failures immediately close WAL/lock resources, remove the in-process writer claim, and remove cancellable claim/lifecycle switch hooks.
- explicit release reaches an unavailable terminal lifecycle even when cleanup raises; every WAL/lock close is attempted, all causes and backtraces are retained, and cleanup never replaces the primary construction failure silently.
- the in-process writer claim is removed only after all physical closes succeed. Any uncertain close keeps the claim attached to the owning switch, preventing premature writer re-admission.
- long-lived switches do not retain released Store/index graphs; this has a causal weak-reachability test.
- long list/tree/index traversals yield cooperatively; queue detach is constant-time and repeated unknown outcomes do not create a filesystem hot loop.
- per-event JSON codec work is still CPU-bound on the Eio domain. The next performance PR will inject one application-lifetime `Eio.Executor_pool`; it will not spawn a domain per event or choose work by an arbitrary size heuristic.

## Boundary / external use

- all three execution modules remain OAS-private modules.
- OAS runtime integration will own `run` / `resume`; an SDK user should not construct a Store, manage a WAL, or understand reconciliation internals.
- MASC may consume typed receipts/cursors and decide when to wake a Keeper. OAS contains no Keeper, dashboard, model, provider, or MASC policy, and OAS never imports MASC.
- observations (`queue_depth`, committed counts, reconciliation evidence, cursor lag) are measurements only. They never admit, pause, stop, or terminate execution.

## Adversarial invariants covered

- submit/close linearization loses no accepted ticket.
- same-switch waiter cannot deadlock actor shutdown.
- close-before-await cannot lose its wake.
- one external wake cannot authorize multiple retries.
- already-durable sibling tickets cannot be relabeled failed by callback/supervisor races.
- unresolved callback shutdown retains both callback and durability evidence.
- clean reopen continues the exact cursor; successful unknown reconciliation reopens the exact original event.
- frozen pages retain full cursor scope identity, not only sequence equality.
- stale released writer is rejected even with a valid next-sequence batch, and cannot move the new owner's authority.
- normal, failed-switch, explicit-release, and long-lived-switch Store lifecycles are covered.

## Verification

- focused library + tests + `@fmt`: pass
- `test_execution_journal`: 17/17 pass
- `test_execution_event_store`: 28/28 pass
- `test_execution_lane_writer`: 17/17 pass
- `scripts/check-sdk-independence.sh`: pass
- `scripts/check-execution-store-boundary.sh`: pass
- `git diff --check`: pass
- latest `main` (`aba2b591`, #2620) propagated through #2608 -> #2611 -> #2617 before refreshing this branch

Full build/test authority remains GitHub CI.

## Official design evidence

- [근거] [OCaml 5.4 manual](https://ocaml.org/manual/5.4/index.html), checked 2026-07-16 KST, confidence High.
- [근거] [Eio Switch](https://ocaml-multicore.github.io/eio/eio/Eio/Switch/), checked 2026-07-16 KST, confidence High. `Switch.run` owns structured resource lifetime; cancellable release hooks are removable with `try_remove_hook`.
- [근거] [Eio Condition](https://ocaml-multicore.github.io/eio/eio/Eio/Condition/index.html), checked 2026-07-16 KST, confidence High. Condition predicates are tested under the mutex and rechecked after broadcast.
- [근거] [Eio Cancel](https://ocaml-multicore.github.io/eio/eio/Eio/Cancel/index.html), checked 2026-07-16 KST, confidence High. Cancellation protection is limited to atomic publication/cleanup boundaries.
- [근거] [Eio Mutex](https://ocaml-multicore.github.io/eio/eio/Eio/Mutex/index.html), checked 2026-07-16 KST, confidence High. Mutable critical sections use protected writer locks and read-only access uses non-poisoning reads.
- [근거] [Eio Executor_pool](https://ocaml-multicore.github.io/eio/eio/Eio/Executor_pool/index.html), checked 2026-07-16 KST, confidence High. The documented application-lifetime shared pool is the planned CPU codec boundary.

## Follow-up hard cuts

1. wire `durable Tool_attempt -> Tool effect exactly once -> cancellation-protected Tool_receipt -> next provider turn` and delete lossy string ToolResult reconstruction;
2. move CPU-heavy event codec/compare work to an injected application-lifetime executor pool;
3. expose the typed recursive block/receipt stream through the OAS runtime boundary without leaking Store/Journal complexity;
4. pin the released OAS version in MASC, build the lossless hierarchical dashboard projection, then run real Qwen/DeepSeek Thinking+Tools+Multiturn failure/recovery smoke tests.

Only step 4 can establish that the original live `sangsu` disappearance/timeout path is resolved end-to-end.
