### PR TITLE
feat(llm_provider): add total JSON decode boundary to Json_util

### DIFF
--- a/lib/llm_provider/json_util.ml
+++ b/lib/llm_provider/json_util.ml
@@ -8,3 +8,22 @@ let json_type_name = function
   | `Bool _ -> "boolean"
   | `Null -> "null"
 ;;
+
+let decode_json_with decoder raw =
+  match Yojson.Safe.from_string raw with
+  | exception Yojson.Json_error detail -> Error ("invalid JSON: " ^ detail)
+  | json ->
+    (try Ok (decoder json) with
+     | Yojson.Safe.Util.Type_error (detail, offending) ->
+       Error
+         (Printf.sprintf
+            "unexpected JSON shape: %s (got %s)"
+            detail
+            (json_type_name offending))
+     | Yojson.Safe.Util.Undefined (detail, offending) ->
+       Error
+         (Printf.sprintf
+            "unexpected JSON shape: %s (got %s)"
+            detail
+            (json_type_name offending)))
+;;

--- a/lib/llm_provider/json_util.mli
+++ b/lib/llm_provider/json_util.mli
@@ -5,3 +5,14 @@
     Uses JSON-schema vocabulary: [object], [array], [string], [number],
     [boolean], [null]. *)
 val json_type_name : Yojson.Safe.t -> string
+
+(** Run [decoder] over a raw provider payload.
+
+    Contains every exception Yojson raises at this boundary —
+    [Yojson.Json_error] on malformed syntax, [Yojson.Safe.Util.Type_error]
+    and [Yojson.Safe.Util.Undefined] on shape mismatch (e.g. [Util.member]
+    applied to a 2xx body that is [null], an array, or a scalar) — and
+    returns them as [Error message]. Provider response parsers must decode
+    through this function instead of catching [Yojson.Json_error] alone,
+    which lets shape exceptions escape the [result] contract. *)
+val decode_json_with : (Yojson.Safe.t -> 'a) -> string -> ('a, string) result

--- a/test/test_llm_provider_cov.ml
+++ b/test/test_llm_provider_cov.ml
@@ -1729,6 +1729,82 @@ let test_thinking_disable_satisfiable_with_control_format () =
     (Complete_common.thinking_control_disable_unsatisfiable ~caps config)
 ;;
 
+(* ── Json_util.decode_json_with (provider parse boundary) ────────── *)
+
+let string_contains ~needle haystack =
+  let nl = String.length needle in
+  let hl = String.length haystack in
+  let rec go i = i + nl <= hl && (String.sub haystack i nl = needle || go (i + 1)) in
+  nl = 0 || go 0
+;;
+
+let test_decode_json_with_object () =
+  match
+    Json_util.decode_json_with
+      (fun json -> Yojson.Safe.Util.(json |> member "data" |> to_list |> List.length))
+      {|{"data":[1,2]}|}
+  with
+  | Ok n -> Alcotest.(check int) "decoded list length" 2 n
+  | Error message -> Alcotest.failf "expected Ok, got Error %s" message
+;;
+
+let test_decode_json_with_syntax_error () =
+  match Json_util.decode_json_with (fun json -> json) "{not-json" with
+  | Error message ->
+    Alcotest.(check bool)
+      "syntax failure is labelled"
+      true
+      (string_contains ~needle:"invalid JSON:" message)
+  | Ok _ -> Alcotest.fail "malformed body must not decode"
+;;
+
+let test_decode_json_with_null_body_contained () =
+  (* 2xx + valid JSON that is not an object: [Util.member] raises
+     [Type_error], which a [Json_error]-only guard lets escape the
+     [result] contract. This boundary must contain it. *)
+  match
+    Json_util.decode_json_with (fun json -> Yojson.Safe.Util.member "data" json) "null"
+  with
+  | Error message ->
+    Alcotest.(check bool)
+      "shape failure names the offending type"
+      true
+      (string_contains ~needle:"unexpected JSON shape:" message
+       && string_contains ~needle:"null" message)
+  | Ok _ -> Alcotest.fail "non-object body must not decode through member"
+;;
+
+let test_decode_json_with_array_body_contained () =
+  match
+    Json_util.decode_json_with (fun json -> Yojson.Safe.Util.member "data" json) "[1,2]"
+  with
+  | Error message ->
+    Alcotest.(check bool)
+      "array body reported"
+      true
+      (string_contains ~needle:"array" message)
+  | Ok _ -> Alcotest.fail "array body must not decode through member"
+;;
+
+let test_decode_json_with_undefined_contained () =
+  match
+    Json_util.decode_json_with (fun json -> Yojson.Safe.Util.index 5 json) "[1,2]"
+  with
+  | Error message ->
+    Alcotest.(check bool)
+      "out-of-bounds index reported"
+      true
+      (string_contains ~needle:"unexpected JSON shape:" message)
+  | Ok _ -> Alcotest.fail "out-of-bounds index must not decode"
+;;
+
+let test_decode_json_with_foreign_exception_propagates () =
+  (* Only Yojson boundary exceptions are contained: a decoder bug must
+     surface as an exception, not dissolve into [Error]. *)
+  Alcotest.check_raises "decoder bug propagates" (Failure "decoder bug") (fun () ->
+    ignore (Json_util.decode_json_with (fun _ -> failwith "decoder bug") {|{"ok":true}|}))
+;;
+
 (* ═══════════════════════════════════════════════════
    Test runner
    ═══════════════════════════════════════════════════ *)
@@ -1736,7 +1812,30 @@ let test_thinking_disable_satisfiable_with_control_format () =
 let () =
   Alcotest.run
     "llm_provider_cov"
-    [ ( "complete.gemini_url"
+    [ ( "json_util.decode_json_with"
+      , [ Alcotest.test_case "object decodes" `Quick test_decode_json_with_object
+        ; Alcotest.test_case
+            "syntax error contained"
+            `Quick
+            test_decode_json_with_syntax_error
+        ; Alcotest.test_case
+            "null body contained"
+            `Quick
+            test_decode_json_with_null_body_contained
+        ; Alcotest.test_case
+            "array body contained"
+            `Quick
+            test_decode_json_with_array_body_contained
+        ; Alcotest.test_case
+            "out-of-bounds index contained"
+            `Quick
+            test_decode_json_with_undefined_contained
+        ; Alcotest.test_case
+            "foreign exception propagates"
+            `Quick
+            test_decode_json_with_foreign_exception_propagates
+        ] )
+    ; ( "complete.gemini_url"
       , [ Alcotest.test_case "sync no key" `Quick test_gemini_url_sync_no_key
         ; Alcotest.test_case "sync with key" `Quick test_gemini_url_sync_with_key
         ; Alcotest.test_case "stream with key" `Quick test_gemini_url_stream_with_key


### PR DESCRIPTION
## 문제 (#2619)

`Yojson.Safe.Util.member`는 비객체 JSON(`null`/`[]`/scalar)에서 `Type_error`를, `Util.index`는 범위 밖에서 `Undefined`를 raise합니다. `try ... with Yojson.Json_error`만 잡는 파서는 2xx + 유효 JSON 비객체 응답에서 예외가 `result` 계약을 뚫습니다. open PR 3곳(#2610, #2612, #2615)의 `parse_response`가 정확히 이 패턴이며, 각 PR에 `with Type_error`를 덧대는 것은 N-of-M 패치라 공유 경계 하나로 닫습니다.

## 수정

`Json_util.decode_json_with : (Yojson.Safe.t -> 'a) -> string -> ('a, string) result`

- 기존 `Sessions_store_parsers.decode_json_with` idiom을 llm_provider 계층으로 미러 (sessions 모듈은 상위 계층이라 llm_provider에서 직접 의존 불가)
- `Json_error`(구문) + `Type_error`/`Undefined`(형상) 3종만 포획, 위반 JSON의 타입명을 에러 메시지에 포함 (`json_type_name` 재사용)
- **비-Yojson 예외는 전파** — decoder 버그를 `Error`로 녹여 은폐하지 않음 (계약을 테스트로 고정)

## 검증

- 신규 6케이스: object decode / syntax containment / **null body containment**(#2610:230 탈출 경로 재현) / array containment / out-of-bounds index / foreign exception propagation
- `test_llm_provider_cov` 전체 **138/138**
- `ocamlformat --check` clean (변경 3파일)

## 후속

#2610/#2612/#2615는 이 PR 착지 후 `Json_util.decode_json_with`로 rebase하면 각자의 `with Json_error` 블록을 제거할 수 있습니다.

Closes #2619.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
