### PR TITLE
fix(provider): type empty-completion ContextWindowExceeded as Api ContextOverflow

### DIFF
--- a/lib/api.ml
+++ b/lib/api.ml
@@ -37,6 +37,24 @@ let create_message_error_of_http_error = function
       http_error
       (Retry.InvalidRequest { message; reason = Unknown_invalid_request })
   | Llm_provider.Http_client.ProviderFailure
+      { kind =
+          Llm_provider.Http_client.Empty_completion
+            { stop_reason = Llm_provider.Types.ContextWindowExceeded }
+      ; message
+      } as http_error ->
+    (* An empty turn whose typed stop_reason is ContextWindowExceeded is a
+       context-overflow contract, not provider unavailability: retrying or
+       rotating replays the same oversized prompt, so only the consumer's
+       context recovery (compaction) can make progress. The provider does not
+       report its limit on this path, hence [limit = None]. *)
+    attributed_retry_error
+      http_error
+      (Retry.ContextOverflow
+         { message =
+             "empty completion (stop_reason=model_context_window_exceeded): " ^ message
+         ; limit = None
+         })
+  | Llm_provider.Http_client.ProviderFailure
       { kind = Llm_provider.Http_client.Empty_completion _; _ } as http_error ->
     Completion_error http_error
   | Llm_provider.Http_client.ProviderFailure { kind; message } as http_error ->
@@ -440,6 +458,35 @@ let%test "Retry.Timeout classifies as retryable" =
   Retry.is_retryable
     (Retry.Timeout
        { message = "HTTP request exceeded 60.0s wall-clock timeout"; phase = None })
+;;
+
+let%test "empty completion with ContextWindowExceeded types as ContextOverflow" =
+  match
+    create_message_error_of_http_error
+      (Llm_provider.Http_client.ProviderFailure
+         { kind =
+             Llm_provider.Http_client.Empty_completion
+               { stop_reason = Llm_provider.Types.ContextWindowExceeded }
+         ; message = "provider returned an empty assistant turn"
+         })
+  with
+  | Attributed_retry_error { retry_error = Retry.ContextOverflow { limit = None; _ }; _ }
+    -> true
+  | _ -> false
+;;
+
+let%test "empty completion with other stop_reason stays a completion error" =
+  match
+    create_message_error_of_http_error
+      (Llm_provider.Http_client.ProviderFailure
+         { kind =
+             Llm_provider.Http_client.Empty_completion
+               { stop_reason = Llm_provider.Types.EndTurn }
+         ; message = "provider returned an empty assistant turn"
+         })
+  with
+  | Completion_error _ -> true
+  | _ -> false
 ;;
 
 let%test "re-exported max_response_body is positive" = max_response_body > 0

--- a/lib/provider_failure_attribution.ml
+++ b/lib/provider_failure_attribution.ml
@@ -57,6 +57,23 @@ let sdk_error_of_http_error ?(accept_rejected = Api_invalid_request) err =
      | Api_invalid_request -> invalid_request reason
      | Config_invalid_config { field } ->
        Error.Config (Error.InvalidConfig { field; detail = reason }))
+  | Http.ProviderFailure
+      { kind =
+          Http.Empty_completion { stop_reason = Llm_provider.Types.ContextWindowExceeded }
+      ; message
+      } ->
+    (* An empty turn whose typed stop_reason is ContextWindowExceeded is a
+       context-overflow contract, not provider unavailability: retrying or
+       rotating replays the same oversized prompt, so only the consumer's
+       context recovery (compaction) can make progress. Surfacing it as
+       [Api ContextOverflow] lets downstream overflow classifiers fire on the
+       streaming path exactly as they do for HTTP-classified overflows. *)
+    Error.Api
+      (Retry.ContextOverflow
+         { message =
+             "empty completion (stop_reason=model_context_window_exceeded): " ^ message
+         ; limit = None
+         })
   | Http.ProviderTerminal _ | Http.ProviderFailure _ ->
     Error.Provider (Llm_provider.Error.of_http_error err)
 ;;

--- a/test/test_provider_failure_attribution.ml
+++ b/test/test_provider_failure_attribution.ml
@@ -412,6 +412,31 @@ let test_agent_sync_stream_and_legacy_projection () =
   check_bool "stream exact legacy projection" true (stream_legacy = stream_detailed.error)
 ;;
 
+let test_empty_completion_overflow_types_as_context_overflow () =
+  match
+    Attribution.sdk_error_of_http_error
+      (Http.ProviderFailure
+         { kind = Http.Empty_completion { stop_reason = Types.ContextWindowExceeded }
+         ; message = "provider returned an empty assistant turn"
+         })
+  with
+  | Error.Api (Llm_provider.Retry.ContextOverflow { limit = None; _ }) -> ()
+  | other -> Alcotest.failf "expected Api ContextOverflow, got %s" (Error.to_string other)
+;;
+
+let test_empty_completion_end_turn_stays_provider_unavailable () =
+  match
+    Attribution.sdk_error_of_http_error
+      (Http.ProviderFailure
+         { kind = Http.Empty_completion { stop_reason = Types.EndTurn }
+         ; message = "provider returned an empty assistant turn"
+         })
+  with
+  | Error.Provider (Llm_provider.Error.ProviderUnavailable _) -> ()
+  | other ->
+    Alcotest.failf "expected Provider unavailable, got %s" (Error.to_string other)
+;;
+
 let test_stream_finalization_keeps_empty_completion_evidence () =
   Eio_main.run
   @@ fun env ->
@@ -494,6 +519,16 @@ let () =
             "redacted attribution JSON"
             `Quick
             test_attribution_json_omits_diagnostics
+        ] )
+    ; ( "empty completion classification"
+      , [ Alcotest.test_case
+            "ContextWindowExceeded types as Api ContextOverflow"
+            `Quick
+            test_empty_completion_overflow_types_as_context_overflow
+        ; Alcotest.test_case
+            "EndTurn stays provider unavailable"
+            `Quick
+            test_empty_completion_end_turn_stays_provider_unavailable
         ] )
     ; ( "agent detailed API"
       , [ Alcotest.test_case


### PR DESCRIPTION
## 문제 (masc#24838 P0의 oas측 절반)

빈 assistant 턴의 typed `stop_reason`이 `ContextWindowExceeded`여도 다른 empty completion과 함께 provider unavailability로 뭉개집니다. 소비자(masc)는 unavailability를 보고 **다른 runtime으로 rotation**하는데, 같은 초과 크기 프롬프트를 그대로 재전송하므로 절대 성공할 수 없습니다 — 2026-07-16 masc fleet 사건에서 executor가 GLM `context_window_exceeded` → rotation → ollama.com 게이트웨이 opaque 400 루프로 수 시간 wedge된 경로입니다.

소비자의 overflow 분류기(`Api (Retry.ContextOverflow ...)` 매치 → compaction 트리거)는 이미 존재하지만, 이 경로에서는 그 형상이 생성되지 않아 dead arm이었습니다.

## 수정 (typed, 경계 2곳 = 이 형상의 전체 sdk 승격 지점)

`Empty_completion { stop_reason = ContextWindowExceeded }`만 `Retry.ContextOverflow { limit = None }`으로 분류 (provider가 이 경로에선 한계값을 보고하지 않으므로 `limit = None`):

1. **`api.ml create_message_error_of_http_error`** — 비스트리밍 create_message seam
2. **`provider_failure_attribution.ml sdk_error_of_http_error`** — 스트리밍/structured/attribution 공용 choke point (streaming.ml, structured.ml, http_error_sdk, Completion_error 경로 전부 여기로 수렴; 사건의 실경로)

그 외 stop_reason의 empty completion은 기존 경로(Completion_error / ProviderUnavailable) 유지. attribution ownership(Attempt_local)과 typed evidence 불변. 문자열 파싱 없음 — stop_reason은 이미 wire 경계에서 typed(`types.ml:578`).

## 검증

- api.ml 인라인 테스트 2건 (overflow→ContextOverflow / EndTurn→Completion_error), `@lib/runtest` green
- attribution 스위트 **10/10** (신규 2건 포함: streaming seam의 Api ContextOverflow 승격 / EndTurn 불변)
- `ocamlformat` clean

## 소비자 배선 (masc측 후속)

masc `context_overflow_event_of_error`(keeper_turn_runtime_budget.ml:404)가 이 형상을 이미 매치 → `Compaction_trigger.Provider_overflow` → 기존 recovery 레인 발화. 나머지 절반(pre-dispatch 크기 가드 — opaque 게이트웨이 400은 응답으로 분류 불가)은 masc PR로 분리.

Refs: jeong-sik/masc#24838

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
