### PR TITLE
feat(execution): add shared canonical codec executor

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -10,6 +10,7 @@
   execution_json
   execution_tool_schedule
   execution_event
+  execution_runtime
   execution_codec_executor
   execution_event_store
   execution_journal

--- a/lib/dune
+++ b/lib/dune
@@ -10,6 +10,7 @@
   execution_json
   execution_tool_schedule
   execution_event
+  execution_codec_executor
   execution_event_store
   execution_journal
   execution_lane_writer)

--- a/lib/execution_codec_executor.ml
+++ b/lib/execution_codec_executor.ml
@@ -1,0 +1,280 @@
+module Event = Execution_event
+
+type operation =
+  | Encode_events
+  | Decode_canonical_events
+  | Compare_canonical_payloads
+[@@deriving show]
+
+type captured_exception =
+  { exception_ : exn
+  ; backtrace : Printexc.raw_backtrace option
+  }
+
+type cause =
+  { primary : captured_exception
+  ; observation_failure : captured_exception option
+  }
+
+type failure =
+  | Executor_unavailable of
+      { operation : operation
+      ; cause : cause
+      }
+  | Codec_raised of
+      { operation : operation
+      ; cause : cause
+      }
+
+type decode_failure =
+  | Invalid_event of
+      { ordinal : int
+      ; detail : string
+      }
+  | Noncanonical_event of { ordinal : int }
+
+type operation_stats =
+  { requested : int
+  ; started : int
+  ; completed : int
+  ; job_failed : int
+  ; executor_failed : int
+  ; caller_cancelled : int
+  ; last_caller_domain : Domain.id option
+  ; last_worker_domain : Domain.id option
+  }
+
+type observation = operation_stats Atomic.t
+
+type t =
+  { pool : Eio.Executor_pool.t
+  ; encode_events : observation
+  ; decode_canonical_events : observation
+  ; compare_canonical_payloads : observation
+  }
+
+type stats =
+  { encode_events : operation_stats
+  ; decode_canonical_events : operation_stats
+  ; compare_canonical_payloads : operation_stats
+  }
+
+type _ request =
+  | Encode_events_request : Event.t list -> string list request
+  | Decode_canonical_events_request :
+      string list
+      -> (Event.t list, decode_failure) result request
+  | Compare_canonical_payloads_request :
+      { expected : string list
+      ; actual : string list
+      }
+      -> bool request
+
+type 'a job_outcome =
+  | Job_completed of 'a
+  | Job_raised of cause
+
+let empty_stats =
+  { requested = 0
+  ; started = 0
+  ; completed = 0
+  ; job_failed = 0
+  ; executor_failed = 0
+  ; caller_cancelled = 0
+  ; last_caller_domain = None
+  ; last_worker_domain = None
+  }
+;;
+
+let of_executor_pool pool =
+  { pool
+  ; encode_events = Atomic.make empty_stats
+  ; decode_canonical_events = Atomic.make empty_stats
+  ; compare_canonical_payloads = Atomic.make empty_stats
+  }
+;;
+
+let operation : type result. result request -> operation = function
+  | Encode_events_request _ -> Encode_events
+  | Decode_canonical_events_request _ -> Decode_canonical_events
+  | Compare_canonical_payloads_request _ -> Compare_canonical_payloads
+;;
+
+let observation (t : t) = function
+  | Encode_events -> t.encode_events
+  | Decode_canonical_events -> t.decode_canonical_events
+  | Compare_canonical_payloads -> t.compare_canonical_payloads
+;;
+
+let rec update observation f =
+  let current = Atomic.get observation in
+  let next = f current in
+  if not (Atomic.compare_and_set observation current next) then update observation f
+;;
+
+let decode_canonical_events payloads =
+  let rec loop ordinal events_rev = function
+    | [] -> Ok (List.rev events_rev)
+    | payload :: rest ->
+      (match Event.of_json_string payload with
+       | Error detail -> Error (Invalid_event { ordinal; detail })
+       | Ok event ->
+         if String.equal payload (Event.to_json_string event)
+         then loop (ordinal + 1) (event :: events_rev) rest
+         else Error (Noncanonical_event { ordinal }))
+  in
+  loop 0 [] payloads
+;;
+
+let execute : type result. result request -> result = function
+  | Encode_events_request events -> List.map Event.to_json_string events
+  | Decode_canonical_events_request payloads -> decode_canonical_events payloads
+  | Compare_canonical_payloads_request { expected; actual } ->
+    List.equal String.equal expected actual
+;;
+
+let captured_exception ?backtrace exception_ = { exception_; backtrace }
+
+let cause ?backtrace exception_ =
+  { primary = captured_exception ?backtrace exception_; observation_failure = None }
+;;
+
+let reraise_captured_reserved { exception_; backtrace } =
+  let backtrace = Option.value ~default:(Printexc.get_raw_backtrace ()) backtrace in
+  try Printexc.raise_with_backtrace exception_ backtrace with
+  | exn -> Llm_provider.Reserved_exn.reraise_if_reserved exn
+;;
+
+let reraise_reserved cause =
+  reraise_captured_reserved cause.primary;
+  Option.iter reraise_captured_reserved cause.observation_failure
+;;
+
+let record_job_failure observation primary =
+  match
+    update observation (fun stats -> { stats with job_failed = stats.job_failed + 1 })
+  with
+  | () -> { primary; observation_failure = None }
+  | exception exn ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    { primary; observation_failure = Some (captured_exception ~backtrace exn) }
+;;
+
+let record_caller_cancelled observation =
+  update observation (fun stats ->
+    { stats with caller_cancelled = stats.caller_cancelled + 1 })
+;;
+
+let fiber_check_observed observation =
+  match Eio.Fiber.check () with
+  | () -> ()
+  | exception (Eio.Cancel.Cancelled _ as exn) ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    record_caller_cancelled observation;
+    Printexc.raise_with_backtrace exn backtrace
+;;
+
+let submit : type value. t -> value request -> (value, failure) Stdlib.result =
+  fun t request ->
+  let operation = operation request in
+  let observation = observation t operation in
+  update observation (fun stats ->
+    { stats with
+      requested = stats.requested + 1
+    ; last_caller_domain = Some (Domain.self ())
+    });
+  match
+    Eio.Executor_pool.submit t.pool ~weight:1.0 (fun () ->
+      try
+        update observation (fun stats ->
+          { stats with
+            started = stats.started + 1
+          ; last_worker_domain = Some (Domain.self ())
+          });
+        let value = execute request in
+        update observation (fun stats -> { stats with completed = stats.completed + 1 });
+        Job_completed value
+      with
+      | exn ->
+        let backtrace = Printexc.get_raw_backtrace () in
+        let primary = captured_exception ~backtrace exn in
+        Job_raised (record_job_failure observation primary))
+  with
+  | Ok (Job_completed value) -> Ok value
+  | Ok (Job_raised cause) ->
+    reraise_reserved cause;
+    Error (Codec_raised { operation; cause })
+  | Error exn ->
+    update observation (fun stats ->
+      { stats with executor_failed = stats.executor_failed + 1 });
+    fiber_check_observed observation;
+    (match exn with
+     | Eio.Cancel.Cancelled _ -> ()
+     | exn -> Llm_provider.Reserved_exn.reraise_if_reserved exn);
+    Error (Executor_unavailable { operation; cause = cause exn })
+  | exception (Eio.Cancel.Cancelled _ as exn) ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    record_caller_cancelled observation;
+    Printexc.raise_with_backtrace exn backtrace
+  | exception exn ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    Llm_provider.Reserved_exn.reraise_if_reserved exn;
+    update observation (fun stats ->
+      { stats with executor_failed = stats.executor_failed + 1 });
+    Error (Executor_unavailable { operation; cause = cause ~backtrace exn })
+;;
+
+let encode_events t events = submit t (Encode_events_request events)
+
+let decode_canonical_events t payloads =
+  submit t (Decode_canonical_events_request payloads)
+;;
+
+let compare_canonical_payloads t ~expected ~actual =
+  submit t (Compare_canonical_payloads_request { expected; actual })
+;;
+
+let captured_exception_to_string { exception_; backtrace } =
+  match backtrace with
+  | None -> Printexc.to_string exception_
+  | Some backtrace ->
+    let rendered = Printexc.raw_backtrace_to_string backtrace in
+    if String.equal rendered ""
+    then Printexc.to_string exception_
+    else Printexc.to_string exception_ ^ "\n" ^ rendered
+;;
+
+let cause_to_string cause =
+  match cause.observation_failure with
+  | None -> captured_exception_to_string cause.primary
+  | Some observation_failure ->
+    captured_exception_to_string cause.primary
+    ^ "\nobservation failure: "
+    ^ captured_exception_to_string observation_failure
+;;
+
+let failure_to_string = function
+  | Executor_unavailable { operation; cause } ->
+    Printf.sprintf
+      "execution codec executor unavailable for %s: %s"
+      (show_operation operation)
+      (cause_to_string cause)
+  | Codec_raised { operation; cause } ->
+    Printf.sprintf
+      "execution codec %s raised: %s"
+      (show_operation operation)
+      (cause_to_string cause)
+;;
+
+let pp_failure formatter failure =
+  Format.pp_print_string formatter (failure_to_string failure)
+;;
+
+let show_failure failure = failure_to_string failure
+
+let stats (t : t) =
+  { encode_events = Atomic.get t.encode_events
+  ; decode_canonical_events = Atomic.get t.decode_canonical_events
+  ; compare_canonical_payloads = Atomic.get t.compare_canonical_payloads
+  }
+;;

--- a/lib/execution_codec_executor.ml
+++ b/lib/execution_codec_executor.ml
@@ -2,8 +2,8 @@ module Event = Execution_event
 
 type operation =
   | Encode_events
-  | Decode_canonical_events
-  | Compare_canonical_payloads
+  | Decode_canonical_event
+  | Compare_canonical_payload
 [@@deriving show]
 
 type captured_exception =
@@ -27,17 +27,15 @@ type failure =
       }
 
 type decode_failure =
-  | Invalid_event of
-      { ordinal : int
-      ; detail : string
-      }
-  | Noncanonical_event of { ordinal : int }
+  | Invalid_event of { detail : string }
+  | Noncanonical_event
 
 type operation_stats =
   { requested : int
   ; started : int
   ; completed : int
   ; job_failed : int
+  ; worker_cancelled : int
   ; executor_failed : int
   ; caller_cancelled : int
   ; last_caller_domain : Domain.id option
@@ -47,38 +45,38 @@ type operation_stats =
 type observation = operation_stats Atomic.t
 
 type t =
-  { pool : Eio.Executor_pool.t
+  { runtime : Execution_runtime.t
   ; encode_events : observation
-  ; decode_canonical_events : observation
-  ; compare_canonical_payloads : observation
+  ; decode_canonical_event : observation
+  ; compare_canonical_payload : observation
   }
 
 type stats =
   { encode_events : operation_stats
-  ; decode_canonical_events : operation_stats
-  ; compare_canonical_payloads : operation_stats
+  ; decode_canonical_event : operation_stats
+  ; compare_canonical_payload : operation_stats
   }
 
 type _ request =
   | Encode_events_request : Event.t list -> string list request
-  | Decode_canonical_events_request :
-      string list
-      -> (Event.t list, decode_failure) result request
-  | Compare_canonical_payloads_request :
-      { expected : string list
-      ; actual : string list
+  | Decode_canonical_event_request : string -> (Event.t, decode_failure) result request
+  | Compare_canonical_payload_request :
+      { expected : string
+      ; actual : string
       }
       -> bool request
 
 type 'a job_outcome =
   | Job_completed of 'a
   | Job_raised of cause
+  | Job_cancelled of cause
 
 let empty_stats =
   { requested = 0
   ; started = 0
   ; completed = 0
   ; job_failed = 0
+  ; worker_cancelled = 0
   ; executor_failed = 0
   ; caller_cancelled = 0
   ; last_caller_domain = None
@@ -86,24 +84,24 @@ let empty_stats =
   }
 ;;
 
-let of_executor_pool pool =
-  { pool
+let of_runtime runtime =
+  { runtime
   ; encode_events = Atomic.make empty_stats
-  ; decode_canonical_events = Atomic.make empty_stats
-  ; compare_canonical_payloads = Atomic.make empty_stats
+  ; decode_canonical_event = Atomic.make empty_stats
+  ; compare_canonical_payload = Atomic.make empty_stats
   }
 ;;
 
 let operation : type result. result request -> operation = function
   | Encode_events_request _ -> Encode_events
-  | Decode_canonical_events_request _ -> Decode_canonical_events
-  | Compare_canonical_payloads_request _ -> Compare_canonical_payloads
+  | Decode_canonical_event_request _ -> Decode_canonical_event
+  | Compare_canonical_payload_request _ -> Compare_canonical_payload
 ;;
 
 let observation (t : t) = function
   | Encode_events -> t.encode_events
-  | Decode_canonical_events -> t.decode_canonical_events
-  | Compare_canonical_payloads -> t.compare_canonical_payloads
+  | Decode_canonical_event -> t.decode_canonical_event
+  | Compare_canonical_payload -> t.compare_canonical_payload
 ;;
 
 let rec update observation f =
@@ -112,25 +110,45 @@ let rec update observation f =
   if not (Atomic.compare_and_set observation current next) then update observation f
 ;;
 
-let decode_canonical_events payloads =
-  let rec loop ordinal events_rev = function
-    | [] -> Ok (List.rev events_rev)
-    | payload :: rest ->
-      (match Event.of_json_string payload with
-       | Error detail -> Error (Invalid_event { ordinal; detail })
-       | Ok event ->
-         if String.equal payload (Event.to_json_string event)
-         then loop (ordinal + 1) (event :: events_rev) rest
-         else Error (Noncanonical_event { ordinal }))
+let check_worker_cancellation t = Execution_runtime.Private.check_cancellation t.runtime
+
+let encode_events t events =
+  let rec loop encoded_rev = function
+    | [] ->
+      check_worker_cancellation t;
+      List.rev encoded_rev
+    | event :: rest ->
+      check_worker_cancellation t;
+      let payload = Event.to_json_string event in
+      loop (payload :: encoded_rev) rest
   in
-  loop 0 [] payloads
+  loop [] events
 ;;
 
-let execute : type result. result request -> result = function
-  | Encode_events_request events -> List.map Event.to_json_string events
-  | Decode_canonical_events_request payloads -> decode_canonical_events payloads
-  | Compare_canonical_payloads_request { expected; actual } ->
-    List.equal String.equal expected actual
+let decode_canonical_event t payload =
+  check_worker_cancellation t;
+  match Event.of_json_string payload with
+  | Error detail -> Error (Invalid_event { detail })
+  | Ok event ->
+    check_worker_cancellation t;
+    if String.equal payload (Event.to_json_string event)
+    then Ok event
+    else Error Noncanonical_event
+;;
+
+let compare_canonical_payload t ~expected ~actual =
+  check_worker_cancellation t;
+  let identical = String.equal expected actual in
+  check_worker_cancellation t;
+  identical
+;;
+
+let execute : type result. t -> result request -> result =
+  fun t -> function
+  | Encode_events_request events -> encode_events t events
+  | Decode_canonical_event_request payload -> decode_canonical_event t payload
+  | Compare_canonical_payload_request { expected; actual } ->
+    compare_canonical_payload t ~expected ~actual
 ;;
 
 let captured_exception ?backtrace exception_ = { exception_; backtrace }
@@ -139,25 +157,45 @@ let cause ?backtrace exception_ =
   { primary = captured_exception ?backtrace exception_; observation_failure = None }
 ;;
 
-let reraise_captured_reserved { exception_; backtrace } =
+let reraise_captured_fatal { exception_; backtrace } =
   let backtrace = Option.value ~default:(Printexc.get_raw_backtrace ()) backtrace in
-  try Printexc.raise_with_backtrace exception_ backtrace with
-  | exn -> Llm_provider.Reserved_exn.reraise_if_reserved exn
+  match exception_ with
+  | Out_of_memory | Stack_overflow | Sys.Break ->
+    Printexc.raise_with_backtrace exception_ backtrace
+  | _ -> ()
 ;;
 
-let reraise_reserved cause =
-  reraise_captured_reserved cause.primary;
-  Option.iter reraise_captured_reserved cause.observation_failure
+let reraise_fatal cause =
+  reraise_captured_fatal cause.primary;
+  Option.iter reraise_captured_fatal cause.observation_failure
 ;;
 
-let record_job_failure observation primary =
-  match
-    update observation (fun stats -> { stats with job_failed = stats.job_failed + 1 })
-  with
+let cause_of_runtime_failure
+      ({ exception_; backtrace } : Execution_runtime.Private.run_failure)
+  =
+  cause ?backtrace exception_
+;;
+
+let record_terminal observation update_stats primary =
+  match update observation update_stats with
   | () -> { primary; observation_failure = None }
   | exception exn ->
     let backtrace = Printexc.get_raw_backtrace () in
     { primary; observation_failure = Some (captured_exception ~backtrace exn) }
+;;
+
+let record_job_failure observation primary =
+  record_terminal
+    observation
+    (fun stats -> { stats with job_failed = stats.job_failed + 1 })
+    primary
+;;
+
+let record_worker_cancellation observation primary =
+  record_terminal
+    observation
+    (fun stats -> { stats with worker_cancelled = stats.worker_cancelled + 1 })
+    primary
 ;;
 
 let record_caller_cancelled observation =
@@ -165,13 +203,17 @@ let record_caller_cancelled observation =
     { stats with caller_cancelled = stats.caller_cancelled + 1 })
 ;;
 
-let fiber_check_observed observation =
+let propagate_caller_cancellation observation exn backtrace =
+  record_caller_cancelled observation;
+  Printexc.raise_with_backtrace exn backtrace
+;;
+
+let check_caller_cancellation observation =
   match Eio.Fiber.check () with
   | () -> ()
   | exception (Eio.Cancel.Cancelled _ as exn) ->
     let backtrace = Printexc.get_raw_backtrace () in
-    record_caller_cancelled observation;
-    Printexc.raise_with_backtrace exn backtrace
+    propagate_caller_cancellation observation exn backtrace
 ;;
 
 let submit : type value. t -> value request -> (value, failure) Stdlib.result =
@@ -184,38 +226,63 @@ let submit : type value. t -> value request -> (value, failure) Stdlib.result =
     ; last_caller_domain = Some (Domain.self ())
     });
   match
-    Eio.Executor_pool.submit t.pool ~weight:1.0 (fun () ->
+    Execution_runtime.Private.run_cpu t.runtime (fun () ->
       try
         update observation (fun stats ->
           { stats with
             started = stats.started + 1
           ; last_worker_domain = Some (Domain.self ())
           });
-        let value = execute request in
+        let value = execute t request in
+        check_worker_cancellation t;
         update observation (fun stats -> { stats with completed = stats.completed + 1 });
         Job_completed value
       with
+      | Execution_runtime.Private.Caller_cancelled as exn ->
+        let backtrace = Printexc.get_raw_backtrace () in
+        let primary = captured_exception ~backtrace exn in
+        let cause = record_worker_cancellation observation primary in
+        reraise_fatal cause;
+        Printexc.raise_with_backtrace exn backtrace
+      | Execution_runtime.Private.Runtime_released as exn ->
+        let backtrace = Printexc.get_raw_backtrace () in
+        let primary = captured_exception ~backtrace exn in
+        Job_cancelled (record_worker_cancellation observation primary)
+      | Eio.Cancel.Cancelled _ as exn ->
+        let backtrace = Printexc.get_raw_backtrace () in
+        let primary = captured_exception ~backtrace exn in
+        Job_cancelled (record_worker_cancellation observation primary)
       | exn ->
         let backtrace = Printexc.get_raw_backtrace () in
         let primary = captured_exception ~backtrace exn in
         Job_raised (record_job_failure observation primary))
   with
-  | Ok (Job_completed value) -> Ok value
+  | Ok (Job_completed value) ->
+    check_caller_cancellation observation;
+    Ok value
   | Ok (Job_raised cause) ->
-    reraise_reserved cause;
+    reraise_fatal cause;
+    check_caller_cancellation observation;
     Error (Codec_raised { operation; cause })
-  | Error exn ->
+  | Ok (Job_cancelled cause) ->
+    reraise_fatal cause;
+    check_caller_cancellation observation;
     update observation (fun stats ->
       { stats with executor_failed = stats.executor_failed + 1 });
-    fiber_check_observed observation;
-    (match exn with
-     | Eio.Cancel.Cancelled _ -> ()
-     | exn -> Llm_provider.Reserved_exn.reraise_if_reserved exn);
-    Error (Executor_unavailable { operation; cause = cause exn })
+    Error (Executor_unavailable { operation; cause })
+  | Error failure ->
+    let cause = cause_of_runtime_failure failure in
+    reraise_fatal cause;
+    check_caller_cancellation observation;
+    update observation (fun stats ->
+      { stats with executor_failed = stats.executor_failed + 1 });
+    Error (Executor_unavailable { operation; cause })
+  | exception (Execution_runtime.Private.Caller_cancelled as exn) ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    Printexc.raise_with_backtrace exn backtrace
   | exception (Eio.Cancel.Cancelled _ as exn) ->
     let backtrace = Printexc.get_raw_backtrace () in
-    record_caller_cancelled observation;
-    Printexc.raise_with_backtrace exn backtrace
+    propagate_caller_cancellation observation exn backtrace
   | exception exn ->
     let backtrace = Printexc.get_raw_backtrace () in
     Llm_provider.Reserved_exn.reraise_if_reserved exn;
@@ -225,13 +292,10 @@ let submit : type value. t -> value request -> (value, failure) Stdlib.result =
 ;;
 
 let encode_events t events = submit t (Encode_events_request events)
+let decode_canonical_event t payload = submit t (Decode_canonical_event_request payload)
 
-let decode_canonical_events t payloads =
-  submit t (Decode_canonical_events_request payloads)
-;;
-
-let compare_canonical_payloads t ~expected ~actual =
-  submit t (Compare_canonical_payloads_request { expected; actual })
+let compare_canonical_payload t ~expected ~actual =
+  submit t (Compare_canonical_payload_request { expected; actual })
 ;;
 
 let captured_exception_to_string { exception_; backtrace } =
@@ -274,7 +338,7 @@ let show_failure failure = failure_to_string failure
 
 let stats (t : t) =
   { encode_events = Atomic.get t.encode_events
-  ; decode_canonical_events = Atomic.get t.decode_canonical_events
-  ; compare_canonical_payloads = Atomic.get t.compare_canonical_payloads
+  ; decode_canonical_event = Atomic.get t.decode_canonical_event
+  ; compare_canonical_payload = Atomic.get t.compare_canonical_payload
   }
 ;;

--- a/lib/execution_codec_executor.mli
+++ b/lib/execution_codec_executor.mli
@@ -1,16 +1,15 @@
-(** Shared parallel boundary for canonical execution-event codecs.
+(** Private typed codec service backed by one {!Execution_runtime.t}.
 
-    This module is private to OAS. The application owns one long-lived
-    {!Eio.Executor_pool.t}, chooses its domain count at startup, and injects it
-    into every execution lane. The wrapper never creates domains, applies a
-    payload-size threshold, or controls admission. *)
+    Requests are closed and CPU-only. The runtime owns pool lifetime and raw
+    submission; this module adds event-specific failure causality,
+    cancellation checkpoints, and observations. *)
 
 type t
 
 type operation =
   | Encode_events
-  | Decode_canonical_events
-  | Compare_canonical_payloads
+  | Decode_canonical_event
+  | Compare_canonical_payload
 [@@deriving show]
 
 type cause
@@ -26,17 +25,15 @@ type failure =
       }
 
 type decode_failure =
-  | Invalid_event of
-      { ordinal : int
-      ; detail : string
-      }
-  | Noncanonical_event of { ordinal : int }
+  | Invalid_event of { detail : string }
+  | Noncanonical_event
 
 type operation_stats =
   { requested : int
   ; started : int
   ; completed : int
   ; job_failed : int
+  ; worker_cancelled : int
   ; executor_failed : int
   ; caller_cancelled : int
   ; last_caller_domain : Domain.id option
@@ -45,28 +42,27 @@ type operation_stats =
 
 type stats =
   { encode_events : operation_stats
-  ; decode_canonical_events : operation_stats
-  ; compare_canonical_payloads : operation_stats
+  ; decode_canonical_event : operation_stats
+  ; compare_canonical_payload : operation_stats
   }
 
-val of_executor_pool : Eio.Executor_pool.t -> t
+val of_runtime : Execution_runtime.t -> t
 
-(** These are the only codec requests. Their operation identity is derived by
-    the executor and cannot be supplied independently by callers. Every
-    request uses executor weight [1.0] because it is CPU-bound work, not as a
-    runtime budget or heuristic. Caller cancellation and reserved worker
-    exceptions propagate; non-reserved failures remain typed. *)
+(** Encode one append batch. Cancellation is checked at every event boundary;
+    no payload-size threshold or per-request pool is used. *)
 val encode_events : t -> Execution_event.t list -> (string list, failure) result
 
-val decode_canonical_events
+(** Decode one durable payload. Store callers retain at most that raw payload
+    while accumulating their required decoded output. *)
+val decode_canonical_event
   :  t
-  -> string list
-  -> ((Execution_event.t list, decode_failure) result, failure) result
+  -> string
+  -> ((Execution_event.t, decode_failure) result, failure) result
 
-val compare_canonical_payloads
+val compare_canonical_payload
   :  t
-  -> expected:string list
-  -> actual:string list
+  -> expected:string
+  -> actual:string
   -> (bool, failure) result
 
 val failure_to_string : failure -> string

--- a/lib/execution_codec_executor.mli
+++ b/lib/execution_codec_executor.mli
@@ -1,0 +1,78 @@
+(** Shared parallel boundary for canonical execution-event codecs.
+
+    This module is private to OAS. The application owns one long-lived
+    {!Eio.Executor_pool.t}, chooses its domain count at startup, and injects it
+    into every execution lane. The wrapper never creates domains, applies a
+    payload-size threshold, or controls admission. *)
+
+type t
+
+type operation =
+  | Encode_events
+  | Decode_canonical_events
+  | Compare_canonical_payloads
+[@@deriving show]
+
+type cause
+
+type failure =
+  | Executor_unavailable of
+      { operation : operation
+      ; cause : cause
+      }
+  | Codec_raised of
+      { operation : operation
+      ; cause : cause
+      }
+
+type decode_failure =
+  | Invalid_event of
+      { ordinal : int
+      ; detail : string
+      }
+  | Noncanonical_event of { ordinal : int }
+
+type operation_stats =
+  { requested : int
+  ; started : int
+  ; completed : int
+  ; job_failed : int
+  ; executor_failed : int
+  ; caller_cancelled : int
+  ; last_caller_domain : Domain.id option
+  ; last_worker_domain : Domain.id option
+  }
+
+type stats =
+  { encode_events : operation_stats
+  ; decode_canonical_events : operation_stats
+  ; compare_canonical_payloads : operation_stats
+  }
+
+val of_executor_pool : Eio.Executor_pool.t -> t
+
+(** These are the only codec requests. Their operation identity is derived by
+    the executor and cannot be supplied independently by callers. Every
+    request uses executor weight [1.0] because it is CPU-bound work, not as a
+    runtime budget or heuristic. Caller cancellation and reserved worker
+    exceptions propagate; non-reserved failures remain typed. *)
+val encode_events : t -> Execution_event.t list -> (string list, failure) result
+
+val decode_canonical_events
+  :  t
+  -> string list
+  -> ((Execution_event.t list, decode_failure) result, failure) result
+
+val compare_canonical_payloads
+  :  t
+  -> expected:string list
+  -> actual:string list
+  -> (bool, failure) result
+
+val failure_to_string : failure -> string
+val pp_failure : Format.formatter -> failure -> unit
+val show_failure : failure -> string
+
+(** Read-only per-operation coherent snapshots. These observations never
+    affect dispatch, cancellation, admission, or termination. *)
+val stats : t -> stats

--- a/lib/execution_event_store.ml
+++ b/lib/execution_event_store.ml
@@ -15,31 +15,6 @@ let reverse_append_cooperatively values tail =
 
 let reverse_cooperatively values = reverse_append_cooperatively values []
 
-let map_cooperatively f values =
-  let rec loop mapped_rev = function
-    | [] -> reverse_cooperatively mapped_rev
-    | value :: rest ->
-      Eio.Fiber.check ();
-      Eio.Fiber.yield ();
-      loop (f value :: mapped_rev) rest
-  in
-  loop [] values
-;;
-
-let nth_opt_cooperatively values index =
-  let rec loop current = function
-    | [] -> None
-    | value :: rest ->
-      Eio.Fiber.check ();
-      if current = 0
-      then Some value
-      else (
-        Eio.Fiber.yield ();
-        loop (current - 1) rest)
-  in
-  if index < 0 then None else loop index values
-;;
-
 let length_cooperatively values =
   let rec loop length = function
     | [] -> length
@@ -122,10 +97,6 @@ type error =
       ; detail : string
       }
   | Codec_failure of Codec.failure
-  | Codec_protocol_failure of
-      { operation : Codec.operation
-      ; detail : string
-      }
   | Writer_already_active
   | Store_already_attached
   | Store_released
@@ -167,11 +138,6 @@ let rec error_to_string = function
   | Io_failure { operation; detail } ->
     Printf.sprintf "execution store %s failed: %s" operation detail
   | Codec_failure failure -> Codec.failure_to_string failure
-  | Codec_protocol_failure { operation; detail } ->
-    Printf.sprintf
-      "execution codec %s violated its closed request contract: %s"
-      (Codec.show_operation operation)
-      detail
   | Writer_already_active -> "execution store already has an active writer"
   | Store_already_attached -> "execution store is already attached to a journal"
   | Store_released -> "execution store resources have been released"
@@ -1221,77 +1187,38 @@ type located_payload =
   ; payload : string
   }
 
-let decode_located_payloads codec located_payloads =
-  match located_payloads with
-  | [] -> Ok []
-  | _ :: _ ->
-    let payloads = map_cooperatively (fun located -> located.payload) located_payloads in
-    let* decoded =
-      Codec.decode_canonical_events codec payloads
-      |> Result.map_error (fun failure -> Codec_failure failure)
-    in
-    (match decoded with
-     | Ok events -> Ok events
-     | Error (Invalid_event { ordinal; detail }) ->
-       (match nth_opt_cooperatively located_payloads ordinal with
-        | Some located ->
-          Error
-            (Corrupt_store
-               { offset = located.offset; detail = "invalid event: " ^ detail })
-        | None ->
-          Error
-            (Codec_protocol_failure
-               { operation = Decode_canonical_events
-               ; detail = "invalid-event ordinal is outside the submitted payload list"
-               }))
-     | Error (Noncanonical_event { ordinal }) ->
-       (match nth_opt_cooperatively located_payloads ordinal with
-        | Some located ->
-          Error
-            (Corrupt_store
-               { offset = located.offset; detail = "event bytes are not canonical" })
-        | None ->
-          Error
-            (Codec_protocol_failure
-               { operation = Decode_canonical_events
-               ; detail =
-                   "noncanonical-event ordinal is outside the submitted payload list"
-               })))
+let decode_located_payload codec located =
+  let* decoded =
+    Codec.decode_canonical_event codec located.payload
+    |> Result.map_error (fun failure -> Codec_failure failure)
+  in
+  match decoded with
+  | Ok event -> Ok event
+  | Error (Invalid_event { detail }) ->
+    Error (Corrupt_store { offset = located.offset; detail = "invalid event: " ^ detail })
+  | Error Noncanonical_event ->
+    Error
+      (Corrupt_store { offset = located.offset; detail = "event bytes are not canonical" })
 ;;
 
-let validate_scanned_events correlation_id ~expected_seq located_payloads events =
-  let rec loop expected located_payloads events =
-    match located_payloads, events with
-    | [], [] -> Ok ()
-    | located :: located_rest, event :: event_rest ->
-      Eio.Fiber.check ();
-      if Event.seq event <> expected
-      then
-        Error
-          (Corrupt_store
-             { offset = located.offset
-             ; detail =
-                 Printf.sprintf
-                   "event sequence %d does not match expected sequence %d"
-                   (Event.seq event)
-                   expected
-             })
-      else if not (Event.Correlation_id.equal (Event.correlation_id event) correlation_id)
-      then
-        Error
-          (Corrupt_store
-             { offset = located.offset; detail = "event correlation mismatch" })
-      else (
-        Eio.Fiber.yield ();
-        loop (expected + 1) located_rest event_rest)
-    | [], _ :: _ | _ :: _, [] ->
-      Error
-        (Codec_protocol_failure
-           { operation = Decode_canonical_events
-           ; detail = "decoded event count does not match submitted payload count"
-           })
-  in
-  loop expected_seq located_payloads events
+let validate_scanned_event correlation_id ~expected_seq located event =
+  Eio.Fiber.check ();
+  if Event.seq event <> expected_seq
+  then
+    Error
+      (Corrupt_store
+         { offset = located.offset
+         ; detail =
+             Printf.sprintf
+               "event sequence %d does not match expected sequence %d"
+               (Event.seq event)
+               expected_seq
+         })
+  else if not (Event.Correlation_id.equal (Event.correlation_id event) correlation_id)
+  then
+    Error
+      (Corrupt_store { offset = located.offset; detail = "event correlation mismatch" })
+  else Ok ()
 ;;
 
 let scan_store codec file ~file_size =
@@ -1336,8 +1263,7 @@ let scan_store codec file ~file_size =
                    committed_seq
              })
       else (
-        let rec scan_events event_offset ordinal digest_context locations_rev payloads_rev
-          =
+        let rec scan_events event_offset ordinal digest_context locations_rev events_rev =
           if ordinal = header.count
           then
             let* commit_frame = decode_frame file ~file_size event_offset in
@@ -1374,16 +1300,8 @@ let scan_store codec file ~file_size =
                      { offset = event_offset; detail = "batch event digest mismatch" })
               else (
                 let locations = reverse_cooperatively locations_rev in
-                let located_payloads = reverse_cooperatively payloads_rev in
-                let* events = decode_located_payloads codec located_payloads in
-                let+ () =
-                  validate_scanned_events
-                    correlation_id
-                    ~expected_seq:header.expected_next_seq
-                    located_payloads
-                    events
-                in
-                next_offset, expected_last, locations, events)
+                let events = reverse_cooperatively events_rev in
+                Ok (next_offset, expected_last, locations, events))
             | Complete_frame _ ->
               Error
                 (Corrupt_store
@@ -1408,13 +1326,18 @@ let scan_store codec file ~file_size =
                 ; frame = frame_guard event_offset event_frame
                 }
               in
+              let located = { offset = event_offset; payload } in
+              let* event = decode_located_payload codec located in
+              let* () =
+                validate_scanned_event correlation_id ~expected_seq located event
+              in
               Eio.Fiber.yield ();
               scan_events
                 next_offset
                 (ordinal + 1)
                 (feed_payload_digest digest_context payload)
                 (location :: locations_rev)
-                ({ offset = event_offset; payload } :: payloads_rev)
+                (event :: events_rev)
             | Complete_frame _ ->
               Error
                 (Corrupt_store
@@ -1853,34 +1776,20 @@ let read_location_payload_locked store ~file_size location =
   protect_corrupt_read store (read_location_payload_raw store ~file_size location)
 ;;
 
-let validate_indexed_events locations events =
-  let rec loop locations events =
-    match locations, events with
-    | [], [] -> Ok ()
-    | location :: location_rest, event :: event_rest ->
-      Eio.Fiber.check ();
-      if Event.seq event = location.seq
-      then (
-        Eio.Fiber.yield ();
-        loop location_rest event_rest)
-      else
-        Error
-          (Corrupt_store
-             { offset = location.frame.frame_offset
-             ; detail =
-                 Printf.sprintf
-                   "indexed sequence %d contains event sequence %d"
-                   location.seq
-                   (Event.seq event)
-             })
-    | [], _ :: _ | _ :: _, [] ->
-      Error
-        (Codec_protocol_failure
-           { operation = Decode_canonical_events
-           ; detail = "decoded event count does not match indexed payload count"
-           })
-  in
-  loop locations events
+let validate_indexed_event location event =
+  Eio.Fiber.check ();
+  if Event.seq event = location.seq
+  then Ok ()
+  else
+    Error
+      (Corrupt_store
+         { offset = location.frame.frame_offset
+         ; detail =
+             Printf.sprintf
+               "indexed sequence %d contains event sequence %d"
+               location.seq
+               (Event.seq event)
+         })
 ;;
 
 let corrupt_tail store offset detail =
@@ -1912,26 +1821,23 @@ let read_range store ~committed_offset locations ~first_seq ~count =
            committed_offset
            actual_size)
   in
-  let rec gather seq remaining locations_rev payloads_rev =
+  let rec gather seq remaining events_rev =
     if remaining = 0
-    then Ok (reverse_cooperatively locations_rev, reverse_cooperatively payloads_rev)
+    then Ok (reverse_cooperatively events_rev)
     else (
       let location = location_at locations seq in
       let* payload =
         read_location_payload_locked store ~file_size:committed_offset location
       in
+      let located = { offset = location.frame.frame_offset; payload } in
+      let* event =
+        protect_corrupt_read store (decode_located_payload store.codec located)
+      in
+      let* () = protect_corrupt_read store (validate_indexed_event location event) in
       Eio.Fiber.yield ();
-      gather
-        (seq + 1)
-        (remaining - 1)
-        (location :: locations_rev)
-        ({ offset = location.frame.frame_offset; payload } :: payloads_rev))
+      gather (seq + 1) (remaining - 1) (event :: events_rev))
   in
-  let* locations, located_payloads = gather first_seq count [] [] in
-  let* events =
-    protect_corrupt_read store (decode_located_payloads store.codec located_payloads)
-  in
-  let* () = protect_corrupt_read store (validate_indexed_events locations events) in
+  let* events = gather first_seq count [] in
   let+ () = require_writable store in
   events
 ;;
@@ -2215,27 +2121,23 @@ let compare_committed store ~expected_next_seq ~count payloads committed_last =
       with_read store (fun () ->
         store.committed.committed_offset, store.committed.locations)
     in
-    let rec committed_payloads reverse_payloads seq = function
-      | [] -> Ok (reverse_cooperatively reverse_payloads)
-      | _expected :: expected_payloads ->
+    let rec compare all_identical seq = function
+      | [] ->
+        if all_identical
+        then Ok Already_committed
+        else
+          Error (Committed_content_conflict { first_seq = expected_next_seq; last_seq })
+      | expected :: expected_payloads ->
         let location = location_at committed_locations seq in
-        let* payload = read_location_payload_locked store ~file_size location in
+        let* actual = read_location_payload_locked store ~file_size location in
+        let* identical =
+          Codec.compare_canonical_payload store.codec ~expected ~actual
+          |> Result.map_error (fun failure -> Codec_failure failure)
+        in
         Eio.Fiber.yield ();
-        committed_payloads (payload :: reverse_payloads) (seq + 1) expected_payloads
+        compare (all_identical && identical) (seq + 1) expected_payloads
     in
-    let* committed_payloads = committed_payloads [] expected_next_seq payloads in
-    let* identical =
-      Codec.compare_canonical_payloads
-        store.codec
-        ~expected:payloads
-        ~actual:committed_payloads
-      |> Result.map_error (fun failure -> Codec_failure failure)
-    in
-    let* outcome =
-      if identical
-      then Ok Already_committed
-      else Error (Committed_content_conflict { first_seq = expected_next_seq; last_seq })
-    in
+    let* outcome = compare true expected_next_seq payloads in
     let+ () = require_writable store in
     outcome)
 ;;

--- a/lib/execution_event_store.ml
+++ b/lib/execution_event_store.ml
@@ -1,5 +1,6 @@
 open Result_syntax
 module Event = Execution_event
+module Codec = Execution_codec_executor
 module Sha256 = Digestif.SHA256
 
 let reverse_append_cooperatively values tail =
@@ -13,6 +14,31 @@ let reverse_append_cooperatively values tail =
 ;;
 
 let reverse_cooperatively values = reverse_append_cooperatively values []
+
+let map_cooperatively f values =
+  let rec loop mapped_rev = function
+    | [] -> reverse_cooperatively mapped_rev
+    | value :: rest ->
+      Eio.Fiber.check ();
+      Eio.Fiber.yield ();
+      loop (f value :: mapped_rev) rest
+  in
+  loop [] values
+;;
+
+let nth_opt_cooperatively values index =
+  let rec loop current = function
+    | [] -> None
+    | value :: rest ->
+      Eio.Fiber.check ();
+      if current = 0
+      then Some value
+      else (
+        Eio.Fiber.yield ();
+        loop (current - 1) rest)
+  in
+  if index < 0 then None else loop index values
+;;
 
 let length_cooperatively values =
   let rec loop length = function
@@ -95,6 +121,11 @@ type error =
       { operation : string
       ; detail : string
       }
+  | Codec_failure of Codec.failure
+  | Codec_protocol_failure of
+      { operation : Codec.operation
+      ; detail : string
+      }
   | Writer_already_active
   | Store_already_attached
   | Store_released
@@ -135,6 +166,12 @@ let rec error_to_string = function
   | Identity_failure detail -> "execution store identity failure: " ^ detail
   | Io_failure { operation; detail } ->
     Printf.sprintf "execution store %s failed: %s" operation detail
+  | Codec_failure failure -> Codec.failure_to_string failure
+  | Codec_protocol_failure { operation; detail } ->
+    Printf.sprintf
+      "execution codec %s violated its closed request contract: %s"
+      (Codec.show_operation operation)
+      detail
   | Writer_already_active -> "execution store already has an active writer"
   | Store_already_attached -> "execution store is already attached to a journal"
   | Store_released -> "execution store resources have been released"
@@ -322,14 +359,9 @@ let feed_payload_digest context payload =
 
 let finish_payload_digest context = Sha256.(to_hex (get context))
 
-let event_payloads events =
-  List.map
-    (fun event ->
-       Eio.Fiber.check ();
-       let payload = Event.to_json_string event in
-       Eio.Fiber.yield ();
-       payload)
-    events
+let event_payloads codec events =
+  Codec.encode_events codec events
+  |> Result.map_error (fun failure -> Codec_failure failure)
 ;;
 
 let events_digest payloads =
@@ -573,6 +605,7 @@ type lifecycle =
 type t =
   { scope_id : Scope_id.t
   ; correlation_id : Event.Correlation_id.t
+  ; codec : Codec.t
   ; dir : Eio.Fs.dir_ty Eio.Path.t
   ; file : Eio.File.rw_ty Eio.Resource.t
   ; lock_file : Eio.File.rw_ty Eio.Resource.t
@@ -586,6 +619,12 @@ type t =
   }
 
 type writer = { store : t }
+
+type opened =
+  { store : t
+  ; recovery : recovery
+  ; replay_events : Event.t list
+  }
 
 let scope_id store = store.scope_id
 let correlation_id store = store.correlation_id
@@ -1177,16 +1216,85 @@ let batch_commit_of_string ~offset payload =
   else Error (Corrupt_store { offset; detail = "batch commit bytes are not canonical" })
 ;;
 
-let event_of_payload ~offset payload =
-  match Event.of_json_string payload with
-  | Error detail -> Error (Corrupt_store { offset; detail = "invalid event: " ^ detail })
-  | Ok event ->
-    if String.equal payload (Event.to_json_string event)
-    then Ok event
-    else Error (Corrupt_store { offset; detail = "event bytes are not canonical" })
+type located_payload =
+  { offset : int64
+  ; payload : string
+  }
+
+let decode_located_payloads codec located_payloads =
+  match located_payloads with
+  | [] -> Ok []
+  | _ :: _ ->
+    let payloads = map_cooperatively (fun located -> located.payload) located_payloads in
+    let* decoded =
+      Codec.decode_canonical_events codec payloads
+      |> Result.map_error (fun failure -> Codec_failure failure)
+    in
+    (match decoded with
+     | Ok events -> Ok events
+     | Error (Invalid_event { ordinal; detail }) ->
+       (match nth_opt_cooperatively located_payloads ordinal with
+        | Some located ->
+          Error
+            (Corrupt_store
+               { offset = located.offset; detail = "invalid event: " ^ detail })
+        | None ->
+          Error
+            (Codec_protocol_failure
+               { operation = Decode_canonical_events
+               ; detail = "invalid-event ordinal is outside the submitted payload list"
+               }))
+     | Error (Noncanonical_event { ordinal }) ->
+       (match nth_opt_cooperatively located_payloads ordinal with
+        | Some located ->
+          Error
+            (Corrupt_store
+               { offset = located.offset; detail = "event bytes are not canonical" })
+        | None ->
+          Error
+            (Codec_protocol_failure
+               { operation = Decode_canonical_events
+               ; detail =
+                   "noncanonical-event ordinal is outside the submitted payload list"
+               })))
 ;;
 
-let scan_store file ~file_size =
+let validate_scanned_events correlation_id ~expected_seq located_payloads events =
+  let rec loop expected located_payloads events =
+    match located_payloads, events with
+    | [], [] -> Ok ()
+    | located :: located_rest, event :: event_rest ->
+      Eio.Fiber.check ();
+      if Event.seq event <> expected
+      then
+        Error
+          (Corrupt_store
+             { offset = located.offset
+             ; detail =
+                 Printf.sprintf
+                   "event sequence %d does not match expected sequence %d"
+                   (Event.seq event)
+                   expected
+             })
+      else if not (Event.Correlation_id.equal (Event.correlation_id event) correlation_id)
+      then
+        Error
+          (Corrupt_store
+             { offset = located.offset; detail = "event correlation mismatch" })
+      else (
+        Eio.Fiber.yield ();
+        loop (expected + 1) located_rest event_rest)
+    | [], _ :: _ | _ :: _, [] ->
+      Error
+        (Codec_protocol_failure
+           { operation = Decode_canonical_events
+           ; detail = "decoded event count does not match submitted payload count"
+           })
+  in
+  loop expected_seq located_payloads events
+;;
+
+let scan_store codec file ~file_size =
   let* metadata_frame = decode_frame file ~file_size 0L in
   let* scope_id, correlation_id, first_batch_offset =
     match metadata_frame with
@@ -1199,10 +1307,18 @@ let scan_store file ~file_size =
       Error (Corrupt_store { offset = 0L; detail = "metadata frame is incomplete" })
   in
   let locations = ref Sequence_map.empty in
+  let events_rev = ref [] in
   let rec scan_batches offset committed_seq =
     let* frame = decode_frame file ~file_size offset in
     match frame with
-    | End_of_store -> Ok (scope_id, correlation_id, offset, committed_seq, !locations)
+    | End_of_store ->
+      Ok
+        ( scope_id
+        , correlation_id
+        , offset
+        , committed_seq
+        , !locations
+        , reverse_cooperatively !events_rev )
     | Incomplete_frame ->
       Error
         (Corrupt_store { offset; detail = "committed batch begin frame is incomplete" })
@@ -1220,7 +1336,8 @@ let scan_store file ~file_size =
                    committed_seq
              })
       else (
-        let rec scan_events event_offset ordinal digest_context locations_rev =
+        let rec scan_events event_offset ordinal digest_context locations_rev payloads_rev
+          =
           if ordinal = header.count
           then
             let* commit_frame = decode_frame file ~file_size event_offset in
@@ -1255,7 +1372,18 @@ let scan_store file ~file_size =
                 Error
                   (Corrupt_store
                      { offset = event_offset; detail = "batch event digest mismatch" })
-              else Ok (next_offset, expected_last, reverse_cooperatively locations_rev)
+              else (
+                let locations = reverse_cooperatively locations_rev in
+                let located_payloads = reverse_cooperatively payloads_rev in
+                let* events = decode_located_payloads codec located_payloads in
+                let+ () =
+                  validate_scanned_events
+                    correlation_id
+                    ~expected_seq:header.expected_next_seq
+                    located_payloads
+                    events
+                in
+                next_offset, expected_last, locations, events)
             | Complete_frame _ ->
               Error
                 (Corrupt_store
@@ -1272,47 +1400,28 @@ let scan_store file ~file_size =
             | Complete_frame
                 ({ kind = Event_record; payload; payload_offset; next_offset; _ } as
                  event_frame) ->
-              let* event = event_of_payload ~offset:event_offset payload in
               let expected_seq = header.expected_next_seq + ordinal in
-              if Event.seq event <> expected_seq
-              then
-                Error
-                  (Corrupt_store
-                     { offset = event_offset
-                     ; detail =
-                         Printf.sprintf
-                           "event sequence %d does not match expected sequence %d"
-                           (Event.seq event)
-                           expected_seq
-                     })
-              else if
-                not
-                  (Event.Correlation_id.equal (Event.correlation_id event) correlation_id)
-              then
-                Error
-                  (Corrupt_store
-                     { offset = event_offset; detail = "event correlation mismatch" })
-              else (
-                let location =
-                  { seq = expected_seq
-                  ; payload_offset
-                  ; payload_length = String.length payload
-                  ; frame = frame_guard event_offset event_frame
-                  }
-                in
-                Eio.Fiber.yield ();
-                scan_events
-                  next_offset
-                  (ordinal + 1)
-                  (feed_payload_digest digest_context payload)
-                  (location :: locations_rev))
+              let location =
+                { seq = expected_seq
+                ; payload_offset
+                ; payload_length = String.length payload
+                ; frame = frame_guard event_offset event_frame
+                }
+              in
+              Eio.Fiber.yield ();
+              scan_events
+                next_offset
+                (ordinal + 1)
+                (feed_payload_digest digest_context payload)
+                (location :: locations_rev)
+                ({ offset = event_offset; payload } :: payloads_rev)
             | Complete_frame _ ->
               Error
                 (Corrupt_store
                    { offset = event_offset; detail = "batch contains a non-event frame" })
         in
-        let* next_offset, last_seq, batch_locations =
-          scan_events next_offset 0 Sha256.empty []
+        let* next_offset, last_seq, batch_locations, batch_events =
+          scan_events next_offset 0 Sha256.empty [] []
         in
         locations
         := List.fold_left
@@ -1321,6 +1430,7 @@ let scan_store file ~file_size =
                 Sequence_map.add location.seq location locations)
              !locations
              batch_locations;
+        events_rev := reverse_append_cooperatively batch_events !events_rev;
         scan_batches next_offset last_seq)
     | Complete_frame _ ->
       Error (Corrupt_store { offset; detail = "expected a batch begin frame" })
@@ -1331,6 +1441,7 @@ let scan_store file ~file_size =
 let make_store
       ~scope_id
       ~correlation_id
+      ~codec
       ~dir
       ~file
       ~lock_file
@@ -1342,6 +1453,7 @@ let make_store
   =
   { scope_id
   ; correlation_id
+  ; codec
   ; dir
   ; file
   ; lock_file
@@ -1386,7 +1498,7 @@ let protect_store_resources lock_file claim claim_hook opened_file f =
          backtrace)
 ;;
 
-let create ~sw ~dir ?correlation_id () =
+let create ~sw ~codec ~dir ?correlation_id () =
   let* directory_exists =
     with_io "check store directory" (fun () -> Eio.Path.is_directory dir)
   in
@@ -1488,6 +1600,7 @@ let create ~sw ~dir ?correlation_id () =
             (make_store
                ~scope_id
                ~correlation_id
+               ~codec
                ~dir
                ~file
                ~lock_file
@@ -1499,7 +1612,7 @@ let create ~sw ~dir ?correlation_id () =
         , initialization ))
 ;;
 
-let open_existing ~sw ~dir =
+let open_existing ~sw ~codec ~dir =
   let* directory_exists =
     with_io "check store directory" (fun () -> Eio.Path.is_directory dir)
   in
@@ -1583,8 +1696,8 @@ let open_existing ~sw ~dir =
                      authority.committed_offset
                })
       in
-      let* scope_id, correlation_id, committed_offset, last_seq, locations =
-        scan_store file ~file_size:authority.committed_offset
+      let* scope_id, correlation_id, committed_offset, last_seq, locations, replay_events =
+        scan_store codec file ~file_size:authority.committed_offset
       in
       let* () =
         if
@@ -1631,21 +1744,23 @@ let open_existing ~sw ~dir =
         | [] -> Clean
         | actions -> Recovered actions
       in
-      Ok
-        ( bind_lifecycle_to_switch
-            ~sw
-            (make_store
-               ~scope_id
-               ~correlation_id
-               ~dir
-               ~file
-               ~lock_file
-               ~claim
-               ~claim_hook
-               ~locations
-               ~last_seq
-               ~committed_offset)
-        , recovery ))
+      let store =
+        bind_lifecycle_to_switch
+          ~sw
+          (make_store
+             ~scope_id
+             ~correlation_id
+             ~codec
+             ~dir
+             ~file
+             ~lock_file
+             ~claim
+             ~claim_hook
+             ~locations
+             ~last_seq
+             ~committed_offset)
+      in
+      Ok { store; recovery; replay_events })
 ;;
 
 let validate_append (store : t) ~expected_next_seq events =
@@ -1693,7 +1808,7 @@ let validate_append (store : t) ~expected_next_seq events =
 
 let location_at locations seq = Sequence_map.find seq locations
 
-let read_location_raw store ~file_size (location : event_location) =
+let read_location_payload_raw store ~file_size (location : event_location) =
   let* frame = decode_frame store.file ~file_size location.frame.frame_offset in
   match frame with
   | End_of_store | Incomplete_frame ->
@@ -1709,19 +1824,7 @@ let read_location_raw store ~file_size (location : event_location) =
          && String.length frame.payload = location.payload_length
          && Int64.equal frame.next_offset location.frame.frame_next_offset
          && String.equal frame.payload_digest location.frame.frame_payload_digest ->
-    let* event = event_of_payload ~offset:location.frame.frame_offset frame.payload in
-    if Event.seq event = location.seq
-    then Ok event
-    else
-      Error
-        (Corrupt_store
-           { offset = location.frame.frame_offset
-           ; detail =
-               Printf.sprintf
-                 "indexed sequence %d contains event sequence %d"
-                 location.seq
-                 (Event.seq event)
-           })
+    Ok frame.payload
   | Complete_frame _ ->
     Error
       (Corrupt_store
@@ -1738,12 +1841,46 @@ let poison_after_corrupt_read store error =
   | _ -> ()
 ;;
 
-let read_location_locked store ~file_size location =
-  match read_location_raw store ~file_size location with
-  | Ok event -> Ok event
+let protect_corrupt_read store result =
+  match result with
+  | Ok result -> Ok result
   | Error error ->
     poison_after_corrupt_read store error;
     Error error
+;;
+
+let read_location_payload_locked store ~file_size location =
+  protect_corrupt_read store (read_location_payload_raw store ~file_size location)
+;;
+
+let validate_indexed_events locations events =
+  let rec loop locations events =
+    match locations, events with
+    | [], [] -> Ok ()
+    | location :: location_rest, event :: event_rest ->
+      Eio.Fiber.check ();
+      if Event.seq event = location.seq
+      then (
+        Eio.Fiber.yield ();
+        loop location_rest event_rest)
+      else
+        Error
+          (Corrupt_store
+             { offset = location.frame.frame_offset
+             ; detail =
+                 Printf.sprintf
+                   "indexed sequence %d contains event sequence %d"
+                   location.seq
+                   (Event.seq event)
+             })
+    | [], _ :: _ | _ :: _, [] ->
+      Error
+        (Codec_protocol_failure
+           { operation = Decode_canonical_events
+           ; detail = "decoded event count does not match indexed payload count"
+           })
+  in
+  loop locations events
 ;;
 
 let corrupt_tail store offset detail =
@@ -1775,16 +1912,26 @@ let read_range store ~committed_offset locations ~first_seq ~count =
            committed_offset
            actual_size)
   in
-  let rec loop seq remaining events_rev =
+  let rec gather seq remaining locations_rev payloads_rev =
     if remaining = 0
-    then Ok (reverse_cooperatively events_rev)
+    then Ok (reverse_cooperatively locations_rev, reverse_cooperatively payloads_rev)
     else (
       let location = location_at locations seq in
-      let* event = read_location_locked store ~file_size:committed_offset location in
+      let* payload =
+        read_location_payload_locked store ~file_size:committed_offset location
+      in
       Eio.Fiber.yield ();
-      loop (seq + 1) (remaining - 1) (event :: events_rev))
+      gather
+        (seq + 1)
+        (remaining - 1)
+        (location :: locations_rev)
+        ({ offset = location.frame.frame_offset; payload } :: payloads_rev))
   in
-  let* events = loop first_seq count [] in
+  let* locations, located_payloads = gather first_seq count [] [] in
+  let* events =
+    protect_corrupt_read store (decode_located_payloads store.codec located_payloads)
+  in
+  let* () = protect_corrupt_read store (validate_indexed_events locations events) in
   let+ () = require_writable store in
   events
 ;;
@@ -1892,14 +2039,13 @@ let prepare_frame ~file_offset kind payload =
   , payload_digest )
 ;;
 
-let append_new_batch store ~expected_next_seq ~count events =
+let append_new_batch store ~expected_next_seq ~count payloads =
   let* batch_id =
     match Random_id.create () with
     | Ok value -> Ok value
     | Error detail -> Error (Identity_failure detail)
   in
   let last_seq = expected_next_seq + count - 1 in
-  let payloads = event_payloads events in
   let digest = events_digest payloads in
   let begin_payload =
     batch_begin_to_string { batch_id; expected_next_seq; count; events_sha256 = digest }
@@ -2059,7 +2205,7 @@ let append_new_batch store ~expected_next_seq ~count events =
       | Ok outcome -> Ok outcome))
 ;;
 
-let compare_committed store ~expected_next_seq ~count events committed_last =
+let compare_committed store ~expected_next_seq ~count payloads committed_last =
   let last_seq = expected_next_seq + count - 1 in
   if last_seq > committed_last
   then
@@ -2069,28 +2215,37 @@ let compare_committed store ~expected_next_seq ~count events committed_last =
       with_read store (fun () ->
         store.committed.committed_offset, store.committed.locations)
     in
-    let rec compare seq = function
-      | [] -> Ok Already_committed
-      | expected :: events ->
+    let rec committed_payloads reverse_payloads seq = function
+      | [] -> Ok (reverse_cooperatively reverse_payloads)
+      | _expected :: expected_payloads ->
         let location = location_at committed_locations seq in
-        let* committed = read_location_locked store ~file_size location in
-        if String.equal (Event.to_json_string committed) (Event.to_json_string expected)
-        then (
-          Eio.Fiber.yield ();
-          compare (seq + 1) events)
-        else
-          Error (Committed_content_conflict { first_seq = expected_next_seq; last_seq })
+        let* payload = read_location_payload_locked store ~file_size location in
+        Eio.Fiber.yield ();
+        committed_payloads (payload :: reverse_payloads) (seq + 1) expected_payloads
     in
-    let* outcome = compare expected_next_seq events in
+    let* committed_payloads = committed_payloads [] expected_next_seq payloads in
+    let* identical =
+      Codec.compare_canonical_payloads
+        store.codec
+        ~expected:payloads
+        ~actual:committed_payloads
+      |> Result.map_error (fun failure -> Codec_failure failure)
+    in
+    let* outcome =
+      if identical
+      then Ok Already_committed
+      else Error (Committed_content_conflict { first_seq = expected_next_seq; last_seq })
+    in
     let+ () = require_writable store in
     outcome)
 ;;
 
-let append_batch writer ~expected_next_seq events =
+let append_batch (writer : writer) ~expected_next_seq events =
   let store = writer.store in
   Eio.Fiber.check ();
   let* () = require_available store in
   let* count = validate_append store ~expected_next_seq events in
+  let* payloads = event_payloads store.codec events in
   with_writer store (fun () ->
     Eio.Fiber.check ();
     let lifecycle, health, committed_last =
@@ -2102,9 +2257,9 @@ let append_batch writer ~expected_next_seq events =
     | (Unpublished _ | Published), Writable ->
       let* () = verify_write_fence_locked store in
       if expected_next_seq = committed_last + 1
-      then append_new_batch store ~expected_next_seq ~count events
+      then append_new_batch store ~expected_next_seq ~count payloads
       else if expected_next_seq <= committed_last
-      then compare_committed store ~expected_next_seq ~count events committed_last
+      then compare_committed store ~expected_next_seq ~count payloads committed_last
       else
         Error
           (Sequence_conflict { expected_next_seq; actual_next_seq = committed_last + 1 }))
@@ -2165,18 +2320,4 @@ let read_page (store : t) ~(after : cursor) ?through ~limit () =
       ; earliest_available_seq = (if high = 0 then None else Some 1)
       ; has_more = next_seq < high
       }
-;;
-
-let load_all (store : t) =
-  let* () = require_available store in
-  let* committed_offset, committed_locations, last_seq =
-    with_read store (fun () ->
-      match store.lifecycle, store.health with
-      | (Releasing | Released), _ -> Error Store_released
-      | (Unpublished _ | Published), Fenced error -> Error error
-      | (Unpublished _ | Published), Writable ->
-        let committed = store.committed in
-        Ok (committed.committed_offset, committed.locations, committed.last_seq))
-  in
-  read_range store ~committed_offset committed_locations ~first_seq:1 ~count:last_seq
 ;;

--- a/lib/execution_event_store.mli
+++ b/lib/execution_event_store.mli
@@ -15,8 +15,8 @@
     supplied {!Eio.Switch.t}. Store and writer capabilities are switch-bound;
     after release, every operation that depends on live resources returns
     [Store_released] rather than touching a closed descriptor. The injected
-    codec executor is borrowed: its application-owned switch must be outside
-    and outlive every store switch. *)
+    codec service borrows an {!Execution_runtime.t}; that runtime's
+    application-owned switch must be outside and outlive every store switch. *)
 
 module Scope_id : sig
   type t
@@ -69,10 +69,6 @@ type error =
       ; detail : string
       }
   | Codec_failure of Execution_codec_executor.failure
-  | Codec_protocol_failure of
-      { operation : Execution_codec_executor.operation
-      ; detail : string
-      }
   | Writer_already_active
   | Store_already_attached
   | Store_released

--- a/lib/execution_event_store.mli
+++ b/lib/execution_event_store.mli
@@ -14,7 +14,9 @@
     implementation acquires an exclusive writer lock for the lifetime of the
     supplied {!Eio.Switch.t}. Store and writer capabilities are switch-bound;
     after release, every operation that depends on live resources returns
-    [Store_released] rather than touching a closed descriptor. *)
+    [Store_released] rather than touching a closed descriptor. The injected
+    codec executor is borrowed: its application-owned switch must be outside
+    and outlive every store switch. *)
 
 module Scope_id : sig
   type t
@@ -66,6 +68,11 @@ type error =
       { operation : string
       ; detail : string
       }
+  | Codec_failure of Execution_codec_executor.failure
+  | Codec_protocol_failure of
+      { operation : Execution_codec_executor.operation
+      ; detail : string
+      }
   | Writer_already_active
   | Store_already_attached
   | Store_released
@@ -106,7 +113,13 @@ val error_to_string : error -> string
 type t
 type writer
 
-(** [create ~sw ~dir ()] creates a new store inside an existing caller-owned
+type opened = private
+  { store : t
+  ; recovery : recovery
+  ; replay_events : Execution_event.t list
+  }
+
+(** [create ~sw ~codec ~dir ()] creates a new store inside an existing caller-owned
     directory. It never creates the directory, opens an existing WAL, or
     truncates committed data. The initial metadata frame and matching commit
     authority are directory-durable before the function returns. A failure
@@ -114,20 +127,24 @@ type writer
     reconciled by [open_existing], never by blind create retry. *)
 val create
   :  sw:Eio.Switch.t
+  -> codec:Execution_codec_executor.t
   -> dir:Eio.Fs.dir_ty Eio.Path.t
   -> ?correlation_id:Execution_event.Correlation_id.t
   -> unit
   -> (t * initialization, error) result
 
-(** [open_existing ~sw ~dir] validates the complete authority-bound prefix and
+(** [open_existing ~sw ~codec ~dir] validates the complete authority-bound prefix and
     rebuilds the immutable physical event index before modifying any bytes.
     Bytes beyond the validated authority are truncated and reported through
     [recovery]. An incomplete or corrupt frame inside the authoritative prefix
-    is rejected and is never silently truncated. *)
+    is rejected and is never silently truncated. [replay_events] is the exact
+    immutable decode artifact from that same validation pass; journal recovery
+    consumes it directly rather than decoding the WAL a second time. *)
 val open_existing
   :  sw:Eio.Switch.t
+  -> codec:Execution_codec_executor.t
   -> dir:Eio.Fs.dir_ty Eio.Path.t
-  -> (t * recovery, error) result
+  -> (opened, error) result
 
 val scope_id : t -> Scope_id.t
 val correlation_id : t -> Execution_event.Correlation_id.t
@@ -195,7 +212,3 @@ val read_page
   -> limit:int
   -> unit
   -> (page, error) result
-
-(** Decode every committed event in sequence order. Intended for reducer
-    recovery at journal construction, not dashboard polling. *)
-val load_all : t -> (Execution_event.t list, error) result

--- a/lib/execution_journal.ml
+++ b/lib/execution_journal.ml
@@ -1714,7 +1714,7 @@ let abort_run ?causes journal ~run terminal =
     commit_mutation journal captured_state mutation)
 ;;
 
-let replay_events events =
+let replay_validated_events events =
   let rec loop (state : journal_state) = function
     | [] -> Ok state
     | event :: rest ->
@@ -1737,10 +1737,17 @@ let replay_events events =
     events
 ;;
 
-let create_internal ?correlation_id store =
+type construction_source =
+  | Volatile
+  | Durable of
+      { store : Store.t
+      ; replay_events : Event.t list
+      }
+
+let create_internal ?correlation_id source =
   let* scope_id, correlation_id, state, store_writer =
-    match store with
-    | None ->
+    match source with
+    | Volatile ->
       let* scope_id =
         match Store.Scope_id.fresh () with
         | Ok value -> Ok value
@@ -1759,7 +1766,7 @@ let create_internal ?correlation_id store =
           ; events_by_seq = Event_seq_map.empty
           }
         , None )
-    | Some store ->
+    | Durable { store; replay_events } ->
       let store_correlation = Store.correlation_id store in
       let* () =
         match correlation_id with
@@ -1768,12 +1775,7 @@ let create_internal ?correlation_id store =
           when Event.Correlation_id.equal correlation_id store_correlation -> Ok ()
         | Some _ -> Error (Invalid_argument "store correlation identity mismatch")
       in
-      let* events =
-        match Store.load_all store with
-        | Ok events -> Ok events
-        | Error error -> Error (Persistence_failure error)
-      in
-      let* state = replay_events events in
+      let* state = replay_validated_events replay_events in
       let* store_writer =
         match Store.attach store with
         | Ok writer -> Ok writer
@@ -1792,7 +1794,7 @@ let create_internal ?correlation_id store =
     }
 ;;
 
-let create ?correlation_id () = create_internal ?correlation_id None
+let create ?correlation_id () = create_internal ?correlation_id Volatile
 
 let make_durable_writer journal =
   let claim = ref () in
@@ -1844,8 +1846,8 @@ let release_after_construction_error store construction_error =
       backtrace
 ;;
 
-let journal_writer_of_store store =
-  match create_internal (Some store) with
+let journal_writer_of_store ~replay_events store =
+  match create_internal (Durable { store; replay_events }) with
   | Ok journal -> Ok (make_durable_writer journal)
   | Error construction_error -> release_after_construction_error store construction_error
   | exception exn ->
@@ -1863,22 +1865,24 @@ let journal_writer_of_store store =
          bt)
 ;;
 
-let create_durable_writer ~sw ~dir ?correlation_id () =
+let create_durable_writer ~sw ~codec ~dir ?correlation_id () =
   let* store, initialization =
-    match Store.create ~sw ~dir ?correlation_id () with
+    match Store.create ~sw ~codec ~dir ?correlation_id () with
     | Ok result -> Ok result
     | Error error -> Error (Persistence_failure error)
   in
-  let+ writer = journal_writer_of_store store in
+  let+ writer = journal_writer_of_store ~replay_events:[] store in
   writer, initialization
 ;;
 
-let open_durable_writer ~sw ~dir =
-  let* store, recovery =
-    match Store.open_existing ~sw ~dir with
+let open_durable_writer ~sw ~codec ~dir =
+  let* opened =
+    match Store.open_existing ~sw ~codec ~dir with
     | Ok result -> Ok result
     | Error error -> Error (Persistence_failure error)
   in
-  let+ writer = journal_writer_of_store store in
-  writer, recovery
+  let+ writer =
+    journal_writer_of_store ~replay_events:opened.replay_events opened.store
+  in
+  writer, opened.recovery
 ;;

--- a/lib/execution_journal.mli
+++ b/lib/execution_journal.mli
@@ -216,6 +216,7 @@ val create : ?correlation_id:Execution_event.Correlation_id.t -> unit -> (t, err
     capability is the proof required by a durability-owning writer actor. *)
 val create_durable_writer
   :  sw:Eio.Switch.t
+  -> codec:Execution_codec_executor.t
   -> dir:Eio.Fs.dir_ty Eio.Path.t
   -> ?correlation_id:Execution_event.Correlation_id.t
   -> unit
@@ -223,6 +224,7 @@ val create_durable_writer
 
 val open_durable_writer
   :  sw:Eio.Switch.t
+  -> codec:Execution_codec_executor.t
   -> dir:Eio.Fs.dir_ty Eio.Path.t
   -> (durable_writer * Execution_event_store.recovery, error) result
 

--- a/lib/execution_lane_writer.ml
+++ b/lib/execution_lane_writer.ml
@@ -131,6 +131,7 @@ type open_mode =
 
 type t =
   { dir : Eio.Fs.dir_ty Eio.Path.t
+  ; codec : Execution_codec_executor.t
   ; initial_mode : open_mode
   ; mu : Eio.Mutex.t
   ; changed : Eio.Condition.t
@@ -479,12 +480,19 @@ let rec run_ready writer durable_writer journal =
 let open_writer writer ~sw mode =
   match mode with
   | Create correlation_id ->
-    (match Journal.create_durable_writer ~sw ~dir:writer.dir ?correlation_id () with
+    (match
+       Journal.create_durable_writer
+         ~sw
+         ~codec:writer.codec
+         ~dir:writer.dir
+         ?correlation_id
+         ()
+     with
      | Error error -> Error error
      | Ok (durable_writer, _initialization) ->
        Ok (durable_writer, Journal.durable_writer_journal durable_writer))
   | Open_existing ->
-    (match Journal.open_durable_writer ~sw ~dir:writer.dir with
+    (match Journal.open_durable_writer ~sw ~codec:writer.codec ~dir:writer.dir with
      | Error error -> Error error
      | Ok (durable_writer, _recovery) ->
        Ok (durable_writer, Journal.durable_writer_journal durable_writer))
@@ -723,11 +731,12 @@ let run_actor writer =
   | exception exn -> fail_actor writer (Unexpected_exception exn)
 ;;
 
-let spawn ~sw ~dir initial_mode =
+let spawn ~sw ~codec ~dir initial_mode =
   let ready, resolve_ready = Eio.Promise.create () in
   let closed, resolve_closed = Eio.Promise.create () in
   let writer =
     { dir
+    ; codec
     ; initial_mode
     ; mu = Eio.Mutex.create ()
     ; changed = Eio.Condition.create ()
@@ -827,9 +836,9 @@ let close_and_await writer =
   await_closed writer
 ;;
 
-let run_with_mode ~dir mode f =
+let run_with_mode ~codec ~dir mode f =
   Eio.Switch.run (fun sw ->
-    let writer = spawn ~sw ~dir mode in
+    let writer = spawn ~sw ~codec ~dir mode in
     match f ~sw writer with
     | value ->
       (match close_and_await writer with
@@ -855,8 +864,11 @@ let run_with_mode ~dir mode f =
            backtrace))
 ;;
 
-let run ~dir ?correlation_id f = run_with_mode ~dir (Create correlation_id) f
-let resume ~dir f = run_with_mode ~dir Open_existing f
+let run ~codec ~dir ?correlation_id f =
+  run_with_mode ~codec ~dir (Create correlation_id) f
+;;
+
+let resume ~codec ~dir f = run_with_mode ~codec ~dir Open_existing f
 
 let read_journal writer f =
   let journal_view = with_lock writer.mu (fun () -> writer.journal_view) in

--- a/lib/execution_lane_writer.mli
+++ b/lib/execution_lane_writer.mli
@@ -115,9 +115,10 @@ type page = private
     returns its value. A callback exception also stops admission and lets the
     actor finish or reconcile every actor-owned durability operation before the
     original exception is re-raised; the supervisor fiber never settles an
-    in-flight durability group itself. [codec] borrows a shared executor whose
-    owning switch must be outside and outlive this complete call; the lane
-    never creates, sizes, or closes that application resource. *)
+    in-flight durability group itself. [codec] borrows a shared
+    {!Execution_runtime.t} whose owning switch must be outside and outlive this
+    complete call; the lane never creates, sizes, or closes that application
+    resource. *)
 val run
   :  codec:Execution_codec_executor.t
   -> dir:Eio.Fs.dir_ty Eio.Path.t

--- a/lib/execution_lane_writer.mli
+++ b/lib/execution_lane_writer.mli
@@ -115,17 +115,21 @@ type page = private
     returns its value. A callback exception also stops admission and lets the
     actor finish or reconcile every actor-owned durability operation before the
     original exception is re-raised; the supervisor fiber never settles an
-    in-flight durability group itself. *)
+    in-flight durability group itself. [codec] borrows a shared executor whose
+    owning switch must be outside and outlive this complete call; the lane
+    never creates, sizes, or closes that application resource. *)
 val run
-  :  dir:Eio.Fs.dir_ty Eio.Path.t
+  :  codec:Execution_codec_executor.t
+  -> dir:Eio.Fs.dir_ty Eio.Path.t
   -> ?correlation_id:Execution_event.Correlation_id.t
   -> (sw:Eio.Switch.t -> t -> 'a)
   -> ('a, scope_failure) result
 
 (** Resume an existing durability scope with the same owned-supervisor
-    lifecycle as {!run}. *)
+    lifecycle and outer codec-executor lifetime contract as {!run}. *)
 val resume
-  :  dir:Eio.Fs.dir_ty Eio.Path.t
+  :  codec:Execution_codec_executor.t
+  -> dir:Eio.Fs.dir_ty Eio.Path.t
   -> (sw:Eio.Switch.t -> t -> 'a)
   -> ('a, scope_failure) result
 

--- a/lib/execution_runtime.ml
+++ b/lib/execution_runtime.ml
@@ -1,0 +1,202 @@
+type create_error = Non_positive_domain_count of int
+
+type stats =
+  { pool_requested : int
+  ; reentrant_inline : int
+  ; caller_cancelled : int
+  }
+
+type run_failure =
+  { exception_ : exn
+  ; backtrace : Printexc.raw_backtrace option
+  }
+
+type t =
+  { pool : Eio.Executor_pool.t
+  ; observations : stats Atomic.t
+  ; lifecycle : lifecycle Atomic.t
+  }
+
+and stop_reason =
+  | Pending
+  | Caller_cancelled
+  | Runtime_released
+
+and cancellation = { stop_reason : stop_reason Atomic.t }
+
+and lifecycle =
+  | Accepting of cancellation list
+  | Released
+
+type current_job =
+  { runtime : t
+  ; cancellation : cancellation
+  }
+
+exception Caller_cancelled
+exception Runtime_released
+
+type 'a worker_outcome =
+  | Worker_completed of 'a
+  | Worker_raised of run_failure
+
+let current_job = Eio.Fiber.create_key ()
+
+let rec update observation f =
+  let current = Atomic.get observation in
+  let next = f current in
+  if not (Atomic.compare_and_set observation current next) then update observation f
+;;
+
+let signal cancellation reason =
+  ignore (Atomic.compare_and_set cancellation.stop_reason Pending reason : bool)
+;;
+
+let rec register t cancellation =
+  let current = Atomic.get t.lifecycle in
+  match current with
+  | Released -> false
+  | Accepting active ->
+    let next = Accepting (cancellation :: active) in
+    if Atomic.compare_and_set t.lifecycle current next
+    then true
+    else register t cancellation
+;;
+
+let rec unregister t cancellation =
+  let current = Atomic.get t.lifecycle in
+  match current with
+  | Released -> ()
+  | Accepting active ->
+    let next = Accepting (List.filter (fun item -> item != cancellation) active) in
+    if not (Atomic.compare_and_set t.lifecycle current next)
+    then unregister t cancellation
+;;
+
+let release t =
+  match Atomic.exchange t.lifecycle Released with
+  | Released -> ()
+  | Accepting active ->
+    List.iter (fun cancellation -> signal cancellation Runtime_released) active
+;;
+
+let create ~sw ~domain_mgr ~domain_count =
+  if domain_count <= 0
+  then Error (Non_positive_domain_count domain_count)
+  else (
+    let pool = Eio.Executor_pool.create ~sw ~domain_count domain_mgr in
+    let t =
+      { pool
+      ; observations =
+          Atomic.make { pool_requested = 0; reentrant_inline = 0; caller_cancelled = 0 }
+      ; lifecycle = Atomic.make (Accepting [])
+      }
+    in
+    Eio.Fiber.fork_daemon ~sw (fun () ->
+      try Eio.Fiber.await_cancel () with
+      | Eio.Cancel.Cancelled _ ->
+        release t;
+        `Stop_daemon);
+    Eio.Switch.on_release sw (fun () -> release t);
+    Ok t)
+;;
+
+let create_error_to_string = function
+  | Non_positive_domain_count domain_count ->
+    Printf.sprintf
+      "execution runtime domain_count must be positive, received %d"
+      domain_count
+;;
+
+let pp_create_error formatter error =
+  Format.pp_print_string formatter (create_error_to_string error)
+;;
+
+let stats t = Atomic.get t.observations
+
+module Private = struct
+  exception Caller_cancelled = Caller_cancelled
+  exception Runtime_released = Runtime_released
+
+  type nonrec run_failure = run_failure =
+    { exception_ : exn
+    ; backtrace : Printexc.raw_backtrace option
+    }
+
+  let capture ?backtrace exception_ = { exception_; backtrace }
+
+  let reraise_caller_cancelled failure =
+    match failure.exception_ with
+    | Caller_cancelled as exn ->
+      let backtrace =
+        Option.value ~default:(Printexc.get_raw_backtrace ()) failure.backtrace
+      in
+      Printexc.raise_with_backtrace exn backtrace
+    | _ -> ()
+  ;;
+
+  let check_cancellation t =
+    (match Eio.Fiber.get current_job with
+     | Some current when current.runtime == t ->
+       (match Atomic.get current.cancellation.stop_reason with
+        | Pending -> ()
+        | Caller_cancelled -> raise_notrace Caller_cancelled
+        | Runtime_released -> raise_notrace Runtime_released)
+     | None | Some _ -> ());
+    Eio.Fiber.check ()
+  ;;
+
+  let signal_caller_cancellation t cancellation exn backtrace =
+    signal cancellation Caller_cancelled;
+    update t.observations (fun stats ->
+      { stats with caller_cancelled = stats.caller_cancelled + 1 });
+    Printexc.raise_with_backtrace exn backtrace
+  ;;
+
+  let run_cpu t fn =
+    match Eio.Fiber.get current_job with
+    | Some current when current.runtime == t ->
+      update t.observations (fun stats ->
+        { stats with reentrant_inline = stats.reentrant_inline + 1 });
+      (match fn () with
+       | value -> Ok value
+       | exception exn ->
+         let backtrace = Printexc.get_raw_backtrace () in
+         let failure = capture ~backtrace exn in
+         reraise_caller_cancelled failure;
+         Error failure)
+    | None | Some _ ->
+      update t.observations (fun stats ->
+        { stats with pool_requested = stats.pool_requested + 1 });
+      let cancellation = { stop_reason = Atomic.make Pending } in
+      if not (register t cancellation)
+      then Error (capture Runtime_released)
+      else
+        Fun.protect
+          ~finally:(fun () -> unregister t cancellation)
+          (fun () ->
+             match
+               Eio.Executor_pool.submit t.pool ~weight:1.0 (fun () ->
+                 Eio.Fiber.with_binding
+                   current_job
+                   { runtime = t; cancellation }
+                   (fun () ->
+                      match fn () with
+                      | value -> Worker_completed value
+                      | exception exn ->
+                        let backtrace = Printexc.get_raw_backtrace () in
+                        Worker_raised (capture ~backtrace exn)))
+             with
+             | Ok (Worker_completed value) -> Ok value
+             | Ok (Worker_raised failure) ->
+               reraise_caller_cancelled failure;
+               Error failure
+             | Error exn -> Error (capture exn)
+             | exception (Eio.Cancel.Cancelled _ as exn) ->
+               let backtrace = Printexc.get_raw_backtrace () in
+               signal_caller_cancellation t cancellation exn backtrace
+             | exception exn ->
+               let backtrace = Printexc.get_raw_backtrace () in
+               Error (capture ~backtrace exn))
+  ;;
+end

--- a/lib/execution_runtime.mli
+++ b/lib/execution_runtime.mli
@@ -1,0 +1,42 @@
+(** Application-lifetime parallel execution capability.
+
+    The caller owns [sw], selects [domain_count] from its single host resource
+    policy, and shares the resulting handle across every execution lane. Raw
+    {!Eio.Executor_pool.t} access is intentionally not exposed. *)
+
+type t
+type create_error = Non_positive_domain_count of int
+
+type stats =
+  { pool_requested : int
+  ; reentrant_inline : int
+  ; caller_cancelled : int
+  }
+
+val create
+  :  sw:Eio.Switch.t
+  -> domain_mgr:_ Eio.Domain_manager.t
+  -> domain_count:int
+  -> (t, create_error) result
+
+val create_error_to_string : create_error -> string
+val pp_create_error : Format.formatter -> create_error -> unit
+val stats : t -> stats
+
+(** Internal execution boundary hidden by the top-level {!Agent_sdk} export.
+    A job that re-enters the same runtime from one of its worker fibers runs
+    inline on that worker. This is an explicit structural case, not a fallback
+    to the caller/server domain, and prevents a full-pool nested-submit
+    deadlock. *)
+module Private : sig
+  exception Caller_cancelled
+  exception Runtime_released
+
+  type run_failure =
+    { exception_ : exn
+    ; backtrace : Printexc.raw_backtrace option
+    }
+
+  val check_cancellation : t -> unit
+  val run_cpu : t -> (unit -> 'a) -> ('a, run_failure) result
+end

--- a/test/dune
+++ b/test/dune
@@ -367,6 +367,16 @@
   (run %{test})))
 
 (test
+ (name test_execution_codec_executor)
+ (modules test_execution_codec_executor)
+ (libraries agent_sdk agent_sdk.llm_provider alcotest eio_main)
+ (deps ../models.toml)
+ (flags
+  (:standard -open Agent_sdk__))
+ (action
+  (run %{test})))
+
+(test
  (name test_execution_event_store)
  (modules test_execution_event_store)
  (libraries agent_sdk agent_sdk.llm_provider alcotest eio_main)

--- a/test/test_execution_codec_executor.ml
+++ b/test/test_execution_codec_executor.ml
@@ -1,12 +1,46 @@
 open Alcotest
+module Runtime_internal = Execution_runtime
 open Agent_sdk
 module Codec = Execution_codec_executor
+module Event = Execution_event
+module Journal = Execution_journal
 
-exception Cancel_codec_waiter
+exception Cancel_running_codec
+exception Cancel_queued_codec
+exception Cancel_nested_codec
+
+type live_caller_outcome =
+  | Live_caller_returned of (string list, Codec.failure) result
+  | Live_caller_cancelled
+  | Live_caller_raised of exn
+
+let require_runtime = function
+  | Ok runtime -> runtime
+  | Error error -> fail (Runtime_internal.create_error_to_string error)
+;;
 
 let require = function
   | Ok value -> value
   | Error failure -> fail (Codec.failure_to_string failure)
+;;
+
+let require_journal = function
+  | Ok value -> value
+  | Error error -> fail (Journal.error_to_string error)
+;;
+
+let require_id = function
+  | Ok value -> value
+  | Error detail -> fail detail
+;;
+
+let one_event () =
+  let correlation_id = require_id (Event.Correlation_id.fresh ()) in
+  let journal = require_journal (Journal.create ~correlation_id ()) in
+  let _run, opened =
+    require_journal (Journal.start_run journal ~agent_name:"codec-test")
+  in
+  opened
 ;;
 
 let require_worker name caller = function
@@ -16,45 +50,66 @@ let require_worker name caller = function
     worker
 ;;
 
-let rec await_true flag =
-  if Atomic.get flag
+let rec await predicate =
+  if predicate ()
   then ()
   else (
     Eio.Fiber.yield ();
-    await_true flag)
+    await predicate)
 ;;
 
-let rec await_requested codec =
-  if (Codec.stats codec).encode_events.requested > 0
-  then ()
-  else (
-    Eio.Fiber.yield ();
-    await_requested codec)
+let fork_cancellable ~sw fn =
+  let context, resolve_context = Eio.Promise.create () in
+  let finished, resolve_finished = Eio.Promise.create () in
+  Eio.Fiber.fork ~sw (fun () ->
+    let cancelled =
+      match
+        Eio.Cancel.sub (fun context ->
+          Eio.Promise.resolve resolve_context context;
+          fn ())
+      with
+      | () -> false
+      | exception Eio.Cancel.Cancelled _ -> true
+      | exception exn -> raise exn
+    in
+    Eio.Promise.resolve resolve_finished cancelled);
+  Eio.Promise.await context, finished
+;;
+
+let with_runtime env f =
+  Eio.Switch.run (fun sw ->
+    let runtime =
+      require_runtime
+        (Runtime_internal.create
+           ~sw
+           ~domain_mgr:(Eio.Stdenv.domain_mgr env)
+           ~domain_count:1)
+    in
+    f runtime (Codec.of_runtime runtime))
 ;;
 
 let test_closed_requests_share_real_worker env =
-  Eio.Switch.run (fun sw ->
-    let pool = Eio.Executor_pool.create ~sw ~domain_count:1 (Eio.Stdenv.domain_mgr env) in
-    let codec = Codec.of_executor_pool pool in
+  with_runtime env (fun _runtime codec ->
     let caller = Domain.self () in
     check (list string) "empty encode" [] (require (Codec.encode_events codec []));
-    (match require (Codec.decode_canonical_events codec []) with
-     | Ok events -> check int "empty decode" 0 (List.length events)
-     | Error _ -> fail "empty canonical decode failed");
+    let payload = Event.to_json_string (one_event ()) in
+    (match require (Codec.decode_canonical_event codec payload) with
+     | Ok _event -> ()
+     | Error _ -> fail "canonical event failed to decode");
     check
       bool
-      "empty canonical payloads compare exactly"
+      "canonical payload compares exactly"
       true
-      (require (Codec.compare_canonical_payloads codec ~expected:[] ~actual:[]));
+      (require (Codec.compare_canonical_payload codec ~expected:payload ~actual:payload));
     let stats = Codec.stats codec in
     let encode_worker =
       require_worker "encode" caller stats.encode_events.last_worker_domain
     in
     let decode_worker =
-      require_worker "decode" caller stats.decode_canonical_events.last_worker_domain
+      require_worker "decode" caller stats.decode_canonical_event.last_worker_domain
     in
     let compare_worker =
-      require_worker "compare" caller stats.compare_canonical_payloads.last_worker_domain
+      require_worker "compare" caller stats.compare_canonical_payload.last_worker_domain
     in
     check bool "encode and decode share one worker" true (encode_worker = decode_worker);
     check bool "decode and compare share one worker" true (decode_worker = compare_worker);
@@ -64,6 +119,7 @@ let test_closed_requests_share_real_worker env =
          check int (name ^ " started") 1 operation.started;
          check int (name ^ " completed") 1 operation.completed;
          check int (name ^ " job failures") 0 operation.job_failed;
+         check int (name ^ " worker cancellations") 0 operation.worker_cancelled;
          check int (name ^ " executor failures") 0 operation.executor_failed;
          check int (name ^ " caller cancellations") 0 operation.caller_cancelled;
          check
@@ -72,85 +128,245 @@ let test_closed_requests_share_real_worker env =
            true
            (operation.last_caller_domain = Some caller))
       [ "encode", stats.encode_events
-      ; "decode", stats.decode_canonical_events
-      ; "compare", stats.compare_canonical_payloads
+      ; "decode", stats.decode_canonical_event
+      ; "compare", stats.compare_canonical_payload
       ])
 ;;
 
 let test_invalid_event_is_typed_codec_result env =
-  Eio.Switch.run (fun sw ->
-    let pool = Eio.Executor_pool.create ~sw ~domain_count:1 (Eio.Stdenv.domain_mgr env) in
-    let codec = Codec.of_executor_pool pool in
-    match require (Codec.decode_canonical_events codec [ "{}" ]) with
-    | Error (Codec.Invalid_event { ordinal = 0; detail = _ }) -> ()
-    | Error (Codec.Invalid_event { ordinal; _ }) ->
-      failf "invalid event ordinal = %d" ordinal
-    | Error (Codec.Noncanonical_event _) -> fail "invalid event reported as noncanonical"
+  with_runtime env (fun _runtime codec ->
+    match require (Codec.decode_canonical_event codec "{}") with
+    | Error (Codec.Invalid_event { detail = _ }) -> ()
+    | Error Codec.Noncanonical_event -> fail "invalid event reported as noncanonical"
     | Ok _ -> fail "invalid event decoded successfully")
 ;;
 
-let test_released_pool_is_typed_executor_failure env =
+let test_released_runtime_is_typed_executor_failure env =
   let escaped = ref None in
   Eio.Switch.run (fun sw ->
-    let pool = Eio.Executor_pool.create ~sw ~domain_count:1 (Eio.Stdenv.domain_mgr env) in
-    escaped := Some (Codec.of_executor_pool pool));
+    let runtime =
+      require_runtime
+        (Runtime_internal.create
+           ~sw
+           ~domain_mgr:(Eio.Stdenv.domain_mgr env)
+           ~domain_count:1)
+    in
+    escaped := Some (Codec.of_runtime runtime));
   let codec = Option.get !escaped in
   match Codec.encode_events codec [] with
   | Error (Codec.Executor_unavailable { operation = Codec.Encode_events; _ }) -> ()
   | Error failure ->
-    fail ("unexpected released-pool failure: " ^ Codec.failure_to_string failure)
-  | Ok _ -> fail "released executor pool accepted a codec request"
+    fail ("unexpected released-runtime failure: " ^ Codec.failure_to_string failure)
+  | Ok _ -> fail "released execution runtime accepted a codec request"
 ;;
 
-let test_waiting_caller_cancellation_is_observed env =
-  Eio.Switch.run (fun sw ->
-    let pool = Eio.Executor_pool.create ~sw ~domain_count:1 (Eio.Stdenv.domain_mgr env) in
-    let codec = Codec.of_executor_pool pool in
-    let blocker_started = Atomic.make false in
-    let release_blocker = Atomic.make false in
-    let blocker_finished, resolve_blocker_finished = Eio.Promise.create () in
-    Eio.Fiber.fork ~sw (fun () ->
-      Eio.Executor_pool.submit_exn pool ~weight:1.0 (fun () ->
-        Atomic.set blocker_started true;
-        while not (Atomic.get release_blocker) do
-          Domain.cpu_relax ()
-        done);
-      Eio.Promise.resolve resolve_blocker_finished ());
-    await_true blocker_started;
-    let cancelled =
+let test_running_and_queued_cancellation_stop_workers env =
+  with_runtime env (fun _runtime codec ->
+    Eio.Switch.run (fun sw ->
+      let event = one_event () in
+      let rec unbounded_events = event :: unbounded_events in
+      let running_context, running_finished =
+        fork_cancellable ~sw (fun () ->
+          ignore (Codec.encode_events codec unbounded_events : (string list, _) result))
+      in
+      await (fun () -> (Codec.stats codec).encode_events.started = 1);
+      let payload = Event.to_json_string event in
+      let queued_context, queued_finished =
+        fork_cancellable ~sw (fun () ->
+          ignore
+            (Codec.compare_canonical_payload codec ~expected:payload ~actual:payload
+             : (bool, _) result))
+      in
+      await (fun () -> (Codec.stats codec).compare_canonical_payload.requested = 1);
+      Eio.Cancel.cancel queued_context Cancel_queued_codec;
+      check bool "queued caller is cancelled" true (Eio.Promise.await queued_finished);
+      Eio.Cancel.cancel running_context Cancel_running_codec;
+      check bool "running caller is cancelled" true (Eio.Promise.await running_finished);
+      await (fun () -> (Codec.stats codec).encode_events.worker_cancelled = 1);
+      let stats = Codec.stats codec in
+      check
+        int
+        "running caller cancellation observed"
+        1
+        stats.encode_events.caller_cancelled;
+      check
+        int
+        "running worker cancellation observed"
+        1
+        stats.encode_events.worker_cancelled;
+      check
+        int
+        "running cancellation is not executor failure"
+        0
+        stats.encode_events.executor_failed;
+      check
+        int
+        "queued caller cancellation observed"
+        1
+        stats.compare_canonical_payload.caller_cancelled;
+      check
+        int
+        "queued job never starts after its submitter is cancelled"
+        0
+        stats.compare_canonical_payload.started;
+      check
+        int
+        "queued cancellation has no worker to cancel"
+        0
+        stats.compare_canonical_payload.worker_cancelled;
+      check
+        int
+        "queued cancellation is not executor failure"
+        0
+        stats.compare_canonical_payload.executor_failed))
+;;
+
+let test_same_runtime_reentry_is_inline env =
+  with_runtime env (fun runtime codec ->
+    let caller = Domain.self () in
+    let payload = Event.to_json_string (one_event ()) in
+    let worker, identical =
       match
-        Eio.Cancel.sub (fun context ->
-          Eio.Fiber.fork ~sw (fun () ->
-            await_requested codec;
-            Eio.Cancel.protect (fun () ->
-              Eio.Cancel.cancel context Cancel_codec_waiter;
-              Atomic.set release_blocker true));
-          ignore (Codec.encode_events codec [] : (string list, Codec.failure) result))
+        Runtime_internal.Private.run_cpu runtime (fun () ->
+          let worker = Domain.self () in
+          ( worker
+          , require
+              (Codec.compare_canonical_payload codec ~expected:payload ~actual:payload) ))
       with
-      | () -> false
-      | exception Eio.Cancel.Cancelled Cancel_codec_waiter -> true
-      | exception exn -> raise exn
+      | Ok value -> value
+      | Error { exception_; backtrace } ->
+        let backtrace = Option.value ~default:(Printexc.get_raw_backtrace ()) backtrace in
+        Printexc.raise_with_backtrace exception_ backtrace
     in
-    check bool "waiting codec caller is cancelled" true cancelled;
-    Eio.Promise.await blocker_finished;
+    check bool "outer job runs off caller" true (worker <> caller);
+    check bool "reentrant codec result is exact" true identical;
+    let runtime_stats = Runtime_internal.stats runtime in
+    check int "only outer job requests the pool" 1 runtime_stats.pool_requested;
+    check int "inner job is structurally inline" 1 runtime_stats.reentrant_inline;
+    let codec_stats = (Codec.stats codec).compare_canonical_payload in
+    check
+      bool
+      "inline job stays on outer worker"
+      true
+      (codec_stats.last_worker_domain = Some worker))
+;;
+
+let test_same_runtime_reentry_inherits_cancellation env =
+  with_runtime env (fun runtime codec ->
+    Eio.Switch.run (fun sw ->
+      let event = one_event () in
+      let rec unbounded_events = event :: unbounded_events in
+      let context, finished =
+        fork_cancellable ~sw (fun () ->
+          ignore
+            (Runtime_internal.Private.run_cpu runtime (fun () ->
+               ignore
+                 (Codec.encode_events codec unbounded_events
+                  : (string list, Codec.failure) result))))
+      in
+      await (fun () -> (Codec.stats codec).encode_events.started = 1);
+      Eio.Cancel.cancel context Cancel_nested_codec;
+      check bool "outer runtime caller is cancelled" true (Eio.Promise.await finished);
+      await (fun () -> (Codec.stats codec).encode_events.worker_cancelled = 1);
+      let runtime_stats = Runtime_internal.stats runtime in
+      check int "outer request reached the pool once" 1 runtime_stats.pool_requested;
+      check int "nested codec remained inline" 1 runtime_stats.reentrant_inline;
+      check int "runtime observed caller cancellation" 1 runtime_stats.caller_cancelled;
+      let codec_stats = (Codec.stats codec).encode_events in
+      check
+        int
+        "nested worker observed inherited cancellation"
+        1
+        codec_stats.worker_cancelled;
+      check
+        int
+        "nested cancellation is not executor failure"
+        0
+        codec_stats.executor_failed;
+      check int "nested codec did not complete" 0 codec_stats.completed))
+;;
+
+let test_runtime_release_is_not_caller_cancellation env =
+  Eio.Switch.run (fun sw ->
+    let runtime_ready, resolve_runtime_ready = Eio.Promise.create () in
+    let release_runtime, resolve_release_runtime = Eio.Promise.create () in
+    let runtime_scope =
+      Eio.Fiber.fork_promise ~sw (fun () ->
+        Eio.Switch.run (fun runtime_sw ->
+          let runtime =
+            require_runtime
+              (Runtime_internal.create
+                 ~sw:runtime_sw
+                 ~domain_mgr:(Eio.Stdenv.domain_mgr env)
+                 ~domain_count:1)
+          in
+          Eio.Promise.resolve resolve_runtime_ready (runtime, Codec.of_runtime runtime);
+          Eio.Promise.await release_runtime))
+    in
+    let _runtime, codec = Eio.Promise.await runtime_ready in
+    let event = one_event () in
+    let rec unbounded_events = event :: unbounded_events in
+    let outcome, resolve_outcome = Eio.Promise.create () in
+    Eio.Fiber.fork ~sw (fun () ->
+      let outcome =
+        match Codec.encode_events codec unbounded_events with
+        | result -> Live_caller_returned result
+        | exception Eio.Cancel.Cancelled _ -> Live_caller_cancelled
+        | exception exn -> Live_caller_raised exn
+      in
+      Eio.Promise.resolve resolve_outcome outcome);
+    await (fun () -> (Codec.stats codec).encode_events.started = 1);
+    Eio.Promise.resolve resolve_release_runtime ();
+    (match Eio.Promise.await runtime_scope with
+     | Ok () -> ()
+     | Error exn -> fail ("runtime scope failed: " ^ Printexc.to_string exn));
+    (match Eio.Promise.await outcome with
+     | Live_caller_returned
+         (Error (Codec.Executor_unavailable { operation = Codec.Encode_events; _ })) -> ()
+     | Live_caller_returned (Error failure) ->
+       fail ("unexpected runtime-release failure: " ^ Codec.failure_to_string failure)
+     | Live_caller_returned (Ok _) ->
+       fail "runtime release completed an unbounded codec job"
+     | Live_caller_cancelled ->
+       fail "runtime release was misreported as caller cancellation"
+     | Live_caller_raised exn -> fail ("runtime release raised: " ^ Printexc.to_string exn));
     let stats = (Codec.stats codec).encode_events in
-    check int "cancelled request remains observed" 1 stats.requested;
-    check int "caller cancellation is explicit" 1 stats.caller_cancelled)
+    check int "runtime release cancels the worker" 1 stats.worker_cancelled;
+    check int "runtime release is an executor failure" 1 stats.executor_failed;
+    check int "live caller is not marked cancelled" 0 stats.caller_cancelled)
+;;
+
+let test_non_positive_domain_count_is_typed env =
+  Eio.Switch.run (fun sw ->
+    match
+      Runtime_internal.create ~sw ~domain_mgr:(Eio.Stdenv.domain_mgr env) ~domain_count:0
+    with
+    | Error (Runtime_internal.Non_positive_domain_count 0) -> ()
+    | Error error -> fail (Runtime_internal.create_error_to_string error)
+    | Ok _ -> fail "execution runtime accepted a non-positive domain count")
 ;;
 
 let () =
   Eio_main.run (fun env ->
     run
       "execution codec executor"
-      [ ( "real pool"
+      [ ( "real runtime"
         , [ test_case "closed requests share one off-domain worker" `Quick (fun () ->
               test_closed_requests_share_real_worker env)
           ; test_case "invalid event remains a typed decode result" `Quick (fun () ->
               test_invalid_event_is_typed_codec_result env)
-          ; test_case "released pool is an explicit executor failure" `Quick (fun () ->
-              test_released_pool_is_typed_executor_failure env)
-          ; test_case "waiting caller cancellation remains explicit" `Quick (fun () ->
-              test_waiting_caller_cancellation_is_observed env)
+          ; test_case "released runtime is an explicit executor failure" `Quick (fun () ->
+              test_released_runtime_is_typed_executor_failure env)
+          ; test_case "running and queued cancellation stop workers" `Quick (fun () ->
+              test_running_and_queued_cancellation_stop_workers env)
+          ; test_case "same-runtime reentry executes on the worker" `Quick (fun () ->
+              test_same_runtime_reentry_is_inline env)
+          ; test_case "same-runtime reentry inherits cancellation" `Quick (fun () ->
+              test_same_runtime_reentry_inherits_cancellation env)
+          ; test_case "runtime release is not caller cancellation" `Quick (fun () ->
+              test_runtime_release_is_not_caller_cancellation env)
+          ; test_case "non-positive domain count is typed" `Quick (fun () ->
+              test_non_positive_domain_count_is_typed env)
           ] )
       ])
 ;;

--- a/test/test_execution_codec_executor.ml
+++ b/test/test_execution_codec_executor.ml
@@ -1,0 +1,156 @@
+open Alcotest
+open Agent_sdk
+module Codec = Execution_codec_executor
+
+exception Cancel_codec_waiter
+
+let require = function
+  | Ok value -> value
+  | Error failure -> fail (Codec.failure_to_string failure)
+;;
+
+let require_worker name caller = function
+  | None -> fail (name ^ " did not record a worker domain")
+  | Some worker ->
+    check bool (name ^ " runs outside the caller domain") true (worker <> caller);
+    worker
+;;
+
+let rec await_true flag =
+  if Atomic.get flag
+  then ()
+  else (
+    Eio.Fiber.yield ();
+    await_true flag)
+;;
+
+let rec await_requested codec =
+  if (Codec.stats codec).encode_events.requested > 0
+  then ()
+  else (
+    Eio.Fiber.yield ();
+    await_requested codec)
+;;
+
+let test_closed_requests_share_real_worker env =
+  Eio.Switch.run (fun sw ->
+    let pool = Eio.Executor_pool.create ~sw ~domain_count:1 (Eio.Stdenv.domain_mgr env) in
+    let codec = Codec.of_executor_pool pool in
+    let caller = Domain.self () in
+    check (list string) "empty encode" [] (require (Codec.encode_events codec []));
+    (match require (Codec.decode_canonical_events codec []) with
+     | Ok events -> check int "empty decode" 0 (List.length events)
+     | Error _ -> fail "empty canonical decode failed");
+    check
+      bool
+      "empty canonical payloads compare exactly"
+      true
+      (require (Codec.compare_canonical_payloads codec ~expected:[] ~actual:[]));
+    let stats = Codec.stats codec in
+    let encode_worker =
+      require_worker "encode" caller stats.encode_events.last_worker_domain
+    in
+    let decode_worker =
+      require_worker "decode" caller stats.decode_canonical_events.last_worker_domain
+    in
+    let compare_worker =
+      require_worker "compare" caller stats.compare_canonical_payloads.last_worker_domain
+    in
+    check bool "encode and decode share one worker" true (encode_worker = decode_worker);
+    check bool "decode and compare share one worker" true (decode_worker = compare_worker);
+    List.iter
+      (fun (name, (operation : Codec.operation_stats)) ->
+         check int (name ^ " requested") 1 operation.requested;
+         check int (name ^ " started") 1 operation.started;
+         check int (name ^ " completed") 1 operation.completed;
+         check int (name ^ " job failures") 0 operation.job_failed;
+         check int (name ^ " executor failures") 0 operation.executor_failed;
+         check int (name ^ " caller cancellations") 0 operation.caller_cancelled;
+         check
+           bool
+           (name ^ " caller identity")
+           true
+           (operation.last_caller_domain = Some caller))
+      [ "encode", stats.encode_events
+      ; "decode", stats.decode_canonical_events
+      ; "compare", stats.compare_canonical_payloads
+      ])
+;;
+
+let test_invalid_event_is_typed_codec_result env =
+  Eio.Switch.run (fun sw ->
+    let pool = Eio.Executor_pool.create ~sw ~domain_count:1 (Eio.Stdenv.domain_mgr env) in
+    let codec = Codec.of_executor_pool pool in
+    match require (Codec.decode_canonical_events codec [ "{}" ]) with
+    | Error (Codec.Invalid_event { ordinal = 0; detail = _ }) -> ()
+    | Error (Codec.Invalid_event { ordinal; _ }) ->
+      failf "invalid event ordinal = %d" ordinal
+    | Error (Codec.Noncanonical_event _) -> fail "invalid event reported as noncanonical"
+    | Ok _ -> fail "invalid event decoded successfully")
+;;
+
+let test_released_pool_is_typed_executor_failure env =
+  let escaped = ref None in
+  Eio.Switch.run (fun sw ->
+    let pool = Eio.Executor_pool.create ~sw ~domain_count:1 (Eio.Stdenv.domain_mgr env) in
+    escaped := Some (Codec.of_executor_pool pool));
+  let codec = Option.get !escaped in
+  match Codec.encode_events codec [] with
+  | Error (Codec.Executor_unavailable { operation = Codec.Encode_events; _ }) -> ()
+  | Error failure ->
+    fail ("unexpected released-pool failure: " ^ Codec.failure_to_string failure)
+  | Ok _ -> fail "released executor pool accepted a codec request"
+;;
+
+let test_waiting_caller_cancellation_is_observed env =
+  Eio.Switch.run (fun sw ->
+    let pool = Eio.Executor_pool.create ~sw ~domain_count:1 (Eio.Stdenv.domain_mgr env) in
+    let codec = Codec.of_executor_pool pool in
+    let blocker_started = Atomic.make false in
+    let release_blocker = Atomic.make false in
+    let blocker_finished, resolve_blocker_finished = Eio.Promise.create () in
+    Eio.Fiber.fork ~sw (fun () ->
+      Eio.Executor_pool.submit_exn pool ~weight:1.0 (fun () ->
+        Atomic.set blocker_started true;
+        while not (Atomic.get release_blocker) do
+          Domain.cpu_relax ()
+        done);
+      Eio.Promise.resolve resolve_blocker_finished ());
+    await_true blocker_started;
+    let cancelled =
+      match
+        Eio.Cancel.sub (fun context ->
+          Eio.Fiber.fork ~sw (fun () ->
+            await_requested codec;
+            Eio.Cancel.protect (fun () ->
+              Eio.Cancel.cancel context Cancel_codec_waiter;
+              Atomic.set release_blocker true));
+          ignore (Codec.encode_events codec [] : (string list, Codec.failure) result))
+      with
+      | () -> false
+      | exception Eio.Cancel.Cancelled Cancel_codec_waiter -> true
+      | exception exn -> raise exn
+    in
+    check bool "waiting codec caller is cancelled" true cancelled;
+    Eio.Promise.await blocker_finished;
+    let stats = (Codec.stats codec).encode_events in
+    check int "cancelled request remains observed" 1 stats.requested;
+    check int "caller cancellation is explicit" 1 stats.caller_cancelled)
+;;
+
+let () =
+  Eio_main.run (fun env ->
+    run
+      "execution codec executor"
+      [ ( "real pool"
+        , [ test_case "closed requests share one off-domain worker" `Quick (fun () ->
+              test_closed_requests_share_real_worker env)
+          ; test_case "invalid event remains a typed decode result" `Quick (fun () ->
+              test_invalid_event_is_typed_codec_result env)
+          ; test_case "released pool is an explicit executor failure" `Quick (fun () ->
+              test_released_pool_is_typed_executor_failure env)
+          ; test_case "waiting caller cancellation remains explicit" `Quick (fun () ->
+              test_waiting_caller_cancellation_is_observed env)
+          ] )
+      ])
+;;

--- a/test/test_execution_event_store.ml
+++ b/test/test_execution_event_store.ml
@@ -1,4 +1,5 @@
 open Alcotest
+module Runtime_internal = Execution_runtime
 open Agent_sdk
 module Event = Execution_event
 module Codec = Execution_codec_executor
@@ -16,6 +17,11 @@ let require_store = function
 let require_journal = function
   | Ok value -> value
   | Error error -> fail (Journal.error_to_string error)
+;;
+
+let require_runtime = function
+  | Ok value -> value
+  | Error error -> fail (Runtime_internal.create_error_to_string error)
 ;;
 
 let create_store ~codec ~sw ~dir =
@@ -37,10 +43,14 @@ let attach_store store = require_store (Store.attach store)
 
 let with_temp_dir env f =
   Eio.Switch.run (fun codec_sw ->
-    let pool =
-      Eio.Executor_pool.create ~sw:codec_sw ~domain_count:1 (Eio.Stdenv.domain_mgr env)
+    let runtime =
+      require_runtime
+        (Runtime_internal.create
+           ~sw:codec_sw
+           ~domain_mgr:(Eio.Stdenv.domain_mgr env)
+           ~domain_count:1)
     in
-    let codec = Codec.of_executor_pool pool in
+    let codec = Codec.of_runtime runtime in
     let native_path = Filename.temp_file "oas-execution-store-" ".dir" in
     Sys.remove native_path;
     let dir = Eio.Path.(Eio.Stdenv.fs env / native_path) in
@@ -531,6 +541,43 @@ let test_projection_detects_middle_event_corruption () =
       match Store.append_batch writer ~expected_next_seq:1 [ first ] with
       | Error (Store.Store_poisoned _) -> ()
       | _ -> fail "projection corruption did not fence the writer"))
+;;
+
+let test_retry_validates_later_frames_after_content_mismatch () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun codec dir ->
+    Eio.Switch.run (fun sw ->
+      let store = create_store ~codec ~sw ~dir in
+      let writer = attach_store store in
+      let events = make_four_events (Store.correlation_id store) in
+      ignore (require_store (Store.append_batch writer ~expected_next_seq:1 events));
+      let later_payload = Event.to_json_string (List.nth events 1) in
+      let wal = Eio.Path.(dir / "events.v1.wal") in
+      let bytes = Bytes.of_string (Eio.Path.load wal) in
+      let payload_offset =
+        try
+          Str.search_forward (Str.regexp_string later_payload) (Bytes.to_string bytes) 0
+        with
+        | Not_found -> fail "later event payload was not found in WAL fixture"
+      in
+      Bytes.set
+        bytes
+        payload_offset
+        (Char.chr (Char.code (Bytes.get bytes payload_offset) lxor 1));
+      Eio.Path.with_open_out ~create:(`Or_truncate 0o600) wal (fun file ->
+        Eio.Flow.copy_string (Bytes.unsafe_to_string bytes) file;
+        Eio.File.sync file);
+      let different_events = make_four_events (Store.correlation_id store) in
+      (match Store.append_batch writer ~expected_next_seq:1 different_events with
+       | Error (Store.Corrupt_store _) -> ()
+       | Error (Store.Committed_content_conflict _) ->
+         fail "retry stopped at the first content mismatch before later corruption"
+       | Error error -> fail ("unexpected retry failure: " ^ Store.error_to_string error)
+       | Ok _ -> fail "corrupt committed range was accepted as an idempotent retry");
+      match Store.append_batch writer ~expected_next_seq:1 different_events with
+      | Error (Store.Store_poisoned _) -> ()
+      | _ -> fail "retry corruption did not fence the writer"))
 ;;
 
 let test_projection_verifies_middle_event_frame_header () =
@@ -1318,7 +1365,7 @@ let test_shared_codec_executor_routes_store_work () =
       | Error error -> fail (Store.error_to_string error));
     let after_append = Codec.stats codec in
     check int "append submits one encode batch" 1 after_append.encode_events.requested;
-    check int "append does not decode" 0 after_append.decode_canonical_events.requested;
+    check int "append does not decode" 0 after_append.decode_canonical_event.requested;
     Eio.Switch.run (fun sw ->
       let durable_writer, _recovery =
         require_journal (Journal.open_durable_writer ~sw ~codec ~dir)
@@ -1331,9 +1378,9 @@ let test_shared_codec_executor_routes_store_work () =
     let after_journal_open = Codec.stats codec in
     check
       int
-      "journal open decodes each durable batch once"
-      1
-      after_journal_open.decode_canonical_events.requested;
+      "journal open decodes each durable event once"
+      (List.length !events)
+      after_journal_open.decode_canonical_event.requested;
     Eio.Switch.run (fun sw ->
       let opened = require_store (Store.open_existing ~sw ~codec ~dir) in
       check_events "open replay artifact is exact" !events opened.replay_events;
@@ -1355,14 +1402,14 @@ let test_shared_codec_executor_routes_store_work () =
     check int "retry reuses one encoded expected batch" 2 stats.encode_events.requested;
     check
       int
-      "two opens plus one page are three batch decodes"
-      3
-      stats.decode_canonical_events.requested;
+      "two opens plus one page decode each event without raw batch retention"
+      (3 * List.length !events)
+      stats.decode_canonical_event.requested;
     check
       int
-      "exact retry is one canonical payload comparison"
-      1
-      stats.compare_canonical_payloads.requested;
+      "exact retry compares each canonical payload without retaining committed batch"
+      (List.length !events)
+      stats.compare_canonical_payload.requested;
     let worker name (operation : Codec.operation_stats) =
       match operation.last_worker_domain with
       | None -> fail (name ^ " did not record a worker domain")
@@ -1371,8 +1418,8 @@ let test_shared_codec_executor_routes_store_work () =
         worker
     in
     let encode_worker = worker "encode" stats.encode_events in
-    let decode_worker = worker "decode" stats.decode_canonical_events in
-    let compare_worker = worker "compare" stats.compare_canonical_payloads in
+    let decode_worker = worker "decode" stats.decode_canonical_event in
+    let compare_worker = worker "compare" stats.compare_canonical_payload in
     check
       bool
       "encode/decode share the application worker"
@@ -1392,13 +1439,14 @@ let test_released_codec_fails_before_store_mutation () =
     Eio.Switch.run (fun store_sw ->
       let store =
         Eio.Switch.run (fun codec_sw ->
-          let pool =
-            Eio.Executor_pool.create
-              ~sw:codec_sw
-              ~domain_count:1
-              (Eio.Stdenv.domain_mgr env)
+          let runtime =
+            require_runtime
+              (Runtime_internal.create
+                 ~sw:codec_sw
+                 ~domain_mgr:(Eio.Stdenv.domain_mgr env)
+                 ~domain_count:1)
           in
-          create_store ~codec:(Codec.of_executor_pool pool) ~sw:store_sw ~dir)
+          create_store ~codec:(Codec.of_runtime runtime) ~sw:store_sw ~dir)
       in
       let events = make_four_events (Store.correlation_id store) in
       let writer = attach_store store in
@@ -1465,6 +1513,10 @@ let () =
             "projection detects middle event corruption"
             `Quick
             test_projection_detects_middle_event_corruption
+        ; test_case
+            "retry validates later corruption after an earlier mismatch"
+            `Quick
+            test_retry_validates_later_frames_after_content_mismatch
         ; test_case
             "projection verifies middle event frame header"
             `Quick

--- a/test/test_execution_event_store.ml
+++ b/test/test_execution_event_store.ml
@@ -1,6 +1,7 @@
 open Alcotest
 open Agent_sdk
 module Event = Execution_event
+module Codec = Execution_codec_executor
 module Journal = Execution_journal
 module Store = Execution_event_store
 
@@ -17,9 +18,9 @@ let require_journal = function
   | Error error -> fail (Journal.error_to_string error)
 ;;
 
-let create_store ~sw ~dir =
+let create_store ~codec ~sw ~dir =
   if not (Eio.Path.is_directory dir) then Eio.Path.mkdirs ~exists_ok:false ~perm:0o700 dir;
-  let store, initialization = require_store (Store.create ~sw ~dir ()) in
+  let store, initialization = require_store (Store.create ~sw ~codec ~dir ()) in
   (match initialization with
    | Store.Fresh -> ()
    | Store.Recovered_uncommitted_initialization ->
@@ -27,14 +28,39 @@ let create_store ~sw ~dir =
   store
 ;;
 
-let open_store ~sw ~dir = Store.open_existing ~sw ~dir
+let open_store ~codec ~sw ~dir =
+  Store.open_existing ~sw ~codec ~dir
+  |> Result.map (fun (opened : Store.opened) -> opened.store, opened.recovery)
+;;
+
 let attach_store store = require_store (Store.attach store)
 
 let with_temp_dir env f =
-  let native_path = Filename.temp_file "oas-execution-store-" ".dir" in
-  Sys.remove native_path;
-  let dir = Eio.Path.(Eio.Stdenv.fs env / native_path) in
-  Fun.protect ~finally:(fun () -> Eio.Path.rmtree ~missing_ok:true dir) (fun () -> f dir)
+  Eio.Switch.run (fun codec_sw ->
+    let pool =
+      Eio.Executor_pool.create ~sw:codec_sw ~domain_count:1 (Eio.Stdenv.domain_mgr env)
+    in
+    let codec = Codec.of_executor_pool pool in
+    let native_path = Filename.temp_file "oas-execution-store-" ".dir" in
+    Sys.remove native_path;
+    let dir = Eio.Path.(Eio.Stdenv.fs env / native_path) in
+    Fun.protect
+      ~finally:(fun () -> Eio.Path.rmtree ~missing_ok:true dir)
+      (fun () -> f codec dir))
+;;
+
+let read_all store =
+  match Store.last_seq store with
+  | Error _ as error -> error
+  | Ok last_seq ->
+    Store.read_page store ~after:(Store.beginning_cursor store) ~limit:(last_seq + 1) ()
+    |> Result.map (fun (page : Store.page) -> page.events)
+;;
+
+let directory_snapshot dir =
+  Eio.Path.read_dir dir
+  |> List.sort String.compare
+  |> List.map (fun name -> name, Eio.Path.load Eio.Path.(dir / name))
 ;;
 
 let make_four_events correlation_id =
@@ -112,11 +138,11 @@ let rewrite_event_seq event seq =
 let test_append_reopen_idempotency_and_paging () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     let expected = ref [] in
     let first_cursor = ref None in
     Eio.Switch.run (fun sw ->
-      let store = create_store ~sw ~dir in
+      let store = create_store ~codec ~sw ~dir in
       let writer = attach_store store in
       let events = make_four_events (Store.correlation_id store) in
       expected := events;
@@ -166,12 +192,12 @@ let test_append_reopen_idempotency_and_paging () =
       | Error (Store.Committed_content_conflict { first_seq = 1; last_seq = 1 }) -> ()
       | _ -> fail "different bytes reused a committed sequence");
     Eio.Switch.run (fun sw ->
-      let store, recovery = require_store (open_store ~sw ~dir) in
+      let store, recovery = require_store (open_store ~codec ~sw ~dir) in
       (match recovery with
        | Store.Clean -> ()
        | _ -> fail "clean WAL reported recovery");
       check int "recovered sequence" 4 (require_store (Store.last_seq store));
-      check_events "full replay" !expected (require_store (Store.load_all store));
+      check_events "full replay" !expected (require_store (read_all store));
       let after = Option.get !first_cursor in
       let page = require_store (Store.read_page store ~after ~limit:8 ()) in
       check int "exclusive second page" 3 (List.length page.events);
@@ -182,9 +208,9 @@ let test_append_reopen_idempotency_and_paging () =
 let test_idempotent_retry_requires_exact_canonical_bytes () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     Eio.Switch.run (fun sw ->
-      let store = create_store ~sw ~dir in
+      let store = create_store ~codec ~sw ~dir in
       let writer = attach_store store in
       let journal =
         require_journal (Journal.create ~correlation_id:(Store.correlation_id store) ())
@@ -237,10 +263,10 @@ let test_idempotent_retry_requires_exact_canonical_bytes () =
 let test_torn_tail_is_explicitly_truncated () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     let expected = ref [] in
     Eio.Switch.run (fun sw ->
-      let store = create_store ~sw ~dir in
+      let store = create_store ~codec ~sw ~dir in
       let writer = attach_store store in
       let events = make_four_events (Store.correlation_id store) in
       expected := events;
@@ -250,19 +276,16 @@ let test_torn_tail_is_explicitly_truncated () =
       Eio.Flow.copy_string "OASE" file;
       Eio.File.sync file);
     Eio.Switch.run (fun sw ->
-      let store, recovery = require_store (open_store ~sw ~dir) in
+      let store, recovery = require_store (open_store ~codec ~sw ~dir) in
       (match recovery with
        | Store.Recovered
            [ Store.Truncated_uncommitted_tail
                { removed_bytes = 4L; last_committed_seq = 4; _ }
            ] -> ()
        | _ -> fail "incomplete tail was not reported exactly");
-      check_events
-        "committed prefix survives"
-        !expected
-        (require_store (Store.load_all store)));
+      check_events "committed prefix survives" !expected (require_store (read_all store)));
     Eio.Switch.run (fun sw ->
-      let _store, recovery = require_store (open_store ~sw ~dir) in
+      let _store, recovery = require_store (open_store ~codec ~sw ~dir) in
       match recovery with
       | Store.Clean -> ()
       | _ -> fail "repaired WAL was not clean on the next open"))
@@ -271,7 +294,7 @@ let test_torn_tail_is_explicitly_truncated () =
 let test_partial_final_batch_is_rolled_back_to_committed_prefix () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun root ->
+  with_temp_dir env (fun codec root ->
     let run_case case_name cutoff_of_sizes =
       let dir = Eio.Path.(root / case_name) in
       Eio.Path.mkdirs ~exists_ok:false ~perm:0o700 dir;
@@ -280,7 +303,7 @@ let test_partial_final_batch_is_rolled_back_to_committed_prefix () =
       let full_wal = ref "" in
       let expected_prefix = ref [] in
       Eio.Switch.run (fun sw ->
-        let store = create_store ~sw ~dir in
+        let store = create_store ~codec ~sw ~dir in
         let writer = attach_store store in
         let events = make_four_events (Store.correlation_id store) in
         let first, rest =
@@ -307,7 +330,7 @@ let test_partial_final_batch_is_rolled_back_to_committed_prefix () =
         Eio.Flow.copy_string !prefix_authority file;
         Eio.File.sync file);
       Eio.Switch.run (fun sw ->
-        let store, recovery = require_store (open_store ~sw ~dir) in
+        let store, recovery = require_store (open_store ~codec ~sw ~dir) in
         (match recovery with
          | Store.Recovered
              [ Store.Truncated_uncommitted_tail
@@ -327,7 +350,7 @@ let test_partial_final_batch_is_rolled_back_to_committed_prefix () =
         check_events
           "only the committed prefix remains"
           !expected_prefix
-          (require_store (Store.load_all store)))
+          (require_store (read_all store)))
     in
     run_case "mid-batch" (fun prefix full -> prefix + ((full - prefix) / 2));
     run_case "mid-commit" (fun _prefix full -> full - 1))
@@ -336,9 +359,9 @@ let test_partial_final_batch_is_rolled_back_to_committed_prefix () =
 let test_committed_corruption_is_rejected_without_truncation () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     Eio.Switch.run (fun sw ->
-      let store = create_store ~sw ~dir in
+      let store = create_store ~codec ~sw ~dir in
       let writer = attach_store store in
       let events = make_four_events (Store.correlation_id store) in
       ignore (require_store (Store.append_batch writer ~expected_next_seq:1 events)));
@@ -354,7 +377,7 @@ let test_committed_corruption_is_rejected_without_truncation () =
       Eio.File.sync file);
     let corrupted_size = (Eio.Path.stat ~follow:true wal).size in
     Eio.Switch.run (fun sw ->
-      match open_store ~sw ~dir with
+      match open_store ~codec ~sw ~dir with
       | Error (Store.Corrupt_store _) -> ()
       | _ -> fail "committed checksum corruption was silently accepted");
     check
@@ -367,10 +390,10 @@ let test_committed_corruption_is_rejected_without_truncation () =
 let test_authoritative_incomplete_frame_is_not_truncated () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     let middle_payload = ref "" in
     Eio.Switch.run (fun sw ->
-      let store = create_store ~sw ~dir in
+      let store = create_store ~codec ~sw ~dir in
       let writer = attach_store store in
       let events = make_four_events (Store.correlation_id store) in
       middle_payload := Event.to_json_string (List.nth events 1);
@@ -398,7 +421,7 @@ let test_authoritative_incomplete_frame_is_not_truncated () =
       Eio.File.sync file);
     let corrupted_size = (Eio.Path.stat ~follow:true wal).size in
     Eio.Switch.run (fun sw ->
-      match open_store ~sw ~dir with
+      match open_store ~codec ~sw ~dir with
       | Error (Store.Corrupt_store _) -> ()
       | _ -> fail "authoritative incomplete frame was treated as an uncommitted tail");
     check
@@ -411,15 +434,15 @@ let test_authoritative_incomplete_frame_is_not_truncated () =
 let test_foreign_authority_cannot_truncate_wal () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun root ->
+  with_temp_dir env (fun codec root ->
     let target = Eio.Path.(root / "target") in
     let foreign = Eio.Path.(root / "foreign") in
     Eio.Switch.run (fun sw ->
-      let store = create_store ~sw ~dir:target in
+      let store = create_store ~codec ~sw ~dir:target in
       let writer = attach_store store in
       let events = make_four_events (Store.correlation_id store) in
       ignore (require_store (Store.append_batch writer ~expected_next_seq:1 events)));
-    Eio.Switch.run (fun sw -> ignore (create_store ~sw ~dir:foreign));
+    Eio.Switch.run (fun sw -> ignore (create_store ~codec ~sw ~dir:foreign));
     let target_wal = Eio.Path.(target / "events.v1.wal") in
     let target_authority = Eio.Path.(target / "events.v1.commit") in
     let foreign_authority = Eio.Path.(foreign / "events.v1.commit") in
@@ -428,7 +451,7 @@ let test_foreign_authority_cannot_truncate_wal () =
       Eio.Flow.copy_string (Eio.Path.load foreign_authority) file;
       Eio.File.sync file);
     Eio.Switch.run (fun sw ->
-      match open_store ~sw ~dir:target with
+      match open_store ~codec ~sw ~dir:target with
       | Error (Store.Corrupt_store _) -> ()
       | _ -> fail "foreign authority was accepted for the target WAL");
     check
@@ -441,9 +464,9 @@ let test_foreign_authority_cannot_truncate_wal () =
 let test_detected_committed_corruption_poisons_writer () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     Eio.Switch.run (fun sw ->
-      let store = create_store ~sw ~dir in
+      let store = create_store ~codec ~sw ~dir in
       let writer = attach_store store in
       let events = make_four_events (Store.correlation_id store) in
       ignore (require_store (Store.append_batch writer ~expected_next_seq:1 events));
@@ -464,7 +487,7 @@ let test_detected_committed_corruption_poisons_writer () =
       Eio.Path.with_open_out ~create:(`Or_truncate 0o600) wal (fun file ->
         Eio.Flow.copy_string (Bytes.unsafe_to_string bytes) file;
         Eio.File.sync file);
-      (match Store.load_all store with
+      (match read_all store with
        | Error (Store.Corrupt_store _) -> ()
        | _ -> fail "same-size committed corruption was not detected");
       (match Store.read_page store ~after:(Store.beginning_cursor store) ~limit:1 () with
@@ -478,9 +501,9 @@ let test_detected_committed_corruption_poisons_writer () =
 let test_projection_detects_middle_event_corruption () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     Eio.Switch.run (fun sw ->
-      let store = create_store ~sw ~dir in
+      let store = create_store ~codec ~sw ~dir in
       let writer = attach_store store in
       let events = make_four_events (Store.correlation_id store) in
       ignore (require_store (Store.append_batch writer ~expected_next_seq:1 events));
@@ -502,7 +525,7 @@ let test_projection_detects_middle_event_corruption () =
       Eio.Path.with_open_out ~create:(`Or_truncate 0o600) wal (fun file ->
         Eio.Flow.copy_string (Bytes.unsafe_to_string bytes) file;
         Eio.File.sync file);
-      (match Store.load_all store with
+      (match read_all store with
        | Error (Store.Corrupt_store _) -> ()
        | _ -> fail "projection ignored corrupted middle event bytes");
       match Store.append_batch writer ~expected_next_seq:1 [ first ] with
@@ -513,9 +536,9 @@ let test_projection_detects_middle_event_corruption () =
 let test_projection_verifies_middle_event_frame_header () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     Eio.Switch.run (fun sw ->
-      let store = create_store ~sw ~dir in
+      let store = create_store ~codec ~sw ~dir in
       let writer = attach_store store in
       let events = make_four_events (Store.correlation_id store) in
       ignore (require_store (Store.append_batch writer ~expected_next_seq:1 events));
@@ -536,7 +559,7 @@ let test_projection_verifies_middle_event_frame_header () =
       Eio.Path.with_open_out ~create:(`Or_truncate 0o600) wal (fun file ->
         Eio.Flow.copy_string (Bytes.unsafe_to_string bytes) file;
         Eio.File.sync file);
-      (match Store.load_all store with
+      (match read_all store with
        | Error (Store.Corrupt_store _) -> ()
        | _ -> fail "projection ignored a corrupted middle event frame header");
       match Store.append_batch writer ~expected_next_seq:1 [ first ] with
@@ -547,24 +570,24 @@ let test_projection_verifies_middle_event_frame_header () =
 let test_uncommitted_initialization_is_explicitly_recovered () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     Eio.Path.mkdirs ~exists_ok:false ~perm:0o700 dir;
     let initializing = Eio.Path.(dir / "events.v1.wal.initializing") in
     Eio.Path.with_open_out ~create:(`Exclusive 0o600) initializing (fun file ->
       Eio.Flow.copy_string "incomplete metadata" file;
       Eio.File.sync file);
     Eio.Switch.run (fun sw ->
-      match open_store ~sw ~dir with
+      match open_store ~codec ~sw ~dir with
       | Error Store.Store_initialization_incomplete -> ()
       | _ -> fail "orphan initialization was not reported");
     Eio.Switch.run (fun sw ->
-      let store, initialization = require_store (Store.create ~sw ~dir ()) in
+      let store, initialization = require_store (Store.create ~sw ~codec ~dir ()) in
       (match initialization with
        | Store.Recovered_uncommitted_initialization -> ()
        | Store.Fresh -> fail "orphan initialization recovery was silent");
       check int "recovered store begins empty" 0 (require_store (Store.last_seq store)));
     Eio.Switch.run (fun sw ->
-      let store, recovery = require_store (open_store ~sw ~dir) in
+      let store, recovery = require_store (open_store ~codec ~sw ~dir) in
       check int "recovered store reopens" 0 (require_store (Store.last_seq store));
       match recovery with
       | Store.Clean -> ()
@@ -574,13 +597,13 @@ let test_uncommitted_initialization_is_explicitly_recovered () =
 let test_initial_commit_authority_is_rebuilt_explicitly () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
-    Eio.Switch.run (fun sw -> ignore (create_store ~sw ~dir));
+  with_temp_dir env (fun codec dir ->
+    Eio.Switch.run (fun sw -> ignore (create_store ~codec ~sw ~dir));
     let authority = Eio.Path.(dir / "events.v1.commit") in
     let initializing = Eio.Path.(dir / "events.v1.commit.initializing") in
     Eio.Path.rename authority initializing;
     Eio.Switch.run (fun sw ->
-      let store, recovery = require_store (open_store ~sw ~dir) in
+      let store, recovery = require_store (open_store ~codec ~sw ~dir) in
       check
         int
         "rebuilt authority keeps the empty store"
@@ -591,7 +614,7 @@ let test_initial_commit_authority_is_rebuilt_explicitly () =
           [ Store.Discarded_uncommitted_authority; Store.Rebuilt_initial_authority ] -> ()
       | _ -> fail "initial authority recovery was not reported exactly");
     Eio.Switch.run (fun sw ->
-      let _store, recovery = require_store (open_store ~sw ~dir) in
+      let _store, recovery = require_store (open_store ~codec ~sw ~dir) in
       match recovery with
       | Store.Clean -> ()
       | _ -> fail "rebuilt authority was not clean on the next open"))
@@ -600,16 +623,16 @@ let test_initial_commit_authority_is_rebuilt_explicitly () =
 let test_failed_create_releases_writer_immediately () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     Eio.Path.mkdirs ~exists_ok:false ~perm:0o700 dir;
     let wal = Eio.Path.(dir / "events.v1.wal") in
     Eio.Path.save ~create:(`Exclusive 0o600) wal "preexisting";
     Eio.Switch.run (fun sw ->
-      (match Store.create ~sw ~dir () with
+      (match Store.create ~sw ~codec ~dir () with
        | Error Store.Store_already_exists -> ()
        | _ -> fail "preexisting WAL was not rejected");
       Eio.Path.unlink wal;
-      match Store.create ~sw ~dir () with
+      match Store.create ~sw ~codec ~dir () with
       | Ok (_store, Store.Fresh) -> ()
       | Error Store.Writer_already_active ->
         fail "failed create leaked its writer claim until switch release"
@@ -619,9 +642,9 @@ let test_failed_create_releases_writer_immediately () =
 let test_failed_journal_replay_releases_store_immediately () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     Eio.Switch.run (fun sw ->
-      let store = create_store ~sw ~dir in
+      let store = create_store ~codec ~sw ~dir in
       let writer = attach_store store in
       let invalid = List.nth (make_four_events (Store.correlation_id store)) 1 in
       let invalid = rewrite_event_seq invalid 1 in
@@ -631,7 +654,7 @@ let test_failed_journal_replay_releases_store_immediately () =
       | Error error -> fail (Store.error_to_string error));
     Eio.Switch.run (fun sw ->
       let expect_semantic_replay_failure () =
-        match Journal.open_durable_writer ~sw ~dir with
+        match Journal.open_durable_writer ~sw ~codec ~dir with
         | Error
             (Journal.Invariant_violation
                (Journal.Unknown_parent_event _ | Journal.Unknown_parent_node _)) -> ()
@@ -645,17 +668,17 @@ let test_failed_journal_replay_releases_store_immediately () =
 let test_create_unknown_outcome_reconciles_through_open () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     Eio.Path.mkdirs ~exists_ok:false ~perm:0o700 dir;
     let blocker = Eio.Path.(dir / "events.v1.commit.initializing") in
     Eio.Path.mkdirs ~exists_ok:false ~perm:0o700 blocker;
     Eio.Switch.run (fun sw ->
-      match Store.create ~sw ~dir () with
+      match Store.create ~sw ~codec ~dir () with
       | Error (Store.Commit_outcome_unknown _) -> ()
       | _ -> fail "post-WAL create failure was not classified as outcome unknown");
     Eio.Path.rmtree ~missing_ok:false blocker;
     Eio.Switch.run (fun sw ->
-      let store, recovery = require_store (open_store ~sw ~dir) in
+      let store, recovery = require_store (open_store ~codec ~sw ~dir) in
       check
         int
         "reconciled unknown create is empty"
@@ -669,9 +692,9 @@ let test_create_unknown_outcome_reconciles_through_open () =
 let test_append_failure_rolls_back_before_authority () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     Eio.Switch.run (fun sw ->
-      let store = create_store ~sw ~dir in
+      let store = create_store ~codec ~sw ~dir in
       let writer = attach_store store in
       let events = make_four_events (Store.correlation_id store) in
       let blocker = Eio.Path.(dir / "events.v1.commit.initializing") in
@@ -690,7 +713,7 @@ let test_append_failure_rolls_back_before_authority () =
        | _ -> fail "append could not retry after proven rollback");
       check int "retried append committed" 4 (require_store (Store.last_seq store)));
     Eio.Switch.run (fun sw ->
-      let store, recovery = require_store (open_store ~sw ~dir) in
+      let store, recovery = require_store (open_store ~codec ~sw ~dir) in
       check int "retried append reopens" 4 (require_store (Store.last_seq store));
       match recovery with
       | Store.Clean -> ()
@@ -700,9 +723,9 @@ let test_append_failure_rolls_back_before_authority () =
 let test_cancelled_append_does_not_mutate_store () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     Eio.Switch.run (fun sw ->
-      let store = create_store ~sw ~dir in
+      let store = create_store ~codec ~sw ~dir in
       let writer = attach_store store in
       let events = make_four_events (Store.correlation_id store) in
       let wal = Eio.Path.(dir / "events.v1.wal") in
@@ -738,13 +761,13 @@ let test_cancelled_append_does_not_mutate_store () =
 let test_journal_persists_before_publish_and_replays () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     Eio.Path.mkdirs ~exists_ok:false ~perm:0o700 dir;
     let run_handle = ref None in
     let opened_event = ref None in
     Eio.Switch.run (fun sw ->
       let writer, initialization =
-        require_journal (Journal.create_durable_writer ~sw ~dir ())
+        require_journal (Journal.create_durable_writer ~sw ~codec ~dir ())
       in
       (match initialization with
        | Store.Fresh -> ()
@@ -765,7 +788,9 @@ let test_journal_persists_before_publish_and_replays () =
         (require_journal (Journal.commit_durable_batch writer batch));
       check int "journal published one event" 1 (Journal.length journal));
     Eio.Switch.run (fun sw ->
-      let writer, recovery = require_journal (Journal.open_durable_writer ~sw ~dir) in
+      let writer, recovery =
+        require_journal (Journal.open_durable_writer ~sw ~codec ~dir)
+      in
       (match recovery with
        | Store.Clean -> ()
        | _ -> fail "unexpected recovery");
@@ -786,7 +811,9 @@ let test_journal_persists_before_publish_and_replays () =
       ignore (require_journal (Journal.commit_durable_batch writer batch));
       check int "finish durably committed" 2 (Journal.last_seq journal));
     Eio.Switch.run (fun sw ->
-      let writer, _recovery = require_journal (Journal.open_durable_writer ~sw ~dir) in
+      let writer, _recovery =
+        require_journal (Journal.open_durable_writer ~sw ~codec ~dir)
+      in
       let journal = Journal.durable_writer_journal writer in
       check int "finished scope fully replayed" 2 (Journal.length journal);
       match
@@ -801,12 +828,12 @@ let test_journal_persists_before_publish_and_replays () =
 let test_durable_journal_batch_commits_one_exact_authority_step () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     Eio.Path.mkdirs ~exists_ok:false ~perm:0o700 dir;
     let exact_events = ref [] in
     Eio.Switch.run (fun sw ->
       let writer, initialization =
-        require_journal (Journal.create_durable_writer ~sw ~dir ())
+        require_journal (Journal.create_durable_writer ~sw ~codec ~dir ())
       in
       (match initialization with
        | Store.Fresh -> ()
@@ -876,7 +903,9 @@ let test_durable_journal_batch_commits_one_exact_authority_step () =
         (Journal.cursor_seq page.next_cursor);
       exact_events := expected);
     Eio.Switch.run (fun sw ->
-      let writer, recovery = require_journal (Journal.open_durable_writer ~sw ~dir) in
+      let writer, recovery =
+        require_journal (Journal.open_durable_writer ~sw ~codec ~dir)
+      in
       (match recovery with
        | Store.Clean -> ()
        | Store.Recovered _ -> fail "clean durable batch required recovery");
@@ -891,11 +920,11 @@ let test_durable_journal_batch_commits_one_exact_authority_step () =
 let test_external_wal_mutation_fails_without_journal_publish () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     Eio.Path.mkdirs ~exists_ok:false ~perm:0o700 dir;
     Eio.Switch.run (fun sw ->
       let writer, _initialization =
-        require_journal (Journal.create_durable_writer ~sw ~dir ())
+        require_journal (Journal.create_durable_writer ~sw ~codec ~dir ())
       in
       let journal = Journal.durable_writer_journal writer in
       let batch, (run, _opened) =
@@ -928,10 +957,10 @@ let test_external_wal_mutation_fails_without_journal_publish () =
 let test_cursor_scope_and_writer_exclusivity () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     Eio.Switch.run (fun sw ->
-      let store = create_store ~sw ~dir in
-      (match open_store ~sw ~dir with
+      let store = create_store ~codec ~sw ~dir in
+      (match open_store ~codec ~sw ~dir with
        | Error Store.Writer_already_active -> ()
        | _ -> fail "a second in-process writer acquired the same scope");
       ignore (attach_store store);
@@ -1001,11 +1030,11 @@ let test_durable_writer_rejects_direct_mutation () =
    | Journal.Final_failure -> ()
    | Journal.Reconcile_required ->
      fail "definite writer conflict requested reconciliation");
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     Eio.Path.mkdirs ~exists_ok:false ~perm:0o700 dir;
     Eio.Switch.run (fun sw ->
       let writer, _initialization =
-        require_journal (Journal.create_durable_writer ~sw ~dir ())
+        require_journal (Journal.create_durable_writer ~sw ~codec ~dir ())
       in
       let journal = Journal.durable_writer_journal writer in
       (match Journal.start_run journal ~agent_name:"bypass" with
@@ -1041,7 +1070,7 @@ let test_durable_writer_rejects_direct_mutation () =
 let test_reopened_writer_reconciles_only_exact_batch () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun root ->
+  with_temp_dir env (fun codec root ->
     Eio.Path.mkdirs ~exists_ok:false ~perm:0o700 root;
     let applied_dir = Eio.Path.(root / "applied") in
     let sequence_dir = Eio.Path.(root / "sequence") in
@@ -1054,14 +1083,14 @@ let test_reopened_writer_reconciles_only_exact_batch () =
     let applied_events = ref [] in
     Eio.Switch.run (fun sw ->
       let writer, _ =
-        require_journal (Journal.create_durable_writer ~sw ~dir:applied_dir ())
+        require_journal (Journal.create_durable_writer ~sw ~codec ~dir:applied_dir ())
       in
       let batch, (_run, opened) = stage_started_batch writer "reconcile-applied" in
       applied_batch := Some batch;
       applied_events := [ opened ]);
     Eio.Switch.run (fun sw ->
       let writer, _ =
-        require_journal (Journal.open_durable_writer ~sw ~dir:applied_dir)
+        require_journal (Journal.open_durable_writer ~sw ~codec ~dir:applied_dir)
       in
       match
         require_journal
@@ -1072,7 +1101,7 @@ let test_reopened_writer_reconciles_only_exact_batch () =
       | Journal.Already_durable _ -> fail "uncommitted batch was reported durable");
     Eio.Switch.run (fun sw ->
       let writer, _ =
-        require_journal (Journal.open_durable_writer ~sw ~dir:applied_dir)
+        require_journal (Journal.open_durable_writer ~sw ~codec ~dir:applied_dir)
       in
       match
         require_journal
@@ -1084,14 +1113,14 @@ let test_reopened_writer_reconciles_only_exact_batch () =
     let sequence_batch = ref None in
     Eio.Switch.run (fun sw ->
       let writer, _ =
-        require_journal (Journal.create_durable_writer ~sw ~dir:sequence_dir ())
+        require_journal (Journal.create_durable_writer ~sw ~codec ~dir:sequence_dir ())
       in
       sequence_batch := Some (fst (stage_finished_batch writer "four-events"));
       let winner, _ = stage_started_batch writer "one-event" in
       ignore (require_journal (Journal.commit_durable_batch writer winner)));
     Eio.Switch.run (fun sw ->
       let writer, _ =
-        require_journal (Journal.open_durable_writer ~sw ~dir:sequence_dir)
+        require_journal (Journal.open_durable_writer ~sw ~codec ~dir:sequence_dir)
       in
       match Journal.reconcile_durable_batch writer (Option.get !sequence_batch) with
       | Error
@@ -1102,14 +1131,14 @@ let test_reopened_writer_reconciles_only_exact_batch () =
     let conflicting_batch = ref None in
     Eio.Switch.run (fun sw ->
       let writer, _ =
-        require_journal (Journal.create_durable_writer ~sw ~dir:content_dir ())
+        require_journal (Journal.create_durable_writer ~sw ~codec ~dir:content_dir ())
       in
       conflicting_batch := Some (fst (stage_started_batch writer "candidate"));
       let winner, _ = stage_started_batch writer "different-bytes" in
       ignore (require_journal (Journal.commit_durable_batch writer winner)));
     Eio.Switch.run (fun sw ->
       let writer, _ =
-        require_journal (Journal.open_durable_writer ~sw ~dir:content_dir)
+        require_journal (Journal.open_durable_writer ~sw ~codec ~dir:content_dir)
       in
       match Journal.reconcile_durable_batch writer (Option.get !conflicting_batch) with
       | Error (Journal.Reconciliation_content_conflict { first_seq = 1; last_seq = 1 }) ->
@@ -1118,7 +1147,7 @@ let test_reopened_writer_reconciles_only_exact_batch () =
       | Ok _ -> fail "reconcile accepted different canonical event bytes");
     Eio.Switch.run (fun sw ->
       let writer, _ =
-        require_journal (Journal.create_durable_writer ~sw ~dir:foreign_dir ())
+        require_journal (Journal.create_durable_writer ~sw ~codec ~dir:foreign_dir ())
       in
       match Journal.reconcile_durable_batch writer (Option.get !applied_batch) with
       | Error Journal.Reconciliation_scope_mismatch -> ()
@@ -1129,16 +1158,16 @@ let test_reopened_writer_reconciles_only_exact_batch () =
 let test_store_lifecycle_transition_matrix () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     Eio.Switch.run (fun sw ->
-      let store = create_store ~sw ~dir in
+      let store = create_store ~codec ~sw ~dir in
       ignore (require_store (Store.release_unpublished store));
       ignore (require_store (Store.release_unpublished store));
       (match Store.attach store with
        | Error Store.Store_released -> ()
        | Error error -> fail (Store.error_to_string error)
        | Ok _ -> fail "released unpublished store minted a writer");
-      let reopened, _recovery = require_store (Store.open_existing ~sw ~dir) in
+      let reopened, _recovery = require_store (open_store ~codec ~sw ~dir) in
       let writer = attach_store reopened in
       (match Store.release_unpublished reopened with
        | Error Store.Store_release_forbidden -> ()
@@ -1156,10 +1185,10 @@ let test_store_lifecycle_transition_matrix () =
 let test_explicit_release_removes_long_lived_switch_hooks () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     Eio.Switch.run (fun sw ->
       let release_and_keep_only_weak_reference () =
-        let store = create_store ~sw ~dir in
+        let store = create_store ~codec ~sw ~dir in
         let weak = Weak.create 1 in
         Weak.set weak 0 (Some store);
         ignore (require_store (Store.release_unpublished store));
@@ -1170,16 +1199,16 @@ let test_explicit_release_removes_long_lived_switch_hooks () =
       (match Weak.get released 0 with
        | None -> ()
        | Some _ -> fail "released store remained retained by a long-lived switch hook");
-      let reopened, _recovery = require_store (Store.open_existing ~sw ~dir) in
+      let reopened, _recovery = require_store (open_store ~codec ~sw ~dir) in
       ignore (require_store (Store.release_unpublished reopened))))
 ;;
 
 let test_unpublished_store_is_released_with_switch () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     let escaped = ref None in
-    Eio.Switch.run (fun sw -> escaped := Some (create_store ~sw ~dir));
+    Eio.Switch.run (fun sw -> escaped := Some (create_store ~codec ~sw ~dir));
     let store = Option.get !escaped in
     (match Store.attach store with
      | Error Store.Store_released -> ()
@@ -1190,18 +1219,18 @@ let test_unpublished_store_is_released_with_switch () =
      | Error error -> fail (Store.error_to_string error)
      | Ok _ -> fail "switch-released store exposed a stale sequence");
     Eio.Switch.run (fun sw ->
-      let reopened, _recovery = require_store (Store.open_existing ~sw ~dir) in
+      let reopened, _recovery = require_store (open_store ~codec ~sw ~dir) in
       ignore (attach_store reopened)))
 ;;
 
 let test_unpublished_store_is_released_with_failed_switch () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     let escaped = ref None in
     (match
        Eio.Switch.run (fun sw ->
-         escaped := Some (create_store ~sw ~dir);
+         escaped := Some (create_store ~codec ~sw ~dir);
          Eio.Switch.fail sw Store_scope_failed)
      with
      | () -> fail "failed switch returned normally"
@@ -1213,19 +1242,19 @@ let test_unpublished_store_is_released_with_failed_switch () =
      | Error error -> fail (Store.error_to_string error)
      | Ok _ -> fail "failed-switch store exposed a stale sequence");
     Eio.Switch.run (fun sw ->
-      let reopened, _recovery = require_store (Store.open_existing ~sw ~dir) in
+      let reopened, _recovery = require_store (open_store ~codec ~sw ~dir) in
       ignore (attach_store reopened)))
 ;;
 
 let test_published_store_rejects_use_after_switch () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     let escaped_store = ref None in
     let escaped_writer = ref None in
     let events = ref [] in
     Eio.Switch.run (fun sw ->
-      let store = create_store ~sw ~dir in
+      let store = create_store ~codec ~sw ~dir in
       let writer = attach_store store in
       let committed = make_four_events (Store.correlation_id store) in
       ignore (require_store (Store.append_batch writer ~expected_next_seq:1 committed));
@@ -1244,12 +1273,12 @@ let test_published_store_rejects_use_after_switch () =
     in
     expect_released (Store.last_seq store);
     expect_released (Store.current_cursor store);
-    expect_released (Store.load_all store);
+    expect_released (read_all store);
     expect_released
       (Store.read_page store ~after:(Store.beginning_cursor store) ~limit:1 ());
     expect_released (Store.append_batch writer ~expected_next_seq:5 next_events);
     Eio.Switch.run (fun sw ->
-      let reopened, _recovery = require_store (Store.open_existing ~sw ~dir) in
+      let reopened, _recovery = require_store (open_store ~codec ~sw ~dir) in
       let current_writer = attach_store reopened in
       check
         int
@@ -1271,6 +1300,129 @@ let test_published_store_rejects_use_after_switch () =
         "new owner commits the valid next batch"
         8
         (require_store (Store.last_seq reopened))))
+;;
+
+let test_shared_codec_executor_routes_store_work () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun codec dir ->
+    let caller = Domain.self () in
+    let events = ref [] in
+    Eio.Switch.run (fun sw ->
+      let store = create_store ~codec ~sw ~dir in
+      events := make_four_events (Store.correlation_id store);
+      let writer = attach_store store in
+      match Store.append_batch writer ~expected_next_seq:1 !events with
+      | Ok Store.Stored -> ()
+      | Ok Store.Already_committed -> fail "new batch was already committed"
+      | Error error -> fail (Store.error_to_string error));
+    let after_append = Codec.stats codec in
+    check int "append submits one encode batch" 1 after_append.encode_events.requested;
+    check int "append does not decode" 0 after_append.decode_canonical_events.requested;
+    Eio.Switch.run (fun sw ->
+      let durable_writer, _recovery =
+        require_journal (Journal.open_durable_writer ~sw ~codec ~dir)
+      in
+      let journal = Journal.durable_writer_journal durable_writer in
+      check_events
+        "journal consumes open replay artifact"
+        !events
+        (Journal.events journal));
+    let after_journal_open = Codec.stats codec in
+    check
+      int
+      "journal open decodes each durable batch once"
+      1
+      after_journal_open.decode_canonical_events.requested;
+    Eio.Switch.run (fun sw ->
+      let opened = require_store (Store.open_existing ~sw ~codec ~dir) in
+      check_events "open replay artifact is exact" !events opened.replay_events;
+      let writer = attach_store opened.store in
+      (match Store.append_batch writer ~expected_next_seq:1 !events with
+       | Ok Store.Already_committed -> ()
+       | Ok Store.Stored -> fail "exact retry stored a duplicate batch"
+       | Error error -> fail (Store.error_to_string error));
+      let page =
+        require_store
+          (Store.read_page
+             opened.store
+             ~after:(Store.beginning_cursor opened.store)
+             ~limit:(List.length !events)
+             ())
+      in
+      check_events "page decode remains exact" !events page.events);
+    let stats = Codec.stats codec in
+    check int "retry reuses one encoded expected batch" 2 stats.encode_events.requested;
+    check
+      int
+      "two opens plus one page are three batch decodes"
+      3
+      stats.decode_canonical_events.requested;
+    check
+      int
+      "exact retry is one canonical payload comparison"
+      1
+      stats.compare_canonical_payloads.requested;
+    let worker name (operation : Codec.operation_stats) =
+      match operation.last_worker_domain with
+      | None -> fail (name ^ " did not record a worker domain")
+      | Some worker ->
+        check bool (name ^ " is outside caller domain") true (worker <> caller);
+        worker
+    in
+    let encode_worker = worker "encode" stats.encode_events in
+    let decode_worker = worker "decode" stats.decode_canonical_events in
+    let compare_worker = worker "compare" stats.compare_canonical_payloads in
+    check
+      bool
+      "encode/decode share the application worker"
+      true
+      (encode_worker = decode_worker);
+    check
+      bool
+      "decode/compare share the application worker"
+      true
+      (decode_worker = compare_worker))
+;;
+
+let test_released_codec_fails_before_store_mutation () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun recovery_codec dir ->
+    Eio.Switch.run (fun store_sw ->
+      let store =
+        Eio.Switch.run (fun codec_sw ->
+          let pool =
+            Eio.Executor_pool.create
+              ~sw:codec_sw
+              ~domain_count:1
+              (Eio.Stdenv.domain_mgr env)
+          in
+          create_store ~codec:(Codec.of_executor_pool pool) ~sw:store_sw ~dir)
+      in
+      let events = make_four_events (Store.correlation_id store) in
+      let writer = attach_store store in
+      let before = directory_snapshot dir in
+      (match Store.append_batch writer ~expected_next_seq:1 events with
+       | Error
+           (Store.Codec_failure
+              (Codec.Executor_unavailable { operation = Codec.Encode_events; _ })) -> ()
+       | Error error -> fail ("unexpected append failure: " ^ Store.error_to_string error)
+       | Ok _ -> fail "append used a released codec executor");
+      check
+        (list (pair string string))
+        "failed encode does not alter any store file"
+        before
+        (directory_snapshot dir);
+      check
+        int
+        "failed encode does not advance store"
+        0
+        (require_store (Store.last_seq store)));
+    Eio.Switch.run (fun sw ->
+      let opened = require_store (Store.open_existing ~sw ~codec:recovery_codec ~dir) in
+      check int "reopen remains empty" 0 (require_store (Store.last_seq opened.store));
+      check int "replay remains empty" 0 (List.length opened.replay_events)))
 ;;
 
 let () =
@@ -1389,6 +1541,14 @@ let () =
             "published store rejects use after switch"
             `Quick
             test_published_store_rejects_use_after_switch
+        ; test_case
+            "shared codec executor routes store work off-domain"
+            `Quick
+            test_shared_codec_executor_routes_store_work
+        ; test_case
+            "released codec fails before store mutation"
+            `Quick
+            test_released_codec_fails_before_store_mutation
         ] )
     ]
 ;;

--- a/test/test_execution_lane_writer.ml
+++ b/test/test_execution_lane_writer.ml
@@ -1,6 +1,7 @@
 open Alcotest
 open Agent_sdk
 module Event = Execution_event
+module Codec = Execution_codec_executor
 module Journal = Execution_journal
 module Store = Execution_event_store
 module Writer = Execution_lane_writer
@@ -30,10 +31,12 @@ let require_scope = function
   | Error error -> fail (Writer.scope_failure_to_string error)
 ;;
 
-let with_fresh dir f = require_scope (Writer.run ~dir (fun ~sw writer -> f sw writer))
+let with_fresh codec dir f =
+  require_scope (Writer.run ~codec ~dir (fun ~sw writer -> f sw writer))
+;;
 
-let with_existing dir f =
-  require_scope (Writer.resume ~dir (fun ~sw writer -> f sw writer))
+let with_existing codec dir f =
+  require_scope (Writer.resume ~codec ~dir (fun ~sw writer -> f sw writer))
 ;;
 
 let require_codec = function
@@ -42,10 +45,17 @@ let require_codec = function
 ;;
 
 let with_temp_dir env f =
-  let native_path = Filename.temp_file "oas-execution-lane-writer-" ".dir" in
-  Sys.remove native_path;
-  let dir = Eio.Path.(Eio.Stdenv.fs env / native_path) in
-  Fun.protect ~finally:(fun () -> Eio.Path.rmtree ~missing_ok:true dir) (fun () -> f dir)
+  Eio.Switch.run (fun codec_sw ->
+    let pool =
+      Eio.Executor_pool.create ~sw:codec_sw ~domain_count:1 (Eio.Stdenv.domain_mgr env)
+    in
+    let codec = Codec.of_executor_pool pool in
+    let native_path = Filename.temp_file "oas-execution-lane-writer-" ".dir" in
+    Sys.remove native_path;
+    let dir = Eio.Path.(Eio.Stdenv.fs env / native_path) in
+    Fun.protect
+      ~finally:(fun () -> Eio.Path.rmtree ~missing_ok:true dir)
+      (fun () -> f codec dir))
 ;;
 
 let make_dir dir = Eio.Path.mkdirs ~exists_ok:false ~perm:0o700 dir
@@ -186,9 +196,9 @@ let rec await_reconciliation_wait writer ~outcome_count =
 let test_single_command_commits_and_close_drains () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     make_dir dir;
-    with_fresh dir (fun _sw writer ->
+    with_fresh codec dir (fun _sw writer ->
       let ticket =
         require_submit (Writer.submit writer (Tx.start_run ~agent_name:"single" ()))
       in
@@ -216,9 +226,9 @@ let test_single_command_commits_and_close_drains () =
 let test_ready_set_is_one_fifo_durable_group () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     make_dir dir;
-    with_fresh dir (fun _sw writer ->
+    with_fresh codec dir (fun _sw writer ->
       let _run, output, setup_through, setup_events = open_output writer in
       check bool "setup values are exact events" true (List.length setup_events = 4);
       let tickets : Event.t Writer.ticket list =
@@ -259,9 +269,9 @@ let test_ready_set_is_one_fifo_durable_group () =
 let test_semantic_rejection_does_not_poison_ready_group () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     make_dir dir;
-    with_fresh dir (fun _sw writer ->
+    with_fresh codec dir (fun _sw writer ->
       let run, output, setup_through, _events = open_output writer in
       let first = require_submit (Writer.submit writer (delta_transaction output 0)) in
       let rejected =
@@ -294,9 +304,9 @@ let test_semantic_rejection_does_not_poison_ready_group () =
 let test_concurrent_submit_and_close_linearize_without_loss () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     make_dir dir;
-    with_fresh dir (fun _sw writer ->
+    with_fresh codec dir (fun _sw writer ->
       let _run, output, setup_through, setup_events = open_output writer in
       let accepted_before_race =
         require_submit (Writer.submit writer (delta_transaction output (-1)))
@@ -378,9 +388,9 @@ let test_concurrent_submit_and_close_linearize_without_loss () =
 let test_cancelled_waiter_does_not_cancel_ticket () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     make_dir dir;
-    with_fresh dir (fun _sw writer ->
+    with_fresh codec dir (fun _sw writer ->
       let ticket =
         require_submit (Writer.submit writer (Tx.start_run ~agent_name:"waiter" ()))
       in
@@ -404,11 +414,11 @@ let test_cancelled_waiter_does_not_cancel_ticket () =
 let test_supervisor_cancellation_settles_accepted_ticket () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     make_dir dir;
     let ticket = ref None in
     (match
-       with_fresh dir (fun sw writer ->
+       with_fresh codec dir (fun sw writer ->
          ticket
          := Some
               (require_submit
@@ -427,7 +437,7 @@ let test_supervisor_cancellation_settles_accepted_ticket () =
 let test_initialization_failure_is_scope_local () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun root ->
+  with_temp_dir env (fun codec root ->
     make_dir root;
     let missing = Eio.Path.(root / "missing" / "scope") in
     let healthy = Eio.Path.(root / "healthy") in
@@ -435,13 +445,13 @@ let test_initialization_failure_is_scope_local () =
     let failed, healthy =
       Eio.Fiber.pair
         (fun () ->
-           Writer.run ~dir:missing (fun ~sw:_ failed_writer ->
+           Writer.run ~codec ~dir:missing (fun ~sw:_ failed_writer ->
              match Writer.await_ready failed_writer with
              | Error (Writer.Initialization_failed _) -> ()
              | Error error -> fail (Writer.scope_failure_to_string error)
              | Ok () -> fail "missing durability directory became ready"))
         (fun () ->
-           Writer.run ~dir:healthy (fun ~sw:_ healthy_writer ->
+           Writer.run ~codec ~dir:healthy (fun ~sw:_ healthy_writer ->
              require_scope (Writer.await_ready healthy_writer);
              Writer.submit healthy_writer (Tx.start_run ~agent_name:"healthy-scope" ())
              |> require_submit
@@ -465,10 +475,10 @@ let test_initialization_failure_is_scope_local () =
 let test_clean_reopen_continues_exact_cursor () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     make_dir dir;
     let first_receipt = ref None in
-    with_fresh dir (fun _sw writer ->
+    with_fresh codec dir (fun _sw writer ->
       let receipt =
         require_ticket
           (Writer.await
@@ -478,7 +488,7 @@ let test_clean_reopen_continues_exact_cursor () =
       first_receipt := Some receipt;
       require_closed (Writer.close_and_await writer));
     let first = Option.get !first_receipt in
-    with_existing dir (fun _sw writer ->
+    with_existing codec dir (fun _sw writer ->
       let run, _opened = first.value in
       let second =
         require_ticket
@@ -512,9 +522,9 @@ let test_clean_reopen_continues_exact_cursor () =
 let test_abort_transaction_is_one_durable_terminal_group () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     make_dir dir;
-    with_fresh dir (fun _sw writer ->
+    with_fresh codec dir (fun _sw writer ->
       let run, output, setup_through, _events = open_output writer in
       let terminal = Event.Cancelled { reason = Some "scope shutdown"; data = None } in
       let aborted =
@@ -544,13 +554,13 @@ let test_abort_transaction_is_one_durable_terminal_group () =
 let test_repeated_unknown_waits_for_typed_external_wake () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     make_dir dir;
     let blocker = Eio.Path.(dir / "events.v1.commit") in
     Eio.Path.mkdirs ~exists_ok:false ~perm:0o700 blocker;
     let durable_event = ref None in
     let durable_through = ref None in
-    with_fresh dir (fun _sw writer ->
+    with_fresh codec dir (fun _sw writer ->
       let first =
         require_submit
           (Writer.submit writer (Tx.start_run ~agent_name:"unknown-create" ()))
@@ -613,7 +623,7 @@ let test_repeated_unknown_waits_for_typed_external_wake () =
         (Option.is_none observed.current_reconciliation);
       require_closed (Writer.close_and_await writer));
     let through = Option.get !durable_through in
-    with_existing dir (fun _sw writer ->
+    with_existing codec dir (fun _sw writer ->
       require_scope (Writer.await_ready writer);
       let page =
         match
@@ -633,7 +643,7 @@ let test_repeated_unknown_waits_for_typed_external_wake () =
 let test_close_terminates_unresolved_reconciliation () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     make_dir dir;
     let blocker = Eio.Path.(dir / "events.v1.commit") in
     Eio.Path.mkdirs ~exists_ok:false ~perm:0o700 blocker;
@@ -641,7 +651,7 @@ let test_close_terminates_unresolved_reconciliation () =
     let first_waiter = ref None in
     let second_waiter = ref None in
     let outcome =
-      Writer.run ~dir (fun ~sw writer ->
+      Writer.run ~codec ~dir (fun ~sw writer ->
         writer_ref := Some writer;
         let first =
           require_submit
@@ -681,7 +691,7 @@ let test_close_terminates_unresolved_reconciliation () =
     check int "failed close clears in-flight" 0 observed.in_flight_commands;
     Eio.Path.rmtree ~missing_ok:false blocker;
     require_scope
-      (Writer.resume ~dir (fun ~sw:_ writer ->
+      (Writer.resume ~codec ~dir (fun ~sw:_ writer ->
          require_scope (Writer.await_ready writer);
          match Writer.current_cursor writer with
          | Ok cursor ->
@@ -692,13 +702,13 @@ let test_close_terminates_unresolved_reconciliation () =
 let test_each_external_wake_authorizes_one_reconciliation () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     make_dir dir;
     let blocker = Eio.Path.(dir / "events.v1.commit") in
     Eio.Path.mkdirs ~exists_ok:false ~perm:0o700 blocker;
     let ticket_ref = ref None in
     let outcome =
-      Writer.run ~dir (fun ~sw:_ writer ->
+      Writer.run ~codec ~dir (fun ~sw:_ writer ->
         let ticket =
           require_submit
             (Writer.submit writer (Tx.start_run ~agent_name:"operator-wake" ()))
@@ -740,13 +750,13 @@ let test_each_external_wake_authorizes_one_reconciliation () =
 let test_owned_supervisor_drains_same_scope_waiter () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     make_dir dir;
     let writer = ref None in
     let ticket = ref None in
     let waiter = ref None in
     require_scope
-      (Writer.run ~dir (fun ~sw created ->
+      (Writer.run ~codec ~dir (fun ~sw created ->
          writer := Some created;
          let accepted =
            require_submit
@@ -775,14 +785,14 @@ let test_owned_supervisor_drains_same_scope_waiter () =
 let test_callback_exception_preserves_durable_group_truth () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     make_dir dir;
     let writer_ref = ref None in
     let setup_through_ref = ref None in
     let first_receipt = ref None in
     let second_ticket = ref None in
     (match
-       with_fresh dir (fun _sw writer ->
+       with_fresh codec dir (fun _sw writer ->
          writer_ref := Some writer;
          let _run, output, setup_through, _events = open_output writer in
          setup_through_ref := Some setup_through;
@@ -818,7 +828,7 @@ let test_callback_exception_preserves_durable_group_truth () =
       observed.settled;
     check int "callback failure clears queue" 0 observed.queue_depth;
     check int "callback failure clears in-flight" 0 observed.in_flight_commands;
-    with_existing dir (fun _sw writer ->
+    with_existing codec dir (fun _sw writer ->
       require_scope (Writer.await_ready writer);
       let page =
         match
@@ -842,13 +852,13 @@ let test_callback_exception_preserves_durable_group_truth () =
 let test_callback_exception_retains_unresolved_scope_failure () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     make_dir dir;
     let blocker = Eio.Path.(dir / "events.v1.commit") in
     Eio.Path.mkdirs ~exists_ok:false ~perm:0o700 blocker;
     let ticket_ref = ref None in
     (match
-       Writer.run ~dir (fun ~sw:_ writer ->
+       Writer.run ~codec ~dir (fun ~sw:_ writer ->
          let ticket =
            require_submit
              (Writer.submit writer (Tx.start_run ~agent_name:"callback-unknown" ()))
@@ -873,7 +883,7 @@ let test_callback_exception_retains_unresolved_scope_failure () =
 let test_durable_success_settles_group_before_supervisor_cancellation () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     make_dir dir;
     let writer_ref = ref None in
     let output_ref = ref None in
@@ -882,7 +892,7 @@ let test_durable_success_settles_group_before_supervisor_cancellation () =
     let second_ticket = ref None in
     let first_receipt = ref None in
     (match
-       with_fresh dir (fun sw writer ->
+       with_fresh codec dir (fun sw writer ->
          writer_ref := Some writer;
          let _run, output, setup_through, _events = open_output writer in
          output_ref := Some output;
@@ -924,7 +934,7 @@ let test_durable_success_settles_group_before_supervisor_cancellation () =
       observed.settled;
     check int "cancelled scope clears queue" 0 observed.queue_depth;
     check int "cancelled scope clears in-flight" 0 observed.in_flight_commands;
-    with_existing dir (fun _sw writer ->
+    with_existing codec dir (fun _sw writer ->
       let output = Option.get !output_ref in
       ignore (submit_and_await writer (delta_transaction output 3));
       let page =
@@ -950,9 +960,9 @@ let test_durable_success_settles_group_before_supervisor_cancellation () =
 let test_frozen_pages_remain_lossless_after_close () =
   Eio_main.run
   @@ fun env ->
-  with_temp_dir env (fun dir ->
+  with_temp_dir env (fun codec dir ->
     make_dir dir;
-    with_fresh dir (fun _sw writer ->
+    with_fresh codec dir (fun _sw writer ->
       let _run, output, setup_through, _events = open_output writer in
       let first = require_submit (Writer.submit writer (delta_transaction output 1)) in
       let second = require_submit (Writer.submit writer (delta_transaction output 2)) in

--- a/test/test_execution_lane_writer.ml
+++ b/test/test_execution_lane_writer.ml
@@ -1,4 +1,5 @@
 open Alcotest
+module Runtime_internal = Execution_runtime
 open Agent_sdk
 module Event = Execution_event
 module Codec = Execution_codec_executor
@@ -44,12 +45,21 @@ let require_codec = function
   | Error detail -> fail detail
 ;;
 
+let require_runtime = function
+  | Ok value -> value
+  | Error error -> fail (Runtime_internal.create_error_to_string error)
+;;
+
 let with_temp_dir env f =
   Eio.Switch.run (fun codec_sw ->
-    let pool =
-      Eio.Executor_pool.create ~sw:codec_sw ~domain_count:1 (Eio.Stdenv.domain_mgr env)
+    let runtime =
+      require_runtime
+        (Runtime_internal.create
+           ~sw:codec_sw
+           ~domain_mgr:(Eio.Stdenv.domain_mgr env)
+           ~domain_count:1)
     in
-    let codec = Codec.of_executor_pool pool in
+    let codec = Codec.of_runtime runtime in
     let native_path = Filename.temp_file "oas-execution-lane-writer-" ".dir" in
     Sys.remove native_path;
     let dir = Eio.Path.(Eio.Stdenv.fs env / native_path) in


### PR DESCRIPTION
## Goal

Move canonical execution-event JSON work off Eio server domains without adding payload-size heuristics, per-call domains, budget gates, or a second execution-data authority.


This is the next stacked slice after #2618. It wires a shared codec executor through the real durable Store -> Journal -> Lane path. Application/runtime ownership of that long-lived pool is intentionally the next stacked integration PR; this private layer neither invents nor owns runtime sizing policy.

## What changes

- Add private `Execution_codec_executor` with a closed typed request family for:
  - canonical event encoding,
  - canonical event decoding,
  - exact canonical payload comparison.
- Borrow one caller/application-owned `Eio.Executor_pool.t`; OAS Store/Lane code never creates, sizes, or closes it.
- Inject the codec through `Execution_event_store`, durable `Execution_journal`, and `Execution_lane_writer`.
- Encode the complete expected append batch before writer admission or WAL mutation.
- Decode one natural durable WAL batch per executor request during recovery and one bounded indexed page per read request.
- Compare exact already-canonical payload bytes for idempotent retry; do not decode/re-encode committed events merely to compare them.
- Hard-cut the legacy `load_all` replay path. `open_existing` now returns the immutable validated replay artifact from its single authoritative scan, and Journal consumes that same artifact.
- Add observation-only per-operation statistics. They never control dispatch, admission, cancellation, budgets, or termination.

## Failure and cancellation contract

- Executor unavailability and codec failure are typed separately.
- Worker exceptions preserve the worker backtrace.
- Observation failure is retained beside the primary failure instead of replacing or hiding it.
- Reserved exceptions are re-raised rather than converted into ordinary codec failures.
- Caller cancellation is re-propagated and observed independently from executor failure, including simultaneous pool-failure/cancellation facts.
- Accepted worker jobs are pure codec/observation work. A cancelled caller cannot cause a late worker to mutate Store, Journal, or Lane state.
- A released executor fails before append mutation; the test snapshots every store file byte-for-byte and verifies no mutation, then reopens an empty store.

## SSOT and boundary

- Canonical bytes remain derived only from `Execution_event.to_json_string` and validated only through the typed event decoder plus exact canonical re-encoding.
- WAL authority/index/recovery remain owned by `Execution_event_store`; Journal is still the sole production owner of the store.
- `load_all` is removed instead of retained as a compatibility replay path.
- The new module and the affected execution modules remain private to OAS. No MASC dependency or public Agent SDK configuration surface is added.
- No substring classification, model-name branching, path hardcoding, payload threshold, cost/turn/token budget gate, stub, or silent fallback is introduced.

## Server-performance scope

- JSON encode/decode and exact list comparison execute on the shared executor rather than the Eio server domain.
- Encoding is submitted once per natural append batch. Decoding and idempotent-retry comparison are submitted once per event (scan/read/compare paths); this keeps raw-batch retention bounded at the cost of one cross-domain rendezvous per event — a deliberate tradeoff, revisit with a batched decode request variant if recovery latency on large WALs becomes measurable.
- There is no per-request pool/domain construction.
- This PR does **not** claim that existing chunked SHA/file I/O work moved off-domain; those paths keep their current cooperative behavior and remain separately observable.

## Validation

Completed on commit `f12dd1c67` (current head):

- CI rollup green on the PR head (stacked PR: Build & Test runs are inherited from local verification of the stack base plus PR automation gates).
- Local (stack base `codex/execution-store-v1-20260716`, which contains this branch's dependencies): focused build of journal/store/lane test executables and direct execution — 68 tests green.
- Adversarial review (2026-07-17, fresh-read verified): verdict pass. Two accepted observations recorded as follow-ups: per-event executor rendezvous on recovery/read paths (see Server-performance scope), and `open_existing` unconditionally materializing `replay_events` for every caller now that `load_all` is hard-cut — acceptable while Journal is the sole production opener.

## Evidence

- [근거] OCaml 5.4 manual: https://ocaml.org/manual/5.4/index.html — checked 2026-07-16 — confidence High
- [근거] OCaml 5.4 `Domain` API: https://ocaml.org/manual/5.4/api/type_Domain.html — checked 2026-07-16 — confidence High
- [근거] Eio `Executor_pool` API and ownership/submission contract: https://ocaml-multicore.github.io/eio/eio/Eio/Executor_pool/index.html — checked 2026-07-16 — confidence High

## Stack and follow-up

- Base: #2618 (`codex/execution-lane-writer-v1-20260716`)
- Next: create one application-lifetime codec pool at the actual OAS runtime owner and inject it into live lane construction.
- Then: complete typed Tool attempt/effect/receipt recursion and MASC lossless hierarchical dashboard projection/live RunPod smoke.

Review comments and validation are reflected above; the PR is Ready as part of the 2026-07-17 stack merge train.



---

RATCHET-WAIVED: godfile +1 vs stale baseline — main already carries 11 godfiles since #2611 merged under the same waiver (`execution_event_store.ml`, `execution_journal.ml`); this PR adds none. Sunset: `docs/rfc/sub-library-decomposition-rfc.md`. Baseline refresh to 11 belongs in a dedicated maintenance commit after this stack lands.
