### PR TITLE
feat(llm_provider): add typed input token count contract

### DIFF
--- a/lib/llm_provider/input_token_count.ml
+++ b/lib/llm_provider/input_token_count.ml
@@ -1,0 +1,77 @@
+type protocol =
+  | Anthropic_messages_count_tokens
+  | Openai_responses_input_tokens
+  | Gemini_count_tokens
+[@@deriving show, eq]
+
+type count =
+  { input_tokens : int
+  ; protocol : protocol
+  ; model_id : string
+  }
+[@@deriving show, eq]
+
+type error =
+  | Unsupported of
+      { protocol : protocol
+      ; model_id : string
+      }
+  | Transport of Http_client.http_error
+  | Invalid_response of
+      { protocol : protocol
+      ; model_id : string
+      ; detail : string
+      }
+
+let token_field = function
+  | Anthropic_messages_count_tokens | Openai_responses_input_tokens -> "input_tokens"
+  | Gemini_count_tokens -> "totalTokens"
+;;
+
+let invalid protocol model_id detail =
+  Error (Invalid_response { protocol; model_id; detail })
+;;
+
+let nonnegative_int ~protocol ~model_id ~field = function
+  | `Int value when value >= 0 -> Ok value
+  | `Int _ -> invalid protocol model_id (Printf.sprintf "%s must be non-negative" field)
+  | `Intlit _ ->
+    invalid
+      protocol
+      model_id
+      (Printf.sprintf "%s is outside the supported integer range" field)
+  | json ->
+    invalid
+      protocol
+      model_id
+      (Printf.sprintf
+         "%s must be an integer (got %s)"
+         field
+         (Json_util.json_type_name json))
+;;
+
+let decode_response ~protocol ~model_id body =
+  match Json_util.decode_json_with Fun.id body with
+  | Error detail -> invalid protocol model_id detail
+  | Ok (`Assoc fields) ->
+    let field = token_field protocol in
+    (match List.assoc_opt field fields with
+     | None ->
+       invalid protocol model_id (Printf.sprintf "missing required field %s" field)
+     | Some json ->
+       Result.map
+         (fun input_tokens -> { input_tokens; protocol; model_id })
+         (nonnegative_int ~protocol ~model_id ~field json))
+  | Ok json ->
+    invalid
+      protocol
+      model_id
+      (Printf.sprintf
+         "input-token count response must be an object (got %s)"
+         (Json_util.json_type_name json))
+;;
+
+let decode_transport_result ~protocol ~model_id = function
+  | Error error -> Error (Transport error)
+  | Ok body -> decode_response ~protocol ~model_id body
+;;

--- a/lib/llm_provider/input_token_count.mli
+++ b/lib/llm_provider/input_token_count.mli
@@ -1,0 +1,50 @@
+(** Provider-reported input-token count contract.
+
+    This module owns only the typed protocol vocabulary and response decoding.
+    Endpoint selection, request construction, and transport execution remain
+    outside this boundary.
+
+    @stability Internal *)
+
+type protocol =
+  | Anthropic_messages_count_tokens
+  | Openai_responses_input_tokens
+  | Gemini_count_tokens
+[@@deriving show, eq]
+
+type count = private
+  { input_tokens : int
+  ; protocol : protocol
+  ; model_id : string
+  }
+[@@deriving show, eq]
+
+type error =
+  | Unsupported of
+      { protocol : protocol
+      ; model_id : string
+      }
+  | Transport of Http_client.http_error
+  | Invalid_response of
+      { protocol : protocol
+      ; model_id : string
+      ; detail : string
+      }
+
+(** Decode one successful provider response.
+
+    [model_id] is carried byte-for-byte as caller-owned identity. It is never
+    inspected to select a protocol. All protocols accept zero and reject
+    negative or non-integral token counts. *)
+val decode_response
+  :  protocol:protocol
+  -> model_id:string
+  -> string
+  -> (count, error) result
+
+(** Preserve an existing typed HTTP failure or decode the successful body. *)
+val decode_transport_result
+  :  protocol:protocol
+  -> model_id:string
+  -> (string, Http_client.http_error) result
+  -> (count, error) result

--- a/test/dune
+++ b/test/dune
@@ -394,6 +394,11 @@
  (libraries llm_provider alcotest))
 
 (test
+ (name test_input_token_count)
+ (modules test_input_token_count)
+ (libraries llm_provider alcotest))
+
+(test
  (name test_complete_http)
  (modules test_complete_http)
  (libraries agent_sdk llm_provider alcotest eio_main eio.mock))

--- a/test/test_input_token_count.ml
+++ b/test/test_input_token_count.ml
@@ -1,0 +1,139 @@
+open Alcotest
+open Llm_provider
+open Input_token_count
+
+let protocols =
+  [ Anthropic_messages_count_tokens, "input_tokens"
+  ; Openai_responses_input_tokens, "input_tokens"
+  ; Gemini_count_tokens, "totalTokens"
+  ]
+;;
+
+let body field value = Printf.sprintf {|{"%s":%s}|} field value
+
+let expect_count ~protocol ~model_id expected response =
+  match decode_response ~protocol ~model_id response with
+  | Ok count ->
+    check int "input tokens" expected count.input_tokens;
+    check string "model id is exact" model_id count.model_id;
+    check bool "protocol is exact" true (equal_protocol protocol count.protocol)
+  | Error _ -> fail "expected a decoded input-token count"
+;;
+
+let expect_invalid ~protocol ~model_id response =
+  match decode_response ~protocol ~model_id response with
+  | Error (Invalid_response { protocol = actual; model_id = actual_model; detail }) ->
+    check bool "protocol evidence" true (equal_protocol protocol actual);
+    check string "model evidence" model_id actual_model;
+    check bool "detail is explicit" true (String.length detail > 0)
+  | Error (Unsupported _ | Transport _) -> fail "expected Invalid_response"
+  | Ok _ -> fail "expected response rejection"
+;;
+
+let test_positive_counts () =
+  List.iter
+    (fun (protocol, field) ->
+       expect_count ~protocol ~model_id:"model/exact" 42 (body field "42"))
+    protocols
+;;
+
+let test_zero_is_valid () =
+  List.iter
+    (fun (protocol, field) ->
+       expect_count ~protocol ~model_id:"zero-model" 0 (body field "0"))
+    protocols
+;;
+
+let test_missing_field_is_invalid () =
+  List.iter
+    (fun (protocol, _) ->
+       expect_invalid ~protocol ~model_id:"missing-model" {|{"other":1}|})
+    protocols
+;;
+
+let test_non_integer_is_invalid () =
+  List.iter
+    (fun (protocol, field) ->
+       expect_invalid ~protocol ~model_id:"non-integer-model" (body field {|1.5|}))
+    protocols
+;;
+
+let test_negative_is_invalid () =
+  List.iter
+    (fun (protocol, field) ->
+       expect_invalid ~protocol ~model_id:"negative-model" (body field "-1"))
+    protocols
+;;
+
+let test_out_of_range_is_invalid () =
+  List.iter
+    (fun (protocol, field) ->
+       expect_invalid
+         ~protocol
+         ~model_id:"out-of-range-model"
+         (body field "999999999999999999999999999999999999"))
+    protocols
+;;
+
+let test_malformed_and_non_object_are_invalid () =
+  List.iter
+    (fun (protocol, _) ->
+       expect_invalid ~protocol ~model_id:"bad-json-model" "{";
+       expect_invalid ~protocol ~model_id:"array-model" "[]")
+    protocols
+;;
+
+let test_transport_error_is_preserved () =
+  let transport =
+    Http_client.TimeoutError
+      { message = "provider deadline"; phase = Http_client.First_token }
+  in
+  match
+    decode_transport_result
+      ~protocol:Openai_responses_input_tokens
+      ~model_id:"transport-model"
+      (Error transport)
+  with
+  | Error (Transport (Http_client.TimeoutError { message; phase })) ->
+    check string "message" "provider deadline" message;
+    check bool "phase" true (phase = Http_client.First_token)
+  | Error (Unsupported _ | Invalid_response _ | Transport _) ->
+    fail "transport error shape changed"
+  | Ok _ -> fail "transport error was silently accepted"
+;;
+
+let test_transport_success_is_decoded () =
+  match
+    decode_transport_result
+      ~protocol:Gemini_count_tokens
+      ~model_id:"transport-success-model"
+      (Ok {|{"totalTokens":7}|})
+  with
+  | Ok count -> check int "input tokens" 7 count.input_tokens
+  | Error _ -> fail "successful transport body was not decoded"
+;;
+
+let () =
+  run
+    "input-token-count"
+    [ ( "response"
+      , [ test_case "positive counts" `Quick test_positive_counts
+        ; test_case "zero is valid" `Quick test_zero_is_valid
+        ; test_case "missing field is invalid" `Quick test_missing_field_is_invalid
+        ; test_case "non-integer is invalid" `Quick test_non_integer_is_invalid
+        ; test_case "negative is invalid" `Quick test_negative_is_invalid
+        ; test_case "out-of-range is invalid" `Quick test_out_of_range_is_invalid
+        ; test_case
+            "malformed and non-object are invalid"
+            `Quick
+            test_malformed_and_non_object_are_invalid
+        ] )
+    ; ( "transport"
+      , [ test_case
+            "typed HTTP error is preserved"
+            `Quick
+            test_transport_error_is_preserved
+        ; test_case "successful body is decoded" `Quick test_transport_success_is_decoded
+        ] )
+    ]
+;;


### PR DESCRIPTION
## What changed

- Added a closed input-token protocol type:
  - `Anthropic_messages_count_tokens`
  - `Openai_responses_input_tokens`
  - `Gemini_count_tokens`
- Added an immutable typed result carrying `input_tokens`, the exact protocol, and the caller-supplied `model_id`.
- Added explicit `Unsupported`, typed `Transport`, and `Invalid_response` failures.
- Added a pure response decoder for the documented `input_tokens` and `totalTokens` fields.

## Boundary

- No network execution, endpoint construction, endpoint probing, or credential handling.
- No provider/model/URL string inference.
- No token estimation or fallback heuristic.
- Existing `Http_client.http_error` values pass through without conversion or diagnostic-string parsing.

## Validation

- `scripts/dune-local.sh build test/test_input_token_count.exe`
- `_build/default/test/test_input_token_count.exe` — 9/9 passed
- `ocamlformat --check lib/llm_provider/input_token_count.mli lib/llm_provider/input_token_count.ml test/test_input_token_count.ml`
- `git diff --check`

The tests cover positive and zero counts, missing fields, non-integer values,
negative values, values outside the OCaml integer range, malformed/non-object
JSON, exact model/protocol evidence, typed transport preservation, and the
successful transport-body path.

## Official contract evidence

Checked 2026-07-16:

- Anthropic documents `POST /v1/messages/count_tokens` returning
  `input_tokens`: https://platform.claude.com/docs/en/api/messages/count_tokens
- OpenAI's generated official SDK calls `/responses/input_tokens` and returns
  `InputTokenCountResponse.input_tokens`:
  - https://github.com/openai/openai-python/blob/f16fbbd2bd25dc1ff150b5f78dbd15ff6bab6d91/src/openai/resources/responses/input_tokens.py
  - https://github.com/openai/openai-python/blob/f16fbbd2bd25dc1ff150b5f78dbd15ff6bab6d91/src/openai/types/responses/input_token_count_response.py
- Gemini documents `models.countTokens` returning non-negative `totalTokens`:
  https://ai.google.dev/api/tokens

Zero is accepted because the official count schemas are non-negative counts;
this avoids inventing an undocumented positive-only restriction.
