### PR TITLE
chore(ci): refresh code-smell ratchet baseline after 0.214.0 stack

### DIFF
--- a/.ci/code-smell-baseline.json
+++ b/.ci/code-smell-baseline.json
@@ -1,9 +1,9 @@
 {
   "_comment": "Code-smell monotone-decrease ratchet baseline. Source: docs/rfc/RFC-OAS-022-code-smell-monotone-decrease-ratchet.md §3 (Reproducibility commands). PRs may decrease or hold counts; increases fail unless PR body carries RATCHET-WAIVED: <reason>. Updated only on main via scripts/ci-code-smell-ratchet.sh --rebaseline.",
-  "godfile": 10,
-  "catch_all": 768,
-  "duplicate_helpers": 9,
-  "ignore_calls": 15,
-  "lastUpdated": "2026-05-20T00:00:00Z",
-  "lastUpdatedCommit": "d845cad7b3410a2fafa2ce1743f122a21bef9be1"
+  "godfile": 11,
+  "catch_all": 358,
+  "duplicate_helpers": 3,
+  "ignore_calls": 14,
+  "lastUpdated": "2026-07-16T19:28:05Z",
+  "lastUpdatedCommit": "9b5f0835a1c8d579ae53987c092c889617b7f8ea"
 }


### PR DESCRIPTION
main의 Code Smell Ratchet workflow가 0.214.0 스택 착지 후 red 상태입니다 (baseline godfile=10 vs 실측 11 — #2611/#2622의 RATCHET-WAIVED 부채). 공식 절차(`--rebaseline`)로 baseline을 main HEAD 실측값으로 갱신합니다.

- godfile 10→11 (sunset: `docs/rfc/sub-library-decomposition-rfc.md`)
- **감소 잠금**: catch_all 768→358, duplicate_helpers 9→3, ignore_calls 15→14

RATCHET-WAIVED: baseline maintenance commit (godfile 11 = main 현재 트리 실측, sunset docs/rfc/sub-library-decomposition-rfc.md)