### PR TITLE
feat(tool)!: expose exact invocation occurrence

### DIFF
--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -376,8 +376,14 @@ let find_and_execute_tool_with_index
          { result = validation_error_result ~input message; deferred_failure }
        | Ok exact_input ->
          let t0 = Unix.gettimeofday () in
+         let invocation =
+           Tool.Invocation.create
+             ~tool_use_id:id
+             ~turn:turn_count
+             ~planned_index:schedule.planned_index
+         in
          let result =
-           try Tool.execute ~context tool exact_input with
+           try Tool.execute ~context ~invocation tool exact_input with
            | exn ->
              Llm_provider.Reserved_exn.reraise_if_reserved exn;
              Error

--- a/lib/base/tool.ml
+++ b/lib/base/tool.ml
@@ -8,6 +8,21 @@ type tool_handler = Yojson.Safe.t -> Types.tool_result
 (** Context-aware tool handler *)
 type context_tool_handler = Context.t -> Yojson.Safe.t -> Types.tool_result
 
+module Invocation = struct
+  type t =
+    { tool_use_id : string
+    ; turn : int
+    ; planned_index : int
+    }
+
+  let create ~tool_use_id ~turn ~planned_index = { tool_use_id; turn; planned_index }
+  let tool_use_id t = t.tool_use_id
+  let turn t = t.turn
+  let planned_index t = t.planned_index
+end
+
+type invocation_tool_handler = Invocation.t -> Yojson.Safe.t -> Types.tool_result
+
 type execution_mode =
   | Concurrent
   | Serial
@@ -34,6 +49,7 @@ type descriptor = { execution_mode : execution_mode }
 type handler_kind =
   | Simple of tool_handler
   | WithContext of context_tool_handler
+  | WithInvocation of invocation_tool_handler
 
 type t =
   { schema : tool_schema
@@ -53,8 +69,13 @@ let create_with_context ?descriptor ~name ~description ~parameters handler =
   { schema; descriptor; handler = WithContext handler }
 ;;
 
-(** Execute a tool, optionally passing context *)
-let execute ?context tool input =
+let create_with_invocation ?descriptor ~name ~description ~parameters handler =
+  let schema = { name; description; parameters; strict = None } in
+  { schema; descriptor; handler = WithInvocation handler }
+;;
+
+(** Execute a tool with the explicit resources required by its handler kind. *)
+let execute ?context ?invocation tool input =
   match tool.handler with
   | Simple f -> f input
   | WithContext f ->
@@ -63,6 +84,15 @@ let execute ?context tool input =
      | None ->
        Error
          { message = "context-aware tool requires explicit context"
+         ; recoverable = false
+         ; error_class = Some Deterministic
+         })
+  | WithInvocation f ->
+    (match invocation with
+     | Some invocation -> f invocation input
+     | None ->
+       Error
+         { message = "invocation-aware tool requires explicit invocation"
          ; recoverable = false
          ; error_class = Some Deterministic
          })
@@ -108,6 +138,8 @@ let with_defaults (defaults : (string * Yojson.Safe.t) list) (tool : t) : t =
     match tool.handler with
     | Simple f -> Simple (fun input -> f (inject_defaults input))
     | WithContext f -> WithContext (fun ctx input -> f ctx (inject_defaults input))
+    | WithInvocation f ->
+      WithInvocation (fun invocation input -> f invocation (inject_defaults input))
   in
   { tool with handler }
 ;;

--- a/lib/base/tool.ml
+++ b/lib/base/tool.ml
@@ -21,7 +21,18 @@ module Invocation = struct
   let planned_index t = t.planned_index
 end
 
-type invocation_tool_handler = Invocation.t -> Yojson.Safe.t -> Types.tool_result
+module Execution_env = struct
+  type t =
+    { context : Context.t option
+    ; invocation : Invocation.t option
+    }
+
+  let create ?context ?invocation () = { context; invocation }
+  let context t = t.context
+  let invocation t = t.invocation
+end
+
+type execution_env_tool_handler = Execution_env.t -> Yojson.Safe.t -> Types.tool_result
 
 type execution_mode =
   | Concurrent
@@ -49,7 +60,7 @@ type descriptor = { execution_mode : execution_mode }
 type handler_kind =
   | Simple of tool_handler
   | WithContext of context_tool_handler
-  | WithInvocation of invocation_tool_handler
+  | WithExecutionEnv of execution_env_tool_handler
 
 type t =
   { schema : tool_schema
@@ -69,9 +80,9 @@ let create_with_context ?descriptor ~name ~description ~parameters handler =
   { schema; descriptor; handler = WithContext handler }
 ;;
 
-let create_with_invocation ?descriptor ~name ~description ~parameters handler =
+let create_with_execution_env ?descriptor ~name ~description ~parameters handler =
   let schema = { name; description; parameters; strict = None } in
-  { schema; descriptor; handler = WithInvocation handler }
+  { schema; descriptor; handler = WithExecutionEnv handler }
 ;;
 
 (** Execute a tool with the explicit resources required by its handler kind. *)
@@ -87,15 +98,7 @@ let execute ?context ?invocation tool input =
          ; recoverable = false
          ; error_class = Some Deterministic
          })
-  | WithInvocation f ->
-    (match invocation with
-     | Some invocation -> f invocation input
-     | None ->
-       Error
-         { message = "invocation-aware tool requires explicit invocation"
-         ; recoverable = false
-         ; error_class = Some Deterministic
-         })
+  | WithExecutionEnv f -> f (Execution_env.create ?context ?invocation ()) input
 ;;
 
 let descriptor tool = tool.descriptor
@@ -138,8 +141,9 @@ let with_defaults (defaults : (string * Yojson.Safe.t) list) (tool : t) : t =
     match tool.handler with
     | Simple f -> Simple (fun input -> f (inject_defaults input))
     | WithContext f -> WithContext (fun ctx input -> f ctx (inject_defaults input))
-    | WithInvocation f ->
-      WithInvocation (fun invocation input -> f invocation (inject_defaults input))
+    | WithExecutionEnv f ->
+      WithExecutionEnv
+        (fun execution_env input -> f execution_env (inject_defaults input))
   in
   { tool with handler }
 ;;

--- a/lib/base/tool.mli
+++ b/lib/base/tool.mli
@@ -21,7 +21,22 @@ module Invocation : sig
   val planned_index : t -> int
 end
 
-type invocation_tool_handler = Invocation.t -> Yojson.Safe.t -> Types.tool_result
+(** Explicit resources available at one tool execution occurrence.
+    Context and invocation are orthogonal optional capabilities, not mutually
+    exclusive handler variants. Future execution metadata belongs in this
+    record-shaped boundary rather than in additional [handler_kind]
+    constructors.
+
+    @since 0.215.0 *)
+module Execution_env : sig
+  type t
+
+  val create : ?context:Context.t -> ?invocation:Invocation.t -> unit -> t
+  val context : t -> Context.t option
+  val invocation : t -> Invocation.t option
+end
+
+type execution_env_tool_handler = Execution_env.t -> Yojson.Safe.t -> Types.tool_result
 
 type execution_mode =
   | Concurrent
@@ -36,7 +51,7 @@ type descriptor = { execution_mode : execution_mode }
 type handler_kind =
   | Simple of tool_handler
   | WithContext of context_tool_handler
-  | WithInvocation of invocation_tool_handler
+  | WithExecutionEnv of execution_env_tool_handler
 
 type t =
   { schema : Types.tool_schema
@@ -60,16 +75,17 @@ val create_with_context
   -> context_tool_handler
   -> t
 
-(** Creates a raw JSON tool whose handler receives exact invocation occurrence
-    metadata. Typed-tool projection is a separate API surface.
+(** Creates a raw JSON tool whose handler receives the explicit execution
+    environment. The environment can contain both shared {!Context.t} and exact
+    {!Invocation.t} occurrence metadata.
 
     @since 0.215.0 *)
-val create_with_invocation
+val create_with_execution_env
   :  ?descriptor:descriptor
   -> name:string
   -> description:string
   -> parameters:Types.tool_param list
-  -> invocation_tool_handler
+  -> execution_env_tool_handler
   -> t
 
 val execute

--- a/lib/base/tool.mli
+++ b/lib/base/tool.mli
@@ -6,6 +6,23 @@
 type tool_handler = Yojson.Safe.t -> Types.tool_result
 type context_tool_handler = Context.t -> Yojson.Safe.t -> Types.tool_result
 
+(** Exact occurrence metadata for correlation and observability only.
+    It does not authorize tool execution. [turn] and [planned_index] scope
+    provider [tool_use_id] values that may be blank or repeated. The embedding
+    runtime owns any broader agent/run identity.
+
+    @since 0.215.0 *)
+module Invocation : sig
+  type t
+
+  val create : tool_use_id:string -> turn:int -> planned_index:int -> t
+  val tool_use_id : t -> string
+  val turn : t -> int
+  val planned_index : t -> int
+end
+
+type invocation_tool_handler = Invocation.t -> Yojson.Safe.t -> Types.tool_result
+
 type execution_mode =
   | Concurrent
   | Serial
@@ -19,6 +36,7 @@ type descriptor = { execution_mode : execution_mode }
 type handler_kind =
   | Simple of tool_handler
   | WithContext of context_tool_handler
+  | WithInvocation of invocation_tool_handler
 
 type t =
   { schema : Types.tool_schema
@@ -42,7 +60,25 @@ val create_with_context
   -> context_tool_handler
   -> t
 
-val execute : ?context:Context.t -> t -> Yojson.Safe.t -> Types.tool_result
+(** Creates a raw JSON tool whose handler receives exact invocation occurrence
+    metadata. Typed-tool projection is a separate API surface.
+
+    @since 0.215.0 *)
+val create_with_invocation
+  :  ?descriptor:descriptor
+  -> name:string
+  -> description:string
+  -> parameters:Types.tool_param list
+  -> invocation_tool_handler
+  -> t
+
+val execute
+  :  ?context:Context.t
+  -> ?invocation:Invocation.t
+  -> t
+  -> Yojson.Safe.t
+  -> Types.tool_result
+
 val descriptor : t -> descriptor option
 
 (** Exact declared execution mode, or [Serial] when no descriptor exists. *)

--- a/test/test_tool.ml
+++ b/test/test_tool.ml
@@ -96,47 +96,74 @@ let test_context_handler_requires_context () =
   | Ok _ -> fail "expected missing-context error"
 ;;
 
-let test_invocation_handler_receives_exact_id () =
+let missing_invocation_error () =
+  Error
+    { Types.message = "execution environment requires exact invocation"
+    ; recoverable = false
+    ; error_class = Some Types.Deterministic
+    }
+;;
+
+let test_execution_env_handler_receives_context_and_invocation () =
   let tool =
-    Tool.create_with_invocation
-      ~name:"invocation"
-      ~description:"Read invocation"
+    Tool.create_with_execution_env
+      ~name:"execution_env"
+      ~description:"Read context and invocation"
       ~parameters:[]
-      (fun invocation _input ->
-         Ok
-           { Types.content =
-               Printf.sprintf
-                 "%s:%d:%d"
-                 (Tool.Invocation.tool_use_id invocation)
-                 (Tool.Invocation.turn invocation)
-                 (Tool.Invocation.planned_index invocation)
-           ; _meta = None
-           })
+      (fun execution_env _input ->
+         match
+           ( Tool.Execution_env.context execution_env
+           , Tool.Execution_env.invocation execution_env )
+         with
+         | Some context, Some invocation ->
+           let context_value =
+             match Context.get context "key" with
+             | Some (`String value) -> value
+             | _ -> "missing"
+           in
+           Ok
+             { Types.content =
+                 Printf.sprintf
+                   "%s:%s:%d:%d"
+                   context_value
+                   (Tool.Invocation.tool_use_id invocation)
+                   (Tool.Invocation.turn invocation)
+                   (Tool.Invocation.planned_index invocation)
+             ; _meta = None
+             }
+         | _, None -> missing_invocation_error ()
+         | None, Some _ ->
+           Error
+             { Types.message = "execution environment requires context"
+             ; recoverable = false
+             ; error_class = Some Types.Deterministic
+             })
   in
+  let context = Context.create_sync () in
+  Context.set context "key" (`String "ctx");
   let invocation =
     Tool.Invocation.create ~tool_use_id:"provider-call-17" ~turn:4 ~planned_index:2
   in
-  match Tool.execute ~invocation tool `Null with
+  match Tool.execute ~context ~invocation tool `Null with
   | Ok { content; _meta = _ } ->
-    check string "exact occurrence" "provider-call-17:4:2" content
-  | Error _ -> fail "expected invocation-aware tool to run"
+    check string "orthogonal execution resources" "ctx:provider-call-17:4:2" content
+  | Error _ -> fail "expected execution-environment tool to run"
 ;;
 
-let test_invocation_handler_requires_invocation () =
+let test_execution_env_handler_observes_missing_invocation () =
   let tool =
-    Tool.create_with_invocation
-      ~name:"invocation"
+    Tool.create_with_execution_env
+      ~name:"execution_env"
       ~description:"Read invocation"
       ~parameters:[]
-      (fun _invocation _input -> Ok { Types.content = "unexpected"; _meta = None })
+      (fun execution_env _input ->
+         match Tool.Execution_env.invocation execution_env with
+         | Some _ -> Ok { Types.content = "unexpected"; _meta = None }
+         | None -> missing_invocation_error ())
   in
   match Tool.execute tool `Null with
   | Error { message; recoverable; error_class } ->
-    check
-      string
-      "error message"
-      "invocation-aware tool requires explicit invocation"
-      message;
+    check string "error message" "execution environment requires exact invocation" message;
     check bool "not recoverable" false recoverable;
     check
       bool
@@ -281,12 +308,15 @@ let () =
         ; test_case "writes context" `Quick test_context_handler_writes_context
         ; test_case "requires context" `Quick test_context_handler_requires_context
         ] )
-    ; ( "invocation_handler"
-      , [ test_case "receives exact id" `Quick test_invocation_handler_receives_exact_id
-        ; test_case
-            "requires invocation"
+    ; ( "execution_env_handler"
+      , [ test_case
+            "receives context and exact invocation"
             `Quick
-            test_invocation_handler_requires_invocation
+            test_execution_env_handler_receives_context_and_invocation
+        ; test_case
+            "observes missing invocation"
+            `Quick
+            test_execution_env_handler_observes_missing_invocation
         ] )
     ; ( "schema"
       , [ test_case "json structure" `Quick test_schema_to_json_structure
@@ -357,21 +387,24 @@ let () =
             | Ok { content; _meta = _ } ->
               check string "default in ctx handler" "worker-1" content
             | Error _ -> fail "expected Ok")
-        ; test_case "works with invocation handler" `Quick (fun () ->
+        ; test_case "works with execution environment handler" `Quick (fun () ->
             let tool =
-              Tool.create_with_invocation
-                ~name:"invocation_greet"
-                ~description:"Greet from invocation"
+              Tool.create_with_execution_env
+                ~name:"execution_env_greet"
+                ~description:"Greet from execution environment"
                 ~parameters:[]
-                (fun invocation input ->
+                (fun execution_env input ->
                    let open Yojson.Safe.Util in
-                   Ok
-                     { Types.content =
-                         Tool.Invocation.tool_use_id invocation
-                         ^ ":"
-                         ^ (input |> member "name" |> to_string)
-                     ; _meta = None
-                     })
+                   match Tool.Execution_env.invocation execution_env with
+                   | Some invocation ->
+                     Ok
+                       { Types.content =
+                           Tool.Invocation.tool_use_id invocation
+                           ^ ":"
+                           ^ (input |> member "name" |> to_string)
+                       ; _meta = None
+                       }
+                   | None -> missing_invocation_error ())
             in
             let wrapped = Tool.with_defaults [ "name", `String "default" ] tool in
             let invocation =

--- a/test/test_tool.ml
+++ b/test/test_tool.ml
@@ -96,6 +96,58 @@ let test_context_handler_requires_context () =
   | Ok _ -> fail "expected missing-context error"
 ;;
 
+let test_invocation_handler_receives_exact_id () =
+  let tool =
+    Tool.create_with_invocation
+      ~name:"invocation"
+      ~description:"Read invocation"
+      ~parameters:[]
+      (fun invocation _input ->
+         Ok
+           { Types.content =
+               Printf.sprintf
+                 "%s:%d:%d"
+                 (Tool.Invocation.tool_use_id invocation)
+                 (Tool.Invocation.turn invocation)
+                 (Tool.Invocation.planned_index invocation)
+           ; _meta = None
+           })
+  in
+  let invocation =
+    Tool.Invocation.create ~tool_use_id:"provider-call-17" ~turn:4 ~planned_index:2
+  in
+  match Tool.execute ~invocation tool `Null with
+  | Ok { content; _meta = _ } ->
+    check string "exact occurrence" "provider-call-17:4:2" content
+  | Error _ -> fail "expected invocation-aware tool to run"
+;;
+
+let test_invocation_handler_requires_invocation () =
+  let tool =
+    Tool.create_with_invocation
+      ~name:"invocation"
+      ~description:"Read invocation"
+      ~parameters:[]
+      (fun _invocation _input -> Ok { Types.content = "unexpected"; _meta = None })
+  in
+  match Tool.execute tool `Null with
+  | Error { message; recoverable; error_class } ->
+    check
+      string
+      "error message"
+      "invocation-aware tool requires explicit invocation"
+      message;
+    check bool "not recoverable" false recoverable;
+    check
+      bool
+      "deterministic"
+      true
+      (match error_class with
+       | Some Types.Deterministic -> true
+       | _ -> false)
+  | Ok _ -> fail "expected missing-invocation error"
+;;
+
 let test_schema_to_json_structure () =
   let tool =
     Tool.create
@@ -229,6 +281,13 @@ let () =
         ; test_case "writes context" `Quick test_context_handler_writes_context
         ; test_case "requires context" `Quick test_context_handler_requires_context
         ] )
+    ; ( "invocation_handler"
+      , [ test_case "receives exact id" `Quick test_invocation_handler_receives_exact_id
+        ; test_case
+            "requires invocation"
+            `Quick
+            test_invocation_handler_requires_invocation
+        ] )
     ; ( "schema"
       , [ test_case "json structure" `Quick test_schema_to_json_structure
         ; test_case "param types" `Quick test_schema_param_types
@@ -297,6 +356,30 @@ let () =
             match Tool.execute ~context:ctx wrapped (`Assoc []) with
             | Ok { content; _meta = _ } ->
               check string "default in ctx handler" "worker-1" content
+            | Error _ -> fail "expected Ok")
+        ; test_case "works with invocation handler" `Quick (fun () ->
+            let tool =
+              Tool.create_with_invocation
+                ~name:"invocation_greet"
+                ~description:"Greet from invocation"
+                ~parameters:[]
+                (fun invocation input ->
+                   let open Yojson.Safe.Util in
+                   Ok
+                     { Types.content =
+                         Tool.Invocation.tool_use_id invocation
+                         ^ ":"
+                         ^ (input |> member "name" |> to_string)
+                     ; _meta = None
+                     })
+            in
+            let wrapped = Tool.with_defaults [ "name", `String "default" ] tool in
+            let invocation =
+              Tool.Invocation.create ~tool_use_id:"call-1" ~turn:3 ~planned_index:1
+            in
+            match Tool.execute ~invocation wrapped (`Assoc []) with
+            | Ok { content; _meta = _ } ->
+              check string "invocation and default preserved" "call-1:default" content
             | Error _ -> fail "expected Ok")
         ] )
     ]

--- a/test/test_tool_execution.ml
+++ b/test/test_tool_execution.ml
@@ -703,22 +703,30 @@ let test_serial_barrier_splits_concurrent_batches () =
 
 let test_dispatch_passes_exact_tool_invocation () =
   let tool =
-    Tool.create_with_invocation
+    Tool.create_with_execution_env
       ~descriptor:(descriptor_with Tool.Concurrent)
       ~name:"observe_invocation"
       ~description:"Return exact invocation identity"
       ~parameters:[]
-      (fun invocation _ ->
-         Eio.Fiber.yield ();
-         Ok
-           { Types.content =
-               Printf.sprintf
-                 "%s:%d:%d"
-                 (Tool.Invocation.tool_use_id invocation)
-                 (Tool.Invocation.turn invocation)
-                 (Tool.Invocation.planned_index invocation)
-           ; _meta = None
-           })
+      (fun execution_env _ ->
+         match Tool.Execution_env.invocation execution_env with
+         | Some invocation ->
+           Eio.Fiber.yield ();
+           Ok
+             { Types.content =
+                 Printf.sprintf
+                   "%s:%d:%d"
+                   (Tool.Invocation.tool_use_id invocation)
+                   (Tool.Invocation.turn invocation)
+                   (Tool.Invocation.planned_index invocation)
+             ; _meta = None
+             }
+         | None ->
+           Error
+             { Types.message = "missing exact invocation"
+             ; recoverable = false
+             ; error_class = Some Types.Deterministic
+             })
   in
   match
     run_execute_with_tools

--- a/test/test_tool_execution.ml
+++ b/test/test_tool_execution.ml
@@ -701,6 +701,49 @@ let test_serial_barrier_splits_concurrent_batches () =
   | _ -> fail "serial tool should separate concurrent batches"
 ;;
 
+let test_dispatch_passes_exact_tool_invocation () =
+  let tool =
+    Tool.create_with_invocation
+      ~descriptor:(descriptor_with Tool.Concurrent)
+      ~name:"observe_invocation"
+      ~description:"Return exact invocation identity"
+      ~parameters:[]
+      (fun invocation _ ->
+         Eio.Fiber.yield ();
+         Ok
+           { Types.content =
+               Printf.sprintf
+                 "%s:%d:%d"
+                 (Tool.Invocation.tool_use_id invocation)
+                 (Tool.Invocation.turn invocation)
+                 (Tool.Invocation.planned_index invocation)
+           ; _meta = None
+           })
+  in
+  match
+    run_execute_with_tools
+      ~tools:[ tool ]
+      ~hooks:Hooks.empty
+      [ ToolUse
+          { id = "provider-call-duplicate"
+          ; name = "observe_invocation"
+          ; input = `Assoc []
+          }
+      ; ToolUse
+          { id = "provider-call-duplicate"
+          ; name = "observe_invocation"
+          ; input = `Assoc []
+          }
+      ]
+  with
+  | [ first; second ] ->
+    check string "first exact occurrence" "provider-call-duplicate:0:0" first.content;
+    check string "second exact occurrence" "provider-call-duplicate:0:1" second.content;
+    check bool "first tool succeeded" false (tool_result_outcome_is_error first.outcome);
+    check bool "second tool succeeded" false (tool_result_outcome_is_error second.outcome)
+  | _ -> fail "expected two invocation-aware results"
+;;
+
 let test_tool_exception_still_publishes_tool_completed () =
   Eio_main.run
   @@ fun env ->
@@ -770,6 +813,10 @@ let () =
             "unknown tools are uniform validation failures with full diagnostics"
             `Quick
             test_unknown_tool_is_uniform_validation_with_full_diagnostics
+        ; test_case
+            "dispatch passes exact tool invocation"
+            `Quick
+            test_dispatch_passes_exact_tool_invocation
         ] )
     ; ( "non_tool_use_filtering"
       , [ test_case


### PR DESCRIPTION
## Outcome

OAS exposes exact tool-call occurrence metadata through one explicit execution
environment without fiber-local state, globals, provider heuristics, or product
semantics.

- adds immutable `Tool.Invocation.t`
- scopes the exact provider `tool_use_id` with `turn + planned_index`
- adds `Tool.Execution_env.t` containing orthogonal optional `Context.t` and
  `Invocation.t` resources
- adds `Tool.create_with_execution_env`
- passes the occurrence explicitly from the sole Agent tool dispatch path
- preserves the execution environment through `Tool.with_defaults`
- keeps occurrence metadata correlation/observability-only; it never authorizes
  execution

## Review correction

The first head added an exclusive `WithInvocation` handler variant. That shape
could not represent a handler needing both shared context and exact invocation,
and would have required another public variant for every future execution
dimension.

The corrected head replaces it with `WithExecutionEnv`. Context and invocation
can now be consumed together, and future trace/budget metadata has one
record-shaped extension boundary.

## Boundary

OAS knows only generic tool execution. It does not know MASC, Keeper,
compaction, governance, vendors, repositories, or tool-name semantics. Broader
agent/run identity remains owned by the embedding runtime.

The immediate downstream requirement is MASC's exact tool-invocation identity
work; adoption follows the OAS release and pin update.

## Breaking change

`Tool.handler_kind` is a Stable public variant and gains `WithExecutionEnv`.
Exhaustive downstream matches must handle the new constructor. With
`bump-minor-pre-major`, this targets OAS `0.215.0`.

## Verification

- rebased onto current `main`
- `scripts/dune-local.sh build test/test_tool.exe test/test_tool_execution.exe`
- `test_tool`: 17/17
- `test_tool_execution`: 17/17
- regression proves one handler receives context and exact invocation together
- duplicate provider ID + concurrent dispatch distinguishes `turn:index`
  occurrences
- `ocamlformat --check` on all changed OCaml files
- `git diff --check`

BREAKING CHANGE: `Tool.handler_kind` gains `WithExecutionEnv`; execution-aware
handlers receive an explicit environment containing optional context and exact
invocation occurrence metadata.
