### PR TITLE
fix(streaming): total SSE decode boundary + shared Gemini Interactions envelope

### DIFF
--- a/lib/llm_provider/gemini_interactions.ml
+++ b/lib/llm_provider/gemini_interactions.ml
@@ -1,0 +1,144 @@
+type usage =
+  { input_tokens : int option
+  ; output_tokens : int option
+  ; total_tokens : int option
+  ; cached_tokens : int option
+  ; thought_tokens : int option
+  ; tool_use_tokens : int option
+  }
+
+type 'payload response =
+  { provider_response_id : string
+  ; created_at_rfc3339 : string option
+  ; payload : 'payload
+  ; usage : usage option
+  }
+
+let parse_failure ~parser message =
+  Error
+    (Http_client.ProviderFailure
+       { kind = Http_client.Provider_parse_error { parser = Some parser }; message })
+;;
+
+(* A well-formed interaction whose status is not "completed" is a
+   provider-reported outcome, not a parser defect: keep it out of
+   Provider_parse_error so parse-error alarms stay meaningful. *)
+let status_failure status =
+  Error
+    (Http_client.ProviderFailure
+       { kind =
+           Http_client.Unknown_provider_failure
+             { reason = Some (Printf.sprintf "gemini interaction status %s" status) }
+       ; message =
+           Printf.sprintf
+             "Gemini interaction finished with status %S, not completed"
+             status
+       })
+;;
+
+let optional_string ~parser name json =
+  match Yojson.Safe.Util.member name json with
+  | `Null -> Ok None
+  | `String value when String.trim value <> "" -> Ok (Some value)
+  | _ ->
+    parse_failure ~parser (Printf.sprintf "Gemini interaction %s must be non-empty" name)
+;;
+
+let required_string ~parser name json =
+  match optional_string ~parser name json with
+  | Ok (Some value) -> Ok value
+  | Ok None ->
+    parse_failure ~parser (Printf.sprintf "Gemini interaction %s is required" name)
+  | Error _ as error -> error
+;;
+
+let optional_int ~parser name json =
+  match Yojson.Safe.Util.member name json with
+  | `Null -> Ok None
+  | `Int value -> Ok (Some value)
+  | _ ->
+    parse_failure ~parser (Printf.sprintf "Gemini interaction %s must be an integer" name)
+;;
+
+let usage_of_json ~parser json =
+  match Yojson.Safe.Util.member "usage" json with
+  | `Null -> Ok None
+  | `Assoc _ as usage_json ->
+    let ( let* ) = Result.bind in
+    let* input_tokens = optional_int ~parser "total_input_tokens" usage_json in
+    let* output_tokens = optional_int ~parser "total_output_tokens" usage_json in
+    let* total_tokens = optional_int ~parser "total_tokens" usage_json in
+    let* cached_tokens = optional_int ~parser "total_cached_tokens" usage_json in
+    let* thought_tokens = optional_int ~parser "total_thought_tokens" usage_json in
+    let* tool_use_tokens = optional_int ~parser "total_tool_use_tokens" usage_json in
+    Ok
+      (Some
+         { input_tokens
+         ; output_tokens
+         ; total_tokens
+         ; cached_tokens
+         ; thought_tokens
+         ; tool_use_tokens
+         })
+  | _ -> parse_failure ~parser "Gemini interaction usage must be an object"
+;;
+
+let model_output_items ~parser ~content_type ~item_of_json json =
+  let open Yojson.Safe.Util in
+  let add_content acc = function
+    | `Assoc _ as content ->
+      (match member "type" content with
+       | `String kind when String.equal kind content_type ->
+         Result.map (fun item -> item :: acc) (item_of_json content)
+       | `String kind ->
+         parse_failure
+           ~parser
+           (Printf.sprintf "unexpected Gemini model_output content type %S" kind)
+       | _ -> parse_failure ~parser "Gemini model_output content requires a type")
+    | _ -> parse_failure ~parser "Gemini model_output content must be an object"
+  in
+  let add_step acc = function
+    | `Assoc _ as step ->
+      (match member "type" step with
+       | `String "thought" -> Ok acc
+       | `String "model_output" ->
+         (match member "content" step with
+          | `List contents ->
+            List.fold_left
+              (fun result item -> Result.bind result (fun acc -> add_content acc item))
+              (Ok acc)
+              contents
+          | _ -> parse_failure ~parser "Gemini model_output content must be a list")
+       | `String kind ->
+         parse_failure
+           ~parser
+           (Printf.sprintf "unexpected Gemini interaction step %S" kind)
+       | _ -> parse_failure ~parser "Gemini interaction step requires a type")
+    | _ -> parse_failure ~parser "Gemini interaction step must be an object"
+  in
+  match Yojson.Safe.Util.member "steps" json with
+  | `List steps ->
+    Result.map
+      List.rev
+      (List.fold_left
+         (fun result step -> Result.bind result (fun acc -> add_step acc step))
+         (Ok [])
+         steps)
+  | _ -> parse_failure ~parser "Gemini interaction steps must be a list"
+;;
+
+let decode_envelope ~parser ~payload_of_json body =
+  let decode json =
+    let ( let* ) = Result.bind in
+    let* provider_response_id = required_string ~parser "id" json in
+    let* status = required_string ~parser "status" json in
+    let* () = if String.equal status "completed" then Ok () else status_failure status in
+    let* created_at_rfc3339 = optional_string ~parser "created" json in
+    let* payload = payload_of_json json in
+    let* usage = usage_of_json ~parser json in
+    Ok { provider_response_id; created_at_rfc3339; payload; usage }
+  in
+  match Json_util.decode_json_with decode body with
+  | Ok result -> result
+  | Error message -> parse_failure ~parser ("invalid Gemini interaction JSON: " ^ message)
+;;

--- a/lib/llm_provider/gemini_interactions.mli
+++ b/lib/llm_provider/gemini_interactions.mli
@@ -1,0 +1,84 @@
+(** Shared response-envelope decoding for the Gemini Interactions API.
+
+    Image generation and speech generation both consume Interactions
+    responses; this module owns the modality-independent envelope — field
+    readers, the usage block, the status gate, and the steps/model_output
+    walker — so the two consumers cannot drift apart (oas#2633). Modality
+    payloads (image sources, audio blocks) stay in their own modules and are
+    injected as decoders.
+
+    @stability Internal *)
+
+(** Interaction usage block ([usage.total_*] fields). Absent fields stay
+    [None] rather than becoming zero. *)
+type usage =
+  { input_tokens : int option
+  ; output_tokens : int option
+  ; total_tokens : int option
+  ; cached_tokens : int option
+  ; thought_tokens : int option
+  ; tool_use_tokens : int option
+  }
+
+(** Decoded envelope around one modality payload. *)
+type 'payload response =
+  { provider_response_id : string
+  ; created_at_rfc3339 : string option
+  ; payload : 'payload
+  ; usage : usage option
+  }
+
+(** Typed parse failure attributed to [parser] (e.g. ["image_generation"]). *)
+val parse_failure : parser:string -> string -> ('a, Http_client.http_error) result
+
+(** A well-formed interaction whose status is not ["completed"]: a
+    provider-reported outcome ([Unknown_provider_failure]), not a parser
+    defect, so parse-error alarms stay meaningful. *)
+val status_failure : string -> ('a, Http_client.http_error) result
+
+(** [required_string ~parser name json]: missing/null reports
+    ["%s is required"], a blank or non-string value reports
+    ["%s must be non-empty"]. *)
+val required_string
+  :  parser:string
+  -> string
+  -> Yojson.Safe.t
+  -> (string, Http_client.http_error) result
+
+val optional_string
+  :  parser:string
+  -> string
+  -> Yojson.Safe.t
+  -> (string option, Http_client.http_error) result
+
+val optional_int
+  :  parser:string
+  -> string
+  -> Yojson.Safe.t
+  -> (int option, Http_client.http_error) result
+
+(** Decode the interaction [usage] object; [`Null]/absent is [Ok None]. *)
+val usage_of_json
+  :  parser:string
+  -> Yojson.Safe.t
+  -> (usage option, Http_client.http_error) result
+
+(** Walk [steps]: skip [thought] steps, and inside every [model_output] step
+    decode each content item of [content_type] with [item_of_json]. Any other
+    step or content type fails closed. Returns items in wire order; emptiness
+    is the caller's policy. *)
+val model_output_items
+  :  parser:string
+  -> content_type:string
+  -> item_of_json:(Yojson.Safe.t -> ('a, Http_client.http_error) result)
+  -> Yojson.Safe.t
+  -> ('a list, Http_client.http_error) result
+
+(** Decode one raw Interactions body through the shared total JSON boundary
+    ({!Json_util.decode_json_with}): required [id], the ["completed"] status
+    gate, optional [created], the injected payload, then [usage]. *)
+val decode_envelope
+  :  parser:string
+  -> payload_of_json:(Yojson.Safe.t -> ('p, Http_client.http_error) result)
+  -> string
+  -> ('p response, Http_client.http_error) result

--- a/lib/llm_provider/image_generation.ml
+++ b/lib/llm_provider/image_generation.ml
@@ -7,7 +7,7 @@ type source =
 
 type image = { source : source }
 
-type usage =
+type usage = Gemini_interactions.usage =
   { input_tokens : int option
   ; output_tokens : int option
   ; total_tokens : int option
@@ -261,19 +261,6 @@ let parse_openai_response body =
   | Error message -> parse_failure ("invalid image response JSON: " ^ message)
 ;;
 
-let required_non_empty_string name json =
-  match Yojson.Safe.Util.member name json with
-  | `String value when String.trim value <> "" -> Ok value
-  | _ -> parse_failure (Printf.sprintf "Gemini interaction %s must be non-empty" name)
-;;
-
-let optional_non_empty_string name json =
-  match Yojson.Safe.Util.member name json with
-  | `Null -> Ok None
-  | `String value when String.trim value <> "" -> Ok (Some value)
-  | _ -> parse_failure (Printf.sprintf "Gemini interaction %s must be non-empty" name)
-;;
-
 let gemini_source_of_json json =
   let open Yojson.Safe.Util in
   match member "data" json, member "uri" json, member "mime_type" json with
@@ -285,112 +272,36 @@ let gemini_source_of_json json =
   | _ -> parse_failure "Gemini image requires exactly one data+mime_type or uri source"
 ;;
 
+let gemini_parser = "image_generation"
+
 let gemini_images_of_json json =
-  let open Yojson.Safe.Util in
-  let add_content acc = function
-    | `Assoc _ as content ->
-      (match member "type" content with
-       | `String "image" ->
-         Result.map (fun source -> { source } :: acc) (gemini_source_of_json content)
-       | `String kind ->
-         parse_failure
-           (Printf.sprintf "unexpected Gemini model_output content type %S" kind)
-       | _ -> parse_failure "Gemini model_output content requires a type")
-    | _ -> parse_failure "Gemini model_output content must be an object"
+  let items =
+    Gemini_interactions.model_output_items
+      ~parser:gemini_parser
+      ~content_type:"image"
+      ~item_of_json:(fun content ->
+        Result.map (fun source -> { source }) (gemini_source_of_json content))
+      json
   in
-  let add_step acc = function
-    | `Assoc _ as step ->
-      (match member "type" step with
-       | `String "thought" -> Ok acc
-       | `String "model_output" ->
-         (match member "content" step with
-          | `List contents ->
-            List.fold_left
-              (fun result item -> Result.bind result (fun acc -> add_content acc item))
-              (Ok acc)
-              contents
-          | _ -> parse_failure "Gemini model_output content must be a list")
-       | `String kind ->
-         parse_failure (Printf.sprintf "unexpected Gemini interaction step %S" kind)
-       | _ -> parse_failure "Gemini interaction step requires a type")
-    | _ -> parse_failure "Gemini interaction step must be an object"
-  in
-  match member "steps" json with
-  | `List steps ->
-    (match
-       List.fold_left
-         (fun result step -> Result.bind result (fun acc -> add_step acc step))
-         (Ok [])
-         steps
-     with
-     | Ok [] -> parse_failure "Gemini interaction returned no image"
-     | Ok images -> Ok (List.rev images)
-     | Error _ as error -> error)
-  | _ -> parse_failure "Gemini interaction steps must be a list"
-;;
-
-let gemini_usage_of_json json =
-  match Yojson.Safe.Util.member "usage" json with
-  | `Null -> Ok None
-  | `Assoc _ as usage_json ->
-    let ( let* ) = Result.bind in
-    let* input_tokens = optional_int_field "total_input_tokens" usage_json in
-    let* output_tokens = optional_int_field "total_output_tokens" usage_json in
-    let* total_tokens = optional_int_field "total_tokens" usage_json in
-    let* cached_tokens = optional_int_field "total_cached_tokens" usage_json in
-    let* thought_tokens = optional_int_field "total_thought_tokens" usage_json in
-    let* tool_use_tokens = optional_int_field "total_tool_use_tokens" usage_json in
-    Ok
-      (Some
-         { input_tokens
-         ; output_tokens
-         ; total_tokens
-         ; cached_tokens
-         ; thought_tokens
-         ; tool_use_tokens
-         })
-  | _ -> parse_failure "Gemini interaction usage must be an object"
-;;
-
-(* A well-formed interaction whose status is not "completed" is a
-   provider-reported outcome, not a parser defect: keep it out of
-   Provider_parse_error so parse-error alarms stay meaningful. *)
-let gemini_status_failure status =
-  Error
-    (Http_client.ProviderFailure
-       { kind =
-           Http_client.Unknown_provider_failure
-             { reason = Some (Printf.sprintf "gemini interaction status %s" status) }
-       ; message =
-           Printf.sprintf
-             "Gemini interaction finished with status %S, not completed"
-             status
-       })
+  Result.bind items (function
+    | [] -> parse_failure "Gemini interaction returned no image"
+    | images -> Ok images)
 ;;
 
 let parse_gemini_response body =
-  let decode json =
-    let ( let* ) = Result.bind in
-    let* provider_response_id = required_non_empty_string "id" json in
-    let* status = required_non_empty_string "status" json in
-    let* () =
-      if String.equal status "completed" then Ok () else gemini_status_failure status
-    in
-    let* created_at_rfc3339 = optional_non_empty_string "created" json in
-    let* images = gemini_images_of_json json in
-    let* usage = gemini_usage_of_json json in
-    Ok
-      { created_at = None
-      ; created_at_rfc3339
-      ; provider_response_id = Some provider_response_id
-      ; images
-      ; usage
-      ; content_filter = []
-      }
-  in
-  match Json_util.decode_json_with decode body with
-  | Ok result -> result
-  | Error message -> parse_failure ("invalid Gemini interaction JSON: " ^ message)
+  Result.map
+    (fun { Gemini_interactions.provider_response_id; created_at_rfc3339; payload; usage } ->
+       { created_at = None
+       ; created_at_rfc3339
+       ; provider_response_id = Some provider_response_id
+       ; images = payload
+       ; usage
+       ; content_filter = []
+       })
+    (Gemini_interactions.decode_envelope
+       ~parser:gemini_parser
+       ~payload_of_json:gemini_images_of_json
+       body)
 ;;
 
 let parse_response ~protocol body =

--- a/lib/llm_provider/speech_generation.ml
+++ b/lib/llm_provider/speech_generation.ml
@@ -25,7 +25,7 @@ type audio =
   ; channels : int option
   }
 
-type usage =
+type usage = Gemini_interactions.usage =
   { input_tokens : int option
   ; output_tokens : int option
   ; total_tokens : int option
@@ -185,49 +185,8 @@ let gemini_request_body ~(config : Provider_config.t) ~text ~voice ~format =
       (gemini_media_type format)
 ;;
 
-let optional_string name json =
-  match Yojson.Safe.Util.member name json with
-  | `Null -> Ok None
-  | `String value when String.trim value <> "" -> Ok (Some value)
-  | _ -> parse_failure (Printf.sprintf "Gemini interaction %s must be non-empty" name)
-;;
-
-let required_string name json =
-  match optional_string name json with
-  | Ok (Some value) -> Ok value
-  | Ok None -> parse_failure (Printf.sprintf "Gemini interaction %s is required" name)
-  | Error _ as error -> error
-;;
-
-let optional_int name json =
-  match Yojson.Safe.Util.member name json with
-  | `Null -> Ok None
-  | `Int value -> Ok (Some value)
-  | _ -> parse_failure (Printf.sprintf "Gemini interaction %s must be an integer" name)
-;;
-
-let usage_of_json json =
-  match Yojson.Safe.Util.member "usage" json with
-  | `Null -> Ok None
-  | `Assoc _ as usage ->
-    let ( let* ) = Result.bind in
-    let* input_tokens = optional_int "total_input_tokens" usage in
-    let* output_tokens = optional_int "total_output_tokens" usage in
-    let* total_tokens = optional_int "total_tokens" usage in
-    let* cached_tokens = optional_int "total_cached_tokens" usage in
-    let* thought_tokens = optional_int "total_thought_tokens" usage in
-    let* tool_use_tokens = optional_int "total_tool_use_tokens" usage in
-    Ok
-      (Some
-         { input_tokens
-         ; output_tokens
-         ; total_tokens
-         ; cached_tokens
-         ; thought_tokens
-         ; tool_use_tokens
-         })
-  | _ -> parse_failure "Gemini interaction usage must be an object"
-;;
+let gemini_parser = "speech_generation"
+let optional_int = Gemini_interactions.optional_int ~parser:gemini_parser
 
 let audio_of_json expected json =
   let open Yojson.Safe.Util in
@@ -257,81 +216,30 @@ let audio_of_json expected json =
 ;;
 
 let audios_of_json expected json =
-  let open Yojson.Safe.Util in
-  let add_content acc content =
-    match member "type" content with
-    | `String "audio" ->
-      Result.map (fun audio -> audio :: acc) (audio_of_json expected content)
-    | `String kind ->
-      parse_failure (Printf.sprintf "unexpected Gemini speech content %S" kind)
-    | _ -> parse_failure "Gemini speech content requires a type"
+  let items =
+    Gemini_interactions.model_output_items
+      ~parser:gemini_parser
+      ~content_type:"audio"
+      ~item_of_json:(audio_of_json expected)
+      json
   in
-  let add_step acc step =
-    match member "type" step with
-    | `String "thought" -> Ok acc
-    | `String "model_output" ->
-      (match member "content" step with
-       | `List items ->
-         List.fold_left
-           (fun result item -> Result.bind result (fun acc -> add_content acc item))
-           (Ok acc)
-           items
-       | _ -> parse_failure "Gemini model_output content must be a list")
-    | `String kind ->
-      parse_failure (Printf.sprintf "unexpected Gemini speech step %S" kind)
-    | _ -> parse_failure "Gemini speech step requires a type"
-  in
-  match member "steps" json with
-  | `List steps ->
-    let result =
-      List.fold_left
-        (fun result step -> Result.bind result (fun acc -> add_step acc step))
-        (Ok [])
-        steps
-    in
-    Result.bind result (function
-      | [] -> parse_failure "Gemini interaction returned no audio"
-      | audios -> Ok (List.rev audios))
-  | _ -> parse_failure "Gemini interaction steps must be a list"
-;;
-
-(* A well-formed interaction whose status is not "completed" is a
-   provider-reported outcome, not a parser defect: keep it out of
-   Provider_parse_error so parse-error alarms stay meaningful. *)
-let gemini_status_failure status =
-  Error
-    (Http_client.ProviderFailure
-       { kind =
-           Http_client.Unknown_provider_failure
-             { reason = Some (Printf.sprintf "gemini interaction status %s" status) }
-       ; message =
-           Printf.sprintf
-             "Gemini interaction finished with status %S, not completed"
-             status
-       })
+  Result.bind items (function
+    | [] -> parse_failure "Gemini interaction returned no audio"
+    | audios -> Ok audios)
 ;;
 
 let parse_gemini_response expected body =
-  let decode json =
-    let ( let* ) = Result.bind in
-    let* provider_response_id = required_string "id" json in
-    let* status = required_string "status" json in
-    let* () =
-      if String.equal status "completed" then Ok () else gemini_status_failure status
-    in
-    let* created_at_rfc3339 = optional_string "created" json in
-    let* audios = audios_of_json expected json in
-    let* usage = usage_of_json json in
-    Ok
-      { provider_response_id = Some provider_response_id
-      ; created_at_rfc3339
-      ; audios
-      ; usage
-      }
-  in
-  match Json_util.decode_json_with decode body with
-  | Ok result -> result
-  | Error message -> parse_failure ("invalid Gemini interaction JSON: " ^ message)
+  Result.map
+    (fun { Gemini_interactions.provider_response_id; created_at_rfc3339; payload; usage } ->
+       { provider_response_id = Some provider_response_id
+       ; created_at_rfc3339
+       ; audios = payload
+       ; usage
+       })
+    (Gemini_interactions.decode_envelope
+       ~parser:gemini_parser
+       ~payload_of_json:(audios_of_json expected)
+       body)
 ;;
 
 let generate

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -1462,10 +1462,10 @@ let responses_sse_to_events (state : openai_stream_state) event_type data_str
   if String.equal data_str openai_done_sentinel
   then [], None
   else (
-    match Yojson.Safe.from_string data_str with
-    | exception Yojson.Json_error msg ->
-      [ SSEParseFailed { raw = data_str; reason = "json_error: " ^ msg } ], None
-    | json ->
+    (* Decode through the shared total boundary (#2620): a valid-JSON
+       non-object frame raises Util.Type_error out of [member], which a
+       Json_error-only guard would let escape the parser (oas#2632). *)
+    let decode json =
       let open Yojson.Safe.Util in
       let evt_type =
         match event_type with
@@ -1589,7 +1589,11 @@ let responses_sse_to_events (state : openai_stream_state) event_type data_str
        | "response.refusal.done"
        | "response.queued" -> ()
        | other -> emit (SSEUnknownEventType { event_type = other; raw = data_str }));
-      List.rev !events, None)
+      List.rev !events, None
+    in
+    match Json_util.decode_json_with decode data_str with
+    | Ok result -> result
+    | Error reason -> [ SSEParseFailed { raw = data_str; reason } ], None)
 ;;
 
 (** {1 Gemini SSE Streaming}

--- a/lib/sessions_store_parsers.ml
+++ b/lib/sessions_store_parsers.ml
@@ -23,8 +23,12 @@ let parse_runtime_json of_yojson raw =
 
 let decode_json_with decoder raw =
   let* json = parse_json_string raw in
+  (* Exception coverage mirrors Llm_provider.Json_util.decode_json_with
+     (Json_error via parse_json_string, Type_error and Undefined here); the
+     error type differs — this boundary reports typed session parse errors. *)
   try Ok (decoder json) with
-  | Yojson.Safe.Util.Type_error (detail, _) -> Error (json_parse_error detail)
+  | Yojson.Safe.Util.Type_error (detail, _) | Yojson.Safe.Util.Undefined (detail, _) ->
+    Error (json_parse_error detail)
 ;;
 
 let tool_contract_of_json json =

--- a/test/test_streaming_openai.ml
+++ b/test/test_streaming_openai.ml
@@ -987,6 +987,22 @@ let test_events_reasoning_details_accumulates_typed () =
   | Error _ -> Alcotest.fail "expected successful accumulator finalization"
 ;;
 
+let test_responses_non_object_frame_is_parse_failure () =
+  let state =
+    S.create_openai_stream_state ~provider:"openai_compat" ~model:"gpt-5.5" ()
+  in
+  (* Valid JSON that is not an object: Util.member raises Type_error, which
+     must surface as SSEParseFailed instead of escaping the parser (#2632). *)
+  List.iter
+    (fun frame ->
+       match S.responses_sse_to_events state (Some "response.created") frame with
+       | [ SSEParseFailed { raw; reason } ], None ->
+         Alcotest.(check string) "raw preserved" frame raw;
+         Alcotest.(check bool) "reason non-empty" true (String.length reason > 0)
+       | _ -> Alcotest.fail ("non-object frame must fail closed: " ^ frame))
+    [ "null"; "[]"; "42" ]
+;;
+
 let test_responses_stream_reasoning_tool_and_terminal () =
   let state =
     S.create_openai_stream_state ~provider:"openai_compat" ~model:"gpt-5.5" ()
@@ -1600,6 +1616,10 @@ let () =
         ] )
     ; ( "responses_sse_to_events"
       , [ test_case
+            "non-object frame is a typed parse failure"
+            `Quick
+            test_responses_non_object_frame_is_parse_failure
+        ; test_case
             "reasoning tool and terminal"
             `Quick
             test_responses_stream_reasoning_tool_and_terminal


### PR DESCRIPTION
## 요약

0.214.0 사후 감사(#2632, #2633)에서 확인된 두 가지 품질 결함 수리.

**커밋 1 — fix(streaming) (#2632)**: `responses_sse_to_events`가 `Yojson.Json_error`만 잡은 채 `Util.member`를 적용해, 유효 JSON 비객체 SSE frame(`null`/`[]`/`42`)에서 `Type_error`가 파서 밖으로 탈출. `Json_util.decode_json_with`(#2620) 경유로 봉합 + 회귀 테스트(`non-object frame is a typed parse failure`). `sessions_store_parsers.decode_json_with`도 `Undefined` 커버리지를 공유 경계와 일치시킴.

**커밋 2 — refactor(llm_provider) (#2633)**: image/speech가 각자 들고 있던 Gemini Interactions envelope(필드 리더·usage·status 게이트·steps walker)를 `Gemini_interactions` 단일 모듈로 추출. 이미 발생한 drift(누락 필드 메시지 상이, image의 Gemini usage 진단 'image response usage.*' 오라벨)를 해소. 양쪽 usage 레코드는 공유 타입의 equation. `build_count_tokens_request`의 `request_mode` 공유 패턴을 따름.

## 검증

- `@lib/llm_provider/runtest` (image/speech/count 인라인 전체) green
- test_streaming_openai 49 / test_streaming_edge_cases 11 / test_sessions_cov2 23 green
- 에러 taxonomy 불변: parser 이름은 모듈별로 유지("image_generation"/"speech_generation"), status_failure reason 문자열 불변

Closes #2632, Closes #2633
