### PR TITLE
fix(llm_provider): surface silent capability drops + tools/schema coexistence proofs

### DIFF
--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -247,6 +247,9 @@ let build_openai_body_unchecked
                 ~is_zai_glm
                 capabilities
                 serialization_config.tool_choice -> Some entries
+    | Some entries when entries <> [] && not capabilities.supports_tools ->
+      warn_capability_drop ~model_id:model_str ~field:"tools";
+      None
     | None | Some _ -> None
   in
   let provider_messages =
@@ -390,7 +393,13 @@ let build_openai_body_unchecked
       (match response_format_to_openai_json serialization_config.response_format with
        | Some response_format -> ("response_format", response_format) :: body_assoc
        | None -> body_assoc)
-    | JsonSchema _ | JsonMode | Off -> body_assoc
+    | JsonMode ->
+      warn_capability_drop ~model_id:model_str ~field:"response_format_json";
+      body_assoc
+    | JsonSchema _ ->
+      warn_capability_drop ~model_id:model_str ~field:"structured_output";
+      body_assoc
+    | Off -> body_assoc
   in
   let body_assoc =
     match slot_id with

--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -140,6 +140,20 @@ let build_request_artifact
     match tools with
     | [] -> body
     | ts ->
+      (* The native /api/chat wire has no parallel-disable field (unlike
+         OpenAI [parallel_tool_calls] or Anthropic
+         [tool_choice.disable_parallel_tool_use]), so an effective disable
+         request cannot be honored — surface the drop instead of ignoring
+         it silently, mirroring the Gemini backend. *)
+      if
+        Capabilities.effective_disable_parallel_tool_use
+          ~caller_disabled:config.disable_parallel_tool_use
+          ~supports_parallel_tool_calls:caps.supports_parallel_tool_calls
+          ~tools_present:true
+      then
+        Backend_openai.warn_capability_drop
+          ~model_id:config.model_id
+          ~field:"disable_parallel_tool_use";
       ("tools", `List (List.map Backend_openai_serialize.build_openai_tool_json ts))
       :: body
   in

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -34,7 +34,7 @@ let warn_capability_drop ~model_id ~field =
     (Metrics.get_global ()).on_capability_drop ~model_id ~field;
     Diag.warn
       "backend_openai"
-      "dropping sampling field %s for model %s: capability record reports supports_%s = \
+      "dropping request field %s for model %s: capability record reports supports_%s = \
        false. Update Capabilities.for_model_id if this model actually supports it, \
        otherwise remove the field from your request config."
       field

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -2,7 +2,7 @@
 
     Replaces the monolithic run_turn_core with named stages:
     1. Input   — lifecycle, BeforeTurn hook, elicitation
-    2. Parse   — BeforeTurnParams hook, context reduction, tool preparation
+    2. Parse   — BeforeTurnParams hook, tool preparation
     3. Route   — provider selection, API call dispatch (sync/stream)
     4. Collect — usage accumulation, AfterTurn hook, events, message append
     5. Execute — exact-name tool execution on StopToolUse
@@ -122,8 +122,8 @@ let sdk_error_of_http_error = Pipeline_stage_route.sdk_error_of_http_error
 (** Sync dispatch via {!Llm_provider.Complete.complete}.  Routes all
     provider kinds through the consolidated path so [on_request_end]
     metrics fire and [Llm_transport.t] (set via [agent.options.transport])
-    handles CLI providers.  Legacy {!Api.create_message} remains for
-    Stream fallback pending PR-O2b. *)
+    handles CLI providers.  Streaming dispatch is likewise consolidated on
+    {!Llm_provider.Complete.complete_stream}; no legacy fallback remains. *)
 let dispatch_sync = Pipeline_stage_route.dispatch_sync
 
 let dispatch_stream = Pipeline_stage_route.dispatch_stream

--- a/lib/pipeline/pipeline_common.ml
+++ b/lib/pipeline/pipeline_common.ml
@@ -6,7 +6,7 @@ open Agent_trace
 
     Replaces the monolithic run_turn_core with named stages:
     1. Input   — lifecycle, BeforeTurn hook, elicitation
-    2. Parse   — BeforeTurnParams hook, context reduction, tool preparation
+    2. Parse   — BeforeTurnParams hook, tool preparation
     3. Route   — provider selection, API call dispatch (sync/stream)
     4. Collect — usage accumulation, AfterTurn hook, events, message append
     5. Execute — exact-name tool execution on StopToolUse

--- a/test/test_provider_complete.ml
+++ b/test/test_provider_complete.ml
@@ -1238,6 +1238,41 @@ let test_complete_rejects_output_schema_for_glm () =
   | Error _ -> Alcotest.fail "expected AcceptRejected for glm output_schema"
 ;;
 
+let test_complete_stream_rejects_output_schema_for_glm () =
+  (* The streaming entry must run the same pre-wire validation as sync: a
+     regression that skipped validate_all in complete_stream would turn this
+     red before any transport I/O happens. *)
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let net = Eio.Stdenv.net env in
+  let config =
+    PC.make
+      ~kind:Glm
+      ~model_id:"glm-5"
+      ~base_url:"https://api.z.ai/api/coding/paas/v4"
+      ~output_schema:(`Assoc [ "type", `String "object" ])
+      ()
+  in
+  match
+    Llm_provider.Complete.complete_stream
+      ~sw
+      ~net
+      ~config
+      ~messages:[ user_msg "hi" ]
+      ~on_event:(fun _ -> ())
+      ()
+  with
+  | Error (Llm_provider.Http_client.AcceptRejected { reason }) ->
+    Alcotest.(check bool)
+      "mentions glm json mode"
+      true
+      (contains_substring ~sub:"json mode" (String.lowercase_ascii reason))
+  | Ok _ -> Alcotest.fail "expected stream AcceptRejected for glm output_schema"
+  | Error _ -> Alcotest.fail "expected stream AcceptRejected for glm output_schema"
+;;
+
 let test_annotate_response_cost () =
   let response : api_response =
     { id = "resp-1"
@@ -1662,6 +1697,10 @@ let () =
             "glm output schema rejected before request"
             `Quick
             test_complete_rejects_output_schema_for_glm
+        ; test_case
+            "glm output schema rejected before stream request"
+            `Quick
+            test_complete_stream_rejects_output_schema_for_glm
         ] )
     ; ( "capability_drift"
       , [ test_case

--- a/test/test_snapshot_provider_serialization.ml
+++ b/test/test_snapshot_provider_serialization.ml
@@ -767,6 +767,50 @@ let test_ollama_output_schema () =
     (contains ~needle:{|"required":["answer"]|} body)
 ;;
 
+let test_anthropic_tools_with_output_schema () =
+  (* Tools + structured output in ONE request: the output_config format merge
+     must not clobber tool wiring, and vice versa. *)
+  let body =
+    Backend_anthropic.build_request
+      ~config:anthropic_schema_cfg
+      ~messages
+      ~tools:[ tool_decl ]
+      ()
+  in
+  check
+    bool
+    "format.json_schema coexists with tools"
+    true
+    (contains ~needle:{|"format":{"type":"json_schema","schema":{|} body);
+  check
+    bool
+    "tool declaration on the wire"
+    true
+    (contains ~needle:{|"name":"get_weather"|} body);
+  check
+    bool
+    "tool input_schema on the wire"
+    true
+    (contains ~needle:{|"input_schema"|} body)
+;;
+
+let test_openai_tools_with_response_format () =
+  let cfg = schema_cfg ~kind:OpenAI_compat ~base_url:"https://api.openai.com/v1" in
+  let body =
+    Backend_openai_request.build_request ~config:cfg ~messages ~tools:[ tool_decl ] ()
+  in
+  check
+    bool
+    "response_format json_schema coexists with tools"
+    true
+    (contains ~needle:{|"response_format":{"type":"json_schema"|} body);
+  check
+    bool
+    "tool declaration on the wire"
+    true
+    (contains ~needle:{|"function":{"name":"get_weather"|} body)
+;;
+
 let test_anthropic_output_schema () =
   let body =
     Backend_anthropic.build_request
@@ -855,6 +899,14 @@ let () =
             "anthropic output_schema -> format.json_schema"
             `Quick
             test_anthropic_output_schema
+        ; test_case
+            "anthropic tools coexist with output_schema"
+            `Quick
+            test_anthropic_tools_with_output_schema
+        ; test_case
+            "openai tools coexist with response_format"
+            `Quick
+            test_openai_tools_with_response_format
         ] )
     ]
 ;;


### PR DESCRIPTION
## 요약

0.214.0 upgrade-proof 감사(5-agent, 2026-07-17)에서 확인된 fail-open/문서 거짓/테스트 공백 후속 수리.

- **silent capability drop 봉합**: 레거시 `Api.create_message` 경로가 `supports_tools=false`면 tools 전체를, capability 부재 시 `response_format`(JsonMode/JsonSchema)을 **무경고 드롭** — sampling 파라미터만 warn하던 비대칭 해소 (`warn_capability_drop` + `on_capability_drop` 메트릭 발화). masc는 이 경로를 쓰지 않지만 export된 표면이므로 fail-open 제거.
- **Ollama parallel-disable 무시 경고**: native /api/chat엔 parallel-disable wire가 없어 요청이 소실되던 것을 Gemini backend와 동일하게 1회/모델 경고.
- **stale 문서 정정**: stage-2 "context reduction" 주장(#2590/#2603에서 hard-delete됨) 제거, "legacy stream fallback pending PR-O2b" 주석 현행화.
- **테스트 공백 봉합**: ① streaming 진입도 `validate_all`을 거친다는 증명(GLM output_schema stream 거부), ② tools+structured output **동시** 요청의 wire 공존 증명(Anthropic `format.json_schema`+tools, OpenAI `response_format`+tools) — 기존에 이 조합을 검증하는 테스트 0건.

## 검증
- test_snapshot_provider_serialization 22 / test_provider_complete 52 green (신규 4 케이스 포함)

감사 잔여 중 이 PR에서 다루지 않은 것: Anthropic/Gemini/DashScope kind의 structured-output per-model 게이트 비대칭(fail-loud라 위험도 낮음 — 후속 판단), media generate HTTP e2e mock 테스트(별도 PR 후보).
