### PR TITLE
fix(execution): bind recursive work to exact tool attempts

### DIFF
--- a/lib/execution_event_store.ml
+++ b/lib/execution_event_store.ml
@@ -110,6 +110,10 @@ type error =
   | Store_not_found
   | Store_initialization_incomplete
   | Store_initialization_conflict
+  | Unsupported_store_version of
+      { expected : int
+      ; actual : int
+      }
   | Corrupt_store of
       { offset : int64
       ; detail : string
@@ -156,6 +160,11 @@ let rec error_to_string = function
   | Store_initialization_incomplete -> "execution store has an uncommitted initialization"
   | Store_initialization_conflict ->
     "execution store has both committed and initializing WAL paths"
+  | Unsupported_store_version { expected; actual } ->
+    Printf.sprintf
+      "execution store format version %d is unsupported; expected version %d"
+      actual
+      expected
   | Corrupt_store { offset; detail } ->
     Printf.sprintf "execution store is corrupt at byte %Ld: %s" offset detail
   | Correlation_mismatch -> "execution store correlation identity mismatch"
@@ -208,6 +217,9 @@ let authority_initializing_name = "events.v1.commit.initializing"
 let lock_name = ".writer.lock"
 let frame_magic = "OASE"
 let frame_version = 1
+
+(* Version 2 hard-cuts recursive work to exact tool attempts; WAL framing is unchanged. *)
+let store_format_version = 2
 let frame_header_size = 48
 
 module Active_path_map = Map.Make (String)
@@ -916,7 +928,7 @@ type commit_authority =
 
 let authority_payload_to_yojson authority =
   `Assoc
-    [ "format_version", `Int 1
+    [ "format_version", `Int store_format_version
     ; "scope_id", `String (Scope_id.to_string authority.scope_id)
     ; "correlation_id", `String (Event.Correlation_id.to_string authority.correlation_id)
     ; "committed_offset", `String (Int64.to_string authority.committed_offset)
@@ -992,6 +1004,14 @@ let authority_of_string payload =
     | Error detail -> corrupt detail
   in
   let* format_version = int_field "format_version" in
+  let* () =
+    if format_version = store_format_version
+    then Ok ()
+    else
+      Error
+        (Unsupported_store_version
+           { expected = store_format_version; actual = format_version })
+  in
   let* scope_text = string_field "scope_id" in
   let* correlation_text = string_field "correlation_id" in
   let* committed_offset_text = string_field "committed_offset" in
@@ -1012,11 +1032,6 @@ let authority_of_string payload =
       when Int64.compare value 0L > 0
            && String.equal committed_offset_text (Int64.to_string value) -> Ok value
     | Some _ | None -> corrupt "commit authority offset is not canonical and positive"
-  in
-  let* () =
-    if format_version = 1
-    then Ok ()
-    else corrupt "unsupported commit authority format version"
   in
   let* () =
     if last_seq >= 0 then Ok () else corrupt "commit authority sequence is negative"

--- a/lib/execution_event_store.mli
+++ b/lib/execution_event_store.mli
@@ -82,6 +82,10 @@ type error =
   | Store_not_found
   | Store_initialization_incomplete
   | Store_initialization_conflict
+  | Unsupported_store_version of
+      { expected : int
+      ; actual : int
+      }
   | Corrupt_store of
       { offset : int64
       ; detail : string

--- a/lib/execution_journal.ml
+++ b/lib/execution_journal.ml
@@ -106,7 +106,7 @@ type run_status =
 type run_view =
   { run : run
   ; opened : Event.node event_record
-  ; parent_invocation : Event.Node_id.t option
+  ; parent_attempt : Event.Node_id.t option
   ; status : run_status
   ; through_seq : int
   }
@@ -150,7 +150,7 @@ type invariant_violation =
       { parent : Event.Node_id.t
       ; child : Event.Node_id.t
       }
-  | Invalid_child_run_parent of Event.Node_id.t
+  | Child_run_parent_not_tool_attempt of Event.Node_id.t
   | Root_parent_event_mismatch
   | Parent_event_mismatch of
       { expected : Event.Event_id.t
@@ -508,6 +508,7 @@ module Reducer = struct
     | Event.Agent_turn _, Event.Provider_attempt _ -> true
     | Event.Provider_attempt _, (Event.Output_block _ | Event.Tool_invocation _) -> true
     | Event.Tool_invocation _, Event.Tool_attempt -> true
+    | Event.Tool_attempt, Event.Tool_invocation _ -> true
     | ( ( Event.Agent_run _
         | Event.Agent_turn _
         | Event.Provider_attempt _
@@ -638,7 +639,7 @@ module Reducer = struct
     if Run_id_map.mem run_id state.runs
     then Error (Duplicate_run_id run_id)
     else
-      let* parent_invocation =
+      let* parent_attempt =
         match Event.parent_node_id node with
         | None ->
           let* () = validate_root_parent event in
@@ -654,22 +655,17 @@ module Reducer = struct
            | Some parent_record ->
              let* () = ensure_node_open parent_id parent_record in
              (match Event.node_kind parent_record.node with
-              | Event.Tool_invocation _ ->
-                if Option.is_none parent_record.tool_input
-                then Error (Tool_input_not_materialized parent_id)
-                else if Option.is_some parent_record.tool_result
-                then Error (Child_after_tool_result parent_id)
-                else
-                  let+ () = validate_parent_event event parent_record.last_event_id in
-                  Some parent_id
-              | _ -> Error (Invalid_child_run_parent parent_id)))
+              | Event.Tool_attempt ->
+                let+ () = validate_parent_event event parent_record.last_event_id in
+                Some parent_id
+              | _ -> Error (Child_run_parent_not_tool_attempt parent_id)))
       in
       let run = { id = run_id; root = node_id } in
       let run_record =
         { view =
             { run
             ; opened = { event; value = node }
-            ; parent_invocation
+            ; parent_attempt
             ; status = Running
             ; through_seq = 0
             }
@@ -1255,7 +1251,7 @@ let node_last_event (state : journal_state) node_id =
   | Some event_id -> Ok event_id
 ;;
 
-let stage_start_run ?parent_invocation ?causes journal state ~agent_name =
+let stage_start_run ?parent_attempt ?causes journal state ~agent_name =
   let* run_id = identity_result (Event.Run_id.fresh ()) in
   let* root = identity_result (Event.Node_id.fresh ()) in
   let* event_id = identity_result (Event.Event_id.fresh ()) in
@@ -1264,7 +1260,7 @@ let stage_start_run ?parent_invocation ?causes journal state ~agent_name =
       Event.make_node
         ~node_id:root
         ~run_id
-        ~parent_node_id:parent_invocation
+        ~parent_node_id:parent_attempt
         ~kind:(Event.Agent_run { agent_name })
     with
     | Ok node -> Ok node
@@ -1272,7 +1268,7 @@ let stage_start_run ?parent_invocation ?causes journal state ~agent_name =
   in
   let* payload = payload_result (Event.validate_payload (Event.Node_opened node)) in
   let* parent_event_id =
-    match parent_invocation with
+    match parent_attempt with
     | None -> Ok None
     | Some node_id ->
       let+ event_id = node_last_event state node_id in
@@ -1445,9 +1441,9 @@ let stage_abort_run ?causes journal captured_state ~run terminal =
     { next_state; events; value = events }
 ;;
 
-let start_run ?parent_invocation ?causes journal ~agent_name =
+let start_run ?parent_attempt ?causes journal ~agent_name =
   with_write journal (fun state ->
-    stage_start_run ?parent_invocation ?causes journal state ~agent_name)
+    stage_start_run ?parent_attempt ?causes journal state ~agent_name)
 ;;
 
 let open_node ?causes journal ~run ~parent ~kind =
@@ -1511,7 +1507,7 @@ let extend_batch batch mutation =
 module Transaction = struct
   type _ t =
     | Start_run :
-        { parent_invocation : Event.Node_id.t option
+        { parent_attempt : Event.Node_id.t option
         ; causes : Event.cause list
         ; agent_name : string
         }
@@ -1548,8 +1544,8 @@ module Transaction = struct
         }
         -> Event.t list t
 
-  let start_run ?parent_invocation ?(causes = []) ~agent_name () =
-    Start_run { parent_invocation; causes; agent_name }
+  let start_run ?parent_attempt ?(causes = []) ~agent_name () =
+    Start_run { parent_attempt; causes; agent_name }
   ;;
 
   let open_node ?(causes = []) ~run ~parent ~kind () =
@@ -1569,10 +1565,10 @@ let stage : type value. batch -> value Transaction.t -> (batch * value, error) r
     extend_batch batch mutation
   in
   match transaction with
-  | Transaction.Start_run { parent_invocation; causes; agent_name } ->
+  | Transaction.Start_run { parent_attempt; causes; agent_name } ->
     stage_mutation
       (stage_start_run
-         ?parent_invocation
+         ?parent_attempt
          ~causes
          batch.journal
          batch.staged_state

--- a/lib/execution_journal.mli
+++ b/lib/execution_journal.mli
@@ -1,8 +1,9 @@
 (** In-memory, append-only journal for one finite execution scope.
 
     A journal admits exactly one top-level [Agent_run] and any child runs
-    recursively invoked beneath it. It owns one global logical sequence across
-    that tree. Timestamps are observations only; ordering uses [seq].
+    recursively invoked beneath exact [Tool_attempt] occurrences. It owns one
+    global logical sequence across that tree. Timestamps are observations only;
+    ordering uses [seq].
 
     Events remain in memory for the lifetime of [t]. A claimed durable writer
     hides the physical store behind this semantic boundary; consumers obtain
@@ -52,7 +53,7 @@ type run_status =
 type run_view = private
   { run : run
   ; opened : Execution_event.node event_record
-  ; parent_invocation : Execution_event.Node_id.t option
+  ; parent_attempt : Execution_event.Node_id.t option
   ; status : run_status
   ; through_seq : int
   }
@@ -98,7 +99,7 @@ type invariant_violation =
       { parent : Execution_event.Node_id.t
       ; child : Execution_event.Node_id.t
       }
-  | Invalid_child_run_parent of Execution_event.Node_id.t
+  | Child_run_parent_not_tool_attempt of Execution_event.Node_id.t
   | Root_parent_event_mismatch
   | Parent_event_mismatch of
       { expected : Execution_event.Event_id.t
@@ -293,7 +294,7 @@ module Transaction : sig
   type 'a t
 
   val start_run
-    :  ?parent_invocation:Execution_event.Node_id.t
+    :  ?parent_attempt:Execution_event.Node_id.t
     -> ?causes:Execution_event.cause list
     -> agent_name:string
     -> unit
@@ -367,12 +368,12 @@ val reconcile_durable_batch
   -> batch
   -> (durable_batch_reconciliation, error) result
 
-(** Start the journal's sole top-level run, or a child run beneath an existing
-    open [Tool_invocation]. Once the top-level run has started, the journal can
+(** Start the journal's sole top-level run, or a child run beneath one exact
+    open [Tool_attempt]. Once the top-level run has started, the journal can
     never be reused for another top-level run, including after it finishes. The
     journal allocates both run and root-node identity. *)
 val start_run
-  :  ?parent_invocation:Execution_event.Node_id.t
+  :  ?parent_attempt:Execution_event.Node_id.t
   -> ?causes:Execution_event.cause list
   -> t
   -> agent_name:string
@@ -380,7 +381,8 @@ val start_run
 
 (** Open a non-root node. The journal allocates node identity and enforces the
     hierarchy [Agent_run -> Agent_turn -> Provider_attempt ->
-    (Output_block | Tool_invocation)] and [Tool_invocation -> Tool_attempt]. *)
+    (Output_block | Tool_invocation)], [Tool_invocation -> Tool_attempt], and
+    recursive [Tool_attempt -> Tool_invocation]. *)
 val open_node
   :  ?causes:Execution_event.cause list
   -> t

--- a/test/dune
+++ b/test/dune
@@ -360,6 +360,7 @@
  (name test_execution_journal)
  (modules test_execution_journal)
  (libraries agent_sdk agent_sdk.llm_provider alcotest eio_main)
+ (flags (:standard -alias-deps))
  (deps ../models.toml)
  (action
   (run %{test})))
@@ -368,6 +369,7 @@
  (name test_execution_codec_executor)
  (modules test_execution_codec_executor)
  (libraries agent_sdk agent_sdk.llm_provider alcotest eio_main)
+ (flags (:standard -alias-deps))
  (deps ../models.toml)
  (action
   (run %{test})))
@@ -375,7 +377,8 @@
 (test
  (name test_execution_event_store)
  (modules test_execution_event_store)
- (libraries agent_sdk agent_sdk.llm_provider alcotest eio_main)
+ (libraries agent_sdk agent_sdk.llm_provider alcotest digestif eio_main)
+ (flags (:standard -alias-deps))
  (deps ../models.toml)
  (action
   (run %{test})))
@@ -384,6 +387,7 @@
  (name test_execution_lane_writer)
  (modules test_execution_lane_writer)
  (libraries agent_sdk agent_sdk.llm_provider alcotest eio_main)
+ (flags (:standard -alias-deps))
  (deps ../models.toml)
  (action
   (run %{test})))

--- a/test/dune
+++ b/test/dune
@@ -360,7 +360,8 @@
  (name test_execution_journal)
  (modules test_execution_journal)
  (libraries agent_sdk agent_sdk.llm_provider alcotest eio_main)
- (flags (:standard -alias-deps))
+ (flags
+  (:standard -alias-deps))
  (deps ../models.toml)
  (action
   (run %{test})))
@@ -369,7 +370,8 @@
  (name test_execution_codec_executor)
  (modules test_execution_codec_executor)
  (libraries agent_sdk agent_sdk.llm_provider alcotest eio_main)
- (flags (:standard -alias-deps))
+ (flags
+  (:standard -alias-deps))
  (deps ../models.toml)
  (action
   (run %{test})))
@@ -378,7 +380,8 @@
  (name test_execution_event_store)
  (modules test_execution_event_store)
  (libraries agent_sdk agent_sdk.llm_provider alcotest digestif eio_main)
- (flags (:standard -alias-deps))
+ (flags
+  (:standard -alias-deps))
  (deps ../models.toml)
  (action
   (run %{test})))
@@ -387,7 +390,8 @@
  (name test_execution_lane_writer)
  (modules test_execution_lane_writer)
  (libraries agent_sdk agent_sdk.llm_provider alcotest eio_main)
- (flags (:standard -alias-deps))
+ (flags
+  (:standard -alias-deps))
  (deps ../models.toml)
  (action
   (run %{test})))

--- a/test/dune
+++ b/test/dune
@@ -361,8 +361,6 @@
  (modules test_execution_journal)
  (libraries agent_sdk agent_sdk.llm_provider alcotest eio_main)
  (deps ../models.toml)
- (flags
-  (:standard -open Agent_sdk__))
  (action
   (run %{test})))
 
@@ -371,8 +369,6 @@
  (modules test_execution_codec_executor)
  (libraries agent_sdk agent_sdk.llm_provider alcotest eio_main)
  (deps ../models.toml)
- (flags
-  (:standard -open Agent_sdk__))
  (action
   (run %{test})))
 
@@ -381,8 +377,6 @@
  (modules test_execution_event_store)
  (libraries agent_sdk agent_sdk.llm_provider alcotest eio_main)
  (deps ../models.toml)
- (flags
-  (:standard -open Agent_sdk__))
  (action
   (run %{test})))
 
@@ -391,8 +385,6 @@
  (modules test_execution_lane_writer)
  (libraries agent_sdk agent_sdk.llm_provider alcotest eio_main)
  (deps ../models.toml)
- (flags
-  (:standard -open Agent_sdk__))
  (action
   (run %{test})))
 

--- a/test/test_execution_codec_executor.ml
+++ b/test/test_execution_codec_executor.ml
@@ -1,9 +1,10 @@
 open Alcotest
-module Runtime_internal = Execution_runtime
 open Agent_sdk
-module Codec = Execution_codec_executor
-module Event = Execution_event
-module Journal = Execution_journal
+module Internal = Agent_sdk__
+module Runtime_internal = Internal.Execution_runtime
+module Codec = Internal.Execution_codec_executor
+module Event = Internal.Execution_event
+module Journal = Internal.Execution_journal
 
 exception Cancel_running_codec
 exception Cancel_queued_codec

--- a/test/test_execution_event_store.ml
+++ b/test/test_execution_event_store.ml
@@ -1,10 +1,11 @@
 open Alcotest
-module Runtime_internal = Execution_runtime
 open Agent_sdk
-module Event = Execution_event
-module Codec = Execution_codec_executor
-module Journal = Execution_journal
-module Store = Execution_event_store
+module Internal = Agent_sdk__
+module Runtime_internal = Internal.Execution_runtime
+module Event = Internal.Execution_event
+module Codec = Internal.Execution_codec_executor
+module Journal = Internal.Execution_journal
+module Store = Internal.Execution_event_store
 
 exception Cancel_before_append
 exception Store_scope_failed

--- a/test/test_execution_event_store.ml
+++ b/test/test_execution_event_store.ml
@@ -139,42 +139,17 @@ let manual_event ~correlation_id ~run_id ~seq ?parent_event_id payload =
 ;;
 
 let legacy_recursive_events correlation_id =
-  let parent_run_id = fresh Event.Run_id.fresh in
-  let child_run_id = fresh Event.Run_id.fresh in
-  let root_id = fresh Event.Node_id.fresh in
-  let turn_id = fresh Event.Node_id.fresh in
-  let provider_id = fresh Event.Node_id.fresh in
-  let invocation_id = fresh Event.Node_id.fresh in
-  let child_root_id = fresh Event.Node_id.fresh in
-  let node ~node_id ~run_id ~parent_node_id ~kind =
-    require_event (Event.make_node ~node_id ~run_id ~parent_node_id ~kind)
+  let journal = require_journal (Journal.create ~correlation_id ()) in
+  let parent_run, _ =
+    require_journal (Journal.start_run journal ~agent_name:"legacy-parent")
   in
-  let open_node ~run_id ~seq ?parent_event node =
-    manual_event
-      ~correlation_id
-      ~run_id
-      ~seq
-      ?parent_event_id:
-        (Option.map Event.event_id parent_event |> Option.map Event.Event_id.to_string)
-      (Event.Node_opened node)
-  in
-  let root =
-    node
-      ~node_id:root_id
-      ~run_id:parent_run_id
-      ~parent_node_id:None
-      ~kind:(Event.Agent_run { agent_name = "legacy-parent" })
-  in
-  let root_opened = open_node ~run_id:parent_run_id ~seq:1 root in
-  let turn =
-    node
-      ~node_id:turn_id
-      ~run_id:parent_run_id
-      ~parent_node_id:(Some root_id)
-      ~kind:(Event.Agent_turn { ordinal = 0 })
-  in
-  let turn_opened =
-    open_node ~run_id:parent_run_id ~seq:2 ~parent_event:root_opened turn
+  let turn, _ =
+    require_journal
+      (Journal.open_node
+         journal
+         ~run:parent_run
+         ~parent:(Journal.run_root parent_run)
+         ~kind:(Event.Agent_turn { ordinal = 0 }))
   in
   let config =
     Llm_provider.Provider_config.make
@@ -191,67 +166,56 @@ let legacy_recursive_events correlation_id =
     |> require_event
   in
   let provider_kind = require_event (Event.provider_attempt ~ordinal:0 binding) in
-  let provider =
-    node
-      ~node_id:provider_id
-      ~run_id:parent_run_id
-      ~parent_node_id:(Some turn_id)
-      ~kind:provider_kind
+  let provider, _ =
+    require_journal
+      (Journal.open_node journal ~run:parent_run ~parent:turn ~kind:provider_kind)
   in
-  let provider_opened =
-    open_node ~run_id:parent_run_id ~seq:3 ~parent_event:turn_opened provider
-  in
-  let invocation =
-    node
-      ~node_id:invocation_id
-      ~run_id:parent_run_id
-      ~parent_node_id:(Some provider_id)
-      ~kind:
-        (Event.Tool_invocation
-           { provider_tool_use_id = Some "legacy-tool-use"
-           ; tool_name = "legacy-tool"
-           ; schedule =
-               { planned_index = 0
-               ; batch_index = 0
-               ; batch_size = 1
-               ; execution_mode = Tool.Serial
-               }
-           })
-  in
-  let invocation_opened =
-    open_node ~run_id:parent_run_id ~seq:4 ~parent_event:provider_opened invocation
+  let invocation, _ =
+    require_journal
+      (Journal.open_node
+         journal
+         ~run:parent_run
+         ~parent:provider
+         ~kind:
+           (Event.Tool_invocation
+              { provider_tool_use_id = Some "legacy-tool-use"
+              ; tool_name = "legacy-tool"
+              ; schedule =
+                  { planned_index = 0
+                  ; batch_index = 0
+                  ; batch_size = 1
+                  ; execution_mode = Tool.Serial
+                  }
+              }))
   in
   let input_materialized =
-    manual_event
-      ~correlation_id
-      ~run_id:parent_run_id
-      ~seq:5
-      ~parent_event_id:(Event.Event_id.to_string (Event.event_id invocation_opened))
-      (Event.Node_updated
-         { node_id = invocation_id
-         ; update =
-             Event.Tool_input_snapshot
-               (Llm_provider.Types.ToolUse
-                  { id = "legacy-tool-use"; name = "legacy-tool"; input = `Assoc [] })
-         })
+    require_journal
+      (Journal.update_node
+         journal
+         ~node:invocation
+         (Event.Tool_input_snapshot
+            (Llm_provider.Types.ToolUse
+               { id = "legacy-tool-use"; name = "legacy-tool"; input = `Assoc [] })))
   in
+  let child_run_id = fresh Event.Run_id.fresh in
+  let child_root_id = fresh Event.Node_id.fresh in
   let child_root =
-    node
-      ~node_id:child_root_id
-      ~run_id:child_run_id
-      ~parent_node_id:(Some invocation_id)
-      ~kind:(Event.Agent_run { agent_name = "legacy-child" })
+    require_event
+      (Event.make_node
+         ~node_id:child_root_id
+         ~run_id:child_run_id
+         ~parent_node_id:(Some invocation)
+         ~kind:(Event.Agent_run { agent_name = "legacy-child" }))
   in
   let child_opened =
-    open_node ~run_id:child_run_id ~seq:6 ~parent_event:input_materialized child_root
+    manual_event
+      ~correlation_id
+      ~run_id:child_run_id
+      ~seq:(Journal.last_seq journal + 1)
+      ~parent_event_id:(Event.Event_id.to_string (Event.event_id input_materialized))
+      (Event.Node_opened child_root)
   in
-  [ root_opened
-  ; turn_opened
-  ; provider_opened
-  ; invocation_opened
-  ; input_materialized
-  ; child_opened
-  ]
+  Journal.events journal @ [ child_opened ]
 ;;
 
 let rec reverse_failure_data = function

--- a/test/test_execution_event_store.ml
+++ b/test/test_execution_event_store.ml
@@ -122,6 +122,138 @@ let require_event = function
   | Error detail -> fail detail
 ;;
 
+let fresh identity = require_event (identity ())
+
+let manual_event ~correlation_id ~run_id ~seq ?parent_event_id payload =
+  let event_id = fresh Event.Event_id.fresh in
+  let envelope =
+    Event_envelope.make
+      ~event_id:(Event.Event_id.to_string event_id)
+      ~correlation_id:(Event.Correlation_id.to_string correlation_id)
+      ~run_id:(Event.Run_id.to_string run_id)
+      ~seq
+      ?parent_event_id
+      ()
+  in
+  require_event (Event.make ~envelope payload)
+;;
+
+let legacy_recursive_events correlation_id =
+  let parent_run_id = fresh Event.Run_id.fresh in
+  let child_run_id = fresh Event.Run_id.fresh in
+  let root_id = fresh Event.Node_id.fresh in
+  let turn_id = fresh Event.Node_id.fresh in
+  let provider_id = fresh Event.Node_id.fresh in
+  let invocation_id = fresh Event.Node_id.fresh in
+  let child_root_id = fresh Event.Node_id.fresh in
+  let node ~node_id ~run_id ~parent_node_id ~kind =
+    require_event (Event.make_node ~node_id ~run_id ~parent_node_id ~kind)
+  in
+  let open_node ~run_id ~seq ?parent_event node =
+    manual_event
+      ~correlation_id
+      ~run_id
+      ~seq
+      ?parent_event_id:
+        (Option.map Event.event_id parent_event |> Option.map Event.Event_id.to_string)
+      (Event.Node_opened node)
+  in
+  let root =
+    node
+      ~node_id:root_id
+      ~run_id:parent_run_id
+      ~parent_node_id:None
+      ~kind:(Event.Agent_run { agent_name = "legacy-parent" })
+  in
+  let root_opened = open_node ~run_id:parent_run_id ~seq:1 root in
+  let turn =
+    node
+      ~node_id:turn_id
+      ~run_id:parent_run_id
+      ~parent_node_id:(Some root_id)
+      ~kind:(Event.Agent_turn { ordinal = 0 })
+  in
+  let turn_opened =
+    open_node ~run_id:parent_run_id ~seq:2 ~parent_event:root_opened turn
+  in
+  let config =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_kind.OpenAI_compat
+      ~provider_id:"legacy-provider"
+      ~model_id:"legacy-model"
+      ~base_url:"https://provider.test"
+      ()
+  in
+  let binding =
+    Binding_identity.of_provider_config
+      ~transport:(Binding_identity.transport_for_call ~injected:false)
+      config
+    |> require_event
+  in
+  let provider_kind = require_event (Event.provider_attempt ~ordinal:0 binding) in
+  let provider =
+    node
+      ~node_id:provider_id
+      ~run_id:parent_run_id
+      ~parent_node_id:(Some turn_id)
+      ~kind:provider_kind
+  in
+  let provider_opened =
+    open_node ~run_id:parent_run_id ~seq:3 ~parent_event:turn_opened provider
+  in
+  let invocation =
+    node
+      ~node_id:invocation_id
+      ~run_id:parent_run_id
+      ~parent_node_id:(Some provider_id)
+      ~kind:
+        (Event.Tool_invocation
+           { provider_tool_use_id = Some "legacy-tool-use"
+           ; tool_name = "legacy-tool"
+           ; schedule =
+               { planned_index = 0
+               ; batch_index = 0
+               ; batch_size = 1
+               ; execution_mode = Tool.Serial
+               }
+           })
+  in
+  let invocation_opened =
+    open_node ~run_id:parent_run_id ~seq:4 ~parent_event:provider_opened invocation
+  in
+  let input_materialized =
+    manual_event
+      ~correlation_id
+      ~run_id:parent_run_id
+      ~seq:5
+      ~parent_event_id:(Event.Event_id.to_string (Event.event_id invocation_opened))
+      (Event.Node_updated
+         { node_id = invocation_id
+         ; update =
+             Event.Tool_input_snapshot
+               (Llm_provider.Types.ToolUse
+                  { id = "legacy-tool-use"; name = "legacy-tool"; input = `Assoc [] })
+         })
+  in
+  let child_root =
+    node
+      ~node_id:child_root_id
+      ~run_id:child_run_id
+      ~parent_node_id:(Some invocation_id)
+      ~kind:(Event.Agent_run { agent_name = "legacy-child" })
+  in
+  let child_opened =
+    open_node ~run_id:child_run_id ~seq:6 ~parent_event:input_materialized child_root
+  in
+  [ root_opened
+  ; turn_opened
+  ; provider_opened
+  ; invocation_opened
+  ; input_materialized
+  ; child_opened
+  ]
+;;
+
 let rec reverse_failure_data = function
   | `Assoc fields ->
     `Assoc
@@ -299,8 +431,16 @@ let test_old_store_format_is_explicitly_rejected () =
     Eio.Switch.run (fun sw ->
       let store = create_store ~codec ~sw ~dir in
       let writer = attach_store store in
-      let events = make_four_events (Store.correlation_id store) in
+      let events = legacy_recursive_events (Store.correlation_id store) in
       ignore (require_store (Store.append_batch writer ~expected_next_seq:1 events)));
+    Eio.Switch.run (fun sw ->
+      match Journal.open_durable_writer ~sw ~codec ~dir with
+      | Error (Journal.Invariant_violation (Journal.Child_run_parent_not_tool_attempt _))
+        -> ()
+      | Error error ->
+        fail ("legacy fixture failed elsewhere: " ^ Journal.error_to_string error)
+      | Ok _ ->
+        fail "legacy recursive fixture did not reach the changed reducer invariant");
     let wal = Eio.Path.(dir / "events.v1.wal") in
     let authority = Eio.Path.(dir / "events.v1.commit") in
     let wal_before = Eio.Path.load wal in
@@ -311,10 +451,13 @@ let test_old_store_format_is_explicitly_rejected () =
       Eio.Flow.copy_string old_authority file;
       Eio.File.sync file);
     Eio.Switch.run (fun sw ->
-      match open_store ~codec ~sw ~dir with
-      | Error (Store.Unsupported_store_version { expected = 2; actual = 1 }) -> ()
-      | Error error -> fail ("unexpected open failure: " ^ Store.error_to_string error)
-      | Ok _ -> fail "old execution store format was reopened");
+      match Journal.open_durable_writer ~sw ~codec ~dir with
+      | Error
+          (Journal.Persistence_failure
+             (Store.Unsupported_store_version { expected = 2; actual = 1 })) -> ()
+      | Error error ->
+        fail ("unexpected journal failure: " ^ Journal.error_to_string error)
+      | Ok _ -> fail "old recursive execution store was reopened");
     check string "rejected store remains untouched" wal_before (Eio.Path.load wal))
 ;;
 

--- a/test/test_execution_event_store.ml
+++ b/test/test_execution_event_store.ml
@@ -74,6 +74,27 @@ let directory_snapshot dir =
   |> List.map (fun name -> name, Eio.Path.load Eio.Path.(dir / name))
 ;;
 
+let authority_with_format_version ~version payload =
+  let authority =
+    match Yojson.Safe.from_string payload with
+    | `Assoc fields ->
+      (match List.assoc_opt "authority" fields with
+       | Some (`Assoc authority_fields) ->
+         `Assoc
+           (List.map
+              (function
+                | "format_version", _ -> "format_version", `Int version
+                | field -> field)
+              authority_fields)
+       | Some _ | None -> fail "authority fixture has no object payload")
+    | _ -> fail "authority fixture is not an object"
+  in
+  let authority_bytes = Yojson.Safe.to_string authority in
+  let authority_sha256 = Digestif.SHA256.(to_hex (digest_string authority_bytes)) in
+  Yojson.Safe.to_string
+    (`Assoc [ "authority", authority; "authority_sha256", `String authority_sha256 ])
+;;
+
 let make_four_events correlation_id =
   let journal = require_journal (Journal.create ~correlation_id ()) in
   let run, _opened =
@@ -269,6 +290,32 @@ let test_idempotent_retry_requires_exact_canonical_bytes () =
       with
       | Error (Store.Committed_content_conflict { first_seq = 2; last_seq = 2 }) -> ()
       | _ -> fail "semantic-only equality admitted a non-byte-identical retry"))
+;;
+
+let test_old_store_format_is_explicitly_rejected () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun codec dir ->
+    Eio.Switch.run (fun sw ->
+      let store = create_store ~codec ~sw ~dir in
+      let writer = attach_store store in
+      let events = make_four_events (Store.correlation_id store) in
+      ignore (require_store (Store.append_batch writer ~expected_next_seq:1 events)));
+    let wal = Eio.Path.(dir / "events.v1.wal") in
+    let authority = Eio.Path.(dir / "events.v1.commit") in
+    let wal_before = Eio.Path.load wal in
+    let old_authority =
+      Eio.Path.load authority |> authority_with_format_version ~version:1
+    in
+    Eio.Path.with_open_out ~create:(`Or_truncate 0o600) authority (fun file ->
+      Eio.Flow.copy_string old_authority file;
+      Eio.File.sync file);
+    Eio.Switch.run (fun sw ->
+      match open_store ~codec ~sw ~dir with
+      | Error (Store.Unsupported_store_version { expected = 2; actual = 1 }) -> ()
+      | Error error -> fail ("unexpected open failure: " ^ Store.error_to_string error)
+      | Ok _ -> fail "old execution store format was reopened");
+    check string "rejected store remains untouched" wal_before (Eio.Path.load wal))
 ;;
 
 let test_torn_tail_is_explicitly_truncated () =
@@ -1486,6 +1533,10 @@ let () =
             "idempotent retry requires exact canonical bytes"
             `Quick
             test_idempotent_retry_requires_exact_canonical_bytes
+        ; test_case
+            "old store format is explicitly rejected"
+            `Quick
+            test_old_store_format_is_explicitly_rejected
         ; test_case
             "torn tail is explicitly truncated"
             `Quick

--- a/test/test_execution_journal.ml
+++ b/test/test_execution_journal.ml
@@ -1,7 +1,8 @@
 open Alcotest
 open Agent_sdk
-module Event = Execution_event
-module Journal = Execution_journal
+module Internal = Agent_sdk__
+module Event = Internal.Execution_event
+module Journal = Internal.Execution_journal
 
 let require_ok = function
   | Ok value -> value
@@ -170,18 +171,18 @@ let build_recursive_run journal =
           journal
           ~node:attempt
           (Event.Tool_progress (`Assoc [ "bytes", `Int 512 ]))));
-  let attempt_closed =
-    require_ok (Journal.close_node journal ~node:attempt Event.Succeeded)
-  in
   let child_run =
     require_started_run
-      (Journal.start_run ~parent_invocation:invocation journal ~agent_name:"reviewer")
+      (Journal.start_run ~parent_attempt:attempt journal ~agent_name:"reviewer")
   in
   let child_agent_turn, child_turn = open_provider_attempt journal child_run in
   ignore (require_ok (Journal.close_node journal ~node:child_turn Event.Succeeded));
   ignore (require_ok (Journal.close_node journal ~node:child_agent_turn Event.Succeeded));
   let child_finished =
     require_ok (Journal.finish_run journal ~run:child_run Event.Succeeded)
+  in
+  let attempt_closed =
+    require_ok (Journal.close_node journal ~node:attempt Event.Succeeded)
   in
   ignore
     (require_ok
@@ -248,17 +249,17 @@ let test_recursive_tree_and_global_sequence () =
   (match Journal.find_run journal (Journal.run_id parent_run) with
    | Some
        { status = Journal.Finished { value = Event.Succeeded; _ }
-       ; parent_invocation = None
+       ; parent_attempt = None
        ; _
        } -> ()
    | _ -> fail "parent run was not finished as a root run");
   match Journal.find_run journal (Journal.run_id child_run) with
   | Some
       { status = Journal.Finished { value = Event.Succeeded; _ }
-      ; parent_invocation = Some _
+      ; parent_attempt = Some _
       ; _
       } -> ()
-  | _ -> fail "child run did not retain its invocation parent"
+  | _ -> fail "child run did not retain its exact attempt parent"
 ;;
 
 let test_codec_roundtrip_and_exactness () =
@@ -517,8 +518,9 @@ let test_hierarchy_and_lifecycle_rejections () =
   (match Journal.close_node journal ~node:turn Event.Succeeded with
    | Error (Journal.Invariant_violation (Journal.Node_has_open_children _)) -> ()
    | _ -> fail "node with an open child was closed");
-  (match Journal.start_run ~parent_invocation:turn journal ~agent_name:"bad-child" with
-   | Error (Journal.Invariant_violation (Journal.Invalid_child_run_parent _)) -> ()
+  (match Journal.start_run ~parent_attempt:turn journal ~agent_name:"bad-child" with
+   | Error (Journal.Invariant_violation (Journal.Child_run_parent_not_tool_attempt _)) ->
+     ()
    | _ -> fail "child run under a provider turn was accepted");
   (match Journal.close_node journal ~node:root Event.Succeeded with
    | Error (Journal.Invariant_violation (Journal.Root_must_use_finish_run _)) -> ()
@@ -626,6 +628,26 @@ let test_hierarchy_and_lifecycle_rejections () =
     require_opened_node
       (Journal.open_node journal ~run ~parent:invocation ~kind:Event.Tool_attempt)
   in
+  (match
+     Journal.start_run ~parent_attempt:invocation journal ~agent_name:"merged-retry"
+   with
+   | Error (Journal.Invariant_violation (Journal.Child_run_parent_not_tool_attempt _)) ->
+     ()
+   | _ -> fail "child run was attached to a logical invocation instead of an attempt");
+  let nested_invocation =
+    require_opened_node
+      (Journal.open_node journal ~run ~parent:attempt ~kind:(tool_invocation "nested"))
+  in
+  (match Journal.close_node journal ~node:attempt Event.Succeeded with
+   | Error (Journal.Invariant_violation (Journal.Node_has_open_children _)) -> ()
+   | _ -> fail "tool attempt closed while exact nested work remained open");
+  ignore
+    (require_ok
+       (Journal.close_node
+          journal
+          ~node:nested_invocation
+          (Event.Failed
+             { kind = Event.Tool_failure; detail = "nested tool rejected"; data = None })));
   (match
      Journal.update_node
        journal
@@ -1172,9 +1194,13 @@ let test_abort_run_closes_recursive_subtree_atomically () =
           ~node:invocation
           (Event.Tool_input_snapshot
              (tool_use "delegate" (`Assoc [ "task", `String "review" ])))));
+  let attempt =
+    require_opened_node
+      (Journal.open_node journal ~run ~parent:invocation ~kind:Event.Tool_attempt)
+  in
   let child =
     require_started_run
-      (Journal.start_run ~parent_invocation:invocation journal ~agent_name:"child")
+      (Journal.start_run ~parent_attempt:attempt journal ~agent_name:"child")
   in
   let _child_agent_turn, child_turn = open_provider_attempt journal child in
   let before_rejected_success = Journal.length journal in
@@ -1208,7 +1234,7 @@ let test_abort_run_closes_recursive_subtree_atomically () =
   let closed =
     require_ok (Journal.abort_run ~causes:[ cancellation_trigger ] journal ~run terminal)
   in
-  check int "every open recursive node was closed" 8 (List.length closed);
+  check int "every open recursive node was closed" 9 (List.length closed);
   let root_closed = List.hd (List.rev closed) in
   (match Event.causes root_closed with
    | [ Event.External_event _; Event.Internal_event child_terminal ] ->
@@ -1262,10 +1288,14 @@ let test_abort_run_handles_deep_recursive_composition_iteratively () =
             ~node:invocation
             (Event.Tool_input_snapshot
                (tool_use ("deep-" ^ string_of_int index) (`Assoc [ "depth", `Int index ])))));
+    let attempt =
+      require_opened_node
+        (Journal.open_node journal ~run ~parent:invocation ~kind:Event.Tool_attempt)
+    in
     current_run
     := require_started_run
          (Journal.start_run
-            ~parent_invocation:invocation
+            ~parent_attempt:attempt
             journal
             ~agent_name:("deep-agent-" ^ string_of_int index))
   done;
@@ -1296,7 +1326,7 @@ let test_abort_run_handles_deep_recursive_composition_iteratively () =
   check
     int
     "every deep recursive node closed"
-    (1 + (4 * deep_chain_depth))
+    (1 + (5 * deep_chain_depth))
     (List.length closed);
   let page =
     require_ok

--- a/test/test_execution_lane_writer.ml
+++ b/test/test_execution_lane_writer.ml
@@ -1,11 +1,12 @@
 open Alcotest
-module Runtime_internal = Execution_runtime
 open Agent_sdk
-module Event = Execution_event
-module Codec = Execution_codec_executor
-module Journal = Execution_journal
-module Store = Execution_event_store
-module Writer = Execution_lane_writer
+module Internal = Agent_sdk__
+module Runtime_internal = Internal.Execution_runtime
+module Event = Internal.Execution_event
+module Codec = Internal.Execution_codec_executor
+module Journal = Internal.Execution_journal
+module Store = Internal.Execution_event_store
+module Writer = Internal.Execution_lane_writer
 module Tx = Journal.Transaction
 
 exception Cancel_waiter


### PR DESCRIPTION
## Outcome

This is a production-quality prerequisite for the eventual execution-journal single-writer cut. It does **not** wire the new journal into `Agent.run` yet and does not claim that legacy journal removal is safe.

Recursive child work is now owned by one exact `Tool_attempt` occurrence:

```text
Tool_invocation
  -> Tool_attempt
       -> nested Tool_invocation
       -> child Agent_run
```

A retry therefore cannot merge its child execution history with another attempt under the same logical invocation.

## Root cause

The private reducer previously started child `Agent_run` nodes directly beneath `Tool_invocation`. Because one invocation may contain multiple attempts, that parent edge erased which attempt created the child. Persisting that topology before the live hard cut would make the new SSOT permanently ambiguous.

The same reducer also did not admit recursive Tool invocation beneath an attempt, so heterogeneous Tool-as-Tool composition could not retain exact attempt ownership.

## Changes

- rename the child-run parent contract from logical `parent_invocation` to exact `parent_attempt`
- reject child runs whose supplied parent is not an open `Tool_attempt`
- admit nested `Tool_invocation` only beneath an exact `Tool_attempt`
- retain the existing open-child fence, so an attempt cannot close while nested work remains open
- hard-cut the durable store authority to format v2; a v1 authority returns typed `Unsupported_store_version` before WAL scan or reducer replay
- update recursive abort/deep-tree proofs for the extra attempt node
- use `-alias-deps` for private execution tests, closing the stale native-interface race rather than accepting an incremental false green

No migration, compatibility alias, or legacy replay path is retained. WAL framing itself remains v1 because its bytes did not change; v2 is the authority-level semantic topology contract.

## Current writer coverage (adversarial)

| Capability | Legacy `Durable_event` | New execution stack on current main | Cut status |
| --- | --- | --- | --- |
| live Agent/Pipeline writer | yes: turn/provider/tool/checkpoint call sites | no live call site | **blocked** |
| recursive occurrence topology | no; flat turn/tool rows | typed root/turn/provider/output/invocation/attempt; exact attempt recursion after this PR | prerequisite improved |
| durable append/reopen/cursor | full-file dump callback, not an append authority | WAL + commit authority + scoped cursor + reconciliation | available privately |
| external-effect receipt | FNV-derived advisory key; live runtime never consumes `find_completed_activity` | not implemented | **blocked by jeong-sik/masc#27899** |
| checkpoint projection | marker after caller checkpoint sink | not implemented | **blocked** |
| Event_bus projection | optional `Journal_bridge`, duplicates native events | not implemented | **blocked** |
| provider/tool live wiring | yes, lossy/flat | not implemented | **blocked** |
| retention | whole in-memory legacy list | finite scope but whole reducer/event history retained | production wiring still requires an explicit decision |

Consequently, deleting `Durable_event` or adding a second live writer in this PR would both be incorrect. The eventual transition must wire provider/tool/checkpoint/Event_bus projections and delete legacy writers in one single-writer hard cut.

## Boundary

- OAS remains generic: no MASC, Keeper, Gate, provider-name, tool-name, risk, or product semantics.
- no timeout, count, capacity, cost, token, or turn gate
- no string classifier, silent fallback, stub, or raw writer API
- immutable staging and the closed reducer remain the only topology authority
- normal external Builder/Agent use is unchanged

## Validation

- focused `@install` plus four execution test executables built successfully
- `test_execution_journal`: 18/18
- `test_execution_codec_executor`: 8/8
- `test_execution_event_store`: 32/32
- `test_execution_lane_writer`: 17/17
- total: 75/75
- `scripts/check-sdk-independence.sh`
- `scripts/check-execution-store-boundary.sh`
- `scripts/hardening-ratchet.sh --check`
- `scripts/ci-code-smell-ratchet.sh --check`
- `ocamlformat --check`
- `git diff --check`

Full OCaml 5.4/5.5 build and suite remain CI authority.

[근거] `git rev-parse origin/main` = `94a4cae15acceb6045150f0006dbc761521b1c50`, checked 2026-07-17 KST, confidence High.
