### PR TITLE
feat(llm_provider): admit concurrent dispatches per endpoint identity

### DIFF
--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -75,7 +75,7 @@ let complete
      | Some result -> ensure_nonempty_completion result
      | None ->
        m.on_request_start ~model_id;
-       let { Llm_transport.response = result; latency_ms } =
+       let dispatch () =
          match transport with
          | Some t ->
            let run_transport () =
@@ -124,6 +124,12 @@ let complete
                ()
            in
            { Llm_transport.response = resp; latency_ms = lat }
+       in
+       let { Llm_transport.response = result; latency_ms } =
+         (* The permit spans the full provider round-trip; cache hits above
+            never take one. Waiting for a permit is queueing, not part of the
+            provider interaction, so body_timeout_s does not cover it. *)
+         Provider_admission.with_admission ~config:request_config dispatch
        in
        (* HTTP-backed transports bypass complete_http, so emit the status
          here using the transport result. Non-HTTP CLI transports must
@@ -263,7 +269,7 @@ let complete_stream
            | Error failure -> emit_wire_observer_failure failure)
         wire_observer
     in
-    let result =
+    let dispatch () =
       match transport with
       | Some t ->
         t.complete_stream
@@ -294,6 +300,12 @@ let complete_stream
           ~tools
           ~on_event
           ()
+    in
+    let result =
+      (* The permit spans the entire stream: the provider holds the
+         connection open until the final SSE event, so concurrency
+         accounting must too. *)
+      Provider_admission.with_admission ~config:request_config dispatch
     in
     Result.map
       (fun resp ->

--- a/lib/llm_provider/complete_common.ml
+++ b/lib/llm_provider/complete_common.ml
@@ -458,6 +458,21 @@ let validate_thinking_control_request (config : Provider_config.t) =
   else Ok ()
 ;;
 
+(* An admission bound of zero or less would mean "no request may ever
+   dispatch" — a config authoring error, not a throttle. Reject it before
+   dispatch instead of letting Slot_scheduler.create raise mid-request. *)
+let validate_admission_declaration (config : Provider_config.t) =
+  match config.max_concurrent_requests with
+  | None -> Ok ()
+  | Some n when n >= 1 -> Ok ()
+  | Some n ->
+    Error
+      (Http_client.AcceptRejected
+         { reason =
+             Printf.sprintf "max_concurrent_requests must be >= 1 when declared, got %d" n
+         })
+;;
+
 let validate_all (config : Provider_config.t) =
   match validate_request_path config with
   | Error _ as e -> e
@@ -470,7 +485,10 @@ let validate_all (config : Provider_config.t) =
         | Ok () ->
           (match validate_reasoning_effort_request config with
            | Error _ as e -> e
-           | Ok () -> validate_thinking_control_request config)))
+           | Ok () ->
+             (match validate_thinking_control_request config with
+              | Error _ as e -> e
+              | Ok () -> validate_admission_declaration config))))
 ;;
 
 let serialize_http_request ~stream ~(config : Provider_config.t) ~messages ~tools =

--- a/lib/llm_provider/complete_sampling.ml
+++ b/lib/llm_provider/complete_sampling.ml
@@ -58,6 +58,7 @@ let%test "gemini_url sync no api_key" =
     ; seed = None
     ; previous_response_id = None
     ; connect_timeout_s = None
+    ; max_concurrent_requests = None
     }
   in
   let url = gemini_url ~config ~stream:false in
@@ -100,6 +101,7 @@ let%test "gemini_url sync with api_key" =
     ; seed = None
     ; previous_response_id = None
     ; connect_timeout_s = None
+    ; max_concurrent_requests = None
     }
   in
   let url = gemini_url ~config ~stream:false in
@@ -142,6 +144,7 @@ let%test "gemini_url stream with api_key" =
     ; seed = None
     ; previous_response_id = None
     ; connect_timeout_s = None
+    ; max_concurrent_requests = None
     }
   in
   let url = gemini_url ~config ~stream:true in
@@ -185,6 +188,7 @@ let%test "gemini_url stream no api_key" =
     ; seed = None
     ; previous_response_id = None
     ; connect_timeout_s = None
+    ; max_concurrent_requests = None
     }
   in
   let url = gemini_url ~config ~stream:true in
@@ -228,6 +232,7 @@ let%test "gemini_url never leaks api_key even when set" =
     ; seed = None
     ; previous_response_id = None
     ; connect_timeout_s = None
+    ; max_concurrent_requests = None
     }
   in
   let contains_substring haystack needle =
@@ -284,6 +289,7 @@ let%test "gemini_url empty base_url no trailing slash" =
     ; seed = None
     ; previous_response_id = None
     ; connect_timeout_s = None
+    ; max_concurrent_requests = None
     }
   in
   let url = gemini_url ~config ~stream:false in

--- a/lib/llm_provider/provider_admission.ml
+++ b/lib/llm_provider/provider_admission.ml
@@ -1,0 +1,94 @@
+(** Per-endpoint admission of concurrent provider requests. See the .mli for
+    the contract. *)
+
+type key =
+  { kind : string
+  ; base_url : string
+  ; secret : Secret.identity option
+  }
+
+module Key = struct
+  type t = key
+
+  let equal a b =
+    String.equal a.kind b.kind
+    && String.equal a.base_url b.base_url
+    && Option.equal Secret.equal_identity a.secret b.secret
+  ;;
+
+  let hash { kind; base_url; secret } =
+    let secret_hash =
+      match secret with
+      | None -> 0
+      | Some identity -> Secret.hash_identity identity
+    in
+    Hashtbl.hash (kind, base_url, secret_hash)
+  ;;
+end
+
+module Table = Hashtbl.Make (Key)
+
+type entry =
+  { scheduler : Slot_scheduler.t
+  ; declared_max : int
+  ; mutable conflict_warned : bool
+  }
+
+(* Stdlib.Mutex rather than Eio.Mutex: the critical section is a table
+   lookup/insert that never blocks or switches fibers, and the table is
+   shared by every domain that dispatches completions. All waiting happens
+   inside Slot_scheduler, whose Eio primitives are domain-safe. *)
+let table : entry Table.t = Table.create 8
+let table_mutex = Stdlib.Mutex.create ()
+
+let key_of_config (config : Provider_config.t) =
+  { kind = Provider_config.string_of_provider_kind config.kind
+  ; base_url = config.base_url
+  ; secret = Secret.identity config.api_key
+  }
+;;
+
+let entry_for ~key ~max =
+  Stdlib.Mutex.protect table_mutex (fun () ->
+    match Table.find_opt table key with
+    | Some entry ->
+      if entry.declared_max <> max && not entry.conflict_warned
+      then (
+        entry.conflict_warned <- true;
+        Diag.warn
+          "provider_admission"
+          "conflicting max_concurrent_requests for %s %s: scheduler holds %d, a config \
+           declares %d; the first declaration stays authoritative"
+          key.kind
+          key.base_url
+          entry.declared_max
+          max);
+      entry
+    | None ->
+      let entry =
+        { scheduler = Slot_scheduler.create ~max_slots:max
+        ; declared_max = max
+        ; conflict_warned = false
+        }
+      in
+      Table.add table key entry;
+      entry)
+;;
+
+let with_admission ~(config : Provider_config.t) f =
+  match config.max_concurrent_requests with
+  | None -> f ()
+  | Some max ->
+    (* max >= 1 is enforced by Complete_common.validate_all before any
+       dispatch reaches this point; Slot_scheduler.create re-checks and
+       raises on a bypassing caller rather than admitting silently. *)
+    let entry = entry_for ~key:(key_of_config config) ~max in
+    Slot_scheduler.with_permit entry.scheduler f
+;;
+
+let snapshot_for ~(config : Provider_config.t) =
+  let key = key_of_config config in
+  Stdlib.Mutex.protect table_mutex (fun () ->
+    Table.find_opt table key
+    |> Option.map (fun entry -> Slot_scheduler.snapshot entry.scheduler))
+;;

--- a/lib/llm_provider/provider_admission.mli
+++ b/lib/llm_provider/provider_admission.mli
@@ -1,0 +1,38 @@
+(** Per-endpoint admission of concurrent provider requests.
+
+    A provider account enforces a concurrency allowance and rejects excess
+    in-flight requests (e.g. ollama.com returns HTTP 429 with body
+    [{"error":"too many concurrent requests"}]). When a consumer declares
+    [max_concurrent_requests] on a {!Provider_config.t}, every completion
+    dispatch for that endpoint identity acquires a permit from a process-wide
+    fair FIFO {!Slot_scheduler}, waiting while the endpoint is saturated
+    instead of dispatching a request the provider will reject.
+
+    Identity is [(kind, base_url, api-key identity)] — the unit a provider
+    accounts concurrency against. Configs with different API keys are
+    different accounts and are admitted independently.
+
+    No declaration ([max_concurrent_requests = None]) means no admission:
+    dispatch behavior is unchanged. OAS never selects a limit from provider
+    kind, URL, model, or process environment — the consumer declares it
+    (declaration-over-probing, the same contract as [connect_timeout_s]).
+
+    Waiting for a permit is not pre-dispatch denial: no request is refused,
+    reordered across the FIFO, or dropped. Retry policy remains the
+    consumer's responsibility.
+
+    @since 0.216.0 *)
+
+(** [with_admission ~config f] runs [f] under the endpoint's concurrency
+    permit when [config.max_concurrent_requests] is declared, and directly
+    otherwise. Waiting joins a FIFO; cancellation while waiting does not
+    leak a permit (see {!Slot_scheduler.with_permit}).
+
+    Conflicting declarations for the same endpoint identity keep the first
+    declaration authoritative and emit one diagnostic warning per identity. *)
+val with_admission : config:Provider_config.t -> (unit -> 'a) -> 'a
+
+(** Point-in-time scheduler snapshot for [config]'s endpoint identity, or
+    [None] when no dispatch has declared admission for it yet.
+    Diagnostics only. *)
+val snapshot_for : config:Provider_config.t -> Slot_scheduler.snapshot option

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -78,6 +78,7 @@ type t =
   ; seed : int option
   ; previous_response_id : string option
   ; connect_timeout_s : float option
+  ; max_concurrent_requests : int option
   }
 
 let make
@@ -116,6 +117,7 @@ let make
       ?seed
       ?previous_response_id
       ?connect_timeout_s
+      ?max_concurrent_requests
       ()
   =
   let response_format =
@@ -180,6 +182,7 @@ let make
   ; seed
   ; previous_response_id
   ; connect_timeout_s
+  ; max_concurrent_requests
   }
 ;;
 

--- a/lib/llm_provider/provider_config.mli
+++ b/lib/llm_provider/provider_config.mli
@@ -193,6 +193,18 @@ type t =
       The consumer declares any deadline; OAS never selects one from provider
       kind, URL, model, or process environment.
       @since 0.207.9 *)
+  ; max_concurrent_requests : int option
+    (** Per-endpoint bound on concurrent in-flight completion dispatches.
+      [None] applies no bound. [Some n] admits at most [n] concurrent
+      dispatches process-wide for this endpoint identity
+      [(kind, base_url, api-key identity)]; excess dispatches wait in FIFO
+      order (see {!Provider_admission}). Must be [>= 1] when declared;
+      {!Complete.complete} rejects the request otherwise.
+
+      The consumer declares the allowance its provider account grants; OAS
+      never selects one from provider kind, URL, model, or process
+      environment.
+      @since 0.216.0 *)
   }
 
 (** Default config for quick construction. Only [kind], [model_id],
@@ -233,6 +245,7 @@ val make
   -> ?seed:int
   -> ?previous_response_id:string
   -> ?connect_timeout_s:float
+  -> ?max_concurrent_requests:int
   -> unit
   -> t
 

--- a/test/dune
+++ b/test/dune
@@ -131,6 +131,7 @@
   test_pipeline_metrics
   test_plan
   test_provider
+  test_provider_admission
   test_provider_failure_attribution
   test_provider_catalog_coverage
   test_provider_config
@@ -296,6 +297,7 @@
   test_pipeline_metrics
   test_plan
   test_provider
+  test_provider_admission
   test_provider_failure_attribution
   test_provider_catalog_coverage
   test_provider_config

--- a/test/test_provider_admission.ml
+++ b/test/test_provider_admission.ml
@@ -20,7 +20,11 @@ let contains_substring ~sub text =
   sub_len = 0 || loop 0
 ;;
 
-let make_config ?(base_url = "http://admission.test:1") ?(api_key = "test-key") ?max_concurrent_requests ()
+let make_config
+      ?(base_url = "http://admission.test:1")
+      ?(api_key = "test-key")
+      ?max_concurrent_requests
+      ()
   =
   Provider_config.make
     ~kind:Provider_config.OpenAI_compat
@@ -124,7 +128,8 @@ let test_conflicting_declaration_first_wins () =
 let reject_dispatch_transport : Llm_transport.t =
   { complete_sync = (fun _ -> fail "invalid declaration must never dispatch")
   ; complete_stream =
-      (fun ?on_telemetry:_ ~on_event:_ _ -> fail "invalid declaration must never dispatch")
+      (fun ?on_telemetry:_ ~on_event:_ _ ->
+        fail "invalid declaration must never dispatch")
   }
 ;;
 
@@ -133,7 +138,9 @@ let test_zero_declaration_rejected_before_dispatch () =
   @@ fun env ->
   Eio.Switch.run
   @@ fun sw ->
-  let config = make_config ~base_url:"http://invalid.test:1" ~max_concurrent_requests:0 () in
+  let config =
+    make_config ~base_url:"http://invalid.test:1" ~max_concurrent_requests:0 ()
+  in
   match
     Complete.complete
       ~sw
@@ -196,14 +203,21 @@ let test_complete_dispatch_is_admitted () =
   Eio.Fiber.all (List.init 6 (fun _ -> job));
   check int "every dispatch completed" 0 (Atomic.get in_flight);
   check bool "bound was contended" true (Atomic.get max_seen >= 2);
-  check bool "Complete.complete respects the declared bound" true (Atomic.get max_seen <= 2)
+  check
+    bool
+    "Complete.complete respects the declared bound"
+    true
+    (Atomic.get max_seen <= 2)
 ;;
 
 let () =
   run
     "provider_admission"
     [ ( "admission"
-      , [ test_case "no declaration runs directly" `Quick test_no_declaration_runs_directly
+      , [ test_case
+            "no declaration runs directly"
+            `Quick
+            test_no_declaration_runs_directly
         ; test_case "bounded concurrency" `Quick test_bounded_concurrency
         ; test_case "api keys admit independently" `Quick test_identity_separates_api_keys
         ; test_case

--- a/test/test_provider_admission.ml
+++ b/test/test_provider_admission.ml
@@ -1,0 +1,223 @@
+(** Tests for per-endpoint admission of concurrent provider requests.
+
+    Each test uses a distinct base_url so schedulers registered by one test
+    never leak into another — the admission registry is process-global by
+    design and exposes no reset. *)
+
+open Alcotest
+open Llm_provider
+
+let contains_substring ~sub text =
+  let sub_len = String.length sub in
+  let text_len = String.length text in
+  let rec loop index =
+    if index + sub_len > text_len
+    then false
+    else if String.sub text index sub_len = sub
+    then true
+    else loop (index + 1)
+  in
+  sub_len = 0 || loop 0
+;;
+
+let make_config ?(base_url = "http://admission.test:1") ?(api_key = "test-key") ?max_concurrent_requests ()
+  =
+  Provider_config.make
+    ~kind:Provider_config.OpenAI_compat
+    ~model_id:"admission-model"
+    ~base_url
+    ~request_path:"/v1/chat/completions"
+    ~api_key
+    ?max_concurrent_requests
+    ()
+;;
+
+let test_no_declaration_runs_directly () =
+  let config = make_config ~base_url:"http://undeclared.test:1" () in
+  let hits = ref 0 in
+  let out =
+    Provider_admission.with_admission ~config (fun () ->
+      incr hits;
+      42)
+  in
+  check int "returns f's result" 42 out;
+  check int "f ran exactly once" 1 !hits;
+  check
+    bool
+    "no scheduler registered without a declaration"
+    true
+    (Option.is_none (Provider_admission.snapshot_for ~config))
+;;
+
+let record_max_seen ~in_flight ~max_seen =
+  let now = Atomic.fetch_and_add in_flight 1 + 1 in
+  let rec record () =
+    let seen = Atomic.get max_seen in
+    if now > seen && not (Atomic.compare_and_set max_seen seen now) then record ()
+  in
+  record ()
+;;
+
+let test_bounded_concurrency () =
+  Eio_main.run
+  @@ fun _env ->
+  let config =
+    make_config ~base_url:"http://bounded.test:1" ~max_concurrent_requests:2 ()
+  in
+  let in_flight = Atomic.make 0 in
+  let max_seen = Atomic.make 0 in
+  let job () =
+    Provider_admission.with_admission ~config (fun () ->
+      record_max_seen ~in_flight ~max_seen;
+      (* Yield while holding the permit so competing fibers get their chance
+         to over-admit if the bound were broken. *)
+      Eio.Fiber.yield ();
+      Eio.Fiber.yield ();
+      Atomic.decr in_flight)
+  in
+  Eio.Fiber.all (List.init 8 (fun _ -> job));
+  check int "every dispatch completed" 0 (Atomic.get in_flight);
+  check bool "declared bound was contended" true (Atomic.get max_seen >= 2);
+  check bool "declared bound was never exceeded" true (Atomic.get max_seen <= 2);
+  match Provider_admission.snapshot_for ~config with
+  | None -> fail "scheduler must be registered after admitted dispatches"
+  | Some snap ->
+    check int "all permits returned" 0 snap.Slot_scheduler.active;
+    check int "no waiters left behind" 0 snap.Slot_scheduler.queue_length
+;;
+
+let test_identity_separates_api_keys () =
+  Eio_main.run
+  @@ fun _env ->
+  let base_url = "http://identity.test:1" in
+  let a = make_config ~base_url ~api_key:"key-a" ~max_concurrent_requests:1 () in
+  let b = make_config ~base_url ~api_key:"key-b" ~max_concurrent_requests:1 () in
+  let a_started, resolve_a_started = Eio.Promise.create () in
+  let release_a, resolve_release_a = Eio.Promise.create () in
+  Eio.Fiber.both
+    (fun () ->
+       Provider_admission.with_admission ~config:a (fun () ->
+         Eio.Promise.resolve resolve_a_started ();
+         Eio.Promise.await release_a))
+    (fun () ->
+       Eio.Promise.await a_started;
+       (* If both keys shared one max=1 scheduler this would deadlock: a's
+          permit is still held and nothing releases it until b completes. *)
+       Provider_admission.with_admission ~config:b (fun () -> ());
+       Eio.Promise.resolve resolve_release_a ())
+;;
+
+let test_conflicting_declaration_first_wins () =
+  Eio_main.run
+  @@ fun _env ->
+  let base_url = "http://conflict.test:1" in
+  let first = make_config ~base_url ~max_concurrent_requests:1 () in
+  let second = make_config ~base_url ~max_concurrent_requests:5 () in
+  Provider_admission.with_admission ~config:first (fun () -> ());
+  Provider_admission.with_admission ~config:second (fun () -> ());
+  match Provider_admission.snapshot_for ~config:second with
+  | None -> fail "scheduler must exist after first admitted dispatch"
+  | Some snap ->
+    check int "first declaration stays authoritative" 1 snap.Slot_scheduler.max_slots
+;;
+
+let reject_dispatch_transport : Llm_transport.t =
+  { complete_sync = (fun _ -> fail "invalid declaration must never dispatch")
+  ; complete_stream =
+      (fun ?on_telemetry:_ ~on_event:_ _ -> fail "invalid declaration must never dispatch")
+  }
+;;
+
+let test_zero_declaration_rejected_before_dispatch () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let config = make_config ~base_url:"http://invalid.test:1" ~max_concurrent_requests:0 () in
+  match
+    Complete.complete
+      ~sw
+      ~net:(Eio.Stdenv.net env)
+      ~transport:reject_dispatch_transport
+      ~config
+      ~messages:[]
+      ()
+  with
+  | Error (Http_client.AcceptRejected { reason }) ->
+    check
+      bool
+      "rejection names the offending field"
+      true
+      (contains_substring ~sub:"max_concurrent_requests" reason)
+  | Ok _ -> fail "expected AcceptRejected for max_concurrent_requests = 0"
+  | Error _ -> fail "expected AcceptRejected, got a different error kind"
+;;
+
+(* Wiring-level counterfactual: this goes through Complete.complete, so it
+   fails if the with_admission call is ever removed from the dispatch path —
+   unlike the module-level tests above, which would keep passing. *)
+let test_complete_dispatch_is_admitted () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let config =
+    make_config ~base_url:"http://wired.test:1" ~max_concurrent_requests:2 ()
+  in
+  let in_flight = Atomic.make 0 in
+  let max_seen = Atomic.make 0 in
+  let counting_transport : Llm_transport.t =
+    { complete_sync =
+        (fun _ ->
+          record_max_seen ~in_flight ~max_seen;
+          Eio.Fiber.yield ();
+          Eio.Fiber.yield ();
+          Atomic.decr in_flight;
+          { Llm_transport.response =
+              Error
+                (Http_client.NetworkError
+                   { message = "test transport declines"; kind = Http_client.Unknown })
+          ; latency_ms = None
+          })
+    ; complete_stream =
+        (fun ?on_telemetry:_ ~on_event:_ _ -> fail "sync test must not stream")
+    }
+  in
+  let job () =
+    ignore
+      (Complete.complete
+         ~sw
+         ~net:(Eio.Stdenv.net env)
+         ~transport:counting_transport
+         ~config
+         ~messages:[]
+         ())
+  in
+  Eio.Fiber.all (List.init 6 (fun _ -> job));
+  check int "every dispatch completed" 0 (Atomic.get in_flight);
+  check bool "bound was contended" true (Atomic.get max_seen >= 2);
+  check bool "Complete.complete respects the declared bound" true (Atomic.get max_seen <= 2)
+;;
+
+let () =
+  run
+    "provider_admission"
+    [ ( "admission"
+      , [ test_case "no declaration runs directly" `Quick test_no_declaration_runs_directly
+        ; test_case "bounded concurrency" `Quick test_bounded_concurrency
+        ; test_case "api keys admit independently" `Quick test_identity_separates_api_keys
+        ; test_case
+            "conflicting declaration keeps first"
+            `Quick
+            test_conflicting_declaration_first_wins
+        ; test_case
+            "zero declaration rejected before dispatch"
+            `Quick
+            test_zero_declaration_rejected_before_dispatch
+        ; test_case
+            "Complete.complete dispatch is admitted"
+            `Quick
+            test_complete_dispatch_is_admitted
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Why

Live incident 2026-07-17 (jeong-sik/masc#24886): an unbounded caller fan-out drove 17,747 completion attempts against ollama.com in 44 minutes; the provider rejected all but 630 with HTTP 429 `{"error":"too many concurrent requests"}`. OAS had no way to bound concurrent dispatches per endpoint, so every caller-side burst reached the wire.

`Slot_scheduler` (a fair FIFO permit scheduler, cancel-safe, shipped in 0.96.0) existed but had zero call sites. This PR wires it in.

## What

- `Provider_config.max_concurrent_requests : int option` — a consumer declaration, same contract shape as `connect_timeout_s` (declaration-over-probing; OAS never invents a limit from kind/URL/model/env). `None` = behavior unchanged.
- New `Provider_admission`: process-global registry of `Slot_scheduler.t` keyed by `(kind, base_url, api-key identity)` — the unit a provider accounts concurrency against. Different API keys admit independently. Conflicting declarations keep the first and warn once per identity.
- `Complete.complete` / `Complete.complete_stream` dispatch under `with_admission`. The permit spans the full round-trip including stream consumption (the provider holds the connection until the last SSE event). Cache hits never take a permit.
- `validate_all` rejects `Some n` with `n < 1` as `AcceptRejected` before dispatch.

## What this is NOT

- Not retry, failover, or rate-limit policy — those stay with the consumer (CLAUDE.md "Provider Routing", #2590 hard-cut). Waiting in FIFO is not pre-dispatch denial: nothing is refused or dropped.
- Not a default: without a declaration nothing changes for any existing consumer.

## Verification

- `test_provider_admission` (6 tests): module-level bound contention (8 fibers, max 2, observed max in-flight == 2), api-key identity separation (deadlock-free independence), first-declaration-wins on conflict, `n=0` rejected before a fake transport that fails on dispatch, and a **wiring-level counterfactual** through `Complete.complete` with a counting fake transport.
- Counterfactual executed: temporarily replacing `with_admission ... dispatch` with `dispatch ()` makes exactly the wiring test fail (1 failure / 6 tests), restored and re-verified green.
- `test_provider_config`, `test_complete_ext` pass unchanged. `scripts/dune-local.sh build lib` clean.

## Consumer wiring

masc will declare `max_concurrent_requests` for ollama_cloud runtimes from runtime.toml in the board-attention worker PR (masc side of the same incident).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KXQWcg9KtaC7KruGQTnwX
