### PR TITLE
fix(llm_provider): carry Retry-After and rate-limit prose through typed errors

### DIFF
--- a/lib/agent/agent_registry.ml
+++ b/lib/agent/agent_registry.ml
@@ -114,7 +114,7 @@ let list_by_tool t tool_name =
 let fetch_remote_card ~sw ~net url =
   let card_url = url ^ "/.well-known/agent.json" in
   let error_detail = function
-    | Llm_provider.Http_client.HttpError { code; body } ->
+    | Llm_provider.Http_client.HttpError { code; body; _ } ->
       Printf.sprintf "HTTP %d: %s" code body
     | NetworkError { message; _ } -> message
     | TimeoutError { message; _ } -> message

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -18,8 +18,10 @@ let attributed_retry_error http_error retry_error =
 ;;
 
 let create_message_error_of_http_error = function
-  | Llm_provider.Http_client.HttpError { code; body } as http_error ->
-    attributed_retry_error http_error (Retry.classify_error ~status:code ~body)
+  | Llm_provider.Http_client.HttpError { code; body; retry_after_header } as http_error ->
+    attributed_retry_error
+      http_error
+      (Retry.classify_error ~retry_after_header ~status:code ~body)
   | Llm_provider.Http_client.NetworkError
       { message; kind = Llm_provider.Http_client.Timeout } as http_error ->
     attributed_retry_error http_error (Retry.Timeout { message; phase = None })
@@ -373,7 +375,8 @@ let create_message_detailed
                  | `HttpError (code, body_str) ->
                    Error
                      (create_message_error_of_http_error
-                        (Llm_provider.Http_client.HttpError { code; body = body_str }))
+                        (Llm_provider.Http_client.HttpError
+                           { code; body = body_str; retry_after_header = None }))
                  | `TransportError err -> Error err
                with
                | Eio.Io _ as exn ->

--- a/lib/error_domain.ml
+++ b/lib/error_domain.ml
@@ -4,7 +4,7 @@ module Retry = Llm_provider.Retry
 module Http_client = Llm_provider.Http_client
 
 type provider_error =
-  [ `Rate_limited of float option
+  [ `Rate_limited of float option * string (** retry_after seconds, message *)
   | `Auth_error of string
   | `Authorization_error of string
   | `Server_error of int * string
@@ -75,7 +75,7 @@ let is_streaming_timeout_phase = function
 
 let of_api_error (err : Retry.api_error) : provider_error =
   match err with
-  | Retry.RateLimited r -> `Rate_limited r.retry_after
+  | Retry.RateLimited r -> `Rate_limited (r.retry_after, r.message)
   | Retry.AuthError r -> `Auth_error r.message
   | Retry.AuthorizationError r -> `Authorization_error r.message
   | Retry.ServerError r -> `Server_error (r.status, r.message)
@@ -94,8 +94,8 @@ let of_api_error (err : Retry.api_error) : provider_error =
 
 let of_provider_error (err : Llm_provider.Error.provider_error) : provider_error =
   match err with
-  | Llm_provider.Error.RateLimit r -> `Rate_limited r.retry_after
-  | Llm_provider.Error.HardQuota r -> `Rate_limited r.retry_after
+  | Llm_provider.Error.RateLimit r -> `Rate_limited (r.retry_after, r.detail)
+  | Llm_provider.Error.HardQuota r -> `Rate_limited (r.retry_after, r.detail)
   | Llm_provider.Error.AuthError r -> `Auth_error r.detail
   | Llm_provider.Error.AuthorizationError r -> `Authorization_error r.detail
   | Llm_provider.Error.ServerError r -> `Server_error (r.code, r.detail)
@@ -147,8 +147,8 @@ let of_sdk_error (err : Error.sdk_error) : sdk_error_poly =
 (* ── Conversion back to Error.sdk_error ─────────────────── *)
 
 let provider_to_sdk : provider_error -> Error.sdk_error = function
-  | `Rate_limited after ->
-    Error.Api (Retry.RateLimited { retry_after = after; message = "rate limited" })
+  | `Rate_limited (after, message) ->
+    Error.Api (Retry.RateLimited { retry_after = after; message })
   | `Auth_error msg -> Error.Api (Retry.AuthError { message = msg })
   | `Authorization_error msg -> Error.Api (Retry.AuthorizationError { message = msg })
   | `Server_error (status, msg) -> Error.Api (Retry.ServerError { status; message = msg })

--- a/lib/error_domain.mli
+++ b/lib/error_domain.mli
@@ -13,7 +13,7 @@
 
       (* Callers only handle relevant variants *)
       match result with
-      | Error (`Rate_limited r) -> retry r
+      | Error (`Rate_limited (retry_after, _message)) -> retry retry_after
       | Error (`Auth_error msg) -> fail msg
       | Ok response -> ...
     ]}
@@ -22,7 +22,7 @@
 (** {1 Provider errors} *)
 
 type provider_error =
-  [ `Rate_limited of float option (** retry_after seconds *)
+  [ `Rate_limited of float option * string (** retry_after seconds, message *)
   | `Auth_error of string
   | `Authorization_error of string
   | `Server_error of int * string (** status, message *)

--- a/lib/llm_provider/complete_sync.ml
+++ b/lib/llm_provider/complete_sync.ml
@@ -130,6 +130,7 @@ let complete_http
                      body_len
                      body_str.[0]
                      body_str.[body_len - 1]
+               ; retry_after_header = None
                })
         , None ))
       else (
@@ -184,16 +185,24 @@ let complete_http
                 | Provider_http_codec.Ollama_chat ->
                   (match Backend_ollama.parse_ollama_response body with
                    | Ok resp -> Ok resp
-                   | Error msg -> Error (Http_client.HttpError { code = 400; body = msg }))
+                   | Error msg ->
+                     Error
+                       (Http_client.HttpError
+                          { code = 400; body = msg; retry_after_header = None }))
                 | Provider_http_codec.Openai_responses ->
                   (match Backend_openai_responses.parse_response_result body with
                    | Ok resp -> Ok resp
-                   | Error msg -> Error (Http_client.HttpError { code = 400; body = msg }))
+                   | Error msg ->
+                     Error
+                       (Http_client.HttpError
+                          { code = 400; body = msg; retry_after_header = None }))
                 | Provider_http_codec.Openai_chat ->
                   (match Backend_openai_parse.parse_openai_response_result body with
                    | Ok resp -> Ok resp
                    | Error (Backend_openai_parse.Provider_error msg) ->
-                     Error (Http_client.HttpError { code = 400; body = msg })
+                     Error
+                       (Http_client.HttpError
+                          { code = 400; body = msg; retry_after_header = None })
                    | Error (Backend_openai_parse.Empty_completion e) ->
                      (* oas#2483: fail closed through the same typed transport
                         fact as streaming. Policy remains downstream of the
@@ -221,7 +230,11 @@ let complete_http
               | Backend_gemini.Gemini_api_error msg ->
                 Diag.error "complete" "Gemini API error: %s" msg;
                 Error
-                  (Http_client.HttpError { code = 400; body = "Gemini API error: " ^ msg })
+                  (Http_client.HttpError
+                     { code = 400
+                     ; body = "Gemini API error: " ^ msg
+                     ; retry_after_header = None
+                     })
               | Backend_glm.Glm_api_error err ->
                 (match err.origin with
                  | Backend_glm.Response_parse ->
@@ -250,13 +263,18 @@ let complete_http
                         "Glm API error (code absent class=%d): %s"
                         semantic_code
                         err.message);
-                   Error (Http_client.HttpError { code = semantic_code; body }))
+                   Error
+                     (Http_client.HttpError
+                        { code = semantic_code; body; retry_after_header = None }))
               | exn ->
                 let exn_str = Printexc.to_string exn in
                 Diag.error "complete" "Unexpected parsing exception: %s" exn_str;
                 Error
                   (Http_client.HttpError
-                     { code = 500; body = "Unexpected parsing exception: " ^ exn_str }))
+                     { code = 500
+                     ; body = "Unexpected parsing exception: " ^ exn_str
+                     ; retry_after_header = None
+                     }))
             else (
               (* Log request body diagnostics on error responses to help debug
              Ollama "closing '}' symbol" and similar body-rejection errors. *)
@@ -309,7 +327,7 @@ let complete_http
               let body =
                 http_error_diagnostic_body ~provider_name ~config ~url ~code ~body
               in
-              Error (Http_client.HttpError { code; body }))
+              Error (Http_client.HttpError { code; body; retry_after_header = None }))
         in
         let latency_ms = latency_ms_int latency_counter in
         result, latency_ms))

--- a/lib/llm_provider/count_tokens_sync.ml
+++ b/lib/llm_provider/count_tokens_sync.ml
@@ -50,7 +50,8 @@ let count_anthropic
          with
          | Error _ as error -> error
          | Ok (code, response) when code >= 200 && code < 300 -> Ok response
-         | Ok (code, body) -> Error (Http_client.HttpError { code; body }))
+         | Ok (code, body) ->
+           Error (Http_client.HttpError { code; body; retry_after_header = None }))
     in
     Input_token_count.decode_transport_result
       ~protocol

--- a/lib/llm_provider/error.ml
+++ b/lib/llm_provider/error.ml
@@ -299,8 +299,9 @@ let of_provider_failure ?provider kind message =
 ;;
 
 let of_http_error ?provider = function
-  | Http_client.HttpError { code; body } ->
-    Retry.classify_error ~status:code ~body |> of_retry_api_error ?provider
+  | Http_client.HttpError { code; body; retry_after_header } ->
+    Retry.classify_error ~retry_after_header ~status:code ~body
+    |> of_retry_api_error ?provider
   | Http_client.NetworkError { message; kind } ->
     NetworkError
       { provider = provider_name provider; kind; timeout_phase = None; detail = message }

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -100,6 +100,7 @@ type http_error =
   | HttpError of
       { code : int
       ; body : string
+      ; retry_after_header : float option
       }
   | NetworkError of
       { message : string
@@ -540,6 +541,141 @@ let is_local_resource_exhaustion = function
   | NetworkError _ -> false
   | ProviderTerminal _ -> false
   | ProviderFailure _ -> false
+;;
+
+(* ── Retry-After header parsing (RFC 9110 S10.2.3) ────────── *)
+
+let all_digits s = String.length s > 0 && String.for_all (fun c -> c >= '0' && c <= '9') s
+let digits_of_len n s = String.length s = n && all_digits s
+
+let month_of_abbrev = function
+  | "Jan" -> Some 1
+  | "Feb" -> Some 2
+  | "Mar" -> Some 3
+  | "Apr" -> Some 4
+  | "May" -> Some 5
+  | "Jun" -> Some 6
+  | "Jul" -> Some 7
+  | "Aug" -> Some 8
+  | "Sep" -> Some 9
+  | "Oct" -> Some 10
+  | "Nov" -> Some 11
+  | "Dec" -> Some 12
+  | _ -> None
+;;
+
+(* Days since the Unix epoch (1970-01-01) for a proleptic-Gregorian civil
+   date. Howard Hinnant's [days_from_civil] algorithm ("chrono-Compatible
+   Low-Level Date Algorithms"); OCaml's stdlib has no [timegm] equivalent,
+   so this is the standard hand-rolled replacement. Verified against the
+   RFC 9110 example date 1994-11-06 08:49:37 GMT -> epoch 784111777. *)
+let days_from_civil ~year ~month ~day =
+  let y = if month <= 2 then year - 1 else year in
+  let era = (if y >= 0 then y else y - 399) / 400 in
+  let yoe = y - (era * 400) in
+  let mp = (month + 9) mod 12 in
+  let doy = (((153 * mp) + 2) / 5) + day - 1 in
+  let doe = (yoe * 365) + (yoe / 4) - (yoe / 100) + doy in
+  (era * 146097) + doe - 719468
+;;
+
+(* Strict IMF-fixdate parser (RFC 9110 S5.6.7), e.g.
+   ["Sun, 06 Nov 1994 08:49:37 GMT"]. Obsolete HTTP-date forms (RFC 850,
+   asctime) are not accepted — real Retry-After emitters use delay-seconds
+   almost exclusively, and this codebase does not need to interoperate
+   with clients emitting the obsolete forms. Never raises: any deviation
+   from the exact grammar returns [None]. *)
+let parse_imf_fixdate (s : string) : float option =
+  match String.split_on_char ' ' s with
+  | [ day_name; day_str; month_str; year_str; time_str; "GMT" ] ->
+    let day_name_ok = String.length day_name = 4 && day_name.[3] = ',' in
+    if
+      (not day_name_ok)
+      || (not (digits_of_len 2 day_str))
+      || not (digits_of_len 4 year_str)
+    then None
+    else (
+      match month_of_abbrev month_str with
+      | None -> None
+      | Some month ->
+        (match String.split_on_char ':' time_str with
+         | [ hh; mm; ss ]
+           when digits_of_len 2 hh && digits_of_len 2 mm && digits_of_len 2 ss ->
+           let day = int_of_string day_str in
+           let year = int_of_string year_str in
+           let hour = int_of_string hh in
+           let minute = int_of_string mm in
+           let second = int_of_string ss in
+           (* second <= 60 admits the RFC 9110 leap-second allowance. *)
+           if day < 1 || day > 31 || hour > 23 || minute > 59 || second > 60
+           then None
+           else (
+             let days = days_from_civil ~year ~month ~day in
+             let epoch_seconds =
+               (float_of_int days *. 86400.0)
+               +. float_of_int ((hour * 3600) + (minute * 60) + second)
+             in
+             Some epoch_seconds)
+         | _ -> None))
+  | _ -> None
+;;
+
+let parse_retry_after_seconds ~now (raw : string) : float option =
+  let trimmed = String.trim raw in
+  if all_digits trimmed
+  then (
+    match int_of_string_opt trimmed with
+    | Some seconds -> Some (float_of_int seconds)
+    | None -> None (* overflowed int range; reject rather than guess *))
+  else (
+    match parse_imf_fixdate trimmed with
+    | Some epoch_seconds -> Some (Float.max 0.0 (epoch_seconds -. now))
+    | None -> None)
+;;
+
+let%test "parse_retry_after_seconds: delay-seconds" =
+  parse_retry_after_seconds ~now:1_700_000_000.0 "120" = Some 120.0
+;;
+
+let%test "parse_retry_after_seconds: delay-seconds ignores surrounding whitespace" =
+  parse_retry_after_seconds ~now:1_700_000_000.0 " 45 " = Some 45.0
+;;
+
+let%test "parse_retry_after_seconds: negative delay-seconds is malformed" =
+  parse_retry_after_seconds ~now:1_700_000_000.0 "-5" = None
+;;
+
+let%test "parse_retry_after_seconds: HTTP-date in the future yields positive delay" =
+  (* now is 100s before the RFC 9110 S5.6.7 example date -> a 100s delay. *)
+  parse_retry_after_seconds ~now:784111677.0 "Sun, 06 Nov 1994 08:49:37 GMT" = Some 100.0
+;;
+
+let%test "parse_retry_after_seconds: HTTP-date in the past clamps to zero" =
+  (* now is well after the example date; the naive delay would be
+     negative, which must clamp to 0.0 rather than signal "retry in the
+     past". *)
+  parse_retry_after_seconds ~now:1_700_000_000.0 "Sun, 06 Nov 1994 08:49:37 GMT"
+  = Some 0.0
+;;
+
+let%test "parse_retry_after_seconds: malformed value yields None" =
+  parse_retry_after_seconds ~now:1_700_000_000.0 "not-a-value" = None
+;;
+
+let%test "parse_retry_after_seconds: empty value yields None" =
+  parse_retry_after_seconds ~now:1_700_000_000.0 "" = None
+;;
+
+let%test "parse_retry_after_seconds: RFC 850 obsolete form is rejected" =
+  parse_retry_after_seconds ~now:1_700_000_000.0 "Sunday, 06-Nov-94 08:49:37 GMT" = None
+;;
+
+(* [Http.Header.get] is case-insensitive per cohttp's contract (mirrors the
+   "server"/"cf-ray" lookups in [profile_headers_on_client_error] above). *)
+let retry_after_header_of_response_headers resp_headers =
+  match Http.Header.get resp_headers "retry-after" with
+  | None -> None
+  | Some raw -> parse_retry_after_seconds ~now:(Unix.gettimeofday ()) raw
 ;;
 
 (* ── Public API ────────────────────────────────────────────── *)
@@ -1077,13 +1213,11 @@ let post_stream ?cache ?clock ?connect_timeout_s ~sw ~net ~url ~headers ~body ()
     | `OK -> Ok (Eio.Buf_read.of_flow ~max_size:Api_common.max_response_body resp_body)
     | status ->
       let code = Cohttp.Code.code_of_status status in
-      profile_headers_on_client_error
-        ~url
-        ~code
-        ~resp_headers:(Cohttp.Response.headers resp)
-        headers_with_length;
+      let resp_headers = Cohttp.Response.headers resp in
+      profile_headers_on_client_error ~url ~code ~resp_headers headers_with_length;
+      let retry_after_header = retry_after_header_of_response_headers resp_headers in
       let* body_str = read_response_body resp_body in
-      Error (HttpError { code; body = body_str }))
+      Error (HttpError { code; body = body_str; retry_after_header }))
 ;;
 
 let with_post_stream ?cache ?clock ?connect_timeout_s ~net ~url ~headers ~body ~f () =
@@ -1154,15 +1288,13 @@ let with_post_stream ?cache ?clock ?connect_timeout_s ~net ~url ~headers ~body ~
             , Eio.Buf_read.of_flow ~max_size:Api_common.max_response_body resp_body )
         | status ->
           let code = Cohttp.Code.code_of_status status in
-          profile_headers_on_client_error
-            ~url
-            ~code
-            ~resp_headers:(Cohttp.Response.headers resp)
-            headers_with_length;
+          let resp_headers = Cohttp.Response.headers resp in
+          profile_headers_on_client_error ~url ~code ~resp_headers headers_with_length;
+          let retry_after_header = retry_after_header_of_response_headers resp_headers in
           (match read_response_body resp_body with
            | Ok body_str ->
              Eio.Resource.close conn;
-             Error (HttpError { code; body = body_str })
+             Error (HttpError { code; body = body_str; retry_after_header })
            | Error err ->
              Eio.Resource.close conn;
              Error err)
@@ -1583,7 +1715,9 @@ let%test "resource exhaustion: normal connection refused is not" =
 ;;
 
 let%test "resource exhaustion: HTTP error is not" =
-  not (is_local_resource_exhaustion (HttpError { code = 500; body = "internal" }))
+  not
+    (is_local_resource_exhaustion
+       (HttpError { code = 500; body = "internal"; retry_after_header = None }))
 ;;
 
 let%test "resource exhaustion: DNS failure is not" =

--- a/lib/llm_provider/http_client.mli
+++ b/lib/llm_provider/http_client.mli
@@ -152,6 +152,17 @@ type http_error =
   | HttpError of
       { code : int
       ; body : string
+      ; retry_after_header : float option
+        (** Parsed [Retry-After] response header (RFC 9110 S10.2.3), resolved
+          to a delay in seconds relative to when the response was observed.
+          [None] when the header was absent, malformed, or when the call
+          site producing this error only has [(code, body)] available and
+          never saw response headers (see {!get_sync}/{!post_sync}, whose
+          callers construct [HttpError] themselves without header access).
+          This is diagnostic transport evidence only; provider-specific
+          JSON body fields (e.g. an [error.retry_after] number) remain the
+          more precise signal and take priority over this field wherever
+          both are consulted. *)
       }
   | NetworkError of
       { message : string
@@ -443,6 +454,19 @@ val read_ndjson
     (ephemeral port depletion, FD limit).  Cascading to another
     provider cannot help — the bottleneck is the local machine. *)
 val is_local_resource_exhaustion : http_error -> bool
+
+(** Parse an HTTP [Retry-After] header value (RFC 9110 S10.2.3) into a
+    delay in seconds. Accepts either grammar the spec allows:
+    - [delay-seconds]: a non-negative integer, returned as-is.
+    - [HTTP-date] (IMF-fixdate, e.g. ["Sun, 06 Nov 1994 08:49:37 GMT"]):
+      converted to a delay relative to [now] (a Unix timestamp in
+      seconds); a date at or before [now] yields [0.0] rather than a
+      negative delay.
+
+    Obsolete HTTP-date forms (RFC 850, asctime) and any value that is
+    neither a bare non-negative integer nor IMF-fixdate are malformed and
+    return [None]. Never raises. *)
+val parse_retry_after_seconds : now:float -> string -> float option
 
 (** Inject ["stream": true] into a JSON body string.
     Any caller-supplied [stream] is replaced to avoid duplicate object keys. *)

--- a/lib/llm_provider/image_generation.ml
+++ b/lib/llm_provider/image_generation.ml
@@ -342,7 +342,8 @@ let generate
      | Ok (code, response_body) when code >= 200 && code < 300 ->
        parse_response ~protocol response_body
      | Ok (code, response_body) ->
-       Error (Http_client.HttpError { code; body = response_body }))
+       Error
+         (Http_client.HttpError { code; body = response_body; retry_after_header = None }))
 ;;
 
 let test_caps task = { Capabilities.default_capabilities with task }

--- a/lib/llm_provider/retry.ml
+++ b/lib/llm_provider/retry.ml
@@ -117,8 +117,28 @@ let extract_error_message (body : string) : string =
     body
 ;;
 
+(** Parse the provider-specific [error.retry_after] JSON body field, if
+    present and well-formed. This is provider prose, not transport
+    evidence, but it is the more precise of the two retry_after signals
+    when a provider bothers to emit it. *)
+let parse_body_retry_after (body : string) : float option =
+  try
+    let json = Yojson.Safe.from_string body in
+    let open Yojson.Safe.Util in
+    Some (json |> member "error" |> member "retry_after" |> to_float)
+  with
+  | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ | Yojson.Safe.Util.Undefined _ ->
+    None
+;;
+
+let resolve_retry_after ~body ~header : float option =
+  match parse_body_retry_after body with
+  | Some _ as from_body -> from_body
+  | None -> header
+;;
+
 (** Classify HTTP status + body into structured api_error *)
-let classify_error ~status ~body : api_error =
+let classify_error ~retry_after_header ~status ~body : api_error =
   let message = extract_error_message body in
   match status with
   | 401 -> AuthError { message }
@@ -133,16 +153,8 @@ let classify_error ~status ~body : api_error =
     AuthorizationError { message }
   | 400 | 422 -> InvalidRequest { message; reason = Unknown_invalid_request }
   | 429 ->
-    let parsed_retry_after =
-      try
-        let json = Yojson.Safe.from_string body in
-        let open Yojson.Safe.Util in
-        Some (json |> member "error" |> member "retry_after" |> to_float)
-      with
-      | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ | Yojson.Safe.Util.Undefined _
-        -> None
-    in
-    RateLimited { retry_after = parsed_retry_after; message }
+    let retry_after = resolve_retry_after ~body ~header:retry_after_header in
+    RateLimited { retry_after; message }
   | 404 -> NotFound { message }
   | 529 -> Overloaded { message }
   | s when s >= 500 -> ServerError { status = s; message }
@@ -181,7 +193,7 @@ let%test "is_retryable: flat Ollama provider prose is not retryable" =
      is still provider prose, so raw HTTP classification must not infer a typed
      parser-boundary reason from it. *)
   let body = {|{"error":"Value looks like object, but can't find closing '}' symbol"}|} in
-  match classify_error ~status:400 ~body with
+  match classify_error ~retry_after_header:None ~status:400 ~body with
   | InvalidRequest { reason = Unknown_invalid_request; _ } as err ->
     not (is_retryable err)
   | InvalidRequest { reason = Json_parse_error; _ } -> false
@@ -201,7 +213,7 @@ let%test "HTTP 400 prose does not synthesize ContextOverflow" =
   let body =
     {|{"error":{"message":"request exceeds the available context size (8192)"}}|}
   in
-  match classify_error ~status:400 ~body with
+  match classify_error ~retry_after_header:None ~status:400 ~body with
   | InvalidRequest { reason = Unknown_invalid_request; _ } -> true
   | InvalidRequest { reason = Json_parse_error; _ }
   | ContextOverflow _
@@ -218,7 +230,7 @@ let%test "HTTP 400 prose does not synthesize ContextOverflow" =
 
 let%test "classify_error returns Unknown InvalidRequest for non-overflow 400" =
   let body = {|{"error":{"message":"bad tool schema"}}|} in
-  match classify_error ~status:400 ~body with
+  match classify_error ~retry_after_header:None ~status:400 ~body with
   | InvalidRequest { reason = Unknown_invalid_request; _ } -> true
   | InvalidRequest { reason = Json_parse_error; _ } -> false
   | RateLimited _
@@ -328,7 +340,7 @@ let%test "classify_error 429 preserves structured retry_after regardless of pros
   let body =
     {|{"error":{"retry_after":5.0,"message":"Insufficient balance or no resource package"}}|}
   in
-  match classify_error ~status:429 ~body with
+  match classify_error ~retry_after_header:None ~status:429 ~body with
   | RateLimited { retry_after = Some value; _ } -> Float.equal value 5.0
   | RateLimited { retry_after = None; _ }
   | Overloaded _
@@ -347,9 +359,70 @@ let%test "classify_error 429 transient preserves retry_after" =
   let body =
     {|{"error":{"retry_after":3.0,"message":"Too many requests, please slow down"}}|}
   in
-  match classify_error ~status:429 ~body with
+  match classify_error ~retry_after_header:None ~status:429 ~body with
   | RateLimited { retry_after = Some ra; _ } -> Float.equal ra 3.0
   | RateLimited { retry_after = None; _ }
+  | Overloaded _
+  | ServerError _
+  | AuthError _
+  | AuthorizationError _
+  | PaymentRequired _
+  | InvalidRequest _
+  | NotFound _
+  | ContextOverflow _
+  | NetworkError _
+  | Timeout _ -> false
+;;
+
+(* oas 429 typed completion (2026-07): incident context — ollama.com
+   returned HTTP 429 with a flat-string body (no [error.retry_after]
+   field) while carrying a standard [Retry-After] response header. The
+   classifier must fall back to the header when the body has nothing, and
+   must prefer the body when both are present (provider prose is more
+   precise than a generic transport header). *)
+
+let%test "classify_error 429: body retry_after wins over header" =
+  let body = {|{"error":{"retry_after":5.0,"message":"slow down"}}|} in
+  match classify_error ~status:429 ~body ~retry_after_header:(Some 30.0) with
+  | RateLimited { retry_after = Some ra; message } ->
+    Float.equal ra 5.0 && String.equal message "slow down"
+  | RateLimited { retry_after = None; _ }
+  | Overloaded _
+  | ServerError _
+  | AuthError _
+  | AuthorizationError _
+  | PaymentRequired _
+  | InvalidRequest _
+  | NotFound _
+  | ContextOverflow _
+  | NetworkError _
+  | Timeout _ -> false
+;;
+
+let%test "classify_error 429: header-only (flat provider body) works" =
+  let body = {|{"error":"too many concurrent requests"}|} in
+  match classify_error ~status:429 ~body ~retry_after_header:(Some 12.0) with
+  | RateLimited { retry_after = Some ra; message } ->
+    Float.equal ra 12.0 && String.equal message "too many concurrent requests"
+  | RateLimited { retry_after = None; _ }
+  | Overloaded _
+  | ServerError _
+  | AuthError _
+  | AuthorizationError _
+  | PaymentRequired _
+  | InvalidRequest _
+  | NotFound _
+  | ContextOverflow _
+  | NetworkError _
+  | Timeout _ -> false
+;;
+
+let%test "classify_error 429: neither body nor header yields None, message preserved" =
+  let body = {|{"error":"too many concurrent requests"}|} in
+  match classify_error ~retry_after_header:None ~status:429 ~body with
+  | RateLimited { retry_after = None; message } ->
+    String.equal message "too many concurrent requests"
+  | RateLimited { retry_after = Some _; _ }
   | Overloaded _
   | ServerError _
   | AuthError _
@@ -366,7 +439,7 @@ let%test "classify_error 429 transient preserves retry_after" =
    Unknown_invalid_request catch-all (see PaymentRequired variant doc). *)
 let%test "classify_error 402 maps to PaymentRequired" =
   let body = {|{"error":{"message":"Insufficient Balance"}}|} in
-  match classify_error ~status:402 ~body with
+  match classify_error ~retry_after_header:None ~status:402 ~body with
   | PaymentRequired { message } -> String.equal message "Insufficient Balance"
   | RateLimited _
   | Overloaded _
@@ -384,7 +457,7 @@ let%test "classify_error 402 is not retryable" =
   let body =
     {|{"error":{"message":"Insufficient Balance","type":"insufficient_balance_error"}}|}
   in
-  match classify_error ~status:402 ~body with
+  match classify_error ~retry_after_header:None ~status:402 ~body with
   | PaymentRequired _ as err -> not (is_retryable err)
   | RateLimited _
   | Overloaded _

--- a/lib/llm_provider/retry.mli
+++ b/lib/llm_provider/retry.mli
@@ -45,4 +45,23 @@ type api_error =
 
 val is_retryable : api_error -> bool
 val error_message : api_error -> string
-val classify_error : status:int -> body:string -> api_error
+
+(** Merge a provider's structured [retry_after] evidence: the JSON body's
+    [error.retry_after] field wins when present (provider-specific, more
+    precise); the transport's parsed [Retry-After] response header
+    ({!Http_client.parse_retry_after_seconds}) is the fallback. [None] when
+    neither is present or parseable. *)
+val resolve_retry_after : body:string -> header:float option -> float option
+
+(** [retry_after_header] carries the transport's parsed [Retry-After]
+    response header, if any ({!Http_client.HttpError.retry_after_header}).
+    Required (not optional-with-default) so every call site states
+    explicitly whether header evidence was available, rather than
+    silently defaulting to [None]. On the 429 branch it is merged via
+    {!resolve_retry_after}; on other branches it is unused (those statuses
+    do not carry an HTTP-level retry hint in this classification). *)
+val classify_error
+  :  retry_after_header:float option
+  -> status:int
+  -> body:string
+  -> api_error

--- a/lib/llm_provider/slot_cache.ml
+++ b/lib/llm_provider/slot_cache.ml
@@ -21,7 +21,7 @@ let slot_action ~sw ~net ~endpoint ~slot_id ~action ~body_fields =
         (if String.length resp_body > 200 then String.sub resp_body 0 200 else resp_body)
     in
     Error msg
-  | Error (Http_client.HttpError { code; body }) ->
+  | Error (Http_client.HttpError { code; body; _ }) ->
     Error (Printf.sprintf "slot %s HTTP error %d: %s" action code body)
   | Error (Http_client.AcceptRejected { reason }) ->
     Error (Printf.sprintf "slot %s rejected: %s" action reason)

--- a/lib/llm_provider/speech_generation.ml
+++ b/lib/llm_provider/speech_generation.ml
@@ -299,7 +299,8 @@ let generate
                  ; usage = None
                  }
            | Gemini_interaction -> parse_gemini_response format response_body)
-        | Ok (code, body) -> Error (Http_client.HttpError { code; body })))
+        | Ok (code, body) ->
+          Error (Http_client.HttpError { code; body; retry_after_header = None })))
 ;;
 
 let test_caps task = { Capabilities.default_capabilities with task }

--- a/lib/provider_failure_attribution.ml
+++ b/lib/provider_failure_attribution.ml
@@ -48,7 +48,8 @@ let invalid_request reason =
 
 let sdk_error_of_http_error ?(accept_rejected = Api_invalid_request) err =
   match err with
-  | Http.HttpError { code; body } -> Error.Api (Retry.classify_error ~status:code ~body)
+  | Http.HttpError { code; body; retry_after_header } ->
+    Error.Api (Retry.classify_error ~retry_after_header ~status:code ~body)
   | Http.NetworkError { message; kind } ->
     Error.Api (Retry.NetworkError { message; kind })
   | Http.TimeoutError _ -> Error.Provider (Llm_provider.Error.of_http_error err)
@@ -194,6 +195,24 @@ let ownership_of_provider_failure ~binding = function
 ;;
 
 let attribution_of_http_error ~binding = function
+  | Http.HttpError { code = 429; body; retry_after_header } ->
+    (* HTTP 429 alone carries no provider-specific evidence of which lane
+       is exhausted (model/account/region/provider) — that finer signal
+       only exists in [Http.Capacity_exhausted] from transports that parse
+       it out of provider-specific payloads. A raw 429 is honestly
+       [Failure_scope_unknown] rather than a guess, but it is still routed
+       through the typed capacity vocabulary (not the generic [Http_status]
+       catch-all) so the retry_after evidence survives into attribution
+       instead of being visible only in the classified [Retry.api_error]. *)
+    let retry_after = Retry.resolve_retry_after ~body ~header:retry_after_header in
+    let kind =
+      Http.Capacity_exhausted
+        { scope = Http.Failure_scope_unknown; retry_after; model = None }
+    in
+    { ownership = ownership_of_provider_failure ~binding kind
+    ; binding = Some binding
+    ; evidence = Provider_failure kind
+    }
   | Http.HttpError { code; _ } ->
     { ownership = ownership_of_http_status ~binding code
     ; binding = Some binding

--- a/test/test_anthropic_input_token_count.ml
+++ b/test/test_anthropic_input_token_count.ml
@@ -199,7 +199,7 @@ let test_transport_error () =
     Count_tokens_sync.count_anthropic ~sw ~net ~config:(config base_url) ~messages ()
   in
   match result with
-  | Error (Count.Transport (Http_client.HttpError { code = 429; body })) ->
+  | Error (Count.Transport (Http_client.HttpError { code = 429; body; _ })) ->
     check string "provider body" "rate limited" body
   | Ok _ | Error _ -> fail "expected typed HTTP 429"
 ;;

--- a/test/test_complete_ext.ml
+++ b/test/test_complete_ext.ml
@@ -125,7 +125,7 @@ let transport_of_sync sync_response =
 ;;
 
 let string_of_http_error = function
-  | Http_client.HttpError { code; body } -> Printf.sprintf "HTTP %d: %s" code body
+  | Http_client.HttpError { code; body; _ } -> Printf.sprintf "HTTP %d: %s" code body
   | NetworkError { message; _ } -> message
   | TimeoutError { message; _ } -> message
   | AcceptRejected { reason } -> reason
@@ -364,7 +364,9 @@ let test_complete_transport_failure_is_one_shot () =
     transport_of_sync (fun () ->
       incr attempts;
       { Llm_transport.response =
-          Error (Http_client.HttpError { code = 500; body = "temporary" })
+          Error
+            (Http_client.HttpError
+               { code = 500; body = "temporary"; retry_after_header = None })
       ; latency_ms = Some 3
       })
   in
@@ -378,7 +380,7 @@ let test_complete_transport_failure_is_one_shot () =
        ~metrics
        ()
    with
-   | Error (Http_client.HttpError { code = 500; body = "temporary" }) -> ()
+   | Error (Http_client.HttpError { code = 500; body = "temporary"; _ }) -> ()
    | Error err -> failf "unexpected typed error: %s" (string_of_http_error err)
    | Ok _ -> fail "expected provider failure");
   check int "one provider attempt" 1 !attempts;

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -338,7 +338,7 @@ let test_complete_http_empty_error_body_has_context () =
     in
     match Complete.complete ~sw ~net:env#net ~config ~messages () with
     | Ok _ -> fail "expected Error"
-    | Error (Http_client.HttpError { code; body }) ->
+    | Error (Http_client.HttpError { code; body; _ }) ->
       check int "status 404" 404 code;
       check
         string
@@ -944,7 +944,10 @@ let test_complete_transport_http_metrics_error () =
       }
     in
     let transport =
-      make_transport (Error (Http_client.HttpError { code = 429; body = "rate limited" }))
+      make_transport
+        (Error
+           (Http_client.HttpError
+              { code = 429; body = "rate limited"; retry_after_header = None }))
     in
     match Complete.complete ~sw ~net:env#net ~transport ~config ~messages ~metrics () with
     | Ok _ -> fail "expected Error"

--- a/test/test_error_domain.ml
+++ b/test/test_error_domain.ml
@@ -12,16 +12,32 @@ let test_roundtrip_api_rate_limited () =
   in
   let poly = Error_domain.of_sdk_error orig in
   (match poly with
-   | `Rate_limited (Some 1.5) -> ()
-   | _ -> Alcotest.fail "expected Rate_limited");
+   | `Rate_limited (Some 1.5, "slow down") -> ()
+   | _ -> Alcotest.fail "expected Rate_limited (Some 1.5, \"slow down\")");
   let back = Error_domain.to_sdk_error poly in
-  (* Message is lost in roundtrip — by design, poly variants are lightweight *)
-  Alcotest.(check bool)
-    "is Api"
-    true
-    (match back with
-     | Error.Api _ -> true
-     | _ -> false)
+  Alcotest.(check bool) "roundtrip is exact" true (orig = back)
+;;
+
+(* oas 429 typed completion (2026-07): incident context — Ollama's actual
+   429 body ("too many concurrent requests") was collapsed into the
+   hardcoded literal "rate limited" by [provider_to_sdk] (the [to_sdk_error]
+   path for provider errors) because the [`Rate_limited] poly variant only
+   carried [float option], discarding the message on the way into
+   [Error_domain]. Counterfactual: reverting the payload back to a bare
+   [float option] makes this test fail to compile (the message field would
+   not exist to check). *)
+let test_provider_to_sdk_preserves_rate_limit_message () =
+  let poly : Error_domain.sdk_error_poly =
+    `Rate_limited (Some 3.0, "too many concurrent requests")
+  in
+  match Error_domain.to_sdk_error poly with
+  | Error.Api (Retry.RateLimited { retry_after; message }) ->
+    Alcotest.(check (option (float 0.001))) "retry_after preserved" (Some 3.0) retry_after;
+    Alcotest.(check string)
+      "provider message preserved (not the hardcoded literal)"
+      "too many concurrent requests"
+      message
+  | _ -> Alcotest.fail "expected Error.Api (Retry.RateLimited _)"
 ;;
 
 let test_roundtrip_config_missing_env () =
@@ -66,7 +82,7 @@ let test_retryable_rate_limited () =
   Alcotest.(check bool)
     "rate_limited retryable"
     true
-    (Error_domain.is_retryable (`Rate_limited (Some 1.0)))
+    (Error_domain.is_retryable (`Rate_limited (Some 1.0, "slow down")))
 ;;
 
 let test_retryable_server_error () =
@@ -111,8 +127,8 @@ let test_to_string_nonempty () =
 let test_to_string_each_variant () =
   (* Verify to_string produces non-empty strings for every variant *)
   let variants : Error_domain.sdk_error_poly list =
-    [ `Rate_limited (Some 2.0)
-    ; `Rate_limited None
+    [ `Rate_limited (Some 2.0, "slow down")
+    ; `Rate_limited (None, "no retry hint")
     ; `Auth_error "forbidden"
     ; `Authorization_error "permission refused"
     ; `Server_error (503, "unavailable")
@@ -150,7 +166,7 @@ let test_to_string_each_variant () =
 
 let test_all_variants_convert () =
   let all_polys : Error_domain.sdk_error_poly list =
-    [ `Rate_limited None
+    [ `Rate_limited (None, "x")
     ; `Auth_error "x"
     ; `Authorization_error "x"
     ; `Server_error (500, "x")
@@ -751,8 +767,8 @@ let test_to_sdk_error_tool_timeout () =
 let test_provider_roundtrip_all_via_to_sdk () =
   (* Test that all provider_error variants roundtrip through to_sdk_error *)
   let variants : Error_domain.provider_error list =
-    [ `Rate_limited (Some 1.0)
-    ; `Rate_limited None
+    [ `Rate_limited (Some 1.0, "slow down")
+    ; `Rate_limited (None, "no retry hint")
     ; `Auth_error "x"
     ; `Authorization_error "x"
     ; `Server_error (500, "x")
@@ -784,6 +800,10 @@ let () =
     "Error_domain"
     [ ( "roundtrip"
       , [ Alcotest.test_case "api rate_limited" `Quick test_roundtrip_api_rate_limited
+        ; Alcotest.test_case
+            "provider_to_sdk preserves rate limit message"
+            `Quick
+            test_provider_to_sdk_preserves_rate_limit_message
         ; Alcotest.test_case "api auth_error" `Quick test_roundtrip_api_auth_error
         ; Alcotest.test_case
             "api authorization_error"

--- a/test/test_http_client.ml
+++ b/test/test_http_client.ml
@@ -561,7 +561,7 @@ let test_error_domain_retryable () =
   Alcotest.(check bool)
     "rate limited retryable"
     true
-    (Error_domain.is_retryable (`Rate_limited (Some 1.0)));
+    (Error_domain.is_retryable (`Rate_limited (Some 1.0, "slow down")));
   Alcotest.(check bool)
     "network retryable"
     true

--- a/test/test_llm_provider_error.ml
+++ b/test/test_llm_provider_error.ml
@@ -286,7 +286,7 @@ let test_http_server_error_mapping () =
   let err =
     Error.of_http_error
       ~provider:"openai"
-      (Http_client.HttpError { code = 503; body = "down" })
+      (Http_client.HttpError { code = 503; body = "down"; retry_after_header = None })
   in
   match err with
   | Error.ServerError { provider; code; transient; detail } ->

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -1005,7 +1005,7 @@ let test_error_domain_is_retryable () =
   Alcotest.(check bool)
     "rate limited is retryable"
     true
-    (Error_domain.is_retryable (`Rate_limited (Some 1.0)));
+    (Error_domain.is_retryable (`Rate_limited (Some 1.0, "slow down")));
   Alcotest.(check bool)
     "internal not retryable"
     false

--- a/test/test_pipeline_metrics.ml
+++ b/test/test_pipeline_metrics.ml
@@ -222,7 +222,10 @@ let test_sdk_error_of_http_error_classifies () =
   (* Pure smoke test for the conversion helper introduced in pipeline.ml *)
   let _ : Error.sdk_error =
     Error.Api
-      (Retry.classify_error ~status:429 ~body:{|{"error":{"message":"rate limit"}}|})
+      (Retry.classify_error
+         ~retry_after_header:None
+         ~status:429
+         ~body:{|{"error":{"message":"rate limit"}}|})
   in
   ()
 ;;

--- a/test/test_provider_failure_attribution.ml
+++ b/test/test_provider_failure_attribution.ml
@@ -231,42 +231,46 @@ let test_closed_ownership_matrix () =
     "401 with identity is credential pool"
     Attribution.Credential_pool
     with_credential
-    (Http.HttpError { code = 401; body = "auth" });
+    (Http.HttpError { code = 401; body = "auth"; retry_after_header = None });
   check_ownership
     "401 without identity fails local"
     Attribution.Unclassified
     without_credential
-    (Http.HttpError { code = 401; body = "auth" });
+    (Http.HttpError { code = 401; body = "auth"; retry_after_header = None });
   check_ownership
     "402 with identity is credential pool"
     Attribution.Credential_pool
     with_credential
-    (Http.HttpError { code = 402; body = "payment" });
+    (Http.HttpError { code = 402; body = "payment"; retry_after_header = None });
   check_ownership
     "402 without identity fails local"
     Attribution.Unclassified
     without_credential
-    (Http.HttpError { code = 402; body = "payment" });
+    (Http.HttpError { code = 402; body = "payment"; retry_after_header = None });
+  (* 429 is handled by its own dedicated test below (test_429_capacity_evidence):
+     it is no longer part of the generic "ambiguous" catch-all — it now routes
+     through the typed capacity vocabulary instead of [Http_status]. *)
   List.iter
     (fun code ->
        check_ownership
          (Printf.sprintf "ambiguous HTTP %d" code)
          Attribution.Unclassified
          with_credential
-         (Http.HttpError { code; body = "ambiguous" }))
-    [ 403; 429 ];
+         (Http.HttpError { code; body = "ambiguous"; retry_after_header = None }))
+    [ 403 ];
   check_ownership
     "binding HTTP 404"
     Attribution.Runtime_binding
     with_credential
-    (Http.HttpError { code = 404; body = "binding" });
+    (Http.HttpError { code = 404; body = "binding"; retry_after_header = None });
   List.iter
     (fun code ->
        check_ownership
          (Printf.sprintf "ambiguous server HTTP %d" code)
          Attribution.Unclassified
          with_credential
-         (Http.HttpError { code; body = "ambiguous server failure" }))
+         (Http.HttpError
+            { code; body = "ambiguous server failure"; retry_after_header = None }))
     [ 500; 503 ];
   List.iter
     (fun kind ->
@@ -366,6 +370,68 @@ let test_closed_ownership_matrix () =
        { kind = Http.Cli_startup_failed { reason = Http.Authentication_unavailable }
        ; message = "startup detail"
        })
+;;
+
+(* oas 429 typed completion (2026-07): a raw HTTP 429 used to fall into the
+   generic [Http_status] evidence via [ownership_of_http_status]'s [_ ->
+   Unclassified] catch-all, discarding any retry_after evidence. It must
+   now route through the typed capacity vocabulary — [Provider_failure
+   (Capacity_exhausted { scope = Failure_scope_unknown; retry_after; _ })]
+   — carrying retry_after and staying distinguishable from the [Http_status]
+   evidence produced for genuinely unclassifiable statuses (e.g. 403). The
+   ownership is still [Unclassified] (honest: a raw 429 carries no
+   provider-specific evidence of which lane is exhausted), but it is now
+   reached deliberately through [ownership_of_capacity ~scope:Failure_scope_unknown]
+   instead of the blind catch-all. *)
+let test_429_capacity_evidence () =
+  let with_credential = identity ~api_key:"credential-a" () in
+  let body_only =
+    Http.HttpError
+      { code = 429
+      ; body = {|{"error":{"retry_after":7.0,"message":"slow down"}}|}
+      ; retry_after_header = None
+      }
+  in
+  (match Attribution.of_http_error ~binding:with_credential body_only with
+   | { provider_failure =
+         Some
+           { ownership = Attribution.Unclassified
+           ; evidence =
+               Attribution.Provider_failure
+                 (Http.Capacity_exhausted
+                    { scope = Http.Failure_scope_unknown
+                    ; retry_after = Some ra
+                    ; model = None
+                    })
+           ; _
+           }
+     ; _
+     } -> check_bool "body retry_after carried" true (Float.equal ra 7.0)
+   | _ -> Alcotest.fail "expected typed capacity evidence with body retry_after");
+  let header_fallback =
+    Http.HttpError
+      { code = 429
+      ; body = {|{"error":"too many concurrent requests"}|}
+      ; retry_after_header = Some 15.0
+      }
+  in
+  match Attribution.of_http_error ~binding:with_credential header_fallback with
+  | { provider_failure =
+        Some
+          { ownership = Attribution.Unclassified
+          ; evidence =
+              Attribution.Provider_failure
+                (Http.Capacity_exhausted
+                   { scope = Http.Failure_scope_unknown
+                   ; retry_after = Some ra
+                   ; model = None
+                   })
+          ; _
+          }
+    ; _
+    } ->
+    check_bool "header retry_after carried when body has none" true (Float.equal ra 15.0)
+  | _ -> Alcotest.fail "expected typed capacity evidence with header retry_after"
 ;;
 
 let test_coarse_sdk_provider_errors_fail_closed () =
@@ -614,6 +680,10 @@ let () =
         ] )
     ; ( "ownership"
       , [ Alcotest.test_case "closed matrix" `Quick test_closed_ownership_matrix
+        ; Alcotest.test_case
+            "429 typed capacity evidence"
+            `Quick
+            test_429_capacity_evidence
         ; Alcotest.test_case
             "coarse provider fail-closed"
             `Quick

--- a/test/test_retry.ml
+++ b/test/test_retry.ml
@@ -28,18 +28,27 @@ let expect_overloaded err =
 ;;
 
 let test_classify_error () =
-  Retry.classify_error ~status:429 ~body:{|{"error":{"message":"rate limited"}}|}
+  Retry.classify_error
+    ~retry_after_header:None
+    ~status:429
+    ~body:{|{"error":{"message":"rate limited"}}|}
   |> expect_rate_limited;
-  Retry.classify_error ~status:401 ~body:{|{"error":{"message":"invalid key"}}|}
+  Retry.classify_error
+    ~retry_after_header:None
+    ~status:401
+    ~body:{|{"error":{"message":"invalid key"}}|}
   |> expect_auth_error;
-  Retry.classify_error ~status:500 ~body:"internal error" |> expect_server_error;
-  Retry.classify_error ~status:529 ~body:"overloaded" |> expect_overloaded
+  Retry.classify_error ~retry_after_header:None ~status:500 ~body:"internal error"
+  |> expect_server_error;
+  Retry.classify_error ~retry_after_header:None ~status:529 ~body:"overloaded"
+  |> expect_overloaded
 ;;
 
 let test_classify_error_edge_cases () =
   (* 429 with retry_after field *)
   (match
      Retry.classify_error
+       ~retry_after_header:None
        ~status:429
        ~body:{|{"error":{"message":"slow down","retry_after":2.5}}|}
    with
@@ -48,28 +57,34 @@ let test_classify_error_edge_cases () =
    | Retry.RateLimited { retry_after = None; _ } -> fail "expected retry_after to be Some"
    | _ -> fail "expected RateLimited");
   (* 422 -> InvalidRequest *)
-  (match Retry.classify_error ~status:422 ~body:"validation error" with
+  (match
+     Retry.classify_error ~retry_after_header:None ~status:422 ~body:"validation error"
+   with
    | Retry.InvalidRequest { message } ->
      check string "422 message" "validation error" message
    | _ -> fail "expected InvalidRequest for 422");
   (* 502 -> ServerError *)
-  (match Retry.classify_error ~status:502 ~body:"bad gateway" with
+  (match
+     Retry.classify_error ~retry_after_header:None ~status:502 ~body:"bad gateway"
+   with
    | Retry.ServerError { status; _ } -> check int "502 status" 502 status
    | _ -> fail "expected ServerError for 502");
   (* malformed JSON body -> falls back to raw body *)
-  (match Retry.classify_error ~status:500 ~body:"not json at all" with
+  (match
+     Retry.classify_error ~retry_after_header:None ~status:500 ~body:"not json at all"
+   with
    | Retry.ServerError { message; _ } ->
      check string "raw body fallback" "not json at all" message
    | _ -> fail "expected ServerError with raw body");
   (* 404 -> NotFound *)
-  match Retry.classify_error ~status:404 ~body:"not found" with
+  match Retry.classify_error ~retry_after_header:None ~status:404 ~body:"not found" with
   | Retry.NotFound { message } -> check string "404 not found" "not found" message
   | _ -> fail "expected NotFound for 404"
 ;;
 
 let test_classify_error_402_payment_required () =
   let body = {|{"error":{"message":"Insufficient Balance"}}|} in
-  let err = Retry.classify_error ~status:402 ~body in
+  let err = Retry.classify_error ~retry_after_header:None ~status:402 ~body in
   (match err with
    | Retry.PaymentRequired { message } ->
      check string "402 message" "Insufficient Balance" message
@@ -86,7 +101,7 @@ let test_classify_error_403_authorization_denied () =
   let body =
     {|{"error":{"message":"You've reached your usage limit for this billing cycle"}}|}
   in
-  let err = Retry.classify_error ~status:403 ~body in
+  let err = Retry.classify_error ~retry_after_header:None ~status:403 ~body in
   (match err with
    | Retry.AuthorizationError { message } ->
      check
@@ -149,7 +164,7 @@ let test_is_retryable () =
 
 let test_invalid_request_reason_boundary () =
   let expect_unknown body =
-    match Retry.classify_error ~status:400 ~body with
+    match Retry.classify_error ~retry_after_header:None ~status:400 ~body with
     | Retry.InvalidRequest { reason = Unknown_invalid_request; _ } as err ->
       check bool "generic invalid request is not retryable" false (Retry.is_retryable err)
     | _ -> fail "expected Unknown_invalid_request"

--- a/test/test_stream_accumulator.ml
+++ b/test/test_stream_accumulator.ml
@@ -443,7 +443,8 @@ let test_finalize_unknown_block_type_fails_closed () =
 let test_map_http_error_http () =
   let err =
     Streaming.map_http_error
-      (Llm_provider.Http_client.HttpError { code = 429; body = "rate limited" })
+      (Llm_provider.Http_client.HttpError
+         { code = 429; body = "rate limited"; retry_after_header = None })
   in
   match err with
   | Error.Api (Retry.RateLimited _) -> ()

--- a/test/test_streaming_coverage.ml
+++ b/test/test_streaming_coverage.ml
@@ -667,7 +667,8 @@ let test_full_tool_use_sequence () =
 
 let test_map_http_error_http_error () =
   let http_err =
-    Llm_provider.Http_client.HttpError { code = 429; body = "rate limited" }
+    Llm_provider.Http_client.HttpError
+      { code = 429; body = "rate limited"; retry_after_header = None }
   in
   let sdk_err = Streaming.map_http_error http_err in
   match sdk_err with
@@ -690,7 +691,10 @@ let test_map_http_error_network_error () =
 let test_map_http_error_server_error () =
   let http_err =
     Llm_provider.Http_client.HttpError
-      { code = 500; body = {|{"error":{"message":"Internal server error"}}|} }
+      { code = 500
+      ; body = {|{"error":{"message":"Internal server error"}}|}
+      ; retry_after_header = None
+      }
   in
   let sdk_err = Streaming.map_http_error http_err in
   match sdk_err with
@@ -700,7 +704,8 @@ let test_map_http_error_server_error () =
 
 let test_map_http_error_auth_error () =
   let http_err =
-    Llm_provider.Http_client.HttpError { code = 401; body = "unauthorized" }
+    Llm_provider.Http_client.HttpError
+      { code = 401; body = "unauthorized"; retry_after_header = None }
   in
   let sdk_err = Streaming.map_http_error http_err in
   match sdk_err with


### PR DESCRIPTION
## Why

2026-07-17 429 storm (jeong-sik/masc#24886) 진단 중 확인된 typed-error 갭 3건. provider가 보낸 회복 신호(Retry-After)와 원인 설명("too many concurrent requests")이 파이프라인을 통과하며 소실되어, route-stage 로그가 `Rate limited: rate limited`라는 무정보 문자열로 끝났다.

## What

1. **Retry-After 헤더 캡처** — `HttpError`에 `retry_after_header : float option` 추가. 응답 헤더를 실제로 보는 두 지점(`post_stream`/`with_post_stream`)에서 파싱, `Retry.resolve_retry_after`로 body JSON `error.retry_after`(우선)와 병합. 새 순수 파서 `parse_retry_after_seconds`: delay-seconds + IMF-fixdate(RFC 9110 §10.2.3, 예제 날짜로 핀), 과거 날짜는 0.0 clamp, obsolete 폼(RFC 850/asctime)은 None. `classify_error`의 `~retry_after_header`는 **required option-typed 파라미터** — 모든 call site가 헤더 증거 보유 여부를 명시하게 강제.
2. **429 attribution 승격** — raw 429가 `ownership_of_http_status`의 `_ -> Unclassified` catch-all로 낙하하던 것을, typed capacity 어휘 `Capacity_exhausted { scope = Failure_scope_unknown; retry_after }`로 명시 라우팅. bare 429는 scope 증거가 없으므로 scope는 정직하게 unknown 유지(ownership 값 불변, 도달 경로만 typed).
3. **원문 보존** — `` `Rate_limited `` payload를 `float option` → `(float option * string)`으로 확장, `provider_to_sdk`의 하드코딩 `"rate limited"` 리터럴 제거. 기존 "Message is lost in roundtrip — by design" 테스트를 정확 roundtrip 동등성 단언으로 교체 + counterfactual 테스트 추가.

## Known follow-up (별도 이슈)

`get_sync`/`post_sync`는 기존 계약상 `(code, body)`만 반환해 헤더를 보지 못하므로 sync completion 경로(`complete_sync` — 이번 인시던트의 429가 도착한 바로 그 경로)는 `retry_after_header = None`으로 정직하게 표기됨. sync 경로 헤더 배관은 ~9개 call site 파급이라 본 PR 범위 밖 — 후속 이슈로 등록.

## Verification

- 새 테스트: 헤더 파서 8종(inline let%test), classify_error 429 3종(body-wins/header-only/neither), attribution `test_429_capacity_evidence`, error_domain roundtrip counterfactual.
- 터치된 alcotest 실행파일 12개(301 케이스) + `@lib/llm_provider/runtest` 전부 green, ocamlformat 수렴 확인.
- 시블링 브랜치(feat/provider-slot-admission)의 파일은 불터치.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KXQWcg9KtaC7KruGQTnwX
