### PR TITLE
feat(llm_provider): measure an exact completion request

### DIFF
--- a/lib/llm_provider/count_tokens_sync.ml
+++ b/lib/llm_provider/count_tokens_sync.ml
@@ -65,3 +65,71 @@ let count_anthropic
   | Provider_config.DashScope ->
     Error (Input_token_count.Unsupported { protocol; model_id = config.model_id })
 ;;
+
+type completion_request_measurement =
+  { input_count : Input_token_count.count
+  ; output_token_receipt : Types.output_token_receipt
+  }
+
+type completion_request_error =
+  | Input_count_failed of Input_token_count.error
+  | Output_token_resolution_failed of Types.required_output_token_error
+  | Invalid_completion_request of string
+
+let measure_completion_request
+      ?connection_cache
+      ?clock
+      ?timeout_s
+      ~sw
+      ~net
+      (request : Llm_transport.completion_request)
+  =
+  let config = request.config in
+  match config.kind with
+  | Provider_config.Anthropic ->
+    let artifact =
+      try
+        Backend_anthropic.build_request_artifact
+          ~config
+          ~messages:request.messages
+          ~tools:request.tools
+          ()
+        |> Result.map_error (fun error -> Output_token_resolution_failed error)
+      with
+      | Invalid_argument detail -> Error (Invalid_completion_request detail)
+    in
+    (match artifact with
+     | Error _ as error -> error
+     | Ok artifact ->
+       (match
+          count_anthropic
+            ?connection_cache
+            ?clock
+            ?timeout_s
+            ~sw
+            ~net
+            ~config
+            ~messages:request.messages
+            ~tools:request.tools
+            ()
+        with
+        | Error error -> Error (Input_count_failed error)
+        | Ok input_count ->
+          Ok
+            { input_count
+            ; output_token_receipt =
+                Backend_anthropic.request_output_token_receipt artifact
+            }))
+  | Provider_config.Kimi
+  | Provider_config.OpenAI_compat
+  | Provider_config.Ollama
+  | Provider_config.Gemini
+  | Provider_config.Glm
+  | Provider_config.DashScope ->
+    Error
+      (Input_count_failed
+         (Input_token_count.Unsupported
+            { protocol = Input_token_count.Anthropic_messages_count_tokens
+            ; model_id = config.model_id
+            }))
+;;

--- a/lib/llm_provider/count_tokens_sync.mli
+++ b/lib/llm_provider/count_tokens_sync.mli
@@ -30,3 +30,39 @@ val count_anthropic
   -> ?tools:Yojson.Safe.t list
   -> unit
   -> (Input_token_count.count, Input_token_count.error) result
+
+(** Exact provider-owned measurement of one fully prepared completion request.
+
+    The caller supplies the immutable {!Llm_transport.completion_request} that
+    reached its transport boundary, after Agent turn hooks, tool projection,
+    and caller-owned message projection. The input count uses the provider's
+    native count endpoint. The output receipt comes from the opaque completion
+    request artifact built from the same config, messages, and tools.
+
+    This is a lower-level transport-adapter primitive. Application callers
+    must not reconstruct a completion request to call it: final Agent-level
+    fit admission must measure the same opaque prepared request that it later
+    dispatches. This function neither dispatches nor returns that artifact, so
+    its receipt alone does not prove a later dispatch reused the measured
+    request value.
+
+    Unsupported provider protocols fail before I/O. No character estimate,
+    context-window fallback, fit policy, retry, or truncation is performed. *)
+type completion_request_measurement = private
+  { input_count : Input_token_count.count
+  ; output_token_receipt : Types.output_token_receipt
+  }
+
+type completion_request_error =
+  | Input_count_failed of Input_token_count.error
+  | Output_token_resolution_failed of Types.required_output_token_error
+  | Invalid_completion_request of string
+
+val measure_completion_request
+  :  ?connection_cache:Http_client.cache
+  -> ?clock:_ Eio.Time.clock
+  -> ?timeout_s:float
+  -> sw:Eio.Switch.t
+  -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> Llm_transport.completion_request
+  -> (completion_request_measurement, completion_request_error) result

--- a/test/test_anthropic_input_token_count.ml
+++ b/test/test_anthropic_input_token_count.ml
@@ -75,6 +75,16 @@ let config
     ()
 ;;
 
+let completion_request config : Llm_transport.completion_request =
+  { config
+  ; messages
+  ; tools = [ tool ]
+  ; capture_id = Some "request-count-fixture"
+  ; observe_wire_chunk = None
+  ; stream_idle_timeout_s = None
+  }
+;;
+
 let assoc body =
   match Yojson.Safe.from_string body with
   | `Assoc fields -> fields
@@ -157,23 +167,31 @@ let test_transport_success () =
   let result, (path, headers, body) =
     with_mock ~status:`OK ~response:{|{"input_tokens":321}|}
     @@ fun ~sw ~net ~base_url ->
-    Count_tokens_sync.count_anthropic
+    Count_tokens_sync.measure_completion_request
       ~sw
       ~net
-      ~config:(config base_url)
-      ~messages
-      ~tools:[ tool ]
-      ()
+      (completion_request (config base_url))
   in
   (match result with
-   | Ok count ->
+   | Ok measurement ->
+     let count = measurement.input_count in
      check int "input tokens" 321 count.input_tokens;
      check string "model id" "input-count-fixture" count.model_id;
      check
        bool
        "protocol"
        true
-       (Count.equal_protocol count.protocol Count.Anthropic_messages_count_tokens)
+       (Count.equal_protocol count.protocol Count.Anthropic_messages_count_tokens);
+     check
+       (option int)
+       "exact requested output"
+       (Some 64)
+       (Types.output_token_receipt_requested measurement.output_token_receipt);
+     check
+       (option int)
+       "exact effective output"
+       (Some 64)
+       (Types.output_token_receipt_effective measurement.output_token_receipt)
    | Error _ -> fail "expected native Anthropic count success");
   check string "custom proxy path" "/proxy/messages/count_tokens" path;
   let check_header name value =
@@ -210,17 +228,39 @@ let test_unsupported () =
   Eio.Switch.run
   @@ fun sw ->
   match
-    Count_tokens_sync.count_anthropic
+    Count_tokens_sync.measure_completion_request
       ~sw
       ~net:(Eio.Stdenv.net env)
-      ~config:(config ~kind:Provider_config.OpenAI_compat "not a URL")
-      ~messages
-      ()
+      (completion_request (config ~kind:Provider_config.OpenAI_compat "not a URL"))
   with
   | Error
-      (Count.Unsupported { protocol = Count.Anthropic_messages_count_tokens; model_id })
+      (Count_tokens_sync.Input_count_failed
+         (Count.Unsupported { protocol = Count.Anthropic_messages_count_tokens; model_id }))
     -> check string "model id" "input-count-fixture" model_id
   | Ok _ | Error _ -> fail "expected typed Unsupported before transport"
+;;
+
+let test_missing_output_ceiling_precedes_io () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let cfg =
+    { (config "not a URL") with
+      model_id = "request-measurement-missing-output-ceiling"
+    ; max_tokens = None
+    }
+  in
+  match
+    Count_tokens_sync.measure_completion_request
+      ~sw
+      ~net:(Eio.Stdenv.net env)
+      (completion_request cfg)
+  with
+  | Error
+      (Count_tokens_sync.Output_token_resolution_failed
+         Types.Required_output_token_ceiling_missing) -> ()
+  | Ok _ | Error _ -> fail "expected typed output-token failure before count I/O"
 ;;
 
 let test_count_tokens_url () =
@@ -247,6 +287,10 @@ let () =
       , [ test_case "native success" `Quick test_transport_success
         ; test_case "typed HTTP error" `Quick test_transport_error
         ; test_case "non-Anthropic unsupported" `Quick test_unsupported
+        ; test_case
+            "missing output ceiling precedes I/O"
+            `Quick
+            test_missing_output_ceiling_precedes_io
         ; test_case "count-tokens URL insertion" `Quick test_count_tokens_url
         ] )
     ]


### PR DESCRIPTION
## Scope

- measure one immutable Llm_transport.completion_request through provider-native input counting
- return the exact effective output-token receipt resolved from the same config, messages, and tools
- surface input-count, output-resolution, and invalid-request failures as typed variants
- reject unsupported provider protocols before I/O

## Explicit boundary

This is a lower-level transport prerequisite, not final fit admission. It neither dispatches nor returns the opaque prepared request, so it cannot prove a later call reused the measured value. Application code must not reconstruct a completion request to call it. The final Agent/transport slice must measure and dispatch the same post-hook, post-tool, post-projection prepared request, or emit a typed pre-dispatch fit/overflow receipt bound to it.

A source-free manual compaction still cannot claim that an unknown future request fits.

## Verification

- scripts/dune-local.sh build test/test_anthropic_input_token_count.exe
- direct focused proof: 6/6 passed
- ocamlformat check passed
- git diff --check passed

## Change size

172 changed lines. Full build remains CI authority.