### PR TITLE
fix(execution): preserve opaque provider tool ids

### DIFF
--- a/lib/execution_event.ml
+++ b/lib/execution_event.ml
@@ -120,11 +120,6 @@ let validate_non_blank field value =
   else Ok ()
 ;;
 
-let validate_optional_non_blank field = function
-  | None -> Ok ()
-  | Some value -> validate_non_blank field value
-;;
-
 let validate_json = Execution_json.validate
 
 let validate_node_kind = function
@@ -135,8 +130,7 @@ let validate_node_kind = function
     if ordinal < 0 then Error "provider attempt ordinal must be non-negative" else Ok ()
   | Output_block { ordinal; _ } ->
     if ordinal < 0 then Error "output block ordinal must be non-negative" else Ok ()
-  | Tool_invocation { provider_tool_use_id; tool_name; schedule } ->
-    let* () = validate_optional_non_blank "provider_tool_use_id" provider_tool_use_id in
+  | Tool_invocation { provider_tool_use_id = _; tool_name; schedule } ->
     let* () = validate_non_blank "tool_name" tool_name in
     Execution_tool_schedule.validate schedule
   | Tool_attempt -> Ok ()
@@ -305,11 +299,8 @@ let validate_content_block block =
   if block = decoded
   then (
     match block with
-    | ToolUse { id; name; _ } ->
-      let* () = validate_non_blank "tool-use identifier" id in
-      validate_non_blank "tool-use name" name
-    | ToolResult { tool_use_id; _ } ->
-      validate_non_blank "tool-result tool-use identifier" tool_use_id
+    | ToolUse { id = _; name; _ } -> validate_non_blank "tool-use name" name
+    | ToolResult { tool_use_id = _; _ } -> Ok ()
     | Text _
     | Thinking _
     | ReasoningDetails _

--- a/test/test_execution_journal.ml
+++ b/test/test_execution_journal.ml
@@ -1000,12 +1000,42 @@ let test_json_terminal_and_id_boundaries () =
   expect_invalid_node_kind
     (Event.Tool_invocation
        { provider_tool_use_id = None; tool_name = " \t"; schedule = serial_schedule });
-  expect_invalid_node_kind
-    (Event.Tool_invocation
-       { provider_tool_use_id = Some " \n"
-       ; tool_name = "valid_tool"
-       ; schedule = serial_schedule
-       });
+  let exact_provider_id = " \n" in
+  let exact_provider_kind =
+    Event.Tool_invocation
+      { provider_tool_use_id = Some exact_provider_id
+      ; tool_name = "valid_tool"
+      ; schedule = serial_schedule
+      }
+  in
+  (match Event.node_kind_to_yojson exact_provider_kind with
+   | Error _ -> fail "opaque provider tool id did not encode"
+   | Ok json ->
+     (match Event.node_kind_of_yojson json with
+      | Ok (Event.Tool_invocation { provider_tool_use_id = Some decoded; _ }) ->
+        check string "provider tool id roundtrip is exact" exact_provider_id decoded
+      | Ok _ | Error _ -> fail "opaque provider tool id did not roundtrip exactly"));
+  let opaque_tool_use =
+    Llm_provider.Types.ToolUse { id = " \t"; name = "valid_tool"; input = `Assoc [] }
+  in
+  let opaque_tool_result =
+    Llm_provider.Types.ToolResult
+      { tool_use_id = "\n "
+      ; content = "ok"
+      ; outcome = Llm_provider.Types.Tool_succeeded
+      ; json = None
+      ; content_blocks = None
+      }
+  in
+  List.iter
+    (fun update ->
+       match Event.node_update_to_yojson update with
+       | Error _ -> fail "opaque content-block provider id did not encode"
+       | Ok json ->
+         (match Event.node_update_of_yojson json with
+          | Ok decoded when decoded = update -> ()
+          | Ok _ | Error _ -> fail "opaque content-block provider id changed"))
+    [ Event.Tool_input_snapshot opaque_tool_use; Event.Tool_result opaque_tool_result ];
   let before_invalid_response_id = Journal.length journal in
   (match
      Journal.update_node journal ~node:turn (Event.Provider_response_id_snapshot " \t")


### PR DESCRIPTION
## What

- preserve provider-assigned tool IDs byte-for-byte, including blank, whitespace, and repeated values
- keep `Node_id` and `Tool.Invocation` as the typed occurrence authority
- round-trip the exact provider ID through `Tool_invocation`, `ToolUse`, and `ToolResult` execution-event codecs without normalization or semantic inference

## Boundary

This is a generic OAS execution identity contract. It contains no MASC, Keeper, Gate, vendor, command, or tool-name policy. It is now based directly on current `main` and no longer depends on the speculative checkpoint/execution stack.

## Validation

- `scripts/dune-local.sh build @fmt test/test_execution_journal.exe`
- `_build/default/test/test_execution_journal.exe` (19/19 green)
- `git diff --check`

## Not claimed

This PR does not execute or resume pending effects. It only prevents lossy provider-ID normalization at the canonical execution-event boundary.
