### PR TITLE
feat(execution): add private exact tool settlement authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ original tag dates. `0.100.4` was never tagged or released.
 
 ### Breaking Changes
 
+* **tool lifecycle:** `PreToolUse`, `PostToolUse`, `PostToolUseFailure`,
+  `ToolCalled`, and `ToolCompleted` now carry the exact typed
+  `Tool.Invocation.t`. Existing flat tool-call id, turn, and planned-index
+  fields remain compatibility projections; code constructing these public
+  variants must supply the new `invocation` field.
 * **agent-as-tool inputs:** remove `Agent_tool.config.input_parameters` and
   scalar-string invocation. The advertised and consumed input contract is now
   exactly one required object field, `prompt`; see the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,12 @@ original tag dates. `0.100.4` was never tagged or released.
   re-export. Scripted provider responses remain test-only code, not an SDK
   runtime provider.
 
+### Features
+
+* **checkpoint stages:** expose exhaustive equality and a closed JSON codec for
+  the three public mutation-boundary stages. Unknown labels and non-string
+  values are rejected instead of being reinterpreted.
+
 ### Bug Fixes
 
 * **eval collection:** atomically cancel and drain event-bus subscriptions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,14 @@ original tag dates. `0.100.4` was never tagged or released.
 
 ### Breaking Changes
 
-* **tool lifecycle:** `PreToolUse`, `PostToolUse`, `PostToolUseFailure`,
-  `ToolCalled`, and `ToolCompleted` now carry the exact typed
-  `Tool.Invocation.t`. Existing flat tool-call id, turn, and planned-index
-  fields remain compatibility projections; code constructing these public
-  variants must supply the new `invocation` field.
+* **tool lifecycle:** replace independently writable tool-call id, turn, and
+  schedule copies across hooks, events, results, failures, and execution
+  callbacks with one run-scoped `Tool.Invocation.t`. The invocation now owns
+  its canonical `Tool.schedule`; `Hooks.tool_schedule` remains a type alias,
+  not a second representation. Provider wire messages, raw-trace records, SDK
+  errors, and the compatible durable journal retain their external shapes and
+  are projected from the invocation at those boundaries. See the
+  [0.216 migration guide](docs/migrations/0.216-tool-invocation-ssot.md).
 * **agent-as-tool inputs:** remove `Agent_tool.config.input_parameters` and
   scalar-string invocation. The advertised and consumed input contract is now
   exactly one required object field, `prompt`; see the

--- a/docs/EVENT-CATALOG.md
+++ b/docs/EVENT-CATALOG.md
@@ -70,8 +70,8 @@ Pattern-matchable OCaml sum type. **Stable across every provider.**
 | `TurnStarted` | `pipeline/pipeline_stage_prepare.ml` | Start of a single agent turn |
 | `TurnReady` | `pipeline/pipeline_stage_prepare.ml` | Exact caller-supplied tool surface serialized for this turn |
 | `TurnCompleted` | `pipeline/pipeline.ml` | End of a single agent turn |
-| `ToolCalled` | `agent/agent_tools.ml` | Tool invocation requested by LLM; carries `tool_use_id` and `turn` |
-| `ToolCompleted` | `agent/agent_tools.ml` | Tool invocation result available; carries matching `tool_use_id` and `turn` |
+| `ToolCalled` | `agent/agent_tools.ml` | Tool invocation requested by LLM; carries exact typed `Tool.Invocation.t` plus compatibility `tool_use_id` and `turn` projections |
+| `ToolCompleted` | `agent/agent_tools.ml` | Tool invocation result available; carries the same exact typed invocation plus compatibility projections |
 | `HandoffRequested` | `agent/agent.ml` | Agent delegates control to another agent |
 | `HandoffCompleted` | `agent/agent.ml` | Handoff target finished |
 | `ElicitationCompleted` | `pipeline/pipeline_stage_prepare.ml` | User elicitation round completed |

--- a/docs/EVENT-CATALOG.md
+++ b/docs/EVENT-CATALOG.md
@@ -7,7 +7,7 @@ relate, and the contracts downstream consumers can rely on.
 **Scope**: `agent_sdk` library (`lib/`).
 **Status**: Stable catalog; entries marked *Evolving* may change with
 deprecation notice.
-**Last updated**: v0.211.3.
+**Last updated**: v0.216.0.
 
 ---
 
@@ -70,8 +70,8 @@ Pattern-matchable OCaml sum type. **Stable across every provider.**
 | `TurnStarted` | `pipeline/pipeline_stage_prepare.ml` | Start of a single agent turn |
 | `TurnReady` | `pipeline/pipeline_stage_prepare.ml` | Exact caller-supplied tool surface serialized for this turn |
 | `TurnCompleted` | `pipeline/pipeline.ml` | End of a single agent turn |
-| `ToolCalled` | `agent/agent_tools.ml` | Tool invocation requested by LLM; carries exact typed `Tool.Invocation.t` plus compatibility `tool_use_id` and `turn` projections |
-| `ToolCompleted` | `agent/agent_tools.ml` | Tool invocation result available; carries the same exact typed invocation plus compatibility projections |
+| `ToolCalled` | `agent/agent_tools.ml` | Tool invocation requested by LLM; carries the exact run-scoped `Tool.Invocation.t` |
+| `ToolCompleted` | `agent/agent_tools.ml` | Tool invocation result available; carries the same exact typed invocation |
 | `HandoffRequested` | `agent/agent.ml` | Agent delegates control to another agent |
 | `HandoffCompleted` | `agent/agent.ml` | Handoff target finished |
 | `ElicitationCompleted` | `pipeline/pipeline_stage_prepare.ml` | User elicitation round completed |

--- a/docs/migrations/0.216-tool-invocation-ssot.md
+++ b/docs/migrations/0.216-tool-invocation-ssot.md
@@ -1,0 +1,50 @@
+# 0.216 tool invocation SSOT migration
+
+OAS 0.216 represents one run-scoped model tool occurrence with exactly one
+`Tool.Invocation.t`. Provider IDs may be blank or repeated, so the invocation
+also owns the turn and canonical scheduler placement.
+
+## Constructing an invocation
+
+```ocaml
+let schedule : Tool.schedule =
+  { planned_index = 2
+  ; batch_index = 0
+  ; batch_size = 1
+  ; execution_mode = Tool.Serial
+  }
+in
+let invocation =
+  Tool.Invocation.create ~tool_use_id:"provider-id" ~turn:4 ~schedule
+```
+
+`Hooks.tool_schedule` remains an alias of `Tool.schedule` for code that names
+the old type. It is not a second stored schedule.
+
+## Reading former flat fields
+
+Hook and event variants, `Agent_tools.tool_execution_result`, hook failures,
+and execution callbacks now carry `invocation` instead of independent
+`tool_use_id`, `turn`, or `schedule` fields.
+
+```ocaml
+let id = Tool.Invocation.tool_use_id invocation in
+let turn = Tool.Invocation.turn invocation in
+let schedule = Tool.Invocation.schedule invocation in
+let planned_index = Tool.Invocation.planned_index invocation in
+```
+
+`Agent_tools.find_and_execute_tool` now accepts `~invocation`; it no longer
+mints an occurrence from independently supplied identity arguments.
+
+## Compatibility boundaries
+
+Provider `ToolUse`/`ToolResult` messages retain their wire-level tool-call ID.
+SDK errors and the compatible durable journal retain their existing external
+shapes. OAS derives those values from the invocation only when projecting to
+the boundary.
+
+Raw-trace JSON remains readable without migration. New start and finish
+records both include `tool_planned_index`, allowing repeated or blank provider
+IDs to pair exactly. Historical records without that field use the previous
+ID-only validation behavior.

--- a/examples/error_handling.ml
+++ b/examples/error_handling.ml
@@ -43,7 +43,7 @@ let error_hooks : Hooks.hooks =
     on_tool_error =
       Some
         (function
-          | OnToolError { tool_name; error } ->
+          | OnToolError { tool_name; error; invocation = _ } ->
             Printf.eprintf "[error-hook] Tool %s failed: %s\n%!" tool_name error;
             Continue
           | _ -> Continue)

--- a/examples/observable_agent.ml
+++ b/examples/observable_agent.ml
@@ -34,14 +34,14 @@ let print_event (event : Event_bus.event) =
     Printf.eprintf "%s %s turn %d started\n%!" (dim t) (cyan agent_name) turn
   | TurnCompleted { agent_name; turn } ->
     Printf.eprintf "%s %s turn %d completed\n%!" (dim t) (cyan agent_name) turn
-  | ToolCalled { agent_name; tool_name; input; turn = _ } ->
+  | ToolCalled { agent_name; tool_name; input; invocation = _ } ->
     Printf.eprintf
       "%s %s %s called: %s\n%!"
       (dim t)
       (cyan agent_name)
       (yellow tool_name)
       (Yojson.Safe.to_string input)
-  | ToolCompleted { agent_name; tool_name; output; turn = _ } ->
+  | ToolCompleted { agent_name; tool_name; output; invocation = _ } ->
     let status =
       match output with
       | Ok { content; _meta = _ } -> green (Printf.sprintf "ok: %s" content)

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -20,6 +20,9 @@ type checkpoint_stage = Agent_types.checkpoint_stage =
   | After_context_injection
 
 val checkpoint_stage_to_string : checkpoint_stage -> string
+val checkpoint_stage_equal : checkpoint_stage -> checkpoint_stage -> bool
+val checkpoint_stage_to_yojson : checkpoint_stage -> Yojson.Safe.t
+val checkpoint_stage_of_yojson : Yojson.Safe.t -> (checkpoint_stage, string) result
 
 type checkpoint_snapshot = Agent_types.checkpoint_snapshot =
   { stage : checkpoint_stage

--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -283,7 +283,8 @@ let find_and_execute_tool_with_index
       ?correlation_id
       ?run_id
       ?on_hook_invoked
-      ~schedule
+      ~(schedule : Hooks.tool_schedule)
+      ~invocation
       name
       input
       id
@@ -321,7 +322,13 @@ let find_and_execute_tool_with_index
           ?correlation_id
           ?run_id
           (ToolCalled
-             { agent_name; tool_name = name; tool_use_id = id; input; turn = turn_count })
+             { invocation
+             ; agent_name
+             ; tool_name = name
+             ; tool_use_id = Tool.Invocation.tool_use_id invocation
+             ; input
+             ; turn = Tool.Invocation.turn invocation
+             })
       in
       (try
          Event_bus.publish bus ev;
@@ -357,7 +364,13 @@ let find_and_execute_tool_with_index
           ~tool_use_id:id
           hooks.post_tool_use_failure
           (Hooks.PostToolUseFailure
-             { tool_use_id = id; tool_name = name; input; error = message; schedule })
+             { invocation
+             ; tool_use_id = Tool.Invocation.tool_use_id invocation
+             ; tool_name = name
+             ; input
+             ; error = message
+             ; schedule
+             })
       in
       (* Tool inputs cross this boundary unchanged. The schema either accepts
            the exact JSON value or produces a typed validation failure for the
@@ -376,12 +389,6 @@ let find_and_execute_tool_with_index
          { result = validation_error_result ~input message; deferred_failure }
        | Ok exact_input ->
          let t0 = Unix.gettimeofday () in
-         let invocation =
-           Tool.Invocation.create
-             ~tool_use_id:id
-             ~turn:turn_count
-             ~planned_index:schedule.planned_index
-         in
          let result =
            try Tool.execute ~context ~invocation tool exact_input with
            | exn ->
@@ -410,7 +417,8 @@ let find_and_execute_tool_with_index
              ~tool_use_id:id
              hooks.post_tool_use
              (Hooks.PostToolUse
-                { tool_use_id = id
+                { invocation
+                ; tool_use_id = Tool.Invocation.tool_use_id invocation
                 ; tool_name = name
                 ; input = exact_input
                 ; output = result
@@ -434,7 +442,8 @@ let find_and_execute_tool_with_index
                ~tool_use_id:id
                hooks.post_tool_use_failure
                (Hooks.PostToolUseFailure
-                  { tool_use_id = id
+                  { invocation
+                  ; tool_use_id = Tool.Invocation.tool_use_id invocation
                   ; tool_name = name
                   ; input = exact_input
                   ; error = message
@@ -530,11 +539,12 @@ let find_and_execute_tool_with_index
              ?run_id
              ?caused_by:tool_called_run_id
              (ToolCompleted
-                { agent_name
+                { invocation
+                ; agent_name
                 ; tool_name = name
-                ; tool_use_id = id
+                ; tool_use_id = Tool.Invocation.tool_use_id invocation
                 ; output
-                ; turn = turn_count
+                ; turn = Tool.Invocation.turn invocation
                 }))
       with
       | exception_ ->
@@ -555,12 +565,18 @@ let find_and_execute_tool
       ?correlation_id
       ?run_id
       ?on_hook_invoked
-      ~schedule
+      ~(schedule : Hooks.tool_schedule)
       name
       input
       id
   =
   let tool_index = build_index tools in
+  let invocation =
+    Tool.Invocation.create
+      ~tool_use_id:id
+      ~turn:turn_count
+      ~planned_index:schedule.planned_index
+  in
   try
     find_and_execute_tool_with_index
       ~context
@@ -574,6 +590,7 @@ let find_and_execute_tool
       ?run_id
       ?on_hook_invoked
       ~schedule
+      ~invocation
       name
       input
       id
@@ -612,10 +629,16 @@ let execute_scheduled_tool
       ?on_tool_execution_started
       ?on_tool_execution_finished
       ?on_hook_invoked
-      ~schedule
+      ~(schedule : Hooks.tool_schedule)
       (tool_use : scheduled_tool_use)
   =
   let { index; id; name; input; _ } = tool_use in
+  let invocation =
+    Tool.Invocation.create
+      ~tool_use_id:id
+      ~turn:turn_count
+      ~planned_index:schedule.planned_index
+  in
   let completed_dispatch = ref None in
   let first_failure = ref None in
   let record_failure failure =
@@ -668,11 +691,12 @@ let execute_scheduled_tool
         ~hook_name:"pre_tool_use"
         hooks.pre_tool_use
         (Hooks.PreToolUse
-           { tool_use_id = id
+           { invocation
+           ; tool_use_id = Tool.Invocation.tool_use_id invocation
            ; tool_name = name
            ; input
            ; accumulated_cost_usd = usage.Types.estimated_cost_usd
-           ; turn = turn_count
+           ; turn = Tool.Invocation.turn invocation
            ; schedule
            })
     in
@@ -760,6 +784,7 @@ let execute_scheduled_tool
                     ?run_id
                     ?on_hook_invoked
                     ~schedule
+                    ~invocation
                     name
                     input
                     id

--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -15,7 +15,7 @@ type tool_failure_kind = Types.tool_failure_kind =
   | Unattributed_tool_error
 
 type tool_execution_result =
-  { tool_use_id : string
+  { invocation : Tool.Invocation.t
   ; tool_name : string
   ; input : Yojson.Safe.t
   ; content : string
@@ -27,7 +27,7 @@ type execution_error =
       { hook_name : string
       ; stage : Hooks.hook_stage
       ; tool_name : string
-      ; tool_use_id : string
+      ; invocation : Tool.Invocation.t
       ; detail : string
       }
 
@@ -100,8 +100,8 @@ let unknown_tool_failure ~requested ~available =
 
 let resolve_tool_call tool_index name input = name, input, find_in_index tool_index name
 
-let tool_failure_result ~id ~name ~input ~content ~error_class =
-  { tool_use_id = id
+let tool_failure_result ~invocation ~name ~input ~content ~error_class =
+  { invocation
   ; tool_name = name
   ; input
   ; content
@@ -111,8 +111,8 @@ let tool_failure_result ~id ~name ~input ~content ~error_class =
   }
 ;;
 
-let blocked_tool_result ~id ~name ~input ~content =
-  tool_failure_result ~id ~name ~input ~content ~error_class:Types.Deterministic
+let blocked_tool_result ~invocation ~name ~input ~content =
+  tool_failure_result ~invocation ~name ~input ~content ~error_class:Types.Deterministic
 ;;
 
 let schedule_tool_use ~tool_index index (id, name, input) =
@@ -142,7 +142,7 @@ let execution_batches tool_uses =
 ;;
 
 let hook_schedule_of_tool_use ~batch_index ~batch_size (tool_use : scheduled_tool_use)
-  : Hooks.tool_schedule
+  : Tool.schedule
   =
   { planned_index = tool_use.index
   ; batch_index
@@ -212,21 +212,21 @@ type tool_dispatch =
   ; deferred_failure : deferred_failure option
   }
 
-let hook_execution_error ~hook_name ~stage ~tool_name ~tool_use_id ~detail =
-  Hook_execution_failed { hook_name; stage; tool_name; tool_use_id; detail }
+let hook_execution_error ~hook_name ~stage ~tool_name ~invocation ~detail =
+  Hook_execution_failed { hook_name; stage; tool_name; invocation; detail }
 ;;
 
 let invoke_post_hook
       ?on_hook_invoked
       ~tracer
       ~agent_name
-      ~turn_count
+      ~invocation
       ~hook_name
       ~tool_name
-      ~tool_use_id
       hook_opt
       event
   =
+  let turn_count = Tool.Invocation.turn invocation in
   try
     match
       invoke_hook
@@ -242,7 +242,7 @@ let invoke_post_hook
     | Hooks.HookFailed { stage; detail } ->
       Some
         (Hook_failure
-           (hook_execution_error ~hook_name ~stage ~tool_name ~tool_use_id ~detail))
+           (hook_execution_error ~hook_name ~stage ~tool_name ~invocation ~detail))
     | decision ->
       let stage = Hooks.stage_of_event event in
       Some
@@ -251,7 +251,7 @@ let invoke_post_hook
               ~hook_name
               ~stage
               ~tool_name
-              ~tool_use_id
+              ~invocation
               ~detail:
                 (Printf.sprintf
                    "illegal decision %s escaped hook validation"
@@ -279,16 +279,14 @@ let find_and_execute_tool_with_index
       ~event_bus
       ~tracer
       ~agent_name
-      ~turn_count
       ?correlation_id
       ?run_id
       ?on_hook_invoked
-      ~(schedule : Hooks.tool_schedule)
       ~invocation
       name
       input
-      id
   =
+  let id = Tool.Invocation.tool_use_id invocation in
   let requested_name = name in
   let name, input, tool_opt = resolve_tool_call tool_index name input in
   let first_deferred_failure = ref None in
@@ -321,14 +319,7 @@ let find_and_execute_tool_with_index
         Event_bus.mk_event
           ?correlation_id
           ?run_id
-          (ToolCalled
-             { invocation
-             ; agent_name
-             ; tool_name = name
-             ; tool_use_id = Tool.Invocation.tool_use_id invocation
-             ; input
-             ; turn = Tool.Invocation.turn invocation
-             })
+          (ToolCalled { invocation; agent_name; tool_name = name; input })
       in
       (try
          Event_bus.publish bus ev;
@@ -344,7 +335,7 @@ let find_and_execute_tool_with_index
     match tool_opt with
     | Some tool ->
       let validation_error_result ~input message =
-        { tool_use_id = id
+        { invocation
         ; tool_name = name
         ; input
         ; content = message
@@ -358,19 +349,12 @@ let find_and_execute_tool_with_index
           ?on_hook_invoked
           ~tracer
           ~agent_name
-          ~turn_count
+          ~invocation
           ~hook_name:"post_tool_use_failure"
           ~tool_name:name
-          ~tool_use_id:id
           hooks.post_tool_use_failure
           (Hooks.PostToolUseFailure
-             { invocation
-             ; tool_use_id = Tool.Invocation.tool_use_id invocation
-             ; tool_name = name
-             ; input
-             ; error = message
-             ; schedule
-             })
+             { invocation; tool_name = name; input; error = message })
       in
       (* Tool inputs cross this boundary unchanged. The schema either accepts
            the exact JSON value or produces a typed validation failure for the
@@ -411,20 +395,17 @@ let find_and_execute_tool_with_index
              ?on_hook_invoked
              ~tracer
              ~agent_name
-             ~turn_count
+             ~invocation
              ~hook_name:"post_tool_use"
              ~tool_name:name
-             ~tool_use_id:id
              hooks.post_tool_use
              (Hooks.PostToolUse
                 { invocation
-                ; tool_use_id = Tool.Invocation.tool_use_id invocation
                 ; tool_name = name
                 ; input = exact_input
                 ; output = result
                 ; result_bytes
                 ; duration_ms
-                ; schedule
                 })
          in
          let deferred_failure =
@@ -436,19 +417,12 @@ let find_and_execute_tool_with_index
                ?on_hook_invoked
                ~tracer
                ~agent_name
-               ~turn_count
+               ~invocation
                ~hook_name:"post_tool_use_failure"
                ~tool_name:name
-               ~tool_use_id:id
                hooks.post_tool_use_failure
                (Hooks.PostToolUseFailure
-                  { invocation
-                  ; tool_use_id = Tool.Invocation.tool_use_id invocation
-                  ; tool_name = name
-                  ; input = exact_input
-                  ; error = message
-                  ; schedule
-                  })
+                  { invocation; tool_name = name; input = exact_input; error = message })
          in
          let deferred_failure =
            match deferred_failure, result with
@@ -463,12 +437,11 @@ let find_and_execute_tool_with_index
                ?on_hook_invoked
                ~tracer
                ~agent_name
-               ~turn_count
+               ~invocation
                ~hook_name:"on_tool_error"
                ~tool_name:name
-               ~tool_use_id:id
                hooks.on_tool_error
-               (Hooks.OnToolError { tool_name = name; error = message })
+               (Hooks.OnToolError { invocation; tool_name = name; error = message })
          in
          let content, outcome =
            match result with
@@ -480,7 +453,7 @@ let find_and_execute_tool_with_index
              message, Tool_failed { failure_kind; error_class }
          in
          { result =
-             { tool_use_id = id; tool_name = name; input = exact_input; content; outcome }
+             { invocation; tool_name = name; input = exact_input; content; outcome }
          ; deferred_failure
          })
     | None ->
@@ -505,16 +478,18 @@ let find_and_execute_tool_with_index
           ?on_hook_invoked
           ~tracer
           ~agent_name
-          ~turn_count
+          ~invocation
           ~hook_name:"on_error"
           ~tool_name:requested_name
-          ~tool_use_id:id
           hooks.on_error
           (Hooks.OnError
-             { detail = message; context = "agent_tools.find_and_execute_tool" })
+             { invocation = Some invocation
+             ; detail = message
+             ; context = "agent_tools.find_and_execute_tool"
+             })
       in
       { result =
-          { tool_use_id = id
+          { invocation
           ; tool_name = requested_name
           ; input
           ; content = message
@@ -538,14 +513,7 @@ let find_and_execute_tool_with_index
              ?correlation_id
              ?run_id
              ?caused_by:tool_called_run_id
-             (ToolCompleted
-                { invocation
-                ; agent_name
-                ; tool_name = name
-                ; tool_use_id = Tool.Invocation.tool_use_id invocation
-                ; output
-                ; turn = Tool.Invocation.turn invocation
-                }))
+             (ToolCompleted { invocation; agent_name; tool_name = name; output }))
       with
       | exception_ ->
         let backtrace = Printexc.get_raw_backtrace () in
@@ -561,22 +529,14 @@ let find_and_execute_tool
       ~event_bus
       ~tracer
       ~agent_name
-      ~turn_count
       ?correlation_id
       ?run_id
       ?on_hook_invoked
-      ~(schedule : Hooks.tool_schedule)
+      ~invocation
       name
       input
-      id
   =
   let tool_index = build_index tools in
-  let invocation =
-    Tool.Invocation.create
-      ~tool_use_id:id
-      ~turn:turn_count
-      ~planned_index:schedule.planned_index
-  in
   try
     find_and_execute_tool_with_index
       ~context
@@ -585,15 +545,12 @@ let find_and_execute_tool
       ~event_bus
       ~tracer
       ~agent_name
-      ~turn_count
       ?correlation_id
       ?run_id
       ?on_hook_invoked
-      ~schedule
       ~invocation
       name
       input
-      id
     |> resolve_dispatch
   with
   | Hook_observer_raised (exn, backtrace) -> reraise_hook_observer exn backtrace
@@ -629,16 +586,13 @@ let execute_scheduled_tool
       ?on_tool_execution_started
       ?on_tool_execution_finished
       ?on_hook_invoked
-      ~(schedule : Hooks.tool_schedule)
+      ~(schedule : Tool.schedule)
       (tool_use : scheduled_tool_use)
   =
   let { index; id; name; input; _ } = tool_use in
-  let invocation =
-    Tool.Invocation.create
-      ~tool_use_id:id
-      ~turn:turn_count
-      ~planned_index:schedule.planned_index
-  in
+  let invocation = Tool.Invocation.create ~tool_use_id:id ~turn:turn_count ~schedule in
+  let id = Tool.Invocation.tool_use_id invocation in
+  let turn_count = Tool.Invocation.turn invocation in
   let completed_dispatch = ref None in
   let first_failure = ref None in
   let record_failure failure =
@@ -692,12 +646,9 @@ let execute_scheduled_tool
         hooks.pre_tool_use
         (Hooks.PreToolUse
            { invocation
-           ; tool_use_id = Tool.Invocation.tool_use_id invocation
            ; tool_name = name
            ; input
            ; accumulated_cost_usd = usage.Types.estimated_cost_usd
-           ; turn = Tool.Invocation.turn invocation
-           ; schedule
            })
     in
     match decision with
@@ -706,7 +657,8 @@ let execute_scheduled_tool
          not a tool execution. No Tool_called/Tool_completed lifecycle evidence
          is emitted for a call that never crossed the caller's gate. *)
       { index
-      ; completed_result = Some (blocked_tool_result ~id ~name ~input ~content:reason)
+      ; completed_result =
+          Some (blocked_tool_result ~invocation ~name ~input ~content:reason)
       ; failure = None
       }
     | Hooks.HookFailed { stage; detail } ->
@@ -719,7 +671,7 @@ let execute_scheduled_tool
                   ~hook_name:"pre_tool_use"
                   ~stage
                   ~tool_name:name
-                  ~tool_use_id:id
+                  ~invocation
                   ~detail))
       }
     | (Hooks.AdjustParams _ | Hooks.ElicitInput _ | Hooks.Nudge _) as decision ->
@@ -732,7 +684,7 @@ let execute_scheduled_tool
                   ~hook_name:"pre_tool_use"
                   ~stage:Hooks.Pre_tool_use
                   ~tool_name:name
-                  ~tool_use_id:id
+                  ~invocation
                   ~detail:
                     (Printf.sprintf
                        "illegal decision %s escaped hook validation"
@@ -758,7 +710,7 @@ let execute_scheduled_tool
                     append_journal
                       j
                       (Tool_called
-                         { turn = turn_count
+                         { turn = Tool.Invocation.turn invocation
                          ; tool_name = name
                          ; idempotency_key = idem_key
                          ; input_hash = Digest.string (Yojson.Safe.to_string input)
@@ -767,8 +719,7 @@ let execute_scheduled_tool
                   | None -> ());
                 observe_before_completion (fun () ->
                   match on_tool_execution_started with
-                  | Some callback ->
-                    callback ~tool_use_id:id ~tool_name:name ~input ~schedule
+                  | Some callback -> callback ~invocation ~tool_name:name ~input
                   | None -> ());
                 let t0_tool = Unix.gettimeofday () in
                 let dispatch =
@@ -779,15 +730,12 @@ let execute_scheduled_tool
                     ~event_bus
                     ~tracer
                     ~agent_name
-                    ~turn_count
                     ?correlation_id
                     ?run_id
                     ?on_hook_invoked
-                    ~schedule
                     ~invocation
                     name
                     input
-                    id
                 in
                 completed_dispatch := Some dispatch;
                 Option.iter record_failure dispatch.deferred_failure;
@@ -798,7 +746,7 @@ let execute_scheduled_tool
                     append_journal
                       j
                       (Tool_completed
-                         { turn = turn_count
+                         { turn = Tool.Invocation.turn invocation
                          ; tool_name = name
                          ; idempotency_key = idem_key
                          ; output_json = `String dispatch.result.content
@@ -812,7 +760,7 @@ let execute_scheduled_tool
                   match on_tool_execution_finished with
                   | Some callback ->
                     callback
-                      ~tool_use_id:id
+                      ~invocation
                       ~tool_name:name
                       ~content:dispatch.result.content
                       ~is_error:

--- a/lib/agent/agent_tools.mli
+++ b/lib/agent/agent_tools.mli
@@ -45,7 +45,7 @@ type tool_failure_kind = Types.tool_failure_kind =
   | Unattributed_tool_error
 
 type tool_execution_result =
-  { tool_use_id : string
+  { invocation : Tool.Invocation.t
   ; tool_name : string
   ; input : Yojson.Safe.t
     (** Exact input received from the typed [ToolUse] block. Validation never
@@ -59,7 +59,7 @@ type execution_error =
       { hook_name : string
       ; stage : Hooks.hook_stage
       ; tool_name : string
-      ; tool_use_id : string
+      ; invocation : Tool.Invocation.t
       ; detail : string
       }
 
@@ -98,15 +98,13 @@ val find_and_execute_tool
   -> event_bus:Event_bus.t option
   -> tracer:Tracing.t
   -> agent_name:string
-  -> turn_count:int
   -> ?correlation_id:string
   -> ?run_id:string
   -> ?on_hook_invoked:
        (hook_name:string -> decision:Hooks.hook_decision -> detail:string option -> unit)
-  -> schedule:Hooks.tool_schedule
+  -> invocation:Tool.Invocation.t
   -> string
   -> Yojson.Safe.t
-  -> string
   -> (tool_execution_result, execution_error) result
 
 (** {1 Tool scheduling and execution} *)
@@ -158,13 +156,13 @@ val execute_tools
   -> ?correlation_id:string
   -> ?run_id:string
   -> ?on_tool_execution_started:
-       (tool_use_id:string
-        -> tool_name:string
-        -> input:Yojson.Safe.t
-        -> schedule:Hooks.tool_schedule
-        -> unit)
+       (invocation:Tool.Invocation.t -> tool_name:string -> input:Yojson.Safe.t -> unit)
   -> ?on_tool_execution_finished:
-       (tool_use_id:string -> tool_name:string -> content:string -> is_error:bool -> unit)
+       (invocation:Tool.Invocation.t
+        -> tool_name:string
+        -> content:string
+        -> is_error:bool
+        -> unit)
   -> ?on_hook_invoked:
        (hook_name:string -> decision:Hooks.hook_decision -> detail:string option -> unit)
   -> Types.content_block list

--- a/lib/agent/agent_trace.ml
+++ b/lib/agent/agent_trace.ml
@@ -42,7 +42,8 @@ let execute_tools_with_trace agent active_run tool_uses =
     | None -> None
     | Some active ->
       Some
-        (fun ~tool_use_id ~tool_name ~input ~schedule ->
+        (fun ~invocation ~tool_name ~input ->
+          let schedule = Tool.Invocation.schedule invocation in
           let ts = Unix.gettimeofday () in
           set_lifecycle
             agent
@@ -53,10 +54,10 @@ let execute_tools_with_trace agent active_run tool_uses =
           Raw_trace.raise_if_error
             (Raw_trace.record_tool_execution_started
                active
-               ~tool_use_id
+               ~tool_use_id:(Tool.Invocation.tool_use_id invocation)
                ~tool_name
                ~tool_input:input
-               ~planned_index:schedule.Hooks.planned_index
+               ~planned_index:schedule.planned_index
                ~batch_index:schedule.batch_index
                ~batch_size:schedule.batch_size
                ~execution_mode:schedule.execution_mode))
@@ -66,7 +67,7 @@ let execute_tools_with_trace agent active_run tool_uses =
     | None -> None
     | Some active ->
       Some
-        (fun ~tool_use_id ~tool_name ~content ~is_error ->
+        (fun ~invocation ~tool_name ~content ~is_error ->
           let ts = Unix.gettimeofday () in
           set_lifecycle
             agent
@@ -77,7 +78,8 @@ let execute_tools_with_trace agent active_run tool_uses =
           Raw_trace.raise_if_error
             (Raw_trace.record_tool_execution_finished
                active
-               ~tool_use_id
+               ~tool_use_id:(Tool.Invocation.tool_use_id invocation)
+               ~planned_index:(Tool.Invocation.planned_index invocation)
                ~tool_name
                ~tool_result:content
                ~tool_error:is_error

--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -248,7 +248,7 @@ let make_tool_results results =
   List.map
     (fun (result : Agent_tools.tool_execution_result) ->
        ToolResult
-         { tool_use_id = result.tool_use_id
+         { tool_use_id = Tool.Invocation.tool_use_id result.invocation
          ; content = result.content
          ; outcome = result.outcome
          ; json = None
@@ -260,7 +260,10 @@ let make_tool_results results =
 (* === make_tool_results inline tests === *)
 
 let mock_result ?(is_error = false) ~id content : Agent_tools.tool_execution_result =
-  { tool_use_id = id
+  let schedule : Tool.schedule =
+    { planned_index = 0; batch_index = 0; batch_size = 1; execution_mode = Tool.Serial }
+  in
+  { invocation = Tool.Invocation.create ~tool_use_id:id ~turn:0 ~schedule
   ; tool_name = "test"
   ; input = `Null
   ; content

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -18,6 +18,31 @@ let checkpoint_stage_to_string = function
   | After_context_injection -> "after_context_injection"
 ;;
 
+let checkpoint_stage_equal left right =
+  match left, right with
+  | After_assistant_collected, After_assistant_collected
+  | After_tool_results_appended, After_tool_results_appended
+  | After_context_injection, After_context_injection -> true
+  | After_assistant_collected, (After_tool_results_appended | After_context_injection)
+  | After_tool_results_appended, (After_assistant_collected | After_context_injection)
+  | After_context_injection, (After_assistant_collected | After_tool_results_appended) ->
+    false
+;;
+
+let checkpoint_stage_to_yojson stage = `String (checkpoint_stage_to_string stage)
+
+let checkpoint_stage_of_yojson = function
+  | `String "after_assistant_collected" -> Ok After_assistant_collected
+  | `String "after_tool_results_appended" -> Ok After_tool_results_appended
+  | `String "after_context_injection" -> Ok After_context_injection
+  | `String label -> Error (Printf.sprintf "unknown checkpoint stage: %S" label)
+  | json ->
+    Error
+      (Printf.sprintf
+         "checkpoint stage must be a string, got %s"
+         (Yojson.Safe.to_string json))
+;;
+
 type checkpoint_snapshot =
   { stage : checkpoint_stage
   ; turn : int

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -25,6 +25,7 @@ val checkpoint_stage_equal : checkpoint_stage -> checkpoint_stage -> bool
 (** Closed durable codec. Only the exact labels produced by
     {!checkpoint_stage_to_string} are accepted. *)
 val checkpoint_stage_to_yojson : checkpoint_stage -> Yojson.Safe.t
+
 val checkpoint_stage_of_yojson : Yojson.Safe.t -> (checkpoint_stage, string) result
 
 type checkpoint_snapshot =

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -20,6 +20,12 @@ type checkpoint_stage =
   | After_context_injection
 
 val checkpoint_stage_to_string : checkpoint_stage -> string
+val checkpoint_stage_equal : checkpoint_stage -> checkpoint_stage -> bool
+
+(** Closed durable codec. Only the exact labels produced by
+    {!checkpoint_stage_to_string} are accepted. *)
+val checkpoint_stage_to_yojson : checkpoint_stage -> Yojson.Safe.t
+val checkpoint_stage_of_yojson : Yojson.Safe.t -> (checkpoint_stage, string) result
 
 type checkpoint_snapshot =
   { stage : checkpoint_stage

--- a/lib/base/hooks.ml
+++ b/lib/base/hooks.ml
@@ -96,7 +96,8 @@ type hook_event =
       ; response : api_response
       }
   | PreToolUse of
-      { tool_use_id : string
+      { invocation : Tool.Invocation.t
+      ; tool_use_id : string
       ; tool_name : string
       ; input : Yojson.Safe.t
       ; accumulated_cost_usd : float
@@ -104,7 +105,8 @@ type hook_event =
       ; schedule : tool_schedule
       }
   | PostToolUse of
-      { tool_use_id : string
+      { invocation : Tool.Invocation.t
+      ; tool_use_id : string
       ; tool_name : string
       ; input : Yojson.Safe.t
       ; output : Types.tool_result
@@ -113,7 +115,8 @@ type hook_event =
       ; schedule : tool_schedule
       }
   | PostToolUseFailure of
-      { tool_use_id : string
+      { invocation : Tool.Invocation.t
+      ; tool_use_id : string
       ; tool_name : string
       ; input : Yojson.Safe.t
       ; error : string

--- a/lib/base/hooks.ml
+++ b/lib/base/hooks.ml
@@ -45,12 +45,7 @@ let empty_reasoning_summary =
   { thinking_blocks = []; has_uncertainty = false; tool_rationale = None }
 ;;
 
-type tool_schedule =
-  { planned_index : int
-  ; batch_index : int
-  ; batch_size : int
-  ; execution_mode : Tool.execution_mode
-  }
+type tool_schedule = Tool.schedule
 
 (** Extract structured reasoning summary from message list.
     This only preserves provider-emitted Thinking blocks; it does not infer
@@ -97,41 +92,36 @@ type hook_event =
       }
   | PreToolUse of
       { invocation : Tool.Invocation.t
-      ; tool_use_id : string
       ; tool_name : string
       ; input : Yojson.Safe.t
       ; accumulated_cost_usd : float
-      ; turn : int
-      ; schedule : tool_schedule
       }
   | PostToolUse of
       { invocation : Tool.Invocation.t
-      ; tool_use_id : string
       ; tool_name : string
       ; input : Yojson.Safe.t
       ; output : Types.tool_result
       ; result_bytes : int
       ; duration_ms : float
-      ; schedule : tool_schedule
       }
   | PostToolUseFailure of
       { invocation : Tool.Invocation.t
-      ; tool_use_id : string
       ; tool_name : string
       ; input : Yojson.Safe.t
       ; error : string
-      ; schedule : tool_schedule
       }
   | OnStop of
       { reason : stop_reason
       ; response : api_response
       }
   | OnError of
-      { detail : string
+      { invocation : Tool.Invocation.t option
+      ; detail : string
       ; context : string
       }
   | OnToolError of
-      { tool_name : string
+      { invocation : Tool.Invocation.t
+      ; tool_name : string
       ; error : string
       }
 

--- a/lib/base/hooks.mli
+++ b/lib/base/hooks.mli
@@ -56,7 +56,11 @@ type hook_event =
       ; response : Types.api_response
       }
   | PreToolUse of
-      { tool_use_id : string
+      { invocation : Tool.Invocation.t
+        (** Exact model-tool occurrence. [tool_use_id], [turn], and
+            [schedule.planned_index] below are compatibility projections of
+            this typed value. @since 0.216.0 *)
+      ; tool_use_id : string
       ; tool_name : string
       ; input : Yojson.Safe.t
       ; accumulated_cost_usd : float
@@ -64,7 +68,10 @@ type hook_event =
       ; schedule : tool_schedule
       }
   | PostToolUse of
-      { tool_use_id : string
+      { invocation : Tool.Invocation.t
+        (** Same exact occurrence as the matching [PreToolUse].
+            @since 0.216.0 *)
+      ; tool_use_id : string
       ; tool_name : string
       ; input : Yojson.Safe.t
       ; output : Types.tool_result
@@ -73,7 +80,10 @@ type hook_event =
       ; schedule : tool_schedule
       }
   | PostToolUseFailure of
-      { tool_use_id : string
+      { invocation : Tool.Invocation.t
+        (** Same exact occurrence as the matching [PreToolUse].
+            @since 0.216.0 *)
+      ; tool_use_id : string
       ; tool_name : string
       ; input : Yojson.Safe.t
       ; error : string

--- a/lib/base/hooks.mli
+++ b/lib/base/hooks.mli
@@ -30,13 +30,9 @@ type reasoning_summary =
 val empty_reasoning_summary : reasoning_summary
 val extract_reasoning : Types.message list -> reasoning_summary
 
-(** Deterministic scheduling metadata attached to a tool execution plan. *)
-type tool_schedule =
-  { planned_index : int
-  ; batch_index : int
-  ; batch_size : int
-  ; execution_mode : Tool.execution_mode
-  }
+(** Compatibility name for the canonical tool schedule type. This alias owns
+    no second representation; new code should use {!Tool.schedule}. *)
+type tool_schedule = Tool.schedule
 
 (** Events emitted during agent execution *)
 type hook_event =
@@ -57,48 +53,43 @@ type hook_event =
       }
   | PreToolUse of
       { invocation : Tool.Invocation.t
-        (** Exact model-tool occurrence. [tool_use_id], [turn], and
-            [schedule.planned_index] below are compatibility projections of
-            this typed value. @since 0.216.0 *)
-      ; tool_use_id : string
+        (** Exact run-scoped model-tool occurrence. @since 0.216.0 *)
       ; tool_name : string
       ; input : Yojson.Safe.t
       ; accumulated_cost_usd : float
-      ; turn : int
-      ; schedule : tool_schedule
       }
   | PostToolUse of
       { invocation : Tool.Invocation.t
         (** Same exact occurrence as the matching [PreToolUse].
             @since 0.216.0 *)
-      ; tool_use_id : string
       ; tool_name : string
       ; input : Yojson.Safe.t
       ; output : Types.tool_result
       ; result_bytes : int
       ; duration_ms : float
-      ; schedule : tool_schedule
       }
   | PostToolUseFailure of
       { invocation : Tool.Invocation.t
         (** Same exact occurrence as the matching [PreToolUse].
             @since 0.216.0 *)
-      ; tool_use_id : string
       ; tool_name : string
       ; input : Yojson.Safe.t
       ; error : string
-      ; schedule : tool_schedule
       }
   | OnStop of
       { reason : Types.stop_reason
       ; response : Types.api_response
       }
   | OnError of
-      { detail : string
+      { invocation : Tool.Invocation.t option
+        (** [Some] for an error attributable to one exact tool occurrence;
+            [None] for non-tool errors. *)
+      ; detail : string
       ; context : string
       }
   | OnToolError of
-      { tool_name : string
+      { invocation : Tool.Invocation.t
+      ; tool_name : string
       ; error : string
       }
 

--- a/lib/base/tool.ml
+++ b/lib/base/tool.ml
@@ -8,32 +8,7 @@ type tool_handler = Yojson.Safe.t -> Types.tool_result
 (** Context-aware tool handler *)
 type context_tool_handler = Context.t -> Yojson.Safe.t -> Types.tool_result
 
-module Invocation = struct
-  type t =
-    { tool_use_id : string
-    ; turn : int
-    ; planned_index : int
-    }
-
-  let create ~tool_use_id ~turn ~planned_index = { tool_use_id; turn; planned_index }
-  let tool_use_id t = t.tool_use_id
-  let turn t = t.turn
-  let planned_index t = t.planned_index
-end
-
-module Execution_env = struct
-  type t =
-    { context : Context.t option
-    ; invocation : Invocation.t option
-    }
-
-  let create ?context ?invocation () = { context; invocation }
-  let context t = t.context
-  let invocation t = t.invocation
-end
-
-type execution_env_tool_handler = Execution_env.t -> Yojson.Safe.t -> Types.tool_result
-
+(** Tool execution ordering *)
 type execution_mode =
   | Concurrent
   | Serial
@@ -54,6 +29,39 @@ let execution_mode_of_yojson = function
          (Yojson.Safe.to_string value))
 ;;
 
+type schedule =
+  { planned_index : int
+  ; batch_index : int
+  ; batch_size : int
+  ; execution_mode : execution_mode
+  }
+
+module Invocation = struct
+  type t =
+    { tool_use_id : string
+    ; turn : int
+    ; schedule : schedule
+    }
+
+  let create ~tool_use_id ~turn ~schedule = { tool_use_id; turn; schedule }
+  let tool_use_id t = t.tool_use_id
+  let turn t = t.turn
+  let schedule t = t.schedule
+  let planned_index t = t.schedule.planned_index
+end
+
+module Execution_env = struct
+  type t =
+    { context : Context.t option
+    ; invocation : Invocation.t option
+    }
+
+  let create ?context ?invocation () = { context; invocation }
+  let context t = t.context
+  let invocation t = t.invocation
+end
+
+type execution_env_tool_handler = Execution_env.t -> Yojson.Safe.t -> Types.tool_result
 type descriptor = { execution_mode : execution_mode }
 
 (** Handler kind: preserves backward compatibility via Simple variant *)

--- a/lib/base/tool.mli
+++ b/lib/base/tool.mli
@@ -6,18 +6,39 @@
 type tool_handler = Yojson.Safe.t -> Types.tool_result
 type context_tool_handler = Context.t -> Yojson.Safe.t -> Types.tool_result
 
-(** Exact occurrence metadata for correlation and observability only.
-    It does not authorize tool execution. [turn] and [planned_index] scope
-    provider [tool_use_id] values that may be blank or repeated. The embedding
-    runtime owns any broader agent/run identity.
+(** Declared execution ordering for a tool. *)
+type execution_mode =
+  | Concurrent
+  | Serial
+[@@deriving show]
 
-    @since 0.215.0 *)
+val execution_mode_to_yojson : execution_mode -> Yojson.Safe.t
+val execution_mode_of_yojson : Yojson.Safe.t -> (execution_mode, string) result
+
+(** Exact scheduler placement for one tool occurrence.
+
+    @since 0.216.0 *)
+type schedule =
+  { planned_index : int
+  ; batch_index : int
+  ; batch_size : int
+  ; execution_mode : execution_mode
+  }
+
+(** Exact occurrence metadata for correlation and observability only.
+    It does not authorize tool execution. [turn] and [schedule.planned_index]
+    scope provider [tool_use_id] values that may be blank or repeated. The
+    embedding runtime owns any broader agent/run identity.
+
+    @since 0.215.0
+    @since 0.216.0 Owns the canonical [schedule]. *)
 module Invocation : sig
   type t
 
-  val create : tool_use_id:string -> turn:int -> planned_index:int -> t
+  val create : tool_use_id:string -> turn:int -> schedule:schedule -> t
   val tool_use_id : t -> string
   val turn : t -> int
+  val schedule : t -> schedule
   val planned_index : t -> int
 end
 
@@ -37,15 +58,6 @@ module Execution_env : sig
 end
 
 type execution_env_tool_handler = Execution_env.t -> Yojson.Safe.t -> Types.tool_result
-
-type execution_mode =
-  | Concurrent
-  | Serial
-[@@deriving show]
-
-val execution_mode_to_yojson : execution_mode -> Yojson.Safe.t
-val execution_mode_of_yojson : Yojson.Safe.t -> (execution_mode, string) result
-
 type descriptor = { execution_mode : execution_mode }
 
 type handler_kind =

--- a/lib/dune
+++ b/lib/dune
@@ -14,7 +14,8 @@
   execution_codec_executor
   execution_event_store
   execution_journal
-  execution_lane_writer)
+  execution_lane_writer
+  execution_tool_settlement)
  (libraries
   llm_provider
   (re_export agent_sdk_base)

--- a/lib/event_bus.ml
+++ b/lib/event_bus.ml
@@ -45,17 +45,13 @@ type payload =
       { invocation : Tool.Invocation.t
       ; agent_name : string
       ; tool_name : string
-      ; tool_use_id : string
       ; input : Yojson.Safe.t
-      ; turn : int
       }
   | ToolCompleted of
       { invocation : Tool.Invocation.t
       ; agent_name : string
       ; tool_name : string
-      ; tool_use_id : string
       ; output : Types.tool_result
-      ; turn : int
       }
   | TurnStarted of
       { agent_name : string

--- a/lib/event_bus.ml
+++ b/lib/event_bus.ml
@@ -42,14 +42,16 @@ type payload =
       ; elapsed : float
       }
   | ToolCalled of
-      { agent_name : string
+      { invocation : Tool.Invocation.t
+      ; agent_name : string
       ; tool_name : string
       ; tool_use_id : string
       ; input : Yojson.Safe.t
       ; turn : int
       }
   | ToolCompleted of
-      { agent_name : string
+      { invocation : Tool.Invocation.t
+      ; agent_name : string
       ; tool_name : string
       ; tool_use_id : string
       ; output : Types.tool_result

--- a/lib/event_bus.mli
+++ b/lib/event_bus.mli
@@ -59,7 +59,11 @@ type payload =
           [Result.is_error] check.
           @since 0.154.0 *)
   | ToolCalled of
-      { agent_name : string
+      { invocation : Tool.Invocation.t
+        (** Exact model-tool occurrence. [tool_use_id] and [turn] below remain
+            compatibility projections of this typed value.
+            @since 0.216.0 *)
+      ; agent_name : string
       ; tool_name : string
       ; tool_use_id : string
         (** Provider tool-call id (e.g. Anthropic [tool_use.id], OpenAI
@@ -78,7 +82,10 @@ type payload =
             @since 0.207.0 (#SSOT-DRIFT-REMEDIATION) *)
       }
   | ToolCompleted of
-      { agent_name : string
+      { invocation : Tool.Invocation.t
+        (** Same exact occurrence as the matching [ToolCalled].
+            @since 0.216.0 *)
+      ; agent_name : string
       ; tool_name : string
       ; tool_use_id : string
         (** Same id as the matching [ToolCalled]; see its doc.

--- a/lib/event_bus.mli
+++ b/lib/event_bus.mli
@@ -60,26 +60,10 @@ type payload =
           @since 0.154.0 *)
   | ToolCalled of
       { invocation : Tool.Invocation.t
-        (** Exact model-tool occurrence. [tool_use_id] and [turn] below remain
-            compatibility projections of this typed value.
-            @since 0.216.0 *)
+        (** Exact run-scoped model-tool occurrence. @since 0.216.0 *)
       ; agent_name : string
       ; tool_name : string
-      ; tool_use_id : string
-        (** Provider tool-call id (e.g. Anthropic [tool_use.id], OpenAI
-            [tool_call.id]) for the invocation this event describes. The
-            same value reaches {!Hooks.PreToolUse}/{!Hooks.PostToolUse},
-            so subscribers can join bus events with hook-side records
-            deterministically instead of guessing by tool name and
-            timestamp. Empty string when the provider supplied no id.
-            @since 0.206.2 *)
       ; input : Yojson.Safe.t
-      ; turn : int
-        (** Zero-based turn index within the current agent run. Lets
-            downstream FSM observers correlate a tool event
-            with the turn that emitted it without reaching into OAS
-            internals. OAS does not interpret this field.
-            @since 0.207.0 (#SSOT-DRIFT-REMEDIATION) *)
       }
   | ToolCompleted of
       { invocation : Tool.Invocation.t
@@ -87,13 +71,7 @@ type payload =
             @since 0.216.0 *)
       ; agent_name : string
       ; tool_name : string
-      ; tool_use_id : string
-        (** Same id as the matching [ToolCalled]; see its doc.
-            @since 0.206.2 *)
       ; output : Types.tool_result
-      ; turn : int
-        (** Same turn index as the matching [ToolCalled]. See its doc.
-            @since 0.207.0 (#SSOT-DRIFT-REMEDIATION) *)
       }
   | TurnStarted of
       { agent_name : string

--- a/lib/execution_event.ml
+++ b/lib/execution_event.ml
@@ -120,11 +120,6 @@ let validate_non_blank field value =
   else Ok ()
 ;;
 
-let validate_optional_non_blank field = function
-  | None -> Ok ()
-  | Some value -> validate_non_blank field value
-;;
-
 let validate_json = Execution_json.validate
 
 let validate_node_kind = function
@@ -135,8 +130,7 @@ let validate_node_kind = function
     if ordinal < 0 then Error "provider attempt ordinal must be non-negative" else Ok ()
   | Output_block { ordinal; _ } ->
     if ordinal < 0 then Error "output block ordinal must be non-negative" else Ok ()
-  | Tool_invocation { provider_tool_use_id; tool_name; schedule } ->
-    let* () = validate_optional_non_blank "provider_tool_use_id" provider_tool_use_id in
+  | Tool_invocation { provider_tool_use_id = _; tool_name; schedule } ->
     let* () = validate_non_blank "tool_name" tool_name in
     Execution_tool_schedule.validate schedule
   | Tool_attempt -> Ok ()
@@ -305,11 +299,8 @@ let validate_content_block block =
   if block = decoded
   then (
     match block with
-    | ToolUse { id; name; _ } ->
-      let* () = validate_non_blank "tool-use identifier" id in
-      validate_non_blank "tool-use name" name
-    | ToolResult { tool_use_id; _ } ->
-      validate_non_blank "tool-result tool-use identifier" tool_use_id
+    | ToolUse { id = _; name; _ } -> validate_non_blank "tool-use name" name
+    | ToolResult { tool_use_id = _; _ } -> Ok ()
     | Text _
     | Thinking _
     | ReasoningDetails _

--- a/lib/execution_journal.ml
+++ b/lib/execution_journal.ml
@@ -1370,6 +1370,67 @@ let stage_close_node ?causes journal state ~node terminal =
       payload
 ;;
 
+let stage_begin_tool_attempt journal state ~run ~invocation =
+  let* invocation_record = node_record_or_error state invocation in
+  let* () =
+    match Event.node_kind invocation_record.node, invocation_record.children_rev with
+    | Event.Tool_invocation _, [] -> Ok ()
+    | Event.Tool_invocation _, _ :: _ ->
+      Error (Invalid_argument "tool invocation already has an attempt")
+    | ( ( Event.Agent_run _
+        | Event.Agent_turn _
+        | Event.Provider_attempt _
+        | Event.Output_block _
+        | Event.Tool_attempt )
+      , _ ) -> Error (Invalid_argument "tool attempt requires a Tool_invocation node")
+  in
+  stage_open_node journal state ~run ~parent:invocation ~kind:Event.Tool_attempt
+;;
+
+let stage_settle_tool_attempt journal state ~attempt ~invocation ~result =
+  let* attempt_record = node_record_or_error state attempt in
+  let* () =
+    match
+      Event.node_kind attempt_record.node, Event.parent_node_id attempt_record.node
+    with
+    | Event.Tool_attempt, Some parent when Event.Node_id.equal parent invocation -> Ok ()
+    | Event.Tool_attempt, (None | Some _) ->
+      Error (Invalid_argument "tool attempt does not belong to the invocation")
+    | ( ( Event.Agent_run _
+        | Event.Agent_turn _
+        | Event.Provider_attempt _
+        | Event.Output_block _
+        | Event.Tool_invocation _ )
+      , _ ) -> Error (Invalid_argument "tool settlement requires a Tool_attempt node")
+  in
+  let* invocation_record = node_record_or_error state invocation in
+  let* () =
+    match Event.node_kind invocation_record.node with
+    | Event.Tool_invocation _ -> Ok ()
+    | Event.Agent_run _
+    | Event.Agent_turn _
+    | Event.Provider_attempt _
+    | Event.Output_block _
+    | Event.Tool_attempt ->
+      Error (Invalid_argument "tool settlement requires a Tool_invocation node")
+  in
+  let* attempt_closed = stage_close_node journal state ~node:attempt Event.Succeeded in
+  let* result_committed =
+    stage_update_node
+      journal
+      attempt_closed.next_state
+      ~node:invocation
+      (Event.Tool_result result)
+  in
+  let+ invocation_closed =
+    stage_close_node journal result_committed.next_state ~node:invocation Event.Succeeded
+  in
+  { next_state = invocation_closed.next_state
+  ; events = [ attempt_closed.value; result_committed.value; invocation_closed.value ]
+  ; value = [ attempt_closed.value; result_committed.value; invocation_closed.value ]
+  }
+;;
+
 let stage_finish_run ?causes journal state ~run terminal =
   let* event_id = identity_result (Event.Event_id.fresh ()) in
   let* terminal = payload_result (Event.validate_terminal terminal) in
@@ -1531,6 +1592,17 @@ module Transaction = struct
         ; terminal : Event.terminal
         }
         -> Event.t t
+    | Begin_tool_attempt :
+        { run : run
+        ; invocation : Event.Node_id.t
+        }
+        -> (Event.Node_id.t * Event.t) t
+    | Settle_tool_attempt :
+        { attempt : Event.Node_id.t
+        ; invocation : Event.Node_id.t
+        ; result : Llm_provider.Types.content_block
+        }
+        -> Event.t list t
     | Finish_run :
         { causes : Event.cause list
         ; run : run
@@ -1554,6 +1626,12 @@ module Transaction = struct
 
   let update_node ?(causes = []) ~node update = Update_node { causes; node; update }
   let close_node ?(causes = []) ~node terminal = Close_node { causes; node; terminal }
+  let begin_tool_attempt ~run ~invocation () = Begin_tool_attempt { run; invocation }
+
+  let settle_tool_attempt ~attempt ~invocation ~result () =
+    Settle_tool_attempt { attempt; invocation; result }
+  ;;
+
   let finish_run ?(causes = []) ~run terminal = Finish_run { causes; run; terminal }
   let abort_run ?(causes = []) ~run terminal = Abort_run { causes; run; terminal }
 end
@@ -1582,6 +1660,17 @@ let stage : type value. batch -> value Transaction.t -> (batch * value, error) r
   | Transaction.Close_node { causes; node; terminal } ->
     stage_mutation
       (stage_close_node ~causes batch.journal batch.staged_state ~node terminal)
+  | Transaction.Begin_tool_attempt { run; invocation } ->
+    stage_mutation
+      (stage_begin_tool_attempt batch.journal batch.staged_state ~run ~invocation)
+  | Transaction.Settle_tool_attempt { attempt; invocation; result } ->
+    stage_mutation
+      (stage_settle_tool_attempt
+         batch.journal
+         batch.staged_state
+         ~attempt
+         ~invocation
+         ~result)
   | Transaction.Finish_run { causes; run; terminal } ->
     stage_mutation
       (stage_finish_run ~causes batch.journal batch.staged_state ~run terminal)

--- a/lib/execution_journal.mli
+++ b/lib/execution_journal.mli
@@ -320,6 +320,20 @@ module Transaction : sig
     -> Execution_event.terminal
     -> Execution_event.t t
 
+  val begin_tool_attempt
+    :  run:run
+    -> invocation:Execution_event.Node_id.t
+    -> unit
+    -> (Execution_event.Node_id.t * Execution_event.t) t
+
+  (** Atomically commit one exact attempt, ToolResult, and invocation. *)
+  val settle_tool_attempt
+    :  attempt:Execution_event.Node_id.t
+    -> invocation:Execution_event.Node_id.t
+    -> result:Llm_provider.Types.content_block
+    -> unit
+    -> Execution_event.t list t
+
   val finish_run
     :  ?causes:Execution_event.cause list
     -> run:run

--- a/lib/execution_lane_writer.ml
+++ b/lib/execution_lane_writer.ml
@@ -883,6 +883,10 @@ let current_cursor writer =
   read_journal writer (fun journal -> Ok (Journal.current_cursor journal))
 ;;
 
+let find_node writer node =
+  read_journal writer (fun journal -> Ok (Journal.find_node journal node))
+;;
+
 let read_page writer ~after ?through ~limit () =
   read_journal writer (fun journal ->
     match Journal.read_page journal ~after ?through ~limit () with

--- a/lib/execution_lane_writer.mli
+++ b/lib/execution_lane_writer.mli
@@ -168,6 +168,11 @@ val wake_reconciliation : t -> source:reconciliation_wake_source -> bool
     may retain its last acknowledged cursor and replay after any wake hint. *)
 val current_cursor : t -> (Execution_journal.cursor, read_error) result
 
+val find_node
+  :  t
+  -> Execution_event.Node_id.t
+  -> (Execution_journal.node_view option, read_error) result
+
 val read_page
   :  t
   -> after:Execution_journal.cursor

--- a/lib/execution_tool_settlement.ml
+++ b/lib/execution_tool_settlement.ml
@@ -1,0 +1,146 @@
+module Event = Execution_event
+module Journal = Execution_journal
+module Writer = Execution_lane_writer
+
+type t =
+  { writer : Writer.t
+  ; run : Journal.run
+  ; invocation_node : Event.Node_id.t
+  ; invocation : Tool.Invocation.t
+  }
+
+type attempt =
+  { authority : t
+  ; node : Event.Node_id.t
+  }
+
+type status =
+  | Ready_to_execute
+  | Outcome_unknown
+  | Settled of Llm_provider.Types.content_block
+
+type error =
+  | Authority_unavailable of Writer.read_error
+  | Invocation_not_found
+  | Invocation_identity_mismatch
+  | Attempt_admission_failed of Writer.submit_error
+  | Attempt_commit_failed of Writer.ticket_error
+  | Receipt_admission_outcome_unknown of Writer.submit_error
+  | Receipt_settlement_outcome_unknown of Writer.ticket_error
+
+type receipt =
+  { invocation : Tool.Invocation.t
+  ; result : Llm_provider.Types.content_block
+  ; through : Journal.cursor
+  }
+
+let read_node writer node =
+  match Writer.find_node writer node with
+  | Error error -> Error (Authority_unavailable error)
+  | Ok None -> Error Invocation_not_found
+  | Ok (Some view) -> Ok view
+;;
+
+let parent_node view = Event.parent_node_id view.Journal.node
+
+let create ~writer ~run ~invocation_node ~invocation =
+  let open Result_syntax in
+  let* invocation_view = read_node writer invocation_node in
+  let* provider_attempt =
+    match Event.node_kind invocation_view.node, parent_node invocation_view with
+    | Event.Tool_invocation { provider_tool_use_id; schedule; _ }, Some parent
+      when Option.equal
+             String.equal
+             provider_tool_use_id
+             (Some (Tool.Invocation.tool_use_id invocation))
+           && Execution_tool_schedule.equal schedule (Tool.Invocation.schedule invocation)
+           && Event.Run_id.equal
+                (Event.node_run_id invocation_view.node)
+                (Journal.run_id run) -> Ok parent
+    | Event.Tool_invocation _, (None | Some _)
+    | ( ( Event.Agent_run _
+        | Event.Agent_turn _
+        | Event.Provider_attempt _
+        | Event.Output_block _
+        | Event.Tool_attempt )
+      , _ ) -> Error Invocation_identity_mismatch
+  in
+  let* provider_view = read_node writer provider_attempt in
+  let* turn_node =
+    match Event.node_kind provider_view.node, parent_node provider_view with
+    | Event.Provider_attempt _, Some parent -> Ok parent
+    | Event.Provider_attempt _, None
+    | ( ( Event.Agent_run _
+        | Event.Agent_turn _
+        | Event.Output_block _
+        | Event.Tool_invocation _
+        | Event.Tool_attempt )
+      , _ ) -> Error Invocation_identity_mismatch
+  in
+  let* turn_view = read_node writer turn_node in
+  match Event.node_kind turn_view.node with
+  | Event.Agent_turn { ordinal } when ordinal = Tool.Invocation.turn invocation ->
+    Ok { writer; run; invocation_node; invocation }
+  | Event.Agent_turn _
+  | Event.Agent_run _
+  | Event.Provider_attempt _
+  | Event.Output_block _
+  | Event.Tool_invocation _
+  | Event.Tool_attempt -> Error Invocation_identity_mismatch
+;;
+
+let status authority =
+  match read_node authority.writer authority.invocation_node with
+  | Error _ as error -> error
+  | Ok view ->
+    (match view.materialized, view.children, view.status with
+     | Journal.Tool_invocation_state { result = Some result; _ }, _, _ ->
+       Ok (Settled result)
+     | Journal.Tool_invocation_state { result = None; _ }, [], Journal.Open ->
+       Ok Ready_to_execute
+     | ( Journal.Tool_invocation_state { result = None; _ }
+       , _
+       , (Journal.Open | Journal.Closed _) ) -> Ok Outcome_unknown
+     | ( ( Journal.Agent_run_state
+         | Journal.Agent_turn_state
+         | Journal.Provider_attempt_state _
+         | Journal.Output_block_state _
+         | Journal.Tool_attempt_state )
+       , _
+       , _ ) -> Error Invocation_identity_mismatch)
+;;
+
+let begin_attempt authority =
+  let transaction =
+    Journal.Transaction.begin_tool_attempt
+      ~run:authority.run
+      ~invocation:authority.invocation_node
+      ()
+  in
+  match Writer.submit authority.writer transaction with
+  | Error error -> Error (Attempt_admission_failed error)
+  | Ok ticket ->
+    (match Writer.await ticket with
+     | Error error -> Error (Attempt_commit_failed error)
+     | Ok committed ->
+       let node, _event = committed.value in
+       Ok { authority; node })
+;;
+
+let settle attempt ~result =
+  let authority = attempt.authority in
+  let transaction =
+    Journal.Transaction.settle_tool_attempt
+      ~attempt:attempt.node
+      ~invocation:authority.invocation_node
+      ~result
+      ()
+  in
+  match Writer.submit authority.writer transaction with
+  | Error error -> Error (Receipt_admission_outcome_unknown error)
+  | Ok ticket ->
+    (match Writer.await ticket with
+     | Error error -> Error (Receipt_settlement_outcome_unknown error)
+     | Ok committed ->
+       Ok { invocation = authority.invocation; result; through = committed.through })
+;;

--- a/lib/execution_tool_settlement.mli
+++ b/lib/execution_tool_settlement.mli
@@ -1,0 +1,35 @@
+(** Private authority: handlers run only after [begin_attempt] returns. *)
+
+type t
+type attempt
+
+type status =
+  | Ready_to_execute
+  | Outcome_unknown
+  | Settled of Llm_provider.Types.content_block
+
+type error =
+  | Authority_unavailable of Execution_lane_writer.read_error
+  | Invocation_not_found
+  | Invocation_identity_mismatch
+  | Attempt_admission_failed of Execution_lane_writer.submit_error
+  | Attempt_commit_failed of Execution_lane_writer.ticket_error
+  | Receipt_admission_outcome_unknown of Execution_lane_writer.submit_error
+  | Receipt_settlement_outcome_unknown of Execution_lane_writer.ticket_error
+
+type receipt = private
+  { invocation : Tool.Invocation.t
+  ; result : Llm_provider.Types.content_block
+  ; through : Execution_journal.cursor
+  }
+
+val create
+  :  writer:Execution_lane_writer.t
+  -> run:Execution_journal.run
+  -> invocation_node:Execution_event.Node_id.t
+  -> invocation:Tool.Invocation.t
+  -> (t, error) result
+
+val status : t -> (status, error) result
+val begin_attempt : t -> (attempt, error) result
+val settle : attempt -> result:Llm_provider.Types.content_block -> (receipt, error) result

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -396,13 +396,13 @@ let stage_execute ?raw_trace_run ?before_tool_execution agent tool_uses_nonempty
        | Some
            (Agent_tools.Hook_failure
               (Agent_tools.Hook_execution_failed
-                 { hook_name; stage; tool_name; tool_use_id; detail })) ->
+                 { hook_name; stage; tool_name; invocation; detail })) ->
          Error
            (Pipeline_common.hook_failed_sdk_error
               ~hook_name
               ~stage
               ~tool_name:(Some tool_name)
-              ~tool_use_id:(Some tool_use_id)
+              ~tool_use_id:(Some (Tool.Invocation.tool_use_id invocation))
               ~detail)
        | Some (Agent_tools.Observer_failure { exception_; backtrace }) ->
          Printexc.raise_with_backtrace exception_ backtrace

--- a/lib/raw_trace.ml
+++ b/lib/raw_trace.ml
@@ -638,6 +638,7 @@ let record_tool_execution_started
 let record_tool_execution_finished
       active
       ~tool_use_id
+      ~planned_index
       ~tool_name
       ~tool_result
       ~tool_error
@@ -647,6 +648,7 @@ let record_tool_execution_finished
     active
     ~record_type:Tool_execution_finished
     ~tool_use_id
+    ~tool_planned_index:planned_index
     ~tool_name
     ~tool_result
     ~tool_error

--- a/lib/raw_trace.mli
+++ b/lib/raw_trace.mli
@@ -176,6 +176,7 @@ val record_tool_execution_started
 val record_tool_execution_finished
   :  active_run
   -> tool_use_id:string
+  -> planned_index:int
   -> tool_name:string
   -> tool_result:string
   -> tool_error:bool

--- a/lib/raw_trace_query.ml
+++ b/lib/raw_trace_query.ml
@@ -196,24 +196,39 @@ let validate_run run_ref =
       (fun (record : Raw_trace.record) -> record.record_type = Run_finished)
       records
   in
-  let pair_table : (string, int * int) Hashtbl.t = Hashtbl.create 8 in
+  let legacy_tool_ids : (string, unit) Hashtbl.t = Hashtbl.create 8 in
+  List.iter
+    (fun (record : Raw_trace.record) ->
+       match record.record_type, record.tool_use_id, record.tool_planned_index with
+       | (Tool_execution_started | Tool_execution_finished), Some tool_use_id, None ->
+         Hashtbl.replace legacy_tool_ids tool_use_id ()
+       | _ -> ())
+    records;
+  let pair_key (record : Raw_trace.record) tool_use_id =
+    if Hashtbl.mem legacy_tool_ids tool_use_id
+    then tool_use_id, None
+    else tool_use_id, record.tool_planned_index
+  in
+  let pair_table : (string * int option, int * int) Hashtbl.t = Hashtbl.create 8 in
   List.iter
     (fun (record : Raw_trace.record) ->
        match record.record_type, record.tool_use_id with
        | Tool_execution_started, Some tool_use_id ->
+         let key = pair_key record tool_use_id in
          let started, finished =
-           match Hashtbl.find_opt pair_table tool_use_id with
+           match Hashtbl.find_opt pair_table key with
            | Some counts -> counts
            | None -> 0, 0
          in
-         Hashtbl.replace pair_table tool_use_id (started + 1, finished)
+         Hashtbl.replace pair_table key (started + 1, finished)
        | Tool_execution_finished, Some tool_use_id ->
+         let key = pair_key record tool_use_id in
          let started, finished =
-           match Hashtbl.find_opt pair_table tool_use_id with
+           match Hashtbl.find_opt pair_table key with
            | Some counts -> counts
            | None -> 0, 0
          in
-         Hashtbl.replace pair_table tool_use_id (started, finished + 1)
+         Hashtbl.replace pair_table key (started, finished + 1)
        | _ -> ())
     records;
   let tool_pairs_ok =

--- a/test/test_agent_turn.ml
+++ b/test/test_agent_turn.ml
@@ -2,6 +2,13 @@
 
 open Agent_sdk
 
+let invocation tool_use_id =
+  let schedule : Tool.schedule =
+    { planned_index = 0; batch_index = 0; batch_size = 1; execution_mode = Tool.Serial }
+  in
+  Tool.Invocation.create ~tool_use_id ~turn:0 ~schedule
+;;
+
 let context_messages = function
   | Ok messages -> messages
   | Error error -> Alcotest.fail error.Agent_turn.detail
@@ -382,13 +389,13 @@ let test_accumulate_usage_records_incomplete_cache_pricing () =
 
 let test_make_tool_results () =
   let results =
-    [ { Agent_tools.tool_use_id = "t1"
+    [ { Agent_tools.invocation = invocation "t1"
       ; tool_name = "tool-1"
       ; input = `Null
       ; content = "success output"
       ; outcome = Tool_succeeded
       }
-    ; { tool_use_id = "t2"
+    ; { invocation = invocation "t2"
       ; tool_name = "tool-2"
       ; input = `Null
       ; content = "error msg"
@@ -497,7 +504,7 @@ let test_apply_context_injection_no_injector () =
     ]
   in
   let results =
-    [ { Agent_tools.tool_use_id = "t1"
+    [ { Agent_tools.invocation = invocation "t1"
       ; tool_name = "search"
       ; input = `Assoc [ "q", `String "test" ]
       ; content = "result"
@@ -526,7 +533,7 @@ let test_apply_context_injection_with_context_update () =
   in
   let tool_uses = [ make_tool_use "search" {|{"q":"test"}|} ] in
   let results =
-    [ { Agent_tools.tool_use_id = "t1"
+    [ { Agent_tools.invocation = invocation "t1"
       ; tool_name = "search"
       ; input = `Assoc [ "q", `String "test" ]
       ; content = "found it"
@@ -563,7 +570,7 @@ let test_apply_context_injection_with_extra_messages () =
   in
   let tool_uses = [ make_tool_use "search" {|{"q":"test"}|} ] in
   let results =
-    [ { Agent_tools.tool_use_id = "t1"
+    [ { Agent_tools.invocation = invocation "t1"
       ; tool_name = "search"
       ; input = `Assoc [ "q", `String "test" ]
       ; content = "result"
@@ -604,7 +611,7 @@ let test_apply_context_injection_exception_is_error () =
   in
   let tool_uses = [ make_tool_use "search" {|{"q":"test"}|} ] in
   let results =
-    [ { Agent_tools.tool_use_id = "t1"
+    [ { Agent_tools.invocation = invocation "t1"
       ; tool_name = "search"
       ; input = `Assoc [ "q", `String "test" ]
       ; content = "result"
@@ -639,7 +646,7 @@ let test_apply_context_injection_preserves_non_retryable_error () =
   let tool_uses = [ make_tool_use "search" {|{"q":"test"}|} ] in
   let received_output = ref None in
   let results =
-    [ { Agent_tools.tool_use_id = "t1"
+    [ { Agent_tools.invocation = invocation "t1"
       ; tool_name = "search"
       ; input = `Assoc [ "q", `String "test" ]
       ; content = "fatal"

--- a/test/test_checkpoint.ml
+++ b/test/test_checkpoint.ml
@@ -1,5 +1,12 @@
 open Agent_sdk
 
+let invocation tool_use_id =
+  let schedule : Tool.schedule =
+    { planned_index = 0; batch_index = 0; batch_size = 1; execution_mode = Tool.Serial }
+  in
+  Tool.Invocation.create ~tool_use_id ~turn:0 ~schedule
+;;
+
 let check_context_backend label expected ctx =
   Alcotest.(check bool) label true (Context.concurrency_backend ctx = expected)
 ;;
@@ -406,7 +413,7 @@ let () =
             `Quick
             (fun () ->
                let execution_result : Agent_tools.tool_execution_result =
-                 { tool_use_id = "failed-1"
+                 { invocation = invocation "failed-1"
                  ; tool_name = "Execute"
                  ; input = `Assoc [ "cwd", `String "/missing" ]
                  ; content = "working directory is unavailable"

--- a/test/test_eval.ml
+++ b/test/test_eval.ml
@@ -191,6 +191,8 @@ let test_run_metrics_yojson () =
 
 (* ── eval_collector tests ─────────────────────────────────────── *)
 
+let invocation () = Tool.Invocation.create ~tool_use_id:"tu-test" ~turn:0 ~planned_index:0
+
 let test_eval_collector_basic () =
   Eio_main.run
   @@ fun _env ->
@@ -212,7 +214,8 @@ let test_eval_collector_basic () =
     bus
     (Event_bus.mk_event
        (ToolCalled
-          { agent_name = "test"
+          { invocation = invocation ()
+          ; agent_name = "test"
           ; tool_name = "t1"
           ; tool_use_id = "tu-test"
           ; input = `Null
@@ -222,7 +225,8 @@ let test_eval_collector_basic () =
     bus
     (Event_bus.mk_event
        (ToolCompleted
-          { agent_name = "test"
+          { invocation = invocation ()
+          ; agent_name = "test"
           ; tool_name = "t1"
           ; tool_use_id = "tu-test"
           ; output = Ok { Types.content = "done"; _meta = None }

--- a/test/test_eval.ml
+++ b/test/test_eval.ml
@@ -191,7 +191,12 @@ let test_run_metrics_yojson () =
 
 (* ── eval_collector tests ─────────────────────────────────────── *)
 
-let invocation () = Tool.Invocation.create ~tool_use_id:"tu-test" ~turn:0 ~planned_index:0
+let invocation () =
+  let schedule : Tool.schedule =
+    { planned_index = 0; batch_index = 0; batch_size = 1; execution_mode = Tool.Serial }
+  in
+  Tool.Invocation.create ~tool_use_id:"tu-test" ~turn:0 ~schedule
+;;
 
 let test_eval_collector_basic () =
   Eio_main.run
@@ -217,9 +222,7 @@ let test_eval_collector_basic () =
           { invocation = invocation ()
           ; agent_name = "test"
           ; tool_name = "t1"
-          ; tool_use_id = "tu-test"
           ; input = `Null
-          ; turn = 0
           }));
   Event_bus.publish
     bus
@@ -228,9 +231,7 @@ let test_eval_collector_basic () =
           { invocation = invocation ()
           ; agent_name = "test"
           ; tool_name = "t1"
-          ; tool_use_id = "tu-test"
           ; output = Ok { Types.content = "done"; _meta = None }
-          ; turn = 0
           }));
   let rm = Eval_collector.finalize ec in
   (* Check auto-collected metrics *)

--- a/test/test_event_bus.ml
+++ b/test/test_event_bus.ml
@@ -26,6 +26,10 @@ let mock_response text =
 (** Shorthand: wrap a payload into an event with a fresh envelope. *)
 let ev payload = Event_bus.mk_event payload
 
+let invocation ?(tool_use_id = "tu-test") ?(turn = 0) ?(planned_index = 0) () =
+  Tool.Invocation.create ~tool_use_id ~turn ~planned_index
+;;
+
 let subscription_config_exn ~capacity ~overflow =
   match Event_bus.subscription_config ~capacity ~overflow with
   | Ok config -> config
@@ -185,7 +189,8 @@ let test_accept_all_subscriber_gets_all_events () =
     bus
     (ev
        (ToolCalled
-          { agent_name = "a"
+          { invocation = invocation ~tool_use_id:"1" ()
+          ; agent_name = "a"
           ; tool_name = "t"
           ; tool_use_id = "1"
           ; input = `Null
@@ -251,7 +256,8 @@ let test_filter_tools_only () =
     bus
     (ev
        (ToolCalled
-          { agent_name = "a"
+          { invocation = invocation ()
+          ; agent_name = "a"
           ; tool_name = "calc"
           ; tool_use_id = "tu-test"
           ; input = `Null
@@ -261,7 +267,8 @@ let test_filter_tools_only () =
     bus
     (ev
        (ToolCompleted
-          { agent_name = "a"
+          { invocation = invocation ()
+          ; agent_name = "a"
           ; tool_name = "calc"
           ; tool_use_id = "tu-test"
           ; output = Ok { Types.content = "42"; _meta = None }
@@ -292,7 +299,8 @@ let test_accept_all () =
     bus
     (ev
        (ToolCalled
-          { agent_name = "a"
+          { invocation = invocation ()
+          ; agent_name = "a"
           ; tool_name = "x"
           ; tool_use_id = "tu-test"
           ; input = `Null
@@ -328,7 +336,8 @@ let test_payload_kind_canonical_labels () =
     ; Event_bus.TurnReady { agent_name = "a"; turn = 0; tool_names = [] }, "turn_ready"
     ; Event_bus.TurnCompleted { agent_name = "a"; turn = 0 }, "turn_completed"
     ; ( Event_bus.ToolCalled
-          { agent_name = "a"
+          { invocation = invocation ()
+          ; agent_name = "a"
           ; tool_name = "f"
           ; tool_use_id = "tu-test"
           ; input = `Null
@@ -395,7 +404,8 @@ let test_multiple_event_types () =
     bus
     (ev
        (ToolCalled
-          { agent_name = "a"
+          { invocation = invocation ()
+          ; agent_name = "a"
           ; tool_name = "f"
           ; tool_use_id = "tu-test"
           ; input = `Null
@@ -405,7 +415,8 @@ let test_multiple_event_types () =
     bus
     (ev
        (ToolCompleted
-          { agent_name = "a"
+          { invocation = invocation ()
+          ; agent_name = "a"
           ; tool_name = "f"
           ; tool_use_id = "tu-test"
           ; output = Ok { Types.content = "ok"; _meta = None }
@@ -450,7 +461,8 @@ let test_tool_called_fields () =
     bus
     (ev
        (ToolCalled
-          { agent_name = "a"
+          { invocation = invocation ()
+          ; agent_name = "a"
           ; tool_name = "calc"
           ; tool_use_id = "tu-test"
           ; input

--- a/test/test_event_bus.ml
+++ b/test/test_event_bus.ml
@@ -27,7 +27,10 @@ let mock_response text =
 let ev payload = Event_bus.mk_event payload
 
 let invocation ?(tool_use_id = "tu-test") ?(turn = 0) ?(planned_index = 0) () =
-  Tool.Invocation.create ~tool_use_id ~turn ~planned_index
+  let schedule : Tool.schedule =
+    { planned_index; batch_index = 0; batch_size = 1; execution_mode = Tool.Serial }
+  in
+  Tool.Invocation.create ~tool_use_id ~turn ~schedule
 ;;
 
 let subscription_config_exn ~capacity ~overflow =
@@ -192,9 +195,7 @@ let test_accept_all_subscriber_gets_all_events () =
           { invocation = invocation ~tool_use_id:"1" ()
           ; agent_name = "a"
           ; tool_name = "t"
-          ; tool_use_id = "1"
           ; input = `Null
-          ; turn = 0
           }));
   let all_events = Event_bus.drain all_sub in
   let tool_events = Event_bus.drain tool_sub in
@@ -259,9 +260,7 @@ let test_filter_tools_only () =
           { invocation = invocation ()
           ; agent_name = "a"
           ; tool_name = "calc"
-          ; tool_use_id = "tu-test"
           ; input = `Null
-          ; turn = 0
           }));
   Event_bus.publish
     bus
@@ -270,9 +269,7 @@ let test_filter_tools_only () =
           { invocation = invocation ()
           ; agent_name = "a"
           ; tool_name = "calc"
-          ; tool_use_id = "tu-test"
           ; output = Ok { Types.content = "42"; _meta = None }
-          ; turn = 0
           }));
   Event_bus.publish bus (ev (TurnCompleted { agent_name = "a"; turn = 0 }));
   let events = Event_bus.drain sub in
@@ -299,13 +296,7 @@ let test_accept_all () =
     bus
     (ev
        (ToolCalled
-          { invocation = invocation ()
-          ; agent_name = "a"
-          ; tool_name = "x"
-          ; tool_use_id = "tu-test"
-          ; input = `Null
-          ; turn = 0
-          }));
+          { invocation = invocation (); agent_name = "a"; tool_name = "x"; input = `Null }));
   Event_bus.publish bus (ev (Custom ("test", `Null)));
   let events = Event_bus.drain sub in
   check int "all three events" 3 (List.length events)
@@ -336,13 +327,7 @@ let test_payload_kind_canonical_labels () =
     ; Event_bus.TurnReady { agent_name = "a"; turn = 0; tool_names = [] }, "turn_ready"
     ; Event_bus.TurnCompleted { agent_name = "a"; turn = 0 }, "turn_completed"
     ; ( Event_bus.ToolCalled
-          { invocation = invocation ()
-          ; agent_name = "a"
-          ; tool_name = "f"
-          ; tool_use_id = "tu-test"
-          ; input = `Null
-          ; turn = 0
-          }
+          { invocation = invocation (); agent_name = "a"; tool_name = "f"; input = `Null }
       , "tool_called" )
     ; ( Event_bus.HandoffRequested { from_agent = "a"; to_agent = "b"; reason = "" }
       , "handoff_requested" )
@@ -404,13 +389,7 @@ let test_multiple_event_types () =
     bus
     (ev
        (ToolCalled
-          { invocation = invocation ()
-          ; agent_name = "a"
-          ; tool_name = "f"
-          ; tool_use_id = "tu-test"
-          ; input = `Null
-          ; turn = 0
-          }));
+          { invocation = invocation (); agent_name = "a"; tool_name = "f"; input = `Null }));
   Event_bus.publish
     bus
     (ev
@@ -418,9 +397,7 @@ let test_multiple_event_types () =
           { invocation = invocation ()
           ; agent_name = "a"
           ; tool_name = "f"
-          ; tool_use_id = "tu-test"
           ; output = Ok { Types.content = "ok"; _meta = None }
-          ; turn = 0
           }));
   Event_bus.publish bus (ev (TurnCompleted { agent_name = "a"; turn = 0 }));
   Event_bus.publish
@@ -461,19 +438,13 @@ let test_tool_called_fields () =
     bus
     (ev
        (ToolCalled
-          { invocation = invocation ()
-          ; agent_name = "a"
-          ; tool_name = "calc"
-          ; tool_use_id = "tu-test"
-          ; input
-          ; turn = 0
-          }));
+          { invocation = invocation (); agent_name = "a"; tool_name = "calc"; input }));
   match Event_bus.drain sub with
   | [ { payload = ToolCalled r; _ } ] ->
     check string "agent_name" "a" r.agent_name;
     check string "tool_name" "calc" r.tool_name;
     check string "input json" {|{"x":1}|} (Yojson.Safe.to_string r.input);
-    check int "turn" 0 r.turn
+    check int "turn" 0 (Tool.Invocation.turn r.invocation)
   | _ -> fail "expected ToolCalled"
 ;;
 
@@ -511,13 +482,11 @@ let test_tool_completed_preserves_non_retryable_flag () =
       ~event_bus:(Some bus)
       ~tracer:Tracing.null
       ~agent_name:"agent"
-      ~turn_count:0
       ~correlation_id:"sess-event"
       ~run_id:"run-event"
-      ~schedule
+      ~invocation:(Tool.Invocation.create ~tool_use_id:"tool-1" ~turn:0 ~schedule)
       "fail"
       (`Assoc [])
-      "tool-1"
     |> require_tool_execution
   in
   match Event_bus.drain sub with
@@ -572,7 +541,8 @@ let test_on_tool_error_hook_fires_on_tool_failure () =
     Some
       (fun event ->
         (match event with
-         | Hooks.OnToolError { tool_name; error } -> fired := (tool_name, error) :: !fired
+         | Hooks.OnToolError { tool_name; error; invocation = _ } ->
+           fired := (tool_name, error) :: !fired
          | _ -> ());
         Hooks.Continue)
   in
@@ -585,13 +555,11 @@ let test_on_tool_error_hook_fires_on_tool_failure () =
       ~event_bus:(Some bus)
       ~tracer:Tracing.null
       ~agent_name:"agent"
-      ~turn_count:0
       ~correlation_id:"c"
       ~run_id:"r"
-      ~schedule
+      ~invocation:(Tool.Invocation.create ~tool_use_id:"tool-1" ~turn:0 ~schedule)
       "fail"
       (`Assoc [])
-      "tool-1"
     |> require_tool_execution
   in
   match List.rev !fired with
@@ -630,13 +598,11 @@ let test_on_tool_error_hook_silent_on_success () =
       ~event_bus:(Some bus)
       ~tracer:Tracing.null
       ~agent_name:"agent"
-      ~turn_count:0
       ~correlation_id:"c"
       ~run_id:"r"
-      ~schedule
+      ~invocation:(Tool.Invocation.create ~tool_use_id:"tool-2" ~turn:0 ~schedule)
       "ok"
       (`Assoc [])
-      "tool-2"
     |> require_tool_execution
   in
   check int "hook not fired on Ok result" 0 !fired
@@ -657,7 +623,8 @@ let test_on_error_fires_on_tool_not_found () =
     Some
       (fun event ->
         (match event with
-         | Hooks.OnError { detail; context } -> fired := (detail, context) :: !fired
+         | Hooks.OnError { detail; context; invocation } ->
+           fired := (detail, context, invocation) :: !fired
          | _ -> ());
         Hooks.Continue)
   in
@@ -671,17 +638,15 @@ let test_on_error_fires_on_tool_not_found () =
       ~event_bus:(Some bus)
       ~tracer:Tracing.null
       ~agent_name:"agent"
-      ~turn_count:0
       ~correlation_id:"c"
       ~run_id:"r"
-      ~schedule
+      ~invocation:(Tool.Invocation.create ~tool_use_id:"tool-1" ~turn:0 ~schedule)
       "ghost_tool"
       (`Assoc [])
-      "tool-1"
     |> require_tool_execution
   in
   match List.rev !fired with
-  | [ (detail, ctx) ] ->
+  | [ (detail, ctx, Some error_invocation) ] ->
     check
       bool
       "detail mentions tool name"
@@ -694,7 +659,13 @@ let test_on_error_fires_on_tool_not_found () =
          true
        with
        | Not_found -> false);
-    check string "context labels dispatch site" "agent_tools.find_and_execute_tool" ctx
+    check string "context labels dispatch site" "agent_tools.find_and_execute_tool" ctx;
+    check
+      string
+      "error retains exact tool occurrence"
+      "tool-1"
+      (Tool.Invocation.tool_use_id error_invocation)
+  | [ (_, _, None) ] -> fail "tool-attributed on_error lost its invocation"
   | [] -> fail "on_error hook not fired"
   | _ -> fail "on_error fired more than once"
 ;;
@@ -716,7 +687,8 @@ let test_unknown_tool_reports_available_tools_and_retries () =
     Some
       (fun event ->
         (match event with
-         | Hooks.OnError { detail; context } -> fired := (detail, context) :: !fired
+         | Hooks.OnError { detail; context; invocation = _ } ->
+           fired := (detail, context) :: !fired
          | _ -> ());
         Hooks.Continue)
   in
@@ -729,13 +701,11 @@ let test_unknown_tool_reports_available_tools_and_retries () =
       ~event_bus:(Some bus)
       ~tracer:Tracing.null
       ~agent_name:"agent"
-      ~turn_count:0
       ~correlation_id:"c"
       ~run_id:"r"
-      ~schedule
+      ~invocation:(Tool.Invocation.create ~tool_use_id:"tool-unknown" ~turn:0 ~schedule)
       "MissingRead"
       (`Assoc [])
-      "tool-unknown"
     |> require_tool_execution
   in
   check
@@ -817,11 +787,10 @@ let test_execution_rejects_invalid_input_unchanged () =
       ~event_bus:None
       ~tracer:Tracing.null
       ~agent_name:"agent"
-      ~turn_count:0
-      ~schedule
+      ~invocation:
+        (Tool.Invocation.create ~tool_use_id:"tool-invalid-input" ~turn:0 ~schedule)
       "Count"
       (`Assoc [ "count", `String "42" ])
-      "tool-invalid-input"
     |> require_tool_execution
   in
   check bool "handler not called" true (Yojson.Safe.equal `Null !handler_input);
@@ -863,13 +832,11 @@ let test_on_error_silent_on_successful_dispatch () =
       ~event_bus:(Some bus)
       ~tracer:Tracing.null
       ~agent_name:"agent"
-      ~turn_count:0
       ~correlation_id:"c"
       ~run_id:"r"
-      ~schedule
+      ~invocation:(Tool.Invocation.create ~tool_use_id:"tool-2" ~turn:0 ~schedule)
       "ok"
       (`Assoc [])
-      "tool-2"
     |> require_tool_execution
   in
   check int "on_error not fired on success" 0 !fired

--- a/test/test_execution_journal.ml
+++ b/test/test_execution_journal.ml
@@ -1000,12 +1000,21 @@ let test_json_terminal_and_id_boundaries () =
   expect_invalid_node_kind
     (Event.Tool_invocation
        { provider_tool_use_id = None; tool_name = " \t"; schedule = serial_schedule });
-  expect_invalid_node_kind
-    (Event.Tool_invocation
-       { provider_tool_use_id = Some " \n"
-       ; tool_name = "valid_tool"
-       ; schedule = serial_schedule
-       });
+  let exact_provider_id = " \n" in
+  let exact_provider_kind =
+    Event.Tool_invocation
+      { provider_tool_use_id = Some exact_provider_id
+      ; tool_name = "valid_tool"
+      ; schedule = serial_schedule
+      }
+  in
+  (match Event.node_kind_to_yojson exact_provider_kind with
+   | Error _ -> fail "opaque provider tool id did not encode"
+   | Ok json ->
+     (match Event.node_kind_of_yojson json with
+      | Ok (Event.Tool_invocation { provider_tool_use_id = Some decoded; _ }) ->
+        check string "provider tool id roundtrip is exact" exact_provider_id decoded
+      | Ok _ | Error _ -> fail "opaque provider tool id did not roundtrip exactly"));
   let before_invalid_response_id = Journal.length journal in
   (match
      Journal.update_node journal ~node:turn (Event.Provider_response_id_snapshot " \t")

--- a/test/test_execution_lane_writer.ml
+++ b/test/test_execution_lane_writer.ml
@@ -7,6 +7,7 @@ module Codec = Internal.Execution_codec_executor
 module Journal = Internal.Execution_journal
 module Store = Internal.Execution_event_store
 module Writer = Internal.Execution_lane_writer
+module Settlement = Internal.Execution_tool_settlement
 module Tx = Journal.Transaction
 
 exception Cancel_waiter
@@ -169,6 +170,101 @@ let open_output writer =
 
 let delta_transaction output index =
   Tx.update_node ~node:output (Event.Output_delta (`Assoc [ "index", `Int index ]))
+;;
+
+let test_exact_tool_settlement_authority () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun codec dir ->
+    make_dir dir;
+    with_fresh codec dir (fun _sw writer ->
+      let run, _ =
+        (submit_and_await writer (Tx.start_run ~agent_name:"tools" ())).value
+      in
+      let turn, _ =
+        (submit_and_await
+           writer
+           (Tx.open_node
+              ~run
+              ~parent:(Journal.run_root run)
+              ~kind:(Event.Agent_turn { ordinal = 3 })
+              ()))
+          .value
+      in
+      let provider, _ =
+        (submit_and_await
+           writer
+           (Tx.open_node ~run ~parent:turn ~kind:(provider_attempt 0) ()))
+          .value
+      in
+      let open_invocation planned_index =
+        let schedule : Hooks.tool_schedule =
+          { planned_index; batch_index = 0; batch_size = 2; execution_mode = Tool.Serial }
+        in
+        let node, _ =
+          (submit_and_await
+             writer
+             (Tx.open_node
+                ~run
+                ~parent:provider
+                ~kind:
+                  (Event.Tool_invocation
+                     { provider_tool_use_id = Some ""; tool_name = "effect"; schedule })
+                ()))
+            .value
+        in
+        ignore
+          (submit_and_await
+             writer
+             (Tx.update_node
+                ~node
+                (Event.Tool_input_snapshot
+                   (Types.ToolUse { id = ""; name = "effect"; input = `Int planned_index }))));
+        let invocation = Tool.Invocation.create ~tool_use_id:"" ~turn:3 ~schedule in
+        node, invocation
+      in
+      let first_node, first_invocation = open_invocation 0 in
+      let second_node, second_invocation = open_invocation 1 in
+      let authority node invocation =
+        match Settlement.create ~writer ~run ~invocation_node:node ~invocation with
+        | Ok authority -> authority
+        | Error _ -> fail "exact settlement authority rejected its invocation"
+      in
+      let first = authority first_node first_invocation in
+      let second = authority second_node second_invocation in
+      (match Settlement.status first, Settlement.status second with
+       | Ok Settlement.Ready_to_execute, Ok Settlement.Ready_to_execute -> ()
+       | _ -> fail "blank-id occurrences were not independently ready");
+      let attempt =
+        match Settlement.begin_attempt first with
+        | Ok attempt -> attempt
+        | Error _ -> fail "durable attempt admission failed"
+      in
+      (match Settlement.status first with
+       | Ok Settlement.Outcome_unknown -> ()
+       | _ -> fail "open effect attempt was not outcome-unknown");
+      (match Settlement.begin_attempt first with
+       | Error _ -> ()
+       | Ok _ -> fail "a second effect attempt was admitted");
+      let seq = Journal.cursor_seq in
+      let before = Writer.current_cursor writer |> Result.get_ok in
+      let result =
+        Types.ToolResult
+          { tool_use_id = ""
+          ; content = "done"
+          ; outcome = Types.Tool_succeeded
+          ; json = None
+          ; content_blocks = None
+          }
+      in
+      (match Settlement.settle attempt ~result with
+       | Ok receipt ->
+         check int "three settlement facts" (seq before + 3) (seq receipt.through)
+       | Error _ -> fail "canonical result settlement failed");
+      match Settlement.status first, Settlement.status second with
+      | Ok (Settlement.Settled committed), Ok Settlement.Ready_to_execute ->
+        check bool "exact result retained" true (committed = result)
+      | _ -> fail "settlement crossed repeated blank-id occurrences"))
 ;;
 
 let rec await_reconciliation_phase writer =
@@ -1083,6 +1179,10 @@ let () =
             "semantic rejection does not poison ready group"
             `Quick
             test_semantic_rejection_does_not_poison_ready_group
+        ; test_case
+            "exact tool settlement authority"
+            `Quick
+            test_exact_tool_settlement_authority
         ; test_case
             "concurrent submit and close linearize without loss"
             `Quick

--- a/test/test_hooks.ml
+++ b/test/test_hooks.ml
@@ -10,11 +10,14 @@ let default_schedule
       ?(execution_mode = Tool.Serial)
       ()
   =
-  Hooks.{ planned_index; batch_index; batch_size; execution_mode }
+  let schedule : Tool.schedule =
+    { planned_index; batch_index; batch_size; execution_mode }
+  in
+  schedule
 ;;
 
 let invocation ?(tool_use_id = "tu-test") ?(turn = 0) ?(planned_index = 0) () =
-  Tool.Invocation.create ~tool_use_id ~turn ~planned_index
+  Tool.Invocation.create ~tool_use_id ~turn ~schedule:(default_schedule ~planned_index ())
 ;;
 
 let test_empty_hooks () =
@@ -55,12 +58,9 @@ let test_hook_receives_event () =
       (Some hook)
       (Hooks.PreToolUse
          { invocation = invocation ()
-         ; tool_use_id = "tu-test"
          ; tool_name = "test_tool"
          ; input = `Null
          ; accumulated_cost_usd = 0.0
-         ; turn = 0
-         ; schedule = default_schedule ()
          })
   in
   check string "hook received tool_name" "test_tool" !received
@@ -79,13 +79,11 @@ let test_post_tool_use_event () =
       (Some hook)
       (Hooks.PostToolUse
          { invocation = invocation ~tool_use_id:"tu-echo" ()
-         ; tool_use_id = "tu-echo"
          ; tool_name = "echo"
          ; input = `Null
          ; output = Ok { Types.content = "hello"; _meta = None }
          ; result_bytes = 5
          ; duration_ms = 1.0
-         ; schedule = default_schedule ()
          })
   in
   check string "hook received output" "hello" !received_output
@@ -104,11 +102,9 @@ let test_post_tool_use_failure_event () =
       (Some hook)
       (Hooks.PostToolUseFailure
          { invocation = invocation ~tool_use_id:"tu-echo" ()
-         ; tool_use_id = "tu-echo"
          ; tool_name = "echo"
          ; input = `Null
          ; error = "boom"
-         ; schedule = default_schedule ()
          })
   in
   check string "hook received error" "boom" !received_error
@@ -121,12 +117,9 @@ let test_invoke_block () =
       (Some hook)
       (Hooks.PreToolUse
          { invocation = invocation ~tool_use_id:"tu-danger" ()
-         ; tool_use_id = "tu-danger"
          ; tool_name = "dangerous"
          ; input = `Null
          ; accumulated_cost_usd = 0.0
-         ; turn = 0
-         ; schedule = default_schedule ()
          })
   in
   check bool "hook returns Block" true (result = Hooks.Block "blocked")
@@ -137,12 +130,9 @@ let test_invoke_block () =
 let dummy_pre_tool_use =
   Hooks.PreToolUse
     { invocation = invocation ~tool_use_id:"tu-1" ~turn:1 ()
-    ; tool_use_id = "tu-1"
     ; tool_name = "t"
     ; input = `Null
     ; accumulated_cost_usd = 0.0
-    ; turn = 1
-    ; schedule = default_schedule ()
     }
 ;;
 
@@ -175,24 +165,20 @@ let dummy_after_turn =
 let dummy_post_tool_use =
   Hooks.PostToolUse
     { invocation = invocation ~tool_use_id:"tu-1" ~turn:1 ()
-    ; tool_use_id = "tu-1"
     ; tool_name = "t"
     ; input = `Null
     ; output = Ok { Types.content = "ok"; _meta = None }
     ; result_bytes = 2
     ; duration_ms = 1.0
-    ; schedule = default_schedule ()
     }
 ;;
 
 let dummy_post_tool_use_failure =
   Hooks.PostToolUseFailure
     { invocation = invocation ~tool_use_id:"tu-1" ~turn:1 ()
-    ; tool_use_id = "tu-1"
     ; tool_name = "t"
     ; input = `Null
     ; error = "err"
-    ; schedule = default_schedule ()
     }
 ;;
 
@@ -210,8 +196,11 @@ let dummy_on_stop =
     }
 ;;
 
-let dummy_on_error = Hooks.OnError { detail = "d"; context = "c" }
-let dummy_on_tool_error = Hooks.OnToolError { tool_name = "t"; error = "e" }
+let dummy_on_error = Hooks.OnError { invocation = None; detail = "d"; context = "c" }
+
+let dummy_on_tool_error =
+  Hooks.OnToolError { invocation = invocation (); tool_name = "t"; error = "e" }
+;;
 
 (** Test that each (stage, decision) pair in the matrix is accepted. *)
 let test_validate_legal_before_turn () =

--- a/test/test_hooks.ml
+++ b/test/test_hooks.ml
@@ -13,6 +13,10 @@ let default_schedule
   Hooks.{ planned_index; batch_index; batch_size; execution_mode }
 ;;
 
+let invocation ?(tool_use_id = "tu-test") ?(turn = 0) ?(planned_index = 0) () =
+  Tool.Invocation.create ~tool_use_id ~turn ~planned_index
+;;
+
 let test_empty_hooks () =
   let hooks = Hooks.empty in
   check bool "before_turn is None" true (hooks.before_turn = None);
@@ -50,7 +54,8 @@ let test_hook_receives_event () =
     Hooks.invoke_validated
       (Some hook)
       (Hooks.PreToolUse
-         { tool_use_id = "tu-test"
+         { invocation = invocation ()
+         ; tool_use_id = "tu-test"
          ; tool_name = "test_tool"
          ; input = `Null
          ; accumulated_cost_usd = 0.0
@@ -73,7 +78,8 @@ let test_post_tool_use_event () =
     Hooks.invoke_validated
       (Some hook)
       (Hooks.PostToolUse
-         { tool_use_id = "tu-echo"
+         { invocation = invocation ~tool_use_id:"tu-echo" ()
+         ; tool_use_id = "tu-echo"
          ; tool_name = "echo"
          ; input = `Null
          ; output = Ok { Types.content = "hello"; _meta = None }
@@ -97,7 +103,8 @@ let test_post_tool_use_failure_event () =
     Hooks.invoke_validated
       (Some hook)
       (Hooks.PostToolUseFailure
-         { tool_use_id = "tu-echo"
+         { invocation = invocation ~tool_use_id:"tu-echo" ()
+         ; tool_use_id = "tu-echo"
          ; tool_name = "echo"
          ; input = `Null
          ; error = "boom"
@@ -113,7 +120,8 @@ let test_invoke_block () =
     Hooks.invoke_validated
       (Some hook)
       (Hooks.PreToolUse
-         { tool_use_id = "tu-danger"
+         { invocation = invocation ~tool_use_id:"tu-danger" ()
+         ; tool_use_id = "tu-danger"
          ; tool_name = "dangerous"
          ; input = `Null
          ; accumulated_cost_usd = 0.0
@@ -128,7 +136,8 @@ let test_invoke_block () =
 
 let dummy_pre_tool_use =
   Hooks.PreToolUse
-    { tool_use_id = "tu-1"
+    { invocation = invocation ~tool_use_id:"tu-1" ~turn:1 ()
+    ; tool_use_id = "tu-1"
     ; tool_name = "t"
     ; input = `Null
     ; accumulated_cost_usd = 0.0
@@ -165,7 +174,8 @@ let dummy_after_turn =
 
 let dummy_post_tool_use =
   Hooks.PostToolUse
-    { tool_use_id = "tu-1"
+    { invocation = invocation ~tool_use_id:"tu-1" ~turn:1 ()
+    ; tool_use_id = "tu-1"
     ; tool_name = "t"
     ; input = `Null
     ; output = Ok { Types.content = "ok"; _meta = None }
@@ -177,7 +187,8 @@ let dummy_post_tool_use =
 
 let dummy_post_tool_use_failure =
   Hooks.PostToolUseFailure
-    { tool_use_id = "tu-1"
+    { invocation = invocation ~tool_use_id:"tu-1" ~turn:1 ()
+    ; tool_use_id = "tu-1"
     ; tool_name = "t"
     ; input = `Null
     ; error = "err"

--- a/test/test_multivendor_events.ml
+++ b/test/test_multivendor_events.ml
@@ -39,7 +39,10 @@ let stub_api_response : Types.api_response =
 let stub_tool_result : Types.tool_result = Ok { Types.content = "ok"; _meta = None }
 
 let invocation ?(tool_use_id = "tu-test") ?(turn = 0) ?(planned_index = 0) () =
-  Tool.Invocation.create ~tool_use_id ~turn ~planned_index
+  let schedule : Tool.schedule =
+    { planned_index; batch_index = 0; batch_size = 1; execution_mode = Tool.Serial }
+  in
+  Tool.Invocation.create ~tool_use_id ~turn ~schedule
 ;;
 
 (* ── I1/I2: envelope preserved across variants ────────────────── *)
@@ -63,17 +66,13 @@ let test_envelope_preserved_across_variants () =
         { invocation = invocation ()
         ; agent_name = "alpha"
         ; tool_name = "echo"
-        ; tool_use_id = "tu-test"
         ; input = `Null
-        ; turn = 0
         }
     ; ToolCompleted
         { invocation = invocation ()
         ; agent_name = "alpha"
         ; tool_name = "echo"
-        ; tool_use_id = "tu-test"
         ; output = stub_tool_result
-        ; turn = 0
         }
     ; TurnCompleted { agent_name = "alpha"; turn = 0 }
     ; HandoffRequested { from_agent = "alpha"; to_agent = "beta"; reason = "delegate" }
@@ -122,21 +121,13 @@ let test_payload_kind_mapping () =
     ; TurnStarted { agent_name = "a"; turn = 0 }, "turn_started"
     ; TurnCompleted { agent_name = "a"; turn = 0 }, "turn_completed"
     ; ( ToolCalled
-          { invocation = invocation ()
-          ; agent_name = "a"
-          ; tool_name = "t"
-          ; tool_use_id = "tu-test"
-          ; input = `Null
-          ; turn = 0
-          }
+          { invocation = invocation (); agent_name = "a"; tool_name = "t"; input = `Null }
       , "tool_called" )
     ; ( ToolCompleted
           { invocation = invocation ()
           ; agent_name = "a"
           ; tool_name = "t"
-          ; tool_use_id = "tu-test"
           ; output = stub_tool_result
-          ; turn = 0
           }
       , "tool_completed" )
     ; ( HandoffRequested { from_agent = "a"; to_agent = "b"; reason = "r" }
@@ -232,9 +223,7 @@ let test_golden_lifecycle_transcript () =
           { invocation = invocation ()
           ; agent_name = "a"
           ; tool_name = "echo"
-          ; tool_use_id = "tu-test"
           ; input = `Null
-          ; turn = 0
           }));
   Event_bus.publish
     bus
@@ -243,9 +232,7 @@ let test_golden_lifecycle_transcript () =
           { invocation = invocation ()
           ; agent_name = "a"
           ; tool_name = "echo"
-          ; tool_use_id = "tu-test"
           ; output = stub_tool_result
-          ; turn = 0
           }));
   Event_bus.publish bus (mk (TurnCompleted { agent_name = "a"; turn = 0 }));
   Event_bus.publish

--- a/test/test_multivendor_events.ml
+++ b/test/test_multivendor_events.ml
@@ -38,6 +38,10 @@ let stub_api_response : Types.api_response =
 
 let stub_tool_result : Types.tool_result = Ok { Types.content = "ok"; _meta = None }
 
+let invocation ?(tool_use_id = "tu-test") ?(turn = 0) ?(planned_index = 0) () =
+  Tool.Invocation.create ~tool_use_id ~turn ~planned_index
+;;
+
 (* ── I1/I2: envelope preserved across variants ────────────────── *)
 
 let test_envelope_preserved_across_variants () =
@@ -56,14 +60,16 @@ let test_envelope_preserved_across_variants () =
     [ AgentStarted { agent_name = "alpha"; task_id = "t1" }
     ; TurnStarted { agent_name = "alpha"; turn = 0 }
     ; ToolCalled
-        { agent_name = "alpha"
+        { invocation = invocation ()
+        ; agent_name = "alpha"
         ; tool_name = "echo"
         ; tool_use_id = "tu-test"
         ; input = `Null
         ; turn = 0
         }
     ; ToolCompleted
-        { agent_name = "alpha"
+        { invocation = invocation ()
+        ; agent_name = "alpha"
         ; tool_name = "echo"
         ; tool_use_id = "tu-test"
         ; output = stub_tool_result
@@ -116,7 +122,8 @@ let test_payload_kind_mapping () =
     ; TurnStarted { agent_name = "a"; turn = 0 }, "turn_started"
     ; TurnCompleted { agent_name = "a"; turn = 0 }, "turn_completed"
     ; ( ToolCalled
-          { agent_name = "a"
+          { invocation = invocation ()
+          ; agent_name = "a"
           ; tool_name = "t"
           ; tool_use_id = "tu-test"
           ; input = `Null
@@ -124,7 +131,8 @@ let test_payload_kind_mapping () =
           }
       , "tool_called" )
     ; ( ToolCompleted
-          { agent_name = "a"
+          { invocation = invocation ()
+          ; agent_name = "a"
           ; tool_name = "t"
           ; tool_use_id = "tu-test"
           ; output = stub_tool_result
@@ -221,7 +229,8 @@ let test_golden_lifecycle_transcript () =
     bus
     (mk
        (ToolCalled
-          { agent_name = "a"
+          { invocation = invocation ()
+          ; agent_name = "a"
           ; tool_name = "echo"
           ; tool_use_id = "tu-test"
           ; input = `Null
@@ -231,7 +240,8 @@ let test_golden_lifecycle_transcript () =
     bus
     (mk
        (ToolCompleted
-          { agent_name = "a"
+          { invocation = invocation ()
+          ; agent_name = "a"
           ; tool_name = "echo"
           ; tool_use_id = "tu-test"
           ; output = stub_tool_result

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -7,6 +7,13 @@ open Agent_sdk
 module Internal_agent = Agent_sdk__Agent_types
 module Internal_pipeline = Agent_sdk__Pipeline
 
+let invocation tool_use_id =
+  let schedule : Tool.schedule =
+    { planned_index = 0; batch_index = 0; batch_size = 1; execution_mode = Tool.Serial }
+  in
+  Tool.Invocation.create ~tool_use_id ~turn:0 ~schedule
+;;
+
 (* ── Provider mock: verify pipeline stages via mock responses ── *)
 
 let test_mock_text_response () =
@@ -781,13 +788,13 @@ let test_prepare_turn_preserves_messages () =
 
 let test_make_tool_results_ok () =
   let results =
-    [ { Agent_tools.tool_use_id = "tu1"
+    [ { Agent_tools.invocation = invocation "tu1"
       ; tool_name = "tool-1"
       ; input = `Null
       ; content = "result1"
       ; outcome = Tool_succeeded
       }
-    ; { tool_use_id = "tu2"
+    ; { invocation = invocation "tu2"
       ; tool_name = "tool-2"
       ; input = `Null
       ; content = "result2"
@@ -811,7 +818,7 @@ let test_make_tool_results_ok () =
 
 let test_make_tool_results_error () =
   let results =
-    [ { Agent_tools.tool_use_id = "tu1"
+    [ { Agent_tools.invocation = invocation "tu1"
       ; tool_name = "tool-1"
       ; input = `Null
       ; content = "failed"
@@ -831,13 +838,13 @@ let test_make_tool_results_error () =
 
 let test_make_tool_results_mixed () =
   let results =
-    [ { Agent_tools.tool_use_id = "tu1"
+    [ { Agent_tools.invocation = invocation "tu1"
       ; tool_name = "tool-1"
       ; input = `Null
       ; content = "good"
       ; outcome = Tool_succeeded
       }
-    ; { tool_use_id = "tu2"
+    ; { invocation = invocation "tu2"
       ; tool_name = "tool-2"
       ; input = `Null
       ; content = "bad"

--- a/test/test_pipeline_common_coverage.ml
+++ b/test/test_pipeline_common_coverage.ml
@@ -88,10 +88,7 @@ let test_agent_type_checkpoint_stage_labels () =
        check_bool "stage JSON label" true (json = `String label);
        match Agent.checkpoint_stage_of_yojson json with
        | Ok decoded ->
-         check_bool
-           "stage roundtrip"
-           true
-           (Agent.checkpoint_stage_equal stage decoded)
+         check_bool "stage roundtrip" true (Agent.checkpoint_stage_equal stage decoded)
        | Error error -> Alcotest.fail error)
     stages;
   List.iter

--- a/test/test_pipeline_common_coverage.ml
+++ b/test/test_pipeline_common_coverage.ml
@@ -75,18 +75,41 @@ let test_strategy_and_outcome_constructors () =
 ;;
 
 let test_agent_type_checkpoint_stage_labels () =
-  check_string
-    "assistant collected"
-    "after_assistant_collected"
-    (Internal_agent.checkpoint_stage_to_string After_assistant_collected);
-  check_string
-    "tool results appended"
-    "after_tool_results_appended"
-    (Internal_agent.checkpoint_stage_to_string After_tool_results_appended);
-  check_string
-    "context injection"
-    "after_context_injection"
-    (Internal_agent.checkpoint_stage_to_string After_context_injection)
+  let stages =
+    [ Agent.After_assistant_collected, "after_assistant_collected"
+    ; Agent.After_tool_results_appended, "after_tool_results_appended"
+    ; Agent.After_context_injection, "after_context_injection"
+    ]
+  in
+  List.iter
+    (fun (stage, label) ->
+       check_string "stage label" label (Agent.checkpoint_stage_to_string stage);
+       let json = Agent.checkpoint_stage_to_yojson stage in
+       check_bool "stage JSON label" true (json = `String label);
+       match Agent.checkpoint_stage_of_yojson json with
+       | Ok decoded ->
+         check_bool
+           "stage roundtrip"
+           true
+           (Agent.checkpoint_stage_equal stage decoded)
+       | Error error -> Alcotest.fail error)
+    stages;
+  List.iter
+    (fun (left, _) ->
+       List.iter
+         (fun (right, _) ->
+            check_bool
+              "stage equality"
+              (left = right)
+              (Agent.checkpoint_stage_equal left right))
+         stages)
+    stages;
+  (match Agent.checkpoint_stage_of_yojson (`String "after_tool_execution") with
+   | Error _ -> ()
+   | Ok _ -> Alcotest.fail "unknown checkpoint stage was accepted");
+  match Agent.checkpoint_stage_of_yojson (`Int 1) with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "non-string checkpoint stage was accepted"
 ;;
 
 let test_agent_type_accessors_card_and_state_mutators () =

--- a/test/test_pipeline_deep.ml
+++ b/test/test_pipeline_deep.ml
@@ -10,6 +10,13 @@
 
 open Agent_sdk
 
+let invocation tool_use_id =
+  let schedule : Tool.schedule =
+    { planned_index = 0; batch_index = 0; batch_size = 1; execution_mode = Tool.Serial }
+  in
+  Tool.Invocation.create ~tool_use_id ~turn:0 ~schedule
+;;
+
 let context_messages = function
   | Ok messages -> messages
   | Error error -> Alcotest.fail error.Agent_turn.detail
@@ -465,7 +472,7 @@ let test_context_injection_sets_values () =
   in
   let tool_uses = [ Types.ToolUse { id = "tu_1"; name = "search"; input = `Assoc [] } ] in
   let results =
-    [ { Agent_tools.tool_use_id = "tu_1"
+    [ { Agent_tools.invocation = invocation "tu_1"
       ; tool_name = "search"
       ; input = `Assoc []
       ; content = "result text"
@@ -506,7 +513,7 @@ let test_context_injection_none () =
   let injector ~tool_name:_ ~input:_ ~output:_ = None in
   let tool_uses = [ Types.ToolUse { id = "tu_n"; name = "tool"; input = `Assoc [] } ] in
   let results =
-    [ { Agent_tools.tool_use_id = "tu_n"
+    [ { Agent_tools.invocation = invocation "tu_n"
       ; tool_name = "tool"
       ; input = `Assoc []
       ; content = "ok"
@@ -555,7 +562,7 @@ let test_context_injection_extra_messages () =
   in
   let tool_uses = [ Types.ToolUse { id = "tu_m"; name = "tool"; input = `Assoc [] } ] in
   let results =
-    [ { Agent_tools.tool_use_id = "tu_m"
+    [ { Agent_tools.invocation = invocation "tu_m"
       ; tool_name = "tool"
       ; input = `Assoc []
       ; content = "ok"
@@ -590,7 +597,7 @@ let test_context_injection_error_result () =
   in
   let tool_uses = [ Types.ToolUse { id = "tu_err"; name = "tool"; input = `Assoc [] } ] in
   let results =
-    [ { Agent_tools.tool_use_id = "tu_err"
+    [ { Agent_tools.invocation = invocation "tu_err"
       ; tool_name = "tool"
       ; input = `Assoc []
       ; content = "something went wrong"
@@ -627,7 +634,7 @@ let test_context_injection_raises () =
   let injector ~tool_name:_ ~input:_ ~output:_ = failwith "injector crash" in
   let tool_uses = [ Types.ToolUse { id = "tu_ex"; name = "tool"; input = `Assoc [] } ] in
   let results =
-    [ { Agent_tools.tool_use_id = "tu_ex"
+    [ { Agent_tools.invocation = invocation "tu_ex"
       ; tool_name = "tool"
       ; input = `Assoc []
       ; content = "ok"

--- a/test/test_raw_trace.ml
+++ b/test/test_raw_trace.ml
@@ -393,6 +393,18 @@ let test_agent_run_stream_append_only_raw_trace () =
       (List.map
          (fun (record : Raw_trace.record) -> record.tool_planned_index)
          started_records);
+    let finished_records =
+      List.filter
+        (fun (record : Raw_trace.record) ->
+           record.record_type = Raw_trace.Tool_execution_finished)
+        run1_records
+    in
+    Alcotest.(check (list (option int)))
+      "finished planned indices"
+      [ Some 0; Some 0; Some 0; Some 0 ]
+      (List.map
+         (fun (record : Raw_trace.record) -> record.tool_planned_index)
+         finished_records);
     Alcotest.(check (list (option int)))
       "batch indices"
       [ Some 0; Some 0; Some 0; Some 0 ]

--- a/test/test_raw_trace_deep.ml
+++ b/test/test_raw_trace_deep.ml
@@ -578,6 +578,7 @@ let test_validate_run_pass () =
         ~tool_use_id:(Some "tu-1")
         ~tool_name:(Some "read")
         ~tool_input:(Some `Null)
+        ~tool_planned_index:(Some 0)
         ~tool_execution_mode:(Some Tool.Serial)
         ()
     ; mk_record
@@ -588,6 +589,7 @@ let test_validate_run_pass () =
         ~tool_name:(Some "read")
         ~tool_result:(Some "content")
         ~tool_error:(Some false)
+        (* Historical finish records did not persist the planned index. *)
         ()
     ; mk_record
         ~seq:4
@@ -704,6 +706,62 @@ let test_validate_run_unmatched_tool_pairs () =
     Alcotest.fail (Printf.sprintf "validate_run error: %s" (Error.to_string err))
 ;;
 
+let test_validate_run_distinguishes_repeated_blank_ids_by_planned_index () =
+  let dir = tmpdir () in
+  let path = Filename.concat dir "validate_exact_occurrence.jsonl" in
+  let tool_record ~seq ~record_type ~planned_index =
+    mk_record
+      ~seq
+      ~record_type
+      ~prompt:None
+      ~tool_use_id:(Some "")
+      ~tool_name:(Some "repeat")
+      ~tool_planned_index:(Some planned_index)
+      ~tool_execution_mode:
+        (match record_type with
+         | Raw_trace.Tool_execution_started -> Some Tool.Serial
+         | _ -> None)
+      ()
+  in
+  let records =
+    [ mk_record ~seq:1 ~record_type:Raw_trace.Run_started ~prompt:(Some "go") ()
+    ; tool_record ~seq:2 ~record_type:Raw_trace.Tool_execution_started ~planned_index:0
+    ; tool_record ~seq:3 ~record_type:Raw_trace.Tool_execution_started ~planned_index:1
+    ; tool_record ~seq:4 ~record_type:Raw_trace.Tool_execution_finished ~planned_index:0
+    ; tool_record ~seq:5 ~record_type:Raw_trace.Tool_execution_finished ~planned_index:0
+    ; mk_record
+        ~seq:6
+        ~record_type:Raw_trace.Run_finished
+        ~prompt:None
+        ~final_text:(Some "done")
+        ~stop_reason:(Some "end_turn")
+        ()
+    ]
+  in
+  write_jsonl path records;
+  let run_ref : Raw_trace.run_ref =
+    { worker_run_id = "wr-test-0001"
+    ; path
+    ; start_seq = 1
+    ; end_seq = 6
+    ; agent_name = "test_agent"
+    ; session_id = Some "s-test-001"
+    }
+  in
+  match Raw_trace_query.validate_run run_ref with
+  | Ok validation ->
+    let tool_pairs =
+      List.find
+        (fun (check : Raw_trace.validation_check) -> check.name = "tool_pairs")
+        validation.checks
+    in
+    Alcotest.(check bool)
+      "same id does not hide occurrence mismatch"
+      false
+      tool_pairs.passed
+  | Error err -> Alcotest.fail (Error.to_string err)
+;;
+
 (* ── read_runs ──────────────────────────────────────────────────── *)
 
 let test_read_runs () =
@@ -805,6 +863,10 @@ let () =
             "unmatched tool pairs"
             `Quick
             test_validate_run_unmatched_tool_pairs
+        ; Alcotest.test_case
+            "repeated blank ids use planned index"
+            `Quick
+            test_validate_run_distinguishes_repeated_blank_ids_by_planned_index
         ] )
     ; "read_runs", [ Alcotest.test_case "multi-run file" `Quick test_read_runs ]
     ]

--- a/test/test_tool.ml
+++ b/test/test_tool.ml
@@ -142,7 +142,15 @@ let test_execution_env_handler_receives_context_and_invocation () =
   let context = Context.create_sync () in
   Context.set context "key" (`String "ctx");
   let invocation =
-    Tool.Invocation.create ~tool_use_id:"provider-call-17" ~turn:4 ~planned_index:2
+    Tool.Invocation.create
+      ~tool_use_id:"provider-call-17"
+      ~turn:4
+      ~schedule:
+        { planned_index = 2
+        ; batch_index = 0
+        ; batch_size = 1
+        ; execution_mode = Tool.Serial
+        }
   in
   match Tool.execute ~context ~invocation tool `Null with
   | Ok { content; _meta = _ } ->
@@ -408,7 +416,15 @@ let () =
             in
             let wrapped = Tool.with_defaults [ "name", `String "default" ] tool in
             let invocation =
-              Tool.Invocation.create ~tool_use_id:"call-1" ~turn:3 ~planned_index:1
+              Tool.Invocation.create
+                ~tool_use_id:"call-1"
+                ~turn:3
+                ~schedule:
+                  { planned_index = 1
+                  ; batch_index = 0
+                  ; batch_size = 1
+                  ; execution_mode = Tool.Serial
+                  }
             in
             match Tool.execute ~invocation wrapped (`Assoc []) with
             | Ok { content; _meta = _ } ->

--- a/test/test_tool_execution.ml
+++ b/test/test_tool_execution.ml
@@ -752,6 +752,101 @@ let test_dispatch_passes_exact_tool_invocation () =
   | _ -> fail "expected two invocation-aware results"
 ;;
 
+let invocation_key invocation =
+  Printf.sprintf
+    "%S:%d:%d"
+    (Tool.Invocation.tool_use_id invocation)
+    (Tool.Invocation.turn invocation)
+    (Tool.Invocation.planned_index invocation)
+;;
+
+let test_lifecycle_surfaces_share_exact_tool_invocation () =
+  Eio_main.run
+  @@ fun env ->
+  let pre_invocations = ref [] in
+  let post_invocations = ref [] in
+  let failure_invocations = ref [] in
+  let capture target invocation = target := invocation_key invocation :: !target in
+  let hooks =
+    { Hooks.empty with
+      pre_tool_use =
+        Some
+          (function
+            | Hooks.PreToolUse { invocation; _ } ->
+              capture pre_invocations invocation;
+              Hooks.Continue
+            | _ -> fail "expected PreToolUse")
+    ; post_tool_use =
+        Some
+          (function
+            | Hooks.PostToolUse { invocation; _ } ->
+              capture post_invocations invocation;
+              Hooks.Continue
+            | _ -> fail "expected PostToolUse")
+    ; post_tool_use_failure =
+        Some
+          (function
+            | Hooks.PostToolUseFailure { invocation; _ } ->
+              capture failure_invocations invocation;
+              Hooks.Continue
+            | _ -> fail "expected PostToolUseFailure")
+    }
+  in
+  let event_bus = Event_bus.create () in
+  let config =
+    Event_bus.subscription_config ~capacity:6 ~overflow:Event_bus.Drop_newest
+    |> Result.get_ok
+  in
+  let subscription = Event_bus.subscribe ~config event_bus in
+  let tool name result =
+    Tool.create ~name ~description:"" ~parameters:[] (fun _ -> result)
+  in
+  let success = Ok { Types.content = "done"; _meta = None } in
+  let failure =
+    Error
+      { Types.message = "expected failure"
+      ; recoverable = false
+      ; error_class = Some Types.Deterministic
+      }
+  in
+  let results =
+    execute_with_tools_in_env
+      env
+      ~tools:[ tool "exact_occurrence" success; tool "exact_failure" failure ]
+      ~hooks
+      ~event_bus
+      [ ToolUse { id = ""; name = "exact_occurrence"; input = `Assoc [] }
+      ; ToolUse { id = ""; name = "exact_occurrence"; input = `Assoc [] }
+      ; ToolUse { id = ""; name = "exact_failure"; input = `Assoc [] }
+      ]
+  in
+  check int "all blank-id calls completed" 3 (List.length results);
+  let called_invocations, completed_invocations =
+    List.fold_left
+      (fun (called, completed) (event : Event_bus.event) ->
+         match event.payload with
+         | ToolCalled { invocation; _ } -> invocation_key invocation :: called, completed
+         | ToolCompleted { invocation; _ } ->
+           called, invocation_key invocation :: completed
+         | _ -> called, completed)
+      ([], [])
+      (Event_bus.drain subscription)
+  in
+  let expected_all = [ "\"\":0:0"; "\"\":0:1"; "\"\":0:2" ] in
+  let expected_failure = [ "\"\":0:2" ] in
+  let check_occurrences label expected actual =
+    check (list string) label expected (List.rev actual)
+  in
+  check_occurrences "PreToolUse exact occurrences" expected_all !pre_invocations;
+  check_occurrences "PostToolUse exact occurrences" expected_all !post_invocations;
+  check_occurrences
+    "PostToolUseFailure exact occurrences"
+    expected_failure
+    !failure_invocations;
+  check_occurrences "ToolCalled exact occurrences" expected_all called_invocations;
+  check_occurrences "ToolCompleted exact occurrences" expected_all completed_invocations
+;;
+
 let test_tool_exception_still_publishes_tool_completed () =
   Eio_main.run
   @@ fun env ->
@@ -825,6 +920,10 @@ let () =
             "dispatch passes exact tool invocation"
             `Quick
             test_dispatch_passes_exact_tool_invocation
+        ; test_case
+            "lifecycle surfaces share exact tool invocation"
+            `Quick
+            test_lifecycle_surfaces_share_exact_tool_invocation
         ] )
     ; ( "non_tool_use_filtering"
       , [ test_case

--- a/test/test_tool_execution.ml
+++ b/test/test_tool_execution.ml
@@ -6,6 +6,10 @@ open Types
 
 let descriptor_with execution_mode = { Tool.execution_mode }
 
+let result_id (result : Agent_tools.tool_execution_result) =
+  Tool.Invocation.tool_use_id result.invocation
+;;
+
 let contains_substring ~needle haystack =
   let needle_len = String.length needle in
   let haystack_len = String.length haystack in
@@ -163,12 +167,12 @@ let test_tool_lifecycle_callback_exceptions_propagate () =
          ~on_tool_execution_finished
          [ ToolUse { id = "t1"; name = "safe"; input = `Assoc [ "x", `Int 1 ] } ])
   in
-  let no_started_failure ~tool_use_id:_ ~tool_name:_ ~input:_ ~schedule:_ = () in
-  let no_finished_failure ~tool_use_id:_ ~tool_name:_ ~content:_ ~is_error:_ = () in
-  let started_failure ~tool_use_id:_ ~tool_name:_ ~input:_ ~schedule:_ =
+  let no_started_failure ~invocation:_ ~tool_name:_ ~input:_ = () in
+  let no_finished_failure ~invocation:_ ~tool_name:_ ~content:_ ~is_error:_ = () in
+  let started_failure ~invocation:_ ~tool_name:_ ~input:_ =
     failwith "started callback boom"
   in
-  let finished_failure ~tool_use_id:_ ~tool_name:_ ~content:_ ~is_error:_ =
+  let finished_failure ~invocation:_ ~tool_name:_ ~content:_ ~is_error:_ =
     failwith "finished callback boom"
   in
   check_raises
@@ -200,9 +204,7 @@ let test_pre_hook_observer_exception_propagates () =
 ;;
 
 let test_reserved_callback_exception_is_not_tagged () =
-  let on_tool_execution_started ~tool_use_id:_ ~tool_name:_ ~input:_ ~schedule:_ =
-    raise Sys.Break
-  in
+  let on_tool_execution_started ~invocation:_ ~tool_name:_ ~input:_ = raise Sys.Break in
   match
     run_execute_with_tools
       ~tools:[ make_echo_tool "safe" ]
@@ -226,10 +228,8 @@ let test_post_hook_observer_exception_propagates_after_completion () =
   let observer ~hook_name ~decision:_ ~detail:_ =
     if String.equal hook_name "post_tool_use" then failwith "post observer boom"
   in
-  let on_tool_execution_started ~tool_use_id:_ ~tool_name:_ ~input:_ ~schedule:_ =
-    incr started
-  in
-  let on_tool_execution_finished ~tool_use_id:_ ~tool_name:_ ~content:_ ~is_error:_ =
+  let on_tool_execution_started ~invocation:_ ~tool_name:_ ~input:_ = incr started in
+  let on_tool_execution_finished ~invocation:_ ~tool_name:_ ~content:_ ~is_error:_ =
     incr finished
   in
   check_raises
@@ -268,11 +268,10 @@ let test_post_hook_failure_is_typed_agent_error () =
       env
       ~tools:[ tool ]
       ~hooks
-      ~on_tool_execution_started:(fun ~tool_use_id:_ ~tool_name:_ ~input:_ ~schedule:_ ->
-        incr started)
+      ~on_tool_execution_started:(fun ~invocation:_ ~tool_name:_ ~input:_ -> incr started)
       ~on_tool_execution_finished:
         (fun
-          ~tool_use_id:_ ~tool_name:_ ~content:_ ~is_error:_ -> incr finished)
+          ~invocation:_ ~tool_name:_ ~content:_ ~is_error:_ -> incr finished)
       [ ToolUse { id = "t1"; name = "safe"; input = `Assoc [] } ]
   in
   (match result with
@@ -284,10 +283,11 @@ let test_post_hook_failure_is_typed_agent_error () =
                 { hook_name = "post_tool_use"
                 ; stage = Hooks.Post_tool_use
                 ; tool_name = "safe"
-                ; tool_use_id = "t1"
+                ; invocation
                 ; detail
                 })
        } ->
+     check string "hook invocation id" "t1" (Tool.Invocation.tool_use_id invocation);
      check
        bool
        "hook exception detail retained"
@@ -349,8 +349,8 @@ let test_concurrent_journal_failure_retains_sibling_results () =
         ]
       ~hooks:Hooks.empty
       ~journal
-      ~on_tool_execution_finished:(fun ~tool_use_id ~tool_name:_ ~content:_ ~is_error:_ ->
-        finished_ids := tool_use_id :: !finished_ids)
+      ~on_tool_execution_finished:(fun ~invocation ~tool_name:_ ~content:_ ~is_error:_ ->
+        finished_ids := Tool.Invocation.tool_use_id invocation :: !finished_ids)
       [ ToolUse { id = "t1"; name = "first"; input = `Assoc [] }
       ; ToolUse { id = "t2"; name = "sibling"; input = `Assoc [] }
       ; ToolUse { id = "t3"; name = "later_serial"; input = `Assoc [] }
@@ -361,8 +361,8 @@ let test_concurrent_journal_failure_retains_sibling_results () =
        { Agent_tools.completed_results = [ first; sibling ]
        ; cause = Agent_tools.Observer_failure { exception_; _ }
        } ->
-     check string "first result order" "t1" first.tool_use_id;
-     check string "sibling result order" "t2" sibling.tool_use_id;
+     check string "first result order" "t1" (result_id first);
+     check string "sibling result order" "t2" (result_id sibling);
      check string "first result retained" "first" first.content;
      check string "sibling result retained" "sibling" sibling.content;
      check
@@ -405,11 +405,10 @@ let test_block_emits_no_execution_lifecycle () =
     run_execute_with_tools
       ~tools:[ tool ]
       ~hooks
-      ~on_tool_execution_started:(fun ~tool_use_id:_ ~tool_name:_ ~input:_ ~schedule:_ ->
-        incr started)
+      ~on_tool_execution_started:(fun ~invocation:_ ~tool_name:_ ~input:_ -> incr started)
       ~on_tool_execution_finished:
         (fun
-          ~tool_use_id:_ ~tool_name:_ ~content:_ ~is_error:_ -> incr finished)
+          ~invocation:_ ~tool_name:_ ~content:_ ~is_error:_ -> incr finished)
       [ ToolUse { id = "t1"; name = "safe"; input = `Assoc [] } ]
   in
   (match results with
@@ -442,7 +441,7 @@ let test_block_is_deterministic_failure () =
   in
   match results with
   | [ result ] ->
-    check string "id" "t1" result.tool_use_id;
+    check string "id" "t1" (result_id result);
     check string "reason is verbatim" "caller denied" result.content;
     check bool "is error" true (tool_result_outcome_is_error result.outcome);
     (match result.outcome with
@@ -506,12 +505,12 @@ let test_non_tool_use_blocks_filtered () =
   (* Only the 2 ToolUse blocks should produce results *)
   check int "result count" 2 (List.length results);
   let sorted =
-    List.sort (fun a b -> String.compare a.Agent_tools.tool_use_id b.tool_use_id) results
+    List.sort (fun a b -> String.compare (result_id a) (result_id b)) results
   in
   match sorted with
   | [ first; second ] ->
-    check string "first id" "t1" first.tool_use_id;
-    check string "second id" "t2" second.tool_use_id
+    check string "first id" "t1" (result_id first);
+    check string "second id" "t2" (result_id second)
   | _ -> fail "expected exactly two results"
 ;;
 
@@ -753,11 +752,20 @@ let test_dispatch_passes_exact_tool_invocation () =
 ;;
 
 let invocation_key invocation =
+  let schedule = Tool.Invocation.schedule invocation in
+  let execution_mode =
+    match schedule.execution_mode with
+    | Tool.Concurrent -> "concurrent"
+    | Tool.Serial -> "serial"
+  in
   Printf.sprintf
-    "%S:%d:%d"
+    "%S:%d:%d:%d:%d:%s"
     (Tool.Invocation.tool_use_id invocation)
     (Tool.Invocation.turn invocation)
-    (Tool.Invocation.planned_index invocation)
+    schedule.planned_index
+    schedule.batch_index
+    schedule.batch_size
+    execution_mode
 ;;
 
 let test_lifecycle_surfaces_share_exact_tool_invocation () =
@@ -766,6 +774,9 @@ let test_lifecycle_surfaces_share_exact_tool_invocation () =
   let pre_invocations = ref [] in
   let post_invocations = ref [] in
   let failure_invocations = ref [] in
+  let handler_invocations = ref [] in
+  let started_invocations = ref [] in
+  let finished_invocations = ref [] in
   let capture target invocation = target := invocation_key invocation :: !target in
   let hooks =
     { Hooks.empty with
@@ -799,7 +810,15 @@ let test_lifecycle_surfaces_share_exact_tool_invocation () =
   in
   let subscription = Event_bus.subscribe ~config event_bus in
   let tool name result =
-    Tool.create ~name ~description:"" ~parameters:[] (fun _ -> result)
+    Tool.create_with_execution_env
+      ~name
+      ~description:""
+      ~parameters:[]
+      (fun execution_env _ ->
+         Option.iter
+           (capture handler_invocations)
+           (Tool.Execution_env.invocation execution_env);
+         result)
   in
   let success = Ok { Types.content = "done"; _meta = None } in
   let failure =
@@ -815,6 +834,10 @@ let test_lifecycle_surfaces_share_exact_tool_invocation () =
       ~tools:[ tool "exact_occurrence" success; tool "exact_failure" failure ]
       ~hooks
       ~event_bus
+      ~on_tool_execution_started:(fun ~invocation ~tool_name:_ ~input:_ ->
+        capture started_invocations invocation)
+      ~on_tool_execution_finished:(fun ~invocation ~tool_name:_ ~content:_ ~is_error:_ ->
+        capture finished_invocations invocation)
       [ ToolUse { id = ""; name = "exact_occurrence"; input = `Assoc [] }
       ; ToolUse { id = ""; name = "exact_occurrence"; input = `Assoc [] }
       ; ToolUse { id = ""; name = "exact_failure"; input = `Assoc [] }
@@ -832,8 +855,16 @@ let test_lifecycle_surfaces_share_exact_tool_invocation () =
       ([], [])
       (Event_bus.drain subscription)
   in
-  let expected_all = [ "\"\":0:0"; "\"\":0:1"; "\"\":0:2" ] in
-  let expected_failure = [ "\"\":0:2" ] in
+  let expected_all =
+    [ "\"\":0:0:0:1:serial"; "\"\":0:1:1:1:serial"; "\"\":0:2:2:1:serial" ]
+  in
+  let expected_failure = [ "\"\":0:2:2:1:serial" ] in
+  let result_invocations =
+    List.map
+      (fun (result : Agent_tools.tool_execution_result) ->
+         invocation_key result.invocation)
+      results
+  in
   let check_occurrences label expected actual =
     check (list string) label expected (List.rev actual)
   in
@@ -844,7 +875,11 @@ let test_lifecycle_surfaces_share_exact_tool_invocation () =
     expected_failure
     !failure_invocations;
   check_occurrences "ToolCalled exact occurrences" expected_all called_invocations;
-  check_occurrences "ToolCompleted exact occurrences" expected_all completed_invocations
+  check_occurrences "ToolCompleted exact occurrences" expected_all completed_invocations;
+  check_occurrences "handler exact occurrences" expected_all !handler_invocations;
+  check_occurrences "start callback exact occurrences" expected_all !started_invocations;
+  check_occurrences "finish callback exact occurrences" expected_all !finished_invocations;
+  check (list string) "result exact occurrences" expected_all result_invocations
 ;;
 
 let test_tool_exception_still_publishes_tool_completed () =
@@ -882,10 +917,10 @@ let test_tool_exception_still_publishes_tool_completed () =
       (fun (event : Event_bus.event) -> event.payload)
       (Event_bus.drain subscription)
   with
-  | [ ToolCalled { tool_name = "boom"; tool_use_id = called_id; _ }
+  | [ ToolCalled { tool_name = "boom"; invocation = called; _ }
     ; ToolCompleted
         { tool_name = "boom"
-        ; tool_use_id = completed_id
+        ; invocation = completed
         ; output = Error { message; recoverable = false; error_class = Some Unknown }
         ; _
         }
@@ -895,10 +930,18 @@ let test_tool_exception_still_publishes_tool_completed () =
       "completion event reports exception"
       true
       (contains_substring ~needle:"Tool 'boom' raised" message);
-    (* Both events carry the provider tool_use id, so subscribers can
-       join called/completed pairs (and hook-side records) on it. *)
-    check string "ToolCalled carries the provider id" "t1" called_id;
-    check string "ToolCompleted carries the provider id" "t1" completed_id
+    (* Both events carry the same exact occurrence, while the provider ID
+       remains available as a boundary projection. *)
+    check
+      string
+      "ToolCalled carries the provider id"
+      "t1"
+      (Tool.Invocation.tool_use_id called);
+    check
+      string
+      "ToolCompleted carries the provider id"
+      "t1"
+      (Tool.Invocation.tool_use_id completed)
   | _ -> fail "expected ToolCalled followed by ToolCompleted error"
 ;;
 


### PR DESCRIPTION
## What

- add a private Agent-owned settlement authority for one exact `Tool.Invocation.schedule`
- atomically fence the first attempt before any Tool effect can run
- commit attempt closure, canonical `ToolResult`, and invocation closure in one journal batch
- reject schedule mismatch, replay conflict, and stale settlement explicitly

## Boundary

`execution_tool_settlement` is listed in `private_modules`; callers cannot synthesize settlement through the public SDK. The contract is generic run/node/tool-occurrence state and contains no MASC product vocabulary or risk hierarchy. This is stacked on #2648.

## Validation

- `scripts/dune-local.sh exec test/test_execution_lane_writer.exe` — 18/18 green, including exact settlement authority cases
- all touched OCaml files pass `ocamlformat --check`
- `git diff --check` clean
- leaf diff: 396 changed lines

## Not claimed

This is an internal prerequisite only. It does not yet wire production `Agent` execution, expose public pending-tool resume, or hard-cut legacy `Durable_event` writers. Those remain explicit follow-up leaves.