### PR TITLE
feat(execution): fence provider and tool effects

### DIFF
--- a/lib/execution_tool_settlement.ml
+++ b/lib/execution_tool_settlement.ml
@@ -23,6 +23,7 @@ type error =
   | Authority_unavailable of Writer.read_error
   | Invocation_not_found
   | Invocation_identity_mismatch
+  | Effect_outcome_unknown
   | Attempt_admission_failed of Writer.submit_error
   | Attempt_commit_failed of Writer.ticket_error
   | Receipt_admission_outcome_unknown of Writer.submit_error
@@ -33,6 +34,10 @@ type receipt =
   ; result : Llm_provider.Types.content_block
   ; through : Journal.cursor
   }
+
+type execution =
+  | Executed of receipt
+  | Replayed of Llm_provider.Types.content_block
 
 let read_node writer node =
   match Writer.find_node writer node with
@@ -143,4 +148,17 @@ let settle attempt ~result =
      | Error error -> Error (Receipt_settlement_outcome_unknown error)
      | Ok committed ->
        Ok { invocation = authority.invocation; result; through = committed.through })
+;;
+
+let execute authority ~invoke =
+  let open Result_syntax in
+  let* current = status authority in
+  match current with
+  | Settled result -> Ok (Replayed result)
+  | Outcome_unknown -> Error Effect_outcome_unknown
+  | Ready_to_execute ->
+    let* attempt = begin_attempt authority in
+    let result = invoke () in
+    let+ receipt = settle attempt ~result in
+    Executed receipt
 ;;

--- a/lib/execution_tool_settlement.mli
+++ b/lib/execution_tool_settlement.mli
@@ -1,7 +1,6 @@
-(** Private authority: handlers run only after [begin_attempt] returns. *)
+(** Private authority: [execute] commits the exact attempt before invoking a handler. *)
 
 type t
-type attempt
 
 type status =
   | Ready_to_execute
@@ -12,6 +11,7 @@ type error =
   | Authority_unavailable of Execution_lane_writer.read_error
   | Invocation_not_found
   | Invocation_identity_mismatch
+  | Effect_outcome_unknown
   | Attempt_admission_failed of Execution_lane_writer.submit_error
   | Attempt_commit_failed of Execution_lane_writer.ticket_error
   | Receipt_admission_outcome_unknown of Execution_lane_writer.submit_error
@@ -23,6 +23,10 @@ type receipt = private
   ; through : Execution_journal.cursor
   }
 
+type execution =
+  | Executed of receipt
+  | Replayed of Llm_provider.Types.content_block
+
 val create
   :  writer:Execution_lane_writer.t
   -> run:Execution_journal.run
@@ -31,5 +35,15 @@ val create
   -> (t, error) result
 
 val status : t -> (status, error) result
-val begin_attempt : t -> (attempt, error) result
-val settle : attempt -> result:Llm_provider.Types.content_block -> (receipt, error) result
+
+(** [execute authority ~invoke] commits
+    the exact attempt before invoking [invoke], then atomically settles the
+    canonical result. A previously settled invocation is replayed without
+    invoking [invoke]. An open prior attempt is returned explicitly as
+    [Effect_outcome_unknown]; it is never retried. Exceptions from [invoke]
+    propagate with their original backtrace and leave that committed attempt
+    open, so a later caller observes the unknown outcome. *)
+val execute
+  :  t
+  -> invoke:(unit -> Llm_provider.Types.content_block)
+  -> (execution, error) result

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -135,6 +135,7 @@ let stage_route
       ~api_strategy
       ?raw_trace_run
       ?on_provider_failure
+      ?before_provider_attempt
       ~turn_config
       agent
       prep
@@ -157,6 +158,7 @@ let stage_route
            ?clock
            ~trace_context
            ?on_provider_failure
+           ?before_provider_attempt
            ~turn_config
            agent
            prep)
@@ -184,6 +186,7 @@ let stage_route
            ?capture_id
            ?on_telemetry
            ?on_provider_failure
+           ?before_provider_attempt
            ())
 ;;
 
@@ -550,6 +553,7 @@ let run_turn
       ~api_strategy
       ?raw_trace_run
       ?on_provider_failure
+      ?before_provider_attempt
       ?before_tool_execution
       agent
   =
@@ -609,6 +613,7 @@ let run_turn
         ~api_strategy
         ?raw_trace_run
         ?on_provider_failure
+        ?before_provider_attempt
         ~turn_config
         agent
         prep

--- a/lib/pipeline/pipeline.mli
+++ b/lib/pipeline/pipeline.mli
@@ -35,13 +35,18 @@ val persist_turn_checkpoint_for_state
     [before_tool_execution], when present, runs exactly once for a non-empty
     tool batch after assistant collection has committed successfully and before
     the first tool hook or implementation starts.  Exceptions propagate and
-    prevent tool execution. *)
+    prevent tool execution.
+
+    [before_provider_attempt], when present, receives the exact immutable
+    binding selected for dispatch after configuration resolution and before
+    provider I/O. A typed rejection prevents that provider attempt. *)
 val run_turn
   :  sw:Eio.Switch.t
   -> ?clock:_ Eio.Time.clock
   -> api_strategy:api_strategy
   -> ?raw_trace_run:Raw_trace.active_run
   -> ?on_provider_failure:(Provider_failure_attribution.t option -> unit)
+  -> ?before_provider_attempt:(Binding_identity.t -> (unit, Error.sdk_error) result)
   -> ?before_tool_execution:(unit -> unit)
   -> Agent_types.t
   -> (turn_outcome, Error.sdk_error) result

--- a/lib/pipeline/pipeline_stage_route.ml
+++ b/lib/pipeline/pipeline_stage_route.ml
@@ -20,6 +20,12 @@ let binding_identity_for_call agent provider_config =
   Binding_identity.of_provider_config ~transport provider_config
 ;;
 
+let admit_provider_attempt callback binding =
+  match callback with
+  | None -> Ok ()
+  | Some callback -> callback binding
+;;
+
 let provider_config_for_turn ~turn_config agent =
   match agent.provider_config with
   | Some provider_config ->
@@ -36,6 +42,7 @@ let dispatch_sync
       ?clock
       ?(trace_context = [])
       ?on_provider_failure
+      ?before_provider_attempt
       ~turn_config
       agent
       (prep : Agent_turn.turn_preparation)
@@ -52,6 +59,7 @@ let dispatch_sync
       binding_identity_for_call agent pc
       |> Result.map_error (binding_identity_error ?on_provider_failure)
     in
+    let* () = admit_provider_attempt before_provider_attempt binding in
     let call () =
       Llm_provider.Complete.complete
         ~sw
@@ -86,6 +94,7 @@ let dispatch_stream
       ?(trace_context = [])
       ?on_telemetry
       ?on_provider_failure
+      ?before_provider_attempt
       ()
   =
   let ( let* ) = Result.bind in
@@ -100,6 +109,7 @@ let dispatch_stream
       binding_identity_for_call agent pc
       |> Result.map_error (binding_identity_error ?on_provider_failure)
     in
+    let* () = admit_provider_attempt before_provider_attempt binding in
     let call () =
       Llm_provider.Complete.complete_stream
         ~sw

--- a/test/test_execution_lane_writer.ml
+++ b/test/test_execution_lane_writer.ml
@@ -13,6 +13,7 @@ module Tx = Journal.Transaction
 exception Cancel_waiter
 exception Cancel_scope
 exception Callback_failed
+exception Effect_raised
 
 let require_submit = function
   | Ok ticket -> ticket
@@ -199,7 +200,7 @@ let test_exact_tool_settlement_authority () =
       in
       let open_invocation planned_index =
         let schedule : Hooks.tool_schedule =
-          { planned_index; batch_index = 0; batch_size = 2; execution_mode = Tool.Serial }
+          { planned_index; batch_index = 0; batch_size = 3; execution_mode = Tool.Serial }
         in
         let node, _ =
           (submit_and_await
@@ -225,6 +226,7 @@ let test_exact_tool_settlement_authority () =
       in
       let first_node, first_invocation = open_invocation 0 in
       let second_node, second_invocation = open_invocation 1 in
+      let third_node, third_invocation = open_invocation 2 in
       let authority node invocation =
         match Settlement.create ~writer ~run ~invocation_node:node ~invocation with
         | Ok authority -> authority
@@ -232,20 +234,14 @@ let test_exact_tool_settlement_authority () =
       in
       let first = authority first_node first_invocation in
       let second = authority second_node second_invocation in
-      (match Settlement.status first, Settlement.status second with
-       | Ok Settlement.Ready_to_execute, Ok Settlement.Ready_to_execute -> ()
+      let third = authority third_node third_invocation in
+      (match
+         Settlement.status first, Settlement.status second, Settlement.status third
+       with
+       | ( Ok Settlement.Ready_to_execute
+         , Ok Settlement.Ready_to_execute
+         , Ok Settlement.Ready_to_execute ) -> ()
        | _ -> fail "blank-id occurrences were not independently ready");
-      let attempt =
-        match Settlement.begin_attempt first with
-        | Ok attempt -> attempt
-        | Error _ -> fail "durable attempt admission failed"
-      in
-      (match Settlement.status first with
-       | Ok Settlement.Outcome_unknown -> ()
-       | _ -> fail "open effect attempt was not outcome-unknown");
-      (match Settlement.begin_attempt first with
-       | Error _ -> ()
-       | Ok _ -> fail "a second effect attempt was admitted");
       let seq = Journal.cursor_seq in
       let before = Writer.current_cursor writer |> Result.get_ok in
       let result =
@@ -257,12 +253,43 @@ let test_exact_tool_settlement_authority () =
           ; content_blocks = None
           }
       in
-      (match Settlement.settle attempt ~result with
-       | Ok receipt ->
-         check int "three settlement facts" (seq before + 3) (seq receipt.through)
+      let effect_calls = ref 0 in
+      (match
+         Settlement.execute first ~invoke:(fun () ->
+           incr effect_calls;
+           (match Settlement.status first with
+            | Ok Settlement.Outcome_unknown -> ()
+            | _ -> fail "effect ran before its attempt became durable");
+           result)
+       with
+       | Ok (Settlement.Executed receipt) ->
+         check
+           int
+           "attempt plus three settlement facts"
+           (seq before + 4)
+           (seq receipt.through)
+       | Ok (Settlement.Replayed _) -> fail "fresh effect was reported as replayed"
        | Error _ -> fail "canonical result settlement failed");
-      match Settlement.status first, Settlement.status second with
-      | Ok (Settlement.Settled committed), Ok Settlement.Ready_to_execute ->
+      (match Settlement.execute first ~invoke:(fun () -> fail "replay reran effect") with
+       | Ok (Settlement.Replayed committed) ->
+         check bool "exact replay retained" true (committed = result)
+       | Ok (Settlement.Executed _) -> fail "settled effect executed twice"
+       | Error _ -> fail "settled effect did not replay");
+      check int "effect ran once" 1 !effect_calls;
+      (match Settlement.execute third ~invoke:(fun () -> raise Effect_raised) with
+       | exception Effect_raised -> ()
+       | Ok _ | Error _ -> fail "effect exception did not propagate");
+      (match
+         Settlement.execute third ~invoke:(fun () -> fail "unknown effect retried")
+       with
+       | Error Settlement.Effect_outcome_unknown -> ()
+       | Ok _ | Error _ -> fail "unknown effect outcome was not fenced");
+      match
+        Settlement.status first, Settlement.status second, Settlement.status third
+      with
+      | ( Ok (Settlement.Settled committed)
+        , Ok Settlement.Ready_to_execute
+        , Ok Settlement.Outcome_unknown ) ->
         check bool "exact result retained" true (committed = result)
       | _ -> fail "settlement crossed repeated blank-id occurrences"))
 ;;

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -211,8 +211,7 @@ let transport_returning response =
   }
 ;;
 
-let make_pipeline_test_agent ~net ~response =
-  let transport = transport_returning response in
+let make_pipeline_test_agent_with_transport ~net ~transport =
   let options =
     { Internal_agent.default_options with
       transport = Some transport
@@ -233,6 +232,10 @@ let make_pipeline_test_agent ~net ~response =
     agent
     { (Internal_agent.state agent) with messages = [ Types.user_msg "hello" ] };
   agent
+;;
+
+let make_pipeline_test_agent ~net ~response =
+  make_pipeline_test_agent_with_transport ~net ~transport:(transport_returning response)
 ;;
 
 let test_pipeline_sends_exact_supplied_tools () =
@@ -282,6 +285,100 @@ let test_pipeline_sends_exact_supplied_tools () =
     "provider receives exact caller tool schemas"
     true
     (Option.equal (List.equal Yojson.Safe.equal) (Some expected) !captured)
+;;
+
+let test_provider_attempt_boundary_precedes_dispatch () =
+  Eio_main.run
+  @@ fun env ->
+  List.iter
+    (fun (label, strategy) ->
+       Eio.Switch.run
+       @@ fun sw ->
+       let admitted = ref None in
+       let transport_calls = ref 0 in
+       let response = pipeline_response EndTurn in
+       let verify_request request =
+         incr transport_calls;
+         let expected =
+           Binding_identity.of_provider_config
+             ~transport:(Binding_identity.transport_for_call ~injected:true)
+             request.Llm_provider.Llm_transport.config
+         in
+         match expected, !admitted with
+         | Ok expected, Some observed ->
+           Alcotest.(check bool)
+             (label ^ " exact binding admitted before I/O")
+             true
+             (Binding_identity.equal expected observed)
+         | Error detail, _ -> Alcotest.fail detail
+         | Ok _, None -> Alcotest.fail (label ^ " provider I/O preceded admission")
+       in
+       let transport : Llm_provider.Llm_transport.t =
+         { complete_sync =
+             (fun request ->
+               verify_request request;
+               { response = Ok response; latency_ms = Some 0 })
+         ; complete_stream =
+             (fun ?on_telemetry:_ ~on_event:_ request ->
+               verify_request request;
+               Ok response)
+         }
+       in
+       let agent =
+         make_pipeline_test_agent_with_transport ~net:(Eio.Stdenv.net env) ~transport
+       in
+       let before_provider_attempt binding =
+         admitted := Some binding;
+         Ok ()
+       in
+       (match
+          Internal_pipeline.run_turn
+            ~sw
+            ~api_strategy:strategy
+            ~before_provider_attempt
+            agent
+        with
+        | Ok (Internal_pipeline.Complete _) -> ()
+        | Ok (Internal_pipeline.ToolsExecuted _) ->
+          Alcotest.fail (label ^ " expected terminal response")
+        | Error error -> Alcotest.fail (Error.to_string error));
+       Alcotest.(check int) (label ^ " one admission") 1 !transport_calls)
+    [ "sync", Internal_pipeline.Sync
+    ; "stream", Internal_pipeline.Stream { on_event = ignore; on_telemetry = None }
+    ]
+;;
+
+let test_provider_attempt_rejection_prevents_dispatch () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let transport_calls = ref 0 in
+  let response = pipeline_response EndTurn in
+  let transport : Llm_provider.Llm_transport.t =
+    { complete_sync =
+        (fun _request ->
+          incr transport_calls;
+          { response = Ok response; latency_ms = Some 0 })
+    ; complete_stream = (fun ?on_telemetry:_ ~on_event:_ _request -> Ok response)
+    }
+  in
+  let agent =
+    make_pipeline_test_agent_with_transport ~net:(Eio.Stdenv.net env) ~transport
+  in
+  let rejection = Error.Internal "provider attempt journal rejected" in
+  (match
+     Internal_pipeline.run_turn
+       ~sw
+       ~api_strategy:Internal_pipeline.Sync
+       ~before_provider_attempt:(fun _binding -> Error rejection)
+       agent
+   with
+   | Error (Error.Internal detail) ->
+     Alcotest.(check string) "exact rejection" "provider attempt journal rejected" detail
+   | Error error -> Alcotest.fail (Error.to_string error)
+   | Ok _ -> Alcotest.fail "provider attempt rejection was ignored");
+  Alcotest.(check int) "provider I/O prevented" 0 !transport_calls
 ;;
 
 let unwrap_raw_trace = function
@@ -1099,6 +1196,14 @@ let () =
             "provider receives exact supplied tools"
             `Quick
             test_pipeline_sends_exact_supplied_tools
+        ; Alcotest.test_case
+            "provider attempt boundary precedes dispatch"
+            `Quick
+            test_provider_attempt_boundary_precedes_dispatch
+        ; Alcotest.test_case
+            "provider attempt rejection prevents dispatch"
+            `Quick
+            test_provider_attempt_rejection_prevents_dispatch
         ; Alcotest.test_case
             "output rejects unknown terminal"
             `Quick


### PR DESCRIPTION
## What

- replace externally composable `begin_attempt`/`settle` with private `Settlement.execute`
- enforce `attempt commit → Tool effect → atomic settle` in one authority
- return exact replay without rerunning the effect and surface an open attempt as typed `Effect_outcome_unknown`
- add a typed `before_provider_attempt` boundary carrying the exact `Binding_identity.t` before sync or stream provider I/O
- ensure callback rejection prevents provider I/O

## Boundary

The settlement implementation remains private and generic. No MASC, Keeper, Gate, vendor, command, path inference, risk level, cap, or heuristic enters OAS. This is stacked on #2649.

## Validation

- focused `test_execution_lane_writer.exe` build green; direct 18/18 green
- focused `test_pipeline.exe` build green; direct 39/39 green
- all touched files pass `ocamlformat --check`
- `git diff --check` clean
- leaf diff: 236 changed lines

## Honest status

This is still a prerequisite, not production Journal wiring. OAS does not yet have an Agent-owned `Execution_journal` scope/factory and neither new boundary has a production producer. Legacy `Durable_event` Tool_called/Tool_completed, direct Raw_trace lifecycle writes, and Journal_bridge remain live. They can only be hard-cut after one Agent scope owns run/turn/provider/invocation topology without leaking private modules or inferring storage paths.