### PR TITLE
feat(execution): add private Agent journal scope

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -15,6 +15,7 @@
   execution_event_store
   execution_journal
   execution_lane_writer
+  execution_agent_scope
   execution_tool_settlement)
  (libraries
   llm_provider

--- a/lib/execution_agent_scope.ml
+++ b/lib/execution_agent_scope.ml
@@ -1,0 +1,127 @@
+module Event = Execution_event
+module Journal = Execution_journal
+module Settlement = Execution_tool_settlement
+module Writer = Execution_lane_writer
+module Tx = Journal.Transaction
+
+type t =
+  { writer : Writer.t
+  ; run : Journal.run
+  }
+
+type turn =
+  { scope : t
+  ; node : Event.Node_id.t
+  }
+
+type provider_attempt =
+  { turn : turn
+  ; node : Event.Node_id.t
+  }
+
+type invocation = { authority : Settlement.t }
+
+type error =
+  | Admission_failed of Writer.submit_error
+  | Mutation_failed of Writer.ticket_error
+  | Invalid_provider_attempt of string
+  | Settlement_failed of Settlement.error
+
+let settlement_error_to_string = function
+  | Settlement.Authority_unavailable error -> Writer.read_error_to_string error
+  | Settlement.Invocation_not_found -> "execution invocation was not found"
+  | Settlement.Invocation_identity_mismatch -> "execution invocation identity mismatch"
+  | Settlement.Effect_outcome_unknown -> "tool effect outcome is unknown"
+  | Settlement.Attempt_admission_failed error -> Writer.submit_error_to_string error
+  | Settlement.Attempt_commit_failed error -> Writer.ticket_error_to_string error
+  | Settlement.Receipt_admission_outcome_unknown error ->
+    Writer.submit_error_to_string error
+  | Settlement.Receipt_settlement_outcome_unknown error ->
+    Writer.ticket_error_to_string error
+;;
+
+let error_to_string = function
+  | Admission_failed error -> Writer.submit_error_to_string error
+  | Mutation_failed error -> Writer.ticket_error_to_string error
+  | Invalid_provider_attempt detail -> "invalid provider attempt: " ^ detail
+  | Settlement_failed error -> settlement_error_to_string error
+;;
+
+let transact writer transaction =
+  match Writer.submit writer transaction with
+  | Error error -> Error (Admission_failed error)
+  | Ok ticket ->
+    (match Writer.await ticket with
+     | Error error -> Error (Mutation_failed error)
+     | Ok receipt -> Ok receipt.value)
+;;
+
+let start ~writer ~agent_name =
+  Result.map
+    (fun (run, _event) -> { writer; run })
+    (transact writer (Tx.start_run ~agent_name ()))
+;;
+
+let open_turn scope ~ordinal =
+  transact
+    scope.writer
+    (Tx.open_node
+       ~run:scope.run
+       ~parent:(Journal.run_root scope.run)
+       ~kind:(Event.Agent_turn { ordinal })
+       ())
+  |> Result.map (fun (node, _event) -> { scope; node })
+;;
+
+let before_provider_attempt turn ~ordinal binding =
+  match Event.provider_attempt ~ordinal binding with
+  | Error detail -> Error (Invalid_provider_attempt detail)
+  | Ok kind ->
+    transact
+      turn.scope.writer
+      (Tx.open_node ~run:turn.scope.run ~parent:turn.node ~kind ())
+    |> Result.map (fun (node, _event) -> { turn; node })
+;;
+
+let open_invocation provider ~invocation ~tool_name ~input =
+  let scope = provider.turn.scope in
+  match
+    transact
+      scope.writer
+      (Tx.open_tool_invocation
+         ~run:scope.run
+         ~provider_attempt:provider.node
+         ~invocation
+         ~tool_name
+         ~input
+         ())
+  with
+  | Error _ as error -> error
+  | Ok (node, _events) ->
+    Settlement.create
+      ~writer:scope.writer
+      ~run:scope.run
+      ~invocation_node:node
+      ~invocation
+    |> Result.map (fun authority -> { authority })
+    |> Result.map_error (fun error -> Settlement_failed error)
+;;
+
+let execute invocation ~invoke =
+  Settlement.execute invocation.authority ~invoke
+  |> Result.map_error (fun error -> Settlement_failed error)
+;;
+
+let close_node writer node terminal =
+  transact writer (Tx.close_node ~node terminal) |> Result.map ignore
+;;
+
+let close_provider_attempt provider terminal =
+  close_node provider.turn.scope.writer provider.node terminal
+;;
+
+let close_turn turn terminal = close_node turn.scope.writer turn.node terminal
+
+let finish scope terminal =
+  transact scope.writer (Tx.finish_run ~run:scope.run terminal) |> Result.map ignore
+;;

--- a/lib/execution_agent_scope.mli
+++ b/lib/execution_agent_scope.mli
@@ -1,0 +1,50 @@
+(** Private typed ownership chain for one Agent execution journal. Construction
+    requires an owned durable writer and never discovers paths or product policy.
+    Abstract descendants cannot be moved across another scope. *)
+
+type t
+type turn
+type provider_attempt
+type invocation
+
+type error =
+  | Admission_failed of Execution_lane_writer.submit_error
+  | Mutation_failed of Execution_lane_writer.ticket_error
+  | Invalid_provider_attempt of string
+  | Settlement_failed of Execution_tool_settlement.error
+
+val error_to_string : error -> string
+
+(** Start the sole top-level Agent run in [writer]. *)
+val start : writer:Execution_lane_writer.t -> agent_name:string -> (t, error) result
+
+val open_turn : t -> ordinal:int -> (turn, error) result
+
+(** Durable producer for Pipeline's exact [before_provider_attempt] boundary. *)
+val before_provider_attempt
+  :  turn
+  -> ordinal:int
+  -> Binding_identity.t
+  -> (provider_attempt, error) result
+
+(** Atomically open an invocation and materialize the exact ToolUse input. *)
+val open_invocation
+  :  provider_attempt
+  -> invocation:Tool.Invocation.t
+  -> tool_name:string
+  -> input:Yojson.Safe.t
+  -> (invocation, error) result
+
+(** The only effect boundary: durable attempt, invoke once, atomic settlement. *)
+val execute
+  :  invocation
+  -> invoke:(unit -> Llm_provider.Types.content_block)
+  -> (Execution_tool_settlement.execution, error) result
+
+val close_provider_attempt
+  :  provider_attempt
+  -> Execution_event.terminal
+  -> (unit, error) result
+
+val close_turn : turn -> Execution_event.terminal -> (unit, error) result
+val finish : t -> Execution_event.terminal -> (unit, error) result

--- a/lib/execution_journal.ml
+++ b/lib/execution_journal.ml
@@ -1370,6 +1370,70 @@ let stage_close_node ?causes journal state ~node terminal =
       payload
 ;;
 
+let stage_open_tool_invocation
+      journal
+      state
+      ~run
+      ~provider_attempt
+      ~invocation
+      ~tool_name
+      ~input
+  =
+  let* provider_record = node_record_or_error state provider_attempt in
+  let* turn_node =
+    match
+      Event.node_kind provider_record.node, Event.parent_node_id provider_record.node
+    with
+    | Event.Provider_attempt _, Some turn_node -> Ok turn_node
+    | Event.Provider_attempt _, None
+    | ( ( Event.Agent_run _
+        | Event.Agent_turn _
+        | Event.Output_block _
+        | Event.Tool_invocation _
+        | Event.Tool_attempt )
+      , _ ) -> Error (Invalid_argument "tool invocation requires a Provider_attempt node")
+  in
+  let* turn_record = node_record_or_error state turn_node in
+  let* () =
+    match Event.node_kind turn_record.node with
+    | Event.Agent_turn { ordinal } when ordinal = Tool.Invocation.turn invocation -> Ok ()
+    | Event.Agent_turn _ ->
+      Error (Invalid_argument "tool invocation turn does not match its Agent_turn")
+    | Event.Agent_run _
+    | Event.Provider_attempt _
+    | Event.Output_block _
+    | Event.Tool_invocation _
+    | Event.Tool_attempt ->
+      Error (Invalid_argument "provider attempt parent is not an Agent_turn")
+  in
+  let provider_tool_use_id = Some (Tool.Invocation.tool_use_id invocation) in
+  let schedule = Tool.Invocation.schedule invocation in
+  let* opened =
+    stage_open_node
+      journal
+      state
+      ~run
+      ~parent:provider_attempt
+      ~kind:(Event.Tool_invocation { provider_tool_use_id; tool_name; schedule })
+  in
+  let invocation_node, opened_event = opened.value in
+  let input_block =
+    Llm_provider.Types.ToolUse
+      { id = Tool.Invocation.tool_use_id invocation; name = tool_name; input }
+  in
+  let+ materialized =
+    stage_update_node
+      journal
+      opened.next_state
+      ~node:invocation_node
+      (Event.Tool_input_snapshot input_block)
+  in
+  { next_state = materialized.next_state
+  ; events = [ opened_event; materialized.value ]
+  ; value = invocation_node, [ opened_event; materialized.value ]
+  }
+;;
+
 let stage_begin_tool_attempt journal state ~run ~invocation =
   let* invocation_record = node_record_or_error state invocation in
   let* () =
@@ -1592,6 +1656,14 @@ module Transaction = struct
         ; terminal : Event.terminal
         }
         -> Event.t t
+    | Open_tool_invocation :
+        { run : run
+        ; provider_attempt : Event.Node_id.t
+        ; invocation : Tool.Invocation.t
+        ; tool_name : string
+        ; input : Yojson.Safe.t
+        }
+        -> (Event.Node_id.t * Event.t list) t
     | Begin_tool_attempt :
         { run : run
         ; invocation : Event.Node_id.t
@@ -1626,6 +1698,11 @@ module Transaction = struct
 
   let update_node ?(causes = []) ~node update = Update_node { causes; node; update }
   let close_node ?(causes = []) ~node terminal = Close_node { causes; node; terminal }
+
+  let open_tool_invocation ~run ~provider_attempt ~invocation ~tool_name ~input () =
+    Open_tool_invocation { run; provider_attempt; invocation; tool_name; input }
+  ;;
+
   let begin_tool_attempt ~run ~invocation () = Begin_tool_attempt { run; invocation }
 
   let settle_tool_attempt ~attempt ~invocation ~result () =
@@ -1660,6 +1737,17 @@ let stage : type value. batch -> value Transaction.t -> (batch * value, error) r
   | Transaction.Close_node { causes; node; terminal } ->
     stage_mutation
       (stage_close_node ~causes batch.journal batch.staged_state ~node terminal)
+  | Transaction.Open_tool_invocation
+      { run; provider_attempt; invocation; tool_name; input } ->
+    stage_mutation
+      (stage_open_tool_invocation
+         batch.journal
+         batch.staged_state
+         ~run
+         ~provider_attempt
+         ~invocation
+         ~tool_name
+         ~input)
   | Transaction.Begin_tool_attempt { run; invocation } ->
     stage_mutation
       (stage_begin_tool_attempt batch.journal batch.staged_state ~run ~invocation)

--- a/lib/execution_journal.mli
+++ b/lib/execution_journal.mli
@@ -320,6 +320,17 @@ module Transaction : sig
     -> Execution_event.terminal
     -> Execution_event.t t
 
+  (** Atomically open one exact Tool invocation and materialize its canonical
+      ToolUse input. A rejected input leaves no partial invocation node. *)
+  val open_tool_invocation
+    :  run:run
+    -> provider_attempt:Execution_event.Node_id.t
+    -> invocation:Tool.Invocation.t
+    -> tool_name:string
+    -> input:Yojson.Safe.t
+    -> unit
+    -> (Execution_event.Node_id.t * Execution_event.t list) t
+
   val begin_tool_attempt
     :  run:run
     -> invocation:Execution_event.Node_id.t

--- a/test/test_execution_lane_writer.ml
+++ b/test/test_execution_lane_writer.ml
@@ -8,6 +8,7 @@ module Journal = Internal.Execution_journal
 module Store = Internal.Execution_event_store
 module Writer = Internal.Execution_lane_writer
 module Settlement = Internal.Execution_tool_settlement
+module Agent_scope = Internal.Execution_agent_scope
 module Tx = Journal.Transaction
 
 exception Cancel_waiter
@@ -33,6 +34,11 @@ let require_closed = function
 let require_scope = function
   | Ok value -> value
   | Error error -> fail (Writer.scope_failure_to_string error)
+;;
+
+let require_agent_scope = function
+  | Ok value -> value
+  | Error error -> fail (Agent_scope.error_to_string error)
 ;;
 
 let with_fresh codec dir f =
@@ -292,6 +298,118 @@ let test_exact_tool_settlement_authority () =
         , Ok Settlement.Outcome_unknown ) ->
         check bool "exact result retained" true (committed = result)
       | _ -> fail "settlement crossed repeated blank-id occurrences"))
+;;
+
+let test_agent_scope_owns_effect_boundaries () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun codec dir ->
+    make_dir dir;
+    with_fresh codec dir (fun _sw writer ->
+      let scope = require_agent_scope (Agent_scope.start ~writer ~agent_name:"agent") in
+      let before = cursor_at (Writer.current_cursor writer |> Result.get_ok) 0 in
+      let turn = require_agent_scope (Agent_scope.open_turn scope ~ordinal:3) in
+      let config =
+        Llm_provider.Provider_config.make
+          ~kind:Llm_provider.Provider_kind.OpenAI_compat
+          ~provider_id:"scope-provider"
+          ~model_id:"scope-model"
+          ~base_url:"https://provider.test"
+          ()
+      in
+      let binding =
+        Binding_identity.of_provider_config
+          ~transport:(Binding_identity.transport_for_call ~injected:false)
+          config
+        |> require_codec
+      in
+      let provider =
+        require_agent_scope (Agent_scope.before_provider_attempt turn ~ordinal:0 binding)
+      in
+      let schedule : Tool.schedule =
+        { planned_index = 0
+        ; batch_index = 0
+        ; batch_size = 1
+        ; execution_mode = Tool.Serial
+        }
+      in
+      let wrong_turn = Tool.Invocation.create ~tool_use_id:"" ~turn:4 ~schedule in
+      (match
+         Agent_scope.open_invocation
+           provider
+           ~invocation:wrong_turn
+           ~tool_name:"effect"
+           ~input:`Null
+       with
+       | Error _ -> ()
+       | Ok _ -> fail "mismatched invocation turn entered the scope");
+      check
+        int
+        "rejected invocation left no partial node"
+        3
+        (Writer.current_cursor writer |> Result.get_ok |> Journal.cursor_seq);
+      let exact_invocation = Tool.Invocation.create ~tool_use_id:"" ~turn:3 ~schedule in
+      let invocation =
+        require_agent_scope
+          (Agent_scope.open_invocation
+             provider
+             ~invocation:exact_invocation
+             ~tool_name:"effect"
+             ~input:(`Assoc [ "value", `Int 7 ]))
+      in
+      let result =
+        Types.ToolResult
+          { tool_use_id = ""
+          ; content = "done"
+          ; outcome = Types.Tool_succeeded
+          ; json = None
+          ; content_blocks = None
+          }
+      in
+      let calls = ref 0 in
+      (match
+         Agent_scope.execute invocation ~invoke:(fun () ->
+           incr calls;
+           result)
+       with
+       | Ok (Settlement.Executed _) -> ()
+       | Ok (Settlement.Replayed _) -> fail "fresh scoped effect was replayed"
+       | Error error -> fail (Agent_scope.error_to_string error));
+      (match Agent_scope.execute invocation ~invoke:(fun () -> fail "effect reran") with
+       | Ok (Settlement.Replayed replayed) ->
+         check bool "exact scoped result replayed" true (replayed = result)
+       | Ok (Settlement.Executed _) -> fail "scoped effect executed twice"
+       | Error error -> fail (Agent_scope.error_to_string error));
+      check int "scoped effect call count" 1 !calls;
+      require_agent_scope (Agent_scope.close_provider_attempt provider Event.Succeeded);
+      require_agent_scope (Agent_scope.close_turn turn Event.Succeeded);
+      require_agent_scope (Agent_scope.finish scope Event.Succeeded);
+      let events, through = read_complete_page writer ~after:before ~limit:12 in
+      check int "closed scope event count" 12 (List.length events);
+      check int "closed scope cursor" 12 (Journal.cursor_seq through);
+      match List.map Event.payload events with
+      | Event.Node_opened root
+        :: Event.Node_opened turn_node
+        :: Event.Node_opened provider_node
+        :: Event.Node_opened invocation_node
+        :: Event.Node_updated { update = Event.Tool_input_snapshot input; _ }
+        :: _ ->
+        (match
+           ( Event.node_kind root
+           , Event.node_kind turn_node
+           , Event.node_kind provider_node
+           , Event.node_kind invocation_node
+           , input )
+         with
+         | ( Event.Agent_run { agent_name = "agent" }
+           , Event.Agent_turn { ordinal = 3 }
+           , Event.Provider_attempt { ordinal = 0; _ }
+           , Event.Tool_invocation
+               { provider_tool_use_id = Some ""; tool_name = "effect"; _ }
+           , Types.ToolUse
+               { id = ""; name = "effect"; input = `Assoc [ ("value", `Int 7) ] } ) -> ()
+         | _ -> fail "scope did not retain exact typed topology")
+      | _ -> fail "scope did not write its topology before the effect"))
 ;;
 
 let rec await_reconciliation_phase writer =
@@ -1210,6 +1328,10 @@ let () =
             "exact tool settlement authority"
             `Quick
             test_exact_tool_settlement_authority
+        ; test_case
+            "Agent scope owns provider and tool effect boundaries"
+            `Quick
+            test_agent_scope_owns_effect_boundaries
         ; test_case
             "concurrent submit and close linearize without loss"
             `Quick


### PR DESCRIPTION
## What

- add a private immutable capability chain for one execution journal: Agent scope → turn → provider attempt → Tool invocation
- atomically open an invocation together with its exact ToolUse input
- expose the private `Settlement.execute` fence only through the matching invocation capability
- reject cross-turn identity mismatch without advancing the journal cursor or leaving a partial node
- keep run, node, binding, schedule, and receipt ownership typed throughout

## Boundary

Construction requires an already-owned `Execution_lane_writer.t`; this module never discovers a path, reads env, or knows MASC/Keeper/Gate/vendor policy. It is private and stacked on #2650.

## Validation

- focused `scripts/dune-local.sh build lib/agent_sdk.cmxa` green
- focused lane-writer test build green; direct 19/19 green
- all touched files pass `ocamlformat --check`
- `git diff --check` clean
- exact leaf: 399 additions

## Honest status

This is still not wired into production Agent construction. The public Agent has no explicit durable directory+codec ownership yet, so deleting `Durable_event`, direct Raw_trace writes, or Journal_bridge here would lose behavior.

A separate typed blocker was found: live `Agent_tools` treats `batch_index` as a serial-batch ordinal, while `Execution_tool_schedule.validate` requires `batch_index < batch_size`. That mismatch must be fixed explicitly before production scope wiring; it is not hidden inside this 399-line leaf.