### PR TITLE
fix(execution): align tool batch schedule semantics

### DIFF
--- a/lib/base/tool.mli
+++ b/lib/base/tool.mli
@@ -20,8 +20,8 @@ val execution_mode_of_yojson : Yojson.Safe.t -> (execution_mode, string) result
     @since 0.216.0 *)
 type schedule =
   { planned_index : int
-  ; batch_index : int
-  ; batch_size : int
+  ; batch_index : int (** Zero-based execution-batch ordinal within the turn. *)
+  ; batch_size : int (** Number of invocations in that execution batch. *)
   ; execution_mode : execution_mode
   }
 

--- a/lib/execution_tool_schedule.ml
+++ b/lib/execution_tool_schedule.ml
@@ -7,8 +7,6 @@ let validate (schedule : Hooks.tool_schedule) =
   then Error "tool schedule batch_index must be non-negative"
   else if schedule.batch_size <= 0
   then Error "tool schedule batch_size must be positive"
-  else if schedule.batch_index >= schedule.batch_size
-  then Error "tool schedule batch_index must be less than batch_size"
   else Ok ()
 ;;
 

--- a/test/test_execution_journal.ml
+++ b/test/test_execution_journal.ml
@@ -991,6 +991,24 @@ let test_json_terminal_and_id_boundaries () =
   check int "invalid agent name did not advance journal" 0 (Journal.length journal);
   let run = require_started_run (Journal.start_run journal ~agent_name:"validation") in
   let agent_turn, turn = open_provider_attempt journal run in
+  let later_batch : Tool.schedule =
+    { planned_index = 0; batch_index = 2; batch_size = 1; execution_mode = Tool.Serial }
+  in
+  let later_batch_kind =
+    Event.Tool_invocation
+      { provider_tool_use_id = Some "provider-later-batch"
+      ; tool_name = "valid_tool"
+      ; schedule = later_batch
+      }
+  in
+  (match Event.node_kind_to_yojson later_batch_kind with
+   | Error message -> fail ("valid later batch was rejected: " ^ message)
+   | Ok json ->
+     (match Event.node_kind_of_yojson json with
+      | Ok (Event.Tool_invocation { schedule; _ }) ->
+        check int "later batch ordinal roundtrip" 2 schedule.batch_index;
+        check int "batch size roundtrip" 1 schedule.batch_size
+      | Ok _ | Error _ -> fail "valid later batch did not roundtrip"));
   let expect_invalid_node_kind kind =
     match Event.node_kind_to_yojson kind with
     | Error _ -> ()


### PR DESCRIPTION
## Problem

`Agent_tools.run_batches` emits serial execution batches as `(batch_index, batch_size) = (0,1), (1,1), (2,1)`: the index identifies the turn-local batch while size is the number of invocations in that batch. `Execution_tool_schedule.validate` incorrectly required `batch_index < batch_size`, so the second serial batch was rejected by the canonical execution-event codec.

## Change

- document the exact generic semantics of both fields
- remove only the invalid cross-field inequality
- retain structural invariants: `planned_index >= 0`, `batch_index >= 0`, and `batch_size > 0`
- add a standalone public codec regression for the live `(2,1)` shape

This PR is now independent and based directly on current `main`; it no longer depends on the private execution-scope stack.

## Validation

- `scripts/dune-local.sh build @fmt test/test_execution_journal.exe`
- `_build/default/test/test_execution_journal.exe` (9/9 green)
- `git diff --check`

## Boundary

No MASC/Keeper/Gate/vendor/tool-name/path/env/timeout/budget/cap policy is introduced. This changes only the invalid schedule relation and its exact codec contract.
