### PR TITLE
feat(llm_provider): bind prepared request measurements

### DIFF
--- a/lib/llm_provider/count_tokens_sync.ml
+++ b/lib/llm_provider/count_tokens_sync.ml
@@ -64,3 +64,71 @@ let count_anthropic
   | Provider_config.DashScope ->
     Error (Input_token_count.Unsupported { protocol; model_id = config.model_id })
 ;;
+
+type completion_request_measurement =
+  { input_count : Input_token_count.count
+  ; output_token_receipt : Types.output_token_receipt
+  }
+
+type completion_request_error =
+  | Input_count_failed of Input_token_count.error
+  | Output_token_resolution_failed of Types.required_output_token_error
+  | Invalid_completion_request of string
+
+let measure_completion_request
+      ?connection_cache
+      ?clock
+      ?timeout_s
+      ~sw
+      ~net
+      (request : Llm_transport.completion_request)
+  =
+  let config = request.config in
+  match config.kind with
+  | Provider_config.Anthropic ->
+    let artifact =
+      try
+        Backend_anthropic.build_request_artifact
+          ~config
+          ~messages:request.messages
+          ~tools:request.tools
+          ()
+        |> Result.map_error (fun error -> Output_token_resolution_failed error)
+      with
+      | Invalid_argument detail -> Error (Invalid_completion_request detail)
+    in
+    (match artifact with
+     | Error _ as error -> error
+     | Ok artifact ->
+       (match
+          count_anthropic
+            ?connection_cache
+            ?clock
+            ?timeout_s
+            ~sw
+            ~net
+            ~config
+            ~messages:request.messages
+            ~tools:request.tools
+            ()
+        with
+        | Error error -> Error (Input_count_failed error)
+        | Ok input_count ->
+          Ok
+            { input_count
+            ; output_token_receipt =
+                Backend_anthropic.request_output_token_receipt artifact
+            }))
+  | Provider_config.Kimi
+  | Provider_config.OpenAI_compat
+  | Provider_config.Ollama
+  | Provider_config.Gemini
+  | Provider_config.Glm
+  | Provider_config.DashScope ->
+    Error
+      (Input_count_failed
+         (Input_token_count.Unsupported
+            { protocol = Input_token_count.Anthropic_messages_count_tokens
+            ; model_id = config.model_id
+            }))
+;;

--- a/lib/llm_provider/count_tokens_sync.mli
+++ b/lib/llm_provider/count_tokens_sync.mli
@@ -30,3 +30,39 @@ val count_anthropic
   -> ?tools:Yojson.Safe.t list
   -> unit
   -> (Input_token_count.count, Input_token_count.error) result
+
+(** Exact provider-owned measurement of one fully prepared completion request.
+
+    The caller supplies the immutable {!Llm_transport.completion_request} that
+    reached its transport boundary, after Agent turn hooks, tool projection,
+    and caller-owned message projection. The input count uses the provider's
+    native count endpoint. The output receipt comes from the opaque completion
+    request artifact built from the same config, messages, and tools.
+
+    This is a lower-level transport-adapter primitive. Application callers
+    must not reconstruct a completion request to call it: final Agent-level
+    fit admission must measure the same opaque prepared request that it later
+    dispatches. This function neither dispatches nor returns that artifact, so
+    its receipt alone does not prove a later dispatch reused the measured
+    request value.
+
+    Unsupported provider protocols fail before I/O. No character estimate,
+    context-window fallback, fit policy, retry, or truncation is performed. *)
+type completion_request_measurement = private
+  { input_count : Input_token_count.count
+  ; output_token_receipt : Types.output_token_receipt
+  }
+
+type completion_request_error =
+  | Input_count_failed of Input_token_count.error
+  | Output_token_resolution_failed of Types.required_output_token_error
+  | Invalid_completion_request of string
+
+val measure_completion_request
+  :  ?connection_cache:Http_client.cache
+  -> ?clock:_ Eio.Time.clock
+  -> ?timeout_s:float
+  -> sw:Eio.Switch.t
+  -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> Llm_transport.completion_request
+  -> (completion_request_measurement, completion_request_error) result

--- a/lib/llm_provider/prepared_completion_request.ml
+++ b/lib/llm_provider/prepared_completion_request.ml
@@ -1,0 +1,39 @@
+type t = { request : Llm_transport.completion_request }
+type identity = t
+
+type measurement_evidence =
+  { request_identity : identity
+  ; measurement : Count_tokens_sync.completion_request_measurement
+  }
+
+type measured =
+  { prepared : t
+  ; evidence : measurement_evidence
+  }
+
+type 'a prepared_request_use =
+  { measurement_evidence : measurement_evidence
+  ; value : 'a
+  }
+
+let prepare request = { request }
+let identity prepared = prepared
+let same_identity left right = left == right
+
+let measure ?connection_cache ?clock ?timeout_s ~sw ~net prepared =
+  Count_tokens_sync.measure_completion_request
+    ?connection_cache
+    ?clock
+    ?timeout_s
+    ~sw
+    ~net
+    prepared.request
+  |> Result.map (fun measurement ->
+    { prepared; evidence = { request_identity = prepared; measurement } })
+;;
+
+let measurement_evidence measured = measured.evidence
+
+let with_request measured ~f =
+  { measurement_evidence = measured.evidence; value = f measured.prepared.request }
+;;

--- a/lib/llm_provider/prepared_completion_request.mli
+++ b/lib/llm_provider/prepared_completion_request.mli
@@ -1,0 +1,67 @@
+(** Immutable ownership boundary for one fully prepared completion request.
+
+    A routing layer calls {!prepare} only after every message, tool, provider,
+    and transport projection is complete.  The resulting value retains that
+    exact {!Llm_transport.completion_request}; it never rebuilds the request.
+
+    The identity is an in-process witness for one prepared value.  It is
+    intentionally opaque, has no string projection, and makes no durable or
+    cross-process identity claim.  {!same_identity} is true only for evidence
+    derived from the same prepared value, not merely structurally equal
+    requests.
+
+    This module is a low-level prerequisite for Agent-owned fit admission.
+    Regular Agent callers do not need to construct transport requests. *)
+
+type t
+type identity
+type measured
+
+type measurement_evidence = private
+  { request_identity : identity
+  ; measurement : Count_tokens_sync.completion_request_measurement
+  }
+
+type 'a prepared_request_use = private
+  { measurement_evidence : measurement_evidence
+  ; value : 'a
+  }
+
+(** Retain one exact immutable request without copying or normalizing it. *)
+val prepare : Llm_transport.completion_request -> t
+
+(** Return the opaque in-process identity of this prepared value. *)
+val identity : t -> identity
+
+(** Compare two in-process prepared-value identities. *)
+val same_identity : identity -> identity -> bool
+
+(** Measure the exact request retained by [prepared].  Success returns an
+    opaque measured state, preventing the typed dispatch path from being used
+    with independently reconstructed request fields.
+
+    Provider errors remain the exact typed errors from
+    {!Count_tokens_sync.measure_completion_request}. *)
+val measure
+  :  ?connection_cache:Http_client.cache
+  -> ?clock:_ Eio.Time.clock
+  -> ?timeout_s:float
+  -> sw:Eio.Switch.t
+  -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> t
+  -> (measured, Count_tokens_sync.completion_request_error) result
+
+(** Inspect the typed measurement and its prepared-value identity. *)
+val measurement_evidence : measured -> measurement_evidence
+
+(** Invoke [f] once with the exact request retained before measurement.  The
+    returned value binds that continuation use to the same measurement
+    identity.
+
+    This is prepared-request use evidence only.  It does not claim that [f]
+    dispatched provider I/O.  The function adds no retry, timeout, truncation,
+    fallback, or exception translation. *)
+val with_request
+  :  measured
+  -> f:(Llm_transport.completion_request -> 'a)
+  -> 'a prepared_request_use

--- a/test/test_anthropic_input_token_count.ml
+++ b/test/test_anthropic_input_token_count.ml
@@ -75,6 +75,16 @@ let config
     ()
 ;;
 
+let completion_request config : Llm_transport.completion_request =
+  { config
+  ; messages
+  ; tools = [ tool ]
+  ; capture_id = Some "request-count-fixture"
+  ; observe_wire_chunk = None
+  ; stream_idle_timeout_s = None
+  }
+;;
+
 let assoc body =
   match Yojson.Safe.from_string body with
   | `Assoc fields -> fields
@@ -157,23 +167,31 @@ let test_transport_success () =
   let result, (path, headers, body) =
     with_mock ~status:`OK ~response:{|{"input_tokens":321}|}
     @@ fun ~sw ~net ~base_url ->
-    Count_tokens_sync.count_anthropic
+    Count_tokens_sync.measure_completion_request
       ~sw
       ~net
-      ~config:(config base_url)
-      ~messages
-      ~tools:[ tool ]
-      ()
+      (completion_request (config base_url))
   in
   (match result with
-   | Ok count ->
+   | Ok measurement ->
+     let count = measurement.input_count in
      check int "input tokens" 321 count.input_tokens;
      check string "model id" "input-count-fixture" count.model_id;
      check
        bool
        "protocol"
        true
-       (Count.equal_protocol count.protocol Count.Anthropic_messages_count_tokens)
+       (Count.equal_protocol count.protocol Count.Anthropic_messages_count_tokens);
+     check
+       (option int)
+       "exact requested output"
+       (Some 64)
+       (Types.output_token_receipt_requested measurement.output_token_receipt);
+     check
+       (option int)
+       "exact effective output"
+       (Some 64)
+       (Types.output_token_receipt_effective measurement.output_token_receipt)
    | Error _ -> fail "expected native Anthropic count success");
   check string "custom proxy path" "/proxy/messages/count_tokens" path;
   let check_header name value =
@@ -210,17 +228,39 @@ let test_unsupported () =
   Eio.Switch.run
   @@ fun sw ->
   match
-    Count_tokens_sync.count_anthropic
+    Count_tokens_sync.measure_completion_request
       ~sw
       ~net:(Eio.Stdenv.net env)
-      ~config:(config ~kind:Provider_config.OpenAI_compat "not a URL")
-      ~messages
-      ()
+      (completion_request (config ~kind:Provider_config.OpenAI_compat "not a URL"))
   with
   | Error
-      (Count.Unsupported { protocol = Count.Anthropic_messages_count_tokens; model_id })
+      (Count_tokens_sync.Input_count_failed
+         (Count.Unsupported { protocol = Count.Anthropic_messages_count_tokens; model_id }))
     -> check string "model id" "input-count-fixture" model_id
   | Ok _ | Error _ -> fail "expected typed Unsupported before transport"
+;;
+
+let test_missing_output_ceiling_precedes_io () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let cfg =
+    { (config "not a URL") with
+      model_id = "request-measurement-missing-output-ceiling"
+    ; max_tokens = None
+    }
+  in
+  match
+    Count_tokens_sync.measure_completion_request
+      ~sw
+      ~net:(Eio.Stdenv.net env)
+      (completion_request cfg)
+  with
+  | Error
+      (Count_tokens_sync.Output_token_resolution_failed
+         Types.Required_output_token_ceiling_missing) -> ()
+  | Ok _ | Error _ -> fail "expected typed output-token failure before count I/O"
 ;;
 
 let test_count_tokens_url () =
@@ -247,6 +287,10 @@ let () =
       , [ test_case "native success" `Quick test_transport_success
         ; test_case "typed HTTP error" `Quick test_transport_error
         ; test_case "non-Anthropic unsupported" `Quick test_unsupported
+        ; test_case
+            "missing output ceiling precedes I/O"
+            `Quick
+            test_missing_output_ceiling_precedes_io
         ; test_case "count-tokens URL insertion" `Quick test_count_tokens_url
         ] )
     ]

--- a/test/test_anthropic_input_token_count.ml
+++ b/test/test_anthropic_input_token_count.ml
@@ -210,6 +210,53 @@ let test_transport_success () =
     body
 ;;
 
+let test_prepared_request_identity_and_use () =
+  let raw_request = completion_request (config "unused") in
+  let prepared = Prepared_completion_request.prepare raw_request in
+  let separately_prepared = Prepared_completion_request.prepare raw_request in
+  check
+    bool
+    "separate preparation has a distinct identity"
+    false
+    (Prepared_completion_request.same_identity
+       (Prepared_completion_request.identity prepared)
+       (Prepared_completion_request.identity separately_prepared));
+  let (measured, prepared, exact_request), _captured =
+    with_mock ~status:`OK ~response:{|{"input_tokens":321}|}
+    @@ fun ~sw ~net ~base_url ->
+    let request = completion_request (config base_url) in
+    let prepared = Prepared_completion_request.prepare request in
+    match Prepared_completion_request.measure ~sw ~net prepared with
+    | Error _ -> fail "expected prepared request measurement"
+    | Ok measured -> measured, prepared, request
+  in
+  let measurement_evidence = Prepared_completion_request.measurement_evidence measured in
+  check
+    bool
+    "measurement identity is the prepared identity"
+    true
+    (Prepared_completion_request.same_identity
+       (Prepared_completion_request.identity prepared)
+       measurement_evidence.request_identity);
+  check
+    int
+    "measurement remains available"
+    321
+    measurement_evidence.measurement.input_count.input_tokens;
+  let request_use =
+    Prepared_completion_request.with_request measured ~f:(fun retained ->
+      retained == exact_request)
+  in
+  check bool "continuation receives exact request value" true request_use.value;
+  check
+    bool
+    "request use retains measurement identity"
+    true
+    (Prepared_completion_request.same_identity
+       measurement_evidence.request_identity
+       request_use.measurement_evidence.request_identity)
+;;
+
 let test_transport_error () =
   let result, _captured =
     with_mock ~status:`Too_many_requests ~response:"rate limited"
@@ -285,6 +332,10 @@ let () =
     [ "request", [ test_case "shared canonical projection" `Quick test_shared_projection ]
     ; ( "transport"
       , [ test_case "native success" `Quick test_transport_success
+        ; test_case
+            "prepared identity binds measurement and use"
+            `Quick
+            test_prepared_request_identity_and_use
         ; test_case "typed HTTP error" `Quick test_transport_error
         ; test_case "non-Anthropic unsupported" `Quick test_unsupported
         ; test_case


### PR DESCRIPTION
## What

- wrap one fully projected immutable `completion_request` in an opaque prepared value
- assign a process-local typed identity with no string/digest projection
- return a measured type-state only after provider-native measurement succeeds
- allow continuation only through `with_request`, which receives the exact retained request value
- bind the measurement and later use witness to the same prepared identity

## Boundary

This is a low-level prerequisite stacked on #2647. It never rebuilds messages, tools, hooks, provider framing, or transport projection and adds no estimate, margin, truncation, retry, fallback, timeout, vendor/name/URL heuristic, or product vocabulary. Regular Agent callers do not construct transport requests.

## Validation

- focused `test_anthropic_input_token_count.exe` build green
- direct suite 7/7 green, including exact prepared identity/use
- `ocamlformat --check` green
- `git diff --check` clean
- 3 files, 157 additions

## Honest status

`with_request` proves only that a continuation received the same in-process value; it does not claim that an arbitrary callback performed provider I/O. Production `Pipeline_stage_route` still calls `Complete.complete/complete_stream` from config/messages/tools and must be refactored to consume this prepared value through a trusted internal dispatch path before MASC can claim measure/dispatch identity or source-bound fit.