### PR TITLE
fix(ci): run full CI matrix on stacked PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
     types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
   workflow_dispatch: {}
 


### PR DESCRIPTION
## What
`ci.yml`의 `pull_request` 트리거에서 `branches: [main]` 필터를 제거한다. base가 feature 브랜치인 스택 PR에서도 Build & Test(5.4.1/5.5.0) / Lint / Format / Boundary 게이트가 실행된다.

## Why
#2655: 오늘 열린 7단 execution 체인(#2646~#2653) 전부에서 풀 CI가 0회 실행됐다. 경량 게이트 2종만 돌아 rollup이 green으로 보였고, PR body의 "N/N green"은 전부 로컬 자기보고였다. 체크가 head SHA에 귀속되므로 base가 나중에 main으로 재타겟돼도 빌드 증거 없는 green이 유지된다 (false-green 클래스).

## Not claimed
- `edited`(base 리타겟) 재실행은 추가하지 않았다 — title/body 수정에도 발화해 풀 매트릭스 노이즈가 커진다. 이 수정으로 스택 상태에서도 head SHA에 빌드 체크가 항상 존재하므로, 리타겟 시 재실행 부재는 "main이 전진했을 때 기존 PR의 merge-commit 체크가 낡는" 일반적 노출과 동급이 된다.
- `push` 트리거는 main 유지 (변경 없음).

## Cost
스택 PR마다 풀 매트릭스 실행 — 기존 concurrency 그룹(cancel-in-progress)이 연속 push를 상쇄한다.

Closes #2655.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvELzG8FNa99yDKAs8Yz3A
