### PR TITLE
fix(llm_provider): promote empty-completion overflow in of_http_error

### DIFF
--- a/lib/llm_provider/error.ml
+++ b/lib/llm_provider/error.ml
@@ -276,6 +276,23 @@ let of_provider_failure ?provider kind message =
       { detail =
           Printf.sprintf "provider response exceeded %d bytes: %s" limit_bytes message
       }
+  | Http_client.Empty_completion { stop_reason = Types.ContextWindowExceeded } ->
+    (* Third promotion site of the #2621 misclassification fix: an empty
+       completion whose typed stop_reason is ContextWindowExceeded is a
+       caller-fixable context overflow, not provider unavailability.  Retrying
+       or rotating replays the same oversized prompt, so render it through the
+       same [Retry.ContextOverflow] path as the Api branch above. *)
+    InvalidRequest
+      { provider
+      ; reason =
+          Retry.error_message
+            (Retry.ContextOverflow
+               { message =
+                   "empty completion (stop_reason=model_context_window_exceeded): "
+                   ^ message
+               ; limit = None
+               })
+      }
   | Http_client.Empty_completion { stop_reason } ->
     (* [stop_reason] stays typed until this deliberate SDK boundary.  The public
        error surface remains source-compatible: callers already handle an empty

--- a/test/test_llm_provider_error.ml
+++ b/test/test_llm_provider_error.ml
@@ -611,8 +611,7 @@ let test_empty_completion_overflow_maps_to_invalid_request () =
       ~provider:"anthropic"
       (Http_client.ProviderFailure
          { kind =
-             Http_client.Empty_completion
-               { stop_reason = Types.ContextWindowExceeded }
+             Http_client.Empty_completion { stop_reason = Types.ContextWindowExceeded }
          ; message = "no content blocks"
          })
   in
@@ -623,8 +622,8 @@ let test_empty_completion_overflow_maps_to_invalid_request () =
       Retry.error_message
         (Retry.ContextOverflow
            { message =
-               "empty completion (stop_reason=model_context_window_exceeded): \
-                no content blocks"
+               "empty completion (stop_reason=model_context_window_exceeded): no content \
+                blocks"
            ; limit = None
            })
     in

--- a/test/test_llm_provider_error.ml
+++ b/test/test_llm_provider_error.ml
@@ -605,6 +605,48 @@ let test_is_retryable_matrix () =
   not_retryable (Error.NotFound { provider = "p"; detail = "model" })
 ;;
 
+let test_empty_completion_overflow_maps_to_invalid_request () =
+  let err =
+    Error.of_http_error
+      ~provider:"anthropic"
+      (Http_client.ProviderFailure
+         { kind =
+             Http_client.Empty_completion
+               { stop_reason = Types.ContextWindowExceeded }
+         ; message = "no content blocks"
+         })
+  in
+  match err with
+  | Error.InvalidRequest { provider; reason } ->
+    check string "overflow provider" "anthropic" provider;
+    let expected =
+      Retry.error_message
+        (Retry.ContextOverflow
+           { message =
+               "empty completion (stop_reason=model_context_window_exceeded): \
+                no content blocks"
+           ; limit = None
+           })
+    in
+    check string "overflow reason" expected reason
+  | _ -> fail "expected InvalidRequest for empty completion context overflow"
+;;
+
+let test_empty_completion_other_stop_reason_stays_unavailable () =
+  let err =
+    Error.of_http_error
+      ~provider:"anthropic"
+      (Http_client.ProviderFailure
+         { kind = Http_client.Empty_completion { stop_reason = Types.MaxTokens }
+         ; message = "no content blocks"
+         })
+  in
+  match err with
+  | Error.ProviderUnavailable { provider; detail = _ } ->
+    check string "unavailable provider" "anthropic" provider
+  | _ -> fail "expected ProviderUnavailable for non-overflow empty completion"
+;;
+
 let () =
   run
     "llm_provider_error"
@@ -635,6 +677,14 @@ let () =
             "Retry overloaded unknown provider"
             `Quick
             test_retry_overloaded_unknown_provider_mapping
+        ; test_case
+            "Empty completion overflow -> InvalidRequest"
+            `Quick
+            test_empty_completion_overflow_maps_to_invalid_request
+        ; test_case
+            "Empty completion non-overflow stays ProviderUnavailable"
+            `Quick
+            test_empty_completion_other_stop_reason_stays_unavailable
         ; test_case "HTTP capacity failure" `Quick test_http_capacity_failure_mapping
         ; test_case "HTTP server error" `Quick test_http_server_error_mapping
         ; test_case "HTTP terminal" `Quick test_http_terminal_mapping


### PR DESCRIPTION
## What
`Llm_provider.Error.of_http_error`에서 `Empty_completion { stop_reason = ContextWindowExceeded }`를 `ProviderUnavailable`이 아니라 `InvalidRequest`(= `Retry.ContextOverflow` 렌더링, Api 분기와 동일 경로)로 승격한다. 다른 stop_reason은 기존 `ProviderUnavailable` 경로 유지.

## Why (24h 병합 감사 발견, N-of-M 잔여 사이트)
#2621은 이 오분류를 **두 곳**(Api.create_message, Provider_failure_attribution)에서 고치면서 body에 "이 형상의 전체 sdk 승격 지점"이라고 썼지만, 세 번째 public 지점이 남아 있었다:
- `lib/llm_provider/error.ml:279`(수정 전) — stop_reason과 무관하게 무조건 `ProviderUnavailable`.
- `complete.mli`는 `Complete.complete`를 "Self-contained... Consumers can call these functions directly"로 공개 API로 문서화 — 이 직접 경로 소비자는 #2621 이후에도 구 버그를 그대로 겪는다. 컨텍스트 오버플로가 "provider 장애"로 보이면 소비자는 같은 oversized prompt를 재시도/로테이션한다 (masc#24838 인시던트 클래스).
- 기존 테스트에 `ContextWindowExceeded` 케이스 0건이었다 — 양방향 회귀 테스트 추가.

## 검증
- 회귀 테스트 2건 추가 (overflow→InvalidRequest 정확 문자열, MaxTokens→ProviderUnavailable 유지).
- 빌드/테스트는 CI에서 확인.

## 하위호환
`provider_error` variant 추가/제거 없음 — 특정 입력의 분류만 교정. 이 분류를 근거로 분기하던 소비자가 있다면 의도된 동작 변화다(오분류 교정).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvELzG8FNa99yDKAs8Yz3A
