### PR TITLE
feat(llm_provider): retain private prepared request evidence

### DIFF
--- a/lib/llm_provider/dune
+++ b/lib/llm_provider/dune
@@ -7,7 +7,8 @@
   model_catalog_embedded
   provider_http_codec
   output_token_wire_internal
-  request_artifact_internal)
+  request_artifact_internal
+  prepared_completion_request)
  (libraries
   yojson
   otoml

--- a/lib/llm_provider/prepared_completion_request.ml
+++ b/lib/llm_provider/prepared_completion_request.ml
@@ -1,0 +1,92 @@
+type t = { request : Llm_transport.completion_request }
+type identity = t
+
+type measurement_evidence =
+  { request_identity : identity
+  ; measurement : Count_tokens_sync.completion_request_measurement
+  }
+
+type measured =
+  { prepared : t
+  ; evidence : measurement_evidence
+  }
+
+let prepare request = { request }
+
+let prepare_sync ~config ~messages ?(tools = []) ?(trace_context = []) () =
+  prepare
+    { Llm_transport.config =
+        Complete_common.config_with_trace_context config trace_context
+    ; messages
+    ; tools
+    ; capture_id = None
+    ; observe_wire_chunk = None
+    ; stream_idle_timeout_s = None
+    }
+;;
+
+let prepare_stream
+      ~config
+      ~messages
+      ?(tools = [])
+      ?(trace_context = [])
+      ?capture_id
+      ?stream_idle_timeout_s
+      ()
+  =
+  prepare
+    { Llm_transport.config =
+        Complete_common.config_with_trace_context config trace_context
+    ; messages
+    ; tools
+    ; capture_id
+    ; observe_wire_chunk = None
+    ; stream_idle_timeout_s
+    }
+;;
+
+let request prepared = prepared.request
+let identity prepared = prepared
+let same_identity left right = left == right
+
+let measure ?connection_cache ?clock ?timeout_s ~sw ~net prepared =
+  Count_tokens_sync.measure_completion_request
+    ?connection_cache
+    ?clock
+    ?timeout_s
+    ~sw
+    ~net
+    prepared.request
+  |> Result.map (fun measurement ->
+    { prepared; evidence = { request_identity = prepared; measurement } })
+;;
+
+let measurement_evidence measured = measured.evidence
+
+let inline_test_request () =
+  let config =
+    Provider_config.make
+      ~kind:Provider_config.Anthropic
+      ~model_id:"prepared-identity-test"
+      ~base_url:"https://example.invalid"
+      ~api_key:"test-key"
+      ~max_tokens:1
+      ()
+  in
+  { Llm_transport.config
+  ; messages = []
+  ; tools = []
+  ; capture_id = None
+  ; observe_wire_chunk = None
+  ; stream_idle_timeout_s = None
+  }
+;;
+
+let%test "prepare retains the exact request with allocation-specific identity" =
+  let raw = inline_test_request () in
+  let left = prepare raw in
+  let right = prepare raw in
+  request left == raw
+  && identity left == left
+  && not (same_identity (identity left) (identity right))
+;;

--- a/lib/llm_provider/prepared_completion_request.mli
+++ b/lib/llm_provider/prepared_completion_request.mli
@@ -1,0 +1,58 @@
+(** Private immutable ownership boundary for one projected completion request.
+
+    This module is a Dune [private_module].  Its raw request accessor therefore
+    exists only in the library-private CMI and cannot become SDK dispatch
+    authority.  Public admission surfaces must wrap its values in opaque types
+    and expose typed facts and decisions only. *)
+
+type t
+type identity
+type measured
+
+type measurement_evidence = private
+  { request_identity : identity
+  ; measurement : Count_tokens_sync.completion_request_measurement
+  }
+
+(** Retain one exact immutable transport request. *)
+val prepare : Llm_transport.completion_request -> t
+
+(** Project the synchronous request used by the public Complete wrapper. *)
+val prepare_sync
+  :  config:Provider_config.t
+  -> messages:Types.message list
+  -> ?tools:Yojson.Safe.t list
+  -> ?trace_context:(string * string) list
+  -> unit
+  -> t
+
+(** Project the streaming request used by the public Complete wrapper. *)
+val prepare_stream
+  :  config:Provider_config.t
+  -> messages:Types.message list
+  -> ?tools:Yojson.Safe.t list
+  -> ?trace_context:(string * string) list
+  -> ?capture_id:string
+  -> ?stream_idle_timeout_s:float
+  -> unit
+  -> t
+
+(** Private raw accessor.  This declaration is never installed in the public
+    [agent_sdk.llm_provider] module graph. *)
+val request : t -> Llm_transport.completion_request
+
+val identity : t -> identity
+val same_identity : identity -> identity -> bool
+
+(** Measure the exact retained request.  No fit policy, retry, truncation,
+    completion dispatch, or caller continuation is performed. *)
+val measure
+  :  ?connection_cache:Http_client.cache
+  -> ?clock:_ Eio.Time.clock
+  -> ?timeout_s:float
+  -> sw:Eio.Switch.t
+  -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> t
+  -> (measured, Count_tokens_sync.completion_request_error) result
+
+val measurement_evidence : measured -> measurement_evidence


### PR DESCRIPTION
## Goal

Create an immutable, library-private ownership boundary for one exact projected completion request.

## Boundary

- Dune private module; no public Complete or Pipeline API is added.
- No dispatch, fit policy, retry, truncation, callback, or transport authority is exposed.
- Measurement is evidence only and remains attached to the exact prepared value.

## Proof

- 153 changed lines.
- Complete.mli and Pipeline are unchanged.
- Focused llm_provider tests and formatting pass.

## Honest limit

This is foundation only. Provider-fit and measured-to-dispatch admission are not live in this PR.