### PR TITLE
refactor(agent): centralize execution event writes

### DIFF
--- a/lib/agent/agent_execution_event_writer.ml
+++ b/lib/agent/agent_execution_event_writer.ml
@@ -1,0 +1,8 @@
+type t = Durable_event.journal
+type event = Durable_event.event
+
+let append journal event =
+  match Durable_event.append journal event with
+  | Ok () -> ()
+  | Error { exception_; backtrace } -> Printexc.raise_with_backtrace exception_ backtrace
+;;

--- a/lib/agent/agent_execution_event_writer.mli
+++ b/lib/agent/agent_execution_event_writer.mli
@@ -1,0 +1,10 @@
+(** Private single effect boundary for Agent execution events.
+
+    This module adds no policy or state. It preserves the current
+    {!Durable_event} authority while keeping append failure propagation in one
+    production writer. *)
+
+type t = Durable_event.journal
+type event = Durable_event.event
+
+val append : t -> event -> unit

--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -570,12 +570,6 @@ type scheduled_tool_outcome =
 
 exception Abort_tool_dispatch
 
-let append_journal journal event =
-  match Durable_event.append journal event with
-  | Ok () -> ()
-  | Error { exception_; backtrace } -> Printexc.raise_with_backtrace exception_ backtrace
-;;
-
 let execute_scheduled_tool
       ~context
       ~tools:_
@@ -720,7 +714,7 @@ let execute_scheduled_tool
                 observe_before_completion (fun () ->
                   match journal with
                   | Some j ->
-                    append_journal
+                    Agent_execution_event_writer.append
                       j
                       (Tool_called
                          { turn = Tool.Invocation.turn invocation
@@ -756,7 +750,7 @@ let execute_scheduled_tool
                 observe_after_completion (fun () ->
                   match journal with
                   | Some j ->
-                    append_journal
+                    Agent_execution_event_writer.append
                       j
                       (Tool_completed
                          { turn = Tool.Invocation.turn invocation

--- a/lib/dune
+++ b/lib/dune
@@ -14,7 +14,8 @@
   execution_codec_executor
   execution_event_store
   execution_journal
-  execution_lane_writer)
+  execution_lane_writer
+  agent_execution_event_writer)
  (libraries
   llm_provider
   (re_export agent_sdk_base)

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -23,12 +23,6 @@ let _log = Log.create ~module_name:"pipeline" ()
    cancellation); the thin wrapper keeps this module's log label. *)
 let safe_publish bus event = Pipeline_common.safe_publish ~log:_log bus event
 
-let append_journal journal event =
-  match Durable_event.append journal event with
-  | Ok () -> ()
-  | Error { exception_; backtrace } -> Printexc.raise_with_backtrace exception_ backtrace
-;;
-
 open Result_syntax
 
 type api_strategy =
@@ -62,7 +56,7 @@ let persist_turn_checkpoint_for_state agent stage state =
      | Ok () ->
        (match agent.options.journal with
         | Some journal ->
-          append_journal
+          Agent_execution_event_writer.append
             journal
             (Checkpoint_saved
                { checkpoint_id = Printf.sprintf "%s-%d" stage_label turn; timestamp })
@@ -337,7 +331,7 @@ let stage_collect ?raw_trace_run ?clock agent response =
                   })));
        (match agent.options.journal with
         | Some j ->
-          append_journal
+          Agent_execution_event_writer.append
             j
             (State_transition
                { from_state = "turn_running"
@@ -593,7 +587,7 @@ let run_turn
        error; OAS does not mutate the transcript or retry implicitly. *)
     (match agent.options.journal with
      | Some j ->
-       append_journal
+       Agent_execution_event_writer.append
          j
          (Llm_request
             { turn = agent.state.turn_count
@@ -622,7 +616,7 @@ let run_turn
          | Some u -> Some u.input_tokens, Some u.output_tokens
          | None -> None, None
        in
-       append_journal
+       Agent_execution_event_writer.append
          j
          (Llm_response
             { turn = agent.state.turn_count
@@ -633,7 +627,7 @@ let run_turn
             ; timestamp = Pipeline_common.timestamp_now ?clock ()
             })
      | Some j, Error err ->
-       append_journal
+       Agent_execution_event_writer.append
          j
          (Error_occurred
             { turn = agent.state.turn_count

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -15,12 +15,6 @@ let _stage_log = Log.create ~module_name:"pipeline_stage_prepare" ()
    the thin wrapper keeps this module's log label. *)
 let safe_publish bus event = Pipeline_common.safe_publish ~log:_stage_log bus event
 
-let append_journal journal event =
-  match Durable_event.append journal event with
-  | Ok () -> ()
-  | Error { exception_; backtrace } -> Printexc.raise_with_backtrace exception_ backtrace
-;;
-
 let stage_input ?raw_trace_run ?clock agent =
   let ts = Pipeline_common.timestamp_now ?clock () in
   set_lifecycle agent ~ready_at:ts Ready;
@@ -239,7 +233,7 @@ let stage_parse ?raw_trace_run ?clock agent =
    | None -> ());
   (match agent.options.journal with
    | Some j ->
-     append_journal
+     Agent_execution_event_writer.append
        j
        (Turn_started
           { turn = agent.state.turn_count


### PR DESCRIPTION
## Why

OAS currently emits the canonical `Durable_event` execution stream from three implementation modules. Before replacing its backing store, the write effect must have one private production boundary so a later hard cut cannot leave mixed writers behind.

This is deliberately behavior-preserving. It does not introduce a second journal, path inference, runtime policy, product hierarchy, or public API.

## What changed

- route all eight production execution-event emissions through private `Agent_execution_event_writer`
- keep `Durable_event` as the unchanged backing/serialization/replay authority
- preserve the existing exception and backtrace propagation exactly
- keep direct `Durable_event.append` calls only in journal/tests that exercise the primitive itself

## Verification

- `scripts/dune-local.sh build lib/agent_sdk.cmxa test/test_agent_auto_dump.exe test/test_durable_event.exe test/test_journal_bridge.exe test/test_tool_execution.exe test/test_telemetry_pipeline.exe`
- focused executables: 62/62 pass
- `scripts/check-execution-store-boundary.sh`
- `git diff --check`

## Scope boundary

This is C1 only. It does **not** claim durable lane storage is wired yet. The next vertical must accept one caller-owned opaque storage capability and atomically replace the backing writer before legacy wiring is deleted.
