### PR TITLE
feat(execution): add durable tool effect authority

### DIFF
--- a/lib/agent/agent_execution_event_writer.ml
+++ b/lib/agent/agent_execution_event_writer.ml
@@ -1,0 +1,8 @@
+type t = Durable_event.journal
+type event = Durable_event.event
+
+let append journal event =
+  match Durable_event.append journal event with
+  | Ok () -> ()
+  | Error { exception_; backtrace } -> Printexc.raise_with_backtrace exception_ backtrace
+;;

--- a/lib/agent/agent_execution_event_writer.mli
+++ b/lib/agent/agent_execution_event_writer.mli
@@ -1,0 +1,10 @@
+(** Private single effect boundary for Agent execution events.
+
+    This module adds no policy or state. It preserves the current
+    {!Durable_event} authority while keeping append failure propagation in one
+    production writer. *)
+
+type t = Durable_event.journal
+type event = Durable_event.event
+
+val append : t -> event -> unit

--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -570,12 +570,6 @@ type scheduled_tool_outcome =
 
 exception Abort_tool_dispatch
 
-let append_journal journal event =
-  match Durable_event.append journal event with
-  | Ok () -> ()
-  | Error { exception_; backtrace } -> Printexc.raise_with_backtrace exception_ backtrace
-;;
-
 let execute_scheduled_tool
       ~context
       ~tools:_
@@ -720,7 +714,7 @@ let execute_scheduled_tool
                 observe_before_completion (fun () ->
                   match journal with
                   | Some j ->
-                    append_journal
+                    Agent_execution_event_writer.append
                       j
                       (Tool_called
                          { turn = Tool.Invocation.turn invocation
@@ -756,7 +750,7 @@ let execute_scheduled_tool
                 observe_after_completion (fun () ->
                   match journal with
                   | Some j ->
-                    append_journal
+                    Agent_execution_event_writer.append
                       j
                       (Tool_completed
                          { turn = Tool.Invocation.turn invocation

--- a/lib/dune
+++ b/lib/dune
@@ -15,6 +15,7 @@
   execution_event_store
   execution_journal
   execution_lane_writer
+  execution_tool_settlement
   agent_execution_event_writer)
  (libraries
   llm_provider

--- a/lib/dune
+++ b/lib/dune
@@ -14,7 +14,8 @@
   execution_codec_executor
   execution_event_store
   execution_journal
-  execution_lane_writer)
+  execution_lane_writer
+  agent_execution_event_writer)
  (libraries
   llm_provider
   (re_export agent_sdk_base)

--- a/lib/execution_journal.ml
+++ b/lib/execution_journal.ml
@@ -1370,6 +1370,73 @@ let stage_close_node ?causes journal state ~node terminal =
       payload
 ;;
 
+let stage_begin_tool_attempt journal state ~invocation =
+  let* invocation_record = node_record_or_error state invocation in
+  let* run =
+    match Event.node_kind invocation_record.node, invocation_record.children_rev with
+    | Event.Tool_invocation _, [] ->
+      let run_id = Event.node_run_id invocation_record.node in
+      (match Reducer.find_run state.reducer run_id with
+       | Some { run; status = Running; _ } -> Ok run
+       | Some { status = Finished _; _ } ->
+         Error (Invariant_violation (Run_already_finished run_id))
+       | None -> Error (Invariant_violation (Unknown_run run_id)))
+    | Event.Tool_invocation _, _ :: _ ->
+      Error (Invalid_argument "tool invocation already has an attempt")
+    | ( ( Event.Agent_run _
+        | Event.Agent_turn _
+        | Event.Provider_attempt _
+        | Event.Output_block _
+        | Event.Tool_attempt )
+      , _ ) -> Error (Invalid_argument "tool attempt requires a Tool_invocation node")
+  in
+  stage_open_node journal state ~run ~parent:invocation ~kind:Event.Tool_attempt
+;;
+
+let stage_settle_tool_attempt journal state ~attempt ~invocation ~result =
+  let* attempt_record = node_record_or_error state attempt in
+  let* () =
+    match
+      Event.node_kind attempt_record.node, Event.parent_node_id attempt_record.node
+    with
+    | Event.Tool_attempt, Some parent when Event.Node_id.equal parent invocation -> Ok ()
+    | Event.Tool_attempt, (None | Some _) ->
+      Error (Invalid_argument "tool attempt does not belong to the invocation")
+    | ( ( Event.Agent_run _
+        | Event.Agent_turn _
+        | Event.Provider_attempt _
+        | Event.Output_block _
+        | Event.Tool_invocation _ )
+      , _ ) -> Error (Invalid_argument "tool settlement requires a Tool_attempt node")
+  in
+  let* invocation_record = node_record_or_error state invocation in
+  let* () =
+    match Event.node_kind invocation_record.node with
+    | Event.Tool_invocation _ -> Ok ()
+    | Event.Agent_run _
+    | Event.Agent_turn _
+    | Event.Provider_attempt _
+    | Event.Output_block _
+    | Event.Tool_attempt ->
+      Error (Invalid_argument "tool settlement requires a Tool_invocation node")
+  in
+  let* attempt_closed = stage_close_node journal state ~node:attempt Event.Succeeded in
+  let* result_committed =
+    stage_update_node
+      journal
+      attempt_closed.next_state
+      ~node:invocation
+      (Event.Tool_result result)
+  in
+  let+ invocation_closed =
+    stage_close_node journal result_committed.next_state ~node:invocation Event.Succeeded
+  in
+  { next_state = invocation_closed.next_state
+  ; events = [ attempt_closed.value; result_committed.value; invocation_closed.value ]
+  ; value = [ attempt_closed.value; result_committed.value; invocation_closed.value ]
+  }
+;;
+
 let stage_finish_run ?causes journal state ~run terminal =
   let* event_id = identity_result (Event.Event_id.fresh ()) in
   let* terminal = payload_result (Event.validate_terminal terminal) in
@@ -1531,6 +1598,15 @@ module Transaction = struct
         ; terminal : Event.terminal
         }
         -> Event.t t
+    | Begin_tool_attempt :
+        { invocation : Event.Node_id.t }
+        -> (Event.Node_id.t * Event.t) t
+    | Settle_tool_attempt :
+        { attempt : Event.Node_id.t
+        ; invocation : Event.Node_id.t
+        ; result : Llm_provider.Types.content_block
+        }
+        -> Event.t list t
     | Finish_run :
         { causes : Event.cause list
         ; run : run
@@ -1554,6 +1630,12 @@ module Transaction = struct
 
   let update_node ?(causes = []) ~node update = Update_node { causes; node; update }
   let close_node ?(causes = []) ~node terminal = Close_node { causes; node; terminal }
+  let begin_tool_attempt ~invocation () = Begin_tool_attempt { invocation }
+
+  let settle_tool_attempt ~attempt ~invocation ~result () =
+    Settle_tool_attempt { attempt; invocation; result }
+  ;;
+
   let finish_run ?(causes = []) ~run terminal = Finish_run { causes; run; terminal }
   let abort_run ?(causes = []) ~run terminal = Abort_run { causes; run; terminal }
 end
@@ -1582,6 +1664,16 @@ let stage : type value. batch -> value Transaction.t -> (batch * value, error) r
   | Transaction.Close_node { causes; node; terminal } ->
     stage_mutation
       (stage_close_node ~causes batch.journal batch.staged_state ~node terminal)
+  | Transaction.Begin_tool_attempt { invocation } ->
+    stage_mutation (stage_begin_tool_attempt batch.journal batch.staged_state ~invocation)
+  | Transaction.Settle_tool_attempt { attempt; invocation; result } ->
+    stage_mutation
+      (stage_settle_tool_attempt
+         batch.journal
+         batch.staged_state
+         ~attempt
+         ~invocation
+         ~result)
   | Transaction.Finish_run { causes; run; terminal } ->
     stage_mutation
       (stage_finish_run ~causes batch.journal batch.staged_state ~run terminal)

--- a/lib/execution_journal.mli
+++ b/lib/execution_journal.mli
@@ -320,6 +320,20 @@ module Transaction : sig
     -> Execution_event.terminal
     -> Execution_event.t t
 
+  (** Open an attempt under a materialized invocation-derived run. *)
+  val begin_tool_attempt
+    :  invocation:Execution_event.Node_id.t
+    -> unit
+    -> (Execution_event.Node_id.t * Execution_event.t) t
+
+  (** Atomically close attempt, materialize ToolResult, and close invocation. *)
+  val settle_tool_attempt
+    :  attempt:Execution_event.Node_id.t
+    -> invocation:Execution_event.Node_id.t
+    -> result:Llm_provider.Types.content_block
+    -> unit
+    -> Execution_event.t list t
+
   val finish_run
     :  ?causes:Execution_event.cause list
     -> run:run

--- a/lib/execution_lane_writer.ml
+++ b/lib/execution_lane_writer.ml
@@ -883,6 +883,10 @@ let current_cursor writer =
   read_journal writer (fun journal -> Ok (Journal.current_cursor journal))
 ;;
 
+let find_node writer node =
+  read_journal writer (fun journal -> Ok (Journal.find_node journal node))
+;;
+
 let read_page writer ~after ?through ~limit () =
   read_journal writer (fun journal ->
     match Journal.read_page journal ~after ?through ~limit () with

--- a/lib/execution_lane_writer.mli
+++ b/lib/execution_lane_writer.mli
@@ -168,6 +168,11 @@ val wake_reconciliation : t -> source:reconciliation_wake_source -> bool
     may retain its last acknowledged cursor and replay after any wake hint. *)
 val current_cursor : t -> (Execution_journal.cursor, read_error) result
 
+val find_node
+  :  t
+  -> Execution_event.Node_id.t
+  -> (Execution_journal.node_view option, read_error) result
+
 val read_page
   :  t
   -> after:Execution_journal.cursor

--- a/lib/execution_tool_settlement.ml
+++ b/lib/execution_tool_settlement.ml
@@ -1,0 +1,150 @@
+module Event = Execution_event
+module Journal = Execution_journal
+module Writer = Execution_lane_writer
+
+type t =
+  { writer : Writer.t
+  ; invocation_node : Event.Node_id.t
+  }
+
+type status =
+  | Ready_to_execute
+  | Outcome_unknown
+  | Settled of Llm_provider.Types.content_block
+
+type error =
+  | Authority_unavailable of Writer.read_error
+  | Invocation_not_found
+  | Invocation_identity_mismatch
+  | Effect_outcome_unknown
+  | Attempt_admission_failed of Writer.submit_error
+  | Attempt_commit_failed of Writer.ticket_error
+  | Receipt_admission_outcome_unknown of Writer.submit_error
+  | Receipt_settlement_outcome_unknown of Writer.ticket_error
+
+type execution =
+  | Executed of Llm_provider.Types.content_block * Journal.cursor * int
+  | Replayed of Llm_provider.Types.content_block
+
+let read_node writer node =
+  match Writer.find_node writer node with
+  | Error error -> Error (Authority_unavailable error)
+  | Ok None -> Error Invocation_not_found
+  | Ok (Some view) -> Ok view
+;;
+
+let parent_node view = Event.parent_node_id view.Journal.node
+
+let create ~writer ~invocation_node ~invocation =
+  let open Result_syntax in
+  let* invocation_view = read_node writer invocation_node in
+  let* provider_attempt =
+    match
+      ( Event.node_kind invocation_view.node
+      , parent_node invocation_view
+      , invocation_view.materialized )
+    with
+    | ( Event.Tool_invocation { schedule; _ }
+      , Some parent
+      , Journal.Tool_invocation_state
+          { input = Some (Llm_provider.Types.ToolUse { id; _ }); _ } )
+      when String.equal id (Tool.Invocation.tool_use_id invocation)
+           && Execution_tool_schedule.equal schedule (Tool.Invocation.schedule invocation)
+      -> Ok parent
+    | ( ( Event.Agent_run _
+        | Event.Agent_turn _
+        | Event.Provider_attempt _
+        | Event.Output_block _
+        | Event.Tool_invocation _
+        | Event.Tool_attempt )
+      , (None | Some _)
+      , _ ) -> Error Invocation_identity_mismatch
+  in
+  let* provider_view = read_node writer provider_attempt in
+  let* turn_node =
+    match Event.node_kind provider_view.node, parent_node provider_view with
+    | Event.Provider_attempt _, Some parent -> Ok parent
+    | Event.Provider_attempt _, None
+    | ( ( Event.Agent_run _
+        | Event.Agent_turn _
+        | Event.Output_block _
+        | Event.Tool_invocation _
+        | Event.Tool_attempt )
+      , _ ) -> Error Invocation_identity_mismatch
+  in
+  let* turn_view = read_node writer turn_node in
+  match Event.node_kind turn_view.node with
+  | Event.Agent_turn { ordinal } when ordinal = Tool.Invocation.turn invocation ->
+    Ok { writer; invocation_node }
+  | Event.Agent_turn _
+  | Event.Agent_run _
+  | Event.Provider_attempt _
+  | Event.Output_block _
+  | Event.Tool_invocation _
+  | Event.Tool_attempt -> Error Invocation_identity_mismatch
+;;
+
+let status authority =
+  match read_node authority.writer authority.invocation_node with
+  | Error _ as error -> error
+  | Ok view ->
+    (match view.materialized, view.children, view.status with
+     | Journal.Tool_invocation_state { result = Some result; _ }, _, _ ->
+       Ok (Settled result)
+     | Journal.Tool_invocation_state { result = None; _ }, [], Journal.Open ->
+       Ok Ready_to_execute
+     | ( Journal.Tool_invocation_state { result = None; _ }
+       , _
+       , (Journal.Open | Journal.Closed _) ) -> Ok Outcome_unknown
+     | ( ( Journal.Agent_run_state
+         | Journal.Agent_turn_state
+         | Journal.Provider_attempt_state _
+         | Journal.Output_block_state _
+         | Journal.Tool_attempt_state )
+       , _
+       , _ ) -> Error Invocation_identity_mismatch)
+;;
+
+let begin_attempt authority =
+  match
+    Writer.submit
+      authority.writer
+      (Journal.Transaction.begin_tool_attempt ~invocation:authority.invocation_node ())
+  with
+  | Error error -> Error (Attempt_admission_failed error)
+  | Ok ticket ->
+    (match Writer.await ticket with
+     | Error error -> Error (Attempt_commit_failed error)
+     | Ok committed ->
+       let node, _event = committed.value in
+       Ok node)
+;;
+
+let settle authority attempt result =
+  let transaction =
+    Journal.Transaction.settle_tool_attempt
+      ~attempt
+      ~invocation:authority.invocation_node
+      ~result
+      ()
+  in
+  match Writer.submit authority.writer transaction with
+  | Error error -> Error (Receipt_admission_outcome_unknown error)
+  | Ok ticket ->
+    (match Writer.await ticket with
+     | Error error -> Error (Receipt_settlement_outcome_unknown error)
+     | Ok committed -> Ok (result, committed.through, committed.group_event_count))
+;;
+
+let execute authority ~invoke =
+  let open Result_syntax in
+  let* current = status authority in
+  match current with
+  | Settled result -> Ok (Replayed result)
+  | Outcome_unknown -> Error Effect_outcome_unknown
+  | Ready_to_execute ->
+    let* attempt = begin_attempt authority in
+    let result = invoke () in
+    let+ committed, through, event_count = settle authority attempt result in
+    Executed (committed, through, event_count)
+;;

--- a/lib/execution_tool_settlement.mli
+++ b/lib/execution_tool_settlement.mli
@@ -1,0 +1,26 @@
+type t
+
+type error =
+  | Authority_unavailable of Execution_lane_writer.read_error
+  | Invocation_not_found
+  | Invocation_identity_mismatch
+  | Effect_outcome_unknown
+  | Attempt_admission_failed of Execution_lane_writer.submit_error
+  | Attempt_commit_failed of Execution_lane_writer.ticket_error
+  | Receipt_admission_outcome_unknown of Execution_lane_writer.submit_error
+  | Receipt_settlement_outcome_unknown of Execution_lane_writer.ticket_error
+
+type execution =
+  | Executed of Llm_provider.Types.content_block * Execution_journal.cursor * int
+  | Replayed of Llm_provider.Types.content_block
+
+val create
+  :  writer:Execution_lane_writer.t
+  -> invocation_node:Execution_event.Node_id.t
+  -> invocation:Tool.Invocation.t
+  -> (t, error) result
+
+val execute
+  :  t
+  -> invoke:(unit -> Llm_provider.Types.content_block)
+  -> (execution, error) result

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -23,12 +23,6 @@ let _log = Log.create ~module_name:"pipeline" ()
    cancellation); the thin wrapper keeps this module's log label. *)
 let safe_publish bus event = Pipeline_common.safe_publish ~log:_log bus event
 
-let append_journal journal event =
-  match Durable_event.append journal event with
-  | Ok () -> ()
-  | Error { exception_; backtrace } -> Printexc.raise_with_backtrace exception_ backtrace
-;;
-
 open Result_syntax
 
 type api_strategy =
@@ -62,7 +56,7 @@ let persist_turn_checkpoint_for_state agent stage state =
      | Ok () ->
        (match agent.options.journal with
         | Some journal ->
-          append_journal
+          Agent_execution_event_writer.append
             journal
             (Checkpoint_saved
                { checkpoint_id = Printf.sprintf "%s-%d" stage_label turn; timestamp })
@@ -337,7 +331,7 @@ let stage_collect ?raw_trace_run ?clock agent response =
                   })));
        (match agent.options.journal with
         | Some j ->
-          append_journal
+          Agent_execution_event_writer.append
             j
             (State_transition
                { from_state = "turn_running"
@@ -593,7 +587,7 @@ let run_turn
        error; OAS does not mutate the transcript or retry implicitly. *)
     (match agent.options.journal with
      | Some j ->
-       append_journal
+       Agent_execution_event_writer.append
          j
          (Llm_request
             { turn = agent.state.turn_count
@@ -622,7 +616,7 @@ let run_turn
          | Some u -> Some u.input_tokens, Some u.output_tokens
          | None -> None, None
        in
-       append_journal
+       Agent_execution_event_writer.append
          j
          (Llm_response
             { turn = agent.state.turn_count
@@ -633,7 +627,7 @@ let run_turn
             ; timestamp = Pipeline_common.timestamp_now ?clock ()
             })
      | Some j, Error err ->
-       append_journal
+       Agent_execution_event_writer.append
          j
          (Error_occurred
             { turn = agent.state.turn_count

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -15,12 +15,6 @@ let _stage_log = Log.create ~module_name:"pipeline_stage_prepare" ()
    the thin wrapper keeps this module's log label. *)
 let safe_publish bus event = Pipeline_common.safe_publish ~log:_stage_log bus event
 
-let append_journal journal event =
-  match Durable_event.append journal event with
-  | Ok () -> ()
-  | Error { exception_; backtrace } -> Printexc.raise_with_backtrace exception_ backtrace
-;;
-
 let stage_input ?raw_trace_run ?clock agent =
   let ts = Pipeline_common.timestamp_now ?clock () in
   set_lifecycle agent ~ready_at:ts Ready;
@@ -239,7 +233,7 @@ let stage_parse ?raw_trace_run ?clock agent =
    | None -> ());
   (match agent.options.journal with
    | Some j ->
-     append_journal
+     Agent_execution_event_writer.append
        j
        (Turn_started
           { turn = agent.state.turn_count

--- a/test/test_execution_lane_writer.ml
+++ b/test/test_execution_lane_writer.ml
@@ -7,11 +7,13 @@ module Codec = Internal.Execution_codec_executor
 module Journal = Internal.Execution_journal
 module Store = Internal.Execution_event_store
 module Writer = Internal.Execution_lane_writer
+module Settlement = Internal.Execution_tool_settlement
 module Tx = Journal.Transaction
 
 exception Cancel_waiter
 exception Cancel_scope
 exception Callback_failed
+exception Effect_raised
 
 let require_submit = function
   | Ok ticket -> ticket
@@ -169,6 +171,104 @@ let open_output writer =
 
 let delta_transaction output index =
   Tx.update_node ~node:output (Event.Output_delta (`Assoc [ "index", `Int index ]))
+;;
+
+let test_effect_attempt_and_settlement_survive_restart () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun codec dir ->
+    make_dir dir;
+    let restart_pairs = ref None in
+    let result =
+      Types.ToolResult
+        { tool_use_id = "call-0"
+        ; content = "done"
+        ; outcome = Types.Tool_succeeded
+        ; json = None
+        ; content_blocks = None
+        }
+    in
+    with_fresh codec dir (fun _sw writer ->
+      let value transaction = (submit_and_await writer transaction).value in
+      let run, _ = value (Tx.start_run ~agent_name:"effect" ()) in
+      let turn, _ =
+        value
+          (Tx.open_node
+             ~run
+             ~parent:(Journal.run_root run)
+             ~kind:(Event.Agent_turn { ordinal = 1 })
+             ())
+      in
+      let provider, _ =
+        value (Tx.open_node ~run ~parent:turn ~kind:(provider_attempt 0) ())
+      in
+      let open_invocation planned_index =
+        let schedule : Tool.schedule =
+          { planned_index; batch_index = 0; batch_size = 2; execution_mode = Tool.Serial }
+        in
+        let tool_use_id = Printf.sprintf "call-%d" planned_index in
+        let node, _ =
+          value
+            (Tx.open_node
+               ~run
+               ~parent:provider
+               ~kind:
+                 (Event.Tool_invocation
+                    { provider_tool_use_id = Some tool_use_id
+                    ; tool_name = "effect"
+                    ; schedule
+                    })
+               ())
+        in
+        let invocation = Tool.Invocation.create ~tool_use_id ~turn:1 ~schedule in
+        (match Settlement.create ~writer ~invocation_node:node ~invocation with
+         | Error Settlement.Invocation_identity_mismatch -> ()
+         | Ok _ | Error _ -> fail "unmaterialized invocation gained effect authority");
+        ignore
+          (value
+             (Tx.update_node
+                ~node
+                (Event.Tool_input_snapshot
+                   (Types.ToolUse { id = tool_use_id; name = "effect"; input = `Null }))));
+        node, invocation
+      in
+      let authority (node, invocation) =
+        match Settlement.create ~writer ~invocation_node:node ~invocation with
+        | Ok authority -> authority
+        | Error _ -> fail "durable invocation authority rejected exact identity"
+      in
+      let first_pair = open_invocation 0 in
+      let first = authority first_pair in
+      let seq () = Journal.cursor_seq (Result.get_ok (Writer.current_cursor writer)) in
+      let before_seq = seq () in
+      (match
+         Settlement.execute first ~invoke:(fun () ->
+           check int "attempt durable" (before_seq + 1) (seq ());
+           result)
+       with
+       | Ok (Settlement.Executed (_committed, through, event_count)) ->
+         check int "one settlement batch" 3 event_count;
+         check int "four durable events" (before_seq + 4) (Journal.cursor_seq through)
+       | Ok (Settlement.Replayed _) | Error _ -> fail "fresh effect did not settle");
+      let second_pair = open_invocation 1 in
+      let second = authority second_pair in
+      match Settlement.execute second ~invoke:(fun () -> raise Effect_raised) with
+      | exception Effect_raised -> restart_pairs := Some (first_pair, second_pair)
+      | Ok _ | Error _ -> fail "effect exception did not propagate");
+    let first_pair, second_pair = Option.get !restart_pairs in
+    with_existing codec dir (fun _sw writer ->
+      ignore (require_scope (Writer.await_ready writer));
+      let authority (node, invocation) =
+        Result.get_ok (Settlement.create ~writer ~invocation_node:node ~invocation)
+      in
+      let never () = fail "effect reran" in
+      (match Settlement.execute (authority first_pair) ~invoke:never with
+       | Ok (Settlement.Replayed replayed) when replayed = result -> ()
+       | Ok (Settlement.Replayed _ | Settlement.Executed _) | Error _ ->
+         fail "restart lost settlement");
+      match Settlement.execute (authority second_pair) ~invoke:never with
+      | Error Settlement.Effect_outcome_unknown -> ()
+      | Ok _ | Error _ -> fail "restart did not fence unknown effect"))
 ;;
 
 let rec await_reconciliation_phase writer =
@@ -1083,6 +1183,10 @@ let () =
             "semantic rejection does not poison ready group"
             `Quick
             test_semantic_rejection_does_not_poison_ready_group
+        ; test_case
+            "effect attempt and settlement survive restart"
+            `Quick
+            test_effect_attempt_and_settlement_survive_restart
         ; test_case
             "concurrent submit and close linearize without loss"
             `Quick


### PR DESCRIPTION
## Outcome

Add one Dune-private, generic OAS authority that durably records an exact Tool attempt before entering an effect and atomically settles its exact result. Restart replays a settled result without rerunning; an open attempt is typed `Effect_outcome_unknown` and cannot rerun blindly.

## Invariants

- authority requires a materialized exact ToolUse plus matching invocation ID, typed schedule, and turn topology
- attempt commit occurs before the handler is entered
- ToolResult + attempt close + invocation close commit as one three-event durable batch
- effect exceptions retain their original exception and leave a durable unknown fence
- no MASC/Keeper/Gate/product vocabulary or public `Agent_sdk` API

## Scope boundary

This is a 396-line C2 foundation stacked on #2668. It has **zero production callers** and does not claim legacy writer hard-cut, provider I/O wiring, a new backing store, or completed single-writer migration. Atomic invocation-open + ToolUse snapshot and the production caller are subsequent verticals.

## Verification

- cache-disabled clean focused build and `@fmt`: PASS
- execution journal: 19/19
- execution lane writer: 18/18
- execution-store boundary, code-smell ratchet, hardening ratchet: PASS
- public `agent_sdk.ml/.mli` diff: 0
- added product vocabulary and legacy writer references: 0

[근거] exact diff `e025c5b8d..10a97bb398`, clean focused build/test and boundary scripts; checked 2026-07-17 KST; confidence High.