### PR TITLE
feat(execution): atomically produce tool invocations

### DIFF
--- a/lib/execution_journal.ml
+++ b/lib/execution_journal.ml
@@ -171,6 +171,11 @@ type invariant_violation =
   | Tool_input_snapshot_identity_mismatch of Event.Node_id.t
   | Tool_input_delta_after_snapshot of Event.Node_id.t
   | Tool_input_not_materialized of Event.Node_id.t
+  | Tool_occurrence_already_opened of
+      { provider_attempt : Event.Node_id.t
+      ; planned_index : int
+      ; existing : Event.Node_id.t
+      }
   | Tool_result_already_materialized of Event.Node_id.t
   | Tool_result_snapshot_not_tool_result of Event.Node_id.t
   | Tool_result_snapshot_identity_mismatch of Event.Node_id.t
@@ -1393,6 +1398,101 @@ let stage_begin_tool_attempt journal state ~invocation =
   stage_open_node journal state ~run ~parent:invocation ~kind:Event.Tool_attempt
 ;;
 
+let stage_open_tool_invocation
+      journal
+      state
+      ~run
+      ~provider_attempt
+      ~invocation
+      ~tool_name
+      ~input
+  =
+  let* provider_record = node_record_or_error state provider_attempt in
+  let* () =
+    match
+      Event.node_kind provider_record.node, Event.parent_node_id provider_record.node
+    with
+    | Event.Provider_attempt _, Some turn_node ->
+      let* turn_record = node_record_or_error state turn_node in
+      (match Event.node_kind turn_record.node with
+       | Event.Agent_turn { ordinal } when ordinal = Tool.Invocation.turn invocation ->
+         Ok ()
+       | Event.Agent_turn _ ->
+         Error
+           (Invalid_argument "tool invocation turn does not match its provider attempt")
+       | Event.Agent_run _
+       | Event.Provider_attempt _
+       | Event.Output_block _
+       | Event.Tool_invocation _
+       | Event.Tool_attempt ->
+         Error
+           (Invalid_argument
+              "tool invocation requires a provider attempt under an agent turn"))
+    | Event.Provider_attempt _, None ->
+      Error
+        (Invalid_argument
+           "tool invocation requires a provider attempt under an agent turn")
+    | ( ( Event.Agent_run _
+        | Event.Agent_turn _
+        | Event.Output_block _
+        | Event.Tool_invocation _
+        | Event.Tool_attempt )
+      , _ ) -> Error (Invalid_argument "tool invocation requires a provider attempt")
+  in
+  let tool_use_id = Tool.Invocation.tool_use_id invocation in
+  let planned_index = Tool.Invocation.planned_index invocation in
+  let* () =
+    match
+      List.find_map
+        (fun (child : Event.node event_record) ->
+           match Event.node_kind child.value with
+           | Event.Tool_invocation { schedule; _ }
+             when schedule.planned_index = planned_index ->
+             Some (Event.node_id child.value)
+           | Event.Agent_run _
+           | Event.Agent_turn _
+           | Event.Provider_attempt _
+           | Event.Output_block _
+           | Event.Tool_invocation _
+           | Event.Tool_attempt -> None)
+        provider_record.children_rev
+    with
+    | None -> Ok ()
+    | Some existing ->
+      Error
+        (Invariant_violation
+           (Tool_occurrence_already_opened { provider_attempt; planned_index; existing }))
+  in
+  let* opened =
+    stage_open_node
+      journal
+      state
+      ~run
+      ~parent:provider_attempt
+      ~kind:
+        (Event.Tool_invocation
+           { provider_tool_use_id = Some tool_use_id
+           ; tool_name
+           ; schedule = Tool.Invocation.schedule invocation
+           })
+  in
+  let tool_use =
+    Llm_provider.Types.ToolUse { id = tool_use_id; name = tool_name; input }
+  in
+  let+ materialized =
+    stage_update_node
+      journal
+      opened.next_state
+      ~node:(fst opened.value)
+      (Event.Tool_input_snapshot tool_use)
+  in
+  let node, opened_event = opened.value in
+  { next_state = materialized.next_state
+  ; events = [ opened_event; materialized.value ]
+  ; value = node, [ opened_event; materialized.value ]
+  }
+;;
+
 let stage_settle_tool_attempt journal state ~attempt ~invocation ~result =
   let* attempt_record = node_record_or_error state attempt in
   let* () =
@@ -1601,6 +1701,14 @@ module Transaction = struct
     | Begin_tool_attempt :
         { invocation : Event.Node_id.t }
         -> (Event.Node_id.t * Event.t) t
+    | Open_tool_invocation :
+        { run : run
+        ; provider_attempt : Event.Node_id.t
+        ; invocation : Tool.Invocation.t
+        ; tool_name : string
+        ; input : Yojson.Safe.t
+        }
+        -> (Event.Node_id.t * Event.t list) t
     | Settle_tool_attempt :
         { attempt : Event.Node_id.t
         ; invocation : Event.Node_id.t
@@ -1631,6 +1739,10 @@ module Transaction = struct
   let update_node ?(causes = []) ~node update = Update_node { causes; node; update }
   let close_node ?(causes = []) ~node terminal = Close_node { causes; node; terminal }
   let begin_tool_attempt ~invocation () = Begin_tool_attempt { invocation }
+
+  let open_tool_invocation ~run ~provider_attempt ~invocation ~tool_name ~input () =
+    Open_tool_invocation { run; provider_attempt; invocation; tool_name; input }
+  ;;
 
   let settle_tool_attempt ~attempt ~invocation ~result () =
     Settle_tool_attempt { attempt; invocation; result }
@@ -1666,6 +1778,17 @@ let stage : type value. batch -> value Transaction.t -> (batch * value, error) r
       (stage_close_node ~causes batch.journal batch.staged_state ~node terminal)
   | Transaction.Begin_tool_attempt { invocation } ->
     stage_mutation (stage_begin_tool_attempt batch.journal batch.staged_state ~invocation)
+  | Transaction.Open_tool_invocation
+      { run; provider_attempt; invocation; tool_name; input } ->
+    stage_mutation
+      (stage_open_tool_invocation
+         batch.journal
+         batch.staged_state
+         ~run
+         ~provider_attempt
+         ~invocation
+         ~tool_name
+         ~input)
   | Transaction.Settle_tool_attempt { attempt; invocation; result } ->
     stage_mutation
       (stage_settle_tool_attempt

--- a/lib/execution_journal.mli
+++ b/lib/execution_journal.mli
@@ -120,6 +120,11 @@ type invariant_violation =
   | Tool_input_snapshot_identity_mismatch of Execution_event.Node_id.t
   | Tool_input_delta_after_snapshot of Execution_event.Node_id.t
   | Tool_input_not_materialized of Execution_event.Node_id.t
+  | Tool_occurrence_already_opened of
+      { provider_attempt : Execution_event.Node_id.t
+      ; planned_index : int
+      ; existing : Execution_event.Node_id.t
+      }
   | Tool_result_already_materialized of Execution_event.Node_id.t
   | Tool_result_snapshot_not_tool_result of Execution_event.Node_id.t
   | Tool_result_snapshot_identity_mismatch of Execution_event.Node_id.t
@@ -325,6 +330,17 @@ module Transaction : sig
     :  invocation:Execution_event.Node_id.t
     -> unit
     -> (Execution_event.Node_id.t * Execution_event.t) t
+
+  (** Atomically open and materialize one exact provider ToolUse occurrence.
+      The invocation turn must match the parent provider attempt's turn. *)
+  val open_tool_invocation
+    :  run:run
+    -> provider_attempt:Execution_event.Node_id.t
+    -> invocation:Tool.Invocation.t
+    -> tool_name:string
+    -> input:Yojson.Safe.t
+    -> unit
+    -> (Execution_event.Node_id.t * Execution_event.t list) t
 
   (** Atomically close attempt, materialize ToolResult, and close invocation. *)
   val settle_tool_attempt

--- a/lib/execution_tool_settlement.ml
+++ b/lib/execution_tool_settlement.ml
@@ -105,7 +105,10 @@ let status authority =
        , _ ) -> Error Invocation_identity_mismatch)
 ;;
 
+let await_accepted ticket = Eio.Cancel.protect (fun () -> Writer.await ticket)
+
 let begin_attempt authority =
+  Eio.Fiber.check ();
   match
     Writer.submit
       authority.writer
@@ -113,7 +116,7 @@ let begin_attempt authority =
   with
   | Error error -> Error (Attempt_admission_failed error)
   | Ok ticket ->
-    (match Writer.await ticket with
+    (match await_accepted ticket with
      | Error error -> Error (Attempt_commit_failed error)
      | Ok committed ->
        let node, _event = committed.value in
@@ -128,12 +131,13 @@ let settle authority attempt result =
       ~result
       ()
   in
-  match Writer.submit authority.writer transaction with
-  | Error error -> Error (Receipt_admission_outcome_unknown error)
-  | Ok ticket ->
-    (match Writer.await ticket with
-     | Error error -> Error (Receipt_settlement_outcome_unknown error)
-     | Ok committed -> Ok (result, committed.through, committed.group_event_count))
+  Eio.Cancel.protect (fun () ->
+    match Writer.submit authority.writer transaction with
+    | Error error -> Error (Receipt_admission_outcome_unknown error)
+    | Ok ticket ->
+      (match Writer.await ticket with
+       | Error error -> Error (Receipt_settlement_outcome_unknown error)
+       | Ok committed -> Ok (result, committed.through, committed.group_event_count)))
 ;;
 
 let execute authority ~invoke =
@@ -144,6 +148,7 @@ let execute authority ~invoke =
   | Outcome_unknown -> Error Effect_outcome_unknown
   | Ready_to_execute ->
     let* attempt = begin_attempt authority in
+    Eio.Fiber.check ();
     let result = invoke () in
     let+ committed, through, event_count = settle authority attempt result in
     Executed (committed, through, event_count)

--- a/test/test_execution_lane_writer.ml
+++ b/test/test_execution_lane_writer.ml
@@ -207,29 +207,21 @@ let test_effect_attempt_and_settlement_survive_restart () =
           { planned_index; batch_index = 0; batch_size = 2; execution_mode = Tool.Serial }
         in
         let tool_use_id = Printf.sprintf "call-%d" planned_index in
-        let node, _ =
-          value
-            (Tx.open_node
+        let invocation = Tool.Invocation.create ~tool_use_id ~turn:1 ~schedule in
+        let receipt =
+          submit_and_await
+            writer
+            (Tx.open_tool_invocation
                ~run
-               ~parent:provider
-               ~kind:
-                 (Event.Tool_invocation
-                    { provider_tool_use_id = Some tool_use_id
-                    ; tool_name = "effect"
-                    ; schedule
-                    })
+               ~provider_attempt:provider
+               ~invocation
+               ~tool_name:"effect"
+               ~input:`Null
                ())
         in
-        let invocation = Tool.Invocation.create ~tool_use_id ~turn:1 ~schedule in
-        (match Settlement.create ~writer ~invocation_node:node ~invocation with
-         | Error Settlement.Invocation_identity_mismatch -> ()
-         | Ok _ | Error _ -> fail "unmaterialized invocation gained effect authority");
-        ignore
-          (value
-             (Tx.update_node
-                ~node
-                (Event.Tool_input_snapshot
-                   (Types.ToolUse { id = tool_use_id; name = "effect"; input = `Null }))));
+        let node, events = receipt.value in
+        check int "open and materialize in one group" 2 (List.length events);
+        check int "one durable producer group" 2 receipt.group_event_count;
         node, invocation
       in
       let authority (node, invocation) =
@@ -240,6 +232,60 @@ let test_effect_attempt_and_settlement_survive_restart () =
       let first_pair = open_invocation 0 in
       let first = authority first_pair in
       let seq () = Journal.cursor_seq (Result.get_ok (Writer.current_cursor writer)) in
+      let before_duplicate = seq () in
+      let first_node, first_invocation = first_pair in
+      (match
+         Writer.await
+           (require_submit
+              (Writer.submit
+                 writer
+                 (Tx.open_tool_invocation
+                    ~run
+                    ~provider_attempt:provider
+                    ~invocation:first_invocation
+                    ~tool_name:"effect"
+                    ~input:`Null
+                    ())))
+       with
+       | Error
+           (Writer.Transaction_rejected
+              (Journal.Invariant_violation
+                 (Journal.Tool_occurrence_already_opened
+                    { provider_attempt; planned_index = 0; existing })))
+         when Event.Node_id.equal provider_attempt provider
+              && Event.Node_id.equal existing first_node -> ()
+       | Ok _ | Error _ -> fail "duplicate tool occurrence was accepted");
+      check int "duplicate producer is atomic" before_duplicate (seq ());
+      let before_rejected_producer = seq () in
+      let wrong_schedule : Tool.schedule =
+        { planned_index = 99
+        ; batch_index = 1
+        ; batch_size = 1
+        ; execution_mode = Tool.Serial
+        }
+      in
+      let wrong_invocation =
+        Tool.Invocation.create ~tool_use_id:"wrong-turn" ~turn:2 ~schedule:wrong_schedule
+      in
+      (match
+         Writer.await
+           (require_submit
+              (Writer.submit
+                 writer
+                 (Tx.open_tool_invocation
+                    ~run
+                    ~provider_attempt:provider
+                    ~invocation:wrong_invocation
+                    ~tool_name:"effect"
+                    ~input:`Null
+                    ())))
+       with
+       | Error
+           (Writer.Transaction_rejected
+              (Journal.Invalid_argument
+                 "tool invocation turn does not match its provider attempt")) -> ()
+       | Ok _ | Error _ -> fail "mismatched invocation turn was accepted");
+      check int "rejected producer is atomic" before_rejected_producer (seq ());
       let before_seq = seq () in
       (match
          Settlement.execute first ~invoke:(fun () ->
@@ -250,12 +296,40 @@ let test_effect_attempt_and_settlement_survive_restart () =
          check int "one settlement batch" 3 event_count;
          check int "four durable events" (before_seq + 4) (Journal.cursor_seq through)
        | Ok (Settlement.Replayed _) | Error _ -> fail "fresh effect did not settle");
+      let cancelled_pair = open_invocation 2 in
+      let cancelled = authority cancelled_pair in
+      let cancelled_result =
+        Types.ToolResult
+          { tool_use_id = "call-2"
+          ; content = "settled after cancellation"
+          ; outcome = Types.Tool_succeeded
+          ; json = None
+          ; content_blocks = None
+          }
+      in
+      (match
+         Eio.Cancel.sub (fun cancellation ->
+           match
+             Settlement.execute cancelled ~invoke:(fun () ->
+               Eio.Cancel.cancel cancellation Cancel_scope;
+               cancelled_result)
+           with
+           | Ok (Settlement.Executed _) -> ()
+           | Ok (Settlement.Replayed _) | Error _ ->
+             fail "post-effect cancellation lost settlement")
+       with
+       | () -> ()
+       | exception Eio.Cancel.Cancelled Cancel_scope -> ()
+       | exception exn -> raise exn);
       let second_pair = open_invocation 1 in
       let second = authority second_pair in
       match Settlement.execute second ~invoke:(fun () -> raise Effect_raised) with
-      | exception Effect_raised -> restart_pairs := Some (first_pair, second_pair)
+      | exception Effect_raised ->
+        restart_pairs := Some (first_pair, second_pair, cancelled_pair, cancelled_result)
       | Ok _ | Error _ -> fail "effect exception did not propagate");
-    let first_pair, second_pair = Option.get !restart_pairs in
+    let first_pair, second_pair, cancelled_pair, cancelled_result =
+      Option.get !restart_pairs
+    in
     with_existing codec dir (fun _sw writer ->
       ignore (require_scope (Writer.await_ready writer));
       let authority (node, invocation) =
@@ -266,6 +340,10 @@ let test_effect_attempt_and_settlement_survive_restart () =
        | Ok (Settlement.Replayed replayed) when replayed = result -> ()
        | Ok (Settlement.Replayed _ | Settlement.Executed _) | Error _ ->
          fail "restart lost settlement");
+      (match Settlement.execute (authority cancelled_pair) ~invoke:never with
+       | Ok (Settlement.Replayed settled) when settled = cancelled_result -> ()
+       | Ok (Settlement.Replayed _ | Settlement.Executed _) | Error _ ->
+         fail "post-effect cancellation left no durable receipt");
       match Settlement.execute (authority second_pair) ~invoke:never with
       | Error Settlement.Effect_outcome_unknown -> ()
       | Ok _ | Error _ -> fail "restart did not fence unknown effect"))


### PR DESCRIPTION
## Outcome

Add the closed producer transaction required before durable tool execution can be wired to production. One transaction opens one exact Tool invocation occurrence and materializes its canonical ToolUse input together.

## Scope

- add private `Execution_journal.Transaction.open_tool_invocation`
- bind the node to the exact provider attempt, Tool invocation turn, schedule, provider tool id, name, and input
- reject a turn mismatch without committing either event
- enforce one planned occurrence per provider attempt with a typed duplicate error and zero-event rejection
- protect accepted attempt acknowledgements and the complete post-effect settlement admission/acknowledgement boundary from cancellation
- prove a cancellation raised by the effect still leaves a replayable durable receipt after writer restart

This is C3 stacked on #2669. It is foundation only: production `Agent_tools` still has zero callers of this authority, and no such wiring is claimed here.

## Stack

- C1 #2668: single private Durable_event writer
- C2 #2669: durable tool settlement authority
- C3 this PR: atomic, occurrence-unique invocation producer and cancellation-safe settlement boundary

## Verification

- focused wrapper build: PASS
- `test_execution_lane_writer`: 18/18
- `check-execution-store-boundary.sh`: PASS
- `check-sdk-independence.sh`: PASS
- `ocamlformat --check`: PASS
- `git diff --check`: PASS
- 280 changed lines, below the 400-line leaf limit

[근거] exact diff `10a97bb398..aad478627`, focused OCaml wrapper output, and repository boundary scripts; checked 2026-07-17 21:55 KST; confidence High.