### PR TITLE
feat(execution): enforce structural occurrence identity

### DIFF
--- a/lib/execution_journal.ml
+++ b/lib/execution_journal.ml
@@ -171,8 +171,10 @@ type invariant_violation =
   | Tool_input_snapshot_identity_mismatch of Event.Node_id.t
   | Tool_input_delta_after_snapshot of Event.Node_id.t
   | Tool_input_not_materialized of Event.Node_id.t
-  | Tool_occurrence_already_opened of
-      { provider_attempt : Event.Node_id.t
+  | Tool_invocation_requires_atomic_open
+  | Occurrence_already_opened of Event.Node_id.t
+  | Tool_occurrence_conflict of
+      { parent : Event.Node_id.t
       ; planned_index : int
       ; existing : Event.Node_id.t
       }
@@ -523,6 +525,60 @@ module Reducer = struct
       , _ ) -> false
   ;;
 
+  let find_child parent_record matches =
+    List.find_map
+      (fun (child : Event.node event_record) ->
+         if matches (Event.node_kind child.value)
+         then Some (Event.node_id child.value)
+         else None)
+      parent_record.children_rev
+  ;;
+
+  let ensure_occurrence_available parent_id parent_record child_kind =
+    let existing =
+      match Event.node_kind parent_record.node, child_kind with
+      | Event.Agent_run _, Event.Agent_turn { ordinal } ->
+        find_child parent_record (function
+          | Event.Agent_turn child -> child.ordinal = ordinal
+          | Event.Agent_run _
+          | Event.Provider_attempt _
+          | Event.Output_block _
+          | Event.Tool_invocation _
+          | Event.Tool_attempt -> false)
+      | Event.Agent_turn _, Event.Provider_attempt { ordinal; target = _ } ->
+        find_child parent_record (function
+          | Event.Provider_attempt child -> child.ordinal = ordinal
+          | Event.Agent_run _
+          | Event.Agent_turn _
+          | Event.Output_block _
+          | Event.Tool_invocation _
+          | Event.Tool_attempt -> false)
+      | (Event.Provider_attempt _ | Event.Tool_attempt), Event.Tool_invocation tool ->
+        find_child parent_record (function
+          | Event.Tool_invocation child ->
+            child.schedule.planned_index = tool.schedule.planned_index
+          | Event.Agent_run _
+          | Event.Agent_turn _
+          | Event.Provider_attempt _
+          | Event.Output_block _
+          | Event.Tool_attempt -> false)
+      | ( ( Event.Agent_run _
+          | Event.Agent_turn _
+          | Event.Provider_attempt _
+          | Event.Output_block _
+          | Event.Tool_invocation _
+          | Event.Tool_attempt )
+        , _ ) -> None
+    in
+    match existing, child_kind with
+    | None, _ -> Ok ()
+    | Some existing, Event.Tool_invocation { schedule; _ } ->
+      Error
+        (Tool_occurrence_conflict
+           { parent = parent_id; planned_index = schedule.planned_index; existing })
+    | Some existing, _ -> Error (Occurrence_already_opened existing)
+  ;;
+
   let validate_update (record : node_record) node_id update =
     match Event.node_kind record.node, update with
     | Event.Provider_attempt _, Event.Provider_event _ -> Ok ()
@@ -715,6 +771,9 @@ module Reducer = struct
       if parent_accepts_child (Event.node_kind parent_record.node) (Event.node_kind node)
       then Ok ()
       else Error (Invalid_parent_kind { parent = parent_id; child = node_id })
+    in
+    let* () =
+      ensure_occurrence_available parent_id parent_record (Event.node_kind node)
     in
     let* () =
       (* Ordering fences per parent kind. The match is exhaustive on parent
@@ -1459,9 +1518,35 @@ let stage_open_tool_invocation
     with
     | None -> Ok ()
     | Some existing ->
-      Error
-        (Invariant_violation
-           (Tool_occurrence_already_opened { provider_attempt; planned_index; existing }))
+      let* existing_record = node_record_or_error state existing in
+      let exact_duplicate =
+        match Event.node_kind existing_record.node, existing_record.tool_input with
+        | ( Event.Tool_invocation
+              { provider_tool_use_id; tool_name = existing_name; schedule }
+          , Some
+              (Llm_provider.Types.ToolUse
+                 { id = existing_id; name = input_name; input = existing_input }) ) ->
+          Option.equal String.equal provider_tool_use_id (Some tool_use_id)
+          && String.equal existing_name tool_name
+          && Execution_tool_schedule.equal schedule (Tool.Invocation.schedule invocation)
+          && String.equal existing_id tool_use_id
+          && String.equal input_name tool_name
+          && Yojson.Safe.equal existing_input input
+        | ( ( Event.Agent_run _
+            | Event.Agent_turn _
+            | Event.Provider_attempt _
+            | Event.Output_block _
+            | Event.Tool_attempt )
+          , _ )
+        | Event.Tool_invocation _, (None | Some _) -> false
+      in
+      if exact_duplicate
+      then Error (Invariant_violation (Occurrence_already_opened existing))
+      else
+        Error
+          (Invariant_violation
+             (Tool_occurrence_conflict
+                { parent = provider_attempt; planned_index; existing }))
   in
   let* opened =
     stage_open_node
@@ -1767,6 +1852,8 @@ let stage : type value. batch -> value Transaction.t -> (batch * value, error) r
          batch.journal
          batch.staged_state
          ~agent_name)
+  | Transaction.Open_node { kind = Event.Tool_invocation _; _ } ->
+    Error (Invariant_violation Tool_invocation_requires_atomic_open)
   | Transaction.Open_node { causes; run; parent; kind } ->
     stage_mutation
       (stage_open_node ~causes batch.journal batch.staged_state ~run ~parent ~kind)

--- a/lib/execution_journal.mli
+++ b/lib/execution_journal.mli
@@ -120,8 +120,10 @@ type invariant_violation =
   | Tool_input_snapshot_identity_mismatch of Execution_event.Node_id.t
   | Tool_input_delta_after_snapshot of Execution_event.Node_id.t
   | Tool_input_not_materialized of Execution_event.Node_id.t
-  | Tool_occurrence_already_opened of
-      { provider_attempt : Execution_event.Node_id.t
+  | Tool_invocation_requires_atomic_open
+  | Occurrence_already_opened of Execution_event.Node_id.t
+  | Tool_occurrence_conflict of
+      { parent : Execution_event.Node_id.t
       ; planned_index : int
       ; existing : Execution_event.Node_id.t
       }

--- a/test/test_execution_journal.ml
+++ b/test/test_execution_journal.ml
@@ -39,11 +39,11 @@ let provider_attempt ?(model_id = "test-model") ordinal =
   require_codec_ok (Event.provider_attempt ~ordinal binding)
 ;;
 
-let tool_invocation name =
+let tool_invocation ?(planned_index = 0) name =
   Event.Tool_invocation
     { provider_tool_use_id = Some ("provider-" ^ name)
     ; tool_name = name
-    ; schedule = serial_schedule
+    ; schedule = { serial_schedule with planned_index; batch_index = planned_index }
     }
 ;;
 
@@ -734,7 +734,7 @@ let test_hierarchy_and_lifecycle_rejections () =
          journal
          ~run
          ~parent:turn
-         ~kind:(tool_invocation "parse_failure"))
+         ~kind:(tool_invocation ~planned_index:1 "parse_failure"))
   in
   ignore
     (require_ok
@@ -756,7 +756,7 @@ let test_hierarchy_and_lifecycle_rejections () =
            (Event.Tool_invocation
               { provider_tool_use_id = None
               ; tool_name = "late_identity"
-              ; schedule = serial_schedule
+              ; schedule = { serial_schedule with planned_index = 2; batch_index = 2 }
               }))
   in
   let canonical_tool_use =

--- a/test/test_execution_lane_writer.ml
+++ b/test/test_execution_lane_writer.ml
@@ -104,11 +104,11 @@ let read_complete_page writer ~after ~limit =
     page.events, page.next_cursor
 ;;
 
-let provider_attempt ordinal =
+let provider_attempt_for ~provider_id ordinal =
   let config =
     Llm_provider.Provider_config.make
       ~kind:Llm_provider.Provider_kind.OpenAI_compat
-      ~provider_id:"lane-writer-test"
+      ~provider_id
       ~model_id:"lane-writer-model"
       ~base_url:"https://provider.test"
       ()
@@ -120,6 +120,10 @@ let provider_attempt ordinal =
     |> require_codec
   in
   require_codec (Event.provider_attempt ~ordinal binding)
+;;
+
+let provider_attempt ordinal =
+  provider_attempt_for ~provider_id:"lane-writer-test" ordinal
 ;;
 
 let submit_and_await writer transaction =
@@ -249,11 +253,8 @@ let test_effect_attempt_and_settlement_survive_restart () =
        with
        | Error
            (Writer.Transaction_rejected
-              (Journal.Invariant_violation
-                 (Journal.Tool_occurrence_already_opened
-                    { provider_attempt; planned_index = 0; existing })))
-         when Event.Node_id.equal provider_attempt provider
-              && Event.Node_id.equal existing first_node -> ()
+              (Journal.Invariant_violation (Journal.Occurrence_already_opened existing)))
+         when Event.Node_id.equal existing first_node -> ()
        | Ok _ | Error _ -> fail "duplicate tool occurrence was accepted");
       check int "duplicate producer is atomic" before_duplicate (seq ());
       let before_rejected_producer = seq () in
@@ -347,6 +348,173 @@ let test_effect_attempt_and_settlement_survive_restart () =
       match Settlement.execute (authority second_pair) ~invoke:never with
       | Error Settlement.Effect_outcome_unknown -> ()
       | Ok _ | Error _ -> fail "restart did not fence unknown effect"))
+;;
+
+let test_structural_occurrence_identity_is_parent_local () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun codec dir ->
+    make_dir dir;
+    with_fresh codec dir (fun _sw writer ->
+      let value transaction = (submit_and_await writer transaction).value in
+      let seq () = Writer.current_cursor writer |> Result.get_ok |> Journal.cursor_seq in
+      let expect_rejected_without_events label transaction matches =
+        let before = seq () in
+        (match Writer.await (require_submit (Writer.submit writer transaction)) with
+         | Error (Writer.Transaction_rejected (Journal.Invariant_violation violation))
+           when matches violation -> ()
+         | Error error -> fail (label ^ ": " ^ Writer.ticket_error_to_string error)
+         | Ok _ -> fail (label ^ ": duplicate occurrence was accepted"));
+        check int (label ^ " is atomic") before (seq ())
+      in
+      let run, _ = value (Tx.start_run ~agent_name:"occurrence" ()) in
+      let turn_0, _ =
+        value
+          (Tx.open_node
+             ~run
+             ~parent:(Journal.run_root run)
+             ~kind:(Event.Agent_turn { ordinal = 0 })
+             ())
+      in
+      expect_rejected_without_events
+        "duplicate turn"
+        (Tx.open_node
+           ~run
+           ~parent:(Journal.run_root run)
+           ~kind:(Event.Agent_turn { ordinal = 0 })
+           ())
+        (function
+          | Journal.Occurrence_already_opened existing ->
+            Event.Node_id.equal existing turn_0
+          | _ -> false);
+      let turn_1, _ =
+        value
+          (Tx.open_node
+             ~run
+             ~parent:(Journal.run_root run)
+             ~kind:(Event.Agent_turn { ordinal = 1 })
+             ())
+      in
+      let provider_0, _ =
+        value (Tx.open_node ~run ~parent:turn_0 ~kind:(provider_attempt 0) ())
+      in
+      expect_rejected_without_events
+        "duplicate provider ordinal ignores diagnostic binding"
+        (Tx.open_node
+           ~run
+           ~parent:turn_0
+           ~kind:(provider_attempt_for ~provider_id:"different-binding" 0)
+           ())
+        (function
+          | Journal.Occurrence_already_opened existing ->
+            Event.Node_id.equal existing provider_0
+          | _ -> false);
+      let provider_1, _ =
+        value (Tx.open_node ~run ~parent:turn_1 ~kind:(provider_attempt 0) ())
+      in
+      let schedule : Tool.schedule =
+        { planned_index = 0
+        ; batch_index = 0
+        ; batch_size = 1
+        ; execution_mode = Tool.Serial
+        }
+      in
+      let input = `Assoc [ "value", `Int 7 ] in
+      let occurrence_0 = Tool.Invocation.create ~tool_use_id:"call" ~turn:0 ~schedule in
+      let tool_0, _ =
+        value
+          (Tx.open_tool_invocation
+             ~run
+             ~provider_attempt:provider_0
+             ~invocation:occurrence_0
+             ~tool_name:"effect"
+             ~input
+             ())
+      in
+      expect_rejected_without_events
+        "exact tool duplicate"
+        (Tx.open_tool_invocation
+           ~run
+           ~provider_attempt:provider_0
+           ~invocation:occurrence_0
+           ~tool_name:"effect"
+           ~input
+           ())
+        (function
+        | Journal.Occurrence_already_opened existing ->
+          Event.Node_id.equal existing tool_0
+        | _ -> false);
+      let changed_schedule : Tool.schedule =
+        { schedule with
+          batch_index = 1
+        ; batch_size = 2
+        ; execution_mode = Tool.Concurrent
+        }
+      in
+      let conflicts =
+        [ ( "tool schedule conflict"
+          , Tool.Invocation.create ~tool_use_id:"call" ~turn:0 ~schedule:changed_schedule
+          , "effect"
+          , input )
+        ; ( "tool id conflict"
+          , Tool.Invocation.create ~tool_use_id:"other-call" ~turn:0 ~schedule
+          , "effect"
+          , input )
+        ; "tool name conflict", occurrence_0, "other-effect", input
+        ; "tool input conflict", occurrence_0, "effect", `Assoc [ "value", `Int 8 ]
+        ]
+      in
+      List.iter
+        (fun (label, invocation, tool_name, input) ->
+           expect_rejected_without_events
+             label
+             (Tx.open_tool_invocation
+                ~run
+                ~provider_attempt:provider_0
+                ~invocation
+                ~tool_name
+                ~input
+                ())
+             (function
+             | Journal.Tool_occurrence_conflict { parent; planned_index = 0; existing } ->
+               Event.Node_id.equal parent provider_0
+               && Event.Node_id.equal existing tool_0
+             | _ -> false))
+        conflicts;
+      expect_rejected_without_events
+        "first raw tool open cannot bypass atomic producer"
+        (Tx.open_node
+           ~run
+           ~parent:provider_1
+           ~kind:
+             (Event.Tool_invocation
+                { provider_tool_use_id = Some "raw"; tool_name = "raw"; schedule })
+           ())
+        (function
+          | Journal.Tool_invocation_requires_atomic_open -> true
+          | _ -> false);
+      let occurrence_1 = Tool.Invocation.create ~tool_use_id:"call" ~turn:1 ~schedule in
+      ignore
+        (value
+           (Tx.open_tool_invocation
+              ~run
+              ~provider_attempt:provider_1
+              ~invocation:occurrence_1
+              ~tool_name:"effect"
+              ~input
+              ()));
+      let attempt, _ = value (Tx.begin_tool_attempt ~invocation:tool_0 ()) in
+      let child_run, _ =
+        value (Tx.start_run ~parent_attempt:attempt ~agent_name:"child" ())
+      in
+      ignore
+        (value
+           (Tx.open_node
+              ~run:child_run
+              ~parent:(Journal.run_root child_run)
+              ~kind:(Event.Agent_turn { ordinal = 0 })
+              ()));
+      check int "same ordinal under different parents is allowed" 12 (seq ())))
 ;;
 
 let rec await_reconciliation_phase writer =
@@ -1265,6 +1433,10 @@ let () =
             "effect attempt and settlement survive restart"
             `Quick
             test_effect_attempt_and_settlement_survive_restart
+        ; test_case
+            "structural occurrence identity is parent local"
+            `Quick
+            test_structural_occurrence_identity_is_parent_local
         ; test_case
             "concurrent submit and close linearize without loss"
             `Quick


### PR DESCRIPTION
## Scope

- make agent-turn and provider-attempt occurrence identity parent-local and ordinal-unique
- reject duplicate tool planned occurrences atomically as exact duplicates or typed durable conflicts
- reject first raw `Transaction.open_node Tool_invocation`; tool invocations must enter through the atomic producer
- allow equal ordinals under different parents

## Boundary

Provider binding snapshots are not identity and are never compared for ownership or reconstruction. This leaf enforces only journal structure. It does not yet provide process-restart scope recovery or a production `Agent_tools` caller.

## Verification

- focused cold build: PASS
- execution lane writer: 19/19 PASS
- execution-store boundary: PASS
- SDK independence: PASS
- `@fmt`: PASS
- `git diff --check`: PASS
- hostile review: P0 none, P1 none

## Size

289 changed lines (+275/-14, <400).
