### PR TITLE
feat(execution): add private agent journal scope

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -15,6 +15,7 @@
   execution_event_store
   execution_journal
   execution_lane_writer
+  execution_agent_scope
   execution_tool_settlement
   agent_execution_event_writer)
  (libraries

--- a/lib/execution_agent_scope.ml
+++ b/lib/execution_agent_scope.ml
@@ -1,0 +1,168 @@
+module Event = Execution_event
+module Journal = Execution_journal
+module Settlement = Execution_tool_settlement
+module Writer = Execution_lane_writer
+module Tx = Journal.Transaction
+
+type t =
+  { writer : Writer.t
+  ; run : Journal.run
+  }
+
+type turn =
+  { scope : t
+  ; node : Event.Node_id.t
+  }
+
+type provider_attempt =
+  { turn : turn
+  ; node : Event.Node_id.t
+  }
+
+type invocation_locator =
+  { node : Event.Node_id.t
+  ; occurrence : Tool.Invocation.t
+  }
+
+type invocation =
+  { authority : Settlement.t
+  ; locator : invocation_locator
+  }
+
+type abort_reason =
+  | Failed of Event.failure
+  | Cancelled of
+      { reason : string option
+      ; data : Yojson.Safe.t option
+      }
+
+type error =
+  | Admission_failed of Writer.submit_error
+  | Mutation_failed of Writer.ticket_error
+  | Invalid_provider_attempt of string
+  | Settlement_failed of Settlement.error
+
+let settlement_error_to_string = function
+  | Settlement.Authority_unavailable error -> Writer.read_error_to_string error
+  | Settlement.Invocation_not_found -> "execution invocation was not found"
+  | Settlement.Invocation_identity_mismatch ->
+    "execution invocation identity does not match its durable topology"
+  | Settlement.Effect_outcome_unknown -> "tool effect outcome is unknown"
+  | Settlement.Attempt_admission_failed error -> Writer.submit_error_to_string error
+  | Settlement.Attempt_commit_failed error -> Writer.ticket_error_to_string error
+  | Settlement.Receipt_admission_outcome_unknown error ->
+    Writer.submit_error_to_string error
+  | Settlement.Receipt_settlement_outcome_unknown error ->
+    Writer.ticket_error_to_string error
+;;
+
+let error_to_string = function
+  | Admission_failed error -> Writer.submit_error_to_string error
+  | Mutation_failed error -> Writer.ticket_error_to_string error
+  | Invalid_provider_attempt detail -> "invalid provider attempt: " ^ detail
+  | Settlement_failed error -> settlement_error_to_string error
+;;
+
+let transact writer transaction =
+  Eio.Fiber.check ();
+  match Writer.submit writer transaction with
+  | Error error -> Error (Admission_failed error)
+  | Ok ticket ->
+    (match Eio.Cancel.protect (fun () -> Writer.await ticket) with
+     | Error error -> Error (Mutation_failed error)
+     | Ok receipt -> Ok receipt.value)
+;;
+
+let transact_cleanup writer transaction =
+  Eio.Cancel.protect (fun () ->
+    match Writer.submit writer transaction with
+    | Error error -> Error (Admission_failed error)
+    | Ok ticket ->
+      (match Writer.await ticket with
+       | Error error -> Error (Mutation_failed error)
+       | Ok receipt -> Ok receipt.value))
+;;
+
+let start ~writer ~agent_name =
+  transact writer (Tx.start_run ~agent_name ())
+  |> Result.map (fun (run, _event) -> { writer; run })
+;;
+
+let open_turn scope ~ordinal =
+  transact
+    scope.writer
+    (Tx.open_node
+       ~run:scope.run
+       ~parent:(Journal.run_root scope.run)
+       ~kind:(Event.Agent_turn { ordinal })
+       ())
+  |> Result.map (fun (node, _event) -> { scope; node })
+;;
+
+let open_provider_attempt turn ~ordinal binding =
+  match Event.provider_attempt ~ordinal binding with
+  | Error detail -> Error (Invalid_provider_attempt detail)
+  | Ok kind ->
+    transact
+      turn.scope.writer
+      (Tx.open_node ~run:turn.scope.run ~parent:turn.node ~kind ())
+    |> Result.map (fun (node, _event) -> { turn; node })
+;;
+
+let open_invocation provider ~invocation ~tool_name ~input =
+  let scope = provider.turn.scope in
+  match
+    transact
+      scope.writer
+      (Tx.open_tool_invocation
+         ~run:scope.run
+         ~provider_attempt:provider.node
+         ~invocation
+         ~tool_name
+         ~input
+         ())
+  with
+  | Error _ as error -> error
+  | Ok (node, _events) ->
+    let locator = { node; occurrence = invocation } in
+    Settlement.create ~writer:scope.writer ~invocation_node:node ~invocation
+    |> Result.map (fun authority -> { authority; locator })
+    |> Result.map_error (fun error -> Settlement_failed error)
+;;
+
+let invocation_locator invocation = invocation.locator
+
+let rebind_invocation ~writer locator =
+  Settlement.create ~writer ~invocation_node:locator.node ~invocation:locator.occurrence
+  |> Result.map (fun authority -> { authority; locator })
+  |> Result.map_error (fun error -> Settlement_failed error)
+;;
+
+let execute invocation ~invoke =
+  Settlement.execute invocation.authority ~invoke
+  |> Result.map_error (fun error -> Settlement_failed error)
+;;
+
+let close_node writer node terminal =
+  transact writer (Tx.close_node ~node terminal) |> Result.map ignore
+;;
+
+let close_provider_attempt provider terminal =
+  close_node provider.turn.scope.writer provider.node terminal
+;;
+
+let close_turn turn terminal = close_node turn.scope.writer turn.node terminal
+
+let finish scope terminal =
+  transact scope.writer (Tx.finish_run ~run:scope.run terminal) |> Result.map ignore
+;;
+
+let abort scope reason =
+  let terminal =
+    match reason with
+    | Failed failure -> Event.Failed failure
+    | Cancelled { reason; data } -> Event.Cancelled { reason; data }
+  in
+  transact_cleanup scope.writer (Tx.abort_run ~run:scope.run terminal)
+  |> Result.map ignore
+;;

--- a/lib/execution_agent_scope.mli
+++ b/lib/execution_agent_scope.mli
@@ -1,0 +1,66 @@
+(** Private typed ownership chain for one Agent execution journal.
+    Construction requires an owned writer and never discovers paths or product
+    policy. Abstract descendants cannot be moved across another scope. *)
+
+type t
+type turn
+type provider_attempt
+type invocation_locator
+type invocation
+
+type abort_reason =
+  | Failed of Execution_event.failure
+  | Cancelled of
+      { reason : string option
+      ; data : Yojson.Safe.t option
+      }
+
+type error =
+  | Admission_failed of Execution_lane_writer.submit_error
+  | Mutation_failed of Execution_lane_writer.ticket_error
+  | Invalid_provider_attempt of string
+  | Settlement_failed of Execution_tool_settlement.error
+
+val error_to_string : error -> string
+val start : writer:Execution_lane_writer.t -> agent_name:string -> (t, error) result
+val open_turn : t -> ordinal:int -> (turn, error) result
+
+(** Materialize the exact binding selected for provider dispatch. *)
+val open_provider_attempt
+  :  turn
+  -> ordinal:int
+  -> Binding_identity.t
+  -> (provider_attempt, error) result
+
+(** Atomically open an invocation and materialize the exact ToolUse input. *)
+val open_invocation
+  :  provider_attempt
+  -> invocation:Tool.Invocation.t
+  -> tool_name:string
+  -> input:Yojson.Safe.t
+  -> (invocation, error) result
+
+(** Stable opaque coordinates for rebinding after the writer is reopened. *)
+val invocation_locator : invocation -> invocation_locator
+
+val rebind_invocation
+  :  writer:Execution_lane_writer.t
+  -> invocation_locator
+  -> (invocation, error) result
+
+(** Commit the attempt before the effect and atomically settle its result. *)
+val execute
+  :  invocation
+  -> invoke:(unit -> Llm_provider.Types.content_block)
+  -> (Execution_tool_settlement.execution, error) result
+
+val close_provider_attempt
+  :  provider_attempt
+  -> Execution_event.terminal
+  -> (unit, error) result
+
+val close_turn : turn -> Execution_event.terminal -> (unit, error) result
+val finish : t -> Execution_event.terminal -> (unit, error) result
+
+(** Atomically terminate every open descendant and the run root. *)
+val abort : t -> abort_reason -> (unit, error) result

--- a/test/test_execution_lane_writer.ml
+++ b/test/test_execution_lane_writer.ml
@@ -8,6 +8,7 @@ module Journal = Internal.Execution_journal
 module Store = Internal.Execution_event_store
 module Writer = Internal.Execution_lane_writer
 module Settlement = Internal.Execution_tool_settlement
+module Agent_scope = Internal.Execution_agent_scope
 module Tx = Journal.Transaction
 
 exception Cancel_waiter
@@ -33,6 +34,11 @@ let require_closed = function
 let require_scope = function
   | Ok value -> value
   | Error error -> fail (Writer.scope_failure_to_string error)
+;;
+
+let require_agent_scope = function
+  | Ok value -> value
+  | Error error -> fail (Agent_scope.error_to_string error)
 ;;
 
 let with_fresh codec dir f =
@@ -515,6 +521,153 @@ let test_structural_occurrence_identity_is_parent_local () =
               ~kind:(Event.Agent_turn { ordinal = 0 })
               ()));
       check int "same ordinal under different parents is allowed" 12 (seq ())))
+;;
+
+let test_agent_scope_owns_effect_topology () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun codec dir ->
+    make_dir dir;
+    let locator = ref None in
+    let calls = ref 0 in
+    let result =
+      Types.ToolResult
+        { tool_use_id = ""
+        ; content = "done"
+        ; outcome = Types.Tool_succeeded
+        ; json = None
+        ; content_blocks = None
+        }
+    in
+    with_fresh codec dir (fun _sw writer ->
+      let scope = require_agent_scope (Agent_scope.start ~writer ~agent_name:"agent") in
+      let before_cancelled =
+        Writer.current_cursor writer |> Result.get_ok |> Journal.cursor_seq
+      in
+      (match
+         Eio.Cancel.sub (fun cancellation ->
+           Eio.Cancel.cancel cancellation Cancel_scope;
+           ignore (Agent_scope.open_turn scope ~ordinal:99))
+       with
+       | exception Eio.Cancel.Cancelled Cancel_scope -> ()
+       | () -> fail "pre-cancelled topology mutation returned"
+       | exception exn -> raise exn);
+      check
+        int
+        "pre-cancelled topology mutation admitted no event"
+        before_cancelled
+        (Writer.current_cursor writer |> Result.get_ok |> Journal.cursor_seq);
+      let before = cursor_at (Result.get_ok (Writer.current_cursor writer)) 0 in
+      let turn = require_agent_scope (Agent_scope.open_turn scope ~ordinal:3) in
+      let config =
+        Llm_provider.Provider_config.make
+          ~kind:Llm_provider.Provider_kind.OpenAI_compat
+          ~provider_id:"scope-provider"
+          ~model_id:"scope-model"
+          ~base_url:"https://provider.test"
+          ()
+      in
+      let binding =
+        Binding_identity.of_provider_config
+          ~transport:(Binding_identity.transport_for_call ~injected:false)
+          config
+        |> require_codec
+      in
+      let provider =
+        require_agent_scope (Agent_scope.open_provider_attempt turn ~ordinal:0 binding)
+      in
+      let schedule : Tool.schedule =
+        { planned_index = 0
+        ; batch_index = 0
+        ; batch_size = 1
+        ; execution_mode = Tool.Serial
+        }
+      in
+      let wrong_turn = Tool.Invocation.create ~tool_use_id:"" ~turn:4 ~schedule in
+      (match
+         Agent_scope.open_invocation
+           provider
+           ~invocation:wrong_turn
+           ~tool_name:"effect"
+           ~input:`Null
+       with
+       | Error _ -> ()
+       | Ok _ -> fail "mismatched invocation turn entered the scope");
+      check
+        int
+        "rejected invocation left no partial node"
+        3
+        (Writer.current_cursor writer |> Result.get_ok |> Journal.cursor_seq);
+      let exact_invocation = Tool.Invocation.create ~tool_use_id:"" ~turn:3 ~schedule in
+      let invocation =
+        require_agent_scope
+          (Agent_scope.open_invocation
+             provider
+             ~invocation:exact_invocation
+             ~tool_name:"effect"
+             ~input:(`Assoc [ "value", `Int 7 ]))
+      in
+      locator := Some (Agent_scope.invocation_locator invocation);
+      (match
+         Agent_scope.execute invocation ~invoke:(fun () ->
+           incr calls;
+           result)
+       with
+       | Ok (Settlement.Executed _) -> ()
+       | Ok (Settlement.Replayed _) -> fail "fresh scoped effect was replayed"
+       | Error error -> fail (Agent_scope.error_to_string error));
+      check int "scoped effect call count" 1 !calls;
+      let abort_result =
+        match
+          Eio.Cancel.sub (fun cancellation ->
+            Eio.Cancel.cancel cancellation Cancel_scope;
+            Agent_scope.abort
+              scope
+              (Agent_scope.Cancelled { reason = Some "scope test complete"; data = None }))
+        with
+        | result -> result
+        | exception Eio.Cancel.Cancelled Cancel_scope ->
+          fail "cancelled cleanup context lost the durable abort receipt"
+        | exception exn -> raise exn
+      in
+      require_agent_scope abort_result;
+      let events, through = read_complete_page writer ~after:before ~limit:12 in
+      check int "closed scope event count" 12 (List.length events);
+      check int "closed scope cursor" 12 (Journal.cursor_seq through);
+      match List.map Event.payload events with
+      | Event.Node_opened root
+        :: Event.Node_opened turn_node
+        :: Event.Node_opened provider_node
+        :: Event.Node_opened invocation_node
+        :: Event.Node_updated { update = Event.Tool_input_snapshot input; _ }
+        :: _ ->
+        (match
+           ( Event.node_kind root
+           , Event.node_kind turn_node
+           , Event.node_kind provider_node
+           , Event.node_kind invocation_node
+           , input )
+         with
+         | ( Event.Agent_run { agent_name = "agent" }
+           , Event.Agent_turn { ordinal = 3 }
+           , Event.Provider_attempt { ordinal = 0; _ }
+           , Event.Tool_invocation
+               { provider_tool_use_id = Some ""; tool_name = "effect"; _ }
+           , Types.ToolUse
+               { id = ""; name = "effect"; input = `Assoc [ ("value", `Int 7) ] } ) -> ()
+         | _ -> fail "scope did not retain exact typed topology")
+      | _ -> fail "scope did not write its topology before the effect");
+    with_existing codec dir (fun _sw writer ->
+      ignore (require_scope (Writer.await_ready writer));
+      let invocation =
+        require_agent_scope (Agent_scope.rebind_invocation ~writer (Option.get !locator))
+      in
+      (match Agent_scope.execute invocation ~invoke:(fun () -> fail "effect reran") with
+       | Ok (Settlement.Replayed replayed) ->
+         check bool "reopened scope replays exact result" true (replayed = result)
+       | Ok (Settlement.Executed _) -> fail "reopened scope executed effect twice"
+       | Error error -> fail (Agent_scope.error_to_string error));
+      check int "reopened scope preserves call count" 1 !calls))
 ;;
 
 let rec await_reconciliation_phase writer =
@@ -1437,6 +1590,10 @@ let () =
             "structural occurrence identity is parent local"
             `Quick
             test_structural_occurrence_identity_is_parent_local
+        ; test_case
+            "Agent scope owns effect topology"
+            `Quick
+            test_agent_scope_owns_effect_topology
         ; test_case
             "concurrent submit and close linearize without loss"
             `Quick


### PR DESCRIPTION
## Scope

- add a Dune-private Agent execution scope with opaque run → turn → provider → invocation ownership
- retain exact selected provider binding without exposing it as identity
- retain opaque invocation locators across `Writer.resume` within the process
- make normal mutation admission cancellation-aware
- make abort cleanup cancellation-safe with a private `Failed | Cancelled` reason type

## Cancellation law

Normal mutations check cancellation before admission. Abort cleanup deliberately performs submit + accepted await inside `Eio.Cancel.protect`, so a pre-cancelled context still durably records the terminal abort receipt.

## Boundary / remaining blockers

This is a private foundation, not a production hard-cut. Production `Agent_tools` wiring remains zero. The next leaves must add a closed process-restart locator/scope codec and narrow execute results to a caller-owned invocation identity; arbitrary `content_block` results are not yet acceptable production authority.

## Verification

- focused build: PASS
- execution lane writer: 20/20 PASS
- execution-store boundary: PASS
- SDK independence: PASS
- `@fmt`: PASS
- `git diff --check`: PASS
- hostile review: private leaf PASS; production hard-cut BLOCKED as documented above

## Size

392 changed lines (<400).
