### PR TITLE
feat(error): expose canonical SDK error categories

### DIFF
--- a/lib/base/error.ml
+++ b/lib/base/error.ml
@@ -115,6 +115,41 @@ type sdk_error =
   | Orchestration of orchestration_error
   | Internal of string
 
+type category =
+  | Api_category
+  | Provider_category
+  | Agent_category
+  | Mcp_category
+  | Config_category
+  | Serialization_category
+  | Io_category
+  | Orchestration_category
+  | Internal_category
+
+let category : sdk_error -> category = function
+  | Api _ -> Api_category
+  | Provider _ -> Provider_category
+  | Agent _ -> Agent_category
+  | Mcp _ -> Mcp_category
+  | Config _ -> Config_category
+  | Serialization _ -> Serialization_category
+  | Io _ -> Io_category
+  | Orchestration _ -> Orchestration_category
+  | Internal _ -> Internal_category
+;;
+
+let category_label : category -> string = function
+  | Api_category -> "api"
+  | Provider_category -> "provider"
+  | Agent_category -> "agent"
+  | Mcp_category -> "mcp"
+  | Config_category -> "config"
+  | Serialization_category -> "serialization"
+  | Io_category -> "io"
+  | Orchestration_category -> "orchestration"
+  | Internal_category -> "internal"
+;;
+
 (* ── Human-readable messages ──────────────────────────────────────── *)
 
 let agent_error_to_string = function

--- a/lib/base/error.mli
+++ b/lib/base/error.mli
@@ -110,7 +110,27 @@ type sdk_error =
   | Orchestration of orchestration_error
   | Internal of string
 
+(** Non-identifying top-level category derived from an [sdk_error].
+    This projection is for observation only; it does not define retry,
+    fallback, or scheduling policy. *)
+type category =
+  | Api_category
+  | Provider_category
+  | Agent_category
+  | Mcp_category
+  | Config_category
+  | Serialization_category
+  | Io_category
+  | Orchestration_category
+  | Internal_category
+
 (** {1 Operations} *)
+
+(** Project an SDK error to its top-level category. *)
+val category : sdk_error -> category
+
+(** Canonical observation label for a top-level category. *)
+val category_label : category -> string
 
 (** Human-readable error message. *)
 val to_string : sdk_error -> string

--- a/test/test_error.ml
+++ b/test/test_error.ml
@@ -8,6 +8,64 @@ let sdk_error_testable =
   Alcotest.testable (fun fmt e -> Format.pp_print_string fmt (Error.to_string e)) ( = )
 ;;
 
+let category_testable =
+  Alcotest.testable
+    (fun fmt category -> Format.pp_print_string fmt (Error.category_label category))
+    ( = )
+;;
+
+let category_cases : (string * Error.sdk_error * Error.category * string) list =
+  [ "Api", Error.Api (Retry.AuthError { message = "bad key" }), Error.Api_category, "api"
+  ; ( "Provider"
+    , Error.Provider
+        (Llm_provider.Error.InvalidConfig { field = "model"; detail = "invalid" })
+    , Error.Provider_category
+    , "provider" )
+  ; ( "Agent"
+    , Error.Agent (Error.UnrecognizedStopReason { reason = "unknown" })
+    , Error.Agent_category
+    , "agent" )
+  ; ( "Mcp"
+    , Error.Mcp (Error.InitializeFailed { detail = "handshake failed" })
+    , Error.Mcp_category
+    , "mcp" )
+  ; ( "Config"
+    , Error.Config (Error.MissingEnvVar { var_name = "API_KEY" })
+    , Error.Config_category
+    , "config" )
+  ; ( "Serialization"
+    , Error.Serialization (Error.JsonParseError { detail = "invalid JSON" })
+    , Error.Serialization_category
+    , "serialization" )
+  ; ( "Io"
+    , Error.Io (Error.ValidationFailed { detail = "invalid path" })
+    , Error.Io_category
+    , "io" )
+  ; ( "Orchestration"
+    , Error.Orchestration (Error.UnknownAgent { name = "missing" })
+    , Error.Orchestration_category
+    , "orchestration" )
+  ; "Internal", Error.Internal "invariant failed", Error.Internal_category, "internal"
+  ]
+;;
+
+let category_tests =
+  List.map
+    (fun (name, error, expected_category, expected_label) ->
+       test_case name `Quick (fun () ->
+         check
+           category_testable
+           (name ^ " category")
+           expected_category
+           (Error.category error);
+         check
+           string
+           (name ^ " label")
+           expected_label
+           (Error.category_label expected_category)))
+    category_cases
+;;
+
 (* ── to_string tests ──────────────────────────────────────────────── *)
 
 let test_api_rate_limited () =
@@ -246,7 +304,8 @@ let test_inequality () =
 let () =
   run
     "Error"
-    [ ( "to_string"
+    [ "category", category_tests
+    ; ( "to_string"
       , [ test_case "Api RateLimited" `Quick test_api_rate_limited
         ; test_case "Api AuthError" `Quick test_api_auth_error
         ; test_case "Provider timeout phase" `Quick test_provider_timeout_phase


### PR DESCRIPTION
## Outcome

OAS now owns one public, non-identifying projection from `Agent_sdk.Error.sdk_error` to a closed category and canonical observation label.

## What changed

- add a closed 9-variant `Agent_sdk.Error.category` type;
- add exhaustive `Error.category : sdk_error -> category` with no wildcard;
- add exhaustive `Error.category_label : category -> string`;
- test every SDK error constructor and every canonical label.

The projection is explicitly observational. It does not define retry, fallback, scheduling, pause, or budget policy.

## Boundary / no dual source

OAS owns the SDK error representation, so its canonical category projection belongs in OAS. There are no MASC/Keeper/product imports or policy constructors here.

After an OAS release and MASC pin, MASC should hard-delete only its duplicate SDK-category projectors: the overlapping `sdk_error_kind` functions/aliases in `Oas_compat`, `Keeper_agent_error`, `Keeper_turn_runtime_budget_routing`, and their forwarding surface. MASC-owned user messages, termination classification, terminal reasons, runtime outcomes, and other product behavior remain in MASC. No compatibility classifier or dual-run period is planned.

## Validation

- `ocamlformat --check lib/base/error.ml lib/base/error.mli test/test_error.ml`
- `git diff --check`
- `test/test_error.exe`: 39/39 pass
- adversarial code review: P0/P1 none

Base: `oas/main@2102d4de5` (`0.216.3`).

[근거] exact diff, focused executable output, and current OAS/MASC source inspection; checked 2026-07-18 KST; confidence High.
