### PR TITLE
refactor(capabilities): make thinking-control codec exact

### DIFF
--- a/docs/rfc/RFC-OAS-033-thinking-control-format-variant-relocation.md
+++ b/docs/rfc/RFC-OAS-033-thinking-control-format-variant-relocation.md
@@ -5,9 +5,10 @@
 | Status | Implemented |
 | Author | jeong-sik (audit: provider SSOT sweep, 2026-06-30) |
 | Created | 2026-06-30 |
+| Amended | 2026-07-18 — exact lossless thinking-control codec contract |
 | Target | `lib/llm_provider/capability_vocab.ml`, `capabilities.ml`(+`.mli`), `provider_catalog.ml`, `capability_manifest.ml`, `model_catalog.ml`, `reasoning_dialect.ml` |
 | Supplements | RFC-OAS-023 (capability axis reshape), RFC-OAS-029 §1.2 (string classifier bypassing typed kind) |
-| Boundary | OAS internal refactor — no wire/contract change. Deriving/show/equality surface preserved via alias. |
+| Boundary | OAS capability vocabulary and catalog-input contract. Variant ownership remains internal; the public codec rejects non-canonical labels and invalid token combinations. |
 
 ## 0. Summary
 
@@ -21,15 +22,23 @@ vocabulary. Because `capability_vocab` is a leaf module with no dependency on
 needed `variant <-> wire-string` reimplemented literal matches. That was the
 cycle-break bug: the leaf owned the vocabulary intent, but not the variant.
 
-Current `main` has adopted Option A from this RFC:
+The implemented design adopts Option A from this RFC:
 
 - `capability_vocab.ml` owns the `thinking_control_format` and
   `preserve_thinking_control_format` variants.
-- It owns one canonical table per vocabulary and derives `values` and
-  `*_of_string` from that table.
+- It owns one exhaustive canonical-label projection for
+  `thinking_control_format`, exact typed encode/decode functions, and one
+  canonical table for `preserve_thinking_control_format`.
 - `capabilities.ml` re-exports the variants via type/constructor aliases, so
   existing `Capabilities.*` call sites compile unchanged.
-- `provider_catalog.ml` delegates parsing to `Capability_vocab`.
+- capability manifests, model catalogs, and provider catalogs delegate the
+  complete `{ label; token }` declaration to `Capability_vocab`.
+
+The thinking-control declaration is an exact contract. Labels are compared
+with `String.equal`; they are never trimmed, case-folded, or aliased. A
+`Chat_template_token` preserves its token byte-for-byte, but empty,
+whitespace-only, or padded tokens are rejected. Declaration absence remains
+`None` and never defaults to `No_thinking_control`.
 
 This document is therefore a design record and verification contract for the
 landed implementation, not a request to perform a future relocation.
@@ -64,15 +73,27 @@ cycle break.
 ### 2.1 Option A — variants owned by `capability_vocab` (ADOPTED)
 
 The variant definitions live in `capability_vocab.ml`, alongside the existing
-`reasoning_replay_override` / `assistant_tool_content_format`. Each vocabulary
-has a single canonical table, and every public parser/value surface is derived
-from that table:
+`reasoning_replay_override` / `assistant_tool_content_format`.
 
-- `values = List.map fst table`
-- `of_string = List.assoc_opt normalized table`
-- `to_string` is intentionally absent unless a real serializer consumer is
-  introduced; if added later, it must be reverse-derived from the same table,
-  not a third hand-written match.
+`thinking_control_format` cannot use a flat `string * variant` table because
+`Chat_template_token` carries caller-owned data. Its single vocabulary owner is
+therefore:
+
+- an exhaustive `canonical_label_of_thinking_control_format` projection;
+- `tokenless_thinking_control_formats`, whose labels derive from that
+  projection;
+- `encode_thinking_control_format`, which validates the public token-bearing
+  constructor and returns a typed result;
+- `decode_thinking_control_format`, which accepts only an exact canonical
+  `{ label; token }` pair;
+- `decode_optional_thinking_control_format`, which preserves absent
+  declarations and rejects orphan tokens.
+
+The codec error family is closed: `Unknown_label`, `Token_required`,
+`Token_forbidden`, and raw-preserving `Invalid_token`. Token trimming is used
+only to detect invalid empty or padded input; no trimmed value is accepted or
+emitted. `preserve_thinking_control_format` remains a data-less vocabulary
+derived from its canonical table.
 
 `capabilities.ml` is a consumer with a type alias and constructor re-export:
 
@@ -86,8 +107,8 @@ type thinking_control_format = Capability_vocab.thinking_control_format =
 The OCaml constructor alias keeps `Capabilities.No_thinking_control` valid at
 existing call sites, including `reasoning_dialect.ml` and the matches across
 `backend_openai_request`, `backend_anthropic`, `api_openai`, and related files.
-Duplicated parsers are replaced by `Capability_vocab.*_of_string`
-delegation.
+Duplicated parsers are replaced by delegation to the exact codec for thinking
+control and the canonical table parser for preserve-thinking control.
 
 **Dependency direction:** `capability_vocab` (leaf) ← `capabilities` ← everyone else. No cycle: `capability_vocab` still depends on nothing. `capabilities` already depends on `capability_vocab` (it aliases `reasoning_replay_override` today), so the new edge is not even new.
 
@@ -105,11 +126,12 @@ Over-engineered for a flat 8-constructor enum. Rejected.
 
 | step | change | blast radius |
 |---|---|---|
-| 1 | `capability_vocab`: add `type thinking_control_format` + `preserve_thinking_control_format` + one canonical table per vocabulary; derive `values` and `of_string` from that table. | leaf only |
+| 1 | `capability_vocab`: own both variants; derive thinking-control labels from one exhaustive projection and preserve-thinking values from one canonical table. | leaf only |
 | 2 | `capabilities.ml` (+`.mli`): replace owned type defs with aliases `= Capability_vocab.*`; re-export constructors | type-only, call sites unchanged |
-| 3 | `provider_catalog.ml`: `parse_thinking_control_format` / `parse_preserve_thinking_control_format` delegate to `Capability_vocab` | parser collapse |
-| 4 | manifest/catalog unknown values remain fail-closed with observable diagnostics at their call sites | silent-failure guard |
-| 5 | tests: exported values parse through the canonical table; future additions must update the table and aliases together | drift guard |
+| 3 | capability manifest, model catalog, and provider catalog pass the raw optional label/token pair to `decode_optional_thinking_control_format`; preserve-thinking parsing still delegates to `Capability_vocab`. | parser collapse |
+| 4 | exact decode rejects unknown/non-canonical labels, missing/orphan tokens, and empty or padded tokens with a typed raw-preserving error. | fail-closed contract |
+| 5 | exact encode validates token-bearing public constructors instead of emitting an invalid declaration. | serializer guard |
+| 6 | tests cover every format round-trip, canonical-label uniqueness, exact rejection, token preservation, absence, and all three loader boundaries. | drift guard |
 
 The migration is complete for the thinking-control vocabularies. This RFC no
 longer asks maintainers to perform these steps.
@@ -118,23 +140,28 @@ longer asks maintainers to perform these steps.
 
 - **Compiler**: aliases keep existing constructors visible while preserving
   exhaustiveness checks at match sites.
-- **Single-table proof**: exported `values` must be derived from the same table
-  used by `of_string`; a round-trip test alone is not enough because independent
-  encodings can round-trip accidentally.
-- **Property test**: `List.for_all (fun s -> Capability_vocab.thinking_control_format_of_string s <> None) Capability_vocab.thinking_control_format_values` plus equivalent preserve-thinking coverage.
-- **Delegation test**: provider/catalog parsing must delegate to
-  `Capability_vocab` instead of reintroducing local literal matches.
-- **Warning preservation**: manifest/catalog unknown-value call sites must keep
-  observable warning/error behavior after delegating to `Capability_vocab`;
-  `None` without a warning is a silent failure regression.
+- **Single-owner proof**: every thinking-control label derives from the
+  exhaustive canonical projection; no independent label table or normalizing
+  parser exists.
+- **Exact codec proof**: every valid format round-trips, canonical labels are
+  unique, and rejected labels/tokens retain the original bytes in the typed
+  error.
+- **Absence proof**: a missing declaration decodes to `Ok None`; it never
+  selects a default. An orphan token fails typed.
+- **Delegation proof**: manifest, model-catalog, and provider-catalog loaders
+  invoke the same optional codec and fail closed; they do not reproduce label
+  or cross-field logic.
+- **Preserve-thinking proof**: its exported values and parser remain derived
+  from one canonical table.
 
 ## 5. Why not bundle into the SSOT-audit subset PRs
 
 The 2026-06-30 audit produced three surgical PRs (#2333 provider-kind
 round-trip, #2334 stop_reason wire SSOT, #2335 catch-all exhaustiveness) that
-were zero-runtime-change. This RFC's move was also zero runtime change, but it
-touched broader type ownership and parser delegation. Keeping it separate made
-the review boundary explicit.
+were zero-runtime-change. The original variant relocation preserved runtime
+behavior. The later exact codec amendment intentionally tightens catalog-input
+and public-encode behavior, so it remains isolated here rather than being
+hidden inside an unrelated SSOT cleanup.
 
 ## 6. Non-goals
 
@@ -148,5 +175,6 @@ the review boundary explicit.
 - `Modality.t` priority still follows a similar vocabulary pattern. It can be
   evaluated separately; it is not a blocker for the implemented
   `thinking_control_format` relocation.
-- Any future `to_string` surface for these vocabularies must be introduced only
-  with a real serializer consumer and must be derived from the canonical table.
+- Any future thinking-control serializer must consume
+  `encode_thinking_control_format`; it must not add a second label projection or
+  bypass typed token validation.

--- a/lib/llm_provider/capability_manifest.ml
+++ b/lib/llm_provider/capability_manifest.ml
@@ -395,18 +395,22 @@ let parse_entry json =
     | None -> Ok None
     | Some raw -> Result.map (fun label -> Some label) (base_label_of_string raw)
   in
-  (* Read the raw label and the exact-validated token, then join them:
-     [thinking_control_format_of_label_and_token] validates the label against the
-     vocab and enforces the chat_template_token <-> token cross-field invariant. *)
+  (* Read the raw label/token pair and decode it through the exact vocabulary
+     authority. The codec owns label exactness, token exactness, and the
+     cross-field invariant. *)
   let* thinking_control_format_raw =
     member_string_closed "thinking_control_format" json
   in
-  let* thinking_control_token = non_empty_member_string "thinking_control_token" json in
+  let* thinking_control_token = member_string_closed "thinking_control_token" json in
   let* thinking_control_format =
-    Capability_vocab.thinking_control_format_of_label_and_token
-      ~format:thinking_control_format_raw
+    Capability_vocab.decode_optional_thinking_control_format
+      ~label:thinking_control_format_raw
       ~token:thinking_control_token
-    |> Result.map_error (fun msg -> Printf.sprintf "entry %S %s" id_prefix msg)
+    |> Result.map_error (fun error ->
+      Printf.sprintf
+        "entry %S %s"
+        id_prefix
+        (Capability_vocab.thinking_control_format_codec_error_to_string error))
   in
   let* anthropic_thinking_control =
     canonical_anthropic_thinking_control "anthropic_thinking_control" json

--- a/lib/llm_provider/capability_vocab.ml
+++ b/lib/llm_provider/capability_vocab.ml
@@ -94,31 +94,66 @@ let anthropic_thinking_control_of_string raw =
   List.assoc_opt (normalize raw) anthropic_thinking_control_table
 ;;
 
-(* The chat-template-token label needs a companion token, so unlike the data-less
-   variants it cannot live in a plain [string -> t] table. The label is still
-   listed in [thinking_control_format_values] for vocab-membership validation;
-   build the full value with [thinking_control_format_of_label_and_token]. *)
-let chat_template_token_label = "chat_template_token"
+(** The one canonical label projection for thinking-control formats. This match
+    is deliberately exhaustive: the encoder, exact decoder lookup, and
+    advertised vocabulary below derive their labels from it. *)
+let canonical_label_of_thinking_control_format = function
+  | No_thinking_control -> "none"
+  | Thinking_object -> "thinking_object"
+  | Thinking_object_adaptive -> "thinking_object_adaptive"
+  | Thinking_object_only -> "thinking_object_only"
+  | Chat_template_kwargs -> "chat_template_kwargs"
+  | Chat_template_token _ -> "chat_template_token"
+  | Ollama_think -> "ollama_think"
+  | Reasoning_effort -> "reasoning_effort"
+  | Enable_thinking -> "enable_thinking"
+;;
 
-let thinking_control_format_tokenless_table =
-  [ "none", No_thinking_control
-  ; "thinking_object", Thinking_object
-  ; "thinking_object_adaptive", Thinking_object_adaptive
-  ; "thinking_object_only", Thinking_object_only
-  ; "chat_template_kwargs", Chat_template_kwargs
-  ; "ollama_think", Ollama_think
-  ; "reasoning_effort", Reasoning_effort
-  ; "enable_thinking", Enable_thinking
+(* These formats carry no companion token and can therefore serve directly as
+   exact decoder results. Their labels are always obtained from the exhaustive
+   canonical projection above; this list contains no second wire vocabulary. *)
+let tokenless_thinking_control_formats =
+  [ No_thinking_control
+  ; Thinking_object
+  ; Thinking_object_adaptive
+  ; Thinking_object_only
+  ; Chat_template_kwargs
+  ; Ollama_think
+  ; Reasoning_effort
+  ; Enable_thinking
   ]
 ;;
 
-let thinking_control_format_values =
-  List.map fst thinking_control_format_tokenless_table @ [ chat_template_token_label ]
+let chat_template_token_label =
+  canonical_label_of_thinking_control_format (Chat_template_token "")
 ;;
 
+let thinking_control_format_values =
+  List.map canonical_label_of_thinking_control_format tokenless_thinking_control_formats
+  @ [ chat_template_token_label ]
+;;
+
+type thinking_control_format_fields =
+  { label : string
+  ; token : string option
+  }
+
+type thinking_control_token_invalidity =
+  | Empty_token
+  | Leading_or_trailing_whitespace
+
+type thinking_control_format_codec_error =
+  | Unknown_label of string
+  | Token_required
+  | Token_forbidden
+  | Invalid_token of
+      { token : string
+      ; invalidity : thinking_control_token_invalidity
+      }
+
 (* The chat-template thinking token carried by [Chat_template_token], or [None]
-   for every other wire format. Exhaustive so a new [thinking_control_format]
-   variant is compiler-checked here. *)
+   for every other wire format. Exhaustive so adding a format requires an
+   explicit token-policy decision. *)
 let token_of_thinking_control_format = function
   | Chat_template_token token -> Some token
   | No_thinking_control
@@ -131,58 +166,90 @@ let token_of_thinking_control_format = function
   | Enable_thinking -> None
 ;;
 
-(* Join a [thinking_control_format] wire label with its companion
-   [thinking_control_token]. The two are one concept: [chat_template_token]
-   carries its token in the constructor, so a chat_template_token label REQUIRES a
-   token, and a token REQUIRES the chat_template_token label. Every crossed
-   combination fails closed here rather than parsing into a value a request
-   builder would reject later.
+let validate_thinking_control_token token =
+  let trimmed = String.trim token in
+  if String.equal trimmed ""
+  then Error (Invalid_token { token; invalidity = Empty_token })
+  else if not (String.equal token trimmed)
+  then Error (Invalid_token { token; invalidity = Leading_or_trailing_whitespace })
+  else Ok token
+;;
 
-   Callers validate [format] against [thinking_control_format_values] and [token]
-   for exactness before calling; this function enforces only the cross-field
-   invariant and returns a message the caller prefixes with the offending entry
-   id. *)
-let thinking_control_format_of_label_and_token ~format ~token
-  : (thinking_control_format option, string) result
+let validate_optional_thinking_control_token = function
+  | None -> Ok None
+  | Some token -> Result.map Option.some (validate_thinking_control_token token)
+;;
+
+(** The canonical, lossless operator representation of a thinking-control
+    format. Both fields derive from exhaustive projections rather than carrying
+    their own wire-label table. The public constructor can carry any string, so
+    encoding validates its token and returns a typed error instead of emitting
+    an invalid declaration. *)
+let encode_thinking_control_format format
+  : (thinking_control_format_fields, thinking_control_format_codec_error) result
   =
-  let token_present =
-    match token with
-    | Some t when String.trim t <> "" -> Some t
-    | Some _ | None -> None
-  in
-  let orphan_token_error =
+  Result.map
+    (fun token -> { label = canonical_label_of_thinking_control_format format; token })
+    (validate_optional_thinking_control_token (token_of_thinking_control_format format))
+;;
+
+(** Decode only exact canonical labels. No trimming, case folding, aliasing, or
+    default selection occurs here. [thinking_control_token] is part of the same
+    declaration: it is required by [chat_template_token], forbidden elsewhere,
+    and retained byte-for-byte when valid. *)
+let decode_thinking_control_format ({ label; token } : thinking_control_format_fields)
+  : (thinking_control_format, thinking_control_format_codec_error) result
+  =
+  Result.bind (validate_optional_thinking_control_token token) (fun token ->
+    if String.equal label chat_template_token_label
+    then (
+      match token with
+      | None -> Error Token_required
+      | Some token -> Ok (Chat_template_token token))
+    else (
+      match
+        List.find_opt
+          (fun format ->
+             String.equal label (canonical_label_of_thinking_control_format format))
+          tokenless_thinking_control_formats
+      with
+      | None -> Error (Unknown_label label)
+      | Some _ when Option.is_some token -> Error Token_forbidden
+      | Some format -> Ok format))
+;;
+
+(** Optional catalog/manifest declaration wrapper. Absence is preserved as
+    absence; it never selects [No_thinking_control]. An orphan token is rejected
+    by the same typed error as a token attached to a tokenless format. *)
+let decode_optional_thinking_control_format ~label ~token
+  : (thinking_control_format option, thinking_control_format_codec_error) result
+  =
+  match label with
+  | None ->
+    Result.bind (validate_optional_thinking_control_token token) (function
+      | None -> Ok None
+      | Some _ -> Error Token_forbidden)
+  | Some label -> Result.map Option.some (decode_thinking_control_format { label; token })
+;;
+
+let thinking_control_format_codec_error_to_string = function
+  | Unknown_label label ->
+    Printf.sprintf
+      "unknown thinking_control_format %S (canonical: %s)"
+      label
+      (String.concat ", " thinking_control_format_values)
+  | Token_required ->
+    Printf.sprintf
+      "thinking_control_format %S requires a non-empty thinking_control_token"
+      chat_template_token_label
+  | Token_forbidden ->
     Printf.sprintf
       "thinking_control_token is only valid with thinking_control_format = %S"
       chat_template_token_label
-  in
-  match format with
-  | None ->
-    (match token_present with
-     | None -> Ok None
-     | Some _ -> Error orphan_token_error)
-  | Some raw ->
-    let normalized = normalize raw in
-    if String.equal normalized chat_template_token_label
-    then (
-      match token_present with
-      | Some token -> Ok (Some (Chat_template_token token))
-      | None ->
-        Error
-          (Printf.sprintf
-             "thinking_control_format %S requires a non-empty thinking_control_token"
-             chat_template_token_label))
-    else (
-      match token_present with
-      | Some _ -> Error orphan_token_error
-      | None ->
-        (match List.assoc_opt normalized thinking_control_format_tokenless_table with
-         | Some fmt -> Ok (Some fmt)
-         | None ->
-           Error
-             (Printf.sprintf
-                "unknown thinking_control_format %S (canonical: %s)"
-                normalized
-                (String.concat ", " thinking_control_format_values))))
+  | Invalid_token { invalidity = Empty_token; _ } ->
+    "thinking_control_token must not be empty"
+  | Invalid_token { invalidity = Leading_or_trailing_whitespace; _ } ->
+    "thinking_control_token must not have leading or trailing whitespace"
 ;;
 
 let preserve_thinking_control_format_table =
@@ -204,48 +271,111 @@ let preserve_thinking_control_format_of_string raw =
   | normalized -> List.assoc_opt normalized preserve_thinking_control_format_table
 ;;
 
-let%test "thinking_control_format labels resolve through the canonical vocab" =
+let%test "thinking_control_format exact codec round-trips every format" =
   List.for_all
-    (fun raw ->
-       let token =
-         if String.equal (normalize raw) chat_template_token_label
-         then Some "<|think|>"
-         else None
-       in
-       match thinking_control_format_of_label_and_token ~format:(Some raw) ~token with
-       | Ok (Some _) -> true
-       | Ok None | Error _ -> false)
-    thinking_control_format_values
+    (fun format ->
+       match encode_thinking_control_format format with
+       | Error _ -> false
+       | Ok encoded ->
+         (match decode_thinking_control_format encoded with
+          | Ok decoded -> decoded = format
+          | Error _ -> false))
+    (Chat_template_token "<|think|>" :: tokenless_thinking_control_formats)
 ;;
 
-let%test "chat_template_token label without a token fails closed" =
-  match
-    thinking_control_format_of_label_and_token
-      ~format:(Some chat_template_token_label)
-      ~token:None
-  with
-  | Error _ -> true
-  | Ok _ -> false
+let%test "thinking_control_format encoder preserves the exact template token" =
+  encode_thinking_control_format (Chat_template_token "<|exact token|>")
+  = Ok { label = chat_template_token_label; token = Some "<|exact token|>" }
 ;;
 
-let%test "chat_template_token label carries its token into the constructor" =
-  match
-    thinking_control_format_of_label_and_token
-      ~format:(Some chat_template_token_label)
-      ~token:(Some "<|think|>")
-  with
-  | Ok (Some (Chat_template_token "<|think|>")) -> true
+let%test "thinking_control_format encoder rejects an empty public token" =
+  match encode_thinking_control_format (Chat_template_token "") with
+  | Error (Invalid_token { token = ""; invalidity = Empty_token }) -> true
   | Ok _ | Error _ -> false
 ;;
 
-let%test "a token declared without the chat_template_token label fails closed" =
+let%test "thinking_control_format encoder rejects a whitespace-only public token" =
+  match encode_thinking_control_format (Chat_template_token " \t ") with
+  | Error (Invalid_token { token = " \t "; invalidity = Empty_token }) -> true
+  | Ok _ | Error _ -> false
+;;
+
+let%test "thinking_control_format encoder rejects a padded public token" =
+  match encode_thinking_control_format (Chat_template_token " <|think|> ") with
+  | Error
+      (Invalid_token
+         { token = " <|think|> "; invalidity = Leading_or_trailing_whitespace }) -> true
+  | Ok _ | Error _ -> false
+;;
+
+let%test "thinking_control_format canonical labels are unique" =
+  List.length (List.sort_uniq String.compare thinking_control_format_values)
+  = List.length thinking_control_format_values
+;;
+
+let%test "thinking_control_format decoder rejects noncanonical labels exactly" =
+  List.for_all
+    (fun label ->
+       match decode_thinking_control_format { label; token = None } with
+       | Error (Unknown_label rejected) -> String.equal rejected label
+       | Ok _ | Error _ -> false)
+    [ " thinking_object"
+    ; "thinking_object "
+    ; "Thinking_object"
+    ; "thinking-object"
+    ; "no_thinking_control"
+    ; ""
+    ]
+;;
+
+let%test "chat_template_token requires a token" =
+  decode_thinking_control_format { label = chat_template_token_label; token = None }
+  = Error Token_required
+;;
+
+let%test "tokenless thinking_control_format forbids a token" =
+  decode_thinking_control_format
+    { label = canonical_label_of_thinking_control_format Thinking_object
+    ; token = Some "<|think|>"
+    }
+  = Error Token_forbidden
+;;
+
+let%test "chat_template_token rejects an empty token" =
   match
-    thinking_control_format_of_label_and_token
-      ~format:(Some "thinking_object")
-      ~token:(Some "<|think|>")
+    decode_thinking_control_format { label = chat_template_token_label; token = Some "" }
   with
-  | Error _ -> true
-  | Ok _ -> false
+  | Error (Invalid_token { invalidity = Empty_token; _ }) -> true
+  | Ok _ | Error _ -> false
+;;
+
+let%test "chat_template_token rejects a whitespace-only token as empty" =
+  match
+    decode_thinking_control_format
+      { label = chat_template_token_label; token = Some " \t " }
+  with
+  | Error (Invalid_token { token = " \t "; invalidity = Empty_token }) -> true
+  | Ok _ | Error _ -> false
+;;
+
+let%test "chat_template_token rejects a padded token without normalizing it" =
+  match
+    decode_thinking_control_format
+      { label = chat_template_token_label; token = Some " <|think|> " }
+  with
+  | Error
+      (Invalid_token
+         { token = " <|think|> "; invalidity = Leading_or_trailing_whitespace }) -> true
+  | Ok _ | Error _ -> false
+;;
+
+let%test "optional thinking_control_format preserves absence without a default" =
+  decode_optional_thinking_control_format ~label:None ~token:None = Ok None
+;;
+
+let%test "optional thinking_control_format rejects an orphan token" =
+  decode_optional_thinking_control_format ~label:None ~token:(Some "<|think|>")
+  = Error Token_forbidden
 ;;
 
 let%test "preserve_thinking_control_format values parse through the canonical table" =

--- a/lib/llm_provider/model_catalog.ml
+++ b/lib/llm_provider/model_catalog.ml
@@ -110,24 +110,6 @@ let non_empty_string_field ~entry_id key toml =
     else Ok (Some (String.lowercase_ascii raw))
 ;;
 
-let exact_non_empty_string_field ~entry_id key toml =
-  match find_string_field ~entry_id key toml with
-  | Error _ as e -> e
-  | Ok None -> Ok None
-  | Ok (Some raw) ->
-    let trimmed = String.trim raw in
-    if trimmed = ""
-    then Error (Printf.sprintf "model entry %S field %S must not be empty" entry_id key)
-    else if raw <> trimmed
-    then
-      Error
-        (Printf.sprintf
-           "model entry %S field %S must not have leading or trailing whitespace"
-           entry_id
-           key)
-    else Ok (Some raw)
-;;
-
 let canonical_string_opt ~entry_id key ~allowed toml =
   match find_string_field ~entry_id key toml with
   | Error _ as e -> e
@@ -458,13 +440,17 @@ let parse_entry entry_toml =
     find_string_field ~entry_id:id_prefix "thinking_control_format" entry_toml
   in
   let* thinking_control_token =
-    exact_non_empty_string_field ~entry_id:id_prefix "thinking_control_token" entry_toml
+    find_string_field ~entry_id:id_prefix "thinking_control_token" entry_toml
   in
   let* thinking_control_format =
-    Capability_vocab.thinking_control_format_of_label_and_token
-      ~format:thinking_control_format_raw
+    Capability_vocab.decode_optional_thinking_control_format
+      ~label:thinking_control_format_raw
       ~token:thinking_control_token
-    |> Result.map_error (Printf.sprintf "model entry %S %s" id_prefix)
+    |> Result.map_error (fun error ->
+      Printf.sprintf
+        "model entry %S %s"
+        id_prefix
+        (Capability_vocab.thinking_control_format_codec_error_to_string error))
   in
   let* anthropic_thinking_control =
     anthropic_thinking_control_opt

--- a/lib/llm_provider/provider_catalog.ml
+++ b/lib/llm_provider/provider_catalog.ml
@@ -633,8 +633,9 @@ let parse_capabilities provider_json =
        [thinking_control_token] key pair; join them so a chat_template_token
        preset without a token — or a token without that format — fails closed. *)
     let* raw = member_string "thinking_control_format" cap_json in
-    let* token = member_exact_non_empty_string_strict "thinking_control_token" cap_json in
-    Capability_vocab.thinking_control_format_of_label_and_token ~format:raw ~token
+    let* token = member_string "thinking_control_token" cap_json in
+    Capability_vocab.decode_optional_thinking_control_format ~label:raw ~token
+    |> Result.map_error Capability_vocab.thinking_control_format_codec_error_to_string
   in
   let* preserve_thinking_control_format =
     let* raw = member_string "preserve_thinking_control_format" cap_json in


### PR DESCRIPTION
## Outcome

OAS now has one exact, lossless thinking-control wire codec, and every OAS catalog loader uses it.

## What changed

- make one exhaustive constructor-to-canonical-label projection the only owner of the 9 wire labels;
- add exact `decode_thinking_control_format` over `{ label; token }`;
- make `encode_thinking_control_format` return a typed result, so invalid values from the public `Chat_template_token of string` constructor cannot cross the codec;
- use one closed codec-error family: `Unknown_label`, `Token_required`, `Token_forbidden`, and raw-preserving `Invalid_token`;
- preserve declaration absence as `None`; it never defaults to `No_thinking_control`;
- route capability manifest, model catalog, and provider catalog through this codec;
- delete the normalizing `thinking_control_format_of_label_and_token` path and the duplicate label table;
- update implemented RFC-OAS-033 so the versioned contract describes the exact codec rather than the retired normalizing parser.

Decoder label comparison is exact `String.equal`. Token trimming is used only to reject empty/padded input; no normalized value is accepted or emitted.

## Contract change

This is an intentional public codec/catalog-input tightening, not a no-op refactor. Non-canonical labels, invalid cross-field token combinations, and invalid public token-bearing constructors now fail typed instead of being normalized or emitted. RFC-OAS-033 records this exact contract and its verification obligations.

## Boundary / no dual source

This is OAS vocabulary/catalog behavior only; it contains no MASC/Keeper/product vocabulary.

After release and MASC pin, MASC must delete its duplicate thinking-control schema fields, label tables, aliases, defaults, and field-copy projection. Dashboard output must encode the resolved effective OAS binding and surface a typed encode failure. No compatibility decoder or dual declaration period is planned.

## Validation

- focused wrapper: `lib/llm_provider/llm_provider.cma` and `@lib/llm_provider/runtest` pass
- `test_capabilities.exe`: 100/100 pass
- `test_provider_catalog_coverage.exe`: 17/17 pass
- invalid public encode: empty, whitespace-only, and padded tokens rejected
- exact decode, roundtrip, label uniqueness, absence, orphan-token, and loader fail-closed cases pass
- `ocamlformat --check` and `git diff --check` pass
- retired helper/table references in live source: 0; RFC-OAS-033 keeps only explicitly labelled original-audit evidence

Base: `oas/main@2102d4de5` (`0.216.3`). Head: `5c9055a55`.

[근거] exact diff, focused executable outputs, and amended RFC contract; checked 2026-07-18 KST; confidence High.
