### PR TITLE
feat(llm_provider): profile request shape on client 4xx for opaque provider rejections

### DIFF
--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -530,9 +530,24 @@ let request_body_shape_profile (body : string) : Yojson.Safe.t =
                 else None)
              (List.sort_uniq String.compare names))
       in
+      (* Every top-level key NAME present, so a rejection caused by an
+         unrecognised or misspelled field is diagnosable even though it is not
+         one of the typed fields below. Key names are our own serialisation
+         vocabulary (schema), not request TEXT, so this leaks no user content.
+         Reporting the full key set also makes the profile schema-agnostic
+         rather than a curated per-provider key list: the typed fields are
+         richer detail on commonly-relevant keys, not the limit of what is
+         seen. *)
+      let top_level_keys =
+        `List
+          (List.map
+             (fun name -> `String name)
+             (List.sort_uniq String.compare (List.map fst fields)))
+      in
       `Assoc
         ([ "parseable", `Bool true
          ; "body_bytes", `Int (String.length body)
+         ; "top_level_keys", top_level_keys
          ; "model", string_field_label (List.assoc_opt "model" fields)
          ; "message_count", list_len_field_label messages_field
          ]
@@ -614,6 +629,49 @@ let%test "request_body_shape_profile extracts shape without message text" =
   && field "thinking_present" = `Bool true
   && field "max_tokens_present" = `Bool false
   && (not (contains ~needle:"secret prompt" s))
+  && not (contains ~needle:"private" s)
+;;
+
+(* The profile reports EVERY top-level key by NAME, so a 4xx caused by an
+   unrecognised or misspelled field is diagnosable even though that field is not
+   one of the typed fields. Key names are our own serialisation vocabulary
+   (schema), not request TEXT, so no value or user content leaks through them. *)
+let%test "shape profile surfaces unrecognised top-level keys without their values" =
+  let body =
+    {|{"model":"m","messages":[{"role":"user","content":"private"}],"unexpected_knob":"leak-me","typo_max_tokens":4}|}
+  in
+  let profile = request_body_shape_profile body in
+  let s = Yojson.Safe.to_string profile in
+  let contains ~needle haystack =
+    let nl = String.length needle
+    and hl = String.length haystack in
+    let rec loop i =
+      if i + nl > hl
+      then false
+      else if String.sub haystack i nl = needle
+      then true
+      else loop (i + 1)
+    in
+    nl = 0 || loop 0
+  in
+  let keys =
+    match Yojson.Safe.Util.member "top_level_keys" profile with
+    | `List xs ->
+      List.filter_map
+        (function
+          | `String s -> Some s
+          | _ -> None)
+        xs
+    | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _ -> []
+  in
+  let has_key k = List.mem k keys in
+  (* unrecognised keys are visible by NAME ... *)
+  has_key "unexpected_knob"
+  && has_key "typo_max_tokens"
+  && has_key "model"
+  && has_key "messages"
+  (* ... but their VALUES are not echoed, and message content stays absent *)
+  && (not (contains ~needle:"leak-me" s))
   && not (contains ~needle:"private" s)
 ;;
 

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -382,6 +382,164 @@ let profile_headers_on_client_error ~url ~code ~resp_headers request_headers =
     Diag.warn "http_client" "%s" (Yojson.Safe.to_string json))
 ;;
 
+(* On a 4xx, the response body from a provider edge is frequently an opaque
+   "Bad Request" with no field-level cause (observed 2026-07-18 against
+   ollama.com/v1 deepseek-v4-flash: ~78% of turns rejected, empty-detail body).
+   The request that provoked it is then lost, because [HttpError] only carries
+   the RESPONSE body. This logs a STRUCTURAL profile of the REQUEST body so a
+   recurring provider 4xx can be attributed to a request shape without a repro
+   harness or a full-body dump.
+
+   Only structural facts are emitted — field presence, counts, message role
+   sequence, and enumerable option values (response_format type, reasoning
+   effort). Prompt/message TEXT and tool argument values are never logged: they
+   may carry user content and do not distinguish an accepted shape from a
+   rejected one. A body that is not JSON is reported as such rather than
+   parsed. *)
+(* Exhaustive over the closed [Yojson.Safe.t] variant — no catch-all, so a
+   future Yojson constructor forces a compile update rather than silently
+   mislabelling. Non-string JSON collapses to a sentinel that is
+   distinguishable from an absent field ([`Null]). *)
+let json_as_string_label : Yojson.Safe.t -> Yojson.Safe.t = function
+  | `String s -> `String s
+  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `Assoc _ | `List _ ->
+    `String "<non-string>"
+;;
+
+let json_list_len_label : Yojson.Safe.t -> Yojson.Safe.t = function
+  | `List xs -> `Int (List.length xs)
+  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _ ->
+    `String "<non-list>"
+;;
+
+let json_is_present : Yojson.Safe.t -> bool = function
+  | `Null -> false
+  | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _ | `List _ -> true
+;;
+
+let request_body_shape_profile (body : string) : Yojson.Safe.t =
+  match Yojson.Safe.from_string body with
+  | exception (Yojson.Json_error _ | Yojson.Safe.Util.Type_error _) ->
+    `Assoc [ "parseable", `Bool false; "body_bytes", `Int (String.length body) ]
+  | `Assoc fields ->
+    let has key = List.mem_assoc key fields in
+    (* [absent] ([`Null]) is reserved for a missing field; a present-but-wrong
+       shape gets a distinct sentinel from the label helpers above. *)
+    let field key = if has key then List.assoc key fields else `Null in
+    let string_field key = json_as_string_label (field key) in
+    let messages =
+      match field "messages" with
+      | `List ms -> ms
+      | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _ -> []
+    in
+    let role_of_message : Yojson.Safe.t -> Yojson.Safe.t = function
+      | `Assoc mfields ->
+        (match List.assoc_opt "role" mfields with
+         | Some (`String r) -> `String r
+         | Some (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `Assoc _ | `List _) ->
+           `String "<non-string-role>"
+         | None -> `String "<no-role>")
+      | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ ->
+        `String "<non-object>"
+    in
+    let roles = List.map role_of_message messages in
+    let response_format_type =
+      match field "response_format" with
+      | `Assoc rf ->
+        (match List.assoc_opt "type" rf with
+         | Some (`String t) -> `String t
+         | Some (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `Assoc _ | `List _) ->
+           `String "<non-string-type>"
+         | None -> `String "<no-type>")
+      | `Null -> `Null
+      | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ ->
+        `String "<non-object>"
+    in
+    let stream =
+      match field "stream" with
+      | `Bool b -> `Bool b
+      | `Null | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _ | `List _ -> `Null
+    in
+    `Assoc
+      [ "parseable", `Bool true
+      ; "body_bytes", `Int (String.length body)
+      ; "model", string_field "model"
+      ; "message_count", `Int (List.length messages)
+      ; "message_roles", `List roles
+      ; "tool_count", json_list_len_label (field "tools")
+      ; "response_format_type", response_format_type
+      ; "reasoning_effort", string_field "reasoning_effort"
+      ; "thinking_present", `Bool (json_is_present (field "thinking"))
+      ; "max_tokens_present", `Bool (has "max_tokens")
+      ; "stream", stream
+      ]
+  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ ->
+    `Assoc
+      [ "parseable", `Bool true
+      ; "body_bytes", `Int (String.length body)
+      ; "top_level", `String "<non-object>"
+      ]
+;;
+
+(* Companion to [profile_headers_on_client_error]: names the request SHAPE on a
+   4xx so an opaque provider "Bad Request" can be diagnosed from the always-on
+   log, without enabling body-level debug or reproducing the exact turn. *)
+let profile_request_on_client_error ~url ~code ~request_body =
+  if code >= 400 && code < 500
+  then (
+    let json =
+      `Assoc
+        [ "event", `String "http_client_4xx_request_shape"
+        ; "url", `String url
+        ; "status", `Int code
+        ; "request_shape", request_body_shape_profile request_body
+        ; ( "note"
+          , `String
+              "4xx from an LLM endpoint. Structural request facts only; message and \
+               tool-argument TEXT omitted (may carry user content and does not \
+               distinguish accepted from rejected shapes)." )
+        ]
+    in
+    Diag.warn "http_client" "%s" (Yojson.Safe.to_string json))
+;;
+
+let%test "request_body_shape_profile reports non-json bodies without raising" =
+  (* Result is always an [`Assoc]; [member] yields [`Null] for a missing key,
+     so no catch-all is needed to read a field. *)
+  Yojson.Safe.Util.member "parseable" (request_body_shape_profile "Bad Request")
+  = `Bool false
+;;
+
+let%test "request_body_shape_profile extracts shape without message text" =
+  let body =
+    {|{"model":"deepseek-v4-flash","messages":[{"role":"system","content":"secret prompt"},{"role":"user","content":"private"}],"tools":[{"type":"function"}],"response_format":{"type":"json_schema"},"reasoning_effort":"high","thinking":{"type":"enabled"}}|}
+  in
+  let profile = request_body_shape_profile body in
+  let s = Yojson.Safe.to_string profile in
+  let contains ~needle haystack =
+    let nl = String.length needle
+    and hl = String.length haystack in
+    let rec loop i =
+      if i + nl > hl
+      then false
+      else if String.sub haystack i nl = needle
+      then true
+      else loop (i + 1)
+    in
+    nl = 0 || loop 0
+  in
+  let field key = Yojson.Safe.Util.member key profile in
+  (* structural facts present, message content absent *)
+  field "model" = `String "deepseek-v4-flash"
+  && field "message_count" = `Int 2
+  && field "response_format_type" = `String "json_schema"
+  && field "reasoning_effort" = `String "high"
+  && field "thinking_present" = `Bool true
+  && field "max_tokens_present" = `Bool false
+  && (not (contains ~needle:"secret prompt" s))
+  && not (contains ~needle:"private" s)
+;;
+
 let%test "header_line_bytes = key + value + 4 (\": \" + CRLF)" =
   (* "x-runtime-mcp" = 13, "abc" = 3, + 4 = 20 *)
   header_line_bytes ("x-runtime-mcp", "abc") = 20
@@ -1171,6 +1329,7 @@ let post_sync ?cache ?clock ?timeout_s ~sw ~net ~url ~headers ~body () =
           ~code
           ~resp_headers:(Cohttp.Response.headers resp)
           headers_with_length;
+        profile_request_on_client_error ~url ~code ~request_body:body;
         let* body_str = read_response_body resp_body in
         Ok (code, body_str))))
 ;;
@@ -1215,6 +1374,7 @@ let post_stream ?cache ?clock ?connect_timeout_s ~sw ~net ~url ~headers ~body ()
       let code = Cohttp.Code.code_of_status status in
       let resp_headers = Cohttp.Response.headers resp in
       profile_headers_on_client_error ~url ~code ~resp_headers headers_with_length;
+      profile_request_on_client_error ~url ~code ~request_body:body;
       let retry_after_header = retry_after_header_of_response_headers resp_headers in
       let* body_str = read_response_body resp_body in
       Error (HttpError { code; body = body_str; retry_after_header }))
@@ -1290,6 +1450,7 @@ let with_post_stream ?cache ?clock ?connect_timeout_s ~net ~url ~headers ~body ~
           let code = Cohttp.Code.code_of_status status in
           let resp_headers = Cohttp.Response.headers resp in
           profile_headers_on_client_error ~url ~code ~resp_headers headers_with_length;
+          profile_request_on_client_error ~url ~code ~request_body:body;
           let retry_after_header = retry_after_header_of_response_headers resp_headers in
           (match read_response_body resp_body with
            | Ok body_str ->

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -398,18 +398,53 @@ let profile_headers_on_client_error ~url ~code ~resp_headers request_headers =
    parsed. *)
 (* Exhaustive over the closed [Yojson.Safe.t] variant — no catch-all, so a
    future Yojson constructor forces a compile update rather than silently
-   mislabelling. Non-string JSON collapses to a sentinel that is
-   distinguishable from an absent field ([`Null]). *)
-let json_as_string_label : Yojson.Safe.t -> Yojson.Safe.t = function
-  | `String s -> `String s
-  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `Assoc _ | `List _ ->
+   mislabelling. The label helpers take a [Yojson.Safe.t option] so an ABSENT
+   top-level field is distinguished from a present field whose value is [`Null]
+   or the wrong type: a missing field and a malformed field are separate
+   diagnostic facts, and reporting one as the other makes the profile lie. *)
+let string_field_label : Yojson.Safe.t option -> Yojson.Safe.t = function
+  | None -> `String "<absent>"
+  | Some (`String s) -> `String s
+  | Some `Null -> `String "<null>"
+  | Some (`Bool _ | `Int _ | `Intlit _ | `Float _ | `Assoc _ | `List _) ->
     `String "<non-string>"
 ;;
 
-let json_list_len_label : Yojson.Safe.t -> Yojson.Safe.t = function
-  | `List xs -> `Int (List.length xs)
-  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _ ->
+(* Tri-state length of an optional top-level list field. An empty list and an
+   absent field are separate facts (a body with no [messages] key differs from
+   one with [messages: []]); a present non-list value is a third. *)
+let list_len_field_label : Yojson.Safe.t option -> Yojson.Safe.t = function
+  | None -> `String "<absent>"
+  | Some (`List xs) -> `Int (List.length xs)
+  | Some (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _) ->
     `String "<non-list>"
+;;
+
+(* Some providers wrap every function declaration in a single top-level [tools]
+   element (Gemini nests them under [functionDeclarations]), so [tool_count] is
+   1 regardless of how many declarations it holds. Reveal the nested count
+   generically: if the first [tools] element is an object with a list-valued
+   field, report that list's length. No provider key is named — any object with
+   an inner list qualifies; anything else is [<n/a>]. *)
+let first_inner_list_len : Yojson.Safe.t option -> Yojson.Safe.t =
+  let inner_len fields =
+    List.find_map
+      (function
+        | _key, `List inner -> Some (List.length inner)
+        | _key, (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _)
+          -> None)
+      fields
+  in
+  function
+  | Some (`List (`Assoc first :: _)) ->
+    (match inner_len first with
+     | Some n -> `Int n
+     | None -> `String "<n/a>")
+  | Some (`List [])
+  | Some
+      (`List ((`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _) :: _))
+  | Some (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _)
+  | None -> `String "<n/a>"
 ;;
 
 let json_is_present : Yojson.Safe.t -> bool = function
@@ -417,68 +452,110 @@ let json_is_present : Yojson.Safe.t -> bool = function
   | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _ | `List _ -> true
 ;;
 
+(* A rejected POST body can embed base64 media; parsing it whole on the 4xx
+   failure path adds allocation and latency for no diagnostic gain. Above this
+   size the parse is skipped and only the byte count is reported. 64 KiB holds a
+   text-only chat request (messages, tools, options) while excluding
+   media-laden bodies. *)
+let max_profiled_body_bytes = 64 * 1024
+
 let request_body_shape_profile (body : string) : Yojson.Safe.t =
-  match Yojson.Safe.from_string body with
-  | exception (Yojson.Json_error _ | Yojson.Safe.Util.Type_error _) ->
-    `Assoc [ "parseable", `Bool false; "body_bytes", `Int (String.length body) ]
-  | `Assoc fields ->
-    let has key = List.mem_assoc key fields in
-    (* [absent] ([`Null]) is reserved for a missing field; a present-but-wrong
-       shape gets a distinct sentinel from the label helpers above. *)
-    let field key = if has key then List.assoc key fields else `Null in
-    let string_field key = json_as_string_label (field key) in
-    let messages =
-      match field "messages" with
-      | `List ms -> ms
-      | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _ -> []
-    in
-    let role_of_message : Yojson.Safe.t -> Yojson.Safe.t = function
-      | `Assoc mfields ->
-        (match List.assoc_opt "role" mfields with
-         | Some (`String r) -> `String r
-         | Some (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `Assoc _ | `List _) ->
-           `String "<non-string-role>"
-         | None -> `String "<no-role>")
-      | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ ->
-        `String "<non-object>"
-    in
-    let roles = List.map role_of_message messages in
-    let response_format_type =
-      match field "response_format" with
-      | `Assoc rf ->
-        (match List.assoc_opt "type" rf with
-         | Some (`String t) -> `String t
-         | Some (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `Assoc _ | `List _) ->
-           `String "<non-string-type>"
-         | None -> `String "<no-type>")
-      | `Null -> `Null
-      | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ ->
-        `String "<non-object>"
-    in
-    let stream =
-      match field "stream" with
-      | `Bool b -> `Bool b
-      | `Null | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _ | `List _ -> `Null
-    in
+  if String.length body > max_profiled_body_bytes
+  then
+    (* Oversized: skip the full parse. [parseable] is [false] because no parse
+       was attempted; [skipped_oversized] records the reason so a consumer does
+       not read it as a malformed body. *)
     `Assoc
-      [ "parseable", `Bool true
+      [ "parseable", `Bool false
       ; "body_bytes", `Int (String.length body)
-      ; "model", string_field "model"
-      ; "message_count", `Int (List.length messages)
-      ; "message_roles", `List roles
-      ; "tool_count", json_list_len_label (field "tools")
-      ; "response_format_type", response_format_type
-      ; "reasoning_effort", string_field "reasoning_effort"
-      ; "thinking_present", `Bool (json_is_present (field "thinking"))
-      ; "max_tokens_present", `Bool (has "max_tokens")
-      ; "stream", stream
+      ; "skipped_oversized", `Bool true
       ]
-  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ ->
-    `Assoc
-      [ "parseable", `Bool true
-      ; "body_bytes", `Int (String.length body)
-      ; "top_level", `String "<non-object>"
-      ]
+  else (
+    match Yojson.Safe.from_string body with
+    | exception (Yojson.Json_error _ | Yojson.Safe.Util.Type_error _) ->
+      `Assoc [ "parseable", `Bool false; "body_bytes", `Int (String.length body) ]
+    | `Assoc fields ->
+      let has key = List.mem_assoc key fields in
+      (* [field] collapses absent-or-null; [List.assoc_opt] is used directly
+         where absent must be told apart from present-null (see the label
+         helpers above). *)
+      let field key = if has key then List.assoc key fields else `Null in
+      let messages_field = List.assoc_opt "messages" fields in
+      let role_of_message : Yojson.Safe.t -> Yojson.Safe.t = function
+        | `Assoc mfields ->
+          (match List.assoc_opt "role" mfields with
+           | Some (`String r) -> `String r
+           | Some (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `Assoc _ | `List _)
+             -> `String "<non-string-role>"
+           | None -> `String "<no-role>")
+        | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ ->
+          `String "<non-object>"
+      in
+      (* Roles are reported only when [messages] is a real list; an absent or
+         non-list [messages] carries no role sequence to report. *)
+      let message_roles_field =
+        match messages_field with
+        | Some (`List ms) -> [ "message_roles", `List (List.map role_of_message ms) ]
+        | Some (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _)
+        | None -> []
+      in
+      let response_format_type =
+        match field "response_format" with
+        | `Assoc rf ->
+          (match List.assoc_opt "type" rf with
+           | Some (`String t) -> `String t
+           | Some (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `Assoc _ | `List _)
+             -> `String "<non-string-type>"
+           | None -> `String "<no-type>")
+        | `Null -> `Null
+        | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ ->
+          `String "<non-object>"
+      in
+      let stream =
+        match field "stream" with
+        | `Bool b -> `Bool b
+        | `Null | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _ | `List _ -> `Null
+      in
+      (* [List.assoc]/[List.mem_assoc] keep only the first binding, so a body
+         with duplicate top-level keys — itself a rejection class — would profile
+         as if deduped. Report every key that occurs more than once. *)
+      let duplicate_keys =
+        let names = List.map fst fields in
+        `List
+          (List.filter_map
+             (fun name ->
+                let count = List.length (List.filter (String.equal name) names) in
+                if count > 1
+                then Some (`Assoc [ "name", `String name; "count", `Int count ])
+                else None)
+             (List.sort_uniq String.compare names))
+      in
+      `Assoc
+        ([ "parseable", `Bool true
+         ; "body_bytes", `Int (String.length body)
+         ; "model", string_field_label (List.assoc_opt "model" fields)
+         ; "message_count", list_len_field_label messages_field
+         ]
+         @ message_roles_field
+         @ [ "contents_count", list_len_field_label (List.assoc_opt "contents" fields)
+           ; "input_count", list_len_field_label (List.assoc_opt "input" fields)
+           ; "tool_count", list_len_field_label (List.assoc_opt "tools" fields)
+           ; ( "tool_first_inner_count"
+             , first_inner_list_len (List.assoc_opt "tools" fields) )
+           ; "response_format_type", response_format_type
+           ; ( "reasoning_effort"
+             , string_field_label (List.assoc_opt "reasoning_effort" fields) )
+           ; "thinking_present", `Bool (json_is_present (field "thinking"))
+           ; "max_tokens_present", `Bool (has "max_tokens")
+           ; "stream", stream
+           ; "duplicate_keys", duplicate_keys
+           ])
+    | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ ->
+      `Assoc
+        [ "parseable", `Bool true
+        ; "body_bytes", `Int (String.length body)
+        ; "top_level", `String "<non-object>"
+        ])
 ;;
 
 (* Companion to [profile_headers_on_client_error]: names the request SHAPE on a
@@ -538,6 +615,89 @@ let%test "request_body_shape_profile extracts shape without message text" =
   && field "max_tokens_present" = `Bool false
   && (not (contains ~needle:"secret prompt" s))
   && not (contains ~needle:"private" s)
+;;
+
+(* Finding 1: an absent field, a present-null field, and a present-non-string
+   field are three distinct facts — the profile must not report an absent field
+   as a malformed one. *)
+let%test "shape profile distinguishes absent from malformed string fields" =
+  let m key j = Yojson.Safe.Util.member key j in
+  let absent = request_body_shape_profile {|{"model":"m"}|} in
+  let present_null = request_body_shape_profile {|{"reasoning_effort":null}|} in
+  let present_int = request_body_shape_profile {|{"reasoning_effort":3}|} in
+  m "reasoning_effort" absent = `String "<absent>"
+  && m "reasoning_effort" present_null = `String "<null>"
+  && m "reasoning_effort" present_int = `String "<non-string>"
+  && m "model" absent = `String "m"
+  && m "model" present_null = `String "<absent>"
+;;
+
+(* Finding 2: absent messages / non-list messages must not both read as an empty
+   array; roles are attached only for a real list. *)
+let%test "shape profile reports messages presence honestly" =
+  let m key j = Yojson.Safe.Util.member key j in
+  let absent = request_body_shape_profile {|{"model":"m"}|} in
+  let empty = request_body_shape_profile {|{"messages":[]}|} in
+  let non_list = request_body_shape_profile {|{"messages":"oops"}|} in
+  m "message_count" absent = `String "<absent>"
+  && m "message_count" empty = `Int 0
+  && m "message_count" non_list = `String "<non-list>"
+  && m "message_roles" empty = `List []
+  && m "message_roles" absent = `Null (* key omitted -> member is `Null *)
+  && m "message_roles" non_list = `Null
+;;
+
+(* Finding 3: non-chat containers ([contents] for Gemini, [input] for OpenAI
+   Responses) are reported with the same tri-state as [messages]. *)
+let%test "shape profile reports contents and input container counts" =
+  let m key j = Yojson.Safe.Util.member key j in
+  let gemini =
+    request_body_shape_profile {|{"contents":[{"role":"user"},{"role":"model"}]}|}
+  in
+  let responses = request_body_shape_profile {|{"input":[{"type":"message"}]}|} in
+  let neither = request_body_shape_profile {|{"model":"m"}|} in
+  m "contents_count" gemini = `Int 2
+  && m "input_count" gemini = `String "<absent>"
+  && m "input_count" responses = `Int 1
+  && m "contents_count" neither = `String "<absent>"
+  && m "contents_count" responses = `String "<absent>"
+;;
+
+(* Finding 4: Gemini wraps all declarations in one top-level [tools] element, so
+   [tool_count] is 1; the nested list length is surfaced generically. *)
+let%test "shape profile reveals nested function-declaration count" =
+  let m key j = Yojson.Safe.Util.member key j in
+  let gemini =
+    request_body_shape_profile
+      {|{"tools":[{"functionDeclarations":[{"name":"a"},{"name":"b"},{"name":"c"}]}]}|}
+  in
+  let flat = request_body_shape_profile {|{"tools":[{"type":"function"}]}|} in
+  let none = request_body_shape_profile {|{"model":"m"}|} in
+  m "tool_count" gemini = `Int 1
+  && m "tool_first_inner_count" gemini = `Int 3
+  && m "tool_first_inner_count" flat = `String "<n/a>"
+  && m "tool_count" none = `String "<absent>"
+  && m "tool_first_inner_count" none = `String "<n/a>"
+;;
+
+(* Finding 5: bodies over [max_profiled_body_bytes] skip the full parse. *)
+let%test "shape profile skips parsing oversized bodies" =
+  let big = {|{"x":"|} ^ String.make (max_profiled_body_bytes + 1) 'a' ^ {|"}|} in
+  let profile = request_body_shape_profile big in
+  let m key = Yojson.Safe.Util.member key profile in
+  m "skipped_oversized" = `Bool true
+  && m "parseable" = `Bool false
+  && m "body_bytes" = `Int (String.length big)
+;;
+
+(* Finding 6: duplicate top-level keys (a rejection class) are surfaced with
+   their occurrence count instead of being silently deduped. *)
+let%test "shape profile reports duplicate top-level keys" =
+  let m key j = Yojson.Safe.Util.member key j in
+  let dup = request_body_shape_profile {|{"model":"a","model":"b","stream":true}|} in
+  let clean = request_body_shape_profile {|{"model":"a","stream":true}|} in
+  m "duplicate_keys" dup = `List [ `Assoc [ "name", `String "model"; "count", `Int 2 ] ]
+  && m "duplicate_keys" clean = `List []
 ;;
 
 let%test "header_line_bytes = key + value + 4 (\": \" + CRLF)" =


### PR DESCRIPTION
## Why

Provider edges (observed: ollama.com/v1 `deepseek-v4-flash`) return opaque `Bad Request` with an empty-detail body. On a 4xx `HttpError` carries only the RESPONSE body, so the request that provoked it is lost — the failure is undiagnosable without a repro harness.

Live impact (2026-07-18, masc fleet): deepseek-v4-flash **78% turn rejection** (2859/3650), 3 days running (~90k cumulative). Every isolated client reproduction of the request shape returns HTTP 200 (all fields, combinations, verbatim captured prompt, unbounded generation, 12x concurrent, 9KB header) — so the poison is in the exact assembled wire body, which nothing captures. See masc#25031.

## What

`profile_request_on_client_error`, companion to the existing `profile_headers_on_client_error`, called at all three client error sites (non-stream x1 `post_sync`, stream x2 `post_stream` + `with_post_stream`). On a 4xx it emits a **structural** profile of the request body via `Diag.warn` (always-on, no debug restart needed):

- `model`, `message_count`, `message_roles` (role sequence only), `tool_count`, `response_format_type`, `reasoning_effort`, `thinking_present`, `max_tokens_present`, `stream`, `body_bytes`

**Privacy**: message and tool-argument TEXT is never logged — it may carry user content and does not distinguish an accepted shape from a rejected one (mirrors the header profile omitting values that may carry credentials). Non-JSON bodies report `parseable:false` rather than parsing.

## Verification

- `llm_provider` inline tests pass, including a new case asserting the profile extracts structural facts (`model`/`message_count`/`response_format_type`/`reasoning_effort`/`thinking_present`/`max_tokens_present`) while the serialized profile contains neither the system nor user message text.
- Non-JSON body case (`"Bad Request"`) returns `parseable:false` without raising.
- `ocamlformat --check` clean.

RFC-WAIVED: observability-only addition in `lib/llm_provider` (not a credential/keeper/operator subsystem); no behavior change to request/response handling.

Refs: masc#25031 (root diagnostic blocker this unblocks), roadmap gate #12 (causal observability).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KXQWcg9KtaC7KruGQTnwX
