### PR TITLE
feat(agent): enforce prepared-request fit admission

### DIFF
--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -537,6 +537,7 @@ let run_handoff_target ~sw ?clock agent (target : Handoff.handoff_target) prompt
       ~net:agent.net
       ~config:target.config
       ~tools:target.tools
+      ~context_fit_admission:agent.context_fit_admission
       ~options:
         { default_options with
           base_url = agent.options.base_url
@@ -607,6 +608,7 @@ let resume
       ?context
       ?(options = default_options)
       ?provider_config
+      ?(context_fit_admission = Disabled)
       ?checkpoint_sink
       ?config
       ()
@@ -627,6 +629,7 @@ let resume
   ; context = ctx
   ; options
   ; provider_config
+  ; context_fit_admission
   ; checkpoint_sink
   }
 ;;

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -30,6 +30,14 @@ type checkpoint_snapshot = Agent_types.checkpoint_snapshot =
 
 type checkpoint_sink = Agent_types.checkpoint_sink
 
+(** Agent-level provider-fit policy. [Disabled] preserves the historical
+    single-call path. [Enforce_when_supported] uses provider-native request
+    measurement for protocols that OAS supports and otherwise preserves that
+    protocol's historical path; it never estimates token counts. *)
+type context_fit_admission = Agent_types.context_fit_admission =
+  | Disabled
+  | Enforce_when_supported
+
 type options = Agent_types.options =
   { base_url : string
   ; provider : Provider.config option
@@ -95,7 +103,10 @@ val sdk_version : string
 
     [provider_config] is the exact typed provider carrier. When supplied it
     replaces [options.provider]; endpoint, credential, request path, headers,
-    and capability overrides are not reconstructed from the legacy option. *)
+    and capability overrides are not reconstructed from the legacy option.
+
+    [context_fit_admission] is separate from [options] so callers that construct
+    options records remain source-compatible. *)
 val create
   :  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> config:Types.agent_config
@@ -103,6 +114,7 @@ val create
   -> ?context:Context.t
   -> ?options:options
   -> ?provider_config:Llm_provider.Provider_config.t
+  -> ?context_fit_admission:context_fit_admission
   -> ?checkpoint_sink:checkpoint_sink
   -> unit
   -> t
@@ -381,7 +393,9 @@ val run_with_handoffs_blocks_detailed
     turn-boundary checkpoint sink used by {!create}. It is not stored in
     {!options}; pass it explicitly when resumed turns should continue emitting
     crash-recovery checkpoints. An explicit [provider_config] replaces
-    [options.provider] under the same exact-carrier contract as {!create}. *)
+    [options.provider] under the same exact-carrier contract as {!create}.
+    [context_fit_admission] must be supplied again when a resumed Agent should
+    retain opt-in provider-fit enforcement. *)
 val resume
   :  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> checkpoint:Checkpoint.t
@@ -389,6 +403,7 @@ val resume
   -> ?context:Context.t
   -> ?options:options
   -> ?provider_config:Llm_provider.Provider_config.t
+  -> ?context_fit_admission:context_fit_admission
   -> ?checkpoint_sink:checkpoint_sink
   -> ?config:Types.agent_config
   -> unit

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -27,6 +27,10 @@ type checkpoint_snapshot =
 
 type checkpoint_sink = checkpoint_snapshot -> (unit, string) result
 
+type context_fit_admission =
+  | Disabled
+  | Enforce_when_supported
+
 type options =
   { base_url : string
   ; provider : Provider.config option
@@ -132,6 +136,7 @@ type t =
   ; context : Context.t
   ; options : options
   ; provider_config : Llm_provider.Provider_config.t option
+  ; context_fit_admission : context_fit_admission
   ; checkpoint_sink : checkpoint_sink option
   }
 
@@ -270,6 +275,7 @@ let create
       ?context
       ?(options = default_options)
       ?provider_config
+      ?(context_fit_admission = Disabled)
       ?checkpoint_sink
       ()
   =
@@ -298,6 +304,7 @@ let create
   ; context = ctx
   ; options
   ; provider_config
+  ; context_fit_admission
   ; checkpoint_sink
   }
 ;;
@@ -319,6 +326,7 @@ let clone ?(copy_context = false) agent =
   ; context = ctx
   ; options = agent.options
   ; provider_config = agent.provider_config
+  ; context_fit_admission = agent.context_fit_admission
   ; checkpoint_sink = agent.checkpoint_sink
   }
 ;;

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -30,6 +30,10 @@ type checkpoint_snapshot =
 
 type checkpoint_sink = checkpoint_snapshot -> (unit, string) result
 
+type context_fit_admission =
+  | Disabled
+  | Enforce_when_supported
+
 type options =
   { base_url : string
   ; provider : Provider.config option
@@ -146,6 +150,7 @@ type t =
   ; context : Context.t
   ; options : options
   ; provider_config : Llm_provider.Provider_config.t option
+  ; context_fit_admission : context_fit_admission
   ; checkpoint_sink : checkpoint_sink option
   }
 
@@ -179,6 +184,7 @@ val create
   -> ?context:Context.t
   -> ?options:options
   -> ?provider_config:Llm_provider.Provider_config.t
+  -> ?context_fit_admission:context_fit_admission
   -> ?checkpoint_sink:checkpoint_sink
   -> unit
   -> t

--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -30,6 +30,7 @@ type t =
   ; base_url : string
   ; provider : Provider.config option
   ; provider_config : Llm_provider.Provider_config.t option
+  ; context_fit_admission : Agent.context_fit_admission
   ; stream_idle_timeout_s : float option
   ; body_timeout_s : float option
   ; hooks : Hooks.hooks
@@ -79,6 +80,7 @@ let create ~net ~model =
   ; base_url = Api.default_base_url
   ; provider = None
   ; provider_config = None
+  ; context_fit_admission = Agent.Disabled
   ; stream_idle_timeout_s = None
   ; body_timeout_s = None
   ; hooks = Hooks.empty
@@ -179,6 +181,7 @@ let with_provider_config (pc : Llm_provider.Provider_config.t) b =
   }
 ;;
 
+let with_context_fit_admission context_fit_admission b = { b with context_fit_admission }
 let with_base_url url b = { b with base_url = url }
 let with_mcp_clients clients b = { b with mcp_clients = clients }
 let with_guardrails_async guardrails_async b = { b with guardrails_async }
@@ -284,6 +287,7 @@ let build b =
     ?context
     ~options
     ?provider_config:b.provider_config
+    ~context_fit_admission:b.context_fit_admission
     ?checkpoint_sink:b.checkpoint_sink
     ()
 ;;

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -111,6 +111,10 @@ val with_provider : Provider.config -> t -> t
     {!with_provider} replaces the legacy selection. *)
 val with_provider_config : Llm_provider.Provider_config.t -> t -> t
 
+(** Select Agent-level provider-fit admission without changing standalone
+    [Complete] compatibility behavior. *)
+val with_context_fit_admission : Agent.context_fit_admission -> t -> t
+
 val with_base_url : string -> t -> t
 
 (** Inject an {!Llm_provider.Llm_transport.t} for non-HTTP providers.

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -12,21 +12,22 @@ include Complete_common
 include Complete_sync
 include Complete_stream
 
-let complete
+let complete_prepared_sync
       ~sw
       ~net
       ?clock
       ?(transport : Llm_transport.t option)
-      ~(config : Provider_config.t)
-      ~(messages : Types.message list)
-      ?(tools = [])
-      ?(trace_context = [])
+      ~(prepared : Prepared_completion_request.t)
       ?(cache : Cache.t option)
       ?(connection_cache : Http_client.cache option)
       ?(metrics : Metrics.t option)
       ?body_timeout_s
       ()
   =
+  let request = Prepared_completion_request.request prepared in
+  let config = request.Llm_transport.config in
+  let messages = request.messages in
+  let tools = request.tools in
   let preflight =
     match validate_all config with
     | Error err -> Error err
@@ -46,7 +47,7 @@ let complete
       | None -> Metrics.get_global ()
     in
     let model_id = config.model_id in
-    let request_config = config_with_trace_context config trace_context in
+    let request_config = config in
     (* Cache lookup *)
     (* Compute fingerprint once; reuse for both lookup and store *)
     let cache_key =
@@ -78,16 +79,7 @@ let complete
        let dispatch () =
          match transport with
          | Some t ->
-           let run_transport () =
-             t.complete_sync
-               { Llm_transport.config = request_config
-               ; messages
-               ; tools
-               ; capture_id = None
-               ; observe_wire_chunk = None
-               ; stream_idle_timeout_s = None (* sync path: no streaming idle deadline *)
-               }
-           in
+           let run_transport () = t.complete_sync request in
            (match body_deadline with
             | Http_client.Unbounded ->
               Http_client.with_explicit_deadline body_deadline run_transport
@@ -195,6 +187,37 @@ let complete
           in
           m.on_error ~model_id ~error:err_str;
           Error err))
+;;
+
+let complete
+      ~sw
+      ~net
+      ?clock
+      ?transport
+      ~(config : Provider_config.t)
+      ~(messages : Types.message list)
+      ?(tools = [])
+      ?(trace_context = [])
+      ?cache
+      ?connection_cache
+      ?metrics
+      ?body_timeout_s
+      ()
+  =
+  let prepared =
+    Prepared_completion_request.prepare_sync ~config ~messages ~tools ~trace_context ()
+  in
+  complete_prepared_sync
+    ~sw
+    ~net
+    ?clock
+    ?transport
+    ~prepared
+    ?cache
+    ?connection_cache
+    ?metrics
+    ?body_timeout_s
+    ()
 ;;
 
 (* ── Streaming ───────────────────────────────────────── *)

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -12,6 +12,31 @@ include Complete_common
 include Complete_sync
 include Complete_stream
 
+type prepared_request = Prepared_completion_request.t
+type measured_request = Prepared_completion_request.measured
+type admitted_request = Prepared_completion_request.admitted
+
+type context_fit = Prepared_completion_request.context_fit =
+  { input_tokens : int
+  ; reserved_output_tokens : int
+  ; max_context_tokens : int
+  }
+
+type fit_error = Prepared_completion_request.fit_error =
+  | Context_limit_unknown of { model_id : string }
+  | Invalid_context_limit of
+      { model_id : string
+      ; max_context_tokens : int
+      }
+  | Output_reservation_unknown of { model_id : string }
+  | Context_window_exceeded of context_fit
+
+let prepare_request = Prepared_completion_request.prepare
+let measure_request = Prepared_completion_request.measure
+let request_measurement = Prepared_completion_request.measurement
+let admit_request = Prepared_completion_request.admit
+let admitted_fit = Prepared_completion_request.admitted_fit
+
 let complete_prepared_sync
       ~sw
       ~net
@@ -204,15 +229,38 @@ let complete
       ?body_timeout_s
       ()
   =
-  let prepared =
-    Prepared_completion_request.prepare_sync ~config ~messages ~tools ~trace_context ()
-  in
+  let prepared = prepare_request ~config ~messages ~tools ~trace_context () in
   complete_prepared_sync
     ~sw
     ~net
     ?clock
     ?transport
     ~prepared
+    ?cache
+    ?connection_cache
+    ?metrics
+    ?body_timeout_s
+    ()
+;;
+
+let complete_admitted
+      ~sw
+      ~net
+      ?clock
+      ?transport
+      admitted
+      ?cache
+      ?connection_cache
+      ?metrics
+      ?body_timeout_s
+      ()
+  =
+  complete_prepared_sync
+    ~sw
+    ~net
+    ?clock
+    ?transport
+    ~prepared:(Prepared_completion_request.admitted_request admitted)
     ?cache
     ?connection_cache
     ?metrics
@@ -361,7 +409,7 @@ let complete_stream
       ()
   =
   let prepared =
-    Prepared_completion_request.prepare_stream
+    prepare_request
       ~config
       ~messages
       ~tools
@@ -377,6 +425,33 @@ let complete_stream
     ?transport
     ?wire_observer
     ~prepared
+    ~on_event
+    ?metrics
+    ?connection_cache
+    ?on_telemetry
+    ()
+;;
+
+let complete_stream_admitted
+      ~sw
+      ~net
+      ?clock
+      ?transport
+      ?wire_observer
+      admitted
+      ~on_event
+      ?metrics
+      ?connection_cache
+      ?on_telemetry
+      ()
+  =
+  complete_prepared_stream
+    ~sw
+    ~net
+    ?clock
+    ?transport
+    ?wire_observer
+    ~prepared:(Prepared_completion_request.admitted_request admitted)
     ~on_event
     ?metrics
     ?connection_cache

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -222,29 +222,28 @@ let complete
 
 (* ── Streaming ───────────────────────────────────────── *)
 
-let complete_stream
+let complete_prepared_stream
       ~sw
       ~net
       ?clock
-      ?stream_idle_timeout_s
       ?(transport : Llm_transport.t option)
-      ?capture_id
       ?wire_observer
-      ~(config : Provider_config.t)
-      ~(messages : Types.message list)
-      ?(tools = [])
-      ?(trace_context = [])
+      ~(prepared : Prepared_completion_request.t)
       ~(on_event : Types.sse_event -> unit)
       ?metrics
       ?(connection_cache : Http_client.cache option)
       ?(on_telemetry : (Telemetry_event.t -> unit) option)
       ()
   =
+  let request = Prepared_completion_request.request prepared in
+  let config = request.Llm_transport.config in
+  let messages = request.messages in
+  let tools = request.tools in
   match validate_all config with
   | Error err -> Error err
   | Ok () ->
     let on_event = emit_stream_event on_event in
-    let request_config = config_with_trace_context config trace_context in
+    let request_config = config in
     let latency_counter = start_latency_counter ?clock () in
     let metrics_opt = metrics in
     let metrics = Option.value metrics ~default:(Metrics.get_global ()) in
@@ -282,38 +281,34 @@ let complete_stream
           (Printexc.to_string exn)
           (Wire_observer.show_failure failure)
     in
-    let observe_wire_chunk =
-      Option.map
-        (fun try_observe ~provider ~model ~chunk ->
-           match
-             Wire_observer.observe try_observe ~capture_id ~provider ~model ~chunk
-           with
-           | Ok () -> ()
-           | Error failure -> emit_wire_observer_failure failure)
-        wire_observer
+    let request =
+      match wire_observer with
+      | None -> request
+      | Some try_observe ->
+        let observe_wire_chunk ~provider ~model ~chunk =
+          match
+            Wire_observer.observe
+              try_observe
+              ~capture_id:request.capture_id
+              ~provider
+              ~model
+              ~chunk
+          with
+          | Ok () -> ()
+          | Error failure -> emit_wire_observer_failure failure
+        in
+        { request with observe_wire_chunk = Some observe_wire_chunk }
     in
     let dispatch () =
       match transport with
-      | Some t ->
-        t.complete_stream
-          ?on_telemetry:transport_on_telemetry
-          ~on_event
-          { Llm_transport.config = request_config
-          ; messages
-          ; tools
-          ; capture_id
-          ; observe_wire_chunk
-          ; stream_idle_timeout_s
-            (* RFC-OAS-026: carry the idle deadline through the transport
-               boundary so the [Some t] dispatch can no longer drop it. *)
-          }
+      | Some t -> t.complete_stream ?on_telemetry:transport_on_telemetry ~on_event request
       | None ->
         complete_stream_http
           ~sw
           ~net
           ?clock
-          ?stream_idle_timeout_s
-          ?observe_wire_chunk
+          ?stream_idle_timeout_s:request.stream_idle_timeout_s
+          ?observe_wire_chunk:request.observe_wire_chunk
           ~latency_counter
           ?on_telemetry
           ~metrics
@@ -345,6 +340,48 @@ let complete_stream
            resp;
          resp)
       (ensure_nonempty_completion result)
+;;
+
+let complete_stream
+      ~sw
+      ~net
+      ?clock
+      ?stream_idle_timeout_s
+      ?transport
+      ?capture_id
+      ?wire_observer
+      ~(config : Provider_config.t)
+      ~(messages : Types.message list)
+      ?(tools = [])
+      ?(trace_context = [])
+      ~on_event
+      ?metrics
+      ?connection_cache
+      ?on_telemetry
+      ()
+  =
+  let prepared =
+    Prepared_completion_request.prepare_stream
+      ~config
+      ~messages
+      ~tools
+      ~trace_context
+      ?capture_id
+      ?stream_idle_timeout_s
+      ()
+  in
+  complete_prepared_stream
+    ~sw
+    ~net
+    ?clock
+    ?transport
+    ?wire_observer
+    ~prepared
+    ~on_event
+    ?metrics
+    ?connection_cache
+    ?on_telemetry
+    ()
 ;;
 
 (* ── HTTP Transport constructor ─────────────────────── *)

--- a/lib/llm_provider/complete.mli
+++ b/lib/llm_provider/complete.mli
@@ -50,9 +50,11 @@ val prepare_request
   -> unit
   -> prepared_request
 
-(** Measure the exact prepared request through the provider-native count
-    protocol. Unsupported protocols return the existing typed [Unsupported]
-    measurement error; no estimate or model-name inference is used. *)
+(** Validate and measure the exact prepared request through the provider-native
+    count protocol. Invalid local configuration fails before admission or I/O;
+    the count round-trip uses the same provider admission authority as
+    completion dispatch. Unsupported protocols return the existing typed
+    [Unsupported] measurement error; no estimate is used. *)
 val measure_request
   :  ?connection_cache:Http_client.cache
   -> ?clock:_ Eio.Time.clock
@@ -66,9 +68,10 @@ val request_measurement
   :  measured_request
   -> Count_tokens_sync.completion_request_measurement
 
-(** Admit the measured request against its exact declared [max_context]. The
-    output-token reservation is the effective value carried by the same
-    provider request artifact. Unknown limits and overflow are explicit. *)
+(** Admit the measured request against an explicit [max_context], or the exact
+    model capability when no explicit limit was supplied. The output-token
+    reservation is the effective value carried by the same provider request
+    artifact. Unknown limits and overflow are explicit. *)
 val admit_request : measured_request -> (admitted_request, fit_error) result
 
 val admitted_fit : admitted_request -> context_fit

--- a/lib/llm_provider/complete.mli
+++ b/lib/llm_provider/complete.mli
@@ -11,6 +11,68 @@
     @stability Internal
     @since 0.93.1 *)
 
+(** {1 Canonical Prepared Request} *)
+
+(** One opaque completion request after all caller-owned projection. *)
+type prepared_request
+
+(** The same request paired with provider-native measurement evidence. *)
+type measured_request
+
+(** The measured request after its declared context window admits it. *)
+type admitted_request
+
+type context_fit =
+  { input_tokens : int
+  ; reserved_output_tokens : int
+  ; max_context_tokens : int
+  }
+
+type fit_error =
+  | Context_limit_unknown of { model_id : string }
+  | Invalid_context_limit of
+      { model_id : string
+      ; max_context_tokens : int
+      }
+  | Output_reservation_unknown of { model_id : string }
+  | Context_window_exceeded of context_fit
+
+(** Build the single request value used by measurement and dispatch. Existing
+    [complete] and [complete_stream] calls are compatibility wrappers over this
+    constructor; they no longer own a separate request projection. *)
+val prepare_request
+  :  config:Provider_config.t
+  -> messages:Types.message list
+  -> ?tools:Yojson.Safe.t list
+  -> ?trace_context:(string * string) list
+  -> ?capture_id:string
+  -> ?stream_idle_timeout_s:float
+  -> unit
+  -> prepared_request
+
+(** Measure the exact prepared request through the provider-native count
+    protocol. Unsupported protocols return the existing typed [Unsupported]
+    measurement error; no estimate or model-name inference is used. *)
+val measure_request
+  :  ?connection_cache:Http_client.cache
+  -> ?clock:_ Eio.Time.clock
+  -> ?timeout_s:float
+  -> sw:Eio.Switch.t
+  -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> prepared_request
+  -> (measured_request, Count_tokens_sync.completion_request_error) result
+
+val request_measurement
+  :  measured_request
+  -> Count_tokens_sync.completion_request_measurement
+
+(** Admit the measured request against its exact declared [max_context]. The
+    output-token reservation is the effective value carried by the same
+    provider request artifact. Unknown limits and overflow are explicit. *)
+val admit_request : measured_request -> (admitted_request, fit_error) result
+
+val admitted_fit : admitted_request -> context_fit
+
 (** {1 Gemini URL Construction} *)
 
 (** Construct Gemini API URL with model_id in path and optional key param.
@@ -81,6 +143,22 @@ val complete
   -> messages:Types.message list
   -> ?tools:Yojson.Safe.t list
   -> ?trace_context:(string * string) list
+  -> ?cache:Cache.t
+  -> ?connection_cache:Http_client.cache
+  -> ?metrics:Metrics.t
+  -> ?body_timeout_s:float
+  -> unit
+  -> (Types.api_response, Http_client.http_error) result
+
+(** Dispatch an already measured and admitted request. The transport receives
+    the request owned by [admitted_request]; callers cannot substitute config,
+    messages, tools, or trace context after measurement. *)
+val complete_admitted
+  :  sw:Eio.Switch.t
+  -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> ?clock:_ Eio.Time.clock
+  -> ?transport:Llm_transport.t
+  -> admitted_request
   -> ?cache:Cache.t
   -> ?connection_cache:Http_client.cache
   -> ?metrics:Metrics.t
@@ -177,6 +255,23 @@ val complete_stream
   -> messages:Types.message list
   -> ?tools:Yojson.Safe.t list
   -> ?trace_context:(string * string) list
+  -> on_event:(Types.sse_event -> unit)
+  -> ?metrics:Metrics.t
+  -> ?connection_cache:Http_client.cache
+  -> ?on_telemetry:(Telemetry_event.t -> unit)
+  -> unit
+  -> (Types.api_response, Http_client.http_error) result
+
+(** Streaming counterpart of {!complete_admitted}. Capture identity and idle
+    deadline are fixed when the request is prepared. Wire observation remains
+    an OAS-owned operational sink and cannot alter provider payload fields. *)
+val complete_stream_admitted
+  :  sw:Eio.Switch.t
+  -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> ?clock:_ Eio.Time.clock
+  -> ?transport:Llm_transport.t
+  -> ?wire_observer:Wire_observer.try_observe
+  -> admitted_request
   -> on_event:(Types.sse_event -> unit)
   -> ?metrics:Metrics.t
   -> ?connection_cache:Http_client.cache

--- a/lib/llm_provider/count_tokens_sync.ml
+++ b/lib/llm_provider/count_tokens_sync.ml
@@ -76,6 +76,17 @@ type completion_request_error =
   | Output_token_resolution_failed of Types.required_output_token_error
   | Invalid_completion_request of string
 
+let supports_completion_request_measurement (config : Provider_config.t) =
+  match config.kind with
+  | Provider_config.Anthropic -> true
+  | Provider_config.Kimi
+  | Provider_config.OpenAI_compat
+  | Provider_config.Ollama
+  | Provider_config.Gemini
+  | Provider_config.Glm
+  | Provider_config.DashScope -> false
+;;
+
 let measure_completion_request
       ?connection_cache
       ?clock
@@ -85,8 +96,8 @@ let measure_completion_request
       (request : Llm_transport.completion_request)
   =
   let config = request.config in
-  match config.kind with
-  | Provider_config.Anthropic ->
+  if supports_completion_request_measurement config
+  then (
     let artifact =
       try
         Backend_anthropic.build_request_artifact
@@ -98,34 +109,29 @@ let measure_completion_request
       with
       | Invalid_argument detail -> Error (Invalid_completion_request detail)
     in
-    (match artifact with
-     | Error _ as error -> error
-     | Ok artifact ->
-       (match
-          count_anthropic
-            ?connection_cache
-            ?clock
-            ?timeout_s
-            ~sw
-            ~net
-            ~config
-            ~messages:request.messages
-            ~tools:request.tools
-            ()
-        with
-        | Error error -> Error (Input_count_failed error)
-        | Ok input_count ->
-          Ok
-            { input_count
-            ; output_token_receipt =
-                Backend_anthropic.request_output_token_receipt artifact
-            }))
-  | Provider_config.Kimi
-  | Provider_config.OpenAI_compat
-  | Provider_config.Ollama
-  | Provider_config.Gemini
-  | Provider_config.Glm
-  | Provider_config.DashScope ->
+    match artifact with
+    | Error _ as error -> error
+    | Ok artifact ->
+      (match
+         count_anthropic
+           ?connection_cache
+           ?clock
+           ?timeout_s
+           ~sw
+           ~net
+           ~config
+           ~messages:request.messages
+           ~tools:request.tools
+           ()
+       with
+       | Error error -> Error (Input_count_failed error)
+       | Ok input_count ->
+         Ok
+           { input_count
+           ; output_token_receipt =
+               Backend_anthropic.request_output_token_receipt artifact
+           }))
+  else
     Error
       (Input_count_failed
          (Input_token_count.Unsupported

--- a/lib/llm_provider/count_tokens_sync.mli
+++ b/lib/llm_provider/count_tokens_sync.mli
@@ -58,6 +58,11 @@ type completion_request_error =
   | Output_token_resolution_failed of Types.required_output_token_error
   | Invalid_completion_request of string
 
+(** Whether OAS has an exact provider-native measurement adapter for this
+    request configuration. This is the support SSOT used by both measurement
+    dispatch and Agent admission routing. *)
+val supports_completion_request_measurement : Provider_config.t -> bool
+
 val measure_completion_request
   :  ?connection_cache:Http_client.cache
   -> ?clock:_ Eio.Time.clock

--- a/lib/llm_provider/dune
+++ b/lib/llm_provider/dune
@@ -7,7 +7,8 @@
   model_catalog_embedded
   provider_http_codec
   output_token_wire_internal
-  request_artifact_internal)
+  request_artifact_internal
+  prepared_completion_request)
  (libraries
   yojson
   otoml

--- a/lib/llm_provider/prepared_completion_request.ml
+++ b/lib/llm_provider/prepared_completion_request.ml
@@ -1,31 +1,31 @@
 type t = { request : Llm_transport.completion_request }
-type identity = t
-
-type measurement_evidence =
-  { request_identity : identity
-  ; measurement : Count_tokens_sync.completion_request_measurement
-  }
 
 type measured =
   { prepared : t
-  ; evidence : measurement_evidence
+  ; measurement : Count_tokens_sync.completion_request_measurement
   }
 
-let prepare request = { request }
+type context_fit =
+  { input_tokens : int
+  ; reserved_output_tokens : int
+  ; max_context_tokens : int
+  }
 
-let prepare_sync ~config ~messages ?(tools = []) ?(trace_context = []) () =
-  prepare
-    { Llm_transport.config =
-        Complete_common.config_with_trace_context config trace_context
-    ; messages
-    ; tools
-    ; capture_id = None
-    ; observe_wire_chunk = None
-    ; stream_idle_timeout_s = None
-    }
-;;
+type fit_error =
+  | Context_limit_unknown of { model_id : string }
+  | Invalid_context_limit of
+      { model_id : string
+      ; max_context_tokens : int
+      }
+  | Output_reservation_unknown of { model_id : string }
+  | Context_window_exceeded of context_fit
 
-let prepare_stream
+type admitted =
+  { measured : measured
+  ; fit : context_fit
+  }
+
+let prepare
       ~config
       ~messages
       ?(tools = [])
@@ -34,20 +34,19 @@ let prepare_stream
       ?stream_idle_timeout_s
       ()
   =
-  prepare
-    { Llm_transport.config =
-        Complete_common.config_with_trace_context config trace_context
-    ; messages
-    ; tools
-    ; capture_id
-    ; observe_wire_chunk = None
-    ; stream_idle_timeout_s
-    }
+  { request =
+      { Llm_transport.config =
+          Complete_common.config_with_trace_context config trace_context
+      ; messages
+      ; tools
+      ; capture_id
+      ; observe_wire_chunk = None
+      ; stream_idle_timeout_s
+      }
+  }
 ;;
 
 let request prepared = prepared.request
-let identity prepared = prepared
-let same_identity left right = left == right
 
 let measure ?connection_cache ?clock ?timeout_s ~sw ~net prepared =
   Count_tokens_sync.measure_completion_request
@@ -57,36 +56,37 @@ let measure ?connection_cache ?clock ?timeout_s ~sw ~net prepared =
     ~sw
     ~net
     prepared.request
-  |> Result.map (fun measurement ->
-    { prepared; evidence = { request_identity = prepared; measurement } })
+  |> Result.map (fun measurement -> { prepared; measurement })
 ;;
 
-let measurement_evidence measured = measured.evidence
+let measurement measured = measured.measurement
 
-let inline_test_request () =
-  let config =
-    Provider_config.make
-      ~kind:Provider_config.Anthropic
-      ~model_id:"prepared-identity-test"
-      ~base_url:"https://example.invalid"
-      ~api_key:"test-key"
-      ~max_tokens:1
-      ()
-  in
-  { Llm_transport.config
-  ; messages = []
-  ; tools = []
-  ; capture_id = None
-  ; observe_wire_chunk = None
-  ; stream_idle_timeout_s = None
-  }
+let admit measured =
+  let request = measured.prepared.request in
+  match request.config.max_context with
+  | None -> Error (Context_limit_unknown { model_id = request.config.model_id })
+  | Some max_context_tokens when max_context_tokens <= 0 ->
+    Error
+      (Invalid_context_limit { model_id = request.config.model_id; max_context_tokens })
+  | Some max_context_tokens ->
+    let input_tokens = measured.measurement.input_count.input_tokens in
+    let reserved_output_tokens =
+      Types.output_token_receipt_effective measured.measurement.output_token_receipt
+    in
+    (match reserved_output_tokens with
+     | None ->
+       (* [measure_completion_request] currently returns only a required
+          receipt. Keep this branch total if a future provider protocol can
+          report an optional output ceiling. *)
+       Error (Output_reservation_unknown { model_id = request.config.model_id })
+     | Some reserved_output_tokens ->
+       let fit = { input_tokens; reserved_output_tokens; max_context_tokens } in
+       if
+         reserved_output_tokens > max_context_tokens
+         || input_tokens > max_context_tokens - reserved_output_tokens
+       then Error (Context_window_exceeded fit)
+       else Ok { measured; fit })
 ;;
 
-let%test "prepare retains the exact request with allocation-specific identity" =
-  let raw = inline_test_request () in
-  let left = prepare raw in
-  let right = prepare raw in
-  request left == raw
-  && identity left == left
-  && not (same_identity (identity left) (identity right))
-;;
+let admitted_request admitted = admitted.measured.prepared
+let admitted_fit admitted = admitted.fit

--- a/lib/llm_provider/prepared_completion_request.ml
+++ b/lib/llm_provider/prepared_completion_request.ml
@@ -49,21 +49,38 @@ let prepare
 let request prepared = prepared.request
 
 let measure ?connection_cache ?clock ?timeout_s ~sw ~net prepared =
-  Count_tokens_sync.measure_completion_request
-    ?connection_cache
-    ?clock
-    ?timeout_s
-    ~sw
-    ~net
-    prepared.request
-  |> Result.map (fun measurement -> { prepared; measurement })
+  let config = prepared.request.Llm_transport.config in
+  let measured () =
+    Count_tokens_sync.measure_completion_request
+      ?connection_cache
+      ?clock
+      ?timeout_s
+      ~sw
+      ~net
+      prepared.request
+    |> Result.map (fun measurement -> { prepared; measurement })
+  in
+  match Complete_common.validate_all config with
+  | Error (Http_client.AcceptRejected { reason }) ->
+    Error (Count_tokens_sync.Invalid_completion_request reason)
+  | Error error ->
+    Error (Count_tokens_sync.Input_count_failed (Input_token_count.Transport error))
+  | Ok () -> Provider_admission.with_admission ~config measured
 ;;
 
 let measurement measured = measured.measurement
 
 let admit measured =
   let request = measured.prepared.request in
-  match request.config.max_context with
+  let max_context =
+    match request.config.max_context with
+    | Some _ as explicit -> explicit
+    | None ->
+      Option.bind
+        (Provider_config.capabilities_for_config_model request.config)
+        (fun capabilities -> capabilities.Capabilities.max_context_tokens)
+  in
+  match max_context with
   | None -> Error (Context_limit_unknown { model_id = request.config.model_id })
   | Some max_context_tokens when max_context_tokens <= 0 ->
     Error

--- a/lib/llm_provider/prepared_completion_request.ml
+++ b/lib/llm_provider/prepared_completion_request.ml
@@ -1,0 +1,92 @@
+type t = { request : Llm_transport.completion_request }
+type identity = t
+
+type measurement_evidence =
+  { request_identity : identity
+  ; measurement : Count_tokens_sync.completion_request_measurement
+  }
+
+type measured =
+  { prepared : t
+  ; evidence : measurement_evidence
+  }
+
+let prepare request = { request }
+
+let prepare_sync ~config ~messages ?(tools = []) ?(trace_context = []) () =
+  prepare
+    { Llm_transport.config =
+        Complete_common.config_with_trace_context config trace_context
+    ; messages
+    ; tools
+    ; capture_id = None
+    ; observe_wire_chunk = None
+    ; stream_idle_timeout_s = None
+    }
+;;
+
+let prepare_stream
+      ~config
+      ~messages
+      ?(tools = [])
+      ?(trace_context = [])
+      ?capture_id
+      ?stream_idle_timeout_s
+      ()
+  =
+  prepare
+    { Llm_transport.config =
+        Complete_common.config_with_trace_context config trace_context
+    ; messages
+    ; tools
+    ; capture_id
+    ; observe_wire_chunk = None
+    ; stream_idle_timeout_s
+    }
+;;
+
+let request prepared = prepared.request
+let identity prepared = prepared
+let same_identity left right = left == right
+
+let measure ?connection_cache ?clock ?timeout_s ~sw ~net prepared =
+  Count_tokens_sync.measure_completion_request
+    ?connection_cache
+    ?clock
+    ?timeout_s
+    ~sw
+    ~net
+    prepared.request
+  |> Result.map (fun measurement ->
+    { prepared; evidence = { request_identity = prepared; measurement } })
+;;
+
+let measurement_evidence measured = measured.evidence
+
+let inline_test_request () =
+  let config =
+    Provider_config.make
+      ~kind:Provider_config.Anthropic
+      ~model_id:"prepared-identity-test"
+      ~base_url:"https://example.invalid"
+      ~api_key:"test-key"
+      ~max_tokens:1
+      ()
+  in
+  { Llm_transport.config
+  ; messages = []
+  ; tools = []
+  ; capture_id = None
+  ; observe_wire_chunk = None
+  ; stream_idle_timeout_s = None
+  }
+;;
+
+let%test "prepare retains the exact request with allocation-specific identity" =
+  let raw = inline_test_request () in
+  let left = prepare raw in
+  let right = prepare raw in
+  request left == raw
+  && identity left == left
+  && not (same_identity (identity left) (identity right))
+;;

--- a/lib/llm_provider/prepared_completion_request.mli
+++ b/lib/llm_provider/prepared_completion_request.mli
@@ -1,0 +1,58 @@
+(** Private immutable ownership boundary for one projected completion request.
+
+    This module is a Dune [private_module].  Its raw request accessor therefore
+    exists only in the library-private CMI and cannot become SDK dispatch
+    authority.  Public admission surfaces must wrap its values in opaque types
+    and expose typed facts and decisions only. *)
+
+type t
+type identity
+type measured
+
+type measurement_evidence = private
+  { request_identity : identity
+  ; measurement : Count_tokens_sync.completion_request_measurement
+  }
+
+(** Retain one exact immutable transport request. *)
+val prepare : Llm_transport.completion_request -> t
+
+(** Project the synchronous request used by the public Complete wrapper. *)
+val prepare_sync
+  :  config:Provider_config.t
+  -> messages:Types.message list
+  -> ?tools:Yojson.Safe.t list
+  -> ?trace_context:(string * string) list
+  -> unit
+  -> t
+
+(** Project the streaming request used by the public Complete wrapper. *)
+val prepare_stream
+  :  config:Provider_config.t
+  -> messages:Types.message list
+  -> ?tools:Yojson.Safe.t list
+  -> ?trace_context:(string * string) list
+  -> ?capture_id:string
+  -> ?stream_idle_timeout_s:float
+  -> unit
+  -> t
+
+(** Private raw accessor.  This declaration is never installed in the public
+    [agent_sdk.llm_provider] module graph. *)
+val request : t -> Llm_transport.completion_request
+
+val identity : t -> identity
+val same_identity : identity -> identity -> bool
+
+(** Measure the exact retained request.  No fit policy, retry, truncation,
+    completion dispatch, or caller continuation is performed. *)
+val measure
+  :  ?connection_cache:Http_client.cache
+  -> ?clock:_ Eio.Time.clock
+  -> ?timeout_s:float
+  -> sw:Eio.Switch.t
+  -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> t
+  -> (measured, Count_tokens_sync.completion_request_error) result
+
+val measurement_evidence : measured -> measurement_evidence

--- a/lib/llm_provider/prepared_completion_request.mli
+++ b/lib/llm_provider/prepared_completion_request.mli
@@ -1,33 +1,29 @@
-(** Private immutable ownership boundary for one projected completion request.
+(** Private state machine for one canonical completion request.
 
-    This module is a Dune [private_module].  Its raw request accessor therefore
-    exists only in the library-private CMI and cannot become SDK dispatch
-    authority.  Public admission surfaces must wrap its values in opaque types
-    and expose typed facts and decisions only. *)
+    A measurement cannot be detached from one request and attached to another:
+    [measured] owns the exact [t], and [admitted] owns that [measured] value.
+    The public {!Complete} module exposes these states opaquely. *)
 
 type t
-type identity
 type measured
+type admitted
 
-type measurement_evidence = private
-  { request_identity : identity
-  ; measurement : Count_tokens_sync.completion_request_measurement
+type context_fit =
+  { input_tokens : int
+  ; reserved_output_tokens : int
+  ; max_context_tokens : int
   }
 
-(** Retain one exact immutable transport request. *)
-val prepare : Llm_transport.completion_request -> t
+type fit_error =
+  | Context_limit_unknown of { model_id : string }
+  | Invalid_context_limit of
+      { model_id : string
+      ; max_context_tokens : int
+      }
+  | Output_reservation_unknown of { model_id : string }
+  | Context_window_exceeded of context_fit
 
-(** Project the synchronous request used by the public Complete wrapper. *)
-val prepare_sync
-  :  config:Provider_config.t
-  -> messages:Types.message list
-  -> ?tools:Yojson.Safe.t list
-  -> ?trace_context:(string * string) list
-  -> unit
-  -> t
-
-(** Project the streaming request used by the public Complete wrapper. *)
-val prepare_stream
+val prepare
   :  config:Provider_config.t
   -> messages:Types.message list
   -> ?tools:Yojson.Safe.t list
@@ -37,15 +33,8 @@ val prepare_stream
   -> unit
   -> t
 
-(** Private raw accessor.  This declaration is never installed in the public
-    [agent_sdk.llm_provider] module graph. *)
 val request : t -> Llm_transport.completion_request
 
-val identity : t -> identity
-val same_identity : identity -> identity -> bool
-
-(** Measure the exact retained request.  No fit policy, retry, truncation,
-    completion dispatch, or caller continuation is performed. *)
 val measure
   :  ?connection_cache:Http_client.cache
   -> ?clock:_ Eio.Time.clock
@@ -55,4 +44,7 @@ val measure
   -> t
   -> (measured, Count_tokens_sync.completion_request_error) result
 
-val measurement_evidence : measured -> measurement_evidence
+val measurement : measured -> Count_tokens_sync.completion_request_measurement
+val admit : measured -> (admitted, fit_error) result
+val admitted_request : admitted -> t
+val admitted_fit : admitted -> context_fit

--- a/lib/pipeline/pipeline_stage_route.ml
+++ b/lib/pipeline/pipeline_stage_route.ml
@@ -20,6 +20,114 @@ let binding_identity_for_call agent provider_config =
   Binding_identity.of_provider_config ~transport provider_config
 ;;
 
+let invalid_request message =
+  Error.Api
+    (Llm_provider.Retry.InvalidRequest
+       { message; reason = Llm_provider.Retry.Unknown_invalid_request })
+;;
+
+let measurement_error ~binding = function
+  | Llm_provider.Count_tokens_sync.Input_count_failed
+      (Llm_provider.Input_token_count.Transport http_error) ->
+    Provider_failure_attribution.of_http_error ~binding http_error
+  | Llm_provider.Count_tokens_sync.Input_count_failed
+      (Llm_provider.Input_token_count.Unsupported { protocol; model_id }) ->
+    Provider_failure_attribution.of_request_validation_error
+      ~binding
+      (invalid_request
+         (Printf.sprintf
+            "provider-native input measurement %s is unsupported for model %s"
+            (Llm_provider.Input_token_count.show_protocol protocol)
+            model_id))
+  | Llm_provider.Count_tokens_sync.Input_count_failed
+      (Llm_provider.Input_token_count.Invalid_response { protocol; model_id; detail }) ->
+    Provider_failure_attribution.of_request_validation_error
+      ~binding
+      (invalid_request
+         (Printf.sprintf
+            "invalid %s input measurement for model %s: %s"
+            (Llm_provider.Input_token_count.show_protocol protocol)
+            model_id
+            detail))
+  | Llm_provider.Count_tokens_sync.Output_token_resolution_failed
+      Llm_provider.Types.Required_output_token_ceiling_missing ->
+    Provider_failure_attribution.of_request_validation_error
+      ~binding
+      (invalid_request "prepared request has no effective output-token ceiling")
+  | Llm_provider.Count_tokens_sync.Invalid_completion_request detail ->
+    Provider_failure_attribution.of_request_validation_error
+      ~binding
+      (invalid_request ("invalid prepared completion request: " ^ detail))
+;;
+
+let fit_error ~binding = function
+  | Llm_provider.Complete.Context_limit_unknown { model_id } ->
+    Provider_failure_attribution.of_request_validation_error
+      ~binding
+      (Error.Config
+         (InvalidConfig
+            { field = "max_context"
+            ; detail = Printf.sprintf "model %s has no declared context limit" model_id
+            }))
+  | Llm_provider.Complete.Invalid_context_limit { model_id; max_context_tokens } ->
+    Provider_failure_attribution.of_request_validation_error
+      ~binding
+      (Error.Config
+         (InvalidConfig
+            { field = "max_context"
+            ; detail =
+                Printf.sprintf
+                  "model %s declares invalid context limit %d"
+                  model_id
+                  max_context_tokens
+            }))
+  | Llm_provider.Complete.Output_reservation_unknown { model_id } ->
+    Provider_failure_attribution.of_request_validation_error
+      ~binding
+      (invalid_request
+         (Printf.sprintf "model %s has no effective output-token reservation" model_id))
+  | Llm_provider.Complete.Context_window_exceeded
+      { input_tokens; reserved_output_tokens; max_context_tokens } ->
+    Provider_failure_attribution.of_request_validation_error
+      ~binding
+      (Error.Api
+         (Llm_provider.Retry.ContextOverflow
+            { message =
+                Printf.sprintf
+                  "prepared request requires %d input + %d reserved output tokens, limit \
+                   %d"
+                  input_tokens
+                  reserved_output_tokens
+                  max_context_tokens
+            ; limit = Some max_context_tokens
+            }))
+;;
+
+let supports_native_request_measurement = function
+  | Llm_provider.Provider_config.Anthropic -> true
+  | Llm_provider.Provider_config.Kimi
+  | Llm_provider.Provider_config.OpenAI_compat
+  | Llm_provider.Provider_config.Ollama
+  | Llm_provider.Provider_config.Gemini
+  | Llm_provider.Provider_config.Glm
+  | Llm_provider.Provider_config.DashScope -> false
+;;
+
+let enforce_context_fit agent (provider_config : Llm_provider.Provider_config.t) =
+  match agent.context_fit_admission with
+  | Disabled -> false
+  | Enforce_when_supported -> supports_native_request_measurement provider_config.kind
+;;
+
+let finish_call ?on_provider_failure = function
+  | Ok response ->
+    notify_attribution on_provider_failure None;
+    Ok response
+  | Error (detailed : Provider_failure_attribution.detailed_error) ->
+    notify_attribution on_provider_failure detailed.provider_failure;
+    Error detailed.error
+;;
+
 let provider_config_for_turn ~turn_config agent =
   match agent.provider_config with
   | Some provider_config ->
@@ -52,7 +160,7 @@ let dispatch_sync
       binding_identity_for_call agent pc
       |> Result.map_error (binding_identity_error ?on_provider_failure)
     in
-    let call () =
+    let compatibility_call () =
       Llm_provider.Complete.complete
         ~sw
         ~net:agent.net
@@ -64,15 +172,36 @@ let dispatch_sync
         ~trace_context
         ?body_timeout_s:agent.options.body_timeout_s
         ()
+      |> Result.map_error (Provider_failure_attribution.of_http_error ~binding)
     in
-    (match call () with
-     | Ok resp ->
-       notify_attribution on_provider_failure None;
-       Ok resp
-     | Error err ->
-       let detailed = Provider_failure_attribution.of_http_error ~binding err in
-       notify_attribution on_provider_failure detailed.provider_failure;
-       Error detailed.error)
+    let admitted_call () =
+      let prepared =
+        Llm_provider.Complete.prepare_request
+          ~config:pc
+          ~messages:prep.Agent_turn.effective_messages
+          ~tools
+          ~trace_context
+          ()
+      in
+      match Llm_provider.Complete.measure_request ~sw ~net:agent.net ?clock prepared with
+      | Error error -> Error (measurement_error ~binding error)
+      | Ok measured ->
+        (match Llm_provider.Complete.admit_request measured with
+         | Error error -> Error (fit_error ~binding error)
+         | Ok admitted ->
+           Llm_provider.Complete.complete_admitted
+             ~sw
+             ~net:agent.net
+             ?clock
+             ?transport:agent.options.transport
+             admitted
+             ?body_timeout_s:agent.options.body_timeout_s
+             ()
+           |> Result.map_error (Provider_failure_attribution.of_http_error ~binding))
+    in
+    if enforce_context_fit agent pc
+    then finish_call ?on_provider_failure (admitted_call ())
+    else finish_call ?on_provider_failure (compatibility_call ())
 ;;
 
 let dispatch_stream
@@ -100,7 +229,7 @@ let dispatch_stream
       binding_identity_for_call agent pc
       |> Result.map_error (binding_identity_error ?on_provider_failure)
     in
-    let call () =
+    let compatibility_call () =
       Llm_provider.Complete.complete_stream
         ~sw
         ~net:agent.net
@@ -115,13 +244,37 @@ let dispatch_stream
         ?on_telemetry
         ?stream_idle_timeout_s:agent.options.stream_idle_timeout_s
         ()
+      |> Result.map_error (Provider_failure_attribution.of_http_error ~binding)
     in
-    (match call () with
-     | Ok resp ->
-       notify_attribution on_provider_failure None;
-       Ok resp
-     | Error err ->
-       let detailed = Provider_failure_attribution.of_http_error ~binding err in
-       notify_attribution on_provider_failure detailed.provider_failure;
-       Error detailed.error)
+    let admitted_call () =
+      let prepared =
+        Llm_provider.Complete.prepare_request
+          ~config:pc
+          ~messages:prep.Agent_turn.effective_messages
+          ~tools
+          ~trace_context
+          ?capture_id
+          ?stream_idle_timeout_s:agent.options.stream_idle_timeout_s
+          ()
+      in
+      match Llm_provider.Complete.measure_request ~sw ~net:agent.net ?clock prepared with
+      | Error error -> Error (measurement_error ~binding error)
+      | Ok measured ->
+        (match Llm_provider.Complete.admit_request measured with
+         | Error error -> Error (fit_error ~binding error)
+         | Ok admitted ->
+           Llm_provider.Complete.complete_stream_admitted
+             ~sw
+             ~net:agent.net
+             ?clock
+             ?transport:agent.options.transport
+             admitted
+             ~on_event
+             ?on_telemetry
+             ()
+           |> Result.map_error (Provider_failure_attribution.of_http_error ~binding))
+    in
+    if enforce_context_fit agent pc
+    then finish_call ?on_provider_failure (admitted_call ())
+    else finish_call ?on_provider_failure (compatibility_call ())
 ;;

--- a/lib/pipeline/pipeline_stage_route.ml
+++ b/lib/pipeline/pipeline_stage_route.ml
@@ -41,14 +41,18 @@ let measurement_error ~binding = function
             model_id))
   | Llm_provider.Count_tokens_sync.Input_count_failed
       (Llm_provider.Input_token_count.Invalid_response { protocol; model_id; detail }) ->
-    Provider_failure_attribution.of_request_validation_error
+    Provider_failure_attribution.of_response_parse_error
       ~binding
-      (invalid_request
-         (Printf.sprintf
-            "invalid %s input measurement for model %s: %s"
-            (Llm_provider.Input_token_count.show_protocol protocol)
-            model_id
-            detail))
+      (Error.Api
+         (Llm_provider.Retry.InvalidRequest
+            { message =
+                Printf.sprintf
+                  "invalid %s input measurement for model %s: %s"
+                  (Llm_provider.Input_token_count.show_protocol protocol)
+                  model_id
+                  detail
+            ; reason = Llm_provider.Retry.Json_parse_error
+            }))
   | Llm_provider.Count_tokens_sync.Output_token_resolution_failed
       Llm_provider.Types.Required_output_token_ceiling_missing ->
     Provider_failure_attribution.of_request_validation_error

--- a/lib/pipeline/pipeline_stage_route.ml
+++ b/lib/pipeline/pipeline_stage_route.ml
@@ -103,20 +103,11 @@ let fit_error ~binding = function
             }))
 ;;
 
-let supports_native_request_measurement = function
-  | Llm_provider.Provider_config.Anthropic -> true
-  | Llm_provider.Provider_config.Kimi
-  | Llm_provider.Provider_config.OpenAI_compat
-  | Llm_provider.Provider_config.Ollama
-  | Llm_provider.Provider_config.Gemini
-  | Llm_provider.Provider_config.Glm
-  | Llm_provider.Provider_config.DashScope -> false
-;;
-
 let enforce_context_fit agent (provider_config : Llm_provider.Provider_config.t) =
   match agent.context_fit_admission with
   | Disabled -> false
-  | Enforce_when_supported -> supports_native_request_measurement provider_config.kind
+  | Enforce_when_supported ->
+    Llm_provider.Count_tokens_sync.supports_completion_request_measurement provider_config
 ;;
 
 let finish_call ?on_provider_failure = function

--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -700,7 +700,7 @@ let provider_config_with_agent_config
     else Llm_provider.Provider_config.output_schema_of_response_format response_format
   in
   let max_context, model_capabilities_override, supports_structured_output_override =
-    if String.equal model_id provider_config.model_id
+    if model_id = provider_config.model_id
     then
       ( provider_config.max_context
       , provider_config.model_capabilities_override

--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -692,14 +692,40 @@ let provider_config_with_agent_config
       ~(config : Types.agent_config)
       (provider_config : Llm_provider.Provider_config.t)
   =
+  let model_id = Types.model_to_string config.model in
   let response_format = config.response_format in
   let output_schema =
     if response_format = provider_config.response_format
     then provider_config.output_schema
     else Llm_provider.Provider_config.output_schema_of_response_format response_format
   in
+  let max_context, model_capabilities_override, supports_structured_output_override =
+    if String.equal model_id provider_config.model_id
+    then
+      ( provider_config.max_context
+      , provider_config.model_capabilities_override
+      , provider_config.supports_structured_output_override )
+    else (
+      let target_model =
+        { provider_config with
+          model_id
+        ; max_context = None
+        ; model_capabilities_override = None
+        ; supports_structured_output_override = None
+        }
+      in
+      let max_context =
+        Option.bind
+          (Llm_provider.Provider_config.capabilities_for_config_model target_model)
+          (fun capabilities -> capabilities.max_context_tokens)
+      in
+      max_context, None, None)
+  in
   { provider_config with
-    model_id = Types.model_to_string config.model
+    model_id
+  ; max_context
+  ; model_capabilities_override
+  ; supports_structured_output_override
   ; max_tokens = config.max_tokens
   ; temperature = config.temperature
   ; top_p = config.top_p

--- a/lib/provider.mli
+++ b/lib/provider.mli
@@ -315,11 +315,11 @@ val provider_config_of_agent
 
 (** Project the caller-owned agent turn controls onto an exact provider
     configuration. Provider identity, wire kind, endpoint, credential, headers,
-    request path, and capability overrides remain unchanged. Fields that only
-    exist on {!Llm_provider.Provider_config.t} also remain unchanged.
-
-    This is the typed Builder/Agent path; it never consults a provider catalog,
-    endpoint URL, model syntax, or process environment. *)
+    and request path remain unchanged. For the same model, explicit limits and
+    capability overrides remain unchanged. When the turn selects another
+    model, parent-model overrides are cleared and the target model's context
+    limit is resolved through {!Llm_provider.Provider_config}'s capability
+    SSOT, so handoffs cannot inherit the parent's model window. *)
 val provider_config_with_agent_config
   :  config:Types.agent_config
   -> Llm_provider.Provider_config.t

--- a/test/dune
+++ b/test/dune
@@ -447,7 +447,7 @@
 (test
  (name test_anthropic_input_token_count)
  (modules test_anthropic_input_token_count)
- (libraries llm_provider alcotest eio_main))
+ (libraries agent_sdk llm_provider alcotest eio_main))
 
 (test
  (name test_complete_http)

--- a/test/test_anthropic_input_token_count.ml
+++ b/test/test_anthropic_input_token_count.ml
@@ -53,6 +53,7 @@ let messages =
 let config
       ?(kind = Provider_config.Anthropic)
       ?(request_path = "/proxy/messages")
+      ?max_context
       base_url
   =
   Provider_config.make
@@ -63,6 +64,7 @@ let config
     ~headers:[ "Content-Type", "application/json"; "anthropic-version", "2023-06-01" ]
     ~request_path
     ~max_tokens:64
+    ?max_context
     ~temperature:0.2
     ~top_p:0.8
     ~top_k:40
@@ -73,6 +75,28 @@ let config
     ~supports_tool_choice_override:true
     ~output_schema:(`Assoc [ "type", `String "object" ])
     ()
+;;
+
+let response =
+  { id = "prepared-response"
+  ; model = "input-count-fixture"
+  ; stop_reason = EndTurn
+  ; content = [ Text "accepted" ]
+  ; usage = None
+  ; telemetry = None
+  }
+;;
+
+let build_admission_agent ~net ~provider_config ~transport =
+  Agent_sdk.Builder.create ~net ~model:provider_config.Provider_config.model_id
+  |> Agent_sdk.Builder.with_provider_config provider_config
+  |> Agent_sdk.Builder.with_context_fit_admission Agent_sdk.Agent.Enforce_when_supported
+  |> Agent_sdk.Builder.with_transport transport
+  |> Agent_sdk.Builder.without_event_bus
+  |> Agent_sdk.Builder.build_safe
+  |> function
+  | Ok agent -> agent
+  | Error error -> fail (Agent_sdk.Error.to_string error)
 ;;
 
 let completion_request config : Llm_transport.completion_request =
@@ -210,6 +234,199 @@ let test_transport_success () =
     body
 ;;
 
+let test_prepared_measure_admit_dispatch () =
+  let (result, fit, dispatched), _captured =
+    with_mock ~status:`OK ~response:{|{"input_tokens":321}|}
+    @@ fun ~sw ~net ~base_url ->
+    let cfg = config ~max_context:512 base_url in
+    let prepared =
+      Complete.prepare_request
+        ~config:cfg
+        ~messages
+        ~tools:[ tool ]
+        ~trace_context:[ "x-oas-trace", "prepared-ssot" ]
+        ()
+    in
+    let measured =
+      match Complete.measure_request ~sw ~net prepared with
+      | Ok measured -> measured
+      | Error _ -> fail "expected prepared request measurement"
+    in
+    let admitted =
+      match Complete.admit_request measured with
+      | Ok admitted -> admitted
+      | Error _ -> fail "expected prepared request admission"
+    in
+    let fit = Complete.admitted_fit admitted in
+    let dispatched = ref None in
+    let transport =
+      { Llm_transport.complete_sync =
+          (fun request ->
+            dispatched := Some request;
+            { Llm_transport.response = Ok response; latency_ms = Some 1 })
+      ; complete_stream =
+          (fun ?on_telemetry:_ ~on_event:_ _ -> fail "unexpected streaming dispatch")
+      }
+    in
+    let result = Complete.complete_admitted ~sw ~net ~transport admitted () in
+    result, fit, !dispatched
+  in
+  (match result with
+   | Ok actual ->
+     check string "response" "accepted" (Types.visible_text_of_response actual)
+   | Error _ -> fail "expected admitted dispatch success");
+  check int "measured input" 321 fit.Complete.input_tokens;
+  check int "reserved output" 64 fit.reserved_output_tokens;
+  check int "declared context" 512 fit.max_context_tokens;
+  match dispatched with
+  | None -> fail "admitted request was not dispatched"
+  | Some request ->
+    check string "same model" "input-count-fixture" request.config.model_id;
+    check int "same messages" (List.length messages) (List.length request.messages);
+    check int "same tools" 1 (List.length request.tools);
+    check
+      (option string)
+      "same trace projection"
+      (Some "prepared-ssot")
+      (List.assoc_opt "x-oas-trace" request.config.headers)
+;;
+
+let test_prepared_context_overflow_is_typed () =
+  let result, _captured =
+    with_mock ~status:`OK ~response:{|{"input_tokens":500}|}
+    @@ fun ~sw ~net ~base_url ->
+    let prepared =
+      Complete.prepare_request
+        ~config:(config ~max_context:512 base_url)
+        ~messages
+        ~tools:[ tool ]
+        ()
+    in
+    match Complete.measure_request ~sw ~net prepared with
+    | Error _ -> fail "expected prepared request measurement"
+    | Ok measured -> Complete.admit_request measured
+  in
+  match result with
+  | Error
+      (Complete.Context_window_exceeded
+         { input_tokens = 500; reserved_output_tokens = 64; max_context_tokens = 512 }) ->
+    ()
+  | Ok _ | Error _ -> fail "expected typed prepared context overflow"
+;;
+
+let test_agent_route_uses_prepared_admission () =
+  let result, _captured =
+    with_mock ~status:`OK ~response:{|{"input_tokens":321}|}
+    @@ fun ~sw ~net ~base_url ->
+    let provider_config = config ~max_context:512 base_url in
+    let dispatched = ref None in
+    let transport =
+      { Llm_transport.complete_sync =
+          (fun request ->
+            dispatched := Some request;
+            { Llm_transport.response = Ok response; latency_ms = Some 1 })
+      ; complete_stream =
+          (fun ?on_telemetry:_ ~on_event:_ request ->
+            dispatched := Some request;
+            Ok response)
+      }
+    in
+    let agent = build_admission_agent ~net ~provider_config ~transport in
+    let result = Agent_sdk.Agent.run ~sw agent "measure this exact turn" in
+    result, !dispatched
+  in
+  match result with
+  | Error error, _ -> fail (Agent_sdk.Error.to_string error)
+  | Ok actual, None ->
+    check string "response" "accepted" (Types.visible_text_of_response actual);
+    fail "Agent route did not dispatch the admitted request"
+  | Ok actual, Some request ->
+    check string "response" "accepted" (Types.visible_text_of_response actual);
+    check string "agent dispatch model" "input-count-fixture" request.config.model_id;
+    check int "agent dispatch messages" 1 (List.length request.messages)
+;;
+
+let test_agent_stream_route_uses_prepared_admission () =
+  let result, _captured =
+    with_mock ~status:`OK ~response:{|{"input_tokens":321}|}
+    @@ fun ~sw ~net ~base_url ->
+    let provider_config = config ~max_context:512 base_url in
+    let dispatched = ref None in
+    let transport =
+      { Llm_transport.complete_sync = (fun _ -> fail "unexpected sync dispatch")
+      ; complete_stream =
+          (fun ?on_telemetry:_ ~on_event:_ request ->
+            dispatched := Some request;
+            Ok response)
+      }
+    in
+    let agent = build_admission_agent ~net ~provider_config ~transport in
+    let result = Agent_sdk.Agent.run_stream ~sw ~on_event:(fun _ -> ()) agent "stream" in
+    result, !dispatched
+  in
+  match result with
+  | Error error, _ -> fail (Agent_sdk.Error.to_string error)
+  | Ok _, None -> fail "Agent stream route did not dispatch the admitted request"
+  | Ok actual, Some request ->
+    check string "stream response" "accepted" (Types.visible_text_of_response actual);
+    check string "stream dispatch model" "input-count-fixture" request.config.model_id;
+    check int "stream dispatch messages" 1 (List.length request.messages)
+;;
+
+let test_agent_overflow_blocks_dispatch () =
+  let result, _captured =
+    with_mock ~status:`OK ~response:{|{"input_tokens":500}|}
+    @@ fun ~sw ~net ~base_url ->
+    let provider_config = config ~max_context:512 base_url in
+    let dispatched = ref false in
+    let transport =
+      { Llm_transport.complete_sync =
+          (fun _ ->
+            dispatched := true;
+            { Llm_transport.response = Ok response; latency_ms = None })
+      ; complete_stream =
+          (fun ?on_telemetry:_ ~on_event:_ _ -> fail "unexpected stream dispatch")
+      }
+    in
+    let agent = build_admission_agent ~net ~provider_config ~transport in
+    let result = Agent_sdk.Agent.run ~sw agent "overflow" in
+    result, !dispatched
+  in
+  match result with
+  | Error (Agent_sdk.Error.Api (Retry.ContextOverflow { limit = Some 512; _ })), false ->
+    ()
+  | Error error, _ -> fail (Agent_sdk.Error.to_string error)
+  | Ok _, _ -> fail "overflowed prepared request must not dispatch"
+;;
+
+let test_unsupported_provider_preserves_compatibility () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let net = Eio.Stdenv.net env in
+  let provider_config =
+    { (config ~kind:Provider_config.OpenAI_compat ~max_context:512 "not-used") with
+      output_schema = None
+    ; response_format = Types.Off
+    }
+  in
+  let dispatched = ref false in
+  let transport =
+    { Llm_transport.complete_sync =
+        (fun _ ->
+          dispatched := true;
+          { Llm_transport.response = Ok response; latency_ms = None })
+    ; complete_stream =
+        (fun ?on_telemetry:_ ~on_event:_ _ -> fail "unexpected stream dispatch")
+    }
+  in
+  let agent = build_admission_agent ~net ~provider_config ~transport in
+  match Agent_sdk.Agent.run ~sw agent "compatibility" with
+  | Error error -> fail (Agent_sdk.Error.to_string error)
+  | Ok _ -> check bool "compatibility dispatch" true !dispatched
+;;
+
 let test_transport_error () =
   let result, _captured =
     with_mock ~status:`Too_many_requests ~response:"rate limited"
@@ -285,6 +502,30 @@ let () =
     [ "request", [ test_case "shared canonical projection" `Quick test_shared_projection ]
     ; ( "transport"
       , [ test_case "native success" `Quick test_transport_success
+        ; test_case
+            "prepared measure admit dispatch"
+            `Quick
+            test_prepared_measure_admit_dispatch
+        ; test_case
+            "prepared context overflow is typed"
+            `Quick
+            test_prepared_context_overflow_is_typed
+        ; test_case
+            "Agent route uses prepared admission"
+            `Quick
+            test_agent_route_uses_prepared_admission
+        ; test_case
+            "Agent stream route uses prepared admission"
+            `Quick
+            test_agent_stream_route_uses_prepared_admission
+        ; test_case
+            "Agent overflow blocks dispatch"
+            `Quick
+            test_agent_overflow_blocks_dispatch
+        ; test_case
+            "unsupported provider preserves compatibility"
+            `Quick
+            test_unsupported_provider_preserves_compatibility
         ; test_case "typed HTTP error" `Quick test_transport_error
         ; test_case "non-Anthropic unsupported" `Quick test_unsupported
         ; test_case

--- a/test/test_anthropic_input_token_count.ml
+++ b/test/test_anthropic_input_token_count.ml
@@ -54,6 +54,7 @@ let config
       ?(kind = Provider_config.Anthropic)
       ?(request_path = "/proxy/messages")
       ?max_context
+      ?max_concurrent_requests
       base_url
   =
   Provider_config.make
@@ -74,6 +75,7 @@ let config
     ~disable_parallel_tool_use:true
     ~supports_tool_choice_override:true
     ~output_schema:(`Assoc [ "type", `String "object" ])
+    ?max_concurrent_requests
     ()
 ;;
 
@@ -314,6 +316,67 @@ let test_prepared_context_overflow_is_typed () =
   | Ok _ | Error _ -> fail "expected typed prepared context overflow"
 ;;
 
+let test_prepared_admission_resolves_catalog_context_limit () =
+  let result, _captured =
+    with_mock ~status:`OK ~response:{|{"input_tokens":321}|}
+    @@ fun ~sw ~net ~base_url ->
+    let cfg = { (config base_url) with model_id = "claude-sonnet-4-5" } in
+    let expected =
+      Option.bind (Provider_config.capabilities_for_config_model cfg) (fun capabilities ->
+        capabilities.Capabilities.max_context_tokens)
+      |> Option.get
+    in
+    let prepared = Complete.prepare_request ~config:cfg ~messages ~tools:[ tool ] () in
+    let measured = Complete.measure_request ~sw ~net prepared |> Result.get_ok in
+    Complete.admit_request measured, expected
+  in
+  match result with
+  | Error _, _ -> fail "catalog-backed context admission unexpectedly failed"
+  | Ok admitted, expected ->
+    check
+      int
+      "catalog context is the admission limit"
+      expected
+      (Complete.admitted_fit admitted).max_context_tokens
+;;
+
+let test_measurement_validates_before_io () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let cfg =
+    config ~request_path:"/v1/responses" ~max_concurrent_requests:0 "http://127.0.0.1:1"
+  in
+  let prepared = Complete.prepare_request ~config:cfg ~messages ~tools:[ tool ] () in
+  match Complete.measure_request ~sw ~net:(Eio.Stdenv.net env) prepared with
+  | Error (Count_tokens_sync.Invalid_completion_request detail) ->
+    check bool "validation identifies local config" true (String.length detail > 0);
+    check
+      bool
+      "invalid request never creates an admission lane"
+      true
+      (Option.is_none (Provider_admission.snapshot_for ~config:cfg))
+  | Ok _ | Error _ -> fail "invalid prepared request must fail before provider I/O"
+;;
+
+let test_measurement_uses_provider_admission () =
+  let result, _captured =
+    with_mock ~status:`OK ~response:{|{"input_tokens":321}|}
+    @@ fun ~sw ~net ~base_url ->
+    let cfg = config ~max_context:512 ~max_concurrent_requests:1 base_url in
+    let prepared = Complete.prepare_request ~config:cfg ~messages ~tools:[ tool ] () in
+    let result = Complete.measure_request ~sw ~net prepared in
+    result, Provider_admission.snapshot_for ~config:cfg
+  in
+  match result with
+  | Error _, _ -> fail "admitted measurement unexpectedly failed"
+  | Ok _, None -> fail "measurement bypassed provider admission"
+  | Ok _, Some snapshot ->
+    check int "declared measurement bound" 1 snapshot.Slot_scheduler.max_slots;
+    check int "measurement permit returned" 0 snapshot.active
+;;
+
 let test_agent_route_uses_prepared_admission () =
   let result, _captured =
     with_mock ~status:`OK ~response:{|{"input_tokens":321}|}
@@ -397,6 +460,34 @@ let test_agent_overflow_blocks_dispatch () =
     ()
   | Error error, _ -> fail (Agent_sdk.Error.to_string error)
   | Ok _, _ -> fail "overflowed prepared request must not dispatch"
+;;
+
+let test_invalid_count_response_is_provider_parse_failure () =
+  let result, _captured =
+    with_mock ~status:`OK ~response:{|{"unexpected":true}|}
+    @@ fun ~sw ~net ~base_url ->
+    let provider_config = config ~max_context:512 base_url in
+    let transport =
+      { Llm_transport.complete_sync =
+          (fun _ -> fail "malformed count response must block completion dispatch")
+      ; complete_stream =
+          (fun ?on_telemetry:_ ~on_event:_ _ ->
+            fail "malformed count response must block streaming dispatch")
+      }
+    in
+    let agent = build_admission_agent ~net ~provider_config ~transport in
+    Agent_sdk.Agent.run_detailed ~sw agent "malformed count response"
+  in
+  match result with
+  | Error
+      { Agent_sdk.Agent.error =
+          Agent_sdk.Error.Api
+            (Retry.InvalidRequest { reason = Retry.Json_parse_error; _ })
+      ; provider_failure =
+          Some { Agent_sdk.Provider_failure_attribution.evidence = Response_parse; _ }
+      } -> ()
+  | Error detailed -> fail (Agent_sdk.Error.to_string detailed.error)
+  | Ok _ -> fail "malformed provider count response must fail"
 ;;
 
 let test_unsupported_provider_preserves_compatibility () =
@@ -511,6 +602,18 @@ let () =
             `Quick
             test_prepared_context_overflow_is_typed
         ; test_case
+            "prepared admission resolves catalog context limit"
+            `Quick
+            test_prepared_admission_resolves_catalog_context_limit
+        ; test_case
+            "measurement validates before I/O"
+            `Quick
+            test_measurement_validates_before_io
+        ; test_case
+            "measurement uses provider admission"
+            `Quick
+            test_measurement_uses_provider_admission
+        ; test_case
             "Agent route uses prepared admission"
             `Quick
             test_agent_route_uses_prepared_admission
@@ -522,6 +625,10 @@ let () =
             "Agent overflow blocks dispatch"
             `Quick
             test_agent_overflow_blocks_dispatch
+        ; test_case
+            "invalid count response is provider parse failure"
+            `Quick
+            test_invalid_count_response_is_provider_parse_failure
         ; test_case
             "unsupported provider preserves compatibility"
             `Quick

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -1432,6 +1432,44 @@ let test_provider_config_of_agent_custom_registered_unknown_name () =
   | Ok _ -> Alcotest.fail "should error on unregistered name"
 ;;
 
+let test_provider_config_rebinds_model_specific_context () =
+  let parent_capabilities =
+    { Llm_provider.Capabilities.anthropic_capabilities with
+      max_context_tokens = Some 12_345
+    }
+  in
+  let parent =
+    Llm_provider.Provider_config.make
+      ~kind:Anthropic
+      ~model_id:"claude-opus-4-1"
+      ~base_url:"https://api.anthropic.com"
+      ~max_context:12_345
+      ~model_capabilities_override:parent_capabilities
+      ()
+  in
+  let target_config = Types.default_config ~model:"claude-sonnet-4-5" in
+  let target = Provider.provider_config_with_agent_config ~config:target_config parent in
+  let expected =
+    let clean_target =
+      { parent with
+        model_id = "claude-sonnet-4-5"
+      ; max_context = None
+      ; model_capabilities_override = None
+      ; supports_structured_output_override = None
+      }
+    in
+    Option.bind
+      (Llm_provider.Provider_config.capabilities_for_config_model clean_target)
+      (fun capabilities -> capabilities.max_context_tokens)
+  in
+  Alcotest.(check string) "target model" "claude-sonnet-4-5" target.model_id;
+  Alcotest.(check (option int)) "target context SSOT" expected target.max_context;
+  Alcotest.(check bool)
+    "parent model capability override is not inherited"
+    true
+    (Option.is_none target.model_capabilities_override)
+;;
+
 let () =
   install_embedded_model_catalog ();
   Alcotest.run
@@ -1594,6 +1632,10 @@ let () =
             "custom registered unknown name errors"
             `Quick
             test_provider_config_of_agent_custom_registered_unknown_name
+        ; Alcotest.test_case
+            "model rebind clears parent context"
+            `Quick
+            test_provider_config_rebinds_model_specific_context
         ] )
     ]
 ;;


### PR DESCRIPTION
## Outcome

Replace the three foundation-only prepared-request drafts (#2665, #2666, #2664) with one production vertical:

`project once -> measure the same opaque value -> admit it -> dispatch that admitted value`

## SSOT boundary

- `Complete.prepared_request`, `measured_request`, and `admitted_request` are opaque states.
- Measurement evidence cannot be detached and attached to a different request.
- `Complete.complete` and `complete_stream` remain source-compatible wrappers over the same canonical preparation path.
- The private raw request accessor stays inside `agent_sdk.llm_provider`; consumers receive no transport authority.
- Allocation/physical-identity checks from the foundation draft are removed.

## Production wiring

- `Agent.Enforce_when_supported` enables provider-native fit admission.
- Sync and streaming `Pipeline_stage_route` both use the admitted request.
- Anthropic uses the typed native `count_tokens` protocol already shipped in v0.216.x.
- Protocols without a native measurement adapter retain their historical dispatch path; no token estimate, model-name match, or silent measurement fallback is introduced.
- Missing/invalid context limits and missing output reservations are typed validation failures.
- Overflow becomes `Retry.ContextOverflow` before transport dispatch.
- The default remains `Disabled` for backward runtime compatibility; downstream consumers opt in through `Builder.with_context_fit_admission`.

## Verification

- `test_anthropic_input_token_count`: 12/12
  - prepared measure/admit/dispatch
  - sync Agent production caller
  - streaming Agent production caller
  - typed overflow blocks dispatch
  - unsupported-provider compatibility
- `test_complete_ext`: 9/9
- `test_agent_pipeline`: 9/9
- `test_builder_coverage`: 14/14
- `test_agent_stream`: 28/28
- `test_complete_http`: 57/57
- `scripts/check-sdk-independence.sh`: PASS
- `@fmt`: PASS

## Deliberate limits

- This PR does not add estimates for providers without an authoritative native count protocol.
- It does not own compaction, retry, provider selection, or truncation policy.
- MASC opt-in wiring follows only after this OAS contract is green and released.
