### PR TITLE
feat(execution): rebind agent scopes after restart

### DIFF
--- a/lib/execution_agent_scope.ml
+++ b/lib/execution_agent_scope.ml
@@ -3,6 +3,7 @@ module Journal = Execution_journal
 module Settlement = Execution_tool_settlement
 module Writer = Execution_lane_writer
 module Tx = Journal.Transaction
+module Json = Execution_json
 
 type t =
   { writer : Writer.t
@@ -19,13 +20,15 @@ type provider_attempt =
   ; node : Event.Node_id.t
   }
 
+type scope_locator = { run_id : Event.Run_id.t }
+
 type invocation_locator =
-  { node : Event.Node_id.t
-  ; occurrence : Tool.Invocation.t
+  { run_id : Event.Run_id.t
+  ; node : Event.Node_id.t
   }
 
 type invocation =
-  { authority : Settlement.t
+  { durable : Settlement.durable_invocation
   ; locator : invocation_locator
   }
 
@@ -40,6 +43,9 @@ type error =
   | Admission_failed of Writer.submit_error
   | Mutation_failed of Writer.ticket_error
   | Invalid_provider_attempt of string
+  | Scope_unavailable of Writer.read_error
+  | Run_not_found
+  | Invocation_locator_mismatch
   | Settlement_failed of Settlement.error
 
 let settlement_error_to_string = function
@@ -60,7 +66,70 @@ let error_to_string = function
   | Admission_failed error -> Writer.submit_error_to_string error
   | Mutation_failed error -> Writer.ticket_error_to_string error
   | Invalid_provider_attempt detail -> "invalid provider attempt: " ^ detail
+  | Scope_unavailable error -> Writer.read_error_to_string error
+  | Run_not_found -> "execution run was not found"
+  | Invocation_locator_mismatch ->
+    "execution invocation locator does not match durable topology"
   | Settlement_failed error -> settlement_error_to_string error
+;;
+
+let locator_version = 1
+
+let require_locator_version fields =
+  match Json.int_field "version" fields with
+  | Ok version when version = locator_version -> Ok ()
+  | Ok version ->
+    Error (Printf.sprintf "unsupported execution locator version %d" version)
+  | Error _ as error -> error
+;;
+
+let scope_locator scope = { run_id = Journal.run_id scope.run }
+
+let scope_locator_to_yojson (locator : scope_locator) =
+  `Assoc
+    [ "version", `Int locator_version
+    ; "run_id", `String (Event.Run_id.to_string locator.run_id)
+    ]
+;;
+
+let scope_locator_of_yojson json =
+  let open Result_syntax in
+  let* fields =
+    Json.object_fields
+      ~context:"execution scope locator"
+      ~required:[ "version"; "run_id" ]
+      ~optional:[]
+      json
+  in
+  let* () = require_locator_version fields in
+  let* run_id = Json.string_field "run_id" fields in
+  let+ run_id = Event.Run_id.of_string run_id in
+  { run_id }
+;;
+
+let invocation_locator_to_yojson (locator : invocation_locator) =
+  `Assoc
+    [ "version", `Int locator_version
+    ; "run_id", `String (Event.Run_id.to_string locator.run_id)
+    ; "node_id", `String (Event.Node_id.to_string locator.node)
+    ]
+;;
+
+let invocation_locator_of_yojson json =
+  let open Result_syntax in
+  let* fields =
+    Json.object_fields
+      ~context:"execution invocation locator"
+      ~required:[ "version"; "run_id"; "node_id" ]
+      ~optional:[]
+      json
+  in
+  let* () = require_locator_version fields in
+  let* run_id_text = Json.string_field "run_id" fields in
+  let* run_id = Event.Run_id.of_string run_id_text in
+  let* node_text = Json.string_field "node_id" fields in
+  let+ node = Event.Node_id.of_string node_text in
+  { run_id; node }
 ;;
 
 let transact writer transaction =
@@ -86,6 +155,13 @@ let transact_cleanup writer transaction =
 let start ~writer ~agent_name =
   transact writer (Tx.start_run ~agent_name ())
   |> Result.map (fun (run, _event) -> { writer; run })
+;;
+
+let resume ~writer (locator : scope_locator) =
+  match Writer.find_run writer locator.run_id with
+  | Error error -> Error (Scope_unavailable error)
+  | Ok None -> Error Run_not_found
+  | Ok (Some view) -> Ok { writer; run = view.Journal.run }
 ;;
 
 let open_turn scope ~ordinal =
@@ -124,22 +200,32 @@ let open_invocation provider ~invocation ~tool_name ~input =
   with
   | Error _ as error -> error
   | Ok (node, _events) ->
-    let locator = { node; occurrence = invocation } in
-    Settlement.create ~writer:scope.writer ~invocation_node:node ~invocation
-    |> Result.map (fun authority -> { authority; locator })
+    let locator = { run_id = Journal.run_id scope.run; node } in
+    Settlement.rebind ~writer:scope.writer ~invocation_node:node
+    |> Result.map (fun durable -> { durable; locator })
     |> Result.map_error (fun error -> Settlement_failed error)
 ;;
 
 let invocation_locator invocation = invocation.locator
 
-let rebind_invocation ~writer locator =
-  Settlement.create ~writer ~invocation_node:locator.node ~invocation:locator.occurrence
-  |> Result.map (fun authority -> { authority; locator })
-  |> Result.map_error (fun error -> Settlement_failed error)
+let rebind_invocation scope locator =
+  if not (Event.Run_id.equal locator.run_id (Journal.run_id scope.run))
+  then Error Invocation_locator_mismatch
+  else (
+    match Settlement.rebind ~writer:scope.writer ~invocation_node:locator.node with
+    | Error error -> Error (Settlement_failed error)
+    | Ok durable ->
+      if Event.Run_id.equal durable.run_id locator.run_id
+      then Ok { durable; locator }
+      else Error Invocation_locator_mismatch)
 ;;
 
 let execute invocation ~invoke =
-  Settlement.execute invocation.authority ~invoke
+  Settlement.execute invocation.durable.authority ~invoke:(fun () ->
+    invoke
+      ~invocation:invocation.durable.invocation
+      ~tool_name:invocation.durable.tool_name
+      ~input:invocation.durable.input)
   |> Result.map_error (fun error -> Settlement_failed error)
 ;;
 

--- a/lib/execution_agent_scope.mli
+++ b/lib/execution_agent_scope.mli
@@ -5,6 +5,7 @@
 type t
 type turn
 type provider_attempt
+type scope_locator
 type invocation_locator
 type invocation
 
@@ -19,10 +20,17 @@ type error =
   | Admission_failed of Execution_lane_writer.submit_error
   | Mutation_failed of Execution_lane_writer.ticket_error
   | Invalid_provider_attempt of string
+  | Scope_unavailable of Execution_lane_writer.read_error
+  | Run_not_found
+  | Invocation_locator_mismatch
   | Settlement_failed of Execution_tool_settlement.error
 
 val error_to_string : error -> string
 val start : writer:Execution_lane_writer.t -> agent_name:string -> (t, error) result
+val scope_locator : t -> scope_locator
+val scope_locator_to_yojson : scope_locator -> Yojson.Safe.t
+val scope_locator_of_yojson : Yojson.Safe.t -> (scope_locator, string) result
+val resume : writer:Execution_lane_writer.t -> scope_locator -> (t, error) result
 val open_turn : t -> ordinal:int -> (turn, error) result
 
 (** Materialize the exact binding selected for provider dispatch. *)
@@ -40,18 +48,23 @@ val open_invocation
   -> input:Yojson.Safe.t
   -> (invocation, error) result
 
-(** Stable opaque coordinates for rebinding after the writer is reopened. *)
+(** Stable opaque coordinates for rebinding after the writer is reopened.
+    The locator contains no copied Tool name, input, turn, or schedule; those
+    values are reconstructed from the journal's exact durable topology. *)
 val invocation_locator : invocation -> invocation_locator
 
-val rebind_invocation
-  :  writer:Execution_lane_writer.t
-  -> invocation_locator
-  -> (invocation, error) result
+val invocation_locator_to_yojson : invocation_locator -> Yojson.Safe.t
+val invocation_locator_of_yojson : Yojson.Safe.t -> (invocation_locator, string) result
+val rebind_invocation : t -> invocation_locator -> (invocation, error) result
 
 (** Commit the attempt before the effect and atomically settle its result. *)
 val execute
   :  invocation
-  -> invoke:(unit -> Llm_provider.Types.content_block)
+  -> invoke:
+       (invocation:Tool.Invocation.t
+        -> tool_name:string
+        -> input:Yojson.Safe.t
+        -> Llm_provider.Types.content_block)
   -> (Execution_tool_settlement.execution, error) result
 
 val close_provider_attempt

--- a/lib/execution_lane_writer.ml
+++ b/lib/execution_lane_writer.ml
@@ -887,6 +887,10 @@ let find_node writer node =
   read_journal writer (fun journal -> Ok (Journal.find_node journal node))
 ;;
 
+let find_run writer run_id =
+  read_journal writer (fun journal -> Ok (Journal.find_run journal run_id))
+;;
+
 let read_page writer ~after ?through ~limit () =
   read_journal writer (fun journal ->
     match Journal.read_page journal ~after ?through ~limit () with

--- a/lib/execution_lane_writer.mli
+++ b/lib/execution_lane_writer.mli
@@ -173,6 +173,11 @@ val find_node
   -> Execution_event.Node_id.t
   -> (Execution_journal.node_view option, read_error) result
 
+val find_run
+  :  t
+  -> Execution_event.Run_id.t
+  -> (Execution_journal.run_view option, read_error) result
+
 val read_page
   :  t
   -> after:Execution_journal.cursor

--- a/lib/execution_tool_settlement.ml
+++ b/lib/execution_tool_settlement.ml
@@ -7,6 +7,14 @@ type t =
   ; invocation_node : Event.Node_id.t
   }
 
+type durable_invocation =
+  { authority : t
+  ; run_id : Event.Run_id.t
+  ; invocation : Tool.Invocation.t
+  ; tool_name : string
+  ; input : Yojson.Safe.t
+  }
+
 type status =
   | Ready_to_execute
   | Outcome_unknown
@@ -35,22 +43,22 @@ let read_node writer node =
 
 let parent_node view = Event.parent_node_id view.Journal.node
 
-let create ~writer ~invocation_node ~invocation =
+let rebind ~writer ~invocation_node =
   let open Result_syntax in
   let* invocation_view = read_node writer invocation_node in
-  let* provider_attempt =
+  let* provider_attempt, run_id, tool_use_id, schedule, tool_name, input =
     match
       ( Event.node_kind invocation_view.node
       , parent_node invocation_view
       , invocation_view.materialized )
     with
-    | ( Event.Tool_invocation { schedule; _ }
+    | ( Event.Tool_invocation { provider_tool_use_id; tool_name; schedule }
       , Some parent
       , Journal.Tool_invocation_state
-          { input = Some (Llm_provider.Types.ToolUse { id; _ }); _ } )
-      when String.equal id (Tool.Invocation.tool_use_id invocation)
-           && Execution_tool_schedule.equal schedule (Tool.Invocation.schedule invocation)
-      -> Ok parent
+          { input = Some (Llm_provider.Types.ToolUse { id; name; input }); _ } )
+      when Option.equal String.equal provider_tool_use_id (Some id)
+           && String.equal tool_name name ->
+      Ok (parent, Event.node_run_id invocation_view.node, id, schedule, tool_name, input)
     | ( ( Event.Agent_run _
         | Event.Agent_turn _
         | Event.Provider_attempt _
@@ -63,8 +71,10 @@ let create ~writer ~invocation_node ~invocation =
   let* provider_view = read_node writer provider_attempt in
   let* turn_node =
     match Event.node_kind provider_view.node, parent_node provider_view with
-    | Event.Provider_attempt _, Some parent -> Ok parent
+    | Event.Provider_attempt _, Some parent
+      when Event.Run_id.equal run_id (Event.node_run_id provider_view.node) -> Ok parent
     | Event.Provider_attempt _, None
+    | Event.Provider_attempt _, Some _
     | ( ( Event.Agent_run _
         | Event.Agent_turn _
         | Event.Output_block _
@@ -74,8 +84,15 @@ let create ~writer ~invocation_node ~invocation =
   in
   let* turn_view = read_node writer turn_node in
   match Event.node_kind turn_view.node with
-  | Event.Agent_turn { ordinal } when ordinal = Tool.Invocation.turn invocation ->
-    Ok { writer; invocation_node }
+  | Event.Agent_turn { ordinal }
+    when Event.Run_id.equal run_id (Event.node_run_id turn_view.node) ->
+    Ok
+      { authority = { writer; invocation_node }
+      ; run_id
+      ; invocation = Tool.Invocation.create ~tool_use_id ~turn:ordinal ~schedule
+      ; tool_name
+      ; input
+      }
   | Event.Agent_turn _
   | Event.Agent_run _
   | Event.Provider_attempt _

--- a/lib/execution_tool_settlement.mli
+++ b/lib/execution_tool_settlement.mli
@@ -1,5 +1,13 @@
 type t
 
+type durable_invocation = private
+  { authority : t
+  ; run_id : Execution_event.Run_id.t
+  ; invocation : Tool.Invocation.t
+  ; tool_name : string
+  ; input : Yojson.Safe.t
+  }
+
 type error =
   | Authority_unavailable of Execution_lane_writer.read_error
   | Invocation_not_found
@@ -14,11 +22,11 @@ type execution =
   | Executed of Llm_provider.Types.content_block * Execution_journal.cursor * int
   | Replayed of Llm_provider.Types.content_block
 
-val create
+(** Reconstruct one executable command from the journal's exact topology. *)
+val rebind
   :  writer:Execution_lane_writer.t
   -> invocation_node:Execution_event.Node_id.t
-  -> invocation:Tool.Invocation.t
-  -> (t, error) result
+  -> (durable_invocation, error) result
 
 val execute
   :  t

--- a/test/test_execution_lane_writer.ml
+++ b/test/test_execution_lane_writer.ml
@@ -110,7 +110,7 @@ let read_complete_page writer ~after ~limit =
     page.events, page.next_cursor
 ;;
 
-let provider_attempt_for ~provider_id ordinal =
+let binding_for ~provider_id =
   let config =
     Llm_provider.Provider_config.make
       ~kind:Llm_provider.Provider_kind.OpenAI_compat
@@ -119,13 +119,14 @@ let provider_attempt_for ~provider_id ordinal =
       ~base_url:"https://provider.test"
       ()
   in
-  let binding =
-    Binding_identity.of_provider_config
-      ~transport:(Binding_identity.transport_for_call ~injected:false)
-      config
-    |> require_codec
-  in
-  require_codec (Event.provider_attempt ~ordinal binding)
+  Binding_identity.of_provider_config
+    ~transport:(Binding_identity.transport_for_call ~injected:false)
+    config
+  |> require_codec
+;;
+
+let provider_attempt_for ~provider_id ordinal =
+  require_codec (Event.provider_attempt ~ordinal (binding_for ~provider_id))
 ;;
 
 let provider_attempt ordinal =
@@ -234,9 +235,9 @@ let test_effect_attempt_and_settlement_survive_restart () =
         check int "one durable producer group" 2 receipt.group_event_count;
         node, invocation
       in
-      let authority (node, invocation) =
-        match Settlement.create ~writer ~invocation_node:node ~invocation with
-        | Ok authority -> authority
+      let authority (node, _invocation) =
+        match Settlement.rebind ~writer ~invocation_node:node with
+        | Ok durable -> durable.authority
         | Error _ -> fail "durable invocation authority rejected exact identity"
       in
       let first_pair = open_invocation 0 in
@@ -339,8 +340,8 @@ let test_effect_attempt_and_settlement_survive_restart () =
     in
     with_existing codec dir (fun _sw writer ->
       ignore (require_scope (Writer.await_ready writer));
-      let authority (node, invocation) =
-        Result.get_ok (Settlement.create ~writer ~invocation_node:node ~invocation)
+      let authority (node, _invocation) =
+        (Result.get_ok (Settlement.rebind ~writer ~invocation_node:node)).authority
       in
       let never () = fail "effect reran" in
       (match Settlement.execute (authority first_pair) ~invoke:never with
@@ -528,7 +529,8 @@ let test_agent_scope_owns_effect_topology () =
   @@ fun env ->
   with_temp_dir env (fun codec dir ->
     make_dir dir;
-    let locator = ref None in
+    let scope_locator_json = ref None in
+    let invocation_locator_json = ref None in
     let calls = ref 0 in
     let result =
       Types.ToolResult
@@ -541,6 +543,8 @@ let test_agent_scope_owns_effect_topology () =
     in
     with_fresh codec dir (fun _sw writer ->
       let scope = require_agent_scope (Agent_scope.start ~writer ~agent_name:"agent") in
+      scope_locator_json
+      := Some (Agent_scope.scope_locator_to_yojson (Agent_scope.scope_locator scope));
       let before_cancelled =
         Writer.current_cursor writer |> Result.get_ok |> Journal.cursor_seq
       in
@@ -559,22 +563,12 @@ let test_agent_scope_owns_effect_topology () =
         (Writer.current_cursor writer |> Result.get_ok |> Journal.cursor_seq);
       let before = cursor_at (Result.get_ok (Writer.current_cursor writer)) 0 in
       let turn = require_agent_scope (Agent_scope.open_turn scope ~ordinal:3) in
-      let config =
-        Llm_provider.Provider_config.make
-          ~kind:Llm_provider.Provider_kind.OpenAI_compat
-          ~provider_id:"scope-provider"
-          ~model_id:"scope-model"
-          ~base_url:"https://provider.test"
-          ()
-      in
-      let binding =
-        Binding_identity.of_provider_config
-          ~transport:(Binding_identity.transport_for_call ~injected:false)
-          config
-        |> require_codec
-      in
       let provider =
-        require_agent_scope (Agent_scope.open_provider_attempt turn ~ordinal:0 binding)
+        require_agent_scope
+          (Agent_scope.open_provider_attempt
+             turn
+             ~ordinal:0
+             (binding_for ~provider_id:"scope-provider"))
       in
       let schedule : Tool.schedule =
         { planned_index = 0
@@ -607,11 +601,16 @@ let test_agent_scope_owns_effect_topology () =
              ~tool_name:"effect"
              ~input:(`Assoc [ "value", `Int 7 ]))
       in
-      locator := Some (Agent_scope.invocation_locator invocation);
+      invocation_locator_json
+      := Some
+           (Agent_scope.invocation_locator_to_yojson
+              (Agent_scope.invocation_locator invocation));
       (match
-         Agent_scope.execute invocation ~invoke:(fun () ->
-           incr calls;
-           result)
+         Agent_scope.execute
+           invocation
+           ~invoke:(fun ~invocation:_ ~tool_name:_ ~input:_ ->
+             incr calls;
+             result)
        with
        | Ok (Settlement.Executed _) -> ()
        | Ok (Settlement.Replayed _) -> fail "fresh scoped effect was replayed"
@@ -659,15 +658,106 @@ let test_agent_scope_owns_effect_topology () =
       | _ -> fail "scope did not write its topology before the effect");
     with_existing codec dir (fun _sw writer ->
       ignore (require_scope (Writer.await_ready writer));
-      let invocation =
-        require_agent_scope (Agent_scope.rebind_invocation ~writer (Option.get !locator))
+      let scope =
+        require_agent_scope
+          (Agent_scope.resume
+             ~writer
+             (require_codec
+                (Agent_scope.scope_locator_of_yojson (Option.get !scope_locator_json))))
       in
-      (match Agent_scope.execute invocation ~invoke:(fun () -> fail "effect reran") with
+      let invocation =
+        Option.get !invocation_locator_json
+        |> Agent_scope.invocation_locator_of_yojson
+        |> require_codec
+        |> Agent_scope.rebind_invocation scope
+        |> require_agent_scope
+      in
+      (match
+         Agent_scope.execute
+           invocation
+           ~invoke:(fun ~invocation:_ ~tool_name:_ ~input:_ -> fail "effect reran")
+       with
        | Ok (Settlement.Replayed replayed) ->
          check bool "reopened scope replays exact result" true (replayed = result)
        | Ok (Settlement.Executed _) -> fail "reopened scope executed effect twice"
        | Error error -> fail (Agent_scope.error_to_string error));
       check int "reopened scope preserves call count" 1 !calls))
+;;
+
+let test_agent_scope_executes_pending_after_restart () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun codec dir ->
+    make_dir dir;
+    let scope_json, invocation_json = ref None, ref None in
+    let expected_input = `Assoc [ "path", `String "durable" ] in
+    with_fresh codec dir (fun _sw writer ->
+      let scope = require_agent_scope (Agent_scope.start ~writer ~agent_name:"agent") in
+      scope_json
+      := Some (Agent_scope.scope_locator_to_yojson (Agent_scope.scope_locator scope));
+      let turn = require_agent_scope (Agent_scope.open_turn scope ~ordinal:0) in
+      let provider =
+        require_agent_scope
+          (Agent_scope.open_provider_attempt
+             turn
+             ~ordinal:0
+             (binding_for ~provider_id:"pending-provider"))
+      in
+      let schedule : Tool.schedule =
+        { planned_index = 0
+        ; batch_index = 0
+        ; batch_size = 1
+        ; execution_mode = Tool.Serial
+        }
+      in
+      let invocation =
+        require_agent_scope
+          (Agent_scope.open_invocation
+             provider
+             ~invocation:(Tool.Invocation.create ~tool_use_id:"pending" ~turn:0 ~schedule)
+             ~tool_name:"durable-tool"
+             ~input:expected_input)
+      in
+      invocation_json
+      := Some
+           (Agent_scope.invocation_locator_to_yojson
+              (Agent_scope.invocation_locator invocation)));
+    with_existing codec dir (fun _sw writer ->
+      ignore (require_scope (Writer.await_ready writer));
+      let scope =
+        Option.get !scope_json
+        |> Agent_scope.scope_locator_of_yojson
+        |> require_codec
+        |> Agent_scope.resume ~writer
+        |> require_agent_scope
+      in
+      let invocation =
+        Option.get !invocation_json
+        |> Agent_scope.invocation_locator_of_yojson
+        |> require_codec
+        |> Agent_scope.rebind_invocation scope
+        |> require_agent_scope
+      in
+      (match
+         Agent_scope.execute invocation ~invoke:(fun ~invocation ~tool_name ~input ->
+           check string "rebound tool name" "durable-tool" tool_name;
+           check bool "rebound tool input" true (Yojson.Safe.equal input expected_input);
+           let tool_use_id = Tool.Invocation.tool_use_id invocation in
+           check string "rebound Tool invocation" "pending" tool_use_id;
+           Types.ToolResult
+             { tool_use_id
+             ; content = "done"
+             ; outcome = Types.Tool_succeeded
+             ; json = None
+             ; content_blocks = None
+             })
+       with
+       | Ok (Settlement.Executed (Types.ToolResult _, _, _)) -> ()
+       | Ok (Settlement.Executed _ | Settlement.Replayed _) ->
+         fail "pending command mismatch"
+       | Error error -> fail (Agent_scope.error_to_string error));
+      let cancelled = Agent_scope.Cancelled { reason = Some "done"; data = None } in
+      require_agent_scope (Agent_scope.abort scope cancelled)))
 ;;
 
 let rec await_reconciliation_phase writer =
@@ -1594,6 +1684,10 @@ let () =
             "Agent scope owns effect topology"
             `Quick
             test_agent_scope_owns_effect_topology
+        ; test_case
+            "pending Agent scope resumes exact command"
+            `Quick
+            test_agent_scope_executes_pending_after_restart
         ; test_case
             "concurrent submit and close linearize without loss"
             `Quick


### PR DESCRIPTION
## Summary

- bind one Agent execution scope to a durable Journal run
- serialize opaque run/invocation locators without copying Tool name, input, turn, or schedule
- reconstruct the exact pending Tool command from committed Journal topology after writer restart
- reject invocation locators from another run before execution

## Boundary

- OAS owns generic Agent/Tool execution only; this leaf contains no MASC, Keeper, Gate, Board, Connector, or Fusion vocabulary
- the Journal remains the sole production execution-store owner
- this leaf adds no production caller; production wiring and the legacy-writer hard cut remain a later atomic leaf
- no risk level, product policy, command matching, timeout, budget, or semantic heuristic is introduced

## Adversarial repairs in this leaf

- caller-provided Tool name/input are not trusted during resume; one Journal traversal materializes the immutable durable invocation
- `rebind_invocation` is scoped to the resumed run and rejects a structurally valid locator from a recursive child run
- pending restart execution receives the exact durable `Tool.Invocation.t`, Tool name, and input; its ToolResult ID is derived from that invocation
- Tool invocations settle only with a typed `ToolResult`; meaningless cancellation without reason/data remains rejected

## Size

- base: `d4545219fe9573b60ec2d183fc406bc4f2fe625a` (#2672)
- head: `e4918d9c12f439cb91ab702da22f42ac67d814cb`
- 7 files, 292 insertions, 65 deletions = 357 changed lines

## Verification

- exact-head GitHub `Build & Test (OCaml 5.4.1)`: passed
- exact-head GitHub `Build & Test (OCaml 5.5.0)`: passed
- hostile exact-head review: P0 0, P1 0
- `scripts/check-execution-store-boundary.sh`: Journal is the sole production owner
- `scripts/check-sdk-independence.sh`: passed
- product-vocabulary boundary grep over changed execution modules: zero matches
- `git diff --check`: passed

Stacked on #2672. Draft only; exact-head full OCaml 5.4/5.5 CI is green.
