### PR TITLE
feat(execution): hard-cut Agent tool authority

### DIFF
--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -29,6 +29,14 @@ type detailed_error = Provider_failure_attribution.detailed_error =
 
 let detailed_error_of_sdk_error = Provider_failure_attribution.of_sdk_error
 
+type execution_runtime = Agent_execution_runner.runtime
+type execution_store = Agent_execution_runner.store
+type execution_locator = Agent_execution_runner.locator
+
+let create_execution_runtime = Agent_execution_runner.create_runtime
+let execution_store = Agent_execution_runner.store
+let execution_locator_to_yojson = Agent_execution_runner.locator_to_yojson
+
 let replace_projected_error error detailed =
   { detailed with Provider_failure_attribution.error }
 ;;
@@ -46,6 +54,7 @@ let run_turn_core_detailed
       ~api_strategy
       ?raw_trace_run
       ?before_tool_execution
+      ?execution_scope
       agent
   =
   let provider_failure = ref None in
@@ -74,6 +83,7 @@ let run_turn_core_detailed
            ~api_strategy:api_strat
            ?raw_trace_run
            ?before_tool_execution
+           ?execution_scope
            ~on_provider_failure:(fun attribution -> provider_failure := attribution)
            agent
        with
@@ -102,79 +112,10 @@ let provide_input agent request response =
 
 (* ── Unified run loop ────────────────────────────────────────── *)
 
-(** Prepend initial_messages on first run (when messages are empty). *)
-let base_messages agent =
-  match agent.state.messages with
-  | [] -> agent.state.config.initial_messages
-  | msgs -> msgs
-;;
-
-let sanitize_user_input_blocks =
-  List.map (function
-    | Text s -> Text (Llm_provider.Utf8_sanitize.sanitize s)
-    | block -> block)
-;;
-
-let trace_prompt_of_blocks blocks =
-  let parts =
-    blocks
-    |> List.filter_map (function
-      | Text s -> Some (Llm_provider.Utf8_sanitize.sanitize s)
-      | Image { media_type; data; _ } ->
-        Some (Printf.sprintf "[image:%s data_chars=%d]" media_type (String.length data))
-      | Document { media_type; data; _ } ->
-        Some
-          (Printf.sprintf "[document:%s data_chars=%d]" media_type (String.length data))
-      | Audio { media_type; data; _ } ->
-        Some (Printf.sprintf "[audio:%s data_chars=%d]" media_type (String.length data))
-      | Thinking _ | ReasoningDetails _ | RedactedThinking _ | ToolUse _ | ToolResult _ ->
-        None)
-  in
-  match String.concat "\n" parts with
-  | "" -> "[multimodal input]"
-  | text -> text
-;;
-
-let validate_user_input_blocks blocks =
-  let unsupported =
-    List.find_map
-      (function
-        | Text _ | Image _ | Document _ | Audio _ -> None
-        | Thinking _ -> Some "Thinking"
-        | ReasoningDetails _ -> Some "ReasoningDetails"
-        | RedactedThinking _ -> Some "RedactedThinking"
-        | ToolUse _ -> Some "ToolUse"
-        | ToolResult _ -> Some "ToolResult")
-      blocks
-  in
-  match unsupported with
-  | None -> Ok ()
-  | Some kind ->
-    Error
-      (Error.Config
-         (Error.InvalidConfig
-            { field = "user_blocks"
-            ; detail =
-                Printf.sprintf
-                  "user input blocks may contain only Text, Image, Document, or Audio; \
-                   got %s"
-                  kind
-            }))
-;;
-
-let append_user_input agent user_blocks =
-  let user_msg =
-    { role = User
-    ; content = sanitize_user_input_blocks user_blocks
-    ; name = None
-    ; tool_call_id = None
-    ; metadata = []
-    }
-  in
-  update_state agent (fun s ->
-    { s with messages = Util.snoc (base_messages agent) user_msg });
-  user_msg.content
-;;
+let base_messages = Agent_input.base_messages
+let trace_prompt_of_blocks = Agent_input.trace_prompt_of_blocks
+let validate_user_input_blocks = Agent_input.validate_user_input_blocks
+let append_user_input = Agent_input.append_user_input
 
 (** Per-turn timing observability helper. Emits one structured record
     per turn so operators diagnosing wall-clock timeouts can see
@@ -239,15 +180,16 @@ let acquire_provider_lease ~yield_enabled ~on_resume = function
   | Released -> Held
 ;;
 
-let run_loop_detailed ~sw ?clock ~api_strategy ?on_yield ?on_resume agent user_blocks =
-  let user_blocks = append_user_input agent user_blocks in
-  let trace_prompt = trace_prompt_of_blocks user_blocks in
-  with_raw_trace_run_result
-    ~of_sdk_error:detailed_error_of_sdk_error
-    ~error_to_string:(fun detailed -> Error.to_string detailed.error)
-    agent
-    trace_prompt
-  @@ fun raw_trace_run ->
+let run_loop_turns_detailed
+      ~sw
+      ?clock
+      ~api_strategy
+      ?on_yield
+      ?on_resume
+      ?raw_trace_run
+      ?execution_scope
+      agent
+  =
   let yield_enabled = agent.state.config.yield_on_tool in
   let run_start = Unix.gettimeofday () in
   let rec loop lease =
@@ -262,6 +204,7 @@ let run_loop_detailed ~sw ?clock ~api_strategy ?on_yield ?on_resume agent user_b
         ~api_strategy
         ?raw_trace_run
         ?before_tool_execution:release.before_tool_execution
+        ?execution_scope
         agent
     in
     match result with
@@ -293,8 +236,76 @@ let run_loop_detailed ~sw ?clock ~api_strategy ?on_yield ?on_resume agent user_b
   loop Held
 ;;
 
-let run_loop ~sw ?clock ~api_strategy ?on_yield ?on_resume agent user_blocks =
-  run_loop_detailed ~sw ?clock ~api_strategy ?on_yield ?on_resume agent user_blocks
+let run_loop_detailed
+      ~sw
+      ?clock
+      ~api_strategy
+      ?on_yield
+      ?on_resume
+      ?execution_store
+      ?execution_scope_factory
+      agent
+      user_blocks
+  =
+  let user_blocks = append_user_input agent user_blocks in
+  let trace_prompt = trace_prompt_of_blocks user_blocks in
+  with_raw_trace_run_result
+    ~of_sdk_error:detailed_error_of_sdk_error
+    ~error_to_string:(fun detailed -> Error.to_string detailed.error)
+    agent
+    trace_prompt
+  @@ fun raw_trace_run ->
+  let run ~sw execution_scope =
+    run_loop_turns_detailed
+      ~sw
+      ?clock
+      ~api_strategy
+      ?on_yield
+      ?on_resume
+      ?raw_trace_run
+      ?execution_scope
+      agent
+  in
+  match execution_store, execution_scope_factory with
+  | None, None -> run ~sw None
+  | Some store, None ->
+    Agent_execution_runner.with_fresh store agent (fun ~sw execution_scope ->
+      run ~sw (Some execution_scope))
+  | None, Some start_scope ->
+    (match start_scope () with
+     | Error error ->
+       Error
+         (detailed_error_of_sdk_error
+            (Error.Internal
+               ("durable child scope: " ^ Execution_agent_scope.error_to_string error)))
+     | Ok execution_scope ->
+       Agent_execution_runner.with_scope execution_scope (fun () ->
+         run ~sw (Some execution_scope)))
+  | Some _, Some _ ->
+    Error
+      (detailed_error_of_sdk_error
+         (Error.Internal "execution store and child scope factory are mutually exclusive"))
+;;
+
+let run_loop
+      ~sw
+      ?clock
+      ~api_strategy
+      ?on_yield
+      ?on_resume
+      ?execution_store
+      agent
+      user_blocks
+  =
+  run_loop_detailed
+    ~sw
+    ?clock
+    ~api_strategy
+    ?on_yield
+    ?on_resume
+    ?execution_store
+    agent
+    user_blocks
   |> project_detailed_error
 ;;
 
@@ -371,7 +382,8 @@ let validate_run_callbacks ~on_yield ~on_resume =
   | Some _, Some _ | None, None -> Ok ()
 ;;
 
-let run_blocks_detailed ~sw ?clock ?on_yield ?on_resume agent user_blocks =
+let run_blocks_detailed ~sw ?clock ?on_yield ?on_resume ?execution_store agent user_blocks
+  =
   match validate_user_input_blocks user_blocks with
   | Error error -> Error (detailed_error_of_sdk_error error)
   | Ok () ->
@@ -385,24 +397,41 @@ let run_blocks_detailed ~sw ?clock ?on_yield ?on_resume agent user_blocks =
            ~api_strategy:Sync
            ?on_yield
            ?on_resume
+           ?execution_store
            agent
            user_blocks))
 ;;
 
-let run_blocks ~sw ?clock ?on_yield ?on_resume agent user_blocks =
-  run_blocks_detailed ~sw ?clock ?on_yield ?on_resume agent user_blocks
+let run_blocks ~sw ?clock ?on_yield ?on_resume ?execution_store agent user_blocks =
+  run_blocks_detailed ~sw ?clock ?on_yield ?on_resume ?execution_store agent user_blocks
   |> project_detailed_error
 ;;
 
-let run_detailed ~sw ?clock ?on_yield ?on_resume agent user_prompt =
-  run_blocks_detailed ~sw ?clock ?on_yield ?on_resume agent [ Text user_prompt ]
+let run_detailed ~sw ?clock ?on_yield ?on_resume ?execution_store agent user_prompt =
+  run_blocks_detailed
+    ~sw
+    ?clock
+    ?on_yield
+    ?on_resume
+    ?execution_store
+    agent
+    [ Text user_prompt ]
 ;;
 
-let run ~sw ?clock ?on_yield ?on_resume agent user_prompt =
-  run_detailed ~sw ?clock ?on_yield ?on_resume agent user_prompt |> project_detailed_error
+let run ~sw ?clock ?on_yield ?on_resume ?execution_store agent user_prompt =
+  run_detailed ~sw ?clock ?on_yield ?on_resume ?execution_store agent user_prompt
+  |> project_detailed_error
 ;;
 
-let run_stream_blocks_detailed ~sw ?clock ~on_event ?on_yield ?on_resume agent user_blocks
+let run_stream_blocks_detailed
+      ~sw
+      ?clock
+      ~on_event
+      ?on_yield
+      ?on_resume
+      ?execution_store
+      agent
+      user_blocks
   =
   match validate_user_input_blocks user_blocks with
   | Error error -> Error (detailed_error_of_sdk_error error)
@@ -422,28 +451,73 @@ let run_stream_blocks_detailed ~sw ?clock ~on_event ?on_yield ?on_resume agent u
            ~api_strategy:(Stream { on_event; on_telemetry })
            ?on_yield
            ?on_resume
+           ?execution_store
            agent
            user_blocks))
 ;;
 
-let run_stream_blocks ~sw ?clock ~on_event ?on_yield ?on_resume agent user_blocks =
-  run_stream_blocks_detailed ~sw ?clock ~on_event ?on_yield ?on_resume agent user_blocks
-  |> project_detailed_error
-;;
-
-let run_stream_detailed ~sw ?clock ~on_event ?on_yield ?on_resume agent user_prompt =
+let run_stream_blocks
+      ~sw
+      ?clock
+      ~on_event
+      ?on_yield
+      ?on_resume
+      ?execution_store
+      agent
+      user_blocks
+  =
   run_stream_blocks_detailed
     ~sw
     ?clock
     ~on_event
     ?on_yield
     ?on_resume
+    ?execution_store
+    agent
+    user_blocks
+  |> project_detailed_error
+;;
+
+let run_stream_detailed
+      ~sw
+      ?clock
+      ~on_event
+      ?on_yield
+      ?on_resume
+      ?execution_store
+      agent
+      user_prompt
+  =
+  run_stream_blocks_detailed
+    ~sw
+    ?clock
+    ~on_event
+    ?on_yield
+    ?on_resume
+    ?execution_store
     agent
     [ Text user_prompt ]
 ;;
 
-let run_stream ~sw ?clock ~on_event ?on_yield ?on_resume agent user_prompt =
-  run_stream_detailed ~sw ?clock ~on_event ?on_yield ?on_resume agent user_prompt
+let run_stream
+      ~sw
+      ?clock
+      ~on_event
+      ?on_yield
+      ?on_resume
+      ?execution_store
+      agent
+      user_prompt
+  =
+  run_stream_detailed
+    ~sw
+    ?clock
+    ~on_event
+    ?on_yield
+    ?on_resume
+    ?execution_store
+    agent
+    user_prompt
   |> project_detailed_error
 ;;
 
@@ -547,7 +621,19 @@ let run_handoff_target ~sw ?clock agent (target : Handoff.handoff_target) prompt
       ?provider_config:agent.provider_config
       ()
   in
-  let result = run ~sw ?clock sub prompt in
+  let result =
+    match Execution_context.child_scope_factory () with
+    | None -> run ~sw ?clock sub prompt
+    | Some start_child ->
+      run_loop_detailed
+        ~sw
+        ?clock
+        ~api_strategy:Sync
+        ~execution_scope_factory:(fun () -> start_child ~agent_name:target.config.name)
+        sub
+        [ Text prompt ]
+      |> project_detailed_error
+  in
   publish_handoff_completed
     agent
     target
@@ -565,7 +651,14 @@ let run_handoff_target ~sw ?clock agent (target : Handoff.handoff_target) prompt
       }
 ;;
 
-let run_with_handoffs_blocks_detailed ~sw ?clock agent ~targets user_blocks =
+let run_with_handoffs_blocks_detailed
+      ~sw
+      ?clock
+      ?execution_store
+      agent
+      ~targets
+      user_blocks
+  =
   match validate_user_input_blocks user_blocks with
   | Error error -> Error (detailed_error_of_sdk_error error)
   | Ok () ->
@@ -582,20 +675,26 @@ let run_with_handoffs_blocks_detailed ~sw ?clock agent ~targets user_blocks =
        in
        let all_tools = Tool_set.merge agent.tools (Tool_set.of_list handoff_tools) in
        let agent_with_handoffs = { agent with tools = all_tools } in
-       run_blocks_detailed ~sw ?clock agent_with_handoffs user_blocks)
+       run_blocks_detailed ~sw ?clock ?execution_store agent_with_handoffs user_blocks)
 ;;
 
-let run_with_handoffs_detailed ~sw ?clock agent ~targets user_prompt =
-  run_with_handoffs_blocks_detailed ~sw ?clock agent ~targets [ Text user_prompt ]
+let run_with_handoffs_detailed ~sw ?clock ?execution_store agent ~targets user_prompt =
+  run_with_handoffs_blocks_detailed
+    ~sw
+    ?clock
+    ?execution_store
+    agent
+    ~targets
+    [ Text user_prompt ]
 ;;
 
-let run_with_handoffs ~sw ?clock agent ~targets user_prompt =
-  run_with_handoffs_detailed ~sw ?clock agent ~targets user_prompt
+let run_with_handoffs ~sw ?clock ?execution_store agent ~targets user_prompt =
+  run_with_handoffs_detailed ~sw ?clock ?execution_store agent ~targets user_prompt
   |> project_detailed_error
 ;;
 
-let run_with_handoffs_blocks ~sw ?clock agent ~targets user_blocks =
-  run_with_handoffs_blocks_detailed ~sw ?clock agent ~targets user_blocks
+let run_with_handoffs_blocks ~sw ?clock ?execution_store agent ~targets user_blocks =
+  run_with_handoffs_blocks_detailed ~sw ?clock ?execution_store agent ~targets user_blocks
   |> project_detailed_error
 ;;
 
@@ -680,25 +779,17 @@ module Advanced = struct
     | Yielded _ -> Run_yielded { stop_reason = raw_trace_yield_stop_reason }
   ;;
 
-  let run_loop_detailed
+  let run_loop_turns_detailed
         ~sw
         ?clock
         ~api_strategy
         ?on_yield
         ?on_resume
+        ?raw_trace_run
+        ?execution_scope
         ~on_tool_boundary
         agent
-        user_blocks
     =
-    let user_blocks = append_user_input agent user_blocks in
-    let trace_prompt = trace_prompt_of_blocks user_blocks in
-    with_raw_trace_run_classified_result
-      ~of_sdk_error:detailed_error_of_sdk_error
-      ~error_to_string:(fun detailed -> Error.to_string detailed.error)
-      ~classify_success:classify_trace_success
-      agent
-      trace_prompt
-    @@ fun raw_trace_run ->
     let yield_enabled = agent.state.config.yield_on_tool in
     let run_start = Unix.gettimeofday () in
     let rec loop lease =
@@ -713,6 +804,7 @@ module Advanced = struct
           ~api_strategy
           ?raw_trace_run
           ?before_tool_execution:release.before_tool_execution
+          ?execution_scope
           agent
       with
       | Error error ->
@@ -753,11 +845,51 @@ module Advanced = struct
     loop Held
   ;;
 
+  let run_loop_detailed
+        ~sw
+        ?clock
+        ~api_strategy
+        ?on_yield
+        ?on_resume
+        ?execution_store
+        ~on_tool_boundary
+        agent
+        user_blocks
+    =
+    let user_blocks = append_user_input agent user_blocks in
+    let trace_prompt = trace_prompt_of_blocks user_blocks in
+    with_raw_trace_run_classified_result
+      ~of_sdk_error:detailed_error_of_sdk_error
+      ~error_to_string:(fun detailed -> Error.to_string detailed.error)
+      ~classify_success:classify_trace_success
+      agent
+      trace_prompt
+    @@ fun raw_trace_run ->
+    let run ~sw execution_scope =
+      run_loop_turns_detailed
+        ~sw
+        ?clock
+        ~api_strategy
+        ?on_yield
+        ?on_resume
+        ?raw_trace_run
+        ?execution_scope
+        ~on_tool_boundary
+        agent
+    in
+    match execution_store with
+    | None -> run ~sw None
+    | Some store ->
+      Agent_execution_runner.with_fresh store agent (fun ~sw execution_scope ->
+        run ~sw (Some execution_scope))
+  ;;
+
   let run_blocks_detailed
         ~sw
         ?clock
         ?on_yield
         ?on_resume
+        ?execution_store
         ~api_strategy
         ~on_tool_boundary
         agent
@@ -776,6 +908,7 @@ module Advanced = struct
              ~api_strategy
              ?on_yield
              ?on_resume
+             ?execution_store
              ~on_tool_boundary
              agent
              user_blocks))
@@ -786,6 +919,7 @@ module Advanced = struct
         ?clock
         ?on_yield
         ?on_resume
+        ?execution_store
         ~api_strategy
         ~on_tool_boundary
         agent
@@ -796,6 +930,7 @@ module Advanced = struct
       ?clock
       ?on_yield
       ?on_resume
+      ?execution_store
       ~api_strategy
       ~on_tool_boundary
       agent
@@ -804,19 +939,27 @@ module Advanced = struct
   ;;
 end
 
-let run_turn_stream_detailed ~sw ?clock ~on_event ?on_telemetry agent =
-  run_turn_core_detailed
-    ~sw
-    ?clock
-    ~api_strategy:(Stream { on_event; on_telemetry })
-    agent
+let run_turn_stream_detailed ~sw ?clock ~on_event ?on_telemetry ?execution_store agent =
+  let run ~sw ?execution_scope () =
+    run_turn_core_detailed
+      ~sw
+      ?clock
+      ~api_strategy:(Stream { on_event; on_telemetry })
+      ?execution_scope
+      agent
+  in
+  (match execution_store with
+   | None -> run ~sw ()
+   | Some store ->
+     Agent_execution_runner.with_fresh store agent (fun ~sw execution_scope ->
+       run ~sw ~execution_scope ()))
   |> Result.map (function
     | `Complete response -> `Complete response
     | `ToolsExecuted _ -> `ToolsExecuted)
 ;;
 
-let run_turn_stream ~sw ?clock ~on_event ?on_telemetry agent =
-  run_turn_stream_detailed ~sw ?clock ~on_event ?on_telemetry agent
+let run_turn_stream ~sw ?clock ~on_event ?on_telemetry ?execution_store agent =
+  run_turn_stream_detailed ~sw ?clock ~on_event ?on_telemetry ?execution_store agent
   |> project_detailed_error
 ;;
 

--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -36,6 +36,7 @@ type execution_locator = Agent_execution_runner.locator
 let create_execution_runtime = Agent_execution_runner.create_runtime
 let execution_store = Agent_execution_runner.store
 let execution_locator_to_yojson = Agent_execution_runner.locator_to_yojson
+let execution_locator_of_yojson = Agent_execution_runner.locator_of_yojson
 
 let replace_projected_error error detailed =
   { detailed with Provider_failure_attribution.error }
@@ -54,7 +55,6 @@ let run_turn_core_detailed
       ~api_strategy
       ?raw_trace_run
       ?before_tool_execution
-      ?execution_scope
       agent
   =
   let provider_failure = ref None in
@@ -83,7 +83,6 @@ let run_turn_core_detailed
            ~api_strategy:api_strat
            ?raw_trace_run
            ?before_tool_execution
-           ?execution_scope
            ~on_provider_failure:(fun attribution -> provider_failure := attribution)
            agent
        with
@@ -116,6 +115,7 @@ let base_messages = Agent_input.base_messages
 let trace_prompt_of_blocks = Agent_input.trace_prompt_of_blocks
 let validate_user_input_blocks = Agent_input.validate_user_input_blocks
 let append_user_input = Agent_input.append_user_input
+let resume_user_input = Agent_input.resume_user_input
 
 (** Per-turn timing observability helper. Emits one structured record
     per turn so operators diagnosing wall-clock timeouts can see
@@ -187,7 +187,6 @@ let run_loop_turns_detailed
       ?on_yield
       ?on_resume
       ?raw_trace_run
-      ?execution_scope
       agent
   =
   let yield_enabled = agent.state.config.yield_on_tool in
@@ -204,7 +203,6 @@ let run_loop_turns_detailed
         ~api_strategy
         ?raw_trace_run
         ?before_tool_execution:release.before_tool_execution
-        ?execution_scope
         agent
     in
     match result with
@@ -247,7 +245,18 @@ let run_loop_detailed
       agent
       user_blocks
   =
-  let user_blocks = append_user_input agent user_blocks in
+  let open Result_syntax in
+  let resuming =
+    match execution_store with
+    | Some store -> Agent_execution_runner.is_resume store
+    | None -> false
+  in
+  let* user_blocks =
+    if resuming
+    then
+      resume_user_input agent user_blocks |> Result.map_error detailed_error_of_sdk_error
+    else Ok (append_user_input agent user_blocks)
+  in
   let trace_prompt = trace_prompt_of_blocks user_blocks in
   with_raw_trace_run_result
     ~of_sdk_error:detailed_error_of_sdk_error
@@ -255,7 +264,7 @@ let run_loop_detailed
     agent
     trace_prompt
   @@ fun raw_trace_run ->
-  let run ~sw execution_scope =
+  let run ~sw =
     run_loop_turns_detailed
       ~sw
       ?clock
@@ -263,14 +272,12 @@ let run_loop_detailed
       ?on_yield
       ?on_resume
       ?raw_trace_run
-      ?execution_scope
       agent
   in
   match execution_store, execution_scope_factory with
-  | None, None -> run ~sw None
+  | None, None -> run ~sw
   | Some store, None ->
-    Agent_execution_runner.with_fresh store agent (fun ~sw execution_scope ->
-      run ~sw (Some execution_scope))
+    Agent_execution_runner.with_store store agent (fun ~sw _execution_scope -> run ~sw)
   | None, Some start_scope ->
     (match start_scope () with
      | Error error ->
@@ -279,8 +286,7 @@ let run_loop_detailed
             (Error.Internal
                ("durable child scope: " ^ Execution_agent_scope.error_to_string error)))
      | Ok execution_scope ->
-       Agent_execution_runner.with_scope execution_scope (fun () ->
-         run ~sw (Some execution_scope)))
+       Agent_execution_runner.with_scope execution_scope (fun () -> run ~sw))
   | Some _, Some _ ->
     Error
       (detailed_error_of_sdk_error
@@ -786,7 +792,6 @@ module Advanced = struct
         ?on_yield
         ?on_resume
         ?raw_trace_run
-        ?execution_scope
         ~on_tool_boundary
         agent
     =
@@ -804,7 +809,6 @@ module Advanced = struct
           ~api_strategy
           ?raw_trace_run
           ?before_tool_execution:release.before_tool_execution
-          ?execution_scope
           agent
       with
       | Error error ->
@@ -856,7 +860,19 @@ module Advanced = struct
         agent
         user_blocks
     =
-    let user_blocks = append_user_input agent user_blocks in
+    let open Result_syntax in
+    let resuming =
+      match execution_store with
+      | Some store -> Agent_execution_runner.is_resume store
+      | None -> false
+    in
+    let* user_blocks =
+      if resuming
+      then
+        resume_user_input agent user_blocks
+        |> Result.map_error detailed_error_of_sdk_error
+      else Ok (append_user_input agent user_blocks)
+    in
     let trace_prompt = trace_prompt_of_blocks user_blocks in
     with_raw_trace_run_classified_result
       ~of_sdk_error:detailed_error_of_sdk_error
@@ -865,7 +881,7 @@ module Advanced = struct
       agent
       trace_prompt
     @@ fun raw_trace_run ->
-    let run ~sw execution_scope =
+    let run ~sw =
       run_loop_turns_detailed
         ~sw
         ?clock
@@ -873,15 +889,13 @@ module Advanced = struct
         ?on_yield
         ?on_resume
         ?raw_trace_run
-        ?execution_scope
         ~on_tool_boundary
         agent
     in
     match execution_store with
-    | None -> run ~sw None
+    | None -> run ~sw
     | Some store ->
-      Agent_execution_runner.with_fresh store agent (fun ~sw execution_scope ->
-        run ~sw (Some execution_scope))
+      Agent_execution_runner.with_store store agent (fun ~sw _execution_scope -> run ~sw)
   ;;
 
   let run_blocks_detailed
@@ -940,19 +954,18 @@ module Advanced = struct
 end
 
 let run_turn_stream_detailed ~sw ?clock ~on_event ?on_telemetry ?execution_store agent =
-  let run ~sw ?execution_scope () =
+  let run ~sw () =
     run_turn_core_detailed
       ~sw
       ?clock
       ~api_strategy:(Stream { on_event; on_telemetry })
-      ?execution_scope
       agent
   in
   (match execution_store with
    | None -> run ~sw ()
    | Some store ->
-     Agent_execution_runner.with_fresh store agent (fun ~sw execution_scope ->
-       run ~sw ~execution_scope ()))
+     Agent_execution_runner.with_store store agent (fun ~sw _execution_scope ->
+       run ~sw ()))
   |> Result.map (function
     | `Complete response -> `Complete response
     | `ToolsExecuted _ -> `ToolsExecuted)

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -141,6 +141,39 @@ type detailed_error = Provider_failure_attribution.detailed_error =
   ; provider_failure : Provider_failure_attribution.t option
   }
 
+(** Application-lifetime CPU capability shared by execution journals. *)
+type execution_runtime
+
+(** One caller-owned directory for one fresh Agent API-call execution scope. *)
+type execution_store
+
+(** Opaque durable identity for one Agent API-call execution scope. *)
+type execution_locator
+
+val execution_locator_to_yojson : execution_locator -> Yojson.Safe.t
+
+val create_execution_runtime
+  :  sw:Eio.Switch.t
+  -> domain_mgr:_ Eio.Domain_manager.t
+  -> domain_count:int
+  -> (execution_runtime, Error.sdk_error) result
+
+(** Configure one fresh durable execution scope. The same optional value is
+    accepted by regular, streaming, handoff, single-turn, and [Advanced] run
+    entry points; no parallel durable run surface is introduced. One store and
+    directory must be used for exactly one API call. A cooperative [Yielded]
+    return is a successful terminal boundary for that call.
+
+    [on_scope_ready], when supplied, must persist the opaque locator before
+    provider or Tool effects begin; failure aborts the scope and the Agent
+    call. *)
+val execution_store
+  :  runtime:execution_runtime
+  -> dir:Eio.Fs.dir_ty Eio.Path.t
+  -> ?on_scope_ready:(execution_locator -> (unit, string) result)
+  -> unit
+  -> execution_store
+
 (** Advanced host-driven execution.  The regular {!run}, {!run_blocks}, and
     streaming entry points remain the simple run-to-completion API. *)
 module Advanced : sig
@@ -194,6 +227,7 @@ module Advanced : sig
     -> ?clock:_ Eio.Time.clock
     -> ?on_yield:(unit -> unit)
     -> ?on_resume:(unit -> unit)
+    -> ?execution_store:execution_store
     -> api_strategy:api_strategy
     -> on_tool_boundary:(tool_boundary -> boundary_decision)
     -> t
@@ -206,6 +240,7 @@ module Advanced : sig
     -> ?clock:_ Eio.Time.clock
     -> ?on_yield:(unit -> unit)
     -> ?on_resume:(unit -> unit)
+    -> ?execution_store:execution_store
     -> api_strategy:api_strategy
     -> on_tool_boundary:(tool_boundary -> boundary_decision)
     -> t
@@ -219,6 +254,7 @@ val run_detailed
   -> ?clock:_ Eio.Time.clock
   -> ?on_yield:(unit -> unit)
   -> ?on_resume:(unit -> unit)
+  -> ?execution_store:execution_store
   -> t
   -> string
   -> (Types.api_response, detailed_error) result
@@ -249,6 +285,7 @@ val run
   -> ?clock:_ Eio.Time.clock
   -> ?on_yield:(unit -> unit)
   -> ?on_resume:(unit -> unit)
+  -> ?execution_store:execution_store
   -> t
   -> string
   -> (Types.api_response, Error.sdk_error) result
@@ -262,6 +299,7 @@ val run_blocks
   -> ?clock:_ Eio.Time.clock
   -> ?on_yield:(unit -> unit)
   -> ?on_resume:(unit -> unit)
+  -> ?execution_store:execution_store
   -> t
   -> Types.content_block list
   -> (Types.api_response, Error.sdk_error) result
@@ -272,6 +310,7 @@ val run_blocks_detailed
   -> ?clock:_ Eio.Time.clock
   -> ?on_yield:(unit -> unit)
   -> ?on_resume:(unit -> unit)
+  -> ?execution_store:execution_store
   -> t
   -> Types.content_block list
   -> (Types.api_response, detailed_error) result
@@ -284,6 +323,7 @@ val run_stream
   -> on_event:(Types.sse_event -> unit)
   -> ?on_yield:(unit -> unit)
   -> ?on_resume:(unit -> unit)
+  -> ?execution_store:execution_store
   -> t
   -> string
   -> (Types.api_response, Error.sdk_error) result
@@ -295,6 +335,7 @@ val run_stream_detailed
   -> on_event:(Types.sse_event -> unit)
   -> ?on_yield:(unit -> unit)
   -> ?on_resume:(unit -> unit)
+  -> ?execution_store:execution_store
   -> t
   -> string
   -> (Types.api_response, detailed_error) result
@@ -307,6 +348,7 @@ val run_stream_blocks
   -> on_event:(Types.sse_event -> unit)
   -> ?on_yield:(unit -> unit)
   -> ?on_resume:(unit -> unit)
+  -> ?execution_store:execution_store
   -> t
   -> Types.content_block list
   -> (Types.api_response, Error.sdk_error) result
@@ -318,6 +360,7 @@ val run_stream_blocks_detailed
   -> on_event:(Types.sse_event -> unit)
   -> ?on_yield:(unit -> unit)
   -> ?on_resume:(unit -> unit)
+  -> ?execution_store:execution_store
   -> t
   -> Types.content_block list
   -> (Types.api_response, detailed_error) result
@@ -329,6 +372,7 @@ val run_turn_stream
   -> ?clock:_ Eio.Time.clock
   -> on_event:(Types.sse_event -> unit)
   -> ?on_telemetry:(Llm_provider.Telemetry_event.t -> unit)
+  -> ?execution_store:execution_store
   -> t
   -> ([ `Complete of Types.api_response | `ToolsExecuted ], Error.sdk_error) result
 
@@ -338,6 +382,7 @@ val run_turn_stream_detailed
   -> ?clock:_ Eio.Time.clock
   -> on_event:(Types.sse_event -> unit)
   -> ?on_telemetry:(Llm_provider.Telemetry_event.t -> unit)
+  -> ?execution_store:execution_store
   -> t
   -> ([ `Complete of Types.api_response | `ToolsExecuted ], detailed_error) result
 
@@ -352,6 +397,7 @@ val provide_input : t -> Error.input_required -> Hooks.elicitation_response -> u
 val run_with_handoffs
   :  sw:Eio.Switch.t
   -> ?clock:_ Eio.Time.clock
+  -> ?execution_store:execution_store
   -> t
   -> targets:Handoff.handoff_target list
   -> string
@@ -361,6 +407,7 @@ val run_with_handoffs
 val run_with_handoffs_detailed
   :  sw:Eio.Switch.t
   -> ?clock:_ Eio.Time.clock
+  -> ?execution_store:execution_store
   -> t
   -> targets:Handoff.handoff_target list
   -> string
@@ -369,6 +416,7 @@ val run_with_handoffs_detailed
 val run_with_handoffs_blocks
   :  sw:Eio.Switch.t
   -> ?clock:_ Eio.Time.clock
+  -> ?execution_store:execution_store
   -> t
   -> targets:Handoff.handoff_target list
   -> Types.content_block list
@@ -378,6 +426,7 @@ val run_with_handoffs_blocks
 val run_with_handoffs_blocks_detailed
   :  sw:Eio.Switch.t
   -> ?clock:_ Eio.Time.clock
+  -> ?execution_store:execution_store
   -> t
   -> targets:Handoff.handoff_target list
   -> Types.content_block list

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -152,25 +152,38 @@ type execution_locator
 
 val execution_locator_to_yojson : execution_locator -> Yojson.Safe.t
 
+(** Decode the exact versioned locator emitted by
+    {!execution_locator_to_yojson}. Unknown versions or fields are rejected. *)
+val execution_locator_of_yojson : Yojson.Safe.t -> (execution_locator, string) result
+
 val create_execution_runtime
   :  sw:Eio.Switch.t
   -> domain_mgr:_ Eio.Domain_manager.t
   -> domain_count:int
   -> (execution_runtime, Error.sdk_error) result
 
-(** Configure one fresh durable execution scope. The same optional value is
-    accepted by regular, streaming, handoff, single-turn, and [Advanced] run
-    entry points; no parallel durable run surface is introduced. One store and
-    directory must be used for exactly one API call. A cooperative [Yielded]
-    return is a successful terminal boundary for that call.
+(** Configure one durable execution scope. Without [resume], the directory must
+    be new and the call starts a fresh scope. With [resume], the same Agent API
+    reopens that scope in the same directory, validates Agent identity and the
+    restored user input, and replays settled ToolResults without rerunning tool
+    gates, handlers, or completion observers. An admitted Tool attempt without
+    a settled result fails closed because its external outcome is unknown.
+
+    The same optional value is accepted by regular, streaming, handoff,
+    single-turn, and [Advanced] run entry points; no parallel durable run
+    surface is introduced. One store and directory must be used for exactly one
+    API call. A cooperative [Yielded] return is a successful terminal boundary
+    for that call.
 
     [on_scope_ready], when supplied, must persist the opaque locator before
-    provider or Tool effects begin; failure aborts the scope and the Agent
-    call. *)
+    provider or Tool effects begin. It is invoked for both fresh and resumed
+    scopes, so the sink should be idempotent. Failure aborts the scope and the
+    Agent call. *)
 val execution_store
   :  runtime:execution_runtime
   -> dir:Eio.Fs.dir_ty Eio.Path.t
   -> ?on_scope_ready:(execution_locator -> (unit, string) result)
+  -> ?resume:execution_locator
   -> unit
   -> execution_store
 

--- a/lib/agent/agent_execution_runner.ml
+++ b/lib/agent/agent_execution_runner.ml
@@ -36,6 +36,15 @@ let abort_failure_of_error (detailed : Provider_failure_attribution.detailed_err
     { kind = Internal_failure; detail = Error.to_string detailed.error; data = None }
 ;;
 
+let reraise_after_abort_failure exn backtrace abort_detail =
+  match Llm_provider.Reserved_exn.reraise_if_reserved exn with
+  | () ->
+    Printexc.raise_with_backtrace
+      (Abort_failed_after_exception (exn, backtrace, abort_detail))
+      backtrace
+  | exception reserved -> Printexc.raise_with_backtrace reserved backtrace
+;;
+
 let abort_after_exception scope exn backtrace =
   let reason =
     match exn with
@@ -50,10 +59,10 @@ let abort_after_exception scope exn backtrace =
   match Execution_agent_scope.abort scope reason with
   | Ok () -> Printexc.raise_with_backtrace exn backtrace
   | Error abort_error ->
-    Printexc.raise_with_backtrace
-      (Abort_failed_after_exception
-         (exn, backtrace, Execution_agent_scope.error_to_string abort_error))
+    reraise_after_abort_failure
+      exn
       backtrace
+      (Execution_agent_scope.error_to_string abort_error)
 ;;
 
 let abort_error scope detailed =
@@ -94,9 +103,17 @@ let settle_success scope value =
                (Execution_agent_scope.error_to_string abort_error))))
 ;;
 
+let settle_success_after_run scope value =
+  match Eio.Cancel.protect (fun () -> settle_success scope value) with
+  | result -> result
+  | exception exn ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    abort_after_exception scope exn backtrace
+;;
+
 let with_scope scope run =
   match run () with
-  | Ok value -> settle_success scope value
+  | Ok value -> settle_success_after_run scope value
   | Error detailed -> abort_error scope detailed
   | exception exn ->
     let backtrace = Printexc.get_raw_backtrace () in
@@ -133,3 +150,9 @@ let with_fresh store agent run =
   | Error failure ->
     Error (execution_failure (Execution_lane_writer.scope_failure_to_string failure))
 ;;
+
+module For_testing = struct
+  let reraise_after_abort_failure exn =
+    reraise_after_abort_failure exn (Printexc.get_callstack 8) "injected abort failure"
+  ;;
+end

--- a/lib/agent/agent_execution_runner.ml
+++ b/lib/agent/agent_execution_runner.ml
@@ -47,11 +47,13 @@ let reraise_after_abort_failure exn backtrace abort_detail =
 
 let%test "abort failure preserves cancellation class" =
   try
-    reraise_after_abort_failure
-      (Eio.Cancel.Cancelled Exit)
-      (Printexc.get_callstack 8)
-      "injected abort failure";
-    false
+    match
+      reraise_after_abort_failure
+        (Eio.Cancel.Cancelled Exit)
+        (Printexc.get_callstack 8)
+        "injected abort failure"
+    with
+    | () -> false
   with
   | Eio.Cancel.Cancelled Exit -> true
   | Eio.Cancel.Cancelled _ | Abort_failed_after_exception _ -> false
@@ -59,11 +61,13 @@ let%test "abort failure preserves cancellation class" =
 
 let%test "abort failure preserves reserved runtime exception" =
   try
-    reraise_after_abort_failure
-      Sys.Break
-      (Printexc.get_callstack 8)
-      "injected abort failure";
-    false
+    match
+      reraise_after_abort_failure
+        Sys.Break
+        (Printexc.get_callstack 8)
+        "injected abort failure"
+    with
+    | () -> false
   with
   | Sys.Break -> true
   | Abort_failed_after_exception _ -> false

--- a/lib/agent/agent_execution_runner.ml
+++ b/lib/agent/agent_execution_runner.ml
@@ -197,19 +197,25 @@ let with_resumed store locator agent run =
   match
     Execution_lane_writer.resume ~codec:store.codec ~dir:store.dir
     @@ fun ~sw writer ->
-    match
-      Execution_agent_scope.resume
-        ~writer
-        ~agent_name:agent.Agent_types.state.config.name
-        locator
-    with
-    | Error error ->
-      Error (execution_failure (Execution_agent_scope.error_to_string error))
-    | Ok scope ->
-      (match prepare_scope store scope with
-       | Error detail ->
-         abort_error scope (execution_failure ("scope locator sink failed: " ^ detail))
-       | Ok () -> with_scope scope (fun () -> run ~sw scope))
+    match Execution_lane_writer.await_ready writer with
+    | Error failure ->
+      Error (execution_failure (Execution_lane_writer.scope_failure_to_string failure))
+    | Ok () ->
+      (match
+         Execution_agent_scope.resume_running
+           ~writer
+           ~agent_name:agent.Agent_types.state.config.name
+           locator
+       with
+       | Error error ->
+         Error (execution_failure (Execution_agent_scope.error_to_string error))
+       | Ok scope ->
+         (match prepare_scope store scope with
+          | Error detail ->
+            abort_error scope (execution_failure ("scope locator sink failed: " ^ detail))
+          | Ok () ->
+            Execution_context.with_resume_once (fun () ->
+              with_scope scope (fun () -> run ~sw scope))))
   with
   | Ok result -> result
   | Error failure ->

--- a/lib/agent/agent_execution_runner.ml
+++ b/lib/agent/agent_execution_runner.ml
@@ -45,6 +45,30 @@ let reraise_after_abort_failure exn backtrace abort_detail =
   | exception reserved -> Printexc.raise_with_backtrace reserved backtrace
 ;;
 
+let%test "abort failure preserves cancellation class" =
+  match
+    reraise_after_abort_failure
+      (Eio.Cancel.Cancelled Exit)
+      (Printexc.get_callstack 8)
+      "injected abort failure"
+  with
+  | _ -> false
+  | exception Eio.Cancel.Cancelled Exit -> true
+  | exception _ -> false
+;;
+
+let%test "abort failure preserves reserved runtime exception" =
+  match
+    reraise_after_abort_failure
+      Sys.Break
+      (Printexc.get_callstack 8)
+      "injected abort failure"
+  with
+  | _ -> false
+  | exception Sys.Break -> true
+  | exception _ -> false
+;;
+
 let abort_after_exception scope exn backtrace =
   let reason =
     match exn with
@@ -150,9 +174,3 @@ let with_fresh store agent run =
   | Error failure ->
     Error (execution_failure (Execution_lane_writer.scope_failure_to_string failure))
 ;;
-
-module For_testing = struct
-  let reraise_after_abort_failure exn =
-    reraise_after_abort_failure exn (Printexc.get_callstack 8) "injected abort failure"
-  ;;
-end

--- a/lib/agent/agent_execution_runner.ml
+++ b/lib/agent/agent_execution_runner.ml
@@ -46,27 +46,27 @@ let reraise_after_abort_failure exn backtrace abort_detail =
 ;;
 
 let%test "abort failure preserves cancellation class" =
-  match
+  try
     reraise_after_abort_failure
       (Eio.Cancel.Cancelled Exit)
       (Printexc.get_callstack 8)
-      "injected abort failure"
+      "injected abort failure";
+    false
   with
-  | _ -> false
-  | exception Eio.Cancel.Cancelled Exit -> true
-  | exception _ -> false
+  | Eio.Cancel.Cancelled Exit -> true
+  | Eio.Cancel.Cancelled _ | Abort_failed_after_exception _ -> false
 ;;
 
 let%test "abort failure preserves reserved runtime exception" =
-  match
+  try
     reraise_after_abort_failure
       Sys.Break
       (Printexc.get_callstack 8)
-      "injected abort failure"
+      "injected abort failure";
+    false
   with
-  | _ -> false
-  | exception Sys.Break -> true
-  | exception _ -> false
+  | Sys.Break -> true
+  | Abort_failed_after_exception _ -> false
 ;;
 
 let abort_after_exception scope exn backtrace =

--- a/lib/agent/agent_execution_runner.ml
+++ b/lib/agent/agent_execution_runner.ml
@@ -1,10 +1,15 @@
 type runtime = { codec : Execution_codec_executor.t }
 type locator = Execution_agent_scope.scope_locator
 
+type store_mode =
+  | Fresh
+  | Resume of locator
+
 type store =
   { codec : Execution_codec_executor.t
   ; dir : Eio.Fs.dir_ty Eio.Path.t
   ; on_scope_ready : (locator -> (unit, string) result) option
+  ; mode : store_mode
   }
 
 exception Abort_failed_after_exception of exn * Printexc.raw_backtrace * string
@@ -20,11 +25,17 @@ let create_runtime ~sw ~domain_mgr ~domain_count =
          }))
 ;;
 
-let store ~(runtime : runtime) ~dir ?on_scope_ready () =
-  { codec = runtime.codec; dir; on_scope_ready }
+let store ~(runtime : runtime) ~dir ?on_scope_ready ?resume () =
+  let mode =
+    match resume with
+    | None -> Fresh
+    | Some locator -> Resume locator
+  in
+  { codec = runtime.codec; dir; on_scope_ready; mode }
 ;;
 
 let locator_to_yojson = Execution_agent_scope.scope_locator_to_yojson
+let locator_of_yojson = Execution_agent_scope.scope_locator_of_yojson
 
 let execution_failure detail =
   Provider_failure_attribution.of_sdk_error
@@ -140,12 +151,25 @@ let settle_success_after_run scope value =
 ;;
 
 let with_scope scope run =
-  match run () with
-  | Ok value -> settle_success_after_run scope value
-  | Error detailed -> abort_error scope detailed
-  | exception exn ->
-    let backtrace = Printexc.get_raw_backtrace () in
-    abort_after_exception scope exn backtrace
+  Execution_context.with_agent_scope scope (fun () ->
+    match run () with
+    | Ok value -> settle_success_after_run scope value
+    | Error detailed -> abort_error scope detailed
+    | exception exn ->
+      let backtrace = Printexc.get_raw_backtrace () in
+      abort_after_exception scope exn backtrace)
+;;
+
+let prepare_scope store scope =
+  let locator = Execution_agent_scope.scope_locator scope in
+  match store.on_scope_ready with
+  | None -> Ok ()
+  | Some persist ->
+    (match persist locator with
+     | result -> result
+     | exception exn ->
+       let backtrace = Printexc.get_raw_backtrace () in
+       abort_after_exception scope exn backtrace)
 ;;
 
 let with_fresh store agent run =
@@ -158,17 +182,7 @@ let with_fresh store agent run =
     | Error error ->
       Error (execution_failure (Execution_agent_scope.error_to_string error))
     | Ok scope ->
-      let locator = Execution_agent_scope.scope_locator scope in
-      let ready =
-        match store.on_scope_ready with
-        | None -> Ok ()
-        | Some persist ->
-          (match persist locator with
-           | result -> result
-           | exception exn ->
-             let backtrace = Printexc.get_raw_backtrace () in
-             abort_after_exception scope exn backtrace)
-      in
+      let ready = prepare_scope store scope in
       (match ready with
        | Error detail ->
          abort_error scope (execution_failure ("scope locator sink failed: " ^ detail))
@@ -177,4 +191,39 @@ let with_fresh store agent run =
   | Ok result -> result
   | Error failure ->
     Error (execution_failure (Execution_lane_writer.scope_failure_to_string failure))
+;;
+
+let with_resumed store locator agent run =
+  match
+    Execution_lane_writer.resume ~codec:store.codec ~dir:store.dir
+    @@ fun ~sw writer ->
+    match
+      Execution_agent_scope.resume
+        ~writer
+        ~agent_name:agent.Agent_types.state.config.name
+        locator
+    with
+    | Error error ->
+      Error (execution_failure (Execution_agent_scope.error_to_string error))
+    | Ok scope ->
+      (match prepare_scope store scope with
+       | Error detail ->
+         abort_error scope (execution_failure ("scope locator sink failed: " ^ detail))
+       | Ok () -> with_scope scope (fun () -> run ~sw scope))
+  with
+  | Ok result -> result
+  | Error failure ->
+    Error (execution_failure (Execution_lane_writer.scope_failure_to_string failure))
+;;
+
+let with_store store agent run =
+  match store.mode with
+  | Fresh -> with_fresh store agent run
+  | Resume locator -> with_resumed store locator agent run
+;;
+
+let is_resume store =
+  match store.mode with
+  | Fresh -> false
+  | Resume _ -> true
 ;;

--- a/lib/agent/agent_execution_runner.ml
+++ b/lib/agent/agent_execution_runner.ml
@@ -1,0 +1,135 @@
+type runtime = { codec : Execution_codec_executor.t }
+type locator = Execution_agent_scope.scope_locator
+
+type store =
+  { codec : Execution_codec_executor.t
+  ; dir : Eio.Fs.dir_ty Eio.Path.t
+  ; on_scope_ready : (locator -> (unit, string) result) option
+  }
+
+exception Abort_failed_after_exception of exn * Printexc.raw_backtrace * string
+
+let create_runtime ~sw ~domain_mgr ~domain_count =
+  Execution_runtime.create ~sw ~domain_mgr ~domain_count
+  |> Result.map (fun runtime -> { codec = Execution_codec_executor.of_runtime runtime })
+  |> Result.map_error (fun error ->
+    Error.Config
+      (InvalidConfig
+         { field = "execution_domain_count"
+         ; detail = Execution_runtime.create_error_to_string error
+         }))
+;;
+
+let store ~(runtime : runtime) ~dir ?on_scope_ready () =
+  { codec = runtime.codec; dir; on_scope_ready }
+;;
+
+let locator_to_yojson = Execution_agent_scope.scope_locator_to_yojson
+
+let execution_failure detail =
+  Provider_failure_attribution.of_sdk_error
+    (Error.Internal ("durable execution: " ^ detail))
+;;
+
+let abort_failure_of_error (detailed : Provider_failure_attribution.detailed_error) =
+  Execution_event.
+    { kind = Internal_failure; detail = Error.to_string detailed.error; data = None }
+;;
+
+let abort_after_exception scope exn backtrace =
+  let reason =
+    match exn with
+    | Eio.Cancel.Cancelled _ ->
+      Execution_agent_scope.Cancelled
+        { reason = Some (Printexc.to_string exn); data = None }
+    | _ ->
+      Execution_agent_scope.Failed
+        Execution_event.
+          { kind = Internal_failure; detail = Printexc.to_string exn; data = None }
+  in
+  match Execution_agent_scope.abort scope reason with
+  | Ok () -> Printexc.raise_with_backtrace exn backtrace
+  | Error abort_error ->
+    Printexc.raise_with_backtrace
+      (Abort_failed_after_exception
+         (exn, backtrace, Execution_agent_scope.error_to_string abort_error))
+      backtrace
+;;
+
+let abort_error scope detailed =
+  match
+    Execution_agent_scope.abort
+      scope
+      (Execution_agent_scope.Failed (abort_failure_of_error detailed))
+  with
+  | Ok () -> Error detailed
+  | Error abort_error ->
+    Error
+      (execution_failure
+         (Printf.sprintf
+            "agent failed: %s; abort failed: %s"
+            (Error.to_string detailed.Provider_failure_attribution.error)
+            (Execution_agent_scope.error_to_string abort_error)))
+;;
+
+let settle_success scope value =
+  match Execution_agent_scope.finish scope Execution_event.Succeeded with
+  | Ok () -> Ok value
+  | Error error ->
+    let detail = Execution_agent_scope.error_to_string error in
+    let detailed = execution_failure ("run settlement failed: " ^ detail) in
+    (match
+       Execution_agent_scope.abort
+         scope
+         (Execution_agent_scope.Failed
+            Execution_event.{ kind = Persistence_failure; detail; data = None })
+     with
+     | Ok () -> Error detailed
+     | Error abort_error ->
+       Error
+         (execution_failure
+            (Printf.sprintf
+               "run settlement failed: %s; abort failed: %s"
+               detail
+               (Execution_agent_scope.error_to_string abort_error))))
+;;
+
+let with_scope scope run =
+  match run () with
+  | Ok value -> settle_success scope value
+  | Error detailed -> abort_error scope detailed
+  | exception exn ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    abort_after_exception scope exn backtrace
+;;
+
+let with_fresh store agent run =
+  match
+    Execution_lane_writer.run ~codec:store.codec ~dir:store.dir
+    @@ fun ~sw writer ->
+    match
+      Execution_agent_scope.start ~writer ~agent_name:agent.Agent_types.state.config.name
+    with
+    | Error error ->
+      Error (execution_failure (Execution_agent_scope.error_to_string error))
+    | Ok scope ->
+      let locator = Execution_agent_scope.scope_locator scope in
+      let ready =
+        match store.on_scope_ready with
+        | None -> Ok ()
+        | Some persist ->
+          (match persist locator with
+           | result -> result
+           | exception exn ->
+             let backtrace = Printexc.get_raw_backtrace () in
+             abort_after_exception scope exn backtrace)
+      in
+      (match ready with
+       | Error detail ->
+         abort_error scope (execution_failure ("scope locator sink failed: " ^ detail))
+       | Ok () -> with_scope scope (fun () -> run ~sw scope))
+  with
+  | Ok result -> result
+  | Error failure ->
+    Error (execution_failure (Execution_lane_writer.scope_failure_to_string failure))
+;;

--- a/lib/agent/agent_execution_runner.mli
+++ b/lib/agent/agent_execution_runner.mli
@@ -31,7 +31,3 @@ val with_scope
   :  Execution_agent_scope.t
   -> (unit -> ('a, Provider_failure_attribution.detailed_error) result)
   -> ('a, Provider_failure_attribution.detailed_error) result
-
-module For_testing : sig
-  val reraise_after_abort_failure : exn -> 'a
-end

--- a/lib/agent/agent_execution_runner.mli
+++ b/lib/agent/agent_execution_runner.mli
@@ -1,0 +1,33 @@
+(** Private ownership wrapper for one fresh Agent execution journal. *)
+
+type runtime
+type store
+type locator
+
+val create_runtime
+  :  sw:Eio.Switch.t
+  -> domain_mgr:_ Eio.Domain_manager.t
+  -> domain_count:int
+  -> (runtime, Error.sdk_error) result
+
+val store
+  :  runtime:runtime
+  -> dir:Eio.Fs.dir_ty Eio.Path.t
+  -> ?on_scope_ready:(locator -> (unit, string) result)
+  -> unit
+  -> store
+
+val locator_to_yojson : locator -> Yojson.Safe.t
+
+val with_fresh
+  :  store
+  -> Agent_types.t
+  -> (sw:Eio.Switch.t
+      -> Execution_agent_scope.t
+      -> ('a, Provider_failure_attribution.detailed_error) result)
+  -> ('a, Provider_failure_attribution.detailed_error) result
+
+val with_scope
+  :  Execution_agent_scope.t
+  -> (unit -> ('a, Provider_failure_attribution.detailed_error) result)
+  -> ('a, Provider_failure_attribution.detailed_error) result

--- a/lib/agent/agent_execution_runner.mli
+++ b/lib/agent/agent_execution_runner.mli
@@ -14,10 +14,12 @@ val store
   :  runtime:runtime
   -> dir:Eio.Fs.dir_ty Eio.Path.t
   -> ?on_scope_ready:(locator -> (unit, string) result)
+  -> ?resume:locator
   -> unit
   -> store
 
 val locator_to_yojson : locator -> Yojson.Safe.t
+val locator_of_yojson : Yojson.Safe.t -> (locator, string) result
 
 val with_fresh
   :  store
@@ -26,6 +28,16 @@ val with_fresh
       -> Execution_agent_scope.t
       -> ('a, Provider_failure_attribution.detailed_error) result)
   -> ('a, Provider_failure_attribution.detailed_error) result
+
+val with_store
+  :  store
+  -> Agent_types.t
+  -> (sw:Eio.Switch.t
+      -> Execution_agent_scope.t
+      -> ('a, Provider_failure_attribution.detailed_error) result)
+  -> ('a, Provider_failure_attribution.detailed_error) result
+
+val is_resume : store -> bool
 
 val with_scope
   :  Execution_agent_scope.t

--- a/lib/agent/agent_execution_runner.mli
+++ b/lib/agent/agent_execution_runner.mli
@@ -31,3 +31,7 @@ val with_scope
   :  Execution_agent_scope.t
   -> (unit -> ('a, Provider_failure_attribution.detailed_error) result)
   -> ('a, Provider_failure_attribution.detailed_error) result
+
+module For_testing : sig
+  val reraise_after_abort_failure : exn -> 'a
+end

--- a/lib/agent/agent_input.ml
+++ b/lib/agent/agent_input.ml
@@ -1,0 +1,75 @@
+open Types
+open Agent_types
+
+let base_messages agent =
+  match agent.state.messages with
+  | [] -> agent.state.config.initial_messages
+  | msgs -> msgs
+;;
+
+let sanitize_user_input_blocks =
+  List.map (function
+    | Text s -> Text (Llm_provider.Utf8_sanitize.sanitize s)
+    | block -> block)
+;;
+
+let trace_prompt_of_blocks blocks =
+  let parts =
+    blocks
+    |> List.filter_map (function
+      | Text s -> Some (Llm_provider.Utf8_sanitize.sanitize s)
+      | Image { media_type; data; _ } ->
+        Some (Printf.sprintf "[image:%s data_chars=%d]" media_type (String.length data))
+      | Document { media_type; data; _ } ->
+        Some
+          (Printf.sprintf "[document:%s data_chars=%d]" media_type (String.length data))
+      | Audio { media_type; data; _ } ->
+        Some (Printf.sprintf "[audio:%s data_chars=%d]" media_type (String.length data))
+      | Thinking _ | ReasoningDetails _ | RedactedThinking _ | ToolUse _ | ToolResult _ ->
+        None)
+  in
+  match String.concat "\n" parts with
+  | "" -> "[multimodal input]"
+  | text -> text
+;;
+
+let validate_user_input_blocks blocks =
+  let unsupported =
+    List.find_map
+      (function
+        | Text _ | Image _ | Document _ | Audio _ -> None
+        | Thinking _ -> Some "Thinking"
+        | ReasoningDetails _ -> Some "ReasoningDetails"
+        | RedactedThinking _ -> Some "RedactedThinking"
+        | ToolUse _ -> Some "ToolUse"
+        | ToolResult _ -> Some "ToolResult")
+      blocks
+  in
+  match unsupported with
+  | None -> Ok ()
+  | Some kind ->
+    Error
+      (Error.Config
+         (Error.InvalidConfig
+            { field = "user_blocks"
+            ; detail =
+                Printf.sprintf
+                  "user input blocks may contain only Text, Image, Document, or Audio; \
+                   got %s"
+                  kind
+            }))
+;;
+
+let append_user_input agent user_blocks =
+  let user_msg =
+    { role = User
+    ; content = sanitize_user_input_blocks user_blocks
+    ; name = None
+    ; tool_call_id = None
+    ; metadata = []
+    }
+  in
+  update_state agent (fun state ->
+    { state with messages = Util.snoc (base_messages agent) user_msg });
+  user_msg.content
+;;

--- a/lib/agent/agent_input.ml
+++ b/lib/agent/agent_input.ml
@@ -73,3 +73,33 @@ let append_user_input agent user_blocks =
     { state with messages = Util.snoc (base_messages agent) user_msg });
   user_msg.content
 ;;
+
+let resume_user_input agent user_blocks =
+  let exact_input = sanitize_user_input_blocks user_blocks in
+  let existing =
+    List.find_map
+      (fun message ->
+         match message.role with
+         | User -> Some message.content
+         | System | Assistant | Tool -> None)
+      (List.rev agent.state.messages)
+  in
+  match existing with
+  | Some content when content = exact_input -> Ok exact_input
+  | Some _ ->
+    Error
+      (Error.Config
+         (Error.InvalidConfig
+            { field = "execution_store.resume"
+            ; detail =
+                "resume input differs from the latest User message in the restored Agent \
+                 checkpoint"
+            }))
+  | None ->
+    Error
+      (Error.Config
+         (Error.InvalidConfig
+            { field = "execution_store.resume"
+            ; detail = "restored Agent checkpoint contains no User message to resume"
+            }))
+;;

--- a/lib/agent/agent_input.mli
+++ b/lib/agent/agent_input.mli
@@ -1,0 +1,13 @@
+(** Private user-input normalization for Agent run entry points. *)
+
+val base_messages : Agent_types.t -> Types.message list
+val trace_prompt_of_blocks : Types.content_block list -> string
+
+val validate_user_input_blocks
+  :  Types.content_block list
+  -> (unit, Error.sdk_error) result
+
+val append_user_input
+  :  Agent_types.t
+  -> Types.content_block list
+  -> Types.content_block list

--- a/lib/agent/agent_input.mli
+++ b/lib/agent/agent_input.mli
@@ -11,3 +11,8 @@ val append_user_input
   :  Agent_types.t
   -> Types.content_block list
   -> Types.content_block list
+
+val resume_user_input
+  :  Agent_types.t
+  -> Types.content_block list
+  -> (Types.content_block list, Error.sdk_error) result

--- a/lib/agent/agent_tool_execution_types.ml
+++ b/lib/agent/agent_tool_execution_types.ml
@@ -1,0 +1,33 @@
+type tool_execution_result =
+  { invocation : Tool.Invocation.t
+  ; tool_name : string
+  ; input : Yojson.Safe.t
+  ; content : string
+  ; outcome : Types.tool_result_outcome
+  }
+
+type execution_error =
+  | Hook_execution_failed of
+      { hook_name : string
+      ; stage : Hooks.hook_stage
+      ; tool_name : string
+      ; invocation : Tool.Invocation.t
+      ; detail : string
+      }
+
+type execution_failure_cause =
+  | Hook_failure of execution_error
+  | Durability_failure of
+      { invocation : Tool.Invocation.t
+      ; detail : string
+      }
+  | Observer_failure of
+      { invocation : Tool.Invocation.t
+      ; exception_ : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+
+type execution_failure =
+  { completed_results : tool_execution_result list
+  ; cause : execution_failure_cause
+  }

--- a/lib/agent/agent_tool_execution_types.ml
+++ b/lib/agent/agent_tool_execution_types.ml
@@ -31,3 +31,55 @@ type execution_failure =
   { completed_results : tool_execution_result list
   ; cause : execution_failure_cause
   }
+
+type deferred_failure =
+  | Deferred_hook_failure of execution_error
+  | Deferred_observer_failure of
+      { invocation : Tool.Invocation.t
+      ; exception_ : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+
+type tool_dispatch =
+  { result : tool_execution_result
+  ; deferred_failure : deferred_failure option
+  }
+
+type pending_tool_dispatch =
+  { result : tool_execution_result
+  ; finish_observers : unit -> tool_dispatch
+  }
+
+let failure_priority = function
+  | Durability_failure _ -> 3
+  | Observer_failure _ -> 2
+  | Hook_failure _ -> 1
+;;
+
+let prefer_failure current candidate =
+  match current with
+  | None -> Some candidate
+  | Some primary ->
+    if failure_priority candidate > failure_priority primary
+    then Some candidate
+    else current
+;;
+
+let%test "durability failure dominates an earlier observer failure" =
+  let schedule : Tool.schedule =
+    { planned_index = 0; batch_index = 0; batch_size = 1; execution_mode = Tool.Serial }
+  in
+  let invocation = Tool.Invocation.create ~tool_use_id:"priority" ~turn:0 ~schedule in
+  let observer =
+    Observer_failure
+      { invocation
+      ; exception_ = Failure "observer"
+      ; backtrace = Printexc.get_callstack 1
+      }
+  in
+  match
+    prefer_failure (Some observer) (Durability_failure { invocation; detail = "lost" })
+  with
+  | Some (Durability_failure _) -> true
+  | Some (Hook_failure _ | Observer_failure _) | None -> false
+;;

--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -14,35 +14,7 @@ type tool_failure_kind = Types.tool_failure_kind =
   | Reported_tool_error
   | Unattributed_tool_error
 
-type tool_execution_result =
-  { invocation : Tool.Invocation.t
-  ; tool_name : string
-  ; input : Yojson.Safe.t
-  ; content : string
-  ; outcome : Types.tool_result_outcome
-  }
-
-type execution_error =
-  | Hook_execution_failed of
-      { hook_name : string
-      ; stage : Hooks.hook_stage
-      ; tool_name : string
-      ; invocation : Tool.Invocation.t
-      ; detail : string
-      }
-
-type execution_failure_cause =
-  | Hook_failure of execution_error
-  | Observer_failure of
-      { invocation : Tool.Invocation.t
-      ; exception_ : exn
-      ; backtrace : Printexc.raw_backtrace
-      }
-
-type execution_failure =
-  { completed_results : tool_execution_result list
-  ; cause : execution_failure_cause
-  }
+include Agent_tool_execution_types
 
 let observer_failure ~invocation exception_ backtrace =
   Llm_provider.Reserved_exn.reraise_if_reserved exception_;
@@ -59,7 +31,42 @@ let observer_failure ~invocation exception_ backtrace =
 let failure_summary = function
   | Hook_failure (Hook_execution_failed { hook_name; detail; _ }) ->
     Printf.sprintf "hook %s failed: %s" hook_name detail
+  | Durability_failure { detail; _ } -> "durable execution failed: " ^ detail
   | Observer_failure { exception_; _ } -> Printexc.to_string exception_
+;;
+
+let failure_priority = function
+  | Durability_failure _ -> 3
+  | Observer_failure _ -> 2
+  | Hook_failure _ -> 1
+;;
+
+let prefer_failure current candidate =
+  match current with
+  | None -> Some candidate
+  | Some primary ->
+    if failure_priority candidate > failure_priority primary
+    then Some candidate
+    else current
+;;
+
+let%test "durability failure dominates an earlier observer failure" =
+  let schedule : Tool.schedule =
+    { planned_index = 0; batch_index = 0; batch_size = 1; execution_mode = Tool.Serial }
+  in
+  let invocation = Tool.Invocation.create ~tool_use_id:"priority" ~turn:0 ~schedule in
+  let observer =
+    Observer_failure
+      { invocation
+      ; exception_ = Failure "observer"
+      ; backtrace = Printexc.get_callstack 1
+      }
+  in
+  match
+    prefer_failure (Some observer) (Durability_failure { invocation; detail = "lost" })
+  with
+  | Some (Durability_failure _) -> true
+  | Some (Hook_failure _ | Observer_failure _) | None -> false
 ;;
 
 type scheduled_tool_use =
@@ -214,7 +221,23 @@ let invoke_hook ?on_hook_invoked ~tracer ~agent_name ~turn_count ~hook_name hook
     raise_hook_observer exn
 ;;
 
-type deferred_failure = execution_failure_cause
+type deferred_failure =
+  | Deferred_hook_failure of execution_error
+  | Deferred_observer_failure of
+      { invocation : Tool.Invocation.t
+      ; exception_ : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+
+let execution_failure_of_deferred = function
+  | Deferred_hook_failure error -> Hook_failure error
+  | Deferred_observer_failure { invocation; exception_; backtrace } ->
+    Observer_failure { invocation; exception_; backtrace }
+;;
+
+let deferred_failure_summary deferred =
+  failure_summary (execution_failure_of_deferred deferred)
+;;
 
 type tool_dispatch =
   { result : tool_execution_result
@@ -250,12 +273,12 @@ let invoke_post_hook
     | Hooks.Continue -> None
     | Hooks.HookFailed { stage; detail } ->
       Some
-        (Hook_failure
+        (Deferred_hook_failure
            (hook_execution_error ~hook_name ~stage ~tool_name ~invocation ~detail))
     | decision ->
       let stage = Hooks.stage_of_event event in
       Some
-        (Hook_failure
+        (Deferred_hook_failure
            (hook_execution_error
               ~hook_name
               ~stage
@@ -267,14 +290,15 @@ let invoke_post_hook
                    (Hooks.decision_kind_to_string (Hooks.classify_decision decision)))))
   with
   | Hook_observer_raised (exception_, backtrace) ->
-    Some (observer_failure ~invocation exception_ backtrace)
+    Llm_provider.Reserved_exn.reraise_if_reserved exception_;
+    Some (Deferred_observer_failure { invocation; exception_; backtrace })
 ;;
 
 let resolve_dispatch dispatch =
   match dispatch.deferred_failure with
   | None -> Ok dispatch.result
-  | Some (Hook_failure error) -> Error error
-  | Some (Observer_failure { exception_; backtrace; _ }) ->
+  | Some (Deferred_hook_failure error) -> Error error
+  | Some (Deferred_observer_failure { exception_; backtrace; _ }) ->
     reraise_hook_observer exception_ backtrace
 ;;
 
@@ -304,7 +328,7 @@ let find_and_execute_tool_with_index
     | Some primary ->
       let retained, suppressed =
         match primary, failure with
-        | Hook_failure _, Observer_failure _ ->
+        | Deferred_hook_failure _, Deferred_observer_failure _ ->
           first_deferred_failure := Some failure;
           failure, primary
         | _ -> primary, failure
@@ -314,12 +338,14 @@ let find_and_execute_tool_with_index
         "additional tool dispatch failure"
         [ Log.S ("tool", name)
         ; Log.S ("tool_use_id", id)
-        ; Log.S ("retained", failure_summary retained)
-        ; Log.S ("suppressed", failure_summary suppressed)
+        ; Log.S ("retained", deferred_failure_summary retained)
+        ; Log.S ("suppressed", deferred_failure_summary suppressed)
         ]
   in
   let record_deferred_exception exception_ backtrace =
-    record_deferred_failure (observer_failure ~invocation exception_ backtrace)
+    Llm_provider.Reserved_exn.reraise_if_reserved exception_;
+    record_deferred_failure
+      (Deferred_observer_failure { invocation; exception_; backtrace })
   in
   (* ToolCalled event — capture the published envelope's run_id so the
      matching ToolCompleted records it as caused_by, preserving the
@@ -577,6 +603,7 @@ let execute_scheduled_tool
       ~(hooks : Hooks.hooks)
       ~event_bus
       ?journal
+      ?execution_provider
       ~tracer
       ~agent_name
       ~turn_count
@@ -600,11 +627,11 @@ let execute_scheduled_tool
     | None -> first_failure := Some failure
     | Some primary ->
       let retained, suppressed =
-        match primary, failure with
-        | Hook_failure _, Observer_failure _ ->
+        if failure_priority failure > failure_priority primary
+        then (
           first_failure := Some failure;
-          failure, primary
-        | _ -> primary, failure
+          failure, primary)
+        else primary, failure
       in
       Log.error
         _log
@@ -616,6 +643,7 @@ let execute_scheduled_tool
         ]
   in
   let record_caught_exception exception_ backtrace =
+    Llm_provider.Reserved_exn.reraise_if_reserved exception_;
     record_failure (observer_failure ~invocation exception_ backtrace)
   in
   let observe_before_completion callback =
@@ -700,6 +728,43 @@ let execute_scheduled_tool
     | Hooks.Continue ->
       let idem_key = Durable_event.make_idempotency_key ~tool_name:name ~input in
       (try
+         let execute_effect ~tool_name ~input =
+           observe_before_completion (fun () ->
+             match on_tool_execution_started with
+             | Some callback -> callback ~invocation ~tool_name ~input
+             | None -> ());
+           let t0_tool = Unix.gettimeofday () in
+           let dispatch =
+             find_and_execute_tool_with_index
+               ~context
+               ~tool_index
+               ~hooks
+               ~event_bus
+               ~tracer
+               ~agent_name
+               ?correlation_id
+               ?run_id
+               ?on_hook_invoked
+               ~invocation
+               tool_name
+               input
+           in
+           completed_dispatch := Some dispatch;
+           Option.iter
+             (fun deferred -> record_failure (execution_failure_of_deferred deferred))
+             dispatch.deferred_failure;
+           let duration_ms_tool = (Unix.gettimeofday () -. t0_tool) *. 1000.0 in
+           observe_after_completion (fun () ->
+             match on_tool_execution_finished with
+             | Some callback ->
+               callback
+                 ~invocation
+                 ~tool_name
+                 ~content:dispatch.result.content
+                 ~is_error:(Types.tool_result_outcome_is_error dispatch.result.outcome)
+             | None -> ());
+           dispatch, duration_ms_tool
+         in
          let dispatch =
            Tracing.with_span
              tracer
@@ -711,69 +776,98 @@ let execute_scheduled_tool
              ; links = []
              }
              (fun _tracer ->
-                observe_before_completion (fun () ->
-                  match journal with
-                  | Some j ->
-                    Agent_execution_event_writer.append
-                      j
-                      (Tool_called
-                         { turn = Tool.Invocation.turn invocation
-                         ; tool_name = name
-                         ; idempotency_key = idem_key
-                         ; input_hash = Digest.string (Yojson.Safe.to_string input)
-                         ; timestamp = Unix.gettimeofday ()
-                         })
-                  | None -> ());
-                observe_before_completion (fun () ->
-                  match on_tool_execution_started with
-                  | Some callback -> callback ~invocation ~tool_name:name ~input
-                  | None -> ());
-                let t0_tool = Unix.gettimeofday () in
-                let dispatch =
-                  find_and_execute_tool_with_index
-                    ~context
-                    ~tool_index
-                    ~hooks
-                    ~event_bus
-                    ~tracer
-                    ~agent_name
-                    ?correlation_id
-                    ?run_id
-                    ?on_hook_invoked
-                    ~invocation
-                    name
-                    input
-                in
-                completed_dispatch := Some dispatch;
-                Option.iter record_failure dispatch.deferred_failure;
-                let duration_ms_tool = (Unix.gettimeofday () -. t0_tool) *. 1000.0 in
-                observe_after_completion (fun () ->
-                  match journal with
-                  | Some j ->
-                    Agent_execution_event_writer.append
-                      j
-                      (Tool_completed
-                         { turn = Tool.Invocation.turn invocation
-                         ; tool_name = name
-                         ; idempotency_key = idem_key
-                         ; output_json = `String dispatch.result.content
-                         ; is_error =
-                             Types.tool_result_outcome_is_error dispatch.result.outcome
-                         ; duration_ms = duration_ms_tool
-                         ; timestamp = Unix.gettimeofday ()
-                         })
-                  | None -> ());
-                observe_after_completion (fun () ->
-                  match on_tool_execution_finished with
-                  | Some callback ->
-                    callback
-                      ~invocation
-                      ~tool_name:name
-                      ~content:dispatch.result.content
-                      ~is_error:
-                        (Types.tool_result_outcome_is_error dispatch.result.outcome)
-                  | None -> ());
-                dispatch)
+                match execution_provider with
+                | Some provider ->
+                  (match
+                     Execution_agent_scope.open_invocation
+                       provider
+                       ~invocation
+                       ~tool_name:name
+                       ~input
+                   with
+                   | Error error ->
+                     record_failure
+                       (Durability_failure
+                          { invocation
+                          ; detail = Execution_agent_scope.error_to_string error
+                          });
+                     raise Abort_tool_dispatch
+                   | Ok durable_invocation ->
+                     (match
+                        Execution_agent_scope.execute
+                          durable_invocation
+                          ~invoke:(fun ~start_child ~tool_name ~input ->
+                            Execution_context.with_child_scope_factory
+                              start_child
+                              (fun () ->
+                                 let dispatch, _duration_ms =
+                                   execute_effect ~tool_name ~input
+                                 in
+                                 dispatch.result.content, dispatch.result.outcome))
+                      with
+                      | Error error ->
+                        (* The effect may already have returned, but without an
+                           atomic settlement there is no result authority to
+                           expose to the transcript. *)
+                        completed_dispatch := None;
+                        record_failure
+                          (Durability_failure
+                             { invocation
+                             ; detail = Execution_agent_scope.error_to_string error
+                             });
+                        raise Abort_tool_dispatch
+                      | Ok (Execution_agent_scope.Executed (result, _, _))
+                      | Ok (Execution_agent_scope.Replayed result) ->
+                        let dispatch =
+                          match !completed_dispatch with
+                          | Some dispatch -> dispatch
+                          | None ->
+                            { result =
+                                { invocation = result.invocation
+                                ; tool_name = result.tool_name
+                                ; input = result.input
+                                ; content = result.content
+                                ; outcome = result.outcome
+                                }
+                            ; deferred_failure = None
+                            }
+                        in
+                        completed_dispatch := Some dispatch;
+                        dispatch))
+                | None ->
+                  observe_before_completion (fun () ->
+                    match journal with
+                    | Some j ->
+                      Agent_execution_event_writer.append
+                        j
+                        (Tool_called
+                           { turn = Tool.Invocation.turn invocation
+                           ; tool_name = name
+                           ; idempotency_key = idem_key
+                           ; input_hash = Digest.string (Yojson.Safe.to_string input)
+                           ; timestamp = Unix.gettimeofday ()
+                           })
+                    | None -> ());
+                  let dispatch, duration_ms_tool =
+                    execute_effect ~tool_name:name ~input
+                  in
+                  observe_after_completion (fun () ->
+                    match journal with
+                    | Some j ->
+                      Agent_execution_event_writer.append
+                        j
+                        (Tool_completed
+                           { turn = Tool.Invocation.turn invocation
+                           ; tool_name = name
+                           ; idempotency_key = idem_key
+                           ; output_json = `String dispatch.result.content
+                           ; is_error =
+                               Types.tool_result_outcome_is_error dispatch.result.outcome
+                           ; duration_ms = duration_ms_tool
+                           ; timestamp = Unix.gettimeofday ()
+                           })
+                    | None -> ());
+                  dispatch)
          in
          completed_dispatch := Some dispatch;
          outcome ()
@@ -802,6 +896,7 @@ let execute_tools
       ~(hooks : Hooks.hooks)
       ~event_bus
       ?journal
+      ?execution_provider
       ~tracer
       ~agent_name
       ~turn_count
@@ -842,6 +937,7 @@ let execute_tools
       ~hooks
       ~event_bus
       ?journal
+      ?execution_provider
       ~tracer
       ~agent_name
       ~turn_count
@@ -859,7 +955,15 @@ let execute_tools
            Option.map (fun result -> outcome.index, result) outcome.completed_result)
         outcomes
     in
-    let failure = List.find_map (fun outcome -> outcome.failure) outcomes in
+    let failure =
+      List.fold_left
+        (fun selected outcome ->
+           match outcome.failure with
+           | None -> selected
+           | Some candidate -> prefer_failure selected candidate)
+        None
+        outcomes
+    in
     completed, failure
   in
   let ordered_results completed =

--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -267,7 +267,7 @@ let find_and_execute_tool_with_index
       ?correlation_id
       ?run_id
       ?on_hook_invoked
-      ~publish_legacy_events
+      ~publish_event_bus
       ~invocation
       name
       input
@@ -312,7 +312,7 @@ let find_and_execute_tool_with_index
      [~run_id] explicitly or we fall back to the fresh id minted by
      [mk_event]. *)
   let tool_called_run_id =
-    match publish_legacy_events, event_bus with
+    match publish_event_bus, event_bus with
     | false, _ -> None
     | true, Some bus ->
       let ev =
@@ -496,7 +496,7 @@ let find_and_execute_tool_with_index
   in
   (* ToolCompleted event *)
   defer_observer (fun () ->
-    match publish_legacy_events, event_bus with
+    match publish_event_bus, event_bus with
     | false, _ -> ()
     | true, Some bus ->
       let output_content = dispatch.result.content in
@@ -551,7 +551,7 @@ let find_and_execute_tool
         ?correlation_id
         ?run_id
         ?on_hook_invoked
-        ~publish_legacy_events:true
+        ~publish_event_bus:true
         ~invocation
         name
         input
@@ -576,7 +576,6 @@ let execute_scheduled_tool
       ~(hooks : Hooks.hooks)
       ~event_bus
       ?journal
-      ?execution_provider
       ~tracer
       ~agent_name
       ~turn_count
@@ -644,119 +643,182 @@ let execute_scheduled_tool
     ; failure = !first_failure
     }
   in
-  try
-    let decision =
-      invoke_hook
-        ?on_hook_invoked
+  let observe_started ~tool_name ~input =
+    match on_tool_execution_started with
+    | Some callback -> callback ~invocation ~tool_name ~input
+    | None -> ()
+  in
+  let begin_effect ~tool_name ~input =
+    let t0_tool = Unix.gettimeofday () in
+    let pending =
+      find_and_execute_tool_with_index
+        ~context
+        ~tool_index
+        ~hooks
+        ~event_bus
         ~tracer
         ~agent_name
-        ~turn_count
-        ~hook_name:"pre_tool_use"
-        hooks.pre_tool_use
-        (Hooks.PreToolUse
-           { invocation
-           ; tool_name = name
-           ; input
-           ; accumulated_cost_usd = usage.Types.estimated_cost_usd
-           })
+        ?correlation_id
+        ?run_id
+        ?on_hook_invoked
+        ~publish_event_bus:true
+        ~invocation
+        tool_name
+        input
     in
-    match decision with
-    | Hooks.Block reason ->
-      (* Intentional caller rejection is a model-visible tool result, but it is
+    completed_dispatch
+    := Some ({ result = pending.result; deferred_failure = None } : tool_dispatch);
+    pending, (Unix.gettimeofday () -. t0_tool) *. 1000.0
+  in
+  let finish_effect pending ~tool_name =
+    let dispatch = pending.finish_observers () in
+    completed_dispatch := Some dispatch;
+    Option.iter
+      (fun deferred -> record_failure (execution_failure_of_deferred deferred))
+      dispatch.deferred_failure;
+    observe_after_completion (fun () ->
+      match on_tool_execution_finished with
+      | Some callback ->
+        callback
+          ~invocation
+          ~tool_name
+          ~content:dispatch.result.content
+          ~is_error:(Types.tool_result_outcome_is_error dispatch.result.outcome)
+      | None -> ());
+    dispatch
+  in
+  let execute_durable durable_invocation =
+    match
+      Execution_agent_scope.execute_phased
+        durable_invocation
+        ~invoke:(fun ~start_child ~tool_name ~input ->
+          observe_before_completion (fun () -> observe_started ~tool_name ~input);
+          Execution_context.with_child_scope_factory start_child (fun () ->
+            let pending, _duration_ms = begin_effect ~tool_name ~input in
+            ( (pending.result.content, pending.result.outcome)
+            , fun () ->
+                let (_ : tool_dispatch) = finish_effect pending ~tool_name in
+                () )))
+    with
+    | Error error ->
+      (* The effect may already have returned, but without an atomic settlement
+         there is no result authority to expose to the transcript. *)
+      completed_dispatch := None;
+      record_failure
+        (Durability_failure
+           { invocation; detail = Execution_agent_scope.error_to_string error });
+      raise Abort_tool_dispatch
+    | Ok (Execution_agent_scope.Executed (result, _, _))
+    | Ok (Execution_agent_scope.Replayed result) ->
+      let dispatch =
+        match !completed_dispatch with
+        | Some dispatch -> dispatch
+        | None ->
+          { result =
+              { invocation = result.invocation
+              ; tool_name = result.tool_name
+              ; input = result.input
+              ; content = result.content
+              ; outcome = result.outcome
+              }
+          ; deferred_failure = None
+          }
+      in
+      completed_dispatch := Some dispatch;
+      dispatch
+  in
+  let with_tool_span run =
+    Tracing.with_span
+      tracer
+      { kind = Tool_exec; name; agent_name; turn = turn_count; extra = []; links = [] }
+      (fun _tracer -> run ())
+  in
+  let durability_failure error =
+    record_failure
+      (Durability_failure
+         { invocation; detail = Execution_agent_scope.error_to_string error });
+    raise Abort_tool_dispatch
+  in
+  try
+    let execution_provider = Execution_context.provider_attempt () in
+    let existing =
+      match execution_provider with
+      | None -> Ok None
+      | Some provider ->
+        Execution_agent_scope.find_invocation provider ~invocation ~tool_name:name ~input
+    in
+    match existing with
+    | Error error -> durability_failure error
+    | Ok (Some durable_invocation) ->
+      (* An existing durable occurrence proves the pre-tool gate already
+         admitted this exact call. Replaying it must not invoke the gate or any
+         lifecycle observer again. If no attempt was committed, [execute_phased]
+         starts the effect once; an in-flight attempt fails closed. *)
+      let (_ : tool_dispatch) =
+        with_tool_span (fun () -> execute_durable durable_invocation)
+      in
+      outcome ()
+    | Ok None ->
+      let decision =
+        invoke_hook
+          ?on_hook_invoked
+          ~tracer
+          ~agent_name
+          ~turn_count
+          ~hook_name:"pre_tool_use"
+          hooks.pre_tool_use
+          (Hooks.PreToolUse
+             { invocation
+             ; tool_name = name
+             ; input
+             ; accumulated_cost_usd = usage.Types.estimated_cost_usd
+             })
+      in
+      (match decision with
+       | Hooks.Block reason ->
+         (* Intentional caller rejection is a model-visible tool result, but it is
          not a tool execution. No Tool_called/Tool_completed lifecycle evidence
          is emitted for a call that never crossed the caller's gate. *)
-      { index
-      ; completed_result =
-          Some (blocked_tool_result ~invocation ~name ~input ~content:reason)
-      ; failure = None
-      }
-    | Hooks.HookFailed { stage; detail } ->
-      { index
-      ; completed_result = None
-      ; failure =
-          Some
-            (Hook_failure
-               (hook_execution_error
-                  ~hook_name:"pre_tool_use"
-                  ~stage
-                  ~tool_name:name
-                  ~invocation
-                  ~detail))
-      }
-    | (Hooks.AdjustParams _ | Hooks.ElicitInput _ | Hooks.Nudge _) as decision ->
-      { index
-      ; completed_result = None
-      ; failure =
-          Some
-            (Hook_failure
-               (hook_execution_error
-                  ~hook_name:"pre_tool_use"
-                  ~stage:Hooks.Pre_tool_use
-                  ~tool_name:name
-                  ~invocation
-                  ~detail:
-                    (Printf.sprintf
-                       "illegal decision %s escaped hook validation"
-                       (Hooks.decision_kind_to_string (Hooks.classify_decision decision)))))
-      }
-    | Hooks.Continue ->
-      let idem_key = Durable_event.make_idempotency_key ~tool_name:name ~input in
-      (try
-         let observe_started ~tool_name ~input =
-           match on_tool_execution_started with
-           | Some callback -> callback ~invocation ~tool_name ~input
-           | None -> ()
-         in
-         let begin_effect ~publish_legacy_events ~tool_name ~input =
-           let t0_tool = Unix.gettimeofday () in
-           let pending =
-             find_and_execute_tool_with_index
-               ~context
-               ~tool_index
-               ~hooks
-               ~event_bus
-               ~tracer
-               ~agent_name
-               ?correlation_id
-               ?run_id
-               ?on_hook_invoked
-               ~publish_legacy_events
-               ~invocation
-               tool_name
-               input
-           in
-           completed_dispatch
-           := Some ({ result = pending.result; deferred_failure = None } : tool_dispatch);
-           pending, (Unix.gettimeofday () -. t0_tool) *. 1000.0
-         in
-         let finish_effect pending ~tool_name =
-           let dispatch = pending.finish_observers () in
-           completed_dispatch := Some dispatch;
-           Option.iter
-             (fun deferred -> record_failure (execution_failure_of_deferred deferred))
-             dispatch.deferred_failure;
-           observe_after_completion (fun () ->
-             match on_tool_execution_finished with
-             | Some callback ->
-               callback
-                 ~invocation
-                 ~tool_name
-                 ~content:dispatch.result.content
-                 ~is_error:(Types.tool_result_outcome_is_error dispatch.result.outcome)
-             | None -> ());
-           dispatch
-         in
-         let dispatch =
-           Tracing.with_span
-             tracer
-             { kind = Tool_exec
-             ; name
-             ; agent_name
-             ; turn = turn_count
-             ; extra = []
-             ; links = []
-             }
-             (fun _tracer ->
+         { index
+         ; completed_result =
+             Some (blocked_tool_result ~invocation ~name ~input ~content:reason)
+         ; failure = None
+         }
+       | Hooks.HookFailed { stage; detail } ->
+         { index
+         ; completed_result = None
+         ; failure =
+             Some
+               (Hook_failure
+                  (hook_execution_error
+                     ~hook_name:"pre_tool_use"
+                     ~stage
+                     ~tool_name:name
+                     ~invocation
+                     ~detail))
+         }
+       | (Hooks.AdjustParams _ | Hooks.ElicitInput _ | Hooks.Nudge _) as decision ->
+         { index
+         ; completed_result = None
+         ; failure =
+             Some
+               (Hook_failure
+                  (hook_execution_error
+                     ~hook_name:"pre_tool_use"
+                     ~stage:Hooks.Pre_tool_use
+                     ~tool_name:name
+                     ~invocation
+                     ~detail:
+                       (Printf.sprintf
+                          "illegal decision %s escaped hook validation"
+                          (Hooks.decision_kind_to_string
+                             (Hooks.classify_decision decision)))))
+         }
+       | Hooks.Continue ->
+         let idem_key = Durable_event.make_idempotency_key ~tool_name:name ~input in
+         (try
+            let dispatch =
+              with_tool_span (fun () ->
                 match execution_provider with
                 | Some provider ->
                   (match
@@ -766,64 +828,8 @@ let execute_scheduled_tool
                        ~tool_name:name
                        ~input
                    with
-                   | Error error ->
-                     record_failure
-                       (Durability_failure
-                          { invocation
-                          ; detail = Execution_agent_scope.error_to_string error
-                          });
-                     raise Abort_tool_dispatch
-                   | Ok durable_invocation ->
-                     observe_before_completion (fun () ->
-                       observe_started ~tool_name:name ~input);
-                     (match
-                        Execution_agent_scope.execute_phased
-                          durable_invocation
-                          ~invoke:(fun ~start_child ~tool_name ~input ->
-                            Execution_context.with_child_scope_factory
-                              start_child
-                              (fun () ->
-                                 let pending, _duration_ms =
-                                   begin_effect
-                                     ~publish_legacy_events:false
-                                     ~tool_name
-                                     ~input
-                                 in
-                                 ( (pending.result.content, pending.result.outcome)
-                                 , fun () ->
-                                     ignore
-                                       (finish_effect pending ~tool_name : tool_dispatch)
-                                 )))
-                      with
-                      | Error error ->
-                        (* The effect may already have returned, but without an
-                           atomic settlement there is no result authority to
-                           expose to the transcript. *)
-                        completed_dispatch := None;
-                        record_failure
-                          (Durability_failure
-                             { invocation
-                             ; detail = Execution_agent_scope.error_to_string error
-                             });
-                        raise Abort_tool_dispatch
-                      | Ok (Execution_agent_scope.Executed (result, _, _))
-                      | Ok (Execution_agent_scope.Replayed result) ->
-                        let dispatch =
-                          match !completed_dispatch with
-                          | Some dispatch -> dispatch
-                          | None ->
-                            { result =
-                                { invocation = result.invocation
-                                ; tool_name = result.tool_name
-                                ; input = result.input
-                                ; content = result.content
-                                ; outcome = result.outcome
-                                }
-                            ; deferred_failure = None
-                            }
-                        in
-                        completed_dispatch := Some dispatch;
-                        dispatch))
+                   | Error error -> durability_failure error
+                   | Ok durable_invocation -> execute_durable durable_invocation)
                 | None ->
                   observe_before_completion (fun () ->
                     observe_started ~tool_name:name ~input;
@@ -839,9 +845,7 @@ let execute_scheduled_tool
                            ; timestamp = Unix.gettimeofday ()
                            })
                     | None -> ());
-                  let pending, duration_ms_tool =
-                    begin_effect ~publish_legacy_events:true ~tool_name:name ~input
-                  in
+                  let pending, duration_ms_tool = begin_effect ~tool_name:name ~input in
                   let dispatch = finish_effect pending ~tool_name:name in
                   observe_after_completion (fun () ->
                     match journal with
@@ -860,18 +864,18 @@ let execute_scheduled_tool
                            })
                     | None -> ());
                   dispatch)
-         in
-         completed_dispatch := Some dispatch;
-         outcome ()
-       with
-       | Abort_tool_dispatch -> outcome ()
-       | Hook_observer_raised (exception_, backtrace) ->
-         record_caught_exception exception_ backtrace;
-         outcome ()
-       | exception_ ->
-         let backtrace = Printexc.get_raw_backtrace () in
-         record_caught_exception exception_ backtrace;
-         outcome ())
+            in
+            completed_dispatch := Some dispatch;
+            outcome ()
+          with
+          | Abort_tool_dispatch -> outcome ()
+          | Hook_observer_raised (exception_, backtrace) ->
+            record_caught_exception exception_ backtrace;
+            outcome ()
+          | exception_ ->
+            let backtrace = Printexc.get_raw_backtrace () in
+            record_caught_exception exception_ backtrace;
+            outcome ()))
   with
   | Hook_observer_raised (exception_, backtrace) ->
     record_caught_exception exception_ backtrace;
@@ -888,7 +892,6 @@ let execute_tools
       ~(hooks : Hooks.hooks)
       ~event_bus
       ?journal
-      ?execution_provider
       ~tracer
       ~agent_name
       ~turn_count
@@ -929,7 +932,6 @@ let execute_tools
       ~hooks
       ~event_bus
       ?journal
-      ?execution_provider
       ~tracer
       ~agent_name
       ~turn_count

--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -35,40 +35,6 @@ let failure_summary = function
   | Observer_failure { exception_; _ } -> Printexc.to_string exception_
 ;;
 
-let failure_priority = function
-  | Durability_failure _ -> 3
-  | Observer_failure _ -> 2
-  | Hook_failure _ -> 1
-;;
-
-let prefer_failure current candidate =
-  match current with
-  | None -> Some candidate
-  | Some primary ->
-    if failure_priority candidate > failure_priority primary
-    then Some candidate
-    else current
-;;
-
-let%test "durability failure dominates an earlier observer failure" =
-  let schedule : Tool.schedule =
-    { planned_index = 0; batch_index = 0; batch_size = 1; execution_mode = Tool.Serial }
-  in
-  let invocation = Tool.Invocation.create ~tool_use_id:"priority" ~turn:0 ~schedule in
-  let observer =
-    Observer_failure
-      { invocation
-      ; exception_ = Failure "observer"
-      ; backtrace = Printexc.get_callstack 1
-      }
-  in
-  match
-    prefer_failure (Some observer) (Durability_failure { invocation; detail = "lost" })
-  with
-  | Some (Durability_failure _) -> true
-  | Some (Hook_failure _ | Observer_failure _) | None -> false
-;;
-
 type scheduled_tool_use =
   { index : int
   ; id : string
@@ -221,14 +187,6 @@ let invoke_hook ?on_hook_invoked ~tracer ~agent_name ~turn_count ~hook_name hook
     raise_hook_observer exn
 ;;
 
-type deferred_failure =
-  | Deferred_hook_failure of execution_error
-  | Deferred_observer_failure of
-      { invocation : Tool.Invocation.t
-      ; exception_ : exn
-      ; backtrace : Printexc.raw_backtrace
-      }
-
 let execution_failure_of_deferred = function
   | Deferred_hook_failure error -> Hook_failure error
   | Deferred_observer_failure { invocation; exception_; backtrace } ->
@@ -238,11 +196,6 @@ let execution_failure_of_deferred = function
 let deferred_failure_summary deferred =
   failure_summary (execution_failure_of_deferred deferred)
 ;;
-
-type tool_dispatch =
-  { result : tool_execution_result
-  ; deferred_failure : deferred_failure option
-  }
 
 let hook_execution_error ~hook_name ~stage ~tool_name ~invocation ~detail =
   Hook_execution_failed { hook_name; stage; tool_name; invocation; detail }
@@ -314,6 +267,7 @@ let find_and_execute_tool_with_index
       ?correlation_id
       ?run_id
       ?on_hook_invoked
+      ~publish_legacy_events
       ~invocation
       name
       input
@@ -322,6 +276,10 @@ let find_and_execute_tool_with_index
   let requested_name = name in
   let name, input, tool_opt = resolve_tool_call tool_index name input in
   let first_deferred_failure = ref None in
+  let post_effect_observers = ref [] in
+  let defer_observer observer =
+    post_effect_observers := observer :: !post_effect_observers
+  in
   let record_deferred_failure failure =
     match !first_deferred_failure with
     | None -> first_deferred_failure := Some failure
@@ -354,8 +312,9 @@ let find_and_execute_tool_with_index
      [~run_id] explicitly or we fall back to the fresh id minted by
      [mk_event]. *)
   let tool_called_run_id =
-    match event_bus with
-    | Some bus ->
+    match publish_legacy_events, event_bus with
+    | false, _ -> None
+    | true, Some bus ->
       let ev =
         Event_bus.mk_event
           ?correlation_id
@@ -370,7 +329,7 @@ let find_and_execute_tool_with_index
          let backtrace = Printexc.get_raw_backtrace () in
          record_deferred_exception exception_ backtrace;
          None)
-    | None -> None
+    | true, None -> None
   in
   let dispatch =
     match tool_opt with
@@ -407,11 +366,13 @@ let find_and_execute_tool_with_index
           let message =
             Tool_input_validation.format_errors_inline ~tool_name:name ~args:input errors
           in
-          Error (message, emit_post_tool_use_failure ~input message)
+          defer_observer (fun () ->
+            emit_post_tool_use_failure ~input message
+            |> Option.iter record_deferred_failure);
+          Error message
       in
       (match validated_input with
-       | Error (message, deferred_failure) ->
-         Option.iter record_deferred_failure deferred_failure;
+       | Error message ->
          { result = validation_error_result ~input message; deferred_failure = None }
        | Ok exact_input ->
          let t0 = Unix.gettimeofday () in
@@ -432,49 +393,52 @@ let find_and_execute_tool_with_index
            | Ok { content; _meta = _ } -> String.length content
            | Error { message; _ } -> String.length message
          in
-         invoke_post_hook
-           ?on_hook_invoked
-           ~tracer
-           ~agent_name
-           ~invocation
-           ~hook_name:"post_tool_use"
-           ~tool_name:name
-           hooks.post_tool_use
-           (Hooks.PostToolUse
-              { invocation
-              ; tool_name = name
-              ; input = exact_input
-              ; output = result
-              ; result_bytes
-              ; duration_ms
-              })
-         |> Option.iter record_deferred_failure;
+         defer_observer (fun () ->
+           invoke_post_hook
+             ?on_hook_invoked
+             ~tracer
+             ~agent_name
+             ~invocation
+             ~hook_name:"post_tool_use"
+             ~tool_name:name
+             hooks.post_tool_use
+             (Hooks.PostToolUse
+                { invocation
+                ; tool_name = name
+                ; input = exact_input
+                ; output = result
+                ; result_bytes
+                ; duration_ms
+                })
+           |> Option.iter record_deferred_failure);
          (match result with
           | Ok _ -> ()
           | Error { message; _ } ->
-            invoke_post_hook
-              ?on_hook_invoked
-              ~tracer
-              ~agent_name
-              ~invocation
-              ~hook_name:"post_tool_use_failure"
-              ~tool_name:name
-              hooks.post_tool_use_failure
-              (Hooks.PostToolUseFailure
-                 { invocation; tool_name = name; input = exact_input; error = message })
-            |> Option.iter record_deferred_failure;
+            defer_observer (fun () ->
+              invoke_post_hook
+                ?on_hook_invoked
+                ~tracer
+                ~agent_name
+                ~invocation
+                ~hook_name:"post_tool_use_failure"
+                ~tool_name:name
+                hooks.post_tool_use_failure
+                (Hooks.PostToolUseFailure
+                   { invocation; tool_name = name; input = exact_input; error = message })
+              |> Option.iter record_deferred_failure);
             (* [OnToolError] is the compact error projection. The exact
                invocation remains shared with the richer failure hook. *)
-            invoke_post_hook
-              ?on_hook_invoked
-              ~tracer
-              ~agent_name
-              ~invocation
-              ~hook_name:"on_tool_error"
-              ~tool_name:name
-              hooks.on_tool_error
-              (Hooks.OnToolError { invocation; tool_name = name; error = message })
-            |> Option.iter record_deferred_failure);
+            defer_observer (fun () ->
+              invoke_post_hook
+                ?on_hook_invoked
+                ~tracer
+                ~agent_name
+                ~invocation
+                ~hook_name:"on_tool_error"
+                ~tool_name:name
+                hooks.on_tool_error
+                (Hooks.OnToolError { invocation; tool_name = name; error = message })
+              |> Option.iter record_deferred_failure));
          let content, outcome =
            match result with
            | Ok { content; _meta = _ } -> content, Tool_succeeded
@@ -505,7 +469,7 @@ let find_and_execute_tool_with_index
         [ Log.S ("tool", requested_name)
         ; Log.S ("available_tools", render_tool_names available)
         ];
-      let deferred_failure =
+      defer_observer (fun () ->
         invoke_post_hook
           ?on_hook_invoked
           ~tracer
@@ -519,8 +483,7 @@ let find_and_execute_tool_with_index
              ; detail = message
              ; context = "agent_tools.find_and_execute_tool"
              })
-      in
-      Option.iter record_deferred_failure deferred_failure;
+        |> Option.iter record_deferred_failure);
       { result =
           { invocation
           ; tool_name = requested_name
@@ -532,26 +495,33 @@ let find_and_execute_tool_with_index
       }
   in
   (* ToolCompleted event *)
-  (match event_bus with
-   | Some bus ->
-     let output_content = dispatch.result.content in
-     let output =
-       Types.tool_result_of_outcome ~content:output_content dispatch.result.outcome
-     in
-     (try
-        Event_bus.publish
-          bus
-          (Event_bus.mk_event
-             ?correlation_id
-             ?run_id
-             ?caused_by:tool_called_run_id
-             (ToolCompleted { invocation; agent_name; tool_name = name; output }))
-      with
-      | exception_ ->
-        let backtrace = Printexc.get_raw_backtrace () in
-        record_deferred_exception exception_ backtrace)
-   | None -> ());
-  { dispatch with deferred_failure = !first_deferred_failure }
+  defer_observer (fun () ->
+    match publish_legacy_events, event_bus with
+    | false, _ -> ()
+    | true, Some bus ->
+      let output_content = dispatch.result.content in
+      let output =
+        Types.tool_result_of_outcome ~content:output_content dispatch.result.outcome
+      in
+      (try
+         Event_bus.publish
+           bus
+           (Event_bus.mk_event
+              ?correlation_id
+              ?run_id
+              ?caused_by:tool_called_run_id
+              (ToolCompleted { invocation; agent_name; tool_name = name; output }))
+       with
+       | exception_ ->
+         let backtrace = Printexc.get_raw_backtrace () in
+         record_deferred_exception exception_ backtrace)
+    | true, None -> ());
+  { result = dispatch.result
+  ; finish_observers =
+      (fun () ->
+        List.rev !post_effect_observers |> List.iter (fun observe -> observe ());
+        { dispatch with deferred_failure = !first_deferred_failure })
+  }
 ;;
 
 let find_and_execute_tool
@@ -570,20 +540,23 @@ let find_and_execute_tool
   =
   let tool_index = build_index tools in
   try
-    find_and_execute_tool_with_index
-      ~context
-      ~tool_index
-      ~hooks
-      ~event_bus
-      ~tracer
-      ~agent_name
-      ?correlation_id
-      ?run_id
-      ?on_hook_invoked
-      ~invocation
-      name
-      input
-    |> resolve_dispatch
+    let pending =
+      find_and_execute_tool_with_index
+        ~context
+        ~tool_index
+        ~hooks
+        ~event_bus
+        ~tracer
+        ~agent_name
+        ?correlation_id
+        ?run_id
+        ?on_hook_invoked
+        ~publish_legacy_events:true
+        ~invocation
+        name
+        input
+    in
+    pending.finish_observers () |> resolve_dispatch
   with
   | Hook_observer_raised (exn, backtrace) -> reraise_hook_observer exn backtrace
 ;;
@@ -620,7 +593,7 @@ let execute_scheduled_tool
   let invocation = Tool.Invocation.create ~tool_use_id:id ~turn:turn_count ~schedule in
   let id = Tool.Invocation.tool_use_id invocation in
   let turn_count = Tool.Invocation.turn invocation in
-  let completed_dispatch = ref None in
+  let completed_dispatch : tool_dispatch option ref = ref None in
   let first_failure = ref None in
   let record_failure failure =
     match !first_failure with
@@ -666,7 +639,8 @@ let execute_scheduled_tool
   in
   let outcome () =
     { index
-    ; completed_result = Option.map (fun dispatch -> dispatch.result) !completed_dispatch
+    ; completed_result =
+        Option.map (fun (dispatch : tool_dispatch) -> dispatch.result) !completed_dispatch
     ; failure = !first_failure
     }
   in
@@ -728,13 +702,14 @@ let execute_scheduled_tool
     | Hooks.Continue ->
       let idem_key = Durable_event.make_idempotency_key ~tool_name:name ~input in
       (try
-         let execute_effect ~tool_name ~input =
-           observe_before_completion (fun () ->
-             match on_tool_execution_started with
-             | Some callback -> callback ~invocation ~tool_name ~input
-             | None -> ());
+         let observe_started ~tool_name ~input =
+           match on_tool_execution_started with
+           | Some callback -> callback ~invocation ~tool_name ~input
+           | None -> ()
+         in
+         let begin_effect ~publish_legacy_events ~tool_name ~input =
            let t0_tool = Unix.gettimeofday () in
-           let dispatch =
+           let pending =
              find_and_execute_tool_with_index
                ~context
                ~tool_index
@@ -745,15 +720,21 @@ let execute_scheduled_tool
                ?correlation_id
                ?run_id
                ?on_hook_invoked
+               ~publish_legacy_events
                ~invocation
                tool_name
                input
            in
+           completed_dispatch
+           := Some ({ result = pending.result; deferred_failure = None } : tool_dispatch);
+           pending, (Unix.gettimeofday () -. t0_tool) *. 1000.0
+         in
+         let finish_effect pending ~tool_name =
+           let dispatch = pending.finish_observers () in
            completed_dispatch := Some dispatch;
            Option.iter
              (fun deferred -> record_failure (execution_failure_of_deferred deferred))
              dispatch.deferred_failure;
-           let duration_ms_tool = (Unix.gettimeofday () -. t0_tool) *. 1000.0 in
            observe_after_completion (fun () ->
              match on_tool_execution_finished with
              | Some callback ->
@@ -763,7 +744,7 @@ let execute_scheduled_tool
                  ~content:dispatch.result.content
                  ~is_error:(Types.tool_result_outcome_is_error dispatch.result.outcome)
              | None -> ());
-           dispatch, duration_ms_tool
+           dispatch
          in
          let dispatch =
            Tracing.with_span
@@ -793,17 +774,26 @@ let execute_scheduled_tool
                           });
                      raise Abort_tool_dispatch
                    | Ok durable_invocation ->
+                     observe_before_completion (fun () ->
+                       observe_started ~tool_name:name ~input);
                      (match
-                        Execution_agent_scope.execute
+                        Execution_agent_scope.execute_phased
                           durable_invocation
                           ~invoke:(fun ~start_child ~tool_name ~input ->
                             Execution_context.with_child_scope_factory
                               start_child
                               (fun () ->
-                                 let dispatch, _duration_ms =
-                                   execute_effect ~tool_name ~input
+                                 let pending, _duration_ms =
+                                   begin_effect
+                                     ~publish_legacy_events:false
+                                     ~tool_name
+                                     ~input
                                  in
-                                 dispatch.result.content, dispatch.result.outcome))
+                                 ( (pending.result.content, pending.result.outcome)
+                                 , fun () ->
+                                     ignore
+                                       (finish_effect pending ~tool_name : tool_dispatch)
+                                 )))
                       with
                       | Error error ->
                         (* The effect may already have returned, but without an
@@ -836,6 +826,7 @@ let execute_scheduled_tool
                         dispatch))
                 | None ->
                   observe_before_completion (fun () ->
+                    observe_started ~tool_name:name ~input;
                     match journal with
                     | Some j ->
                       Agent_execution_event_writer.append
@@ -848,9 +839,10 @@ let execute_scheduled_tool
                            ; timestamp = Unix.gettimeofday ()
                            })
                     | None -> ());
-                  let dispatch, duration_ms_tool =
-                    execute_effect ~tool_name:name ~input
+                  let pending, duration_ms_tool =
+                    begin_effect ~publish_legacy_events:true ~tool_name:name ~input
                   in
+                  let dispatch = finish_effect pending ~tool_name:name in
                   observe_after_completion (fun () ->
                     match journal with
                     | Some j ->

--- a/lib/agent/agent_tools.mli
+++ b/lib/agent/agent_tools.mli
@@ -73,11 +73,15 @@ type execution_error =
     Ordinary observer failures are values at this boundary so every sibling
     already running in the same concurrent batch can finish.  The pipeline
     re-raises [Observer_failure] with the captured backtrace only after it has
-    committed [completed_results]. If a hook failure happened first, a later
-    observer failure remains the terminal cause so infrastructure faults are
-    never hidden; the hook failure is logged as suppressed. *)
+    committed [completed_results]. Failures are selected across the whole batch:
+    durability dominates observer failure, which dominates hook failure. Equal
+    priorities preserve original [ToolUse] order. *)
 type execution_failure_cause =
   | Hook_failure of execution_error
+  | Durability_failure of
+      { invocation : Tool.Invocation.t
+      ; detail : string
+      }
   | Observer_failure of
       { invocation : Tool.Invocation.t (** Exact occurrence whose observer failed. *)
       ; exception_ : exn
@@ -150,6 +154,14 @@ val find_and_execute_tool
     [Block] produces a model-visible deterministic result without emitting
     tool-execution lifecycle callbacks or durable events, because no tool ran.
 
+    When [execution_provider] is supplied, its recursive execution journal is
+    the sole tool-effect authority: OAS durably opens the exact invocation and
+    commits an attempt before the handler, atomically settles the exact result,
+    and replays a settled result without rerunning observers or the handler.
+    Legacy [journal] Tool_called/Tool_completed projections are suppressed on
+    this path. A durability failure dominates hook and observer failures because
+    effect-outcome truth must not be hidden.
+
     On success, returns one [tool_execution_result] per [ToolUse] block in the
     same relative order as the input. On failure, [completed_results] retains
     every completed result in that order alongside the terminal cause. Serial
@@ -161,6 +173,7 @@ val execute_tools
   -> hooks:Hooks.hooks
   -> event_bus:Event_bus.t option
   -> ?journal:Durable_event.journal
+  -> ?execution_provider:Execution_agent_scope.provider_attempt
   -> tracer:Tracing.t
   -> agent_name:string
   -> turn_count:int

--- a/lib/agent/agent_tools.mli
+++ b/lib/agent/agent_tools.mli
@@ -154,7 +154,7 @@ val find_and_execute_tool
     [Block] produces a model-visible deterministic result without emitting
     tool-execution lifecycle callbacks or durable events, because no tool ran.
 
-    When [execution_provider] is supplied, its recursive execution journal is
+    When an Agent-owned execution provider is bound internally, its recursive execution journal is
     the sole tool-effect authority: OAS durably opens the exact invocation and
     commits an attempt before the handler, atomically settles the exact result,
     and replays a settled result without rerunning observers or the handler.
@@ -173,7 +173,6 @@ val execute_tools
   -> hooks:Hooks.hooks
   -> event_bus:Event_bus.t option
   -> ?journal:Durable_event.journal
-  -> ?execution_provider:Execution_agent_scope.provider_attempt
   -> tracer:Tracing.t
   -> agent_name:string
   -> turn_count:int

--- a/lib/agent/agent_trace.ml
+++ b/lib/agent/agent_trace.ml
@@ -39,7 +39,7 @@ let invoke_hook_with_trace agent ?raw_trace_run ~hook_name hook_opt event =
        decision)
 ;;
 
-let execute_tools_with_trace ?execution_provider agent active_run tool_uses =
+let execute_tools_with_trace agent active_run tool_uses =
   let correlation_id = Option.bind agent.options.raw_trace Raw_trace.session_id in
   let run_id = Option.map Raw_trace.active_run_id active_run in
   let tools = Tool_set.to_list agent.tools in
@@ -94,7 +94,6 @@ let execute_tools_with_trace ?execution_provider agent active_run tool_uses =
     ~hooks:agent.options.hooks
     ~event_bus:agent.options.event_bus
     ?journal:agent.options.journal
-    ?execution_provider
     ~tracer:agent.options.tracer
     ~agent_name:agent.state.config.name
     ~turn_count:agent.state.turn_count

--- a/lib/agent/agent_trace.ml
+++ b/lib/agent/agent_trace.ml
@@ -39,7 +39,7 @@ let invoke_hook_with_trace agent ?raw_trace_run ~hook_name hook_opt event =
        decision)
 ;;
 
-let execute_tools_with_trace agent active_run tool_uses =
+let execute_tools_with_trace ?execution_provider agent active_run tool_uses =
   let correlation_id = Option.bind agent.options.raw_trace Raw_trace.session_id in
   let run_id = Option.map Raw_trace.active_run_id active_run in
   let tools = Tool_set.to_list agent.tools in
@@ -94,6 +94,7 @@ let execute_tools_with_trace agent active_run tool_uses =
     ~hooks:agent.options.hooks
     ~event_bus:agent.options.event_bus
     ?journal:agent.options.journal
+    ?execution_provider
     ~tracer:agent.options.tracer
     ~agent_name:agent.state.config.name
     ~turn_count:agent.state.turn_count

--- a/lib/agent/agent_trace.mli
+++ b/lib/agent/agent_trace.mli
@@ -36,8 +36,7 @@ val invoke_hook_with_trace
     events, lifecycle updates). Delegates to [Agent_tools.execute_tools],
     retaining completed results when a trace observer fails. *)
 val execute_tools_with_trace
-  :  ?execution_provider:Execution_agent_scope.provider_attempt
-  -> t
+  :  t
   -> Raw_trace.active_run option
   -> Types.content_block list
   -> (Agent_tools.tool_execution_result list, Agent_tools.execution_failure) result

--- a/lib/agent/agent_trace.mli
+++ b/lib/agent/agent_trace.mli
@@ -36,7 +36,8 @@ val invoke_hook_with_trace
     events, lifecycle updates). Delegates to [Agent_tools.execute_tools],
     retaining completed results when a trace observer fails. *)
 val execute_tools_with_trace
-  :  t
+  :  ?execution_provider:Execution_agent_scope.provider_attempt
+  -> t
   -> Raw_trace.active_run option
   -> Types.content_block list
   -> (Agent_tools.tool_execution_result list, Agent_tools.execution_failure) result

--- a/lib/dune
+++ b/lib/dune
@@ -15,6 +15,7 @@
   execution_event_store
   execution_journal
   execution_lane_writer
+  execution_agent_scope
   execution_tool_settlement
   agent_execution_event_writer)
  (libraries

--- a/lib/dune
+++ b/lib/dune
@@ -17,6 +17,12 @@
   execution_lane_writer
   execution_agent_scope
   execution_tool_settlement
+  execution_context
+  agent_input
+  agent_tool_execution_types
+  agent_execution_runner
+  pipeline_checkpoint
+  pipeline_execution_scope
   agent_execution_event_writer)
  (libraries
   llm_provider

--- a/lib/dune
+++ b/lib/dune
@@ -15,6 +15,7 @@
   execution_event_store
   execution_journal
   execution_lane_writer
+  execution_tool_settlement
   agent_execution_event_writer)
  (libraries
   llm_provider

--- a/lib/dune
+++ b/lib/dune
@@ -23,6 +23,7 @@
   agent_execution_runner
   pipeline_checkpoint
   pipeline_execution_scope
+  pipeline_execution_resume
   agent_execution_event_writer)
  (libraries
   llm_provider

--- a/lib/execution_agent_scope.ml
+++ b/lib/execution_agent_scope.ml
@@ -3,6 +3,7 @@ module Journal = Execution_journal
 module Settlement = Execution_tool_settlement
 module Writer = Execution_lane_writer
 module Tx = Journal.Transaction
+module Json = Execution_json
 
 type t =
   { writer : Writer.t
@@ -19,13 +20,15 @@ type provider_attempt =
   ; node : Event.Node_id.t
   }
 
+type scope_locator = { run_id : Event.Run_id.t }
+
 type invocation_locator =
-  { node : Event.Node_id.t
-  ; occurrence : Tool.Invocation.t
+  { run_id : Event.Run_id.t
+  ; node : Event.Node_id.t
   }
 
 type invocation =
-  { authority : Settlement.t
+  { durable : Settlement.durable_invocation
   ; locator : invocation_locator
   }
 
@@ -40,6 +43,9 @@ type error =
   | Admission_failed of Writer.submit_error
   | Mutation_failed of Writer.ticket_error
   | Invalid_provider_attempt of string
+  | Scope_unavailable of Writer.read_error
+  | Run_not_found
+  | Invocation_locator_mismatch
   | Settlement_failed of Settlement.error
 
 let settlement_error_to_string = function
@@ -60,7 +66,70 @@ let error_to_string = function
   | Admission_failed error -> Writer.submit_error_to_string error
   | Mutation_failed error -> Writer.ticket_error_to_string error
   | Invalid_provider_attempt detail -> "invalid provider attempt: " ^ detail
+  | Scope_unavailable error -> Writer.read_error_to_string error
+  | Run_not_found -> "execution run was not found"
+  | Invocation_locator_mismatch ->
+    "execution invocation locator does not match durable topology"
   | Settlement_failed error -> settlement_error_to_string error
+;;
+
+let locator_version = 1
+
+let require_locator_version fields =
+  match Json.int_field "version" fields with
+  | Ok version when version = locator_version -> Ok ()
+  | Ok version ->
+    Error (Printf.sprintf "unsupported execution locator version %d" version)
+  | Error _ as error -> error
+;;
+
+let scope_locator scope = { run_id = Journal.run_id scope.run }
+
+let scope_locator_to_yojson (locator : scope_locator) =
+  `Assoc
+    [ "version", `Int locator_version
+    ; "run_id", `String (Event.Run_id.to_string locator.run_id)
+    ]
+;;
+
+let scope_locator_of_yojson json =
+  let open Result_syntax in
+  let* fields =
+    Json.object_fields
+      ~context:"execution scope locator"
+      ~required:[ "version"; "run_id" ]
+      ~optional:[]
+      json
+  in
+  let* () = require_locator_version fields in
+  let* run_id = Json.string_field "run_id" fields in
+  let+ run_id = Event.Run_id.of_string run_id in
+  { run_id }
+;;
+
+let invocation_locator_to_yojson (locator : invocation_locator) =
+  `Assoc
+    [ "version", `Int locator_version
+    ; "run_id", `String (Event.Run_id.to_string locator.run_id)
+    ; "node_id", `String (Event.Node_id.to_string locator.node)
+    ]
+;;
+
+let invocation_locator_of_yojson json =
+  let open Result_syntax in
+  let* fields =
+    Json.object_fields
+      ~context:"execution invocation locator"
+      ~required:[ "version"; "run_id"; "node_id" ]
+      ~optional:[]
+      json
+  in
+  let* () = require_locator_version fields in
+  let* run_id_text = Json.string_field "run_id" fields in
+  let* run_id = Event.Run_id.of_string run_id_text in
+  let* node_text = Json.string_field "node_id" fields in
+  let+ node = Event.Node_id.of_string node_text in
+  { run_id; node }
 ;;
 
 let transact writer transaction =
@@ -86,6 +155,13 @@ let transact_cleanup writer transaction =
 let start ~writer ~agent_name =
   transact writer (Tx.start_run ~agent_name ())
   |> Result.map (fun (run, _event) -> { writer; run })
+;;
+
+let resume ~writer (locator : scope_locator) =
+  match Writer.find_run writer locator.run_id with
+  | Error error -> Error (Scope_unavailable error)
+  | Ok None -> Error Run_not_found
+  | Ok (Some view) -> Ok { writer; run = view.Journal.run }
 ;;
 
 let open_turn scope ~ordinal =
@@ -124,22 +200,29 @@ let open_invocation provider ~invocation ~tool_name ~input =
   with
   | Error _ as error -> error
   | Ok (node, _events) ->
-    let locator = { node; occurrence = invocation } in
-    Settlement.create ~writer:scope.writer ~invocation_node:node ~invocation
-    |> Result.map (fun authority -> { authority; locator })
+    let locator = { run_id = Journal.run_id scope.run; node } in
+    Settlement.rebind ~writer:scope.writer ~invocation_node:node
+    |> Result.map (fun durable -> { durable; locator })
     |> Result.map_error (fun error -> Settlement_failed error)
 ;;
 
 let invocation_locator invocation = invocation.locator
 
-let rebind_invocation ~writer locator =
-  Settlement.create ~writer ~invocation_node:locator.node ~invocation:locator.occurrence
-  |> Result.map (fun authority -> { authority; locator })
-  |> Result.map_error (fun error -> Settlement_failed error)
+let rebind_invocation scope locator =
+  if not (Event.Run_id.equal locator.run_id (Journal.run_id scope.run))
+  then Error Invocation_locator_mismatch
+  else (
+    match Settlement.rebind ~writer:scope.writer ~invocation_node:locator.node with
+    | Error error -> Error (Settlement_failed error)
+    | Ok durable ->
+      if Event.Run_id.equal durable.run_id locator.run_id
+      then Ok { durable; locator }
+      else Error Invocation_locator_mismatch)
 ;;
 
 let execute invocation ~invoke =
-  Settlement.execute invocation.authority ~invoke
+  Settlement.execute invocation.durable.authority ~invoke:(fun () ->
+    invoke ~tool_name:invocation.durable.tool_name ~input:invocation.durable.input)
   |> Result.map_error (fun error -> Settlement_failed error)
 ;;
 

--- a/lib/execution_agent_scope.ml
+++ b/lib/execution_agent_scope.ml
@@ -63,6 +63,7 @@ type error =
       ; actual : string
       }
   | Invocation_locator_mismatch
+  | Resume_topology_mismatch of string
   | Invalid_tool_result
   | Settlement_failed of Settlement.error
 
@@ -93,6 +94,7 @@ let error_to_string = function
       actual
   | Invocation_locator_mismatch ->
     "execution invocation locator does not match durable topology"
+  | Resume_topology_mismatch detail -> "execution resume topology mismatch: " ^ detail
   | Invalid_tool_result -> "execution settlement returned an invalid ToolResult"
   | Settlement_failed error -> settlement_error_to_string error
 ;;
@@ -186,18 +188,21 @@ let resume ~writer ~agent_name (locator : scope_locator) =
   | Error error -> Error (Scope_unavailable error)
   | Ok None -> Error Run_not_found
   | Ok (Some view) ->
-    (match Event.node_kind view.Journal.opened.value with
-     | Event.Agent_run { agent_name = durable_agent_name }
+    (match Event.node_kind view.Journal.opened.value, view.status with
+     | Event.Agent_run { agent_name = durable_agent_name }, Journal.Running
        when String.equal agent_name durable_agent_name ->
        Ok { writer; run = view.Journal.run }
-     | Event.Agent_run { agent_name = durable_agent_name } ->
+     | Event.Agent_run { agent_name = durable_agent_name }, Journal.Running ->
        Error
          (Agent_identity_mismatch { expected = durable_agent_name; actual = agent_name })
-     | Event.Agent_turn _
-     | Event.Provider_attempt _
-     | Event.Output_block _
-     | Event.Tool_invocation _
-     | Event.Tool_attempt -> Error Run_not_found)
+     | Event.Agent_run _, Journal.Finished _ ->
+       Error (Resume_topology_mismatch "execution run is already terminal")
+     | ( ( Event.Agent_turn _
+         | Event.Provider_attempt _
+         | Event.Output_block _
+         | Event.Tool_invocation _
+         | Event.Tool_attempt )
+       , (Journal.Running | Journal.Finished _) ) -> Error Run_not_found)
 ;;
 
 let open_turn scope ~ordinal =
@@ -211,6 +216,37 @@ let open_turn scope ~ordinal =
   |> Result.map (fun (node, _event) -> { scope; node })
 ;;
 
+let resume_turn scope ~ordinal =
+  match Writer.find_node scope.writer (Journal.run_root scope.run) with
+  | Error error -> Error (Scope_unavailable error)
+  | Ok None -> Error Run_not_found
+  | Ok (Some root) ->
+    let matching =
+      List.filter_map
+        (fun (child : Event.node Journal.event_record) ->
+           match Event.node_kind child.value with
+           | Event.Agent_turn { ordinal = existing } when existing = ordinal ->
+             Some (Event.node_id child.value)
+           | Event.Agent_run _
+           | Event.Agent_turn _
+           | Event.Provider_attempt _
+           | Event.Output_block _
+           | Event.Tool_invocation _
+           | Event.Tool_attempt -> None)
+        root.children
+    in
+    (match matching with
+     | [] -> Ok None
+     | [ node ] ->
+       (match Writer.find_node scope.writer node with
+        | Error error -> Error (Scope_unavailable error)
+        | Ok None -> Error (Resume_topology_mismatch "turn child disappeared")
+        | Ok (Some { status = Journal.Open; _ }) -> Ok (Some { scope; node })
+        | Ok (Some { status = Journal.Closed _; _ }) ->
+          Error (Resume_topology_mismatch "requested turn is already closed"))
+     | _ :: _ :: _ -> Error (Resume_topology_mismatch "duplicate turn ordinal"))
+;;
+
 let open_provider_attempt turn ~ordinal binding =
   match Event.provider_attempt ~ordinal binding with
   | Error detail -> Error (Invalid_provider_attempt detail)
@@ -219,6 +255,36 @@ let open_provider_attempt turn ~ordinal binding =
       turn.scope.writer
       (Tx.open_node ~run:turn.scope.run ~parent:turn.node ~kind ())
     |> Result.map (fun (node, _event) -> { turn; node })
+;;
+
+let resume_provider_attempt (turn : turn) =
+  match Writer.find_node turn.scope.writer turn.node with
+  | Error error -> Error (Scope_unavailable error)
+  | Ok None -> Error (Resume_topology_mismatch "turn node disappeared")
+  | Ok (Some view) ->
+    let providers =
+      List.filter_map
+        (fun (child : Event.node Journal.event_record) ->
+           match Event.node_kind child.value with
+           | Event.Provider_attempt _ -> Some (Event.node_id child.value)
+           | Event.Agent_run _
+           | Event.Agent_turn _
+           | Event.Output_block _
+           | Event.Tool_invocation _
+           | Event.Tool_attempt -> None)
+        view.children
+    in
+    (match providers with
+     | [] -> Ok None
+     | [ node ] ->
+       (match Writer.find_node turn.scope.writer node with
+        | Error error -> Error (Scope_unavailable error)
+        | Ok None -> Error (Resume_topology_mismatch "provider child disappeared")
+        | Ok (Some { status = Journal.Open; _ }) -> Ok (Some { turn; node })
+        | Ok (Some { status = Journal.Closed _; _ }) ->
+          Error (Resume_topology_mismatch "requested provider attempt is already closed"))
+     | _ :: _ :: _ ->
+       Error (Resume_topology_mismatch "multiple provider attempts remain open"))
 ;;
 
 let open_invocation provider ~invocation ~tool_name ~input =
@@ -254,6 +320,92 @@ let rebind_invocation scope locator =
       if Event.Run_id.equal durable.run_id locator.run_id
       then Ok { durable; locator; scope }
       else Error Invocation_locator_mismatch)
+;;
+
+let invocation_equal left right =
+  String.equal (Tool.Invocation.tool_use_id left) (Tool.Invocation.tool_use_id right)
+  && Tool.Invocation.turn left = Tool.Invocation.turn right
+  && Execution_tool_schedule.equal
+       (Tool.Invocation.schedule left)
+       (Tool.Invocation.schedule right)
+;;
+
+let find_invocation provider ~invocation ~tool_name ~input =
+  let scope = provider.turn.scope in
+  match Writer.find_node scope.writer provider.node with
+  | Error error -> Error (Scope_unavailable error)
+  | Ok None -> Error (Resume_topology_mismatch "provider attempt disappeared")
+  | Ok (Some view) ->
+    let planned_index = Tool.Invocation.planned_index invocation in
+    let matching =
+      List.filter_map
+        (fun (child : Event.node Journal.event_record) ->
+           match Event.node_kind child.value with
+           | Event.Tool_invocation { schedule; _ }
+             when schedule.planned_index = planned_index ->
+             Some (Event.node_id child.value)
+           | Event.Agent_run _
+           | Event.Agent_turn _
+           | Event.Provider_attempt _
+           | Event.Output_block _
+           | Event.Tool_invocation _
+           | Event.Tool_attempt -> None)
+        view.children
+    in
+    (match matching with
+     | [] -> Ok None
+     | [ node ] ->
+       let locator = { run_id = Journal.run_id scope.run; node } in
+       (match rebind_invocation scope locator with
+        | Error _ as error -> error
+        | Ok rebound
+          when invocation_equal rebound.durable.invocation invocation
+               && String.equal rebound.durable.tool_name tool_name
+               && Yojson.Safe.equal rebound.durable.input input -> Ok (Some rebound)
+        | Ok _ ->
+          Error
+            (Resume_topology_mismatch
+               "tool occurrence identity differs from the restored Agent checkpoint"))
+     | _ :: _ :: _ -> Error (Resume_topology_mismatch "duplicate tool occurrence"))
+;;
+
+let provider_invocations_settled provider =
+  match Writer.find_node provider.turn.scope.writer provider.node with
+  | Error error -> Error (Scope_unavailable error)
+  | Ok None -> Error (Resume_topology_mismatch "provider attempt disappeared")
+  | Ok (Some view) ->
+    let invocation_nodes =
+      List.filter_map
+        (fun (child : Event.node Journal.event_record) ->
+           match Event.node_kind child.value with
+           | Event.Tool_invocation _ -> Some (Event.node_id child.value)
+           | Event.Agent_run _
+           | Event.Agent_turn _
+           | Event.Provider_attempt _
+           | Event.Output_block _
+           | Event.Tool_attempt -> None)
+        view.children
+    in
+    let rec all_settled = function
+      | [] -> Ok true
+      | node :: rest ->
+        (match Writer.find_node provider.turn.scope.writer node with
+         | Error error -> Error (Scope_unavailable error)
+         | Ok None -> Error (Resume_topology_mismatch "tool invocation disappeared")
+         | Ok
+             (Some
+                { materialized = Journal.Tool_invocation_state { result = Some _; _ }; _ })
+           -> all_settled rest
+         | Ok
+             (Some
+                { materialized = Journal.Tool_invocation_state { result = None; _ }; _ })
+           -> Ok false
+         | Ok (Some _) ->
+           Error (Resume_topology_mismatch "provider child changed node kind"))
+    in
+    (match invocation_nodes with
+     | [] -> Ok false
+     | nodes -> all_settled nodes)
 ;;
 
 let tool_result_of_block durable = function

--- a/lib/execution_agent_scope.ml
+++ b/lib/execution_agent_scope.ml
@@ -279,24 +279,29 @@ let tool_result_of_block durable = function
   | Llm_provider.Types.Audio _ -> Error Invalid_tool_result
 ;;
 
-let execute invocation ~invoke =
+let execute_phased invocation ~invoke =
   let durable = invocation.durable in
   let settled =
-    Settlement.execute_with_attempt durable.authority ~invoke:(fun parent_attempt ->
-      let start_child ~agent_name =
-        transact invocation.scope.writer (Tx.start_run ~parent_attempt ~agent_name ())
-        |> Result.map (fun (run, _event) -> { writer = invocation.scope.writer; run })
-      in
-      let content, outcome =
-        invoke ~start_child ~tool_name:durable.tool_name ~input:durable.input
-      in
-      Llm_provider.Types.ToolResult
-        { tool_use_id = Tool.Invocation.tool_use_id durable.invocation
-        ; content
-        ; outcome
-        ; json = None
-        ; content_blocks = None
-        })
+    Settlement.execute_with_attempt_phased
+      durable.authority
+      ~invoke:(fun parent_attempt ->
+        let start_child ~agent_name =
+          transact invocation.scope.writer (Tx.start_run ~parent_attempt ~agent_name ())
+          |> Result.map (fun (run, _event) -> { writer = invocation.scope.writer; run })
+        in
+        let (content, outcome), after_settle =
+          invoke ~start_child ~tool_name:durable.tool_name ~input:durable.input
+        in
+        Settlement.phased_effect
+          ~result:
+            (Llm_provider.Types.ToolResult
+               { tool_use_id = Tool.Invocation.tool_use_id durable.invocation
+               ; content
+               ; outcome
+               ; json = None
+               ; content_blocks = None
+               })
+          ~after_settle)
     |> Result.map_error (fun error -> Settlement_failed error)
   in
   match settled with
@@ -306,6 +311,11 @@ let execute invocation ~invoke =
     |> Result.map (fun result -> Executed (result, through, event_count))
   | Ok (Settlement.Replayed block) ->
     tool_result_of_block durable block |> Result.map (fun result -> Replayed result)
+;;
+
+let execute invocation ~invoke =
+  execute_phased invocation ~invoke:(fun ~start_child ~tool_name ~input ->
+    invoke ~start_child ~tool_name ~input, Fun.id)
 ;;
 
 let close_node writer node terminal =

--- a/lib/execution_agent_scope.ml
+++ b/lib/execution_agent_scope.ml
@@ -188,21 +188,30 @@ let resume ~writer ~agent_name (locator : scope_locator) =
   | Error error -> Error (Scope_unavailable error)
   | Ok None -> Error Run_not_found
   | Ok (Some view) ->
-    (match Event.node_kind view.Journal.opened.value, view.status with
-     | Event.Agent_run { agent_name = durable_agent_name }, Journal.Running
+    (match Event.node_kind view.Journal.opened.value with
+     | Event.Agent_run { agent_name = durable_agent_name }
        when String.equal agent_name durable_agent_name ->
        Ok { writer; run = view.Journal.run }
-     | Event.Agent_run { agent_name = durable_agent_name }, Journal.Running ->
+     | Event.Agent_run { agent_name = durable_agent_name } ->
        Error
          (Agent_identity_mismatch { expected = durable_agent_name; actual = agent_name })
-     | Event.Agent_run _, Journal.Finished _ ->
+     | Event.Agent_turn _
+     | Event.Provider_attempt _
+     | Event.Output_block _
+     | Event.Tool_invocation _
+     | Event.Tool_attempt -> Error Run_not_found)
+;;
+
+let resume_running ~writer ~agent_name locator =
+  match resume ~writer ~agent_name locator with
+  | Error _ as error -> error
+  | Ok scope ->
+    (match Writer.find_run writer locator.run_id with
+     | Error error -> Error (Scope_unavailable error)
+     | Ok (Some { status = Journal.Running; _ }) -> Ok scope
+     | Ok (Some { status = Journal.Finished _; _ }) ->
        Error (Resume_topology_mismatch "execution run is already terminal")
-     | ( ( Event.Agent_turn _
-         | Event.Provider_attempt _
-         | Event.Output_block _
-         | Event.Tool_invocation _
-         | Event.Tool_attempt )
-       , (Journal.Running | Journal.Finished _) ) -> Error Run_not_found)
+     | Ok None -> Error Run_not_found)
 ;;
 
 let open_turn scope ~ordinal =

--- a/lib/execution_agent_scope.ml
+++ b/lib/execution_agent_scope.ml
@@ -1,0 +1,168 @@
+module Event = Execution_event
+module Journal = Execution_journal
+module Settlement = Execution_tool_settlement
+module Writer = Execution_lane_writer
+module Tx = Journal.Transaction
+
+type t =
+  { writer : Writer.t
+  ; run : Journal.run
+  }
+
+type turn =
+  { scope : t
+  ; node : Event.Node_id.t
+  }
+
+type provider_attempt =
+  { turn : turn
+  ; node : Event.Node_id.t
+  }
+
+type invocation_locator =
+  { node : Event.Node_id.t
+  ; occurrence : Tool.Invocation.t
+  }
+
+type invocation =
+  { authority : Settlement.t
+  ; locator : invocation_locator
+  }
+
+type abort_reason =
+  | Failed of Event.failure
+  | Cancelled of
+      { reason : string option
+      ; data : Yojson.Safe.t option
+      }
+
+type error =
+  | Admission_failed of Writer.submit_error
+  | Mutation_failed of Writer.ticket_error
+  | Invalid_provider_attempt of string
+  | Settlement_failed of Settlement.error
+
+let settlement_error_to_string = function
+  | Settlement.Authority_unavailable error -> Writer.read_error_to_string error
+  | Settlement.Invocation_not_found -> "execution invocation was not found"
+  | Settlement.Invocation_identity_mismatch ->
+    "execution invocation identity does not match its durable topology"
+  | Settlement.Effect_outcome_unknown -> "tool effect outcome is unknown"
+  | Settlement.Attempt_admission_failed error -> Writer.submit_error_to_string error
+  | Settlement.Attempt_commit_failed error -> Writer.ticket_error_to_string error
+  | Settlement.Receipt_admission_outcome_unknown error ->
+    Writer.submit_error_to_string error
+  | Settlement.Receipt_settlement_outcome_unknown error ->
+    Writer.ticket_error_to_string error
+;;
+
+let error_to_string = function
+  | Admission_failed error -> Writer.submit_error_to_string error
+  | Mutation_failed error -> Writer.ticket_error_to_string error
+  | Invalid_provider_attempt detail -> "invalid provider attempt: " ^ detail
+  | Settlement_failed error -> settlement_error_to_string error
+;;
+
+let transact writer transaction =
+  Eio.Fiber.check ();
+  match Writer.submit writer transaction with
+  | Error error -> Error (Admission_failed error)
+  | Ok ticket ->
+    (match Eio.Cancel.protect (fun () -> Writer.await ticket) with
+     | Error error -> Error (Mutation_failed error)
+     | Ok receipt -> Ok receipt.value)
+;;
+
+let transact_cleanup writer transaction =
+  Eio.Cancel.protect (fun () ->
+    match Writer.submit writer transaction with
+    | Error error -> Error (Admission_failed error)
+    | Ok ticket ->
+      (match Writer.await ticket with
+       | Error error -> Error (Mutation_failed error)
+       | Ok receipt -> Ok receipt.value))
+;;
+
+let start ~writer ~agent_name =
+  transact writer (Tx.start_run ~agent_name ())
+  |> Result.map (fun (run, _event) -> { writer; run })
+;;
+
+let open_turn scope ~ordinal =
+  transact
+    scope.writer
+    (Tx.open_node
+       ~run:scope.run
+       ~parent:(Journal.run_root scope.run)
+       ~kind:(Event.Agent_turn { ordinal })
+       ())
+  |> Result.map (fun (node, _event) -> { scope; node })
+;;
+
+let open_provider_attempt turn ~ordinal binding =
+  match Event.provider_attempt ~ordinal binding with
+  | Error detail -> Error (Invalid_provider_attempt detail)
+  | Ok kind ->
+    transact
+      turn.scope.writer
+      (Tx.open_node ~run:turn.scope.run ~parent:turn.node ~kind ())
+    |> Result.map (fun (node, _event) -> { turn; node })
+;;
+
+let open_invocation provider ~invocation ~tool_name ~input =
+  let scope = provider.turn.scope in
+  match
+    transact
+      scope.writer
+      (Tx.open_tool_invocation
+         ~run:scope.run
+         ~provider_attempt:provider.node
+         ~invocation
+         ~tool_name
+         ~input
+         ())
+  with
+  | Error _ as error -> error
+  | Ok (node, _events) ->
+    let locator = { node; occurrence = invocation } in
+    Settlement.create ~writer:scope.writer ~invocation_node:node ~invocation
+    |> Result.map (fun authority -> { authority; locator })
+    |> Result.map_error (fun error -> Settlement_failed error)
+;;
+
+let invocation_locator invocation = invocation.locator
+
+let rebind_invocation ~writer locator =
+  Settlement.create ~writer ~invocation_node:locator.node ~invocation:locator.occurrence
+  |> Result.map (fun authority -> { authority; locator })
+  |> Result.map_error (fun error -> Settlement_failed error)
+;;
+
+let execute invocation ~invoke =
+  Settlement.execute invocation.authority ~invoke
+  |> Result.map_error (fun error -> Settlement_failed error)
+;;
+
+let close_node writer node terminal =
+  transact writer (Tx.close_node ~node terminal) |> Result.map ignore
+;;
+
+let close_provider_attempt provider terminal =
+  close_node provider.turn.scope.writer provider.node terminal
+;;
+
+let close_turn turn terminal = close_node turn.scope.writer turn.node terminal
+
+let finish scope terminal =
+  transact scope.writer (Tx.finish_run ~run:scope.run terminal) |> Result.map ignore
+;;
+
+let abort scope reason =
+  let terminal =
+    match reason with
+    | Failed failure -> Event.Failed failure
+    | Cancelled { reason; data } -> Event.Cancelled { reason; data }
+  in
+  transact_cleanup scope.writer (Tx.abort_run ~run:scope.run terminal)
+  |> Result.map ignore
+;;

--- a/lib/execution_agent_scope.ml
+++ b/lib/execution_agent_scope.ml
@@ -32,6 +32,18 @@ type invocation =
   ; locator : invocation_locator
   }
 
+type tool_result =
+  { invocation : Tool.Invocation.t
+  ; tool_name : string
+  ; input : Yojson.Safe.t
+  ; content : string
+  ; outcome : Llm_provider.Types.tool_result_outcome
+  }
+
+type execution =
+  | Executed of tool_result * Journal.cursor * int
+  | Replayed of tool_result
+
 type abort_reason =
   | Failed of Event.failure
   | Cancelled of
@@ -46,6 +58,7 @@ type error =
   | Scope_unavailable of Writer.read_error
   | Run_not_found
   | Invocation_locator_mismatch
+  | Invalid_tool_result
   | Settlement_failed of Settlement.error
 
 let settlement_error_to_string = function
@@ -70,6 +83,7 @@ let error_to_string = function
   | Run_not_found -> "execution run was not found"
   | Invocation_locator_mismatch ->
     "execution invocation locator does not match durable topology"
+  | Invalid_tool_result -> "execution settlement returned an invalid ToolResult"
   | Settlement_failed error -> settlement_error_to_string error
 ;;
 
@@ -220,10 +234,50 @@ let rebind_invocation scope locator =
       else Error Invocation_locator_mismatch)
 ;;
 
+let tool_result_of_block durable = function
+  | Llm_provider.Types.ToolResult { tool_use_id; content; outcome; _ }
+    when String.equal
+           tool_use_id
+           (Tool.Invocation.tool_use_id durable.Settlement.invocation) ->
+    Ok
+      { invocation = durable.invocation
+      ; tool_name = durable.tool_name
+      ; input = durable.input
+      ; content
+      ; outcome
+      }
+  | Llm_provider.Types.Text _
+  | Llm_provider.Types.Thinking _
+  | Llm_provider.Types.ReasoningDetails _
+  | Llm_provider.Types.RedactedThinking _
+  | Llm_provider.Types.ToolUse _
+  | Llm_provider.Types.ToolResult _
+  | Llm_provider.Types.Image _
+  | Llm_provider.Types.Document _
+  | Llm_provider.Types.Audio _ -> Error Invalid_tool_result
+;;
+
 let execute invocation ~invoke =
-  Settlement.execute invocation.durable.authority ~invoke:(fun () ->
-    invoke ~tool_name:invocation.durable.tool_name ~input:invocation.durable.input)
-  |> Result.map_error (fun error -> Settlement_failed error)
+  let durable = invocation.durable in
+  let settled =
+    Settlement.execute durable.authority ~invoke:(fun () ->
+      let content, outcome = invoke ~tool_name:durable.tool_name ~input:durable.input in
+      Llm_provider.Types.ToolResult
+        { tool_use_id = Tool.Invocation.tool_use_id durable.invocation
+        ; content
+        ; outcome
+        ; json = None
+        ; content_blocks = None
+        })
+    |> Result.map_error (fun error -> Settlement_failed error)
+  in
+  match settled with
+  | Error _ as error -> error
+  | Ok (Settlement.Executed (block, through, event_count)) ->
+    tool_result_of_block durable block
+    |> Result.map (fun result -> Executed (result, through, event_count))
+  | Ok (Settlement.Replayed block) ->
+    tool_result_of_block durable block |> Result.map (fun result -> Replayed result)
 ;;
 
 let close_node writer node terminal =

--- a/lib/execution_agent_scope.ml
+++ b/lib/execution_agent_scope.ml
@@ -30,6 +30,7 @@ type invocation_locator =
 type invocation =
   { durable : Settlement.durable_invocation
   ; locator : invocation_locator
+  ; scope : t
   }
 
 type tool_result =
@@ -57,6 +58,10 @@ type error =
   | Invalid_provider_attempt of string
   | Scope_unavailable of Writer.read_error
   | Run_not_found
+  | Agent_identity_mismatch of
+      { expected : string
+      ; actual : string
+      }
   | Invocation_locator_mismatch
   | Invalid_tool_result
   | Settlement_failed of Settlement.error
@@ -81,6 +86,11 @@ let error_to_string = function
   | Invalid_provider_attempt detail -> "invalid provider attempt: " ^ detail
   | Scope_unavailable error -> Writer.read_error_to_string error
   | Run_not_found -> "execution run was not found"
+  | Agent_identity_mismatch { expected; actual } ->
+    Printf.sprintf
+      "execution run belongs to agent %S but caller supplied %S"
+      expected
+      actual
   | Invocation_locator_mismatch ->
     "execution invocation locator does not match durable topology"
   | Invalid_tool_result -> "execution settlement returned an invalid ToolResult"
@@ -171,11 +181,23 @@ let start ~writer ~agent_name =
   |> Result.map (fun (run, _event) -> { writer; run })
 ;;
 
-let resume ~writer (locator : scope_locator) =
+let resume ~writer ~agent_name (locator : scope_locator) =
   match Writer.find_run writer locator.run_id with
   | Error error -> Error (Scope_unavailable error)
   | Ok None -> Error Run_not_found
-  | Ok (Some view) -> Ok { writer; run = view.Journal.run }
+  | Ok (Some view) ->
+    (match Event.node_kind view.Journal.opened.value with
+     | Event.Agent_run { agent_name = durable_agent_name }
+       when String.equal agent_name durable_agent_name ->
+       Ok { writer; run = view.Journal.run }
+     | Event.Agent_run { agent_name = durable_agent_name } ->
+       Error
+         (Agent_identity_mismatch { expected = durable_agent_name; actual = agent_name })
+     | Event.Agent_turn _
+     | Event.Provider_attempt _
+     | Event.Output_block _
+     | Event.Tool_invocation _
+     | Event.Tool_attempt -> Error Run_not_found)
 ;;
 
 let open_turn scope ~ordinal =
@@ -216,7 +238,7 @@ let open_invocation provider ~invocation ~tool_name ~input =
   | Ok (node, _events) ->
     let locator = { run_id = Journal.run_id scope.run; node } in
     Settlement.rebind ~writer:scope.writer ~invocation_node:node
-    |> Result.map (fun durable -> { durable; locator })
+    |> Result.map (fun durable -> { durable; locator; scope })
     |> Result.map_error (fun error -> Settlement_failed error)
 ;;
 
@@ -230,7 +252,7 @@ let rebind_invocation scope locator =
     | Error error -> Error (Settlement_failed error)
     | Ok durable ->
       if Event.Run_id.equal durable.run_id locator.run_id
-      then Ok { durable; locator }
+      then Ok { durable; locator; scope }
       else Error Invocation_locator_mismatch)
 ;;
 
@@ -260,8 +282,14 @@ let tool_result_of_block durable = function
 let execute invocation ~invoke =
   let durable = invocation.durable in
   let settled =
-    Settlement.execute durable.authority ~invoke:(fun () ->
-      let content, outcome = invoke ~tool_name:durable.tool_name ~input:durable.input in
+    Settlement.execute_with_attempt durable.authority ~invoke:(fun parent_attempt ->
+      let start_child ~agent_name =
+        transact invocation.scope.writer (Tx.start_run ~parent_attempt ~agent_name ())
+        |> Result.map (fun (run, _event) -> { writer = invocation.scope.writer; run })
+      in
+      let content, outcome =
+        invoke ~start_child ~tool_name:durable.tool_name ~input:durable.input
+      in
       Llm_provider.Types.ToolResult
         { tool_use_id = Tool.Invocation.tool_use_id durable.invocation
         ; content
@@ -288,7 +316,7 @@ let close_provider_attempt provider terminal =
   close_node provider.turn.scope.writer provider.node terminal
 ;;
 
-let close_turn turn terminal = close_node turn.scope.writer turn.node terminal
+let close_turn (turn : turn) terminal = close_node turn.scope.writer turn.node terminal
 
 let finish scope terminal =
   transact scope.writer (Tx.finish_run ~run:scope.run terminal) |> Result.map ignore

--- a/lib/execution_agent_scope.mli
+++ b/lib/execution_agent_scope.mli
@@ -39,6 +39,7 @@ type error =
       ; actual : string
       }
   | Invocation_locator_mismatch
+  | Resume_topology_mismatch of string
   | Invalid_tool_result
   | Settlement_failed of Execution_tool_settlement.error
 
@@ -55,6 +56,7 @@ val resume
   -> (t, error) result
 
 val open_turn : t -> ordinal:int -> (turn, error) result
+val resume_turn : t -> ordinal:int -> (turn option, error) result
 
 (** Materialize the exact binding selected for provider dispatch. *)
 val open_provider_attempt
@@ -63,6 +65,8 @@ val open_provider_attempt
   -> Binding_identity.t
   -> (provider_attempt, error) result
 
+val resume_provider_attempt : turn -> (provider_attempt option, error) result
+
 (** Atomically open an invocation and materialize the exact ToolUse input. *)
 val open_invocation
   :  provider_attempt
@@ -70,6 +74,15 @@ val open_invocation
   -> tool_name:string
   -> input:Yojson.Safe.t
   -> (invocation, error) result
+
+val find_invocation
+  :  provider_attempt
+  -> invocation:Tool.Invocation.t
+  -> tool_name:string
+  -> input:Yojson.Safe.t
+  -> (invocation option, error) result
+
+val provider_invocations_settled : provider_attempt -> (bool, error) result
 
 (** Stable opaque coordinates for rebinding after the writer is reopened.
     The locator contains no copied Tool name, input, turn, or schedule; those

--- a/lib/execution_agent_scope.mli
+++ b/lib/execution_agent_scope.mli
@@ -9,6 +9,18 @@ type scope_locator
 type invocation_locator
 type invocation
 
+type tool_result = private
+  { invocation : Tool.Invocation.t
+  ; tool_name : string
+  ; input : Yojson.Safe.t
+  ; content : string
+  ; outcome : Llm_provider.Types.tool_result_outcome
+  }
+
+type execution =
+  | Executed of tool_result * Execution_journal.cursor * int
+  | Replayed of tool_result
+
 type abort_reason =
   | Failed of Execution_event.failure
   | Cancelled of
@@ -23,6 +35,7 @@ type error =
   | Scope_unavailable of Execution_lane_writer.read_error
   | Run_not_found
   | Invocation_locator_mismatch
+  | Invalid_tool_result
   | Settlement_failed of Execution_tool_settlement.error
 
 val error_to_string : error -> string
@@ -60,8 +73,11 @@ val rebind_invocation : t -> invocation_locator -> (invocation, error) result
 (** Commit the attempt before the effect and atomically settle its result. *)
 val execute
   :  invocation
-  -> invoke:(tool_name:string -> input:Yojson.Safe.t -> Llm_provider.Types.content_block)
-  -> (Execution_tool_settlement.execution, error) result
+  -> invoke:
+       (tool_name:string
+        -> input:Yojson.Safe.t
+        -> string * Llm_provider.Types.tool_result_outcome)
+  -> (execution, error) result
 
 val close_provider_attempt
   :  provider_attempt

--- a/lib/execution_agent_scope.mli
+++ b/lib/execution_agent_scope.mli
@@ -1,0 +1,66 @@
+(** Private typed ownership chain for one Agent execution journal.
+    Construction requires an owned writer and never discovers paths or product
+    policy. Abstract descendants cannot be moved across another scope. *)
+
+type t
+type turn
+type provider_attempt
+type invocation_locator
+type invocation
+
+type abort_reason =
+  | Failed of Execution_event.failure
+  | Cancelled of
+      { reason : string option
+      ; data : Yojson.Safe.t option
+      }
+
+type error =
+  | Admission_failed of Execution_lane_writer.submit_error
+  | Mutation_failed of Execution_lane_writer.ticket_error
+  | Invalid_provider_attempt of string
+  | Settlement_failed of Execution_tool_settlement.error
+
+val error_to_string : error -> string
+val start : writer:Execution_lane_writer.t -> agent_name:string -> (t, error) result
+val open_turn : t -> ordinal:int -> (turn, error) result
+
+(** Materialize the exact binding selected for provider dispatch. *)
+val open_provider_attempt
+  :  turn
+  -> ordinal:int
+  -> Binding_identity.t
+  -> (provider_attempt, error) result
+
+(** Atomically open an invocation and materialize the exact ToolUse input. *)
+val open_invocation
+  :  provider_attempt
+  -> invocation:Tool.Invocation.t
+  -> tool_name:string
+  -> input:Yojson.Safe.t
+  -> (invocation, error) result
+
+(** Stable opaque coordinates for rebinding after the writer is reopened. *)
+val invocation_locator : invocation -> invocation_locator
+
+val rebind_invocation
+  :  writer:Execution_lane_writer.t
+  -> invocation_locator
+  -> (invocation, error) result
+
+(** Commit the attempt before the effect and atomically settle its result. *)
+val execute
+  :  invocation
+  -> invoke:(unit -> Llm_provider.Types.content_block)
+  -> (Execution_tool_settlement.execution, error) result
+
+val close_provider_attempt
+  :  provider_attempt
+  -> Execution_event.terminal
+  -> (unit, error) result
+
+val close_turn : turn -> Execution_event.terminal -> (unit, error) result
+val finish : t -> Execution_event.terminal -> (unit, error) result
+
+(** Atomically terminate every open descendant and the run root. *)
+val abort : t -> abort_reason -> (unit, error) result

--- a/lib/execution_agent_scope.mli
+++ b/lib/execution_agent_scope.mli
@@ -90,6 +90,17 @@ val execute
         -> string * Llm_provider.Types.tool_result_outcome)
   -> (execution, error) result
 
+(** As {!execute}, but the effect returns a callback that runs only after its
+    ToolResult is durably settled. Replayed results run neither phase. *)
+val execute_phased
+  :  invocation
+  -> invoke:
+       (start_child:(agent_name:string -> (t, error) result)
+        -> tool_name:string
+        -> input:Yojson.Safe.t
+        -> (string * Llm_provider.Types.tool_result_outcome) * (unit -> unit))
+  -> (execution, error) result
+
 val close_provider_attempt
   :  provider_attempt
   -> Execution_event.terminal

--- a/lib/execution_agent_scope.mli
+++ b/lib/execution_agent_scope.mli
@@ -34,6 +34,10 @@ type error =
   | Invalid_provider_attempt of string
   | Scope_unavailable of Execution_lane_writer.read_error
   | Run_not_found
+  | Agent_identity_mismatch of
+      { expected : string
+      ; actual : string
+      }
   | Invocation_locator_mismatch
   | Invalid_tool_result
   | Settlement_failed of Execution_tool_settlement.error
@@ -43,7 +47,13 @@ val start : writer:Execution_lane_writer.t -> agent_name:string -> (t, error) re
 val scope_locator : t -> scope_locator
 val scope_locator_to_yojson : scope_locator -> Yojson.Safe.t
 val scope_locator_of_yojson : Yojson.Safe.t -> (scope_locator, string) result
-val resume : writer:Execution_lane_writer.t -> scope_locator -> (t, error) result
+
+val resume
+  :  writer:Execution_lane_writer.t
+  -> agent_name:string
+  -> scope_locator
+  -> (t, error) result
+
 val open_turn : t -> ordinal:int -> (turn, error) result
 
 (** Materialize the exact binding selected for provider dispatch. *)
@@ -74,7 +84,8 @@ val rebind_invocation : t -> invocation_locator -> (invocation, error) result
 val execute
   :  invocation
   -> invoke:
-       (tool_name:string
+       (start_child:(agent_name:string -> (t, error) result)
+        -> tool_name:string
         -> input:Yojson.Safe.t
         -> string * Llm_provider.Types.tool_result_outcome)
   -> (execution, error) result

--- a/lib/execution_agent_scope.mli
+++ b/lib/execution_agent_scope.mli
@@ -55,6 +55,14 @@ val resume
   -> scope_locator
   -> (t, error) result
 
+(** Resume only a still-running root for public Agent execution. Terminal roots
+    remain readable through {!resume} for audit/replay inspection. *)
+val resume_running
+  :  writer:Execution_lane_writer.t
+  -> agent_name:string
+  -> scope_locator
+  -> (t, error) result
+
 val open_turn : t -> ordinal:int -> (turn, error) result
 val resume_turn : t -> ordinal:int -> (turn option, error) result
 

--- a/lib/execution_agent_scope.mli
+++ b/lib/execution_agent_scope.mli
@@ -5,6 +5,7 @@
 type t
 type turn
 type provider_attempt
+type scope_locator
 type invocation_locator
 type invocation
 
@@ -19,10 +20,17 @@ type error =
   | Admission_failed of Execution_lane_writer.submit_error
   | Mutation_failed of Execution_lane_writer.ticket_error
   | Invalid_provider_attempt of string
+  | Scope_unavailable of Execution_lane_writer.read_error
+  | Run_not_found
+  | Invocation_locator_mismatch
   | Settlement_failed of Execution_tool_settlement.error
 
 val error_to_string : error -> string
 val start : writer:Execution_lane_writer.t -> agent_name:string -> (t, error) result
+val scope_locator : t -> scope_locator
+val scope_locator_to_yojson : scope_locator -> Yojson.Safe.t
+val scope_locator_of_yojson : Yojson.Safe.t -> (scope_locator, string) result
+val resume : writer:Execution_lane_writer.t -> scope_locator -> (t, error) result
 val open_turn : t -> ordinal:int -> (turn, error) result
 
 (** Materialize the exact binding selected for provider dispatch. *)
@@ -40,18 +48,19 @@ val open_invocation
   -> input:Yojson.Safe.t
   -> (invocation, error) result
 
-(** Stable opaque coordinates for rebinding after the writer is reopened. *)
+(** Stable opaque coordinates for rebinding after the writer is reopened.
+    The locator contains no copied Tool name, input, turn, or schedule; those
+    values are reconstructed from the journal's exact durable topology. *)
 val invocation_locator : invocation -> invocation_locator
 
-val rebind_invocation
-  :  writer:Execution_lane_writer.t
-  -> invocation_locator
-  -> (invocation, error) result
+val invocation_locator_to_yojson : invocation_locator -> Yojson.Safe.t
+val invocation_locator_of_yojson : Yojson.Safe.t -> (invocation_locator, string) result
+val rebind_invocation : t -> invocation_locator -> (invocation, error) result
 
 (** Commit the attempt before the effect and atomically settle its result. *)
 val execute
   :  invocation
-  -> invoke:(unit -> Llm_provider.Types.content_block)
+  -> invoke:(tool_name:string -> input:Yojson.Safe.t -> Llm_provider.Types.content_block)
   -> (Execution_tool_settlement.execution, error) result
 
 val close_provider_attempt

--- a/lib/execution_context.ml
+++ b/lib/execution_context.ml
@@ -8,6 +8,8 @@ let provider_attempt_key : Execution_agent_scope.provider_attempt Eio.Fiber.key 
   Eio.Fiber.create_key ()
 ;;
 
+let resume_once_key : bool ref Eio.Fiber.key = Eio.Fiber.create_key ()
+
 let with_child_scope_factory factory run =
   Eio.Fiber.with_binding child_scope_factory_key factory run
 ;;
@@ -21,3 +23,13 @@ let with_provider_attempt provider run =
 ;;
 
 let provider_attempt () = Eio.Fiber.get provider_attempt_key
+let with_resume_once run = Eio.Fiber.with_binding resume_once_key (ref true) run
+
+let take_resume_once () =
+  match Eio.Fiber.get resume_once_key with
+  | None -> false
+  | Some pending ->
+    let value = !pending in
+    pending := false;
+    value
+;;

--- a/lib/execution_context.ml
+++ b/lib/execution_context.ml
@@ -1,0 +1,10 @@
+type child_scope_factory =
+  agent_name:string -> (Execution_agent_scope.t, Execution_agent_scope.error) result
+
+let child_scope_factory_key : child_scope_factory Eio.Fiber.key = Eio.Fiber.create_key ()
+
+let with_child_scope_factory factory run =
+  Eio.Fiber.with_binding child_scope_factory_key factory run
+;;
+
+let child_scope_factory () = Eio.Fiber.get child_scope_factory_key

--- a/lib/execution_context.ml
+++ b/lib/execution_context.ml
@@ -2,9 +2,22 @@ type child_scope_factory =
   agent_name:string -> (Execution_agent_scope.t, Execution_agent_scope.error) result
 
 let child_scope_factory_key : child_scope_factory Eio.Fiber.key = Eio.Fiber.create_key ()
+let agent_scope_key : Execution_agent_scope.t Eio.Fiber.key = Eio.Fiber.create_key ()
+
+let provider_attempt_key : Execution_agent_scope.provider_attempt Eio.Fiber.key =
+  Eio.Fiber.create_key ()
+;;
 
 let with_child_scope_factory factory run =
   Eio.Fiber.with_binding child_scope_factory_key factory run
 ;;
 
 let child_scope_factory () = Eio.Fiber.get child_scope_factory_key
+let with_agent_scope scope run = Eio.Fiber.with_binding agent_scope_key scope run
+let agent_scope () = Eio.Fiber.get agent_scope_key
+
+let with_provider_attempt provider run =
+  Eio.Fiber.with_binding provider_attempt_key provider run
+;;
+
+let provider_attempt () = Eio.Fiber.get provider_attempt_key

--- a/lib/execution_context.mli
+++ b/lib/execution_context.mli
@@ -14,3 +14,5 @@ val with_agent_scope : Execution_agent_scope.t -> (unit -> 'a) -> 'a
 val agent_scope : unit -> Execution_agent_scope.t option
 val with_provider_attempt : Execution_agent_scope.provider_attempt -> (unit -> 'a) -> 'a
 val provider_attempt : unit -> Execution_agent_scope.provider_attempt option
+val with_resume_once : (unit -> 'a) -> 'a
+val take_resume_once : unit -> bool

--- a/lib/execution_context.mli
+++ b/lib/execution_context.mli
@@ -1,0 +1,11 @@
+(** Private fiber-local authority for recursive Agent runs inside Tool effects. *)
+
+val with_child_scope_factory
+  :  (agent_name:string -> (Execution_agent_scope.t, Execution_agent_scope.error) result)
+  -> (unit -> 'a)
+  -> 'a
+
+val child_scope_factory
+  :  unit
+  -> (agent_name:string -> (Execution_agent_scope.t, Execution_agent_scope.error) result)
+       option

--- a/lib/execution_context.mli
+++ b/lib/execution_context.mli
@@ -9,3 +9,8 @@ val child_scope_factory
   :  unit
   -> (agent_name:string -> (Execution_agent_scope.t, Execution_agent_scope.error) result)
        option
+
+val with_agent_scope : Execution_agent_scope.t -> (unit -> 'a) -> 'a
+val agent_scope : unit -> Execution_agent_scope.t option
+val with_provider_attempt : Execution_agent_scope.provider_attempt -> (unit -> 'a) -> 'a
+val provider_attempt : unit -> Execution_agent_scope.provider_attempt option

--- a/lib/execution_journal.ml
+++ b/lib/execution_journal.ml
@@ -1370,6 +1370,73 @@ let stage_close_node ?causes journal state ~node terminal =
       payload
 ;;
 
+let stage_begin_tool_attempt journal state ~invocation =
+  let* invocation_record = node_record_or_error state invocation in
+  let* run =
+    match Event.node_kind invocation_record.node, invocation_record.children_rev with
+    | Event.Tool_invocation _, [] ->
+      let run_id = Event.node_run_id invocation_record.node in
+      (match Reducer.find_run state.reducer run_id with
+       | Some { run; status = Running; _ } -> Ok run
+       | Some { status = Finished _; _ } ->
+         Error (Invariant_violation (Run_already_finished run_id))
+       | None -> Error (Invariant_violation (Unknown_run run_id)))
+    | Event.Tool_invocation _, _ :: _ ->
+      Error (Invalid_argument "tool invocation already has an attempt")
+    | ( ( Event.Agent_run _
+        | Event.Agent_turn _
+        | Event.Provider_attempt _
+        | Event.Output_block _
+        | Event.Tool_attempt )
+      , _ ) -> Error (Invalid_argument "tool attempt requires a Tool_invocation node")
+  in
+  stage_open_node journal state ~run ~parent:invocation ~kind:Event.Tool_attempt
+;;
+
+let stage_settle_tool_attempt journal state ~attempt ~invocation ~result =
+  let* attempt_record = node_record_or_error state attempt in
+  let* () =
+    match
+      Event.node_kind attempt_record.node, Event.parent_node_id attempt_record.node
+    with
+    | Event.Tool_attempt, Some parent when Event.Node_id.equal parent invocation -> Ok ()
+    | Event.Tool_attempt, (None | Some _) ->
+      Error (Invalid_argument "tool attempt does not belong to the invocation")
+    | ( ( Event.Agent_run _
+        | Event.Agent_turn _
+        | Event.Provider_attempt _
+        | Event.Output_block _
+        | Event.Tool_invocation _ )
+      , _ ) -> Error (Invalid_argument "tool settlement requires a Tool_attempt node")
+  in
+  let* invocation_record = node_record_or_error state invocation in
+  let* () =
+    match Event.node_kind invocation_record.node with
+    | Event.Tool_invocation _ -> Ok ()
+    | Event.Agent_run _
+    | Event.Agent_turn _
+    | Event.Provider_attempt _
+    | Event.Output_block _
+    | Event.Tool_attempt ->
+      Error (Invalid_argument "tool settlement requires a Tool_invocation node")
+  in
+  let* attempt_closed = stage_close_node journal state ~node:attempt Event.Succeeded in
+  let* result_committed =
+    stage_update_node
+      journal
+      attempt_closed.next_state
+      ~node:invocation
+      (Event.Tool_result result)
+  in
+  let+ invocation_closed =
+    stage_close_node journal result_committed.next_state ~node:invocation Event.Succeeded
+  in
+  { next_state = invocation_closed.next_state
+  ; events = [ attempt_closed.value; result_committed.value; invocation_closed.value ]
+  ; value = [ attempt_closed.value; result_committed.value; invocation_closed.value ]
+  }
+;;
+
 let stage_finish_run ?causes journal state ~run terminal =
   let* event_id = identity_result (Event.Event_id.fresh ()) in
   let* terminal = payload_result (Event.validate_terminal terminal) in
@@ -1531,6 +1598,15 @@ module Transaction = struct
         ; terminal : Event.terminal
         }
         -> Event.t t
+    | Begin_tool_attempt :
+        { invocation : Event.Node_id.t }
+        -> (Event.Node_id.t * Event.t) t
+    | Settle_tool_attempt :
+        { attempt : Event.Node_id.t
+        ; invocation : Event.Node_id.t
+        ; result : Llm_provider.Types.content_block
+        }
+        -> Event.t list t
     | Finish_run :
         { causes : Event.cause list
         ; run : run
@@ -1554,6 +1630,12 @@ module Transaction = struct
 
   let update_node ?(causes = []) ~node update = Update_node { causes; node; update }
   let close_node ?(causes = []) ~node terminal = Close_node { causes; node; terminal }
+  let begin_tool_attempt ~invocation () = Begin_tool_attempt { invocation }
+
+  let settle_tool_attempt ~attempt ~invocation ~result () =
+    Settle_tool_attempt { attempt; invocation; result }
+  ;;
+
   let finish_run ?(causes = []) ~run terminal = Finish_run { causes; run; terminal }
   let abort_run ?(causes = []) ~run terminal = Abort_run { causes; run; terminal }
 end
@@ -1582,6 +1664,16 @@ let stage : type value. batch -> value Transaction.t -> (batch * value, error) r
   | Transaction.Close_node { causes; node; terminal } ->
     stage_mutation
       (stage_close_node ~causes batch.journal batch.staged_state ~node terminal)
+  | Transaction.Begin_tool_attempt { invocation } ->
+    stage_mutation (stage_begin_tool_attempt batch.journal batch.staged_state ~invocation)
+  | Transaction.Settle_tool_attempt { attempt; invocation; result } ->
+    stage_mutation
+      (stage_settle_tool_attempt
+         batch.journal
+         batch.staged_state
+         ~attempt
+         ~invocation
+         ~result)
   | Transaction.Finish_run { causes; run; terminal } ->
     stage_mutation
       (stage_finish_run ~causes batch.journal batch.staged_state ~run terminal)

--- a/lib/execution_journal.ml
+++ b/lib/execution_journal.ml
@@ -171,8 +171,10 @@ type invariant_violation =
   | Tool_input_snapshot_identity_mismatch of Event.Node_id.t
   | Tool_input_delta_after_snapshot of Event.Node_id.t
   | Tool_input_not_materialized of Event.Node_id.t
-  | Tool_occurrence_already_opened of
-      { provider_attempt : Event.Node_id.t
+  | Tool_invocation_requires_atomic_open
+  | Occurrence_already_opened of Event.Node_id.t
+  | Tool_occurrence_conflict of
+      { parent : Event.Node_id.t
       ; planned_index : int
       ; existing : Event.Node_id.t
       }
@@ -523,6 +525,60 @@ module Reducer = struct
       , _ ) -> false
   ;;
 
+  let find_child parent_record matches =
+    List.find_map
+      (fun (child : Event.node event_record) ->
+         if matches (Event.node_kind child.value)
+         then Some (Event.node_id child.value)
+         else None)
+      parent_record.children_rev
+  ;;
+
+  let ensure_occurrence_available parent_id parent_record child_kind =
+    let existing =
+      match Event.node_kind parent_record.node, child_kind with
+      | Event.Agent_run _, Event.Agent_turn { ordinal } ->
+        find_child parent_record (function
+          | Event.Agent_turn child -> child.ordinal = ordinal
+          | Event.Agent_run _
+          | Event.Provider_attempt _
+          | Event.Output_block _
+          | Event.Tool_invocation _
+          | Event.Tool_attempt -> false)
+      | Event.Agent_turn _, Event.Provider_attempt { ordinal; target = _ } ->
+        find_child parent_record (function
+          | Event.Provider_attempt child -> child.ordinal = ordinal
+          | Event.Agent_run _
+          | Event.Agent_turn _
+          | Event.Output_block _
+          | Event.Tool_invocation _
+          | Event.Tool_attempt -> false)
+      | (Event.Provider_attempt _ | Event.Tool_attempt), Event.Tool_invocation tool ->
+        find_child parent_record (function
+          | Event.Tool_invocation child ->
+            child.schedule.planned_index = tool.schedule.planned_index
+          | Event.Agent_run _
+          | Event.Agent_turn _
+          | Event.Provider_attempt _
+          | Event.Output_block _
+          | Event.Tool_attempt -> false)
+      | ( ( Event.Agent_run _
+          | Event.Agent_turn _
+          | Event.Provider_attempt _
+          | Event.Output_block _
+          | Event.Tool_invocation _
+          | Event.Tool_attempt )
+        , _ ) -> None
+    in
+    match existing, child_kind with
+    | None, _ -> Ok ()
+    | Some existing, Event.Tool_invocation { schedule; _ } ->
+      Error
+        (Tool_occurrence_conflict
+           { parent = parent_id; planned_index = schedule.planned_index; existing })
+    | Some existing, _ -> Error (Occurrence_already_opened existing)
+  ;;
+
   let validate_update (record : node_record) node_id update =
     match Event.node_kind record.node, update with
     | Event.Provider_attempt _, Event.Provider_event _ -> Ok ()
@@ -715,6 +771,9 @@ module Reducer = struct
       if parent_accepts_child (Event.node_kind parent_record.node) (Event.node_kind node)
       then Ok ()
       else Error (Invalid_parent_kind { parent = parent_id; child = node_id })
+    in
+    let* () =
+      ensure_occurrence_available parent_id parent_record (Event.node_kind node)
     in
     let* () =
       (* Ordering fences per parent kind. The match is exhaustive on parent
@@ -1459,9 +1518,35 @@ let stage_open_tool_invocation
     with
     | None -> Ok ()
     | Some existing ->
-      Error
-        (Invariant_violation
-           (Tool_occurrence_already_opened { provider_attempt; planned_index; existing }))
+      let* existing_record = node_record_or_error state existing in
+      let exact_duplicate =
+        match Event.node_kind existing_record.node, existing_record.tool_input with
+        | ( Event.Tool_invocation
+              { provider_tool_use_id; tool_name = existing_name; schedule }
+          , Some
+              (Llm_provider.Types.ToolUse
+                 { id = existing_id; name = input_name; input = existing_input }) ) ->
+          Option.equal String.equal provider_tool_use_id (Some tool_use_id)
+          && String.equal existing_name tool_name
+          && Execution_tool_schedule.equal schedule (Tool.Invocation.schedule invocation)
+          && String.equal existing_id tool_use_id
+          && String.equal input_name tool_name
+          && Yojson.Safe.equal existing_input input
+        | ( ( Event.Agent_run _
+            | Event.Agent_turn _
+            | Event.Provider_attempt _
+            | Event.Output_block _
+            | Event.Tool_attempt )
+          , _ )
+        | Event.Tool_invocation _, (None | Some _) -> false
+      in
+      if exact_duplicate
+      then Error (Invariant_violation (Occurrence_already_opened existing))
+      else
+        Error
+          (Invariant_violation
+             (Tool_occurrence_conflict
+                { parent = provider_attempt; planned_index; existing }))
   in
   let* opened =
     stage_open_node
@@ -1767,6 +1852,8 @@ let stage : type value. batch -> value Transaction.t -> (batch * value, error) r
          batch.journal
          batch.staged_state
          ~agent_name)
+  | Transaction.Open_node { kind = Event.Tool_invocation _; _ } ->
+    Error (Invariant_violation Tool_invocation_requires_atomic_open)
   | Transaction.Open_node { causes; run; parent; kind } ->
     stage_mutation
       (stage_open_node ~causes batch.journal batch.staged_state ~run ~parent ~kind)

--- a/lib/execution_journal.ml
+++ b/lib/execution_journal.ml
@@ -171,6 +171,11 @@ type invariant_violation =
   | Tool_input_snapshot_identity_mismatch of Event.Node_id.t
   | Tool_input_delta_after_snapshot of Event.Node_id.t
   | Tool_input_not_materialized of Event.Node_id.t
+  | Tool_occurrence_already_opened of
+      { provider_attempt : Event.Node_id.t
+      ; planned_index : int
+      ; existing : Event.Node_id.t
+      }
   | Tool_result_already_materialized of Event.Node_id.t
   | Tool_result_snapshot_not_tool_result of Event.Node_id.t
   | Tool_result_snapshot_identity_mismatch of Event.Node_id.t
@@ -1393,6 +1398,101 @@ let stage_begin_tool_attempt journal state ~invocation =
   stage_open_node journal state ~run ~parent:invocation ~kind:Event.Tool_attempt
 ;;
 
+let stage_open_tool_invocation
+      journal
+      state
+      ~run
+      ~provider_attempt
+      ~invocation
+      ~tool_name
+      ~input
+  =
+  let* provider_record = node_record_or_error state provider_attempt in
+  let* () =
+    match
+      Event.node_kind provider_record.node, Event.parent_node_id provider_record.node
+    with
+    | Event.Provider_attempt _, Some turn_node ->
+      let* turn_record = node_record_or_error state turn_node in
+      (match Event.node_kind turn_record.node with
+       | Event.Agent_turn { ordinal } when ordinal = Tool.Invocation.turn invocation ->
+         Ok ()
+       | Event.Agent_turn _ ->
+         Error
+           (Invalid_argument "tool invocation turn does not match its provider attempt")
+       | Event.Agent_run _
+       | Event.Provider_attempt _
+       | Event.Output_block _
+       | Event.Tool_invocation _
+       | Event.Tool_attempt ->
+         Error
+           (Invalid_argument
+              "tool invocation requires a provider attempt under an agent turn"))
+    | Event.Provider_attempt _, None ->
+      Error
+        (Invalid_argument
+           "tool invocation requires a provider attempt under an agent turn")
+    | ( ( Event.Agent_run _
+        | Event.Agent_turn _
+        | Event.Output_block _
+        | Event.Tool_invocation _
+        | Event.Tool_attempt )
+      , _ ) -> Error (Invalid_argument "tool invocation requires a provider attempt")
+  in
+  let tool_use_id = Tool.Invocation.tool_use_id invocation in
+  let planned_index = Tool.Invocation.planned_index invocation in
+  let* () =
+    match
+      List.find_map
+        (fun (child : Event.node event_record) ->
+           match Event.node_kind child.value with
+           | Event.Tool_invocation { schedule; _ }
+             when schedule.planned_index = planned_index ->
+             Some (Event.node_id child.value)
+           | Event.Agent_run _
+           | Event.Agent_turn _
+           | Event.Provider_attempt _
+           | Event.Output_block _
+           | Event.Tool_invocation _
+           | Event.Tool_attempt -> None)
+        provider_record.children_rev
+    with
+    | None -> Ok ()
+    | Some existing ->
+      Error
+        (Invariant_violation
+           (Tool_occurrence_already_opened { provider_attempt; planned_index; existing }))
+  in
+  let* opened =
+    stage_open_node
+      journal
+      state
+      ~run
+      ~parent:provider_attempt
+      ~kind:
+        (Event.Tool_invocation
+           { provider_tool_use_id = Some tool_use_id
+           ; tool_name
+           ; schedule = Tool.Invocation.schedule invocation
+           })
+  in
+  let tool_use =
+    Llm_provider.Types.ToolUse { id = tool_use_id; name = tool_name; input }
+  in
+  let+ materialized =
+    stage_update_node
+      journal
+      opened.next_state
+      ~node:(fst opened.value)
+      (Event.Tool_input_snapshot tool_use)
+  in
+  let node, opened_event = opened.value in
+  { next_state = materialized.next_state
+  ; events = [ opened_event; materialized.value ]
+  ; value = node, [ opened_event; materialized.value ]
+  }
+;;
+
 let stage_settle_tool_attempt journal state ~attempt ~invocation ~result =
   let* attempt_record = node_record_or_error state attempt in
   let* () =
@@ -1601,6 +1701,14 @@ module Transaction = struct
     | Begin_tool_attempt :
         { invocation : Event.Node_id.t }
         -> (Event.Node_id.t * Event.t) t
+    | Open_tool_invocation :
+        { run : run
+        ; provider_attempt : Event.Node_id.t
+        ; invocation : Tool.Invocation.t
+        ; tool_name : string
+        ; input : Yojson.Safe.t
+        }
+        -> (Event.Node_id.t * Event.t list) t
     | Settle_tool_attempt :
         { attempt : Event.Node_id.t
         ; invocation : Event.Node_id.t
@@ -1631,6 +1739,10 @@ module Transaction = struct
   let update_node ?(causes = []) ~node update = Update_node { causes; node; update }
   let close_node ?(causes = []) ~node terminal = Close_node { causes; node; terminal }
   let begin_tool_attempt ~invocation () = Begin_tool_attempt { invocation }
+
+  let open_tool_invocation ~run ~provider_attempt ~invocation ~tool_name ~input () =
+    Open_tool_invocation { run; provider_attempt; invocation; tool_name; input }
+  ;;
 
   let settle_tool_attempt ~attempt ~invocation ~result () =
     Settle_tool_attempt { attempt; invocation; result }
@@ -1666,6 +1778,17 @@ let stage : type value. batch -> value Transaction.t -> (batch * value, error) r
       (stage_close_node ~causes batch.journal batch.staged_state ~node terminal)
   | Transaction.Begin_tool_attempt { invocation } ->
     stage_mutation (stage_begin_tool_attempt batch.journal batch.staged_state ~invocation)
+  | Transaction.Open_tool_invocation
+      { run; provider_attempt; invocation; tool_name; input } ->
+    stage_mutation
+      (stage_open_tool_invocation
+         batch.journal
+         batch.staged_state
+         ~run
+         ~provider_attempt
+         ~invocation
+         ~tool_name
+         ~input)
   | Transaction.Settle_tool_attempt { attempt; invocation; result } ->
     stage_mutation
       (stage_settle_tool_attempt

--- a/lib/execution_journal.mli
+++ b/lib/execution_journal.mli
@@ -120,8 +120,10 @@ type invariant_violation =
   | Tool_input_snapshot_identity_mismatch of Execution_event.Node_id.t
   | Tool_input_delta_after_snapshot of Execution_event.Node_id.t
   | Tool_input_not_materialized of Execution_event.Node_id.t
-  | Tool_occurrence_already_opened of
-      { provider_attempt : Execution_event.Node_id.t
+  | Tool_invocation_requires_atomic_open
+  | Occurrence_already_opened of Execution_event.Node_id.t
+  | Tool_occurrence_conflict of
+      { parent : Execution_event.Node_id.t
       ; planned_index : int
       ; existing : Execution_event.Node_id.t
       }

--- a/lib/execution_journal.mli
+++ b/lib/execution_journal.mli
@@ -120,6 +120,11 @@ type invariant_violation =
   | Tool_input_snapshot_identity_mismatch of Execution_event.Node_id.t
   | Tool_input_delta_after_snapshot of Execution_event.Node_id.t
   | Tool_input_not_materialized of Execution_event.Node_id.t
+  | Tool_occurrence_already_opened of
+      { provider_attempt : Execution_event.Node_id.t
+      ; planned_index : int
+      ; existing : Execution_event.Node_id.t
+      }
   | Tool_result_already_materialized of Execution_event.Node_id.t
   | Tool_result_snapshot_not_tool_result of Execution_event.Node_id.t
   | Tool_result_snapshot_identity_mismatch of Execution_event.Node_id.t
@@ -325,6 +330,17 @@ module Transaction : sig
     :  invocation:Execution_event.Node_id.t
     -> unit
     -> (Execution_event.Node_id.t * Execution_event.t) t
+
+  (** Atomically open and materialize one exact provider ToolUse occurrence.
+      The invocation turn must match the parent provider attempt's turn. *)
+  val open_tool_invocation
+    :  run:run
+    -> provider_attempt:Execution_event.Node_id.t
+    -> invocation:Tool.Invocation.t
+    -> tool_name:string
+    -> input:Yojson.Safe.t
+    -> unit
+    -> (Execution_event.Node_id.t * Execution_event.t list) t
 
   (** Atomically close attempt, materialize ToolResult, and close invocation. *)
   val settle_tool_attempt

--- a/lib/execution_journal.mli
+++ b/lib/execution_journal.mli
@@ -320,6 +320,20 @@ module Transaction : sig
     -> Execution_event.terminal
     -> Execution_event.t t
 
+  (** Open an attempt under a materialized invocation-derived run. *)
+  val begin_tool_attempt
+    :  invocation:Execution_event.Node_id.t
+    -> unit
+    -> (Execution_event.Node_id.t * Execution_event.t) t
+
+  (** Atomically close attempt, materialize ToolResult, and close invocation. *)
+  val settle_tool_attempt
+    :  attempt:Execution_event.Node_id.t
+    -> invocation:Execution_event.Node_id.t
+    -> result:Llm_provider.Types.content_block
+    -> unit
+    -> Execution_event.t list t
+
   val finish_run
     :  ?causes:Execution_event.cause list
     -> run:run

--- a/lib/execution_lane_writer.ml
+++ b/lib/execution_lane_writer.ml
@@ -887,6 +887,10 @@ let find_node writer node =
   read_journal writer (fun journal -> Ok (Journal.find_node journal node))
 ;;
 
+let find_run writer run_id =
+  read_journal writer (fun journal -> Ok (Journal.find_run journal run_id))
+;;
+
 let read_page writer ~after ?through ~limit () =
   read_journal writer (fun journal ->
     match Journal.read_page journal ~after ?through ~limit () with

--- a/lib/execution_lane_writer.ml
+++ b/lib/execution_lane_writer.ml
@@ -883,6 +883,10 @@ let current_cursor writer =
   read_journal writer (fun journal -> Ok (Journal.current_cursor journal))
 ;;
 
+let find_node writer node =
+  read_journal writer (fun journal -> Ok (Journal.find_node journal node))
+;;
+
 let read_page writer ~after ?through ~limit () =
   read_journal writer (fun journal ->
     match Journal.read_page journal ~after ?through ~limit () with

--- a/lib/execution_lane_writer.ml
+++ b/lib/execution_lane_writer.ml
@@ -1,6 +1,8 @@
 module Event = Execution_event
 module Journal = Execution_journal
 
+let _log = Log.create ~module_name:"execution_lane_writer" ()
+
 type reconciliation_evidence =
   { first_outcome_unknown : Journal.error
   ; latest_outcome_unknown : Journal.error
@@ -851,17 +853,33 @@ let run_with_mode ~codec ~dir mode f =
         | result -> result
         | exception shutdown_exn ->
           let shutdown_backtrace = Printexc.get_raw_backtrace () in
-          let combined, combined_backtrace =
-            Eio.Exn.combine (exn, backtrace) (shutdown_exn, shutdown_backtrace)
-          in
-          Printexc.raise_with_backtrace combined combined_backtrace
+          (match Llm_provider.Reserved_exn.reraise_if_reserved exn with
+           | () ->
+             let combined, combined_backtrace =
+               Eio.Exn.combine (exn, backtrace) (shutdown_exn, shutdown_backtrace)
+             in
+             Printexc.raise_with_backtrace combined combined_backtrace
+           | exception reserved ->
+             Log.error
+               _log
+               "writer shutdown raised after reserved callback exception"
+               [ Log.S ("shutdown_exception", Printexc.to_string shutdown_exn) ];
+             Printexc.raise_with_backtrace reserved backtrace)
       in
       (match shutdown with
        | Ok () -> Printexc.raise_with_backtrace exn backtrace
        | Error failure ->
-         Printexc.raise_with_backtrace
-           (Callback_failed_after_scope_failure (exn, failure))
-           backtrace))
+         (match Llm_provider.Reserved_exn.reraise_if_reserved exn with
+          | () ->
+            Printexc.raise_with_backtrace
+              (Callback_failed_after_scope_failure (exn, failure))
+              backtrace
+          | exception reserved ->
+            Log.error
+              _log
+              "writer shutdown failed after reserved callback exception"
+              [ Log.S ("scope_failure", scope_failure_to_string failure) ];
+            Printexc.raise_with_backtrace reserved backtrace)))
 ;;
 
 let run ~codec ~dir ?correlation_id f =

--- a/lib/execution_lane_writer.mli
+++ b/lib/execution_lane_writer.mli
@@ -168,6 +168,11 @@ val wake_reconciliation : t -> source:reconciliation_wake_source -> bool
     may retain its last acknowledged cursor and replay after any wake hint. *)
 val current_cursor : t -> (Execution_journal.cursor, read_error) result
 
+val find_node
+  :  t
+  -> Execution_event.Node_id.t
+  -> (Execution_journal.node_view option, read_error) result
+
 val read_page
   :  t
   -> after:Execution_journal.cursor

--- a/lib/execution_lane_writer.mli
+++ b/lib/execution_lane_writer.mli
@@ -173,6 +173,11 @@ val find_node
   -> Execution_event.Node_id.t
   -> (Execution_journal.node_view option, read_error) result
 
+val find_run
+  :  t
+  -> Execution_event.Run_id.t
+  -> (Execution_journal.run_view option, read_error) result
+
 val read_page
   :  t
   -> after:Execution_journal.cursor

--- a/lib/execution_tool_settlement.ml
+++ b/lib/execution_tool_settlement.ml
@@ -34,6 +34,13 @@ type execution =
   | Executed of Llm_provider.Types.content_block * Journal.cursor * int
   | Replayed of Llm_provider.Types.content_block
 
+type phased_effect =
+  { result : Llm_provider.Types.content_block
+  ; after_settle : unit -> unit
+  }
+
+let phased_effect ~result ~after_settle = { result; after_settle }
+
 let read_node writer node =
   match Writer.find_node writer node with
   | Error error -> Error (Authority_unavailable error)
@@ -157,7 +164,7 @@ let settle authority attempt result =
        | Ok committed -> Ok (result, committed.through, committed.group_event_count)))
 ;;
 
-let execute_with_attempt authority ~invoke =
+let execute_with_attempt_phased_internal authority ~after_attempt_committed ~invoke =
   let open Result_syntax in
   let* current = status authority in
   match current with
@@ -165,12 +172,35 @@ let execute_with_attempt authority ~invoke =
   | Outcome_unknown -> Error Effect_outcome_unknown
   | Ready_to_execute ->
     let* attempt = begin_attempt authority in
-    Eio.Fiber.check ();
-    let result = invoke attempt in
-    let+ committed, through, event_count = settle authority attempt result in
+    after_attempt_committed ();
+    let phase = invoke attempt in
+    let+ committed, through, event_count = settle authority attempt phase.result in
+    phase.after_settle ();
     Executed (committed, through, event_count)
+;;
+
+let execute_with_attempt_phased authority ~invoke =
+  execute_with_attempt_phased_internal authority ~after_attempt_committed:Fun.id ~invoke
+;;
+
+let execute_with_attempt authority ~invoke =
+  execute_with_attempt_phased authority ~invoke:(fun attempt ->
+    { result = invoke attempt; after_settle = Fun.id })
 ;;
 
 let execute authority ~invoke =
   execute_with_attempt authority ~invoke:(fun _ -> invoke ())
 ;;
+
+module For_testing = struct
+  let execute_with_attempt_after_attempt_committed
+        authority
+        ~after_attempt_committed
+        ~invoke
+    =
+    execute_with_attempt_phased_internal
+      authority
+      ~after_attempt_committed
+      ~invoke:(fun attempt -> phased_effect ~result:(invoke attempt) ~after_settle:Fun.id)
+  ;;
+end

--- a/lib/execution_tool_settlement.ml
+++ b/lib/execution_tool_settlement.ml
@@ -157,7 +157,7 @@ let settle authority attempt result =
        | Ok committed -> Ok (result, committed.through, committed.group_event_count)))
 ;;
 
-let execute authority ~invoke =
+let execute_with_attempt authority ~invoke =
   let open Result_syntax in
   let* current = status authority in
   match current with
@@ -166,7 +166,11 @@ let execute authority ~invoke =
   | Ready_to_execute ->
     let* attempt = begin_attempt authority in
     Eio.Fiber.check ();
-    let result = invoke () in
+    let result = invoke attempt in
     let+ committed, through, event_count = settle authority attempt result in
     Executed (committed, through, event_count)
+;;
+
+let execute authority ~invoke =
+  execute_with_attempt authority ~invoke:(fun _ -> invoke ())
 ;;

--- a/lib/execution_tool_settlement.ml
+++ b/lib/execution_tool_settlement.ml
@@ -105,7 +105,10 @@ let status authority =
        , _ ) -> Error Invocation_identity_mismatch)
 ;;
 
+let await_accepted ticket = Eio.Cancel.protect (fun () -> Writer.await ticket)
+
 let begin_attempt authority =
+  Eio.Fiber.check ();
   match
     Writer.submit
       authority.writer
@@ -113,7 +116,7 @@ let begin_attempt authority =
   with
   | Error error -> Error (Attempt_admission_failed error)
   | Ok ticket ->
-    (match Writer.await ticket with
+    (match await_accepted ticket with
      | Error error -> Error (Attempt_commit_failed error)
      | Ok committed ->
        let node, _event = committed.value in
@@ -128,12 +131,13 @@ let settle authority attempt result =
       ~result
       ()
   in
-  match Writer.submit authority.writer transaction with
-  | Error error -> Error (Receipt_admission_outcome_unknown error)
-  | Ok ticket ->
-    (match Writer.await ticket with
-     | Error error -> Error (Receipt_settlement_outcome_unknown error)
-     | Ok committed -> Ok (result, committed.through, committed.group_event_count))
+  Eio.Cancel.protect (fun () ->
+    match Writer.submit authority.writer transaction with
+    | Error error -> Error (Receipt_admission_outcome_unknown error)
+    | Ok ticket ->
+      (match Writer.await ticket with
+       | Error error -> Error (Receipt_settlement_outcome_unknown error)
+       | Ok committed -> Ok (result, committed.through, committed.group_event_count)))
 ;;
 
 let execute authority ~invoke =
@@ -144,6 +148,7 @@ let execute authority ~invoke =
   | Outcome_unknown -> Error Effect_outcome_unknown
   | Ready_to_execute ->
     let* attempt = begin_attempt authority in
+    Eio.Fiber.check ();
     let result = invoke () in
     let+ committed, through, event_count = settle authority attempt result in
     Executed (committed, through, event_count)

--- a/lib/execution_tool_settlement.ml
+++ b/lib/execution_tool_settlement.ml
@@ -7,6 +7,14 @@ type t =
   ; invocation_node : Event.Node_id.t
   }
 
+type durable_invocation =
+  { authority : t
+  ; run_id : Event.Run_id.t
+  ; invocation : Tool.Invocation.t
+  ; tool_name : string
+  ; input : Yojson.Safe.t
+  }
+
 type status =
   | Ready_to_execute
   | Outcome_unknown
@@ -35,22 +43,22 @@ let read_node writer node =
 
 let parent_node view = Event.parent_node_id view.Journal.node
 
-let create ~writer ~invocation_node ~invocation =
+let rebind ~writer ~invocation_node =
   let open Result_syntax in
   let* invocation_view = read_node writer invocation_node in
-  let* provider_attempt =
+  let* provider_attempt, run_id, tool_use_id, schedule, tool_name, input =
     match
       ( Event.node_kind invocation_view.node
       , parent_node invocation_view
       , invocation_view.materialized )
     with
-    | ( Event.Tool_invocation { schedule; _ }
+    | ( Event.Tool_invocation { provider_tool_use_id; tool_name; schedule }
       , Some parent
       , Journal.Tool_invocation_state
-          { input = Some (Llm_provider.Types.ToolUse { id; _ }); _ } )
-      when String.equal id (Tool.Invocation.tool_use_id invocation)
-           && Execution_tool_schedule.equal schedule (Tool.Invocation.schedule invocation)
-      -> Ok parent
+          { input = Some (Llm_provider.Types.ToolUse { id; name; input }); _ } )
+      when Option.equal String.equal provider_tool_use_id (Some id)
+           && String.equal tool_name name ->
+      Ok (parent, Event.node_run_id invocation_view.node, id, schedule, tool_name, input)
     | ( ( Event.Agent_run _
         | Event.Agent_turn _
         | Event.Provider_attempt _
@@ -63,8 +71,10 @@ let create ~writer ~invocation_node ~invocation =
   let* provider_view = read_node writer provider_attempt in
   let* turn_node =
     match Event.node_kind provider_view.node, parent_node provider_view with
-    | Event.Provider_attempt _, Some parent -> Ok parent
+    | Event.Provider_attempt _, Some parent
+      when Event.Run_id.equal run_id (Event.node_run_id provider_view.node) -> Ok parent
     | Event.Provider_attempt _, None
+    | Event.Provider_attempt _, Some _
     | ( ( Event.Agent_run _
         | Event.Agent_turn _
         | Event.Output_block _
@@ -74,8 +84,15 @@ let create ~writer ~invocation_node ~invocation =
   in
   let* turn_view = read_node writer turn_node in
   match Event.node_kind turn_view.node with
-  | Event.Agent_turn { ordinal } when ordinal = Tool.Invocation.turn invocation ->
-    Ok { writer; invocation_node }
+  | Event.Agent_turn { ordinal }
+    when Event.Run_id.equal run_id (Event.node_run_id turn_view.node) ->
+    Ok
+      { authority = { writer; invocation_node }
+      ; run_id
+      ; invocation = Tool.Invocation.create ~tool_use_id ~turn:ordinal ~schedule
+      ; tool_name
+      ; input
+      }
   | Event.Agent_turn _
   | Event.Agent_run _
   | Event.Provider_attempt _

--- a/lib/execution_tool_settlement.ml
+++ b/lib/execution_tool_settlement.ml
@@ -1,0 +1,150 @@
+module Event = Execution_event
+module Journal = Execution_journal
+module Writer = Execution_lane_writer
+
+type t =
+  { writer : Writer.t
+  ; invocation_node : Event.Node_id.t
+  }
+
+type status =
+  | Ready_to_execute
+  | Outcome_unknown
+  | Settled of Llm_provider.Types.content_block
+
+type error =
+  | Authority_unavailable of Writer.read_error
+  | Invocation_not_found
+  | Invocation_identity_mismatch
+  | Effect_outcome_unknown
+  | Attempt_admission_failed of Writer.submit_error
+  | Attempt_commit_failed of Writer.ticket_error
+  | Receipt_admission_outcome_unknown of Writer.submit_error
+  | Receipt_settlement_outcome_unknown of Writer.ticket_error
+
+type execution =
+  | Executed of Llm_provider.Types.content_block * Journal.cursor * int
+  | Replayed of Llm_provider.Types.content_block
+
+let read_node writer node =
+  match Writer.find_node writer node with
+  | Error error -> Error (Authority_unavailable error)
+  | Ok None -> Error Invocation_not_found
+  | Ok (Some view) -> Ok view
+;;
+
+let parent_node view = Event.parent_node_id view.Journal.node
+
+let create ~writer ~invocation_node ~invocation =
+  let open Result_syntax in
+  let* invocation_view = read_node writer invocation_node in
+  let* provider_attempt =
+    match
+      ( Event.node_kind invocation_view.node
+      , parent_node invocation_view
+      , invocation_view.materialized )
+    with
+    | ( Event.Tool_invocation { schedule; _ }
+      , Some parent
+      , Journal.Tool_invocation_state
+          { input = Some (Llm_provider.Types.ToolUse { id; _ }); _ } )
+      when String.equal id (Tool.Invocation.tool_use_id invocation)
+           && Execution_tool_schedule.equal schedule (Tool.Invocation.schedule invocation)
+      -> Ok parent
+    | ( ( Event.Agent_run _
+        | Event.Agent_turn _
+        | Event.Provider_attempt _
+        | Event.Output_block _
+        | Event.Tool_invocation _
+        | Event.Tool_attempt )
+      , (None | Some _)
+      , _ ) -> Error Invocation_identity_mismatch
+  in
+  let* provider_view = read_node writer provider_attempt in
+  let* turn_node =
+    match Event.node_kind provider_view.node, parent_node provider_view with
+    | Event.Provider_attempt _, Some parent -> Ok parent
+    | Event.Provider_attempt _, None
+    | ( ( Event.Agent_run _
+        | Event.Agent_turn _
+        | Event.Output_block _
+        | Event.Tool_invocation _
+        | Event.Tool_attempt )
+      , _ ) -> Error Invocation_identity_mismatch
+  in
+  let* turn_view = read_node writer turn_node in
+  match Event.node_kind turn_view.node with
+  | Event.Agent_turn { ordinal } when ordinal = Tool.Invocation.turn invocation ->
+    Ok { writer; invocation_node }
+  | Event.Agent_turn _
+  | Event.Agent_run _
+  | Event.Provider_attempt _
+  | Event.Output_block _
+  | Event.Tool_invocation _
+  | Event.Tool_attempt -> Error Invocation_identity_mismatch
+;;
+
+let status authority =
+  match read_node authority.writer authority.invocation_node with
+  | Error _ as error -> error
+  | Ok view ->
+    (match view.materialized, view.children, view.status with
+     | Journal.Tool_invocation_state { result = Some result; _ }, _, _ ->
+       Ok (Settled result)
+     | Journal.Tool_invocation_state { result = None; _ }, [], Journal.Open ->
+       Ok Ready_to_execute
+     | ( Journal.Tool_invocation_state { result = None; _ }
+       , _
+       , (Journal.Open | Journal.Closed _) ) -> Ok Outcome_unknown
+     | ( ( Journal.Agent_run_state
+         | Journal.Agent_turn_state
+         | Journal.Provider_attempt_state _
+         | Journal.Output_block_state _
+         | Journal.Tool_attempt_state )
+       , _
+       , _ ) -> Error Invocation_identity_mismatch)
+;;
+
+let begin_attempt authority =
+  match
+    Writer.submit
+      authority.writer
+      (Journal.Transaction.begin_tool_attempt ~invocation:authority.invocation_node ())
+  with
+  | Error error -> Error (Attempt_admission_failed error)
+  | Ok ticket ->
+    (match Writer.await ticket with
+     | Error error -> Error (Attempt_commit_failed error)
+     | Ok committed ->
+       let node, _event = committed.value in
+       Ok node)
+;;
+
+let settle authority attempt result =
+  let transaction =
+    Journal.Transaction.settle_tool_attempt
+      ~attempt
+      ~invocation:authority.invocation_node
+      ~result
+      ()
+  in
+  match Writer.submit authority.writer transaction with
+  | Error error -> Error (Receipt_admission_outcome_unknown error)
+  | Ok ticket ->
+    (match Writer.await ticket with
+     | Error error -> Error (Receipt_settlement_outcome_unknown error)
+     | Ok committed -> Ok (result, committed.through, committed.group_event_count))
+;;
+
+let execute authority ~invoke =
+  let open Result_syntax in
+  let* current = status authority in
+  match current with
+  | Settled result -> Ok (Replayed result)
+  | Outcome_unknown -> Error Effect_outcome_unknown
+  | Ready_to_execute ->
+    let* attempt = begin_attempt authority in
+    let result = invoke () in
+    let+ committed, through, event_count = settle authority attempt result in
+    Executed (committed, through, event_count)
+;;

--- a/lib/execution_tool_settlement.mli
+++ b/lib/execution_tool_settlement.mli
@@ -1,5 +1,13 @@
 type t
 
+type durable_invocation = private
+  { authority : t
+  ; run_id : Execution_event.Run_id.t
+  ; invocation : Tool.Invocation.t
+  ; tool_name : string
+  ; input : Yojson.Safe.t
+  }
+
 type error =
   | Authority_unavailable of Execution_lane_writer.read_error
   | Invocation_not_found
@@ -14,11 +22,11 @@ type execution =
   | Executed of Llm_provider.Types.content_block * Execution_journal.cursor * int
   | Replayed of Llm_provider.Types.content_block
 
-val create
+(** Reconstruct one executable command from the journal's exact topology. *)
+val rebind
   :  writer:Execution_lane_writer.t
   -> invocation_node:Execution_event.Node_id.t
-  -> invocation:Tool.Invocation.t
-  -> (t, error) result
+  -> (durable_invocation, error) result
 
 val execute
   :  t

--- a/lib/execution_tool_settlement.mli
+++ b/lib/execution_tool_settlement.mli
@@ -32,3 +32,8 @@ val execute
   :  t
   -> invoke:(unit -> Llm_provider.Types.content_block)
   -> (execution, error) result
+
+val execute_with_attempt
+  :  t
+  -> invoke:(Execution_event.Node_id.t -> Llm_provider.Types.content_block)
+  -> (execution, error) result

--- a/lib/execution_tool_settlement.mli
+++ b/lib/execution_tool_settlement.mli
@@ -22,6 +22,16 @@ type execution =
   | Executed of Llm_provider.Types.content_block * Execution_journal.cursor * int
   | Replayed of Llm_provider.Types.content_block
 
+type phased_effect = private
+  { result : Llm_provider.Types.content_block
+  ; after_settle : unit -> unit
+  }
+
+val phased_effect
+  :  result:Llm_provider.Types.content_block
+  -> after_settle:(unit -> unit)
+  -> phased_effect
+
 (** Reconstruct one executable command from the journal's exact topology. *)
 val rebind
   :  writer:Execution_lane_writer.t
@@ -37,3 +47,16 @@ val execute_with_attempt
   :  t
   -> invoke:(Execution_event.Node_id.t -> Llm_provider.Types.content_block)
   -> (execution, error) result
+
+val execute_with_attempt_phased
+  :  t
+  -> invoke:(Execution_event.Node_id.t -> phased_effect)
+  -> (execution, error) result
+
+module For_testing : sig
+  val execute_with_attempt_after_attempt_committed
+    :  t
+    -> after_attempt_committed:(unit -> unit)
+    -> invoke:(Execution_event.Node_id.t -> Llm_provider.Types.content_block)
+    -> (execution, error) result
+end

--- a/lib/execution_tool_settlement.mli
+++ b/lib/execution_tool_settlement.mli
@@ -1,0 +1,26 @@
+type t
+
+type error =
+  | Authority_unavailable of Execution_lane_writer.read_error
+  | Invocation_not_found
+  | Invocation_identity_mismatch
+  | Effect_outcome_unknown
+  | Attempt_admission_failed of Execution_lane_writer.submit_error
+  | Attempt_commit_failed of Execution_lane_writer.ticket_error
+  | Receipt_admission_outcome_unknown of Execution_lane_writer.submit_error
+  | Receipt_settlement_outcome_unknown of Execution_lane_writer.ticket_error
+
+type execution =
+  | Executed of Llm_provider.Types.content_block * Execution_journal.cursor * int
+  | Replayed of Llm_provider.Types.content_block
+
+val create
+  :  writer:Execution_lane_writer.t
+  -> invocation_node:Execution_event.Node_id.t
+  -> invocation:Tool.Invocation.t
+  -> (t, error) result
+
+val execute
+  :  t
+  -> invoke:(unit -> Llm_provider.Types.content_block)
+  -> (execution, error) result

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -36,48 +36,7 @@ type turn_outcome =
   | Complete of Types.api_response
   | ToolsExecuted of checkpoint_stage
 
-let persist_turn_checkpoint_for_state agent stage state =
-  match agent.checkpoint_sink with
-  | None -> Ok ()
-  | Some sink ->
-    let checkpoint =
-      Agent_checkpoint.build_checkpoint
-        ~state
-        ~tools:agent.tools
-        ~context:agent.context
-        ~mcp_clients:agent.options.mcp_clients
-        ()
-    in
-    let timestamp = checkpoint.created_at in
-    let turn = state.turn_count in
-    let stage_label = checkpoint_stage_to_string stage in
-    let snapshot = { stage; turn; checkpoint; timestamp } in
-    (match sink snapshot with
-     | Ok () ->
-       (match agent.options.journal with
-        | Some journal ->
-          Agent_execution_event_writer.append
-            journal
-            (Checkpoint_saved
-               { checkpoint_id = Printf.sprintf "%s-%d" stage_label turn; timestamp })
-        | None -> ());
-       Log.info
-         _log
-         "turn checkpoint persisted"
-         [ S ("stage", stage_label)
-         ; I ("turn", turn)
-         ; I ("messages", List.length checkpoint.messages)
-         ];
-       Ok ()
-     | Error detail ->
-       Log.error
-         _log
-         "turn checkpoint sink failed"
-         [ S ("stage", stage_label); I ("turn", turn); S ("detail", detail) ];
-       Error
-         (Error.Internal
-            (Printf.sprintf "checkpoint sink failed at %s: %s" stage_label detail)))
-;;
+let persist_turn_checkpoint_for_state = Pipeline_checkpoint.persist_for_state
 
 let persist_turn_checkpoint agent stage =
   persist_turn_checkpoint_for_state agent stage agent.state
@@ -129,6 +88,7 @@ let stage_route
       ~api_strategy
       ?raw_trace_run
       ?on_provider_failure
+      ?before_provider_attempt
       ~turn_config
       agent
       prep
@@ -151,6 +111,7 @@ let stage_route
            ?clock
            ~trace_context
            ?on_provider_failure
+           ?before_provider_attempt
            ~turn_config
            agent
            prep)
@@ -178,6 +139,7 @@ let stage_route
            ?capture_id
            ?on_telemetry
            ?on_provider_failure
+           ?before_provider_attempt
            ())
 ;;
 
@@ -346,7 +308,13 @@ let stage_collect ?raw_trace_run ?clock agent response =
 (* ── Stage 5: Execute ────────────────────────────────────── *)
 
 (** Handle tool execution and context injection. *)
-let stage_execute ?raw_trace_run ?before_tool_execution agent tool_uses_nonempty =
+let stage_execute
+      ?raw_trace_run
+      ?before_tool_execution
+      ?execution_provider
+      agent
+      tool_uses_nonempty
+  =
   (* The caller (stage_output) proves the tool-call set is non-empty: a
      StopToolUse turn that carried no tool block is rejected before this stage
      (Stop_reason_wire.reconcile downgrades it to Unknown at parse time).
@@ -365,7 +333,9 @@ let stage_execute ?raw_trace_run ?before_tool_execution agent tool_uses_nonempty
     (fun _tracer ->
        Option.iter (fun callback -> callback ()) before_tool_execution;
        let results, failure =
-         match execute_tools_with_trace agent raw_trace_run tool_uses with
+         match
+           execute_tools_with_trace ?execution_provider agent raw_trace_run tool_uses
+         with
          | Ok results -> results, None
          | Error ({ completed_results; cause } : Agent_tools.execution_failure) ->
            completed_results, Some cause
@@ -400,6 +370,8 @@ let stage_execute ?raw_trace_run ?before_tool_execution agent tool_uses_nonempty
               ~detail)
        | Some (Agent_tools.Observer_failure { exception_; backtrace; _ }) ->
          Printexc.raise_with_backtrace exception_ backtrace
+       | Some (Agent_tools.Durability_failure { detail; _ }) ->
+         Error (Error.Internal detail)
        | None ->
          (match agent.options.context_injector with
           | None -> Ok (ToolsExecuted After_tool_results_appended)
@@ -434,7 +406,7 @@ let stage_execute ?raw_trace_run ?before_tool_execution agent tool_uses_nonempty
 (* ── Stage 6: Output ─────────────────────────────────────── *)
 
 (** Map stop_reason to turn_outcome. *)
-let stage_output ?raw_trace_run ?before_tool_execution agent response =
+let stage_output ?raw_trace_run ?before_tool_execution ?execution_provider agent response =
   Tracing.with_span
     agent.options.tracer
     { kind = Hook_invoke
@@ -475,7 +447,12 @@ let stage_output ?raw_trace_run ?before_tool_execution agent response =
                  (UnrecognizedStopReason
                     { reason = "StopToolUse turn carried no tool block" }))
           | Some tool_uses_nonempty ->
-            stage_execute ?raw_trace_run ?before_tool_execution agent tool_uses_nonempty)
+            stage_execute
+              ?raw_trace_run
+              ?before_tool_execution
+              ?execution_provider
+              agent
+              tool_uses_nonempty)
        | UnmatchedToolCalls ->
          (* The wire boundary has already classified this response shape as
             malformed. Keep rejecting it; arbitrary provider terminal reasons
@@ -545,6 +522,7 @@ let run_turn
       ?raw_trace_run
       ?on_provider_failure
       ?before_tool_execution
+      ?execution_scope
       agent
   =
   (* Stage 1: Input *)
@@ -583,6 +561,11 @@ let run_turn
   | Guardrails_async.Fail { validator_name; reason } ->
     Error (Error.Agent (GuardrailViolation { validator = validator_name; reason }))
   | Guardrails_async.Pass ->
+    let* execution =
+      Pipeline_execution_scope.open_turn
+        execution_scope
+        ~ordinal:(agent.state.turn_count + 1)
+    in
     (* Stage 3: Route exactly once. Provider [ContextOverflow] remains a typed
        error; OAS does not mutate the transcript or retry implicitly. *)
     (match agent.options.journal with
@@ -603,6 +586,8 @@ let run_turn
         ~api_strategy
         ?raw_trace_run
         ?on_provider_failure
+        ~before_provider_attempt:
+          (Pipeline_execution_scope.before_provider_attempt execution)
         ~turn_config
         agent
         prep
@@ -637,25 +622,36 @@ let run_turn
             })
      | None, _ -> ());
     (* Stage 4+5+6: Collect, Execute/Output *)
-    (match api_result with
-     | Error e -> Error e
-     | Ok response ->
-       (* RFC-OAS-025 Option A: forced-tool-use enforcement removed.
+    let outcome =
+      match api_result with
+      | Error e -> Error e
+      | Ok response ->
+        (* RFC-OAS-025 Option A: forced-tool-use enforcement removed.
           [tool_choice] is enforced server-side by the provider, so the SDK no
           longer validates the response against a completion contract nor retries
           to coerce a tool call (the former
           [handle_missing_required_tool_use]/[validate_completion_contract]
           pass). *)
-       (* Stage 3.5: Async output validation *)
-       (match Guardrails_async.run_output async_guard.output_validators response with
-        | Guardrails_async.Fail { validator_name; reason } ->
-          Error (Error.Agent (GuardrailViolation { validator = validator_name; reason }))
-        | Guardrails_async.Pass ->
-          let* () =
-            stage_collect ?raw_trace_run ?clock agent response |> tag_error "collect"
-          in
-          stage_output ?raw_trace_run ?before_tool_execution agent response
-          |> tag_error "output"))
+        (* Stage 3.5: Async output validation *)
+        (match Guardrails_async.run_output async_guard.output_validators response with
+         | Guardrails_async.Fail { validator_name; reason } ->
+           Error (Error.Agent (GuardrailViolation { validator = validator_name; reason }))
+         | Guardrails_async.Pass ->
+           let* () =
+             stage_collect ?raw_trace_run ?clock agent response |> tag_error "collect"
+           in
+           stage_output
+             ?raw_trace_run
+             ?before_tool_execution
+             ?execution_provider:(Pipeline_execution_scope.provider execution)
+             agent
+             response
+           |> tag_error "output")
+    in
+    (match outcome with
+     | Error _ as error -> error
+     | Ok value ->
+       Pipeline_execution_scope.close_success execution |> Result.map (fun () -> value))
 ;;
 
 [@@@coverage off]

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -1,12 +1,4 @@
-(** Turn pipeline: 6-stage decomposition of agent turn execution.
-
-    Replaces the monolithic run_turn_core with named stages:
-    1. Input   — lifecycle, BeforeTurn hook, elicitation
-    2. Parse   — BeforeTurnParams hook, tool preparation
-    3. Route   — provider selection, API call dispatch (sync/stream)
-    4. Collect — usage accumulation, AfterTurn hook, events, message append
-    5. Execute — exact-name tool execution on StopToolUse
-    6. Output  — stop reason → turn_outcome
+(** Six-stage Agent turn pipeline: Input, Parse, Route, Collect, Execute, Output.
 
     [Output] ([stage_output]) dispatches [Execute] ([stage_execute]) internally
     on StopToolUse, so Execute is a sub-step of Output, not a stage that runs
@@ -308,13 +300,7 @@ let stage_collect ?raw_trace_run ?clock agent response =
 (* ── Stage 5: Execute ────────────────────────────────────── *)
 
 (** Handle tool execution and context injection. *)
-let stage_execute
-      ?raw_trace_run
-      ?before_tool_execution
-      ?execution_provider
-      agent
-      tool_uses_nonempty
-  =
+let stage_execute ?raw_trace_run ?before_tool_execution agent tool_uses_nonempty =
   (* The caller (stage_output) proves the tool-call set is non-empty: a
      StopToolUse turn that carried no tool block is rejected before this stage
      (Stop_reason_wire.reconcile downgrades it to Unknown at parse time).
@@ -333,9 +319,7 @@ let stage_execute
     (fun _tracer ->
        Option.iter (fun callback -> callback ()) before_tool_execution;
        let results, failure =
-         match
-           execute_tools_with_trace ?execution_provider agent raw_trace_run tool_uses
-         with
+         match execute_tools_with_trace agent raw_trace_run tool_uses with
          | Ok results -> results, None
          | Error ({ completed_results; cause } : Agent_tools.execution_failure) ->
            completed_results, Some cause
@@ -406,7 +390,7 @@ let stage_execute
 (* ── Stage 6: Output ─────────────────────────────────────── *)
 
 (** Map stop_reason to turn_outcome. *)
-let stage_output ?raw_trace_run ?before_tool_execution ?execution_provider agent response =
+let stage_output ?raw_trace_run ?before_tool_execution agent response =
   Tracing.with_span
     agent.options.tracer
     { kind = Hook_invoke
@@ -447,12 +431,7 @@ let stage_output ?raw_trace_run ?before_tool_execution ?execution_provider agent
                  (UnrecognizedStopReason
                     { reason = "StopToolUse turn carried no tool block" }))
           | Some tool_uses_nonempty ->
-            stage_execute
-              ?raw_trace_run
-              ?before_tool_execution
-              ?execution_provider
-              agent
-              tool_uses_nonempty)
+            stage_execute ?raw_trace_run ?before_tool_execution agent tool_uses_nonempty)
        | UnmatchedToolCalls ->
          (* The wire boundary has already classified this response shape as
             malformed. Keep rejecting it; arbitrary provider terminal reasons
@@ -515,14 +494,13 @@ let tag_error stage result =
     Error e
 ;;
 
-let run_turn
+let run_new_turn
       ~sw
       ?clock
       ~api_strategy
       ?raw_trace_run
       ?on_provider_failure
       ?before_tool_execution
-      ?execution_scope
       agent
   =
   (* Stage 1: Input *)
@@ -563,7 +541,7 @@ let run_turn
   | Guardrails_async.Pass ->
     let* execution =
       Pipeline_execution_scope.open_turn
-        execution_scope
+        (Execution_context.agent_scope ())
         ~ordinal:(agent.state.turn_count + 1)
     in
     (* Stage 3: Route exactly once. Provider [ContextOverflow] remains a typed
@@ -640,18 +618,49 @@ let run_turn
            let* () =
              stage_collect ?raw_trace_run ?clock agent response |> tag_error "collect"
            in
-           stage_output
-             ?raw_trace_run
-             ?before_tool_execution
-             ?execution_provider:(Pipeline_execution_scope.provider execution)
-             agent
-             response
+           (match Pipeline_execution_scope.provider execution with
+            | None -> stage_output ?raw_trace_run ?before_tool_execution agent response
+            | Some provider ->
+              Execution_context.with_provider_attempt provider (fun () ->
+                stage_output ?raw_trace_run ?before_tool_execution agent response))
            |> tag_error "output")
     in
     (match outcome with
      | Error _ as error -> error
      | Ok value ->
        Pipeline_execution_scope.close_success execution |> Result.map (fun () -> value))
+;;
+
+let run_turn
+      ~sw
+      ?clock
+      ~api_strategy
+      ?raw_trace_run
+      ?on_provider_failure
+      ?before_tool_execution
+      agent
+  =
+  let* resumed =
+    Pipeline_execution_scope.resume_current
+      (Execution_context.agent_scope ())
+      ~ordinal:agent.state.turn_count
+  in
+  match resumed with
+  | Some execution ->
+    Pipeline_execution_resume.run
+      agent
+      execution
+      ~execute:(stage_execute ?raw_trace_run agent)
+      ~already_settled:(ToolsExecuted After_tool_results_appended)
+  | None ->
+    run_new_turn
+      ~sw
+      ?clock
+      ~api_strategy
+      ?raw_trace_run
+      ?on_provider_failure
+      ?before_tool_execution
+      agent
 ;;
 
 [@@@coverage off]

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -641,9 +641,12 @@ let run_turn
       agent
   =
   let* resumed =
-    Pipeline_execution_scope.resume_current
-      (Execution_context.agent_scope ())
-      ~ordinal:agent.state.turn_count
+    if Execution_context.take_resume_once ()
+    then
+      Pipeline_execution_scope.resume_current
+        (Execution_context.agent_scope ())
+        ~ordinal:agent.state.turn_count
+    else Ok None
   in
   match resumed with
   | Some execution ->

--- a/lib/pipeline/pipeline.mli
+++ b/lib/pipeline/pipeline.mli
@@ -37,9 +37,9 @@ val persist_turn_checkpoint_for_state
     the first tool hook or implementation starts.  Exceptions propagate and
     prevent tool execution.
 
-    [execution_scope], when present, owns the turn and exact selected provider
-    attempt before provider I/O and is threaded into Tool execution. The caller
-    owns root settlement; this function closes its successful turn descendants,
+    A private fiber-local execution scope, when bound by [Agent], owns the turn
+    and exact selected provider attempt before provider I/O. The caller owns
+    root settlement; this function closes its successful turn descendants,
     while an error leaves them open for the caller's atomic abort. *)
 val run_turn
   :  sw:Eio.Switch.t
@@ -48,6 +48,5 @@ val run_turn
   -> ?raw_trace_run:Raw_trace.active_run
   -> ?on_provider_failure:(Provider_failure_attribution.t option -> unit)
   -> ?before_tool_execution:(unit -> unit)
-  -> ?execution_scope:Execution_agent_scope.t
   -> Agent_types.t
   -> (turn_outcome, Error.sdk_error) result

--- a/lib/pipeline/pipeline.mli
+++ b/lib/pipeline/pipeline.mli
@@ -35,7 +35,12 @@ val persist_turn_checkpoint_for_state
     [before_tool_execution], when present, runs exactly once for a non-empty
     tool batch after assistant collection has committed successfully and before
     the first tool hook or implementation starts.  Exceptions propagate and
-    prevent tool execution. *)
+    prevent tool execution.
+
+    [execution_scope], when present, owns the turn and exact selected provider
+    attempt before provider I/O and is threaded into Tool execution. The caller
+    owns root settlement; this function closes its successful turn descendants,
+    while an error leaves them open for the caller's atomic abort. *)
 val run_turn
   :  sw:Eio.Switch.t
   -> ?clock:_ Eio.Time.clock
@@ -43,5 +48,6 @@ val run_turn
   -> ?raw_trace_run:Raw_trace.active_run
   -> ?on_provider_failure:(Provider_failure_attribution.t option -> unit)
   -> ?before_tool_execution:(unit -> unit)
+  -> ?execution_scope:Execution_agent_scope.t
   -> Agent_types.t
   -> (turn_outcome, Error.sdk_error) result

--- a/lib/pipeline/pipeline_checkpoint.ml
+++ b/lib/pipeline/pipeline_checkpoint.ml
@@ -1,0 +1,46 @@
+open Agent_types
+
+let _log = Log.create ~module_name:"pipeline_checkpoint" ()
+
+let persist_for_state agent stage state =
+  match agent.checkpoint_sink with
+  | None -> Ok ()
+  | Some sink ->
+    let checkpoint =
+      Agent_checkpoint.build_checkpoint
+        ~state
+        ~tools:agent.tools
+        ~context:agent.context
+        ~mcp_clients:agent.options.mcp_clients
+        ()
+    in
+    let timestamp = checkpoint.created_at in
+    let turn = state.turn_count in
+    let stage_label = checkpoint_stage_to_string stage in
+    let snapshot = { stage; turn; checkpoint; timestamp } in
+    (match sink snapshot with
+     | Ok () ->
+       (match agent.options.journal with
+        | Some journal ->
+          Agent_execution_event_writer.append
+            journal
+            (Checkpoint_saved
+               { checkpoint_id = Printf.sprintf "%s-%d" stage_label turn; timestamp })
+        | None -> ());
+       Log.info
+         _log
+         "turn checkpoint persisted"
+         [ S ("stage", stage_label)
+         ; I ("turn", turn)
+         ; I ("messages", List.length checkpoint.messages)
+         ];
+       Ok ()
+     | Error detail ->
+       Log.error
+         _log
+         "turn checkpoint sink failed"
+         [ S ("stage", stage_label); I ("turn", turn); S ("detail", detail) ];
+       Error
+         (Error.Internal
+            (Printf.sprintf "checkpoint sink failed at %s: %s" stage_label detail)))
+;;

--- a/lib/pipeline/pipeline_checkpoint.mli
+++ b/lib/pipeline/pipeline_checkpoint.mli
@@ -1,0 +1,7 @@
+(** Private checkpoint persistence for pipeline mutation boundaries. *)
+
+val persist_for_state
+  :  Agent_types.t
+  -> Agent_types.checkpoint_stage
+  -> Types.agent_state
+  -> (unit, Error.sdk_error) result

--- a/lib/pipeline/pipeline_execution_resume.ml
+++ b/lib/pipeline/pipeline_execution_resume.ml
@@ -1,0 +1,114 @@
+open Types
+open Result_syntax
+
+let tool_use_ids blocks =
+  List.filter_map
+    (function
+      | ToolUse { id; _ } -> Some id
+      | Text _
+      | Thinking _
+      | ReasoningDetails _
+      | RedactedThinking _
+      | ToolResult _
+      | Image _
+      | Document _
+      | Audio _ -> None)
+    blocks
+;;
+
+let tool_result_ids blocks =
+  List.filter_map
+    (function
+      | ToolResult { tool_use_id; _ } -> Some tool_use_id
+      | Text _
+      | Thinking _
+      | ReasoningDetails _
+      | RedactedThinking _
+      | ToolUse _
+      | Image _
+      | Document _
+      | Audio _ -> None)
+    blocks
+;;
+
+let last_tool_turn messages =
+  let rec find messages_after_rev = function
+    | [] -> None
+    | message :: rest ->
+      (match message.role with
+       | Assistant ->
+         let tool_blocks =
+           List.filter
+             (function
+               | ToolUse _ -> true
+               | Text _
+               | Thinking _
+               | ReasoningDetails _
+               | RedactedThinking _
+               | ToolResult _
+               | Image _
+               | Document _
+               | Audio _ -> false)
+             message.content
+         in
+         (match tool_blocks with
+          | [] -> None
+          | tool_blocks -> Some (tool_blocks, tool_use_ids tool_blocks, messages_after_rev))
+       | System | User | Tool -> find (message :: messages_after_rev) rest)
+  in
+  find [] (List.rev messages)
+;;
+
+let recovered_tool_result_ids messages_after =
+  List.find_map
+    (fun (message : Types.message) ->
+       match tool_result_ids message.content with
+       | [] -> None
+       | ids -> Some ids)
+    messages_after
+;;
+
+let run agent execution ~execute ~already_settled =
+  let outcome =
+    match last_tool_turn agent.Agent_types.state.messages with
+    | None ->
+      Error
+        (Error.Internal
+           "durable execution resume found an open provider attempt without a restored \
+            ToolUse checkpoint")
+    | Some (tool_blocks, expected_ids, messages_after) ->
+      (match recovered_tool_result_ids messages_after with
+       | None ->
+         (match Nonempty.of_list tool_blocks with
+          | None ->
+            Error
+              (Error.Internal
+                 "durable execution resume restored an empty ToolUse checkpoint")
+          | Some tool_blocks ->
+            (match Pipeline_execution_scope.provider execution with
+             | None ->
+               Error
+                 (Error.Internal "durable execution resume lost its provider authority")
+             | Some provider ->
+               Execution_context.with_provider_attempt provider (fun () ->
+                 execute tool_blocks)))
+       | Some result_ids when result_ids = expected_ids ->
+         let* settled = Pipeline_execution_scope.invocations_settled execution in
+         if settled
+         then Ok already_settled
+         else
+           Error
+             (Error.Internal
+                "durable execution resume checkpoint contains ToolResults but journal \
+                 settlement is incomplete")
+       | Some _ ->
+         Error
+           (Error.Internal
+              "durable execution resume ToolResult identities differ from the restored \
+               ToolUse checkpoint"))
+  in
+  match outcome with
+  | Error _ as error -> error
+  | Ok outcome ->
+    Pipeline_execution_scope.close_success execution |> Result.map (fun () -> outcome)
+;;

--- a/lib/pipeline/pipeline_execution_resume.mli
+++ b/lib/pipeline/pipeline_execution_resume.mli
@@ -1,0 +1,8 @@
+(** Private restart recovery for one already-open durable provider turn. *)
+
+val run
+  :  Agent_types.t
+  -> Pipeline_execution_scope.t
+  -> execute:(Types.content_block Nonempty.t -> ('a, Error.sdk_error) result)
+  -> already_settled:'a
+  -> ('a, Error.sdk_error) result

--- a/lib/pipeline/pipeline_execution_scope.ml
+++ b/lib/pipeline/pipeline_execution_scope.ml
@@ -11,9 +11,28 @@ let open_turn scope ~ordinal =
   match scope with
   | None -> Ok { turn = None; provider = None }
   | Some scope ->
-    Execution_agent_scope.open_turn scope ~ordinal
-    |> Result.map (fun turn -> { turn = Some turn; provider = None })
-    |> Result.map_error sdk_error
+    (match Execution_agent_scope.resume_turn scope ~ordinal with
+     | Error error -> Error (sdk_error error)
+     | Ok (Some turn) -> Ok { turn = Some turn; provider = None }
+     | Ok None ->
+       Execution_agent_scope.open_turn scope ~ordinal
+       |> Result.map (fun turn -> { turn = Some turn; provider = None })
+       |> Result.map_error sdk_error)
+;;
+
+let resume_current scope ~ordinal =
+  match scope with
+  | None -> Ok None
+  | Some scope ->
+    (match Execution_agent_scope.resume_turn scope ~ordinal with
+     | Error error -> Error (sdk_error error)
+     | Ok None -> Ok None
+     | Ok (Some turn) ->
+       Execution_agent_scope.resume_provider_attempt turn
+       |> Result.map (function
+         | None -> None
+         | Some provider -> Some { turn = Some turn; provider = Some provider })
+       |> Result.map_error sdk_error)
 ;;
 
 let before_provider_attempt t binding =
@@ -26,6 +45,14 @@ let before_provider_attempt t binding =
 ;;
 
 let provider t = t.provider
+
+let invocations_settled t =
+  match t.provider with
+  | None -> Ok false
+  | Some provider ->
+    Execution_agent_scope.provider_invocations_settled provider
+    |> Result.map_error sdk_error
+;;
 
 let close_success t =
   match t.provider, t.turn with

--- a/lib/pipeline/pipeline_execution_scope.ml
+++ b/lib/pipeline/pipeline_execution_scope.ml
@@ -1,0 +1,42 @@
+open Result_syntax
+
+type t =
+  { turn : Execution_agent_scope.turn option
+  ; mutable provider : Execution_agent_scope.provider_attempt option
+  }
+
+let sdk_error error = Error.Internal (Execution_agent_scope.error_to_string error)
+
+let open_turn scope ~ordinal =
+  match scope with
+  | None -> Ok { turn = None; provider = None }
+  | Some scope ->
+    Execution_agent_scope.open_turn scope ~ordinal
+    |> Result.map (fun turn -> { turn = Some turn; provider = None })
+    |> Result.map_error sdk_error
+;;
+
+let before_provider_attempt t binding =
+  match t.turn with
+  | None -> Ok ()
+  | Some turn ->
+    Execution_agent_scope.open_provider_attempt turn ~ordinal:0 binding
+    |> Result.map (fun provider -> t.provider <- Some provider)
+    |> Result.map_error sdk_error
+;;
+
+let provider t = t.provider
+
+let close_success t =
+  match t.provider, t.turn with
+  | None, None -> Ok ()
+  | Some provider, Some turn ->
+    let* () =
+      Execution_agent_scope.close_provider_attempt provider Execution_event.Succeeded
+      |> Result.map_error sdk_error
+    in
+    Execution_agent_scope.close_turn turn Execution_event.Succeeded
+    |> Result.map_error sdk_error
+  | None, Some _ | Some _, None ->
+    Error (sdk_error Execution_agent_scope.Invocation_locator_mismatch)
+;;

--- a/lib/pipeline/pipeline_execution_scope.mli
+++ b/lib/pipeline/pipeline_execution_scope.mli
@@ -7,6 +7,12 @@ val open_turn
   -> ordinal:int
   -> (t, Error.sdk_error) result
 
+val resume_current
+  :  Execution_agent_scope.t option
+  -> ordinal:int
+  -> (t option, Error.sdk_error) result
+
 val before_provider_attempt : t -> Binding_identity.t -> (unit, Error.sdk_error) result
 val provider : t -> Execution_agent_scope.provider_attempt option
+val invocations_settled : t -> (bool, Error.sdk_error) result
 val close_success : t -> (unit, Error.sdk_error) result

--- a/lib/pipeline/pipeline_execution_scope.mli
+++ b/lib/pipeline/pipeline_execution_scope.mli
@@ -1,0 +1,12 @@
+(** Private durable-execution ownership for one pipeline turn. *)
+
+type t
+
+val open_turn
+  :  Execution_agent_scope.t option
+  -> ordinal:int
+  -> (t, Error.sdk_error) result
+
+val before_provider_attempt : t -> Binding_identity.t -> (unit, Error.sdk_error) result
+val provider : t -> Execution_agent_scope.provider_attempt option
+val close_success : t -> (unit, Error.sdk_error) result

--- a/lib/pipeline/pipeline_stage_route.ml
+++ b/lib/pipeline/pipeline_stage_route.ml
@@ -123,6 +123,12 @@ let finish_call ?on_provider_failure = function
     Error detailed.error
 ;;
 
+let admit_provider_attempt callback binding =
+  match callback with
+  | None -> Ok ()
+  | Some callback -> callback binding
+;;
+
 let provider_config_for_turn ~turn_config agent =
   match agent.provider_config with
   | Some provider_config ->
@@ -139,6 +145,7 @@ let dispatch_sync
       ?clock
       ?(trace_context = [])
       ?on_provider_failure
+      ?before_provider_attempt
       ~turn_config
       agent
       (prep : Agent_turn.turn_preparation)
@@ -155,6 +162,7 @@ let dispatch_sync
       binding_identity_for_call agent pc
       |> Result.map_error (binding_identity_error ?on_provider_failure)
     in
+    let* () = admit_provider_attempt before_provider_attempt binding in
     let compatibility_call () =
       Llm_provider.Complete.complete
         ~sw
@@ -210,6 +218,7 @@ let dispatch_stream
       ?(trace_context = [])
       ?on_telemetry
       ?on_provider_failure
+      ?before_provider_attempt
       ()
   =
   let ( let* ) = Result.bind in
@@ -224,6 +233,7 @@ let dispatch_stream
       binding_identity_for_call agent pc
       |> Result.map_error (binding_identity_error ?on_provider_failure)
     in
+    let* () = admit_provider_attempt before_provider_attempt binding in
     let compatibility_call () =
       Llm_provider.Complete.complete_stream
         ~sw

--- a/test/test_execution_journal.ml
+++ b/test/test_execution_journal.ml
@@ -39,11 +39,11 @@ let provider_attempt ?(model_id = "test-model") ordinal =
   require_codec_ok (Event.provider_attempt ~ordinal binding)
 ;;
 
-let tool_invocation name =
+let tool_invocation ?(planned_index = 0) name =
   Event.Tool_invocation
     { provider_tool_use_id = Some ("provider-" ^ name)
     ; tool_name = name
-    ; schedule = serial_schedule
+    ; schedule = { serial_schedule with planned_index; batch_index = planned_index }
     }
 ;;
 
@@ -734,7 +734,7 @@ let test_hierarchy_and_lifecycle_rejections () =
          journal
          ~run
          ~parent:turn
-         ~kind:(tool_invocation "parse_failure"))
+         ~kind:(tool_invocation ~planned_index:1 "parse_failure"))
   in
   ignore
     (require_ok
@@ -756,7 +756,7 @@ let test_hierarchy_and_lifecycle_rejections () =
            (Event.Tool_invocation
               { provider_tool_use_id = None
               ; tool_name = "late_identity"
-              ; schedule = serial_schedule
+              ; schedule = { serial_schedule with planned_index = 2; batch_index = 2 }
               }))
   in
   let canonical_tool_use =

--- a/test/test_execution_lane_writer.ml
+++ b/test/test_execution_lane_writer.ml
@@ -8,6 +8,7 @@ module Journal = Internal.Execution_journal
 module Store = Internal.Execution_event_store
 module Writer = Internal.Execution_lane_writer
 module Settlement = Internal.Execution_tool_settlement
+module Agent_scope = Internal.Execution_agent_scope
 module Tx = Journal.Transaction
 
 exception Cancel_waiter
@@ -33,6 +34,11 @@ let require_closed = function
 let require_scope = function
   | Ok value -> value
   | Error error -> fail (Writer.scope_failure_to_string error)
+;;
+
+let require_agent_scope = function
+  | Ok value -> value
+  | Error error -> fail (Agent_scope.error_to_string error)
 ;;
 
 let with_fresh codec dir f =
@@ -515,6 +521,153 @@ let test_structural_occurrence_identity_is_parent_local () =
               ~kind:(Event.Agent_turn { ordinal = 0 })
               ()));
       check int "same ordinal under different parents is allowed" 12 (seq ())))
+;;
+
+let test_agent_scope_owns_effect_topology () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun codec dir ->
+    make_dir dir;
+    let locator = ref None in
+    let calls = ref 0 in
+    let result =
+      Types.ToolResult
+        { tool_use_id = ""
+        ; content = "done"
+        ; outcome = Types.Tool_succeeded
+        ; json = None
+        ; content_blocks = None
+        }
+    in
+    with_fresh codec dir (fun _sw writer ->
+      let scope = require_agent_scope (Agent_scope.start ~writer ~agent_name:"agent") in
+      let before_cancelled =
+        Writer.current_cursor writer |> Result.get_ok |> Journal.cursor_seq
+      in
+      (match
+         Eio.Cancel.sub (fun cancellation ->
+           Eio.Cancel.cancel cancellation Cancel_scope;
+           ignore (Agent_scope.open_turn scope ~ordinal:99))
+       with
+       | exception Eio.Cancel.Cancelled Cancel_scope -> ()
+       | () -> fail "pre-cancelled topology mutation returned"
+       | exception exn -> raise exn);
+      check
+        int
+        "pre-cancelled topology mutation admitted no event"
+        before_cancelled
+        (Writer.current_cursor writer |> Result.get_ok |> Journal.cursor_seq);
+      let before = cursor_at (Result.get_ok (Writer.current_cursor writer)) 0 in
+      let turn = require_agent_scope (Agent_scope.open_turn scope ~ordinal:3) in
+      let config =
+        Llm_provider.Provider_config.make
+          ~kind:Llm_provider.Provider_kind.OpenAI_compat
+          ~provider_id:"scope-provider"
+          ~model_id:"scope-model"
+          ~base_url:"https://provider.test"
+          ()
+      in
+      let binding =
+        Binding_identity.of_provider_config
+          ~transport:(Binding_identity.transport_for_call ~injected:false)
+          config
+        |> require_codec
+      in
+      let provider =
+        require_agent_scope (Agent_scope.open_provider_attempt turn ~ordinal:0 binding)
+      in
+      let schedule : Tool.schedule =
+        { planned_index = 0
+        ; batch_index = 0
+        ; batch_size = 1
+        ; execution_mode = Tool.Serial
+        }
+      in
+      let wrong_turn = Tool.Invocation.create ~tool_use_id:"" ~turn:4 ~schedule in
+      (match
+         Agent_scope.open_invocation
+           provider
+           ~invocation:wrong_turn
+           ~tool_name:"effect"
+           ~input:`Null
+       with
+       | Error _ -> ()
+       | Ok _ -> fail "mismatched invocation turn entered the scope");
+      check
+        int
+        "rejected invocation left no partial node"
+        3
+        (Writer.current_cursor writer |> Result.get_ok |> Journal.cursor_seq);
+      let exact_invocation = Tool.Invocation.create ~tool_use_id:"" ~turn:3 ~schedule in
+      let invocation =
+        require_agent_scope
+          (Agent_scope.open_invocation
+             provider
+             ~invocation:exact_invocation
+             ~tool_name:"effect"
+             ~input:(`Assoc [ "value", `Int 7 ]))
+      in
+      locator := Some (Agent_scope.invocation_locator invocation);
+      (match
+         Agent_scope.execute invocation ~invoke:(fun () ->
+           incr calls;
+           result)
+       with
+       | Ok (Settlement.Executed _) -> ()
+       | Ok (Settlement.Replayed _) -> fail "fresh scoped effect was replayed"
+       | Error error -> fail (Agent_scope.error_to_string error));
+      check int "scoped effect call count" 1 !calls;
+      let abort_result =
+        match
+          Eio.Cancel.sub (fun cancellation ->
+            Eio.Cancel.cancel cancellation Cancel_scope;
+            Agent_scope.abort
+              scope
+              (Agent_scope.Cancelled { reason = Some "scope test complete"; data = None }))
+        with
+        | result -> result
+        | exception Eio.Cancel.Cancelled Cancel_scope ->
+          fail "cancelled cleanup context lost the durable abort receipt"
+        | exception exn -> raise exn
+      in
+      require_agent_scope abort_result;
+      let events, through = read_complete_page writer ~after:before ~limit:12 in
+      check int "closed scope event count" 12 (List.length events);
+      check int "closed scope cursor" 12 (Journal.cursor_seq through);
+      match List.map Event.payload events with
+      | Event.Node_opened root
+        :: Event.Node_opened turn_node
+        :: Event.Node_opened provider_node
+        :: Event.Node_opened invocation_node
+        :: Event.Node_updated { update = Event.Tool_input_snapshot input; _ }
+        :: _ ->
+        (match
+           ( Event.node_kind root
+           , Event.node_kind turn_node
+           , Event.node_kind provider_node
+           , Event.node_kind invocation_node
+           , input )
+         with
+         | ( Event.Agent_run { agent_name = "agent" }
+           , Event.Agent_turn { ordinal = 3 }
+           , Event.Provider_attempt { ordinal = 0; _ }
+           , Event.Tool_invocation
+               { provider_tool_use_id = Some ""; tool_name = "effect"; _ }
+           , Types.ToolUse
+               { id = ""; name = "effect"; input = `Assoc [ ("value", `Int 7) ] } ) -> ()
+         | _ -> fail "scope did not retain exact typed topology")
+      | _ -> fail "scope did not write its topology before the effect");
+    with_existing codec dir (fun _sw writer ->
+      ignore (require_scope (Writer.await_ready writer));
+      let invocation =
+        require_agent_scope (Agent_scope.rebind_invocation ~writer (Option.get !locator))
+      in
+      (match Agent_scope.execute invocation ~invoke:(fun () -> fail "effect reran") with
+       | Ok (Settlement.Replayed replayed) ->
+         check bool "reopened scope replays exact result" true (replayed = result)
+       | Ok (Settlement.Executed _) -> fail "reopened scope executed effect twice"
+       | Error error -> fail (Agent_scope.error_to_string error));
+      check int "reopened scope preserves call count" 1 !calls))
 ;;
 
 let rec await_reconciliation_phase writer =
@@ -1437,6 +1590,10 @@ let () =
             "structural occurrence identity is parent local"
             `Quick
             test_structural_occurrence_identity_is_parent_local
+        ; test_case
+            "Agent scope owns effect topology"
+            `Quick
+            test_agent_scope_owns_effect_topology
         ; test_case
             "concurrent submit and close linearize without loss"
             `Quick

--- a/test/test_execution_lane_writer.ml
+++ b/test/test_execution_lane_writer.ml
@@ -7,11 +7,13 @@ module Codec = Internal.Execution_codec_executor
 module Journal = Internal.Execution_journal
 module Store = Internal.Execution_event_store
 module Writer = Internal.Execution_lane_writer
+module Settlement = Internal.Execution_tool_settlement
 module Tx = Journal.Transaction
 
 exception Cancel_waiter
 exception Cancel_scope
 exception Callback_failed
+exception Effect_raised
 
 let require_submit = function
   | Ok ticket -> ticket
@@ -169,6 +171,104 @@ let open_output writer =
 
 let delta_transaction output index =
   Tx.update_node ~node:output (Event.Output_delta (`Assoc [ "index", `Int index ]))
+;;
+
+let test_effect_attempt_and_settlement_survive_restart () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun codec dir ->
+    make_dir dir;
+    let restart_pairs = ref None in
+    let result =
+      Types.ToolResult
+        { tool_use_id = "call-0"
+        ; content = "done"
+        ; outcome = Types.Tool_succeeded
+        ; json = None
+        ; content_blocks = None
+        }
+    in
+    with_fresh codec dir (fun _sw writer ->
+      let value transaction = (submit_and_await writer transaction).value in
+      let run, _ = value (Tx.start_run ~agent_name:"effect" ()) in
+      let turn, _ =
+        value
+          (Tx.open_node
+             ~run
+             ~parent:(Journal.run_root run)
+             ~kind:(Event.Agent_turn { ordinal = 1 })
+             ())
+      in
+      let provider, _ =
+        value (Tx.open_node ~run ~parent:turn ~kind:(provider_attempt 0) ())
+      in
+      let open_invocation planned_index =
+        let schedule : Tool.schedule =
+          { planned_index; batch_index = 0; batch_size = 2; execution_mode = Tool.Serial }
+        in
+        let tool_use_id = Printf.sprintf "call-%d" planned_index in
+        let node, _ =
+          value
+            (Tx.open_node
+               ~run
+               ~parent:provider
+               ~kind:
+                 (Event.Tool_invocation
+                    { provider_tool_use_id = Some tool_use_id
+                    ; tool_name = "effect"
+                    ; schedule
+                    })
+               ())
+        in
+        let invocation = Tool.Invocation.create ~tool_use_id ~turn:1 ~schedule in
+        (match Settlement.create ~writer ~invocation_node:node ~invocation with
+         | Error Settlement.Invocation_identity_mismatch -> ()
+         | Ok _ | Error _ -> fail "unmaterialized invocation gained effect authority");
+        ignore
+          (value
+             (Tx.update_node
+                ~node
+                (Event.Tool_input_snapshot
+                   (Types.ToolUse { id = tool_use_id; name = "effect"; input = `Null }))));
+        node, invocation
+      in
+      let authority (node, invocation) =
+        match Settlement.create ~writer ~invocation_node:node ~invocation with
+        | Ok authority -> authority
+        | Error _ -> fail "durable invocation authority rejected exact identity"
+      in
+      let first_pair = open_invocation 0 in
+      let first = authority first_pair in
+      let seq () = Journal.cursor_seq (Result.get_ok (Writer.current_cursor writer)) in
+      let before_seq = seq () in
+      (match
+         Settlement.execute first ~invoke:(fun () ->
+           check int "attempt durable" (before_seq + 1) (seq ());
+           result)
+       with
+       | Ok (Settlement.Executed (_committed, through, event_count)) ->
+         check int "one settlement batch" 3 event_count;
+         check int "four durable events" (before_seq + 4) (Journal.cursor_seq through)
+       | Ok (Settlement.Replayed _) | Error _ -> fail "fresh effect did not settle");
+      let second_pair = open_invocation 1 in
+      let second = authority second_pair in
+      match Settlement.execute second ~invoke:(fun () -> raise Effect_raised) with
+      | exception Effect_raised -> restart_pairs := Some (first_pair, second_pair)
+      | Ok _ | Error _ -> fail "effect exception did not propagate");
+    let first_pair, second_pair = Option.get !restart_pairs in
+    with_existing codec dir (fun _sw writer ->
+      ignore (require_scope (Writer.await_ready writer));
+      let authority (node, invocation) =
+        Result.get_ok (Settlement.create ~writer ~invocation_node:node ~invocation)
+      in
+      let never () = fail "effect reran" in
+      (match Settlement.execute (authority first_pair) ~invoke:never with
+       | Ok (Settlement.Replayed replayed) when replayed = result -> ()
+       | Ok (Settlement.Replayed _ | Settlement.Executed _) | Error _ ->
+         fail "restart lost settlement");
+      match Settlement.execute (authority second_pair) ~invoke:never with
+      | Error Settlement.Effect_outcome_unknown -> ()
+      | Ok _ | Error _ -> fail "restart did not fence unknown effect"))
 ;;
 
 let rec await_reconciliation_phase writer =
@@ -1083,6 +1183,10 @@ let () =
             "semantic rejection does not poison ready group"
             `Quick
             test_semantic_rejection_does_not_poison_ready_group
+        ; test_case
+            "effect attempt and settlement survive restart"
+            `Quick
+            test_effect_attempt_and_settlement_survive_restart
         ; test_case
             "concurrent submit and close linearize without loss"
             `Quick

--- a/test/test_execution_lane_writer.ml
+++ b/test/test_execution_lane_writer.ml
@@ -207,29 +207,21 @@ let test_effect_attempt_and_settlement_survive_restart () =
           { planned_index; batch_index = 0; batch_size = 2; execution_mode = Tool.Serial }
         in
         let tool_use_id = Printf.sprintf "call-%d" planned_index in
-        let node, _ =
-          value
-            (Tx.open_node
+        let invocation = Tool.Invocation.create ~tool_use_id ~turn:1 ~schedule in
+        let receipt =
+          submit_and_await
+            writer
+            (Tx.open_tool_invocation
                ~run
-               ~parent:provider
-               ~kind:
-                 (Event.Tool_invocation
-                    { provider_tool_use_id = Some tool_use_id
-                    ; tool_name = "effect"
-                    ; schedule
-                    })
+               ~provider_attempt:provider
+               ~invocation
+               ~tool_name:"effect"
+               ~input:`Null
                ())
         in
-        let invocation = Tool.Invocation.create ~tool_use_id ~turn:1 ~schedule in
-        (match Settlement.create ~writer ~invocation_node:node ~invocation with
-         | Error Settlement.Invocation_identity_mismatch -> ()
-         | Ok _ | Error _ -> fail "unmaterialized invocation gained effect authority");
-        ignore
-          (value
-             (Tx.update_node
-                ~node
-                (Event.Tool_input_snapshot
-                   (Types.ToolUse { id = tool_use_id; name = "effect"; input = `Null }))));
+        let node, events = receipt.value in
+        check int "open and materialize in one group" 2 (List.length events);
+        check int "one durable producer group" 2 receipt.group_event_count;
         node, invocation
       in
       let authority (node, invocation) =
@@ -240,6 +232,60 @@ let test_effect_attempt_and_settlement_survive_restart () =
       let first_pair = open_invocation 0 in
       let first = authority first_pair in
       let seq () = Journal.cursor_seq (Result.get_ok (Writer.current_cursor writer)) in
+      let before_duplicate = seq () in
+      let first_node, first_invocation = first_pair in
+      (match
+         Writer.await
+           (require_submit
+              (Writer.submit
+                 writer
+                 (Tx.open_tool_invocation
+                    ~run
+                    ~provider_attempt:provider
+                    ~invocation:first_invocation
+                    ~tool_name:"effect"
+                    ~input:`Null
+                    ())))
+       with
+       | Error
+           (Writer.Transaction_rejected
+              (Journal.Invariant_violation
+                 (Journal.Tool_occurrence_already_opened
+                    { provider_attempt; planned_index = 0; existing })))
+         when Event.Node_id.equal provider_attempt provider
+              && Event.Node_id.equal existing first_node -> ()
+       | Ok _ | Error _ -> fail "duplicate tool occurrence was accepted");
+      check int "duplicate producer is atomic" before_duplicate (seq ());
+      let before_rejected_producer = seq () in
+      let wrong_schedule : Tool.schedule =
+        { planned_index = 99
+        ; batch_index = 1
+        ; batch_size = 1
+        ; execution_mode = Tool.Serial
+        }
+      in
+      let wrong_invocation =
+        Tool.Invocation.create ~tool_use_id:"wrong-turn" ~turn:2 ~schedule:wrong_schedule
+      in
+      (match
+         Writer.await
+           (require_submit
+              (Writer.submit
+                 writer
+                 (Tx.open_tool_invocation
+                    ~run
+                    ~provider_attempt:provider
+                    ~invocation:wrong_invocation
+                    ~tool_name:"effect"
+                    ~input:`Null
+                    ())))
+       with
+       | Error
+           (Writer.Transaction_rejected
+              (Journal.Invalid_argument
+                 "tool invocation turn does not match its provider attempt")) -> ()
+       | Ok _ | Error _ -> fail "mismatched invocation turn was accepted");
+      check int "rejected producer is atomic" before_rejected_producer (seq ());
       let before_seq = seq () in
       (match
          Settlement.execute first ~invoke:(fun () ->
@@ -250,12 +296,40 @@ let test_effect_attempt_and_settlement_survive_restart () =
          check int "one settlement batch" 3 event_count;
          check int "four durable events" (before_seq + 4) (Journal.cursor_seq through)
        | Ok (Settlement.Replayed _) | Error _ -> fail "fresh effect did not settle");
+      let cancelled_pair = open_invocation 2 in
+      let cancelled = authority cancelled_pair in
+      let cancelled_result =
+        Types.ToolResult
+          { tool_use_id = "call-2"
+          ; content = "settled after cancellation"
+          ; outcome = Types.Tool_succeeded
+          ; json = None
+          ; content_blocks = None
+          }
+      in
+      (match
+         Eio.Cancel.sub (fun cancellation ->
+           match
+             Settlement.execute cancelled ~invoke:(fun () ->
+               Eio.Cancel.cancel cancellation Cancel_scope;
+               cancelled_result)
+           with
+           | Ok (Settlement.Executed _) -> ()
+           | Ok (Settlement.Replayed _) | Error _ ->
+             fail "post-effect cancellation lost settlement")
+       with
+       | () -> ()
+       | exception Eio.Cancel.Cancelled Cancel_scope -> ()
+       | exception exn -> raise exn);
       let second_pair = open_invocation 1 in
       let second = authority second_pair in
       match Settlement.execute second ~invoke:(fun () -> raise Effect_raised) with
-      | exception Effect_raised -> restart_pairs := Some (first_pair, second_pair)
+      | exception Effect_raised ->
+        restart_pairs := Some (first_pair, second_pair, cancelled_pair, cancelled_result)
       | Ok _ | Error _ -> fail "effect exception did not propagate");
-    let first_pair, second_pair = Option.get !restart_pairs in
+    let first_pair, second_pair, cancelled_pair, cancelled_result =
+      Option.get !restart_pairs
+    in
     with_existing codec dir (fun _sw writer ->
       ignore (require_scope (Writer.await_ready writer));
       let authority (node, invocation) =
@@ -266,6 +340,10 @@ let test_effect_attempt_and_settlement_survive_restart () =
        | Ok (Settlement.Replayed replayed) when replayed = result -> ()
        | Ok (Settlement.Replayed _ | Settlement.Executed _) | Error _ ->
          fail "restart lost settlement");
+      (match Settlement.execute (authority cancelled_pair) ~invoke:never with
+       | Ok (Settlement.Replayed settled) when settled = cancelled_result -> ()
+       | Ok (Settlement.Replayed _ | Settlement.Executed _) | Error _ ->
+         fail "post-effect cancellation left no durable receipt");
       match Settlement.execute (authority second_pair) ~invoke:never with
       | Error Settlement.Effect_outcome_unknown -> ()
       | Ok _ | Error _ -> fail "restart did not fence unknown effect"))

--- a/test/test_execution_lane_writer.ml
+++ b/test/test_execution_lane_writer.ml
@@ -1595,7 +1595,7 @@ let test_callback_exception_retains_unresolved_scope_failure () =
              (Writer.submit writer (Tx.start_run ~agent_name:"callback-unknown" ()))
          in
          ticket_ref := Some ticket;
-         ignore (await_reconciliation_wait writer ~outcome_count:2);
+         let _observed = await_reconciliation_wait writer ~outcome_count:2 in
          raise Callback_failed)
      with
      | exception
@@ -1609,6 +1609,30 @@ let test_callback_exception_retains_unresolved_scope_failure () =
       -> check int "ticket retains the same close evidence" 3 evidence.outcome_count
     | Error error -> fail (Writer.ticket_error_to_string error)
     | Ok _ -> fail "ambiguous ticket reported durable success")
+;;
+
+let test_reserved_callback_exception_survives_unresolved_scope_failure () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun codec dir ->
+    make_dir dir;
+    let blocker = Eio.Path.(dir / "events.v1.commit") in
+    Eio.Path.mkdirs ~exists_ok:false ~perm:0o700 blocker;
+    match
+      Writer.run ~codec ~dir (fun ~sw:_ writer ->
+        let ticket =
+          require_submit
+            (Writer.submit writer (Tx.start_run ~agent_name:"reserved-callback" ()))
+        in
+        ignore ticket;
+        ignore (await_reconciliation_wait writer ~outcome_count:2);
+        raise (Eio.Cancel.Cancelled Exit))
+    with
+    | exception Eio.Cancel.Cancelled Exit -> ()
+    | exception Writer.Callback_failed_after_scope_failure _ ->
+      fail "scope shutdown failure masked the reserved callback exception"
+    | exception exn -> raise exn
+    | Ok _ | Error _ -> fail "reserved callback exception returned normally")
 ;;
 
 let test_durable_success_settles_group_before_supervisor_cancellation () =
@@ -1867,6 +1891,10 @@ let () =
             "callback exception retains unresolved scope failure"
             `Quick
             test_callback_exception_retains_unresolved_scope_failure
+        ; test_case
+            "reserved callback survives unresolved scope failure"
+            `Quick
+            test_reserved_callback_exception_survives_unresolved_scope_failure
         ; test_case
             "durable success settles group before supervisor cancellation"
             `Quick

--- a/test/test_execution_lane_writer.ml
+++ b/test/test_execution_lane_writer.ml
@@ -546,7 +546,7 @@ let test_structural_occurrence_identity_is_parent_local () =
           ]
         |> Agent_scope.scope_locator_of_yojson
         |> require_codec
-        |> Agent_scope.resume ~writer
+        |> Agent_scope.resume ~writer ~agent_name:"occurrence"
         |> require_agent_scope
       in
       let foreign =
@@ -635,8 +635,10 @@ let test_agent_scope_owns_effect_topology () =
            (Agent_scope.invocation_locator_to_yojson
               (Agent_scope.invocation_locator invocation));
       (match
-         Agent_scope.execute invocation ~invoke:(fun ~tool_name:_ ~input:_ ->
+         Agent_scope.execute invocation ~invoke:(fun ~start_child ~tool_name:_ ~input:_ ->
            incr calls;
+           let child = require_agent_scope (start_child ~agent_name:"child-agent") in
+           require_agent_scope (Agent_scope.finish child Event.Succeeded);
            "done", Types.Tool_succeeded)
        with
        | Ok (Agent_scope.Executed _) -> ()
@@ -657,9 +659,39 @@ let test_agent_scope_owns_effect_topology () =
         | exception exn -> raise exn
       in
       require_agent_scope abort_result;
-      let events, through = read_complete_page writer ~after:before ~limit:12 in
-      check int "closed scope event count" 12 (List.length events);
-      check int "closed scope cursor" 12 (Journal.cursor_seq through);
+      let events, through = read_complete_page writer ~after:before ~limit:14 in
+      check int "closed scope event count" 14 (List.length events);
+      check int "closed scope cursor" 14 (Journal.cursor_seq through);
+      let tool_attempt =
+        List.find_map
+          (fun event ->
+             match Event.payload event with
+             | Event.Node_opened node when Event.node_kind node = Event.Tool_attempt ->
+               Some node
+             | _ -> None)
+          events
+        |> Option.get
+      in
+      let child_root =
+        List.find_map
+          (fun event ->
+             match Event.payload event with
+             | Event.Node_opened node ->
+               (match Event.node_kind node with
+                | Event.Agent_run { agent_name = "child-agent" } -> Some node
+                | _ -> None)
+             | _ -> None)
+          events
+        |> Option.get
+      in
+      check
+        bool
+        "child run is rooted beneath exact tool attempt"
+        true
+        (Option.equal
+           Event.Node_id.equal
+           (Event.parent_node_id child_root)
+           (Some (Event.node_id tool_attempt)));
       match List.map Event.payload events with
       | Event.Node_opened root
         :: Event.Node_opened turn_node
@@ -685,12 +717,19 @@ let test_agent_scope_owns_effect_topology () =
       | _ -> fail "scope did not write its topology before the effect");
     with_existing codec dir (fun _sw writer ->
       ignore (require_scope (Writer.await_ready writer));
+      let locator =
+        Option.get !scope_locator_json
+        |> Agent_scope.scope_locator_of_yojson
+        |> require_codec
+      in
+      (match Agent_scope.resume ~writer ~agent_name:"other-agent" locator with
+       | Error
+           (Agent_scope.Agent_identity_mismatch
+              { expected = "agent"; actual = "other-agent" }) -> ()
+       | Error error -> fail (Agent_scope.error_to_string error)
+       | Ok _ -> fail "scope resumed under the wrong Agent identity");
       let scope =
-        require_agent_scope
-          (Agent_scope.resume
-             ~writer
-             (require_codec
-                (Agent_scope.scope_locator_of_yojson (Option.get !scope_locator_json))))
+        require_agent_scope (Agent_scope.resume ~writer ~agent_name:"agent" locator)
       in
       let invocation =
         Option.get !invocation_locator_json
@@ -700,8 +739,9 @@ let test_agent_scope_owns_effect_topology () =
         |> require_agent_scope
       in
       (match
-         Agent_scope.execute invocation ~invoke:(fun ~tool_name:_ ~input:_ ->
-           fail "effect reran")
+         Agent_scope.execute
+           invocation
+           ~invoke:(fun ~start_child:_ ~tool_name:_ ~input:_ -> fail "effect reran")
        with
        | Ok (Agent_scope.Replayed replayed) ->
          check string "reopened result content" "done" replayed.content;
@@ -759,7 +799,7 @@ let test_agent_scope_executes_pending_after_restart () =
         Option.get !scope_json
         |> Agent_scope.scope_locator_of_yojson
         |> require_codec
-        |> Agent_scope.resume ~writer
+        |> Agent_scope.resume ~writer ~agent_name:"agent"
         |> require_agent_scope
       in
       let invocation =
@@ -770,7 +810,7 @@ let test_agent_scope_executes_pending_after_restart () =
         |> require_agent_scope
       in
       (match
-         Agent_scope.execute invocation ~invoke:(fun ~tool_name ~input ->
+         Agent_scope.execute invocation ~invoke:(fun ~start_child:_ ~tool_name ~input ->
            check string "rebound tool name" "durable-tool" tool_name;
            check bool "rebound tool input" true (Yojson.Safe.equal input expected_input);
            "done", Types.Tool_succeeded)

--- a/test/test_execution_lane_writer.ml
+++ b/test/test_execution_lane_writer.ml
@@ -570,15 +570,6 @@ let test_agent_scope_owns_effect_topology () =
     let scope_locator_json = ref None in
     let invocation_locator_json = ref None in
     let calls = ref 0 in
-    let result =
-      Types.ToolResult
-        { tool_use_id = ""
-        ; content = "done"
-        ; outcome = Types.Tool_succeeded
-        ; json = None
-        ; content_blocks = None
-        }
-    in
     with_fresh codec dir (fun _sw writer ->
       let scope = require_agent_scope (Agent_scope.start ~writer ~agent_name:"agent") in
       scope_locator_json
@@ -646,10 +637,10 @@ let test_agent_scope_owns_effect_topology () =
       (match
          Agent_scope.execute invocation ~invoke:(fun ~tool_name:_ ~input:_ ->
            incr calls;
-           result)
+           "done", Types.Tool_succeeded)
        with
-       | Ok (Settlement.Executed _) -> ()
-       | Ok (Settlement.Replayed _) -> fail "fresh scoped effect was replayed"
+       | Ok (Agent_scope.Executed _) -> ()
+       | Ok (Agent_scope.Replayed _) -> fail "fresh scoped effect was replayed"
        | Error error -> fail (Agent_scope.error_to_string error));
       check int "scoped effect call count" 1 !calls;
       let abort_result =
@@ -712,9 +703,14 @@ let test_agent_scope_owns_effect_topology () =
          Agent_scope.execute invocation ~invoke:(fun ~tool_name:_ ~input:_ ->
            fail "effect reran")
        with
-       | Ok (Settlement.Replayed replayed) ->
-         check bool "reopened scope replays exact result" true (replayed = result)
-       | Ok (Settlement.Executed _) -> fail "reopened scope executed effect twice"
+       | Ok (Agent_scope.Replayed replayed) ->
+         check string "reopened result content" "done" replayed.content;
+         check
+           bool
+           "reopened result outcome"
+           true
+           (replayed.outcome = Types.Tool_succeeded)
+       | Ok (Agent_scope.Executed _) -> fail "reopened scope executed effect twice"
        | Error error -> fail (Agent_scope.error_to_string error));
       check int "reopened scope preserves call count" 1 !calls))
 ;;
@@ -777,14 +773,17 @@ let test_agent_scope_executes_pending_after_restart () =
          Agent_scope.execute invocation ~invoke:(fun ~tool_name ~input ->
            check string "rebound tool name" "durable-tool" tool_name;
            check bool "rebound tool input" true (Yojson.Safe.equal input expected_input);
-           Types.Text "done")
+           "done", Types.Tool_succeeded)
        with
-       | Ok (Settlement.Executed (Types.Text "done", _, _)) -> ()
-       | Ok (Settlement.Executed _ | Settlement.Replayed _) ->
+       | Ok (Agent_scope.Executed ({ content = "done"; _ }, _, _)) -> ()
+       | Ok (Agent_scope.Executed _ | Agent_scope.Replayed _) ->
          fail "pending command mismatch"
        | Error error -> fail (Agent_scope.error_to_string error));
       require_agent_scope
-        (Agent_scope.abort scope (Agent_scope.Cancelled { reason = None; data = None }))))
+        (Agent_scope.abort
+           scope
+           (Agent_scope.Cancelled
+              { reason = Some "pending command test complete"; data = None }))))
 ;;
 
 let rec await_reconciliation_phase writer =

--- a/test/test_execution_lane_writer.ml
+++ b/test/test_execution_lane_writer.ml
@@ -329,13 +329,61 @@ let test_effect_attempt_and_settlement_survive_restart () =
        | () -> ()
        | exception Eio.Cancel.Cancelled Cancel_scope -> ()
        | exception exn -> raise exn);
+      let pre_effect_cancel_pair = open_invocation 3 in
+      let pre_effect_cancel = authority pre_effect_cancel_pair in
+      let pre_effect_cancel_invoked = ref false in
+      let pre_effect_cancel_result =
+        Types.ToolResult
+          { tool_use_id = "call-3"
+          ; content = "effect ran after committed-attempt cancellation"
+          ; outcome = Types.Tool_succeeded
+          ; json = None
+          ; content_blocks = None
+          }
+      in
+      (match
+         Eio.Cancel.sub (fun cancellation ->
+           match
+             Settlement.For_testing.execute_with_attempt_after_attempt_committed
+               pre_effect_cancel
+               ~after_attempt_committed:(fun () ->
+                 Eio.Cancel.cancel cancellation Cancel_scope)
+               ~invoke:(fun _attempt ->
+                 pre_effect_cancel_invoked := true;
+                 pre_effect_cancel_result)
+           with
+           | Ok (Settlement.Executed _) -> ()
+           | Ok (Settlement.Replayed _) | Error _ ->
+             fail "pre-effect cancellation lost settlement")
+       with
+       | () -> ()
+       | exception Eio.Cancel.Cancelled Cancel_scope -> ()
+       | exception exn -> raise exn);
+      check
+        bool
+        "committed attempt enters effect without a cancellation gap"
+        true
+        !pre_effect_cancel_invoked;
       let second_pair = open_invocation 1 in
       let second = authority second_pair in
       match Settlement.execute second ~invoke:(fun () -> raise Effect_raised) with
       | exception Effect_raised ->
-        restart_pairs := Some (first_pair, second_pair, cancelled_pair, cancelled_result)
+        restart_pairs
+        := Some
+             ( first_pair
+             , second_pair
+             , cancelled_pair
+             , cancelled_result
+             , pre_effect_cancel_pair
+             , pre_effect_cancel_result )
       | Ok _ | Error _ -> fail "effect exception did not propagate");
-    let first_pair, second_pair, cancelled_pair, cancelled_result =
+    let ( first_pair
+        , second_pair
+        , cancelled_pair
+        , cancelled_result
+        , pre_effect_cancel_pair
+        , pre_effect_cancel_result )
+      =
       Option.get !restart_pairs
     in
     with_existing codec dir (fun _sw writer ->
@@ -352,6 +400,10 @@ let test_effect_attempt_and_settlement_survive_restart () =
        | Ok (Settlement.Replayed settled) when settled = cancelled_result -> ()
        | Ok (Settlement.Replayed _ | Settlement.Executed _) | Error _ ->
          fail "post-effect cancellation left no durable receipt");
+      (match Settlement.execute (authority pre_effect_cancel_pair) ~invoke:never with
+       | Ok (Settlement.Replayed settled) when settled = pre_effect_cancel_result -> ()
+       | Ok (Settlement.Replayed _ | Settlement.Executed _) | Error _ ->
+         fail "committed-attempt cancellation poisoned an effect that ran");
       match Settlement.execute (authority second_pair) ~invoke:never with
       | Error Settlement.Effect_outcome_unknown -> ()
       | Ok _ | Error _ -> fail "restart did not fence unknown effect"))
@@ -570,6 +622,7 @@ let test_agent_scope_owns_effect_topology () =
     let scope_locator_json = ref None in
     let invocation_locator_json = ref None in
     let calls = ref 0 in
+    let settled_before_observer = ref false in
     with_fresh codec dir (fun _sw writer ->
       let scope = require_agent_scope (Agent_scope.start ~writer ~agent_name:"agent") in
       scope_locator_json
@@ -634,17 +687,29 @@ let test_agent_scope_owns_effect_topology () =
       := Some
            (Agent_scope.invocation_locator_to_yojson
               (Agent_scope.invocation_locator invocation));
+      let before_effect =
+        Writer.current_cursor writer |> Result.get_ok |> Journal.cursor_seq
+      in
       (match
-         Agent_scope.execute invocation ~invoke:(fun ~start_child ~tool_name:_ ~input:_ ->
-           incr calls;
-           let child = require_agent_scope (start_child ~agent_name:"child-agent") in
-           require_agent_scope (Agent_scope.finish child Event.Succeeded);
-           "done", Types.Tool_succeeded)
+         Agent_scope.execute_phased
+           invocation
+           ~invoke:(fun ~start_child ~tool_name:_ ~input:_ ->
+             incr calls;
+             let child = require_agent_scope (start_child ~agent_name:"child-agent") in
+             require_agent_scope (Agent_scope.finish child Event.Succeeded);
+             ( ("done", Types.Tool_succeeded)
+             , fun () ->
+                 let observed =
+                   Writer.current_cursor writer |> Result.get_ok |> Journal.cursor_seq
+                 in
+                 check int "observer sees durable ToolResult" (before_effect + 6) observed;
+                 settled_before_observer := true ))
        with
        | Ok (Agent_scope.Executed _) -> ()
        | Ok (Agent_scope.Replayed _) -> fail "fresh scoped effect was replayed"
        | Error error -> fail (Agent_scope.error_to_string error));
       check int "scoped effect call count" 1 !calls;
+      check bool "post-effect observer ran after settlement" true !settled_before_observer;
       let abort_result =
         match
           Eio.Cancel.sub (fun cancellation ->

--- a/test/test_execution_lane_writer.ml
+++ b/test/test_execution_lane_writer.ml
@@ -104,11 +104,11 @@ let read_complete_page writer ~after ~limit =
     page.events, page.next_cursor
 ;;
 
-let provider_attempt ordinal =
+let provider_attempt_for ~provider_id ordinal =
   let config =
     Llm_provider.Provider_config.make
       ~kind:Llm_provider.Provider_kind.OpenAI_compat
-      ~provider_id:"lane-writer-test"
+      ~provider_id
       ~model_id:"lane-writer-model"
       ~base_url:"https://provider.test"
       ()
@@ -120,6 +120,10 @@ let provider_attempt ordinal =
     |> require_codec
   in
   require_codec (Event.provider_attempt ~ordinal binding)
+;;
+
+let provider_attempt ordinal =
+  provider_attempt_for ~provider_id:"lane-writer-test" ordinal
 ;;
 
 let submit_and_await writer transaction =
@@ -249,11 +253,8 @@ let test_effect_attempt_and_settlement_survive_restart () =
        with
        | Error
            (Writer.Transaction_rejected
-              (Journal.Invariant_violation
-                 (Journal.Tool_occurrence_already_opened
-                    { provider_attempt; planned_index = 0; existing })))
-         when Event.Node_id.equal provider_attempt provider
-              && Event.Node_id.equal existing first_node -> ()
+              (Journal.Invariant_violation (Journal.Occurrence_already_opened existing)))
+         when Event.Node_id.equal existing first_node -> ()
        | Ok _ | Error _ -> fail "duplicate tool occurrence was accepted");
       check int "duplicate producer is atomic" before_duplicate (seq ());
       let before_rejected_producer = seq () in
@@ -347,6 +348,173 @@ let test_effect_attempt_and_settlement_survive_restart () =
       match Settlement.execute (authority second_pair) ~invoke:never with
       | Error Settlement.Effect_outcome_unknown -> ()
       | Ok _ | Error _ -> fail "restart did not fence unknown effect"))
+;;
+
+let test_structural_occurrence_identity_is_parent_local () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun codec dir ->
+    make_dir dir;
+    with_fresh codec dir (fun _sw writer ->
+      let value transaction = (submit_and_await writer transaction).value in
+      let seq () = Writer.current_cursor writer |> Result.get_ok |> Journal.cursor_seq in
+      let expect_rejected_without_events label transaction matches =
+        let before = seq () in
+        (match Writer.await (require_submit (Writer.submit writer transaction)) with
+         | Error (Writer.Transaction_rejected (Journal.Invariant_violation violation))
+           when matches violation -> ()
+         | Error error -> fail (label ^ ": " ^ Writer.ticket_error_to_string error)
+         | Ok _ -> fail (label ^ ": duplicate occurrence was accepted"));
+        check int (label ^ " is atomic") before (seq ())
+      in
+      let run, _ = value (Tx.start_run ~agent_name:"occurrence" ()) in
+      let turn_0, _ =
+        value
+          (Tx.open_node
+             ~run
+             ~parent:(Journal.run_root run)
+             ~kind:(Event.Agent_turn { ordinal = 0 })
+             ())
+      in
+      expect_rejected_without_events
+        "duplicate turn"
+        (Tx.open_node
+           ~run
+           ~parent:(Journal.run_root run)
+           ~kind:(Event.Agent_turn { ordinal = 0 })
+           ())
+        (function
+          | Journal.Occurrence_already_opened existing ->
+            Event.Node_id.equal existing turn_0
+          | _ -> false);
+      let turn_1, _ =
+        value
+          (Tx.open_node
+             ~run
+             ~parent:(Journal.run_root run)
+             ~kind:(Event.Agent_turn { ordinal = 1 })
+             ())
+      in
+      let provider_0, _ =
+        value (Tx.open_node ~run ~parent:turn_0 ~kind:(provider_attempt 0) ())
+      in
+      expect_rejected_without_events
+        "duplicate provider ordinal ignores diagnostic binding"
+        (Tx.open_node
+           ~run
+           ~parent:turn_0
+           ~kind:(provider_attempt_for ~provider_id:"different-binding" 0)
+           ())
+        (function
+          | Journal.Occurrence_already_opened existing ->
+            Event.Node_id.equal existing provider_0
+          | _ -> false);
+      let provider_1, _ =
+        value (Tx.open_node ~run ~parent:turn_1 ~kind:(provider_attempt 0) ())
+      in
+      let schedule : Tool.schedule =
+        { planned_index = 0
+        ; batch_index = 0
+        ; batch_size = 1
+        ; execution_mode = Tool.Serial
+        }
+      in
+      let input = `Assoc [ "value", `Int 7 ] in
+      let occurrence_0 = Tool.Invocation.create ~tool_use_id:"call" ~turn:0 ~schedule in
+      let tool_0, _ =
+        value
+          (Tx.open_tool_invocation
+             ~run
+             ~provider_attempt:provider_0
+             ~invocation:occurrence_0
+             ~tool_name:"effect"
+             ~input
+             ())
+      in
+      expect_rejected_without_events
+        "exact tool duplicate"
+        (Tx.open_tool_invocation
+           ~run
+           ~provider_attempt:provider_0
+           ~invocation:occurrence_0
+           ~tool_name:"effect"
+           ~input
+           ())
+        (function
+        | Journal.Occurrence_already_opened existing ->
+          Event.Node_id.equal existing tool_0
+        | _ -> false);
+      let changed_schedule : Tool.schedule =
+        { schedule with
+          batch_index = 1
+        ; batch_size = 2
+        ; execution_mode = Tool.Concurrent
+        }
+      in
+      let conflicts =
+        [ ( "tool schedule conflict"
+          , Tool.Invocation.create ~tool_use_id:"call" ~turn:0 ~schedule:changed_schedule
+          , "effect"
+          , input )
+        ; ( "tool id conflict"
+          , Tool.Invocation.create ~tool_use_id:"other-call" ~turn:0 ~schedule
+          , "effect"
+          , input )
+        ; "tool name conflict", occurrence_0, "other-effect", input
+        ; "tool input conflict", occurrence_0, "effect", `Assoc [ "value", `Int 8 ]
+        ]
+      in
+      List.iter
+        (fun (label, invocation, tool_name, input) ->
+           expect_rejected_without_events
+             label
+             (Tx.open_tool_invocation
+                ~run
+                ~provider_attempt:provider_0
+                ~invocation
+                ~tool_name
+                ~input
+                ())
+             (function
+             | Journal.Tool_occurrence_conflict { parent; planned_index = 0; existing } ->
+               Event.Node_id.equal parent provider_0
+               && Event.Node_id.equal existing tool_0
+             | _ -> false))
+        conflicts;
+      expect_rejected_without_events
+        "first raw tool open cannot bypass atomic producer"
+        (Tx.open_node
+           ~run
+           ~parent:provider_1
+           ~kind:
+             (Event.Tool_invocation
+                { provider_tool_use_id = Some "raw"; tool_name = "raw"; schedule })
+           ())
+        (function
+          | Journal.Tool_invocation_requires_atomic_open -> true
+          | _ -> false);
+      let occurrence_1 = Tool.Invocation.create ~tool_use_id:"call" ~turn:1 ~schedule in
+      ignore
+        (value
+           (Tx.open_tool_invocation
+              ~run
+              ~provider_attempt:provider_1
+              ~invocation:occurrence_1
+              ~tool_name:"effect"
+              ~input
+              ()));
+      let attempt, _ = value (Tx.begin_tool_attempt ~invocation:tool_0 ()) in
+      let child_run, _ =
+        value (Tx.start_run ~parent_attempt:attempt ~agent_name:"child" ())
+      in
+      ignore
+        (value
+           (Tx.open_node
+              ~run:child_run
+              ~parent:(Journal.run_root child_run)
+              ~kind:(Event.Agent_turn { ordinal = 0 })
+              ()));
+      check int "same ordinal under different parents is allowed" 12 (seq ())))
 ;;
 
 let rec await_reconciliation_phase writer =
@@ -1265,6 +1433,10 @@ let () =
             "effect attempt and settlement survive restart"
             `Quick
             test_effect_attempt_and_settlement_survive_restart
+        ; test_case
+            "structural occurrence identity is parent local"
+            `Quick
+            test_structural_occurrence_identity_is_parent_local
         ; test_case
             "concurrent submit and close linearize without loss"
             `Quick

--- a/test/test_execution_lane_writer.ml
+++ b/test/test_execution_lane_writer.ml
@@ -110,7 +110,7 @@ let read_complete_page writer ~after ~limit =
     page.events, page.next_cursor
 ;;
 
-let provider_attempt_for ~provider_id ordinal =
+let binding_for ~provider_id =
   let config =
     Llm_provider.Provider_config.make
       ~kind:Llm_provider.Provider_kind.OpenAI_compat
@@ -119,13 +119,14 @@ let provider_attempt_for ~provider_id ordinal =
       ~base_url:"https://provider.test"
       ()
   in
-  let binding =
-    Binding_identity.of_provider_config
-      ~transport:(Binding_identity.transport_for_call ~injected:false)
-      config
-    |> require_codec
-  in
-  require_codec (Event.provider_attempt ~ordinal binding)
+  Binding_identity.of_provider_config
+    ~transport:(Binding_identity.transport_for_call ~injected:false)
+    config
+  |> require_codec
+;;
+
+let provider_attempt_for ~provider_id ordinal =
+  require_codec (Event.provider_attempt ~ordinal (binding_for ~provider_id))
 ;;
 
 let provider_attempt ordinal =
@@ -234,9 +235,9 @@ let test_effect_attempt_and_settlement_survive_restart () =
         check int "one durable producer group" 2 receipt.group_event_count;
         node, invocation
       in
-      let authority (node, invocation) =
-        match Settlement.create ~writer ~invocation_node:node ~invocation with
-        | Ok authority -> authority
+      let authority (node, _invocation) =
+        match Settlement.rebind ~writer ~invocation_node:node with
+        | Ok durable -> durable.authority
         | Error _ -> fail "durable invocation authority rejected exact identity"
       in
       let first_pair = open_invocation 0 in
@@ -339,8 +340,8 @@ let test_effect_attempt_and_settlement_survive_restart () =
     in
     with_existing codec dir (fun _sw writer ->
       ignore (require_scope (Writer.await_ready writer));
-      let authority (node, invocation) =
-        Result.get_ok (Settlement.create ~writer ~invocation_node:node ~invocation)
+      let authority (node, _invocation) =
+        (Result.get_ok (Settlement.rebind ~writer ~invocation_node:node)).authority
       in
       let never () = fail "effect reran" in
       (match Settlement.execute (authority first_pair) ~invoke:never with
@@ -513,14 +514,52 @@ let test_structural_occurrence_identity_is_parent_local () =
       let child_run, _ =
         value (Tx.start_run ~parent_attempt:attempt ~agent_name:"child" ())
       in
-      ignore
-        (value
-           (Tx.open_node
-              ~run:child_run
-              ~parent:(Journal.run_root child_run)
-              ~kind:(Event.Agent_turn { ordinal = 0 })
-              ()));
-      check int "same ordinal under different parents is allowed" 12 (seq ())))
+      let child_turn, _ =
+        value
+          (Tx.open_node
+             ~run:child_run
+             ~parent:(Journal.run_root child_run)
+             ~kind:(Event.Agent_turn { ordinal = 0 })
+             ())
+      in
+      let child_provider, _ =
+        value
+          (Tx.open_node ~run:child_run ~parent:child_turn ~kind:(provider_attempt 0) ())
+      in
+      let child_invocation, _ =
+        value
+          (Tx.open_tool_invocation
+             ~run:child_run
+             ~provider_attempt:child_provider
+             ~invocation:(Tool.Invocation.create ~tool_use_id:"child" ~turn:0 ~schedule)
+             ~tool_name:"child-effect"
+             ~input:`Null
+             ())
+      in
+      let locator run_id node_id =
+        `Assoc [ "version", `Int 1; "run_id", `String run_id; "node_id", `String node_id ]
+      in
+      let root_scope =
+        `Assoc
+          [ "version", `Int 1
+          ; "run_id", `String (Event.Run_id.to_string (Journal.run_id run))
+          ]
+        |> Agent_scope.scope_locator_of_yojson
+        |> require_codec
+        |> Agent_scope.resume ~writer
+        |> require_agent_scope
+      in
+      let foreign =
+        locator
+          (Event.Run_id.to_string (Journal.run_id child_run))
+          (Event.Node_id.to_string child_invocation)
+        |> Agent_scope.invocation_locator_of_yojson
+        |> require_codec
+      in
+      match Agent_scope.rebind_invocation root_scope foreign with
+      | Error Agent_scope.Invocation_locator_mismatch -> ()
+      | Error error -> fail (Agent_scope.error_to_string error)
+      | Ok _ -> fail "foreign run invocation rebound into root scope"))
 ;;
 
 let test_agent_scope_owns_effect_topology () =
@@ -528,7 +567,8 @@ let test_agent_scope_owns_effect_topology () =
   @@ fun env ->
   with_temp_dir env (fun codec dir ->
     make_dir dir;
-    let locator = ref None in
+    let scope_locator_json = ref None in
+    let invocation_locator_json = ref None in
     let calls = ref 0 in
     let result =
       Types.ToolResult
@@ -541,6 +581,8 @@ let test_agent_scope_owns_effect_topology () =
     in
     with_fresh codec dir (fun _sw writer ->
       let scope = require_agent_scope (Agent_scope.start ~writer ~agent_name:"agent") in
+      scope_locator_json
+      := Some (Agent_scope.scope_locator_to_yojson (Agent_scope.scope_locator scope));
       let before_cancelled =
         Writer.current_cursor writer |> Result.get_ok |> Journal.cursor_seq
       in
@@ -559,22 +601,12 @@ let test_agent_scope_owns_effect_topology () =
         (Writer.current_cursor writer |> Result.get_ok |> Journal.cursor_seq);
       let before = cursor_at (Result.get_ok (Writer.current_cursor writer)) 0 in
       let turn = require_agent_scope (Agent_scope.open_turn scope ~ordinal:3) in
-      let config =
-        Llm_provider.Provider_config.make
-          ~kind:Llm_provider.Provider_kind.OpenAI_compat
-          ~provider_id:"scope-provider"
-          ~model_id:"scope-model"
-          ~base_url:"https://provider.test"
-          ()
-      in
-      let binding =
-        Binding_identity.of_provider_config
-          ~transport:(Binding_identity.transport_for_call ~injected:false)
-          config
-        |> require_codec
-      in
       let provider =
-        require_agent_scope (Agent_scope.open_provider_attempt turn ~ordinal:0 binding)
+        require_agent_scope
+          (Agent_scope.open_provider_attempt
+             turn
+             ~ordinal:0
+             (binding_for ~provider_id:"scope-provider"))
       in
       let schedule : Tool.schedule =
         { planned_index = 0
@@ -607,9 +639,12 @@ let test_agent_scope_owns_effect_topology () =
              ~tool_name:"effect"
              ~input:(`Assoc [ "value", `Int 7 ]))
       in
-      locator := Some (Agent_scope.invocation_locator invocation);
+      invocation_locator_json
+      := Some
+           (Agent_scope.invocation_locator_to_yojson
+              (Agent_scope.invocation_locator invocation));
       (match
-         Agent_scope.execute invocation ~invoke:(fun () ->
+         Agent_scope.execute invocation ~invoke:(fun ~tool_name:_ ~input:_ ->
            incr calls;
            result)
        with
@@ -659,15 +694,97 @@ let test_agent_scope_owns_effect_topology () =
       | _ -> fail "scope did not write its topology before the effect");
     with_existing codec dir (fun _sw writer ->
       ignore (require_scope (Writer.await_ready writer));
-      let invocation =
-        require_agent_scope (Agent_scope.rebind_invocation ~writer (Option.get !locator))
+      let scope =
+        require_agent_scope
+          (Agent_scope.resume
+             ~writer
+             (require_codec
+                (Agent_scope.scope_locator_of_yojson (Option.get !scope_locator_json))))
       in
-      (match Agent_scope.execute invocation ~invoke:(fun () -> fail "effect reran") with
+      let invocation =
+        Option.get !invocation_locator_json
+        |> Agent_scope.invocation_locator_of_yojson
+        |> require_codec
+        |> Agent_scope.rebind_invocation scope
+        |> require_agent_scope
+      in
+      (match
+         Agent_scope.execute invocation ~invoke:(fun ~tool_name:_ ~input:_ ->
+           fail "effect reran")
+       with
        | Ok (Settlement.Replayed replayed) ->
          check bool "reopened scope replays exact result" true (replayed = result)
        | Ok (Settlement.Executed _) -> fail "reopened scope executed effect twice"
        | Error error -> fail (Agent_scope.error_to_string error));
       check int "reopened scope preserves call count" 1 !calls))
+;;
+
+let test_agent_scope_executes_pending_after_restart () =
+  Eio_main.run
+  @@ fun env ->
+  with_temp_dir env (fun codec dir ->
+    make_dir dir;
+    let scope_json, invocation_json = ref None, ref None in
+    let expected_input = `Assoc [ "path", `String "durable" ] in
+    with_fresh codec dir (fun _sw writer ->
+      let scope = require_agent_scope (Agent_scope.start ~writer ~agent_name:"agent") in
+      scope_json
+      := Some (Agent_scope.scope_locator_to_yojson (Agent_scope.scope_locator scope));
+      let turn = require_agent_scope (Agent_scope.open_turn scope ~ordinal:0) in
+      let provider =
+        require_agent_scope
+          (Agent_scope.open_provider_attempt
+             turn
+             ~ordinal:0
+             (binding_for ~provider_id:"pending-provider"))
+      in
+      let schedule : Tool.schedule =
+        { planned_index = 0
+        ; batch_index = 0
+        ; batch_size = 1
+        ; execution_mode = Tool.Serial
+        }
+      in
+      let invocation =
+        require_agent_scope
+          (Agent_scope.open_invocation
+             provider
+             ~invocation:(Tool.Invocation.create ~tool_use_id:"pending" ~turn:0 ~schedule)
+             ~tool_name:"durable-tool"
+             ~input:expected_input)
+      in
+      invocation_json
+      := Some
+           (Agent_scope.invocation_locator_to_yojson
+              (Agent_scope.invocation_locator invocation)));
+    with_existing codec dir (fun _sw writer ->
+      ignore (require_scope (Writer.await_ready writer));
+      let scope =
+        Option.get !scope_json
+        |> Agent_scope.scope_locator_of_yojson
+        |> require_codec
+        |> Agent_scope.resume ~writer
+        |> require_agent_scope
+      in
+      let invocation =
+        Option.get !invocation_json
+        |> Agent_scope.invocation_locator_of_yojson
+        |> require_codec
+        |> Agent_scope.rebind_invocation scope
+        |> require_agent_scope
+      in
+      (match
+         Agent_scope.execute invocation ~invoke:(fun ~tool_name ~input ->
+           check string "rebound tool name" "durable-tool" tool_name;
+           check bool "rebound tool input" true (Yojson.Safe.equal input expected_input);
+           Types.Text "done")
+       with
+       | Ok (Settlement.Executed (Types.Text "done", _, _)) -> ()
+       | Ok (Settlement.Executed _ | Settlement.Replayed _) ->
+         fail "pending command mismatch"
+       | Error error -> fail (Agent_scope.error_to_string error));
+      require_agent_scope
+        (Agent_scope.abort scope (Agent_scope.Cancelled { reason = None; data = None }))))
 ;;
 
 let rec await_reconciliation_phase writer =
@@ -1594,6 +1711,10 @@ let () =
             "Agent scope owns effect topology"
             `Quick
             test_agent_scope_owns_effect_topology
+        ; test_case
+            "Agent scope executes pending command after restart"
+            `Quick
+            test_agent_scope_executes_pending_after_restart
         ; test_case
             "concurrent submit and close linearize without loss"
             `Quick

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -1062,6 +1062,153 @@ let test_mock_multi_tool_response () =
   | Error _ -> Alcotest.fail "expected ok"
 ;;
 
+let test_agent_run_uses_durable_tool_authority () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun runtime_sw ->
+  let runtime =
+    match
+      Agent.create_execution_runtime
+        ~sw:runtime_sw
+        ~domain_mgr:(Eio.Stdenv.domain_mgr env)
+        ~domain_count:1
+    with
+    | Ok runtime -> runtime
+    | Error error -> Alcotest.fail (Error.to_string error)
+  in
+  let native_path = Filename.temp_file "oas-agent-execution-" ".dir" in
+  Sys.remove native_path;
+  let dir = Eio.Path.(Eio.Stdenv.fs env / native_path) in
+  Fun.protect
+    ~finally:(fun () -> Eio.Path.rmtree ~missing_ok:true dir)
+    (fun () ->
+       Eio.Path.mkdirs ~exists_ok:false ~perm:0o700 dir;
+       let locator_persisted = ref false in
+       let effect_after_locator = ref false in
+       let effect_count = ref 0 in
+       let completion_cursor = ref None in
+       let committed_cursor () =
+         let authority =
+           Eio.Path.load Eio.Path.(dir / "events.v1.commit") |> Yojson.Safe.from_string
+         in
+         match authority with
+         | `Assoc outer ->
+           (match List.assoc_opt "authority" outer with
+            | Some (`Assoc fields) ->
+              (match List.assoc_opt "last_seq" fields with
+               | Some (`Int value) -> value
+               | _ -> Alcotest.fail "execution authority has no integer last_seq")
+            | _ -> Alcotest.fail "execution commit has no authority object")
+         | _ -> Alcotest.fail "execution commit authority is not an object"
+       in
+       let responses =
+         ref
+           (Provider_mock.tool_then_text
+              ~tool_name:"durable_tool"
+              ~tool_input:(`Assoc [ "value", `Int 7 ])
+              ~final_text:"done"
+              ()
+            |> List.map (fun response -> response []))
+       in
+       let next_response () =
+         match !responses with
+         | response :: rest ->
+           responses := rest;
+           Ok response
+         | [] ->
+           Error
+             (Llm_provider.Http_client.AcceptRejected
+                { reason = "durable execution test exhausted responses" })
+       in
+       let transport : Llm_provider.Llm_transport.t =
+         { complete_sync =
+             (fun _request ->
+               { Llm_provider.Llm_transport.response = next_response ()
+               ; latency_ms = Some 0
+               })
+         ; complete_stream =
+             (fun ?on_telemetry:_ ~on_event:_ _request -> next_response ())
+         }
+       in
+       let journal = Durable_event.create () in
+       let tool =
+         Tool.create
+           ~name:"durable_tool"
+           ~description:"durable execution test"
+           ~parameters:[]
+           (fun _input ->
+              incr effect_count;
+              effect_after_locator := !locator_persisted;
+              Ok { Types.content = "tool-result"; _meta = None })
+       in
+       let options =
+         { Agent.default_options with
+           transport = Some transport
+         ; provider = Some (Provider_mock.to_provider_config ())
+         ; journal = Some journal
+         ; on_run_complete =
+             Some
+               (fun succeeded ->
+                 Alcotest.(check bool) "completion reports success" true succeeded;
+                 completion_cursor := Some (committed_cursor ()))
+         }
+       in
+       let agent =
+         Agent.create
+           ~net:(Eio.Stdenv.net env)
+           ~config:
+             { (Types.default_config ~model:"test-model") with
+               name = "durable-agent-run-test"
+             }
+           ~tools:[ tool ]
+           ~options
+           ()
+       in
+       let execution_store =
+         Agent.execution_store
+           ~runtime
+           ~dir
+           ~on_scope_ready:(fun locator ->
+             (match Agent.execution_locator_to_yojson locator with
+              | `Assoc fields ->
+                Alcotest.(check bool)
+                  "locator contains durable run identity"
+                  true
+                  (List.mem_assoc "run_id" fields)
+              | _ -> Alcotest.fail "execution locator is not an object");
+             locator_persisted := true;
+             Ok ())
+           ()
+       in
+       (match Agent.run ~sw:runtime_sw ~execution_store agent "run the tool" with
+        | Ok response ->
+          Alcotest.(check string)
+            "terminal response"
+            "done"
+            (Types.text_of_response response)
+        | Error error -> Alcotest.fail (Error.to_string error));
+       Alcotest.(check int) "tool effect executes once" 1 !effect_count;
+       Alcotest.(check bool)
+         "locator is durable before tool effect"
+         true
+         !effect_after_locator;
+       Alcotest.(check (option int))
+         "completion observes the final durable cursor"
+         (Some (committed_cursor ()))
+         !completion_cursor;
+       let legacy_tool_events =
+         Durable_event.events journal
+         |> List.filter (function
+           | Durable_event.Tool_called _ | Durable_event.Tool_completed _ -> true
+           | _ -> false)
+       in
+       Alcotest.(check int)
+         "legacy journal does not duplicate tool authority"
+         0
+         (List.length legacy_tool_events))
+;;
+
 (* ── Runner ──────────────────────────────────────────────── *)
 
 let () =
@@ -1143,7 +1290,11 @@ let () =
         ; Alcotest.test_case "provider errors" `Quick test_error_domain_provider_errors
         ] )
     ; ( "provider_mock_extra"
-      , [ Alcotest.test_case "multi tool response" `Quick test_mock_multi_tool_response ]
-      )
+      , [ Alcotest.test_case "multi tool response" `Quick test_mock_multi_tool_response
+        ; Alcotest.test_case
+            "Agent.run uses durable tool authority"
+            `Quick
+            test_agent_run_uses_durable_tool_authority
+        ] )
     ]
 ;;

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -6,6 +6,11 @@
 open Agent_sdk
 module Internal_agent = Agent_sdk__Agent_types
 module Internal_pipeline = Agent_sdk__Pipeline
+module Internal_runtime = Agent_sdk__Execution_runtime
+module Internal_codec = Agent_sdk__Execution_codec_executor
+module Internal_writer = Agent_sdk__Execution_lane_writer
+module Internal_scope = Agent_sdk__Execution_agent_scope
+module Internal_binding = Agent_sdk__Binding_identity
 
 let invocation tool_use_id =
   let schedule : Tool.schedule =
@@ -1132,6 +1137,12 @@ let test_agent_run_uses_durable_tool_authority () =
          }
        in
        let journal = Durable_event.create () in
+       let event_bus = Event_bus.create () in
+       let event_config =
+         Event_bus.subscription_config ~capacity:32 ~overflow:Event_bus.Drop_newest
+         |> Result.get_ok
+       in
+       let event_subscription = Event_bus.subscribe ~config:event_config event_bus in
        let tool =
          Tool.create
            ~name:"durable_tool"
@@ -1147,6 +1158,7 @@ let test_agent_run_uses_durable_tool_authority () =
            transport = Some transport
          ; provider = Some (Provider_mock.to_provider_config ())
          ; journal = Some journal
+         ; event_bus = Some event_bus
          ; on_run_complete =
              Some
                (fun succeeded ->
@@ -1206,7 +1218,218 @@ let test_agent_run_uses_durable_tool_authority () =
        Alcotest.(check int)
          "legacy journal does not duplicate tool authority"
          0
-         (List.length legacy_tool_events))
+         (List.length legacy_tool_events);
+       let public_tool_events =
+         Event_bus.drain event_subscription
+         |> List.filter (fun (event : Event_bus.event) ->
+           match event.payload with
+           | ToolCalled _ | ToolCompleted _ -> true
+           | AgentStarted _
+           | AgentCompleted _
+           | AgentFailed _
+           | TurnStarted _
+           | TurnReady _
+           | TurnCompleted _
+           | HandoffRequested _
+           | HandoffCompleted _
+           | ElicitationCompleted _
+           | InferenceTelemetry _
+           | Custom _ -> false)
+       in
+       Alcotest.(check int)
+         "durable authority preserves public ToolCalled and ToolCompleted"
+         2
+         (List.length public_tool_events))
+;;
+
+let test_agent_run_resumes_settled_tool_without_duplicate_effects () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun runtime_sw ->
+  let domain_mgr = Eio.Stdenv.domain_mgr env in
+  let runtime =
+    match Agent.create_execution_runtime ~sw:runtime_sw ~domain_mgr ~domain_count:1 with
+    | Ok runtime -> runtime
+    | Error error -> Alcotest.fail (Error.to_string error)
+  in
+  let internal_runtime =
+    match Internal_runtime.create ~sw:runtime_sw ~domain_mgr ~domain_count:1 with
+    | Ok runtime -> runtime
+    | Error error -> Alcotest.fail (Internal_runtime.create_error_to_string error)
+  in
+  let codec = Internal_codec.of_runtime internal_runtime in
+  let native_path = Filename.temp_file "oas-agent-resume-" ".dir" in
+  Sys.remove native_path;
+  let dir = Eio.Path.(Eio.Stdenv.fs env / native_path) in
+  Fun.protect
+    ~finally:(fun () -> Eio.Path.rmtree ~missing_ok:true dir)
+    (fun () ->
+       Eio.Path.mkdirs ~exists_ok:false ~perm:0o700 dir;
+       let config =
+         { (Types.default_config ~model:"test-model") with
+           name = "durable-agent-resume-test"
+         }
+       in
+       let tool_input = `Assoc [ "value", `Int 7 ] in
+       let tool_use_id = "restart-tool-use" in
+       let schedule : Tool.schedule =
+         { planned_index = 0
+         ; batch_index = 0
+         ; batch_size = 1
+         ; execution_mode = Tool.Serial
+         }
+       in
+       let locator_json = ref None in
+       let provider_config =
+         Llm_provider.Provider_config.make
+           ~kind:Llm_provider.Provider_config.OpenAI_compat
+           ~model_id:"test-model"
+           ~base_url:"http://resume.invalid"
+           ~api_key:""
+           ~request_path:"/v1/chat/completions"
+           ()
+       in
+       let binding =
+         match
+           Internal_binding.of_provider_config
+             ~transport:Internal_binding.Injected
+             provider_config
+         with
+         | Ok binding -> binding
+         | Error detail -> Alcotest.fail detail
+       in
+       (match
+          Internal_writer.run ~codec ~dir (fun ~sw:_ writer ->
+            let scope =
+              match
+                Internal_scope.start ~writer ~agent_name:"durable-agent-resume-test"
+              with
+              | Ok scope -> scope
+              | Error error -> Alcotest.fail (Internal_scope.error_to_string error)
+            in
+            locator_json
+            := Some
+                 (Internal_scope.scope_locator_to_yojson
+                    (Internal_scope.scope_locator scope));
+            let turn =
+              match Internal_scope.open_turn scope ~ordinal:1 with
+              | Ok turn -> turn
+              | Error error -> Alcotest.fail (Internal_scope.error_to_string error)
+            in
+            let provider =
+              match Internal_scope.open_provider_attempt turn ~ordinal:0 binding with
+              | Ok provider -> provider
+              | Error error -> Alcotest.fail (Internal_scope.error_to_string error)
+            in
+            let invocation = Tool.Invocation.create ~tool_use_id ~turn:1 ~schedule in
+            let durable =
+              match
+                Internal_scope.open_invocation
+                  provider
+                  ~invocation
+                  ~tool_name:"durable_tool"
+                  ~input:tool_input
+              with
+              | Ok durable -> durable
+              | Error error -> Alcotest.fail (Internal_scope.error_to_string error)
+            in
+            match
+              Internal_scope.execute
+                durable
+                ~invoke:(fun ~start_child:_ ~tool_name:_ ~input:_ ->
+                  "settled-before-restart", Types.Tool_succeeded)
+            with
+            | Ok (Internal_scope.Executed _) -> ()
+            | Ok (Internal_scope.Replayed _) ->
+              Alcotest.fail "fixture unexpectedly replayed its first tool effect"
+            | Error error -> Alcotest.fail (Internal_scope.error_to_string error))
+        with
+        | Ok () -> ()
+        | Error failure -> Alcotest.fail (Internal_writer.scope_failure_to_string failure));
+       let locator =
+         match Option.get !locator_json |> Agent.execution_locator_of_yojson with
+         | Ok locator -> locator
+         | Error detail -> Alcotest.fail detail
+       in
+       let response = Provider_mock.text_response "done-after-restart" [] in
+       let transport : Llm_provider.Llm_transport.t =
+         { complete_sync =
+             (fun _request ->
+               { Llm_provider.Llm_transport.response = Ok response; latency_ms = Some 0 })
+         ; complete_stream = (fun ?on_telemetry:_ ~on_event:_ _request -> Ok response)
+         }
+       in
+       let effect_count = ref 0 in
+       let pre_hook_count = ref 0 in
+       let post_hook_count = ref 0 in
+       let tool =
+         Tool.create
+           ~name:"durable_tool"
+           ~description:"must not rerun after restart"
+           ~parameters:[]
+           (fun _input ->
+              incr effect_count;
+              Ok { Types.content = "duplicate"; _meta = None })
+       in
+       let hooks =
+         { Hooks.empty with
+           pre_tool_use =
+             Some
+               (fun _event ->
+                 incr pre_hook_count;
+                 Hooks.Continue)
+         ; post_tool_use =
+             Some
+               (fun _event ->
+                 incr post_hook_count;
+                 Hooks.Continue)
+         }
+       in
+       let options =
+         { Agent.default_options with
+           transport = Some transport
+         ; provider = Some (Provider_mock.to_provider_config ())
+         ; hooks
+         }
+       in
+       let agent =
+         Agent.create ~net:(Eio.Stdenv.net env) ~config ~tools:[ tool ] ~options ()
+       in
+       Agent.set_state
+         agent
+         { config
+         ; messages =
+             [ { Types.role = User
+               ; content = [ Text "run the tool" ]
+               ; name = None
+               ; tool_call_id = None
+               ; metadata = []
+               }
+             ; { Types.role = Assistant
+               ; content =
+                   [ ToolUse
+                       { id = tool_use_id; name = "durable_tool"; input = tool_input }
+                   ]
+               ; name = None
+               ; tool_call_id = None
+               ; metadata = []
+               }
+             ]
+         ; turn_count = 1
+         ; usage = Types.empty_usage
+         };
+       let execution_store = Agent.execution_store ~runtime ~dir ~resume:locator () in
+       (match Agent.run ~sw:runtime_sw ~execution_store agent "run the tool" with
+        | Ok response ->
+          Alcotest.(check string)
+            "terminal response"
+            "done-after-restart"
+            (Types.text_of_response response)
+        | Error error -> Alcotest.fail (Error.to_string error));
+       Alcotest.(check int) "settled tool handler is not rerun" 0 !effect_count;
+       Alcotest.(check int) "settled pre-tool hook is not rerun" 0 !pre_hook_count;
+       Alcotest.(check int) "settled post-tool hook is not rerun" 0 !post_hook_count)
 ;;
 
 (* ── Runner ──────────────────────────────────────────────── *)
@@ -1295,6 +1518,10 @@ let () =
             "Agent.run uses durable tool authority"
             `Quick
             test_agent_run_uses_durable_tool_authority
+        ; Alcotest.test_case
+            "Agent.run resumes settled tool without duplicate effects"
+            `Quick
+            test_agent_run_resumes_settled_tool_without_duplicate_effects
         ] )
     ]
 ;;

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -1062,25 +1062,6 @@ let test_mock_multi_tool_response () =
   | Error _ -> Alcotest.fail "expected ok"
 ;;
 
-let test_abort_failure_preserves_cancellation_class () =
-  match
-    Agent_execution_runner.For_testing.reraise_after_abort_failure
-      (Eio.Cancel.Cancelled Exit)
-  with
-  | _ -> Alcotest.fail "abort failure returned instead of preserving cancellation"
-  | exception Eio.Cancel.Cancelled Exit -> ()
-  | exception exn ->
-    Alcotest.failf "abort failure changed cancellation class: %s" (Printexc.to_string exn)
-;;
-
-let test_abort_failure_preserves_reserved_runtime_exception () =
-  match Agent_execution_runner.For_testing.reraise_after_abort_failure Sys.Break with
-  | _ -> Alcotest.fail "abort failure returned instead of preserving Sys.Break"
-  | exception Sys.Break -> ()
-  | exception exn ->
-    Alcotest.failf "abort failure changed Sys.Break class: %s" (Printexc.to_string exn)
-;;
-
 let test_agent_run_uses_durable_tool_authority () =
   Eio_main.run
   @@ fun env ->
@@ -1310,14 +1291,6 @@ let () =
         ] )
     ; ( "provider_mock_extra"
       , [ Alcotest.test_case "multi tool response" `Quick test_mock_multi_tool_response
-        ; Alcotest.test_case
-            "abort failure preserves cancellation"
-            `Quick
-            test_abort_failure_preserves_cancellation_class
-        ; Alcotest.test_case
-            "abort failure preserves reserved runtime exception"
-            `Quick
-            test_abort_failure_preserves_reserved_runtime_exception
         ; Alcotest.test_case
             "Agent.run uses durable tool authority"
             `Quick

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -4,13 +4,14 @@
     Provider_mock.next_response and agent state inspection. *)
 
 open Agent_sdk
+module Internal = Agent_sdk__
 module Internal_agent = Agent_sdk__Agent_types
 module Internal_pipeline = Agent_sdk__Pipeline
-module Internal_runtime = Agent_sdk__Execution_runtime
-module Internal_codec = Agent_sdk__Execution_codec_executor
-module Internal_writer = Agent_sdk__Execution_lane_writer
-module Internal_scope = Agent_sdk__Execution_agent_scope
-module Internal_binding = Agent_sdk__Binding_identity
+module Internal_runtime = Internal.Execution_runtime
+module Internal_codec = Internal.Execution_codec_executor
+module Internal_writer = Internal.Execution_lane_writer
+module Internal_scope = Internal.Execution_agent_scope
+module Internal_binding = Binding_identity
 
 let invocation tool_use_id =
   let schedule : Tool.schedule =

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -1062,6 +1062,25 @@ let test_mock_multi_tool_response () =
   | Error _ -> Alcotest.fail "expected ok"
 ;;
 
+let test_abort_failure_preserves_cancellation_class () =
+  match
+    Agent_execution_runner.For_testing.reraise_after_abort_failure
+      (Eio.Cancel.Cancelled Exit)
+  with
+  | _ -> Alcotest.fail "abort failure returned instead of preserving cancellation"
+  | exception Eio.Cancel.Cancelled Exit -> ()
+  | exception exn ->
+    Alcotest.failf "abort failure changed cancellation class: %s" (Printexc.to_string exn)
+;;
+
+let test_abort_failure_preserves_reserved_runtime_exception () =
+  match Agent_execution_runner.For_testing.reraise_after_abort_failure Sys.Break with
+  | _ -> Alcotest.fail "abort failure returned instead of preserving Sys.Break"
+  | exception Sys.Break -> ()
+  | exception exn ->
+    Alcotest.failf "abort failure changed Sys.Break class: %s" (Printexc.to_string exn)
+;;
+
 let test_agent_run_uses_durable_tool_authority () =
   Eio_main.run
   @@ fun env ->
@@ -1291,6 +1310,14 @@ let () =
         ] )
     ; ( "provider_mock_extra"
       , [ Alcotest.test_case "multi tool response" `Quick test_mock_multi_tool_response
+        ; Alcotest.test_case
+            "abort failure preserves cancellation"
+            `Quick
+            test_abort_failure_preserves_cancellation_class
+        ; Alcotest.test_case
+            "abort failure preserves reserved runtime exception"
+            `Quick
+            test_abort_failure_preserves_reserved_runtime_exception
         ; Alcotest.test_case
             "Agent.run uses durable tool authority"
             `Quick

--- a/test/test_tool_execution.ml
+++ b/test/test_tool_execution.ml
@@ -124,6 +124,8 @@ let execute_with_tools_in_env
   | Error
       { Agent_tools.cause = Agent_tools.Observer_failure { exception_; backtrace; _ }; _ }
     -> Printexc.raise_with_backtrace exception_ backtrace
+  | Error { Agent_tools.cause = Agent_tools.Durability_failure { detail; _ }; _ } ->
+    failf "unexpected durable execution failure: %s" detail
 ;;
 
 (** Helper: create a minimal agent inside Eio with given hooks.


### PR DESCRIPTION
## Outcome

Replace the remaining foundation-only execution drafts (#2669, #2670, #2671, #2672) with one production vertical that makes the recursive execution journal the Tool-effect authority used by the existing Agent APIs, including exact process-restart recovery through the same public run surface.

## SSOT hard cut

- The exact selected provider binding is durably opened before measurement or completion I/O.
- Each exact Tool invocation and attempt is committed before its effect.
- The exact Tool result and terminal nodes settle atomically; a settled result replays without rerunning the effect.
- A settlement failure exposes no unauthoritative Tool result to the transcript.
- Post-tool hooks and completion observers run only after the durable ToolResult settles.
- Durable execution suppresses duplicate legacy `Durable_event` Tool projections while preserving the public `Event_bus` ToolCalled/ToolCompleted compatibility surface.
- Durability failures outrank observer and hook failures across the whole concurrent batch; equal priorities preserve original `ToolUse` order.
- Final run settlement and tool-result settlement are cancellation-protected.
- Reserved exceptions use `Llm_provider.Reserved_exn` as their classifier and retain their original exception class and backtrace even if abort or unresolved-writer shutdown fails.
- No SDK cancellation point exists between a committed Tool attempt and effect entry.

## Public wiring and restart recovery

- The existing regular, streaming, handoff, single-turn, and `Agent.Advanced` entry points all accept the same optional `execution_store` value; there is no second durable run API.
- The application owns one execution runtime for its lifetime and one directory per Agent API-call execution scope.
- Fresh execution requires a new directory. Restart recovery passes the opaque locator back to `execution_store ~resume` with the same directory and a restored Agent checkpoint.
- The versioned locator decoder rejects unknown versions and fields.
- Resume awaits journal readiness, validates the running root and exact Agent identity, and validates the caller input against the latest restored User message before provider/Tool execution.
- Recovery accepts only the exact open turn/provider topology for the checkpoint turn. Missing or ambiguous topology fails closed.
- A settled invocation replays the durable ToolResult without rerunning pre-tool gates, the handler, public EventBus Tool lifecycle events, raw trace, or post-tool observers.
- An admitted Tool attempt without settlement fails closed because the external outcome is unknown.
- A terminal run cannot be resumed through the public Agent execution path; low-level journal rebinding remains available for audit/replay inspection.
- `on_scope_ready` receives the opaque run locator before provider or Tool effects begin and is invoked for both fresh and resumed scopes.
- Successful durable settlement completes before raw-trace, lifecycle, or `on_run_complete` success is published.
- Handoff targets inherit recursive durable authority: each child `Agent_run` is rooted beneath the exact parent `Tool_attempt`.
- Child scope creation is delayed until the child raw trace starts, so trace-start failure cannot leave an orphan durable root.
- Successful calls close the run; typed errors, exceptions, cancellation, locator-sink failure, and settlement failure abort the open subtree.

## Structure

- Lifecycle ownership is isolated in private `Agent_execution_runner`, `Pipeline_execution_scope`, and `Pipeline_execution_resume` modules.
- Recursive Tool authority and one-shot recovery intent are carried by private fiber-local `Execution_context`; no public alternate run surface was added.
- Checkpoint persistence and user-input normalization are isolated in private focused modules.
- `Agent.ml`, `Pipeline.ml`, and `Agent_tools.ml` remain below the 1000-line god-file threshold (983 / 999 / 992).

## Verification (`1a57d0c6fbdc`)

- Local focused `@install` and `@fmt`: PASS
- `test_execution_lane_writer`: 22/22
- `test_pipeline`: 39/39, including public process-restart replay without Tool/hook/EventBus re-execution
- `test_tool_execution`: 19/19
- private inline regressions cover abort-failure cancellation/runtime exception preservation
- `scripts/ci-code-smell-ratchet.sh`: PASS (`catch_all` decreased 358 -> 357; godfile held at 11)
- `scripts/hardening-ratchet.sh`: PASS
- `scripts/check-execution-store-boundary.sh`: PASS
- `scripts/check-sdk-independence.sh`: PASS
- `ocamlformat` and `git diff --check`: PASS
- GitHub full suite on OCaml 5.4.1 and 5.5.0: PASS

## Caller boundary

OAS owns the execution topology, atomic Tool-effect settlement, locator codec, and exact recovery semantics. It does not infer filesystem paths, retention policy, checkpoint storage, or product ownership. MASC must persist the OAS locator, its directory identity, and the matching Agent checkpoint as one caller-owned recovery record, then pass those values back without parsing or reconstructing OAS WAL topology.

The public process-restart contract previously tracked in #2686 is now implemented here; that issue should be closed as absorbed after this PR merges.
