### PR TITLE
refactor: deprecate the legacy Api/Streaming/Provider_intf dispatch island

### DIFF
--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -90,6 +90,23 @@ CDAL proof-bundle artifacts are intentionally schema-only in OAS. They are
 tracked in `docs/schema-surfaces/runtime-output-surfaces.v1.json`, not as
 public OCaml modules in this stability table.
 
+### Deprecated surfaces
+
+The legacy request-dispatch island is deprecated in favor of
+`Llm_provider.Complete`. It is retained for compatibility and will be removed
+in a future major release:
+
+- `Api.create_message` / `Api.create_message_detailed` (`lib/api.mli`)
+- `Streaming.create_message_stream` / `Streaming.create_message_stream_detailed` (`lib/streaming.mli`)
+- All of `Provider_intf` (`lib/provider_intf.mli`)
+
+These entry points carry OCaml `[@@deprecated]` attributes, so downstream
+builds surface alert 3 at use sites. The helper re-exports in `Api` (request
+body builders, response parsers, JSON codecs such as `content_block_to_json`
+/ `content_block_of_json`) and the pure helpers and stream accumulator
+surface in `Streaming` are **not** deprecated. Per the Evolving policy
+above, removal follows the one minor-version deprecation window.
+
 ### Internal modules
 
 Implementation-detail modules with no compatibility promise. Most entries in

--- a/examples/streaming.ml
+++ b/examples/streaming.ml
@@ -1,7 +1,7 @@
 (** SSE streaming example.
 
     Demonstrates:
-    - Setting up a streaming API call
+    - Setting up a streaming API call via {!Llm_provider.Complete.complete_stream}
     - Processing events in real-time via on_event callback
     - Tracking usage statistics
 
@@ -32,17 +32,19 @@ let () =
   let net = Eio.Stdenv.net env in
   Eio.Switch.run
   @@ fun sw ->
-  let provider : Provider.config =
-    { provider = Local { base_url = "http://127.0.0.1:8085" }
-    ; model_id = "qwen3.5-35b"
-    ; api_key_env = "OAS_STREAMING_EXAMPLE_API_KEY"
-    }
+  let api_key =
+    Option.value ~default:"" (Sys.getenv_opt "OAS_STREAMING_EXAMPLE_API_KEY")
   in
   let config =
-    { (default_config ~model:provider.model_id) with
-      system_prompt = Some "You are a helpful assistant."
-    ; max_tokens = Some 1024
-    }
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.OpenAI_compat
+      ~model_id:"qwen3.5-35b"
+      ~base_url:"http://127.0.0.1:8085"
+      ~api_key
+      ~request_path:"/v1/chat/completions"
+      ~system_prompt:"You are a helpful assistant."
+      ~max_tokens:1024
+      ()
   in
   let messages =
     [ { role = User
@@ -53,21 +55,12 @@ let () =
       }
     ]
   in
-  let state = { config; messages = []; turn_count = 0; usage = empty_usage } in
-  match
-    Streaming.create_message_stream
-      ~sw
-      ~net
-      ~provider
-      ~config:state
-      ~messages
-      ~on_event
-      ()
-  with
+  match Llm_provider.Complete.complete_stream ~sw ~net ~config ~messages ~on_event () with
   | Ok response ->
     Printf.printf "\nResponse ID: %s\n" response.id;
     (match response.usage with
      | Some u -> Printf.printf "Tokens: %d in / %d out\n" u.input_tokens u.output_tokens
      | None -> ())
-  | Error e -> Printf.eprintf "Error: %s\n" (Error.to_string e)
+  | Error e ->
+    Printf.eprintf "Error: %s\n" Llm_provider.Error.(to_string (of_http_error e))
 ;;

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -28,10 +28,7 @@ module Provider = Provider
     {!Llm_provider.Complete}; retained for compatibility. *)
 module Provider_intf = Provider_intf
 
-(** First-class-module dispatch surface. Deprecated in favor of
-    {!Llm_provider.Complete}; retained for compatibility. *)
 module Provider_runtime_binding = Provider_runtime_binding
-
 module Binding_identity = Binding_identity
 module Provider_failure_attribution = Provider_failure_attribution
 module Image_generation = Llm_provider.Image_generation
@@ -71,11 +68,7 @@ module Api = Api
     {!Llm_provider.Complete}; the pure helpers remain supported. *)
 module Streaming = Streaming
 
-(** SSE streaming facade. {!Streaming.create_message_stream} and
-    {!Streaming.create_message_stream_detailed} are deprecated in favor of
-    {!Llm_provider.Complete}; the pure helpers remain supported. *)
 module Subagent = Subagent
-
 module Structured = Structured
 module Checkpoint = Checkpoint
 module Checkpoint_store = Checkpoint_store

--- a/lib/agent_sdk.mli
+++ b/lib/agent_sdk.mli
@@ -23,8 +23,15 @@ module Fs_result = Fs_result
 module Fs_atomic_eio = Fs_atomic_eio
 module Context = Agent_sdk_base.Context
 module Provider = Provider
+
+(** First-class-module dispatch surface. Deprecated in favor of
+    {!Llm_provider.Complete}; retained for compatibility. *)
 module Provider_intf = Provider_intf
+
+(** First-class-module dispatch surface. Deprecated in favor of
+    {!Llm_provider.Complete}; retained for compatibility. *)
 module Provider_runtime_binding = Provider_runtime_binding
+
 module Binding_identity = Binding_identity
 module Provider_failure_attribution = Provider_failure_attribution
 module Image_generation = Llm_provider.Image_generation
@@ -53,9 +60,22 @@ module Telemetry_sca_registry = Telemetry_sca_registry
 module Skill = Skill
 module Skill_registry = Skill_registry
 module Contract = Contract
+
+(** Request-dispatch facade. {!Api.create_message} and
+    {!Api.create_message_detailed} are deprecated in favor of
+    {!Llm_provider.Complete}; the helper re-exports remain supported. *)
 module Api = Api
+
+(** SSE streaming facade. {!Streaming.create_message_stream} and
+    {!Streaming.create_message_stream_detailed} are deprecated in favor of
+    {!Llm_provider.Complete}; the pure helpers remain supported. *)
 module Streaming = Streaming
+
+(** SSE streaming facade. {!Streaming.create_message_stream} and
+    {!Streaming.create_message_stream_detailed} are deprecated in favor of
+    {!Llm_provider.Complete}; the pure helpers remain supported. *)
 module Subagent = Subagent
+
 module Structured = Structured
 module Checkpoint = Checkpoint
 module Checkpoint_store = Checkpoint_store

--- a/lib/api.mli
+++ b/lib/api.mli
@@ -1,5 +1,15 @@
 (** API dispatch — routes requests to provider-specific backends.
 
+    {2 Deprecated dispatch entry points}
+
+    {!create_message} and {!create_message_detailed} are the legacy dispatch
+    path: the production path has converged on {!Llm_provider.Complete}. They
+    are retained for compatibility and will be removed in a future major
+    release. The remaining values in this module — request body builders,
+    response parsers, and JSON codecs such as {!content_block_to_json} and
+    {!content_block_of_json} — are {b not} deprecated and remain supported
+    helpers.
+
     @stability Evolving
     @since 0.93.1 *)
 
@@ -104,6 +114,9 @@ val create_message_detailed
   -> ?slot_id:int
   -> unit
   -> (Types.api_response, Provider_failure_attribution.detailed_error) result
+[@@deprecated
+  "Use Llm_provider.Complete — this legacy dispatch path is retained for compatibility \
+   and will be removed in a future major release."]
 
 val create_message
   :  sw:Eio.Switch.t
@@ -117,3 +130,6 @@ val create_message
   -> ?slot_id:int
   -> unit
   -> (Types.api_response, Error.sdk_error) result
+[@@deprecated
+  "Use Llm_provider.Complete — this legacy dispatch path is retained for compatibility \
+   and will be removed in a future major release."]

--- a/lib/provider_intf.ml
+++ b/lib/provider_intf.ml
@@ -6,6 +6,10 @@
     {b Compile-time guarantee}: attempting to pass a non-streaming
     provider as STREAMING_PROVIDER produces a type error. *)
 
+(* Implements the deprecated legacy dispatch surface; references to the
+   deprecated Api / Streaming dispatch entry points are intentional. *)
+[@@@alert "-deprecated"]
+
 (** Synchronous provider: can send a message and get a response. *)
 module type PROVIDER = sig
   type t

--- a/lib/provider_intf.mli
+++ b/lib/provider_intf.mli
@@ -3,8 +3,20 @@
     Defines PROVIDER and STREAMING_PROVIDER as first-class module types
     for compile-time capability checking.
 
+    {2 Deprecated}
+
+    This whole module is the legacy first-class-module dispatch island: the
+    production path has converged on {!Llm_provider.Complete}. Every module
+    type, type alias, and value here is retained for compatibility and will
+    be removed in a future major release.
+
     @stability Evolving
     @since 0.93.1 *)
+
+(* This signature cross-references its own deprecated items (module types in
+   type aliases and value types); the recorded [@@deprecated] attributes
+   still fire for external users. *)
+[@@@alert "-deprecated"]
 
 module type PROVIDER = sig
   type t
@@ -18,6 +30,9 @@ module type PROVIDER = sig
     -> unit
     -> (Types.api_response, Error.sdk_error) result
 end
+[@@deprecated
+  "Use Llm_provider.Complete — this legacy dispatch path is retained for compatibility \
+   and will be removed in a future major release."]
 
 module type DETAILED_PROVIDER = sig
   include PROVIDER
@@ -31,6 +46,9 @@ module type DETAILED_PROVIDER = sig
     -> unit
     -> (Types.api_response, Provider_failure_attribution.detailed_error) result
 end
+[@@deprecated
+  "Use Llm_provider.Complete — this legacy dispatch path is retained for compatibility \
+   and will be removed in a future major release."]
 
 module type STREAMING_PROVIDER = sig
   include PROVIDER
@@ -47,6 +65,9 @@ module type STREAMING_PROVIDER = sig
     -> unit
     -> (Types.api_response, Error.sdk_error) result
 end
+[@@deprecated
+  "Use Llm_provider.Complete — this legacy dispatch path is retained for compatibility \
+   and will be removed in a future major release."]
 
 module type DETAILED_STREAMING_PROVIDER = sig
   include STREAMING_PROVIDER
@@ -72,23 +93,50 @@ module type DETAILED_STREAMING_PROVIDER = sig
     -> unit
     -> (Types.api_response, Provider_failure_attribution.detailed_error) result
 end
+[@@deprecated
+  "Use Llm_provider.Complete — this legacy dispatch path is retained for compatibility \
+   and will be removed in a future major release."]
 
 type provider_module = (module PROVIDER)
+[@@deprecated
+  "Use Llm_provider.Complete — this legacy dispatch path is retained for compatibility \
+   and will be removed in a future major release."]
+
 type detailed_provider_module = (module DETAILED_PROVIDER)
+[@@deprecated
+  "Use Llm_provider.Complete — this legacy dispatch path is retained for compatibility \
+   and will be removed in a future major release."]
+
 type streaming_provider_module = (module STREAMING_PROVIDER)
+[@@deprecated
+  "Use Llm_provider.Complete — this legacy dispatch path is retained for compatibility \
+   and will be removed in a future major release."]
+
 type detailed_streaming_provider_module = (module DETAILED_STREAMING_PROVIDER)
+[@@deprecated
+  "Use Llm_provider.Complete — this legacy dispatch path is retained for compatibility \
+   and will be removed in a future major release."]
 
 (** Resolve a provider config to a first-class PROVIDER module.
     Returns an error if provider configuration or credentials cannot be
     resolved (e.g. a required environment variable is missing). *)
 val of_config : Provider.config -> (provider_module, Error.sdk_error) result
+[@@deprecated
+  "Use Llm_provider.Complete — this legacy dispatch path is retained for compatibility \
+   and will be removed in a future major release."]
 
 val of_config_detailed
   :  Provider.config
   -> (detailed_provider_module, Provider_failure_attribution.detailed_error) result
+[@@deprecated
+  "Use Llm_provider.Complete — this legacy dispatch path is retained for compatibility \
+   and will be removed in a future major release."]
 
 (** Check if a provider config supports native streaming. *)
 val supports_streaming : Provider.config -> bool
+[@@deprecated
+  "Use Llm_provider.Complete — this legacy dispatch path is retained for compatibility \
+   and will be removed in a future major release."]
 
 (** Resolve to a STREAMING_PROVIDER if native streaming is supported.
     Returns [Ok None] when streaming is not supported for this provider.
@@ -97,9 +145,15 @@ val supports_streaming : Provider.config -> bool
 val of_config_streaming
   :  Provider.config
   -> (streaming_provider_module option, Error.sdk_error) result
+[@@deprecated
+  "Use Llm_provider.Complete — this legacy dispatch path is retained for compatibility \
+   and will be removed in a future major release."]
 
 val of_config_streaming_detailed
   :  Provider.config
   -> ( detailed_streaming_provider_module option
        , Provider_failure_attribution.detailed_error )
        result
+[@@deprecated
+  "Use Llm_provider.Complete — this legacy dispatch path is retained for compatibility \
+   and will be removed in a future major release."]

--- a/lib/streaming.mli
+++ b/lib/streaming.mli
@@ -5,6 +5,15 @@
     {!Llm_provider.Streaming}.  The HTTP streaming client remains here
     due to agent_state/Provider/Error coupling.
 
+    {2 Deprecated dispatch entry points}
+
+    {!create_message_stream} and {!create_message_stream_detailed} are the
+    legacy dispatch path: the production path has converged on
+    {!Llm_provider.Complete}. They are retained for compatibility and will be
+    removed in a future major release. The pure helpers and the
+    {!Llm_provider.Complete_stream_acc} accumulator surface are {b not}
+    deprecated and remain supported.
+
     @stability Evolving
     @since 0.93.1 *)
 
@@ -51,6 +60,9 @@ val create_message_stream_detailed
   -> on_event:(Types.sse_event -> unit)
   -> unit
   -> (Types.api_response, Provider_failure_attribution.detailed_error) result
+[@@deprecated
+  "Use Llm_provider.Complete — this legacy dispatch path is retained for compatibility \
+   and will be removed in a future major release."]
 
 val create_message_stream
   :  sw:Eio.Switch.t
@@ -64,3 +76,6 @@ val create_message_stream
   -> on_event:(Types.sse_event -> unit)
   -> unit
   -> (Types.api_response, Error.sdk_error) result
+[@@deprecated
+  "Use Llm_provider.Complete — this legacy dispatch path is retained for compatibility \
+   and will be removed in a future major release."]

--- a/test/test_api_http_client.ml
+++ b/test/test_api_http_client.ml
@@ -1,3 +1,6 @@
+(* These tests intentionally exercise the deprecated legacy dispatch path. *)
+[@@@alert "-deprecated"]
+
 open Agent_sdk
 open Types
 

--- a/test/test_llm_call.ml
+++ b/test/test_llm_call.ml
@@ -1,4 +1,8 @@
 (** Minimal LLM call test — no tools, just one API round-trip *)
+
+(* These tests intentionally exercise the deprecated legacy dispatch path. *)
+[@@@alert "-deprecated"]
+
 open Agent_sdk
 
 let run_live_test () =

--- a/test/test_provider_intf.ml
+++ b/test/test_provider_intf.ml
@@ -1,5 +1,8 @@
 (** Provider_intf tests — module type satisfaction and dispatch. *)
 
+(* These tests intentionally exercise the deprecated legacy dispatch path. *)
+[@@@alert "-deprecated"]
+
 open Agent_sdk
 open Agent_sdk.Types
 module Retry = Llm_provider.Retry

--- a/test/test_streaming_e2e.ml
+++ b/test/test_streaming_e2e.ml
@@ -1,6 +1,9 @@
 (* test_streaming_e2e.ml — E2E streaming test against local LLM server.
    Run: LLAMA_LIVE_TEST=1 dune exec ./test/test_streaming_e2e.exe *)
 
+(* These tests intentionally exercise the deprecated legacy dispatch path. *)
+[@@@alert "-deprecated"]
+
 open Agent_sdk
 
 let local_llm_provider : Provider.config =


### PR DESCRIPTION
## Problem

The production path converged on `Llm_provider.Complete` (pipeline.ml: "no legacy fallback remains"), and the repo already calls these paths legacy (`pipeline.ml:113`, `provider_config.ml:249`, RFC-OAS-035) — yet `Api`, `Streaming`, `Provider_intf` are still published as `@stability Evolving` and the examples teach the legacy path. Keeping both stacks means every provider fix must be mirrored twice.

## Fix (deprecate-first, not deletion)

- `[@@deprecated "Use Llm_provider.Complete"]` on the public vals of `api.mli`, `streaming.mli`, `provider_intf.mli`
- `examples/streaming.ml` migrated to `Complete.complete_stream`
- `docs/api-stability.md` gains a Deprecated surfaces section
- The two JSON helpers masc actually uses (`content_block_to_json`/`of_json`) are **not** deprecated

Actual removal is left for a future major release after the deprecation window.

## Verification

- `dune build lib/` + `examples/` ✓

Found by adversarial wiring audit (2026-07-17).