### PR TITLE
feat(agent): expose typed execution terminal disposition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,14 @@ original tag dates. `0.100.4` was never tagged or released.
   re-export. Scripted provider responses remain test-only code, not an SDK
   runtime provider.
 
+### Features
+
+* **durable execution:** add an optional typed terminal-disposition sink to
+  `Agent.execution_store`. After the terminal journal commit it distinguishes
+  safe locator retirement from operator repair required for an admitted Tool
+  attempt whose external effect outcome is unknown, without changing the
+  existing Agent run surfaces or classifying error strings (#2687).
+
 ### Bug Fixes
 
 * **eval collection:** atomically cancel and drain event-bus subscriptions

--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -33,6 +33,23 @@ type execution_runtime = Agent_execution_runner.runtime
 type execution_store = Agent_execution_runner.store
 type execution_locator = Agent_execution_runner.locator
 
+type execution_terminal_outcome = Agent_execution_runner.terminal_outcome =
+  | Terminal_succeeded
+  | Terminal_failed
+  | Terminal_cancelled
+
+type execution_operator_repair_reason = Agent_execution_runner.operator_repair_reason =
+  | Effect_outcome_unknown
+
+type execution_recovery_action = Agent_execution_runner.recovery_action =
+  | Retire
+  | Operator_repair_required of execution_operator_repair_reason
+
+type execution_terminal_disposition = Agent_execution_runner.terminal_disposition =
+  { outcome : execution_terminal_outcome
+  ; recovery : execution_recovery_action
+  }
+
 let create_execution_runtime = Agent_execution_runner.create_runtime
 let execution_store = Agent_execution_runner.store
 let execution_locator_to_yojson = Agent_execution_runner.locator_to_yojson
@@ -46,9 +63,8 @@ let project_detailed_error result =
   Result.map_error (fun detailed -> detailed.error) result
 ;;
 
-(** Run a single turn via the 6-stage pipeline.
-    Converts Pipeline.turn_outcome to the polymorphic variant interface
-    expected by run_loop and the public API. *)
+(** Run a single turn via the 6-stage pipeline, converting [Pipeline.turn_outcome]
+    to the polymorphic variant interface expected by [run_loop] and the public API. *)
 let run_turn_core_detailed
       ~sw
       ?clock

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -150,6 +150,22 @@ type execution_store
 (** Opaque durable identity for one Agent API-call execution scope. *)
 type execution_locator
 
+type execution_terminal_outcome =
+  | Terminal_succeeded
+  | Terminal_failed
+  | Terminal_cancelled
+
+type execution_operator_repair_reason = Effect_outcome_unknown
+
+type execution_recovery_action =
+  | Retire
+  | Operator_repair_required of execution_operator_repair_reason
+
+type execution_terminal_disposition =
+  { outcome : execution_terminal_outcome
+  ; recovery : execution_recovery_action
+  }
+
 val execution_locator_to_yojson : execution_locator -> Yojson.Safe.t
 
 (** Decode the exact versioned locator emitted by
@@ -178,11 +194,26 @@ val create_execution_runtime
     [on_scope_ready], when supplied, must persist the opaque locator before
     provider or Tool effects begin. It is invoked for both fresh and resumed
     scopes, so the sink should be idempotent. Failure aborts the scope and the
-    Agent call. *)
+    Agent call.
+
+    [on_terminal_disposition] is invoked after the terminal journal commit and
+    successful writer drain, before this Agent call returns. [Retire] means the
+    caller-owned recovery locator may be removed.
+    [Operator_repair_required Effect_outcome_unknown] means an admitted Tool
+    attempt has no settled result, so automatic retry could duplicate an
+    external effect. The sink should persist the decision idempotently. A
+    returned error or non-reserved exception fails the Agent call with
+    [Error.Internal] after the terminal commit; the recovery locator must
+    remain. If writer drain fails, the sink is not invoked and the locator must
+    likewise remain. Caller cancellation is protected through terminal
+    settlement, writer drain, and callback, then re-raised. If callback cleanup
+    also fails, cancellation remains the primary exception and the cleanup
+    failure is logged. *)
 val execution_store
   :  runtime:execution_runtime
   -> dir:Eio.Fs.dir_ty Eio.Path.t
   -> ?on_scope_ready:(execution_locator -> (unit, string) result)
+  -> ?on_terminal_disposition:(execution_terminal_disposition -> (unit, string) result)
   -> ?resume:execution_locator
   -> unit
   -> execution_store

--- a/lib/agent/agent_execution_runner.ml
+++ b/lib/agent/agent_execution_runner.ml
@@ -1,6 +1,23 @@
 type runtime = { codec : Execution_codec_executor.t }
 type locator = Execution_agent_scope.scope_locator
 
+type terminal_outcome =
+  | Terminal_succeeded
+  | Terminal_failed
+  | Terminal_cancelled
+
+type operator_repair_reason = Execution_agent_scope.operator_repair_reason =
+  | Effect_outcome_unknown
+
+type recovery_action = Execution_agent_scope.recovery_action =
+  | Retire
+  | Operator_repair_required of operator_repair_reason
+
+type terminal_disposition =
+  { outcome : terminal_outcome
+  ; recovery : recovery_action
+  }
+
 type store_mode =
   | Fresh
   | Resume of locator
@@ -9,6 +26,7 @@ type store =
   { codec : Execution_codec_executor.t
   ; dir : Eio.Fs.dir_ty Eio.Path.t
   ; on_scope_ready : (locator -> (unit, string) result) option
+  ; on_terminal_disposition : (terminal_disposition -> (unit, string) result) option
   ; mode : store_mode
   }
 
@@ -25,13 +43,13 @@ let create_runtime ~sw ~domain_mgr ~domain_count =
          }))
 ;;
 
-let store ~(runtime : runtime) ~dir ?on_scope_ready ?resume () =
+let store ~(runtime : runtime) ~dir ?on_scope_ready ?on_terminal_disposition ?resume () =
   let mode =
     match resume with
     | None -> Fresh
     | Some locator -> Resume locator
   in
-  { codec = runtime.codec; dir; on_scope_ready; mode }
+  { codec = runtime.codec; dir; on_scope_ready; on_terminal_disposition; mode }
 ;;
 
 let locator_to_yojson = Execution_agent_scope.scope_locator_to_yojson
@@ -40,6 +58,33 @@ let locator_of_yojson = Execution_agent_scope.scope_locator_of_yojson
 let execution_failure detail =
   Provider_failure_attribution.of_sdk_error
     (Error.Internal ("durable execution: " ^ detail))
+;;
+
+let persist_terminal_disposition persist disposition =
+  match persist disposition with
+  | Ok () -> Ok ()
+  | Error detail ->
+    Error (execution_failure ("terminal disposition sink failed: " ^ detail))
+  | exception exn ->
+    (match Llm_provider.Reserved_exn.reraise_if_reserved exn with
+     | () ->
+       Error
+         (execution_failure
+            ("terminal disposition sink raised: " ^ Printexc.to_string exn))
+     | exception reserved -> raise reserved)
+;;
+
+let notify_terminal scope on_terminal_disposition outcome =
+  match on_terminal_disposition with
+  | None -> Ok ()
+  | Some persist ->
+    (match Execution_agent_scope.terminal_recovery_action scope with
+     | Error error ->
+       Error
+         (execution_failure
+            ("terminal disposition unavailable: "
+             ^ Execution_agent_scope.error_to_string error))
+     | Ok recovery -> persist_terminal_disposition persist { outcome; recovery })
 ;;
 
 let abort_failure_of_error (detailed : Provider_failure_attribution.detailed_error) =
@@ -53,7 +98,11 @@ let reraise_after_abort_failure exn backtrace abort_detail =
     Printexc.raise_with_backtrace
       (Abort_failed_after_exception (exn, backtrace, abort_detail))
       backtrace
-  | exception reserved -> Printexc.raise_with_backtrace reserved backtrace
+  | exception reserved ->
+    Eio.traceln
+      "durable execution cleanup failed while preserving reserved exception: %s"
+      abort_detail;
+    Printexc.raise_with_backtrace reserved backtrace
 ;;
 
 let%test "abort failure preserves cancellation class" =
@@ -84,7 +133,7 @@ let%test "abort failure preserves reserved runtime exception" =
   | Abort_failed_after_exception _ -> false
 ;;
 
-let abort_after_exception scope exn backtrace =
+let abort_after_exception scope on_terminal_disposition exn backtrace =
   let reason =
     match exn with
     | Eio.Cancel.Cancelled _ ->
@@ -95,22 +144,35 @@ let abort_after_exception scope exn backtrace =
         Execution_event.
           { kind = Internal_failure; detail = Printexc.to_string exn; data = None }
   in
-  match Execution_agent_scope.abort scope reason with
+  match
+    Eio.Cancel.protect (fun () ->
+      match Execution_agent_scope.abort scope reason with
+      | Error error -> Error (Execution_agent_scope.error_to_string error)
+      | Ok () ->
+        let outcome =
+          match exn with
+          | Eio.Cancel.Cancelled _ -> Terminal_cancelled
+          | _ -> Terminal_failed
+        in
+        (match notify_terminal scope on_terminal_disposition outcome with
+         | Ok () -> Ok ()
+         | Error detailed ->
+           Error (Error.to_string detailed.Provider_failure_attribution.error)))
+  with
   | Ok () -> Printexc.raise_with_backtrace exn backtrace
-  | Error abort_error ->
-    reraise_after_abort_failure
-      exn
-      backtrace
-      (Execution_agent_scope.error_to_string abort_error)
+  | Error cleanup_detail -> reraise_after_abort_failure exn backtrace cleanup_detail
 ;;
 
-let abort_error scope detailed =
+let abort_error scope on_terminal_disposition detailed =
   match
     Execution_agent_scope.abort
       scope
       (Execution_agent_scope.Failed (abort_failure_of_error detailed))
   with
-  | Ok () -> Error detailed
+  | Ok () ->
+    (match notify_terminal scope on_terminal_disposition Terminal_failed with
+     | Ok () -> Error detailed
+     | Error notification_error -> Error notification_error)
   | Error abort_error ->
     Error
       (execution_failure
@@ -120,9 +182,11 @@ let abort_error scope detailed =
             (Execution_agent_scope.error_to_string abort_error)))
 ;;
 
-let settle_success scope value =
+let settle_success scope on_terminal_disposition value =
   match Execution_agent_scope.finish scope Execution_event.Succeeded with
-  | Ok () -> Ok value
+  | Ok () ->
+    notify_terminal scope on_terminal_disposition Terminal_succeeded
+    |> Result.map (fun () -> value)
   | Error error ->
     let detail = Execution_agent_scope.error_to_string error in
     let detailed = execution_failure ("run settlement failed: " ^ detail) in
@@ -132,7 +196,10 @@ let settle_success scope value =
          (Execution_agent_scope.Failed
             Execution_event.{ kind = Persistence_failure; detail; data = None })
      with
-     | Ok () -> Error detailed
+     | Ok () ->
+       (match notify_terminal scope on_terminal_disposition Terminal_failed with
+        | Ok () -> Error detailed
+        | Error notification_error -> Error notification_error)
      | Error abort_error ->
        Error
          (execution_failure
@@ -142,25 +209,27 @@ let settle_success scope value =
                (Execution_agent_scope.error_to_string abort_error))))
 ;;
 
-let settle_success_after_run scope value =
-  match Eio.Cancel.protect (fun () -> settle_success scope value) with
+let settle_success_after_run scope on_terminal_disposition value =
+  match
+    Eio.Cancel.protect (fun () -> settle_success scope on_terminal_disposition value)
+  with
   | result -> result
   | exception exn ->
     let backtrace = Printexc.get_raw_backtrace () in
-    abort_after_exception scope exn backtrace
+    abort_after_exception scope on_terminal_disposition exn backtrace
 ;;
 
-let with_scope scope run =
+let with_scope ?on_terminal_disposition scope run =
   Execution_context.with_agent_scope scope (fun () ->
     match run () with
-    | Ok value -> settle_success_after_run scope value
-    | Error detailed -> abort_error scope detailed
+    | Ok value -> settle_success_after_run scope on_terminal_disposition value
+    | Error detailed -> abort_error scope on_terminal_disposition detailed
     | exception exn ->
       let backtrace = Printexc.get_raw_backtrace () in
-      abort_after_exception scope exn backtrace)
+      abort_after_exception scope on_terminal_disposition exn backtrace)
 ;;
 
-let prepare_scope store scope =
+let prepare_scope store on_terminal_disposition scope =
   let locator = Execution_agent_scope.scope_locator scope in
   match store.on_scope_ready with
   | None -> Ok ()
@@ -169,11 +238,63 @@ let prepare_scope store scope =
      | result -> result
      | exception exn ->
        let backtrace = Printexc.get_raw_backtrace () in
-       abort_after_exception scope exn backtrace)
+       abort_after_exception scope on_terminal_disposition exn backtrace)
+;;
+
+let captured_terminal_sink store captured =
+  Option.map
+    (fun _ disposition ->
+       match !captured with
+       | None ->
+         captured := Some disposition;
+         Ok ()
+       | Some _ -> Error "terminal disposition emitted more than once")
+    store.on_terminal_disposition
+;;
+
+let deliver_captured_terminal store captured =
+  match store.on_terminal_disposition, !captured with
+  | Some persist, Some disposition -> persist_terminal_disposition persist disposition
+  | None, None | None, Some _ | Some _, None -> Ok ()
+;;
+
+let finish_writer_scope store captured run_writer =
+  match run_writer () with
+  | Ok result ->
+    (match Eio.Cancel.protect (fun () -> deliver_captured_terminal store captured) with
+     | Ok () -> result
+     | Error notification_error -> Error notification_error)
+  | Error failure ->
+    Error (execution_failure (Execution_lane_writer.scope_failure_to_string failure))
+  | exception exn ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    (match Eio.Cancel.protect (fun () -> deliver_captured_terminal store captured) with
+     | Ok () -> Printexc.raise_with_backtrace exn backtrace
+     | Error notification_error ->
+       reraise_after_abort_failure
+         exn
+         backtrace
+         (Error.to_string notification_error.Provider_failure_attribution.error)
+     | exception notification_exn ->
+       let notification_backtrace = Printexc.get_raw_backtrace () in
+       (match Llm_provider.Reserved_exn.reraise_if_reserved exn with
+        | () ->
+          let combined, combined_backtrace =
+            Eio.Exn.combine (exn, backtrace) (notification_exn, notification_backtrace)
+          in
+          Printexc.raise_with_backtrace combined combined_backtrace
+        | exception reserved ->
+          Eio.traceln
+            "durable execution terminal sink raised while preserving reserved exception: \
+             %s"
+            (Printexc.to_string notification_exn);
+          Printexc.raise_with_backtrace reserved backtrace))
 ;;
 
 let with_fresh store agent run =
-  match
+  let captured : terminal_disposition option ref = ref None in
+  let on_terminal_disposition = captured_terminal_sink store captured in
+  finish_writer_scope store captured (fun () ->
     Execution_lane_writer.run ~codec:store.codec ~dir:store.dir
     @@ fun ~sw writer ->
     match
@@ -182,19 +303,20 @@ let with_fresh store agent run =
     | Error error ->
       Error (execution_failure (Execution_agent_scope.error_to_string error))
     | Ok scope ->
-      let ready = prepare_scope store scope in
+      let ready = prepare_scope store on_terminal_disposition scope in
       (match ready with
        | Error detail ->
-         abort_error scope (execution_failure ("scope locator sink failed: " ^ detail))
-       | Ok () -> with_scope scope (fun () -> run ~sw scope))
-  with
-  | Ok result -> result
-  | Error failure ->
-    Error (execution_failure (Execution_lane_writer.scope_failure_to_string failure))
+         abort_error
+           scope
+           on_terminal_disposition
+           (execution_failure ("scope locator sink failed: " ^ detail))
+       | Ok () -> with_scope ?on_terminal_disposition scope (fun () -> run ~sw scope)))
 ;;
 
 let with_resumed store locator agent run =
-  match
+  let captured : terminal_disposition option ref = ref None in
+  let on_terminal_disposition = captured_terminal_sink store captured in
+  finish_writer_scope store captured (fun () ->
     Execution_lane_writer.resume ~codec:store.codec ~dir:store.dir
     @@ fun ~sw writer ->
     match Execution_lane_writer.await_ready writer with
@@ -210,16 +332,15 @@ let with_resumed store locator agent run =
        | Error error ->
          Error (execution_failure (Execution_agent_scope.error_to_string error))
        | Ok scope ->
-         (match prepare_scope store scope with
+         (match prepare_scope store on_terminal_disposition scope with
           | Error detail ->
-            abort_error scope (execution_failure ("scope locator sink failed: " ^ detail))
+            abort_error
+              scope
+              on_terminal_disposition
+              (execution_failure ("scope locator sink failed: " ^ detail))
           | Ok () ->
             Execution_context.with_resume_once (fun () ->
-              with_scope scope (fun () -> run ~sw scope))))
-  with
-  | Ok result -> result
-  | Error failure ->
-    Error (execution_failure (Execution_lane_writer.scope_failure_to_string failure))
+              with_scope ?on_terminal_disposition scope (fun () -> run ~sw scope)))))
 ;;
 
 let with_store store agent run =

--- a/lib/agent/agent_execution_runner.mli
+++ b/lib/agent/agent_execution_runner.mli
@@ -4,6 +4,23 @@ type runtime
 type store
 type locator
 
+type terminal_outcome =
+  | Terminal_succeeded
+  | Terminal_failed
+  | Terminal_cancelled
+
+type operator_repair_reason = Execution_agent_scope.operator_repair_reason =
+  | Effect_outcome_unknown
+
+type recovery_action = Execution_agent_scope.recovery_action =
+  | Retire
+  | Operator_repair_required of operator_repair_reason
+
+type terminal_disposition =
+  { outcome : terminal_outcome
+  ; recovery : recovery_action
+  }
+
 val create_runtime
   :  sw:Eio.Switch.t
   -> domain_mgr:_ Eio.Domain_manager.t
@@ -14,6 +31,7 @@ val store
   :  runtime:runtime
   -> dir:Eio.Fs.dir_ty Eio.Path.t
   -> ?on_scope_ready:(locator -> (unit, string) result)
+  -> ?on_terminal_disposition:(terminal_disposition -> (unit, string) result)
   -> ?resume:locator
   -> unit
   -> store
@@ -40,6 +58,7 @@ val with_store
 val is_resume : store -> bool
 
 val with_scope
-  :  Execution_agent_scope.t
+  :  ?on_terminal_disposition:(terminal_disposition -> (unit, string) result)
+  -> Execution_agent_scope.t
   -> (unit -> ('a, Provider_failure_attribution.detailed_error) result)
   -> ('a, Provider_failure_attribution.detailed_error) result

--- a/lib/execution_agent_scope.ml
+++ b/lib/execution_agent_scope.ml
@@ -52,6 +52,12 @@ type abort_reason =
       ; data : Yojson.Safe.t option
       }
 
+type operator_repair_reason = Effect_outcome_unknown
+
+type recovery_action =
+  | Retire
+  | Operator_repair_required of operator_repair_reason
+
 type error =
   | Admission_failed of Writer.submit_error
   | Mutation_failed of Writer.ticket_error
@@ -501,4 +507,34 @@ let abort scope reason =
   in
   transact_cleanup scope.writer (Tx.abort_run ~run:scope.run terminal)
   |> Result.map ignore
+;;
+
+let terminal_recovery_action scope =
+  let rec visit = function
+    | [] -> Ok Retire
+    | node :: rest ->
+      (match Writer.find_node scope.writer node with
+       | Error error -> Error (Scope_unavailable error)
+       | Ok None -> Error (Resume_topology_mismatch "execution descendant disappeared")
+       | Ok (Some view) ->
+         (match view.Journal.materialized, view.children with
+          | Journal.Tool_invocation_state { result = None; _ }, _ :: _ ->
+            Ok (Operator_repair_required Effect_outcome_unknown)
+          | ( ( Journal.Agent_run_state
+              | Journal.Agent_turn_state
+              | Journal.Provider_attempt_state _
+              | Journal.Output_block_state _
+              | Journal.Tool_attempt_state
+              | Journal.Tool_invocation_state { result = Some _; _ }
+              | Journal.Tool_invocation_state { result = None; _ } )
+            , children ) ->
+            visit
+              (List.rev_append
+                 (List.map
+                    (fun (child : Event.node Journal.event_record) ->
+                       Event.node_id child.value)
+                    children)
+                 rest)))
+  in
+  visit [ Journal.run_root scope.run ]
 ;;

--- a/lib/execution_agent_scope.mli
+++ b/lib/execution_agent_scope.mli
@@ -28,6 +28,12 @@ type abort_reason =
       ; data : Yojson.Safe.t option
       }
 
+type operator_repair_reason = Effect_outcome_unknown
+
+type recovery_action =
+  | Retire
+  | Operator_repair_required of operator_repair_reason
+
 type error =
   | Admission_failed of Execution_lane_writer.submit_error
   | Mutation_failed of Execution_lane_writer.ticket_error
@@ -132,3 +138,8 @@ val finish : t -> Execution_event.terminal -> (unit, error) result
 
 (** Atomically terminate every open descendant and the run root. *)
 val abort : t -> abort_reason -> (unit, error) result
+
+(** Classify the terminal scope from its exact durable topology. An invocation
+    with an admitted attempt and no settled ToolResult cannot be retried
+    automatically because its external effect may already have happened. *)
+val terminal_recovery_action : t -> (recovery_action, error) result

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -20,6 +20,31 @@ let invocation tool_use_id =
   Tool.Invocation.create ~tool_use_id ~turn:0 ~schedule
 ;;
 
+let terminal_outcome_name = function
+  | Agent.Terminal_succeeded -> "succeeded"
+  | Agent.Terminal_failed -> "failed"
+  | Agent.Terminal_cancelled -> "cancelled"
+;;
+
+let recovery_action_name = function
+  | Agent.Retire -> "retire"
+  | Agent.Operator_repair_required Agent.Effect_outcome_unknown ->
+    "operator_repair:effect_outcome_unknown"
+;;
+
+let check_terminal_disposition ~outcome ~recovery = function
+  | None -> Alcotest.fail "terminal disposition callback was not invoked"
+  | Some disposition ->
+    Alcotest.(check string)
+      "terminal outcome"
+      outcome
+      (terminal_outcome_name disposition.Agent.outcome);
+    Alcotest.(check string)
+      "terminal recovery action"
+      recovery
+      (recovery_action_name disposition.Agent.recovery)
+;;
+
 (* ── Provider mock: verify pipeline stages via mock responses ── *)
 
 let test_mock_text_response () =
@@ -1068,6 +1093,195 @@ let test_mock_multi_tool_response () =
   | Error _ -> Alcotest.fail "expected ok"
 ;;
 
+let with_execution_test_dir prefix f =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let runtime =
+    match
+      Agent.create_execution_runtime
+        ~sw
+        ~domain_mgr:(Eio.Stdenv.domain_mgr env)
+        ~domain_count:1
+    with
+    | Ok runtime -> runtime
+    | Error error -> Alcotest.fail (Error.to_string error)
+  in
+  let native_path = Filename.temp_file prefix ".dir" in
+  Sys.remove native_path;
+  let dir = Eio.Path.(Eio.Stdenv.fs env / native_path) in
+  Eio.Path.mkdirs ~exists_ok:false ~perm:0o700 dir;
+  Eio.Switch.on_release sw (fun () -> Eio.Path.rmtree ~missing_ok:true dir);
+  f ~env ~sw ~runtime ~dir
+;;
+
+let test_terminal_disposition_retires_settled_provider_failure () =
+  with_execution_test_dir "oas-agent-terminal-failure-"
+  @@ fun ~env ~sw ~runtime ~dir ->
+  let checkpoint_count = ref 0 in
+  let locator_persisted = ref false in
+  let terminal_disposition = ref None in
+  let responses =
+    ref
+      [ Ok
+          (Provider_mock.tool_use_response
+             ~tool_name:"durable_tool"
+             ~tool_input:(`Assoc [])
+             ()
+             [])
+      ; Error
+          (Llm_provider.Http_client.AcceptRejected
+             { reason = "provider failed after persisted checkpoint" })
+      ]
+  in
+  let next_response () =
+    match !responses with
+    | response :: rest ->
+      responses := rest;
+      response
+    | [] -> Alcotest.fail "provider failure fixture exhausted responses"
+  in
+  let transport : Llm_provider.Llm_transport.t =
+    { complete_sync =
+        (fun _request ->
+          { Llm_provider.Llm_transport.response = next_response (); latency_ms = Some 0 })
+    ; complete_stream = (fun ?on_telemetry:_ ~on_event:_ _request -> next_response ())
+    }
+  in
+  let tool =
+    Tool.create
+      ~name:"durable_tool"
+      ~description:"settled before provider failure"
+      ~parameters:[]
+      (fun _input -> Ok { Types.content = "settled"; _meta = None })
+  in
+  let agent =
+    Agent.create
+      ~net:(Eio.Stdenv.net env)
+      ~config:
+        { (Types.default_config ~model:"test-model") with
+          name = "terminal-provider-failure-test"
+        }
+      ~tools:[ tool ]
+      ~options:
+        { Agent.default_options with
+          transport = Some transport
+        ; provider = Some (Provider_mock.to_provider_config ())
+        }
+      ~checkpoint_sink:(fun _snapshot ->
+        incr checkpoint_count;
+        Ok ())
+      ()
+  in
+  let execution_store =
+    Agent.execution_store
+      ~runtime
+      ~dir
+      ~on_scope_ready:(fun _locator ->
+        locator_persisted := true;
+        Ok ())
+      ~on_terminal_disposition:(fun disposition ->
+        terminal_disposition := Some disposition;
+        Ok ())
+      ()
+  in
+  (match Agent.run ~sw ~execution_store agent "run the tool" with
+   | Error _ -> ()
+   | Ok _ -> Alcotest.fail "provider failure unexpectedly completed");
+  Alcotest.(check bool) "locator persisted" true !locator_persisted;
+  Alcotest.(check bool) "checkpoint persisted" true (!checkpoint_count > 0);
+  check_terminal_disposition ~outcome:"failed" ~recovery:"retire" !terminal_disposition
+;;
+
+let test_terminal_disposition_sink_failure_fails_call () =
+  with_execution_test_dir "oas-agent-terminal-sink-failure-"
+  @@ fun ~env ~sw ~runtime ~dir ->
+  let callback_count = ref 0 in
+  let response = Provider_mock.text_response "done" [] in
+  let transport : Llm_provider.Llm_transport.t =
+    { complete_sync =
+        (fun _request ->
+          { Llm_provider.Llm_transport.response = Ok response; latency_ms = Some 0 })
+    ; complete_stream = (fun ?on_telemetry:_ ~on_event:_ _request -> Ok response)
+    }
+  in
+  let agent =
+    Agent.create
+      ~net:(Eio.Stdenv.net env)
+      ~config:
+        { (Types.default_config ~model:"test-model") with
+          name = "terminal-sink-failure-test"
+        }
+      ~options:
+        { Agent.default_options with
+          transport = Some transport
+        ; provider = Some (Provider_mock.to_provider_config ())
+        }
+      ()
+  in
+  let execution_store =
+    Agent.execution_store
+      ~runtime
+      ~dir
+      ~on_terminal_disposition:(fun _disposition ->
+        incr callback_count;
+        Error "injected persistence failure")
+      ()
+  in
+  (match Agent.run ~sw ~execution_store agent "complete" with
+   | Error (Error.Internal _) -> ()
+   | Error error ->
+     Alcotest.failf "terminal sink failure changed category: %s" (Error.to_string error)
+   | Ok _ -> Alcotest.fail "terminal sink failure unexpectedly completed");
+  Alcotest.(check int) "terminal sink called once" 1 !callback_count;
+  Alcotest.(check bool)
+    "terminal journal committed before sink failure"
+    true
+    (Eio.Path.is_file Eio.Path.(dir / "events.v1.commit"))
+;;
+
+let test_terminal_disposition_observes_cancellation () =
+  with_execution_test_dir "oas-agent-terminal-cancel-"
+  @@ fun ~env ~sw ~runtime ~dir ->
+  let terminal_disposition = ref None in
+  let cancel () = raise (Eio.Cancel.Cancelled Exit) in
+  let transport : Llm_provider.Llm_transport.t =
+    { complete_sync = (fun _request -> cancel ())
+    ; complete_stream = (fun ?on_telemetry:_ ~on_event:_ _request -> cancel ())
+    }
+  in
+  let agent =
+    Agent.create
+      ~net:(Eio.Stdenv.net env)
+      ~config:
+        { (Types.default_config ~model:"test-model") with
+          name = "terminal-cancellation-test"
+        }
+      ~options:
+        { Agent.default_options with
+          transport = Some transport
+        ; provider = Some (Provider_mock.to_provider_config ())
+        }
+      ()
+  in
+  let execution_store =
+    Agent.execution_store
+      ~runtime
+      ~dir
+      ~on_terminal_disposition:(fun disposition ->
+        terminal_disposition := Some disposition;
+        Ok ())
+      ()
+  in
+  (match Agent.run ~sw ~execution_store agent "cancel" with
+   | exception Eio.Cancel.Cancelled Exit -> ()
+   | exception exn ->
+     Alcotest.failf "unexpected cancellation exception: %s" (Printexc.to_string exn)
+   | Ok _ | Error _ -> Alcotest.fail "cancellation did not propagate");
+  check_terminal_disposition ~outcome:"cancelled" ~recovery:"retire" !terminal_disposition
+;;
+
 let test_agent_run_uses_durable_tool_authority () =
   Eio_main.run
   @@ fun env ->
@@ -1094,6 +1308,7 @@ let test_agent_run_uses_durable_tool_authority () =
        let effect_after_locator = ref false in
        let effect_count = ref 0 in
        let completion_cursor = ref None in
+       let terminal_disposition = ref None in
        let committed_cursor () =
          let authority =
            Eio.Path.load Eio.Path.(dir / "events.v1.commit") |> Yojson.Safe.from_string
@@ -1192,6 +1407,10 @@ let test_agent_run_uses_durable_tool_authority () =
               | _ -> Alcotest.fail "execution locator is not an object");
              locator_persisted := true;
              Ok ())
+           ~on_terminal_disposition:(fun disposition ->
+             ignore (committed_cursor ());
+             terminal_disposition := Some disposition;
+             Ok ())
            ()
        in
        (match Agent.run ~sw:runtime_sw ~execution_store agent "run the tool" with
@@ -1206,6 +1425,10 @@ let test_agent_run_uses_durable_tool_authority () =
          "locator is durable before tool effect"
          true
          !effect_after_locator;
+       check_terminal_disposition
+         ~outcome:"succeeded"
+         ~recovery:"retire"
+         !terminal_disposition;
        Alcotest.(check (option int))
          "completion observes the final durable cursor"
          (Some (committed_cursor ()))
@@ -1243,7 +1466,7 @@ let test_agent_run_uses_durable_tool_authority () =
          (List.length public_tool_events))
 ;;
 
-let test_agent_run_resumes_settled_tool_without_duplicate_effects () =
+let test_agent_run_resumes_tool_without_duplicate_effects ~settled () =
   Eio_main.run
   @@ fun env ->
   Eio.Switch.run
@@ -1282,6 +1505,7 @@ let test_agent_run_resumes_settled_tool_without_duplicate_effects () =
          }
        in
        let locator_json = ref None in
+       let exception Effect_interrupted_after_attempt in
        let provider_config =
          Llm_provider.Provider_config.make
            ~kind:Llm_provider.Provider_config.OpenAI_compat
@@ -1339,12 +1563,19 @@ let test_agent_run_resumes_settled_tool_without_duplicate_effects () =
               Internal_scope.execute
                 durable
                 ~invoke:(fun ~start_child:_ ~tool_name:_ ~input:_ ->
-                  "settled-before-restart", Types.Tool_succeeded)
+                  if settled
+                  then "settled-before-restart", Types.Tool_succeeded
+                  else raise Effect_interrupted_after_attempt)
             with
-            | Ok (Internal_scope.Executed _) -> ()
+            | Ok (Internal_scope.Executed _) when settled -> ()
+            | Ok (Internal_scope.Executed _) ->
+              Alcotest.fail "unknown-effect fixture unexpectedly settled"
             | Ok (Internal_scope.Replayed _) ->
               Alcotest.fail "fixture unexpectedly replayed its first tool effect"
-            | Error error -> Alcotest.fail (Internal_scope.error_to_string error))
+            | Error error -> Alcotest.fail (Internal_scope.error_to_string error)
+            | exception Effect_interrupted_after_attempt when not settled -> ()
+            | exception Effect_interrupted_after_attempt ->
+              Alcotest.fail "settled fixture interrupted its tool effect")
         with
         | Ok () -> ()
         | Error failure -> Alcotest.fail (Internal_writer.scope_failure_to_string failure));
@@ -1364,6 +1595,7 @@ let test_agent_run_resumes_settled_tool_without_duplicate_effects () =
        let effect_count = ref 0 in
        let pre_hook_count = ref 0 in
        let post_hook_count = ref 0 in
+       let terminal_disposition = ref None in
        let tool =
          Tool.create
            ~name:"durable_tool"
@@ -1420,17 +1652,51 @@ let test_agent_run_resumes_settled_tool_without_duplicate_effects () =
          ; turn_count = 1
          ; usage = Types.empty_usage
          };
-       let execution_store = Agent.execution_store ~runtime ~dir ~resume:locator () in
-       (match Agent.run ~sw:runtime_sw ~execution_store agent "run the tool" with
-        | Ok response ->
+       let execution_store =
+         Agent.execution_store
+           ~runtime
+           ~dir
+           ~on_terminal_disposition:(fun disposition ->
+             terminal_disposition := Some disposition;
+             Ok ())
+           ~resume:locator
+           ()
+       in
+       (match settled, Agent.run ~sw:runtime_sw ~execution_store agent "run the tool" with
+        | true, Ok response ->
           Alcotest.(check string)
             "terminal response"
             "done-after-restart"
             (Types.text_of_response response)
-        | Error error -> Alcotest.fail (Error.to_string error));
+        | true, Error error -> Alcotest.fail (Error.to_string error)
+        | false, Error (Error.Internal _) -> ()
+        | false, Error error ->
+          Alcotest.failf
+            "unknown effect changed error category: %s"
+            (Error.to_string error)
+        | false, Ok _ -> Alcotest.fail "unknown effect unexpectedly completed");
        Alcotest.(check int) "settled tool handler is not rerun" 0 !effect_count;
        Alcotest.(check int) "settled pre-tool hook is not rerun" 0 !pre_hook_count;
-       Alcotest.(check int) "settled post-tool hook is not rerun" 0 !post_hook_count)
+       Alcotest.(check int) "settled post-tool hook is not rerun" 0 !post_hook_count;
+       if settled
+       then
+         check_terminal_disposition
+           ~outcome:"succeeded"
+           ~recovery:"retire"
+           !terminal_disposition
+       else
+         check_terminal_disposition
+           ~outcome:"failed"
+           ~recovery:"operator_repair:effect_outcome_unknown"
+           !terminal_disposition)
+;;
+
+let test_agent_run_resumes_settled_tool_without_duplicate_effects =
+  test_agent_run_resumes_tool_without_duplicate_effects ~settled:true
+;;
+
+let test_agent_run_reports_unknown_effect_for_operator_repair =
+  test_agent_run_resumes_tool_without_duplicate_effects ~settled:false
 ;;
 
 (* ── Runner ──────────────────────────────────────────────── *)
@@ -1523,6 +1789,22 @@ let () =
             "Agent.run resumes settled tool without duplicate effects"
             `Quick
             test_agent_run_resumes_settled_tool_without_duplicate_effects
+        ; Alcotest.test_case
+            "terminal disposition retires settled provider failure"
+            `Quick
+            test_terminal_disposition_retires_settled_provider_failure
+        ; Alcotest.test_case
+            "terminal disposition requires operator repair for unknown effect"
+            `Quick
+            test_agent_run_reports_unknown_effect_for_operator_repair
+        ; Alcotest.test_case
+            "terminal disposition sink failure fails call"
+            `Quick
+            test_terminal_disposition_sink_failure_fails_call
+        ; Alcotest.test_case
+            "terminal disposition observes cancellation"
+            `Quick
+            test_terminal_disposition_observes_cancellation
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

- add an optional typed `on_terminal_disposition` sink to the existing `Agent.execution_store`
- classify terminal execution topology as safe to retire or operator repair required for an unknown Tool effect
- invoke the sink only after the terminal commit and successful execution-writer drain
- preserve caller cancellation while failing sink errors closed without error-string control flow

## Boundary

OAS remains the sole owner of execution topology, Tool settlement, and the opaque locator. Callers own only persistence of the typed terminal disposition and their recovery slot. This adds no parallel run API and does not expose or reconstruct journal internals.

Closes #2687.

## Verification

- `scripts/dune-local.sh build test/test_pipeline.exe`
- `_build/default/test/test_pipeline.exe` (43/43)
- `bash scripts/check-execution-store-boundary.sh`
- `ocamlformat --check` on touched OCaml files
- `git diff --check`
