### PR TITLE
refactor(llm_provider): consolidate empty-completion overflow rule into a Retry helper

### DIFF
--- a/lib/api.ml
+++ b/lib/api.ml
@@ -39,26 +39,17 @@ let create_message_error_of_http_error = function
       http_error
       (Retry.InvalidRequest { message; reason = Unknown_invalid_request })
   | Llm_provider.Http_client.ProviderFailure
-      { kind =
-          Llm_provider.Http_client.Empty_completion
-            { stop_reason = Llm_provider.Types.ContextWindowExceeded }
-      ; message
-      } as http_error ->
-    (* An empty turn whose typed stop_reason is ContextWindowExceeded is a
-       context-overflow contract, not provider unavailability: retrying or
-       rotating replays the same oversized prompt, so only the consumer's
-       context recovery (compaction) can make progress. The provider does not
-       report its limit on this path, hence [limit = None]. *)
-    attributed_retry_error
-      http_error
-      (Retry.ContextOverflow
-         { message =
-             "empty completion (stop_reason=model_context_window_exceeded): " ^ message
-         ; limit = None
-         })
-  | Llm_provider.Http_client.ProviderFailure
-      { kind = Llm_provider.Http_client.Empty_completion _; _ } as http_error ->
-    Completion_error http_error
+      { kind = Llm_provider.Http_client.Empty_completion { stop_reason }; message }
+    as http_error ->
+    (* The #2621 empty-completion overflow rule lives in one place now:
+       [Retry.overflow_of_empty_completion]. A ContextWindowExceeded empty turn
+       is a context-overflow contract (only compaction makes progress, not
+       retry/rotate); every other stop_reason stays an opaque completion error.
+       This site's wrappers — [attributed_retry_error] / [Completion_error] —
+       are preserved exactly. *)
+    (match Retry.overflow_of_empty_completion ~stop_reason ~message with
+     | Some overflow -> attributed_retry_error http_error overflow
+     | None -> Completion_error http_error)
   | Llm_provider.Http_client.ProviderFailure { kind; message } as http_error ->
     attributed_retry_error
       http_error

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -39,8 +39,8 @@ let create_message_error_of_http_error = function
       http_error
       (Retry.InvalidRequest { message; reason = Unknown_invalid_request })
   | Llm_provider.Http_client.ProviderFailure
-      { kind = Llm_provider.Http_client.Empty_completion { stop_reason }; message }
-    as http_error ->
+      { kind = Llm_provider.Http_client.Empty_completion { stop_reason }; message } as
+    http_error ->
     (* The #2621 empty-completion overflow rule lives in one place now:
        [Retry.overflow_of_empty_completion]. A ContextWindowExceeded empty turn
        is a context-overflow contract (only compaction makes progress, not

--- a/lib/llm_provider/error.ml
+++ b/lib/llm_provider/error.ml
@@ -276,36 +276,30 @@ let of_provider_failure ?provider kind message =
       { detail =
           Printf.sprintf "provider response exceeded %d bytes: %s" limit_bytes message
       }
-  | Http_client.Empty_completion { stop_reason = Types.ContextWindowExceeded } ->
-    (* Third promotion site of the #2621 misclassification fix: an empty
-       completion whose typed stop_reason is ContextWindowExceeded is a
-       caller-fixable context overflow, not provider unavailability.  Retrying
-       or rotating replays the same oversized prompt, so render it through the
-       same [Retry.ContextOverflow] path as the Api branch above. *)
-    InvalidRequest
-      { provider
-      ; reason =
-          Retry.error_message
-            (Retry.ContextOverflow
-               { message =
-                   "empty completion (stop_reason=model_context_window_exceeded): "
-                   ^ message
-               ; limit = None
-               })
-      }
   | Http_client.Empty_completion { stop_reason } ->
-    (* [stop_reason] stays typed until this deliberate SDK boundary.  The public
-       error surface remains source-compatible: callers already handle an empty
-       completion as provider unavailability, and no control flow reparses this
-       diagnostic rendering. *)
-    ProviderUnavailable
-      { provider
-      ; detail =
-          Printf.sprintf
-            "empty completion (stop_reason=%s): %s"
-            (Types.stop_reason_to_string stop_reason)
-            message
-      }
+    (match Retry.overflow_of_empty_completion ~stop_reason ~message with
+     | Some overflow ->
+       (* Third promotion site of the #2621 misclassification fix: a
+          ContextWindowExceeded empty completion is a caller-fixable context
+          overflow, not provider unavailability. The overflow VALUE comes from
+          the shared [Retry.overflow_of_empty_completion] classifier; this
+          deliberate SDK boundary flattens it to a string via
+          [Retry.error_message] into [InvalidRequest], preserving the typed →
+          string boundary that keeps the public surface source-compatible. *)
+       InvalidRequest { provider; reason = Retry.error_message overflow }
+     | None ->
+       (* [stop_reason] stays typed until this deliberate SDK boundary.  The
+          public error surface remains source-compatible: callers already handle
+          a non-overflow empty completion as provider unavailability, and no
+          control flow reparses this diagnostic rendering. *)
+       ProviderUnavailable
+         { provider
+         ; detail =
+             Printf.sprintf
+               "empty completion (stop_reason=%s): %s"
+               (Types.stop_reason_to_string stop_reason)
+               message
+         })
   | Http_client.Unknown_provider_failure { reason } ->
     let reason =
       match reason with

--- a/lib/llm_provider/retry.ml
+++ b/lib/llm_provider/retry.ml
@@ -99,6 +99,62 @@ let is_retryable = function
   | PaymentRequired _ -> false
 ;;
 
+(** [overflow_of_empty_completion ~stop_reason ~message] is the single,
+    compiler-checked source for the #2621 empty-completion overflow rule.
+
+    An empty turn whose typed [stop_reason] is [ContextWindowExceeded] is a
+    context-overflow contract, not provider unavailability: retrying or
+    rotating replays the same oversized prompt, so only the consumer's context
+    recovery (compaction) can make progress. The provider does not report its
+    limit on this path, hence [limit = None].
+
+    Only the typed [ContextOverflow] value is produced here. Each caller keeps
+    its own wrapping of the result — [Api.attributed_retry_error],
+    [Provider_failure_attribution]'s [Error.Api], and the SDK boundary in
+    [Error] that flattens via [error_message] into [InvalidRequest]. Every
+    other stop_reason returns [None] so callers apply their existing
+    non-overflow handling. The match is exhaustive (no [_] catch-all) so adding
+    a new [Types.stop_reason] forces a decision here. *)
+let overflow_of_empty_completion ~(stop_reason : Types.stop_reason) ~message =
+  match stop_reason with
+  | Types.ContextWindowExceeded ->
+    Some
+      (ContextOverflow
+         { message =
+             "empty completion (stop_reason=model_context_window_exceeded): " ^ message
+         ; limit = None
+         })
+  | Types.EndTurn
+  | Types.StopToolUse
+  | Types.MaxTokens
+  | Types.StopSequence
+  | Types.Refusal
+  | Types.ContentFilter
+  | Types.RepetitionTruncation
+  | Types.PauseTurn
+  | Types.Compaction
+  | Types.UnmatchedToolCalls
+  | Types.Unknown _ -> None
+;;
+
+let%test "overflow_of_empty_completion: ContextWindowExceeded yields ContextOverflow" =
+  match
+    overflow_of_empty_completion ~stop_reason:Types.ContextWindowExceeded ~message:"X"
+  with
+  | Some
+      (ContextOverflow
+         { message = "empty completion (stop_reason=model_context_window_exceeded): X"
+         ; limit = None
+         }) -> true
+  | Some _ | None -> false
+;;
+
+let%test "overflow_of_empty_completion: non-overflow stop_reason yields None" =
+  match overflow_of_empty_completion ~stop_reason:Types.EndTurn ~message:"X" with
+  | None -> true
+  | Some _ -> false
+;;
+
 (** Extract a human-readable error message from a provider error body.
     Error prose remains diagnostic data only and is never classified. *)
 let extract_error_message (body : string) : string =

--- a/lib/llm_provider/retry.mli
+++ b/lib/llm_provider/retry.mli
@@ -46,6 +46,19 @@ type api_error =
 val is_retryable : api_error -> bool
 val error_message : api_error -> string
 
+(** [overflow_of_empty_completion ~stop_reason ~message] classifies an empty
+    provider completion into [Some (ContextOverflow …)] when [stop_reason] is
+    [ContextWindowExceeded], else [None]. Single compiler-checked source for the
+    #2621 empty-completion overflow rule shared by [Api],
+    [Provider_failure_attribution], and the SDK boundary in [Error]; each caller
+    keeps its own wrapping of the returned value. The message prefix
+    ["empty completion (stop_reason=model_context_window_exceeded): "] and
+    [limit = None] live here so all three call sites stay byte-identical. *)
+val overflow_of_empty_completion
+  :  stop_reason:Types.stop_reason
+  -> message:string
+  -> api_error option
+
 (** Merge a provider's structured [retry_after] evidence: the JSON body's
     [error.retry_after] field wins when present (provider-specific, more
     precise); the transport's parsed [Retry-After] response header

--- a/lib/provider_failure_attribution.ml
+++ b/lib/provider_failure_attribution.ml
@@ -58,23 +58,17 @@ let sdk_error_of_http_error ?(accept_rejected = Api_invalid_request) err =
      | Api_invalid_request -> invalid_request reason
      | Config_invalid_config { field } ->
        Error.Config (Error.InvalidConfig { field; detail = reason }))
-  | Http.ProviderFailure
-      { kind =
-          Http.Empty_completion { stop_reason = Llm_provider.Types.ContextWindowExceeded }
-      ; message
-      } ->
-    (* An empty turn whose typed stop_reason is ContextWindowExceeded is a
-       context-overflow contract, not provider unavailability: retrying or
-       rotating replays the same oversized prompt, so only the consumer's
-       context recovery (compaction) can make progress. Surfacing it as
-       [Api ContextOverflow] lets downstream overflow classifiers fire on the
-       streaming path exactly as they do for HTTP-classified overflows. *)
-    Error.Api
-      (Retry.ContextOverflow
-         { message =
-             "empty completion (stop_reason=model_context_window_exceeded): " ^ message
-         ; limit = None
-         })
+  | Http.ProviderFailure { kind = Http.Empty_completion { stop_reason }; message } ->
+    (* The #2621 empty-completion overflow rule is centralised in
+       [Retry.overflow_of_empty_completion]. A ContextWindowExceeded empty turn
+       surfaces as [Api ContextOverflow] so downstream overflow classifiers fire
+       on the streaming path exactly as for HTTP-classified overflows; every
+       other stop_reason falls through to the same provider-unavailability
+       handling as [ProviderTerminal] / other [ProviderFailure]. This site's
+       [Error.Api] wrapper is preserved. *)
+    (match Retry.overflow_of_empty_completion ~stop_reason ~message with
+     | Some overflow -> Error.Api overflow
+     | None -> Error.Provider (Llm_provider.Error.of_http_error err))
   | Http.ProviderTerminal _ | Http.ProviderFailure _ ->
     Error.Provider (Llm_provider.Error.of_http_error err)
 ;;


### PR DESCRIPTION
## 증상 (N-of-M abstraction 실패)
#2621의 empty-completion → `ContextOverflow` 분류 규칙이 3개 사이트에 verbatim
하드카피되어 있습니다: `lib/api.ml`, `lib/provider_failure_attribution.ml`,
`lib/llm_provider/error.ml`. #2659가 세 번째 카피(error.ml)를 추가했습니다 —
컴파일러가 동기화를 강제하지 못하는 N-of-M 상태(향후 4번째 site 드리프트 위험).

## 근본 수정
분류 "값"만 `Retry.overflow_of_empty_completion ~stop_reason ~message : api_error
option` 헬퍼로 추출해 **단일 컴파일러 검증 소스**로 만들었습니다. `stop_reason`을
**exhaustive match(catch-all `_` 없음)**로 처리하므로, 새 `Types.stop_reason` 변형이
추가되면 이 한 곳에서 컴파일 타임 결정을 강제합니다.

각 사이트는 **자신의 출력 wrapper를 그대로 유지**합니다:
- api.ml → `attributed_retry_error`
- provider_failure_attribution.ml → `Error.Api`
- llm_provider/error.ml → `Retry.error_message`로 flatten → `InvalidRequest`
  (SDK typed→string 경계 보존).

Option A(생성 시점 `Empty_completion`에 overflow 플래그)는 `http_client.ml`이
stop_reason을 typed로 유지해 policy를 transport 밖에 두는 경계를 위반하므로
채택하지 않았습니다.

## 동작 보존
3사이트 모두 byte-identical 출력. 로컬 검증: `runtest lib` exit 0,
`test_llm_provider_error` 34 pass, `test_provider_failure_attribution` 14 pass,
신규 `retry` inline %test(`ContextWindowExceeded → Some`, `EndTurn → None`) 통과.

Closes #2659 (N-of-M workaround; 하드카피 대신 abstraction 추출).

RFC-WAIVED: `lib/llm_provider/*`, `lib/api.ml` 등 — RFC-gated subsystem 비해당.
