### PR TITLE
feat(agent): expose durable execution projection

### DIFF
--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -50,10 +50,20 @@ type execution_terminal_disposition = Agent_execution_runner.terminal_dispositio
   ; recovery : execution_recovery_action
   }
 
+module Execution_projection = Agent_execution_projection
+
 let create_execution_runtime = Agent_execution_runner.create_runtime
 let execution_store = Agent_execution_runner.store
 let execution_locator_to_yojson = Agent_execution_runner.locator_to_yojson
 let execution_locator_of_yojson = Agent_execution_runner.locator_of_yojson
+
+let open_execution_projection ~runtime ~dir locator =
+  Execution_projection.open_durable
+    ~codec:(Agent_execution_runner.runtime_codec runtime)
+    ~dir
+    ~locator_run_id:(Agent_execution_runner.locator_run_id locator)
+    ()
+;;
 
 let replace_projected_error error detailed =
   { detailed with Provider_failure_attribution.error }
@@ -250,6 +260,32 @@ let run_loop_turns_detailed
   loop Held
 ;;
 
+let ambient_execution_scope_factory agent =
+  Execution_context.child_scope_factory ()
+  |> Option.map (fun start_child () -> start_child ~agent_name:agent.state.config.name)
+;;
+
+let run_with_execution_scope ~sw ?execution_store agent run =
+  let execution_scope_factory = ambient_execution_scope_factory agent in
+  match execution_store, execution_scope_factory with
+  | None, None -> run ~sw
+  | Some store, None ->
+    Agent_execution_runner.with_store store agent (fun ~sw _execution_scope -> run ~sw)
+  | None, Some start_scope ->
+    (match start_scope () with
+     | Error error ->
+       Error
+         (detailed_error_of_sdk_error
+            (Error.Internal
+               ("durable child scope: " ^ Execution_agent_scope.error_to_string error)))
+     | Ok execution_scope ->
+       Agent_execution_runner.with_scope execution_scope (fun () -> run ~sw))
+  | Some _, Some _ ->
+    Error
+      (detailed_error_of_sdk_error
+         (Error.Internal "execution store and child scope factory are mutually exclusive"))
+;;
+
 let run_loop_detailed
       ~sw
       ?clock
@@ -257,7 +293,6 @@ let run_loop_detailed
       ?on_yield
       ?on_resume
       ?execution_store
-      ?execution_scope_factory
       agent
       user_blocks
   =
@@ -290,23 +325,7 @@ let run_loop_detailed
       ?raw_trace_run
       agent
   in
-  match execution_store, execution_scope_factory with
-  | None, None -> run ~sw
-  | Some store, None ->
-    Agent_execution_runner.with_store store agent (fun ~sw _execution_scope -> run ~sw)
-  | None, Some start_scope ->
-    (match start_scope () with
-     | Error error ->
-       Error
-         (detailed_error_of_sdk_error
-            (Error.Internal
-               ("durable child scope: " ^ Execution_agent_scope.error_to_string error)))
-     | Ok execution_scope ->
-       Agent_execution_runner.with_scope execution_scope (fun () -> run ~sw))
-  | Some _, Some _ ->
-    Error
-      (detailed_error_of_sdk_error
-         (Error.Internal "execution store and child scope factory are mutually exclusive"))
+  run_with_execution_scope ~sw ?execution_store agent run
 ;;
 
 let run_loop
@@ -643,19 +662,7 @@ let run_handoff_target ~sw ?clock agent (target : Handoff.handoff_target) prompt
       ?provider_config:agent.provider_config
       ()
   in
-  let result =
-    match Execution_context.child_scope_factory () with
-    | None -> run ~sw ?clock sub prompt
-    | Some start_child ->
-      run_loop_detailed
-        ~sw
-        ?clock
-        ~api_strategy:Sync
-        ~execution_scope_factory:(fun () -> start_child ~agent_name:target.config.name)
-        sub
-        [ Text prompt ]
-      |> project_detailed_error
-  in
+  let result = run ~sw ?clock sub prompt in
   publish_handoff_completed
     agent
     target
@@ -908,10 +915,7 @@ module Advanced = struct
         ~on_tool_boundary
         agent
     in
-    match execution_store with
-    | None -> run ~sw
-    | Some store ->
-      Agent_execution_runner.with_store store agent (fun ~sw _execution_scope -> run ~sw)
+    run_with_execution_scope ~sw ?execution_store agent run
   ;;
 
   let run_blocks_detailed
@@ -977,11 +981,7 @@ let run_turn_stream_detailed ~sw ?clock ~on_event ?on_telemetry ?execution_store
       ~api_strategy:(Stream { on_event; on_telemetry })
       agent
   in
-  (match execution_store with
-   | None -> run ~sw ()
-   | Some store ->
-     Agent_execution_runner.with_store store agent (fun ~sw _execution_scope ->
-       run ~sw ()))
+  run_with_execution_scope ~sw ?execution_store agent (fun ~sw -> run ~sw ())
   |> Result.map (function
     | `Complete response -> `Complete response
     | `ToolsExecuted _ -> `ToolsExecuted)

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -178,6 +178,22 @@ val create_execution_runtime
   -> domain_count:int
   -> (execution_runtime, Error.sdk_error) result
 
+(** Lossless read-only projection of OAS's canonical recursive execution
+    journal. These values are observations only: they cannot append, admit,
+    pause, cancel, or terminate execution. *)
+module Execution_projection : Agent_execution_projection_intf.S
+
+(** Open the same read-only projection for a currently running scope or after
+    process restart. [locator] must identify the top-level run in exactly this
+    directory. The call takes no writer lock and performs no recovery writes.
+    The returned value is safe to share between fibers; sharing also preserves
+    its incremental validated-prefix cache across consumers. *)
+val open_execution_projection
+  :  runtime:execution_runtime
+  -> dir:Eio.Fs.dir_ty Eio.Path.t
+  -> execution_locator
+  -> (Execution_projection.t, Execution_projection.error) result
+
 (** Configure one durable execution scope. Without [resume], the directory must
     be new and the call starts a fresh scope. With [resume], the same Agent API
     reopens that scope in the same directory, validates Agent identity and the
@@ -194,7 +210,9 @@ val create_execution_runtime
     [on_scope_ready], when supplied, must persist the opaque locator before
     provider or Tool effects begin. It is invoked for both fresh and resumed
     scopes, so the sink should be idempotent. Failure aborts the scope and the
-    Agent call.
+    Agent call. The same locator and directory can be passed to
+    {!open_execution_projection} immediately for live reads or later after a
+    restart; the callback is not a separate event or catch-up authority.
 
     [on_terminal_disposition] is invoked after the terminal journal commit and
     successful writer drain, before this Agent call returns. [Retire] means the

--- a/lib/agent/agent_execution_projection.ml
+++ b/lib/agent/agent_execution_projection.ml
@@ -1,0 +1,773 @@
+open Result_syntax
+module Event = Execution_event
+module Journal = Execution_journal
+module Store = Execution_event_store
+module Sequence_map = Map.Make (Int)
+
+module type ID = sig
+  type t
+
+  val to_string : t -> string
+  val equal : t -> t -> bool
+  val compare : t -> t -> int
+  val pp : Format.formatter -> t -> unit
+end
+
+module Event_id = Event.Event_id
+module Run_id = Event.Run_id
+module Node_id = Event.Node_id
+module Correlation_id = Event.Correlation_id
+
+type output_block_kind =
+  | Text_block
+  | Thinking_block
+  | Reasoning_details_block
+  | Redacted_thinking_block
+  | Image_block
+  | Document_block
+  | Audio_block
+
+type node_kind =
+  | Agent_run of { agent_name : string }
+  | Agent_turn of { ordinal : int }
+  | Provider_attempt of
+      { ordinal : int
+      ; target : Binding_identity.Redacted_snapshot.t
+      }
+  | Output_block of
+      { ordinal : int
+      ; block_kind : output_block_kind
+      }
+  | Tool_invocation of
+      { provider_tool_use_id : string option
+      ; tool_name : string
+      ; schedule : Tool.schedule
+      }
+  | Tool_attempt
+
+type node =
+  { node_id : Node_id.t
+  ; run_id : Run_id.t
+  ; parent_node_id : Node_id.t option
+  ; kind : node_kind
+  }
+
+type node_update =
+  | Provider_event of Yojson.Safe.t
+  | Provider_response_id_snapshot of string
+  | Output_delta of Yojson.Safe.t
+  | Output_snapshot of Llm_provider.Types.content_block
+  | Tool_input_delta of Yojson.Safe.t
+  | Tool_input_snapshot of Llm_provider.Types.content_block
+  | Tool_progress of Yojson.Safe.t
+  | Tool_result of Llm_provider.Types.content_block
+
+type failure_kind =
+  | Provider_failure
+  | Tool_failure
+  | Hook_failure
+  | Observer_failure
+  | Persistence_failure
+  | Protocol_failure
+  | Internal_failure
+
+type failure =
+  { kind : failure_kind
+  ; detail : string
+  ; data : Yojson.Safe.t option
+  }
+
+type terminal =
+  | Succeeded
+  | Failed of failure
+  | Cancelled of
+      { reason : string option
+      ; data : Yojson.Safe.t option
+      }
+
+type payload =
+  | Node_opened of node
+  | Node_updated of
+      { node_id : Node_id.t
+      ; update : node_update
+      }
+  | Node_closed of
+      { node_id : Node_id.t
+      ; terminal : terminal
+      }
+
+module External_source = Event.External_source
+
+type cause =
+  | Internal_event of Event_id.t
+  | External_event of
+      { source : External_source.t
+      ; event_id : string
+      }
+
+type event =
+  { event_id : Event_id.t
+  ; run_id : Run_id.t
+  ; correlation_id : Correlation_id.t
+  ; seq : int
+  ; parent_event_id : Event_id.t option
+  ; causes : cause list
+  ; payload : payload
+  ; event_time : float
+  ; observed_at : float
+  ; source_clock : Event_envelope.source_clock
+  }
+
+type cursor =
+  { scope_id : Store.Scope_id.t
+  ; seq : int
+  }
+
+type cursor_field =
+  | Version
+  | Scope_id
+  | Sequence
+
+type cursor_decode_error =
+  | Cursor_not_object
+  | Missing_cursor_field of cursor_field
+  | Unexpected_cursor_field of string
+  | Duplicate_cursor_field of cursor_field
+  | Invalid_cursor_field of
+      { field : cursor_field
+      ; detail : string
+      }
+  | Unsupported_cursor_version of
+      { expected : int
+      ; actual : int
+      }
+
+type unexpected_store_error =
+  | Writer_already_active
+  | Store_already_attached
+  | Store_released
+  | Store_release_forbidden
+  | Resource_cleanup_failed
+  | Construction_cleanup_failed
+  | Store_already_exists
+  | Correlation_mismatch
+  | Sequence_conflict
+  | Committed_content_conflict
+  | Cursor_scope_mismatch
+  | Cursor_ahead
+  | Store_poisoned
+  | Commit_outcome_unknown
+
+type storage_failure =
+  | Invalid_store_argument of string
+  | Store_identity_failure of string
+  | Store_io_failure of
+      { operation : string
+      ; detail : string
+      }
+  | Store_codec_failure of string
+  | Store_not_found
+  | Store_initialization_incomplete
+  | Store_initialization_conflict
+  | Unsupported_store_version of
+      { expected : int
+      ; actual : int
+      }
+  | Corrupt_store of
+      { offset : int64
+      ; detail : string
+      }
+  | Commit_authority_identity_changed
+  | Commit_authority_regressed of
+      { previous_committed_offset : int64
+      ; actual_committed_offset : int64
+      ; previous_last_seq : int
+      ; actual_last_seq : int
+      }
+  | Unexpected_store_failure of
+      { kind : unexpected_store_error
+      ; detail : string
+      }
+
+type cursor_role =
+  | After
+  | Through
+
+type error =
+  | Invalid_limit of int
+  | Cursor_scope_mismatch
+  | Cursor_ahead of
+      { cursor_role : cursor_role
+      ; cursor_seq : int
+      ; high_watermark : int
+      }
+  | Locator_not_found of Run_id.t
+  | Locator_not_top_level of Run_id.t
+  | Semantic_failure of
+      { seq : int
+      ; detail : string
+      }
+  | Storage_failure of storage_failure
+
+type page =
+  { events : event list
+  ; next_cursor : cursor
+  ; high_watermark : cursor
+  ; has_more : bool
+  }
+
+type validated_snapshot =
+  { durable : Store.read_only_snapshot
+  ; reducer : Journal.Reducer.t
+  ; events : event Sequence_map.t
+  }
+
+type refresh_outcome = (validated_snapshot, error) result option
+
+type in_flight_refresh =
+  { promise : refresh_outcome Eio.Promise.t
+  ; resolver : refresh_outcome Eio.Promise.u
+  }
+
+(** [mu] protects only snapshot reads, single-flight ownership, and
+    publication; file I/O, decoding, and reduction run against an immutable
+    base outside the lock. The durable snapshot's typed scope/correlation
+    identity is the directory identity key; a path string is never treated as
+    identity. Reducer and event maps are persistent immutable values shared
+    between successive authority snapshots. *)
+type t =
+  { codec : Execution_codec_executor.t
+  ; dir : Eio.Fs.dir_ty Eio.Path.t
+  ; locator_run_id : Run_id.t
+  ; scope_id : Store.Scope_id.t
+  ; mu : Eio.Mutex.t
+  ; mutable snapshot : validated_snapshot
+  ; mutable in_flight_refresh : in_flight_refresh option
+  }
+
+let cursor_version = 1
+
+let cursor_to_yojson (cursor : cursor) =
+  `Assoc
+    [ "version", `Int cursor_version
+    ; "scope_id", `String (Store.Scope_id.to_string cursor.scope_id)
+    ; "sequence", `Int cursor.seq
+    ]
+;;
+
+let cursor_field_of_name = function
+  | "version" -> Some Version
+  | "scope_id" -> Some Scope_id
+  | "sequence" -> Some Sequence
+  | _ -> None
+;;
+
+let cursor_field_name = function
+  | Version -> "version"
+  | Scope_id -> "scope_id"
+  | Sequence -> "sequence"
+;;
+
+let cursor_decode_error_to_string = function
+  | Cursor_not_object -> "execution projection cursor must be an object"
+  | Missing_cursor_field field ->
+    "execution projection cursor is missing field " ^ cursor_field_name field
+  | Unexpected_cursor_field field ->
+    "execution projection cursor has unexpected field " ^ field
+  | Duplicate_cursor_field field ->
+    "execution projection cursor repeats field " ^ cursor_field_name field
+  | Invalid_cursor_field { field; detail } ->
+    Printf.sprintf
+      "execution projection cursor field %s is invalid: %s"
+      (cursor_field_name field)
+      detail
+  | Unsupported_cursor_version { expected; actual } ->
+    Printf.sprintf
+      "execution projection cursor version %d is unsupported; expected version %d"
+      actual
+      expected
+;;
+
+let cursor_of_yojson json =
+  let* fields =
+    match json with
+    | `Assoc fields -> Ok fields
+    | _ -> Error Cursor_not_object
+  in
+  let rec collect version scope_id sequence = function
+    | [] -> Ok (version, scope_id, sequence)
+    | (name, value) :: rest ->
+      (match cursor_field_of_name name with
+       | None -> Error (Unexpected_cursor_field name)
+       | Some Version ->
+         (match version with
+          | Some _ -> Error (Duplicate_cursor_field Version)
+          | None -> collect (Some value) scope_id sequence rest)
+       | Some Scope_id ->
+         (match scope_id with
+          | Some _ -> Error (Duplicate_cursor_field Scope_id)
+          | None -> collect version (Some value) sequence rest)
+       | Some Sequence ->
+         (match sequence with
+          | Some _ -> Error (Duplicate_cursor_field Sequence)
+          | None -> collect version scope_id (Some value) rest))
+  in
+  let* version, scope_id, sequence = collect None None None fields in
+  let* version =
+    match version with
+    | None -> Error (Missing_cursor_field Version)
+    | Some (`Int value) -> Ok value
+    | Some _ ->
+      Error (Invalid_cursor_field { field = Version; detail = "expected integer" })
+  in
+  let* () =
+    if version = cursor_version
+    then Ok ()
+    else
+      Error (Unsupported_cursor_version { expected = cursor_version; actual = version })
+  in
+  let* scope_id =
+    match scope_id with
+    | None -> Error (Missing_cursor_field Scope_id)
+    | Some (`String value) ->
+      Store.Scope_id.of_string value
+      |> Result.map_error (fun detail ->
+        Invalid_cursor_field { field = Scope_id; detail })
+    | Some _ ->
+      Error (Invalid_cursor_field { field = Scope_id; detail = "expected string" })
+  in
+  let* seq =
+    match sequence with
+    | None -> Error (Missing_cursor_field Sequence)
+    | Some (`Int value) when value >= 0 -> Ok value
+    | Some (`Int _) ->
+      Error
+        (Invalid_cursor_field
+           { field = Sequence; detail = "expected non-negative integer" })
+    | Some _ ->
+      Error (Invalid_cursor_field { field = Sequence; detail = "expected integer" })
+  in
+  Ok { scope_id; seq }
+;;
+
+let cursor_seq (cursor : cursor) = cursor.seq
+
+let output_block_kind = function
+  | Event.Text_block -> Text_block
+  | Event.Thinking_block -> Thinking_block
+  | Event.Reasoning_details_block -> Reasoning_details_block
+  | Event.Redacted_thinking_block -> Redacted_thinking_block
+  | Event.Image_block -> Image_block
+  | Event.Document_block -> Document_block
+  | Event.Audio_block -> Audio_block
+;;
+
+let node_kind = function
+  | Event.Agent_run { agent_name } -> Agent_run { agent_name }
+  | Event.Agent_turn { ordinal } -> Agent_turn { ordinal }
+  | Event.Provider_attempt { ordinal; target } -> Provider_attempt { ordinal; target }
+  | Event.Output_block { ordinal; block_kind = kind } ->
+    Output_block { ordinal; block_kind = output_block_kind kind }
+  | Event.Tool_invocation { provider_tool_use_id; tool_name; schedule } ->
+    Tool_invocation { provider_tool_use_id; tool_name; schedule }
+  | Event.Tool_attempt -> Tool_attempt
+;;
+
+let node value =
+  { node_id = Event.node_id value
+  ; run_id = Event.node_run_id value
+  ; parent_node_id = Event.parent_node_id value
+  ; kind = node_kind (Event.node_kind value)
+  }
+;;
+
+let node_update = function
+  | Event.Provider_event value -> Provider_event value
+  | Event.Provider_response_id_snapshot value -> Provider_response_id_snapshot value
+  | Event.Output_delta value -> Output_delta value
+  | Event.Output_snapshot value -> Output_snapshot value
+  | Event.Tool_input_delta value -> Tool_input_delta value
+  | Event.Tool_input_snapshot value -> Tool_input_snapshot value
+  | Event.Tool_progress value -> Tool_progress value
+  | Event.Tool_result value -> Tool_result value
+;;
+
+let failure_kind = function
+  | Event.Provider_failure -> Provider_failure
+  | Event.Tool_failure -> Tool_failure
+  | Event.Hook_failure -> Hook_failure
+  | Event.Observer_failure -> Observer_failure
+  | Event.Persistence_failure -> Persistence_failure
+  | Event.Protocol_failure -> Protocol_failure
+  | Event.Internal_failure -> Internal_failure
+;;
+
+let failure (value : Event.failure) =
+  { kind = failure_kind value.kind; detail = value.detail; data = value.data }
+;;
+
+let terminal = function
+  | Event.Succeeded -> Succeeded
+  | Event.Failed value -> Failed (failure value)
+  | Event.Cancelled { reason; data } -> Cancelled { reason; data }
+;;
+
+let payload = function
+  | Event.Node_opened value -> Node_opened (node value)
+  | Event.Node_updated { node_id; update } ->
+    Node_updated { node_id; update = node_update update }
+  | Event.Node_closed { node_id; terminal = value } ->
+    Node_closed { node_id; terminal = terminal value }
+;;
+
+let cause = function
+  | Event.Internal_event event_id -> Internal_event event_id
+  | Event.External_event { source; event_id } -> External_event { source; event_id }
+;;
+
+let event value =
+  let envelope = Event.envelope value in
+  { event_id = Event.event_id value
+  ; run_id = Event.run_id value
+  ; correlation_id = Event.correlation_id value
+  ; seq = Event.seq value
+  ; parent_event_id = Event.parent_event_id value
+  ; causes = List.map cause (Event.causes value)
+  ; payload = payload (Event.payload value)
+  ; event_time = envelope.Event_envelope.event_time
+  ; observed_at = envelope.observed_at
+  ; source_clock = envelope.source_clock
+  }
+;;
+
+let unexpected_store_failure kind error =
+  Unexpected_store_failure { kind; detail = Store.error_to_string error }
+;;
+
+let storage_failure error =
+  match error with
+  | Store.Invalid_argument detail -> Invalid_store_argument detail
+  | Store.Identity_failure detail -> Store_identity_failure detail
+  | Store.Io_failure { operation; detail } -> Store_io_failure { operation; detail }
+  | Store.Codec_failure failure ->
+    Store_codec_failure (Execution_codec_executor.failure_to_string failure)
+  | Store.Store_not_found -> Store_not_found
+  | Store.Store_initialization_incomplete -> Store_initialization_incomplete
+  | Store.Store_initialization_conflict -> Store_initialization_conflict
+  | Store.Unsupported_store_version { expected; actual } ->
+    Unsupported_store_version { expected; actual }
+  | Store.Corrupt_store { offset; detail } -> Corrupt_store { offset; detail }
+  | Store.Commit_authority_identity_changed -> Commit_authority_identity_changed
+  | Store.Commit_authority_regressed
+      { previous_committed_offset
+      ; actual_committed_offset
+      ; previous_last_seq
+      ; actual_last_seq
+      } ->
+    Commit_authority_regressed
+      { previous_committed_offset
+      ; actual_committed_offset
+      ; previous_last_seq
+      ; actual_last_seq
+      }
+  | Store.Writer_already_active as error ->
+    unexpected_store_failure Writer_already_active error
+  | Store.Store_already_attached as error ->
+    unexpected_store_failure Store_already_attached error
+  | Store.Store_released as error -> unexpected_store_failure Store_released error
+  | Store.Store_release_forbidden as error ->
+    unexpected_store_failure Store_release_forbidden error
+  | Store.Resource_cleanup_failed _ as error ->
+    unexpected_store_failure Resource_cleanup_failed error
+  | Store.Construction_cleanup_failed _ as error ->
+    unexpected_store_failure Construction_cleanup_failed error
+  | Store.Store_already_exists as error ->
+    unexpected_store_failure Store_already_exists error
+  | Store.Correlation_mismatch as error ->
+    unexpected_store_failure Correlation_mismatch error
+  | Store.Sequence_conflict _ as error -> unexpected_store_failure Sequence_conflict error
+  | Store.Committed_content_conflict _ as error ->
+    unexpected_store_failure Committed_content_conflict error
+  | Store.Cursor_scope_mismatch as error ->
+    unexpected_store_failure Cursor_scope_mismatch error
+  | Store.Cursor_ahead _ as error -> unexpected_store_failure Cursor_ahead error
+  | Store.Store_poisoned _ as error -> unexpected_store_failure Store_poisoned error
+  | Store.Commit_outcome_unknown _ as error ->
+    unexpected_store_failure Commit_outcome_unknown error
+;;
+
+let storage_failure_to_string = function
+  | Invalid_store_argument detail -> "invalid store argument: " ^ detail
+  | Store_identity_failure detail -> "store identity failure: " ^ detail
+  | Store_io_failure { operation; detail } -> operation ^ " failed: " ^ detail
+  | Store_codec_failure detail -> "store codec failed: " ^ detail
+  | Store_not_found -> "execution store does not exist"
+  | Store_initialization_incomplete -> "execution store initialization is incomplete"
+  | Store_initialization_conflict -> "execution store initialization conflicts"
+  | Unsupported_store_version { expected; actual } ->
+    Printf.sprintf "store version %d is unsupported; expected %d" actual expected
+  | Corrupt_store { offset; detail } ->
+    Printf.sprintf "execution store is corrupt at byte %Ld: %s" offset detail
+  | Commit_authority_identity_changed -> "commit authority identity changed"
+  | Commit_authority_regressed
+      { previous_committed_offset
+      ; actual_committed_offset
+      ; previous_last_seq
+      ; actual_last_seq
+      } ->
+    Printf.sprintf
+      "commit authority regressed from offset %Ld sequence %d to offset %Ld sequence %d"
+      previous_committed_offset
+      previous_last_seq
+      actual_committed_offset
+      actual_last_seq
+  | Unexpected_store_failure { kind = _; detail } ->
+    "unexpected read-only execution store failure: " ^ detail
+;;
+
+let error_to_string = function
+  | Invalid_limit limit ->
+    Printf.sprintf "execution projection page limit must be positive, received %d" limit
+  | Cursor_scope_mismatch -> "execution projection cursor belongs to another scope"
+  | Cursor_ahead { cursor_role; cursor_seq; high_watermark } ->
+    let role =
+      match cursor_role with
+      | After -> "after"
+      | Through -> "through"
+    in
+    Printf.sprintf
+      "execution projection %s cursor %d is ahead of high watermark %d"
+      role
+      cursor_seq
+      high_watermark
+  | Locator_not_found run_id ->
+    "execution projection locator run was not found: " ^ Run_id.to_string run_id
+  | Locator_not_top_level run_id ->
+    "execution projection locator does not identify a top-level run: "
+    ^ Run_id.to_string run_id
+  | Semantic_failure { seq; detail } ->
+    Printf.sprintf "execution projection topology failed at sequence %d: %s" seq detail
+  | Storage_failure failure -> storage_failure_to_string failure
+;;
+
+let validate_snapshot ~locator_run_id ?previous (durable : Store.read_only_snapshot) =
+  let reducer, events =
+    match previous with
+    | None -> Journal.Reducer.empty, Sequence_map.empty
+    | Some previous -> previous.reducer, previous.events
+  in
+  let rec reduce reducer events = function
+    | [] -> Ok (reducer, events)
+    | value :: rest ->
+      Eio.Fiber.yield ();
+      (match Journal.Reducer.apply reducer value with
+       | Ok reducer ->
+         let seq = Event.seq value in
+         if Sequence_map.mem seq events
+         then
+           Error
+             (Semantic_failure
+                { seq; detail = "committed suffix repeats an observed sequence" })
+         else reduce reducer (Sequence_map.add seq (event value) events) rest
+       | Error violation ->
+         Error
+           (Semantic_failure
+              { seq = Event.seq value
+              ; detail = Journal.show_invariant_violation violation
+              }))
+  in
+  let* reducer, events = reduce reducer events durable.Store.appended_events in
+  let* () =
+    match Journal.Reducer.find_run reducer locator_run_id with
+    | None -> Error (Locator_not_found locator_run_id)
+    | Some view ->
+      (match view.Journal.parent_attempt with
+       | None -> Ok ()
+       | Some _ -> Error (Locator_not_top_level locator_run_id))
+  in
+  if Journal.Reducer.last_seq reducer = durable.last_seq
+  then Ok { durable; reducer; events }
+  else
+    Error
+      (Semantic_failure
+         { seq = durable.last_seq
+         ; detail = "committed sequence does not equal the projected event count"
+         })
+;;
+
+let load_snapshot ~codec ~dir ~locator_run_id ?previous () =
+  let previous_durable = Option.map (fun value -> value.durable) previous in
+  let* durable =
+    Store.read_only_snapshot ~codec ~dir ?previous:previous_durable ()
+    |> Result.map_error (fun error -> Storage_failure (storage_failure error))
+  in
+  match previous with
+  | Some previous when previous.durable == durable -> Ok previous
+  | None -> validate_snapshot ~locator_run_id durable
+  | Some previous -> validate_snapshot ~locator_run_id ~previous durable
+;;
+
+let open_durable ~codec ~dir ~locator_run_id () =
+  let* snapshot = load_snapshot ~codec ~dir ~locator_run_id () in
+  Ok
+    { codec
+    ; dir
+    ; locator_run_id
+    ; scope_id = snapshot.durable.scope_id
+    ; mu = Eio.Mutex.create ()
+    ; snapshot
+    ; in_flight_refresh = None
+    }
+;;
+
+let with_lock t f = Eio.Mutex.use_rw ~protect:true t.mu f
+let cached_snapshot t = with_lock t (fun () -> t.snapshot)
+
+let claim_refresh t =
+  with_lock t (fun () ->
+    match t.in_flight_refresh with
+    | Some refresh -> `Follow refresh.promise
+    | None ->
+      let promise, resolver = Eio.Promise.create () in
+      let refresh = { promise; resolver } in
+      t.in_flight_refresh <- Some refresh;
+      `Lead (t.snapshot, refresh))
+;;
+
+let settle_refresh t refresh outcome =
+  Eio.Cancel.protect (fun () ->
+    with_lock t (fun () ->
+      t.in_flight_refresh <- None;
+      Eio.Promise.resolve refresh.resolver outcome))
+;;
+
+let publish_snapshot t ~base candidate =
+  with_lock t (fun () ->
+    let current = t.snapshot in
+    if current == base
+    then (
+      t.snapshot <- candidate;
+      Ok candidate)
+    else (
+      let current_offset = current.durable.committed_offset in
+      let candidate_offset = candidate.durable.committed_offset in
+      let current_seq = current.durable.last_seq in
+      let candidate_seq = candidate.durable.last_seq in
+      let offset_order = Int64.compare candidate_offset current_offset in
+      if offset_order <= 0 && candidate_seq <= current_seq
+      then Ok current
+      else if offset_order >= 0 && candidate_seq >= current_seq
+      then (
+        t.snapshot <- candidate;
+        Ok candidate)
+      else (
+        let failure =
+          Corrupt_store
+            { offset = Int64.max current_offset candidate_offset
+            ; detail =
+                "concurrent commit authorities disagree on offset and sequence order"
+            }
+        in
+        Error (Storage_failure failure))))
+;;
+
+let load_and_publish t base =
+  let* candidate =
+    load_snapshot
+      ~codec:t.codec
+      ~dir:t.dir
+      ~locator_run_id:t.locator_run_id
+      ~previous:base
+      ()
+  in
+  publish_snapshot t ~base candidate
+;;
+
+let rec refresh t =
+  match claim_refresh t with
+  | `Follow promise ->
+    (match Eio.Promise.await promise with
+     | Some outcome -> outcome
+     | None -> refresh t)
+  | `Lead (base, in_flight) ->
+    (match load_and_publish t base with
+     | outcome ->
+       settle_refresh t in_flight (Some outcome);
+       Eio.Fiber.check ();
+       outcome
+     | exception exn ->
+       let backtrace = Printexc.get_raw_backtrace () in
+       settle_refresh t in_flight None;
+       Printexc.raise_with_backtrace exn backtrace)
+;;
+
+let beginning_cursor t = { scope_id = t.scope_id; seq = 0 }
+
+let current_cursor t =
+  let+ snapshot = refresh t in
+  { scope_id = t.scope_id; seq = snapshot.durable.last_seq }
+;;
+
+let cursor_matches scope_id (cursor : cursor) =
+  Store.Scope_id.equal scope_id cursor.scope_id
+;;
+
+let events_slice events ~first_seq ~count =
+  let rec collect seq remaining acc =
+    if remaining = 0
+    then Ok (List.rev acc)
+    else (
+      Eio.Fiber.yield ();
+      match Sequence_map.find_opt seq events with
+      | Some event -> collect (seq + 1) (remaining - 1) (event :: acc)
+      | None ->
+        Error
+          (Semantic_failure { seq; detail = "committed projection sequence is missing" }))
+  in
+  collect first_seq count []
+;;
+
+let read_page t ~after ?through ~limit () =
+  if limit <= 0
+  then Error (Invalid_limit limit)
+  else if not (cursor_matches t.scope_id after)
+  then Error Cursor_scope_mismatch
+  else if
+    match through with
+    | None -> false
+    | Some cursor -> not (cursor_matches t.scope_id cursor)
+  then Error Cursor_scope_mismatch
+  else
+    let* snapshot =
+      match through with
+      | Some cursor ->
+        let cached = cached_snapshot t in
+        if cursor.seq <= cached.durable.last_seq then Ok cached else refresh t
+      | None -> refresh t
+    in
+    let high_watermark =
+      match through with
+      | None -> snapshot.durable.last_seq
+      | Some cursor -> cursor.seq
+    in
+    if high_watermark > snapshot.durable.last_seq
+    then
+      Error
+        (Cursor_ahead
+           { cursor_role = Through
+           ; cursor_seq = high_watermark
+           ; high_watermark = snapshot.durable.last_seq
+           })
+    else if after.seq > high_watermark
+    then
+      Error (Cursor_ahead { cursor_role = After; cursor_seq = after.seq; high_watermark })
+    else (
+      let count = min limit (high_watermark - after.seq) in
+      let next_seq = after.seq + count in
+      let+ events = events_slice snapshot.events ~first_seq:(after.seq + 1) ~count in
+      { events
+      ; next_cursor = { scope_id = t.scope_id; seq = next_seq }
+      ; high_watermark = { scope_id = t.scope_id; seq = high_watermark }
+      ; has_more = next_seq < high_watermark
+      })
+;;

--- a/lib/agent/agent_execution_projection.ml
+++ b/lib/agent/agent_execution_projection.ml
@@ -255,12 +255,8 @@ let cursor_to_yojson (cursor : cursor) =
     ]
 ;;
 
-let cursor_field_of_name = function
-  | "version" -> Some Version
-  | "scope_id" -> Some Scope_id
-  | "sequence" -> Some Sequence
-  | _ -> None
-;;
+let cursor_fields = [ "version", Version; "scope_id", Scope_id; "sequence", Sequence ]
+let cursor_field_of_name name = List.assoc_opt name cursor_fields
 
 let cursor_field_name = function
   | Version -> "version"
@@ -292,7 +288,8 @@ let cursor_of_yojson json =
   let* fields =
     match json with
     | `Assoc fields -> Ok fields
-    | _ -> Error Cursor_not_object
+    | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ ->
+      Error Cursor_not_object
   in
   let rec collect version scope_id sequence = function
     | [] -> Ok (version, scope_id, sequence)

--- a/lib/agent/agent_execution_projection.mli
+++ b/lib/agent/agent_execution_projection.mli
@@ -1,0 +1,13 @@
+(** Read-only implementation of one canonical durable Agent execution.
+
+    The public surface is owned solely by {!Agent_execution_projection_intf.S}.
+    The constructor below remains private to the wrapped OAS implementation. *)
+
+include Agent_execution_projection_intf.S
+
+val open_durable
+  :  codec:Execution_codec_executor.t
+  -> dir:Eio.Fs.dir_ty Eio.Path.t
+  -> locator_run_id:Execution_event.Run_id.t
+  -> unit
+  -> (t, error) result

--- a/lib/agent/agent_execution_projection_intf.mli
+++ b/lib/agent/agent_execution_projection_intf.mli
@@ -1,0 +1,244 @@
+(** Single source of truth for the public read-only execution projection. *)
+
+module type S = sig
+  module type ID = sig
+    type t
+
+    val to_string : t -> string
+    val equal : t -> t -> bool
+    val compare : t -> t -> int
+    val pp : Format.formatter -> t -> unit
+  end
+
+  module Event_id : ID
+  module Run_id : ID
+  module Node_id : ID
+  module Correlation_id : ID
+
+  type output_block_kind =
+    | Text_block
+    | Thinking_block
+    | Reasoning_details_block
+    | Redacted_thinking_block
+    | Image_block
+    | Document_block
+    | Audio_block
+
+  type node_kind =
+    | Agent_run of { agent_name : string }
+    | Agent_turn of { ordinal : int }
+    | Provider_attempt of
+        { ordinal : int
+        ; target : Binding_identity.Redacted_snapshot.t
+        }
+    | Output_block of
+        { ordinal : int
+        ; block_kind : output_block_kind
+        }
+    | Tool_invocation of
+        { provider_tool_use_id : string option
+        ; tool_name : string
+        ; schedule : Tool.schedule
+        }
+    | Tool_attempt
+
+  type node = private
+    { node_id : Node_id.t
+    ; run_id : Run_id.t
+    ; parent_node_id : Node_id.t option
+    ; kind : node_kind
+    }
+
+  type node_update =
+    | Provider_event of Yojson.Safe.t
+    | Provider_response_id_snapshot of string
+    | Output_delta of Yojson.Safe.t
+    | Output_snapshot of Llm_provider.Types.content_block
+    | Tool_input_delta of Yojson.Safe.t
+    | Tool_input_snapshot of Llm_provider.Types.content_block
+    | Tool_progress of Yojson.Safe.t
+    | Tool_result of Llm_provider.Types.content_block
+
+  type failure_kind =
+    | Provider_failure
+    | Tool_failure
+    | Hook_failure
+    | Observer_failure
+    | Persistence_failure
+    | Protocol_failure
+    | Internal_failure
+
+  type failure =
+    { kind : failure_kind
+    ; detail : string
+    ; data : Yojson.Safe.t option
+    }
+
+  type terminal =
+    | Succeeded
+    | Failed of failure
+    | Cancelled of
+        { reason : string option
+        ; data : Yojson.Safe.t option
+        }
+
+  type payload =
+    | Node_opened of node
+    | Node_updated of
+        { node_id : Node_id.t
+        ; update : node_update
+        }
+    | Node_closed of
+        { node_id : Node_id.t
+        ; terminal : terminal
+        }
+
+  module External_source : sig
+    type t
+
+    val of_string : string -> (t, string) result
+    val to_string : t -> string
+    val equal : t -> t -> bool
+    val compare : t -> t -> int
+    val pp : Format.formatter -> t -> unit
+  end
+
+  type cause =
+    | Internal_event of Event_id.t
+    | External_event of
+        { source : External_source.t
+        ; event_id : string
+        }
+
+  type event = private
+    { event_id : Event_id.t
+    ; run_id : Run_id.t
+    ; correlation_id : Correlation_id.t
+    ; seq : int
+    ; parent_event_id : Event_id.t option
+    ; causes : cause list
+    ; payload : payload
+    ; event_time : float
+    ; observed_at : float
+    ; source_clock : Event_envelope.source_clock
+    }
+
+  type cursor
+
+  type cursor_field =
+    | Version
+    | Scope_id
+    | Sequence
+
+  type cursor_decode_error =
+    | Cursor_not_object
+    | Missing_cursor_field of cursor_field
+    | Unexpected_cursor_field of string
+    | Duplicate_cursor_field of cursor_field
+    | Invalid_cursor_field of
+        { field : cursor_field
+        ; detail : string
+        }
+    | Unsupported_cursor_version of
+        { expected : int
+        ; actual : int
+        }
+
+  val cursor_to_yojson : cursor -> Yojson.Safe.t
+  val cursor_of_yojson : Yojson.Safe.t -> (cursor, cursor_decode_error) result
+  val cursor_decode_error_to_string : cursor_decode_error -> string
+  val cursor_seq : cursor -> int
+
+  type unexpected_store_error =
+    | Writer_already_active
+    | Store_already_attached
+    | Store_released
+    | Store_release_forbidden
+    | Resource_cleanup_failed
+    | Construction_cleanup_failed
+    | Store_already_exists
+    | Correlation_mismatch
+    | Sequence_conflict
+    | Committed_content_conflict
+    | Cursor_scope_mismatch
+    | Cursor_ahead
+    | Store_poisoned
+    | Commit_outcome_unknown
+
+  type storage_failure =
+    | Invalid_store_argument of string
+    | Store_identity_failure of string
+    | Store_io_failure of
+        { operation : string
+        ; detail : string
+        }
+    | Store_codec_failure of string
+    | Store_not_found
+    | Store_initialization_incomplete
+    | Store_initialization_conflict
+    | Unsupported_store_version of
+        { expected : int
+        ; actual : int
+        }
+    | Corrupt_store of
+        { offset : int64
+        ; detail : string
+        }
+    | Commit_authority_identity_changed
+    | Commit_authority_regressed of
+        { previous_committed_offset : int64
+        ; actual_committed_offset : int64
+        ; previous_last_seq : int
+        ; actual_last_seq : int
+        }
+    | Unexpected_store_failure of
+        { kind : unexpected_store_error
+        ; detail : string
+        }
+
+  type cursor_role =
+    | After
+    | Through
+
+  type error =
+    | Invalid_limit of int
+    | Cursor_scope_mismatch
+    | Cursor_ahead of
+        { cursor_role : cursor_role
+        ; cursor_seq : int
+        ; high_watermark : int
+        }
+    | Locator_not_found of Run_id.t
+    | Locator_not_top_level of Run_id.t
+    | Semantic_failure of
+        { seq : int
+        ; detail : string
+        }
+    | Storage_failure of storage_failure
+
+  val error_to_string : error -> string
+
+  type page = private
+    { events : event list
+    ; next_cursor : cursor
+    ; high_watermark : cursor
+    ; has_more : bool
+    }
+
+  type t
+
+  val beginning_cursor : t -> cursor
+  val current_cursor : t -> (cursor, error) result
+
+  (** Read at most [limit] events strictly after [after]. Without [through], the
+      current atomic authority is observed before the page is selected. Reusing
+      a returned [high_watermark] as [through] freezes later pages to that exact
+      committed prefix. [limit] is a transport boundary only. *)
+  val read_page
+    :  t
+    -> after:cursor
+    -> ?through:cursor
+    -> limit:int
+    -> unit
+    -> (page, error) result
+end

--- a/lib/agent/agent_execution_runner.ml
+++ b/lib/agent/agent_execution_runner.ml
@@ -43,6 +43,8 @@ let create_runtime ~sw ~domain_mgr ~domain_count =
          }))
 ;;
 
+let runtime_codec (runtime : runtime) = runtime.codec
+
 let store ~(runtime : runtime) ~dir ?on_scope_ready ?on_terminal_disposition ?resume () =
   let mode =
     match resume with
@@ -54,6 +56,7 @@ let store ~(runtime : runtime) ~dir ?on_scope_ready ?on_terminal_disposition ?re
 
 let locator_to_yojson = Execution_agent_scope.scope_locator_to_yojson
 let locator_of_yojson = Execution_agent_scope.scope_locator_of_yojson
+let locator_run_id = Execution_agent_scope.scope_locator_run_id
 
 let execution_failure detail =
   Provider_failure_attribution.of_sdk_error

--- a/lib/agent/agent_execution_runner.mli
+++ b/lib/agent/agent_execution_runner.mli
@@ -27,6 +27,8 @@ val create_runtime
   -> domain_count:int
   -> (runtime, Error.sdk_error) result
 
+val runtime_codec : runtime -> Execution_codec_executor.t
+
 val store
   :  runtime:runtime
   -> dir:Eio.Fs.dir_ty Eio.Path.t
@@ -38,6 +40,7 @@ val store
 
 val locator_to_yojson : locator -> Yojson.Safe.t
 val locator_of_yojson : Yojson.Safe.t -> (locator, string) result
+val locator_run_id : locator -> Execution_event.Run_id.t
 
 val with_fresh
   :  store

--- a/lib/dune
+++ b/lib/dune
@@ -3,6 +3,7 @@
 (library
  (name agent_sdk)
  (public_name agent_sdk)
+ (modules_without_implementation agent_execution_projection_intf)
  (private_modules
   random_id
   execution_id
@@ -20,6 +21,7 @@
   execution_context
   agent_input
   agent_tool_execution_types
+  agent_execution_projection
   agent_execution_runner
   pipeline_checkpoint
   pipeline_execution_scope

--- a/lib/execution_agent_scope.ml
+++ b/lib/execution_agent_scope.ml
@@ -116,6 +116,7 @@ let require_locator_version fields =
 ;;
 
 let scope_locator scope = { run_id = Journal.run_id scope.run }
+let scope_locator_run_id (locator : scope_locator) = locator.run_id
 
 let scope_locator_to_yojson (locator : scope_locator) =
   `Assoc

--- a/lib/execution_agent_scope.mli
+++ b/lib/execution_agent_scope.mli
@@ -52,6 +52,7 @@ type error =
 val error_to_string : error -> string
 val start : writer:Execution_lane_writer.t -> agent_name:string -> (t, error) result
 val scope_locator : t -> scope_locator
+val scope_locator_run_id : scope_locator -> Execution_event.Run_id.t
 val scope_locator_to_yojson : scope_locator -> Yojson.Safe.t
 val scope_locator_of_yojson : Yojson.Safe.t -> (scope_locator, string) result
 

--- a/lib/execution_cause.mli
+++ b/lib/execution_cause.mli
@@ -8,6 +8,7 @@ module External_source : sig
   type t
 
   val of_string : string -> (t, string) result
+  val to_string : t -> string
   val equal : t -> t -> bool
   val compare : t -> t -> int
   val pp : Format.formatter -> t -> unit

--- a/lib/execution_event.mli
+++ b/lib/execution_event.mli
@@ -159,6 +159,7 @@ module External_source : sig
   type t
 
   val of_string : string -> (t, string) result
+  val to_string : t -> string
   val equal : t -> t -> bool
   val compare : t -> t -> int
   val pp : Format.formatter -> t -> unit

--- a/lib/execution_event_store.ml
+++ b/lib/execution_event_store.ml
@@ -132,6 +132,13 @@ type error =
       { after_seq : int
       ; high_watermark : int
       }
+  | Commit_authority_identity_changed
+  | Commit_authority_regressed of
+      { previous_committed_offset : int64
+      ; actual_committed_offset : int64
+      ; previous_last_seq : int
+      ; actual_last_seq : int
+      }
   | Store_poisoned of string
   | Commit_outcome_unknown of string
 [@@deriving show]
@@ -184,6 +191,21 @@ let rec error_to_string = function
       "execution store cursor %d is ahead of high watermark %d"
       after_seq
       high_watermark
+  | Commit_authority_identity_changed ->
+    "execution store commit authority identity changed"
+  | Commit_authority_regressed
+      { previous_committed_offset
+      ; actual_committed_offset
+      ; previous_last_seq
+      ; actual_last_seq
+      } ->
+    Printf.sprintf
+      "execution store commit authority regressed from offset %Ld sequence %d to offset \
+       %Ld sequence %d"
+      previous_committed_offset
+      previous_last_seq
+      actual_committed_offset
+      actual_last_seq
   | Store_poisoned detail -> "execution store is poisoned: " ^ detail
   | Commit_outcome_unknown detail ->
     "execution store commit outcome is unknown: " ^ detail
@@ -604,8 +626,16 @@ type opened =
   ; replay_events : Event.t list
   }
 
-let scope_id store = store.scope_id
-let correlation_id store = store.correlation_id
+type read_only_snapshot =
+  { scope_id : Scope_id.t
+  ; correlation_id : Event.Correlation_id.t
+  ; committed_offset : int64
+  ; last_seq : int
+  ; appended_events : Event.t list
+  }
+
+let scope_id (store : t) = store.scope_id
+let correlation_id (store : t) = store.correlation_id
 let with_read store f = Eio.Mutex.use_ro store.mu f
 let with_state_write store f = Eio.Mutex.use_rw ~protect:true store.mu f
 let with_writer store f = Eio.Mutex.use_ro store.writer_gate f
@@ -638,7 +668,7 @@ let last_seq store =
     else Error Store_released)
 ;;
 
-let beginning_cursor store = { scope_id = store.scope_id; seq = 0 }
+let beginning_cursor (store : t) = { scope_id = store.scope_id; seq = 0 }
 
 let current_cursor store =
   let+ seq = last_seq store in
@@ -1236,31 +1266,26 @@ let validate_scanned_event correlation_id ~expected_seq located event =
   else Ok ()
 ;;
 
-let scan_store codec file ~file_size =
-  let* metadata_frame = decode_frame file ~file_size 0L in
-  let* scope_id, correlation_id, first_batch_offset =
-    match metadata_frame with
-    | Complete_frame { kind = Metadata; payload; next_offset; _ } ->
-      let+ scope_id, correlation_id = metadata_of_string ~offset:0L payload in
-      scope_id, correlation_id, next_offset
-    | Complete_frame _ ->
-      Error (Corrupt_store { offset = 0L; detail = "first frame is not metadata" })
-    | End_of_store | Incomplete_frame ->
-      Error (Corrupt_store { offset = 0L; detail = "metadata frame is incomplete" })
-  in
+type scan_mode =
+  | Rebuild_durable_index
+  | Read_only_events
+
+let scan_committed_batches
+      codec
+      file
+      ~file_size
+      ~correlation_id
+      ~first_offset
+      ~committed_seq
+      ~mode
+  =
   let locations = ref Sequence_map.empty in
   let events_rev = ref [] in
   let rec scan_batches offset committed_seq =
     let* frame = decode_frame file ~file_size offset in
     match frame with
     | End_of_store ->
-      Ok
-        ( scope_id
-        , correlation_id
-        , offset
-        , committed_seq
-        , !locations
-        , reverse_cooperatively !events_rev )
+      Ok (offset, committed_seq, !locations, reverse_cooperatively !events_rev)
     | Incomplete_frame ->
       Error
         (Corrupt_store { offset; detail = "committed batch begin frame is incomplete" })
@@ -1334,17 +1359,21 @@ let scan_store codec file ~file_size =
                 ({ kind = Event_record; payload; payload_offset; next_offset; _ } as
                  event_frame) ->
               let expected_seq = header.expected_next_seq + ordinal in
-              let location =
-                { seq = expected_seq
-                ; payload_offset
-                ; payload_length = String.length payload
-                ; frame = frame_guard event_offset event_frame
-                }
-              in
               let located = { offset = event_offset; payload } in
               let* event = decode_located_payload codec located in
               let* () =
                 validate_scanned_event correlation_id ~expected_seq located event
+              in
+              let locations_rev =
+                match mode with
+                | Read_only_events -> locations_rev
+                | Rebuild_durable_index ->
+                  { seq = expected_seq
+                  ; payload_offset
+                  ; payload_length = String.length payload
+                  ; frame = frame_guard event_offset event_frame
+                  }
+                  :: locations_rev
               in
               Eio.Fiber.yield ();
               scan_events
@@ -1361,19 +1390,187 @@ let scan_store codec file ~file_size =
         let* next_offset, last_seq, batch_locations, batch_events =
           scan_events next_offset 0 Sha256.empty [] []
         in
-        locations
-        := List.fold_left
-             (fun locations location ->
-                Eio.Fiber.yield ();
-                Sequence_map.add location.seq location locations)
-             !locations
-             batch_locations;
+        (match mode with
+         | Read_only_events -> ()
+         | Rebuild_durable_index ->
+           locations
+           := List.fold_left
+                (fun locations location ->
+                   Eio.Fiber.yield ();
+                   Sequence_map.add location.seq location locations)
+                !locations
+                batch_locations);
         events_rev := reverse_append_cooperatively batch_events !events_rev;
         scan_batches next_offset last_seq)
     | Complete_frame _ ->
       Error (Corrupt_store { offset; detail = "expected a batch begin frame" })
   in
-  scan_batches first_batch_offset 0
+  scan_batches first_offset committed_seq
+;;
+
+let scan_store codec file ~file_size ~mode =
+  let* metadata_frame = decode_frame file ~file_size 0L in
+  let* scope_id, correlation_id, first_batch_offset =
+    match metadata_frame with
+    | Complete_frame { kind = Metadata; payload; next_offset; _ } ->
+      let+ scope_id, correlation_id = metadata_of_string ~offset:0L payload in
+      scope_id, correlation_id, next_offset
+    | Complete_frame _ ->
+      Error (Corrupt_store { offset = 0L; detail = "first frame is not metadata" })
+    | End_of_store | Incomplete_frame ->
+      Error (Corrupt_store { offset = 0L; detail = "metadata frame is incomplete" })
+  in
+  let+ committed_offset, last_seq, locations, events =
+    scan_committed_batches
+      codec
+      file
+      ~file_size
+      ~correlation_id
+      ~first_offset:first_batch_offset
+      ~committed_seq:0
+      ~mode
+  in
+  scope_id, correlation_id, committed_offset, last_seq, locations, events
+;;
+
+let validate_previous_snapshot
+      (previous : read_only_snapshot)
+      (authority : commit_authority)
+  =
+  if
+    not
+      (Scope_id.equal previous.scope_id authority.scope_id
+       && Event.Correlation_id.equal previous.correlation_id authority.correlation_id)
+  then Error Commit_authority_identity_changed
+  else if
+    Int64.compare authority.committed_offset previous.committed_offset < 0
+    || authority.last_seq < previous.last_seq
+  then
+    Error
+      (Commit_authority_regressed
+         { previous_committed_offset = previous.committed_offset
+         ; actual_committed_offset = authority.committed_offset
+         ; previous_last_seq = previous.last_seq
+         ; actual_last_seq = authority.last_seq
+         })
+  else if
+    Int64.equal authority.committed_offset previous.committed_offset
+    <> (authority.last_seq = previous.last_seq)
+  then
+    Error
+      (Corrupt_store
+         { offset = authority.committed_offset
+         ; detail = "commit authority offset and sequence advanced inconsistently"
+         })
+  else Ok ()
+;;
+
+let read_only_snapshot ~codec ~dir ?previous () =
+  let* directory_exists =
+    with_io "check read-only store directory" (fun () -> Eio.Path.is_directory dir)
+  in
+  if not directory_exists
+  then Error Store_not_found
+  else
+    let* wal_exists =
+      with_io "check read-only WAL existence" (fun () -> Eio.Path.is_file (wal_path dir))
+    in
+    let* initialization_exists =
+      with_io "check read-only initialization WAL existence" (fun () ->
+        Eio.Path.is_file (initializing_path dir))
+    in
+    let* authority_exists =
+      with_io "check read-only commit authority existence" (fun () ->
+        Eio.Path.is_file (authority_path dir))
+    in
+    let* () =
+      match wal_exists, initialization_exists, authority_exists with
+      | true, false, true -> Ok ()
+      | true, false, false | false, true, false -> Error Store_initialization_incomplete
+      | false, false, false -> Error Store_not_found
+      | false, _, true | true, true, _ -> Error Store_initialization_conflict
+    in
+    let* authority = load_authority dir in
+    let* () =
+      match previous with
+      | None -> Ok ()
+      | Some previous -> validate_previous_snapshot previous authority
+    in
+    Eio.Switch.run
+    @@ fun sw ->
+    let* file =
+      with_io "open read-only WAL" (fun () -> Eio.Path.open_in ~sw (wal_path dir))
+    in
+    let* actual_size =
+      with_io "read read-only WAL size" (fun () ->
+        Optint.Int63.to_int64 (Eio.File.size file))
+    in
+    let* () =
+      if Int64.compare actual_size authority.committed_offset >= 0
+      then Ok ()
+      else
+        Error
+          (Corrupt_store
+             { offset = actual_size
+             ; detail =
+                 Printf.sprintf
+                   "WAL size %Ld is below authoritative committed offset %Ld"
+                   actual_size
+                   authority.committed_offset
+             })
+    in
+    match previous with
+    | Some previous when Int64.equal previous.committed_offset authority.committed_offset
+      -> Ok previous
+    | None ->
+      let* scope_id, correlation_id, committed_offset, last_seq, _locations, events =
+        scan_store codec file ~file_size:authority.committed_offset ~mode:Read_only_events
+      in
+      if
+        Scope_id.equal scope_id authority.scope_id
+        && Event.Correlation_id.equal correlation_id authority.correlation_id
+        && Int64.equal committed_offset authority.committed_offset
+        && last_seq = authority.last_seq
+      then
+        Ok
+          { scope_id
+          ; correlation_id
+          ; committed_offset
+          ; last_seq
+          ; appended_events = events
+          }
+      else
+        Error
+          (Corrupt_store
+             { offset = 0L; detail = "commit authority does not match the WAL prefix" })
+    | Some previous ->
+      let* committed_offset, last_seq, _locations, appended_events =
+        scan_committed_batches
+          codec
+          file
+          ~file_size:authority.committed_offset
+          ~correlation_id:previous.correlation_id
+          ~first_offset:previous.committed_offset
+          ~committed_seq:previous.last_seq
+          ~mode:Read_only_events
+      in
+      if
+        Int64.equal committed_offset authority.committed_offset
+        && last_seq = authority.last_seq
+      then
+        Ok
+          { scope_id = previous.scope_id
+          ; correlation_id = previous.correlation_id
+          ; committed_offset
+          ; last_seq
+          ; appended_events
+          }
+      else
+        Error
+          (Corrupt_store
+             { offset = previous.committed_offset
+             ; detail = "commit authority does not match the appended WAL suffix"
+             })
 ;;
 
 let make_store
@@ -1635,7 +1832,11 @@ let open_existing ~sw ~codec ~dir =
                })
       in
       let* scope_id, correlation_id, committed_offset, last_seq, locations, replay_events =
-        scan_store codec file ~file_size:authority.committed_offset
+        scan_store
+          codec
+          file
+          ~file_size:authority.committed_offset
+          ~mode:Rebuild_durable_index
       in
       let* () =
         if

--- a/lib/execution_event_store.ml
+++ b/lib/execution_event_store.ml
@@ -1380,7 +1380,7 @@ let scan_committed_batches
                 next_offset
                 (ordinal + 1)
                 (feed_payload_digest digest_context payload)
-                (location :: locations_rev)
+                locations_rev
                 (event :: events_rev)
             | Complete_frame _ ->
               Error

--- a/lib/execution_event_store.mli
+++ b/lib/execution_event_store.mli
@@ -104,6 +104,13 @@ type error =
       { after_seq : int
       ; high_watermark : int
       }
+  | Commit_authority_identity_changed
+  | Commit_authority_regressed of
+      { previous_committed_offset : int64
+      ; actual_committed_offset : int64
+      ; previous_last_seq : int
+      ; actual_last_seq : int
+      }
   | Store_poisoned of string
   | Commit_outcome_unknown of string
 [@@deriving show]
@@ -118,6 +125,31 @@ type opened = private
   ; recovery : recovery
   ; replay_events : Execution_event.t list
   }
+
+(** One immutable read-only view of the atomic commit authority. It owns no
+    writer claim and never repairs, truncates, renames, or syncs store files.
+    [appended_events] is decoded only from the exact authority-bound WAL
+    prefix. *)
+type read_only_snapshot = private
+  { scope_id : Scope_id.t
+  ; correlation_id : Execution_event.Correlation_id.t
+  ; committed_offset : int64
+  ; last_seq : int
+  ; appended_events : Execution_event.t list
+  }
+
+(** Capture the current committed prefix without acquiring writer authority.
+    Supplying [previous] avoids rescanning the already validated prefix;
+    [appended_events] then contains only the newly committed suffix (and all
+    events for the initial snapshot). Authority identity changes or
+    regressions are rejected rather than interpreted as a new scope.
+    Non-authoritative WAL and authority tails are ignored and never modified. *)
+val read_only_snapshot
+  :  codec:Execution_codec_executor.t
+  -> dir:Eio.Fs.dir_ty Eio.Path.t
+  -> ?previous:read_only_snapshot
+  -> unit
+  -> (read_only_snapshot, error) result
 
 (** [create ~sw ~codec ~dir ()] creates a new store inside an existing caller-owned
     directory. It never creates the directory, opens an existing WAL, or

--- a/lib/execution_journal.ml
+++ b/lib/execution_journal.ml
@@ -566,8 +566,9 @@ module Reducer = struct
 
   let ensure_occurrence_available parent_id parent_record child_kind =
     let existing =
-      occurrence (Event.node_kind parent_record.node) child_kind
-      |> Option.bind (fun key -> Occurrence_map.find_opt key parent_record.occurrences)
+      Option.bind
+        (occurrence (Event.node_kind parent_record.node) child_kind)
+        (fun key -> Occurrence_map.find_opt key parent_record.occurrences)
     in
     match existing, child_kind with
     | None, _ -> Ok ()

--- a/lib/execution_journal.ml
+++ b/lib/execution_journal.ml
@@ -57,6 +57,26 @@ module Run_id_map = Map.Make (struct
     let compare = Event.Run_id.compare
   end)
 
+module Occurrence = struct
+  type t =
+    | Agent_turn of int
+    | Provider_attempt of int
+    | Tool_invocation of int
+
+  let compare left right =
+    match left, right with
+    | Agent_turn left, Agent_turn right
+    | Provider_attempt left, Provider_attempt right
+    | Tool_invocation left, Tool_invocation right -> Int.compare left right
+    | Agent_turn _, (Provider_attempt _ | Tool_invocation _) -> -1
+    | Provider_attempt _, Agent_turn _ -> 1
+    | Provider_attempt _, Tool_invocation _ -> -1
+    | Tool_invocation _, (Agent_turn _ | Provider_attempt _) -> 1
+  ;;
+end
+
+module Occurrence_map = Map.Make (Occurrence)
+
 type run =
   { id : Event.Run_id.t
   ; root : Event.Node_id.t
@@ -332,6 +352,7 @@ module Reducer = struct
     ; last_event_id : Event.Event_id.t
     ; open_children : Node_id_set.t
     ; children_rev : Event.node event_record list
+    ; occurrences : Event.Node_id.t Occurrence_map.t
     ; updates_rev : Event.node_update event_record list
     ; provider_response_id : string option
     ; output_snapshot : Llm_provider.Types.content_block option
@@ -525,50 +546,28 @@ module Reducer = struct
       , _ ) -> false
   ;;
 
-  let find_child parent_record matches =
-    List.find_map
-      (fun (child : Event.node event_record) ->
-         if matches (Event.node_kind child.value)
-         then Some (Event.node_id child.value)
-         else None)
-      parent_record.children_rev
+  let occurrence parent_kind child_kind =
+    match parent_kind, child_kind with
+    | Event.Agent_run _, Event.Agent_turn { ordinal } ->
+      Some (Occurrence.Agent_turn ordinal)
+    | Event.Agent_turn _, Event.Provider_attempt { ordinal; target = _ } ->
+      Some (Occurrence.Provider_attempt ordinal)
+    | ( (Event.Provider_attempt _ | Event.Tool_attempt)
+      , Event.Tool_invocation { schedule; _ } ) ->
+      Some (Occurrence.Tool_invocation schedule.planned_index)
+    | ( ( Event.Agent_run _
+        | Event.Agent_turn _
+        | Event.Provider_attempt _
+        | Event.Output_block _
+        | Event.Tool_invocation _
+        | Event.Tool_attempt )
+      , _ ) -> None
   ;;
 
   let ensure_occurrence_available parent_id parent_record child_kind =
     let existing =
-      match Event.node_kind parent_record.node, child_kind with
-      | Event.Agent_run _, Event.Agent_turn { ordinal } ->
-        find_child parent_record (function
-          | Event.Agent_turn child -> child.ordinal = ordinal
-          | Event.Agent_run _
-          | Event.Provider_attempt _
-          | Event.Output_block _
-          | Event.Tool_invocation _
-          | Event.Tool_attempt -> false)
-      | Event.Agent_turn _, Event.Provider_attempt { ordinal; target = _ } ->
-        find_child parent_record (function
-          | Event.Provider_attempt child -> child.ordinal = ordinal
-          | Event.Agent_run _
-          | Event.Agent_turn _
-          | Event.Output_block _
-          | Event.Tool_invocation _
-          | Event.Tool_attempt -> false)
-      | (Event.Provider_attempt _ | Event.Tool_attempt), Event.Tool_invocation tool ->
-        find_child parent_record (function
-          | Event.Tool_invocation child ->
-            child.schedule.planned_index = tool.schedule.planned_index
-          | Event.Agent_run _
-          | Event.Agent_turn _
-          | Event.Provider_attempt _
-          | Event.Output_block _
-          | Event.Tool_attempt -> false)
-      | ( ( Event.Agent_run _
-          | Event.Agent_turn _
-          | Event.Provider_attempt _
-          | Event.Output_block _
-          | Event.Tool_invocation _
-          | Event.Tool_attempt )
-        , _ ) -> None
+      occurrence (Event.node_kind parent_record.node) child_kind
+      |> Option.bind (fun key -> Occurrence_map.find_opt key parent_record.occurrences)
     in
     match existing, child_kind with
     | None, _ -> Ok ()
@@ -668,6 +667,7 @@ module Reducer = struct
       ; last_event_id = Event.event_id event
       ; open_children = Node_id_set.empty
       ; children_rev = []
+      ; occurrences = Occurrence_map.empty
       ; updates_rev = []
       ; provider_response_id = None
       ; output_snapshot = None
@@ -683,10 +683,18 @@ module Reducer = struct
         (match Node_id_map.find_opt parent_id nodes with
          | None -> Error (Unknown_parent_node parent_id)
          | Some parent_record ->
+           let occurrences =
+             match
+               occurrence (Event.node_kind parent_record.node) (Event.node_kind node)
+             with
+             | None -> parent_record.occurrences
+             | Some key -> Occurrence_map.add key node_id parent_record.occurrences
+           in
            let parent_record =
              { parent_record with
                open_children = Node_id_set.add node_id parent_record.open_children
              ; children_rev = opened :: parent_record.children_rev
+             ; occurrences
              }
            in
            Ok (Node_id_map.add parent_id parent_record nodes))
@@ -938,6 +946,7 @@ module Reducer = struct
       ; last_event_id = Event.event_id event
       ; open_children = record.open_children
       ; children_rev = record.children_rev
+      ; occurrences = record.occurrences
       ; updates_rev = record.updates_rev
       ; provider_response_id = record.provider_response_id
       ; output_snapshot = record.output_snapshot
@@ -1502,19 +1511,9 @@ let stage_open_tool_invocation
   let planned_index = Tool.Invocation.planned_index invocation in
   let* () =
     match
-      List.find_map
-        (fun (child : Event.node event_record) ->
-           match Event.node_kind child.value with
-           | Event.Tool_invocation { schedule; _ }
-             when schedule.planned_index = planned_index ->
-             Some (Event.node_id child.value)
-           | Event.Agent_run _
-           | Event.Agent_turn _
-           | Event.Provider_attempt _
-           | Event.Output_block _
-           | Event.Tool_invocation _
-           | Event.Tool_attempt -> None)
-        provider_record.children_rev
+      Occurrence_map.find_opt
+        (Occurrence.Tool_invocation planned_index)
+        provider_record.occurrences
     with
     | None -> Ok ()
     | Some existing ->

--- a/test/dune
+++ b/test/dune
@@ -389,6 +389,26 @@
   (run %{test})))
 
 (test
+ (name test_execution_projection)
+ (modules test_execution_projection)
+ (libraries agent_sdk agent_sdk.llm_provider alcotest eio_main)
+ (flags
+  (:standard -alias-deps))
+ (deps ../models.toml)
+ (action
+  (run %{test})))
+
+(test
+ (name test_agent_ambient_execution)
+ (modules test_agent_ambient_execution)
+ (libraries agent_sdk agent_sdk.llm_provider alcotest eio_main)
+ (flags
+  (:standard -alias-deps))
+ (deps ../models.toml)
+ (action
+  (run %{test})))
+
+(test
  (name test_execution_lane_writer)
  (modules test_execution_lane_writer)
  (libraries agent_sdk agent_sdk.llm_provider alcotest eio_main)

--- a/test/test_agent_ambient_execution.ml
+++ b/test/test_agent_ambient_execution.ml
@@ -1,0 +1,118 @@
+open Agent_sdk
+open Alcotest
+module Internal = Agent_sdk__
+module Context = Internal.Execution_context
+module Scope = Internal.Execution_agent_scope
+
+let expect_ambient_child ~agent_name run =
+  let observed = ref None in
+  let result =
+    Context.with_child_scope_factory
+      (fun ~agent_name ->
+         observed := Some agent_name;
+         Error Scope.Run_not_found)
+      run
+  in
+  check (option string) "exact child agent identity" (Some agent_name) !observed;
+  match result with
+  | Error (detailed : Agent.detailed_error) ->
+    (match detailed.error, detailed.provider_failure with
+     | Error.Internal _, None -> ()
+     | _ -> fail "ambient child scope failure was not preserved")
+  | Ok _ -> fail "ambient child scope failure was not preserved"
+;;
+
+let test_all_agent_entrypoints_consume_ambient_child () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let agent_name = "ambient-child-agent" in
+  let make_agent () =
+    Agent.create
+      ~net:(Eio.Stdenv.net env)
+      ~config:{ (Types.default_config ~model:"unused") with name = agent_name }
+      ()
+  in
+  expect_ambient_child ~agent_name (fun () ->
+    Agent.run_detailed ~sw (make_agent ()) "regular");
+  expect_ambient_child ~agent_name (fun () ->
+    Agent.Advanced.run_blocks_detailed
+      ~sw
+      ~api_strategy:Agent.Sync
+      ~on_tool_boundary:(fun _ -> Agent.Advanced.Continue)
+      (make_agent ())
+      [ Types.Text "advanced" ]);
+  expect_ambient_child ~agent_name (fun () ->
+    Agent.run_turn_stream_detailed ~sw ~on_event:(fun _ -> ()) (make_agent ()))
+;;
+
+let test_explicit_store_conflicts_with_ambient_child () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let runtime =
+    match
+      Agent.create_execution_runtime
+        ~sw
+        ~domain_mgr:(Eio.Stdenv.domain_mgr env)
+        ~domain_count:1
+    with
+    | Ok runtime -> runtime
+    | Error error -> fail (Error.to_string error)
+  in
+  let native_path = Filename.temp_file "oas-ambient-conflict-" ".dir" in
+  Sys.remove native_path;
+  let dir = Eio.Path.(Eio.Stdenv.fs env / native_path) in
+  Eio.Path.mkdirs ~exists_ok:false ~perm:0o700 dir;
+  Fun.protect
+    ~finally:(fun () -> Eio.Path.rmtree ~missing_ok:true dir)
+    (fun () ->
+       let store = Agent.execution_store ~runtime ~dir () in
+       let factory_called = ref false in
+       let agent =
+         Agent.create
+           ~net:(Eio.Stdenv.net env)
+           ~config:
+             { (Types.default_config ~model:"unused") with
+               name = "ambient-conflict-agent"
+             }
+           ()
+       in
+       let result =
+         Context.with_child_scope_factory
+           (fun ~agent_name:_ ->
+              factory_called := true;
+              Error Scope.Run_not_found)
+           (fun () -> Agent.run_detailed ~sw ~execution_store:store agent "conflict")
+       in
+       check bool "conflict does not consume either authority" false !factory_called;
+       match result with
+       | Error (detailed : Agent.detailed_error) ->
+         (match detailed.error, detailed.provider_failure with
+          | Error.Internal detail, None ->
+            check
+              string
+              "existing conflict remains explicit"
+              "execution store and child scope factory are mutually exclusive"
+              detail
+          | _ -> fail "dual execution authority was not rejected")
+       | Ok _ -> fail "dual execution authority was not rejected")
+;;
+
+let () =
+  Alcotest.run
+    "Ambient recursive execution"
+    [ ( "authority"
+      , [ test_case
+            "all Agent entrypoints consume ambient child"
+            `Quick
+            test_all_agent_entrypoints_consume_ambient_child
+        ; test_case
+            "explicit store conflicts with ambient child"
+            `Quick
+            test_explicit_store_conflicts_with_ambient_child
+        ] )
+    ]
+;;

--- a/test/test_execution_journal.ml
+++ b/test/test_execution_journal.ml
@@ -555,6 +555,16 @@ let test_hierarchy_and_lifecycle_rejections () =
   check int "rejected open is not committed" 1 (Journal.length journal);
   let agent_turn, turn = open_provider_attempt journal run in
   (match
+     Journal.open_node journal ~run ~parent:root ~kind:(Event.Agent_turn { ordinal = 0 })
+   with
+   | Error (Journal.Invariant_violation (Journal.Occurrence_already_opened existing))
+     when Event.Node_id.equal existing agent_turn -> ()
+   | Ok _ | Error _ -> fail "duplicate turn occurrence was not rejected");
+  (match Journal.open_node journal ~run ~parent:agent_turn ~kind:(provider_attempt 0) with
+   | Error (Journal.Invariant_violation (Journal.Occurrence_already_opened existing))
+     when Event.Node_id.equal existing turn -> ()
+   | Ok _ | Error _ -> fail "duplicate provider occurrence was not rejected");
+  (match
      Journal.update_node journal ~node:turn (Event.Output_delta (`String "wrong"))
    with
    | Error (Journal.Invariant_violation (Journal.Invalid_update_for_node _)) -> ()
@@ -600,6 +610,18 @@ let test_hierarchy_and_lifecycle_rejections () =
     require_opened_node
       (Journal.open_node journal ~run ~parent:turn ~kind:(tool_invocation "streamed"))
   in
+  (match
+     Journal.open_node
+       journal
+       ~run
+       ~parent:turn
+       ~kind:(tool_invocation "same-planned-index")
+   with
+   | Error
+       (Journal.Invariant_violation
+          (Journal.Tool_occurrence_conflict { parent; planned_index = 0; existing }))
+     when Event.Node_id.equal parent turn && Event.Node_id.equal existing invocation -> ()
+   | Ok _ | Error _ -> fail "duplicate Tool occurrence was not rejected");
   (match
      Journal.update_node
        journal

--- a/test/test_execution_projection.ml
+++ b/test/test_execution_projection.ml
@@ -1,0 +1,463 @@
+open Agent_sdk
+open Alcotest
+module Internal = Agent_sdk__
+module Runtime = Internal.Execution_runtime
+module Codec = Internal.Execution_codec_executor
+module Writer = Internal.Execution_lane_writer
+module Scope = Internal.Execution_agent_scope
+module Context = Internal.Execution_context
+module Event = Internal.Execution_event
+module Binding = Binding_identity
+module Projection = Agent.Execution_projection
+
+let value = function
+  | Ok value -> value
+  | Error detail -> fail detail
+;;
+
+let scope_value = function
+  | Ok value -> value
+  | Error error -> fail (Scope.error_to_string error)
+;;
+
+let writer_value = function
+  | Ok value -> value
+  | Error error -> fail (Writer.scope_failure_to_string error)
+;;
+
+let projection_value = function
+  | Ok value -> value
+  | Error error -> fail (Projection.error_to_string error)
+;;
+
+let binding () =
+  Llm_provider.Provider_config.make
+    ~kind:Llm_provider.Provider_config.OpenAI_compat
+    ~model_id:"projection-test"
+    ~base_url:"http://projection.invalid"
+    ~api_key:""
+    ~request_path:"/v1/chat/completions"
+    ()
+  |> Binding.of_provider_config ~transport:Binding.Injected
+  |> value
+;;
+
+let child_response : Types.api_response =
+  { id = "projection-child-response"
+  ; model = "projection-child-model"
+  ; stop_reason = Types.EndTurn
+  ; content = [ Types.Text "child-finished" ]
+  ; usage = None
+  ; telemetry = None
+  }
+;;
+
+let child_transport : Llm_provider.Llm_transport.t =
+  { complete_sync =
+      (fun _request ->
+        { Llm_provider.Llm_transport.response = Ok child_response; latency_ms = Some 0 })
+  ; complete_stream = (fun ?on_telemetry:_ ~on_event:_ _request -> Ok child_response)
+  }
+;;
+
+let child_agent ~net =
+  let options =
+    { Agent.default_options with
+      transport = Some child_transport
+    ; provider =
+        Some
+          { Provider.provider = Provider.Local { base_url = "http://projection.invalid" }
+          ; model_id = "projection-child-model"
+          ; api_key_env = ""
+          }
+    }
+  in
+  Agent.create
+    ~net
+    ~config:
+      { (Types.default_config ~model:"projection-child-model") with name = "child-agent" }
+    ~options
+    ()
+;;
+
+let invocation () =
+  let schedule : Tool.schedule =
+    { planned_index = 0; batch_index = 0; batch_size = 1; execution_mode = Tool.Serial }
+  in
+  Tool.Invocation.create ~tool_use_id:"projection-tool-use" ~turn:1 ~schedule
+;;
+
+let public_locator scope =
+  Scope.scope_locator scope
+  |> Scope.scope_locator_to_yojson
+  |> Agent.execution_locator_of_yojson
+  |> value
+;;
+
+let make_dir fs prefix =
+  let native_path = Filename.temp_file prefix ".dir" in
+  Sys.remove native_path;
+  let dir = Eio.Path.(fs / native_path) in
+  Eio.Path.mkdirs ~exists_ok:false ~perm:0o700 dir;
+  dir
+;;
+
+let node_kinds page =
+  List.filter_map
+    (fun (event : Projection.event) ->
+       match event.payload with
+       | Projection.Node_opened node -> Some node
+       | Projection.Node_updated _ | Projection.Node_closed _ -> None)
+    page.Projection.events
+;;
+
+let test_live_and_restart_projection () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun runtime_sw ->
+  let domain_mgr = Eio.Stdenv.domain_mgr env in
+  let runtime =
+    Agent.create_execution_runtime ~sw:runtime_sw ~domain_mgr ~domain_count:1
+    |> Result.map_error Error.to_string
+    |> value
+  in
+  let internal_runtime =
+    Runtime.create ~sw:runtime_sw ~domain_mgr ~domain_count:1
+    |> Result.map_error Runtime.create_error_to_string
+    |> value
+  in
+  let codec = Codec.of_runtime internal_runtime in
+  let fs = Eio.Stdenv.fs env in
+  let dir = make_dir fs "oas-projection-live-" in
+  let other_dir = make_dir fs "oas-projection-other-" in
+  Fun.protect
+    ~finally:(fun () ->
+      Eio.Path.rmtree ~missing_ok:true dir;
+      Eio.Path.rmtree ~missing_ok:true other_dir)
+    (fun () ->
+       let projection_ref = ref None in
+       let locator_ref = ref None in
+       writer_value
+         (Writer.run ~codec ~dir (fun ~sw writer ->
+            let root = scope_value (Scope.start ~writer ~agent_name:"root-agent") in
+            let locator = public_locator root in
+            locator_ref := Some locator;
+            let projection =
+              projection_value (Agent.open_execution_projection ~runtime ~dir locator)
+            in
+            projection_ref := Some projection;
+            let first =
+              projection_value
+                (Projection.read_page
+                   projection
+                   ~after:(Projection.beginning_cursor projection)
+                   ~limit:1
+                   ())
+            in
+            check int "first page has root open" 1 (List.length first.events);
+            check
+              int
+              "first high watermark"
+              1
+              (Projection.cursor_seq first.high_watermark);
+            let turn = scope_value (Scope.open_turn root ~ordinal:1) in
+            let live =
+              projection_value
+                (Projection.read_page projection ~after:first.next_cursor ~limit:8 ())
+            in
+            check int "live page observes committed turn" 1 (List.length live.events);
+            check
+              int
+              "live high watermark advanced"
+              2
+              (Projection.cursor_seq live.high_watermark);
+            let frozen =
+              projection_value
+                (Projection.read_page
+                   projection
+                   ~after:first.next_cursor
+                   ~through:first.high_watermark
+                   ~limit:8
+                   ())
+            in
+            check int "frozen page excludes later commit" 0 (List.length frozen.events);
+            let provider =
+              scope_value (Scope.open_provider_attempt turn ~ordinal:0 (binding ()))
+            in
+            let durable =
+              scope_value
+                (Scope.open_invocation
+                   provider
+                   ~invocation:(invocation ())
+                   ~tool_name:"recursive-tool"
+                   ~input:(`Assoc []))
+            in
+            (match
+               Scope.execute durable ~invoke:(fun ~start_child ~tool_name:_ ~input:_ ->
+                 Context.with_child_scope_factory start_child (fun () ->
+                   match
+                     Agent.run
+                       ~sw
+                       (child_agent ~net:(Eio.Stdenv.net env))
+                       "run as recursive Agent tool"
+                   with
+                   | Ok _ -> "child-finished", Types.Tool_succeeded
+                   | Error error -> fail (Error.to_string error)))
+             with
+             | Ok (Scope.Executed _) -> ()
+             | Ok (Scope.Replayed _) ->
+               fail "fresh recursive effect unexpectedly replayed"
+             | Error error -> fail (Scope.error_to_string error));
+            scope_value (Scope.close_provider_attempt provider Event.Succeeded);
+            scope_value (Scope.close_turn turn Event.Succeeded);
+            scope_value (Scope.finish root Event.Succeeded)));
+       let projection = Option.get !projection_ref in
+       let locator = Option.get !locator_ref in
+       let through = projection_value (Projection.current_cursor projection) in
+       check bool "final cursor advanced" true (Projection.cursor_seq through > 2);
+       Eio.Fiber.all
+         (List.init 16 (fun _ () ->
+            let observed = projection_value (Projection.current_cursor projection) in
+            check
+              int
+              "concurrent refresh observes one authority"
+              (Projection.cursor_seq through)
+              (Projection.cursor_seq observed)));
+       let all =
+         projection_value
+           (Projection.read_page
+              projection
+              ~after:(Projection.beginning_cursor projection)
+              ~through
+              ~limit:128
+              ())
+       in
+       let nodes = node_kinds all in
+       let agent_runs =
+         List.filter_map
+           (fun (node : Projection.node) ->
+              match node.kind with
+              | Projection.Agent_run { agent_name } ->
+                Some (agent_name, Option.is_some node.parent_node_id)
+              | Projection.Agent_turn _
+              | Projection.Provider_attempt _
+              | Projection.Output_block _
+              | Projection.Tool_invocation _
+              | Projection.Tool_attempt -> None)
+           nodes
+       in
+       check
+         (list (pair string bool))
+         "recursive run hierarchy is lossless"
+         [ "root-agent", false; "child-agent", true ]
+         agent_runs;
+       let child_node =
+         List.find
+           (fun (node : Projection.node) ->
+              match node.kind with
+              | Projection.Agent_run { agent_name } ->
+                String.equal agent_name "child-agent"
+              | Projection.Agent_turn _
+              | Projection.Provider_attempt _
+              | Projection.Output_block _
+              | Projection.Tool_invocation _
+              | Projection.Tool_attempt -> false)
+           nodes
+       in
+       let parent_node_id = Option.get child_node.parent_node_id in
+       let parent_node =
+         List.find
+           (fun (node : Projection.node) ->
+              Projection.Node_id.equal node.node_id parent_node_id)
+           nodes
+       in
+       (match parent_node.kind with
+        | Projection.Tool_attempt -> ()
+        | Projection.Agent_run _
+        | Projection.Agent_turn _
+        | Projection.Provider_attempt _
+        | Projection.Output_block _
+        | Projection.Tool_invocation _ ->
+          fail "recursive public Agent.run was not parented by Tool_attempt");
+       check
+         bool
+         "recursive public Agent.run settled"
+         true
+         (List.exists
+            (fun (event : Projection.event) ->
+               match event.payload with
+               | Projection.Node_closed { node_id; terminal = Projection.Succeeded } ->
+                 Projection.Node_id.equal node_id child_node.node_id
+               | Projection.Node_opened _
+               | Projection.Node_updated _
+               | Projection.Node_closed _ -> false)
+            all.events);
+       check
+         int
+         "one exact tool attempt"
+         1
+         (List.length
+            (List.filter
+               (fun (node : Projection.node) ->
+                  match node.kind with
+                  | Projection.Tool_attempt -> true
+                  | Projection.Agent_run _
+                  | Projection.Agent_turn _
+                  | Projection.Provider_attempt _
+                  | Projection.Output_block _
+                  | Projection.Tool_invocation _ -> false)
+               nodes));
+       let reopened =
+         let wal = Eio.Path.(dir / "events.v1.wal") in
+         Eio.Path.with_open_out ~append:true ~create:`Never wal (fun file ->
+           Eio.Flow.copy_string "non-authoritative-tail" file;
+           Eio.File.sync file);
+         let wal_size_with_tail = String.length (Eio.Path.load wal) in
+         let reopened =
+           projection_value (Agent.open_execution_projection ~runtime ~dir locator)
+         in
+         check
+           int
+           "read-only open does not repair or truncate tail"
+           wal_size_with_tail
+           (String.length (Eio.Path.load wal));
+         reopened
+       in
+       let reopened_through = projection_value (Projection.current_cursor reopened) in
+       check
+         int
+         "restart catch-up reaches same authority"
+         (Projection.cursor_seq through)
+         (Projection.cursor_seq reopened_through);
+       (match
+          Projection.read_page
+            reopened
+            ~after:(Projection.beginning_cursor reopened)
+            ~limit:0
+            ()
+        with
+        | Error (Projection.Invalid_limit 0) -> ()
+        | Ok _ | Error _ -> fail "non-positive transport limit was not typed");
+       writer_value
+         (Writer.run ~codec ~dir:other_dir (fun ~sw:_ writer ->
+            let other = scope_value (Scope.start ~writer ~agent_name:"other-agent") in
+            scope_value (Scope.finish other Event.Succeeded)));
+       match Agent.open_execution_projection ~runtime ~dir:other_dir locator with
+       | Error (Projection.Locator_not_found _) -> ()
+       | Ok _ | Error _ -> fail "locator from another directory was not rejected")
+;;
+
+let test_cursor_codec_is_closed_and_versioned () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let runtime =
+    Agent.create_execution_runtime
+      ~sw
+      ~domain_mgr:(Eio.Stdenv.domain_mgr env)
+      ~domain_count:1
+    |> Result.map_error Error.to_string
+    |> value
+  in
+  let dir = make_dir (Eio.Stdenv.fs env) "oas-projection-cursor-" in
+  Fun.protect
+    ~finally:(fun () -> Eio.Path.rmtree ~missing_ok:true dir)
+    (fun () ->
+       let codec_runtime =
+         Runtime.create ~sw ~domain_mgr:(Eio.Stdenv.domain_mgr env) ~domain_count:1
+         |> Result.map_error Runtime.create_error_to_string
+         |> value
+       in
+       let codec = Codec.of_runtime codec_runtime in
+       let locator =
+         writer_value
+           (Writer.run ~codec ~dir (fun ~sw:_ writer ->
+              let scope = scope_value (Scope.start ~writer ~agent_name:"cursor-agent") in
+              let locator = public_locator scope in
+              scope_value (Scope.finish scope Event.Succeeded);
+              locator))
+       in
+       let projection =
+         projection_value (Agent.open_execution_projection ~runtime ~dir locator)
+       in
+       let cursor = Projection.beginning_cursor projection in
+       let fields =
+         match Projection.cursor_to_yojson cursor with
+         | `Assoc fields -> fields
+         | _ -> fail "cursor encoder did not emit object"
+       in
+       let decode json = Projection.cursor_of_yojson (`Assoc json) in
+       (match decode (("unknown", `Null) :: fields) with
+        | Error (Projection.Unexpected_cursor_field "unknown") -> ()
+        | Ok _ | Error _ -> fail "unknown cursor field was not typed");
+       (match decode (("version", `Int 1) :: fields) with
+        | Error (Projection.Duplicate_cursor_field Projection.Version) -> ()
+        | Ok _ | Error _ -> fail "duplicate cursor field was not typed");
+       (match decode (List.remove_assoc "sequence" fields) with
+        | Error (Projection.Missing_cursor_field Projection.Sequence) -> ()
+        | Ok _ | Error _ -> fail "missing cursor field was not typed");
+       let future =
+         List.map
+           (function
+             | "version", _ -> "version", `Int 2
+             | field -> field)
+           fields
+       in
+       (match decode future with
+        | Error (Projection.Unsupported_cursor_version { expected = 1; actual = 2 }) -> ()
+        | Ok _ | Error _ -> fail "future cursor version was not typed");
+       let external_source = Projection.External_source.of_string "discord" |> value in
+       check
+         string
+         "external cause source has a stable round-trip form"
+         "discord"
+         (Projection.External_source.to_string external_source);
+       let current = projection_value (Projection.current_cursor projection) in
+       let current_seq = Projection.cursor_seq current in
+       let ahead_seq = current_seq + 1 in
+       let ahead_fields =
+         List.map
+           (function
+             | "sequence", _ -> "sequence", `Int ahead_seq
+             | field -> field)
+           fields
+       in
+       let ahead =
+         match decode ahead_fields with
+         | Ok cursor -> cursor
+         | Error error -> fail (Projection.cursor_decode_error_to_string error)
+       in
+       (match
+          Projection.read_page projection ~after:cursor ~through:ahead ~limit:1 ()
+        with
+        | Error
+            (Projection.Cursor_ahead
+               { cursor_role = Projection.Through; cursor_seq; high_watermark }) ->
+          check int "through cursor is identified" ahead_seq cursor_seq;
+          check int "through authority is exact" current_seq high_watermark
+        | Ok _ | Error _ -> fail "ahead through cursor role was not typed");
+       match
+         Projection.read_page projection ~after:ahead ~through:current ~limit:1 ()
+       with
+       | Error
+           (Projection.Cursor_ahead
+              { cursor_role = Projection.After; cursor_seq; high_watermark }) ->
+         check int "after cursor is identified" ahead_seq cursor_seq;
+         check int "after authority is exact" current_seq high_watermark
+       | Ok _ | Error _ -> fail "ahead after cursor role was not typed")
+;;
+
+let () =
+  Alcotest.run
+    "Execution projection"
+    [ ( "authority"
+      , [ test_case "live and restart projection" `Quick test_live_and_restart_projection
+        ; test_case
+            "cursor codec is closed and versioned"
+            `Quick
+            test_cursor_codec_is_closed_and_versioned
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Goal

Expose a lossless, read-only projection over OAS's canonical durable execution journal so a host can render live or restarted recursive Agent / Tool execution without creating a second event source.

## Public flow

```ocaml
let runtime = Agent.create_execution_runtime ~sw ~domain_mgr ~domain_count in
let store = Agent.execution_store ~runtime ~dir ~on_scope_ready () in
let result = Agent.run ~sw ~execution_store:store agent prompt in

let projection = Agent.open_execution_projection ~runtime ~dir locator in
let page =
  Agent.Execution_projection.read_page
    projection
    ~after:(Agent.Execution_projection.beginning_cursor projection)
    ~limit
    ()
```

The locator only associates the caller-owned directory with its top-level OAS run. The commit authority and journal remain the only event and catch-up SSOT.

## What changes

- Adds `Agent.Execution_projection`, a closed typed event hierarchy with exact parent node IDs for recursive Agent, turn, provider attempt, output block, Tool invocation, and Tool attempt nodes.
- Adds opaque, versioned, scope-bound cursors and bounded immutable pages. Reusing `high_watermark` freezes pagination to one exact committed prefix.
- Adds a read-only event-store snapshot path that takes no writer claim and performs no recovery write, truncation, rename, or sync.
- Reuses immutable reducer and event-map snapshots, decoding only the newly committed WAL suffix after the initial open.
- Makes regular, `Advanced`, single-turn streaming, and handoff Agent entry points consume the ambient typed child scope, so recursive Agent-as-Tool execution stays under the exact Tool attempt.
- Replaces sibling-list occurrence scans with an immutable typed occurrence map. Long turn/provider/Tool histories validate in `O(log n)` per occurrence rather than replaying quadratically.
- Keeps semantic reduction cancellation-cooperative at exact event boundaries and avoids building the writer recovery location index for read-only projection scans.

## Failure and authority semantics

- Locator mismatch, non-top-level locators, cursor mismatch/ahead, semantic topology failures, storage/codec failures, authority identity change, and authority regression are distinct typed errors.
- Malformed or unknown cursor fields are rejected; no compatibility fallback or inferred cursor exists.
- Concurrent refreshes are single-flight. I/O, decode, and reduction occur outside the publication mutex; a cancelled leader releases followers to retry from the last immutable snapshot.
- Projection page limits are transport boundaries only. They do not admit, pause, cancel, or stop Agent execution, and no cost/turn/token budget is introduced.
- OAS contains no MASC dependency or MASC-specific data type.

## Explicit limitation

This PR does **not** expose or lend a raw `Eio.Executor_pool.t`. A projection uses the same application-lifetime `Agent.execution_runtime` codec service as the execution journal and creates no per-projection pool.

Downstream server/OAS executor-pool unification remains intentionally unresolved: safely sharing an already-entered host pool requires a typed reentrant worker marker or arbiter. Reintroducing raw pool borrowing would permit full-pool nested-submit deadlock, so that is not part of this PR.

## Validation

- Rebased on `db09fc94e` (`origin/main`).
- `ocamlformat --check` passed for every changed OCaml source/interface.
- `ocamlc -stop-after parsing` passed for every changed OCaml source/interface.
- `git diff --check origin/main...HEAD` passed.
- Current-head focused wrapper build passed for `agent_sdk.cmxa`, execution event store, execution projection, execution journal, and ambient recursive execution.
- Current-head focused tests passed: event store 32/32, projection 2/2, journal 19/19, ambient recursive execution 2/2.
- CI run `29690871340` passed lint, format, boundary/SSOT/drift gates, ratchet, and full Build & Test on OCaml 5.4.1 and 5.5.0.

Co-Authored-By: Codex <agent@masc.local>
