### PR TITLE
feat(llm_provider): admit Kimi with native token count

### DIFF
--- a/lib/llm_provider/backend_anthropic.ml
+++ b/lib/llm_provider/backend_anthropic.ml
@@ -482,13 +482,14 @@ let build_request ?stream ~config ~messages ?tools () =
 
 let build_count_tokens_request ~config ~messages ?tools () =
   match config.Provider_config.kind with
-  | Provider_config.Anthropic ->
+  | Provider_config.Anthropic | Provider_config.Kimi ->
     build_request_payload ~request_mode:Count_tokens ~config ~messages ?tools ()
-  | Provider_config.Kimi
   | Provider_config.OpenAI_compat
   | Provider_config.Ollama
   | Provider_config.Gemini
   | Provider_config.Glm
   | Provider_config.DashScope ->
-    invalid_arg "Backend_anthropic.build_count_tokens_request: Anthropic required"
+    invalid_arg
+      ("Backend_anthropic.build_count_tokens_request: Anthropic-compatible Messages "
+       ^ "provider required")
 ;;

--- a/lib/llm_provider/backend_anthropic.mli
+++ b/lib/llm_provider/backend_anthropic.mli
@@ -81,8 +81,9 @@ val build_request
   -> unit
   -> string
 
-(** Build the Anthropic Messages count-tokens request from the same canonical
-    input projection as {!build_request}. Completion-only output and sampling
+(** Build an Anthropic-compatible Messages count-tokens request from the same
+    provider-specific canonical input projection as {!build_request}.
+    Anthropic and Kimi are supported; completion-only output and sampling
     fields are omitted. *)
 val build_count_tokens_request
   :  config:Provider_config.t

--- a/lib/llm_provider/count_tokens_sync.ml
+++ b/lib/llm_provider/count_tokens_sync.ml
@@ -25,7 +25,7 @@ let count_anthropic
   =
   let protocol = Input_token_count.Anthropic_messages_count_tokens in
   match config.kind with
-  | Provider_config.Anthropic ->
+  | Provider_config.Anthropic | Provider_config.Kimi ->
     let request_body =
       try
         Ok (Backend_anthropic.build_count_tokens_request ~config ~messages ~tools ())
@@ -57,7 +57,6 @@ let count_anthropic
       ~protocol
       ~model_id:config.model_id
       response_body
-  | Provider_config.Kimi
   | Provider_config.OpenAI_compat
   | Provider_config.Ollama
   | Provider_config.Gemini
@@ -78,8 +77,7 @@ type completion_request_error =
 
 let supports_completion_request_measurement (config : Provider_config.t) =
   match config.kind with
-  | Provider_config.Anthropic -> true
-  | Provider_config.Kimi
+  | Provider_config.Anthropic | Provider_config.Kimi -> true
   | Provider_config.OpenAI_compat
   | Provider_config.Ollama
   | Provider_config.Gemini

--- a/lib/llm_provider/count_tokens_sync.mli
+++ b/lib/llm_provider/count_tokens_sync.mli
@@ -6,16 +6,17 @@
 
     @stability Internal *)
 
-(** Endpoint for the Anthropic Messages count-tokens call: inserts
+(** Endpoint for an Anthropic-compatible Messages count-tokens call: inserts
     [/count_tokens] after the configured request path, preserving any query
     string carried by custom or proxy configurations. *)
 val count_tokens_url : Provider_config.t -> string
 
-(** Count one Anthropic Messages input through the provider's native
-    [/v1/messages/count_tokens] endpoint.
+(** Count one Anthropic-compatible Messages input through the provider's
+    native [/v1/messages/count_tokens] endpoint.
 
-    The request reuses {!Backend_anthropic}'s completion input projection.
-    Non-Anthropic configs fail with [Unsupported] before any I/O.
+    The request reuses {!Backend_anthropic}'s provider-specific completion
+    input projection. Anthropic and Kimi configs are supported; other configs
+    fail with [Unsupported] before any I/O.
 
     The call is bounded only when [timeout_s] is explicitly supplied;
     enforcing it also requires [clock], mirroring {!Http_client.post_sync}. *)

--- a/test/test_anthropic_input_token_count.ml
+++ b/test/test_anthropic_input_token_count.ml
@@ -79,6 +79,13 @@ let config
     ()
 ;;
 
+let kimi_config ?max_context base_url =
+  { (config ~kind:Provider_config.Kimi ?max_context base_url) with
+    response_format = Off
+  ; output_schema = None
+  }
+;;
+
 let response =
   { id = "prepared-response"
   ; model = "input-count-fixture"
@@ -142,6 +149,28 @@ let test_shared_projection () =
     [ "model"; "messages"; "system"; "tools"; "tool_choice"; "output_config" ];
   List.iter
     (fun name -> check bool ("count omits " ^ name) false (List.mem_assoc name count))
+    [ "max_tokens"; "stream"; "temperature"; "top_p"; "top_k" ]
+;;
+
+let test_kimi_shared_projection () =
+  let cfg = kimi_config "https://api.kimi.com/coding" in
+  let completion =
+    Backend_anthropic.build_request ~config:cfg ~messages ~tools:[ tool ] () |> assoc
+  in
+  let count =
+    Backend_anthropic.build_count_tokens_request ~config:cfg ~messages ~tools:[ tool ] ()
+    |> assoc
+  in
+  List.iter
+    (fun name ->
+       check
+         string
+         ("Kimi shared field " ^ name)
+         (field_json name completion)
+         (field_json name count))
+    [ "model"; "messages"; "system"; "tools"; "tool_choice" ];
+  List.iter
+    (fun name -> check bool ("Kimi count omits " ^ name) false (List.mem_assoc name count))
     [ "max_tokens"; "stream"; "temperature"; "top_p"; "top_k" ]
 ;;
 
@@ -230,6 +259,37 @@ let test_transport_success () =
     "canonical request body"
     (Backend_anthropic.build_count_tokens_request
        ~config:(config "unused")
+       ~messages
+       ~tools:[ tool ]
+       ())
+    body
+;;
+
+let test_kimi_transport_success () =
+  let result, (path, headers, body) =
+    with_mock ~status:`OK ~response:{|{"input_tokens":321}|}
+    @@ fun ~sw ~net ~base_url ->
+    let cfg = kimi_config base_url in
+    Count_tokens_sync.measure_completion_request
+      ~sw
+      ~net
+      (completion_request cfg)
+  in
+  (match result with
+   | Ok measurement ->
+     check int "Kimi input tokens" 321 measurement.input_count.input_tokens
+   | Error _ -> fail "expected native Kimi count success");
+  check string "Kimi count path" "/proxy/messages/count_tokens" path;
+  check
+    (option string)
+    "Kimi x-api-key"
+    (Some "test-key")
+    (Cohttp.Header.get headers "x-api-key");
+  check
+    string
+    "Kimi canonical request body"
+    (Backend_anthropic.build_count_tokens_request
+       ~config:(kimi_config "unused")
        ~messages
        ~tools:[ tool ]
        ())
@@ -462,6 +522,32 @@ let test_agent_overflow_blocks_dispatch () =
   | Ok _, _ -> fail "overflowed prepared request must not dispatch"
 ;;
 
+let test_kimi_agent_overflow_blocks_dispatch () =
+  let result, _captured =
+    with_mock ~status:`OK ~response:{|{"input_tokens":500}|}
+    @@ fun ~sw ~net ~base_url ->
+    let provider_config = kimi_config ~max_context:512 base_url in
+    let dispatched = ref false in
+    let transport =
+      { Llm_transport.complete_sync =
+          (fun _ ->
+            dispatched := true;
+            { Llm_transport.response = Ok response; latency_ms = None })
+      ; complete_stream =
+          (fun ?on_telemetry:_ ~on_event:_ _ -> fail "unexpected stream dispatch")
+      }
+    in
+    let agent = build_admission_agent ~net ~provider_config ~transport in
+    let result = Agent_sdk.Agent.run ~sw agent "overflow" in
+    result, !dispatched
+  in
+  match result with
+  | Error (Agent_sdk.Error.Api (Retry.ContextOverflow { limit = Some 512; _ })), false ->
+    ()
+  | Error error, _ -> fail (Agent_sdk.Error.to_string error)
+  | Ok _, _ -> fail "overflowed Kimi request must not dispatch"
+;;
+
 let test_invalid_count_response_is_provider_parse_failure () =
   let result, _captured =
     with_mock ~status:`OK ~response:{|{"unexpected":true}|}
@@ -590,9 +676,13 @@ let test_count_tokens_url () =
 let () =
   run
     "anthropic-input-token-count"
-    [ "request", [ test_case "shared canonical projection" `Quick test_shared_projection ]
+    [ ( "request"
+      , [ test_case "shared canonical projection" `Quick test_shared_projection
+        ; test_case "Kimi shared canonical projection" `Quick test_kimi_shared_projection
+        ] )
     ; ( "transport"
       , [ test_case "native success" `Quick test_transport_success
+        ; test_case "Kimi native success" `Quick test_kimi_transport_success
         ; test_case
             "prepared measure admit dispatch"
             `Quick
@@ -625,6 +715,10 @@ let () =
             "Agent overflow blocks dispatch"
             `Quick
             test_agent_overflow_blocks_dispatch
+        ; test_case
+            "Kimi Agent overflow blocks dispatch"
+            `Quick
+            test_kimi_agent_overflow_blocks_dispatch
         ; test_case
             "invalid count response is provider parse failure"
             `Quick

--- a/test/test_anthropic_input_token_count.ml
+++ b/test/test_anthropic_input_token_count.ml
@@ -170,7 +170,8 @@ let test_kimi_shared_projection () =
          (field_json name count))
     [ "model"; "messages"; "system"; "tools"; "tool_choice" ];
   List.iter
-    (fun name -> check bool ("Kimi count omits " ^ name) false (List.mem_assoc name count))
+    (fun name ->
+       check bool ("Kimi count omits " ^ name) false (List.mem_assoc name count))
     [ "max_tokens"; "stream"; "temperature"; "top_p"; "top_k" ]
 ;;
 
@@ -270,10 +271,7 @@ let test_kimi_transport_success () =
     with_mock ~status:`OK ~response:{|{"input_tokens":321}|}
     @@ fun ~sw ~net ~base_url ->
     let cfg = kimi_config base_url in
-    Count_tokens_sync.measure_completion_request
-      ~sw
-      ~net
-      (completion_request cfg)
+    Count_tokens_sync.measure_completion_request ~sw ~net (completion_request cfg)
   in
   (match result with
    | Ok measurement ->


### PR DESCRIPTION
## Outcome

Kimi Messages requests can use the existing opaque prepared-request admission path with provider-native input token counts. An over-limit request becomes typed `ContextOverflow` before the completion transport is invoked.

Closes #2704
Related: jeong-sik/masc#25294

## Mechanism

- `Backend_anthropic` builds Kimi count requests from the same provider-specific model/messages/system/tools/tool-choice projection as completion.
- `Count_tokens_sync` marks only Anthropic-compatible Messages kinds (Anthropic and Kimi) as exact-measurement capable.
- Existing prepared → measured → admitted → same-request dispatch type state remains unchanged.
- Unsupported provider kinds retain compatibility dispatch; no estimate, margin, URL inference, or provider prose parsing was added.

## Evidence

- Official endpoint probe on 2026-07-20 KST reached `POST https://api.kimi.com/coding/v1/messages/count_tokens` and returned a typed HTTP 400 without credentials; this proves route reachability only, not authenticated success.
- Regression: Kimi count path/auth/body are asserted.
- Regression: Kimi input 500 + reserved output 64 against context 512 returns typed `ContextOverflow` and completion transport remains uncalled.
- Rebased onto OAS v0.216.5 main at `64525619fc749c310f992bb77190ebade0965783`.
- `scripts/dune-local.sh build test/test_anthropic_input_token_count.exe`: pass.
- `_build/default/test/test_anthropic_input_token_count.exe`: 19/19 pass.
- `ocamlformat --check`: pass.
- `git diff --check`: pass.

## Merge gate

Draft remains until exact-head OCaml 5.4/5.5 CI is green. Then remove `status:do-not-merge`, mark Ready, and merge.

RFC-WAIVED: provider transport capability wiring and focused tests only; no credential schema, identity, operator-control, sandbox, hook, or workflow contract is changed.
