### PR TITLE
fix(agent): make projected provider input the admission SSOT

### DIFF
--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -653,6 +653,7 @@ let run_handoff_target ~sw ?clock agent (target : Handoff.handoff_target) prompt
       ~config:target.config
       ~tools:target.tools
       ~context_fit_admission:agent.context_fit_admission
+      ?model_input_projection:agent.model_input_projection
       ~options:
         { default_options with
           base_url = agent.options.base_url
@@ -737,6 +738,7 @@ let resume
       ?(options = default_options)
       ?provider_config
       ?(context_fit_admission = Disabled)
+      ?model_input_projection
       ?checkpoint_sink
       ?config
       ()
@@ -758,6 +760,7 @@ let resume
   ; options
   ; provider_config
   ; context_fit_admission
+  ; model_input_projection
   ; checkpoint_sink
   }
 ;;

--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -562,8 +562,6 @@ let run_stream
   |> project_detailed_error
 ;;
 
-(* ── Handoff support ─────────────────────────────────────────── *)
-
 let validate_handoff_targets agent (targets : Handoff.handoff_target list) =
   let rec loop seen (remaining : Handoff.handoff_target list) =
     match remaining with
@@ -727,8 +725,6 @@ let run_with_handoffs_blocks ~sw ?clock ?execution_store agent ~targets user_blo
   run_with_handoffs_blocks_detailed ~sw ?clock ?execution_store agent ~targets user_blocks
   |> project_detailed_error
 ;;
-
-(* ── Checkpoint / Resume ─────────────────────────────────────── *)
 
 let resume
       ~net

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -105,8 +105,11 @@ val sdk_version : string
     replaces [options.provider]; endpoint, credential, request path, headers,
     and capability overrides are not reconstructed from the legacy option.
 
-    [context_fit_admission] is separate from [options] so callers that construct
-    options records remain source-compatible. *)
+    [context_fit_admission] and [model_input_projection] are separate from
+    [options] so callers that construct options records remain source-compatible.
+    The optional projection is applied once during turn preparation; native
+    request measurement and provider dispatch consume the same projected
+    messages. *)
 val create
   :  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> config:Types.agent_config
@@ -115,6 +118,7 @@ val create
   -> ?options:options
   -> ?provider_config:Llm_provider.Provider_config.t
   -> ?context_fit_admission:context_fit_admission
+  -> ?model_input_projection:(Types.message list -> Types.message list)
   -> ?checkpoint_sink:checkpoint_sink
   -> unit
   -> t
@@ -505,8 +509,9 @@ val run_with_handoffs_blocks_detailed
     {!options}; pass it explicitly when resumed turns should continue emitting
     crash-recovery checkpoints. An explicit [provider_config] replaces
     [options.provider] under the same exact-carrier contract as {!create}.
-    [context_fit_admission] must be supplied again when a resumed Agent should
-    retain opt-in provider-fit enforcement. *)
+    [context_fit_admission] and [model_input_projection] must be supplied again
+    when a resumed Agent should retain opt-in provider-fit enforcement and
+    caller-owned provider-message projection. *)
 val resume
   :  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> checkpoint:Checkpoint.t
@@ -515,6 +520,7 @@ val resume
   -> ?options:options
   -> ?provider_config:Llm_provider.Provider_config.t
   -> ?context_fit_admission:context_fit_admission
+  -> ?model_input_projection:(Types.message list -> Types.message list)
   -> ?checkpoint_sink:checkpoint_sink
   -> ?config:Types.agent_config
   -> unit

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -38,6 +38,8 @@ type context_fit_admission = Agent_types.context_fit_admission =
   | Disabled
   | Enforce_when_supported
 
+type model_input_projection = Agent_types.model_input_projection
+
 type options = Agent_types.options =
   { base_url : string
   ; provider : Provider.config option
@@ -109,7 +111,8 @@ val sdk_version : string
     [options] so callers that construct options records remain source-compatible.
     The optional projection is applied once during turn preparation; native
     request measurement and provider dispatch consume the same projected
-    messages. *)
+    messages. A returned [Error detail] or non-reserved callback exception
+    fails the turn as {!Error.HookExecutionFailed}. *)
 val create
   :  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> config:Types.agent_config
@@ -118,7 +121,7 @@ val create
   -> ?options:options
   -> ?provider_config:Llm_provider.Provider_config.t
   -> ?context_fit_admission:context_fit_admission
-  -> ?model_input_projection:(Types.message list -> Types.message list)
+  -> ?model_input_projection:model_input_projection
   -> ?checkpoint_sink:checkpoint_sink
   -> unit
   -> t
@@ -520,7 +523,7 @@ val resume
   -> ?options:options
   -> ?provider_config:Llm_provider.Provider_config.t
   -> ?context_fit_admission:context_fit_admission
-  -> ?model_input_projection:(Types.message list -> Types.message list)
+  -> ?model_input_projection:model_input_projection
   -> ?checkpoint_sink:checkpoint_sink
   -> ?config:Types.agent_config
   -> unit

--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -50,13 +50,19 @@ let prepare_messages ~messages ~turn_params () =
 
 let prepare_turn ~tools ~messages ~turn_params ?model_input_projection () =
   let tools_json, visible_tool_names = prepare_tools ~tools () in
+  let prepared = prepare_messages ~messages ~turn_params () in
   let effective_messages =
-    let prepared = prepare_messages ~messages ~turn_params () in
     match model_input_projection with
-    | None -> prepared
-    | Some project -> project prepared
+    | None -> Ok prepared
+    | Some project ->
+      (try project prepared with
+       | exn ->
+         Llm_provider.Reserved_exn.reraise_if_reserved exn;
+         Error (Printexc.to_string exn))
   in
-  { tools_json; effective_messages; visible_tool_names }
+  Result.map
+    (fun effective_messages -> { tools_json; effective_messages; visible_tool_names })
+    effective_messages
 ;;
 
 (* ── Usage accumulation ───────────────────────────────────────── *)

--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -48,9 +48,14 @@ let prepare_messages ~messages ~turn_params () =
     messages @ [ system_msg ]
 ;;
 
-let prepare_turn ~tools ~messages ~turn_params () =
+let prepare_turn ~tools ~messages ~turn_params ?model_input_projection () =
   let tools_json, visible_tool_names = prepare_tools ~tools () in
-  let effective_messages = prepare_messages ~messages ~turn_params () in
+  let effective_messages =
+    let prepared = prepare_messages ~messages ~turn_params () in
+    match model_input_projection with
+    | None -> prepared
+    | Some project -> project prepared
+  in
   { tools_json; effective_messages; visible_tool_names }
 ;;
 

--- a/lib/agent/agent_turn.mli
+++ b/lib/agent/agent_turn.mli
@@ -43,7 +43,8 @@ val prepare_messages
   -> unit
   -> Types.message list
 
-(** Full turn preparation: exact caller-supplied tools plus messages.
+(** Full turn preparation: exact caller-supplied tools plus messages. A failed
+    caller projection is returned before provider measurement or dispatch.
 
     @since 0.185.0 added optional [config] parameter for provider-facing
       thinking preservation. *)
@@ -51,9 +52,9 @@ val prepare_turn
   :  tools:Tool_set.t
   -> messages:Types.message list
   -> turn_params:Hooks.turn_params
-  -> ?model_input_projection:(Types.message list -> Types.message list)
+  -> ?model_input_projection:Agent_types.model_input_projection
   -> unit
-  -> turn_preparation
+  -> (turn_preparation, string) result
 
 (** {1 Usage accumulation} *)
 

--- a/lib/agent/agent_turn.mli
+++ b/lib/agent/agent_turn.mli
@@ -51,6 +51,7 @@ val prepare_turn
   :  tools:Tool_set.t
   -> messages:Types.message list
   -> turn_params:Hooks.turn_params
+  -> ?model_input_projection:(Types.message list -> Types.message list)
   -> unit
   -> turn_preparation
 

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -31,6 +31,8 @@ type context_fit_admission =
   | Disabled
   | Enforce_when_supported
 
+type model_input_projection = message list -> (message list, string) result
+
 type options =
   { base_url : string
   ; provider : Provider.config option
@@ -137,7 +139,7 @@ type t =
   ; options : options
   ; provider_config : Llm_provider.Provider_config.t option
   ; context_fit_admission : context_fit_admission
-  ; model_input_projection : (message list -> message list) option
+  ; model_input_projection : model_input_projection option
   ; checkpoint_sink : checkpoint_sink option
   }
 

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -137,6 +137,7 @@ type t =
   ; options : options
   ; provider_config : Llm_provider.Provider_config.t option
   ; context_fit_admission : context_fit_admission
+  ; model_input_projection : (message list -> message list) option
   ; checkpoint_sink : checkpoint_sink option
   }
 
@@ -276,6 +277,7 @@ let create
       ?(options = default_options)
       ?provider_config
       ?(context_fit_admission = Disabled)
+      ?model_input_projection
       ?checkpoint_sink
       ()
   =
@@ -305,6 +307,7 @@ let create
   ; options
   ; provider_config
   ; context_fit_admission
+  ; model_input_projection
   ; checkpoint_sink
   }
 ;;
@@ -327,6 +330,7 @@ let clone ?(copy_context = false) agent =
   ; options = agent.options
   ; provider_config = agent.provider_config
   ; context_fit_admission = agent.context_fit_admission
+  ; model_input_projection = agent.model_input_projection
   ; checkpoint_sink = agent.checkpoint_sink
   }
 ;;

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -151,6 +151,7 @@ type t =
   ; options : options
   ; provider_config : Llm_provider.Provider_config.t option
   ; context_fit_admission : context_fit_admission
+  ; model_input_projection : (Types.message list -> Types.message list) option
   ; checkpoint_sink : checkpoint_sink option
   }
 
@@ -185,6 +186,7 @@ val create
   -> ?options:options
   -> ?provider_config:Llm_provider.Provider_config.t
   -> ?context_fit_admission:context_fit_admission
+  -> ?model_input_projection:(Types.message list -> Types.message list)
   -> ?checkpoint_sink:checkpoint_sink
   -> unit
   -> t

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -34,6 +34,10 @@ type context_fit_admission =
   | Disabled
   | Enforce_when_supported
 
+(** Caller-owned provider-message projection. [Error detail] aborts the turn
+    before request measurement or dispatch. Canonical Agent state is unchanged. *)
+type model_input_projection = Types.message list -> (Types.message list, string) result
+
 type options =
   { base_url : string
   ; provider : Provider.config option
@@ -151,7 +155,7 @@ type t =
   ; options : options
   ; provider_config : Llm_provider.Provider_config.t option
   ; context_fit_admission : context_fit_admission
-  ; model_input_projection : (Types.message list -> Types.message list) option
+  ; model_input_projection : model_input_projection option
   ; checkpoint_sink : checkpoint_sink option
   }
 
@@ -186,7 +190,7 @@ val create
   -> ?options:options
   -> ?provider_config:Llm_provider.Provider_config.t
   -> ?context_fit_admission:context_fit_admission
-  -> ?model_input_projection:(Types.message list -> Types.message list)
+  -> ?model_input_projection:model_input_projection
   -> ?checkpoint_sink:checkpoint_sink
   -> unit
   -> t

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -56,17 +56,17 @@ type options =
         [stdout_idle_timeout_s] knob via the transport's own config.
         @since 0.176.0 *)
   ; body_timeout_s : float option
-    (** Total deadline applied to non-streaming HTTP completion body
-        consumption. Threaded through {!Pipeline.stage_route} into
-        {!Llm_provider.Complete.complete}, where it wraps the synchronous HTTP
-        body read in [Eio.Time.with_timeout_exn].
+    (** Per-call total deadline applied to non-streaming HTTP response body
+        consumption. Threaded through {!Pipeline.stage_route} into both the
+        provider-native input-count preflight, when enabled, and
+        {!Llm_provider.Complete.complete}. Each round-trip owns a separate
+        deadline; the value is not a combined turn deadline.
         Requires [clock] to be supplied; without a clock the wrapper is
         skipped. A timeout surfaces as
-        [TimeoutError { phase = Non_streaming_body; _ }] and is returned
-        unchanged after that one provider attempt. Streaming requests
-        deliberately ignore this field and use [stream_idle_timeout_s] for
-        inter-line liveness so active long streams are not killed by a total
-        body deadline.
+        [TimeoutError] and is returned unchanged after that provider attempt.
+        The streaming completion itself deliberately ignores this field and
+        uses [stream_idle_timeout_s] for inter-line liveness; only its optional
+        non-streaming count preflight uses this deadline.
         @since 0.181.0 *)
   ; hooks : Hooks.hooks
   ; guardrails_async : Guardrails_async.t

--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -31,6 +31,7 @@ type t =
   ; provider : Provider.config option
   ; provider_config : Llm_provider.Provider_config.t option
   ; context_fit_admission : Agent.context_fit_admission
+  ; model_input_projection : (message list -> message list) option
   ; stream_idle_timeout_s : float option
   ; body_timeout_s : float option
   ; hooks : Hooks.hooks
@@ -81,6 +82,7 @@ let create ~net ~model =
   ; provider = None
   ; provider_config = None
   ; context_fit_admission = Agent.Disabled
+  ; model_input_projection = None
   ; stream_idle_timeout_s = None
   ; body_timeout_s = None
   ; hooks = Hooks.empty
@@ -182,6 +184,11 @@ let with_provider_config (pc : Llm_provider.Provider_config.t) b =
 ;;
 
 let with_context_fit_admission context_fit_admission b = { b with context_fit_admission }
+
+let with_model_input_projection model_input_projection b =
+  { b with model_input_projection = Some model_input_projection }
+;;
+
 let with_base_url url b = { b with base_url = url }
 let with_mcp_clients clients b = { b with mcp_clients = clients }
 let with_guardrails_async guardrails_async b = { b with guardrails_async }
@@ -288,6 +295,7 @@ let build b =
     ~options
     ?provider_config:b.provider_config
     ~context_fit_admission:b.context_fit_admission
+    ?model_input_projection:b.model_input_projection
     ?checkpoint_sink:b.checkpoint_sink
     ()
 ;;

--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -31,7 +31,7 @@ type t =
   ; provider : Provider.config option
   ; provider_config : Llm_provider.Provider_config.t option
   ; context_fit_admission : Agent.context_fit_admission
-  ; model_input_projection : (message list -> message list) option
+  ; model_input_projection : Agent.model_input_projection option
   ; stream_idle_timeout_s : float option
   ; body_timeout_s : float option
   ; hooks : Hooks.hooks

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -85,13 +85,14 @@ val without_event_bus : t -> t
     @since 0.176.0 *)
 val with_stream_idle_timeout : float -> t -> t
 
-(** Set the total deadline applied to non-streaming HTTP completion body
-    consumption. Requires a clock to be provided to the underlying request;
-    without one the wrapper is skipped. A timeout surfaces as
-    [TimeoutError { phase = Non_streaming_body; _ }] which the retry layer
-    treats as retryable. Streaming requests ignore this knob and rely on
-    [with_stream_idle_timeout] for inter-line liveness so active long
-    streams are not killed by total duration. @since 0.181.0 *)
+(** Set the per-call total deadline for non-streaming HTTP response body
+    consumption. This separately bounds a provider-native input-count
+    preflight and a non-streaming completion; it is not a combined turn
+    deadline. Requires a clock to be provided to the underlying request;
+    without one the wrapper is skipped. The streaming completion itself
+    ignores this knob and relies on [with_stream_idle_timeout] for inter-line
+    liveness; only its optional non-streaming count preflight uses this
+    deadline. @since 0.181.0 *)
 val with_body_timeout : float -> t -> t
 
 val with_elicitation : Hooks.elicitation_callback -> t -> t

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -115,6 +115,11 @@ val with_provider_config : Llm_provider.Provider_config.t -> t -> t
     [Complete] compatibility behavior. *)
 val with_context_fit_admission : Agent.context_fit_admission -> t -> t
 
+(** Apply a caller-owned projection once to the complete provider-bound message
+    list. Native request measurement and actual dispatch consume that same
+    projected request; canonical Agent state and checkpoints remain unchanged. *)
+val with_model_input_projection : (Types.message list -> Types.message list) -> t -> t
+
 val with_base_url : string -> t -> t
 
 (** Inject an {!Llm_provider.Llm_transport.t} for non-HTTP providers.

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -117,8 +117,9 @@ val with_context_fit_admission : Agent.context_fit_admission -> t -> t
 
 (** Apply a caller-owned projection once to the complete provider-bound message
     list. Native request measurement and actual dispatch consume that same
-    projected request; canonical Agent state and checkpoints remain unchanged. *)
-val with_model_input_projection : (Types.message list -> Types.message list) -> t -> t
+    projected request; canonical Agent state and checkpoints remain unchanged.
+    [Error detail] fails the turn as a typed hook execution error. *)
+val with_model_input_projection : Agent.model_input_projection -> t -> t
 
 val with_base_url : string -> t -> t
 

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -148,6 +148,17 @@ let prepare_turn_for_agent agent ~turn_params =
     ()
 ;;
 
+let model_input_projection_error detail =
+  Error.Agent
+    (HookExecutionFailed
+       { hook_name = "model_input_projection"
+       ; stage = "turn:parse"
+       ; tool_name = None
+       ; tool_use_id = None
+       ; detail
+       })
+;;
+
 let stage_parse ?raw_trace_run ?clock agent =
   let* turn_params =
     match
@@ -241,7 +252,10 @@ let stage_parse ?raw_trace_run ?clock agent =
           ; timestamp = Pipeline_common.timestamp_now ?clock ()
           })
    | None -> ());
-  let prep = prepare_turn_for_agent agent ~turn_params in
+  let* prep =
+    prepare_turn_for_agent agent ~turn_params
+    |> Result.map_error model_input_projection_error
+  in
   let ready_tool_names = prep.visible_tool_names in
   (* TurnReady reports the exact caller-supplied tool list the LLM will see
      this turn. Downstream substrate observability subscribers use this

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -144,6 +144,7 @@ let prepare_turn_for_agent agent ~turn_params =
     ~tools:agent.tools
     ~messages:agent.state.messages
     ~turn_params
+    ?model_input_projection:agent.model_input_projection
     ()
 ;;
 

--- a/lib/pipeline/pipeline_stage_route.ml
+++ b/lib/pipeline/pipeline_stage_route.ml
@@ -114,12 +114,6 @@ let enforce_context_fit agent (provider_config : Llm_provider.Provider_config.t)
     Llm_provider.Count_tokens_sync.supports_completion_request_measurement provider_config
 ;;
 
-let context_fit_timeout_s agent =
-  match agent.options.body_timeout_s with
-  | Some _ as timeout -> timeout
-  | None -> agent.options.stream_idle_timeout_s
-;;
-
 let finish_call ?on_provider_failure = function
   | Ok response ->
     notify_attribution on_provider_failure None;
@@ -197,7 +191,7 @@ let dispatch_sync
           ~sw
           ~net:agent.net
           ?clock
-          ?timeout_s:(context_fit_timeout_s agent)
+          ?timeout_s:agent.options.body_timeout_s
           prepared
       with
       | Error error -> Error (measurement_error ~binding error)
@@ -280,7 +274,7 @@ let dispatch_stream
           ~sw
           ~net:agent.net
           ?clock
-          ?timeout_s:(context_fit_timeout_s agent)
+          ?timeout_s:agent.options.body_timeout_s
           prepared
       with
       | Error error -> Error (measurement_error ~binding error)

--- a/lib/pipeline/pipeline_stage_route.ml
+++ b/lib/pipeline/pipeline_stage_route.ml
@@ -114,6 +114,12 @@ let enforce_context_fit agent (provider_config : Llm_provider.Provider_config.t)
     Llm_provider.Count_tokens_sync.supports_completion_request_measurement provider_config
 ;;
 
+let context_fit_timeout_s agent =
+  match agent.options.body_timeout_s with
+  | Some _ as timeout -> timeout
+  | None -> agent.options.stream_idle_timeout_s
+;;
+
 let finish_call ?on_provider_failure = function
   | Ok response ->
     notify_attribution on_provider_failure None;
@@ -186,7 +192,14 @@ let dispatch_sync
           ~trace_context
           ()
       in
-      match Llm_provider.Complete.measure_request ~sw ~net:agent.net ?clock prepared with
+      match
+        Llm_provider.Complete.measure_request
+          ~sw
+          ~net:agent.net
+          ?clock
+          ?timeout_s:(context_fit_timeout_s agent)
+          prepared
+      with
       | Error error -> Error (measurement_error ~binding error)
       | Ok measured ->
         (match Llm_provider.Complete.admit_request measured with
@@ -262,7 +275,14 @@ let dispatch_stream
           ?stream_idle_timeout_s:agent.options.stream_idle_timeout_s
           ()
       in
-      match Llm_provider.Complete.measure_request ~sw ~net:agent.net ?clock prepared with
+      match
+        Llm_provider.Complete.measure_request
+          ~sw
+          ~net:agent.net
+          ?clock
+          ?timeout_s:(context_fit_timeout_s agent)
+          prepared
+      with
       | Error error -> Error (measurement_error ~binding error)
       | Ok measured ->
         (match Llm_provider.Complete.admit_request measured with

--- a/test/test_agent_turn.ml
+++ b/test/test_agent_turn.ml
@@ -14,6 +14,11 @@ let context_messages = function
   | Error error -> Alcotest.fail error.Agent_turn.detail
 ;;
 
+let prepared_turn = function
+  | Ok prep -> prep
+  | Error detail -> Alcotest.fail detail
+;;
+
 (* ── prepare_turn tests ────────────────────────────────────── *)
 
 let test_prepare_turn_empty_tools () =
@@ -23,6 +28,7 @@ let test_prepare_turn_empty_tools () =
       ~messages:[]
       ~turn_params:Hooks.default_turn_params
       ()
+    |> prepared_turn
   in
   Alcotest.(check (option (list reject))) "no tools" None prep.tools_json
 ;;
@@ -47,6 +53,7 @@ let test_prepare_turn_with_tools () =
       ~messages:[]
       ~turn_params:Hooks.default_turn_params
       ()
+    |> prepared_turn
   in
   Alcotest.(check bool)
     "tools present"
@@ -71,6 +78,7 @@ let test_prepare_turn_preserves_supplied_tools () =
       ~messages:[]
       ~turn_params:Hooks.default_turn_params
       ()
+    |> prepared_turn
   in
   let count =
     match prep.tools_json with
@@ -94,6 +102,7 @@ let test_prepare_turn_visible_tool_names_empty () =
       ~messages:[]
       ~turn_params:Hooks.default_turn_params
       ()
+    |> prepared_turn
   in
   Alcotest.(check (list string)) "empty when no tools" [] prep.visible_tool_names
 ;;
@@ -106,6 +115,7 @@ let test_prepare_turn_visible_tool_names_preserves_order () =
   let tools = Tool_set.of_list [ make "Bash"; make "Read"; make "Edit" ] in
   let prep =
     Agent_turn.prepare_turn ~tools ~messages:[] ~turn_params:Hooks.default_turn_params ()
+    |> prepared_turn
   in
   Alcotest.(check (list string))
     "registry order preserved"

--- a/test/test_anthropic_input_token_count.ml
+++ b/test/test_anthropic_input_token_count.ml
@@ -686,7 +686,7 @@ let test_kimi_agent_overflow_blocks_dispatch () =
           (fun ?on_telemetry:_ ~on_event:_ _ -> fail "unexpected stream dispatch")
       }
     in
-    let agent = build_admission_agent ~net ~provider_config ~transport in
+    let agent = build_admission_agent ~net ~provider_config ~transport () in
     let result = Agent_sdk.Agent.run ~sw agent "overflow" in
     result, !dispatched
   in

--- a/test/test_anthropic_input_token_count.ml
+++ b/test/test_anthropic_input_token_count.ml
@@ -96,12 +96,32 @@ let response =
   }
 ;;
 
-let build_admission_agent ~net ~provider_config ~transport =
-  Agent_sdk.Builder.create ~net ~model:provider_config.Provider_config.model_id
-  |> Agent_sdk.Builder.with_provider_config provider_config
-  |> Agent_sdk.Builder.with_context_fit_admission Agent_sdk.Agent.Enforce_when_supported
-  |> Agent_sdk.Builder.with_transport transport
-  |> Agent_sdk.Builder.without_event_bus
+let build_admission_agent
+      ?model_input_projection
+      ?stream_idle_timeout_s
+      ~net
+      ~provider_config
+      ~transport
+      ()
+  =
+  let builder =
+    Agent_sdk.Builder.create ~net ~model:provider_config.Provider_config.model_id
+    |> Agent_sdk.Builder.with_provider_config provider_config
+    |> Agent_sdk.Builder.with_context_fit_admission Agent_sdk.Agent.Enforce_when_supported
+    |> Agent_sdk.Builder.with_transport transport
+    |> Agent_sdk.Builder.without_event_bus
+  in
+  let builder =
+    match model_input_projection with
+    | None -> builder
+    | Some project -> Agent_sdk.Builder.with_model_input_projection project builder
+  in
+  let builder =
+    match stream_idle_timeout_s with
+    | None -> builder
+    | Some timeout_s -> Agent_sdk.Builder.with_stream_idle_timeout timeout_s builder
+  in
+  builder
   |> Agent_sdk.Builder.build_safe
   |> function
   | Ok agent -> agent
@@ -188,12 +208,13 @@ let fresh_port () =
   port
 ;;
 
-let with_mock ~status ~response f =
+let with_mock_env ?response_delay_s ~status ~response f =
   Eio_main.run
   @@ fun env ->
   Eio.Switch.run
   @@ fun sw ->
   let net = Eio.Stdenv.net env in
+  let clock = Eio.Stdenv.clock env in
   let port = fresh_port () in
   let captured, resolve_captured = Eio.Promise.create () in
   let handler _conn request body =
@@ -201,6 +222,7 @@ let with_mock ~status ~response f =
     Eio.Promise.resolve
       resolve_captured
       (Cohttp.Request.uri request |> Uri.path, Cohttp.Request.headers request, body);
+    Option.iter (Eio.Time.sleep clock) response_delay_s;
     Cohttp_eio.Server.respond_string ~status ~body:response ()
   in
   let socket =
@@ -215,8 +237,13 @@ let with_mock ~status ~response f =
   Eio.Fiber.fork_daemon ~sw (fun () ->
     Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()));
   let base_url = Printf.sprintf "http://127.0.0.1:%d" port in
-  let result = f ~sw ~net ~base_url in
+  let result = f ~sw ~net ~clock ~base_url in
   result, Eio.Promise.await captured
+;;
+
+let with_mock ~status ~response f =
+  with_mock_env ~status ~response (fun ~sw ~net ~clock:_ ~base_url ->
+    f ~sw ~net ~base_url)
 ;;
 
 let test_transport_success () =
@@ -452,7 +479,7 @@ let test_agent_route_uses_prepared_admission () =
             Ok response)
       }
     in
-    let agent = build_admission_agent ~net ~provider_config ~transport in
+    let agent = build_admission_agent ~net ~provider_config ~transport () in
     let result = Agent_sdk.Agent.run ~sw agent "measure this exact turn" in
     result, !dispatched
   in
@@ -481,7 +508,7 @@ let test_agent_stream_route_uses_prepared_admission () =
             Ok response)
       }
     in
-    let agent = build_admission_agent ~net ~provider_config ~transport in
+    let agent = build_admission_agent ~net ~provider_config ~transport () in
     let result = Agent_sdk.Agent.run_stream ~sw ~on_event:(fun _ -> ()) agent "stream" in
     result, !dispatched
   in
@@ -492,6 +519,86 @@ let test_agent_stream_route_uses_prepared_admission () =
     check string "stream response" "accepted" (Types.visible_text_of_response actual);
     check string "stream dispatch model" "input-count-fixture" request.config.model_id;
     check int "stream dispatch messages" 1 (List.length request.messages)
+;;
+
+let test_agent_projection_is_shared_by_measurement_and_dispatch () =
+  let (result, dispatched), (_, _, measured_body) =
+    with_mock ~status:`OK ~response:{|{"input_tokens":321}|}
+    @@ fun ~sw ~net ~base_url ->
+    let provider_config = config ~max_context:512 base_url in
+    let dispatched = ref None in
+    let transport =
+      { Llm_transport.complete_sync =
+          (fun request ->
+            dispatched := Some request;
+            { Llm_transport.response = Ok response; latency_ms = Some 1 })
+      ; complete_stream =
+          (fun ?on_telemetry:_ ~on_event:_ _ -> fail "unexpected streaming dispatch")
+      }
+    in
+    let hydrated = msg User [ Text "hydrated artifact payload" ] in
+    let agent =
+      build_admission_agent
+        ~net
+        ~provider_config
+        ~transport
+        ~model_input_projection:(fun provider_messages ->
+          provider_messages @ [ hydrated ])
+        ()
+    in
+    let result = Agent_sdk.Agent.run ~sw agent "canonical input" in
+    result, !dispatched
+  in
+  match result, dispatched with
+  | Error error, _ -> fail (Agent_sdk.Error.to_string error)
+  | Ok _, None -> fail "projected request was not dispatched"
+  | Ok _, Some request ->
+    check int "dispatch receives projected messages" 2 (List.length request.messages);
+    check
+      string
+      "measurement and dispatch share exact request"
+      (Backend_anthropic.build_count_tokens_request
+         ~config:request.config
+         ~messages:request.messages
+         ~tools:request.tools
+         ())
+      measured_body
+;;
+
+let test_agent_count_preflight_uses_completion_timeout () =
+  let (result, dispatched), _captured =
+    with_mock_env ~response_delay_s:1.0 ~status:`OK ~response:{|{"input_tokens":321}|}
+    @@ fun ~sw ~net ~clock ~base_url ->
+    let provider_config = config ~max_context:512 base_url in
+    let dispatched = ref false in
+    let transport =
+      { Llm_transport.complete_sync =
+          (fun _ ->
+            dispatched := true;
+            { Llm_transport.response = Ok response; latency_ms = Some 1 })
+      ; complete_stream =
+          (fun ?on_telemetry:_ ~on_event:_ _ -> fail "unexpected streaming dispatch")
+      }
+    in
+    let agent =
+      build_admission_agent
+        ~stream_idle_timeout_s:0.02
+        ~net
+        ~provider_config
+        ~transport
+        ()
+    in
+    let result = Agent_sdk.Agent.run ~sw ~clock agent "bounded count preflight" in
+    result, !dispatched
+  in
+  match result, dispatched with
+  | ( Error
+        (Agent_sdk.Error.Provider
+           (Llm_provider.Error.Timeout
+              { timeout_phase = Some Llm_provider.Http_client.Http_operation; _ }))
+    , false ) -> ()
+  | Error error, _ -> fail (Agent_sdk.Error.to_string error)
+  | Ok _, _ -> fail "stalled count preflight must time out before completion dispatch"
 ;;
 
 let test_agent_overflow_blocks_dispatch () =
@@ -509,7 +616,7 @@ let test_agent_overflow_blocks_dispatch () =
           (fun ?on_telemetry:_ ~on_event:_ _ -> fail "unexpected stream dispatch")
       }
     in
-    let agent = build_admission_agent ~net ~provider_config ~transport in
+    let agent = build_admission_agent ~net ~provider_config ~transport () in
     let result = Agent_sdk.Agent.run ~sw agent "overflow" in
     result, !dispatched
   in
@@ -559,7 +666,7 @@ let test_invalid_count_response_is_provider_parse_failure () =
             fail "malformed count response must block streaming dispatch")
       }
     in
-    let agent = build_admission_agent ~net ~provider_config ~transport in
+    let agent = build_admission_agent ~net ~provider_config ~transport () in
     Agent_sdk.Agent.run_detailed ~sw agent "malformed count response"
   in
   match result with
@@ -596,7 +703,7 @@ let test_unsupported_provider_preserves_compatibility () =
         (fun ?on_telemetry:_ ~on_event:_ _ -> fail "unexpected stream dispatch")
     }
   in
-  let agent = build_admission_agent ~net ~provider_config ~transport in
+  let agent = build_admission_agent ~net ~provider_config ~transport () in
   match Agent_sdk.Agent.run ~sw agent "compatibility" with
   | Error error -> fail (Agent_sdk.Error.to_string error)
   | Ok _ -> check bool "compatibility dispatch" true !dispatched
@@ -709,6 +816,14 @@ let () =
             "Agent stream route uses prepared admission"
             `Quick
             test_agent_stream_route_uses_prepared_admission
+        ; test_case
+            "Agent projection is shared by measurement and dispatch"
+            `Quick
+            test_agent_projection_is_shared_by_measurement_and_dispatch
+        ; test_case
+            "Agent count preflight uses completion timeout"
+            `Quick
+            test_agent_count_preflight_uses_completion_timeout
         ; test_case
             "Agent overflow blocks dispatch"
             `Quick

--- a/test/test_anthropic_input_token_count.ml
+++ b/test/test_anthropic_input_token_count.ml
@@ -568,39 +568,50 @@ let test_agent_projection_is_shared_by_measurement_and_dispatch () =
       measured_body
 ;;
 
-let test_agent_projection_failure_is_typed () =
-  let result =
-    Eio_main.run
-    @@ fun env ->
-    Eio.Switch.run
-    @@ fun sw ->
-    let provider_config = config ~max_context:512 "http://127.0.0.1:1" in
-    let transport =
-      { Llm_transport.complete_sync = (fun _ -> fail "unexpected sync dispatch")
-      ; complete_stream =
-          (fun ?on_telemetry:_ ~on_event:_ _ -> fail "unexpected streaming dispatch")
-      }
-    in
-    let agent =
-      build_admission_agent
-        ~net:(Eio.Stdenv.net env)
-        ~provider_config
-        ~transport
-        ~model_input_projection:(fun _ -> Error "artifact unavailable")
-        ()
-    in
-    Agent_sdk.Agent.run ~sw agent "canonical input"
+let run_failing_projection projection =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let provider_config = config ~max_context:512 "http://127.0.0.1:1" in
+  let transport =
+    { Llm_transport.complete_sync = (fun _ -> fail "unexpected sync dispatch")
+    ; complete_stream =
+        (fun ?on_telemetry:_ ~on_event:_ _ -> fail "unexpected streaming dispatch")
+    }
   in
-  match result with
+  let agent =
+    build_admission_agent
+      ~net:(Eio.Stdenv.net env)
+      ~provider_config
+      ~transport
+      ~model_input_projection:projection
+      ()
+  in
+  Agent_sdk.Agent.run ~sw agent "canonical input"
+;;
+
+let check_projection_failure expected_detail = function
   | Error
       (Agent_sdk.Error.Agent
          (HookExecutionFailed
             { hook_name; stage; tool_name = None; tool_use_id = None; detail })) ->
     check string "projection hook name" "model_input_projection" hook_name;
     check string "projection stage" "turn:parse" stage;
-    check string "projection detail" "artifact unavailable" detail
+    check string "projection detail" expected_detail detail
   | Error error -> fail (Agent_sdk.Error.to_string error)
   | Ok _ -> fail "failed projection must abort the turn"
+;;
+
+let test_agent_projection_failure_is_typed () =
+  run_failing_projection (fun _ -> Error "artifact unavailable")
+  |> check_projection_failure "artifact unavailable"
+;;
+
+let test_agent_projection_exception_is_typed () =
+  let exception_ = Failure "projection exploded" in
+  run_failing_projection (fun _ -> raise exception_)
+  |> check_projection_failure (Printexc.to_string exception_)
 ;;
 
 let test_agent_count_preflight_uses_completion_timeout () =
@@ -857,6 +868,10 @@ let () =
             "Agent projection failure is typed"
             `Quick
             test_agent_projection_failure_is_typed
+        ; test_case
+            "Agent projection exception is typed"
+            `Quick
+            test_agent_projection_exception_is_typed
         ; test_case
             "Agent count preflight uses completion timeout"
             `Quick

--- a/test/test_anthropic_input_token_count.ml
+++ b/test/test_anthropic_input_token_count.ml
@@ -98,7 +98,7 @@ let response =
 
 let build_admission_agent
       ?model_input_projection
-      ?stream_idle_timeout_s
+      ?body_timeout_s
       ~net
       ~provider_config
       ~transport
@@ -117,9 +117,9 @@ let build_admission_agent
     | Some project -> Agent_sdk.Builder.with_model_input_projection project builder
   in
   let builder =
-    match stream_idle_timeout_s with
+    match body_timeout_s with
     | None -> builder
-    | Some timeout_s -> Agent_sdk.Builder.with_stream_idle_timeout timeout_s builder
+    | Some timeout_s -> Agent_sdk.Builder.with_body_timeout timeout_s builder
   in
   builder
   |> Agent_sdk.Builder.build_safe
@@ -522,6 +522,7 @@ let test_agent_stream_route_uses_prepared_admission () =
 ;;
 
 let test_agent_projection_is_shared_by_measurement_and_dispatch () =
+  let projection_calls = ref 0 in
   let (result, dispatched), (_, _, measured_body) =
     with_mock ~status:`OK ~response:{|{"input_tokens":321}|}
     @@ fun ~sw ~net ~base_url ->
@@ -543,7 +544,8 @@ let test_agent_projection_is_shared_by_measurement_and_dispatch () =
         ~provider_config
         ~transport
         ~model_input_projection:(fun provider_messages ->
-          provider_messages @ [ hydrated ])
+          incr projection_calls;
+          Ok (provider_messages @ [ hydrated ]))
         ()
     in
     let result = Agent_sdk.Agent.run ~sw agent "canonical input" in
@@ -553,6 +555,7 @@ let test_agent_projection_is_shared_by_measurement_and_dispatch () =
   | Error error, _ -> fail (Agent_sdk.Error.to_string error)
   | Ok _, None -> fail "projected request was not dispatched"
   | Ok _, Some request ->
+    check int "projection is applied exactly once" 1 !projection_calls;
     check int "dispatch receives projected messages" 2 (List.length request.messages);
     check
       string
@@ -563,6 +566,41 @@ let test_agent_projection_is_shared_by_measurement_and_dispatch () =
          ~tools:request.tools
          ())
       measured_body
+;;
+
+let test_agent_projection_failure_is_typed () =
+  let result =
+    Eio_main.run
+    @@ fun env ->
+    Eio.Switch.run
+    @@ fun sw ->
+    let provider_config = config ~max_context:512 "http://127.0.0.1:1" in
+    let transport =
+      { Llm_transport.complete_sync = (fun _ -> fail "unexpected sync dispatch")
+      ; complete_stream =
+          (fun ?on_telemetry:_ ~on_event:_ _ -> fail "unexpected streaming dispatch")
+      }
+    in
+    let agent =
+      build_admission_agent
+        ~net:(Eio.Stdenv.net env)
+        ~provider_config
+        ~transport
+        ~model_input_projection:(fun _ -> Error "artifact unavailable")
+        ()
+    in
+    Agent_sdk.Agent.run ~sw agent "canonical input"
+  in
+  match result with
+  | Error
+      (Agent_sdk.Error.Agent
+         (HookExecutionFailed
+            { hook_name; stage; tool_name = None; tool_use_id = None; detail })) ->
+    check string "projection hook name" "model_input_projection" hook_name;
+    check string "projection stage" "turn:parse" stage;
+    check string "projection detail" "artifact unavailable" detail
+  | Error error -> fail (Agent_sdk.Error.to_string error)
+  | Ok _ -> fail "failed projection must abort the turn"
 ;;
 
 let test_agent_count_preflight_uses_completion_timeout () =
@@ -581,12 +619,7 @@ let test_agent_count_preflight_uses_completion_timeout () =
       }
     in
     let agent =
-      build_admission_agent
-        ~stream_idle_timeout_s:0.02
-        ~net
-        ~provider_config
-        ~transport
-        ()
+      build_admission_agent ~body_timeout_s:0.02 ~net ~provider_config ~transport ()
     in
     let result = Agent_sdk.Agent.run ~sw ~clock agent "bounded count preflight" in
     result, !dispatched
@@ -820,6 +853,10 @@ let () =
             "Agent projection is shared by measurement and dispatch"
             `Quick
             test_agent_projection_is_shared_by_measurement_and_dispatch
+        ; test_case
+            "Agent projection failure is typed"
+            `Quick
+            test_agent_projection_failure_is_typed
         ; test_case
             "Agent count preflight uses completion timeout"
             `Quick

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -210,6 +210,7 @@ let test_agent_turn_preparation () =
   in
   let prep =
     Agent_turn.prepare_turn ~tools ~messages ~turn_params:Hooks.default_turn_params ()
+    |> Result.get_ok
   in
   (* tools_json should be Some with 2 tools *)
   (match prep.tools_json with
@@ -774,6 +775,7 @@ let test_prepare_turn_no_tools () =
       ~messages
       ~turn_params:Hooks.default_turn_params
       ()
+    |> Result.get_ok
   in
   (match prep.tools_json with
    | None -> ()
@@ -811,6 +813,7 @@ let test_prepare_turn_preserves_messages () =
       ~messages
       ~turn_params:Hooks.default_turn_params
       ()
+    |> Result.get_ok
   in
   Alcotest.(check int) "3 messages" 3 (List.length prep.effective_messages)
 ;;
@@ -993,7 +996,10 @@ let test_prepare_turn_extra_context () =
       extra_system_context = Some "You are in debug mode."
     }
   in
-  let prep = Agent_turn.prepare_turn ~tools:Tool_set.empty ~messages ~turn_params () in
+  let prep =
+    Agent_turn.prepare_turn ~tools:Tool_set.empty ~messages ~turn_params ()
+    |> Result.get_ok
+  in
   (* Extra context is appended at the end to preserve prefix for KV cache *)
   Alcotest.(check int)
     "2 messages (original + context)"


### PR DESCRIPTION
## Summary
- add an optional Agent-owned provider-message projection applied exactly once during turn preparation
- make native request measurement and provider dispatch consume the same immutable prepared request
- make projection failure explicit as a typed `HookExecutionFailed` result before measurement or dispatch
- bound native count-token preflight only with the caller's non-streaming body timeout; stream-idle timeout remains stream-liveness-only
- preserve compatibility by defaulting the projection to `None` and keeping canonical Agent/checkpoint state unchanged

## Why
MASC #25330 currently hydrates provider messages in its HTTP transport after OAS native context-fit admission has already measured the unhydrated request. That creates two request authorities and can admit a different payload than the one dispatched. The correction belongs in OAS: project once before `Complete.prepare_request`, then measure and dispatch that immutable request.

The projection callback returns a result. A caller-owned hydration failure cannot escape as an untyped exception or continue with an unhydrated request. Reserved Eio exceptions still propagate; ordinary exceptions are converted to the same typed hook failure.

## Adversarial corrections
- removed the heuristic fallback from `body_timeout_s` to semantically unrelated `stream_idle_timeout_s`
- added an exact one-call assertion for projection
- added no-dispatch proofs for explicit projection errors and ordinary callback exceptions
- rebased onto OAS main `c9394887755aedb2b69c039838a62595ab146d4a` after Kimi native-count #2705
- repaired the stacked Kimi admission fixture to apply the new builder terminator, proving the combined contract compiles and executes

## Verification
- exact head: `3cb94d4cc6ac8dcd9e69d3a4883336c90cab2e23`
- `scripts/dune-local.sh build test/test_anthropic_input_token_count.exe test/test_agent_turn.exe test/test_pipeline.exe`
- `_build/default/test/test_anthropic_input_token_count.exe` — 23/23 passed
- `_build/default/test/test_agent_turn.exe` — 25/25 passed
- `_build/default/test/test_pipeline.exe` — 43/43 passed
- repository `@fmt` and `git diff --check` passed

## Downstream
After this OAS change is released and pinned, MASC #25330 can pass its hydration projection through `Builder.with_model_input_projection` and delete transport-time request mutation. No MASC pin should move before the release artifact exists.
