### PR TITLE
fix(agent): share exact provider turn identity

### DIFF
--- a/docs/migrations/0.216-tool-invocation-ssot.md
+++ b/docs/migrations/0.216-tool-invocation-ssot.md
@@ -18,6 +18,10 @@ let invocation =
   Tool.Invocation.create ~tool_use_id:"provider-id" ~turn:4 ~schedule
 ```
 
+`turn` is the zero-based provider-turn identity already carried by
+`BeforeTurn`, `AfterTurn`, and `TurnCompleted`; it is not the post-collection
+`Agent.state.turn_count` and must not be recomputed after the state advances.
+
 `Hooks.tool_schedule` remains an alias of `Tool.schedule` for code that names
 the old type. It is not a second stored schedule.
 

--- a/lib/agent/agent_trace.ml
+++ b/lib/agent/agent_trace.ml
@@ -18,13 +18,13 @@ let record_hook_invocation active_run ?invocation ~hook_name ~decision ?detail (
          ())
 ;;
 
-let invoke_hook_with_trace agent ?raw_trace_run ~hook_name hook_opt event =
+let invoke_hook_with_trace agent ?raw_trace_run ~turn ~hook_name hook_opt event =
   Tracing.with_span
     agent.options.tracer
     { kind = Hook_invoke
     ; name = hook_name
     ; agent_name = agent.state.config.name
-    ; turn = agent.state.turn_count
+    ; turn
     ; extra = []
     ; links = []
     }
@@ -39,7 +39,7 @@ let invoke_hook_with_trace agent ?raw_trace_run ~hook_name hook_opt event =
        decision)
 ;;
 
-let execute_tools_with_trace agent active_run tool_uses =
+let execute_tools_with_trace agent active_run ~turn tool_uses =
   let correlation_id = Option.bind agent.options.raw_trace Raw_trace.session_id in
   let run_id = Option.map Raw_trace.active_run_id active_run in
   let tools = Tool_set.to_list agent.tools in
@@ -96,7 +96,7 @@ let execute_tools_with_trace agent active_run tool_uses =
     ?journal:agent.options.journal
     ~tracer:agent.options.tracer
     ~agent_name:agent.state.config.name
-    ~turn_count:agent.state.turn_count
+    ~turn_count:turn
     ~usage:agent.state.usage
     ?correlation_id
     ?run_id

--- a/lib/agent/agent_trace.mli
+++ b/lib/agent/agent_trace.mli
@@ -25,6 +25,7 @@ val record_hook_invocation
 val invoke_hook_with_trace
   :  t
   -> ?raw_trace_run:Raw_trace.active_run
+  -> turn:int
   -> hook_name:string
   -> (Hooks.hook_event -> Hooks.hook_decision) option
   -> Hooks.hook_event
@@ -38,6 +39,7 @@ val invoke_hook_with_trace
 val execute_tools_with_trace
   :  t
   -> Raw_trace.active_run option
+  -> turn:int
   -> Types.content_block list
   -> (Agent_tools.tool_execution_result list, Agent_tools.execution_failure) result
 

--- a/lib/base/tool.mli
+++ b/lib/base/tool.mli
@@ -26,9 +26,12 @@ type schedule =
   }
 
 (** Exact occurrence metadata for correlation and observability only.
-    It does not authorize tool execution. [turn] and [schedule.planned_index]
-    scope provider [tool_use_id] values that may be blank or repeated. The
-    embedding runtime owns any broader agent/run identity.
+    It does not authorize tool execution. [turn] is the zero-based provider
+    turn shared by BeforeTurn, AfterTurn, TurnCompleted, and every tool
+    occurrence produced by that response. Together, [turn] and
+    [schedule.planned_index] scope provider [tool_use_id] values that may be
+    blank or repeated. The embedding runtime owns any broader agent/run
+    identity.
 
     @since 0.215.0
     @since 0.216.0 Owns the canonical [schedule]. *)

--- a/lib/execution_agent_scope.ml
+++ b/lib/execution_agent_scope.ml
@@ -13,6 +13,7 @@ type t =
 type turn =
   { scope : t
   ; node : Event.Node_id.t
+  ; ordinal : int
   }
 
 type provider_attempt =
@@ -229,8 +230,10 @@ let open_turn scope ~ordinal =
        ~parent:(Journal.run_root scope.run)
        ~kind:(Event.Agent_turn { ordinal })
        ())
-  |> Result.map (fun (node, _event) -> { scope; node })
+  |> Result.map (fun (node, _event) -> { scope; node; ordinal })
 ;;
+
+let turn_ordinal turn = turn.ordinal
 
 let resume_turn scope ~ordinal =
   match Writer.find_node scope.writer (Journal.run_root scope.run) with
@@ -257,10 +260,44 @@ let resume_turn scope ~ordinal =
        (match Writer.find_node scope.writer node with
         | Error error -> Error (Scope_unavailable error)
         | Ok None -> Error (Resume_topology_mismatch "turn child disappeared")
-        | Ok (Some { status = Journal.Open; _ }) -> Ok (Some { scope; node })
+        | Ok (Some { status = Journal.Open; _ }) -> Ok (Some { scope; node; ordinal })
         | Ok (Some { status = Journal.Closed _; _ }) ->
           Error (Resume_topology_mismatch "requested turn is already closed"))
      | _ :: _ :: _ -> Error (Resume_topology_mismatch "duplicate turn ordinal"))
+;;
+
+let resume_open_turn scope =
+  match Writer.find_node scope.writer (Journal.run_root scope.run) with
+  | Error error -> Error (Scope_unavailable error)
+  | Ok None -> Error Run_not_found
+  | Ok (Some root) ->
+    let turn_children =
+      List.filter_map
+        (fun (child : Event.node Journal.event_record) ->
+           match Event.node_kind child.value with
+           | Event.Agent_turn { ordinal } -> Some (Event.node_id child.value, ordinal)
+           | Event.Agent_run _
+           | Event.Provider_attempt _
+           | Event.Output_block _
+           | Event.Tool_invocation _
+           | Event.Tool_attempt -> None)
+        root.children
+    in
+    let rec collect_open acc = function
+      | [] -> Ok acc
+      | (node, ordinal) :: rest ->
+        (match Writer.find_node scope.writer node with
+         | Error error -> Error (Scope_unavailable error)
+         | Ok None -> Error (Resume_topology_mismatch "turn child disappeared")
+         | Ok (Some { status = Journal.Open; _ }) ->
+           collect_open ({ scope; node; ordinal } :: acc) rest
+         | Ok (Some { status = Journal.Closed _; _ }) -> collect_open acc rest)
+    in
+    (match collect_open [] turn_children with
+     | Error _ as error -> error
+     | Ok [] -> Ok None
+     | Ok [ turn ] -> Ok (Some turn)
+     | Ok (_ :: _ :: _) -> Error (Resume_topology_mismatch "multiple open agent turns"))
 ;;
 
 let open_provider_attempt turn ~ordinal binding =

--- a/lib/execution_agent_scope.mli
+++ b/lib/execution_agent_scope.mli
@@ -73,6 +73,12 @@ val resume_running
 val open_turn : t -> ordinal:int -> (turn, error) result
 val resume_turn : t -> ordinal:int -> (turn option, error) result
 
+(** Recover the single open turn from durable topology. This is a recovery-only
+    lookup; callers must not reconstruct its ordinal from mutable agent state. *)
+val resume_open_turn : t -> (turn option, error) result
+
+val turn_ordinal : turn -> int
+
 (** Materialize the exact binding selected for provider dispatch. *)
 val open_provider_attempt
   :  turn

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -894,22 +894,6 @@ let%test "last_tool_results_from error tool result" =
   | _ -> false
 ;;
 
-let%test "tag_error with Config error" =
-  let err = Error.Config (MissingEnvVar { var_name = "X" }) in
-  match tag_error "parse" (Error err) with
-  | Error e -> e = err
-  | Ok _ -> false
-;;
-
-let%test "tag_error with Agent error" =
-  let err = Error.Agent (UnrecognizedStopReason { reason = "weird" }) in
-  match tag_error "output" (Error err) with
-  | Error e -> e = err
-  | Ok _ -> false
-;;
-
-let%test "tag_error string result Ok" = tag_error "collect" (Ok "success") = Ok "success"
-
 (* --- Additional pipeline tests --- *)
 
 let%test "last_tool_results_from only non-result roles" =
@@ -980,29 +964,3 @@ let%test "last_tool_results_from user msg with only non-tool content" =
   in
   last_tool_results_from msgs = []
 ;;
-
-let%test "tag_error with Serialization error" =
-  let err = Error.Serialization (JsonParseError { detail = "bad json" }) in
-  match tag_error "route" (Error err) with
-  | Error e -> e = err
-  | Ok _ -> false
-;;
-
-let%test "tag_error with Io error" =
-  let err =
-    Error.Io (FileOpFailed { op = "read"; path = "/tmp/x"; detail = "not found" })
-  in
-  match tag_error "input" (Error err) with
-  | Error e -> e = err
-  | Ok _ -> false
-;;
-
-let%test "tag_error with Mcp error" =
-  let err = Error.Mcp (InitializeFailed { detail = "timeout" }) in
-  match tag_error "parse" (Error err) with
-  | Error e -> e = err
-  | Ok _ -> false
-;;
-
-let%test "tag_error Ok unit" = tag_error "collect" (Ok ()) = Ok ()
-let%test "tag_error Ok list" = tag_error "output" (Ok [ 1; 2; 3 ]) = Ok [ 1; 2; 3 ]

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -77,6 +77,7 @@ let dispatch_stream = Pipeline_stage_route.dispatch_stream
 let stage_route
       ~sw
       ?clock
+      ~turn
       ~api_strategy
       ?raw_trace_run
       ?on_provider_failure
@@ -92,7 +93,7 @@ let stage_route
       { kind = Api_call
       ; name = "create_message"
       ; agent_name = agent.state.config.name
-      ; turn = agent.state.turn_count
+      ; turn
       ; extra = []
       ; links = []
       }
@@ -114,7 +115,7 @@ let stage_route
       { kind = Api_call
       ; name = "create_message_stream"
       ; agent_name = agent.state.config.name
-      ; turn = agent.state.turn_count
+      ; turn
       ; extra = []
       ; links = []
       }
@@ -139,13 +140,13 @@ let stage_route
 
 (** Accumulate usage, invoke AfterTurn hook, emit events, append
     assistant message, and increment turn_count. *)
-let stage_collect ?raw_trace_run ?clock agent response =
+let stage_collect ?raw_trace_run ?clock ~turn agent response =
   Tracing.with_span
     agent.options.tracer
     { kind = Hook_invoke
     ; name = "turn:collect"
     ; agent_name = agent.state.config.name
-    ; turn = agent.state.turn_count
+    ; turn
     ; extra = []
     ; links = []
     }
@@ -172,9 +173,10 @@ let stage_collect ?raw_trace_run ?clock agent response =
          invoke_hook_with_trace
            agent
            ?raw_trace_run
+           ~turn
            ~hook_name:"after_turn"
            agent.options.hooks.after_turn
-           (Hooks.AfterTurn { turn = agent.state.turn_count; response })
+           (Hooks.AfterTurn { turn; response })
        in
        let* () =
          match after_decision with
@@ -194,7 +196,6 @@ let stage_collect ?raw_trace_run ?clock agent response =
                 ~stage:Hooks.After_turn
                 ~decision)
        in
-       let completed_turn = agent.state.turn_count in
        let* assistant_message =
          match Types.assistant_message_of_response response with
          | Ok message -> Ok message
@@ -204,10 +205,11 @@ let stage_collect ?raw_trace_run ?clock agent response =
                 ("assistant response has invalid reasoning provenance: "
                  ^ Types.show_assistant_message_error error))
        in
+       let next_turn = turn + 1 in
        let checkpoint_state =
          { agent.state with
            messages = Util.snoc agent.state.messages assistant_message
-         ; turn_count = agent.state.turn_count + 1
+         ; turn_count = next_turn
          ; usage
          }
        in
@@ -220,7 +222,7 @@ let stage_collect ?raw_trace_run ?clock agent response =
        update_state agent (fun state ->
          { state with
            messages = Util.snoc state.messages assistant_message
-         ; turn_count = state.turn_count + 1
+         ; turn_count = next_turn
          ; usage
          });
        (match agent.options.event_bus with
@@ -228,9 +230,7 @@ let stage_collect ?raw_trace_run ?clock agent response =
           safe_publish
             bus
             { meta = Pipeline_common.event_envelope agent
-            ; payload =
-                TurnCompleted
-                  { agent_name = agent.state.config.name; turn = completed_turn }
+            ; payload = TurnCompleted { agent_name = agent.state.config.name; turn }
             }
         | None -> ());
        (* Observability-as-default: emit per-call inference telemetry beside
@@ -261,7 +261,7 @@ let stage_collect ?raw_trace_run ?clock agent response =
                   ; payload =
                       InferenceTelemetry
                         { agent_name = agent.state.config.name
-                        ; turn = completed_turn
+                        ; turn
                         ; provider = Llm_provider.Provider_kind.to_string provider_kind
                         ; model = response.model
                         ; prompt_tokens =
@@ -300,7 +300,7 @@ let stage_collect ?raw_trace_run ?clock agent response =
 (* ── Stage 5: Execute ────────────────────────────────────── *)
 
 (** Handle tool execution and context injection. *)
-let stage_execute ?raw_trace_run ?before_tool_execution agent tool_uses_nonempty =
+let stage_execute ?raw_trace_run ?before_tool_execution ~turn agent tool_uses_nonempty =
   (* The caller (stage_output) proves the tool-call set is non-empty: a
      StopToolUse turn that carried no tool block is rejected before this stage
      (Stop_reason_wire.reconcile downgrades it to Unknown at parse time).
@@ -312,14 +312,14 @@ let stage_execute ?raw_trace_run ?before_tool_execution agent tool_uses_nonempty
     { kind = Tool_exec
     ; name = "turn:execute"
     ; agent_name = agent.state.config.name
-    ; turn = agent.state.turn_count
+    ; turn
     ; extra = []
     ; links = []
     }
     (fun _tracer ->
        Option.iter (fun callback -> callback ()) before_tool_execution;
        let results, failure =
-         match execute_tools_with_trace agent raw_trace_run tool_uses with
+         match execute_tools_with_trace agent raw_trace_run ~turn tool_uses with
          | Ok results -> results, None
          | Error ({ completed_results; cause } : Agent_tools.execution_failure) ->
            completed_results, Some cause
@@ -390,13 +390,13 @@ let stage_execute ?raw_trace_run ?before_tool_execution agent tool_uses_nonempty
 (* ── Stage 6: Output ─────────────────────────────────────── *)
 
 (** Map stop_reason to turn_outcome. *)
-let stage_output ?raw_trace_run ?before_tool_execution agent response =
+let stage_output ?raw_trace_run ?before_tool_execution ~turn agent response =
   Tracing.with_span
     agent.options.tracer
     { kind = Hook_invoke
     ; name = "turn:output"
     ; agent_name = agent.state.config.name
-    ; turn = agent.state.turn_count
+    ; turn
     ; extra = []
     ; links = []
     }
@@ -431,7 +431,12 @@ let stage_output ?raw_trace_run ?before_tool_execution agent response =
                  (UnrecognizedStopReason
                     { reason = "StopToolUse turn carried no tool block" }))
           | Some tool_uses_nonempty ->
-            stage_execute ?raw_trace_run ?before_tool_execution agent tool_uses_nonempty)
+            stage_execute
+              ?raw_trace_run
+              ?before_tool_execution
+              ~turn
+              agent
+              tool_uses_nonempty)
        | UnmatchedToolCalls ->
          (* The wire boundary has already classified this response shape as
             malformed. Keep rejecting it; arbitrary provider terminal reasons
@@ -453,6 +458,7 @@ let stage_output ?raw_trace_run ?before_tool_execution agent response =
            invoke_hook_with_trace
              agent
              ?raw_trace_run
+             ~turn
              ~hook_name:"on_stop"
              agent.options.hooks.on_stop
              (Hooks.OnStop { reason = response.stop_reason; response })
@@ -503,6 +509,10 @@ let run_new_turn
       ?before_tool_execution
       agent
   =
+  (* One immutable zero-based identity owns the complete provider turn.  The
+     collect stage advances mutable agent state before output/tool dispatch,
+     so reading [state.turn_count] again downstream would name the next turn. *)
+  let turn = agent.state.turn_count in
   (* Stage 1: Input *)
   let* () =
     Tracing.with_span
@@ -510,11 +520,11 @@ let run_new_turn
       { kind = Hook_invoke
       ; name = "turn:input"
       ; agent_name = agent.state.config.name
-      ; turn = agent.state.turn_count
+      ; turn
       ; extra = []
       ; links = []
       }
-      (fun _tracer -> stage_input ?raw_trace_run ?clock agent |> tag_error "input")
+      (fun _tracer -> stage_input ?raw_trace_run ?clock ~turn agent |> tag_error "input")
   in
   (* Stage 2: Parse *)
   let* prep, turn_config, turn_params =
@@ -523,11 +533,11 @@ let run_new_turn
       { kind = Hook_invoke
       ; name = "turn:parse"
       ; agent_name = agent.state.config.name
-      ; turn = agent.state.turn_count
+      ; turn
       ; extra = []
       ; links = []
       }
-      (fun _tracer -> stage_parse ?raw_trace_run ?clock agent |> tag_error "parse")
+      (fun _tracer -> stage_parse ?raw_trace_run ?clock ~turn agent |> tag_error "parse")
   in
   (* Stage 2.5: Async input validation *)
   let async_guard = agent.options.guardrails_async in
@@ -540,9 +550,7 @@ let run_new_turn
     Error (Error.Agent (GuardrailViolation { validator = validator_name; reason }))
   | Guardrails_async.Pass ->
     let* execution =
-      Pipeline_execution_scope.open_turn
-        (Execution_context.agent_scope ())
-        ~ordinal:(agent.state.turn_count + 1)
+      Pipeline_execution_scope.open_turn (Execution_context.agent_scope ()) ~ordinal:turn
     in
     (* Stage 3: Route exactly once. Provider [ContextOverflow] remains a typed
        error; OAS does not mutate the transcript or retry implicitly. *)
@@ -551,7 +559,7 @@ let run_new_turn
        Agent_execution_event_writer.append
          j
          (Llm_request
-            { turn = agent.state.turn_count
+            { turn
             ; model = turn_config.model
             ; timestamp = Pipeline_common.timestamp_now ?clock ()
             })
@@ -561,6 +569,7 @@ let run_new_turn
       stage_route
         ~sw
         ?clock
+        ~turn
         ~api_strategy
         ?raw_trace_run
         ?on_provider_failure
@@ -582,7 +591,7 @@ let run_new_turn
        Agent_execution_event_writer.append
          j
          (Llm_response
-            { turn = agent.state.turn_count
+            { turn
             ; input_tokens
             ; output_tokens
             ; stop_reason = Types.show_stop_reason response.stop_reason
@@ -593,7 +602,7 @@ let run_new_turn
        Agent_execution_event_writer.append
          j
          (Error_occurred
-            { turn = agent.state.turn_count
+            { turn
             ; error_domain = "Api"
             ; detail = Error.to_string err
             ; timestamp = Pipeline_common.timestamp_now ?clock ()
@@ -616,13 +625,15 @@ let run_new_turn
            Error (Error.Agent (GuardrailViolation { validator = validator_name; reason }))
          | Guardrails_async.Pass ->
            let* () =
-             stage_collect ?raw_trace_run ?clock agent response |> tag_error "collect"
+             stage_collect ?raw_trace_run ?clock ~turn agent response
+             |> tag_error "collect"
            in
            (match Pipeline_execution_scope.provider execution with
-            | None -> stage_output ?raw_trace_run ?before_tool_execution agent response
+            | None ->
+              stage_output ?raw_trace_run ?before_tool_execution ~turn agent response
             | Some provider ->
               Execution_context.with_provider_attempt provider (fun () ->
-                stage_output ?raw_trace_run ?before_tool_execution agent response))
+                stage_output ?raw_trace_run ?before_tool_execution ~turn agent response))
            |> tag_error "output")
     in
     (match outcome with
@@ -642,18 +653,16 @@ let run_turn
   =
   let* resumed =
     if Execution_context.take_resume_once ()
-    then
-      Pipeline_execution_scope.resume_current
-        (Execution_context.agent_scope ())
-        ~ordinal:agent.state.turn_count
+    then Pipeline_execution_scope.resume_current (Execution_context.agent_scope ())
     else Ok None
   in
   match resumed with
   | Some execution ->
+    let turn = Pipeline_execution_scope.turn_ordinal execution in
     Pipeline_execution_resume.run
       agent
       execution
-      ~execute:(stage_execute ?raw_trace_run agent)
+      ~execute:(stage_execute ?raw_trace_run ~turn agent)
       ~already_settled:(ToolsExecuted After_tool_results_appended)
   | None ->
     run_new_turn

--- a/lib/pipeline/pipeline_execution_scope.ml
+++ b/lib/pipeline/pipeline_execution_scope.ml
@@ -1,7 +1,11 @@
 open Result_syntax
 
+type turn_authority =
+  | Transient of int
+  | Durable of Execution_agent_scope.turn
+
 type t =
-  { turn : Execution_agent_scope.turn option
+  { turn : turn_authority
   ; mutable provider : Execution_agent_scope.provider_attempt option
   }
 
@@ -9,36 +13,42 @@ let sdk_error error = Error.Internal (Execution_agent_scope.error_to_string erro
 
 let open_turn scope ~ordinal =
   match scope with
-  | None -> Ok { turn = None; provider = None }
+  | None -> Ok { turn = Transient ordinal; provider = None }
   | Some scope ->
     (match Execution_agent_scope.resume_turn scope ~ordinal with
      | Error error -> Error (sdk_error error)
-     | Ok (Some turn) -> Ok { turn = Some turn; provider = None }
+     | Ok (Some turn) -> Ok { turn = Durable turn; provider = None }
      | Ok None ->
        Execution_agent_scope.open_turn scope ~ordinal
-       |> Result.map (fun turn -> { turn = Some turn; provider = None })
+       |> Result.map (fun turn -> { turn = Durable turn; provider = None })
        |> Result.map_error sdk_error)
 ;;
 
-let resume_current scope ~ordinal =
+let resume_current scope =
   match scope with
   | None -> Ok None
   | Some scope ->
-    (match Execution_agent_scope.resume_turn scope ~ordinal with
+    (match Execution_agent_scope.resume_open_turn scope with
      | Error error -> Error (sdk_error error)
      | Ok None -> Ok None
      | Ok (Some turn) ->
        Execution_agent_scope.resume_provider_attempt turn
        |> Result.map (function
          | None -> None
-         | Some provider -> Some { turn = Some turn; provider = Some provider })
+         | Some provider -> Some { turn = Durable turn; provider = Some provider })
        |> Result.map_error sdk_error)
+;;
+
+let turn_ordinal t =
+  match t.turn with
+  | Transient ordinal -> ordinal
+  | Durable turn -> Execution_agent_scope.turn_ordinal turn
 ;;
 
 let before_provider_attempt t binding =
   match t.turn with
-  | None -> Ok ()
-  | Some turn ->
+  | Transient _ -> Ok ()
+  | Durable turn ->
     Execution_agent_scope.open_provider_attempt turn ~ordinal:0 binding
     |> Result.map (fun provider -> t.provider <- Some provider)
     |> Result.map_error sdk_error
@@ -56,14 +66,14 @@ let invocations_settled t =
 
 let close_success t =
   match t.provider, t.turn with
-  | None, None -> Ok ()
-  | Some provider, Some turn ->
+  | None, Transient _ -> Ok ()
+  | Some provider, Durable turn ->
     let* () =
       Execution_agent_scope.close_provider_attempt provider Execution_event.Succeeded
       |> Result.map_error sdk_error
     in
     Execution_agent_scope.close_turn turn Execution_event.Succeeded
     |> Result.map_error sdk_error
-  | None, Some _ | Some _, None ->
+  | None, Durable _ | Some _, Transient _ ->
     Error (sdk_error Execution_agent_scope.Invocation_locator_mismatch)
 ;;

--- a/lib/pipeline/pipeline_execution_scope.mli
+++ b/lib/pipeline/pipeline_execution_scope.mli
@@ -7,11 +7,8 @@ val open_turn
   -> ordinal:int
   -> (t, Error.sdk_error) result
 
-val resume_current
-  :  Execution_agent_scope.t option
-  -> ordinal:int
-  -> (t option, Error.sdk_error) result
-
+val resume_current : Execution_agent_scope.t option -> (t option, Error.sdk_error) result
+val turn_ordinal : t -> int
 val before_provider_attempt : t -> Binding_identity.t -> (unit, Error.sdk_error) result
 val provider : t -> Execution_agent_scope.provider_attempt option
 val invocations_settled : t -> (bool, Error.sdk_error) result

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -15,16 +15,17 @@ let _stage_log = Log.create ~module_name:"pipeline_stage_prepare" ()
    the thin wrapper keeps this module's log label. *)
 let safe_publish bus event = Pipeline_common.safe_publish ~log:_stage_log bus event
 
-let stage_input ?raw_trace_run ?clock agent =
+let stage_input ?raw_trace_run ?clock ~turn agent =
   let ts = Pipeline_common.timestamp_now ?clock () in
   set_lifecycle agent ~ready_at:ts Ready;
   let before_decision =
     invoke_hook_with_trace
       agent
       ?raw_trace_run
+      ~turn
       ~hook_name:"before_turn"
       agent.options.hooks.before_turn
-      (Hooks.BeforeTurn { turn = agent.state.turn_count; messages = agent.state.messages })
+      (Hooks.BeforeTurn { turn; messages = agent.state.messages })
   in
   match before_decision with
   | Hooks.ElicitInput req ->
@@ -56,7 +57,7 @@ let stage_input ?raw_trace_run ?clock agent =
        let input_required =
          Agent_elicitation.input_required_of_request
            ~agent_name:agent.state.config.name
-           ~turn:agent.state.turn_count
+           ~turn
            ~created_at:ts
            req
        in
@@ -159,15 +160,15 @@ let model_input_projection_error detail =
        })
 ;;
 
-let stage_parse ?raw_trace_run ?clock agent =
+let stage_parse ?raw_trace_run ?clock ~turn agent =
   let* turn_params =
     match
       Agent_turn.resolve_turn_params
         ~hooks:agent.options.hooks
         ~messages:agent.state.messages
-        ~turn:agent.state.turn_count
+        ~turn
         ~invoke_hook:(fun ~hook_name hook event ->
-          invoke_hook_with_trace agent ?raw_trace_run ~hook_name hook event)
+          invoke_hook_with_trace agent ?raw_trace_run ~turn ~hook_name hook event)
     with
     | Ok params -> Ok params
     | Error (Agent_turn.Hook_failed { stage; detail }) ->
@@ -238,19 +239,14 @@ let stage_parse ?raw_trace_run ?clock agent =
                 | Some run_id -> run_id
                 | None -> Event_bus.fresh_id ())
              ()
-       ; payload =
-           TurnStarted
-             { agent_name = agent.state.config.name; turn = agent.state.turn_count }
+       ; payload = TurnStarted { agent_name = agent.state.config.name; turn }
        }
    | None -> ());
   (match agent.options.journal with
    | Some j ->
      Agent_execution_event_writer.append
        j
-       (Turn_started
-          { turn = agent.state.turn_count
-          ; timestamp = Pipeline_common.timestamp_now ?clock ()
-          })
+       (Turn_started { turn; timestamp = Pipeline_common.timestamp_now ?clock () })
    | None -> ());
   let* prep =
     prepare_turn_for_agent agent ~turn_params
@@ -282,10 +278,7 @@ let stage_parse ?raw_trace_run ?clock agent =
              ()
        ; payload =
            TurnReady
-             { agent_name = agent.state.config.name
-             ; turn = agent.state.turn_count
-             ; tool_names = ready_tool_names
-             }
+             { agent_name = agent.state.config.name; turn; tool_names = ready_tool_names }
        }
    | None -> ());
   Ok (prep, turn_config, turn_params)

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -316,6 +316,145 @@ let test_pipeline_sends_exact_supplied_tools () =
     (Option.equal (List.equal Yojson.Safe.equal) (Some expected) !captured)
 ;;
 
+let test_provider_turn_identity_is_shared_across_multiturn_tool_loop () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let before_turns = ref [] in
+  let after_turns = ref [] in
+  let pre_tool_turns = ref [] in
+  let handler_turns = ref [] in
+  let hooks =
+    { Hooks.empty with
+      before_turn =
+        Some
+          (function
+            | Hooks.BeforeTurn { turn; _ } ->
+              before_turns := turn :: !before_turns;
+              Hooks.Continue
+            | _ -> Alcotest.fail "expected BeforeTurn")
+    ; after_turn =
+        Some
+          (function
+            | Hooks.AfterTurn { turn; _ } ->
+              after_turns := turn :: !after_turns;
+              Hooks.Continue
+            | _ -> Alcotest.fail "expected AfterTurn")
+    ; pre_tool_use =
+        Some
+          (function
+            | Hooks.PreToolUse { invocation; _ } ->
+              pre_tool_turns := Tool.Invocation.turn invocation :: !pre_tool_turns;
+              Hooks.Continue
+            | _ -> Alcotest.fail "expected PreToolUse")
+    }
+  in
+  let tool =
+    Tool.create_with_execution_env
+      ~name:"identity_tool"
+      ~description:"observe the canonical provider turn"
+      ~parameters:[]
+      (fun execution_env _input ->
+         (match Tool.Execution_env.invocation execution_env with
+          | None -> Alcotest.fail "tool handler received no invocation"
+          | Some invocation ->
+            handler_turns := Tool.Invocation.turn invocation :: !handler_turns);
+         Ok { Types.content = "observed"; _meta = None })
+  in
+  let responses =
+    ref
+      [ { (pipeline_response StopToolUse) with
+          id = "provider-turn-0"
+        ; content =
+            [ ToolUse
+                { id = "provider-tool-0"; name = "identity_tool"; input = `Assoc [] }
+            ]
+        }
+      ; { (pipeline_response EndTurn) with id = "provider-turn-1" }
+      ]
+  in
+  let next_response () =
+    match !responses with
+    | response :: rest ->
+      responses := rest;
+      Ok response
+    | [] ->
+      Error
+        (Llm_provider.Http_client.AcceptRejected
+           { reason = "provider-turn identity fixture exhausted responses" })
+  in
+  let transport : Llm_provider.Llm_transport.t =
+    { complete_sync =
+        (fun _request ->
+          { Llm_provider.Llm_transport.response = next_response (); latency_ms = Some 0 })
+    ; complete_stream = (fun ?on_telemetry:_ ~on_event:_ _request -> next_response ())
+    }
+  in
+  let event_bus = Event_bus.create () in
+  let event_config =
+    Event_bus.subscription_config ~capacity:32 ~overflow:Event_bus.Drop_newest
+    |> Result.get_ok
+  in
+  let subscription = Event_bus.subscribe ~config:event_config event_bus in
+  let agent =
+    Agent.create
+      ~net:(Eio.Stdenv.net env)
+      ~config:
+        { (Types.default_config ~model:"test-model") with
+          name = "provider-turn-identity-test"
+        }
+      ~tools:[ tool ]
+      ~options:
+        { Agent.default_options with
+          transport = Some transport
+        ; provider = Some (Provider_mock.to_provider_config ())
+        ; hooks
+        ; event_bus = Some event_bus
+        }
+      ()
+  in
+  (match Agent.run ~sw agent "run identity_tool" with
+   | Ok response ->
+     Alcotest.(check string) "terminal response" "done" (Types.text_of_response response)
+   | Error error -> Alcotest.fail (Error.to_string error));
+  let turn_started, turn_ready, turn_completed, tool_events =
+    Event_bus.drain subscription
+    |> List.fold_left
+         (fun (started, ready, completed, tools) (event : Event_bus.event) ->
+            match event.payload with
+            | TurnStarted { turn; _ } -> turn :: started, ready, completed, tools
+            | TurnReady { turn; _ } -> started, turn :: ready, completed, tools
+            | TurnCompleted { turn; _ } -> started, ready, turn :: completed, tools
+            | ToolCalled { invocation; _ } | ToolCompleted { invocation; _ } ->
+              started, ready, completed, Tool.Invocation.turn invocation :: tools
+            | AgentStarted _
+            | AgentCompleted _
+            | AgentFailed _
+            | HandoffRequested _
+            | HandoffCompleted _
+            | ElicitationCompleted _
+            | InferenceTelemetry _
+            | Custom _ -> started, ready, completed, tools)
+         ([], [], [], [])
+  in
+  let check_turns label expected actual =
+    Alcotest.(check (list int)) label expected (List.rev actual)
+  in
+  check_turns "BeforeTurn identity" [ 0; 1 ] !before_turns;
+  check_turns "AfterTurn identity" [ 0; 1 ] !after_turns;
+  check_turns "TurnStarted identity" [ 0; 1 ] turn_started;
+  check_turns "TurnReady identity" [ 0; 1 ] turn_ready;
+  check_turns "TurnCompleted identity" [ 0; 1 ] turn_completed;
+  check_turns "PreToolUse identity" [ 0 ] !pre_tool_turns;
+  check_turns "tool handler identity" [ 0 ] !handler_turns;
+  check_turns "public tool event identity" [ 0; 0 ] tool_events;
+  Alcotest.(check int)
+    "state advances after two provider turns"
+    2
+    (Agent.state agent).turn_count
+;;
+
 let unwrap_raw_trace = function
   | Ok value -> value
   | Error error -> Alcotest.fail (Error.to_string error)
@@ -1544,7 +1683,7 @@ let test_agent_run_resumes_tool_without_duplicate_effects ~settled () =
                  (Internal_scope.scope_locator_to_yojson
                     (Internal_scope.scope_locator scope));
             let turn =
-              match Internal_scope.open_turn scope ~ordinal:1 with
+              match Internal_scope.open_turn scope ~ordinal:0 with
               | Ok turn -> turn
               | Error error -> Alcotest.fail (Internal_scope.error_to_string error)
             in
@@ -1553,7 +1692,7 @@ let test_agent_run_resumes_tool_without_duplicate_effects ~settled () =
               | Ok provider -> provider
               | Error error -> Alcotest.fail (Internal_scope.error_to_string error)
             in
-            let invocation = Tool.Invocation.create ~tool_use_id ~turn:1 ~schedule in
+            let invocation = Tool.Invocation.create ~tool_use_id ~turn:0 ~schedule in
             let durable =
               match
                 Internal_scope.open_invocation
@@ -1742,6 +1881,10 @@ let () =
             "provider receives exact supplied tools"
             `Quick
             test_pipeline_sends_exact_supplied_tools
+        ; Alcotest.test_case
+            "provider turn identity spans multiturn tool loop"
+            `Quick
+            test_provider_turn_identity_is_shared_across_multiturn_tool_loop
         ; Alcotest.test_case
             "output rejects unknown terminal"
             `Quick


### PR DESCRIPTION
## Goal

Make one immutable, zero-based provider-turn identity span the complete OAS turn pipeline: BeforeTurn/BeforeTurnParams, provider dispatch, AfterTurn, TurnCompleted/InferenceTelemetry, Tool.Invocation, raw trace, and durable AgentTurn topology.

This closes the failure where `stage_collect` advanced mutable `Agent.state.turn_count` before `stage_output` executed tools, so the same provider response appeared as turn N in hooks and turn N+1 in Tool events.

## Change

- capture the provider turn exactly once at `run_new_turn` entry
- require every stage/hook/tool-trace helper to consume that immutable value
- advance state from the captured value only after the assistant checkpoint is durable
- use the same zero-based value as durable `Agent_turn.ordinal`
- make `Tool.Invocation.turn` explicitly zero-based in the public contract
- replace the recovery-time mutable-state guess with an exact lookup of the single open durable AgentTurn
- represent pipeline ownership as a closed `Transient ordinal | Durable turn` authority, avoiding a second stored ordinal

No MASC type or lifecycle concept enters OAS. There is no model-name matching, string parsing, arithmetic correction in consumers, historical backfill, or compatibility fallback.

## Recovery and performance

- added hot-path work is O(1): one integer capture and explicit parameter passing
- normal tool dispatch performs no new journal lookup or allocation per event
- only crash recovery scans the authoritative run's AgentTurn children once and fails explicitly if more than one is open
- a resumed tool dispatch takes its turn from durable topology, never from post-collection mutable agent state

## Functional proof

- a two-provider-turn Tool loop proves exact `[0; 1]` identity across BeforeTurn, AfterTurn, TurnStarted, TurnReady, and TurnCompleted
- the Tool-producing response proves exact turn `0` across PreToolUse, handler execution environment, ToolCalled, and ToolCompleted
- durable execution and settled/unknown-effect crash-resume tests use the same zero-based AgentTurn/Tool.Invocation identity and still prove no duplicate Tool effect

## Validation

- base: OAS main `c300c0eb248d0fcc749a3be85cf9c269447a9124` (v0.216.6)
- exact head: `fd70aa7b3`
- `scripts/dune-local.sh exec test/test_pipeline.exe`: 44/44 PASS
- `scripts/dune-local.sh build @fmt`: PASS
- `scripts/ci-code-smell-ratchet.sh`: PASS, godfile 11 → 11
- removed eight redundant `tag_error` variant tests already subsumed by the retained generic Ok/Error tests; provider-turn and tool-result behavior tests remain
- `git diff --check origin/main...HEAD`: PASS
- exact-head full CI pending; do-not-merge remains until green

MASC trajectory consumption remains tracked separately in https://github.com/jeong-sik/masc/pull/25184; MASC must not compensate for the old mismatch.

Co-Authored-By: Codex <agent@masc.local>
