### PR TITLE
fix(gemini): fail typed on unresolvable ToolResult name instead of guessing UUID (#2535)

### DIFF
--- a/lib/llm_provider/backend_gemini.ml
+++ b/lib/llm_provider/backend_gemini.ml
@@ -442,15 +442,27 @@ let part_of_content_block id_to_name tool_signatures = function
       match Hashtbl.find_opt id_to_name tool_use_id with
       | Some n -> n
       | None ->
-        Diag.warn
-          "backend_gemini"
-          "ToolResult tool_use_id '%s' has no matching ToolUse in %d-entry lookup table; \
-           using UUID as functionResponse name (Gemini API requires name). This usually \
-           means the ToolUse block was in a conversation turn that was compacted or \
-           trimmed."
-          tool_use_id
-          (Hashtbl.length id_to_name);
-        tool_use_id
+        (* oas#2535: fail closed instead of fabricating a functionResponse name.
+           Gemini requires the real function name; [id_to_name] is the typed
+           retained provenance carrying that name for every ToolUse/ToolResult
+           pair still present in history. A miss means the originating ToolUse
+           was compacted or trimmed away, so no valid name can be recovered.
+           Emitting the raw [tool_use_id] (a UUID) violates Gemini's name
+           grammar and is rejected opaquely downstream. Do NOT infer the name
+           from ID shape or arguments; raise a typed provider-lowering error
+           here, during request building (before HTTP dispatch), consistent with
+           the module's other fail-closed invariants (blank thoughtSignature,
+           malformed inlineData). The message carries the tool_use_id and the
+           lookup-table size for diagnosis. *)
+        raise
+          (Gemini_api_error
+             (Printf.sprintf
+                "Gemini ToolResult tool_use_id %S has no matching ToolUse in the \
+                 %d-entry function-name lookup table; the originating ToolUse was \
+                 compacted or trimmed away, so its function name cannot be recovered. \
+                 Refusing to send the UUID as functionResponse.name."
+                tool_use_id
+                (Hashtbl.length id_to_name)))
     in
     Some
       (`Assoc

--- a/test/test_backend_gemini.ml
+++ b/test/test_backend_gemini.ml
@@ -364,6 +364,182 @@ let test_dangling_tool_use_is_not_synthetically_closed () =
     (List.hd followup_parts |> member "text" |> to_string)
 ;;
 
+(* oas#2535: a ToolResult whose originating ToolUse is absent from history
+   (the ToolUse turn was compacted or trimmed away) must fail closed with a
+   typed provider-lowering error BEFORE HTTP dispatch, rather than fabricating
+   the functionResponse name from the raw tool_use_id (a UUID). This guards the
+   permissive-default regression: pre-fix, build_request silently emitted
+   name = tool_use_id and returned a body. *)
+let test_tool_result_missing_origin_fails_closed () =
+  let config = gemini_config () in
+  let missing_id = "call_orphaned_999" in
+  let messages =
+    [ Types.user_msg "What's the weather?"
+    ; { role = User
+      ; content =
+          [ ToolResult
+              { tool_use_id = missing_id
+              ; content = "Sunny, 25C"
+              ; outcome = Tool_succeeded
+              ; json = None
+              ; content_blocks = None
+              }
+          ]
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = []
+      }
+    ]
+  in
+  match Backend_gemini.build_request ~config ~messages () with
+  | exception Backend_gemini.Gemini_api_error msg ->
+    let contains needle =
+      let nl = String.length needle
+      and hl = String.length msg in
+      let rec go i = i + nl <= hl && (String.sub msg i nl = needle || go (i + 1)) in
+      nl = 0 || go 0
+    in
+    check bool "error names the unresolvable tool_use_id" true (contains missing_id);
+    check
+      bool
+      "error states it refuses the UUID name"
+      true
+      (contains "functionResponse.name")
+  | body ->
+    fail
+      (Printf.sprintf
+         "expected Gemini_api_error for a compacted ToolUse origin, but build_request \
+          succeeded and produced a body: %s"
+         body)
+;;
+
+(* oas#2535: two distinct ToolUse/ToolResult pairs must each resolve to their
+   own retained function name via the id_to_name provenance table. The happy
+   path stays exactly as before the fix. *)
+let test_tool_result_parallel_calls_resolve () =
+  let config = gemini_config () in
+  let messages =
+    [ Types.user_msg "Weather and time?"
+    ; { role = Assistant
+      ; content =
+          [ ToolUse
+              { id = "call_weather"
+              ; name = "get_weather"
+              ; input = `Assoc [ "city", `String "Seoul" ]
+              }
+          ; ToolUse
+              { id = "call_time"
+              ; name = "get_time"
+              ; input = `Assoc [ "tz", `String "KST" ]
+              }
+          ]
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = []
+      }
+    ; { role = User
+      ; content =
+          [ ToolResult
+              { tool_use_id = "call_weather"
+              ; content = "Sunny, 25C"
+              ; outcome = Tool_succeeded
+              ; json = None
+              ; content_blocks = None
+              }
+          ; ToolResult
+              { tool_use_id = "call_time"
+              ; content = "14:09 KST"
+              ; outcome = Tool_succeeded
+              ; json = None
+              ; content_blocks = None
+              }
+          ]
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = []
+      }
+    ]
+  in
+  let body = Backend_gemini.build_request ~config ~messages () in
+  let json = parse_body body in
+  let contents = json |> member "contents" |> to_list in
+  let result_parts = List.nth contents 2 |> member "parts" |> to_list in
+  let name_of part = part |> member "functionResponse" |> member "name" |> to_string in
+  let id_of part = part |> member "functionResponse" |> member "id" |> to_string in
+  check int "two functionResponse parts" 2 (List.length result_parts);
+  let names = List.map (fun p -> id_of p, name_of p) result_parts in
+  check
+    (option string)
+    "weather pair resolves"
+    (Some "get_weather")
+    (List.assoc_opt "call_weather" names);
+  check
+    (option string)
+    "time pair resolves"
+    (Some "get_time")
+    (List.assoc_opt "call_time" names)
+;;
+
+(* oas#2535: both a provider-native-style id and an OAS-allocated UUID-style id
+   resolve to their retained function name when the ToolUse pair is present.
+   The name always comes from typed provenance, never from the id shape. *)
+let test_tool_result_native_and_allocated_ids_resolve () =
+  let config = gemini_config () in
+  let native_id = "get_weather-0" in
+  let allocated_id = "a1b2c3d4-e5f6-7890-abcd-ef0123456789" in
+  let messages =
+    [ Types.user_msg "Weather twice?"
+    ; { role = Assistant
+      ; content =
+          [ ToolUse { id = native_id; name = "get_weather"; input = `Null }
+          ; ToolUse { id = allocated_id; name = "get_forecast"; input = `Null }
+          ]
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = []
+      }
+    ; { role = User
+      ; content =
+          [ ToolResult
+              { tool_use_id = native_id
+              ; content = "Sunny"
+              ; outcome = Tool_succeeded
+              ; json = None
+              ; content_blocks = None
+              }
+          ; ToolResult
+              { tool_use_id = allocated_id
+              ; content = "Rain tomorrow"
+              ; outcome = Tool_succeeded
+              ; json = None
+              ; content_blocks = None
+              }
+          ]
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = []
+      }
+    ]
+  in
+  let body = Backend_gemini.build_request ~config ~messages () in
+  let json = parse_body body in
+  let contents = json |> member "contents" |> to_list in
+  let result_parts = List.nth contents 2 |> member "parts" |> to_list in
+  let name_of part = part |> member "functionResponse" |> member "name" |> to_string in
+  let id_of part = part |> member "functionResponse" |> member "id" |> to_string in
+  let names = List.map (fun p -> id_of p, name_of p) result_parts in
+  check
+    (option string)
+    "native id resolves"
+    (Some "get_weather")
+    (List.assoc_opt native_id names);
+  check
+    (option string)
+    "allocated id resolves"
+    (Some "get_forecast")
+    (List.assoc_opt allocated_id names)
+;;
+
 let test_json_mode () =
   let config = gemini_config ~json_mode:true () in
   let messages = [ Types.user_msg "Return JSON." ] in
@@ -1678,6 +1854,18 @@ let () =
             `Quick
             test_disable_parallel_tool_use_dropped
         ; test_case "tool result" `Quick test_tool_result
+        ; test_case
+            "tool result missing origin fails closed"
+            `Quick
+            test_tool_result_missing_origin_fails_closed
+        ; test_case
+            "tool result parallel calls resolve"
+            `Quick
+            test_tool_result_parallel_calls_resolve
+        ; test_case
+            "tool result native and allocated ids resolve"
+            `Quick
+            test_tool_result_native_and_allocated_ids_resolve
         ; test_case
             "dangling tool use is not synthetically closed"
             `Quick


### PR DESCRIPTION
## Symptom

`backend_gemini.ml`'s `part_of_content_block` `ToolResult` arm resolved the Gemini
`functionResponse.name` from a `id_to_name` lookup table. When the lookup returned
`None`, it emitted a `Diag.warn` and then used the **raw `tool_use_id` (a UUID)** as
the function name. Gemini REQUIRES a real function name; a UUID violates the name
grammar and is rejected opaquely downstream (the request is dispatched and fails at
the provider, not before).

## Anti-pattern closed

**Permissive default** (manifest anti-pattern jeong-sik/oas#2: unknown provenance → fabricated
value instead of explicit failure). Unknown input was silently mapped to a
convenient-but-invalid default rather than an explicit typed failure.

## Decided invariant (issue jeong-sik/masc#27901, "Required invariant")

> Gemini lowering must receive the exact function name from typed retained
> provenance. If it cannot supply the name (the originating ToolUse was
> compacted/trimmed away, so the table misses), **FAIL with a typed
> provider-lowering error BEFORE HTTP dispatch. Do NOT infer the name from ID
> shape, arguments, or a default.**

The issue explicitly ruled out sending the ID as name, heuristic recovery, and
silent drop.

## Why no `ToolResult` type change is needed

The `id_to_name` table IS the typed retained provenance: it is built from every
`ToolUse` block still present in history and supplies the real name for every
retained `ToolUse`/`ToolResult` pair. Therefore a miss can only mean the
originating `ToolUse` was compacted/trimmed away — there is no valid name to
supply. Failing typed on a miss fully satisfies the invariant without widening
`ToolResult`. The `Some n` (retained pair) path is unchanged.

## Error mechanism chosen

Reused the module's existing typed fail-closed exception `Gemini_api_error`
(already exposed in `backend_gemini.mli`, documented as the module's "fail closed"
error) with a `Printf.sprintf` message carrying the `tool_use_id` and the
lookup-table size for diagnosis.

Rationale — this is the least-invasive, most-consistent choice:
- Every other build-time invariant in this module (blank `thoughtSignature`,
  malformed `inlineData`, broken signature-carrier adjacency) fails closed via
  `Gemini_api_error` with a `Printf.sprintf` message. The new failure now behaves
  identically to its siblings.
- The raise happens inside `build_request` → `contents_of_messages` →
  `part_of_content_block`, i.e. during request building, **before HTTP dispatch** —
  the invariant's "before dispatch" is satisfied automatically.
- No `.mli` change required (`Gemini_api_error` is already public); no new
  exception type fragmenting the module's single error convention.

A dedicated `exception Gemini_lowering_error of { tool_use_id; table_size }` was
considered but rejected: it would split the module's uniform error convention and,
because the build path only catches `Invalid_argument` (in `complete_common.serialize_http_request`),
would propagate identically to `Gemini_api_error` anyway — so it buys no cleaner
propagation while costing consistency.

## Files changed

- `lib/llm_provider/backend_gemini.ml` — `None` branch of the `ToolResult` arm:
  `Diag.warn` + fallback-to-UUID replaced with `raise (Gemini_api_error ...)`.
- `test/test_backend_gemini.ml` — three new build_request cases (below).
- `.mli` unchanged (no new public surface).

## Tests

- **tool result missing origin fails closed** — a `ToolResult` whose `ToolUse` is
  absent (compaction) now raises `Gemini_api_error`; the assertion checks the raise
  and that the message names the `tool_use_id`. This case FAILS if the fix is
  reverted (pre-fix it silently produced `name = tool_use_id` and returned a body).
- **tool result parallel calls resolve** — two distinct `ToolUse`/`ToolResult`
  pairs → both names resolve to their correct retained tool names.
- **tool result native and allocated ids resolve** — a provider-native-style id
  and an OAS-allocated UUID-style id both resolve from typed provenance when
  retained (name never inferred from id shape).
- The existing **tool result** test continues to guard the single retained
  happy path.

## Build

`scripts/dune-local.sh build lib/llm_provider` blocked on the shared
`/tmp/me-dune-local.lock` (parallel agents hold it) and was killed at the timeout
per anti-zombie policy — **build-unverified (lock contention)**. `ocamlformat
0.29.0` (== CI) formatted and `--check`-passed both files (confirms they parse);
type-correctness reviewed manually against existing passing tests in the same
suite (identical record fields, constructors, and Alcotest combinators). CI
verifies the compile.

Closes jeong-sik/masc#27901

RFC-WAIVED: lib/llm_provider + test only — not an RFC-gated subsystem
