### PR TITLE
fix(api): reject unencoded explicit thinking on the legacy openai body path too (#2716)

### DIFF
--- a/lib/api_openai.ml
+++ b/lib/api_openai.ml
@@ -165,6 +165,21 @@ let validate_tool_choice_request_for_resolved_config =
   PConfig.validate_tool_choice_request
 ;;
 
+(* Restore #2716's reject-before-transport invariant on the legacy public wire
+   path. [build_openai_body_unchecked] binds the request-control artifact and
+   emits [artifact.fields] but never inspects [artifact.explicit_enable_receipt],
+   so an unencoded explicit-thinking request (receipt [Explicit_enable_not_encoded]
+   on a No_thinking_control model) is silently dropped and still sent. The Complete
+   path rejects the identical config via
+   [Complete_common.validate_thinking_control_request]; reuse the same typed
+   decision here (its [string option] reason form, matching this path's string
+   rejection) so the two wire-assembly sites reject the same config identically. *)
+let validate_thinking_control_request_for_resolved_config (config : PConfig.t) =
+  match Llm_provider.Complete_common.thinking_control_request_rejection_reason config with
+  | None -> Ok ()
+  | Some reason -> Error reason
+;;
+
 let add_sampling_field dialect ~enable_thinking parameter value body_assoc =
   let field = Llm_provider.Capabilities.sampling_parameter_to_string parameter in
   if
@@ -422,16 +437,21 @@ let build_openai_body_result ?provider_config ~config ~messages ?tools ?slot_id 
     (match validate_tool_choice_request_for_resolved_config serialization_config with
      | Error reason -> Error reason
      | Ok () ->
-       (try
-          Ok
-            (build_openai_body_unchecked
-               ~serialization_config
-               ~messages
-               ?tools
-               ?slot_id
-               ())
+       (match
+          validate_thinking_control_request_for_resolved_config serialization_config
         with
-        | Invalid_argument reason -> Error reason))
+        | Error reason -> Error reason
+        | Ok () ->
+          (try
+             Ok
+               (build_openai_body_unchecked
+                  ~serialization_config
+                  ~messages
+                  ?tools
+                  ?slot_id
+                  ())
+           with
+           | Invalid_argument reason -> Error reason)))
 ;;
 
 let build_openai_body_result_for_resolved_config
@@ -444,16 +464,19 @@ let build_openai_body_result_for_resolved_config
   match validate_tool_choice_request_for_resolved_config resolved_config with
   | Error reason -> Error reason
   | Ok () ->
-    (try
-       Ok
-         (build_openai_body_unchecked
-            ~serialization_config:resolved_config
-            ~messages
-            ?tools
-            ?slot_id
-            ())
-     with
-     | Invalid_argument reason -> Error reason)
+    (match validate_thinking_control_request_for_resolved_config resolved_config with
+     | Error reason -> Error reason
+     | Ok () ->
+       (try
+          Ok
+            (build_openai_body_unchecked
+               ~serialization_config:resolved_config
+               ~messages
+               ?tools
+               ?slot_id
+               ())
+        with
+        | Invalid_argument reason -> Error reason))
 ;;
 
 let build_openai_body ?provider_config ~config ~messages ?tools ?slot_id () =

--- a/lib/llm_provider/complete_common.ml
+++ b/lib/llm_provider/complete_common.ml
@@ -500,50 +500,54 @@ let thinking_control_request_rejection
     if disable_not_encodable then Some Disable_not_encodable else None
 ;;
 
-let validate_thinking_control_request (config : Provider_config.t) =
+(* Operator-facing rejection reason for an unsatisfiable thinking-control
+   request, or [None] when the request is admissible. Single source of truth for
+   both the Complete path ([validate_thinking_control_request], which wraps the
+   reason in a typed [Http_client.AcceptRejected]) and the public
+   OpenAI-compatible body builder ([Api_openai.build_openai_body_result*], which
+   wraps it in that path's string rejection). Sharing one function keeps the two
+   wire-assembly sites rejecting the identical config with the identical message
+   instead of one honoring the [explicit_enable_receipt] and the other silently
+   dropping it. *)
+let thinking_control_request_rejection_reason (config : Provider_config.t) =
   let caps, _source = resolve_capabilities_for_config config in
   match thinking_control_request_rejection ~caps config with
-  | None -> Ok ()
+  | None -> None
   | Some Enable_not_declared ->
-    Error
-      (Http_client.AcceptRejected
-         { reason =
-             Printf.sprintf
-               "model %S has no typed capability contract that can satisfy \
-                enable_thinking=true: thinking_control_format=No_thinking_control and \
-                supports_reasoning=false. Declare the model's exact \
-                thinking_control_format, or declare supports_reasoning=true only for a \
-                model whose inherent/default-on reasoning contract is verified."
-               config.model_id
-         })
+    Some
+      (Printf.sprintf
+         "model %S has no typed capability contract that can satisfy \
+          enable_thinking=true: thinking_control_format=No_thinking_control and \
+          supports_reasoning=false. Declare the model's exact thinking_control_format, \
+          or declare supports_reasoning=true only for a model whose inherent/default-on \
+          reasoning contract is verified."
+         config.model_id)
   | Some Enable_not_encodable ->
-    Error
-      (Http_client.AcceptRejected
-         { reason =
-             Printf.sprintf
-               "model %S declares thinking control, but the resolved typed dialect \
-                cannot encode enable_thinking=true on this OpenAI-compatible request \
-                path. Use the dialect's explicit control value (for example \
-                reasoning_effort), or declare the exact wire dialect for this endpoint."
-               config.model_id
-         })
+    Some
+      (Printf.sprintf
+         "model %S declares thinking control, but the resolved typed dialect cannot \
+          encode enable_thinking=true on this OpenAI-compatible request path. Use the \
+          dialect's explicit control value (for example reasoning_effort), or declare \
+          the exact wire dialect for this endpoint."
+         config.model_id)
   | Some (Request_control_invalid rejection) ->
-    Error
-      (Http_client.AcceptRejected
-         { reason = Reasoning_dialect.request_control_rejection_to_message rejection })
+    Some (Reasoning_dialect.request_control_rejection_to_message rejection)
   | Some Disable_not_encodable ->
-    Error
-      (Http_client.AcceptRejected
-         { reason =
-             Printf.sprintf
-               "model %S is reasoning-capable but its capability record declares \
-                thinking_control_format=No_thinking_control: enable_thinking=false \
-                cannot be encoded and would be silently dropped, letting the model think \
-                freely and corrupt JSON-mode output. Declare a thinking_control_format \
-                for this model in Capabilities.for_model_id (models.toml), or route to a \
-                model that supports disabling thinking."
-               config.model_id
-         })
+    Some
+      (Printf.sprintf
+         "model %S is reasoning-capable but its capability record declares \
+          thinking_control_format=No_thinking_control: enable_thinking=false cannot be \
+          encoded and would be silently dropped, letting the model think freely and \
+          corrupt JSON-mode output. Declare a thinking_control_format for this model in \
+          Capabilities.for_model_id (models.toml), or route to a model that supports \
+          disabling thinking."
+         config.model_id)
+;;
+
+let validate_thinking_control_request (config : Provider_config.t) =
+  match thinking_control_request_rejection_reason config with
+  | None -> Ok ()
+  | Some reason -> Error (Http_client.AcceptRejected { reason })
 ;;
 
 (* An admission bound of zero or less would mean "no request may ever

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -1203,6 +1203,59 @@ let test_build_openai_body_rejects_glm_forced_tool_choice () =
   | Ok _ -> fail "expected Result.Error for unsupported GLM named tool_choice"
 ;;
 
+(* #2716 completion (N-of-M validation parity). The LIVE Complete path rejects an
+   unencoded explicit-thinking request before transport, but the legacy public
+   wire path ([Api.create_message_detailed] / streaming ->
+   [build_openai_body_result_for_resolved_config]) ran only tool_choice
+   validation and silently assembled a body with the thinking directive dropped.
+   A raw OpenAI-compatible model whose capability record is [No_thinking_control]
+   + [supports_reasoning=false], with [enable_thinking=Some true], produces an
+   [Explicit_enable_not_encoded] receipt that the Complete path rejects. This
+   asserts the legacy builder now rejects the identical config with the identical
+   shared reason. Reverting the
+   [validate_thinking_control_request_for_resolved_config] call in
+   [Api_openai.build_openai_body_result_for_resolved_config] makes the builder
+   return [Ok] (silent assembly), failing this test. *)
+let test_legacy_openai_body_rejects_unencoded_explicit_thinking () =
+  let caps = Llm_provider.Capabilities.openai_compat_chat_capabilities in
+  let resolved_config =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.OpenAI_compat
+      ~model_id:"unknown-openai-compat-reasoner"
+      ~base_url:"http://127.0.0.1:8085"
+      ~request_path:"/v1/chat/completions"
+      ~max_tokens:1024
+      ~enable_thinking:true
+      ~model_capabilities_override:caps
+      ()
+  in
+  (* Parity anchor: the Complete path's shared decision classifies this config as
+     a rejection with a stable reason. *)
+  let complete_reason =
+    Llm_provider.Complete_common.thinking_control_request_rejection_reason resolved_config
+  in
+  check bool "Complete path rejects this config" true (Option.is_some complete_reason);
+  match
+    Api.build_openai_body_result_for_resolved_config ~resolved_config ~messages:[] ()
+  with
+  | Ok _ ->
+    fail
+      "legacy OpenAI body builder must reject enable_thinking=true on a \
+       No_thinking_control + supports_reasoning=false model instead of silently \
+       assembling a body without the thinking directive"
+  | Error reason ->
+    check
+      bool
+      "rejection mentions the explicit enable_thinking request"
+      true
+      (contains_substring ~sub:"enable_thinking=true" reason);
+    check
+      bool
+      "legacy reason matches the Complete path's shared reason"
+      true
+      (Some reason = complete_reason)
+;;
+
 (* Complement of [test_build_openai_body_glm_preserves_reasoning_content]: the
    same Preserved-Thinking configuration WITHOUT a declared Z.AI endpoint gets
    no GLM dialect behavior. Before the typed-dialect reshape, the prefix-only
@@ -1228,8 +1281,16 @@ let test_build_openai_body_bare_glm_gets_no_glm_dialect () =
   let state =
     { Types.config =
         { (Types.default_config ~model:"test-model") with
-          model = "glm-5"
-        ; enable_thinking = Some true
+          model =
+            "glm-5"
+            (* enable_thinking=Some true on this bare glm-5 (generic
+             OpenAI-compat: No_thinking_control, supports_reasoning=false) is now
+             rejected before assembly by #2716's restored invariant, covered by
+             [test_legacy_openai_body_rejects_unencoded_explicit_thinking]. This
+             suite asserts GLM-dialect selection, which is identical for any
+             admissible enable_thinking on a non-reasoning model (the
+             thinking-control block is skipped when supports_reasoning=false). *)
+        ; enable_thinking = Some false
         ; preserve_thinking = Some true
         }
     ; messages = []
@@ -1456,8 +1517,15 @@ let test_build_openai_body_openai_compat_glm_uses_openai_wire_dialect () =
   let state =
     { Types.config =
         { (Types.default_config ~model:"test-model") with
-          model = provider_config.model_id
-        ; enable_thinking = Some true
+          model =
+            provider_config.model_id
+            (* enable_thinking=Some true on a generic OpenAI-compat glm-5
+             (No_thinking_control, supports_reasoning=false) is now rejected by
+             #2716's restored invariant, covered by
+             [test_legacy_openai_body_rejects_unencoded_explicit_thinking]. The
+             openai-wire-dialect assertions below are unchanged for any admissible
+             enable_thinking on a non-reasoning model. *)
+        ; enable_thinking = Some false
         ; tool_choice = Some Types.Auto
         }
     ; messages = []
@@ -2564,6 +2632,10 @@ let () =
             "glm rejects unsupported forced tool choice"
             `Quick
             test_build_openai_body_rejects_glm_forced_tool_choice
+        ; test_case
+            "legacy openai body rejects unencoded explicit thinking (#2716)"
+            `Quick
+            test_legacy_openai_body_rejects_unencoded_explicit_thinking
         ; test_case
             "bare glm gets no glm dialect"
             `Quick


### PR DESCRIPTION
## Symptom
`#2716` made the LIVE `Complete.complete` / `complete_stream` pipeline reject an unencoded explicit-thinking request before transport. The legacy public wire-assembly path stayed permissive: a config with `enable_thinking = Some true` on an OpenAI-compatible model that resolves to `No_thinking_control` + `supports_reasoning=false` was silently assembled with the thinking directive dropped and **SENT**.

That path is public: `Api.create_message_detailed` (`lib/api.ml`) and `Streaming` (`lib/streaming.ml`) assemble via `Api_openai.build_openai_body_result_for_resolved_config`; `Api.build_openai_body` / `build_openai_body_result` are exported without `[@@deprecated]`. The Complete path rejects the identical config with `AcceptRejected` (`Enable_not_declared`); the legacy path did not — `#2716`'s invariant ("can no longer pass the OpenAI-compatible completion boundary and then disappear from the selected wire") did not hold here.

## Root cause
`build_openai_body_unchecked` (`lib/api_openai.ml`) binds the request-control artifact and emits `artifact.fields` but never inspects `artifact.explicit_enable_receipt`; it raises only on the `Error` (budget/effort) case. The checked builders `build_openai_body_result` / `build_openai_body_result_for_resolved_config` ran only `validate_tool_choice_request_for_resolved_config` — never `validate_thinking_control_request`. So an `Explicit_enable_not_encoded` receipt slipped through as `Ok`.

## Fix (bounded — honor the existing typed decision, no new mechanism)
Reuse the Complete path's validator on both legacy checked builders:
- Extracted `Complete_common.thinking_control_request_rejection_reason : Provider_config.t -> string option` as the single source of truth (the operator-facing reason + decision). `validate_thinking_control_request` now delegates to it — behavior unchanged, byte-identical messages, Complete path untouched.
- `build_openai_body_result` and `build_openai_body_result_for_resolved_config` now call it via `validate_thinking_control_request_for_resolved_config`, mapping `Some reason -> Error reason` to match this path's string-rejection type. `create_message_detailed` / `Streaming` therefore reject the failing config **before HTTP dispatch**, matching Complete.

This completes `#2716`'s invariant across all OpenAI wire-assembly sites — N-of-M closed.

### Why not a new mechanism
The typed receipt (`explicit_enable_receipt`) and the decision (`thinking_control_request_rejection`) already exist; the legacy consumer just wasn't calling them. Inspecting the raw receipt directly would over-reject (`No_thinking_control` + `supports_reasoning=true` yields `Explicit_enable_not_encoded` but is admissible — the model thinks by default), so the fix routes through the full decision. No parallel classifier, no substring match, no catch-all (`ci-code-smell-ratchet.sh --check` PASSES, `catch_all` held at 358).

## Test (revert-red)
`test_legacy_openai_body_rejects_unencoded_explicit_thinking` (`test/test_api.ml`) drives the legacy public `build_openai_body_result_for_resolved_config` with the failing config (raw OpenAI-compat, `enable_thinking=Some true`, `No_thinking_control` + `supports_reasoning=false` via `model_capabilities_override`) and asserts it is rejected with the same shared reason the Complete path uses.
- **Revert-red verified**: neutralizing the `_for_resolved_config` check makes the builder return `Ok` (silent assembly) and the test fails with the expected assertion.
- Two collateral GLM dialect-selection tests used `enable_thinking=Some true` on a bare/generic openai-compat `glm-5` (now rejected by the restored invariant, same class); switched to an admissible `enable_thinking=Some false` — a no-op on a non-reasoning model, so their dialect-selection assertions are unchanged. Rejection coverage now lives in the new test.

## Build status
- `dune build @check` — GREEN (worktree root).
- `test_api` (91), `test_provider_complete` (59), `test_llm_provider_cov` (140), `test_thinking_control_dialects` (43), `test_custom_provider` (15), `test_api_dispatch` (14) — all GREEN.
- `ocamlformat 0.29.0 --inplace` (== CI), idempotent.
- Code-smell ratchet — PASSED.

Refs #2716

RFC-WAIVED: lib/api + lib/api_openai + test only — bounded validation-parity fix, not an RFC-gated subsystem
