### PR TITLE
fix(A-OAS): reasoning_replay_dropped를 Warn→Info (성공한 projection을 실패로 과다로깅)

### DIFF
--- a/lib/llm_provider/reasoning_history_projection.ml
+++ b/lib/llm_provider/reasoning_history_projection.ml
@@ -358,9 +358,16 @@ let observe ~component projection =
              ; "reasoning_on_non_assistant", `Int non_assistant
              ])
      in
-     if missing_source > 0 || incompatible_source > 0
-     then Diag.warn component "%s" payload
-     else Diag.info component "%s" payload);
+     (* All drop reasons here are outcomes of a *successful* projection: the
+        error path raises [invalid_arg] and never reaches this observe hook, so a
+        drop summary always accompanies an [Ok projection] the caller proceeds
+        with. Stripping untagged (missing_source) or cross-target (incompatible_
+        source) prior-turn reasoning is the normal, expected behaviour for
+        OpenAI-compat/Ollama backends where reasoning arrives as an untagged
+        side-channel — an expected lifecycle event (Info), not a failure (Warn).
+        The previous Warn split fired ~973x/day narrating routine replay
+        normalisation. Per-reason counts remain in [payload] for diagnostics. *)
+     Diag.info component "%s" payload);
   match projection.removed_empty_assistant_indices with
   | [] -> ()
   | indices ->


### PR DESCRIPTION
## 무엇을 / 왜

`reasoning_replay_dropped` observe hook은 **`Ok projection` 경로에서만** 도달합니다(error 분기는 `invalid_arg` raise). 즉 drop 요약은 항상 caller가 그대로 진행하는 **성공한 projection**을 서술합니다. 태그 없는(missing_source) 또는 cross-target(incompatible_source) 이전-턴 reasoning을 버리는 건 OpenAI-compat/Ollama 백엔드의 **정상·기대 동작**입니다(reasoning이 태그 없는 side-channel로 와서 faithful replay 불가).

기존 `if missing_source>0 || incompatible_source>0 then Diag.warn` split은 이 정상 정규화를 **하루 ~973회 Warn**으로 찍어(다운스트림 fleet 실측) 비실패 경고 신호를 부풀렸습니다.

이는 masc fleet의 4-concern 로그 감사에서 나온 항목입니다(사용자: *"이 로그들 이상한 논리에서 만들어진 건 아닌지 의심"* — 확정).

## 수정

`Diag.info`로 무조건 강등 — expected lifecycle 이벤트. per-reason 카운트는 payload에 그대로 남겨 진단 유지. severity 외 동작 변화 없음.

## 검증
`dune build` green. severity를 assert하는 테스트 없음(log-level 변경은 기능 단위 표면 없음).

## 후속 (masc)
이 PR merge + release 후 masc가 OAS pin(`scripts/oas-agent-sdk-pin.sh`)을 bump하면 fleet 로그에서 ~973/일 false WARN이 사라집니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
