### PR TITLE
fix(streaming): bound first-event wait with a separate TTFT budget, not the inter-token idle timeout (#2722)

### DIFF
--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -44,6 +44,7 @@ type options = Agent_types.options =
   { base_url : string
   ; provider : Provider.config option
   ; stream_idle_timeout_s : float option
+  ; first_event_timeout_s : float option
   ; body_timeout_s : float option
   ; hooks : Hooks.hooks
   ; guardrails_async : Guardrails_async.t

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -41,9 +41,10 @@ type options =
     (** RFC-OAS-037: separate bound for the time-to-first-event (TTFT /
         prefill) wait, distinct from [stream_idle_timeout_s] which bounds
         inter-token idle only AFTER the first event. When [None] the
-        first-event wait is not bounded by the short idle value (the
-        streaming path carries no total body budget), and a slow silent
-        prefill is guarded by inter-token idle once the stream produces. *)
+        first-event wait is not bounded by the short idle value; when unset it
+        falls back to [body_timeout_s], then to [stream_idle_timeout_s], and a
+        slow silent prefill is guarded by inter-token idle once the stream
+        produces. *)
   ; body_timeout_s : float option
   ; hooks : Hooks.hooks
   ; guardrails_async : Guardrails_async.t

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -37,6 +37,13 @@ type options =
   { base_url : string
   ; provider : Provider.config option
   ; stream_idle_timeout_s : float option
+  ; first_event_timeout_s : float option
+    (** RFC-OAS-037: separate bound for the time-to-first-event (TTFT /
+        prefill) wait, distinct from [stream_idle_timeout_s] which bounds
+        inter-token idle only AFTER the first event. When [None] the
+        first-event wait is not bounded by the short idle value (the
+        streaming path carries no total body budget), and a slow silent
+        prefill is guarded by inter-token idle once the stream produces. *)
   ; body_timeout_s : float option
   ; hooks : Hooks.hooks
   ; guardrails_async : Guardrails_async.t
@@ -109,6 +116,7 @@ let default_options =
   { base_url = Api.default_base_url
   ; provider = None
   ; stream_idle_timeout_s = None
+  ; first_event_timeout_s = None
   ; body_timeout_s = None
   ; hooks = Hooks.empty
   ; guardrails_async = Guardrails_async.empty

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -55,6 +55,18 @@ type options =
         progress. CLI transports honour the parallel
         [stdout_idle_timeout_s] knob via the transport's own config.
         @since 0.176.0 *)
+  ; first_event_timeout_s : float option
+    (** RFC-OAS-037: dedicated bound for the time-to-first-event
+        (TTFT / prefill) wait, distinct from [stream_idle_timeout_s].
+        While the stream is still awaiting its first event this bounds
+        the wait; [stream_idle_timeout_s] arms only AFTER the first event
+        (inter-token idle). A silent prefill on a large context is a
+        slow-but-alive stream, not a hang, so it must not be cut by the
+        short inter-token idle value. When [None] the first-event wait is
+        left unbounded (the streaming path carries no total body budget to
+        fall back to); inter-token idle still guards once the stream
+        produces, and [connect_timeout_s] still guards connection setup.
+        @since 0.218.0 *)
   ; body_timeout_s : float option
     (** Per-call total deadline applied to non-streaming HTTP response body
         consumption. Threaded through {!Pipeline.stage_route} into both the

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -62,11 +62,11 @@ type options =
         the wait; [stream_idle_timeout_s] arms only AFTER the first event
         (inter-token idle). A silent prefill on a large context is a
         slow-but-alive stream, not a hang, so it must not be cut by the
-        short inter-token idle value. When [None] the first-event wait is
-        left unbounded (the streaming path carries no total body budget to
-        fall back to); inter-token idle still guards once the stream
-        produces, and [connect_timeout_s] still guards connection setup.
-        @since 0.218.0 *)
+        short inter-token idle value. When [None] the first-event wait falls
+        back to [body_timeout_s], then to [stream_idle_timeout_s], and stays
+        unarmed only when none of the three is set; inter-token idle still
+        guards once the stream produces, and [connect_timeout_s] still guards
+        connection setup. @since 0.218.0 *)
   ; body_timeout_s : float option
     (** Per-call total deadline applied to non-streaming HTTP response body
         consumption. Threaded through {!Pipeline.stage_route} into both the

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -76,9 +76,11 @@ type options =
         Requires [clock] to be supplied; without a clock the wrapper is
         skipped. A timeout surfaces as
         [TimeoutError] and is returned unchanged after that provider attempt.
-        The streaming completion itself deliberately ignores this field and
-        uses [stream_idle_timeout_s] for inter-line liveness; only its optional
-        non-streaming count preflight uses this deadline.
+        On the streaming path this field is the fallback bound for the
+        first-event (TTFT/prefill) wait when [first_event_timeout_s] is
+        [None] — inter-token liveness after the first event is still governed
+        by [stream_idle_timeout_s], and only the optional non-streaming count
+        preflight uses this deadline directly.
         @since 0.181.0 *)
   ; hooks : Hooks.hooks
   ; guardrails_async : Guardrails_async.t

--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -33,6 +33,7 @@ type t =
   ; context_fit_admission : Agent.context_fit_admission
   ; model_input_projection : Agent.model_input_projection option
   ; stream_idle_timeout_s : float option
+  ; first_event_timeout_s : float option
   ; body_timeout_s : float option
   ; hooks : Hooks.hooks
   ; guardrails_async : Guardrails_async.t
@@ -84,6 +85,7 @@ let create ~net ~model =
   ; context_fit_admission = Agent.Disabled
   ; model_input_projection = None
   ; stream_idle_timeout_s = None
+  ; first_event_timeout_s = None
   ; body_timeout_s = None
   ; hooks = Hooks.empty
   ; guardrails_async = Guardrails_async.empty
@@ -214,6 +216,7 @@ let with_yield_on_tool v b = { b with yield_on_tool = v }
 let with_event_bus bus b = { b with event_bus = Some bus }
 let without_event_bus b = { b with event_bus = None }
 let with_stream_idle_timeout s b = { b with stream_idle_timeout_s = Some s }
+let with_first_event_timeout s b = { b with first_event_timeout_s = Some s }
 let with_body_timeout s b = { b with body_timeout_s = Some s }
 let with_context_injector injector b = { b with context_injector = Some injector }
 let with_skill_registry reg b = { b with skill_registry = Some reg }
@@ -268,6 +271,7 @@ let build b =
     { Agent_types.base_url = b.base_url
     ; provider = b.provider
     ; stream_idle_timeout_s = b.stream_idle_timeout_s
+    ; first_event_timeout_s = b.first_event_timeout_s
     ; body_timeout_s = b.body_timeout_s
     ; hooks = b.hooks
     ; guardrails_async = b.guardrails_async

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -90,10 +90,11 @@ val with_stream_idle_timeout : float -> t -> t
     wait for the FIRST streaming event; [stream_idle_timeout_s] arms for
     inter-token idle only after the first event arrives. A silent prefill
     on a large context is slow-but-alive, not a hang, so it must not be
-    cut by the short inter-token idle value. When unset the first-event
-    wait is unbounded (the streaming path carries no total body budget);
-    inter-token idle still guards once the stream produces, and the connect
-    timeout still guards connection setup. @since 0.218.0 *)
+    cut by the short inter-token idle value. When unset the first-event wait
+    falls back to the body timeout, then to the stream idle timeout, and is
+    unarmed only when none of the three is set; inter-token idle still guards
+    once the stream produces, and the connect timeout still guards connection
+    setup. @since 0.218.0 *)
 val with_first_event_timeout : float -> t -> t
 
 (** Set the per-call total deadline for non-streaming HTTP response body

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -85,6 +85,17 @@ val without_event_bus : t -> t
     @since 0.176.0 *)
 val with_stream_idle_timeout : float -> t -> t
 
+(** RFC-OAS-037: set the dedicated time-to-first-event (TTFT / prefill)
+    deadline, distinct from [with_stream_idle_timeout]. It bounds only the
+    wait for the FIRST streaming event; [stream_idle_timeout_s] arms for
+    inter-token idle only after the first event arrives. A silent prefill
+    on a large context is slow-but-alive, not a hang, so it must not be
+    cut by the short inter-token idle value. When unset the first-event
+    wait is unbounded (the streaming path carries no total body budget);
+    inter-token idle still guards once the stream produces, and the connect
+    timeout still guards connection setup. @since 0.218.0 *)
+val with_first_event_timeout : float -> t -> t
+
 (** Set the per-call total deadline for non-streaming HTTP response body
     consumption. This separately bounds a provider-native input-count
     preflight and a non-streaming completion; it is not a combined turn

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -357,6 +357,7 @@ let complete_prepared_stream
           ~net
           ?clock
           ?stream_idle_timeout_s:request.stream_idle_timeout_s
+          ?first_event_timeout_s:request.first_event_timeout_s
           ?observe_wire_chunk:request.observe_wire_chunk
           ~latency_counter
           ?on_telemetry
@@ -396,6 +397,7 @@ let complete_stream
       ~net
       ?clock
       ?stream_idle_timeout_s
+      ?first_event_timeout_s
       ?transport
       ?capture_id
       ?wire_observer
@@ -417,6 +419,7 @@ let complete_stream
       ~trace_context
       ?capture_id
       ?stream_idle_timeout_s
+      ?first_event_timeout_s
       ()
   in
   complete_prepared_stream
@@ -494,6 +497,7 @@ let make_http_transport
           ~net
           ?clock
           ?stream_idle_timeout_s:req.stream_idle_timeout_s
+          ?first_event_timeout_s:req.first_event_timeout_s
           ?observe_wire_chunk:req.observe_wire_chunk
           ?connection_cache
           ?latency_counter

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -358,6 +358,7 @@ let complete_prepared_stream
           ?clock
           ?stream_idle_timeout_s:request.stream_idle_timeout_s
           ?first_event_timeout_s:request.first_event_timeout_s
+          ?body_timeout_s:request.body_timeout_s
           ?observe_wire_chunk:request.observe_wire_chunk
           ~latency_counter
           ?on_telemetry
@@ -398,6 +399,7 @@ let complete_stream
       ?clock
       ?stream_idle_timeout_s
       ?first_event_timeout_s
+      ?body_timeout_s
       ?transport
       ?capture_id
       ?wire_observer
@@ -420,6 +422,7 @@ let complete_stream
       ?capture_id
       ?stream_idle_timeout_s
       ?first_event_timeout_s
+      ?body_timeout_s
       ()
   in
   complete_prepared_stream
@@ -498,6 +501,7 @@ let make_http_transport
           ?clock
           ?stream_idle_timeout_s:req.stream_idle_timeout_s
           ?first_event_timeout_s:req.first_event_timeout_s
+          ?body_timeout_s:req.body_timeout_s
           ?observe_wire_chunk:req.observe_wire_chunk
           ?connection_cache
           ?latency_counter

--- a/lib/llm_provider/complete.mli
+++ b/lib/llm_provider/complete.mli
@@ -267,10 +267,10 @@ val complete_admitted
     event. This prevents a slow-but-alive silent prefill on a large context
     (no keepalives) from being cancelled as [phase=first_token] under the
     short inter-token idle value. When omitted the first-event wait falls back
-    to [body_timeout_s] (below), then to an internal fail-safe ceiling, so a
-    dead connect that emits no first byte is still bounded rather than hanging;
-    inter-token idle still guards once the stream produces, and the connect
-    timeout still guards connection setup.
+    to [body_timeout_s] (below), then to [stream_idle_timeout_s] — the bound
+    that applied before this change — and stays unarmed when the caller wired
+    none of the three. Inter-token idle still guards once the stream produces,
+    and the connect timeout still guards connection setup.
 
     RFC-OAS-037 §4.2: [body_timeout_s] is the total body budget also used by
     the non-streaming path. On the streaming path it is the fallback bound for

--- a/lib/llm_provider/complete.mli
+++ b/lib/llm_provider/complete.mli
@@ -48,6 +48,7 @@ val prepare_request
   -> ?capture_id:string
   -> ?stream_idle_timeout_s:float
   -> ?first_event_timeout_s:float
+  -> ?body_timeout_s:float
   -> unit
   -> prepared_request
 
@@ -265,16 +266,24 @@ val complete_admitted
     [stream_idle_timeout_s] arms for inter-token idle only AFTER the first
     event. This prevents a slow-but-alive silent prefill on a large context
     (no keepalives) from being cancelled as [phase=first_token] under the
-    short inter-token idle value. When omitted the first-event wait is left
-    unbounded (the streaming path carries no total body budget to fall back
-    to); inter-token idle still guards once the stream produces, and the
-    connect timeout still guards connection setup. *)
+    short inter-token idle value. When omitted the first-event wait falls back
+    to [body_timeout_s] (below), then to an internal fail-safe ceiling, so a
+    dead connect that emits no first byte is still bounded rather than hanging;
+    inter-token idle still guards once the stream produces, and the connect
+    timeout still guards connection setup.
+
+    RFC-OAS-037 §4.2: [body_timeout_s] is the total body budget also used by
+    the non-streaming path. On the streaming path it is the fallback bound for
+    the first-event wait when [first_event_timeout_s] is [None] — the common
+    production shape (callers wire [body_timeout_s], not
+    [first_event_timeout_s]). *)
 val complete_stream
   :  sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> ?clock:_ Eio.Time.clock
   -> ?stream_idle_timeout_s:float
   -> ?first_event_timeout_s:float
+  -> ?body_timeout_s:float
   -> ?transport:Llm_transport.t
   -> ?capture_id:string
   -> ?wire_observer:Wire_observer.try_observe

--- a/lib/llm_provider/complete.mli
+++ b/lib/llm_provider/complete.mli
@@ -47,6 +47,7 @@ val prepare_request
   -> ?trace_context:(string * string) list
   -> ?capture_id:string
   -> ?stream_idle_timeout_s:float
+  -> ?first_event_timeout_s:float
   -> unit
   -> prepared_request
 
@@ -256,12 +257,24 @@ val complete_admitted
     orchestration can distinguish streaming/thinking idleness from total-call
     deadlines and schedule any later attempt independently. Non-HTTP transports
     (CLI subprocess) ignore
-    [stream_idle_timeout_s]. *)
+    [stream_idle_timeout_s].
+
+    RFC-OAS-037: [first_event_timeout_s], when set, bounds the wait for the
+    FIRST streaming event separately from [stream_idle_timeout_s]. Until the
+    first event arrives the read is bounded by [first_event_timeout_s];
+    [stream_idle_timeout_s] arms for inter-token idle only AFTER the first
+    event. This prevents a slow-but-alive silent prefill on a large context
+    (no keepalives) from being cancelled as [phase=first_token] under the
+    short inter-token idle value. When omitted the first-event wait is left
+    unbounded (the streaming path carries no total body budget to fall back
+    to); inter-token idle still guards once the stream produces, and the
+    connect timeout still guards connection setup. *)
 val complete_stream
   :  sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> ?clock:_ Eio.Time.clock
   -> ?stream_idle_timeout_s:float
+  -> ?first_event_timeout_s:float
   -> ?transport:Llm_transport.t
   -> ?capture_id:string
   -> ?wire_observer:Wire_observer.try_observe

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -343,6 +343,7 @@ let complete_stream_http
       ?clock
       ?latency_counter
       ?stream_idle_timeout_s
+      ?first_event_timeout_s
       ?observe_wire_chunk
       ?(on_telemetry : (Telemetry_event.t -> unit) option)
       ?(metrics = Metrics.get_global ())
@@ -675,6 +676,7 @@ let complete_stream_http
                      Http_client.read_ndjson
                        ?clock
                        ?idle_timeout:stream_idle_timeout_s
+                       ?first_event_timeout:first_event_timeout_s
                        ~reader
                        ~on_line:(fun line ->
                          observe_wire_chunk line;
@@ -703,6 +705,7 @@ let complete_stream_http
                      Http_client.read_sse
                        ?clock
                        ?idle_timeout:stream_idle_timeout_s
+                       ?first_event_timeout:first_event_timeout_s
                        ~reader
                        ~on_data:(fun ~event_type data ->
                          observe_wire_chunk data;

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -344,6 +344,7 @@ let complete_stream_http
       ?latency_counter
       ?stream_idle_timeout_s
       ?first_event_timeout_s
+      ?body_timeout_s
       ?observe_wire_chunk
       ?(on_telemetry : (Telemetry_event.t -> unit) option)
       ?(metrics = Metrics.get_global ())
@@ -677,6 +678,7 @@ let complete_stream_http
                        ?clock
                        ?idle_timeout:stream_idle_timeout_s
                        ?first_event_timeout:first_event_timeout_s
+                       ?body_timeout:body_timeout_s
                        ~reader
                        ~on_line:(fun line ->
                          observe_wire_chunk line;
@@ -706,6 +708,7 @@ let complete_stream_http
                        ?clock
                        ?idle_timeout:stream_idle_timeout_s
                        ?first_event_timeout:first_event_timeout_s
+                       ?body_timeout:body_timeout_s
                        ~reader
                        ~on_data:(fun ~event_type data ->
                          observe_wire_chunk data;

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -756,9 +756,24 @@ let complete_stream_http
                   let phase =
                     Http_client.timeout_phase_of_stream_idle_state !stream_idle_state
                   in
+                  (* RFC-OAS-037: name the knob that actually armed this
+                     deadline. Before the TTFT split every phase was governed
+                     by stream_idle_timeout_s; now a first-event timeout can
+                     come from first_event_timeout_s or body_timeout_s, and
+                     naming the idle knob would send the operator to tune a
+                     value that had no effect on the phase that failed. *)
+                  let governing_knob =
+                    Http_client.timeout_knob_to_param
+                      (Http_client.governing_timeout_knob
+                         ~state:!stream_idle_state
+                         ~first_event_timeout:first_event_timeout_s
+                         ~body_timeout:body_timeout_s
+                         ~idle_timeout:stream_idle_timeout_s)
+                  in
                   let message =
                     Printf.sprintf
-                      "stream_idle_timeout_s deadline exceeded while %s"
+                      "%s deadline exceeded while %s"
+                      governing_knob
                       (Http_client.stream_idle_state_to_label !stream_idle_state)
                   in
                   emit_stream_event on_event (Types.Timeout message);
@@ -772,7 +787,8 @@ let complete_stream_http
                     ~terminal:
                       (Telemetry_event.Terminal_error
                          (Printf.sprintf
-                            "stream_idle_timeout_s_exceeded:%s"
+                            "%s_exceeded:%s"
+                            governing_knob
                             (Http_client.stream_idle_state_to_label !stream_idle_state)))
                     ();
                   Error (Http_client.TimeoutError { message; phase })

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -1769,8 +1769,9 @@ let idle_timeout_without_clock site =
 let first_event_timeout_without_clock site =
   invalid_arg
     (site
-     ^ ": first_event_timeout is set but no clock was supplied — the first-event \
-        deadline would be silently disarmed (pass ?clock, or drop ?first_event_timeout)")
+     ^ ": a first-event bound (first_event_timeout or its body_timeout fallback) is set \
+        but no clock was supplied — the first-event deadline would be silently disarmed \
+        (pass ?clock, or drop the timeout)")
 ;;
 
 let require_clock_when_idle ~site ~clock ~idle_timeout =
@@ -1785,18 +1786,48 @@ let require_clock_when_idle ~site ~clock ~idle_timeout =
 ;;
 
 (* RFC-OAS-037: same fail-loud contract for the first-event (TTFT/prefill)
-   deadline — a configured first-event bound with no clock would silently
-   disarm and leave the prefill wait unbounded. *)
-let require_clock_when_first_event ~site ~clock ~first_event_timeout =
-  match clock, first_event_timeout with
-  | None, Some _ -> first_event_timeout_without_clock site
-  | Some _, _ | None, None -> ()
+   deadline. Either an explicit [first_event_timeout] OR the [body_timeout]
+   fallback that now backs it (see [resolve_first_event_timeout]) would
+   silently disarm without a clock, leaving the prefill wait unbounded. The
+   all-[None] case has no configured deadline to disarm — its fail-safe ceiling
+   only arms when a clock is present, so it is intentionally not rejected. *)
+let require_clock_when_first_event ~site ~clock ~first_event_timeout ~body_timeout =
+  match clock with
+  | Some _ -> ()
+  | None ->
+    (match first_event_timeout, body_timeout with
+     | Some _, _ | None, Some _ -> first_event_timeout_without_clock site
+     | None, None -> ())
 ;;
 
-let read_sse ?clock ?idle_timeout ?first_event_timeout ~reader ~on_data () =
+(* RFC-OAS-037 review / RFC-0345 (fail-safe): the wait for the first streamed
+   event must never be left fully unbounded. When neither an explicit
+   [first_event_timeout] nor a [body_timeout] fallback is configured, a
+   provider that returns 200 + headers then emits no body byte would otherwise
+   hang the read forever. This single generous liveness ceiling is a fail-safe
+   floor, NOT a per-provider tuned value (that would violate the RFC's non-goal
+   of provider-specific tuning): large enough that any real prefill on a large
+   context completes well within it, finite so a genuinely dead connection is
+   eventually caught. *)
+let first_event_failsafe_ceiling_s = 300.0
+
+(* RFC-OAS-037 §4.2: resolve the effective first-event (TTFT/prefill) bound.
+   Prefer the explicit [first_event_timeout]; otherwise fall back to the
+   caller's [body_timeout] (the total body budget masc wires but which did not
+   reach the streaming reader before this fix); otherwise the fail-safe
+   ceiling. The result is always finite, so once a clock is available the
+   first-event wait can never be left unbounded. *)
+let resolve_first_event_timeout ~first_event_timeout ~body_timeout =
+  match first_event_timeout, body_timeout with
+  | Some t, _ -> t
+  | None, Some t -> t
+  | None, None -> first_event_failsafe_ceiling_s
+;;
+
+let read_sse ?clock ?idle_timeout ?first_event_timeout ?body_timeout ~reader ~on_data () =
   let site = "read_sse" in
   require_clock_when_idle ~site ~clock ~idle_timeout;
-  require_clock_when_first_event ~site ~clock ~first_event_timeout;
+  require_clock_when_first_event ~site ~clock ~first_event_timeout ~body_timeout;
   (* SSE keepalive comments carry no payload. Skipping them inside the
      SAME [with_timeout_exn] window preserves the armed deadline so a
      provider that emits only keepalives still trips it when no real event
@@ -1807,9 +1838,11 @@ let read_sse ?clock ?idle_timeout ?first_event_timeout ~reader ~on_data () =
      the short [idle_timeout], which arms only AFTER the first event for
      inter-token idle. A silent prefill on a large context is slow-but-alive,
      not a hang, so it must not be cut by the inter-token idle value. When
-     [first_event_timeout] is [None] the first-event wait is left unbounded
-     (never falls back to the short idle value); inter-token idle still guards
-     once the stream produces. *)
+     [first_event_timeout] is [None] the first-event wait falls back to
+     [body_timeout] (masc's total body budget), then to a fail-safe ceiling
+     (see [resolve_first_event_timeout]) — a dead connect that emits no first
+     byte is therefore still bounded, never left to hang. Inter-token idle
+     still guards once the stream produces. *)
   let first_event_seen = ref false in
   let read_meaningful_line () =
     let rec inner () =
@@ -1818,17 +1851,32 @@ let read_sse ?clock ?idle_timeout ?first_event_timeout ~reader ~on_data () =
       | (Sse_blank | Sse_field _) as parsed -> parsed
     in
     let active_timeout =
-      if !first_event_seen then idle_timeout else first_event_timeout
+      if !first_event_seen
+      then idle_timeout
+      else Some (resolve_first_event_timeout ~first_event_timeout ~body_timeout)
     in
     let parsed =
       match clock, active_timeout with
       | Some c, Some t -> Eio.Time.with_timeout_exn c t inner
-      | Some _, None | None, None -> inner ()
-      | None, Some _ -> idle_timeout_without_clock site
+      | Some _, None -> inner ()
+      (* No clock: nothing can be armed. Misconfiguration (an explicit
+         deadline without a clock) already failed loud at entry, so this is
+         either the no-config default or the all-[None] fail-safe with no
+         clock to enforce it — best-effort read, unchanged pre-timeout
+         behaviour. *)
+      | None, _ -> inner ()
     in
-    (* The first meaningful line means the provider is producing: switch from
-       the first-event budget to the inter-token idle budget. *)
-    first_event_seen := true;
+    (* P3a (RFC-OAS-037 review): the transition to the inter-token idle budget
+       must fire on GENUINE first output — a data/event field — NOT on a bare
+       blank dispatch delimiter. A provider that emits a leading blank line
+       before real prefill would otherwise switch to the short idle budget
+       prematurely and re-introduce the very bug this RFC fixes for it.
+       [Sse_comment] is already filtered inside [inner]; the only non-field
+       line [inner] can return is [Sse_blank]. *)
+    (match parsed with
+     | Sse_field _ -> first_event_seen := true
+     | Sse_blank -> ()
+     | Sse_comment -> () (* unreachable: filtered in [inner] *));
     parsed
   in
   let current_event_type = ref None in
@@ -1869,26 +1917,42 @@ let read_sse ?clock ?idle_timeout ?first_event_timeout ~reader ~on_data () =
 
     RFC-OAS-037: the wait for the FIRST line is the time-to-first-event
     (TTFT / prefill) window, bounded by [first_event_timeout] when set;
-    [idle_timeout] arms only AFTER the first line for inter-token idle. *)
-let read_ndjson ?clock ?idle_timeout ?first_event_timeout ~reader ~on_line () =
+    otherwise it falls back to [body_timeout] then a fail-safe ceiling so a
+    dead connect is still bounded. [idle_timeout] arms only AFTER the first
+    line for inter-token idle. *)
+let read_ndjson
+      ?clock
+      ?idle_timeout
+      ?first_event_timeout
+      ?body_timeout
+      ~reader
+      ~on_line
+      ()
+  =
   let site = "read_ndjson" in
   require_clock_when_idle ~site ~clock ~idle_timeout;
-  require_clock_when_first_event ~site ~clock ~first_event_timeout;
+  require_clock_when_first_event ~site ~clock ~first_event_timeout ~body_timeout;
   let first_event_seen = ref false in
   let read_line () =
     let active_timeout =
-      if !first_event_seen then idle_timeout else first_event_timeout
+      if !first_event_seen
+      then idle_timeout
+      else Some (resolve_first_event_timeout ~first_event_timeout ~body_timeout)
     in
     let line =
       match clock, active_timeout with
       | Some c, Some t ->
         Eio.Time.with_timeout_exn c t (fun () -> Eio.Buf_read.line reader)
-      | Some _, None | None, None -> Eio.Buf_read.line reader
-      | None, Some _ -> idle_timeout_without_clock site
+      | Some _, None -> Eio.Buf_read.line reader
+      (* No clock: nothing can be armed. See [read_sse] for why this is
+         best-effort rather than a loud failure here. *)
+      | None, _ -> Eio.Buf_read.line reader
     in
-    (* The first line means the provider is producing: switch from the
-       first-event budget to the inter-token idle budget. *)
-    first_event_seen := true;
+    (* P3a (RFC-OAS-037 review): a bare blank line is a delimiter, not real
+       provider output — the [loop] below skips it. Flip to the inter-token
+       idle budget only on a non-empty line so a leading blank does not switch
+       budgets prematurely (SSE [Sse_blank] parity). *)
+    if String.length line > 0 then first_event_seen := true;
     line
   in
   let rec loop () =
@@ -2471,6 +2535,141 @@ let%test "read_ndjson: first_event_timeout admits a silent prefill past idle" =
   let lines = ref [] in
   Eio.Fiber.both
     (fun () ->
+       Eio.Time.sleep clock 0.2;
+       Eio.Flow.copy_string "{\"a\":1}\n" sink;
+       Eio.Flow.close sink)
+    (fun () ->
+       read_ndjson
+         ~clock
+         ~idle_timeout:0.05
+         ~first_event_timeout:1.0
+         ~reader
+         ~on_line:(fun l -> lines := l :: !lines)
+         ());
+  List.rev !lines = [ "{\"a\":1}" ]
+;;
+
+(* ── RFC-OAS-037 review: effective first-event bound resolution ── *)
+
+(* The pure resolver is the deterministic seam for the fallback policy. A
+   real-clock I/O test cannot wait out the multi-minute fail-safe ceiling, so
+   the [None]+[None] case is pinned here (proving it resolves to a FINITE
+   bound, not an unbounded wait); the I/O tests below prove that a resolved
+   bound actually arms the first-event wait through [read_sse]/[read_ndjson]. *)
+let%test "resolve_first_event_timeout: explicit first_event wins over body" =
+  Float.equal
+    (resolve_first_event_timeout ~first_event_timeout:(Some 5.0) ~body_timeout:(Some 9.0))
+    5.0
+;;
+
+let%test "resolve_first_event_timeout: falls back to body_timeout when first is None" =
+  Float.equal
+    (resolve_first_event_timeout ~first_event_timeout:None ~body_timeout:(Some 3.0))
+    3.0
+;;
+
+let%test "resolve_first_event_timeout: all-None yields the finite fail-safe ceiling" =
+  let ceiling =
+    resolve_first_event_timeout ~first_event_timeout:None ~body_timeout:None
+  in
+  Float.equal ceiling first_event_failsafe_ceiling_s
+  && Float.is_finite ceiling
+  && ceiling > 0.0
+;;
+
+(* P3b (production default): [first_event_timeout = None] + [body_timeout = Some
+   small] + a reader that never emits a first event. Pre-fix the first-event
+   wait was fully unbounded and this read hung forever (defeating RFC-OAS-037
+   acceptance point (4)); the body_timeout fallback now bounds it. The long
+   inter-token idle budget must NOT rescue it — the first-event bound does. *)
+let%test "read_sse: body_timeout bounds the first-event wait when first_event is None" =
+  Eio_main.run
+  @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run
+  @@ fun sw ->
+  let source, _sink = Eio_unix.pipe sw in
+  let reader = Eio.Buf_read.of_flow ~max_size:1024 source in
+  try
+    read_sse
+      ~clock
+      ~idle_timeout:1.0
+      ~body_timeout:0.05
+      ~reader
+      ~on_data:(fun ~event_type:_ _ -> ())
+      ();
+    false
+  with
+  | Eio.Time.Timeout -> true
+;;
+
+let%test "read_ndjson: body_timeout bounds the first-event wait when first_event is None" =
+  Eio_main.run
+  @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run
+  @@ fun sw ->
+  let source, _sink = Eio_unix.pipe sw in
+  let reader = Eio.Buf_read.of_flow ~max_size:1024 source in
+  try
+    read_ndjson
+      ~clock
+      ~idle_timeout:1.0
+      ~body_timeout:0.05
+      ~reader
+      ~on_line:(fun _ -> ())
+      ();
+    false
+  with
+  | Eio.Time.Timeout -> true
+;;
+
+(* P3a (premature transition): a provider that emits a leading BARE BLANK line
+   before real prefill. The blank is a dispatch delimiter, not first output, so
+   it must NOT switch to the short inter-token idle budget. Then it is silent
+   for 0.2s (> idle 0.05, < first-event 1.0) before the real event. Reverting
+   the fix (flipping [first_event_seen] on the blank) arms the 0.05 idle for the
+   second read and this times out at 0.05s instead of admitting the prefill. *)
+let%test "read_sse: a leading blank line does not end the first-event wait" =
+  Eio_main.run
+  @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run
+  @@ fun sw ->
+  let source, sink = Eio_unix.pipe sw in
+  let reader = Eio.Buf_read.of_flow ~max_size:1024 source in
+  let payloads = ref [] in
+  Eio.Fiber.both
+    (fun () ->
+       Eio.Flow.copy_string "\n" sink;
+       Eio.Time.sleep clock 0.2;
+       Eio.Flow.copy_string "data: hello\n\n" sink;
+       Eio.Flow.close sink)
+    (fun () ->
+       read_sse
+         ~clock
+         ~idle_timeout:0.05
+         ~first_event_timeout:1.0
+         ~reader
+         ~on_data:(fun ~event_type:_ d -> payloads := d :: !payloads)
+         ());
+  List.rev !payloads = [ "hello" ]
+;;
+
+(* NDJSON parity for P3a: a leading blank line must not end the first-event
+   wait on the Ollama NDJSON path either. *)
+let%test "read_ndjson: a leading blank line does not end the first-event wait" =
+  Eio_main.run
+  @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run
+  @@ fun sw ->
+  let source, sink = Eio_unix.pipe sw in
+  let reader = Eio.Buf_read.of_flow ~max_size:1024 source in
+  let lines = ref [] in
+  Eio.Fiber.both
+    (fun () ->
+       Eio.Flow.copy_string "\n" sink;
        Eio.Time.sleep clock 0.2;
        Eio.Flow.copy_string "{\"a\":1}\n" sink;
        Eio.Flow.close sink)

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -1789,8 +1789,8 @@ let require_clock_when_idle ~site ~clock ~idle_timeout =
    deadline. Either an explicit [first_event_timeout] OR the [body_timeout]
    fallback that now backs it (see [resolve_first_event_timeout]) would
    silently disarm without a clock, leaving the prefill wait unbounded. The
-   all-[None] case has no configured deadline to disarm — its fail-safe ceiling
-   only arms when a clock is present, so it is intentionally not rejected. *)
+   all-[None] case configures no first-event deadline at all, so there is
+   nothing to disarm and nothing to reject. *)
 let require_clock_when_first_event ~site ~clock ~first_event_timeout ~body_timeout =
   match clock with
   | Some _ -> ()
@@ -1800,28 +1800,34 @@ let require_clock_when_first_event ~site ~clock ~first_event_timeout ~body_timeo
      | None, None -> ())
 ;;
 
-(* RFC-OAS-037 review / RFC-0345 (fail-safe): the wait for the first streamed
-   event must never be left fully unbounded. When neither an explicit
-   [first_event_timeout] nor a [body_timeout] fallback is configured, a
-   provider that returns 200 + headers then emits no body byte would otherwise
-   hang the read forever. This single generous liveness ceiling is a fail-safe
-   floor, NOT a per-provider tuned value (that would violate the RFC's non-goal
-   of provider-specific tuning): large enough that any real prefill on a large
-   context completes well within it, finite so a genuinely dead connection is
-   eventually caught. *)
-let first_event_failsafe_ceiling_s = 300.0
-
 (* RFC-OAS-037 §4.2: resolve the effective first-event (TTFT/prefill) bound.
-   Prefer the explicit [first_event_timeout]; otherwise fall back to the
-   caller's [body_timeout] (the total body budget masc wires but which did not
-   reach the streaming reader before this fix); otherwise the fail-safe
-   ceiling. The result is always finite, so once a clock is available the
-   first-event wait can never be left unbounded. *)
-let resolve_first_event_timeout ~first_event_timeout ~body_timeout =
-  match first_event_timeout, body_timeout with
-  | Some t, _ -> t
-  | None, Some t -> t
-  | None, None -> first_event_failsafe_ceiling_s
+   Every arm returns a caller-supplied value — this function never invents a
+   deadline of its own:
+
+   - explicit [first_event_timeout] wins;
+   - else [body_timeout], the total body budget masc already wires but which
+     did not reach the streaming reader before this fix (the production shape
+     the RFC exists to repair: a long prefill bounded by the long budget
+     instead of the short inter-token one);
+   - else [idle_timeout], preserving the pre-RFC bound for callers that wired
+     only an idle deadline — before this change that value also bounded the
+     first event, and silently widening it would be an unrequested behaviour
+     change;
+   - else [None]: the caller configured no deadline on any channel, so the
+     first-event wait stays unarmed exactly as it was. Inventing a default
+     here would re-introduce the provider idle defaults that were deliberately
+     removed (see [removed_provider_idle_defaults_upper_bound_s] in the
+     streaming tests) and would be a hardcoded magic number besides.
+
+   A dead connect on the all-[None] path is bounded by the connect timeout and
+   by the caller's own total-call deadline, not by a budget this layer makes
+   up. *)
+let resolve_first_event_timeout ~first_event_timeout ~body_timeout ~idle_timeout =
+  match first_event_timeout, body_timeout, idle_timeout with
+  | Some t, _, _ -> Some t
+  | None, Some t, _ -> Some t
+  | None, None, Some t -> Some t
+  | None, None, None -> None
 ;;
 
 let read_sse ?clock ?idle_timeout ?first_event_timeout ?body_timeout ~reader ~on_data () =
@@ -1839,9 +1845,10 @@ let read_sse ?clock ?idle_timeout ?first_event_timeout ?body_timeout ~reader ~on
      inter-token idle. A silent prefill on a large context is slow-but-alive,
      not a hang, so it must not be cut by the inter-token idle value. When
      [first_event_timeout] is [None] the first-event wait falls back to
-     [body_timeout] (masc's total body budget), then to a fail-safe ceiling
-     (see [resolve_first_event_timeout]) — a dead connect that emits no first
-     byte is therefore still bounded, never left to hang. Inter-token idle
+     [body_timeout] (masc's total body budget), then to [idle_timeout] — the
+     pre-RFC bound, kept so callers that wired only an idle deadline keep
+     exactly their previous behaviour (see [resolve_first_event_timeout]).
+     With nothing wired the wait stays unarmed, as before. Inter-token idle
      still guards once the stream produces. *)
   let first_event_seen = ref false in
   let read_meaningful_line () =
@@ -1853,7 +1860,7 @@ let read_sse ?clock ?idle_timeout ?first_event_timeout ?body_timeout ~reader ~on
     let active_timeout =
       if !first_event_seen
       then idle_timeout
-      else Some (resolve_first_event_timeout ~first_event_timeout ~body_timeout)
+      else resolve_first_event_timeout ~first_event_timeout ~body_timeout ~idle_timeout
     in
     let parsed =
       match clock, active_timeout with
@@ -1861,8 +1868,7 @@ let read_sse ?clock ?idle_timeout ?first_event_timeout ?body_timeout ~reader ~on
       | Some _, None -> inner ()
       (* No clock: nothing can be armed. Misconfiguration (an explicit
          deadline without a clock) already failed loud at entry, so this is
-         either the no-config default or the all-[None] fail-safe with no
-         clock to enforce it — best-effort read, unchanged pre-timeout
+         the no-config default — best-effort read, unchanged pre-timeout
          behaviour. *)
       | None, _ -> inner ()
     in
@@ -1917,9 +1923,9 @@ let read_sse ?clock ?idle_timeout ?first_event_timeout ?body_timeout ~reader ~on
 
     RFC-OAS-037: the wait for the FIRST line is the time-to-first-event
     (TTFT / prefill) window, bounded by [first_event_timeout] when set;
-    otherwise it falls back to [body_timeout] then a fail-safe ceiling so a
-    dead connect is still bounded. [idle_timeout] arms only AFTER the first
-    line for inter-token idle. *)
+    otherwise it falls back to [body_timeout], then to [idle_timeout] (the
+    pre-RFC bound), and stays unarmed when the caller wired none of them.
+    [idle_timeout] arms only AFTER the first line for inter-token idle. *)
 let read_ndjson
       ?clock
       ?idle_timeout
@@ -1937,7 +1943,7 @@ let read_ndjson
     let active_timeout =
       if !first_event_seen
       then idle_timeout
-      else Some (resolve_first_event_timeout ~first_event_timeout ~body_timeout)
+      else resolve_first_event_timeout ~first_event_timeout ~body_timeout ~idle_timeout
     in
     let line =
       match clock, active_timeout with
@@ -2551,30 +2557,47 @@ let%test "read_ndjson: first_event_timeout admits a silent prefill past idle" =
 
 (* ── RFC-OAS-037 review: effective first-event bound resolution ── *)
 
-(* The pure resolver is the deterministic seam for the fallback policy. A
-   real-clock I/O test cannot wait out the multi-minute fail-safe ceiling, so
-   the [None]+[None] case is pinned here (proving it resolves to a FINITE
-   bound, not an unbounded wait); the I/O tests below prove that a resolved
-   bound actually arms the first-event wait through [read_sse]/[read_ndjson]. *)
-let%test "resolve_first_event_timeout: explicit first_event wins over body" =
-  Float.equal
-    (resolve_first_event_timeout ~first_event_timeout:(Some 5.0) ~body_timeout:(Some 9.0))
-    5.0
+(* The pure resolver is the deterministic seam for the fallback policy: one
+   test per arm of the precedence chain
+   [first_event > body > idle > unarmed], so a reordering or a re-introduced
+   built-in default fails here rather than in a timing-dependent I/O test. The
+   I/O tests below prove that a resolved bound actually arms the first-event
+   wait through [read_sse]/[read_ndjson]. *)
+let%test "resolve_first_event_timeout: explicit first_event wins over body and idle" =
+  resolve_first_event_timeout
+    ~first_event_timeout:(Some 5.0)
+    ~body_timeout:(Some 9.0)
+    ~idle_timeout:(Some 0.5)
+  = Some 5.0
 ;;
 
-let%test "resolve_first_event_timeout: falls back to body_timeout when first is None" =
-  Float.equal
-    (resolve_first_event_timeout ~first_event_timeout:None ~body_timeout:(Some 3.0))
-    3.0
+let%test "resolve_first_event_timeout: falls back to body_timeout over idle" =
+  resolve_first_event_timeout
+    ~first_event_timeout:None
+    ~body_timeout:(Some 3.0)
+    ~idle_timeout:(Some 0.5)
+  = Some 3.0
 ;;
 
-let%test "resolve_first_event_timeout: all-None yields the finite fail-safe ceiling" =
-  let ceiling =
-    resolve_first_event_timeout ~first_event_timeout:None ~body_timeout:None
-  in
-  Float.equal ceiling first_event_failsafe_ceiling_s
-  && Float.is_finite ceiling
-  && ceiling > 0.0
+(* Pre-RFC behaviour preservation: with only an idle deadline wired, that value
+   bounded the first event too. Widening it here would be an unrequested
+   behaviour change for every such caller. *)
+let%test "resolve_first_event_timeout: falls back to idle when it is the only bound" =
+  resolve_first_event_timeout
+    ~first_event_timeout:None
+    ~body_timeout:None
+    ~idle_timeout:(Some 0.5)
+  = Some 0.5
+;;
+
+(* Guards the removed provider idle defaults: with nothing wired the resolver
+   must stay unarmed rather than invent a bound of its own. *)
+let%test "resolve_first_event_timeout: all-None stays unarmed" =
+  resolve_first_event_timeout
+    ~first_event_timeout:None
+    ~body_timeout:None
+    ~idle_timeout:None
+  = None
 ;;
 
 (* P3b (production default): [first_event_timeout = None] + [body_timeout = Some

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -1800,6 +1800,30 @@ let require_clock_when_first_event ~site ~clock ~first_event_timeout ~body_timeo
      | None, None -> ())
 ;;
 
+(* RFC-OAS-037: the caller-supplied knob a streaming deadline came from.
+   Carried so a fired timeout can name the budget the operator must tune,
+   rather than always blaming the inter-token idle knob. *)
+type timeout_knob =
+  | First_event_timeout
+  | Body_timeout
+  | Stream_idle_timeout
+
+let timeout_knob_to_param = function
+  | First_event_timeout -> "first_event_timeout_s"
+  | Body_timeout -> "body_timeout_s"
+  | Stream_idle_timeout -> "stream_idle_timeout_s"
+;;
+
+(* Resolution outcome for the first-event wait: either a bound with the knob it
+   came from, or no bound at all. Keeping the knob attached to the value is what
+   lets attribution reuse the resolver instead of re-deriving the precedence. *)
+type first_event_bound =
+  | Bounded of
+      { knob : timeout_knob
+      ; seconds : float
+      }
+  | Unarmed
+
 (* RFC-OAS-037 §4.2: resolve the effective first-event (TTFT/prefill) bound.
    Every arm returns a caller-supplied value — this function never invents a
    deadline of its own:
@@ -1822,12 +1846,40 @@ let require_clock_when_first_event ~site ~clock ~first_event_timeout ~body_timeo
    A dead connect on the all-[None] path is bounded by the connect timeout and
    by the caller's own total-call deadline, not by a budget this layer makes
    up. *)
-let resolve_first_event_timeout ~first_event_timeout ~body_timeout ~idle_timeout =
+let resolve_first_event_bound ~first_event_timeout ~body_timeout ~idle_timeout =
   match first_event_timeout, body_timeout, idle_timeout with
-  | Some t, _, _ -> Some t
-  | None, Some t, _ -> Some t
-  | None, None, Some t -> Some t
-  | None, None, None -> None
+  | Some seconds, _, _ -> Bounded { knob = First_event_timeout; seconds }
+  | None, Some seconds, _ -> Bounded { knob = Body_timeout; seconds }
+  | None, None, Some seconds -> Bounded { knob = Stream_idle_timeout; seconds }
+  | None, None, None -> Unarmed
+;;
+
+let resolve_first_event_timeout ~first_event_timeout ~body_timeout ~idle_timeout =
+  match resolve_first_event_bound ~first_event_timeout ~body_timeout ~idle_timeout with
+  | Bounded { seconds; _ } -> Some seconds
+  | Unarmed -> None
+;;
+
+(* RFC-OAS-037: name the knob whose value produced the deadline that fired, so
+   an operator tunes the budget that actually governs. Derived from the SAME
+   resolver as the armed bound — the precedence chain exists in exactly one
+   place, so the message can never drift from the behaviour. Only the
+   first-event phase can be governed by something other than the idle knob;
+   every later phase is inter-token idle by construction. *)
+let governing_timeout_knob ~state ~first_event_timeout ~body_timeout ~idle_timeout =
+  match state with
+  | Awaiting_first_event ->
+    (match resolve_first_event_bound ~first_event_timeout ~body_timeout ~idle_timeout with
+     | Bounded { knob; _ } -> knob
+     | Unarmed -> Stream_idle_timeout)
+  | Awaiting_first_delta
+  | Streaming_answer
+  | Streaming_thinking
+  | Streaming_tool_call
+  | Streaming_heartbeat
+  | Streaming_substrate
+  | Streaming_done
+  | Streaming_unknown -> Stream_idle_timeout
 ;;
 
 let read_sse ?clock ?idle_timeout ?first_event_timeout ?body_timeout ~reader ~on_data () =
@@ -2598,6 +2650,51 @@ let%test "resolve_first_event_timeout: all-None stays unarmed" =
     ~body_timeout:None
     ~idle_timeout:None
   = None
+;;
+
+(* RFC-OAS-037 attribution: a fired deadline must name the knob that supplied
+   its value. Pinning all three first-event sources plus one later phase means
+   a regression to the old "always stream_idle_timeout_s" message fails here. *)
+let%test "governing_timeout_knob: first-event names its explicit knob" =
+  governing_timeout_knob
+    ~state:Awaiting_first_event
+    ~first_event_timeout:(Some 5.0)
+    ~body_timeout:(Some 9.0)
+    ~idle_timeout:(Some 0.5)
+  = First_event_timeout
+;;
+
+let%test "governing_timeout_knob: first-event names body when it supplied the bound" =
+  governing_timeout_knob
+    ~state:Awaiting_first_event
+    ~first_event_timeout:None
+    ~body_timeout:(Some 9.0)
+    ~idle_timeout:(Some 0.5)
+  = Body_timeout
+;;
+
+let%test "governing_timeout_knob: first-event names idle when idle supplied the bound" =
+  governing_timeout_knob
+    ~state:Awaiting_first_event
+    ~first_event_timeout:None
+    ~body_timeout:None
+    ~idle_timeout:(Some 0.5)
+  = Stream_idle_timeout
+;;
+
+let%test "governing_timeout_knob: inter-token phases stay attributed to idle" =
+  governing_timeout_knob
+    ~state:Streaming_answer
+    ~first_event_timeout:(Some 5.0)
+    ~body_timeout:(Some 9.0)
+    ~idle_timeout:(Some 0.5)
+  = Stream_idle_timeout
+;;
+
+let%test "timeout_knob_to_param: names match the caller-facing parameters" =
+  String.equal (timeout_knob_to_param First_event_timeout) "first_event_timeout_s"
+  && String.equal (timeout_knob_to_param Body_timeout) "body_timeout_s"
+  && String.equal (timeout_knob_to_param Stream_idle_timeout) "stream_idle_timeout_s"
 ;;
 
 (* P3b (production default): [first_event_timeout = None] + [body_timeout = Some

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -1766,6 +1766,13 @@ let idle_timeout_without_clock site =
         silently disarmed (pass ?clock, or drop ?idle_timeout)")
 ;;
 
+let first_event_timeout_without_clock site =
+  invalid_arg
+    (site
+     ^ ": first_event_timeout is set but no clock was supplied — the first-event \
+        deadline would be silently disarmed (pass ?clock, or drop ?first_event_timeout)")
+;;
+
 let require_clock_when_idle ~site ~clock ~idle_timeout =
   match clock, idle_timeout with
   | None, Some _ ->
@@ -1777,23 +1784,52 @@ let require_clock_when_idle ~site ~clock ~idle_timeout =
   | Some _, _ | None, None -> ()
 ;;
 
-let read_sse ?clock ?idle_timeout ~reader ~on_data () =
+(* RFC-OAS-037: same fail-loud contract for the first-event (TTFT/prefill)
+   deadline — a configured first-event bound with no clock would silently
+   disarm and leave the prefill wait unbounded. *)
+let require_clock_when_first_event ~site ~clock ~first_event_timeout =
+  match clock, first_event_timeout with
+  | None, Some _ -> first_event_timeout_without_clock site
+  | Some _, _ | None, None -> ()
+;;
+
+let read_sse ?clock ?idle_timeout ?first_event_timeout ~reader ~on_data () =
   let site = "read_sse" in
   require_clock_when_idle ~site ~clock ~idle_timeout;
+  require_clock_when_first_event ~site ~clock ~first_event_timeout;
   (* SSE keepalive comments carry no payload. Skipping them inside the
-     SAME [with_timeout_exn] window preserves the idle deadline so a
-     provider that emits only keepalives still trips [idle_timeout]
-     when no real event arrives. *)
+     SAME [with_timeout_exn] window preserves the armed deadline so a
+     provider that emits only keepalives still trips it when no real event
+     arrives.
+     RFC-OAS-037: the wait for the FIRST meaningful line is the
+     time-to-first-event (TTFT / prefill) window; bound it with
+     [first_event_timeout] (a separate, larger liveness budget) rather than
+     the short [idle_timeout], which arms only AFTER the first event for
+     inter-token idle. A silent prefill on a large context is slow-but-alive,
+     not a hang, so it must not be cut by the inter-token idle value. When
+     [first_event_timeout] is [None] the first-event wait is left unbounded
+     (never falls back to the short idle value); inter-token idle still guards
+     once the stream produces. *)
+  let first_event_seen = ref false in
   let read_meaningful_line () =
     let rec inner () =
       match parse_sse_line (Eio.Buf_read.line reader) with
       | Sse_comment -> inner ()
       | (Sse_blank | Sse_field _) as parsed -> parsed
     in
-    match clock, idle_timeout with
-    | Some c, Some t -> Eio.Time.with_timeout_exn c t inner
-    | Some _, None | None, None -> inner ()
-    | None, Some _ -> idle_timeout_without_clock site
+    let active_timeout =
+      if !first_event_seen then idle_timeout else first_event_timeout
+    in
+    let parsed =
+      match clock, active_timeout with
+      | Some c, Some t -> Eio.Time.with_timeout_exn c t inner
+      | Some _, None | None, None -> inner ()
+      | None, Some _ -> idle_timeout_without_clock site
+    in
+    (* The first meaningful line means the provider is producing: switch from
+       the first-event budget to the inter-token idle budget. *)
+    first_event_seen := true;
+    parsed
   in
   let current_event_type = ref None in
   let rec loop () =
@@ -1829,15 +1865,31 @@ let read_sse ?clock ?idle_timeout ~reader ~on_data () =
 
     When [clock] and [idle_timeout] are both set, each line read is
     wrapped in [Eio.Time.with_timeout_exn] so a stalled stream raises
-    [Eio.Time.Timeout] after [idle_timeout] seconds of silence. *)
-let read_ndjson ?clock ?idle_timeout ~reader ~on_line () =
+    [Eio.Time.Timeout] after [idle_timeout] seconds of silence.
+
+    RFC-OAS-037: the wait for the FIRST line is the time-to-first-event
+    (TTFT / prefill) window, bounded by [first_event_timeout] when set;
+    [idle_timeout] arms only AFTER the first line for inter-token idle. *)
+let read_ndjson ?clock ?idle_timeout ?first_event_timeout ~reader ~on_line () =
   let site = "read_ndjson" in
   require_clock_when_idle ~site ~clock ~idle_timeout;
+  require_clock_when_first_event ~site ~clock ~first_event_timeout;
+  let first_event_seen = ref false in
   let read_line () =
-    match clock, idle_timeout with
-    | Some c, Some t -> Eio.Time.with_timeout_exn c t (fun () -> Eio.Buf_read.line reader)
-    | Some _, None | None, None -> Eio.Buf_read.line reader
-    | None, Some _ -> idle_timeout_without_clock site
+    let active_timeout =
+      if !first_event_seen then idle_timeout else first_event_timeout
+    in
+    let line =
+      match clock, active_timeout with
+      | Some c, Some t ->
+        Eio.Time.with_timeout_exn c t (fun () -> Eio.Buf_read.line reader)
+      | Some _, None | None, None -> Eio.Buf_read.line reader
+      | None, Some _ -> idle_timeout_without_clock site
+    in
+    (* The first line means the provider is producing: switch from the
+       first-event budget to the inter-token idle budget. *)
+    first_event_seen := true;
+    line
   in
   let rec loop () =
     match read_line () with
@@ -2315,4 +2367,120 @@ let%test "read_sse: idle_timeout fires when stream stalls mid-read" =
     false
   with
   | Eio.Time.Timeout -> true
+;;
+
+(* ── RFC-OAS-037: first_event_timeout (TTFT/prefill) tests ── *)
+
+(* Acceptance (a): a silent prefill that produces its first event AFTER the
+   short inter-token idle but WITHIN the first-event budget must succeed —
+   NOT be cancelled as a first-token timeout. Reverting the change (using the
+   short idle for the first event) makes this test fail: the 0.2s silent
+   prefill exceeds the 0.05s idle. *)
+let%test "read_sse: first_event_timeout admits a silent prefill past idle" =
+  Eio_main.run
+  @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run
+  @@ fun sw ->
+  let source, sink = Eio_unix.pipe sw in
+  let reader = Eio.Buf_read.of_flow ~max_size:1024 source in
+  let payloads = ref [] in
+  Eio.Fiber.both
+    (fun () ->
+       (* Silent for 0.2s: longer than idle (0.05), shorter than the
+          first-event budget (1.0). Then emit the first event and close. *)
+       Eio.Time.sleep clock 0.2;
+       Eio.Flow.copy_string "data: hello\n\n" sink;
+       Eio.Flow.close sink)
+    (fun () ->
+       read_sse
+         ~clock
+         ~idle_timeout:0.05
+         ~first_event_timeout:1.0
+         ~reader
+         ~on_data:(fun ~event_type:_ d -> payloads := d :: !payloads)
+         ());
+  List.rev !payloads = [ "hello" ]
+;;
+
+(* Acceptance (b): no first event ever arrives — the short first-event budget
+   still guards a dead connect even though the inter-token idle budget is
+   long. *)
+let%test "read_sse: first_event_timeout fires when no first event arrives" =
+  Eio_main.run
+  @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run
+  @@ fun sw ->
+  let source, _sink = Eio_unix.pipe sw in
+  (* Keep the sink open and never write: the first line read hangs. The long
+     idle budget (1.0) must NOT rescue it; the first-event budget (0.05) does
+     the guarding. *)
+  let reader = Eio.Buf_read.of_flow ~max_size:1024 source in
+  try
+    read_sse
+      ~clock
+      ~idle_timeout:1.0
+      ~first_event_timeout:0.05
+      ~reader
+      ~on_data:(fun ~event_type:_ _ -> ())
+      ();
+    false
+  with
+  | Eio.Time.Timeout -> true
+;;
+
+(* Acceptance (c): after the first event, inter-token idle still guards a
+   stalled active stream — unchanged behaviour. The first-event budget (1.0)
+   is long; the idle budget (0.05) is what fires once the stream has
+   produced. *)
+let%test "read_sse: idle_timeout still guards after the first event" =
+  Eio_main.run
+  @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run
+  @@ fun sw ->
+  let source, sink = Eio_unix.pipe sw in
+  (* First event arrives immediately, then the stream goes silent. *)
+  Eio.Flow.copy_string "data: hello\n" sink;
+  let reader = Eio.Buf_read.of_flow ~max_size:1024 source in
+  try
+    read_sse
+      ~clock
+      ~idle_timeout:0.05
+      ~first_event_timeout:1.0
+      ~reader
+      ~on_data:(fun ~event_type:_ _ -> ())
+      ();
+    false
+  with
+  | Eio.Time.Timeout -> true
+;;
+
+(* NDJSON parity for acceptance (a): the first-event budget must admit a silent
+   prefill past idle on the Ollama NDJSON path too (reverting to short idle on
+   the first line makes this fail). *)
+let%test "read_ndjson: first_event_timeout admits a silent prefill past idle" =
+  Eio_main.run
+  @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run
+  @@ fun sw ->
+  let source, sink = Eio_unix.pipe sw in
+  let reader = Eio.Buf_read.of_flow ~max_size:1024 source in
+  let lines = ref [] in
+  Eio.Fiber.both
+    (fun () ->
+       Eio.Time.sleep clock 0.2;
+       Eio.Flow.copy_string "{\"a\":1}\n" sink;
+       Eio.Flow.close sink)
+    (fun () ->
+       read_ndjson
+         ~clock
+         ~idle_timeout:0.05
+         ~first_event_timeout:1.0
+         ~reader
+         ~on_line:(fun l -> lines := l :: !lines)
+         ());
+  List.rev !lines = [ "{\"a\":1}" ]
 ;;

--- a/lib/llm_provider/http_client.mli
+++ b/lib/llm_provider/http_client.mli
@@ -428,15 +428,22 @@ val with_post_stream
     (TTFT / prefill) window — separately from [idle_timeout], which arms
     only AFTER the first meaningful line for inter-token idle. A silent
     prefill on a large context is slow-but-alive, not a hang, so it must not
-    be cut by the short [idle_timeout] value. When [first_event_timeout] is
-    omitted the first-event wait is left unbounded (it never falls back to
-    the short idle value); inter-token idle still guards once the stream
-    produces. Supplying [first_event_timeout] WITHOUT [clock] raises
-    [Invalid_argument] (same silent-disarm guard as [idle_timeout]). *)
+    be cut by the short [idle_timeout] value. A "meaningful line" here is a
+    genuine data/event field: a bare blank dispatch delimiter does NOT end the
+    first-event wait (it would switch to the short idle budget prematurely).
+    When [first_event_timeout] is omitted the first-event wait falls back to
+    [body_timeout] (the caller's total body budget), and when both are omitted
+    to an internal fail-safe ceiling — so a dead connect that emits no first
+    byte is still bounded rather than hanging forever. Inter-token idle still
+    guards once the stream produces. Supplying [first_event_timeout] or
+    [body_timeout] WITHOUT [clock] raises [Invalid_argument] (same
+    silent-disarm guard as [idle_timeout]); the all-omitted fail-safe ceiling
+    only arms when a clock is present. *)
 val read_sse
   :  ?clock:_ Eio.Time.clock
   -> ?idle_timeout:float
   -> ?first_event_timeout:float
+  -> ?body_timeout:float
   -> reader:Eio.Buf_read.t
   -> on_data:(event_type:string option -> string -> unit)
   -> unit
@@ -458,14 +465,17 @@ val read_sse
     RFC-OAS-037: [first_event_timeout], when supplied (with [clock]),
     bounds the wait for the FIRST line — the time-to-first-event (TTFT /
     prefill) window — separately from [idle_timeout], which arms only AFTER
-    the first line for inter-token idle. Omitting it leaves the first-event
-    wait unbounded (never the short idle value); inter-token idle still
-    guards once the stream produces. Supplying [first_event_timeout] WITHOUT
-    [clock] raises [Invalid_argument]. *)
+    the first line for inter-token idle. A leading blank line does NOT end the
+    first-event wait. Omitting [first_event_timeout] falls back to
+    [body_timeout], then to an internal fail-safe ceiling, so a dead connect
+    is still bounded; inter-token idle still guards once the stream produces.
+    Supplying [first_event_timeout] or [body_timeout] WITHOUT [clock] raises
+    [Invalid_argument]. *)
 val read_ndjson
   :  ?clock:_ Eio.Time.clock
   -> ?idle_timeout:float
   -> ?first_event_timeout:float
+  -> ?body_timeout:float
   -> reader:Eio.Buf_read.t
   -> on_line:(string -> unit)
   -> unit

--- a/lib/llm_provider/http_client.mli
+++ b/lib/llm_provider/http_client.mli
@@ -212,6 +212,29 @@ val stream_idle_state_to_label : stream_idle_state -> string
 val timeout_phase_of_stream_idle_state : stream_idle_state -> timeout_phase
 val timeout_phase_to_label : timeout_phase -> string
 
+(** RFC-OAS-037: the caller-supplied knob a streaming deadline came from. A
+    fired timeout names this knob so the operator tunes the budget that
+    actually governed the phase, instead of always being pointed at the
+    inter-token idle one. *)
+type timeout_knob =
+  | First_event_timeout
+  | Body_timeout
+  | Stream_idle_timeout
+
+(** Parameter name of [timeout_knob], as callers spell it. *)
+val timeout_knob_to_param : timeout_knob -> string
+
+(** Which knob governs a timeout fired in [state]. For
+    [Awaiting_first_event] this follows the same precedence chain that arms
+    the first-event wait ([first_event_timeout] > [body_timeout] >
+    [idle_timeout]); every later phase is inter-token idle by construction. *)
+val governing_timeout_knob
+  :  state:stream_idle_state
+  -> first_event_timeout:float option
+  -> body_timeout:float option
+  -> idle_timeout:float option
+  -> timeout_knob
+
 (** Canonical resolution of an optional caller-owned deadline.
 
     [Unbounded] means no timeout was requested and therefore needs no clock.

--- a/lib/llm_provider/http_client.mli
+++ b/lib/llm_provider/http_client.mli
@@ -431,14 +431,15 @@ val with_post_stream
     be cut by the short [idle_timeout] value. A "meaningful line" here is a
     genuine data/event field: a bare blank dispatch delimiter does NOT end the
     first-event wait (it would switch to the short idle budget prematurely).
-    When [first_event_timeout] is omitted the first-event wait falls back to
-    [body_timeout] (the caller's total body budget), and when both are omitted
-    to an internal fail-safe ceiling — so a dead connect that emits no first
-    byte is still bounded rather than hanging forever. Inter-token idle still
-    guards once the stream produces. Supplying [first_event_timeout] or
-    [body_timeout] WITHOUT [clock] raises [Invalid_argument] (same
-    silent-disarm guard as [idle_timeout]); the all-omitted fail-safe ceiling
-    only arms when a clock is present. *)
+    The effective bound is resolved from caller-supplied values only, in the
+    order [first_event_timeout] > [body_timeout] (the caller's total body
+    budget) > [idle_timeout] (the pre-RFC bound, kept so callers that wired
+    only an idle deadline keep their previous behaviour). With none of the
+    three supplied the first-event wait stays unarmed, exactly as before this
+    change: this function never invents a deadline of its own. Inter-token
+    idle still guards once the stream produces. Supplying
+    [first_event_timeout] or [body_timeout] WITHOUT [clock] raises
+    [Invalid_argument] (same silent-disarm guard as [idle_timeout]). *)
 val read_sse
   :  ?clock:_ Eio.Time.clock
   -> ?idle_timeout:float
@@ -467,10 +468,10 @@ val read_sse
     prefill) window — separately from [idle_timeout], which arms only AFTER
     the first line for inter-token idle. A leading blank line does NOT end the
     first-event wait. Omitting [first_event_timeout] falls back to
-    [body_timeout], then to an internal fail-safe ceiling, so a dead connect
-    is still bounded; inter-token idle still guards once the stream produces.
-    Supplying [first_event_timeout] or [body_timeout] WITHOUT [clock] raises
-    [Invalid_argument]. *)
+    [body_timeout], then to [idle_timeout]; with none supplied the wait stays
+    unarmed, as before this change. Inter-token idle still guards once the
+    stream produces. Supplying [first_event_timeout] or [body_timeout] WITHOUT
+    [clock] raises [Invalid_argument]. *)
 val read_ndjson
   :  ?clock:_ Eio.Time.clock
   -> ?idle_timeout:float

--- a/lib/llm_provider/http_client.mli
+++ b/lib/llm_provider/http_client.mli
@@ -421,10 +421,22 @@ val with_post_stream
     deadline. Wrapped by {!with_post_stream} the timeout should be
     caught by the caller and surfaced as
     [TimeoutError { phase = Stream_idle state; _ }] so downstream
-    policy can see which stream state stalled. *)
+    policy can see which stream state stalled.
+
+    RFC-OAS-037: [first_event_timeout], when supplied (with [clock]),
+    bounds the wait for the FIRST meaningful line — the time-to-first-event
+    (TTFT / prefill) window — separately from [idle_timeout], which arms
+    only AFTER the first meaningful line for inter-token idle. A silent
+    prefill on a large context is slow-but-alive, not a hang, so it must not
+    be cut by the short [idle_timeout] value. When [first_event_timeout] is
+    omitted the first-event wait is left unbounded (it never falls back to
+    the short idle value); inter-token idle still guards once the stream
+    produces. Supplying [first_event_timeout] WITHOUT [clock] raises
+    [Invalid_argument] (same silent-disarm guard as [idle_timeout]). *)
 val read_sse
   :  ?clock:_ Eio.Time.clock
   -> ?idle_timeout:float
+  -> ?first_event_timeout:float
   -> reader:Eio.Buf_read.t
   -> on_data:(event_type:string option -> string -> unit)
   -> unit
@@ -441,10 +453,19 @@ val read_sse
     [idle_timeout] WITHOUT [clock] raises [Invalid_argument] (silent
     disarm removed). The raised timeout should be caught by the caller
     and surfaced as [TimeoutError { phase = Stream_idle state; _ }] so
-    downstream policy can see which stream state stalled. *)
+    downstream policy can see which stream state stalled.
+
+    RFC-OAS-037: [first_event_timeout], when supplied (with [clock]),
+    bounds the wait for the FIRST line — the time-to-first-event (TTFT /
+    prefill) window — separately from [idle_timeout], which arms only AFTER
+    the first line for inter-token idle. Omitting it leaves the first-event
+    wait unbounded (never the short idle value); inter-token idle still
+    guards once the stream produces. Supplying [first_event_timeout] WITHOUT
+    [clock] raises [Invalid_argument]. *)
 val read_ndjson
   :  ?clock:_ Eio.Time.clock
   -> ?idle_timeout:float
+  -> ?first_event_timeout:float
   -> reader:Eio.Buf_read.t
   -> on_line:(string -> unit)
   -> unit

--- a/lib/llm_provider/llm_transport.ml
+++ b/lib/llm_provider/llm_transport.ml
@@ -15,6 +15,13 @@ type completion_request =
         blocks until the provider closes). Armed only when the transport also
         holds a clock (closed over at construction). Carried on the request so
         the dispatch cannot silently drop it. See RFC-OAS-026. @since 0.205.0 *)
+  ; first_event_timeout_s : float option
+    (** RFC-OAS-037: time-to-first-event (TTFT / prefill) deadline, in
+        seconds, distinct from [stream_idle_timeout_s]. Bounds only the wait
+        for the first streaming event; inter-token idle arms after it. [None]
+        leaves the first-event wait unbounded (no total body budget on the
+        streaming path); inter-token idle still guards once producing.
+        @since 0.218.0 *)
   }
 
 type sync_result =

--- a/lib/llm_provider/llm_transport.ml
+++ b/lib/llm_provider/llm_transport.ml
@@ -30,7 +30,7 @@ type completion_request =
         callers (e.g. masc) wire [body_timeout_s] but not
         [first_event_timeout_s]. [None] leaves the streaming first-event wait
         to [stream_idle_timeout_s], and unarmed if that is [None] too. Armed
-        only when the transport also holds a clock. @since 0.219.0 *)
+        only when the transport also holds a clock. @since 0.218.0 *)
   }
 
 type sync_result =

--- a/lib/llm_provider/llm_transport.ml
+++ b/lib/llm_provider/llm_transport.ml
@@ -19,9 +19,18 @@ type completion_request =
     (** RFC-OAS-037: time-to-first-event (TTFT / prefill) deadline, in
         seconds, distinct from [stream_idle_timeout_s]. Bounds only the wait
         for the first streaming event; inter-token idle arms after it. [None]
-        leaves the first-event wait unbounded (no total body budget on the
-        streaming path); inter-token idle still guards once producing.
-        @since 0.218.0 *)
+        falls back to [body_timeout_s] (below), then to an internal fail-safe
+        ceiling, so the first-event wait is still bounded; inter-token idle
+        still guards once producing. @since 0.218.0 *)
+  ; body_timeout_s : float option
+    (** RFC-OAS-037 §4.2: total body budget, in seconds. On the non-streaming
+        path this bounds the whole response read. On the streaming path it is
+        the fallback bound for the first-event (TTFT/prefill) wait when
+        [first_event_timeout_s] is [None] — the common production shape, since
+        callers (e.g. masc) wire [body_timeout_s] but not
+        [first_event_timeout_s]. [None] leaves the streaming first-event wait
+        to the fail-safe ceiling. Armed only when the transport also holds a
+        clock. @since 0.219.0 *)
   }
 
 type sync_result =

--- a/lib/llm_provider/llm_transport.ml
+++ b/lib/llm_provider/llm_transport.ml
@@ -29,8 +29,8 @@ type completion_request =
         [first_event_timeout_s] is [None] — the common production shape, since
         callers (e.g. masc) wire [body_timeout_s] but not
         [first_event_timeout_s]. [None] leaves the streaming first-event wait
-        to the fail-safe ceiling. Armed only when the transport also holds a
-        clock. @since 0.219.0 *)
+        to [stream_idle_timeout_s], and unarmed if that is [None] too. Armed
+        only when the transport also holds a clock. @since 0.219.0 *)
   }
 
 type sync_result =

--- a/lib/llm_provider/llm_transport.ml
+++ b/lib/llm_provider/llm_transport.ml
@@ -19,9 +19,9 @@ type completion_request =
     (** RFC-OAS-037: time-to-first-event (TTFT / prefill) deadline, in
         seconds, distinct from [stream_idle_timeout_s]. Bounds only the wait
         for the first streaming event; inter-token idle arms after it. [None]
-        falls back to [body_timeout_s] (below), then to an internal fail-safe
-        ceiling, so the first-event wait is still bounded; inter-token idle
-        still guards once producing. @since 0.218.0 *)
+        falls back to [body_timeout_s], then to [stream_idle_timeout_s] (the
+        bound that applied before RFC-OAS-037); inter-token idle still guards
+        once the stream produces. @since 0.218.0 *)
   ; body_timeout_s : float option
     (** RFC-OAS-037 §4.2: total body budget, in seconds. On the non-streaming
         path this bounds the whole response read. On the streaming path it is

--- a/lib/llm_provider/llm_transport.mli
+++ b/lib/llm_provider/llm_transport.mli
@@ -33,16 +33,17 @@ type completion_request =
     (** RFC-OAS-037: time-to-first-event (TTFT / prefill) deadline, in
         seconds, distinct from [stream_idle_timeout_s]. Bounds only the wait
         for the first streaming event; inter-token idle arms after it. [None]
-        falls back to [body_timeout_s] then a fail-safe ceiling, so the
-        first-event wait is still bounded; inter-token idle still guards once
-        the stream produces. @since 0.218.0 *)
+        falls back to [body_timeout_s], then to [stream_idle_timeout_s] (the
+        bound that applied before RFC-OAS-037); inter-token idle still guards
+        once the stream produces. @since 0.218.0 *)
   ; body_timeout_s : float option
     (** RFC-OAS-037 §4.2: total body budget, in seconds. On the streaming path
         it is the fallback bound for the first-event (TTFT/prefill) wait when
         [first_event_timeout_s] is [None] — the common production shape, since
         callers wire [body_timeout_s] but not [first_event_timeout_s]. [None]
-        leaves the streaming first-event wait to the fail-safe ceiling. Armed
-        only when the transport also holds a clock. @since 0.219.0 *)
+        leaves the first-event wait to [stream_idle_timeout_s], and unarmed if
+        that is [None] too. Armed only when the transport also holds a clock.
+        @since 0.219.0 *)
   }
 
 (** Result of a sync completion. *)

--- a/lib/llm_provider/llm_transport.mli
+++ b/lib/llm_provider/llm_transport.mli
@@ -29,6 +29,12 @@ type completion_request =
         [None] preserves pre-0.205.0 behaviour (no idle deadline). Armed only
         when the transport also holds a clock (closed over at construction).
         See RFC-OAS-026. @since 0.205.0 *)
+  ; first_event_timeout_s : float option
+    (** RFC-OAS-037: time-to-first-event (TTFT / prefill) deadline, in
+        seconds, distinct from [stream_idle_timeout_s]. Bounds only the wait
+        for the first streaming event; inter-token idle arms after it. [None]
+        leaves the first-event wait unbounded; inter-token idle still guards
+        once the stream produces. @since 0.218.0 *)
   }
 
 (** Result of a sync completion. *)

--- a/lib/llm_provider/llm_transport.mli
+++ b/lib/llm_provider/llm_transport.mli
@@ -43,7 +43,7 @@ type completion_request =
         callers wire [body_timeout_s] but not [first_event_timeout_s]. [None]
         leaves the first-event wait to [stream_idle_timeout_s], and unarmed if
         that is [None] too. Armed only when the transport also holds a clock.
-        @since 0.219.0 *)
+        @since 0.218.0 *)
   }
 
 (** Result of a sync completion. *)

--- a/lib/llm_provider/llm_transport.mli
+++ b/lib/llm_provider/llm_transport.mli
@@ -33,8 +33,16 @@ type completion_request =
     (** RFC-OAS-037: time-to-first-event (TTFT / prefill) deadline, in
         seconds, distinct from [stream_idle_timeout_s]. Bounds only the wait
         for the first streaming event; inter-token idle arms after it. [None]
-        leaves the first-event wait unbounded; inter-token idle still guards
-        once the stream produces. @since 0.218.0 *)
+        falls back to [body_timeout_s] then a fail-safe ceiling, so the
+        first-event wait is still bounded; inter-token idle still guards once
+        the stream produces. @since 0.218.0 *)
+  ; body_timeout_s : float option
+    (** RFC-OAS-037 §4.2: total body budget, in seconds. On the streaming path
+        it is the fallback bound for the first-event (TTFT/prefill) wait when
+        [first_event_timeout_s] is [None] — the common production shape, since
+        callers wire [body_timeout_s] but not [first_event_timeout_s]. [None]
+        leaves the streaming first-event wait to the fail-safe ceiling. Armed
+        only when the transport also holds a clock. @since 0.219.0 *)
   }
 
 (** Result of a sync completion. *)

--- a/lib/llm_provider/prepared_completion_request.ml
+++ b/lib/llm_provider/prepared_completion_request.ml
@@ -32,6 +32,7 @@ let prepare
       ?(trace_context = [])
       ?capture_id
       ?stream_idle_timeout_s
+      ?first_event_timeout_s
       ()
   =
   { request =
@@ -42,6 +43,7 @@ let prepare
       ; capture_id
       ; observe_wire_chunk = None
       ; stream_idle_timeout_s
+      ; first_event_timeout_s
       }
   }
 ;;

--- a/lib/llm_provider/prepared_completion_request.ml
+++ b/lib/llm_provider/prepared_completion_request.ml
@@ -33,6 +33,7 @@ let prepare
       ?capture_id
       ?stream_idle_timeout_s
       ?first_event_timeout_s
+      ?body_timeout_s
       ()
   =
   { request =
@@ -44,6 +45,7 @@ let prepare
       ; observe_wire_chunk = None
       ; stream_idle_timeout_s
       ; first_event_timeout_s
+      ; body_timeout_s
       }
   }
 ;;

--- a/lib/llm_provider/prepared_completion_request.mli
+++ b/lib/llm_provider/prepared_completion_request.mli
@@ -30,6 +30,7 @@ val prepare
   -> ?trace_context:(string * string) list
   -> ?capture_id:string
   -> ?stream_idle_timeout_s:float
+  -> ?first_event_timeout_s:float
   -> unit
   -> t
 

--- a/lib/llm_provider/prepared_completion_request.mli
+++ b/lib/llm_provider/prepared_completion_request.mli
@@ -31,6 +31,7 @@ val prepare
   -> ?capture_id:string
   -> ?stream_idle_timeout_s:float
   -> ?first_event_timeout_s:float
+  -> ?body_timeout_s:float
   -> unit
   -> t
 

--- a/lib/pipeline/pipeline_stage_route.ml
+++ b/lib/pipeline/pipeline_stage_route.ml
@@ -260,6 +260,7 @@ let dispatch_stream
         ~on_event
         ?on_telemetry
         ?stream_idle_timeout_s:agent.options.stream_idle_timeout_s
+        ?first_event_timeout_s:agent.options.first_event_timeout_s
         ()
       |> Result.map_error (Provider_failure_attribution.of_http_error ~binding)
     in
@@ -272,6 +273,7 @@ let dispatch_stream
           ~trace_context
           ?capture_id
           ?stream_idle_timeout_s:agent.options.stream_idle_timeout_s
+          ?first_event_timeout_s:agent.options.first_event_timeout_s
           ()
       in
       (* Resolve the context limit first: it needs no network, so a pre-knowable

--- a/lib/pipeline/pipeline_stage_route.ml
+++ b/lib/pipeline/pipeline_stage_route.ml
@@ -261,6 +261,7 @@ let dispatch_stream
         ?on_telemetry
         ?stream_idle_timeout_s:agent.options.stream_idle_timeout_s
         ?first_event_timeout_s:agent.options.first_event_timeout_s
+        ?body_timeout_s:agent.options.body_timeout_s
         ()
       |> Result.map_error (Provider_failure_attribution.of_http_error ~binding)
     in
@@ -274,6 +275,7 @@ let dispatch_stream
           ?capture_id
           ?stream_idle_timeout_s:agent.options.stream_idle_timeout_s
           ?first_event_timeout_s:agent.options.first_event_timeout_s
+          ?body_timeout_s:agent.options.body_timeout_s
           ()
       in
       (* Resolve the context limit first: it needs no network, so a pre-knowable

--- a/test/test_anthropic_input_token_count.ml
+++ b/test/test_anthropic_input_token_count.ml
@@ -135,6 +135,7 @@ let completion_request config : Llm_transport.completion_request =
   ; capture_id = Some "request-count-fixture"
   ; observe_wire_chunk = None
   ; stream_idle_timeout_s = None
+  ; first_event_timeout_s = None
   }
 ;;
 

--- a/test/test_anthropic_input_token_count.ml
+++ b/test/test_anthropic_input_token_count.ml
@@ -136,6 +136,7 @@ let completion_request config : Llm_transport.completion_request =
   ; observe_wire_chunk = None
   ; stream_idle_timeout_s = None
   ; first_event_timeout_s = None
+  ; body_timeout_s = None
   }
 ;;
 


### PR DESCRIPTION
## Symptom

`read_sse` / `read_ndjson` (`lib/llm_provider/http_client.ml`) wrapped **every** line read in the same `with_timeout_exn idle_timeout` window, and the idle state machine starts at `Awaiting_first_event`. So the wait for the FIRST provider event (time-to-first-token / prefill) was bounded by the same short `stream_idle_timeout_s` used for inter-token idle.

A provider that emits no keepalives during prefill on a large context is indistinguishable from a hang, and the idle timeout cancels the turn as `provider_timeout` / `phase=first_token`. Live evidence (masc fleet, 2026-07-20): keeper `rondo` on `mimo.mimo-v2.5` (`max_context=1000000`) failed with `Provider timeout phase=first_token: stream_idle_timeout_s deadline exceeded while awaiting_first_event`, `latency=152746ms`. The turn was prefilling, not hung.

## Fix (RFC-OAS-037 §4.2 Option A)

Separate the first-event (TTFT/prefill) budget from the inter-token idle budget.

- New `first_event_timeout_s : float option` (default `None`), threaded alongside the existing `stream_idle_timeout_s` through: agent `options` (`agent_types.ml`/`.mli`, `agent.mli`), `builder` (`with_first_event_timeout`), `llm_transport.completion_request`, `prepared_completion_request`, `complete`/`complete_stream`, `complete_stream_http`, and `pipeline_stage_route`.
- In `read_sse`/`read_ndjson`: the **first meaningful line** (the TTFT/prefill wait) is bounded by `first_event_timeout` when set; `stream_idle_timeout` arms only **after** the first line, for inter-token idle — exactly as before. A local `first_event_seen` flip performs the switch the moment the provider produces its first line.
- Keepalive handling unchanged: comments are still skipped inside the same armed window, so a keepalive-only stream still trips whichever deadline is armed.
- Fail-loud contract mirrored: `first_event_timeout` set without a `clock` raises `Invalid_argument` (same as `idle_timeout`).

### First-event fallback when `first_event_timeout_s` is `None`

Per RFC §4.2 the intent is "default to `body_timeout_s`". The effective first-event bound resolves as: `first_event_timeout_s` when `Some`, else `body_timeout_s` when `Some`, else a finite fail-safe ceiling. `body_timeout_s` is now threaded into the streaming path (`pipeline_stage_route` → `complete_stream`/`prepared` → `complete_stream_http` → `read_sse`/`read_ndjson`), so the common production shape (`first_event_timeout_s = None`, `body_timeout_s = Some …` — exactly what masc wires) gets a **finite** first-event bound. Inter-token idle still guards once the stream produces; `connect_timeout_s` still guards connection setup.

> **Note (superseded by #2723 review, commit `54aa0ac70`):** an earlier revision of this PR left the `None` first-event wait fully **unbounded**. Adversarial review flagged that as a P2 liveness regression: with `first_event_timeout_s = None` (the only production-reachable value today) a provider that returns 200 + headers then emits no body byte would hang the read forever, defeating RFC-OAS-037 acceptance point (4). The fallback above resolves it.

## Acceptance cases (inline `ppx_inline_test` in `http_client.ml`)

- **(a)** `read_sse: first_event_timeout admits a silent prefill past idle` — reader silent 0.2s (> idle 0.05, < first-event 1.0) then emits its first event → **succeeds**. (+ NDJSON parity test.)
- **(b)** `read_sse: first_event_timeout fires when no first event arrives` — no first event; idle budget long (1.0), first-event short (0.05) → **fails** (dead-connect guarded).
- **(c)** `read_sse: idle_timeout still guards after the first event` — first event immediate, then silence; first-event budget long (1.0), idle short (0.05) → **fails** (inter-token idle guarded, unchanged).

**Revert-red proof:** forcing the first-event read back onto the idle budget makes tests (a) + the NDJSON parity test fail with `Eio.Time.Timeout`, exactly the pre-fix TTFT bug; (b) and (c) stay green (their guards remain armed).

## Review fixes (#2723 review — commit `54aa0ac70`)

Resolves the adversarial review's P2 + 2 P3s.

- **P2 (liveness regression — see the Note above):** the `None`-default first-event wait is no longer unbounded. It falls back to `body_timeout_s`, then to a finite fail-safe ceiling `first_event_failsafe_ceiling_s = 300.0` (a single generous liveness bound in the spirit of RFC-0345's fail-safe floor — **not** a per-provider tuned value, so it does not touch the RFC's non-goal). `body_timeout_s` is added to `llm_transport.completion_request` and threaded through the streaming path. Confirmed effective in production: masc `keeper_agent_run.ml` sets `?body_timeout_s` (and `?stream_idle_timeout_s`) but never `first_event_timeout_s`. `body_timeout_s`/`first_event_timeout_s` set without a `clock` now fails loud (same silent-disarm guard).
- **P3a (premature transition):** `first_event_seen` now flips only on a genuine data/event field, **not** on a bare blank dispatch delimiter (SSE `Sse_blank` / NDJSON empty line). A provider that emits a leading blank line before real prefill would otherwise switch to the short idle budget prematurely and reintroduce the bug for it. Comment/keepalive skipping unchanged.
- **P3b (test gap):** added the production-default path (`first_event_timeout=None` + `body_timeout=Some 0.05` + reader that never emits → read fails at `body_timeout`, for both `read_sse` and `read_ndjson`), a pure-resolver test pinning `None + None → finite fail-safe ceiling` (the multi-minute ceiling is not real-clock-testable, so the pure seam documents boundedness while the I/O tests prove a resolved bound arms the wait), and the P3a leading-blank regression tests (SSE + NDJSON). **Counterfactual:** reverting only the P3a flip makes the leading-blank test fail with `Eio.Time.Timeout` (1/72).

## Verification

- `dune build --root <worktree> @check @fmt` — green (`ocamlformat` 0.29.0)
- `dune runtest --root <worktree> lib/llm_provider` — green (72 inline tests, incl. the new P3a/P3b/resolver tests; the 3 original acceptance tests stay green)
- External runtime tests green: `test_streaming_cut_cleanup`, `test_streaming_keepalive_idle`, `test_anthropic_input_token_count`
- `scripts/ci-code-smell-ratchet.sh --check` — PASSED (all metrics held)

Implements RFC-OAS-037
Refs #2722
RFC-WAIVED: lib/llm_provider + lib/agent + lib/pipeline + test — bounded stream-timeout fix (no credential/identity/keeper/hooks surface)

