### PR TITLE
feat(agent): publish AgentStarted/AgentCompleted/AgentFailed lifecycle events

### DIFF
--- a/docs/EVENT-CATALOG.md
+++ b/docs/EVENT-CATALOG.md
@@ -64,9 +64,9 @@ Pattern-matchable OCaml sum type. **Stable across every provider.**
 
 | Variant | Emit site | Semantic |
 |---------|-----------|---------|
-| `AgentStarted` | Reserved; no OAS core producer after legacy task lifecycle removal | Legacy task lifecycle start |
-| `AgentCompleted` | Reserved; no OAS core producer after legacy task lifecycle removal | Legacy task lifecycle completion |
-| `AgentFailed` | Reserved; no OAS core producer after legacy task lifecycle removal | Legacy task lifecycle failure |
+| `AgentStarted` | `agent/agent.ml` (`run`, `run_stream` — incl. `run_with_handoffs`) | Run lifecycle start |
+| `AgentCompleted` | `agent/agent.ml` (`run`, `run_stream` — incl. `run_with_handoffs`) | Run lifecycle completion (carries the `result`) |
+| `AgentFailed` | `agent/agent.ml` (`run`, `run_stream` — incl. `run_with_handoffs`) | Run lifecycle failure (companion to `AgentCompleted` on `Error`) |
 | `TurnStarted` | `pipeline/pipeline_stage_prepare.ml` | Start of a single agent turn |
 | `TurnReady` | `pipeline/pipeline_stage_prepare.ml` | Exact caller-supplied tool surface serialized for this turn |
 | `TurnCompleted` | `pipeline/pipeline.ml` | End of a single agent turn |
@@ -279,7 +279,7 @@ on **two channels simultaneously**:
 | `Session_failed` | `runtime.session_failed` |
 
 **Name collision note**: `Runtime.Agent_completed` (session-level
-participant lifecycle) is distinct from the reserved native
+participant lifecycle) is distinct from the native
 `Event_bus.AgentCompleted` payload. They live in different modules with
 different payload shapes. Disambiguate by Custom name prefix:
 `runtime.agent_completed` vs native `AgentCompleted`.

--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -411,36 +411,36 @@ let with_periodic_callbacks ~sw ?clock agent f =
        raise exn)
 ;;
 
-let validate_run_callbacks ~on_yield ~on_resume =
-  match on_yield, on_resume with
-  | Some _, None | None, Some _ ->
-    Error
-      (Error.Config
-         (Error.InvalidConfig
-            { field = "on_yield/on_resume"
-            ; detail = "callbacks must be supplied together or both omitted"
-            }))
-  | Some _, Some _ | None, None -> Ok ()
+let with_run_lifecycle_events agent f =
+  Agent_lifecycle_events.with_run_lifecycle_events
+    ~event_bus:agent.options.event_bus
+    ~agent_name:agent.state.config.name
+    ~raw_trace:agent.options.raw_trace
+    ~current_run_id:(fun () ->
+      Option.bind (lifecycle_snapshot agent) (fun s -> s.current_run_id))
+    ~project:(fun detailed -> detailed.Provider_failure_attribution.error)
+    f
 ;;
 
 let run_blocks_detailed ~sw ?clock ?on_yield ?on_resume ?execution_store agent user_blocks
   =
-  match validate_user_input_blocks user_blocks with
-  | Error error -> Error (detailed_error_of_sdk_error error)
-  | Ok () ->
-    (match validate_run_callbacks ~on_yield ~on_resume with
-     | Error error -> Error (detailed_error_of_sdk_error error)
-     | Ok () ->
-       with_periodic_callbacks ~sw ?clock agent (fun ~sw ->
-         run_loop_detailed
-           ~sw
-           ?clock
-           ~api_strategy:Sync
-           ?on_yield
-           ?on_resume
-           ?execution_store
-           agent
-           user_blocks))
+  with_run_lifecycle_events agent (fun () ->
+    match validate_user_input_blocks user_blocks with
+    | Error error -> Error (detailed_error_of_sdk_error error)
+    | Ok () ->
+      (match Agent_lifecycle_events.validate_run_callbacks ~on_yield ~on_resume with
+       | Error error -> Error (detailed_error_of_sdk_error error)
+       | Ok () ->
+         with_periodic_callbacks ~sw ?clock agent (fun ~sw ->
+           run_loop_detailed
+             ~sw
+             ?clock
+             ~api_strategy:Sync
+             ?on_yield
+             ?on_resume
+             ?execution_store
+             agent
+             user_blocks)))
 ;;
 
 let run_blocks ~sw ?clock ?on_yield ?on_resume ?execution_store agent user_blocks =
@@ -474,27 +474,28 @@ let run_stream_blocks_detailed
       agent
       user_blocks
   =
-  match validate_user_input_blocks user_blocks with
-  | Error error -> Error (detailed_error_of_sdk_error error)
-  | Ok () ->
-    (match validate_run_callbacks ~on_yield ~on_resume with
-     | Error error -> Error (detailed_error_of_sdk_error error)
-     | Ok () ->
-       let on_telemetry =
-         Option.map
-           (fun bus -> Telemetry_bus.publish (Telemetry_bus.of_event_bus bus))
-           agent.options.event_bus
-       in
-       with_periodic_callbacks ~sw ?clock agent (fun ~sw ->
-         run_loop_detailed
-           ~sw
-           ?clock
-           ~api_strategy:(Stream { on_event; on_telemetry })
-           ?on_yield
-           ?on_resume
-           ?execution_store
-           agent
-           user_blocks))
+  with_run_lifecycle_events agent (fun () ->
+    match validate_user_input_blocks user_blocks with
+    | Error error -> Error (detailed_error_of_sdk_error error)
+    | Ok () ->
+      (match Agent_lifecycle_events.validate_run_callbacks ~on_yield ~on_resume with
+       | Error error -> Error (detailed_error_of_sdk_error error)
+       | Ok () ->
+         let on_telemetry =
+           Option.map
+             (fun bus -> Telemetry_bus.publish (Telemetry_bus.of_event_bus bus))
+             agent.options.event_bus
+         in
+         with_periodic_callbacks ~sw ?clock agent (fun ~sw ->
+           run_loop_detailed
+             ~sw
+             ?clock
+             ~api_strategy:(Stream { on_event; on_telemetry })
+             ?on_yield
+             ?on_resume
+             ?execution_store
+             agent
+             user_blocks)))
 ;;
 
 let run_stream_blocks
@@ -931,7 +932,7 @@ module Advanced = struct
     match validate_user_input_blocks user_blocks with
     | Error error -> Error (detailed_error_of_sdk_error error)
     | Ok () ->
-      (match validate_run_callbacks ~on_yield ~on_resume with
+      (match Agent_lifecycle_events.validate_run_callbacks ~on_yield ~on_resume with
        | Error error -> Error (detailed_error_of_sdk_error error)
        | Ok () ->
          with_periodic_callbacks ~sw ?clock agent (fun ~sw ->

--- a/lib/agent/agent_lifecycle_events.ml
+++ b/lib/agent/agent_lifecycle_events.ml
@@ -99,13 +99,34 @@ let with_run_lifecycle_events ~event_bus ~agent_name ~raw_trace ~current_run_id 
       ~agent_name
       ~correlation_id:(Option.bind raw_trace Raw_trace.session_id)
   in
-  let result = f () in
-  publish_finished
-    ~event_bus
-    ~agent_name
-    ~started
-    ~current_run_id:(current_run_id ())
-    ~result:(Result.map_error project result)
-    ~elapsed:(Unix.gettimeofday () -. started_at);
-  result
+  (* Mirror the [with_raw_trace_run_classified_result] exception arm in
+     [Agent_trace]: the terminal lifecycle transition must not be skipped
+     even when [f] raises (e.g. [Eio.Cancel.Cancelled] on switch failure
+     or any synchronous exn from the pipeline).  Subscribers always see
+     [AgentStarted] closed by [AgentCompleted]/[AgentFailed]; the original
+     exception is then re-raised with its backtrace so callers still
+     observe the failure. *)
+  match f () with
+  | result ->
+    publish_finished
+      ~event_bus
+      ~agent_name
+      ~started
+      ~current_run_id:(current_run_id ())
+      ~result:(Result.map_error project result)
+      ~elapsed:(Unix.gettimeofday () -. started_at);
+    result
+  | exception exn ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    let error =
+      Error.Internal (Printf.sprintf "Unhandled exception: %s" (Printexc.to_string exn))
+    in
+    publish_finished
+      ~event_bus
+      ~agent_name
+      ~started
+      ~current_run_id:(current_run_id ())
+      ~result:(Error error)
+      ~elapsed:(Unix.gettimeofday () -. started_at);
+    Printexc.raise_with_backtrace exn backtrace
 ;;

--- a/lib/agent/agent_lifecycle_events.ml
+++ b/lib/agent/agent_lifecycle_events.ml
@@ -1,0 +1,111 @@
+(** Run lifecycle events (AgentStarted/AgentCompleted/AgentFailed).
+
+    The run-level lifecycle triple lost its only producer when the legacy
+    orchestrator was removed (#1755); the variants and downstream subscribers
+    stayed behind.  Envelope identity follows the removed producer's
+    derivation so the triple joins the surrounding event stream:
+    [correlation_id] is the raw-trace session id when present (same source
+    as turn-level events, see [Pipeline_common.event_envelope]);
+    [AgentStarted] opens a fresh run id; the terminal events reuse the
+    lifecycle [current_run_id] (raw-trace run id) when one is active; and
+    terminal [caused_by] points at the started event's run id (#877).
+    [task_id] carries the started run id — the only run-scoped identifier
+    available without an orchestrator task — so subscribers can group the
+    triple of one run invocation. *)
+
+let _log = Log.create ~module_name:"agent_lifecycle_events" ()
+
+let publish_started ~event_bus ~agent_name ~correlation_id =
+  match event_bus with
+  | None -> None
+  | Some bus ->
+    let correlation_id =
+      match correlation_id with
+      | Some session_id -> session_id
+      | None -> Event_bus.fresh_id ()
+    in
+    let run_id = Event_bus.fresh_id () in
+    (try
+       Event_bus.publish
+         bus
+         (Event_bus.mk_event
+            ~correlation_id
+            ~run_id
+            (AgentStarted { agent_name; task_id = run_id }))
+     with
+     | exn ->
+       Llm_provider.Reserved_exn.reraise_if_reserved exn;
+       Log.warn
+         _log
+         "Event_bus.publish failed (AgentStarted)"
+         [ Log.S ("error", Printexc.to_string exn) ]);
+    Some (correlation_id, run_id)
+;;
+
+let publish_finished ~event_bus ~agent_name ~started ~current_run_id ~result ~elapsed =
+  match event_bus, started with
+  | Some bus, Some (correlation_id, started_run_id) ->
+    let run_id =
+      match current_run_id with
+      | Some run_id -> run_id
+      | None -> Event_bus.fresh_id ()
+    in
+    let publish label (payload : Event_bus.payload) =
+      try
+        Event_bus.publish
+          bus
+          (Event_bus.mk_event ~correlation_id ~run_id ~caused_by:started_run_id payload)
+      with
+      | exn ->
+        Llm_provider.Reserved_exn.reraise_if_reserved exn;
+        Log.warn
+          _log
+          (Printf.sprintf "Event_bus.publish failed (%s)" label)
+          [ Log.S ("error", Printexc.to_string exn) ]
+    in
+    publish
+      "AgentCompleted"
+      (AgentCompleted { agent_name; task_id = started_run_id; result; elapsed });
+    (* [AgentFailed] is a companion emitted in addition to [AgentCompleted]
+       so failure-only subscribers match the variant directly instead of
+       destructuring [result]. *)
+    (match result with
+     | Error error ->
+       publish
+         "AgentFailed"
+         (AgentFailed { agent_name; task_id = started_run_id; error; elapsed })
+     | Ok _ -> ())
+  | None, _ | Some _, None -> ()
+;;
+
+let validate_run_callbacks ~on_yield ~on_resume =
+  match on_yield, on_resume with
+  | Some _, None | None, Some _ ->
+    Error
+      (Error.Config
+         (Error.InvalidConfig
+            { field = "on_yield/on_resume"
+            ; detail = "callbacks must be supplied together or both omitted"
+            }))
+  | Some _, Some _ | None, None -> Ok ()
+;;
+
+let with_run_lifecycle_events ~event_bus ~agent_name ~raw_trace ~current_run_id ~project f
+  =
+  let started_at = Unix.gettimeofday () in
+  let started =
+    publish_started
+      ~event_bus
+      ~agent_name
+      ~correlation_id:(Option.bind raw_trace Raw_trace.session_id)
+  in
+  let result = f () in
+  publish_finished
+    ~event_bus
+    ~agent_name
+    ~started
+    ~current_run_id:(current_run_id ())
+    ~result:(Result.map_error project result)
+    ~elapsed:(Unix.gettimeofday () -. started_at);
+  result
+;;

--- a/lib/agent/agent_lifecycle_events.mli
+++ b/lib/agent/agent_lifecycle_events.mli
@@ -1,0 +1,45 @@
+(** Run lifecycle events (AgentStarted/AgentCompleted/AgentFailed).
+
+    The run-level lifecycle triple lost its only producer when the legacy
+    orchestrator was removed (#1755); the variants and downstream subscribers
+    stayed behind.  Envelope identity follows the removed producer's
+    derivation so the triple joins the surrounding event stream:
+    [correlation_id] is the raw-trace session id when present (same source
+    as turn-level events, see [Pipeline_common.event_envelope]);
+    [AgentStarted] opens a fresh run id; the terminal events reuse the
+    lifecycle [current_run_id] (raw-trace run id) when one is active; and
+    terminal [caused_by] points at the started event's run id (#877).
+    [task_id] carries the started run id — the only run-scoped identifier
+    available without an orchestrator task — so subscribers can group the
+    triple of one run invocation.
+
+    @stability Internal
+    @since 0.217.2 *)
+
+(** Validate that [on_yield]/[on_resume] are supplied together or both
+    omitted.  Returns [Error] with an [InvalidConfig] payload otherwise. *)
+val validate_run_callbacks
+  :  on_yield:'a option
+  -> on_resume:'b option
+  -> (unit, Error.sdk_error) result
+
+(** Wrap a run with the [AgentStarted] -> [AgentCompleted] (and companion
+    [AgentFailed] on error) lifecycle triple.
+
+    [current_run_id] is queried lazily so the terminal events reflect the
+    raw-trace run id active at completion time.  [project] collapses the
+    detailed-error channel ([Provider_failure_attribution.detailed_error])
+    into the legacy [Error.sdk_error] carried by the event payload.
+
+    If [f] raises, the terminal events are still published (with an
+    [Error.Internal] projection of the exception) so subscribers always
+    observe [AgentStarted] closed by a terminal event; the original
+    exception is then re-raised with its backtrace intact. *)
+val with_run_lifecycle_events
+  :  event_bus:Event_bus.t option
+  -> agent_name:string
+  -> raw_trace:Raw_trace.t option
+  -> current_run_id:(unit -> string option)
+  -> project:(Provider_failure_attribution.detailed_error -> Error.sdk_error)
+  -> (unit -> (Types.api_response, Provider_failure_attribution.detailed_error) result)
+  -> (Types.api_response, Provider_failure_attribution.detailed_error) result

--- a/test/test_event_integration.ml
+++ b/test/test_event_integration.ml
@@ -1,8 +1,10 @@
-(** Integration tests for new Event_bus native variants (0.154.0):
-    AgentFailed, HandoffRequested, and HandoffCompleted.
+(** Integration tests for Event_bus run/handoff lifecycle variants:
+    AgentStarted, AgentCompleted, AgentFailed, HandoffRequested, and
+    HandoffCompleted.
 
-    These verify that [lib/agent/agent.ml] (run_with_handoffs) publishes
-    the new surface end-to-end — not just that the variants typecheck. *)
+    These verify that [lib/agent/agent.ml] ([run], [run_with_handoffs])
+    publishes the surface end-to-end — not just that the variants
+    typecheck. *)
 
 open Alcotest
 open Agent_sdk
@@ -163,6 +165,183 @@ let test_handoff_emits_request_and_completion () =
   | Exit -> ()
 ;;
 
+(* ── B. Agent.run emits AgentStarted/AgentCompleted/AgentFailed ── *)
+
+(* Run-level lifecycle triple restored in [Agent.run]: the legacy
+   orchestrator producer was removed in #1755, leaving the variants
+   without any producer.  [publish_agent_started]/[publish_agent_finished]
+   in [lib/agent/agent.ml] now emit the triple around every run. *)
+
+let with_mock_server ~handler f =
+  let port = fresh_port () in
+  let base_url = Printf.sprintf "http://127.0.0.1:%d" port in
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let socket =
+      Eio.Net.listen
+        env#net
+        ~sw
+        ~backlog:128
+        ~reuse_addr:true
+        (`Tcp (Eio.Net.Ipaddr.V4.loopback, port))
+    in
+    let server = Cohttp_eio.Server.make ~callback:handler () in
+    Eio.Fiber.fork ~sw (fun () ->
+      Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()));
+    f ~sw env base_url;
+    Eio.Switch.fail sw Exit
+  with
+  | Exit -> ()
+;;
+
+let find_kind kind events =
+  try List.find (fun e -> event_kind e = kind) events with
+  | Not_found -> fail (Printf.sprintf "%s missing" kind)
+;;
+
+let index_of_kind kind names =
+  List.find_index (( = ) kind) names |> Option.value ~default:(-1)
+;;
+
+let run_agent_once ~sw env ~base_url bus =
+  let provider : Provider.config =
+    { provider = Provider.Local { base_url }; model_id = "mock"; api_key_env = "" }
+  in
+  let options =
+    { Agent.default_options with
+      base_url
+    ; provider = Some provider
+    ; event_bus = Some bus
+    }
+  in
+  let agent =
+    Agent.create
+      ~config:(Types.default_config ~model:"test-model")
+      ~net:env#net
+      ~options
+      ()
+  in
+  let result = Agent.run ~sw agent "hello" in
+  agent, result
+;;
+
+let test_run_emits_started_and_completed () =
+  skip_if_bisect "Agent.run emits Started+Completed";
+  with_mock_server ~handler:mock_handler (fun ~sw env base_url ->
+    let bus = Event_bus.create () in
+    let config =
+      Event_bus.subscription_config ~capacity:16 ~overflow:Event_bus.Drop_newest
+      |> Result.get_ok
+    in
+    let sub = Event_bus.subscribe ~config bus in
+    let agent, result = run_agent_once ~sw env ~base_url bus in
+    (match result with
+     | Ok _ -> ()
+     | Error error -> fail (Error.to_string error));
+    let events = Event_bus.drain sub in
+    let names = List.map event_kind events in
+    check bool "agent_started emitted" true (List.mem "agent_started" names);
+    check bool "agent_completed emitted" true (List.mem "agent_completed" names);
+    check bool "agent_failed not emitted" false (List.mem "agent_failed" names);
+    check
+      bool
+      "started before completed"
+      true
+      (index_of_kind "agent_started" names < index_of_kind "agent_completed" names);
+    let started = find_kind "agent_started" events in
+    let completed = find_kind "agent_completed" events in
+    let agent_name = (Agent.state agent).config.name in
+    (match started.payload with
+     | Event_bus.AgentStarted r ->
+       check string "started agent_name" agent_name r.agent_name;
+       check string "started task_id is the started run_id" started.meta.run_id r.task_id
+     | _ -> fail "expected AgentStarted payload");
+    (match completed.payload with
+     | Event_bus.AgentCompleted r ->
+       check string "completed agent_name" agent_name r.agent_name;
+       check string "completed task_id groups the triple" started.meta.run_id r.task_id;
+       check bool "completed carries Ok result" true (Result.is_ok r.result);
+       check bool "completed elapsed non-negative" true (r.elapsed >= 0.)
+     | _ -> fail "expected AgentCompleted payload");
+    check
+      string
+      "shared correlation_id"
+      started.meta.correlation_id
+      completed.meta.correlation_id;
+    check
+      (option string)
+      "completed caused_by points at started.run_id"
+      (Some started.meta.run_id)
+      completed.meta.caused_by)
+;;
+
+(* HTTP 400 classifies as non-retryable [InvalidRequest], so the run fails
+   immediately without retry backoff. *)
+let failing_mock_handler _conn _req _body =
+  Cohttp_eio.Server.respond_string
+    ~status:`Bad_request
+    ~body:
+      {|{"error":{"message":"mock run failure","type":"invalid_request_error","code":400}}|}
+    ()
+;;
+
+let test_run_emits_failed_companion_on_error () =
+  skip_if_bisect "Agent.run emits Failed companion on error";
+  with_mock_server ~handler:failing_mock_handler (fun ~sw env base_url ->
+    let bus = Event_bus.create () in
+    let config =
+      Event_bus.subscription_config ~capacity:16 ~overflow:Event_bus.Drop_newest
+      |> Result.get_ok
+    in
+    let sub = Event_bus.subscribe ~config bus in
+    let agent, result = run_agent_once ~sw env ~base_url bus in
+    (match result with
+     | Ok _ -> fail "expected run failure"
+     | Error _ -> ());
+    let events = Event_bus.drain sub in
+    let names = List.map event_kind events in
+    check bool "agent_started emitted" true (List.mem "agent_started" names);
+    check bool "agent_completed emitted" true (List.mem "agent_completed" names);
+    check bool "agent_failed emitted" true (List.mem "agent_failed" names);
+    check
+      bool
+      "started before failed"
+      true
+      (index_of_kind "agent_started" names < index_of_kind "agent_failed" names);
+    let started = find_kind "agent_started" events in
+    let completed = find_kind "agent_completed" events in
+    let failed = find_kind "agent_failed" events in
+    let agent_name = (Agent.state agent).config.name in
+    (match completed.payload with
+     | Event_bus.AgentCompleted r ->
+       check bool "completed carries Error result" true (Result.is_error r.result)
+     | _ -> fail "expected AgentCompleted payload");
+    (match failed.payload with
+     | Event_bus.AgentFailed r ->
+       check string "failed agent_name" agent_name r.agent_name;
+       check string "failed task_id groups the triple" started.meta.run_id r.task_id;
+       check
+         bool
+         "failed error non-empty"
+         true
+         (String.length (Error.to_string r.error) > 0);
+       check bool "failed elapsed non-negative" true (r.elapsed >= 0.)
+     | _ -> fail "expected AgentFailed payload");
+    check
+      (option string)
+      "completed caused_by points at started.run_id"
+      (Some started.meta.run_id)
+      completed.meta.caused_by;
+    check
+      (option string)
+      "failed caused_by points at started.run_id"
+      (Some started.meta.run_id)
+      failed.meta.caused_by)
+;;
+
 (* ── Entry point ──────────────────────────────────────────────── *)
 
 let () =
@@ -175,6 +354,16 @@ let () =
             "run_with_handoffs emits Requested+Completed"
             `Quick
             test_handoff_emits_request_and_completion
+        ] )
+    ; ( "run_lifecycle"
+      , [ test_case
+            "Agent.run emits Started+Completed"
+            `Quick
+            test_run_emits_started_and_completed
+        ; test_case
+            "Agent.run emits Failed companion on error"
+            `Quick
+            test_run_emits_failed_companion_on_error
         ] )
     ]
 ;;

--- a/test/test_event_integration.ml
+++ b/test/test_event_integration.ml
@@ -166,6 +166,7 @@ let test_handoff_emits_request_and_completion () =
 ;;
 
 (* ── B. Agent.run emits AgentStarted/AgentCompleted/AgentFailed ── *)
+(* ── B. Agent.run emits AgentStarted/AgentCompleted/AgentFailed ── *)
 
 (* Run-level lifecycle triple restored in [Agent.run]: the legacy
    orchestrator producer was removed in #1755, leaving the variants
@@ -342,7 +343,83 @@ let test_run_emits_failed_companion_on_error () =
       failed.meta.caused_by)
 ;;
 
-(* ── Entry point ──────────────────────────────────────────────── *)
+(* ── C. with_run_lifecycle_events closes Started on synchronous exn ── *)
+
+(* F5 regression: when the run switch is cancelled mid-flight, [Agent.run]
+   observes [Eio.Cancel.Cancelled] from the inner pipeline.  Before the
+   exception-arm fix in [lib/agent/agent_lifecycle_events.ml], that path
+   skipped [publish_finished], leaving a dangling [AgentStarted] with no
+   [AgentCompleted]/[AgentFailed].  The wrapper now mirrors the
+   [Agent_trace] exception-arm contract: publish a terminal event, then
+   re-raise. *)
+
+let slow_handler _conn _req _body =
+  (* Hold the connection so the agent is mid HTTP read when the sub-switch
+     is cancelled below.  Cancellation raises [Eio.Cancel.Cancelled]
+     inside the in-flight read. *)
+  Unix.sleepf 30.0 |> ignore;
+  Cohttp_eio.Server.respond_string ~status:`OK ~body:"never" ()
+;;
+
+let test_run_emits_terminal_on_switch_cancel () =
+  skip_if_bisect "Agent.run emits terminal on switch cancel";
+  with_mock_server ~handler:slow_handler (fun ~sw env base_url ->
+    let bus = Event_bus.create () in
+    let config =
+      Event_bus.subscription_config ~capacity:32 ~overflow:Event_bus.Drop_newest
+      |> Result.get_ok
+    in
+    let sub = Event_bus.subscribe ~config bus in
+    let provider : Provider.config =
+      { provider = Provider.Local { base_url }; model_id = "mock"; api_key_env = "" }
+    in
+    let options =
+      { Agent.default_options with
+        base_url
+      ; provider = Some provider
+      ; event_bus = Some bus
+      }
+    in
+    let agent =
+      Agent.create
+        ~config:(Types.default_config ~model:"test-model")
+        ~net:env#net
+        ~options
+        ()
+    in
+    (* Run the agent in its own sub-switch so we can cancel it without
+       tearing down the outer mock-server switch. *)
+    (try
+       Eio.Switch.run
+       @@ fun agent_sw ->
+       let (_ : unit) =
+         Eio.Fiber.fork ~sw:agent_sw (fun () ->
+           let _ = Agent.run ~sw:agent_sw agent "hello" in
+           ())
+       in
+       (* Yield once so the forked fiber can enter [Agent.run] and
+          publish [AgentStarted].  The slow handler keeps the forked
+          fiber in an in-flight HTTP read when we cancel. *)
+       Eio.Fiber.yield ();
+       Eio.Switch.fail agent_sw Exit
+     with
+     | Exit -> ());
+    (* Sub-switch has been torn down.  The outer switch is still live,
+       so [Event_bus.drain] (which uses [Eio.Mutex]) works.  Whatever
+       events were published before the cancellation re-raise must be
+       available on the bus. *)
+    let events = Event_bus.drain sub in
+    let names = List.map event_kind events in
+    check bool "agent_started emitted" true (List.mem "agent_started" names);
+    check
+      bool
+      "terminal event emitted (completed or failed)"
+      true
+      (List.mem "agent_completed" names || List.mem "agent_failed" names);
+    Eio.Switch.fail sw Exit)
+;;
+
+(* ── Entry point ─────────────────────────────────────────────────── *)
 
 let () =
   if Sys.getenv_opt "ANTHROPIC_API_KEY" = None
@@ -364,6 +441,10 @@ let () =
             "Agent.run emits Failed companion on error"
             `Quick
             test_run_emits_failed_companion_on_error
+        ; test_case
+            "Agent.run emits terminal on switch cancel"
+            `Quick
+            test_run_emits_terminal_on_switch_cancel
         ] )
     ]
 ;;


### PR DESCRIPTION
## Problem

The `AgentStarted`/`AgentCompleted`/`AgentFailed` payload variants existed with **zero publishers** — the contract (subscribers, filters, EVENT-CATALOG) was alive but nothing ever emitted. masc's `keeper_event_bridge` has three matching subscriber arms that were permanently dead.

## Fix

Emit at the run boundary, following the legacy derivation:

- `AgentStarted` at run start (fresh `run_id`; `task_id` = run id)
- `AgentCompleted` always, with run result + elapsed
- `AgentFailed` as companion alongside Completed on error paths (per the documented contract), sharing `caused_by`/`correlation_id`

Covers `run`/`run_detailed`/`run_blocks`/`run_stream_blocks` (and `run_with_handoffs` via `run_blocks_detailed`). Payload shape verified field-by-field against masc's dormant subscriber arms — they now fire (SSE + JSONL bridge).

## Verification

- `dune build lib/` + examples ✓
- test_event_integration 3, observability_default 4, telemetry_pipeline 9, event_bus 49, pipeline 51 ✓
- @fmt clean ✓

Found by adversarial wiring audit (2026-07-17).