### PR TITLE
refactor!: drop Pending_input_updated, with_backtrace, and duplicate fresh_id

### DIFF
--- a/docs/EVENT-CATALOG.md
+++ b/docs/EVENT-CATALOG.md
@@ -267,7 +267,6 @@ on **two channels simultaneously**:
 | `Turn_recorded` | `runtime.turn_recorded` |
 | `Input_required` | `runtime.input_required` |
 | `Input_provided` | `runtime.input_provided` |
-| `Pending_input_updated` | `runtime.pending_input_updated` |
 | `Agent_spawn_requested` | `runtime.agent_spawn_requested` |
 | `Agent_became_live` | `runtime.agent_became_live` |
 | `Agent_output_delta` | `runtime.agent_output_delta` |
@@ -305,10 +304,6 @@ different payload shapes. Disambiguate by Custom name prefix:
   while phase is `Input_required`; `Provide_input` emits
   `Input_provided`, clears the payload, and returns the session to
   `Running`.
-- `Runtime.Pending_input_updated` reports ordinary input that arrived while a
-  turn was busy. Status values are `queued`, `applied`, `interrupted`, or
-  `ignored`. The event is intentionally not a lifecycle phase: ordinary queued
-  input must not imply keeper pause/stop.
 - Runtime finalization persists the operator-facing evidence set:
   `report.json`, `proof.json`, `runtime-telemetry-json`,
   `runtime-telemetry`, `runtime-raw-trace-json`, and `runtime-evidence`.

--- a/docs/design/runtime-continuation-boundaries.md
+++ b/docs/design/runtime-continuation-boundaries.md
@@ -23,15 +23,6 @@ the boundary policy.
 Explicit operator interrupts are separate from ordinary input. An interrupt may
 cancel/checkpoint/resume the running turn, but it is not a pause or stop command.
 
-## Runtime Event
-
-`Runtime.Pending_input_updated` reports host queue state with status labels:
-
-- `queued`
-- `applied`
-- `interrupted`
-- `ignored`
-
-This is deliberately not a runtime lifecycle phase. A busy agent with queued
-input should keep running until it reaches a safe boundary or receives an
-explicit interrupt.
+Ordinary input that arrives while a turn is busy is deliberately not a runtime
+lifecycle phase. A busy agent with queued input should keep running until it
+reaches a safe boundary or receives an explicit interrupt.

--- a/lib/error_domain.ml
+++ b/lib/error_domain.ml
@@ -219,10 +219,6 @@ type error_ctx =
 
 let with_stage stage error = { error; stage = Some stage; backtrace = None }
 
-let with_backtrace error =
-  { error; stage = None; backtrace = Some (Printexc.get_backtrace ()) }
-;;
-
 (* ── String / retryable ─────────────────────────────────── *)
 
 let to_string (err : [< sdk_error_poly ]) : string =

--- a/lib/error_domain.mli
+++ b/lib/error_domain.mli
@@ -103,9 +103,6 @@ type error_ctx =
 (** Wrap an error with pipeline stage context. *)
 val with_stage : string -> sdk_error_poly -> error_ctx
 
-(** Wrap an error capturing the current backtrace. *)
-val with_backtrace : sdk_error_poly -> error_ctx
-
 (** {1 Conversion} *)
 
 val of_sdk_error : Error.sdk_error -> sdk_error_poly

--- a/lib/event_bus.ml
+++ b/lib/event_bus.ml
@@ -127,13 +127,7 @@ let payload_kind = function
 
 (* ── ID generation ────────────────────────────────────────────────── *)
 
-let id_counter = Atomic.make 0
-
-let fresh_id () =
-  let n = Atomic.fetch_and_add id_counter 1 in
-  let timestamp_us = Int.of_float (Unix.gettimeofday () *. 1_000_000.) in
-  Printf.sprintf "%x-%x-%x" (Unix.getpid ()) timestamp_us n
-;;
+let fresh_id = Event_envelope.fresh_id
 
 let mk_envelope ?correlation_id ?run_id ?caused_by () =
   let correlation_id =

--- a/lib/runtime.ml
+++ b/lib/runtime.ml
@@ -189,18 +189,6 @@ type input_provided_event =
   }
 [@@deriving yojson, show]
 
-type pending_input_update_event =
-  { input_id : string option
-  ; participant_name : string option
-  ; source : string option
-  ; boundary : Runtime_continuation.continuation_boundary
-  ; policy : Runtime_continuation.pending_input_policy
-  ; status : string
-  ; message : string option
-  ; created_at : float
-  }
-[@@deriving yojson, show]
-
 type spawn_event =
   { participant_name : string
   ; role : string option
@@ -308,7 +296,6 @@ type event_kind =
   | Turn_recorded of turn_event
   | Input_required of input_request
   | Input_provided of input_provided_event
-  | Pending_input_updated of pending_input_update_event
   | Agent_spawn_requested of spawn_event
   | Agent_became_live of participant_live_event
   | Agent_output_delta of output_delta_event

--- a/lib/runtime.mli
+++ b/lib/runtime.mli
@@ -205,18 +205,6 @@ type input_provided_event =
   }
 [@@deriving yojson, show]
 
-type pending_input_update_event =
-  { input_id : string option
-  ; participant_name : string option
-  ; source : string option
-  ; boundary : Runtime_continuation.continuation_boundary
-  ; policy : Runtime_continuation.pending_input_policy
-  ; status : string
-  ; message : string option
-  ; created_at : float
-  }
-[@@deriving yojson, show]
-
 type spawn_event =
   { participant_name : string
   ; role : string option
@@ -317,7 +305,6 @@ type event_kind =
   | Turn_recorded of turn_event
   | Input_required of input_request
   | Input_provided of input_provided_event
-  | Pending_input_updated of pending_input_update_event
   | Agent_spawn_requested of spawn_event
   | Agent_became_live of participant_live_event
   | Agent_output_delta of output_delta_event

--- a/lib/runtime_evidence.ml
+++ b/lib/runtime_evidence.ml
@@ -80,13 +80,6 @@ let participant_and_detail_of_event = function
   | Turn_recorded detail -> detail.actor, Some detail.message
   | Input_required detail -> detail.participant_name, Some detail.question
   | Input_provided detail -> detail.participant_name, Some detail.request_id
-  | Pending_input_updated detail ->
-    let text =
-      match detail.message with
-      | Some message -> detail.status ^ ":" ^ message
-      | None -> detail.status
-    in
-    detail.participant_name, Some text
   | Agent_spawn_requested detail -> Some detail.participant_name, Some detail.prompt
   | Agent_became_live { participant } ->
     Some participant.participant_name, participant.summary
@@ -123,7 +116,6 @@ let anomaly_fields_of_event = function
   | Turn_recorded _
   | Input_required _
   | Input_provided _
-  | Pending_input_updated _
   | Agent_spawn_requested _
   | Agent_became_live _
   | Agent_output_delta _
@@ -140,7 +132,6 @@ let event_name_of_kind = function
   | Turn_recorded _ -> "turn_recorded"
   | Input_required _ -> "input_required"
   | Input_provided _ -> "input_provided"
-  | Pending_input_updated _ -> "pending_input_updated"
   | Agent_spawn_requested _ -> "agent_spawn_requested"
   | Agent_became_live _ -> "agent_became_live"
   | Agent_output_delta _ -> "agent_output_delta"
@@ -162,8 +153,6 @@ let structured_fields_of_event = function
   | Input_required detail ->
     detail.participant_name, None, None, None, None, None, None, None, None, None, None
   | Input_provided detail ->
-    detail.participant_name, None, None, None, None, None, None, None, None, None, None
-  | Pending_input_updated detail ->
     detail.participant_name, None, None, None, None, None, None, None, None, None, None
   | Agent_spawn_requested detail ->
     ( None

--- a/lib/runtime_projection.ml
+++ b/lib/runtime_projection.ml
@@ -141,9 +141,6 @@ let apply_event (session : session) (event : event) =
        Error
          (Error.Internal
             (Printf.sprintf "Input response %s has no pending request" detail.request_id)))
-  | Pending_input_updated _ ->
-    let* session = ensure_active_phase session in
-    Ok session
   | Agent_spawn_requested detail ->
     let* session = ensure_active_phase session in
     Ok

--- a/lib/runtime_server_types.ml
+++ b/lib/runtime_server_types.ml
@@ -402,7 +402,6 @@ let custom_name_of_kind = function
   | Turn_recorded _ -> "runtime.turn_recorded"
   | Input_required _ -> "runtime.input_required"
   | Input_provided _ -> "runtime.input_provided"
-  | Pending_input_updated _ -> "runtime.pending_input_updated"
   | Agent_spawn_requested _ -> "runtime.agent_spawn_requested"
   | Agent_became_live _ -> "runtime.agent_became_live"
   | Agent_output_delta _ -> "runtime.agent_output_delta"
@@ -433,7 +432,6 @@ let event_bus_run_id_of_event (event : event) =
   | Turn_recorded _
   | Input_required _
   | Input_provided _
-  | Pending_input_updated _
   | Agent_spawn_requested _
   | Artifact_attached _
   | Checkpoint_saved _

--- a/test/test_error_domain.ml
+++ b/test/test_error_domain.ml
@@ -708,7 +708,7 @@ let test_retryable_internal () =
     (Error_domain.is_retryable (`Internal "x"))
 ;;
 
-(* ── with_stage / with_backtrace / ctx_to_string ────────── *)
+(* ── with_stage / ctx_to_string ─────────────────────────── *)
 
 let test_with_stage () =
   let ctx = Error_domain.with_stage "route" (`Auth_error "bad") in
@@ -716,16 +716,6 @@ let test_with_stage () =
   Alcotest.(check (option string)) "backtrace" None ctx.backtrace;
   match ctx.error with
   | `Auth_error "bad" -> ()
-  | _ -> Alcotest.fail "wrong error in ctx"
-;;
-
-let test_with_backtrace () =
-  let ctx = Error_domain.with_backtrace (`Internal "boom") in
-  Alcotest.(check (option string)) "stage" None ctx.stage;
-  (* Backtrace is Some (possibly empty string) *)
-  Alcotest.(check bool) "backtrace is some" true (Option.is_some ctx.backtrace);
-  match ctx.error with
-  | `Internal "boom" -> ()
   | _ -> Alcotest.fail "wrong error in ctx"
 ;;
 
@@ -740,7 +730,9 @@ let test_ctx_to_string_with_stage () =
 ;;
 
 let test_ctx_to_string_without_stage () =
-  let ctx = Error_domain.with_backtrace (`Internal "oops") in
+  let ctx : Error_domain.error_ctx =
+    { error = `Internal "oops"; stage = None; backtrace = None }
+  in
   let s = Error_domain.ctx_to_string ctx in
   (* Should not have brackets prefix *)
   Alcotest.(check bool) "no stage prefix" true (String.length s > 0 && s.[0] <> '[')
@@ -913,7 +905,6 @@ let () =
         ] )
     ; ( "context"
       , [ Alcotest.test_case "with_stage" `Quick test_with_stage
-        ; Alcotest.test_case "with_backtrace" `Quick test_with_backtrace
         ; Alcotest.test_case
             "ctx_to_string with stage"
             `Quick

--- a/test/test_runtime_continuation.ml
+++ b/test/test_runtime_continuation.ml
@@ -93,28 +93,6 @@ let test_runtime_status_labels () =
     cases
 ;;
 
-let test_runtime_pending_input_update_roundtrip () =
-  let event =
-    Runtime.Pending_input_updated
-      { input_id = Some "input-1"
-      ; participant_name = Some "keeper"
-      ; source = Some "dashboard"
-      ; boundary = Runtime_continuation.Provider_streaming_reasoning
-      ; policy = Runtime_continuation.Queue_until_safe_boundary
-      ; status = "queued"
-      ; message = Some "ordinary input queued while provider is reasoning"
-      ; created_at = 1.0
-      }
-  in
-  let json = Runtime.event_kind_to_yojson event in
-  match Runtime.event_kind_of_yojson json with
-  | Ok (Runtime.Pending_input_updated decoded) ->
-    Alcotest.(check (option string)) "input_id" (Some "input-1") decoded.input_id;
-    Alcotest.(check string) "status" "queued" decoded.status
-  | Ok other -> Alcotest.failf "unexpected event kind: %s" (Runtime.show_event_kind other)
-  | Error err -> Alcotest.fail err
-;;
-
 let () =
   Alcotest.run
     "runtime_continuation"
@@ -133,12 +111,6 @@ let () =
             `Quick
             test_explicit_interrupt_is_not_pause_or_stop
         ; Alcotest.test_case "status labels" `Quick test_runtime_status_labels
-        ] )
-    ; ( "runtime"
-      , [ Alcotest.test_case
-            "pending input update event roundtrip"
-            `Quick
-            test_runtime_pending_input_update_roundtrip
         ] )
     ]
 ;;

--- a/test/test_runtime_projection_cov2.ml
+++ b/test/test_runtime_projection_cov2.ml
@@ -268,35 +268,6 @@ let test_apply_input_provided_resumes_running () =
   | Error e -> Alcotest.fail (Error.to_string e)
 ;;
 
-let test_apply_pending_input_update_is_not_lifecycle_state () =
-  let request = input_request () in
-  let session =
-    mk_session ~phase:Running ~pending_input:(Some request) ~turn_count:7 ()
-  in
-  let event =
-    mk_event
-      (Pending_input_updated
-         { input_id = Some "pending-1"
-         ; participant_name = Some "alice"
-         ; source = Some "dashboard"
-         ; boundary = Runtime_continuation.Provider_streaming_reasoning
-         ; policy = Runtime_continuation.Queue_until_safe_boundary
-         ; status = "queued"
-         ; message = Some "queued while reasoning"
-         ; created_at = 456.0
-         })
-  in
-  match Runtime_projection.apply_event session event with
-  | Ok s ->
-    Alcotest.(check bool) "phase unchanged" true (s.phase = Running);
-    Alcotest.(check int) "turn_count unchanged" 7 s.turn_count;
-    (match s.pending_input with
-     | Some pending ->
-       Alcotest.(check string) "pending retained" request.request_id pending.request_id
-     | None -> Alcotest.fail "pending input should be retained")
-  | Error e -> Alcotest.fail (Error.to_string e)
-;;
-
 let test_apply_input_provided_rejects_mismatch () =
   let session =
     mk_session
@@ -792,10 +763,6 @@ let () =
             "Input_provided resumes"
             `Quick
             test_apply_input_provided_resumes_running
-        ; Alcotest.test_case
-            "Pending_input_updated is not lifecycle state"
-            `Quick
-            test_apply_pending_input_update_is_not_lifecycle_state
         ; Alcotest.test_case
             "Input_provided mismatch"
             `Quick

--- a/test/test_runtime_server_types.ml
+++ b/test/test_runtime_server_types.ml
@@ -138,17 +138,6 @@ let test_custom_name_of_kind_all_variants () =
           ; response = Runtime.Input_answer (`String "yes")
           }
       , "runtime.input_provided" )
-    ; ( Runtime.Pending_input_updated
-          { input_id = Some "pending-1"
-          ; participant_name = Some "worker-1"
-          ; source = Some "dashboard"
-          ; boundary = Runtime_continuation.Provider_streaming_reasoning
-          ; policy = Runtime_continuation.Queue_until_safe_boundary
-          ; status = "queued"
-          ; message = Some "queued while reasoning"
-          ; created_at = 1.0
-          }
-      , "runtime.pending_input_updated" )
     ; ( Runtime.Agent_spawn_requested
           { participant_name = "worker-1"
           ; role = Some "reviewer"


### PR DESCRIPTION
## Problem

Post-purge leftovers:

1. `Pending_input_updated` wire event variant — zero constructors after the continuation policy half was removed (#2688 removes `Runtime_continuation`). Deleted the variant + its record + the exhaustive match arms + tests + docs.
2. `Error_domain.with_backtrace` — zero callers.
3. `fresh_id` — two implementations (event_bus + event_envelope, same pid/ts/counter shape). event_bus now delegates to `Event_envelope.fresh_id`; emitted ids gain the `evt-` prefix (ids are opaque; nothing parses them).

## Kept after re-verification (audit premise no longer holds on this base)

- `runtime.mli` protocol types — still used by `runtime_server`/`runtime_server_types` until #2688 lands
- `lib/consumer.ml` — still used by `harness_runner` until #2689 lands

**Merge note**: touches `runtime.ml` like #2688 (which keeps the variant but drops 2 fields); whichever lands second needs a rebase — the resolutions are compatible (this PR removes the whole variant).

## Verification

- `dune build lib/` ✓
- error_domain 64, event_bus 49, event_envelope 8, runtime_projection_cov2 37, runtime_continuation 5, runtime_server_types 15 ✓
- @fmt clean ✓