### PR TITLE
fix(llm_provider): reconcile EndTurn with tool blocks to StopToolUse (dangling tool_use prevention)

### DIFF
--- a/lib/llm_provider/backend_tool_call_harness.ml
+++ b/lib/llm_provider/backend_tool_call_harness.ml
@@ -583,7 +583,18 @@ let%test "openai tool_calls response validates correctly" =
     && (List.hd result.tool_calls_found).name = "read_file"
 ;;
 
-let%test "wrong stop_reason for tool calls fails validation" =
+(* Integration guard for the finish_reason=stop/end_turn + tool-block mislabel
+   fix: a provider that emits a complete tool_use block but labels the turn
+   [end_turn] is reconciled by [Backend_anthropic.parse_response]
+   ([Stop_reason_wire.reconcile]) to a [StopToolUse] turn, so the executable
+   tool call is not left dangling (no tool_result) and the parsed response
+   validates as a correct tool turn. Reverting the [reconcile]/[of_finish]
+   [EndTurn]-with-tool-blocks arm turns this RED (the parser would return
+   [EndTurn] and [stop_reason_matches_tool_calls] would flag the tool turn as a
+   stop-reason mismatch). The pure-unit invariant that a *typed* [EndTurn] with
+   tool calls is a mismatch is still asserted separately against
+   [validate_response] on a hand-built [api_response]. *)
+let%test "end_turn + tool_use is reconciled to a valid tool turn" =
   let json =
     `Assoc
       [ "id", `String "msg_bad"
@@ -608,7 +619,7 @@ let%test "wrong stop_reason for tool calls fails validation" =
       ]
   in
   let result = validate_anthropic_response ~declared_tools:[ "test" ] json in
-  not result.stop_reason_correct
+  result.stop_reason_correct && List.length result.tool_calls_found = 1
 ;;
 
 let%test "text-only response passes validation" =

--- a/lib/llm_provider/stop_reason_wire.ml
+++ b/lib/llm_provider/stop_reason_wire.ml
@@ -28,7 +28,14 @@ let of_finish (w : wire_finish) ~has_tool_blocks : Types.stop_reason =
   match w with
   | Tool_calls -> if has_tool_blocks then Types.StopToolUse else Types.UnmatchedToolCalls
   | Length -> Types.MaxTokens
-  | Stop -> Types.EndTurn
+  (* Parse-time parity with [reconcile]: a [Stop] (finish_reason=stop/end_turn)
+     that nonetheless carried complete tool blocks is a provider mislabel of a
+     tool-request turn, so trust the content and upgrade to [StopToolUse]. This
+     keeps the streaming chain ([provisional_of_string] |> [reconcile]) and the
+     non-streaming parser ([of_finish]) in agreement. Scoped to [Stop] only —
+     [Length] stays [MaxTokens] because a length-truncated tool call may be
+     incomplete and unsafe to auto-execute. *)
+  | Stop -> if has_tool_blocks then Types.StopToolUse else Types.EndTurn
   | Refusal -> Types.Refusal
   | Content_filter -> Types.ContentFilter
   | Repetition_truncation -> Types.RepetitionTruncation
@@ -56,6 +63,20 @@ let reconcile (sr : Types.stop_reason) ~has_tool_blocks : Types.stop_reason =
   | Types.StopToolUse when not has_tool_blocks -> Types.UnmatchedToolCalls
   | Types.UnmatchedToolCalls when has_tool_blocks -> Types.StopToolUse
   | Types.Unknown _ when has_tool_blocks -> Types.StopToolUse
+  (* "trust content over label" for normal completion: a provider that emitted
+     complete tool_use blocks but labeled the turn [EndTurn]
+     (OpenAI/GLM finish_reason=stop) is mislabeling a tool-request turn. The
+     tool-block presence is authoritative, so upgrade to [StopToolUse] and let
+     the driver execute the tools instead of ending the turn with dangling
+     tool_uses (tool_use blocks with no tool_result). Mirrors the same upgrade
+     already applied to [UnmatchedToolCalls] + blocks and [Unknown] + blocks.
+     Deliberately scoped to [EndTurn] only. [MaxTokens] + blocks may be a
+     TRUNCATED/incomplete tool call, so auto-executing it is unsafe;
+     [Refusal]/[ContentFilter]/[RepetitionTruncation]/[StopSequence]/
+     [PauseTurn]/[Compaction]/[ContextWindowExceeded] carry specific terminal
+     meaning where executing a stray tool block is unsafe or ambiguous. Only
+     normal completion + blocks is an unambiguous provider mislabel. *)
+  | Types.EndTurn when has_tool_blocks -> Types.StopToolUse
   | Types.StopToolUse
   | Types.EndTurn
   | Types.MaxTokens
@@ -109,6 +130,60 @@ let%test "reconcile downgrades StopToolUse without tools" =
 
 let%test "reconcile preserves StopToolUse with tools" =
   reconcile Types.StopToolUse ~has_tool_blocks:true = Types.StopToolUse
+;;
+
+(* EndTurn + tool blocks is a provider mislabel (finish_reason=stop alongside
+   complete tool_calls): upgrade to StopToolUse so the driver executes the tools
+   instead of persisting dangling tool_uses. Reverting the new [reconcile] arm
+   turns this RED. *)
+let%test "reconcile upgrades EndTurn with tools to StopToolUse" =
+  reconcile Types.EndTurn ~has_tool_blocks:true = Types.StopToolUse
+;;
+
+(* A normal completion with no tool blocks still ends the turn. *)
+let%test "reconcile preserves EndTurn without tools" =
+  reconcile Types.EndTurn ~has_tool_blocks:false = Types.EndTurn
+;;
+
+(* Truncation safety: MaxTokens + tool blocks is NOT upgraded, because a
+   length-truncated tool call may be incomplete and unsafe to auto-execute.
+   Reverting the [EndTurn]-scoping (e.g. widening the guard to MaxTokens) turns
+   this RED. *)
+let%test "reconcile preserves MaxTokens with tools (truncation not upgraded)" =
+  reconcile Types.MaxTokens ~has_tool_blocks:true = Types.MaxTokens
+;;
+
+(* Parse-time counterpart of the upgrade for the non-streaming OpenAI parser,
+   which calls [of_finish] directly (no [reconcile]). Reverting the [of_finish]
+   [Stop] guard turns this RED. *)
+let%test "of_finish Stop with tools is StopToolUse" =
+  of_finish Stop ~has_tool_blocks:true = Types.StopToolUse
+;;
+
+let%test "of_finish Stop without tools is EndTurn" =
+  of_finish Stop ~has_tool_blocks:false = Types.EndTurn
+;;
+
+(* of_finish Length (finish_reason=length) keeps MaxTokens even with tools —
+   truncation is preserved on the parse-time path too. *)
+let%test "of_finish Length with tools stays MaxTokens" =
+  of_finish Length ~has_tool_blocks:true = Types.MaxTokens
+;;
+
+(* Streaming (provisional |> reconcile) and parse-time (of_finish) must agree
+   for finish_reason=stop with tools. Reverting EITHER the reconcile arm OR the
+   of_finish guard breaks parity here (one side changes, the other does not). *)
+let%test "streaming chain matches parse-time of_finish for stop + tools" =
+  let chain hb =
+    reconcile (provisional_of_string "stop") ~has_tool_blocks:hb
+    = of_finish (wire_finish_of_string "stop") ~has_tool_blocks:hb
+  in
+  chain true && chain false
+;;
+
+let%test "streaming chain matches parse-time of_finish for end_turn + tools" =
+  reconcile (provisional_of_string "end_turn") ~has_tool_blocks:true
+  = of_finish (wire_finish_of_string "end_turn") ~has_tool_blocks:true
 ;;
 
 let%test "is_unmatched_tool_calls recognizes only canonical fail-closed value" =

--- a/lib/llm_provider/stop_reason_wire.mli
+++ b/lib/llm_provider/stop_reason_wire.mli
@@ -38,7 +38,12 @@ val wire_finish_of_string : string -> wire_finish
 (** Canonical parse-time mapping for backends that know the assembled tool-block
     set at parse time (the non-streaming OpenAI parser). [Tool_calls] without a
     tool block fails closed to [UnmatchedToolCalls]. [Other] preserves the raw
-    terminal label as [Unknown] when no tool block exists. *)
+    terminal label as [Unknown] when no tool block exists. [Stop]
+    (finish_reason=stop/end_turn) with a tool block present upgrades to
+    [StopToolUse] — a provider that emits complete tool_calls but labels the
+    turn as normal completion is mislabeling a tool-request turn, and the
+    tool-block presence is authoritative. [Length] stays [MaxTokens] even with a
+    tool block, since a length-truncated tool call may be incomplete. *)
 val of_finish : wire_finish -> has_tool_blocks:bool -> Types.stop_reason
 
 (** Faithful wire claim for the streaming chunk boundary, where the accumulated
@@ -48,11 +53,15 @@ val of_finish : wire_finish -> has_tool_blocks:bool -> Types.stop_reason
 val provisional_of_string : string -> Types.stop_reason
 
 (** Enforce parse-time parity after streaming accumulation. Maps [StopToolUse]
-    with [has_tool_blocks = false] to [UnmatchedToolCalls], and maps
-    [Unknown _] with [has_tool_blocks = true] to [StopToolUse] so nonstandard
-    finish labels that carried tool blocks follow {!of_finish}. Leaves other
-    reasons unchanged. Total over {!Types.stop_reason}: no catch-all, so a new
-    [stop_reason] constructor forces a compile error here. *)
+    with [has_tool_blocks = false] to [UnmatchedToolCalls]; maps [Unknown _]
+    with [has_tool_blocks = true] to [StopToolUse]; and maps [EndTurn] with
+    [has_tool_blocks = true] to [StopToolUse] (a finish_reason=stop alongside
+    complete tool blocks is a provider mislabel of a tool-request turn) so these
+    labels follow {!of_finish}. [MaxTokens] and the other terminal reasons are
+    left unchanged even with tool blocks — a truncated or terminally-flagged
+    turn must not auto-execute a possibly-incomplete tool call. Total over
+    {!Types.stop_reason}: no catch-all, so a new [stop_reason] constructor forces
+    a compile error here. *)
 val reconcile : Types.stop_reason -> has_tool_blocks:bool -> Types.stop_reason
 
 (** [true] only for the typed fail-closed value produced when a provider


### PR DESCRIPTION
## Symptom

A provider emits complete, valid `tool_calls` but labels the response
`finish_reason=stop` (OpenAI/GLM-compatible) — decoded to `Types.EndTurn`.
At the wire boundary this passed through unchanged, so the turn driver
(`lib/pipeline/pipeline.ml` `stage_output`) took the `EndTurn` branch →
`Complete response` → the turn **ended without executing the tools**. The
`tool_use` blocks were then persisted as **dangling tool_uses** (no matching
`tool_result`), which blocks keeper compaction downstream (masc
`Overlapping_tool_cycle`).

## Live evidence (as reported)

A keeper checkpoint (`~/.masc/traces/trace-1783834961007-00002/oas-snapshot-*-g0.json`)
contained multiple dangling `tool_use` blocks (ids `call_function_<base>_<index>`,
names `keeper_board_list`/`keeper_tasks_list`) whose `input` is **complete valid
JSON** (`{"limit":3,"sort_by":"recent"}`) — i.e. NOT truncated (not `MaxTokens`);
they are complete tool calls mislabeled with `finish_reason=stop`. Some turns
emitted parallel calls (`_1`+`_2`), both dangling. (Traces are ephemeral
per-host and have since rotated; the fix below was verified independently at the
code-path level.)

## Root cause

`lib/llm_provider/stop_reason_wire.ml` `reconcile` upgrades
`UnmatchedToolCalls`+blocks → `StopToolUse` and `Unknown _`+blocks →
`StopToolUse` (trust content over label), but `EndTurn`+blocks fell into the
pass-through arm (`-> sr`). The non-streaming OpenAI parser also mapped
`Stop -> EndTurn` in `of_finish` regardless of tool blocks.

Verified paths:
- `finish_reason=stop`/`end_turn` → `wire_finish_of_string` → `Stop` →
  `of_finish`/`provisional_of_string` → `EndTurn`.
- `finish_reason=tool_calls` → `Tool_calls` → `StopToolUse` (with blocks).
- OpenAI non-streaming uses `of_finish` **directly** (no `reconcile`); Anthropic
  (`backend_anthropic.ml:70`) and streaming (`complete_stream_acc.ml:468`) use
  `reconcile`. Both boundaries needed the guard for full coverage and parity.
- `has_tool_blocks` = presence of `ToolUse` content blocks in both backends,
  exactly matching `stage_output`'s `ToolUse` filter → the upgrade is
  self-consistent (a `StopToolUse` turn will always find a non-empty tool set).

## Fix (bounded)

`EndTurn` with `has_tool_blocks:true` → `StopToolUse`, applied on **both**:
- `reconcile` (Anthropic + streaming path), and
- `of_finish` `Stop` arm (non-streaming OpenAI parser),

so the streaming chain (`provisional_of_string |> reconcile`) and the
parse-time `of_finish` agree. `.mli` docs updated to match.

**Deliberately scoped to `EndTurn` only.** `MaxTokens`+blocks is NOT upgraded —
a length-truncated tool call may be incomplete and unsafe to auto-execute. The
other terminal reasons (`Refusal`/`ContentFilter`/`RepetitionTruncation`/
`StopSequence`/`PauseTurn`/`Compaction`/`ContextWindowExceeded`) carry specific
terminal meaning where executing a stray tool block is unsafe or ambiguous.
Only normal completion + blocks is an unambiguous provider mislabel. This is the
same "trust content over label" principle already applied to
`UnmatchedToolCalls`+blocks and `Unknown`+blocks (the F1 reconcile invariant).

## Relationship to masc#25392

This is the **upstream prevention**: OAS no longer produces dangling tool_uses
from `finish_reason=stop`-mislabeled tool turns. masc#25392 is the downstream
**compaction tolerance** for already-persisted dangling tool_uses. Complementary.

## Tests (revert-red, verified)

Inline `%test`s in `stop_reason_wire.ml`:
- `reconcile EndTurn ~has_tool_blocks:true = StopToolUse` (the fix)
- `reconcile EndTurn ~has_tool_blocks:false = EndTurn` (unchanged)
- `reconcile MaxTokens ~has_tool_blocks:true = MaxTokens` (truncation preserved)
- `of_finish Stop ~has_tool_blocks:true = StopToolUse` / `...:false = EndTurn`
- `of_finish Length ~has_tool_blocks:true = MaxTokens`
- streaming↔parse-time parity for `stop`/`end_turn` + tools

Repurposed integration guard in `backend_tool_call_harness.ml` (test-only
diagnostic module, not a runtime guardrail): the former "wrong stop_reason for
tool calls fails validation" test asserted the parser leaves `end_turn`+tool_use
flagged as a mismatch — exactly the premise this fix inverts. It now asserts
`end_turn`+tool_use is reconciled to a valid tool turn via
`Backend_anthropic.parse_response`. The pure-unit invariant that a *typed*
`EndTurn` with tool calls is a mismatch (`stop_reason_matches_tool_calls`)
remains asserted separately in `test/test_backend_tool_call_harness.ml`.

**Counterfactual (revert-red) run**: reverting both fix arms turns RED:
- `end_turn + tool_use is reconciled to a valid tool turn` (harness integration)
- `reconcile upgrades EndTurn with tools to StopToolUse`
- `of_finish Stop with tools is StopToolUse`

## Build / gates

- `ocamlformat --inplace` 0.29.0 (== CI) on changed files.
- `dune build @check` GREEN; `dune build @fmt` GREEN.
- `dune runtest lib/llm_provider` GREEN; `dune runtest test` (full suite) GREEN.
- `scripts/ci-code-smell-ratchet.sh --check` PASSED (catch_all 358→357).

RFC-WAIVED: lib/llm_provider + inline tests — bounded stop_reason reconcile extension
