### PR TITLE
fix(llm_provider): drop coordinator name from docstrings for SDK independence

### DIFF
--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -1829,7 +1829,7 @@ type first_event_bound =
    deadline of its own:
 
    - explicit [first_event_timeout] wins;
-   - else [body_timeout], the total body budget masc already wires but which
+   - else [body_timeout], the total body budget callers already wire, but which
      did not reach the streaming reader before this fix (the production shape
      the RFC exists to repair: a long prefill bounded by the long budget
      instead of the short inter-token one);
@@ -1897,7 +1897,7 @@ let read_sse ?clock ?idle_timeout ?first_event_timeout ?body_timeout ~reader ~on
      inter-token idle. A silent prefill on a large context is slow-but-alive,
      not a hang, so it must not be cut by the inter-token idle value. When
      [first_event_timeout] is [None] the first-event wait falls back to
-     [body_timeout] (masc's total body budget), then to [idle_timeout] — the
+     [body_timeout] (the total body budget already wired by the caller), then to [idle_timeout] — the
      pre-RFC bound, kept so callers that wired only an idle deadline keep
      exactly their previous behaviour (see [resolve_first_event_timeout]).
      With nothing wired the wait stays unarmed, as before. Inter-token idle

--- a/lib/llm_provider/llm_transport.ml
+++ b/lib/llm_provider/llm_transport.ml
@@ -27,7 +27,7 @@ type completion_request =
         path this bounds the whole response read. On the streaming path it is
         the fallback bound for the first-event (TTFT/prefill) wait when
         [first_event_timeout_s] is [None] — the common production shape, since
-        callers (e.g. masc) wire [body_timeout_s] but not
+        callers wire [body_timeout_s] but not
         [first_event_timeout_s]. [None] leaves the streaming first-event wait
         to [stream_idle_timeout_s], and unarmed if that is [None] too. Armed
         only when the transport also holds a clock. @since 0.218.0 *)


### PR DESCRIPTION
## Why

SDK Independence Gate (`scripts/check-sdk-independence.sh`) fails on main after #2723: three docstrings referenced the coordinator by name (`\bmasc\b`) in `lib/`, which the gate's strict tier rejects. This blocks #2725/#2689/#2690 (their update-branch pulls main and inherits the gate failure).

## Change
Rephrase to caller-neutral wording (docstrings only, no behaviour change):
- `lib/llm_provider/llm_transport.ml` body_timeout_s
- `lib/llm_provider/http_client.ml` resolve_first_event_bound (2 comments)

## Verify
- `scripts/check-sdk-independence.sh`: OK (passed)
- `dune build @fmt`: clean
- `scripts/dune-local.sh build @install`: exit 0

Co-Authored-By: Claude <noreply@anthropic.com>
