### PR TITLE
fix(llm_provider): surface unmodeled empty-completion stop_reason

### DIFF
--- a/lib/llm_provider/error.ml
+++ b/lib/llm_provider/error.ml
@@ -277,21 +277,36 @@ let of_provider_failure ?provider kind message =
           Printf.sprintf "provider response exceeded %d bytes: %s" limit_bytes message
       }
   | Http_client.Empty_completion { stop_reason } ->
-    (match Retry.overflow_of_empty_completion ~stop_reason ~message with
-     | Some overflow ->
+    (match Retry.verdict_of_empty_completion ~stop_reason ~message with
+     | Retry.Empty_overflow overflow ->
        (* Third promotion site of the #2621 misclassification fix: a
           ContextWindowExceeded empty completion is a caller-fixable context
           overflow, not provider unavailability. The overflow VALUE comes from
-          the shared [Retry.overflow_of_empty_completion] classifier; this
+          the shared [Retry.verdict_of_empty_completion] classifier; this
           deliberate SDK boundary flattens it to a string via
           [Retry.error_message] into [InvalidRequest], preserving the typed →
           string boundary that keeps the public surface source-compatible. *)
        InvalidRequest { provider; reason = Retry.error_message overflow }
-     | None ->
+     | Retry.Empty_unattributed { token } ->
+       (* An empty turn whose stop_reason token this SDK does not model is not
+          evidence of provider unavailability, and rendering it as such invites
+          the caller to retry the identical prompt — which never terminates when
+          the real condition was an overflow reported with an unmodeled token.
+          Flattened to the same [InvalidRequest] surface as the overflow case,
+          naming the token so it can be modelled. *)
+       InvalidRequest
+         { provider
+         ; reason =
+             Printf.sprintf
+               "empty completion with unmodeled stop_reason=%S: %s"
+               token
+               message
+         }
+     | Retry.Empty_attributed ->
        (* [stop_reason] stays typed until this deliberate SDK boundary.  The
           public error surface remains source-compatible: callers already handle
-          a non-overflow empty completion as provider unavailability, and no
-          control flow reparses this diagnostic rendering. *)
+          a recognized non-overflow empty completion as provider unavailability,
+          and no control flow reparses this diagnostic rendering. *)
        ProviderUnavailable
          { provider
          ; detail =

--- a/lib/llm_provider/retry.ml
+++ b/lib/llm_provider/retry.ml
@@ -99,26 +99,36 @@ let is_retryable = function
   | PaymentRequired _ -> false
 ;;
 
-(** [overflow_of_empty_completion ~stop_reason ~message] is the single,
-    compiler-checked source for the #2621 empty-completion overflow rule.
+(** Verdict for a provider turn that produced no content blocks.
 
-    An empty turn whose typed [stop_reason] is [ContextWindowExceeded] is a
-    context-overflow contract, not provider unavailability: retrying or
-    rotating replays the same oversized prompt, so only the consumer's context
-    recovery (compaction) can make progress. The provider does not report its
-    limit on this path, hence [limit = None].
+    An empty turn is never a normal outcome, and the correct recovery differs by
+    attribution. [Empty_overflow] can only progress through the consumer's
+    context recovery (compaction): retrying or rotating replays the same
+    oversized prompt. A recognized non-overflow stop_reason ([Empty_attributed])
+    keeps the existing provider-unavailability handling.
 
-    Only the typed [ContextOverflow] value is produced here. Each caller keeps
-    its own wrapping of the result — [Provider_failure_attribution]'s
-    [Error.Api], and the SDK boundary in [Error] that flattens via
-    [error_message] into [InvalidRequest]. Every
-    other stop_reason returns [None] so callers apply their existing
-    non-overflow handling. The match is exhaustive (no [_] catch-all) so adding
-    a new [Types.stop_reason] forces a decision here. *)
-let overflow_of_empty_completion ~(stop_reason : Types.stop_reason) ~message =
+    [Empty_unattributed] is the third case, previously folded into the second:
+    the provider ended an empty turn with a stop_reason token this SDK does not
+    model. Retrying or rotating replays the same prompt, so attributing it to
+    transient provider unavailability turns an unmodeled provider contract into
+    an invisible retry loop — an overflow signalled with an unmodeled token
+    never reaches the consumer's compaction path and no error is raised. This
+    arm exists so the condition is surfaced rather than guessed. The match is
+    exhaustive (no [_] catch-all) so a new [Types.stop_reason] forces a decision
+    here.
+
+    The verdict is derived from the typed stop_reason alone — no provider
+    identity is consulted, so every backend that reports an empty completion is
+    classified by the same rule. *)
+type empty_completion_verdict =
+  | Empty_overflow of api_error
+  | Empty_attributed
+  | Empty_unattributed of { token : string }
+
+let verdict_of_empty_completion ~(stop_reason : Types.stop_reason) ~message =
   match stop_reason with
   | Types.ContextWindowExceeded ->
-    Some
+    Empty_overflow
       (ContextOverflow
          { message =
              "empty completion (stop_reason=model_context_window_exceeded): " ^ message
@@ -133,8 +143,32 @@ let overflow_of_empty_completion ~(stop_reason : Types.stop_reason) ~message =
   | Types.RepetitionTruncation
   | Types.PauseTurn
   | Types.Compaction
-  | Types.UnmatchedToolCalls
-  | Types.Unknown _ -> None
+  | Types.UnmatchedToolCalls -> Empty_attributed
+  | Types.Unknown token -> Empty_unattributed { token }
+;;
+
+(** [overflow_of_empty_completion ~stop_reason ~message] is the single,
+    compiler-checked source for the #2621 empty-completion overflow rule.
+
+    An empty turn whose typed [stop_reason] is [ContextWindowExceeded] is a
+    context-overflow contract, not provider unavailability: retrying or
+    rotating replays the same oversized prompt, so only the consumer's context
+    recovery (compaction) can make progress. The provider does not report its
+    limit on this path, hence [limit = None].
+
+    Only the typed [ContextOverflow] value is produced here. Each caller keeps
+    its own wrapping of the result — [Provider_failure_attribution]'s
+    [Error.Api], and the SDK boundary in [Error] that flattens via
+    [error_message] into [InvalidRequest].
+
+    This is the overflow-only projection of {!verdict_of_empty_completion}: it
+    collapses both a recognized non-overflow stop_reason and an unmodeled one
+    into [None]. Callers that must not retry an unmodeled contract read the
+    verdict directly instead. *)
+let overflow_of_empty_completion ~(stop_reason : Types.stop_reason) ~message =
+  match verdict_of_empty_completion ~stop_reason ~message with
+  | Empty_overflow overflow -> Some overflow
+  | Empty_attributed | Empty_unattributed _ -> None
 ;;
 
 let%test "overflow_of_empty_completion: ContextWindowExceeded yields ContextOverflow" =
@@ -153,6 +187,48 @@ let%test "overflow_of_empty_completion: non-overflow stop_reason yields None" =
   match overflow_of_empty_completion ~stop_reason:Types.EndTurn ~message:"X" with
   | None -> true
   | Some _ -> false
+;;
+
+let%test "verdict_of_empty_completion: ContextWindowExceeded is Empty_overflow" =
+  match
+    verdict_of_empty_completion ~stop_reason:Types.ContextWindowExceeded ~message:"X"
+  with
+  | Empty_overflow (ContextOverflow { limit = None; _ }) -> true
+  | Empty_overflow _ | Empty_attributed | Empty_unattributed _ -> false
+;;
+
+(* An unmodeled stop_reason token must stay distinguishable from a recognized
+   non-overflow one: folding it into [Empty_attributed] sends the caller to
+   provider-unavailability handling, which retries the identical prompt. *)
+let%test "verdict_of_empty_completion: unmodeled token is Empty_unattributed" =
+  match
+    verdict_of_empty_completion
+      ~stop_reason:(Types.Unknown "provider_specific_overflow")
+      ~message:"X"
+  with
+  | Empty_unattributed { token = "provider_specific_overflow" } -> true
+  | Empty_unattributed _ | Empty_overflow _ | Empty_attributed -> false
+;;
+
+(* Guard against over-classification: a recognized non-overflow stop_reason must
+   not be promoted into the unattributed (fail-loud) arm. *)
+let%test "verdict_of_empty_completion: recognized non-overflow is Empty_attributed" =
+  List.for_all
+    (fun stop_reason ->
+       match verdict_of_empty_completion ~stop_reason ~message:"X" with
+       | Empty_attributed -> true
+       | Empty_overflow _ | Empty_unattributed _ -> false)
+    [ Types.EndTurn
+    ; Types.StopToolUse
+    ; Types.MaxTokens
+    ; Types.StopSequence
+    ; Types.Refusal
+    ; Types.ContentFilter
+    ; Types.RepetitionTruncation
+    ; Types.PauseTurn
+    ; Types.Compaction
+    ; Types.UnmatchedToolCalls
+    ]
 ;;
 
 (** Extract a human-readable error message from a provider error body.

--- a/lib/llm_provider/retry.mli
+++ b/lib/llm_provider/retry.mli
@@ -46,14 +46,41 @@ type api_error =
 val is_retryable : api_error -> bool
 val error_message : api_error -> string
 
-(** [overflow_of_empty_completion ~stop_reason ~message] classifies an empty
-    provider completion into [Some (ContextOverflow …)] when [stop_reason] is
-    [ContextWindowExceeded], else [None]. Single compiler-checked source for the
-    #2621 empty-completion overflow rule shared by [Api],
-    [Provider_failure_attribution], and the SDK boundary in [Error]; each caller
-    keeps its own wrapping of the returned value. The message prefix
+(** Verdict for a provider turn that produced no content blocks.
+
+    [Empty_overflow] carries the typed [ContextOverflow]: only the consumer's
+    context recovery (compaction) can make progress, because retrying or
+    rotating replays the same oversized prompt. [Empty_attributed] means a
+    recognized non-overflow stop_reason, for which the caller's existing
+    provider-unavailability handling applies. [Empty_unattributed] carries the
+    raw stop_reason token the SDK does not model: the caller must surface it
+    instead of folding it into transient provider unavailability, which would
+    retry the identical prompt forever and hide an overflow reported with an
+    unmodeled token. Derived from the typed stop_reason alone — no provider
+    identity is consulted. *)
+type empty_completion_verdict =
+  | Empty_overflow of api_error
+  | Empty_attributed
+  | Empty_unattributed of { token : string }
+
+(** [verdict_of_empty_completion ~stop_reason ~message] is the single,
+    compiler-checked classification of an empty provider completion. The match
+    is exhaustive, so a new [Types.stop_reason] forces a decision here. *)
+val verdict_of_empty_completion
+  :  stop_reason:Types.stop_reason
+  -> message:string
+  -> empty_completion_verdict
+
+(** [overflow_of_empty_completion ~stop_reason ~message] is the overflow-only
+    projection of {!verdict_of_empty_completion}: [Some (ContextOverflow …)]
+    when [stop_reason] is [ContextWindowExceeded], else [None]. Single
+    compiler-checked source for the #2621 empty-completion overflow rule; the
+    message prefix
     ["empty completion (stop_reason=model_context_window_exceeded): "] and
-    [limit = None] live here so all three call sites stay byte-identical. *)
+    [limit = None] live there so all call sites stay byte-identical. Callers
+    that must distinguish an unmodeled stop_reason from a recognized
+    non-overflow one use {!verdict_of_empty_completion} instead — this
+    projection collapses both into [None]. *)
 val overflow_of_empty_completion
   :  stop_reason:Types.stop_reason
   -> message:string

--- a/lib/provider_failure_attribution.ml
+++ b/lib/provider_failure_attribution.ml
@@ -60,15 +60,38 @@ let sdk_error_of_http_error ?(accept_rejected = Api_invalid_request) err =
        Error.Config (Error.InvalidConfig { field; detail = reason }))
   | Http.ProviderFailure { kind = Http.Empty_completion { stop_reason }; message } ->
     (* The #2621 empty-completion overflow rule is centralised in
-       [Retry.overflow_of_empty_completion]. A ContextWindowExceeded empty turn
+       [Retry.verdict_of_empty_completion]. A ContextWindowExceeded empty turn
        surfaces as [Api ContextOverflow] so downstream overflow classifiers fire
-       on the streaming path exactly as for HTTP-classified overflows; every
-       other stop_reason falls through to the same provider-unavailability
-       handling as [ProviderTerminal] / other [ProviderFailure]. This site's
-       [Error.Api] wrapper is preserved. *)
-    (match Retry.overflow_of_empty_completion ~stop_reason ~message with
-     | Some overflow -> Error.Api overflow
-     | None -> Error.Provider (Llm_provider.Error.of_http_error err))
+       on the streaming path exactly as for HTTP-classified overflows; a
+       recognized non-overflow stop_reason falls through to the same
+       provider-unavailability handling as [ProviderTerminal] / other
+       [ProviderFailure]. This site's [Error.Api] wrapper is preserved.
+
+       An empty turn whose stop_reason token this SDK does not model is neither
+       case. Routing it to provider-unavailability makes the consumer retry or
+       rotate the identical prompt, which never terminates when the real
+       condition was an overflow reported with an unmodeled token: the consumer
+       reaches its compaction path only on a typed overflow, so the turn fails
+       repeatedly without an error that names the cause. It is surfaced as a
+       non-retryable request error naming the token instead.
+
+       WORKAROUND: [InvalidRequest] is reused because [api_error] has no
+       "unmodeled provider contract" variant, and adding one breaks every
+       exhaustive matcher in this SDK and in its consumers. Root fix: a
+       dedicated variant, scheduled with the next breaking API change. *)
+    (match Retry.verdict_of_empty_completion ~stop_reason ~message with
+     | Retry.Empty_overflow overflow -> Error.Api overflow
+     | Retry.Empty_attributed -> Error.Provider (Llm_provider.Error.of_http_error err)
+     | Retry.Empty_unattributed { token } ->
+       Error.Api
+         (Retry.InvalidRequest
+            { message =
+                Printf.sprintf
+                  "empty completion with unmodeled stop_reason=%S: %s"
+                  token
+                  message
+            ; reason = Retry.Unknown_invalid_request
+            }))
   | Http.ProviderTerminal _ | Http.ProviderFailure _ ->
     Error.Provider (Llm_provider.Error.of_http_error err)
 ;;

--- a/test/test_provider_failure_attribution.ml
+++ b/test/test_provider_failure_attribution.ml
@@ -594,6 +594,58 @@ let test_empty_completion_end_turn_stays_provider_unavailable () =
     Alcotest.failf "expected Provider unavailable, got %s" (Error.to_string other)
 ;;
 
+(* Regression guard: an empty turn whose stop_reason token the SDK does not
+   model must not be attributed to provider unavailability. That attribution is
+   retried / rotated with the identical prompt, so an overflow reported with an
+   unmodeled token would loop without ever raising an error or reaching the
+   consumer's compaction path. The failure must name the token and must not be
+   retryable. *)
+let test_empty_completion_unmodeled_stop_reason_fails_loud () =
+  let token = "provider_specific_overflow" in
+  match
+    Attribution.sdk_error_of_http_error
+      (Http.ProviderFailure
+         { kind = Http.Empty_completion { stop_reason = Types.Unknown token }
+         ; message = "provider returned an empty assistant turn"
+         })
+  with
+  | Error.Api
+      (Llm_provider.Retry.InvalidRequest
+         { message; reason = Llm_provider.Retry.Unknown_invalid_request } as api) ->
+    check_bool
+      "names the unmodeled stop_reason token"
+      true
+      (Util.string_contains ~needle:token message);
+    check_bool "not retryable" false (Llm_provider.Retry.is_retryable api)
+  | other ->
+    Alcotest.failf
+      "expected Api InvalidRequest naming the unmodeled token, got %s"
+      (Error.to_string other)
+;;
+
+(* The SDK error boundary is the second promotion site for the same rule. If it
+   keeps rendering an unmodeled empty completion as provider unavailability, the
+   retry loop reappears one layer below the attribution fix. *)
+let test_error_boundary_unmodeled_stop_reason_is_invalid_request () =
+  let token = "provider_specific_overflow" in
+  match
+    Llm_provider.Error.of_http_error
+      (Http.ProviderFailure
+         { kind = Http.Empty_completion { stop_reason = Types.Unknown token }
+         ; message = "provider returned an empty assistant turn"
+         })
+  with
+  | Llm_provider.Error.InvalidRequest { reason; _ } ->
+    check_bool
+      "names the unmodeled stop_reason token"
+      true
+      (Util.string_contains ~needle:token reason)
+  | other ->
+    Alcotest.failf
+      "expected InvalidRequest naming the unmodeled token, got %s"
+      (Llm_provider.Error.to_string other)
+;;
+
 let test_stream_finalization_keeps_empty_completion_evidence () =
   Eio_main.run
   @@ fun env ->
@@ -702,6 +754,14 @@ let () =
             "EndTurn stays provider unavailable"
             `Quick
             test_empty_completion_end_turn_stays_provider_unavailable
+        ; Alcotest.test_case
+            "unmodeled stop_reason fails loud instead of retrying"
+            `Quick
+            test_empty_completion_unmodeled_stop_reason_fails_loud
+        ; Alcotest.test_case
+            "error boundary renders unmodeled stop_reason as invalid request"
+            `Quick
+            test_error_boundary_unmodeled_stop_reason_is_invalid_request
         ] )
     ; ( "agent detailed API"
       , [ Alcotest.test_case


### PR DESCRIPTION
## 목표

빈(empty) provider 턴의 `stop_reason` 토큰을 이 SDK가 모델링하지 않을 때, 이를 provider 가용성 문제로 귀속시키던 경로를 제거한다. 해당 귀속은 동일 프롬프트로 재시도/로테이션을 유발하므로, 모델링되지 않은 토큰으로 보고된 context overflow는 소비자의 context recovery 경로에 도달하지 못한 채 원인을 지목하는 에러 없이 반복 실패했다.

## 변경

- `Retry`에 3-way typed verdict 추가: `Empty_overflow | Empty_attributed | Empty_unattributed of { token }`. typed `stop_reason` 만으로 도출하며 provider identity를 참조하지 않는다 — 모든 backend가 동일 규칙으로 분류된다.
- 두 promotion site 모두 verdict를 읽는다:
  - `Provider_failure_attribution.sdk_error_of_http_error` → 토큰을 명시하는 non-retryable `Api InvalidRequest`
  - `Llm_provider.Error.of_http_error` (SDK 경계) → `ProviderUnavailable` 대신 동일 조건을 `InvalidRequest` 로 렌더
- attribution site만 고치면 동일 루프가 한 계층 아래에 그대로 남으므로 두 곳을 함께 변경했다.
- `overflow_of_empty_completion` 은 verdict의 overflow-only projection 으로 유지 — #2621 규칙은 여전히 단일 compiler-checked source 이고 기존 호출자 시그니처는 불변.
- 두 match 모두 exhaustive 유지 (`_` catch-all 없음).

## 검증 (로컬)

| 대상 | 결과 |
|---|---|
| `test_provider_failure_attribution` | 16 tests, 통과 (신규 2건 포함) |
| `test_llm_provider_error` | 34 tests, 통과 |
| `test_complete_ext` | 9 tests, 통과 |
| `test_overflow_wire_e2e` | 6 tests, 통과 |
| `test_backend_openai_codec` | 43 tests, 통과 |
| `test_complete_http` | 57 tests, 통과 |
| `test_http_client` | 27 tests, 통과 |
| `dune build lib` / `@fmt` | 통과, fmt diff 없음 |

신규 테스트: verdict 3 arm (overflow / 모델링되지 않은 토큰 / 인식된 non-overflow 10종 전부 — 과분류 방지 가드), attribution 이 토큰을 명시하는 non-retryable 에러 반환, 에러 경계가 `InvalidRequest` 렌더.

## 검증하지 못한 것

- 라이브 provider 재현은 하지 않았다. 근거는 `Types.Unknown` 토큰을 주입한 단위 테스트다.
- 다운스트림(masc) 은 `Api (InvalidRequest _)` 를 `Non_transient` 로 분류한다(`keeper_error_classify.ml`). 즉 이 조건은 이제 조용한 재시도 대신 표면화된 실패가 된다 — 의도된 변화이나 실제 fleet 영향은 배포 후 확인 대상이다.
- Gemini/Ollama 는 별도 파서(`finishReason` / `done_reason`)를 쓰며 이 `Empty_completion` 경로를 타지 않는다. 그쪽 backend 의 빈 응답 처리는 이 PR 범위 밖이다.

WORKAROUND-WAIVED: 코드 주석의 `WORKAROUND:` 는 `api_error` 에 전용 variant 를 추가하는 대신 기존 `InvalidRequest` 를 재사용한 선택을 설명하는 것이다(전용 variant 추가는 SDK 와 소비자의 모든 exhaustive matcher 를 깨는 breaking change 라 다음 breaking 릴리스로 미룸). 이 PR 자체는 증상 억제가 아니라 silent failure 경로를 typed variant 로 제거하는 근본 수정이며, 텔레메트리 추가·문자열 분류기 추가·N-of-M 패치 어디에도 해당하지 않는다(두 promotion site 를 모두 수정).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
