### PR TITLE
refactor(llm_provider): read provider identity once for reasoning replay

### DIFF
--- a/lib/llm_provider/backend_glm.ml
+++ b/lib/llm_provider/backend_glm.ml
@@ -408,12 +408,13 @@ let%test
     "build_request replays reasoning via typed dialect, not serialize-time branch \
      (RFC-OAS-029 S3.1)"
   =
-  (* The reasoning-replay decision now flows from the typed
+  (* The reasoning-replay decision flows from the typed
      [Reasoning_dialect.replay_policy] resolved once in [for_provider_config],
-     not from a serialize-time [config.kind = Glm]/[glm_should_replay_reasoning]
-     branch in the request builder. A GLM config under Preserved Thinking
-     (enable_thinking + clear_thinking=false) must echo a prior assistant
-     [Thinking] block back as [reasoning_content]; the default config
+     where the branch predicate is the declared
+     [preserve_thinking_control_format], not a provider identity or a
+     serialize-time branch in the request builder. A config under Preserved
+     Thinking (enable_thinking + clear_thinking=false) must echo a prior
+     assistant [Thinking] block back as [reasoning_content]; the default config
      (clear_thinking=true) must not. Reverting the dialect resolution leaves the
      GLM dialect at the dead [No_replay] default and turns the [preserved] case
      red. *)

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -241,12 +241,6 @@ let should_emit_tool_choice (config : Provider_config.t) =
      | None -> (capabilities_of_config config).supports_tool_choice)
 ;;
 
-(* Resolution delegated to [Provider_config.glm_clear_thinking] (SSOT) so the
-   request-body clear_thinking field below and the reasoning-replay gate cannot
-   diverge. *)
-let glm_clear_thinking_of_config = Provider_config.glm_clear_thinking
-let is_zai_glm_request = Provider_config.is_zai_glm_config
-
 (** Build Openai Chat Completions request body from {!Provider_config.t}.
     Returns a JSON string ready for HTTP POST. *)
 let build_request_assoc_artifact
@@ -259,9 +253,9 @@ let build_request_assoc_artifact
   let tools = effective_tools config tools in
   let dialect = Reasoning_dialect.for_provider_config config in
   let caps = capabilities_of_config config in
-  let reasoning_target =
-    match Reasoning_dialect.reasoning_source_for_provider_config config with
-    | Ok source -> source
+  let replay_capability =
+    match Reasoning_dialect.replay_capability_for_provider_config config with
+    | Ok capability -> capability
     | Error detail ->
       invalid_arg ("Backend_openai_request: invalid reasoning target: " ^ detail)
   in
@@ -288,7 +282,7 @@ let build_request_assoc_artifact
       match
         Backend_openai_serialize.dialect_messages_of_history
           ~assistant_tool_content_format
-          ~reasoning_target
+          ~replay_capability
           dialect
           messages
       with
@@ -368,10 +362,12 @@ let build_request_assoc_artifact
     | None -> body
   in
   let body =
-    let zai_glm_clear_thinking =
-      Provider_config.zai_glm_clear_thinking_request_field
-        ~thinking_control_format:caps.thinking_control_format
-        ~is_zai_glm:(is_zai_glm_request config)
+    (* Gated on the declared preserve wire (SSOT:
+       [Provider_config.clear_thinking_object_request_field]), so the request
+       body and the reasoning-replay gate read the same typed capability. *)
+    let clear_thinking_object =
+      Provider_config.clear_thinking_object_request_field
+        ~preserve_thinking_control_format:caps.preserve_thinking_control_format
         ~clear_thinking:config.clear_thinking
         ~preserve_thinking:config.preserve_thinking
     in
@@ -389,7 +385,7 @@ let build_request_assoc_artifact
           ~preserve_thinking:config.preserve_thinking
           ~thinking_budget:config.thinking_budget
           ~reasoning_effort:config.reasoning_effort
-          ?zai_glm_clear_thinking
+          ?clear_thinking_object
           ()
       with
       | Ok artifact -> artifact

--- a/lib/llm_provider/backend_openai_serialize.ml
+++ b/lib/llm_provider/backend_openai_serialize.ml
@@ -512,10 +512,7 @@ let openai_assistant_has_wire_payload (dialect : Reasoning_dialect.t) content =
   || (include_reasoning_details && reasoning_details <> None)
 ;;
 
-let typed_history_projection ~reasoning_target dialect messages =
-  let replay_policy =
-    (Reasoning_dialect.replay_contract dialect).Reasoning_replay_contract.replay_policy
-  in
+let typed_history_projection ~replay_capability dialect messages =
   Reasoning_history_projection.project
     ~assistant_has_payload:(openai_assistant_has_wire_payload dialect)
     ~reasoning_block_supported:(function
@@ -527,8 +524,7 @@ let typed_history_projection ~reasoning_target dialect messages =
       | Image _
       | Document _
       | Audio _ -> false)
-    ~reasoning_target
-    ~replay_policy
+    ~replay_capability
     messages
 ;;
 
@@ -570,11 +566,11 @@ let render_history_projection
 
 let dialect_history_projection
       ?assistant_tool_content_format
-      ~reasoning_target
+      ~replay_capability
       dialect
       messages
   =
-  match typed_history_projection ~reasoning_target dialect messages with
+  match typed_history_projection ~replay_capability dialect messages with
   | Error _ as error -> error
   | Ok projection ->
     Ok (render_history_projection ?assistant_tool_content_format dialect projection)
@@ -582,11 +578,11 @@ let dialect_history_projection
 
 let dialect_messages_of_history
       ?assistant_tool_content_format
-      ~reasoning_target
+      ~replay_capability
       dialect
       messages
   =
-  match typed_history_projection ~reasoning_target dialect messages with
+  match typed_history_projection ~replay_capability dialect messages with
   | Error _ as error -> error
   | Ok projection ->
     Reasoning_history_projection.observe ~component:"backend_openai" projection;

--- a/lib/llm_provider/backend_openai_serialize.mli
+++ b/lib/llm_provider/backend_openai_serialize.mli
@@ -46,14 +46,14 @@ type history_projection =
 
 val dialect_history_projection
   :  ?assistant_tool_content_format:Capability_vocab.assistant_tool_content_format
-  -> reasoning_target:Types.Reasoning_source.t
+  -> replay_capability:Reasoning_dialect.replay_capability
   -> Reasoning_dialect.t
   -> Types.message list
   -> (history_projection, Reasoning_history_projection.error) result
 
 val dialect_messages_of_history
   :  ?assistant_tool_content_format:Capability_vocab.assistant_tool_content_format
-  -> reasoning_target:Types.Reasoning_source.t
+  -> replay_capability:Reasoning_dialect.replay_capability
   -> Reasoning_dialect.t
   -> Types.message list
   -> (Yojson.Safe.t list, Reasoning_history_projection.error) result

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -41,6 +41,9 @@ type preserve_thinking_control_format =
   | Chat_template_kwargs_preserve_thinking
   | Top_level_preserve_thinking
   | Always_preserved_thinking
+  | Thinking_object_clear_thinking
+  (** Provider [thinking] object whose [clear_thinking] member gates prior-turn
+      reasoning replay. See {!Capability_vocab.preserve_thinking_control_format}. *)
 
 (** Optional override for the multi-turn reasoning replay policy. Most providers
     inherit the policy implied by [thinking_control_format]; catalog entries set
@@ -599,6 +602,14 @@ let glm_capabilities =
      Ref: https://docs.z.ai/guides/capabilities/struct-output — checked 2026-04-21. *)
     supports_structured_output = false
   ; supports_native_streaming = true
+  ; (* Z.AI's chat-completion API carries the thinking toggle in a top-level
+       [thinking] object and only echoes prior-turn [reasoning_content] under
+       "preserved thinking" ([clear_thinking = false]). Declaring the wire here
+       is what makes the replay conditional typed capability data: the dialect
+       resolver reads [preserve_thinking_control_format], not a provider
+       identity predicate (RFC-OAS-029 S1.1/S3.1).
+       Ref: https://docs.z.ai/api-reference/llm/chat-completion *)
+    preserve_thinking_control_format = Thinking_object_clear_thinking
   }
 ;;
 

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -29,6 +29,9 @@ type preserve_thinking_control_format =
   | Chat_template_kwargs_preserve_thinking
   | Top_level_preserve_thinking
   | Always_preserved_thinking
+  | Thinking_object_clear_thinking
+  (** Provider [thinking] object whose [clear_thinking] member gates prior-turn
+      reasoning replay. See {!Capability_vocab.preserve_thinking_control_format}. *)
 
 type reasoning_replay_override = Capability_vocab.reasoning_replay_override =
   | Default_reasoning_replay

--- a/lib/llm_provider/capability_vocab.ml
+++ b/lib/llm_provider/capability_vocab.ml
@@ -27,6 +27,13 @@ type preserve_thinking_control_format =
   | Chat_template_kwargs_preserve_thinking
   | Top_level_preserve_thinking
   | Always_preserved_thinking
+  | Thinking_object_clear_thinking
+  (** A provider [thinking] request object whose [clear_thinking] member both
+          carries the toggle and gates prior-turn reasoning replay: the server
+          only echoes prior reasoning back under "preserved thinking", i.e.
+          thinking active AND [clear_thinking = false]. Declaring this wire is
+          what makes replay conditional; no consumer re-derives the condition
+          from a provider identity. *)
 
 type reasoning_replay_override =
   | Default_reasoning_replay
@@ -287,7 +294,22 @@ let preserve_thinking_control_format_table =
   ; "chat_template_kwargs_preserve_thinking", Chat_template_kwargs_preserve_thinking
   ; "top_level_preserve_thinking", Top_level_preserve_thinking
   ; "always_preserved", Always_preserved_thinking
+  ; "thinking_object_clear_thinking", Thinking_object_clear_thinking
   ]
+;;
+
+(* [true] when the preserve wire is a provider [thinking] request object that
+   carries the thinking toggle itself. Such a row encodes an explicit
+   enable/disable on the wire even when its [thinking_control_format] is
+   [No_thinking_control], so admission must not report the request as
+   unencodable. Exhaustive: a new preserve wire has to state its answer. *)
+let preserve_wire_owns_thinking_object = function
+  | Thinking_object_clear_thinking -> true
+  | No_preserve_thinking_control
+  | Thinking_object_keep_all
+  | Chat_template_kwargs_preserve_thinking
+  | Top_level_preserve_thinking
+  | Always_preserved_thinking -> false
 ;;
 
 let preserve_thinking_control_format_values =

--- a/lib/llm_provider/complete_common.ml
+++ b/lib/llm_provider/complete_common.ml
@@ -488,14 +488,17 @@ let thinking_control_request_rejection
       | Provider_config.Gemini
       | Provider_config.Glm
       | Provider_config.DashScope ->
-        let glm_special_case =
-          (* backend_openai_request encodes thinking for typed GLM configs even
-             under [No_thinking_control]. *)
-          Provider_config.is_zai_glm_config config
+        let preserve_wire_encodes_toggle =
+          (* backend_openai_request still encodes an explicit thinking toggle
+             for rows whose preserve wire is a provider [thinking] object, even
+             under [No_thinking_control]. Read from the typed capability, not
+             from a provider identity (RFC-OAS-029 S1.1). *)
+          Capability_vocab.preserve_wire_owns_thinking_object
+            caps.preserve_thinking_control_format
         in
         caps.supports_reasoning
         && caps.thinking_control_format = Capabilities.No_thinking_control
-        && not glm_special_case
+        && not preserve_wire_encodes_toggle
     in
     if disable_not_encodable then Some Disable_not_encodable else None
 ;;

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -267,20 +267,21 @@ let all_reasoning_efforts = Reasoning_effort.all
 let reasoning_effort_to_string = Reasoning_effort.to_string
 let reasoning_effort_of_string = Reasoning_effort.of_string
 
-(* GLM (Z.AI) Preserved-Thinking gate (SSOT).
+(* Preserved-Thinking gate for the [Thinking_object_clear_thinking] preserve
+   wire (SSOT).
 
-   The GLM Chat Completion API replays prior-turn [reasoning_content] from the
-   request history only under Preserved Thinking — that is, when thinking is
-   active AND [clear_thinking] is false. With the default [clear_thinking=true]
-   the server ignores/removes prior-turn reasoning, so sending it back violates
-   the documented contract and grows the request every turn. [clear_thinking]
-   resolves from the explicit field, else the inverse of [preserve_thinking],
-   else the API default [true].
+   Rows declaring that wire carry the thinking toggle in a top-level [thinking]
+   object and only echo prior-turn [reasoning_content] under Preserved
+   Thinking — that is, when thinking is active AND [clear_thinking] is false.
+   With the wire default [clear_thinking = true] the server ignores/removes
+   prior-turn reasoning, so sending it back violates the documented contract and
+   grows the request every turn. [clear_thinking] resolves from the explicit
+   field, else the inverse of [preserve_thinking], else the wire default [true].
 
-   Exposed on raw fields as well as on [t] because the two request builders
-   carry different config records ([Provider_config.t] vs [Types.agent_config]);
-   both route through this one resolver so the gate cannot drift between them. *)
-let glm_clear_thinking_value ~clear_thinking ~preserve_thinking =
+   Exposed on raw fields rather than on [t] because the request builders carry
+   different config records ([Provider_config.t] vs [Types.agent_config]); both
+   route through this one resolver so the gate cannot drift between them. *)
+let clear_thinking_value ~clear_thinking ~preserve_thinking =
   match clear_thinking with
   | Some clear -> clear
   | None ->
@@ -289,49 +290,24 @@ let glm_clear_thinking_value ~clear_thinking ~preserve_thinking =
      | None -> true)
 ;;
 
-let glm_should_replay_reasoning_fields ~enable_thinking ~clear_thinking ~preserve_thinking
-  =
+let preserved_thinking_active ~enable_thinking ~clear_thinking ~preserve_thinking =
   enable_thinking = Some true
-  && not (glm_clear_thinking_value ~clear_thinking ~preserve_thinking)
+  && not (clear_thinking_value ~clear_thinking ~preserve_thinking)
 ;;
 
-let glm_clear_thinking (config : t) =
-  glm_clear_thinking_value
-    ~clear_thinking:config.clear_thinking
-    ~preserve_thinking:config.preserve_thinking
-;;
-
-let zai_glm_clear_thinking_request_field
-      ~thinking_control_format
-      ~is_zai_glm
+let clear_thinking_object_request_field
+      ~(preserve_thinking_control_format : Capabilities.preserve_thinking_control_format)
       ~clear_thinking
       ~preserve_thinking
   =
-  match thinking_control_format with
-  | Capabilities.No_thinking_control when is_zai_glm ->
-    Some (glm_clear_thinking_value ~clear_thinking ~preserve_thinking)
-  | Capabilities.No_thinking_control
-  | Capabilities.Thinking_object
-  | Capabilities.Thinking_object_adaptive
-  | Capabilities.Thinking_object_only
-  | Capabilities.Chat_template_kwargs
-  | Capabilities.Chat_template_token _
-  | Capabilities.Ollama_think
-  | Capabilities.Reasoning_effort
-  | Capabilities.Enable_thinking -> None
-;;
-
-let glm_should_replay_reasoning (config : t) =
-  glm_should_replay_reasoning_fields
-    ~enable_thinking:config.enable_thinking
-    ~clear_thinking:config.clear_thinking
-    ~preserve_thinking:config.preserve_thinking
-;;
-
-let is_zai_glm_config (config : t) =
-  match config.kind with
-  | Glm -> true
-  | OpenAI_compat | Anthropic | Kimi | Ollama | Gemini | DashScope -> false
+  match preserve_thinking_control_format with
+  | Capabilities.Thinking_object_clear_thinking ->
+    Some (clear_thinking_value ~clear_thinking ~preserve_thinking)
+  | Capabilities.No_preserve_thinking_control
+  | Capabilities.Thinking_object_keep_all
+  | Capabilities.Chat_template_kwargs_preserve_thinking
+  | Capabilities.Top_level_preserve_thinking
+  | Capabilities.Always_preserved_thinking -> None
 ;;
 
 type tool_choice_request_rejection =

--- a/lib/llm_provider/provider_config.mli
+++ b/lib/llm_provider/provider_config.mli
@@ -317,39 +317,34 @@ val all_reasoning_efforts : reasoning_effort list
 val reasoning_effort_to_string : reasoning_effort -> string
 val reasoning_effort_of_string : string -> reasoning_effort option
 
-(** Resolve GLM [clear_thinking]: the explicit field, else the inverse of
-    [preserve_thinking], else the API default [true]. SSOT for both request
-    builders' clear_thinking handling. *)
-val glm_clear_thinking_value
+(** Resolve the [thinking.clear_thinking] member: the explicit field, else the
+    inverse of [preserve_thinking], else the wire default [true]. SSOT for both
+    request builders. *)
+val clear_thinking_value
   :  clear_thinking:bool option
   -> preserve_thinking:bool option
   -> bool
 
-val glm_clear_thinking : t -> bool
-
-(** Top-level GLM [thinking.clear_thinking] request-field resolver for
-    OpenAI-compatible ZAI GLM rows that do not expose a normal thinking control
-    capability. Non-GLM rows and rows with an explicit thinking control format
-    omit the compatibility field. *)
-val zai_glm_clear_thinking_request_field
-  :  thinking_control_format:Capabilities.thinking_control_format
-  -> is_zai_glm:bool
-  -> clear_thinking:bool option
-  -> preserve_thinking:bool option
-  -> bool option
-
-(** [true] iff GLM should replay prior-turn [reasoning_content] into request
-    history: thinking active AND [clear_thinking] false (Preserved Thinking).
-    Under the default [clear_thinking=true] the server discards prior reasoning,
-    so replaying it violates the GLM contract and bloats the request. SSOT for
-    every GLM message-serializer routing site. *)
-val glm_should_replay_reasoning_fields
+(** [true] iff the request is under Preserved Thinking: thinking active AND
+    [clear_thinking] false. Rows whose
+    {!Capabilities.preserve_thinking_control_format} is
+    [Thinking_object_clear_thinking] replay prior-turn reasoning exactly then;
+    under the wire default [clear_thinking = true] the server discards prior
+    reasoning, so replaying it violates the contract and bloats the request. *)
+val preserved_thinking_active
   :  enable_thinking:bool option
   -> clear_thinking:bool option
   -> preserve_thinking:bool option
   -> bool
 
-val glm_should_replay_reasoning : t -> bool
+(** Top-level [thinking.clear_thinking] request-field resolver, gated purely on
+    the declared preserve wire. Rows with any other preserve wire omit the
+    field. No provider identity, endpoint, or model id participates. *)
+val clear_thinking_object_request_field
+  :  preserve_thinking_control_format:Capabilities.preserve_thinking_control_format
+  -> clear_thinking:bool option
+  -> preserve_thinking:bool option
+  -> bool option
 
 (** Capability catalog provider identity for [config]. Uses the explicitly
     carried [provider_id], otherwise the typed wire kind. Endpoint URLs and
@@ -363,12 +358,6 @@ val capability_provider_label : t -> string
     select a vendor/model dialect. Generic compatibility callers can provide
     [model_capabilities_override] or an exact [provider_id]. *)
 val capabilities_for_config_model : t -> Capabilities.capabilities option
-
-(** [true] exactly when [config.kind = Glm]. An [OpenAI_compat] config is never
-    promoted to GLM semantics from its provider id, endpoint URL, or model id;
-    callers targeting the native Z.AI contract must select the typed [Glm]
-    kind explicitly. *)
-val is_zai_glm_config : t -> bool
 
 (** Derive a provider-safe schema name for native structured-output APIs
     that require one (for example Openai's [json_schema.name]). *)

--- a/lib/llm_provider/reasoning_dialect.ml
+++ b/lib/llm_provider/reasoning_dialect.ml
@@ -27,20 +27,20 @@ type sampling_policy =
   ; ignored_when_thinking : Capabilities.sampling_parameter list
   }
 
-type replay_policy =
+type replay_policy = Reasoning_replay_contract.replay_policy =
   | No_replay
-  | Drop_without_tool_preserve_with_tool
-  | Latest_user_turn_tool_calls
-  | Preserve_always
-  | Provider_hidden_replay
+  | Tool_call_assistant_messages_all_history
+  | Tool_call_assistant_messages_latest_user_turn
+  | All_assistant_messages
+  | Provider_opaque_state
 
-type streaming_reasoning =
+type streaming_reasoning = Reasoning_replay_contract.streaming_reasoning =
   | No_streaming_reasoning
   | Delta_field of string
   | Delta_reasoning_details
   | Template_parser
 
-type output_wire =
+type output_wire = Reasoning_replay_contract.output_wire =
   | No_output_control
   | Reasoning_split
 
@@ -137,12 +137,13 @@ let base_of_capabilities (caps : Capabilities.capabilities) =
     (match preserve_wire with
      | Always_preserved_thinking ->
        { dialect with
-         replay_policy = Preserve_always
+         replay_policy = All_assistant_messages
        ; streaming = Delta_field "reasoning_content"
        }
      | No_preserve_thinking_control
      | Thinking_object_keep_all
      | Chat_template_kwargs_preserve_thinking
+     | Thinking_object_clear_thinking
      | Top_level_preserve_thinking -> dialect)
   | Thinking_object ->
     { toggle_default = Enabled
@@ -153,7 +154,7 @@ let base_of_capabilities (caps : Capabilities.capabilities) =
         { ignored_always = caps.ignored_sampling_parameters
         ; ignored_when_thinking = deepseek_ignored_sampling_params
         }
-    ; replay_policy = Drop_without_tool_preserve_with_tool
+    ; replay_policy = Tool_call_assistant_messages_all_history
     ; streaming = Delta_field "reasoning_content"
     ; output_wire
     }
@@ -171,9 +172,10 @@ let base_of_capabilities (caps : Capabilities.capabilities) =
   | Thinking_object_only ->
     let replay_policy =
       match preserve_wire with
-      | Thinking_object_keep_all -> Drop_without_tool_preserve_with_tool
+      | Thinking_object_keep_all -> Tool_call_assistant_messages_all_history
       | No_preserve_thinking_control
       | Chat_template_kwargs_preserve_thinking
+      | Thinking_object_clear_thinking
       | Top_level_preserve_thinking
       | Always_preserved_thinking -> default.replay_policy
     in
@@ -227,10 +229,10 @@ let apply_replay_override caps dialect =
   | Default_reasoning_replay -> dialect
   | Force_no_replay -> { dialect with replay_policy = No_replay }
   | Force_drop_without_tool_preserve_with_tool ->
-    { dialect with replay_policy = Drop_without_tool_preserve_with_tool }
+    { dialect with replay_policy = Tool_call_assistant_messages_all_history }
   | Force_latest_user_turn_tool_calls ->
-    { dialect with replay_policy = Latest_user_turn_tool_calls }
-  | Force_preserve_always -> { dialect with replay_policy = Preserve_always }
+    { dialect with replay_policy = Tool_call_assistant_messages_latest_user_turn }
+  | Force_preserve_always -> { dialect with replay_policy = All_assistant_messages }
 ;;
 
 let apply_streaming_format caps dialect =
@@ -247,14 +249,16 @@ let of_capabilities caps =
 
 let with_preserve_thinking ~preserve_thinking dialect =
   match dialect.preserve_wire, preserve_thinking with
-  | Always_preserved_thinking, _ -> { dialect with replay_policy = Preserve_always }
+  | Always_preserved_thinking, _ ->
+    { dialect with replay_policy = All_assistant_messages }
   | ( ( Thinking_object_keep_all
       | Chat_template_kwargs_preserve_thinking
       | Top_level_preserve_thinking )
-    , Some true ) -> { dialect with replay_policy = Preserve_always }
+    , Some true ) -> { dialect with replay_policy = All_assistant_messages }
   | ( ( No_preserve_thinking_control
       | Thinking_object_keep_all
       | Chat_template_kwargs_preserve_thinking
+      | Thinking_object_clear_thinking
       | Top_level_preserve_thinking )
     , _ ) -> dialect
 ;;
@@ -274,6 +278,7 @@ let thinking_object_only_control dialect ~enable_thinking ~preserve_thinking =
        | Some true, Some false | Some false, _ | None, _ -> false)
     | No_preserve_thinking_control
     | Chat_template_kwargs_preserve_thinking
+    | Thinking_object_clear_thinking
     | Top_level_preserve_thinking
     | Always_preserved_thinking -> false
   in
@@ -291,6 +296,7 @@ let chat_template_kwargs_preserve_field dialect ~preserve_thinking =
   | Chat_template_kwargs_preserve_thinking -> preserve_thinking
   | No_preserve_thinking_control
   | Thinking_object_keep_all
+  | Thinking_object_clear_thinking
   | Top_level_preserve_thinking
   | Always_preserved_thinking -> None
 ;;
@@ -301,6 +307,7 @@ let top_level_preserve_field dialect ~preserve_thinking =
   | No_preserve_thinking_control
   | Thinking_object_keep_all
   | Chat_template_kwargs_preserve_thinking
+  | Thinking_object_clear_thinking
   | Always_preserved_thinking -> None
 ;;
 
@@ -371,7 +378,7 @@ let request_control_fields
       ~preserve_thinking
       ~thinking_budget
       ~reasoning_effort
-      ?zai_glm_clear_thinking
+      ?clear_thinking_object
       ()
   =
   match
@@ -502,7 +509,7 @@ let request_control_fields
               | fields -> [ "thinking", `Assoc fields ])
            , explicit_field_encoding )
          | Chat_completions, No_toggle ->
-           (match zai_glm_clear_thinking, enable_thinking with
+           (match clear_thinking_object, enable_thinking with
             | Some clear_thinking, Some true ->
               ( [ ( "thinking"
                   , `Assoc
@@ -537,7 +544,7 @@ let base_for_provider_config (config : Provider_config.t) =
   | Anthropic ->
     { default with
       toggle_wire = Anthropic_thinking
-    ; replay_policy = Preserve_always
+    ; replay_policy = All_assistant_messages
     ; streaming = Delta_field "thinking_delta"
     }
   | Gemini ->
@@ -545,7 +552,7 @@ let base_for_provider_config (config : Provider_config.t) =
       toggle_wire = Gemini_thinking_config
     ; (* GenerateContent is stateless. Signed parts must remain attached to the
          exact model response part and be returned unchanged. *)
-      replay_policy = Preserve_always
+      replay_policy = All_assistant_messages
     ; streaming = Delta_field "thought"
     }
   | Ollama ->
@@ -568,7 +575,7 @@ let base_for_provider_config (config : Provider_config.t) =
        default applies only when the capability row says [Default]. *)
     (match caps.reasoning_replay_override with
      | Default_reasoning_replay ->
-       { dialect with replay_policy = Latest_user_turn_tool_calls }
+       { dialect with replay_policy = Tool_call_assistant_messages_latest_user_turn }
      | Force_no_replay
      | Force_drop_without_tool_preserve_with_tool
      | Force_latest_user_turn_tool_calls
@@ -583,81 +590,107 @@ let base_for_provider_config (config : Provider_config.t) =
     of_capabilities Capabilities.dashscope_capabilities
 ;;
 
-let for_provider_config (config : Provider_config.t) =
-  let dialect =
-    base_for_provider_config config
-    |> with_preserve_thinking ~preserve_thinking:config.preserve_thinking
-  in
-  let dialect =
-    match config.kind with
-    | Kimi | OpenAI_compat | Ollama | Glm ->
-      (* RFC-OAS-029 S3.1: GLM reasoning replay is
-       clear_thinking-conditional (Preserved Thinking = thinking active AND
-       clear_thinking=false). The GLM capability profile carries
-       [No_thinking_control]/[No_preserve_thinking_control], so it resolves to
-       the default [No_replay] dialect and the typed [replay_policy] is a dead
-       value. Resolve the GLM conditional to a typed [replay_policy] here, at
-       the single dialect boundary, so the request serializer consumes only the
-       typed policy (via [should_replay_reasoning]) instead of re-deriving
-       GLM-ness with [is_glm_request]/[glm_should_replay_reasoning] at
-       serialize time (S3.1: replay is typed, one source). *)
-      if Provider_config.is_zai_glm_config config
-      then
-        { dialect with
-          replay_policy =
-            (if Provider_config.glm_should_replay_reasoning config
-             then Preserve_always
-             else No_replay)
-        }
-      else dialect
-    | Anthropic | Gemini | DashScope -> dialect
-  in
+(* Replay activation for the [Thinking_object_clear_thinking] preserve wire.
+   That wire declares that the provider only echoes prior-turn reasoning under
+   "preserved thinking": thinking active AND [clear_thinking = false]. Under the
+   wire default [clear_thinking = true] the server discards prior reasoning, so
+   sending it back violates the contract and grows the request every turn.
+
+   RFC-OAS-029 S1.1/S3.1: the branch predicate is the typed capability the
+   catalog row declares, exactly like the [Thinking_object] arm of
+   [base_of_capabilities]. No provider identity participates, so an operator can
+   move this contract onto another row without touching OCaml. *)
+let apply_clear_thinking_replay_gate (config : Provider_config.t) dialect =
+  match dialect.preserve_wire with
+  | Thinking_object_clear_thinking ->
+    { dialect with
+      replay_policy =
+        (if
+           Provider_config.preserved_thinking_active
+             ~enable_thinking:config.enable_thinking
+             ~clear_thinking:config.clear_thinking
+             ~preserve_thinking:config.preserve_thinking
+         then All_assistant_messages
+         else No_replay)
+    }
+  | No_preserve_thinking_control
+  | Thinking_object_keep_all
+  | Chat_template_kwargs_preserve_thinking
+  | Top_level_preserve_thinking
+  | Always_preserved_thinking -> dialect
+;;
+
+(* The OpenAI Responses envelope keeps reasoning as provider-held state rather
+   than as replayable content. This is the transport fact owned by
+   {!Provider_http_codec} (the single kind-keyed dispatch this module is allowed
+   to consult), applied identically to the stable and the request-local dialect
+   so the stamped contract and the consuming contract cannot disagree. *)
+let apply_transport_replay_override (config : Provider_config.t) dialect =
   match Provider_http_codec.of_config config with
   | Provider_http_codec.Openai_responses ->
-    { dialect with replay_policy = Provider_hidden_replay }
+    { dialect with replay_policy = Provider_opaque_state }
   | Anthropic_messages | Openai_chat | Ollama_chat | Gemini_generate_content | Glm_chat ->
     dialect
 ;;
 
+let for_provider_config (config : Provider_config.t) =
+  base_for_provider_config config
+  |> with_preserve_thinking ~preserve_thinking:config.preserve_thinking
+  |> apply_clear_thinking_replay_gate config
+  |> apply_transport_replay_override config
+;;
+
+(* Field projection, not a translation table: {!replay_policy},
+   {!streaming_reasoning} and {!output_wire} are the leaf
+   {!Reasoning_replay_contract} types by type equation. *)
 let replay_contract dialect : Reasoning_replay_contract.t =
-  let replay_policy =
-    match dialect.replay_policy with
-    | No_replay -> Reasoning_replay_contract.No_replay
-    | Drop_without_tool_preserve_with_tool -> Tool_call_assistant_messages_all_history
-    | Latest_user_turn_tool_calls -> Tool_call_assistant_messages_latest_user_turn
-    | Preserve_always -> All_assistant_messages
-    | Provider_hidden_replay -> Provider_opaque_state
-  in
-  let streaming =
-    match dialect.streaming with
-    | No_streaming_reasoning -> Reasoning_replay_contract.No_streaming_reasoning
-    | Delta_field field -> Delta_field field
-    | Delta_reasoning_details -> Delta_reasoning_details
-    | Template_parser -> Template_parser
-  in
-  let output_wire =
-    match dialect.output_wire with
-    | No_output_control -> Reasoning_replay_contract.No_output_control
-    | Reasoning_split -> Reasoning_split
-  in
-  { replay_policy; streaming; output_wire }
+  { replay_policy = dialect.replay_policy
+  ; streaming = dialect.streaming
+  ; output_wire = dialect.output_wire
+  }
+;;
+
+(* Which stored reasoning a rotation may still carry, decided from the dialect's
+   own typed wire facts.
+
+   [Require_identical_source] is for artifacts the producing endpoint has to
+   validate: [Provider_opaque_state] is a handle to state the provider holds,
+   and the Anthropic/Gemini thinking wires return signed blocks whose signature
+   is checked on replay. Every other wire carries reasoning as self-contained
+   text in a side channel, which the same model on a rotated endpoint accepts
+   unchanged.
+
+   Both matches are exhaustive: a new replay policy or toggle wire has to state
+   its rotation answer instead of inheriting one. *)
+let rotation_policy dialect : Reasoning_replay_contract.rotation_policy =
+  match dialect.replay_policy with
+  | Provider_opaque_state -> Require_identical_source
+  | No_replay
+  | Tool_call_assistant_messages_all_history
+  | Tool_call_assistant_messages_latest_user_turn
+  | All_assistant_messages ->
+    (match dialect.toggle_wire with
+     | Anthropic_thinking | Gemini_thinking_config -> Require_identical_source
+     | No_toggle
+     | Thinking_object _
+     | Thinking_object_adaptive
+     | Thinking_object_only
+     | Chat_template_kwargs
+     | Chat_template_token
+     | Ollama_think
+     | Reasoning_effort
+     | Enable_thinking -> Allow_endpoint_rotation)
+;;
+
+(* Artifact provenance is derived from the stable provider/model/transport
+   shape. Request-local replay selection (for example [preserve_thinking] or the
+   clear-thinking gate) is applied by [for_provider_config] at the consuming
+   boundary and must not rewrite the identity of an already-produced artifact. *)
+let stable_dialect_for_provider_config config =
+  base_for_provider_config config |> apply_transport_replay_override config
 ;;
 
 let reasoning_source_for_provider_config config =
-  (* Artifact compatibility is derived from the stable provider/model codec.
-     Request-local replay selection (for example [preserve_thinking] or GLM
-     [clear_thinking]) is applied by [for_provider_config] at the consuming
-     boundary and must not rewrite the identity of an already-produced
-     artifact. The HTTP codec is part of the stable shape, hence the explicit
-     Responses override below. *)
-  let dialect = base_for_provider_config config in
-  let dialect =
-    match Provider_http_codec.of_config config with
-    | Provider_http_codec.Openai_responses ->
-      { dialect with replay_policy = Provider_hidden_replay }
-    | Anthropic_messages | Openai_chat | Ollama_chat | Gemini_generate_content | Glm_chat
-      -> dialect
-  in
   Types.Reasoning_source.create
     ~provider_kind:config.Provider_config.kind
     ~provider_instance:
@@ -665,7 +698,21 @@ let reasoning_source_for_provider_config config =
          ~base_url:config.base_url
          ~request_path:config.request_path)
     ~canonical_model_id:config.model_id
-    ~replay_contract:(replay_contract dialect)
+    ~replay_contract:(replay_contract (stable_dialect_for_provider_config config))
+;;
+
+type replay_capability =
+  { target : Types.Reasoning_source.t
+  ; contract : Reasoning_replay_contract.t
+  ; rotation : Reasoning_replay_contract.rotation_policy
+  }
+
+let replay_capability_for_provider_config config =
+  Result.map
+    (fun target ->
+       let dialect = for_provider_config config in
+       { target; contract = replay_contract dialect; rotation = rotation_policy dialect })
+    (reasoning_source_for_provider_config config)
 ;;
 
 let sampling_params_ignored_when_thinking dialect =
@@ -712,10 +759,10 @@ let sampling_field_ignored_when_thinking
 
 let should_replay_reasoning dialect ~assistant_had_tool_call =
   match dialect.replay_policy with
-  | No_replay | Provider_hidden_replay -> false
-  | Preserve_always -> true
-  | Drop_without_tool_preserve_with_tool | Latest_user_turn_tool_calls ->
-    assistant_had_tool_call
+  | No_replay | Provider_opaque_state -> false
+  | All_assistant_messages -> true
+  | Tool_call_assistant_messages_all_history
+  | Tool_call_assistant_messages_latest_user_turn -> assistant_had_tool_call
 ;;
 
 let requires_reasoning_replay_on_tool_call dialect =
@@ -740,10 +787,10 @@ let toggle_wire_to_string = function
 
 let replay_policy_to_string = function
   | No_replay -> "no_replay"
-  | Drop_without_tool_preserve_with_tool -> "drop_without_tool_preserve_with_tool"
-  | Latest_user_turn_tool_calls -> "latest_user_turn_tool_calls"
-  | Preserve_always -> "preserve_always"
-  | Provider_hidden_replay -> "provider_hidden_replay"
+  | Tool_call_assistant_messages_all_history -> "drop_without_tool_preserve_with_tool"
+  | Tool_call_assistant_messages_latest_user_turn -> "latest_user_turn_tool_calls"
+  | All_assistant_messages -> "preserve_always"
+  | Provider_opaque_state -> "provider_hidden_replay"
 ;;
 
 [@@@coverage off]
@@ -757,7 +804,7 @@ let%test "reasoning_replay_override Force_preserve_always lifts base no_replay" 
     }
   in
   let dialect = of_capabilities caps in
-  (* base Reasoning_effort yields No_replay; the override lifts it to Preserve_always
+  (* base Reasoning_effort yields No_replay; the override lifts it to All_assistant_messages
      so reasoning is replayed on both plain and tool turns. *)
   should_replay_reasoning dialect ~assistant_had_tool_call:false
   && should_replay_reasoning dialect ~assistant_had_tool_call:true
@@ -878,7 +925,7 @@ let%test "request_control_fields keeps zai glm no-toggle exception explicit" =
     ~preserve_thinking:(Some true)
     ~thinking_budget:None
     ~reasoning_effort:None
-    ~zai_glm_clear_thinking:false
+    ~clear_thinking_object:false
     ()
   = Ok
       { fields =

--- a/lib/llm_provider/reasoning_dialect.mli
+++ b/lib/llm_provider/reasoning_dialect.mli
@@ -37,20 +37,25 @@ type sampling_policy =
   ; ignored_when_thinking : Capabilities.sampling_parameter list
   }
 
-type replay_policy =
+(** The reasoning-replay vocabulary is the leaf
+    {!Reasoning_replay_contract} one, re-exported here as a type equation
+    rather than restated. There is no dialect-level synonym set and therefore
+    no dialect-to-contract translation table to keep in sync: a new policy is
+    added in exactly one module and every consumer sees the same constructor. *)
+type replay_policy = Reasoning_replay_contract.replay_policy =
   | No_replay
-  | Drop_without_tool_preserve_with_tool
-  | Latest_user_turn_tool_calls
-  | Preserve_always
-  | Provider_hidden_replay
+  | Tool_call_assistant_messages_all_history
+  | Tool_call_assistant_messages_latest_user_turn
+  | All_assistant_messages
+  | Provider_opaque_state
 
-type streaming_reasoning =
+type streaming_reasoning = Reasoning_replay_contract.streaming_reasoning =
   | No_streaming_reasoning
   | Delta_field of string
   | Delta_reasoning_details
   | Template_parser
 
-type output_wire =
+type output_wire = Reasoning_replay_contract.output_wire =
   | No_output_control
   | Reasoning_split
 
@@ -104,13 +109,44 @@ type t =
 
 val default : t
 val of_capabilities : Capabilities.capabilities -> t
+
+(** Request-local dialect: the capability base, then the [preserve_thinking]
+    knob, then the declared clear-thinking replay gate, then the transport
+    override. *)
 val for_provider_config : Provider_config.t -> t
+
 val replay_contract : t -> Reasoning_replay_contract.t
 
-(** Exact source binding for a response produced by [config]. *)
+(** Declared rotation rule for [dialect], derived from its typed wire facts
+    only. See {!Reasoning_replay_contract.rotation_policy}. *)
+val rotation_policy : t -> Reasoning_replay_contract.rotation_policy
+
+(** Provenance stamped on a response produced by [config]. Derived from the
+    stable provider/model/transport shape, so request-local knobs never change
+    the identity of an already-produced artifact. *)
 val reasoning_source_for_provider_config
   :  Provider_config.t
   -> (Types.Reasoning_source.t, string) result
+
+(** Everything the reasoning-replay path needs for one request, resolved once.
+
+    Provider identity is consulted while building this record and nowhere
+    downstream: the projection, the serializer and the request builder read
+    [target], [contract] and [rotation] instead of re-deriving a provider kind,
+    an endpoint, or a model name. *)
+type replay_capability =
+  { target : Types.Reasoning_source.t
+    (** Provenance this request replays into, and the stamp its own response
+        carries. *)
+  ; contract : Reasoning_replay_contract.t
+    (** Request-local replay/streaming/output contract. *)
+  ; rotation : Reasoning_replay_contract.rotation_policy
+    (** What a stored artifact from a different source may still do. *)
+  }
+
+val replay_capability_for_provider_config
+  :  Provider_config.t
+  -> (replay_capability, string) result
 
 val with_preserve_thinking : preserve_thinking:bool option -> t -> t
 val thinking_enabled : enable_thinking:bool option -> bool
@@ -139,9 +175,12 @@ val ignores_sampling_param
     This is the single source of truth for both request-body fields and typed
     admission receipts. The low-level [Provider_config]-based builder, the
     high-level Agent API builder, the Responses builder, and Complete preflight
-    all consume projections of this artifact. [zai_glm_clear_thinking] is only
-    used for ZAI GLM's historical [No_toggle] Chat transport, where GLM still
-    accepts a provider-specific [thinking] object. *)
+    all consume projections of this artifact. [clear_thinking_object] carries
+    the resolved [thinking.clear_thinking] member for rows whose
+    {!Capabilities.preserve_thinking_control_format} is
+    [Thinking_object_clear_thinking]: those rows have no ordinary thinking
+    control yet still accept a provider [thinking] object. The caller resolves
+    it from that typed capability, never from a provider identity. *)
 val request_control_fields
   :  openai_request_wire
   -> t
@@ -149,7 +188,7 @@ val request_control_fields
   -> preserve_thinking:bool option
   -> thinking_budget:int option
   -> reasoning_effort:Reasoning_effort.t option
-  -> ?zai_glm_clear_thinking:bool
+  -> ?clear_thinking_object:bool
   -> unit
   -> (request_control_artifact, request_control_rejection) result
 

--- a/lib/llm_provider/reasoning_history_projection.ml
+++ b/lib/llm_provider/reasoning_history_projection.ml
@@ -204,10 +204,14 @@ let replay_selected
 let project
       ~assistant_has_payload
       ~reasoning_block_supported
-      ~reasoning_target
-      ~replay_policy
+      ~(replay_capability : Reasoning_dialect.replay_capability)
       (messages : Types.message list)
   =
+  let reasoning_target = replay_capability.target in
+  let replay_policy =
+    replay_capability.contract.Reasoning_replay_contract.replay_policy
+  in
+  let rotation_policy = replay_capability.rotation in
   match validate_and_classify messages with
   | Error _ as error -> error
   | Ok classified_messages ->
@@ -227,8 +231,16 @@ let project
           | _, false -> Ok (message.content, None)
           | Assistant, true ->
             (match source_classification with
+             (* Continuity across a source change is a declared decision, not an
+                incidental hash comparison: the target dialect's typed
+                [rotation_policy] says which differences a stored artifact may
+                survive (RFC-OAS-029 S3.1). *)
              | Types.Reasoning_source.Present source
-               when not (Types.Reasoning_source.equal source reasoning_target) ->
+               when not
+                      (Types.Reasoning_source.rotation_admits
+                         ~rotation_policy
+                         ~stored:source
+                         ~target:reasoning_target) ->
                Ok
                  ( without_reasoning message.content
                  , Some { message_index; reason = Incompatible_reasoning_source source }
@@ -306,19 +318,10 @@ let project_for_provider_config
       config
       messages
   =
-  let dialect = Reasoning_dialect.for_provider_config config in
-  match Reasoning_dialect.reasoning_source_for_provider_config config with
+  match Reasoning_dialect.replay_capability_for_provider_config config with
   | Error detail -> Error (Invalid_reasoning_target detail)
-  | Ok reasoning_target ->
-    let replay_policy =
-      (Reasoning_dialect.replay_contract dialect).Reasoning_replay_contract.replay_policy
-    in
-    project
-      ~assistant_has_payload
-      ~reasoning_block_supported
-      ~reasoning_target
-      ~replay_policy
-      messages
+  | Ok replay_capability ->
+    project ~assistant_has_payload ~reasoning_block_supported ~replay_capability messages
 ;;
 
 let summarize_drops drops =

--- a/lib/llm_provider/reasoning_history_projection.mli
+++ b/lib/llm_provider/reasoning_history_projection.mli
@@ -53,12 +53,13 @@ val error_to_string : error -> string
 
 (** [assistant_has_payload] states whether an Assistant message still has a
     representable wire payload after projection. [reasoning_block_supported]
-    is the codec's exhaustive declaration of retained reasoning variants. *)
+    is the codec's exhaustive declaration of retained reasoning variants.
+    [replay_capability] is the one record resolved from the provider config:
+    replay target, replay contract, and the declared rotation policy. *)
 val project
   :  assistant_has_payload:(Types.content_block list -> bool)
   -> reasoning_block_supported:(Types.content_block -> bool)
-  -> reasoning_target:Types.Reasoning_source.t
-  -> replay_policy:Reasoning_replay_contract.replay_policy
+  -> replay_capability:Reasoning_dialect.replay_capability
   -> Types.message list
   -> (t, error) result
 

--- a/lib/llm_provider/reasoning_replay_contract.ml
+++ b/lib/llm_provider/reasoning_replay_contract.ml
@@ -18,6 +18,18 @@ type streaming_reasoning =
   | Template_parser
 [@@deriving show, eq, yojson]
 
+(* Declared decision for prior-turn reasoning whose recorded source differs
+   from the source the next request targets (endpoint rotation, model swap,
+   provider change). This replaces an incidental [stored <> target] inequality
+   with a named rule, so a continuity drop is a policy outcome rather than a
+   side effect of comparing hashes. It is deliberately NOT a field of {!t}:
+   {!t} is embedded in the persisted reasoning-source stamp, and adding a
+   member there would invalidate every already-stored artifact. *)
+type rotation_policy =
+  | Require_identical_source
+  | Allow_endpoint_rotation
+[@@deriving show, eq, yojson]
+
 type t =
   { replay_policy : replay_policy
   ; streaming : streaming_reasoning

--- a/lib/llm_provider/reasoning_replay_contract.mli
+++ b/lib/llm_provider/reasoning_replay_contract.mli
@@ -26,6 +26,27 @@ type streaming_reasoning =
   | Template_parser
 [@@deriving show, eq, yojson]
 
+(** Declared decision for prior-turn reasoning whose recorded source differs
+    from the source the next request targets. Resolved once per request from
+    the typed dialect and carried in the replay capability record; consumers
+    never compare source identities on their own terms.
+
+    This type is intentionally not a member of {!t}: {!t} is serialized into
+    the persisted reasoning-source stamp, so adding a field would make every
+    previously stored artifact fail to parse. *)
+type rotation_policy =
+  | Require_identical_source
+  (** The artifact is bound to the exact producing source: it carries a
+      signature the endpoint validates, or it is a handle to state the provider
+      holds. Any difference in provider kind, endpoint instance, model, or
+      replay contract drops it. *)
+  | Allow_endpoint_rotation
+  (** The artifact is self-contained reasoning text with no producer-bound
+      token. It survives a base URL / request path rotation of the same
+      provider kind, canonical model, and replay contract; every other
+      difference still drops it. *)
+[@@deriving show, eq, yojson]
+
 type t =
   { replay_policy : replay_policy
   ; streaming : streaming_reasoning

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -441,6 +441,27 @@ module Reasoning_source = struct
     && Reasoning_replay_contract.equal left.replay_contract right.replay_contract
   ;;
 
+  (* Everything except the concrete endpoint: same provider kind, same
+     canonical request model, same typed replay contract. This is the widest
+     difference a self-contained reasoning text can survive, because none of
+     those three dimensions changed — only the base URL / request path the
+     bytes travelled over. *)
+  let same_contract_and_model stored target =
+    stored.provider_kind = target.provider_kind
+    && String.equal stored.canonical_model_id target.canonical_model_id
+    && Reasoning_replay_contract.equal stored.replay_contract target.replay_contract
+  ;;
+
+  let rotation_admits
+        ~(rotation_policy : Reasoning_replay_contract.rotation_policy)
+        ~stored
+        ~target
+    =
+    match rotation_policy with
+    | Require_identical_source -> equal stored target
+    | Allow_endpoint_rotation -> same_contract_and_model stored target
+  ;;
+
   let to_json source =
     let (Provider_instance_id provider_instance_id) = source.provider_instance in
     `Assoc

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -234,10 +234,12 @@ module Conversation_metadata : sig
   val is_mergeable_followup : metadata -> bool
 end
 
-(** Exact producer binding for stored reasoning artifacts. Replay requires the
-    same concrete provider instance, canonical request model, and typed replay
-    contract. A fallback, endpoint change, or dialect override therefore drops
-    foreign reasoning instead of cross-injecting it. *)
+(** Producer binding stamped on stored reasoning artifacts: provider kind,
+    concrete endpoint instance, canonical request model, and typed replay
+    contract. Whether a difference in any of those dimensions still admits
+    replay is decided by the target dialect's declared
+    {!Reasoning_replay_contract.rotation_policy} through {!rotation_admits} —
+    not by a bare equality test at the consuming site. *)
 module Reasoning_source : sig
   type provider_instance [@@deriving show]
 
@@ -266,6 +268,18 @@ module Reasoning_source : sig
     -> (t, string) result
 
   val equal : t -> t -> bool
+
+  (** [rotation_admits ~rotation_policy ~stored ~target] decides whether a
+      stored reasoning artifact may still be replayed when the request now
+      targets [target]. The answer comes from the declared
+      {!Reasoning_replay_contract.rotation_policy} of the target dialect, never
+      from an ad-hoc comparison at the call site. *)
+  val rotation_admits
+    :  rotation_policy:Reasoning_replay_contract.rotation_policy
+    -> stored:t
+    -> target:t
+    -> bool
+
   val entry : t -> string * Yojson.Safe.t
   val metadata : t -> metadata
   val add : t -> metadata -> (metadata, string) result

--- a/lib/provider.mli
+++ b/lib/provider.mli
@@ -71,6 +71,7 @@ type preserve_thinking_control_format =
   | Chat_template_kwargs_preserve_thinking
   | Top_level_preserve_thinking
   | Always_preserved_thinking
+  | Thinking_object_clear_thinking
 
 type reasoning_replay_override = Llm_provider.Capabilities.reasoning_replay_override =
   | Default_reasoning_replay

--- a/models.toml
+++ b/models.toml
@@ -1708,6 +1708,10 @@ cache_read_multiplier = 0.18333333333333332
 [[models]]
 id_prefix = "glm-4-flash"
 provider_name = "glm"
+# Z.AI chat completions carries the thinking toggle in a top-level [thinking]
+# object and only replays prior reasoning under clear_thinking = false. These
+# rows declare no capability [base], so the wire fact has to be stated here.
+preserve_thinking_control_format = "thinking_object_clear_thinking"
 max_context_tokens = 128000
 max_output_tokens = 4096
 supports_tools = true
@@ -1716,6 +1720,10 @@ supports_native_streaming = true
 [[models]]
 id_prefix = "glm-4v"
 provider_name = "glm"
+# Z.AI chat completions carries the thinking toggle in a top-level [thinking]
+# object and only replays prior reasoning under clear_thinking = false. These
+# rows declare no capability [base], so the wire fact has to be stated here.
+preserve_thinking_control_format = "thinking_object_clear_thinking"
 max_context_tokens = 128000
 max_output_tokens = 4096
 supports_tools = true
@@ -1726,6 +1734,10 @@ supports_native_streaming = true
 [[models]]
 id_prefix = "glm-4"
 provider_name = "glm"
+# Z.AI chat completions carries the thinking toggle in a top-level [thinking]
+# object and only replays prior reasoning under clear_thinking = false. These
+# rows declare no capability [base], so the wire fact has to be stated here.
+preserve_thinking_control_format = "thinking_object_clear_thinking"
 max_context_tokens = 128000
 max_output_tokens = 4096
 supports_tools = true

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -44,6 +44,13 @@ let reasoning_source_for_dialect dialect =
   | Error detail -> Alcotest.failf "invalid codec-test reasoning source: %s" detail
 ;;
 
+let replay_capability_for_dialect dialect : Reasoning_dialect.replay_capability =
+  { target = reasoning_source_for_dialect dialect
+  ; contract = Reasoning_dialect.replay_contract dialect
+  ; rotation = Reasoning_dialect.rotation_policy dialect
+  }
+;;
+
 let reasoning_source_for_config config =
   match Reasoning_dialect.reasoning_source_for_provider_config config with
   | Ok source -> source
@@ -65,12 +72,12 @@ let dialect_messages_of_history
       dialect
       (messages : message list)
   =
-  let reasoning_target = reasoning_source_for_dialect dialect in
-  let messages = stamp_reasoning_history reasoning_target messages in
+  let replay_capability = replay_capability_for_dialect dialect in
+  let messages = stamp_reasoning_history replay_capability.target messages in
   match
     Serialize.dialect_messages_of_history
       ?assistant_tool_content_format
-      ~reasoning_target
+      ~replay_capability
       dialect
       messages
   with
@@ -399,7 +406,7 @@ let test_parse_reasoning_details_and_tool_calls_coexist () =
    | _ -> Alcotest.fail "expected one visible adjacent reasoning block");
   let minimax_dialect =
     { Reasoning_dialect.default with
-      replay_policy = Preserve_always
+      replay_policy = All_assistant_messages
     ; output_wire = Reasoning_split
     }
   in
@@ -888,7 +895,9 @@ let test_assistant_tool_calls_openai_ollama_and_glm () =
     "empty-string capability still emits reasoning_content"
     "because"
     (member "reasoning_content" replay_empty |> to_string);
-  let glm_dialect = { Reasoning_dialect.default with replay_policy = Preserve_always } in
+  let glm_dialect =
+    { Reasoning_dialect.default with replay_policy = All_assistant_messages }
+  in
   let glm =
     render_single_dialect_message
       ~assistant_tool_content_format:Capability_vocab.Assistant_tool_content_empty_string
@@ -1086,7 +1095,9 @@ let test_serializer_ignored_block_variants () =
     "assistant has no tool_calls"
     true
     (member "tool_calls" assistant = `Null);
-  let glm_dialect = { Reasoning_dialect.default with replay_policy = Preserve_always } in
+  let glm_dialect =
+    { Reasoning_dialect.default with replay_policy = All_assistant_messages }
+  in
   let glm =
     render_single_dialect_message
       glm_dialect

--- a/test/test_provider_agnostic_reasoning_replay.ml
+++ b/test/test_provider_agnostic_reasoning_replay.ml
@@ -40,12 +40,29 @@ let reasoning_supported = function
   | Text _ | ToolUse _ | ToolResult _ | Image _ | Document _ | Audio _ -> false
 ;;
 
-let project ~target ~policy messages =
+(* Rotation defaults to the strictest declared rule so existing expectations
+   keep exercising exact-source matching; the rotation-specific cases pass
+   [~rotation] explicitly. *)
+let project
+      ?(rotation = Reasoning_replay_contract.Require_identical_source)
+      ~target
+      ~policy
+      messages
+  =
+  let replay_capability : Reasoning_dialect.replay_capability =
+    { target
+    ; contract =
+        { Reasoning_replay_contract.replay_policy = policy
+        ; streaming = Reasoning_replay_contract.No_streaming_reasoning
+        ; output_wire = Reasoning_replay_contract.No_output_control
+        }
+    ; rotation
+    }
+  in
   Reasoning_history_projection.project
     ~assistant_has_payload:(fun content -> content <> [])
     ~reasoning_block_supported:reasoning_supported
-    ~reasoning_target:target
-    ~replay_policy:policy
+    ~replay_capability
     messages
 ;;
 
@@ -246,8 +263,15 @@ let test_selected_unsupported_block_fails_closed () =
     Reasoning_history_projection.project
       ~assistant_has_payload:(fun content -> content <> [])
       ~reasoning_block_supported:(fun _ -> false)
-      ~reasoning_target:target
-      ~replay_policy:All_assistant_messages
+      ~replay_capability:
+        { target
+        ; contract =
+            { Reasoning_replay_contract.replay_policy = All_assistant_messages
+            ; streaming = Reasoning_replay_contract.No_streaming_reasoning
+            ; output_wire = Reasoning_replay_contract.No_output_control
+            }
+        ; rotation = Reasoning_replay_contract.Require_identical_source
+        }
       [ with_source target Assistant [ Thinking { content = "x"; signature = None } ] ]
   in
   match result with
@@ -583,11 +607,348 @@ let test_openai_responses_replays_only_opaque_item () =
     Yojson.Safe.Util.(List.hd input |> member "type" |> to_string = "reasoning")
 ;;
 
+(* ── RFC-OAS-029 S1.1/S3.1: identity read once, replay read from the record ── *)
+
+let resolved_replay_policy config =
+  (Reasoning_dialect.for_provider_config config).replay_policy
+;;
+
+let clear_thinking_capabilities preserve_thinking_control_format =
+  { Capabilities.default_capabilities with
+    supports_reasoning = true
+  ; supports_extended_thinking = true
+  ; preserve_thinking_control_format
+  }
+;;
+
+(* Pins the resolved replay policy for one config per provider kind, plus every
+   clear-thinking knob combination. The same matrix was captured from the
+   pre-refactor tree and compared byte for byte; a regression in dialect
+   resolution now shows up here as a changed constructor rather than as a silent
+   history drop in production. *)
+let test_provider_replay_policy_matrix_pinned () =
+  let cfg
+        ?request_path
+        ?enable_thinking
+        ?preserve_thinking
+        ?clear_thinking
+        ~kind
+        ~model_id
+        ~base_url
+        ()
+    =
+    Provider_config.make
+      ?request_path
+      ?enable_thinking
+      ?preserve_thinking
+      ?clear_thinking
+      ~kind
+      ~model_id
+      ~base_url
+      ()
+  in
+  let check label expected config =
+    check_bool
+      (Printf.sprintf
+         "%s resolves %s (got %s)"
+         label
+         (Reasoning_replay_contract.show_replay_policy expected)
+         (Reasoning_replay_contract.show_replay_policy (resolved_replay_policy config)))
+      true
+      (resolved_replay_policy config = expected)
+  in
+  check
+    "anthropic"
+    Reasoning_replay_contract.All_assistant_messages
+    (cfg
+       ~kind:Provider_config.Anthropic
+       ~model_id:"claude-sonnet-4-6"
+       ~base_url:"https://api.anthropic.com"
+       ());
+  check
+    "gemini"
+    Reasoning_replay_contract.All_assistant_messages
+    (cfg
+       ~kind:Provider_config.Gemini
+       ~model_id:"gemini-3-pro"
+       ~base_url:"https://generativelanguage.googleapis.com"
+       ());
+  check
+    "ollama"
+    Reasoning_replay_contract.Tool_call_assistant_messages_latest_user_turn
+    (cfg
+       ~kind:Provider_config.Ollama
+       ~model_id:"qwen3"
+       ~base_url:"http://localhost:11434"
+       ());
+  check
+    "kimi"
+    Reasoning_replay_contract.Tool_call_assistant_messages_all_history
+    (cfg
+       ~kind:Provider_config.Kimi
+       ~model_id:"kimi-k2.6"
+       ~base_url:"https://api.moonshot.ai"
+       ());
+  check
+    "openai chat"
+    Reasoning_replay_contract.No_replay
+    (cfg
+       ~kind:Provider_config.OpenAI_compat
+       ~model_id:"gpt-5.4"
+       ~base_url:"https://api.openai.com"
+       ());
+  check
+    "openai responses"
+    Reasoning_replay_contract.Provider_opaque_state
+    (cfg
+       ~request_path:"/v1/responses"
+       ~kind:Provider_config.OpenAI_compat
+       ~model_id:"gpt-5.4"
+       ~base_url:"https://api.openai.com"
+       ());
+  check
+    "dashscope"
+    Reasoning_replay_contract.No_replay
+    (cfg
+       ~kind:Provider_config.DashScope
+       ~model_id:"qwen-max"
+       ~base_url:"https://dashscope.aliyuncs.com"
+       ());
+  List.iter
+    (fun model_id ->
+       let base_url = "https://api.z.ai" in
+       let label suffix = Printf.sprintf "glm/%s %s" model_id suffix in
+       check
+         (label "default")
+         Reasoning_replay_contract.No_replay
+         (cfg ~kind:Provider_config.Glm ~model_id ~base_url ());
+       check
+         (label "enable_thinking only")
+         Reasoning_replay_contract.No_replay
+         (cfg ~enable_thinking:true ~kind:Provider_config.Glm ~model_id ~base_url ());
+       check
+         (label "preserve only")
+         Reasoning_replay_contract.No_replay
+         (cfg ~preserve_thinking:true ~kind:Provider_config.Glm ~model_id ~base_url ());
+       check
+         (label "enable + preserve")
+         Reasoning_replay_contract.All_assistant_messages
+         (cfg
+            ~enable_thinking:true
+            ~preserve_thinking:true
+            ~kind:Provider_config.Glm
+            ~model_id
+            ~base_url
+            ());
+       check
+         (label "enable + clear_thinking=false")
+         Reasoning_replay_contract.All_assistant_messages
+         (cfg
+            ~enable_thinking:true
+            ~clear_thinking:false
+            ~kind:Provider_config.Glm
+            ~model_id
+            ~base_url
+            ()))
+    [ "glm-5"; "glm-5.2"; "glm-4-flash"; "glm-4v"; "glm-4"; "glm-unlisted" ]
+;;
+
+(* The preserved-thinking replay gate is selected by the declared
+   [preserve_thinking_control_format], not by the provider kind. Both directions
+   are asserted: the gate turns on for a non-GLM kind that declares the wire and
+   stays off for the GLM kind that does not. Reverting to a [config.kind = Glm]
+   predicate turns both red. *)
+let test_clear_thinking_gate_is_capability_not_identity () =
+  let preserved kind capabilities =
+    Provider_config.make
+      ~kind
+      ~model_id:"gate-probe"
+      ~base_url:"https://gate.example"
+      ~model_capabilities_override:capabilities
+      ~enable_thinking:true
+      ~preserve_thinking:true
+      ()
+  in
+  let cleared kind capabilities =
+    Provider_config.make
+      ~kind
+      ~model_id:"gate-probe"
+      ~base_url:"https://gate.example"
+      ~model_capabilities_override:capabilities
+      ~enable_thinking:true
+      ()
+  in
+  let declared =
+    clear_thinking_capabilities Capabilities.Thinking_object_clear_thinking
+  in
+  let undeclared =
+    clear_thinking_capabilities Capabilities.No_preserve_thinking_control
+  in
+  check_bool
+    "non-GLM kind declaring the wire gets conditional replay"
+    true
+    (resolved_replay_policy (preserved Provider_config.OpenAI_compat declared)
+     = Reasoning_replay_contract.All_assistant_messages);
+  check_bool
+    "non-GLM kind declaring the wire honours the clear_thinking default"
+    true
+    (resolved_replay_policy (cleared Provider_config.OpenAI_compat declared)
+     = Reasoning_replay_contract.No_replay);
+  check_bool
+    "GLM kind without the declared wire does not get the gate"
+    true
+    (resolved_replay_policy (preserved Provider_config.Glm undeclared)
+     = Reasoning_replay_contract.No_replay);
+  check_bool
+    "GLM kind declaring the wire still gets conditional replay"
+    true
+    (resolved_replay_policy (preserved Provider_config.Glm declared)
+     = Reasoning_replay_contract.All_assistant_messages)
+;;
+
+(* ── RFC-OAS-029 S3.1: the rotation drop is a declared policy ── *)
+
+let test_rotation_policy_is_declared_per_dialect () =
+  let rotation ?request_path ~kind ~model_id ~base_url () =
+    Provider_config.make ?request_path ~kind ~model_id ~base_url ()
+    |> Reasoning_dialect.for_provider_config
+    |> Reasoning_dialect.rotation_policy
+  in
+  let check label expected actual =
+    check_bool
+      (Printf.sprintf
+         "%s declares %s"
+         label
+         (Reasoning_replay_contract.show_rotation_policy expected))
+      true
+      (actual = expected)
+  in
+  check
+    "anthropic signed thinking blocks"
+    Reasoning_replay_contract.Require_identical_source
+    (rotation
+       ~kind:Provider_config.Anthropic
+       ~model_id:"claude-sonnet-4-6"
+       ~base_url:"https://api.anthropic.com"
+       ());
+  check
+    "gemini thought signatures"
+    Reasoning_replay_contract.Require_identical_source
+    (rotation
+       ~kind:Provider_config.Gemini
+       ~model_id:"gemini-3-pro"
+       ~base_url:"https://generativelanguage.googleapis.com"
+       ());
+  check
+    "openai responses opaque state"
+    Reasoning_replay_contract.Require_identical_source
+    (rotation
+       ~request_path:"/v1/responses"
+       ~kind:Provider_config.OpenAI_compat
+       ~model_id:"gpt-5.4"
+       ~base_url:"https://api.openai.com"
+       ());
+  check
+    "glm reasoning_content side channel"
+    Reasoning_replay_contract.Allow_endpoint_rotation
+    (rotation ~kind:Provider_config.Glm ~model_id:"glm-5" ~base_url:"https://api.z.ai" ());
+  check
+    "ollama thinking side channel"
+    Reasoning_replay_contract.Allow_endpoint_rotation
+    (rotation
+       ~kind:Provider_config.Ollama
+       ~model_id:"qwen3"
+       ~base_url:"http://localhost:11434"
+       ());
+  check
+    "kimi reasoning_content side channel"
+    Reasoning_replay_contract.Allow_endpoint_rotation
+    (rotation
+       ~kind:Provider_config.Kimi
+       ~model_id:"kimi-k2.6"
+       ~base_url:"https://api.moonshot.ai"
+       ())
+;;
+
+let incompatible_drop_count (projection : Reasoning_history_projection.t) =
+  List.length
+    (List.filter
+       (fun (drop : Reasoning_history_projection.reasoning_replay_drop) ->
+          match drop.reason with
+          | Incompatible_reasoning_source _ -> true
+          | Replay_policy_excluded _
+          | Missing_reasoning_source
+          | Reasoning_on_non_assistant -> false)
+       projection.reasoning_replay_drops)
+;;
+
+(* Continuity across a rotation follows the declared rule, not a bare identity
+   comparison: the same stored artifact and the same target are dropped under
+   [Require_identical_source] and kept under [Allow_endpoint_rotation], while a
+   model or replay-contract change is dropped under both. *)
+let test_rotation_policy_drives_incompatible_drop () =
+  let target = source All_assistant_messages in
+  let rotated_endpoint =
+    source ~base_url:"https://rotated.example" All_assistant_messages
+  in
+  let other_model = source ~model_id:"model-b" All_assistant_messages in
+  let other_contract = source ~base_url:"https://rotated.example" No_replay in
+  let history stored =
+    [ with_source stored Assistant [ Thinking { content = "prior"; signature = None } ]
+    ; message User [ Text "next" ]
+    ]
+  in
+  let run ~rotation stored =
+    match project ~rotation ~target ~policy:All_assistant_messages (history stored) with
+    | Error error -> Alcotest.fail (Reasoning_history_projection.error_to_string error)
+    | Ok projection -> projection
+  in
+  check_int
+    "identical-source rule drops an endpoint rotation"
+    1
+    (incompatible_drop_count
+       (run ~rotation:Reasoning_replay_contract.Require_identical_source rotated_endpoint));
+  let kept =
+    run ~rotation:Reasoning_replay_contract.Allow_endpoint_rotation rotated_endpoint
+  in
+  check_int "endpoint-rotation rule keeps the artifact" 0 (incompatible_drop_count kept);
+  check_bool
+    "rotated reasoning survives into the projection"
+    true
+    (content_has_reasoning (List.hd kept.messages).content);
+  check_int
+    "endpoint-rotation rule still drops a model change"
+    1
+    (incompatible_drop_count
+       (run ~rotation:Reasoning_replay_contract.Allow_endpoint_rotation other_model));
+  check_int
+    "endpoint-rotation rule still drops a replay-contract change"
+    1
+    (incompatible_drop_count
+       (run ~rotation:Reasoning_replay_contract.Allow_endpoint_rotation other_contract))
+;;
+
 let () =
   Alcotest.run
     "provider_agnostic_reasoning_replay"
     [ ( "typed replay projection"
       , [ Alcotest.test_case
+            "provider replay policy matrix"
+            `Quick
+            test_provider_replay_policy_matrix_pinned
+        ; Alcotest.test_case
+            "clear-thinking gate is capability not identity"
+            `Quick
+            test_clear_thinking_gate_is_capability_not_identity
+        ; Alcotest.test_case
+            "rotation policy declared per dialect"
+            `Quick
+            test_rotation_policy_is_declared_per_dialect
+        ; Alcotest.test_case
+            "rotation policy drives incompatible drop"
+            `Quick
+            test_rotation_policy_drives_incompatible_drop
+        ; Alcotest.test_case
             "source exactness"
             `Quick
             test_source_exactness_and_classification

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -1322,21 +1322,22 @@ let test_validate_reasoning_effort_fails_closed_without_declaration () =
   | Ok () -> Alcotest.fail "undeclared effort capability must fail closed"
 ;;
 
-let test_zai_glm_clear_thinking_request_field () =
+let test_clear_thinking_object_request_field () =
   let resolve
-        ?(thinking_control_format = Capabilities.No_thinking_control)
-        ?(is_zai_glm = true)
+        ?(preserve_thinking_control_format = Capabilities.Thinking_object_clear_thinking)
         ?clear_thinking
         ?preserve_thinking
         ()
     =
-    Provider_config.zai_glm_clear_thinking_request_field
-      ~thinking_control_format
-      ~is_zai_glm
+    Provider_config.clear_thinking_object_request_field
+      ~preserve_thinking_control_format
       ~clear_thinking
       ~preserve_thinking
   in
-  Alcotest.(check (option bool)) "default GLM clears" (Some true) (resolve ());
+  Alcotest.(check (option bool))
+    "declared wire clears by default"
+    (Some true)
+    (resolve ());
   Alcotest.(check (option bool))
     "preserve disables clear"
     (Some false)
@@ -1345,11 +1346,20 @@ let test_zai_glm_clear_thinking_request_field () =
     "explicit clear wins"
     (Some true)
     (resolve ~clear_thinking:true ~preserve_thinking:true ());
-  Alcotest.(check (option bool)) "non-GLM omits" None (resolve ~is_zai_glm:false ());
-  Alcotest.(check (option bool))
-    "typed thinking control omits"
-    None
-    (resolve ~thinking_control_format:Capabilities.Thinking_object ())
+  (* The field is gated on the declared preserve wire alone: every other wire
+     omits it, whatever the provider kind or model id is. *)
+  List.iter
+    (fun (label, preserve_thinking_control_format) ->
+       Alcotest.(check (option bool))
+         label
+         None
+         (resolve ~preserve_thinking_control_format ()))
+    [ "no preserve wire omits", Capabilities.No_preserve_thinking_control
+    ; "thinking_object_keep_all omits", Capabilities.Thinking_object_keep_all
+    ; "chat_template_kwargs omits", Capabilities.Chat_template_kwargs_preserve_thinking
+    ; "top_level omits", Capabilities.Top_level_preserve_thinking
+    ; "always_preserved omits", Capabilities.Always_preserved_thinking
+    ]
 ;;
 
 let test_structured_output_name_of_schema () =
@@ -2429,9 +2439,9 @@ let () =
             `Quick
             test_validate_reasoning_effort_fails_closed_without_declaration
         ; Alcotest.test_case
-            "zai glm clear_thinking request field"
+            "clear_thinking object request field"
             `Quick
-            test_zai_glm_clear_thinking_request_field
+            test_clear_thinking_object_request_field
         ; Alcotest.test_case
             "structured output names"
             `Quick


### PR DESCRIPTION
## 목표

reasoning replay 결정에서 provider **identity** 를 분기 술어로 쓰던 지점들을 제거하고, config-parse 시점에 **한 번만** 해석되는 typed capability record 로 통합한다. 켈베로스 감사(jeong-sik/masc#25550) 개선 P2 · 추적 jeong-sik/masc#27872. 범위 RFC: `RFC-OAS-029-tools-thinking-reasoning-multiturn-standard.md`.

## 근거

감사에서 이 축은 **5/5 고발이 적대 검증을 통과**했다(가장 많은 CONFIRMED). identity 가 4곳에 흩어져 replay 를 결정하고 있었다.

라이브 증거(2026-07-22): kimi-k2.6 이 `replay_policy=All_assistant_messages`(replay ON)인데도 `reasoning_replay_dropped drop_count=213, incompatible_source=52` — 이전 thinking 52건이 **identity 불일치만으로** 폐기.

## 변경

### 1. GLM identity 가드 → typed capability

`is_zai_glm_config` / `glm_should_replay_reasoning{,_fields}` / `glm_clear_thinking` **삭제**. 대신 `Thinking_object_clear_thinking` capability 를 `preserve_thinking_control_format` 에 추가하고, replay 게이트·request 필드·admission **세 사이트 모두** 이 capability 를 읽는다(N-of-M 아님).

`rg "is_zai_glm|glm_should_replay|is_glm_request" lib/ test/` → **0 hits**.

`models.toml` 의 GLM 행 3개(`glm-4`, `glm-4v`, `glm-4-flash`)는 `provider_name = "glm"` 이지만 capability `base` 가 없어 `default_capabilities` 로 떨어진다. 그대로 두면 게이트를 **조용히 잃으므로** wire fact 를 명시 선언했다. 이 3행을 건드린 유일한 이유다.

### 2. replay 어휘 2계층 → 1계층

`Reasoning_dialect.replay_policy` / `streaming_reasoning` / `output_wire` 를 `Reasoning_replay_contract` 에 대한 **타입 등식**으로 만들었다. 기존 5→5 매핑(`reasoning_dialect.ml:622-643`)은 삭제. 문서화된 절충이 아니라 완전 통합이다.

### 3. rotation drop → 선언된 정책

`reasoning_history_projection.ml:229-243` 의 raw `not (Reasoning_source.equal source target)` 를 `rotation_admits ~rotation_policy` 로 교체.

```ocaml
type rotation_policy =
  | Require_identical_source
      (* 서명/불투명 핸들처럼 생산자에 묶인 아티팩트 — 어떤 차이든 drop *)
  | Allow_endpoint_rotation
      (* 자족적 reasoning 텍스트 — 같은 kind·model·contract 면 endpoint 회전 생존 *)
```

`rotation_policy` 를 `Reasoning_replay_contract.t` 의 **필드로 넣지 않았다**: `t` 는 영속 스탬프 `oas.reasoning_source.v2` 로 직렬화되고 디코더가 정확히 4필드를 요구하므로, 필드를 추가하면 배포 즉시 기존 저장 아티팩트가 전부 `Invalid` 로 파싱된다.

### 4. 단일 capability record

```ocaml
type replay_capability =
  { target : Types.Reasoning_source.t
  ; contract : Reasoning_replay_contract.t
  ; rotation : Reasoning_replay_contract.rotation_policy
  }
val replay_capability_for_provider_config : Provider_config.t -> (replay_capability, string) result
```

projection·serialize·request 가 모두 `~replay_capability` 를 받는다. target/policy/rotation 을 따로 해석하는 호출처는 남아있지 않다.

## 의도적으로 남긴 것 (반쪽 마이그레이션 회피)

| 항목 | 상태 |
|---|---|
| `base_for_provider_config` 가 `config.kind` 로 분기 | **보류.** 이제 record 를 생산하는 **유일한** identity dispatch 다. 제대로 고치려면 Anthropic/Gemini/Ollama 의 replay fact 를 capability 행으로 옮겨야 하고, 그건 해당 kind 들의 `toggle_wire` 공급 경로를 바꾼다 — 회귀 위험이 실재해 손대지 않고 남겼다. |
| `provider_http_codec` "kind owns the wire contract" | **설계상 보류.** 직렬화 경계의 transport 선택. 다만 두 resolver 에 중복돼 있던 것을 `apply_transport_replay_override` 하나로 통일했다. |

## 검증

**차등 검증(differential probe)**: 리팩터 트리와 baseline(`git stash`) 양쪽에서 40행 매트릭스(provider kind × knob 조합)의 resolved replay policy + 방출되는 `thinking` request object 를 출력해 diff → **byte-identical (`DIFF_EXIT=0`)**. 프로브는 삭제하고 그 매트릭스를 영구 alcotest 케이스로 재인코딩했다.

리뷰어가 재실행한 독립 검증:

| 대상 | 결과 |
|---|---|
| `scripts/dune-local.sh build lib` | 통과 |
| `test_provider_agnostic_reasoning_replay` | **17 tests** 통과 (신규 4건) |
| `test_provider_config` | 116 tests 통과 |
| `test_capabilities` | 100 tests 통과 |
| `test_thinking_control_dialects` | 43 tests 통과 |
| `@fmt` | diff 없음 |

에이전트 보고 기준 추가: `@test/runtest` 전체 exit 0 (FAIL/ERROR 0줄), `@lib/runtest` exit 0, backend_openai_codec 43 · provider_complete 63 · gemini 55 등 통과.

신규 테스트 중 핵심은 **capability ≠ identity 4-way 교차**다:
- non-GLM kind + wire 선언 → 조건부 replay ✓
- non-GLM kind + wire 선언 + cleared → `No_replay` ✓
- **GLM kind + wire 미선언 → 게이트 없음** ✓ ← identity 로 되돌리면 여기가 red
- GLM kind + wire 선언 → 조건부 replay ✓

## 동작 변화 (1건, 의도적)

`Allow_endpoint_rotation` 를 선언한 wire(OpenAI-compat, GLM, Kimi, Ollama, DashScope, chat-template)에서 **endpoint 회전**(`base_url`/`request_path` 변경, kind·canonical model·contract 동일)이 더 이상 이전 reasoning 을 버리지 않는다. Anthropic · Gemini · OpenAI Responses 는 `Require_identical_source` 로 기존 등식과 동일 — 변화 없음.

**정직한 한계**: 이 변경이 kimi 의 `incompatible_source=52` 를 설명한다고 주장할 수 없다. endpoint-rotation 부류는 해소하지만, 그 52건이 model-id 변경에서 왔다면 여전히 drop 된다 — 다만 이제 **이름 있는 규칙** 아래에서 drop 되므로 후속에서 의도적으로 넓힐 수 있다.

## 후속 (이 PR 범위 밖)

1. 감사 항목 1 — Anthropic/Gemini/Ollama replay fact 를 capability 행으로 이관해 `base_for_provider_config` 의 kind 하드코딩 제거.
2. `replay_policy_to_string` 은 구 라벨(`"preserve_always"` 등)을 유지 — 운영 진단 문자열 churn 회피. 라벨 rename 은 별도의 관측 가능한 변경.
3. RFC 의 S1.1/S3.1 CI grep 게이트 미추가.
4. `glm-4` / `glm-4v` / `glm-4-flash` 행이 `base = "glm"` 없이 preserve wire 만 선언 → GLM 의 tool-choice · assistant-tool-content fact 는 여전히 누락(선행 갭, 별도 검토 대상).

RFC-WAIVED: credential / identity(인증) / operator control / sandbox / hooks / workflow 문서 어디에도 해당하지 않는다. reasoning replay 의 provider-agnostic 리팩터다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
