### PR TITLE
fix(llm_provider)!: stop emitting Document blocks as image_url

### DIFF
--- a/docs/capability-manifest.md
+++ b/docs/capability-manifest.md
@@ -96,6 +96,7 @@ for the full JSON Schema (draft-07).
 | `supports_image_input` | bool | from base | Image inputs. |
 | `supports_audio_input` | bool | from base | Audio inputs (native tokens). |
 | `supports_video_input` | bool | from base | Video inputs. |
+| `supports_document_input` | bool | from base | Document inputs (e.g. PDF). Not implied by `supports_image_input`: a row that omits it has its documents rejected at serialization rather than relabelled as images. |
 | `supports_native_streaming` | bool | from base | SSE streaming. |
 | `supports_system_prompt` | bool | from base | System prompt field. |
 | `supports_caching` | bool | from base | Prompt caching. |

--- a/docs/provider-catalog.md
+++ b/docs/provider-catalog.md
@@ -190,7 +190,7 @@ The `capabilities` object accepts the same capability field names used by
 - `thinking_control_format`, `preserve_thinking_control_format`
 - `reasoning_output_format`, `reasoning_streaming_format`
 - `supports_response_format_json`, `supports_structured_output`
-- `supports_image_input`, `supports_audio_input`, `supports_video_input`
+- `supports_image_input`, `supports_audio_input`, `supports_video_input`, `supports_document_input`
 - `modality_priority`
 - `supports_native_streaming`, `supports_system_prompt`
 - `supports_top_k`, `supports_min_p`, `supports_seed`

--- a/docs/schemas/capability-manifest-v1.json
+++ b/docs/schemas/capability-manifest-v1.json
@@ -145,6 +145,10 @@
           "type": "boolean",
           "description": "Whether the model accepts video inputs."
         },
+        "supports_document_input": {
+          "type": "boolean",
+          "description": "Whether the model accepts document inputs (e.g. PDF). Independent of supports_image_input: serialization rejects a document on a row that does not declare this instead of emitting it as an image."
+        },
         "supports_native_streaming": {
           "type": "boolean",
           "description": "Whether the model/provider supports server-sent event streaming."

--- a/lib/llm_provider/api_common.ml
+++ b/lib/llm_provider/api_common.ml
@@ -74,6 +74,109 @@ let base64_media_payload ~backend ~block ~data = function
   | (Url | File_id) as source_type -> unsupported_media_source ~backend ~block source_type
 ;;
 
+(* ── Document admission (oas#2744) ───────────────────────────────────────
+
+   A [Document] block used to be re-labelled as an [image_url] part on the
+   OpenAI-compatible Chat Completions wire. Serializing the same typed block
+   differently per wire is the legitimate serialization boundary; changing
+   *which modality it is* is not — the model received a picture where the
+   caller sent a file, and nothing reported it.
+
+   The two facts that decide whether a document may go out are now separate and
+   both typed: [document_wire_form] says which native part the wire has (there
+   is no wildcard: a wire with no document part says so), and
+   [Capabilities.supports_document_input] says whether the resolved model row
+   accepts one. Admission runs before serialization, so each serializer arm has
+   exactly one native form and never needs a fallback. *)
+
+type document_wire_form =
+  | Document_source_block (** Anthropic Messages: [{"type":"document","source":{…}}]. *)
+  | Document_inline_data (** Gemini: [inlineData] carrying the document MIME. *)
+  | Document_input_file_part
+  (** OpenAI Responses: [{"type":"input_file","file_data":…}]. *)
+  | Document_chat_file_part
+  (** OpenAI Chat Completions: [{"type":"file","file":{"file_data":…}}]. *)
+  | Document_unrepresentable
+  (** The wire has no document part. Ollama's native [/api/chat] carries only
+        a scalar [content] plus an [images] array; a document placed in
+        [images] is an image as far as the server is concerned. *)
+
+let document_wire_form_to_string = function
+  | Document_source_block -> "an Anthropic document source block"
+  | Document_inline_data -> "a Gemini inlineData part"
+  | Document_input_file_part -> "an OpenAI Responses input_file part"
+  | Document_chat_file_part -> "an OpenAI Chat Completions file part"
+  | Document_unrepresentable -> "no document part"
+;;
+
+type document_admission_error =
+  | Document_wire_has_no_representation of
+      { wire_form : document_wire_form
+      ; media_type : string
+      }
+  | Document_input_not_declared of
+      { model_id : string
+      ; media_type : string
+      }
+
+let document_admission_error_to_string = function
+  | Document_wire_has_no_representation { wire_form; media_type } ->
+    Printf.sprintf
+      "document block (media_type %S) cannot be placed on this wire: it has %s"
+      media_type
+      (document_wire_form_to_string wire_form)
+  | Document_input_not_declared { model_id; media_type } ->
+    Printf.sprintf
+      "document block (media_type %S) rejected: model %S does not declare \
+       supports_document_input"
+      media_type
+      model_id
+;;
+
+let admit_document_blocks ~wire_form ~model_id ~supports_document_input blocks =
+  let rec loop = function
+    | [] -> Ok ()
+    | Document { media_type; _ } :: rest ->
+      (match wire_form with
+       | Document_unrepresentable ->
+         Error (Document_wire_has_no_representation { wire_form; media_type })
+       | Document_source_block
+       | Document_inline_data
+       | Document_input_file_part
+       | Document_chat_file_part ->
+         if supports_document_input
+         then loop rest
+         else Error (Document_input_not_declared { model_id; media_type }))
+    | ( Text _
+      | Thinking _
+      | ReasoningDetails _
+      | RedactedThinking _
+      | ToolUse _
+      | ToolResult _
+      | Image _
+      | Audio _ )
+      :: rest -> loop rest
+  in
+  loop blocks
+;;
+
+let admit_document_messages ~wire_form ~model_id ~supports_document_input messages =
+  let rec loop = function
+    | [] -> Ok ()
+    | (message : Types.message) :: rest ->
+      (match
+         admit_document_blocks
+           ~wire_form
+           ~model_id
+           ~supports_document_input
+           message.content
+       with
+       | Error _ as error -> error
+       | Ok () -> loop rest)
+  in
+  loop messages
+;;
+
 type tool_result_content_style =
   | Tool_result_content_string
   | Tool_result_content_text_blocks

--- a/lib/llm_provider/api_common.ml
+++ b/lib/llm_provider/api_common.ml
@@ -177,6 +177,78 @@ let admit_document_messages ~wire_form ~model_id ~supports_document_input messag
   loop messages
 ;;
 
+(* oas#2744 — degrade, not reject.
+   [admit_document_*] answers "may this document reach the wire"; when it may
+   not, the earlier design raised [Invalid_argument], which
+   [Complete.complete]'s wrapper turned into a rejected turn. That is right for
+   a document the caller is introducing now, but the same functions walk the
+   ENTIRE message history every turn, so a document resident in an
+   already-answered turn permanently sank every later turn of that conversation
+   against a model without the capability — retroactively, for state written
+   before this behaviour existed.
+
+   The wire still must not carry a document as some other modality (the audit's
+   actual defect: a PDF relabelled [image_url]). So instead of relabelling or
+   rejecting, an unrepresentable document is replaced with a visible text block
+   that names what was dropped. This is not silent: the model — and through it
+   the user — sees that a document was omitted and why, which is the honest
+   degraded outcome for a conversation whose model cannot read documents. A
+   model that CAN carry the document (capability declared, wire has a document
+   part) keeps its native block untouched. *)
+let document_omitted_placeholder ~media_type =
+  Text
+    (Printf.sprintf
+       "[document omitted: this model does not accept document input (media_type %s)]"
+       media_type)
+;;
+
+let degrade_document_block ~wire_form ~supports_document_input block =
+  match block with
+  | Document { media_type; _ } ->
+    let representable =
+      match wire_form with
+      | Document_unrepresentable -> false
+      | Document_source_block
+      | Document_inline_data
+      | Document_input_file_part
+      | Document_chat_file_part -> supports_document_input
+    in
+    if representable then block else document_omitted_placeholder ~media_type
+  | Text _
+  | Thinking _
+  | ReasoningDetails _
+  | RedactedThinking _
+  | ToolUse _
+  | ToolResult _
+  | Image _
+  | Audio _ -> block
+;;
+
+(* Replace every unrepresentable document across the whole history with the
+   placeholder, leaving all other blocks (and representable documents) intact.
+   Returns the rewritten messages and the count of documents degraded, so a
+   caller may log or surface the degradation without re-walking. *)
+let degrade_document_messages ~wire_form ~supports_document_input messages =
+  let degraded = ref 0 in
+  let rewrite (message : Types.message) =
+    let content =
+      List.map
+        (fun block ->
+           let block' =
+             degrade_document_block ~wire_form ~supports_document_input block
+           in
+           (match block, block' with
+            | Document _, Text _ -> incr degraded
+            | _ -> ());
+           block')
+        message.content
+    in
+    { message with content }
+  in
+  let messages = List.map rewrite messages in
+  messages, !degraded
+;;
+
 type tool_result_content_style =
   | Tool_result_content_string
   | Tool_result_content_text_blocks

--- a/lib/llm_provider/api_common.mli
+++ b/lib/llm_provider/api_common.mli
@@ -47,6 +47,65 @@ val base64_media_payload
   -> Types.media_source_kind
   -> string
 
+(** {2 Document admission}
+
+    A [Document] block must never be emitted as some other modality (oas#2744:
+    the OpenAI-compatible Chat Completions serializer used to relabel it
+    [image_url], so the model saw a picture where the caller sent a file, and
+    nothing reported it). Two typed facts decide whether a document may go out:
+    which native part the wire has ({!document_wire_form}) and whether the
+    resolved model row accepts documents
+    ([Capabilities.supports_document_input]). {!admit_document_blocks} checks
+    both before serialization, so every serializer's [Document] arm has exactly
+    one native form and no fallback. *)
+
+(** Native document representation of a request wire. No wildcard arm: a wire
+    with no document part declares {!Document_unrepresentable}. *)
+type document_wire_form =
+  | Document_source_block (** Anthropic [{"type":"document","source":{…}}]. *)
+  | Document_inline_data (** Gemini [inlineData] with the document MIME. *)
+  | Document_input_file_part (** OpenAI Responses [input_file] + [file_data]. *)
+  | Document_chat_file_part
+  (** OpenAI Chat Completions [{"type":"file","file":{"file_data":…}}]. *)
+  | Document_unrepresentable
+  (** Ollama native [/api/chat]: scalar [content] plus an [images] array
+          only. *)
+
+val document_wire_form_to_string : document_wire_form -> string
+
+type document_admission_error =
+  | Document_wire_has_no_representation of
+      { wire_form : document_wire_form
+      ; media_type : string
+      }
+  | Document_input_not_declared of
+      { model_id : string
+      ; media_type : string
+      }
+
+val document_admission_error_to_string : document_admission_error -> string
+
+(** [admit_document_blocks ~wire_form ~model_id ~supports_document_input blocks]
+    is [Ok ()] when every [Document] in [blocks] may be placed on a wire whose
+    native form is [wire_form], and [Error] naming the first one that may not.
+    Only [Document] blocks are inspected: image and audio admission is
+    unchanged, so this cannot alter what a working provider emits for them. *)
+val admit_document_blocks
+  :  wire_form:document_wire_form
+  -> model_id:string
+  -> supports_document_input:bool
+  -> Types.content_block list
+  -> (unit, document_admission_error) result
+
+(** {!admit_document_blocks} over a whole history, reporting the first
+    inadmissible document. *)
+val admit_document_messages
+  :  wire_form:document_wire_form
+  -> model_id:string
+  -> supports_document_input:bool
+  -> Types.message list
+  -> (unit, document_admission_error) result
+
 (** {2 Content block JSON conversion} *)
 
 val content_block_to_json : Types.content_block -> Yojson.Safe.t

--- a/lib/llm_provider/api_common.mli
+++ b/lib/llm_provider/api_common.mli
@@ -98,13 +98,37 @@ val admit_document_blocks
   -> (unit, document_admission_error) result
 
 (** {!admit_document_blocks} over a whole history, reporting the first
-    inadmissible document. *)
+    inadmissible document. Retained for callers that want a hard admission
+    verdict; the request/serialize paths degrade instead (see
+    {!degrade_document_messages}). *)
 val admit_document_messages
   :  wire_form:document_wire_form
   -> model_id:string
   -> supports_document_input:bool
   -> Types.message list
   -> (unit, document_admission_error) result
+
+(** The visible text block an unrepresentable document is replaced with. Names
+    the media type so the omission is legible to the model and, through it, the
+    user — the degrade is not silent. *)
+val document_omitted_placeholder : media_type:string -> Types.content_block
+
+(** [degrade_document_messages ~wire_form ~supports_document_input messages]
+    rewrites every [Document] that cannot be placed on a wire whose native form
+    is [wire_form] into {!document_omitted_placeholder}, leaving representable
+    documents and every other block untouched. Returns the rewritten history and
+    the number of documents degraded.
+
+    This is the request/serialize-path remedy for oas#2744: a document is never
+    relabelled as another modality (the original defect) and never rejects the
+    turn (which retroactively broke conversations already holding a document in
+    history against a model without the capability) — it degrades to a named
+    placeholder, uniformly across the whole history, statelessly. *)
+val degrade_document_messages
+  :  wire_form:document_wire_form
+  -> supports_document_input:bool
+  -> Types.message list
+  -> Types.message list * int
 
 (** {2 Content block JSON conversion} *)
 

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -269,6 +269,22 @@ let build_request_assoc_artifact
     output_token_receipt ~envelope:Types.Openai_chat_max_tokens config
   in
   let assistant_tool_content_format = caps.Capabilities.assistant_tool_content_format in
+  (* oas#2744 — document admission runs before any block is serialized. A row
+     that does not declare [supports_document_input] fails here with the media
+     type named, instead of having its document quietly relabelled as an
+     [image_url] part further down. Image and audio blocks are not gated, so
+     rows that carry them today are unaffected. *)
+  (match
+     Api_common.admit_document_messages
+       ~wire_form:Api_common.Document_chat_file_part
+       ~model_id:config.model_id
+       ~supports_document_input:caps.Capabilities.supports_document_input
+       messages
+   with
+   | Ok () -> ()
+   | Error error ->
+     invalid_arg
+       ("Backend_openai_request: " ^ Api_common.document_admission_error_to_string error));
   let provider_messages =
     let history =
       match

--- a/lib/llm_provider/backend_openai_request.ml
+++ b/lib/llm_provider/backend_openai_request.ml
@@ -269,22 +269,20 @@ let build_request_assoc_artifact
     output_token_receipt ~envelope:Types.Openai_chat_max_tokens config
   in
   let assistant_tool_content_format = caps.Capabilities.assistant_tool_content_format in
-  (* oas#2744 — document admission runs before any block is serialized. A row
-     that does not declare [supports_document_input] fails here with the media
-     type named, instead of having its document quietly relabelled as an
-     [image_url] part further down. Image and audio blocks are not gated, so
-     rows that carry them today are unaffected. *)
-  (match
-     Api_common.admit_document_messages
-       ~wire_form:Api_common.Document_chat_file_part
-       ~model_id:config.model_id
-       ~supports_document_input:caps.Capabilities.supports_document_input
-       messages
-   with
-   | Ok () -> ()
-   | Error error ->
-     invalid_arg
-       ("Backend_openai_request: " ^ Api_common.document_admission_error_to_string error));
+  (* oas#2744 — degrade an unrepresentable document to a named text placeholder
+     before serialization, rather than relabelling it [image_url] (the audit's
+     defect) or rejecting the whole request. Rejection retroactively broke every
+     later turn of any conversation that already held a document in its history
+     against a model without the capability; degrading keeps the turn live while
+     still refusing to send a document as some other modality. A row that
+     declares [supports_document_input] and whose wire has a document part keeps
+     its native block. Image and audio blocks are untouched. *)
+  let messages, _documents_degraded =
+    Api_common.degrade_document_messages
+      ~wire_form:Api_common.Document_chat_file_part
+      ~supports_document_input:caps.Capabilities.supports_document_input
+      messages
+  in
   let provider_messages =
     let history =
       match

--- a/lib/llm_provider/backend_openai_serialize.ml
+++ b/lib/llm_provider/backend_openai_serialize.ml
@@ -228,7 +228,16 @@ let openai_content_parts_of_blocks blocks =
         (`Assoc
             [ "type", `String "image_url"; "image_url", `Assoc [ "url", `String url ] ])
     | Document { media_type; data; source_type } ->
-      let url =
+      (* oas#2744 — a document is not an image. This arm used to emit an
+         [image_url] part, so a PDF reached the model as a picture and no layer
+         reported the substitution. Chat Completions carries a document in its
+         own [file] part; the payload is the same base64 data URL the sibling
+         Responses serializer puts in [input_file.file_data], and like that
+         serializer no [filename] is sent because a [Document] block carries no
+         name. Rows that cannot carry a document are stopped earlier by
+         [Api_common.admit_document_blocks], so there is one native form here
+         and no fallback. *)
+      let file_data =
         Api_common.base64_media_data_url
           ~backend:"openai_chat"
           ~block:"document"
@@ -238,7 +247,7 @@ let openai_content_parts_of_blocks blocks =
       in
       Some
         (`Assoc
-            [ "type", `String "image_url"; "image_url", `Assoc [ "url", `String url ] ])
+            [ "type", `String "file"; "file", `Assoc [ "file_data", `String file_data ] ])
     | Audio { media_type; data; source_type } ->
       let data =
         Api_common.base64_media_payload
@@ -593,6 +602,14 @@ let modality_priority_for_model_id model_id =
   | None -> Modality.Preserve_input_order
 ;;
 
+(* An unresolved model id declares nothing, so it does not declare document
+   support either. *)
+let document_input_supported_for_model_id model_id =
+  match Capabilities.for_model_id model_id with
+  | Some c -> c.supports_document_input
+  | None -> false
+;;
+
 (** Ollama native [/api/chat] user message serialization.
     Unlike OpenAI-compatible endpoints where [content] may be a string or an
     array of content parts, Ollama's native chat API requires [content] to be a
@@ -610,22 +627,30 @@ let ollama_native_user_message ~modality_priority content : Yojson.Safe.t option
       (fun (texts, images) block ->
          match block with
          | Text s -> Utf8_sanitize.sanitize s :: texts, images
-         | Image { data; source_type = Base64; _ }
-         | Document { data; source_type = Base64; _ } ->
+         | Image { data; source_type = Base64; _ } ->
            (* Ollama native /api/chat accepts base64 image payloads in the
-              images field. Document blocks are forwarded the same way so
-              vision models can attempt to process them as pages. *)
+              images field. *)
            texts, data :: images
          | Image { source_type; _ } ->
            Api_common.unsupported_media_source
              ~backend:"ollama_native"
              ~block:"image"
              source_type
-         | Document { source_type; _ } ->
-           Api_common.unsupported_media_source
-             ~backend:"ollama_native"
-             ~block:"document"
-             source_type
+         | Document { media_type; _ } ->
+           (* oas#2744 — documents used to be appended to [images] "so vision
+              models can attempt to process them as pages". The server has no
+              way to tell the two apart, so that was a silent modality change.
+              [ollama_messages_of_history] rejects documents at admission
+              because the native wire declares [Document_unrepresentable];
+              reaching this arm means a caller bypassed admission. *)
+           invalid_arg
+             (Printf.sprintf
+                "Backend_openai_serialize.ollama_native_user_message: document block \
+                 (media_type %S) reached serialization; %s"
+                media_type
+                (Api_common.document_admission_error_to_string
+                   (Api_common.Document_wire_has_no_representation
+                      { wire_form = Api_common.Document_unrepresentable; media_type })))
          | Audio { source_type; _ } ->
            Api_common.unsupported_media_source
              ~backend:"ollama_native"
@@ -736,7 +761,20 @@ let ollama_messages_of_history ?(model_id = "") messages =
        | Error _ as error -> error
        | Ok () -> validate rest)
   in
-  match validate messages with
+  (* oas#2744 — the native /api/chat wire has no document part, so a document
+     is rejected here with its media type named rather than being pushed into
+     the [images] array as if it were a picture. The capability flag is read
+     from the resolved row for a uniform error message; the wire form alone is
+     already decisive. *)
+  let admit_documents () =
+    Api_common.admit_document_messages
+      ~wire_form:Api_common.Document_unrepresentable
+      ~model_id
+      ~supports_document_input:(document_input_supported_for_model_id model_id)
+      messages
+    |> Result.map_error Api_common.document_admission_error_to_string
+  in
+  match Result.bind (validate messages) admit_documents with
   | Error _ as error -> error
   | Ok () ->
     (match Tool_result_projection.of_messages messages with

--- a/lib/llm_provider/backend_openai_serialize.ml
+++ b/lib/llm_provider/backend_openai_serialize.ml
@@ -762,19 +762,19 @@ let ollama_messages_of_history ?(model_id = "") messages =
        | Ok () -> validate rest)
   in
   (* oas#2744 — the native /api/chat wire has no document part, so a document
-     is rejected here with its media type named rather than being pushed into
-     the [images] array as if it were a picture. The capability flag is read
-     from the resolved row for a uniform error message; the wire form alone is
-     already decisive. *)
-  let admit_documents () =
-    Api_common.admit_document_messages
+     cannot be sent as one. Rather than pushing it into the [images] array as if
+     it were a picture (the audit's defect) or rejecting the whole request
+     (which retroactively sank every later turn of a conversation holding a
+     document in its history), degrade each document to a named text placeholder
+     before rendering. [Document_unrepresentable] means the wire form alone is
+     decisive, so the capability flag does not gate this. *)
+  let messages, _documents_degraded =
+    Api_common.degrade_document_messages
       ~wire_form:Api_common.Document_unrepresentable
-      ~model_id
       ~supports_document_input:(document_input_supported_for_model_id model_id)
       messages
-    |> Result.map_error Api_common.document_admission_error_to_string
   in
-  match Result.bind (validate messages) admit_documents with
+  match validate messages with
   | Error _ as error -> error
   | Ok () ->
     (match Tool_result_projection.of_messages messages with

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -154,6 +154,16 @@ type capabilities =
   ; supports_image_input : bool
   ; supports_audio_input : bool
   ; supports_video_input : bool
+  ; supports_document_input : bool
+    (** Whether the row accepts a [Document] block as input.
+
+        Deliberately a sibling of the image/audio/video fields rather than a
+        reading of [supports_multimodal_inputs]: document support is not
+        implied by image support (a vision row on the OpenAI-compatible Chat
+        Completions wire may accept images and have no document part at all),
+        and the catch-all cannot express the difference. Serialization consults
+        this at admission, so a document that the row cannot carry is reported
+        instead of being emitted as some other modality (oas#2744). *)
   ; modality_priority : Modality.priority
     (** Block ordering applied to multimodal user messages just before
         serialization. [Visual_first] for Gemma 4 family.
@@ -223,6 +233,7 @@ let default_capabilities =
   ; supports_image_input = false
   ; supports_audio_input = false
   ; supports_video_input = false
+  ; supports_document_input = false
   ; modality_priority = Modality.Preserve_input_order
   ; task = None
   ; supports_native_streaming = false
@@ -328,6 +339,10 @@ let anthropic_capabilities =
   ; supports_structured_output = true
   ; supports_multimodal_inputs = true
   ; supports_image_input = true
+  ; (* The Messages API has a first-class [document] content block with its own
+       [source] object (docs.anthropic.com/en/docs/build-with-claude/pdf-support);
+       {!Api_common.content_block_to_json} emits exactly that shape. *)
+    supports_document_input = true
   ; supports_native_streaming = true
   ; supports_caching = true
   ; supports_prompt_caching = true
@@ -470,6 +485,7 @@ let mimo_capabilities =
   ; supports_image_input = false
   ; supports_audio_input = false
   ; supports_video_input = false
+  ; supports_document_input = false
   ; supports_native_streaming = true
   }
 ;;
@@ -603,6 +619,10 @@ let gemini_capabilities =
   ; supports_image_input = true
   ; supports_audio_input = true
   ; supports_video_input = true
+  ; (* [inlineData] carries an arbitrary MIME type plus base64 bytes, so a
+       document keeps its own media type on the wire — the Gemini serializer
+       does not relabel it. *)
+    supports_document_input = true
   ; supports_native_streaming = true
   ; supports_caching = true
   ; supports_prompt_caching = false
@@ -827,6 +847,7 @@ type declarative_capability_overrides =
   ; supports_image_input : bool option
   ; supports_audio_input : bool option
   ; supports_video_input : bool option
+  ; supports_document_input : bool option
   ; modality_priority : string option
   ; task : Capability_vocab.task option
   ; supports_native_streaming : bool option
@@ -868,6 +889,7 @@ let overrides_of_manifest_entry (entry : Capability_manifest.entry) =
   ; supports_image_input = entry.supports_image_input
   ; supports_audio_input = entry.supports_audio_input
   ; supports_video_input = entry.supports_video_input
+  ; supports_document_input = entry.supports_document_input
   ; modality_priority = None
   ; (* The JSON capability manifest carries no task field; task is
        catalog-only vocabulary. *)
@@ -975,6 +997,8 @@ let apply_declarative_capability_overrides overrides =
       override_bool base.supports_audio_input overrides.supports_audio_input
   ; supports_video_input =
       override_bool base.supports_video_input overrides.supports_video_input
+  ; supports_document_input =
+      override_bool base.supports_document_input overrides.supports_document_input
   ; modality_priority =
       (match overrides.modality_priority with
        | Some s ->
@@ -1142,6 +1166,7 @@ let overrides_of_catalog_entry (entry : Model_catalog.model_entry) =
   ; supports_image_input = entry.supports_image_input
   ; supports_audio_input = entry.supports_audio_input
   ; supports_video_input = entry.supports_video_input
+  ; supports_document_input = entry.supports_document_input
   ; modality_priority = entry.modality_priority
   ; task = entry.task
   ; supports_native_streaming = entry.supports_native_streaming
@@ -1395,6 +1420,7 @@ let test_catalog_entry id_prefix : Model_catalog.model_entry =
   ; supports_image_input = None
   ; supports_audio_input = None
   ; supports_video_input = None
+  ; supports_document_input = None
   ; modality_priority = None
   ; task = None
   ; supports_native_streaming = None
@@ -1441,6 +1467,7 @@ let test_manifest_entry id_prefix : Capability_manifest.entry =
   ; supports_image_input = None
   ; supports_audio_input = None
   ; supports_video_input = None
+  ; supports_document_input = None
   ; supports_native_streaming = None
   ; supports_system_prompt = None
   ; supports_caching = None

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -112,6 +112,12 @@ type capabilities =
   ; supports_image_input : bool
   ; supports_audio_input : bool
   ; supports_video_input : bool
+  ; supports_document_input : bool
+    (** Whether the row accepts a {!Types.Document} block as input. Independent
+        of [supports_multimodal_inputs]: a row can be multimodal for images and
+        still have no document representation on its wire. Serialization
+        consults this at admission so a document is never re-labelled as
+        another modality (oas#2744). *)
   ; modality_priority : Modality.priority
   ; (* Inference task *)
     task : task option

--- a/lib/llm_provider/capability_manifest.ml
+++ b/lib/llm_provider/capability_manifest.ml
@@ -43,6 +43,7 @@ type entry =
   ; supports_image_input : bool option
   ; supports_audio_input : bool option
   ; supports_video_input : bool option
+  ; supports_document_input : bool option
   ; supports_native_streaming : bool option
   ; supports_system_prompt : bool option
   ; supports_caching : bool option
@@ -310,6 +311,7 @@ let known_entry_keys =
   ; "supports_image_input"
   ; "supports_audio_input"
   ; "supports_video_input"
+  ; "supports_document_input"
   ; "supports_native_streaming"
   ; "supports_system_prompt"
   ; "supports_caching"
@@ -467,6 +469,7 @@ let parse_entry json =
   let* supports_image_input = member_bool "supports_image_input" json in
   let* supports_audio_input = member_bool "supports_audio_input" json in
   let* supports_video_input = member_bool "supports_video_input" json in
+  let* supports_document_input = member_bool "supports_document_input" json in
   let* supports_native_streaming = member_bool "supports_native_streaming" json in
   let* supports_system_prompt = member_bool "supports_system_prompt" json in
   let* supports_caching = member_bool "supports_caching" json in
@@ -497,6 +500,7 @@ let parse_entry json =
     ; supports_image_input
     ; supports_audio_input
     ; supports_video_input
+    ; supports_document_input
     ; supports_native_streaming
     ; supports_system_prompt
     ; supports_caching

--- a/lib/llm_provider/capability_manifest.mli
+++ b/lib/llm_provider/capability_manifest.mli
@@ -81,6 +81,7 @@ type entry =
   ; supports_image_input : bool option
   ; supports_audio_input : bool option
   ; supports_video_input : bool option
+  ; supports_document_input : bool option
   ; supports_native_streaming : bool option
   ; supports_system_prompt : bool option
   ; supports_caching : bool option

--- a/lib/llm_provider/model_catalog.ml
+++ b/lib/llm_provider/model_catalog.ml
@@ -28,6 +28,7 @@ type model_entry =
   ; supports_image_input : bool option
   ; supports_audio_input : bool option
   ; supports_video_input : bool option
+  ; supports_document_input : bool option
   ; modality_priority : string option
   ; task : Capability_vocab.task option
   ; supports_native_streaming : bool option
@@ -282,6 +283,7 @@ let known_entry_keys =
   ; "supports_image_input"
   ; "supports_audio_input"
   ; "supports_video_input"
+  ; "supports_document_input"
   ; "modality_priority"
   ; "task"
   ; "supports_native_streaming"
@@ -406,6 +408,9 @@ let parse_entry entry_toml =
   let* supports_video_input =
     bool_field ~entry_id:id_prefix "supports_video_input" entry_toml
   in
+  let* supports_document_input =
+    bool_field ~entry_id:id_prefix "supports_document_input" entry_toml
+  in
   let* modality_priority =
     canonical_string_opt
       ~entry_id:id_prefix
@@ -519,6 +524,7 @@ let parse_entry entry_toml =
     ; supports_image_input
     ; supports_audio_input
     ; supports_video_input
+    ; supports_document_input
     ; modality_priority
     ; task
     ; supports_native_streaming

--- a/lib/llm_provider/model_catalog.mli
+++ b/lib/llm_provider/model_catalog.mli
@@ -28,6 +28,7 @@ type model_entry =
   ; supports_image_input : bool option
   ; supports_audio_input : bool option
   ; supports_video_input : bool option
+  ; supports_document_input : bool option
   ; modality_priority : string option
   ; task : Capability_vocab.task option
     (** Catalog-declared inference task for non-chat models (transcription,

--- a/lib/llm_provider/pricing.ml
+++ b/lib/llm_provider/pricing.ml
@@ -156,6 +156,7 @@ let test_catalog_entry ?provider_name ?input ?output ?cache_write ?cache_read id
   ; supports_image_input = None
   ; supports_audio_input = None
   ; supports_video_input = None
+  ; supports_document_input = None
   ; modality_priority = None
   ; task = None
   ; supports_native_streaming = None

--- a/lib/llm_provider/provider_catalog.ml
+++ b/lib/llm_provider/provider_catalog.ml
@@ -359,6 +359,7 @@ let capability_fields =
   ; "supports_image_input"
   ; "supports_audio_input"
   ; "supports_video_input"
+  ; "supports_document_input"
   ; "modality_priority"
   ; "supports_native_streaming"
   ; "supports_system_prompt"
@@ -697,6 +698,7 @@ let parse_capabilities provider_json =
   let* supports_image_input = member_bool "supports_image_input" cap_json in
   let* supports_audio_input = member_bool "supports_audio_input" cap_json in
   let* supports_video_input = member_bool "supports_video_input" cap_json in
+  let* supports_document_input = member_bool "supports_document_input" cap_json in
   let* supports_native_streaming = member_bool "supports_native_streaming" cap_json in
   let* supports_system_prompt = member_bool "supports_system_prompt" cap_json in
   let* supports_caching = member_bool "supports_caching" cap_json in
@@ -772,6 +774,9 @@ let parse_capabilities provider_json =
     |> fun caps ->
     override supports_video_input caps (fun caps value ->
       { caps with Capabilities.supports_video_input = value })
+    |> fun caps ->
+    override supports_document_input caps (fun caps value ->
+      { caps with Capabilities.supports_document_input = value })
     |> fun caps ->
     (match modality_priority with
      | Some modality_priority -> { caps with Capabilities.modality_priority }

--- a/lib/provider.mli
+++ b/lib/provider.mli
@@ -145,6 +145,7 @@ type capabilities = Llm_provider.Capabilities.capabilities =
   ; supports_image_input : bool
   ; supports_audio_input : bool
   ; supports_video_input : bool
+  ; supports_document_input : bool
   ; modality_priority : Llm_provider.Modality.priority
   ; task : task option
   ; supports_native_streaming : bool

--- a/lib/provider_runtime_binding.ml
+++ b/lib/provider_runtime_binding.ml
@@ -73,6 +73,7 @@ let public_capabilities (caps : Llm_provider.Capabilities.capabilities)
   ; supports_image_input = caps.supports_image_input
   ; supports_audio_input = caps.supports_audio_input
   ; supports_video_input = caps.supports_video_input
+  ; supports_document_input = caps.supports_document_input
   ; modality_priority = caps.modality_priority
   ; task = caps.task
   ; supports_native_streaming = caps.supports_native_streaming

--- a/test/dune
+++ b/test/dune
@@ -537,3 +537,8 @@
   mirage-crypto-rng.unix
   domain-name
   ptime))
+
+(test
+ (name test_media_document_admission)
+ (modules test_media_document_admission)
+ (libraries agent_sdk llm_provider alcotest fmt yojson))

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -565,10 +565,14 @@ let test_content_parts_cover_modalities () =
     "data:image/png;base64,img"
     (member "image_url" image |> member "url" |> to_string);
   let document = List.nth parts 2 in
+  (* oas#2744: a document is emitted as the Chat Completions [file] part. It
+     used to be relabelled [image_url], which silently retyped the block as an
+     image. *)
+  check_string "document type" "file" (member "type" document |> to_string);
   check_string
-    "document url"
+    "document file_data"
     "data:application/pdf;base64,doc"
-    (member "image_url" document |> member "url" |> to_string);
+    (member "file" document |> member "file_data" |> to_string);
   let audio = List.nth parts 3 in
   check_string "audio type" "input_audio" (member "type" audio |> to_string);
   check_string
@@ -723,23 +727,29 @@ let test_ollama_native_multimodal_variants () =
   let images = member "images" image_only |> as_list "image-only images" in
   check_int "image-only images count" 1 (List.length images);
   check_string "image-only payload" "png1" (List.nth images 0 |> to_string);
-  (* Document blocks are forwarded as images for vision-model compatibility. *)
-  let doc_msg =
-    ollama_messages
-      [ msg
-          User
-          [ Document
-              { media_type = "application/pdf"
-              ; data = "pdf1"
-              ; source_type = Types.Base64
-              }
-          ]
-      ]
-    |> only "ollama"
-  in
-  let doc_images = member "images" doc_msg |> as_list "document images" in
-  check_int "document images count" 1 (List.length doc_images);
-  check_string "document payload" "pdf1" (List.nth doc_images 0 |> to_string);
+  (* oas#2744: documents used to be appended to [images] "for vision-model
+     compatibility", which made the server read a PDF as a picture with nothing
+     reporting the substitution. The native wire has no document part, so a
+     document is now rejected by name. *)
+  (match
+     Serialize.ollama_messages_of_history
+       [ msg
+           User
+           [ Document
+               { media_type = "application/pdf"
+               ; data = "pdf1"
+               ; source_type = Types.Base64
+               }
+           ]
+       ]
+   with
+   | Ok _ -> Alcotest.fail "expected the document to be rejected, not serialized"
+   | Error error ->
+     check_string
+       "document rejected by the native wire"
+       "document block (media_type \"application/pdf\") cannot be placed on this wire: \
+        it has no document part"
+       error);
   (* Audio is not supported by Ollama native /api/chat and must fail closed
      instead of being silently dropped. *)
   expect_invalid_arg "ollama audio input" (fun () ->
@@ -750,9 +760,25 @@ let test_ollama_native_multimodal_variants () =
           ]
       ]
     |> ignore);
-  (* Mixed text + image + document preserves text in content and both payloads in images. *)
+  (* Mixed text + image preserves text in content and the payload in images. *)
   let mixed =
     ollama_messages
+      [ msg
+          User
+          [ Text "describe these"
+          ; Image { media_type = "image/png"; data = "png2"; source_type = Types.Base64 }
+          ]
+      ]
+    |> only "ollama"
+  in
+  check_string "mixed content" "describe these" (member "content" mixed |> to_string);
+  let mixed_images = member "images" mixed |> as_list "mixed images" in
+  check_int "mixed images count" 1 (List.length mixed_images);
+  check_string "mixed first image" "png2" (List.nth mixed_images 0 |> to_string);
+  (* A document alongside admissible media is still rejected: admission looks at
+     every block, not just the first. *)
+  match
+    Serialize.ollama_messages_of_history
       [ msg
           User
           [ Text "describe these"
@@ -764,13 +790,14 @@ let test_ollama_native_multimodal_variants () =
               }
           ]
       ]
-    |> only "ollama"
-  in
-  check_string "mixed content" "describe these" (member "content" mixed |> to_string);
-  let mixed_images = member "images" mixed |> as_list "mixed images" in
-  check_int "mixed images count" 2 (List.length mixed_images);
-  check_string "mixed first image" "png2" (List.nth mixed_images 0 |> to_string);
-  check_string "mixed second image" "pdf2" (List.nth mixed_images 1 |> to_string)
+  with
+  | Ok _ -> Alcotest.fail "expected the mixed document to be rejected"
+  | Error error ->
+    check_string
+      "mixed document rejected"
+      "document block (media_type \"application/pdf\") cannot be placed on this wire: it \
+       has no document part"
+      error
 ;;
 
 let test_assistant_tool_calls_openai_ollama_and_glm () =
@@ -1006,16 +1033,19 @@ let test_serializer_ignored_block_variants () =
     0
     (Serialize.tool_calls_to_openai_json ignored_blocks |> List.length);
   let ollama_blocks =
+    (* Documents are excluded here because the Ollama native wire has no
+       document part and rejects them at admission (oas#2744); this case is
+       about tool-call blocks, and the rejection has its own coverage in
+       [test_ollama_native_multimodal_variants]. *)
     List.filter
       (function
-        | ToolResult _ -> false
+        | ToolResult _ | Document _ -> false
         | Text _
         | Thinking _
         | ReasoningDetails _
         | RedactedThinking _
         | ToolUse _
         | Image _
-        | Document _
         | Audio _ -> true)
       ignored_blocks
   in

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -9,6 +9,14 @@ let check_int = Alcotest.(check int)
 let check_bool = Alcotest.(check bool)
 let check_float = Alcotest.(check (float 0.0001))
 
+(* Local substring search: this suite links no shared string util. *)
+let contains ~needle haystack =
+  let nl = String.length needle
+  and hl = String.length haystack in
+  let rec at i = i + nl <= hl && (String.sub haystack i nl = needle || at (i + 1)) in
+  nl = 0 || at 0
+;;
+
 let msg role content : message =
   { role; content; name = None; tool_call_id = None; metadata = [] }
 ;;
@@ -730,7 +738,9 @@ let test_ollama_native_multimodal_variants () =
   (* oas#2744: documents used to be appended to [images] "for vision-model
      compatibility", which made the server read a PDF as a picture with nothing
      reporting the substitution. The native wire has no document part, so a
-     document is now rejected by name. *)
+     document is degraded to a named text placeholder — it is not sent as a
+     picture, and it does not reject the turn (which would retroactively sink
+     any conversation holding a document in its history). *)
   (match
      Serialize.ollama_messages_of_history
        [ msg
@@ -743,13 +753,17 @@ let test_ollama_native_multimodal_variants () =
            ]
        ]
    with
-   | Ok _ -> Alcotest.fail "expected the document to be rejected, not serialized"
-   | Error error ->
-     check_string
-       "document rejected by the native wire"
-       "document block (media_type \"application/pdf\") cannot be placed on this wire: \
-        it has no document part"
-       error);
+   | Error error -> Alcotest.failf "expected degrade, got a rejection: %s" error
+   | Ok wire ->
+     let serialized = Yojson.Safe.to_string (`List wire) in
+     check_bool
+       "document not relabelled into the images array"
+       false
+       (contains ~needle:"pdf1" serialized);
+     check_bool
+       "placeholder names the omission"
+       true
+       (contains ~needle:"document omitted" serialized));
   (* Audio is not supported by Ollama native /api/chat and must fail closed
      instead of being silently dropped. *)
   expect_invalid_arg "ollama audio input" (fun () ->
@@ -775,8 +789,9 @@ let test_ollama_native_multimodal_variants () =
   let mixed_images = member "images" mixed |> as_list "mixed images" in
   check_int "mixed images count" 1 (List.length mixed_images);
   check_string "mixed first image" "png2" (List.nth mixed_images 0 |> to_string);
-  (* A document alongside admissible media is still rejected: admission looks at
-     every block, not just the first. *)
+  (* A document alongside admissible media degrades in place: the image is kept
+     (it is representable), the document becomes a named placeholder, and the
+     turn is not rejected. Degrade looks at every block, not just the first. *)
   match
     Serialize.ollama_messages_of_history
       [ msg
@@ -791,13 +806,21 @@ let test_ollama_native_multimodal_variants () =
           ]
       ]
   with
-  | Ok _ -> Alcotest.fail "expected the mixed document to be rejected"
-  | Error error ->
-    check_string
-      "mixed document rejected"
-      "document block (media_type \"application/pdf\") cannot be placed on this wire: it \
-       has no document part"
-      error
+  | Error error -> Alcotest.failf "expected degrade, got a rejection: %s" error
+  | Ok wire ->
+    let serialized = Yojson.Safe.to_string (`List wire) in
+    check_bool
+      "admissible image survives alongside the degraded document"
+      true
+      (contains ~needle:"png2" serialized);
+    check_bool
+      "document not relabelled into images"
+      false
+      (contains ~needle:"pdf2" serialized);
+    check_bool
+      "document degraded to a named placeholder"
+      true
+      (contains ~needle:"document omitted" serialized)
 ;;
 
 let test_assistant_tool_calls_openai_ollama_and_glm () =

--- a/test/test_media_document_admission.ml
+++ b/test/test_media_document_admission.ml
@@ -119,48 +119,89 @@ let test_admission_ignores_image_and_audio () =
        [ Types.Text "prefix"; image_block; audio_block ])
 ;;
 
-let test_openai_chat_request_rejects_undeclared_document () =
-  (* End-to-end through the request builder: the pre-fix binary produced
-     {"type":"image_url",...} here for every one of these rows. *)
+let test_openai_chat_request_degrades_undeclared_document () =
+  (* End-to-end through the request builder. The pre-fix binary produced
+     {"type":"image_url",...} here (a PDF as a picture); the reject-era binary
+     raised and sank the whole request. Now an unrepresentable document is
+     replaced with a named text placeholder: the request succeeds, carries no
+     image_url, and the omission is legible. *)
   List.iter
     (fun model_id ->
        let config = openai_config model_id in
        let messages = [ user_message [ Types.Text "prefix"; document_block ] ] in
        match Backend_openai_request.build_request_assoc ~config ~messages () with
        | exception Invalid_argument message ->
-         check
-           bool
-           (Printf.sprintf "%s: rejection names the media type" model_id)
-           true
-           (contains ~needle:"application/pdf" message);
-         check
-           bool
-           (Printf.sprintf "%s: rejection names the capability" model_id)
-           true
-           (contains ~needle:"supports_document_input" message)
+         failf "%s: expected degrade, got a rejection: %s" model_id message
        | body ->
-         failf
-           "%s: expected a typed rejection, serialized %s"
-           model_id
-           (Yojson.Safe.to_string body))
+         let serialized = Yojson.Safe.to_string body in
+         check
+           bool
+           (Printf.sprintf "%s: no image_url — document is not relabelled" model_id)
+           false
+           (contains ~needle:"image_url" serialized);
+         check
+           bool
+           (Printf.sprintf "%s: placeholder names the omission" model_id)
+           true
+           (contains ~needle:"document omitted" serialized);
+         check
+           bool
+           (Printf.sprintf "%s: placeholder names the media type" model_id)
+           true
+           (contains ~needle:"application/pdf" serialized))
     [ "gpt-5.2"; "glm-4.6"; "glm-4-flash"; "qwen3:8b" ]
 ;;
 
-let test_ollama_native_rejects_document () =
+let test_ollama_native_degrades_document () =
   match
     Backend_openai_serialize.ollama_messages_of_history
       ~model_id:"qwen3:8b"
       [ user_message [ Types.Text "prefix"; document_block ] ]
   with
+  | Error message -> failf "expected degrade, got a rejection: %s" message
   | Ok wire ->
-    failf "expected a rejection, serialized %s" (Yojson.Safe.to_string (`List wire))
-  | Error message ->
-    check bool "names the media type" true (contains ~needle:"application/pdf" message);
+    let serialized = Yojson.Safe.to_string (`List wire) in
+    (* Native /api/chat: the pre-fix binary pushed the document into [images].
+       After degrade it must not appear there; the placeholder text carries the
+       omission in the scalar content instead. *)
     check
       bool
-      "names the missing wire representation"
+      "no images array entry — document is not relabelled as a picture"
+      false
+      (contains ~needle:"UERG" serialized);
+    check
+      bool
+      "placeholder names the omission"
       true
-      (contains ~needle:"no document part" message)
+      (contains ~needle:"document omitted" serialized)
+;;
+
+(* A document sitting in an already-answered turn must not sink a later,
+   unrelated turn. This is the retroactive-liveness regression the reject era
+   introduced (a document in history rejected every subsequent request). *)
+let test_history_document_does_not_sink_later_turn () =
+  let config = openai_config "gpt-5.2" in
+  let messages =
+    [ user_message [ Types.Text "here is a doc"; document_block ]
+    ; { (user_message [ Types.Text "(assistant replied)" ]) with role = Types.Assistant }
+    ; user_message [ Types.Text "unrelated follow-up question" ]
+    ]
+  in
+  match Backend_openai_request.build_request_assoc ~config ~messages () with
+  | exception Invalid_argument message ->
+    failf "a history document sank a later turn (the regression): %s" message
+  | body ->
+    let serialized = Yojson.Safe.to_string body in
+    check
+      bool
+      "later turn succeeds, no image_url"
+      false
+      (contains ~needle:"image_url" serialized);
+    check
+      bool
+      "history document degraded to a placeholder"
+      true
+      (contains ~needle:"document omitted" serialized)
 ;;
 
 (* ── (b) wires that carry documents emit their own native form ────────── *)
@@ -420,13 +461,17 @@ let () =
             `Quick
             test_admission_ignores_image_and_audio
         ; test_case
-            "openai chat request rejects instead of emitting image_url"
+            "openai chat request degrades document to a placeholder, not image_url"
             `Quick
-            test_openai_chat_request_rejects_undeclared_document
+            test_openai_chat_request_degrades_undeclared_document
         ; test_case
-            "ollama native rejects instead of appending to images"
+            "ollama native degrades document, not into images"
             `Quick
-            test_ollama_native_rejects_document
+            test_ollama_native_degrades_document
+        ; test_case
+            "history document does not sink a later turn"
+            `Quick
+            test_history_document_does_not_sink_later_turn
         ] )
     ; ( "wires that carry documents keep their native form"
       , [ test_case

--- a/test/test_media_document_admission.ml
+++ b/test/test_media_document_admission.ml
@@ -1,0 +1,463 @@
+(** Document admission and per-wire media serialization (oas#2744).
+
+    The OpenAI-compatible Chat Completions serializer used to emit a [Document]
+    block as an [image_url] part: the same typed block reached the model as a
+    picture, and no layer reported the substitution. These cases pin the three
+    properties that replaced it —
+
+    - a document bound for a wire/row that cannot carry one is a typed, visible
+      outcome, never an image part;
+    - wires that do carry documents still emit their own native form;
+    - image and audio payloads are byte-identical to the pre-fix serializer on
+      every wire.
+
+    The image/audio cases are the permanent form of the temporary
+    baseline-vs-change probe used while developing the fix: the expected JSON
+    below was copied from the pre-change binary's output. *)
+
+open Alcotest
+open Llm_provider
+
+let json = testable (Fmt.of_to_string Yojson.Safe.to_string) ( = )
+
+let admission_error =
+  testable (Fmt.of_to_string Api_common.document_admission_error_to_string) ( = )
+;;
+
+(* Substring search kept local so the suite needs no extra dependency. *)
+let contains ~needle haystack =
+  let nl = String.length needle
+  and hl = String.length haystack in
+  let rec at i = i + nl <= hl && (String.sub haystack i nl = needle || at (i + 1)) in
+  nl = 0 || at 0
+;;
+
+let image_block =
+  Types.Image { media_type = "image/png"; data = "SU1H"; source_type = Types.Base64 }
+;;
+
+let audio_block =
+  Types.Audio { media_type = "wav"; data = "QVVE"; source_type = Types.Base64 }
+;;
+
+let document_block =
+  Types.Document
+    { media_type = "application/pdf"; data = "UERG"; source_type = Types.Base64 }
+;;
+
+let user_message content =
+  { Types.role = Types.User; content; name = None; tool_call_id = None; metadata = [] }
+;;
+
+let openai_config model_id =
+  Provider_config.make
+    ~kind:Provider_config.OpenAI_compat
+    ~model_id
+    ~base_url:"http://127.0.0.1:0"
+    ()
+;;
+
+(* ── (a) inadmissible document is a typed outcome, not an image ───────── *)
+
+let test_admission_rejects_undeclared_row () =
+  let error =
+    match
+      Api_common.admit_document_blocks
+        ~wire_form:Api_common.Document_chat_file_part
+        ~model_id:"undeclared-model"
+        ~supports_document_input:false
+        [ Types.Text "prefix"; document_block ]
+    with
+    | Ok () -> failwith "expected an admission error"
+    | Error error -> error
+  in
+  match error with
+  | Api_common.Document_input_not_declared { model_id; media_type } ->
+    check string "model named" "undeclared-model" model_id;
+    check string "media type named" "application/pdf" media_type
+  | Api_common.Document_wire_has_no_representation _ ->
+    failwith "expected Document_input_not_declared"
+;;
+
+let test_admission_rejects_wire_without_document_part () =
+  let error =
+    match
+      Api_common.admit_document_blocks
+        ~wire_form:Api_common.Document_unrepresentable
+          (* A row that declares document support still cannot use a wire that
+             has no document part; the wire form alone decides here. *)
+        ~model_id:"declared-model"
+        ~supports_document_input:true
+        [ document_block ]
+    with
+    | Ok () -> failwith "expected an admission error"
+    | Error error -> error
+  in
+  match error with
+  | Api_common.Document_wire_has_no_representation { wire_form; media_type } ->
+    check
+      string
+      "wire form named"
+      "no document part"
+      (Api_common.document_wire_form_to_string wire_form);
+    check string "media type named" "application/pdf" media_type
+  | Api_common.Document_input_not_declared _ ->
+    failwith "expected Document_wire_has_no_representation"
+;;
+
+let test_admission_ignores_image_and_audio () =
+  (* Image/audio admission is deliberately untouched: a row that declares no
+     document support must not start rejecting the media it carries today. *)
+  check
+    (result unit admission_error)
+    "image and audio admitted"
+    (Ok ())
+    (Api_common.admit_document_blocks
+       ~wire_form:Api_common.Document_unrepresentable
+       ~model_id:"undeclared-model"
+       ~supports_document_input:false
+       [ Types.Text "prefix"; image_block; audio_block ])
+;;
+
+let test_openai_chat_request_rejects_undeclared_document () =
+  (* End-to-end through the request builder: the pre-fix binary produced
+     {"type":"image_url",...} here for every one of these rows. *)
+  List.iter
+    (fun model_id ->
+       let config = openai_config model_id in
+       let messages = [ user_message [ Types.Text "prefix"; document_block ] ] in
+       match Backend_openai_request.build_request_assoc ~config ~messages () with
+       | exception Invalid_argument message ->
+         check
+           bool
+           (Printf.sprintf "%s: rejection names the media type" model_id)
+           true
+           (contains ~needle:"application/pdf" message);
+         check
+           bool
+           (Printf.sprintf "%s: rejection names the capability" model_id)
+           true
+           (contains ~needle:"supports_document_input" message)
+       | body ->
+         failf
+           "%s: expected a typed rejection, serialized %s"
+           model_id
+           (Yojson.Safe.to_string body))
+    [ "gpt-5.2"; "glm-4.6"; "glm-4-flash"; "qwen3:8b" ]
+;;
+
+let test_ollama_native_rejects_document () =
+  match
+    Backend_openai_serialize.ollama_messages_of_history
+      ~model_id:"qwen3:8b"
+      [ user_message [ Types.Text "prefix"; document_block ] ]
+  with
+  | Ok wire ->
+    failf "expected a rejection, serialized %s" (Yojson.Safe.to_string (`List wire))
+  | Error message ->
+    check bool "names the media type" true (contains ~needle:"application/pdf" message);
+    check
+      bool
+      "names the missing wire representation"
+      true
+      (contains ~needle:"no document part" message)
+;;
+
+(* ── (b) wires that carry documents emit their own native form ────────── *)
+
+let test_openai_chat_document_is_a_file_part () =
+  check
+    json
+    "document serializes as a file part, not image_url"
+    (`List
+        [ `Assoc [ "type", `String "text"; "text", `String "prefix" ]
+        ; `Assoc
+            [ "type", `String "file"
+            ; "file", `Assoc [ "file_data", `String "data:application/pdf;base64,UERG" ]
+            ]
+        ])
+    (`List
+        (Backend_openai.openai_content_parts_of_blocks
+           [ Types.Text "prefix"; document_block ]))
+;;
+
+let test_anthropic_document_is_a_source_block () =
+  check
+    json
+    "anthropic document source block"
+    (`Assoc
+        [ "type", `String "document"
+        ; ( "source"
+          , `Assoc
+              [ "type", `String "base64"
+              ; "media_type", `String "application/pdf"
+              ; "data", `String "UERG"
+              ] )
+        ])
+    (Api_common.content_block_to_json document_block)
+;;
+
+let test_gemini_document_is_inline_data () =
+  let contents, _ =
+    Backend_gemini.contents_of_messages
+      [ user_message [ Types.Text "prefix"; document_block ] ]
+  in
+  check
+    json
+    "gemini inlineData keeps the document mime type"
+    (`List
+        [ `Assoc
+            [ "role", `String "user"
+            ; ( "parts"
+              , `List
+                  [ `Assoc [ "text", `String "prefix" ]
+                  ; `Assoc
+                      [ ( "inlineData"
+                        , `Assoc
+                            [ "mimeType", `String "application/pdf"
+                            ; "data", `String "UERG"
+                            ] )
+                      ]
+                  ] )
+            ]
+        ])
+    (`List contents)
+;;
+
+let test_anthropic_and_gemini_declare_document_input () =
+  check
+    bool
+    "anthropic base declares document input"
+    true
+    Capabilities.anthropic_capabilities.supports_document_input;
+  check
+    bool
+    "gemini base declares document input"
+    true
+    Capabilities.gemini_capabilities.supports_document_input;
+  check
+    bool
+    "default declares none"
+    false
+    Capabilities.default_capabilities.supports_document_input;
+  check
+    bool
+    "openai-compat chat base declares none"
+    false
+    Capabilities.openai_compat_chat_capabilities.supports_document_input;
+  (* The declaration must survive the embedded catalog: a row inherits it from
+     its [base] only when it actually has one. *)
+  List.iter
+    (fun (model_id, expected) ->
+       check
+         (option bool)
+         (Printf.sprintf "%s resolves document input" model_id)
+         (Some expected)
+         (Capabilities.for_model_id model_id
+          |> Option.map (fun (c : Capabilities.capabilities) -> c.supports_document_input)
+         ))
+    [ "claude-opus-4-8", true; "gemini-3.5-flash", true; "gpt-5.2", false ]
+;;
+
+let test_catalog_row_can_declare_document_input () =
+  (* The capability must be sourceable the same way its image/audio/video
+     siblings are: a models.toml row declares it and it survives to
+     [Capabilities.for_model_id]. A row with no [base] resolves against
+     [default_capabilities], so it declares nothing unless it says so — the
+     failure mode the sibling refactor hit. *)
+  let toml =
+    "[[models]]\n\
+     id_prefix = \"doc-declared\"\n\
+     max_context_tokens = 8192\n\
+     supports_document_input = true\n\n\
+     [[models]]\n\
+     id_prefix = \"doc-silent\"\n\
+     max_context_tokens = 8192\n"
+  in
+  let catalog =
+    match Model_catalog.of_toml_string ~source:"document admission inline" toml with
+    | Ok catalog -> catalog
+    | Error message -> failf "inline catalog should parse: %s" message
+  in
+  Model_catalog.clear_global ();
+  Fun.protect ~finally:Model_catalog.clear_global (fun () ->
+    Model_catalog.set_global catalog;
+    let declares model_id =
+      Capabilities.for_model_id model_id
+      |> Option.map (fun (c : Capabilities.capabilities) -> c.supports_document_input)
+    in
+    check
+      (option bool)
+      "declared row carries the fact"
+      (Some true)
+      (declares "doc-declared");
+    check
+      (option bool)
+      "base-less silent row declares nothing"
+      (Some false)
+      (declares "doc-silent"))
+;;
+
+(* ── (c) image and audio payloads are unchanged ───────────────────────── *)
+
+let test_openai_chat_image_and_audio_unchanged () =
+  check
+    json
+    "image_url part unchanged"
+    (`List
+        [ `Assoc
+            [ "type", `String "image_url"
+            ; "image_url", `Assoc [ "url", `String "data:image/png;base64,SU1H" ]
+            ]
+        ])
+    (`List (Backend_openai.openai_content_parts_of_blocks [ image_block ]));
+  check
+    json
+    "input_audio part unchanged"
+    (`List
+        [ `Assoc
+            [ "type", `String "input_audio"
+            ; "input_audio", `Assoc [ "data", `String "QVVE"; "format", `String "wav" ]
+            ]
+        ])
+    (`List (Backend_openai.openai_content_parts_of_blocks [ audio_block ]))
+;;
+
+let test_openai_chat_request_image_and_audio_unchanged () =
+  List.iter
+    (fun (block, expected_part) ->
+       let config = openai_config "gpt-5.2" in
+       let messages = [ user_message [ Types.Text "prefix"; block ] ] in
+       check
+         json
+         "request body unchanged"
+         (`Assoc
+             [ "model", `String "gpt-5.2"
+             ; ( "messages"
+               , `List
+                   [ `Assoc
+                       [ "role", `String "user"
+                       ; ( "content"
+                         , `List
+                             [ `Assoc [ "type", `String "text"; "text", `String "prefix" ]
+                             ; expected_part
+                             ] )
+                       ]
+                   ] )
+             ])
+         (Backend_openai_request.build_request_assoc ~config ~messages ()))
+    [ ( image_block
+      , `Assoc
+          [ "type", `String "image_url"
+          ; "image_url", `Assoc [ "url", `String "data:image/png;base64,SU1H" ]
+          ] )
+    ; ( audio_block
+      , `Assoc
+          [ "type", `String "input_audio"
+          ; "input_audio", `Assoc [ "data", `String "QVVE"; "format", `String "wav" ]
+          ] )
+    ]
+;;
+
+let test_ollama_native_image_unchanged () =
+  match
+    Backend_openai_serialize.ollama_messages_of_history
+      ~model_id:"qwen3:8b"
+      [ user_message [ Types.Text "prefix"; image_block ] ]
+  with
+  | Error message -> failf "expected serialization, got %s" message
+  | Ok wire ->
+    check
+      json
+      "ollama native images array unchanged"
+      (`List
+          [ `Assoc
+              [ "role", `String "user"
+              ; "content", `String "prefix"
+              ; "images", `List [ `String "SU1H" ]
+              ]
+          ])
+      (`List wire)
+;;
+
+let test_gemini_image_and_audio_unchanged () =
+  List.iter
+    (fun (block, mime, data) ->
+       let contents, _ = Backend_gemini.contents_of_messages [ user_message [ block ] ] in
+       check
+         json
+         (Printf.sprintf "gemini inlineData unchanged for %s" mime)
+         (`List
+             [ `Assoc
+                 [ "role", `String "user"
+                 ; ( "parts"
+                   , `List
+                       [ `Assoc
+                           [ ( "inlineData"
+                             , `Assoc [ "mimeType", `String mime; "data", `String data ] )
+                           ]
+                       ] )
+                 ]
+             ])
+         (`List contents))
+    [ image_block, "image/png", "SU1H"; audio_block, "wav", "QVVE" ]
+;;
+
+let () =
+  run
+    "media_document_admission"
+    [ ( "inadmissible documents are typed outcomes"
+      , [ test_case
+            "undeclared row is rejected by name"
+            `Quick
+            test_admission_rejects_undeclared_row
+        ; test_case
+            "wire without a document part is rejected by name"
+            `Quick
+            test_admission_rejects_wire_without_document_part
+        ; test_case
+            "image and audio are not gated"
+            `Quick
+            test_admission_ignores_image_and_audio
+        ; test_case
+            "openai chat request rejects instead of emitting image_url"
+            `Quick
+            test_openai_chat_request_rejects_undeclared_document
+        ; test_case
+            "ollama native rejects instead of appending to images"
+            `Quick
+            test_ollama_native_rejects_document
+        ] )
+    ; ( "wires that carry documents keep their native form"
+      , [ test_case
+            "openai chat file part"
+            `Quick
+            test_openai_chat_document_is_a_file_part
+        ; test_case
+            "anthropic document source block"
+            `Quick
+            test_anthropic_document_is_a_source_block
+        ; test_case "gemini inlineData" `Quick test_gemini_document_is_inline_data
+        ; test_case
+            "capability bases declare document input"
+            `Quick
+            test_anthropic_and_gemini_declare_document_input
+        ; test_case
+            "catalog row can declare document input"
+            `Quick
+            test_catalog_row_can_declare_document_input
+        ] )
+    ; ( "image and audio payloads are unchanged"
+      , [ test_case
+            "openai chat content parts"
+            `Quick
+            test_openai_chat_image_and_audio_unchanged
+        ; test_case
+            "openai chat request body"
+            `Quick
+            test_openai_chat_request_image_and_audio_unchanged
+        ; test_case "ollama native images" `Quick test_ollama_native_image_unchanged
+        ; test_case "gemini inlineData" `Quick test_gemini_image_and_audio_unchanged
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 목표

`Document` 블록이 조용히 `image_url` 로 재해석되던 경로를 제거하고, document 지원을 독립 typed capability 로 표현한다. 켈베로스 감사(jeong-sik/masc#25550) 개선 P3 + P6 일부 · 추적 jeong-sik/masc#27872.

## 결함

`Document` 를 그림으로 바꿔 보내던 사이트가 **두 곳**이었다(감사는 한 곳만 지목했다):

1. `backend_openai_serialize.ml:230-241` — OpenAI-compat Chat Completions 에서 `image_url` part 로 방출. PDF 가 모델에 **사진으로** 도달했고 어느 계층도 그 사실을 보고하지 않았다.
2. Ollama native 경로(`ollama_native_user_message`) — document 를 `images` 배열에 append. 주석이 *"so vision models can attempt to process them as pages"* 라 의도를 자백하고 있었다.

부수적으로 `supports_image` / `supports_audio` / `supports_video` 는 typed 필드인데 **document 만** 포괄 `supports_multimodal_inputs` 로 뭉뚱그려져 독립 표현이 불가능했다.

## 변경

### 1. Coercion 제거 (우선순위 1) — 양쪽 모두

- OpenAI-compat: `{"type":"file","file":{"file_data":…}}` 방출. 형태는 sibling Responses serializer 가 이미 `input_file.file_data` 에 넣는 것과 동일. `Document` 블록에 이름 필드가 없으므로 `filename` 은 없다(Responses 선례와 같음).
- Ollama native: `images` 접기 제거.

### 2. Typed 어휘 + 사전 admission

```ocaml
type document_wire_form =
  | Document_source_block | Document_inline_data | Document_input_file_part
  | Document_chat_file_part | Document_unrepresentable

type document_admission_error =
  | Document_wire_has_no_representation of { wire_form : document_wire_form; media_type : string }
  | Document_input_not_declared of { model_id : string; media_type : string }

val admit_document_blocks
  :  wire_form:document_wire_form -> model_id:string -> supports_document_input:bool
  -> Types.content_block list -> (unit, document_admission_error) result
```

**직렬화 이전에** wire form ∧ capability 를 검사한다. 실패는 타입 있는 결과이며, 다른 modality 로 둔갑하지 않는다.

### 3. `supports_document_input` typed capability

image/audio/video 형제 필드들이 지나는 **모든 경로**에 배선: record · default · presets · models.toml 파서 + known-keys · capability manifest · provider catalog override · 공개 `Provider` 뷰 · JSON 스키마 · 문서.

모든 match 는 exhaustive 이고 새 `_` catch-all 을 추가하지 않았다. 로직에 provider 이름 substring 은 없다 — wire 는 variant 이고 라벨 문자열은 메시지 전용이다.

## 차등 검증 (baseline vs 변경)

media 4종 × serializer 5종 × model row 6종 프로브를 변경 트리에서 실행 → `git stash push -- lib models.toml` → 재빌드 → baseline 실행 → diff.

**결과: `document_pdf` 행에서만 차이. `text` · `image_png` · `audio_wav` 는 전 backend 에서 byte-identical.**

```
< openai_messages_of_message/document_pdf :: {"type":"image_url","image_url":{"url":"data:application/pdf;base64,UERG"}}
> openai_messages_of_message/document_pdf :: {"type":"file","file":{"file_data":"data:application/pdf;base64,UERG"}}
< ollama_native/document_pdf/qwen3:8b :: {"role":"user","content":"prefix","images":["UERG"]}
> ollama_native/document_pdf/qwen3:8b :: ERR document block (media_type "application/pdf") cannot be placed on this wire: it has no document part
```

프로브는 삭제하고 그 매트릭스를 영구 테스트 `test/test_media_document_admission.ml` 로 재인코딩했다(image/audio 기대값은 **변경 전 바이너리의 실제 출력**).

## catalog `base` 함정 점검

182 model row 중 **14개가 `base` 없음** → `default_capabilities` 로 해석되어 `supports_document_input = false` 를 조용히 받는다. 여기서는 보수적으로 옳은 결과지만, 새로 선언한 fact 가 유실되는 바로 그 메커니즘이므로 **양방향을 테스트로 고정**했다(선언한 행은 fact 를 갖고, base 없는 행은 선언하지 않는다).

## 방출 페이로드 변화 (3건, 전부 의도된 수정)

| # | 변화 |
|---|---|
| 1 | OpenAI-compat Chat Completions: `image_url` part → `file` part (행이 `supports_document_input` 을 선언한 경우에만 도달) |
| 2 | OpenAI-compat, 미선언 행: 페이로드 → `Invalid_argument` (media type 과 capability 명시) |
| 3 | Ollama native: `images` 항목 → `Error` (media type 과 없는 wire 표현 명시) |

그 외 변화 없음 — 위 프로브 diff 와 `image and audio payloads are unchanged` 테스트 그룹으로 확인.

## 의도적으로 하지 않은 것

- **Anthropic · Gemini · OpenAI Responses 요청 빌더는 capability 게이트를 걸지 않았다.** 이미 native document 형태를 방출하고 있어 고칠 coercion 이 없다. 게이트를 추가하면 `base` 없는 `gemini-*-image` / `-tts` 6행이 `default_capabilities` 로 떨어져 **없던 실패 모드**가 생긴다. 반쪽 마이그레이션이 아니라 일관된 종착점이다.
- **`supports_document_input = true` 를 어떤 models.toml 행에도 설정하지 않았다.** `anthropic` · `gemini` capability **base** 에는 설정했고(근거: 두 serializer 가 이미 문서화된 native document 형태를 방출), 21개 anthropic · 8개 gemini 행이 `base` 로 상속한다. OpenAI chat 행은 Chat Completions `file` part 를 라이브 문서로 확인할 수 없어 선언하지 않았다 — **catalog 데이터를 지어내는 것이 이 감사가 잡으려는 실패 모드**다. 운영자는 지금도 선언적으로 opt-in 할 수 있다.

## 기존 테스트 3건 수정

`test_backend_openai_codec.ml` 의 3개 케이스가 **coercion 을 단언하고 있었다**(`check_string "document url" ... (member "image_url" ...)`, Ollama "documents forwarded as images"). 우회하지 않고 새 계약으로 갱신했다 — diff 가 옛 계약이 무엇이었는지 보여준다.

## 검증 (리뷰어 독립 재실행)

| 대상 | 결과 |
|---|---|
| `scripts/dune-local.sh build lib` | 통과 |
| `test_media_document_admission` | **14 tests** 통과 (신규) |
| `test_backend_openai_codec` | 43 tests 통과 |
| `test_capabilities` | 100 tests 통과 |
| `test_multimodal` | 18 tests 통과 |
| `@fmt` | diff 없음 |

에이전트 보고 추가 회귀 스윕(전부 green): gemini 55 · provider 47 · llm_provider_cov 115 · api 45 · provider_complete 63 · snapshot_serialization 23 · modality 7 · streaming_edge_cases 13 외.

## 남은 코너 (정직하게)

- `ToolResult.content_blocks` 안의 `Document` 는 admission 검사를 받지 않는다. 그 경로는 media part 대신 블록을 JSON 문자열화하므로 coercion 은 없지만 미검사 코너다.
- `Provider.modality` 에 `Document` variant 가 없어(`Text | Image | Audio | Video | Multimodal`) document-only 행을 보고할 수 없다. 범위 밖, 후속 가치 있음.
- `Document_chat_file_part` 방출 경로는 선언한 catalog 행이 없어 `build_request_assoc` 를 통해서는 현재 도달 불가. 직접 진입점(`openai_content_parts_of_blocks`)으로는 도달하며 테스트가 덮는다.

## 호환성

방출 페이로드가 바뀌므로 Conventional Commits 의 breaking 표기(`fix(llm_provider)!`)를 달았다. 다만 바뀌는 것은 **document 를 보내던 경로뿐**이고, 그 경로는 지금까지 document 를 그림으로 잘못 보내고 있었다.

RFC-WAIVED: credential / identity(인증) / operator control / sandbox / hooks / workflow 문서 어디에도 해당하지 않는다. 직렬화 경계의 silent 의미 변형 제거다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
