### PR TITLE
refactor(llm_provider): decide structured-output tier by capability not kind

### DIFF
--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -88,6 +88,15 @@ type task = Capability_vocab.task =
   | Image_generation
   | Video_generation
 
+(** Structured-output tier, projected from the two capability booleans below by
+    {!structured_output_support}. The request-admission decision reads this typed
+    view rather than provider identity. See {!Capability_vocab.structured_output_support}. *)
+type structured_output_support = Capability_vocab.structured_output_support =
+  | No_structured_output
+  | Json_object_only
+  | Native_json_schema
+[@@deriving show, eq]
+
 type capabilities =
   { (* ── Numeric limits ────────────────────────────────── *)
     max_context_tokens : int option (** Model's context window. None = unknown. *)
@@ -232,6 +241,30 @@ let default_capabilities =
   ; emits_usage_tokens = true (* stricter default: most providers report usage *)
   ; supported_models = None
   }
+;;
+
+(** Structured-output tier a resolved capability record advertises.
+
+    Single typed view the request-admission decision
+    ({!Provider_config.validate_output_schema_request}) reads instead of
+    branching on provider identity. It is a total projection of the two
+    independent, catalog-sourced booleans — [supports_structured_output] (native
+    json_schema) and [supports_response_format_json] (json_object mode) — which
+    the provider catalog, model catalog, capability manifest, and public view
+    already thread. It is deliberately not a stored field: the two booleans stay
+    the single source of truth (they are separate, non-interchangeable contracts
+    per docs/provider-capabilities-spec.md), so this projection cannot drift.
+
+    A native schema guarantee is the top tier regardless of the JSON-mode flag,
+    so both [(structured=true, json=true)] and [(structured=true, json=false)]
+    map to [Native_json_schema]. JSON mode without a native schema field is
+    [Json_object_only]; neither flag is [No_structured_output]. *)
+let structured_output_support (caps : capabilities) : structured_output_support =
+  if caps.supports_structured_output
+  then Native_json_schema
+  else if caps.supports_response_format_json
+  then Json_object_only
+  else No_structured_output
 ;;
 
 let effective_disable_parallel_tool_use

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -70,6 +70,15 @@ type task = Capability_vocab.task =
   | Image_generation
   | Video_generation
 
+(** Structured-output tier a resolved capability advertises, projected from the
+    two capability booleans by {!structured_output_support}. The request-admission
+    decision reads this typed view rather than provider identity. *)
+type structured_output_support = Capability_vocab.structured_output_support =
+  | No_structured_output
+  | Json_object_only
+  | Native_json_schema
+[@@deriving show, eq]
+
 type capabilities =
   { (* Numeric limits *)
     max_context_tokens : int option
@@ -146,6 +155,15 @@ type capabilities =
   }
 
 val default_capabilities : capabilities
+
+(** Structured-output tier a resolved capability record advertises. Total
+    projection of [supports_structured_output] and [supports_response_format_json]:
+    native schema support is the top tier regardless of the JSON-mode flag,
+    JSON mode alone is [Json_object_only], neither is [No_structured_output]. This
+    is the typed capability {!Provider_config.validate_output_schema_request}
+    reads instead of branching on provider identity. *)
+val structured_output_support : capabilities -> structured_output_support
+
 val anthropic_capabilities : capabilities
 val kimi_capabilities : capabilities
 val mimo_capabilities : capabilities

--- a/lib/llm_provider/capability_vocab.ml
+++ b/lib/llm_provider/capability_vocab.ml
@@ -43,6 +43,35 @@ type reasoning_output_format =
   | No_reasoning_output_format
   | Split_reasoning_fields
 
+(** Structured-output tier a resolved model/provider capability advertises.
+
+    This is the typed view the request-admission decision
+    ({!Provider_config.validate_output_schema_request}) reads instead of
+    branching on provider identity. It has no wire vocabulary of its own and is
+    never parsed from a catalog/manifest string: it is projected from the two
+    independent, already-threaded capability booleans
+    [supports_structured_output] and [supports_response_format_json]
+    ({!Capabilities.structured_output_support}). Keeping the tier as a closed sum
+    lets the decision match all three cases exhaustively, so a new tier forces a
+    compile error rather than a silent identity branch.
+
+    - [Native_json_schema]: the provider exposes a native schema-constrained
+      request field; the schema is enforced provider-side.
+    - [Json_object_only]: the provider accepts JSON mode
+      ([response_format = json_object]) but documents no native json_schema
+      field, so a caller-supplied output schema cannot be honored on the wire.
+    - [No_structured_output]: neither JSON mode nor native schema output. *)
+type structured_output_support =
+  | No_structured_output
+  | Json_object_only
+  | Native_json_schema
+
+let structured_output_support_to_string = function
+  | No_structured_output -> "none"
+  | Json_object_only -> "json_object_only"
+  | Native_json_schema -> "native_json_schema"
+;;
+
 type reasoning_streaming_format =
   | Default_reasoning_streaming
   | No_reasoning_streaming

--- a/lib/llm_provider/provider_config.ml
+++ b/lib/llm_provider/provider_config.ml
@@ -595,21 +595,6 @@ let structured_schema_requested (config : t) : bool =
   | None, (Types.JsonMode | Types.Off) -> false
 ;;
 
-let validate_model_structured_output_capability (config : t) =
-  let caps =
-    match capabilities_for_config_model config with
-    | Some c -> c
-    | None -> Capabilities.default_capabilities
-  in
-  if not caps.supports_structured_output
-  then
-    Error
-      (Printf.sprintf
-         "model %s does not advertise native structured output"
-         config.model_id)
-  else Ok ()
-;;
-
 let request_path_targets_responses_api request_path =
   let lower = String.lowercase_ascii (String.trim request_path) in
   let path =
@@ -632,19 +617,44 @@ let validate_request_path (config : t) =
   else Ok ()
 ;;
 
+(* Structured-output tier admission (OAS #2744 / masc#25550 audit finding P4).
+   The tier is read from the resolved model/provider capability, never from
+   provider identity. [config.kind] used to gate this (GLM hard-denied, three
+   kinds hard-allowed), so a capability-driven fact was decided by a vendor
+   name. Now the two catalog-sourced booleans project to a typed tier
+   ([Capabilities.structured_output_support]) matched exhaustively here: a
+   provider that declares native json_schema is admitted and one that declares
+   json_object-only is denied regardless of which vendor it is.
+
+   Capabilities are resolved through [request_capabilities_for_config], the same
+   function the request serializers use, so this decision and the wire it gates
+   read one capability record. That matters when a config names no catalog row:
+   the previous inline fallback dropped to [default_capabilities] (structured =
+   false) and would have denied an Anthropic/Gemini/DashScope config that names
+   an off-catalog model, whereas the wire path resolves it to the provider's
+   base record via the [config.kind] arm below. The old kind gate admitted those
+   unconditionally; routing through the shared resolver keeps that behaviour
+   (their base records declare native schema) without reading identity here —
+   identity selects the base capability record, it does not decide the tier. GLM
+   and Kimi base records are json_object-only and stay denied. *)
 let validate_output_schema_request (config : t) =
   match structured_schema_requested config with
   | false -> Ok ()
   | true ->
-    (match config.kind with
-     | Gemini | Anthropic | DashScope -> Ok ()
-     | Ollama -> validate_model_structured_output_capability config
-     | Glm ->
+    let caps = request_capabilities_for_config config in
+    (match Capabilities.structured_output_support caps with
+     | Capabilities.Native_json_schema -> Ok ()
+     | Capabilities.Json_object_only ->
        Error
-         "Glm supports JSON mode (json_object) only; native json_schema output is not \
-          documented in the current Z.AI API"
-     | Kimi -> validate_model_structured_output_capability config
-     | OpenAI_compat -> validate_model_structured_output_capability config)
+         (Printf.sprintf
+            "model %s advertises JSON mode (json_object) only; native json_schema output \
+             is not supported by its declared capability"
+            config.model_id)
+     | Capabilities.No_structured_output ->
+       Error
+         (Printf.sprintf
+            "model %s does not advertise native structured output"
+            config.model_id))
 ;;
 
 let has_host_prefix ~url ~prefix =

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -1128,9 +1128,12 @@ let test_provider_config_of_agent_custom_registered_ollama_cloud_row_separates_j
 ;;
 
 let test_provider_config_of_agent_custom_registered_ollama_cloud_row_rejects_so () =
-  (* minimax-m3 catalog row explicitly does not guarantee schema-shaped output.
-     The named-provider path must reject the request with the model capability
-     error, not silently inherit the provider default. *)
+  (* The ollama_cloud minimax-m3 catalog row declares json_object mode but no
+     native schema guarantee (supports_response_format_json = true,
+     supports_structured_output = false). The named-provider path must reject a
+     schema request with the capability reason, and the reason must name the
+     precise tier — json_object-only — rather than the coarse
+     "no structured output" the identity gate used to emit. *)
   with_env "OLLAMA_CLOUD_API_KEY" (Some "ollama-cloud-test-key") (fun () ->
     let schema = `Assoc [ "type", `String "object" ] in
     let cfg : Provider.config =
@@ -1152,11 +1155,11 @@ let test_provider_config_of_agent_custom_registered_ollama_cloud_row_rejects_so 
       (match Llm_provider.Provider_config.validate_output_schema_request pc with
        | Error msg ->
          Alcotest.(check bool)
-           "rejected with model capability reason"
+           "rejected with the json_object-only capability reason"
            true
            (Util.contains_substring_ci
               ~haystack:msg
-              ~needle:"does not advertise native structured output")
+              ~needle:"JSON mode (json_object) only")
        | Ok () -> Alcotest.fail "expected rejection for ollama_cloud/minimax-m3")
     | Error e -> Alcotest.fail (Printf.sprintf "unexpected error: %s" (Error.to_string e)))
 ;;

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -378,7 +378,8 @@ let test_validate_output_schema_native_ollama_ministral_rejected () =
   | Error msg ->
     check_string
       "rejection"
-      "model ministral-3:8b does not advertise native structured output"
+      "model ministral-3:8b advertises JSON mode (json_object) only; native json_schema \
+       output is not supported by its declared capability"
       msg
   | Ok () -> Alcotest.fail "expected native Ollama model capability rejection"
 ;;
@@ -449,7 +450,8 @@ let test_validate_output_schema_native_ollama_rejects_unverified_model () =
   | Error msg ->
     check_string
       "reason"
-      "model ministral-3:8b does not advertise native structured output"
+      "model ministral-3:8b advertises JSON mode (json_object) only; native json_schema \
+       output is not supported by its declared capability"
       msg
   | Ok () -> Alcotest.fail "expected native Ollama model capability rejection"
 ;;
@@ -597,6 +599,92 @@ let test_validate_output_schema_supported_non_openai () =
     "ollama accepts schema only for models with a native SO guarantee"
     true
     (Result.is_ok (Provider_config.validate_output_schema_request ollama_cfg))
+;;
+
+(* The tier is a projection of the two capability booleans, not the provider
+   name. Prove the identity left the predicate from both sides: a GLM-kind
+   config that declares native schema is admitted, and a non-GLM (OpenAI-compat)
+   config that declares json_object-only is denied. Reintroducing a
+   [match config.kind] gate would flip both. *)
+let test_validate_output_schema_is_capability_not_identity () =
+  let schema = `Assoc [ "type", `String "object" ] in
+  let glm_declaring_native =
+    Provider_config.make
+      ~kind:Glm
+      ~model_id:"glm-native-probe"
+      ~base_url:"https://open.bigmodel.cn/api/paas/v4"
+      ~output_schema:schema
+      ~model_capabilities_override:
+        { Capabilities.glm_capabilities with supports_structured_output = true }
+      ()
+  in
+  check_bool
+    "GLM kind is admitted when its declared capability is native json_schema"
+    true
+    (Result.is_ok (Provider_config.validate_output_schema_request glm_declaring_native));
+  let compat_declaring_json_object_only =
+    Provider_config.make
+      ~kind:OpenAI_compat
+      ~model_id:"compat-json-object-probe"
+      ~base_url:"https://api.example.test/v1"
+      ~response_format_json:true
+      ~output_schema:schema
+      ~model_capabilities_override:
+        { Capabilities.default_capabilities with
+          supports_response_format_json = true
+        ; supports_structured_output = false
+        }
+      ()
+  in
+  check_bool
+    "a non-GLM kind is denied when its declared capability is json_object-only"
+    true
+    (Result.is_error
+       (Provider_config.validate_output_schema_request compat_declaring_json_object_only))
+;;
+
+(* Pin the projection: native schema is the top tier regardless of the JSON-mode
+   flag, so both (structured=true) rows admit; json-mode-without-schema is
+   json_object-only and denies; neither flag denies. Off-catalog configs resolve
+   through request_capabilities_for_config, so a kind whose base record declares
+   native schema (Anthropic here) is admitted even when the model id names no
+   catalog row — identity selects the base record, it does not decide the tier. *)
+let test_validate_output_schema_projection_matrix () =
+  let schema = `Assoc [ "type", `String "object" ] in
+  let outcome ~structured ~json =
+    let cfg =
+      Provider_config.make
+        ~kind:OpenAI_compat
+        ~model_id:"matrix-probe"
+        ~base_url:"https://api.example.test/v1"
+        ~response_format_json:json
+        ~output_schema:schema
+        ~model_capabilities_override:
+          { Capabilities.default_capabilities with
+            supports_structured_output = structured
+          ; supports_response_format_json = json
+          }
+        ()
+    in
+    Result.is_ok (Provider_config.validate_output_schema_request cfg)
+  in
+  check_bool "native+json admits" true (outcome ~structured:true ~json:true);
+  check_bool "native only admits" true (outcome ~structured:true ~json:false);
+  check_bool "json-object only denies" false (outcome ~structured:false ~json:true);
+  check_bool "neither denies" false (outcome ~structured:false ~json:false);
+  (* off-catalog Anthropic model still admits via its base record *)
+  let anthropic_off_catalog =
+    Provider_config.make
+      ~kind:Anthropic
+      ~model_id:"claude-not-in-catalog-probe"
+      ~base_url:"https://api.anthropic.com"
+      ~output_schema:schema
+      ()
+  in
+  check_bool
+    "off-catalog Anthropic model resolves to its native-schema base record"
+    true
+    (Result.is_ok (Provider_config.validate_output_schema_request anthropic_off_catalog))
 ;;
 
 let test_validate_output_schema_capability_rejected () =
@@ -1373,7 +1461,8 @@ let test_validate_output_schema_native_ollama_catalog_rejects_model_without_so (
     | Error msg ->
       check_string
         "rejection reason"
-        "model ministral-3:8b does not advertise native structured output"
+        "model ministral-3:8b advertises JSON mode (json_object) only; native \
+         json_schema output is not supported by its declared capability"
         msg
     | Ok () -> Alcotest.fail "expected native Ollama model capability rejection")
 ;;
@@ -2212,6 +2301,14 @@ let () =
             "supported non-openai providers"
             `Quick
             test_validate_output_schema_supported_non_openai
+        ; Alcotest.test_case
+            "tier is capability not identity"
+            `Quick
+            test_validate_output_schema_is_capability_not_identity
+        ; Alcotest.test_case
+            "tier projection matrix"
+            `Quick
+            test_validate_output_schema_projection_matrix
         ; Alcotest.test_case
             "openai capability rejection"
             `Quick


### PR DESCRIPTION
## 목표

structured-output tier(native `json_schema` vs `json_object` vs neither) 결정을 `config.kind` hardcode 에서 typed capability 로 옮긴다. 켈베로스 감사(jeong-sik/masc#25550) 개선 P4 · 추적 jeong-sik/masc#27872.

## 근거

`validate_output_schema_request` 가 `config.kind` 로 분기했다: GLM 은 Z.AI 특정 메시지로 hard-deny, 3개 kind 는 무조건 hard-allow, 나머지는 capability gate. **capability 로 판단할 사실(이 모델이 native json_schema 요청을 받나)을 vendor 이름이 결정**하고 있었다.

## 설계 결정: 새 stored field 가 아니라 projection

그 사실은 이미 capability record 에 **두 개의 독립 boolean** 으로 존재하고 모든 표면이 배선한다: `supports_structured_output`(native) + `supports_response_format_json`(json_object mode). `docs/provider-capabilities-spec.md`(§68-69, 216)가 둘을 "keep separate / distinct contracts" 로 명시한다.

따라서 세 번째 stored field 는 (a) 두 boolean 과 drift 가능한 **병렬 enum**, (b) spec 위반이다. 대신 **총함수 projection** 을 추가했다:

```ocaml
type structured_output_support =
  | No_structured_output | Json_object_only | Native_json_schema

let structured_output_support (caps : capabilities) : structured_output_support =
  if caps.supports_structured_output then Native_json_schema
  else if caps.supports_response_format_json then Json_object_only
  else No_structured_output
```

native schema 는 JSON-mode flag 와 무관하게 top tier. stored 상태가 아니라 두 SSOT boolean 의 파생이라 **구조적으로 drift 불가**. `validate_output_schema_request` 는 이 projection 을 exhaustive 3-arm match 하고, `match config.kind` 전체가 삭제됐다.

## 회귀 하나를 발견하고 수정

초기 구현은 catalog 미스 시 `default_capabilities`(structured=false)로 떨어져, **off-catalog anthropic/gemini/dashscope 모델을 거부**했다(옛 kind gate 는 무조건 허용). 원인: `validate` 가 `capabilities_for_config_model`(catalog only)을 직접 썼는데, request serializer 는 `request_capabilities_for_config`(catalog 미스 시 **kind→base record fallback**)를 쓴다 — 두 capability 해석 경로가 불일치했다.

수정: `validate` 도 `request_capabilities_for_config` 를 쓴다. 이제 admission 결정과 그것이 gate 하는 wire 가 **한 record** 를 읽는다. off-catalog 모델은 provider base record(anthropic → native)로 해석되어 옛 동작 보존. identity 는 여기서 base record 를 **선택**할 뿐 tier 를 **결정**하지 않는다.

이 회귀는 catalog 실제 행만 돌린 차등 probe 가 놓쳤고(0-diff), **합성 model_id 를 쓰는 기존 단위 테스트**가 잡았다.

## Behavior

| | |
|---|---|
| GLM/Kimi presets (json_object-only) | denied 유지 |
| Anthropic/Gemini/DashScope base (native) | admitted 유지 |
| 14 base-less 행 | `default_capabilities` = `No_structured_output` → 오늘 동작 보존 |
| json_object-only 모델 거부 **메시지** | "does not advertise native structured output"(뭉뚱그림) → "JSON mode (json_object) only"(정밀) |

메시지 정밀화로 기존 테스트 3건(ollama_cloud/minimax-m3, native ollama ministral-3:8b)의 기대 문자열을 새 계약으로 갱신했다. 두 테스트의 주석도 정정했다 — 그 행들은 json_object mode 를 **선언**한 것이지 단순히 structured output 이 없는 게 아니다.

## 검증 (리뷰어 독립 재현)

| 대상 | 결과 |
|---|---|
| `dune build lib` | 통과 |
| `test_provider_config` | **118 tests** (신규 2건) |
| `test_provider` | 47 tests |
| `test_provider_runtime_binding` | 23 tests |
| `test_capabilities` | 100 tests |
| `test_backend_openai_codec` | 43 tests |
| `@fmt` | diff 없음 |
| decision 경로 vendor 이름 grep | **0 hits** |
| `Glm supports JSON mode` / `validate_model_structured_output_capability` 잔여 | **0 hits** |

신규 테스트:
- **tier is capability not identity**: GLM-kind + native 선언 → admit / 비-GLM + json_object-only 선언 → deny. 이 교차가 identity 가 predicate 를 떠났음을 증명(`match config.kind` 복원 시 둘 다 flip).
- **tier projection matrix**: 4개 boolean 조합 전부 + off-catalog anthropic 이 base record 로 admit.

## 협업 노트

구현은 별도 세션(P4 에이전트)이 격리 worktree 에서 작성했고, 나는 그 worktree 에서 빌드·테스트를 **재현**하며 회귀(위 request_capabilities 불일치)를 발견해 직접 수정하고 교차 테스트를 추가한 뒤 커밋했다. 차등 probe(182 행 0-diff)와 base-less 분석은 에이전트 보고를 재확인한 것이다.

## 검증하지 못한 것

- 라이브 provider 재현은 없다. 근거는 catalog 실행 + 합성 config 단위 테스트다.
- 감사가 지적한 masc 측 소비자 3곳(HITL summary, compaction summarizer tiering, memory-bank fan-out)은 이 PR 범위 밖(OAS only)이며 jeong-sik/masc#27872 / masc#25551 에 남겨두었다.

RFC-WAIVED: credential / identity(인증) / operator control / sandbox / hooks / workflow 문서 어디에도 해당하지 않는다. capability 기반 tier 결정으로의 리팩터다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
