### PR TITLE
refactor(llm): isolate capability vocabulary

### DIFF
--- a/lib/llm_provider/capability_vocab.ml
+++ b/lib/llm_provider/capability_vocab.ml
@@ -444,6 +444,52 @@ let modality_priority_values =
   ]
 ;;
 
+let capability_fields =
+  [ "max_context_tokens"
+  ; "max_output_tokens"
+  ; "supports_tools"
+  ; "supports_tool_choice"
+  ; "supports_required_tool_choice"
+  ; "supports_named_tool_choice"
+  ; "supports_parallel_tool_calls"
+  ; "assistant_tool_content_format"
+  ; "supports_reasoning"
+  ; "supports_extended_thinking"
+  ; "supports_reasoning_budget"
+  ; "accepted_reasoning_efforts"
+  ; "thinking_control_format"
+  ; "thinking_control_token"
+  ; "preserve_thinking_control_format"
+  ; "reasoning_output_format"
+  ; "reasoning_streaming_format"
+  ; "reasoning_replay"
+  ; "supports_response_format_json"
+  ; "supports_structured_output"
+  ; "supports_multimodal_inputs"
+  ; "supports_image_input"
+  ; "supports_audio_input"
+  ; "supports_video_input"
+  ; "supports_document_input"
+  ; "modality_priority"
+  ; "supports_native_streaming"
+  ; "supports_system_prompt"
+  ; "supports_caching"
+  ; "supports_prompt_caching"
+  ; "prompt_cache_alignment"
+  ; "supports_top_k"
+  ; "supports_min_p"
+  ; "supports_seed"
+  ; "supports_seed_with_images"
+  ; "ignored_sampling_parameters"
+  ; "supports_computer_use"
+  ; "supports_code_execution"
+  ; "emits_usage_tokens"
+  ; "supported_models"
+  ; "supports_runtime_mcp_tools"
+  ; "supports_runtime_tool_events"
+  ]
+;;
+
 let task_table =
   [ "transcription", Transcription
   ; "speech", Speech

--- a/lib/llm_provider/capability_vocab.mli
+++ b/lib/llm_provider/capability_vocab.mli
@@ -1,0 +1,140 @@
+(** Shared leaf vocabulary for declarative capability fields. *)
+
+type thinking_control_format =
+  | No_thinking_control
+  | Thinking_object
+  | Thinking_object_adaptive
+  | Thinking_object_only
+  | Chat_template_kwargs
+  | Chat_template_token of string
+  | Ollama_think
+  | Reasoning_effort
+  | Enable_thinking
+
+type preserve_thinking_control_format =
+  | No_preserve_thinking_control
+  | Thinking_object_keep_all
+  | Chat_template_kwargs_preserve_thinking
+  | Top_level_preserve_thinking
+  | Always_preserved_thinking
+  | Thinking_object_clear_thinking
+
+type reasoning_replay_override =
+  | Default_reasoning_replay
+  | Force_no_replay
+  | Force_drop_without_tool_preserve_with_tool
+  | Force_latest_user_turn_tool_calls
+  | Force_preserve_always
+
+type assistant_tool_content_format =
+  | Assistant_tool_content_null
+  | Assistant_tool_content_empty_string
+
+type reasoning_output_format =
+  | No_reasoning_output_format
+  | Split_reasoning_fields
+
+type structured_output_support =
+  | No_structured_output
+  | Json_object_only
+  | Native_json_schema
+
+type reasoning_streaming_format =
+  | Default_reasoning_streaming
+  | No_reasoning_streaming
+  | Delta_reasoning_field of string
+  | Template_reasoning_streaming
+
+type sampling_parameter =
+  | Temperature
+  | Top_p
+  | Top_k
+  | Min_p
+  | Presence_penalty
+  | Frequency_penalty
+  | Seed
+
+type task =
+  | Transcription
+  | Speech
+  | Image_generation
+  | Video_generation
+
+type anthropic_thinking_control =
+  | Manual_budget
+  | Adaptive_default
+  | Adaptive_preferred
+  | Adaptive_only
+  | Always_adaptive
+
+type thinking_control_format_fields =
+  { label : string
+  ; token : string option
+  }
+
+type thinking_control_token_invalidity =
+  | Empty_token
+  | Leading_or_trailing_whitespace
+
+type thinking_control_format_codec_error =
+  | Unknown_label of string
+  | Token_required
+  | Token_forbidden
+  | Invalid_token of
+      { token : string
+      ; invalidity : thinking_control_token_invalidity
+      }
+
+val structured_output_support_to_string : structured_output_support -> string
+val anthropic_thinking_control_values : string list
+val anthropic_thinking_control_of_string : string -> anthropic_thinking_control option
+val canonical_label_of_thinking_control_format : thinking_control_format -> string
+val thinking_control_format_values : string list
+val token_of_thinking_control_format : thinking_control_format -> string option
+
+val encode_thinking_control_format
+  :  thinking_control_format
+  -> (thinking_control_format_fields, thinking_control_format_codec_error) result
+
+val decode_thinking_control_format
+  :  thinking_control_format_fields
+  -> (thinking_control_format, thinking_control_format_codec_error) result
+
+val decode_optional_thinking_control_format
+  :  label:string option
+  -> token:string option
+  -> (thinking_control_format option, thinking_control_format_codec_error) result
+
+val thinking_control_format_codec_error_to_string
+  :  thinking_control_format_codec_error
+  -> string
+
+val preserve_wire_owns_thinking_object : preserve_thinking_control_format -> bool
+val preserve_thinking_control_format_values : string list
+
+val preserve_thinking_control_format_of_string
+  :  string
+  -> preserve_thinking_control_format option
+
+val modality_priority_values : string list
+val task_values : string list
+val task_of_string : string -> task option
+val task_to_string : task -> string
+val reasoning_replay_values : string list
+val reasoning_replay_override_of_string : string -> reasoning_replay_override option
+val assistant_tool_content_format_values : string list
+
+val assistant_tool_content_format_of_string
+  :  string
+  -> assistant_tool_content_format option
+
+val reasoning_output_format_values : string list
+val reasoning_output_format_of_string : string -> reasoning_output_format option
+val reasoning_streaming_format_values : string list
+val reasoning_streaming_format_syntax : string
+val reasoning_streaming_format_of_string : string -> reasoning_streaming_format option
+val sampling_parameter_values : string list
+val sampling_parameter_of_string : string -> sampling_parameter option
+val sampling_parameter_to_string : sampling_parameter -> string
+val base_label_values : string list
+val capability_fields : string list

--- a/lib/llm_provider/provider_catalog.ml
+++ b/lib/llm_provider/provider_catalog.ml
@@ -334,52 +334,6 @@ let provider_fields =
 
 let auth_fields = [ "type"; "env"; "key"; "path"; "command" ]
 
-let capability_fields =
-  [ "max_context_tokens"
-  ; "max_output_tokens"
-  ; "supports_tools"
-  ; "supports_tool_choice"
-  ; "supports_required_tool_choice"
-  ; "supports_named_tool_choice"
-  ; "supports_parallel_tool_calls"
-  ; "assistant_tool_content_format"
-  ; "supports_reasoning"
-  ; "supports_extended_thinking"
-  ; "supports_reasoning_budget"
-  ; "accepted_reasoning_efforts"
-  ; "thinking_control_format"
-  ; "thinking_control_token"
-  ; "preserve_thinking_control_format"
-  ; "reasoning_output_format"
-  ; "reasoning_streaming_format"
-  ; "reasoning_replay"
-  ; "supports_response_format_json"
-  ; "supports_structured_output"
-  ; "supports_multimodal_inputs"
-  ; "supports_image_input"
-  ; "supports_audio_input"
-  ; "supports_video_input"
-  ; "supports_document_input"
-  ; "modality_priority"
-  ; "supports_native_streaming"
-  ; "supports_system_prompt"
-  ; "supports_caching"
-  ; "supports_prompt_caching"
-  ; "prompt_cache_alignment"
-  ; "supports_top_k"
-  ; "supports_min_p"
-  ; "supports_seed"
-  ; "supports_seed_with_images"
-  ; "ignored_sampling_parameters"
-  ; "supports_computer_use"
-  ; "supports_code_execution"
-  ; "emits_usage_tokens"
-  ; "supported_models"
-  ; "supports_runtime_mcp_tools"
-  ; "supports_runtime_tool_events"
-  ]
-;;
-
 let auth_env = function
   | Api_key_env env | Setup_token_env env -> env
   | No_auth -> ""
@@ -604,7 +558,7 @@ let parse_capabilities provider_json =
       let* () =
         validate_object_fields
           ~scope:"provider catalog capabilities"
-          ~known:capability_fields
+          ~known:Capability_vocab.capability_fields
           cap_json
       in
       Ok cap_json


### PR DESCRIPTION
## Summary
- move `capability_fields` from the provider catalog into the existing capability vocabulary leaf
- add an explicit `Capability_vocab` interface without narrowing the consumed surface
- restore the code-smell ratchet by real source decomposition, without a baseline edit or waiver

## Evidence
- focused library build passed
- provider catalog coverage: 17/17
- ratchet: godfile 11/11; all metrics pass
- `@fmt` and `git diff --check` passed

## Context
This repairs mainline drift introduced when `provider_catalog.ml` crossed 1000 lines. It unblocks #2761 without hiding new debt. Ratchet governance follow-up: #2762.