### PR TITLE
fix(llm_provider): support stop_reason provider dialects and preserve empty completion stop_reason in GLM parser

### DIFF
--- a/lib/llm_provider/backend_glm.ml
+++ b/lib/llm_provider/backend_glm.ml
@@ -284,10 +284,13 @@ let parse_response body =
   match parse_response_result body with
   | Ok resp -> resp
   | Error (Backend_openai_parse.Provider_error msg) -> raise (glm_parse_error msg)
-  | Error (Backend_openai_parse.Empty_completion _) ->
+  | Error (Backend_openai_parse.Empty_completion empty_comp) ->
+    let stop_reason_str = Types.stop_reason_to_string empty_comp.stop_reason in
     raise
       (glm_parse_error
-         "provider returned an empty assistant turn (no thinking, text, or tool calls)")
+         (Printf.sprintf
+            "empty completion (stop_reason=%s): provider returned an empty assistant turn"
+            stop_reason_str))
 ;;
 
 (* ── Streaming ───────────────────────────────────── *)

--- a/lib/llm_provider/stop_reason_wire.ml
+++ b/lib/llm_provider/stop_reason_wire.ml
@@ -11,16 +11,20 @@ type wire_finish =
 let wire_finish_of_string s =
   match String.lowercase_ascii s with
   | "tool_calls" -> Tool_calls
-  | "length" -> Length
+  | "length" | "max_tokens" | "length_limit" -> Length
   | "stop" | "end_turn" -> Stop
   | "refusal" -> Refusal
   | "content_filter" -> Content_filter
   | "repetition_truncation" -> Repetition_truncation
   (* SSOT parity with [Types.stop_reason_of_string]: the OpenAI/GLM finish-reason
-     decoder must recognize the canonical overflow token so an empty completion
-     that reports it reaches [Retry.overflow_of_empty_completion] as
-     [ContextWindowExceeded] instead of the [Unknown _] dead arm. *)
-  | "model_context_window_exceeded" -> Context_window_exceeded
+     decoder must recognize canonical and provider-dialect overflow tokens so an
+     empty completion that reports it reaches [Retry.overflow_of_empty_completion]
+     as [ContextWindowExceeded] instead of the [Unknown _] dead arm. *)
+  | "model_context_window_exceeded"
+  | "context_window_exceeded"
+  | "context_length_exceeded"
+  | "max_context_length"
+  | "context_limit_exceeded" -> Context_window_exceeded
   | other -> Other other
 ;;
 

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -589,14 +589,18 @@ type stop_reason =
 let stop_reason_of_string = function
   | "end_turn" -> EndTurn
   | "tool_use" -> StopToolUse
-  | "max_tokens" -> MaxTokens
+  | "max_tokens" | "length" | "length_limit" -> MaxTokens
   | "stop_sequence" -> StopSequence
   | "refusal" -> Refusal
   | "content_filter" -> ContentFilter
   | "repetition_truncation" -> RepetitionTruncation
   | "pause_turn" -> PauseTurn
   | "compaction" -> Compaction
-  | "model_context_window_exceeded" -> ContextWindowExceeded
+  | "model_context_window_exceeded"
+  | "context_window_exceeded"
+  | "context_length_exceeded"
+  | "max_context_length"
+  | "context_limit_exceeded" -> ContextWindowExceeded
   | "unmatched_tool_calls" -> UnmatchedToolCalls
   | other -> Unknown other
 ;;

--- a/test/test_stop_reason_ssot.ml
+++ b/test/test_stop_reason_ssot.ml
@@ -94,17 +94,43 @@ let test_metric_label () =
     (Types.stop_reason_to_metric_label (Types.Unknown "anything_at_all"))
 ;;
 
+let test_dialects_mapped_to_canonical () =
+  let cases =
+    [ "context_window_exceeded", Types.ContextWindowExceeded
+    ; "context_length_exceeded", Types.ContextWindowExceeded
+    ; "max_context_length", Types.ContextWindowExceeded
+    ; "context_limit_exceeded", Types.ContextWindowExceeded
+    ; "length_limit", Types.MaxTokens
+    ; "length", Types.MaxTokens
+    ]
+  in
+  List.iter
+    (fun (raw, expected) ->
+       check
+         stop_reason_testable
+         (Printf.sprintf "dialect %S maps to %s" raw (Types.show_stop_reason expected))
+         expected
+         (Types.stop_reason_of_string raw);
+       check
+         stop_reason_testable
+         (Printf.sprintf
+            "wire_finish_of_string %S maps to %s"
+            raw
+            (Types.show_stop_reason expected))
+         expected
+         (Stop_reason_wire.provisional_of_string raw))
+    cases
+;;
+
 let () =
   run
     "stop_reason_ssot"
     [ ( "canonical"
-      , [ test_case "roundtrip known variants" `Quick test_roundtrip_known
-        ; test_case
-            "unknown passthrough roundtrip"
-            `Quick
-            test_roundtrip_unknown_passthrough
-        ; test_case "pinned canonical strings" `Quick test_canonical_strings_pinned
-        ; test_case "metric label semantics" `Quick test_metric_label
+      , [ test_case "roundtrip known" `Quick test_roundtrip_known
+        ; test_case "roundtrip unknown" `Quick test_roundtrip_unknown_passthrough
+        ; test_case "pinned strings" `Quick test_canonical_strings_pinned
+        ; test_case "metric label" `Quick test_metric_label
+        ; test_case "dialect aliases" `Quick test_dialects_mapped_to_canonical
         ] )
     ]
 ;;

--- a/test/test_streaming_edge_cases.ml
+++ b/test/test_streaming_edge_cases.ml
@@ -389,7 +389,9 @@ let test_openai_malformed_tool_call_shapes_fail_closed () =
 ;;
 
 let test_openai_blank_id_and_name_accepted_as_none () =
-  let raw = {|{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"","function":{"name":"","arguments":"\"argv\": "}}]}}]}|} in
+  let raw =
+    {|{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"","function":{"name":"","arguments":"\"argv\": "}}]}}]}|}
+  in
   let parsed = S.parse_openai_sse_chunk raw in
   match parsed with
   | S.Openai_chunk { delta_tool_calls = [ call ]; _ } ->


### PR DESCRIPTION
## Summary
This PR addresses two critical failure-handling gaps in OAS's stop_reason decoding pipeline:

1. **Provider Dialect Alignment (`types.ml` & `stop_reason_wire.ml`):**
   Added provider dialect aliases for `ContextWindowExceeded` (`context_window_exceeded`, `context_length_exceeded`, `max_context_length`, `context_limit_exceeded`) and `MaxTokens` (`length`, `length_limit`). Previously, non-standard finish/error reason strings emitted by providers like ZhipuAI/GLM, vLLM, or Kimi fell through to `Unknown _`, causing downstream orchestrators (MASC) to misclassify context overflow errors as transient errors and enter empty-turn/zombie retry loops.

2. **GLM Parse Exception Preservation (`backend_glm.ml`):**
   Updated `parse_response` in `backend_glm.ml` so that `Backend_openai_parse.Empty_completion` exceptions preserve the typed `stop_reason` in the exception string (`empty completion (stop_reason=...)`) rather than erasing it into a generic string.

## Verification
- Added `test_dialects_mapped_to_canonical` in `test/test_stop_reason_ssot.ml` verifying all dialect aliases map cleanly to canonical constructors (`ContextWindowExceeded`, `MaxTokens`).
- Ran `dune runtest` across all provider test suites (Anthropic, OpenAI, Gemini, Ollama, Pipeline, Provider) — 100% passed.