### PR TITLE
refactor!: make exact-output execution attempt-affine

### DIFF
--- a/lib/llm_provider/dune
+++ b/lib/llm_provider/dune
@@ -13,6 +13,7 @@
   prepared_completion_request
   http_client_phase_observer
   exact_output_catalog_binding
+  exact_output_call_id
   exact_output_resolver
   exact_output_execution
   exact_output_plan)
@@ -31,6 +32,7 @@
   tls-eio
   ca-certs
   digestif
+  mirage-crypto-rng.unix
   uri)
  (inline_tests)
  (preprocess

--- a/lib/llm_provider/exact_output.ml
+++ b/lib/llm_provider/exact_output.ml
@@ -37,8 +37,11 @@ type attempt_state =
   | Response_received_state of int option
   | Terminal_state of int
 
+type call_id = Call_id of string
+
 type receipt =
   { state : attempt_state Atomic.t
+  ; call_id : call_id
   ; plan_fingerprint : string
   ; request_body_sha256 : string
   ; catalog_generation : catalog_generation
@@ -49,6 +52,15 @@ type receipt =
 type ready_plan =
   { plan : Plan.t
   ; provenance : plan_provenance
+  ; plan_fingerprint : string
+  ; request_body_sha256 : string
+  ; catalog_generation : catalog_generation
+  ; catalog_evidence : catalog_evidence
+  ; target_identity : target_identity
+  }
+
+type attempt =
+  { ready : ready_plan
   ; receipt : receipt
   }
 
@@ -102,13 +114,15 @@ type execution_error_cause =
   | Internal_non_json_output
 
 type execution_error =
-  { receipt : receipt
+  { call_id : call_id
+  ; receipt : receipt
   ; cause : execution_error_cause
   ; raw_response : raw_response option
   }
 
 type success =
-  { receipt : receipt
+  { call_id : call_id
+  ; receipt : receipt
   ; output : Yojson.Safe.t
   ; provenance : plan_provenance
   ; raw_response : raw_response
@@ -417,20 +431,39 @@ let admit ~target ~messages requirement =
         ; catalog_evidence = target.evidence
         ; target_identity = target.identity
         }
-    ; receipt =
-        { state = Atomic.make Not_started_state
-        ; plan_fingerprint
-        ; request_body_sha256
-        ; catalog_generation = target.generation
-        ; catalog_evidence = target.evidence
-        ; target_identity = target.identity
-        }
+    ; plan_fingerprint
+    ; request_body_sha256
+    ; catalog_generation = target.generation
+    ; catalog_evidence = target.evidence
+    ; target_identity = target.identity
     })
 ;;
 
 let plan_provenance (ready : ready_plan) = ready.provenance
-let plan_fingerprint (ready : ready_plan) = ready.receipt.plan_fingerprint
-let attempt_receipt (ready : ready_plan) = ready.receipt
+let plan_fingerprint (ready : ready_plan) = ready.plan_fingerprint
+
+type start_attempt_error = Call_id_generation_failed of string
+
+let start_attempt (ready : ready_plan) =
+  match Exact_output_call_id.create () with
+  | Error detail -> Error (Call_id_generation_failed detail)
+  | Ok id ->
+    let receipt =
+      { state = Atomic.make Not_started_state
+      ; call_id = Call_id id
+      ; plan_fingerprint = ready.plan_fingerprint
+      ; request_body_sha256 = ready.request_body_sha256
+      ; catalog_generation = ready.catalog_generation
+      ; catalog_evidence = ready.catalog_evidence
+      ; target_identity = ready.target_identity
+      }
+    in
+    Ok { ready; receipt }
+;;
+
+let call_id_to_string (Call_id id) = id
+let attempt_receipt (attempt : attempt) = attempt.receipt
+let receipt_call_id (receipt : receipt) = receipt.call_id
 
 let receipt_phase receipt =
   match Atomic.get receipt.state with
@@ -519,43 +552,50 @@ let execution_error_cause = function
   | Exec.Output_normalization_failed (Exec.Invalid_json _) -> Invalid_json_output
 ;;
 
-let execute_once ~net ?clock (ready : ready_plan) =
-  if
-    not
-      (Atomic.compare_and_set ready.receipt.state Not_started_state Before_dispatch_state)
+let execute_once ~net ?clock (attempt : attempt) =
+  let ready = attempt.ready in
+  let receipt = attempt.receipt in
+  if not (Atomic.compare_and_set receipt.state Not_started_state Before_dispatch_state)
   then
     Error
-      { receipt = ready.receipt; cause = Attempt_already_started; raw_response = None }
+      { call_id = receipt.call_id
+      ; receipt
+      ; cause = Attempt_already_started
+      ; raw_response = None
+      }
   else (
     match
       Exec.execute_once_with_evidence
         ~net
         ?clock
-        ~on_phase:(observe_phase ready.receipt)
+        ~on_phase:(observe_phase receipt)
         ready.plan
     with
     | Error
-        ({ receipt; cause; raw_response = evidence } :
+        ({ receipt = complete_receipt; cause; raw_response = evidence } :
           Exec.execute_once_error_with_evidence) ->
-      synchronize_receipt ready.receipt receipt;
+      synchronize_receipt receipt complete_receipt;
       Error
-        { receipt = ready.receipt
+        { call_id = receipt.call_id
+        ; receipt
         ; cause = execution_error_cause cause
         ; raw_response = Option.map raw_response evidence
         }
     | Ok { outcome; raw_response = evidence } ->
-      synchronize_receipt ready.receipt outcome.receipt;
+      synchronize_receipt receipt outcome.receipt;
       (match outcome.output with
        | Exec.Json_output { value; _ } ->
          Ok
-           { receipt = ready.receipt
+           { call_id = receipt.call_id
+           ; receipt
            ; output = value
            ; provenance = ready.provenance
            ; raw_response = raw_response evidence
            }
        | Exec.Text_output _ ->
          Error
-           { receipt = ready.receipt
+           { call_id = receipt.call_id
+           ; receipt
            ; cause = Internal_non_json_output
            ; raw_response = Some (raw_response evidence)
            }))

--- a/lib/llm_provider/exact_output.ml
+++ b/lib/llm_provider/exact_output.ml
@@ -487,11 +487,11 @@ let receipt_http_status receipt =
   | Not_started_state | Before_dispatch_state | Dispatch_started_state -> None
 ;;
 
-let receipt_plan_fingerprint receipt = receipt.plan_fingerprint
-let receipt_request_body_sha256 receipt = receipt.request_body_sha256
-let receipt_catalog_generation receipt = receipt.catalog_generation
-let receipt_catalog_evidence receipt = receipt.catalog_evidence
-let receipt_target_identity receipt = receipt.target_identity
+let receipt_plan_fingerprint (receipt : receipt) = receipt.plan_fingerprint
+let receipt_request_body_sha256 (receipt : receipt) = receipt.request_body_sha256
+let receipt_catalog_generation (receipt : receipt) = receipt.catalog_generation
+let receipt_catalog_evidence (receipt : receipt) = receipt.catalog_evidence
+let receipt_target_identity (receipt : receipt) = receipt.target_identity
 
 let state_rank = function
   | Not_started_state -> 0

--- a/lib/llm_provider/exact_output.mli
+++ b/lib/llm_provider/exact_output.mli
@@ -18,7 +18,9 @@ type target_identity
 type selected_target
 type output_requirement
 type ready_plan
+type attempt
 type receipt
+type call_id
 type schema_fingerprint
 type resolver_io = { getenv : string -> (string option, unit) result }
 
@@ -172,13 +174,15 @@ type execution_error_cause =
   | Internal_non_json_output
 
 type execution_error =
-  { receipt : receipt
+  { call_id : call_id
+  ; receipt : receipt
   ; cause : execution_error_cause
   ; raw_response : raw_response option
   }
 
 type success =
-  { receipt : receipt
+  { call_id : call_id
+  ; receipt : receipt
   ; output : Yojson.Safe.t
   ; provenance : plan_provenance
   ; raw_response : raw_response
@@ -245,7 +249,17 @@ val admit
 val plan_provenance : ready_plan -> plan_provenance
 val plan_fingerprint : ready_plan -> string
 val schema_fingerprint_to_string : schema_fingerprint -> string
-val attempt_receipt : ready_plan -> receipt
+
+type start_attempt_error = Call_id_generation_failed of string
+
+(** Allocate a fresh, independent execution attempt for an admitted plan.
+    [admit] remains pure and the same immutable plan may start multiple attempts.
+    Each attempt owns an opaque call identity and affine execution state. *)
+val start_attempt : ready_plan -> (attempt, start_attempt_error) result
+
+val call_id_to_string : call_id -> string
+val attempt_receipt : attempt -> receipt
+val receipt_call_id : receipt -> call_id
 val receipt_phase : receipt -> effect_phase
 val receipt_dispatch_count : receipt -> int
 val receipt_http_status : receipt -> int option
@@ -255,8 +269,8 @@ val receipt_catalog_generation : receipt -> catalog_generation
 val receipt_catalog_evidence : receipt -> catalog_evidence
 val receipt_target_identity : receipt -> target_identity
 
-(** Execute the frozen request once. The plan is a single-use attempt:
-    duplicate or concurrent invocation is rejected before a second dispatch.
+(** Execute the frozen request once. The attempt is single-use: duplicate or
+    concurrent invocation of the same attempt is rejected before a second dispatch.
     Obtain {!attempt_receipt} before entering a cancellation scope; its phase is
     monotonic and remains queryable if cancellation escapes this function. The
     sole invocation performs at most one outward completion POST and never
@@ -264,5 +278,5 @@ val receipt_target_identity : receipt -> target_identity
 val execute_once
   :  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> ?clock:_ Eio.Time.clock
-  -> ready_plan
+  -> attempt
   -> (success, execution_error) result

--- a/lib/llm_provider/exact_output_call_id.ml
+++ b/lib/llm_provider/exact_output_call_id.ml
@@ -1,0 +1,29 @@
+(** Private exact-output call identity generation.
+
+    Every identifier is sampled independently from 128 bits of operating-system
+    entropy. Entropy failure is explicit and never falls back to clocks,
+    counters, process IDs, paths, or content-derived identities. *)
+
+let hex_digit value =
+  if value < 10
+  then Char.chr (Char.code '0' + value)
+  else Char.chr (Char.code 'a' + value - 10)
+;;
+
+let hex_of_string value =
+  let encoded = Bytes.create (String.length value * 2) in
+  String.iteri
+    (fun index byte ->
+       let value = Char.code byte in
+       Bytes.set encoded (index * 2) (hex_digit (value lsr 4));
+       Bytes.set encoded ((index * 2) + 1) (hex_digit (value land 0x0f)))
+    value;
+  Bytes.unsafe_to_string encoded
+;;
+
+let create () =
+  try Ok (Mirage_crypto_rng_unix.getrandom 16 |> hex_of_string) with
+  | exn ->
+    Reserved_exn.reraise_if_reserved exn;
+    Error ("operating-system entropy unavailable: " ^ Printexc.to_string exn)
+;;

--- a/test/test_exact_output_resolver_snapshot.ml
+++ b/test/test_exact_output_resolver_snapshot.ml
@@ -154,6 +154,13 @@ let ready target =
   | Error _ -> fail "exact target should admit"
 ;;
 
+let attempt ready =
+  match EO.start_attempt ready with
+  | Ok attempt -> attempt
+  | Error (EO.Call_id_generation_failed detail) ->
+    failf "exact attempt identity allocation failed: %s" detail
+;;
+
 let generation snapshot =
   EO.resolver_catalog_generation snapshot |> EO.catalog_generation_fingerprint
 ;;
@@ -182,7 +189,7 @@ type frozen_observation =
 let frozen_observation snapshot target =
   let plan = ready target in
   let provenance = EO.plan_provenance plan in
-  let receipt = EO.attempt_receipt plan in
+  let receipt = EO.attempt_receipt (attempt plan) in
   { snapshot_generation = generation snapshot
   ; snapshot_evidence = evidence snapshot
   ; selected_generation =

--- a/test/test_exact_output_single_surface.ml
+++ b/test/test_exact_output_single_surface.ml
@@ -1094,7 +1094,7 @@ let test_parallel_attempts_from_one_plan_do_not_share_identity_or_state () =
   in
   check int "parallel attempts dispatch independently" 2 posts;
   let check_success label expected_id = function
-    | Ok success ->
+    | Ok (success : EO.success) ->
       check string label expected_id (EO.call_id_to_string success.call_id);
       check
         string

--- a/test/test_exact_output_single_surface.ml
+++ b/test/test_exact_output_single_surface.ml
@@ -509,6 +509,13 @@ let assert_absent json field =
   | _ -> fail "captured request body must be a JSON object"
 ;;
 
+let attempt ready =
+  match EO.start_attempt ready with
+  | Ok attempt -> attempt
+  | Error (EO.Call_id_generation_failed detail) ->
+    failf "exact attempt identity allocation failed: %s" detail
+;;
+
 let test_no_measure_one_post_and_wire_authority () =
   let run ?(domain_schema = schema) ~id ~kind ~path ~response inspect =
     let (provenance, plan_fingerprint, result), completion_posts, token_posts, captures =
@@ -526,7 +533,9 @@ let test_no_measure_one_post_and_wire_authority () =
       with_catalog [ entry ]
       @@ fun snapshot ->
       let ready = plan_for_schema snapshot id domain_schema EO.Json_syntax in
-      EO.plan_provenance ready, EO.plan_fingerprint ready, EO.execute_once ~net ready
+      ( EO.plan_provenance ready
+      , EO.plan_fingerprint ready
+      , EO.execute_once ~net (attempt ready) )
     in
     check int (id ^ " completion posts") 1 completion_posts;
     check int (id ^ " token posts") 0 token_posts;
@@ -556,6 +565,11 @@ let test_no_measure_one_post_and_wire_authority () =
         (success.output = `Assoc [ "name", `String "accepted" ]);
       check string (id ^ " raw body") response success.raw_response.body;
       check int (id ^ " receipt dispatch") 1 (EO.receipt_dispatch_count success.receipt);
+      check
+        string
+        (id ^ " stable call identity")
+        (EO.call_id_to_string success.call_id)
+        (EO.receipt_call_id success.receipt |> EO.call_id_to_string);
       check
         string
         (id ^ " receipt plan fingerprint")
@@ -638,12 +652,17 @@ let test_response_received_error_evidence_matrix () =
       in
       with_catalog [ entry ]
       @@ fun snapshot ->
-      EO.execute_once ~net (plan snapshot "error-surface" EO.Json_syntax)
+      EO.execute_once ~net (attempt (plan snapshot "error-surface" EO.Json_syntax))
     in
     check int (label ^ " dispatches once") 1 posts;
     match result with
-    | Error { EO.receipt; cause; raw_response = Some raw } ->
+    | Error { EO.call_id; receipt; cause; raw_response = Some raw } ->
       check bool (label ^ " typed cause") true (matches_cause cause);
+      check
+        string
+        (label ^ " stable call identity")
+        (EO.call_id_to_string call_id)
+        (EO.receipt_call_id receipt |> EO.call_id_to_string);
       check string (label ^ " lossless body") response raw.body;
       check
         string
@@ -695,11 +714,12 @@ let test_public_receipt_phase_matrix () =
     in
     with_catalog [ entry ]
     @@ fun snapshot ->
-    EO.execute_once ~net (plan snapshot "pre-dispatch-surface" EO.Json_syntax)
+    EO.execute_once ~net (attempt (plan snapshot "pre-dispatch-surface" EO.Json_syntax))
   in
   check int "pre-dispatch has zero POSTs" 0 pre_posts;
   (match pre_result with
-   | Error { EO.receipt; cause = EO.Clock_required_for_timeout; raw_response = None } ->
+   | Error { EO.receipt; cause = EO.Clock_required_for_timeout; raw_response = None; _ }
+     ->
      check_receipt
        "pre-dispatch"
        ~phase:EO.Before_dispatch
@@ -720,11 +740,12 @@ let test_public_receipt_phase_matrix () =
         ()
     in
     with_catalog [ entry ]
-    @@ fun snapshot -> EO.execute_once ~net (plan snapshot "abort-surface" EO.Json_syntax)
+    @@ fun snapshot ->
+    EO.execute_once ~net (attempt (plan snapshot "abort-surface" EO.Json_syntax))
   in
   check int "abort observes one POST" 1 abort_posts;
   (match abort_result with
-   | Error { EO.receipt; cause = EO.Completion_failed; raw_response = None } ->
+   | Error { EO.receipt; cause = EO.Completion_failed; raw_response = None; _ } ->
      check_receipt
        "abort"
        ~phase:EO.Dispatch_started
@@ -745,7 +766,8 @@ let test_public_receipt_phase_matrix () =
         ()
     in
     with_catalog [ entry ]
-    @@ fun snapshot -> EO.execute_once ~net (plan snapshot "rate-surface" EO.Json_syntax)
+    @@ fun snapshot ->
+    EO.execute_once ~net (attempt (plan snapshot "rate-surface" EO.Json_syntax))
   in
   check int "429 observes one POST" 1 rate_posts;
   (match rate_result with
@@ -753,6 +775,7 @@ let test_public_receipt_phase_matrix () =
        { EO.receipt
        ; cause = EO.Completion_failed
        ; raw_response = Some { body = "rate limited"; _ }
+       ; _
        } ->
      check_receipt
        "429"
@@ -776,13 +799,14 @@ let test_public_receipt_phase_matrix () =
     with_catalog [ entry ]
     @@ fun snapshot ->
     let ready = plan snapshot "terminal-surface" EO.Json_syntax in
+    let execution = attempt ready in
     check_receipt
       "not-started"
       ~phase:EO.Not_started
       ~dispatch_count:0
       ~http_status:None
-      (EO.attempt_receipt ready);
-    EO.execute_once ~net ready
+      (EO.attempt_receipt execution);
+    EO.execute_once ~net execution
   in
   check int "terminal observes one POST" 1 terminal_posts;
   match terminal_result with
@@ -815,7 +839,9 @@ let test_reasoning_response_bytes_do_not_enter_json_output () =
     in
     with_catalog [ entry ]
     @@ fun snapshot ->
-    EO.execute_once ~net (plan snapshot "reasoning-response-surface" EO.Json_syntax)
+    EO.execute_once
+      ~net
+      (attempt (plan snapshot "reasoning-response-surface" EO.Json_syntax))
   in
   check int "reasoning response dispatches once" 1 posts;
   match result with
@@ -938,11 +964,13 @@ let test_normalization_error_classes () =
       in
       with_catalog [ entry ]
       @@ fun snapshot ->
-      EO.execute_once ~net (plan snapshot "normalization-surface" EO.Json_syntax)
+      EO.execute_once
+        ~net
+        (attempt (plan snapshot "normalization-surface" EO.Json_syntax))
     in
     check int (label ^ " dispatches once") 1 posts;
     match result with
-    | Error { EO.receipt; cause; raw_response = Some _ } ->
+    | Error { EO.receipt; cause; raw_response = Some _; _ } ->
       check bool (label ^ " typed cause") true (matches cause);
       check
         (option int)
@@ -977,7 +1005,7 @@ let test_normalization_error_classes () =
     | _ -> false)
 ;;
 
-let test_plan_rejects_concurrent_duplicate_before_second_dispatch () =
+let test_attempt_rejects_concurrent_duplicate_before_second_dispatch () =
   let response = openai_response {|{"name":"accepted"}|} in
   let (first, second), posts, _, _ =
     with_server ~response
@@ -994,11 +1022,12 @@ let test_plan_rejects_concurrent_duplicate_before_second_dispatch () =
     with_catalog [ entry ]
     @@ fun snapshot ->
     let ready = plan snapshot "concurrent-surface" EO.Json_syntax in
+    let execution = attempt ready in
     let first_promise, first_resolver = Eio.Promise.create () in
     let second_promise, second_resolver = Eio.Promise.create () in
     Eio.Fiber.both
-      (fun () -> EO.execute_once ~net ready |> Eio.Promise.resolve first_resolver)
-      (fun () -> EO.execute_once ~net ready |> Eio.Promise.resolve second_resolver);
+      (fun () -> EO.execute_once ~net execution |> Eio.Promise.resolve first_resolver)
+      (fun () -> EO.execute_once ~net execution |> Eio.Promise.resolve second_resolver);
     Eio.Promise.await first_promise, Eio.Promise.await second_promise
   in
   check int "one concurrent completion post" 1 posts;
@@ -1013,6 +1042,69 @@ let test_plan_rejects_concurrent_duplicate_before_second_dispatch () =
   in
   check int "one concurrent success" 1 successes;
   check int "one concurrent duplicate" 1 duplicates
+;;
+
+let test_parallel_attempts_from_one_plan_do_not_share_identity_or_state () =
+  let response = openai_response {|{"name":"accepted"}|} in
+  let (first_id, first, second_id, second), posts, _, _ =
+    with_server ~response
+    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
+    let entry =
+      catalog_entry
+        ~id:"parallel-attempt-surface"
+        ~kind:Provider_config.OpenAI_compat
+        ~base_url
+        ~request_path:"/v1/chat/completions"
+        ~capabilities:(capabilities ~native:true ~json:true)
+        ()
+    in
+    with_catalog [ entry ]
+    @@ fun snapshot ->
+    let ready = plan snapshot "parallel-attempt-surface" EO.Json_syntax in
+    let first_attempt = attempt ready in
+    let second_attempt = attempt ready in
+    let first_receipt = EO.attempt_receipt first_attempt in
+    let second_receipt = EO.attempt_receipt second_attempt in
+    let first_id = EO.receipt_call_id first_receipt |> EO.call_id_to_string in
+    let second_id = EO.receipt_call_id second_receipt |> EO.call_id_to_string in
+    check
+      bool
+      "parallel call identities differ"
+      true
+      (not (String.equal first_id second_id));
+    check_receipt
+      "first parallel attempt starts fresh"
+      ~phase:EO.Not_started
+      ~dispatch_count:0
+      ~http_status:None
+      first_receipt;
+    check_receipt
+      "second parallel attempt starts fresh"
+      ~phase:EO.Not_started
+      ~dispatch_count:0
+      ~http_status:None
+      second_receipt;
+    let first_promise, first_resolver = Eio.Promise.create () in
+    let second_promise, second_resolver = Eio.Promise.create () in
+    Eio.Fiber.both
+      (fun () -> EO.execute_once ~net first_attempt |> Eio.Promise.resolve first_resolver)
+      (fun () ->
+         EO.execute_once ~net second_attempt |> Eio.Promise.resolve second_resolver);
+    first_id, Eio.Promise.await first_promise, second_id, Eio.Promise.await second_promise
+  in
+  check int "parallel attempts dispatch independently" 2 posts;
+  let check_success label expected_id = function
+    | Ok success ->
+      check string label expected_id (EO.call_id_to_string success.call_id);
+      check
+        string
+        (label ^ " receipt")
+        expected_id
+        (EO.receipt_call_id success.receipt |> EO.call_id_to_string)
+    | Error _ -> fail (label ^ " should succeed independently")
+  in
+  check_success "first parallel identity" first_id first;
+  check_success "second parallel identity" second_id second
 ;;
 
 let test_cancellation_leaves_queryable_monotonic_receipt () =
@@ -1032,16 +1124,17 @@ let test_cancellation_leaves_queryable_monotonic_receipt () =
     with_catalog [ entry ]
     @@ fun snapshot ->
     let ready = plan snapshot "cancel-surface" EO.Json_syntax in
-    let receipt = EO.attempt_receipt ready in
+    let execution = attempt ready in
+    let receipt = EO.attempt_receipt execution in
     let timed_out =
       match
-        Eio.Time.with_timeout clock 0.01 (fun () -> Ok (EO.execute_once ~net ready))
+        Eio.Time.with_timeout clock 0.01 (fun () -> Ok (EO.execute_once ~net execution))
       with
       | Error `Timeout -> true
       | Ok (Ok _ | Error _) -> false
     in
     let phase = EO.receipt_phase receipt in
-    let duplicate = EO.execute_once ~net ready in
+    let duplicate = EO.execute_once ~net execution in
     timed_out, phase, duplicate
   in
   check bool "caller cancellation observed" true timed_out;
@@ -1129,11 +1222,12 @@ let test_body_cancellation_retains_response_status () =
     with_catalog [ entry ]
     @@ fun snapshot ->
     let ready = plan snapshot "body-cancel-surface" EO.Json_syntax in
-    let receipt = EO.attempt_receipt ready in
+    let execution = attempt ready in
+    let receipt = EO.attempt_receipt execution in
     let timed_out =
       try
         match
-          Eio.Time.with_timeout_exn clock 0.05 (fun () -> EO.execute_once ~net ready)
+          Eio.Time.with_timeout_exn clock 0.05 (fun () -> EO.execute_once ~net execution)
         with
         | Ok _ | Error _ -> false
       with
@@ -1224,7 +1318,7 @@ let test_overlay_endpoint_and_credential_are_materialized () =
       | Ok ready -> ready
       | Error _ -> fail "environment target should admit"
     in
-    EO.execute_once ~net ready
+    EO.execute_once ~net (attempt ready)
   in
   check int "environment target dispatches once" 1 posts;
   (match result with
@@ -1316,8 +1410,8 @@ let test_credential_rotation_keeps_snapshot_bound_wire_authority () =
       | Ok ready -> ready
       | Error _ -> fail "credential rotation target should admit a request"
     in
-    let result_a = EO.execute_once ~net (ready target_a) in
-    let result_b = EO.execute_once ~net (ready target_b) in
+    let result_a = EO.execute_once ~net (attempt (ready target_a)) in
+    let result_b = EO.execute_once ~net (attempt (ready target_b)) in
     result_a, result_b
   in
   check int "two frozen credential plans dispatch once each" 2 posts;
@@ -1359,7 +1453,7 @@ let test_identity_survives_success_error_and_cancellation () =
       with_catalog [ entry ]
       @@ fun snapshot ->
       let ready = plan snapshot "identity-surface" EO.Json_syntax in
-      EO.plan_provenance ready, EO.execute_once ~net ready
+      EO.plan_provenance ready, EO.execute_once ~net (attempt ready)
     in
     check int "identity path dispatches once" 1 posts;
     provenance, result
@@ -1370,13 +1464,24 @@ let test_identity_survives_success_error_and_cancellation () =
      check_receipt_provenance "success" success_provenance success.receipt;
      check
        string
+       "success call identity"
+       (EO.call_id_to_string success.call_id)
+       (EO.receipt_call_id success.receipt |> EO.call_id_to_string);
+     check
+       string
        "success result provenance identity"
        (EO.target_identity_fingerprint success_provenance.target_identity)
        (EO.target_identity_fingerprint success.provenance.target_identity)
    | Error _ -> fail "identity success fixture should succeed");
   let error_provenance, error = run ~status:`Too_many_requests "rate limited" in
   (match error with
-   | Error error -> check_receipt_provenance "error" error_provenance error.receipt
+   | Error error ->
+     check_receipt_provenance "error" error_provenance error.receipt;
+     check
+       string
+       "error call identity"
+       (EO.call_id_to_string error.call_id)
+       (EO.receipt_call_id error.receipt |> EO.call_id_to_string)
    | Ok _ -> fail "identity error fixture should fail");
   let (cancel_provenance, cancel_receipt, timed_out), posts, _, _ =
     with_server ~response_delay_s:0.1 ~response:(openai_response {|{"name":"accepted"}|})
@@ -1394,11 +1499,12 @@ let test_identity_survives_success_error_and_cancellation () =
     @@ fun snapshot ->
     let ready = plan snapshot "identity-cancel-surface" EO.Json_syntax in
     let provenance = EO.plan_provenance ready in
-    let receipt = EO.attempt_receipt ready in
+    let execution = attempt ready in
+    let receipt = EO.attempt_receipt execution in
     let timed_out =
       try
         match
-          Eio.Time.with_timeout_exn clock 0.01 (fun () -> EO.execute_once ~net ready)
+          Eio.Time.with_timeout_exn clock 0.01 (fun () -> EO.execute_once ~net execution)
         with
         | Ok _ | Error _ -> false
       with
@@ -1545,7 +1651,11 @@ let () =
         ; test_case
             "concurrent duplicate rejected"
             `Quick
-            test_plan_rejects_concurrent_duplicate_before_second_dispatch
+            test_attempt_rejects_concurrent_duplicate_before_second_dispatch
+        ; test_case
+            "parallel attempts do not share identity or state"
+            `Quick
+            test_parallel_attempts_from_one_plan_do_not_share_identity_or_state
         ; test_case
             "cancellation receipt"
             `Quick

--- a/test/test_exact_output_single_surface.ml
+++ b/test/test_exact_output_single_surface.ml
@@ -557,7 +557,7 @@ let test_no_measure_one_post_and_wire_authority () =
       ];
     inspect provenance body;
     match result with
-    | Ok success ->
+    | Ok (success : EO.success) ->
       check
         bool
         (id ^ " output")


### PR DESCRIPTION
## Summary

- keep `ready_plan` immutable and reusable
- add `start_attempt` as the sole constructor of call identity, receipt, and affine execution state
- make `execute_once` accept only an `attempt`
- reject a second or concurrent execution of the same attempt before dispatch
- keep separate attempts from one ready plan completely independent
- preserve receipt observation across cancellation and provider failures
- carry one OAS-owned call ID through success, error, receipt, and execution provenance

## Execution order

```text
opaque admitted_target
→ resolve_target
→ supported_models/capability admission
→ immutable ready_plan
→ start_attempt
→ call ID + fresh receipt + affine state
→ execute_once attempt
→ single CAS before dispatch
→ at most one provider request for that attempt
```

`ready_plan` contains no receipt, `Atomic.t`, call ID, or started flag. `start_attempt` may be called multiple times for deliberate independent attempts; each receives an independent call ID, receipt, and CAS state. Reusing one attempt is rejected deterministically.

## Cancellation and provenance

The caller can obtain `attempt_receipt` before entering a cancellable execution scope. Receipt transitions remain monotonic and inspectable if cancellation escapes. Call ID equality is proven across public result/error/receipt surfaces; callers must not synthesize or duplicate execution identity.

## Proofs

- same attempt concurrent execution produces at most one dispatch
- one plan creates parallel non-sharing attempts
- call IDs and receipts never alias across attempts
- cancellation preserves receipt observation
- membership/capability failure occurs before plan, attempt, call ID, or dispatch
- credential-rotation A/B snapshots use separate attempts and retain their own frozen wire authority

## Validation

- CI run 29967181414 passed OCaml 5.4.1, OCaml 5.5.0, lint, format, and all applicable boundary gates
- Code Smell Ratchet run 29967181367 passed
- independent hostile review found no P0/P1
- local build/tests intentionally not run per operator instruction; GitHub Actions are the validation authority

## Breaking change

- `execute_once` now requires `attempt`, not `ready_plan`
- receipt access moves from plan-time to `attempt_receipt`
- callers must call `start_attempt` and handle typed call-ID generation failure
- no compatibility shim preserves direct ready-plan execution

BREAKING CHANGE: exact-output execution is attempt-affine; callers must create an attempt with `start_attempt`, retain its receipt before cancellation, and execute that attempt exactly once.
