### PR TITLE
refactor!: bind exact-output admission to immutable catalog snapshots

### DIFF
--- a/lib/llm_provider/exact_output.mli
+++ b/lib/llm_provider/exact_output.mli
@@ -22,10 +22,18 @@ type receipt
 type schema_fingerprint
 type resolver_io = { getenv : string -> (string option, unit) result }
 
-type catalog_overlay =
+type catalog_document =
   { source : string
   ; contents : string
   }
+
+type catalog_overlay = catalog_document
+
+type resolver_catalog_input =
+  | Embedded_default
+  | Embedded_with_overlay of catalog_document
+  | Full_replacement of catalog_document
+  | Full_replacement_file of string
 
 type target_ref_error =
   | Empty_target_ref
@@ -33,6 +41,7 @@ type target_ref_error =
 
 type resolver_catalog_source =
   | Embedded_catalog
+  | Full_replacement_catalog
   | Overlay_catalog
 
 type resolver_collision =
@@ -57,6 +66,10 @@ type resolver_endpoint_error =
   | Invalid_gemini_model_path
 
 type resolver_snapshot_error =
+  | Catalog_read_failed of
+      { path : string
+      ; detail : string
+      }
   | Catalog_parse_failed of
       { source : resolver_catalog_source
       ; detail : string
@@ -94,6 +107,10 @@ type target_selection_error =
       { target_ref : string
       ; environment_variable : string
       }
+
+type target_catalog_admission_error =
+  | Target_ref_rejected of target_ref_error
+  | Target_not_in_catalog of string
 
 type wire_admission_error =
   | Capability_snapshot_missing
@@ -172,14 +189,18 @@ val target_ref : string -> (target_ref, target_ref_error) result
 
 val target_ref_id : target_ref -> string
 
-(** Parse the embedded catalog plus an optional OAS-owned overlay and freeze a
-    private immutable target map. [io.getenv] is consumed during this call and
-    is never retained. Overlay replacement is permitted only for the same
-    primary id; alias shadowing and ambiguous normalized identities fail
-    closed. *)
+(** Parse exactly one typed catalog input and freeze a private immutable target
+    map. The default input is the embedded OAS catalog. [Embedded_with_overlay]
+    applies the existing sparse exact-output overlay precedence to that
+    embedded base. A full replacement, supplied as owned bytes or a file path,
+    suppresses every embedded and overlay row; the input type provides no way
+    to combine a full replacement with an overlay.
+    [io.getenv] is consumed during this call and is never retained. Invalid
+    paths, syntax, bindings, collisions, and endpoint declarations fail closed;
+    no source falls back to the embedded catalog. *)
 val load_resolver_snapshot
   :  io:resolver_io
-  -> ?overlay:catalog_overlay
+  -> ?catalog:resolver_catalog_input
   -> unit
   -> (resolver_snapshot, resolver_snapshot_error) result
 
@@ -193,8 +214,16 @@ val selected_target_identity : selected_target -> target_identity
 val selected_target_catalog_generation : selected_target -> catalog_generation
 val selected_target_catalog_evidence : selected_target -> catalog_evidence
 
+(** Brand [value] and prove that its exact identity exists in [resolver_snapshot].
+    This does not inspect or require the target credential. *)
+val admit_target_ref
+  :  resolver_snapshot
+  -> string
+  -> (target_ref, target_catalog_admission_error) result
+
 (** Resolve exactly one frozen binding. This performs no environment, global,
-    alias, default-model, ranking, probing, or fallback lookup. *)
+    alias, default-model, ranking, probing, or fallback lookup. A missing frozen
+    credential is reported here, after catalog membership admission. *)
 val resolve_target
   :  resolver_snapshot
   -> target_ref

--- a/lib/llm_provider/exact_output.mli
+++ b/lib/llm_provider/exact_output.mli
@@ -206,7 +206,6 @@ val resolver_catalog_generation : resolver_snapshot -> catalog_generation
 val resolver_catalog_evidence : resolver_snapshot -> catalog_evidence
 val catalog_generation_fingerprint : catalog_generation -> string
 val catalog_evidence_sha256 : catalog_evidence -> string
-val target_identity_id : target_identity -> string
 val target_identity_fingerprint : target_identity -> string
 val selected_target_identity : selected_target -> target_identity
 val selected_target_catalog_generation : selected_target -> catalog_generation

--- a/lib/llm_provider/exact_output.mli
+++ b/lib/llm_provider/exact_output.mli
@@ -10,8 +10,8 @@
     tools, reasoning controls, token measurement, and retry/fallback are
     deliberately absent from this interface. *)
 
-type target_ref
 type resolver_snapshot
+type admitted_target
 type catalog_generation
 type catalog_evidence
 type target_identity
@@ -26,8 +26,6 @@ type catalog_document =
   { source : string
   ; contents : string
   }
-
-type catalog_overlay = catalog_document
 
 type resolver_catalog_input =
   | Embedded_default
@@ -80,18 +78,14 @@ type resolver_snapshot_error =
       }
   | Catalog_collision of resolver_collision
   | Target_binding_missing of
-      { target_ref : target_ref
+      { target_ref : string
       ; component : resolver_binding_component
       }
   | Target_endpoint_invalid of
-      { target_ref : target_ref
+      { target_ref : string
       ; cause : resolver_endpoint_error
       }
   | Environment_read_failed of { environment_variable : string }
-  | Target_credential_invalid of
-      { target_ref : target_ref
-      ; environment_variable : string
-      }
 
 type minimum_guarantee =
   | Json_syntax
@@ -102,8 +96,15 @@ type actual_assurance =
   | Provider_schema_requested
 
 type target_selection_error =
-  | Unknown_target of string
   | Missing_target_credential of
+      { target_ref : string
+      ; environment_variable : string
+      }
+  | Target_credential_invalid of
+      { target_ref : string
+      ; environment_variable : string
+      }
+  | Target_credential_read_failed of
       { target_ref : string
       ; environment_variable : string
       }
@@ -183,21 +184,18 @@ type success =
   ; raw_response : raw_response
   }
 
-(** Brand an exact target identifier. Path/query delimiters, whitespace,
-    controls, and non-ASCII bytes are rejected before lookup. *)
-val target_ref : string -> (target_ref, target_ref_error) result
-
-val target_ref_id : target_ref -> string
-
 (** Parse exactly one typed catalog input and freeze a private immutable target
     map. The default input is the embedded OAS catalog. [Embedded_with_overlay]
     applies the existing sparse exact-output overlay precedence to that
     embedded base. A full replacement, supplied as owned bytes or a file path,
     suppresses every embedded and overlay row; the input type provides no way
     to combine a full replacement with an overlay.
-    [io.getenv] is consumed during this call and is never retained. Invalid
-    paths, syntax, bindings, collisions, and endpoint declarations fail closed;
-    no source falls back to the embedded catalog. *)
+    [io.getenv] is observed exactly once per referenced environment name during
+    this call and is never retained. Invalid paths, syntax, bindings,
+    collisions, base-URL environment reads, and endpoint declarations fail
+    closed; missing, invalid, or read-failed credentials are instead frozen as
+    per-target outcomes for [resolve_target]. No source falls back to the
+    embedded catalog. *)
 val load_resolver_snapshot
   :  io:resolver_io
   -> ?catalog:resolver_catalog_input
@@ -208,26 +206,25 @@ val resolver_catalog_generation : resolver_snapshot -> catalog_generation
 val resolver_catalog_evidence : resolver_snapshot -> catalog_evidence
 val catalog_generation_fingerprint : catalog_generation -> string
 val catalog_evidence_sha256 : catalog_evidence -> string
-val target_identity_ref : target_identity -> target_ref
+val target_identity_id : target_identity -> string
 val target_identity_fingerprint : target_identity -> string
 val selected_target_identity : selected_target -> target_identity
 val selected_target_catalog_generation : selected_target -> catalog_generation
 val selected_target_catalog_evidence : selected_target -> catalog_evidence
 
-(** Brand [value] and prove that its exact identity exists in [resolver_snapshot].
-    This does not inspect or require the target credential. *)
+(** Validate [value], prove that its exact identity exists in [resolver_snapshot],
+    and capture that frozen target together with its catalog generation and
+    evidence. Credential outcomes are intentionally deferred to [resolve_target]. *)
 val admit_target_ref
   :  resolver_snapshot
   -> string
-  -> (target_ref, target_catalog_admission_error) result
+  -> (admitted_target, target_catalog_admission_error) result
 
-(** Resolve exactly one frozen binding. This performs no environment, global,
-    alias, default-model, ranking, probing, or fallback lookup. A missing frozen
-    credential is reported here, after catalog membership admission. *)
-val resolve_target
-  :  resolver_snapshot
-  -> target_ref
-  -> (selected_target, target_selection_error) result
+(** Resolve the binding captured by [admit_target_ref]. This performs no map,
+    environment, global, alias, default-model, ranking, probing, or fallback
+    lookup. It injects an available frozen secret into a fresh provider config,
+    or reports the frozen missing, invalid, or read-failed credential outcome. *)
+val resolve_target : admitted_target -> (selected_target, target_selection_error) result
 
 (** Brand an opaque domain JSON schema. OAS never interprets domain keys as a
     provider wire envelope; it always constructs the selected target's wire

--- a/lib/llm_provider/exact_output_resolver.ml
+++ b/lib/llm_provider/exact_output_resolver.ml
@@ -184,7 +184,6 @@ let catalog_generation_fingerprint (Catalog_generation value) = value
 let catalog_evidence_sha256 (Catalog_evidence value) = value
 let resolver_catalog_generation (snapshot : resolver_snapshot) = snapshot.generation
 let resolver_catalog_evidence (snapshot : resolver_snapshot) = snapshot.evidence
-let target_identity_id (identity : target_identity) = target_ref_id identity.target_ref
 let target_identity_fingerprint identity = identity.fingerprint
 let selected_target_identity (target : selected_target) = target.identity
 let selected_target_catalog_generation (target : selected_target) = target.generation

--- a/lib/llm_provider/exact_output_resolver.ml
+++ b/lib/llm_provider/exact_output_resolver.ml
@@ -19,10 +19,18 @@ type target_identity =
 
 type resolver_io = { getenv : string -> (string option, unit) result }
 
-type catalog_overlay =
+type catalog_document =
   { source : string
   ; contents : string
   }
+
+type catalog_overlay = catalog_document
+
+type resolver_catalog_input =
+  | Embedded_default
+  | Embedded_with_overlay of catalog_document
+  | Full_replacement of catalog_document
+  | Full_replacement_file of string
 
 type target_ref_error =
   | Empty_target_ref
@@ -30,6 +38,7 @@ type target_ref_error =
 
 type resolver_catalog_source =
   | Embedded_catalog
+  | Full_replacement_catalog
   | Overlay_catalog
 
 type resolver_collision =
@@ -54,6 +63,10 @@ type resolver_endpoint_error =
   | Invalid_gemini_model_path
 
 type resolver_snapshot_error =
+  | Catalog_read_failed of
+      { path : string
+      ; detail : string
+      }
   | Catalog_parse_failed of
       { source : resolver_catalog_source
       ; detail : string
@@ -116,6 +129,10 @@ type target_selection_error =
       { target_ref : string
       ; environment_variable : string
       }
+
+type target_catalog_admission_error =
+  | Target_ref_rejected of target_ref_error
+  | Target_not_in_catalog of string
 
 let ( let* ) = Result.bind
 let sha256 value = Digestif.SHA256.(to_hex (digest_string value))
@@ -680,31 +697,56 @@ let frozen_environment ~io names =
     (Ok String_map.empty)
 ;;
 
-let load_resolver_snapshot ~io ?overlay () =
+let read_full_replacement_file path =
+  let path = String.trim path in
+  if String.equal path ""
+  then Error (Catalog_read_failed { path; detail = "catalog path is empty" })
+  else (
+    try
+      Ok { source = path; contents = In_channel.with_open_bin path In_channel.input_all }
+    with
+    | exn ->
+      Reserved_exn.reraise_if_reserved exn;
+      Error (Catalog_read_failed { path; detail = Printexc.to_string exn }))
+;;
+
+let load_resolver_snapshot ~io ?(catalog = Embedded_default) () =
   let parse_model_catalog ~source ~parser_source contents =
     match Model_catalog.of_toml_string ~source:parser_source contents with
     | Ok catalog -> Ok catalog
     | Error detail -> Error (Catalog_parse_failed { source; detail })
   in
-  let embedded_contents = Model_catalog_embedded.contents in
-  let* embedded =
+  let embedded_document =
+    { source = "embedded exact-output catalog"
+    ; contents = Model_catalog_embedded.contents
+    }
+  in
+  let* base_source, base_document, overlay =
+    match catalog with
+    | Embedded_default -> Ok (Embedded_catalog, embedded_document, None)
+    | Embedded_with_overlay overlay ->
+      Ok (Embedded_catalog, embedded_document, Some overlay)
+    | Full_replacement document -> Ok (Full_replacement_catalog, document, None)
+    | Full_replacement_file path ->
+      let* document = read_full_replacement_file path in
+      Ok (Full_replacement_catalog, document, None)
+  in
+  let* base =
     parse_model_catalog
-      ~source:Embedded_catalog
-      ~parser_source:"embedded exact-output catalog"
-      embedded_contents
+      ~source:base_source
+      ~parser_source:base_document.source
+      base_document.contents
   in
-  let* embedded_targets =
-    parse_target_catalog ~source:Embedded_catalog embedded_contents
-  in
-  let* () = validate_catalog_source embedded embedded_targets in
+  let* base_targets = parse_target_catalog ~source:base_source base_document.contents in
+  let* () = validate_catalog_source base base_targets in
   let* catalog_models_and_targets =
     match overlay with
-    | None -> Ok (embedded, Model_catalog.model_entries embedded, embedded_targets)
+    | None -> Ok (base, Model_catalog.model_entries base, base_targets)
     | Some overlay ->
       let* overlay_catalog =
         parse_model_catalog
           ~source:Overlay_catalog
-          ~parser_source:"exact-output overlay"
+          ~parser_source:overlay.source
           overlay.contents
       in
       let* overlay_targets =
@@ -713,17 +755,17 @@ let load_resolver_snapshot ~io ?overlay () =
       let* () = validate_catalog_source overlay_catalog overlay_targets in
       let* () =
         validate_overlay_collisions
-          ~base:embedded
-          ~base_targets:embedded_targets
+          ~base
+          ~base_targets
           ~overlay:overlay_catalog
           ~overlay_targets
       in
       Ok
-        ( Model_catalog.merge ~base:embedded ~overlay:overlay_catalog
+        ( Model_catalog.merge ~base ~overlay:overlay_catalog
         , Binding.merge_exact_model_entries
-            ~base:(Model_catalog.model_entries embedded)
+            ~base:(Model_catalog.model_entries base)
             ~overlay:(Model_catalog.model_entries overlay_catalog)
-        , merge_target_declarations ~base:embedded_targets ~overlay:overlay_targets )
+        , merge_target_declarations ~base:base_targets ~overlay:overlay_targets )
   in
   let catalog, model_entries, target_declarations = catalog_models_and_targets in
   let* structural =
@@ -886,6 +928,15 @@ let load_resolver_snapshot ~io ?overlay () =
   in
   let evidence = Catalog_evidence (hash_parts evidence_material) in
   Ok { targets; generation; evidence }
+;;
+
+let admit_target_ref snapshot value =
+  match target_ref value with
+  | Error error -> Error (Target_ref_rejected error)
+  | Ok (Target_ref id as admitted) ->
+    if String_map.mem id snapshot.targets
+    then Ok admitted
+    else Error (Target_not_in_catalog id)
 ;;
 
 let resolve_target snapshot (Target_ref target_ref) =

--- a/lib/llm_provider/exact_output_resolver.ml
+++ b/lib/llm_provider/exact_output_resolver.ml
@@ -24,8 +24,6 @@ type catalog_document =
   ; contents : string
   }
 
-type catalog_overlay = catalog_document
-
 type resolver_catalog_input =
   | Embedded_default
   | Embedded_with_overlay of catalog_document
@@ -77,18 +75,14 @@ type resolver_snapshot_error =
       }
   | Catalog_collision of resolver_collision
   | Target_binding_missing of
-      { target_ref : target_ref
+      { target_ref : string
       ; component : resolver_binding_component
       }
   | Target_endpoint_invalid of
-      { target_ref : target_ref
+      { target_ref : string
       ; cause : resolver_endpoint_error
       }
   | Environment_read_failed of { environment_variable : string }
-  | Target_credential_invalid of
-      { target_ref : target_ref
-      ; environment_variable : string
-      }
 
 type target_declaration =
   { target_ref : target_ref
@@ -98,17 +92,30 @@ type target_declaration =
   ; body_timeout_s : float option
   }
 
+type credential_outcome =
+  | Credential_not_required
+  | Credential_available of Secret.t
+  | Credential_missing of string
+  | Credential_invalid of string
+  | Credential_read_failed of string
+
 type frozen_target =
   { config : PC.t
   ; capabilities : Caps.capabilities
   ; anthropic_thinking_control : Caps.anthropic_thinking_control option
   ; body_timeout_s : float option
-  ; missing_credential_env : string option
+  ; credential : credential_outcome
   ; identity : target_identity
   }
 
 type resolver_snapshot =
   { targets : frozen_target String_map.t
+  ; generation : catalog_generation
+  ; evidence : catalog_evidence
+  }
+
+type admitted_target =
+  { target : frozen_target
   ; generation : catalog_generation
   ; evidence : catalog_evidence
   }
@@ -124,8 +131,15 @@ type selected_target =
   }
 
 type target_selection_error =
-  | Unknown_target of string
   | Missing_target_credential of
+      { target_ref : string
+      ; environment_variable : string
+      }
+  | Target_credential_invalid of
+      { target_ref : string
+      ; environment_variable : string
+      }
+  | Target_credential_read_failed of
       { target_ref : string
       ; environment_variable : string
       }
@@ -170,7 +184,7 @@ let catalog_generation_fingerprint (Catalog_generation value) = value
 let catalog_evidence_sha256 (Catalog_evidence value) = value
 let resolver_catalog_generation (snapshot : resolver_snapshot) = snapshot.generation
 let resolver_catalog_evidence (snapshot : resolver_snapshot) = snapshot.evidence
-let target_identity_ref (identity : target_identity) = identity.target_ref
+let target_identity_id (identity : target_identity) = target_ref_id identity.target_ref
 let target_identity_fingerprint identity = identity.fingerprint
 let selected_target_identity (target : selected_target) = target.identity
 let selected_target_catalog_generation (target : selected_target) = target.generation
@@ -502,6 +516,7 @@ let%test "case-only target overlay shadow fails closed" =
 ;;
 
 let validate_base_url ~target_ref value =
+  let target_ref = target_ref_id target_ref in
   if has_control value
   then Error (Target_endpoint_invalid { target_ref; cause = Malformed_base_url })
   else if String.contains value '?'
@@ -542,6 +557,7 @@ let contains_encoded_control value =
 ;;
 
 let validate_request_path ~target_ref ~kind value =
+  let target_ref = target_ref_id target_ref in
   match kind with
   | PC.Gemini ->
     if value = ""
@@ -567,6 +583,7 @@ let validate_request_path ~target_ref ~kind value =
 ;;
 
 let validate_model_path ~target_ref kind model_id =
+  let target_ref = target_ref_id target_ref in
   match kind with
   | PC.Gemini
     when model_id = ""
@@ -688,13 +705,9 @@ let canonical_catalog_evidence catalog model_entries target_declarations =
 
 let frozen_environment ~io names =
   String_set.fold
-    (fun name result ->
-       let* values = result in
-       match io.getenv name with
-       | Ok value -> Ok (String_map.add name value values)
-       | Error () -> Error (Environment_read_failed { environment_variable = name }))
+    (fun name values -> String_map.add name (io.getenv name) values)
     names
-    (Ok String_map.empty)
+    String_map.empty
 ;;
 
 let read_full_replacement_file path =
@@ -782,11 +795,13 @@ let load_resolver_snapshot ~io ?(catalog = Embedded_default) () =
          | Error Binding.Provider_missing ->
            Error
              (Target_binding_missing
-                { target_ref = target.target_ref; component = Target_provider })
+                { target_ref = target_ref_id target.target_ref
+                ; component = Target_provider
+                })
          | Error Binding.Model_missing ->
            Error
              (Target_binding_missing
-                { target_ref = target.target_ref; component = Target_model })
+                { target_ref = target_ref_id target.target_ref; component = Target_model })
          | Ok (provider, model) -> Ok ((target, provider, model) :: bindings))
       (Ok [])
       target_declarations
@@ -806,11 +821,16 @@ let load_resolver_snapshot ~io ?(catalog = Embedded_default) () =
       String_set.empty
       structural
   in
-  let* environment = frozen_environment ~io environment_names in
-  let getenv name =
+  let environment = frozen_environment ~io environment_names in
+  let observed_environment name =
     match String_map.find_opt name environment with
-    | Some value -> value
-    | None -> None
+    | Some observation -> observation
+    | None -> Ok None
+  in
+  let getenv name =
+    match observed_environment name with
+    | Ok value -> value
+    | Error () -> None
   in
   let* targets =
     List.fold_left
@@ -822,6 +842,15 @@ let load_resolver_snapshot ~io ?(catalog = Embedded_default) () =
          let capabilities = Binding.capabilities_of_catalog_binding provider model in
          let anthropic_thinking_control =
            Binding.anthropic_thinking_control_of_model model
+         in
+         let* () =
+           match provider.base_url_env with
+           | Some name when name <> "" ->
+             (match observed_environment name with
+              | Ok _ -> Ok ()
+              | Error () ->
+                Error (Environment_read_failed { environment_variable = name }))
+           | Some _ | None -> Ok ()
          in
          let base_url = Model_provider_catalog.resolved_base_url ~getenv provider in
          let* () = validate_base_url ~target_ref:target.target_ref base_url in
@@ -881,35 +910,29 @@ let load_resolver_snapshot ~io ?(catalog = Embedded_default) () =
            ; fingerprint = identity_fingerprint
            }
          in
-         let* credential, missing_credential_env =
+         let credential =
            if provider.api_key_env = ""
-           then Ok (None, None)
+           then Credential_not_required
            else (
-             match getenv provider.api_key_env with
-             | Some value when has_control value ->
-               Error
-                 (Target_credential_invalid
-                    { target_ref = target.target_ref
-                    ; environment_variable = provider.api_key_env
-                    })
-             | Some value when String.trim value <> "" -> Ok (Some value, None)
-             | Some _ | None -> Ok (None, Some provider.api_key_env))
-         in
-         let config =
-           match credential with
-           | None -> projection_config
-           | Some credential ->
-             { projection_config with api_key = Secret.of_string credential }
+             match observed_environment provider.api_key_env with
+             | Error () -> Credential_read_failed provider.api_key_env
+             | Ok (Some value) when has_control value ->
+               Credential_invalid provider.api_key_env
+             | Ok (Some value) ->
+               (match Cli_common_env.trim_non_empty value with
+                | Some credential -> Credential_available (Secret.of_string credential)
+                | None -> Credential_missing provider.api_key_env)
+             | Ok None -> Credential_missing provider.api_key_env)
          in
          let target_id = target_ref_id target.target_ref in
          Ok
            (String_map.add
               target_id
-              { config
+              { config = projection_config
               ; capabilities
               ; anthropic_thinking_control
               ; body_timeout_s = target.body_timeout_s
-              ; missing_credential_env
+              ; credential
               ; identity
               }
               targets))
@@ -933,27 +956,37 @@ let load_resolver_snapshot ~io ?(catalog = Embedded_default) () =
 let admit_target_ref snapshot value =
   match target_ref value with
   | Error error -> Error (Target_ref_rejected error)
-  | Ok (Target_ref id as admitted) ->
-    if String_map.mem id snapshot.targets
-    then Ok admitted
-    else Error (Target_not_in_catalog id)
+  | Ok (Target_ref id) ->
+    (match String_map.find_opt id snapshot.targets with
+     | None -> Error (Target_not_in_catalog id)
+     | Some target ->
+       Ok { target; generation = snapshot.generation; evidence = snapshot.evidence })
 ;;
 
-let resolve_target snapshot (Target_ref target_ref) =
-  match String_map.find_opt target_ref snapshot.targets with
-  | None -> Error (Unknown_target target_ref)
-  | Some { missing_credential_env = Some environment_variable; _ } ->
-    Error (Missing_target_credential { target_ref; environment_variable })
-  | Some (target : frozen_target) ->
+let resolve_target (admitted : admitted_target) =
+  let target = admitted.target in
+  let target_ref = target_ref_id target.identity.target_ref in
+  let select frozen_api_key =
+    let config = { target.config with api_key = frozen_api_key } in
     let selected : selected_target =
-      { config = target.config
+      { config
       ; capabilities = target.capabilities
       ; anthropic_thinking_control = target.anthropic_thinking_control
       ; body_timeout_s = target.body_timeout_s
       ; identity = target.identity
-      ; generation = snapshot.generation
-      ; evidence = snapshot.evidence
+      ; generation = admitted.generation
+      ; evidence = admitted.evidence
       }
     in
     Ok selected
+  in
+  match target.credential with
+  | Credential_missing environment_variable ->
+    Error (Missing_target_credential { target_ref; environment_variable })
+  | Credential_invalid environment_variable ->
+    Error (Target_credential_invalid { target_ref; environment_variable })
+  | Credential_read_failed environment_variable ->
+    Error (Target_credential_read_failed { target_ref; environment_variable })
+  | Credential_not_required -> select Secret.empty
+  | Credential_available frozen_api_key -> select frozen_api_key
 ;;

--- a/lib/llm_provider/exact_output_resolver.mli
+++ b/lib/llm_provider/exact_output_resolver.mli
@@ -1,16 +1,14 @@
-type target_ref
 type catalog_generation
 type catalog_evidence
 type target_identity
 type resolver_snapshot
+type admitted_target
 type resolver_io = { getenv : string -> (string option, unit) result }
 
 type catalog_document =
   { source : string
   ; contents : string
   }
-
-type catalog_overlay = catalog_document
 
 type resolver_catalog_input =
   | Embedded_default
@@ -63,18 +61,14 @@ type resolver_snapshot_error =
       }
   | Catalog_collision of resolver_collision
   | Target_binding_missing of
-      { target_ref : target_ref
+      { target_ref : string
       ; component : resolver_binding_component
       }
   | Target_endpoint_invalid of
-      { target_ref : target_ref
+      { target_ref : string
       ; cause : resolver_endpoint_error
       }
   | Environment_read_failed of { environment_variable : string }
-  | Target_credential_invalid of
-      { target_ref : target_ref
-      ; environment_variable : string
-      }
 
 type selected_target = private
   { config : Provider_config.t
@@ -87,8 +81,15 @@ type selected_target = private
   }
 
 type target_selection_error =
-  | Unknown_target of string
   | Missing_target_credential of
+      { target_ref : string
+      ; environment_variable : string
+      }
+  | Target_credential_invalid of
+      { target_ref : string
+      ; environment_variable : string
+      }
+  | Target_credential_read_failed of
       { target_ref : string
       ; environment_variable : string
       }
@@ -97,13 +98,11 @@ type target_catalog_admission_error =
   | Target_ref_rejected of target_ref_error
   | Target_not_in_catalog of string
 
-val target_ref : string -> (target_ref, target_ref_error) result
-val target_ref_id : target_ref -> string
 val catalog_generation_fingerprint : catalog_generation -> string
 val catalog_evidence_sha256 : catalog_evidence -> string
 val resolver_catalog_generation : resolver_snapshot -> catalog_generation
 val resolver_catalog_evidence : resolver_snapshot -> catalog_evidence
-val target_identity_ref : target_identity -> target_ref
+val target_identity_id : target_identity -> string
 val target_identity_fingerprint : target_identity -> string
 val selected_target_identity : selected_target -> target_identity
 val selected_target_catalog_generation : selected_target -> catalog_generation
@@ -121,9 +120,6 @@ val load_resolver_snapshot
 val admit_target_ref
   :  resolver_snapshot
   -> string
-  -> (target_ref, target_catalog_admission_error) result
+  -> (admitted_target, target_catalog_admission_error) result
 
-val resolve_target
-  :  resolver_snapshot
-  -> target_ref
-  -> (selected_target, target_selection_error) result
+val resolve_target : admitted_target -> (selected_target, target_selection_error) result

--- a/lib/llm_provider/exact_output_resolver.mli
+++ b/lib/llm_provider/exact_output_resolver.mli
@@ -5,10 +5,18 @@ type target_identity
 type resolver_snapshot
 type resolver_io = { getenv : string -> (string option, unit) result }
 
-type catalog_overlay =
+type catalog_document =
   { source : string
   ; contents : string
   }
+
+type catalog_overlay = catalog_document
+
+type resolver_catalog_input =
+  | Embedded_default
+  | Embedded_with_overlay of catalog_document
+  | Full_replacement of catalog_document
+  | Full_replacement_file of string
 
 type target_ref_error =
   | Empty_target_ref
@@ -16,6 +24,7 @@ type target_ref_error =
 
 type resolver_catalog_source =
   | Embedded_catalog
+  | Full_replacement_catalog
   | Overlay_catalog
 
 type resolver_collision =
@@ -40,6 +49,10 @@ type resolver_endpoint_error =
   | Invalid_gemini_model_path
 
 type resolver_snapshot_error =
+  | Catalog_read_failed of
+      { path : string
+      ; detail : string
+      }
   | Catalog_parse_failed of
       { source : resolver_catalog_source
       ; detail : string
@@ -80,6 +93,10 @@ type target_selection_error =
       ; environment_variable : string
       }
 
+type target_catalog_admission_error =
+  | Target_ref_rejected of target_ref_error
+  | Target_not_in_catalog of string
+
 val target_ref : string -> (target_ref, target_ref_error) result
 val target_ref_id : target_ref -> string
 val catalog_generation_fingerprint : catalog_generation -> string
@@ -97,9 +114,14 @@ val option_float : float option -> string
 
 val load_resolver_snapshot
   :  io:resolver_io
-  -> ?overlay:catalog_overlay
+  -> ?catalog:resolver_catalog_input
   -> unit
   -> (resolver_snapshot, resolver_snapshot_error) result
+
+val admit_target_ref
+  :  resolver_snapshot
+  -> string
+  -> (target_ref, target_catalog_admission_error) result
 
 val resolve_target
   :  resolver_snapshot

--- a/lib/llm_provider/exact_output_resolver.mli
+++ b/lib/llm_provider/exact_output_resolver.mli
@@ -102,7 +102,6 @@ val catalog_generation_fingerprint : catalog_generation -> string
 val catalog_evidence_sha256 : catalog_evidence -> string
 val resolver_catalog_generation : resolver_snapshot -> catalog_generation
 val resolver_catalog_evidence : resolver_snapshot -> catalog_evidence
-val target_identity_id : target_identity -> string
 val target_identity_fingerprint : target_identity -> string
 val selected_target_identity : selected_target -> target_identity
 val selected_target_catalog_generation : selected_target -> catalog_generation

--- a/scripts/check-exact-output-resolver-boundary.sh
+++ b/scripts/check-exact-output-resolver-boundary.sh
@@ -137,6 +137,38 @@ scan_code() {
   fi
 }
 
+# [Cli_common_env.trim_non_empty] is a pure normalization SSOT, not an ambient
+# environment read. Permit only that exact identifier; every other
+# [Cli_common_env.*] use remains a boundary violation. The token boundary keeps
+# similarly prefixed helpers from inheriting the exception.
+scan_cli_common_env_usage() {
+  local failed=false
+  local source_file hits
+  for source_file in "$@"; do
+    hits="$(
+      strip_ocaml_noncode < "$source_file" \
+        | awk '{
+            gsub(/Cli_common_env[.]trim_non_empty([^[:alnum:]_]|$)/, "")
+            print
+          }' \
+        | grep -En -- 'Cli_common_env[.][[:alnum:]_]+' \
+        || true
+    )"
+    if [[ -n "$hits" ]]; then
+      while IFS= read -r hit; do
+        printf '%s:%s\n' "$source_file" "$hit" >&2
+      done <<< "$hits"
+      failed=true
+    fi
+  done
+  if [[ "$failed" == true ]]; then
+    echo \
+      "exact-output boundary violation: ambient Cli_common_env lookup found" \
+      >&2
+    return 1
+  fi
+}
+
 # Print only explicitly named top-level OCaml [let] definitions while keeping
 # one output line per input line. This lets a boundary rule follow a concrete
 # exact-output call path without granting a file-wide exemption to a legacy
@@ -335,10 +367,15 @@ done
 
 # Provider_config.capabilities_for_config_model is deliberately allowed: it
 # reads only the capability snapshot already frozen into the selected config.
-ambient_forbidden='Provider_catalog|Provider_runtime_binding|Provider_registry\.default|Model_catalog\.(global|set_global|set_global_overlay|clear_global|load_default|load_file)|Capability_manifest|(Capabilities|Caps)\.(for_[[:alnum:]_]+|[[:alnum:]_]+_for_(model_id|provider_id|config_model))|Cli_common_env|Sys\.getenv(_opt)?|Unix\.getenv(_opt)?|select_target|Marshal'
+ambient_forbidden='Provider_catalog|Provider_runtime_binding|Provider_registry\.default|Model_catalog\.(global|set_global|set_global_overlay|clear_global|load_default|load_file)|Capability_manifest|(Capabilities|Caps)\.(for_[[:alnum:]_]+|[[:alnum:]_]+_for_(model_id|provider_id|config_model))|Sys\.getenv(_opt)?|Unix\.getenv(_opt)?|select_target|Marshal'
 scan_code \
   "global, legacy, ambient, or representation-dependent lookup found" \
   "$ambient_forbidden" \
+  "$exact_output_source" \
+  "$resolver_source" \
+  "$catalog_binding_source" \
+  "${downstream_sources[@]}"
+scan_cli_common_env_usage \
   "$exact_output_source" \
   "$resolver_source" \
   "$catalog_binding_source" \
@@ -507,12 +544,17 @@ scan_outside_named_functions \
 # only the already-frozen Secret into Provider_config; it must never reread the
 # environment, reopen a catalog, rebuild provider config, or create a Secret
 # from ambient bytes.
-resolve_ambient_forbidden="${ambient_forbidden}|Model_catalog|Exact_output_catalog_binding|Binding\.|getenv|resolver_snapshot|snapshot|String_map\.(find_opt|mem)|PC\.make|Provider_config\.make|Secret\.of_string"
+resolve_ambient_forbidden="${ambient_forbidden}|Cli_common_env\.|Model_catalog|Exact_output_catalog_binding|Binding\.|getenv|resolver_snapshot|snapshot|String_map\.(find_opt|mem)|PC\.make|Provider_config\.make|Secret\.of_string"
 scan_named_functions \
   "target resolution performed ambient lookup or rebuilt frozen configuration" \
   "$resolve_ambient_forbidden" \
   "$resolver_source" \
   'resolve_target'
+scan_named_functions \
+  "catalog admission performed environment lookup or normalization" \
+  'Cli_common_env\.' \
+  "$resolver_source" \
+  'admit_target_ref'
 require_named_function_pattern \
   "target resolution no longer consumes the frozen credential observation" \
   'credential' \

--- a/scripts/check-exact-output-resolver-boundary.sh
+++ b/scripts/check-exact-output-resolver-boundary.sh
@@ -203,11 +203,91 @@ scan_named_functions() {
   fi
 }
 
+# Print every top-level definition except the explicitly named functions while
+# preserving one output line per input line. This ratchets exclusive ownership
+# of effects such as target-map lookup and Provider_config secret injection.
+exclude_named_functions() {
+  local source_file="$1"
+  local names="$2"
+  awk -v names="$names" '
+    BEGIN {
+      count = split(names, requested, /[[:space:]]+/)
+      for (i = 1; i <= count; i++) {
+        if (requested[i] != "") excluded_names[requested[i]] = 1
+      }
+      exclude = 0
+    }
+    /^let%[[:alnum:]_]+[[:space:]]/ {
+      exclude = 0
+    }
+    /^let[[:space:]]/ {
+      declaration = $0
+      sub(/^let[[:space:]]+(rec[[:space:]]+)?/, "", declaration)
+      name = declaration
+      sub(/[[:space:](].*$/, "", name)
+      exclude = (name in excluded_names)
+      if (exclude) found[name] = 1
+    }
+    {
+      if (exclude) print ""
+      else print $0
+    }
+    END {
+      missing = 0
+      for (name in excluded_names) {
+        if (!found[name]) {
+          print "exact-output ratchet function missing: " name > "/dev/stderr"
+          missing = 1
+        }
+      }
+      if (missing) exit 3
+    }
+  ' "$source_file"
+}
+
+scan_outside_named_functions() {
+  local description="$1"
+  local pattern="$2"
+  local source_file="$3"
+  local names="$4"
+  local extracted hits
+  extracted="$(mktemp)"
+  if ! exclude_named_functions "$source_file" "$names" > "$extracted"; then
+    rm -f "$extracted"
+    echo "exact-output boundary violation: $description" >&2
+    return 1
+  fi
+  hits="$(strip_ocaml_noncode < "$extracted" | grep -En -- "$pattern" || true)"
+  rm -f "$extracted"
+  if [[ -n "$hits" ]]; then
+    while IFS= read -r hit; do
+      printf '%s:%s\n' "$source_file" "$hit" >&2
+    done <<< "$hits"
+    echo "exact-output boundary violation: $description" >&2
+    return 1
+  fi
+}
+
 require_code_pattern() {
   local description="$1"
   local pattern="$2"
   local source_file="$3"
   if ! strip_ocaml_noncode < "$source_file" | grep -E -- "$pattern" >/dev/null; then
+    echo "exact-output boundary violation: $description" >&2
+    return 1
+  fi
+}
+
+# Match a declaration across formatting-only line breaks. The producer is
+# fully consumed by awk before grep runs, avoiding grep -q/SIGPIPE failures
+# under pipefail.
+require_code_sequence() {
+  local description="$1"
+  local pattern="$2"
+  local source_file="$3"
+  local compact
+  compact="$(strip_ocaml_noncode < "$source_file" | awk '{ printf "%s ", $0 } END { print "" }')"
+  if ! grep -E -- "$pattern" <<< "$compact" >/dev/null; then
     echo "exact-output boundary violation: $description" >&2
     return 1
   fi
@@ -374,6 +454,81 @@ scan_named_functions \
   'resolve_exact capabilities_of_catalog_binding functional_capability_projection anthropic_thinking_control_of_model'
 
 module_dir="$(dirname "$exact_output_source")"
+exact_output_interface="$module_dir/exact_output.mli"
+resolver_interface="$module_dir/exact_output_resolver.mli"
+
+# The public surface admits an exact catalog member into one opaque,
+# snapshot-bound handle. The former syntax-only constructor and overlay/path
+# convenience labels must not return under another compatibility layer.
+scan_code \
+  "legacy exact-output catalog admission surface returned" \
+  'type[[:space:]]+catalog_overlay|Unknown_target|\?overlay([[:space:]:]|$)|\?catalog_path([[:space:]:]|$)' \
+  "$exact_output_source" \
+  "$resolver_source" \
+  "$exact_output_interface" \
+  "$resolver_interface"
+scan_code \
+  "raw target_ref constructor or public type returned" \
+  '^[[:space:]]*type[[:space:]]+target_ref([[:space:]]*(=|$))|^[[:space:]]*val[[:space:]]+target_ref[[:space:]]*:' \
+  "$exact_output_interface"
+require_code_pattern \
+  "canonical facade lost its opaque admitted target handle" \
+  '^[[:space:]]*type[[:space:]]+admitted_target[[:space:]]*$' \
+  "$exact_output_interface"
+require_code_sequence \
+  "catalog admission no longer returns the opaque admitted target handle" \
+  'val[[:space:]]+admit_target_ref[[:space:]]*:[[:space:]]*resolver_snapshot[[:space:]]*->[[:space:]]*string[[:space:]]*->[[:space:]]*\(admitted_target,[[:space:]]*target_catalog_admission_error\)[[:space:]]*result' \
+  "$exact_output_interface"
+require_code_sequence \
+  "target resolution no longer consumes only the admitted target handle" \
+  'val[[:space:]]+resolve_target[[:space:]]*:[[:space:]]*admitted_target[[:space:]]*->[[:space:]]*\(selected_target,[[:space:]]*target_selection_error\)[[:space:]]*result' \
+  "$exact_output_interface"
+
+# Membership lookup is performed exactly when the admitted handle is frozen.
+# Resolution may only inspect that handle; accepting or consulting another
+# resolver snapshot would permit a same-id target to be rebound after admission.
+require_named_function_pattern \
+  "catalog admission no longer consults the frozen target map" \
+  'snapshot\.targets' \
+  "$resolver_source" \
+  'admit_target_ref'
+require_named_function_pattern \
+  "catalog admission no longer performs an exact target-map lookup" \
+  'String_map\.(find_opt|mem)' \
+  "$resolver_source" \
+  'admit_target_ref'
+scan_outside_named_functions \
+  "target-map lookup escaped catalog admission" \
+  'snapshot\.targets' \
+  "$resolver_source" \
+  'admit_target_ref'
+
+# Credential observations are frozen before admission. Resolution may inject
+# only the already-frozen Secret into Provider_config; it must never reread the
+# environment, reopen a catalog, rebuild provider config, or create a Secret
+# from ambient bytes.
+resolve_ambient_forbidden="${ambient_forbidden}|Model_catalog|Exact_output_catalog_binding|Binding\.|getenv|resolver_snapshot|snapshot|String_map\.(find_opt|mem)|PC\.make|Provider_config\.make|Secret\.of_string"
+scan_named_functions \
+  "target resolution performed ambient lookup or rebuilt frozen configuration" \
+  "$resolve_ambient_forbidden" \
+  "$resolver_source" \
+  'resolve_target'
+require_named_function_pattern \
+  "target resolution no longer consumes the frozen credential observation" \
+  'credential' \
+  "$resolver_source" \
+  'resolve_target'
+require_named_function_pattern \
+  "Provider_config secret injection disappeared from admitted target resolution" \
+  'api_key[[:space:]]*=' \
+  "$resolver_source" \
+  'resolve_target'
+scan_outside_named_functions \
+  "Provider_config secret injection escaped admitted target resolution" \
+  'api_key[[:space:]]*=' \
+  "$resolver_source" \
+  'resolve_target'
+
 require_code_pattern \
   "canonical facade no longer re-exports the private resolver" \
   'include[[:space:]]+Exact_output_resolver' \

--- a/test/test_exact_output_resolver_snapshot.ml
+++ b/test/test_exact_output_resolver_snapshot.ml
@@ -2,6 +2,23 @@ open Alcotest
 open Llm_provider
 module EO = Agent_sdk.Exact_output
 
+let _load_resolver_snapshot_contract
+  :  io:EO.resolver_io
+  -> ?catalog:EO.resolver_catalog_input
+  -> unit
+  -> (EO.resolver_snapshot, EO.resolver_snapshot_error) result
+  =
+  EO.load_resolver_snapshot
+;;
+
+let _catalog_input_contract : EO.resolver_catalog_input -> unit = function
+  | EO.Embedded_default
+  | EO.Embedded_with_overlay _
+  | EO.Full_replacement _
+  | EO.Full_replacement_file _ -> ()
+[@@warning "+8"]
+;;
+
 let schema =
   `Assoc
     [ "type", `String "object"
@@ -106,23 +123,27 @@ let target_catalog
 
 let snapshot ?(getenv = fun _ -> Ok None) contents =
   let io : EO.resolver_io = { getenv } in
-  let overlay : EO.catalog_overlay = { source = "resolver snapshot fixture"; contents } in
+  let overlay : EO.catalog_document =
+    { source = "resolver snapshot fixture"; contents }
+  in
   match EO.load_resolver_snapshot ~io ~catalog:(EO.Embedded_with_overlay overlay) () with
   | Ok snapshot -> snapshot
   | Error _ -> fail "snapshot should load"
 ;;
 
-let target_ref id =
-  match EO.target_ref id with
-  | Ok target_ref -> target_ref
-  | Error _ -> failf "target ref %S should be valid" id
+let admit snapshot id =
+  match EO.admit_target_ref snapshot id with
+  | Ok admitted -> admitted
+  | Error _ -> failf "target ref %S should be admitted" id
 ;;
 
-let resolve snapshot id =
-  match EO.resolve_target snapshot (target_ref id) with
+let resolve_admitted admitted =
+  match EO.resolve_target admitted with
   | Ok target -> target
-  | Error _ -> failf "target %S should resolve" id
+  | Error _ -> fail "admitted target should resolve"
 ;;
+
+let resolve snapshot id = resolve_admitted (admit snapshot id)
 
 let ready target =
   let requirement =
@@ -254,8 +275,8 @@ let test_exact_target_id_has_no_alias_or_default () =
   ignore (resolve snapshot "snapshot-target" : EO.selected_target);
   List.iter
     (fun id ->
-       match EO.resolve_target snapshot (target_ref id) with
-       | Error (EO.Unknown_target unknown) -> check string "exact miss" id unknown
+       match EO.admit_target_ref snapshot id with
+       | Error (EO.Target_not_in_catalog unknown) -> check string "exact miss" id unknown
        | Ok _ | Error _ -> failf "%S must not alias or default to a target" id)
     [ "snapshot-alias"; "snapshot-fixture"; "different-default" ]
 ;;
@@ -314,23 +335,164 @@ let test_environment_is_consumed_once_and_snapshot_is_immutable () =
          (Hashtbl.find reads "SNAPSHOT_KEY"))
 ;;
 
-let test_missing_credential_is_per_target_typed_error () =
-  let snapshot = snapshot (target_catalog ~api_key_env:"MISSING_FIXTURE_KEY" ()) in
-  let admitted =
-    match EO.admit_target_ref snapshot "snapshot-target" with
-    | Ok target_ref -> target_ref
-    | Error _ -> fail "catalog membership must not require a credential"
+let test_credential_outcomes_are_frozen_per_target () =
+  let contents =
+    String.concat
+      "\n"
+      [ target_catalog
+          ~provider:"credential-no-auth-provider"
+          ~model:"credential-no-auth-model"
+          ~target:"credential-no-auth"
+          ()
+      ; target_catalog
+          ~provider:"credential-available-provider"
+          ~api_key_env:"AVAILABLE_FIXTURE_KEY"
+          ~model:"credential-available-model"
+          ~target:"credential-available"
+          ()
+      ; target_catalog
+          ~provider:"credential-shared-provider"
+          ~api_key_env:"AVAILABLE_FIXTURE_KEY"
+          ~model:"credential-shared-model"
+          ~target:"credential-shared"
+          ()
+      ; target_catalog
+          ~provider:"credential-missing-provider"
+          ~api_key_env:"MISSING_FIXTURE_KEY"
+          ~model:"credential-missing-model"
+          ~target:"credential-missing"
+          ()
+      ; target_catalog
+          ~provider:"credential-invalid-provider"
+          ~api_key_env:"INVALID_FIXTURE_KEY"
+          ~model:"credential-invalid-model"
+          ~target:"credential-invalid"
+          ()
+      ; target_catalog
+          ~provider:"credential-read-failed-provider"
+          ~api_key_env:"READ_FAILED_FIXTURE_KEY"
+          ~model:"credential-read-failed-model"
+          ~target:"credential-read-failed"
+          ()
+      ]
   in
-  (match EO.resolve_target snapshot admitted with
-   | Error
-       (EO.Missing_target_credential
-          { target_ref = "snapshot-target"; environment_variable = "MISSING_FIXTURE_KEY" })
-     -> ()
-   | Ok _ | Error _ -> fail "missing credential must remain a typed resolution error");
-  (match EO.admit_target_ref snapshot "missing-target" with
+  let values =
+    ref
+      [ "AVAILABLE_FIXTURE_KEY", Ok (Some "first-secret")
+      ; "MISSING_FIXTURE_KEY", Ok None
+      ; "INVALID_FIXTURE_KEY", Ok (Some "secret\r\nX-Leak: yes")
+      ; "READ_FAILED_FIXTURE_KEY", Error ()
+      ]
+  in
+  let reads = Hashtbl.create 8 in
+  let getenv name =
+    Hashtbl.replace reads name (1 + Option.value (Hashtbl.find_opt reads name) ~default:0);
+    Option.value (List.assoc_opt name !values) ~default:(Ok None)
+  in
+  let frozen = snapshot ~getenv contents in
+  let no_auth = admit frozen "credential-no-auth" in
+  let available = admit frozen "credential-available" in
+  let shared_available = admit frozen "credential-shared" in
+  let missing = admit frozen "credential-missing" in
+  let invalid = admit frozen "credential-invalid" in
+  let read_failed = admit frozen "credential-read-failed" in
+  ignore (resolve_admitted no_auth : EO.selected_target);
+  let available_target = resolve_admitted available in
+  ignore (resolve_admitted shared_available : EO.selected_target);
+  let expect_missing admitted =
+    match EO.resolve_target admitted with
+    | Error
+        (EO.Missing_target_credential
+           { target_ref = "credential-missing"
+           ; environment_variable = "MISSING_FIXTURE_KEY"
+           }) -> ()
+    | Ok _ | Error _ -> fail "missing credential must remain a typed target outcome"
+  in
+  let expect_invalid admitted =
+    match EO.resolve_target admitted with
+    | Error
+        (EO.Target_credential_invalid
+           { target_ref = "credential-invalid"
+           ; environment_variable = "INVALID_FIXTURE_KEY"
+           }) -> ()
+    | Ok _ | Error _ -> fail "invalid credential must remain a typed target outcome"
+  in
+  let expect_read_failed admitted =
+    match EO.resolve_target admitted with
+    | Error
+        (EO.Target_credential_read_failed
+           { target_ref = "credential-read-failed"
+           ; environment_variable = "READ_FAILED_FIXTURE_KEY"
+           }) -> ()
+    | Ok _ | Error _ -> fail "credential read failure must remain a typed target outcome"
+  in
+  expect_missing missing;
+  expect_invalid invalid;
+  expect_read_failed read_failed;
+  List.iter
+    (fun name ->
+       check
+         int
+         (name ^ " observed once while freezing")
+         1
+         (Option.value (Hashtbl.find_opt reads name) ~default:0))
+    [ "AVAILABLE_FIXTURE_KEY"
+    ; "MISSING_FIXTURE_KEY"
+    ; "INVALID_FIXTURE_KEY"
+    ; "READ_FAILED_FIXTURE_KEY"
+    ];
+  values
+  := [ "AVAILABLE_FIXTURE_KEY", Ok (Some "rotated-secret")
+     ; "MISSING_FIXTURE_KEY", Ok (Some "now-present")
+     ; "INVALID_FIXTURE_KEY", Ok (Some "now-valid")
+     ; "READ_FAILED_FIXTURE_KEY", Ok (Some "read-now-works")
+     ];
+  ignore (resolve_admitted available : EO.selected_target);
+  ignore (resolve_admitted shared_available : EO.selected_target);
+  expect_missing missing;
+  expect_invalid invalid;
+  expect_read_failed read_failed;
+  List.iter
+    (fun name ->
+       check
+         int
+         (name ^ " is not reread while resolving")
+         1
+         (Option.value (Hashtbl.find_opt reads name) ~default:0))
+    [ "AVAILABLE_FIXTURE_KEY"
+    ; "MISSING_FIXTURE_KEY"
+    ; "INVALID_FIXTURE_KEY"
+    ; "READ_FAILED_FIXTURE_KEY"
+    ];
+  let rotated = snapshot ~getenv contents in
+  List.iter
+    (fun id -> ignore (resolve rotated id : EO.selected_target))
+    [ "credential-no-auth"
+    ; "credential-available"
+    ; "credential-shared"
+    ; "credential-missing"
+    ; "credential-invalid"
+    ; "credential-read-failed"
+    ];
+  check
+    string
+    "credential rotation does not change catalog generation"
+    (generation frozen)
+    (generation rotated);
+  check
+    string
+    "credential rotation does not change catalog evidence"
+    (evidence frozen)
+    (evidence rotated);
+  check
+    string
+    "credential rotation does not change target identity"
+    (identity available_target)
+    (identity (resolve rotated "credential-available"));
+  (match EO.admit_target_ref frozen "missing-target" with
    | Error (EO.Target_not_in_catalog "missing-target") -> ()
    | Ok _ | Error _ -> fail "unknown catalog membership must remain typed");
-  match EO.admit_target_ref snapshot "../invalid-target" with
+  match EO.admit_target_ref frozen "../invalid-target" with
   | Error (EO.Target_ref_rejected EO.Invalid_target_ref) -> ()
   | Ok _ | Error _ -> fail "target syntax rejection must remain typed"
 ;;
@@ -356,73 +518,72 @@ let replacement_snapshot contents =
 ;;
 
 let test_full_replacement_path_is_frozen_and_suppresses_embedded () =
-  let contents =
+  let first_contents =
     target_catalog
-      ~provider:"replacement-provider"
-      ~model:"replacement-model"
-      ~target:"replacement-only-target"
+      ~provider:"replacement-a-provider"
+      ~base_url:"https://replacement-a.example"
+      ~model:"replacement-a-model"
+      ~target:"replacement-a-target"
       ()
   in
-  with_temp_catalog contents
+  let second_contents =
+    target_catalog
+      ~provider:"replacement-b-provider"
+      ~base_url:"https://replacement-b.example"
+      ~model:"replacement-b-model"
+      ~target:"replacement-b-target"
+      ()
+  in
+  with_temp_catalog first_contents
   @@ fun path ->
   let io : EO.resolver_io = { getenv = (fun _ -> Ok None) } in
-  let snapshot =
+  let load () =
     match EO.load_resolver_snapshot ~io ~catalog:(EO.Full_replacement_file path) () with
     | Ok snapshot -> snapshot
     | Error _ -> fail "full replacement path should load"
   in
-  let admitted =
-    match EO.admit_target_ref snapshot "replacement-only-target" with
-    | Ok target_ref -> target_ref
-    | Error _ -> fail "replacement-only target must be admitted"
+  let first_snapshot = load () in
+  let first_handle = admit first_snapshot "replacement-a-target" in
+  let first_expected =
+    frozen_observation first_snapshot (resolve_admitted first_handle)
   in
-  ignore (EO.resolve_target snapshot admitted : (EO.selected_target, _) result);
-  match EO.admit_target_ref snapshot "ollama-cloud-minimax-m3-json" with
-  | Error (EO.Target_not_in_catalog "ollama-cloud-minimax-m3-json") -> ()
-  | Ok _ | Error _ -> fail "full replacement must suppress embedded targets"
-;;
-
-let test_catalog_input_keeps_overlay_and_replacement_mutually_exclusive () =
-  let base =
-    target_catalog
-      ~provider:"replacement-provider"
-      ~base_url:"https://base.example"
-      ~model:"replacement-model"
-      ~target:"replacement-target"
-      ()
-  in
-  let overlay : EO.catalog_overlay =
-    { source = "replacement overlay"
-    ; contents =
-        target_catalog
-          ~provider:"replacement-provider"
-          ~base_url:"https://overlay.example"
-          ~model:"replacement-model"
-          ~target:"replacement-target"
-          ()
-    }
-  in
-  let baseline = replacement_snapshot base in
-  let io : EO.resolver_io = { getenv = (fun _ -> Ok None) } in
-  let overlaid =
-    match
-      EO.load_resolver_snapshot ~io ~catalog:(EO.Embedded_with_overlay overlay) ()
-    with
-    | Ok snapshot -> snapshot
-    | Error _ -> fail "embedded overlay snapshot should load"
-  in
-  let baseline_target = resolve baseline "replacement-target" in
-  let overlaid_target = resolve overlaid "replacement-target" in
+  Out_channel.with_open_bin path (fun channel ->
+    Out_channel.output_string channel second_contents);
   check
     bool
-    "embedded overlay and full replacement remain separate generations"
+    "first handle remains coherent after source overwrite"
     true
-    (not (String.equal (generation baseline) (generation overlaid)));
+    (first_expected = frozen_observation first_snapshot (resolve_admitted first_handle));
+  let second_snapshot = load () in
+  let second_handle = admit second_snapshot "replacement-b-target" in
+  let second_expected =
+    frozen_observation second_snapshot (resolve_admitted second_handle)
+  in
+  Sys.remove path;
   check
     bool
-    "embedded overlay cannot mutate the full replacement identity"
+    "first handle remains coherent after source deletion"
     true
-    (not (String.equal (identity baseline_target) (identity overlaid_target)))
+    (first_expected = frozen_observation first_snapshot (resolve_admitted first_handle));
+  check
+    bool
+    "second handle remains coherent after source deletion"
+    true
+    (second_expected = frozen_observation second_snapshot (resolve_admitted second_handle));
+  check
+    bool
+    "separately loaded file snapshots remain distinct"
+    true
+    (first_expected <> second_expected);
+  let expect_absent snapshot id =
+    match EO.admit_target_ref snapshot id with
+    | Error (EO.Target_not_in_catalog actual) -> check string "exact absence" id actual
+    | Ok _ | Error _ -> failf "%S must not belong to this frozen snapshot" id
+  in
+  expect_absent first_snapshot "replacement-b-target";
+  expect_absent second_snapshot "replacement-a-target";
+  expect_absent first_snapshot "ollama-cloud-minimax-m3-json";
+  expect_absent second_snapshot "ollama-cloud-minimax-m3-json"
 ;;
 
 let test_invalid_full_replacement_inputs_fail_without_fallback () =
@@ -591,17 +752,58 @@ let test_every_functional_projection_field_changes_generation () =
      <> (ready (resolve endpoint_changed "snapshot-target") |> EO.plan_fingerprint))
 ;;
 
-let test_old_and_new_whole_tuples_never_mix_across_fibers () =
+let test_one_fresh_handle_is_immutably_shareable_across_domains () =
+  let snapshot = snapshot (target_catalog ~base_url:"https://shared.example" ()) in
+  let handle = admit snapshot "snapshot-target" in
+  let first_domain =
+    Domain.spawn (fun () -> frozen_observation snapshot (resolve_admitted handle))
+  in
+  let second_domain =
+    Domain.spawn (fun () -> frozen_observation snapshot (resolve_admitted handle))
+  in
+  let first_observation = Domain.join first_domain in
+  let second_observation = Domain.join second_domain in
+  check_observation_is_coherent "shared handle first Domain" first_observation;
+  check_observation_is_coherent "shared handle second Domain" second_observation;
+  check
+    bool
+    "one freshly admitted handle yields identical immutable Domain observations"
+    true
+    (first_observation = second_observation)
+;;
+
+let test_old_and_new_whole_tuples_never_mix_across_domains_and_fibers () =
   let old_snapshot = snapshot (target_catalog ~base_url:"https://old.example" ()) in
   let new_snapshot = snapshot (target_catalog ~base_url:"https://new.example" ()) in
-  let expected_old =
-    frozen_observation old_snapshot (resolve old_snapshot "snapshot-target")
+  let old_handle = admit old_snapshot "snapshot-target" in
+  let new_handle = admit new_snapshot "snapshot-target" in
+  let expected_old = frozen_observation old_snapshot (resolve_admitted old_handle) in
+  let expected_new = frozen_observation new_snapshot (resolve_admitted new_handle) in
+  let old_domain =
+    Domain.spawn (fun () -> frozen_observation old_snapshot (resolve_admitted old_handle))
   in
-  let expected_new =
-    frozen_observation new_snapshot (resolve new_snapshot "snapshot-target")
+  let new_domain =
+    Domain.spawn (fun () -> frozen_observation new_snapshot (resolve_admitted new_handle))
   in
-  let observe snapshot signal_arrived gate =
-    let target = resolve snapshot "snapshot-target" in
+  let old_domain_observation = Domain.join old_domain in
+  let new_domain_observation = Domain.join new_domain in
+  check
+    bool
+    "immutable handle A crosses a Domain without rebinding"
+    true
+    (old_domain_observation = expected_old);
+  check
+    bool
+    "immutable handle B crosses a Domain without rebinding"
+    true
+    (new_domain_observation = expected_new);
+  check
+    bool
+    "cross-Domain handles preserve distinct whole tuples"
+    true
+    (old_domain_observation <> new_domain_observation);
+  let observe snapshot admitted signal_arrived gate =
+    let target = resolve_admitted admitted in
     Eio.Promise.resolve signal_arrived ();
     Eio.Promise.await gate;
     frozen_observation snapshot target
@@ -621,10 +823,10 @@ let test_old_and_new_whole_tuples_never_mix_across_fibers () =
     let old_result, resolve_old_result = Eio.Promise.create () in
     let new_result, resolve_new_result = Eio.Promise.create () in
     Eio.Fiber.fork ~sw (fun () ->
-      observe old_snapshot signal_old_arrived gate
+      observe old_snapshot old_handle signal_old_arrived gate
       |> Eio.Promise.resolve resolve_old_result);
     Eio.Fiber.fork ~sw (fun () ->
-      observe new_snapshot signal_new_arrived gate
+      observe new_snapshot new_handle signal_new_arrived gate
       |> Eio.Promise.resolve resolve_new_result);
     Eio.Promise.await old_arrived;
     Eio.Promise.await new_arrived;
@@ -650,7 +852,7 @@ let test_old_and_new_whole_tuples_never_mix_across_fibers () =
 
 let expect_endpoint_error label expected_cause contents =
   let io : EO.resolver_io = { getenv = (fun _ -> Ok None) } in
-  let overlay : EO.catalog_overlay = { source = label; contents } in
+  let overlay : EO.catalog_document = { source = label; contents } in
   match EO.load_resolver_snapshot ~io ~catalog:(EO.Embedded_with_overlay overlay) () with
   | Error (EO.Target_endpoint_invalid { cause; _ }) ->
     check bool (label ^ " exact typed cause") true (cause = expected_cause)
@@ -707,44 +909,27 @@ let test_endpoint_error_cause_table () =
     cases
 ;;
 
-let test_caller_headers_and_crlf_credential_fail_closed () =
+let test_caller_headers_fail_closed () =
   let header_secret = "must-not-appear-in-diagnostic" in
   let contents =
     target_catalog () ^ Printf.sprintf "headers = [\"Authorization: %s\"]\n" header_secret
   in
   let io : EO.resolver_io = { getenv = (fun _ -> Ok None) } in
-  let overlay : EO.catalog_overlay = { source = "caller header"; contents } in
-  (match EO.load_resolver_snapshot ~io ~catalog:(EO.Embedded_with_overlay overlay) () with
-   | Error (EO.Target_catalog_invalid { detail; _ }) ->
-     check
-       bool
-       "rejected caller-header diagnostic omits its value"
-       false
-       (string_contains ~haystack:detail ~needle:header_secret)
-   | Error _ -> fail "caller target headers returned the wrong resolver error class"
-   | Ok _ -> fail "caller target headers must be rejected");
-  let credential = "secret\r\nX-Leak: yes" in
-  let io : EO.resolver_io =
-    { getenv =
-        (fun name ->
-          Ok (if String.equal name "CRLF_FIXTURE_KEY" then Some credential else None))
-    }
-  in
-  let overlay : EO.catalog_overlay =
-    { source = "CRLF credential"
-    ; contents = target_catalog ~api_key_env:"CRLF_FIXTURE_KEY" ()
-    }
-  in
+  let overlay : EO.catalog_document = { source = "caller header"; contents } in
   match EO.load_resolver_snapshot ~io ~catalog:(EO.Embedded_with_overlay overlay) () with
-  | Error (EO.Target_credential_invalid { environment_variable = "CRLF_FIXTURE_KEY"; _ })
-    -> ()
-  | Error _ -> fail "CRLF credential returned the wrong resolver error class"
-  | Ok _ -> fail "CRLF credential must be rejected while freezing the snapshot"
+  | Error (EO.Target_catalog_invalid { detail; _ }) ->
+    check
+      bool
+      "rejected caller-header diagnostic omits its value"
+      false
+      (string_contains ~haystack:detail ~needle:header_secret)
+  | Error _ -> fail "caller target headers returned the wrong resolver error class"
+  | Ok _ -> fail "caller target headers must be rejected"
 ;;
 
 let expect_collision_error label expected contents =
   let io : EO.resolver_io = { getenv = (fun _ -> Ok None) } in
-  let overlay : EO.catalog_overlay = { source = label; contents } in
+  let overlay : EO.catalog_document = { source = label; contents } in
   match EO.load_resolver_snapshot ~io ~catalog:(EO.Embedded_with_overlay overlay) () with
   | Error (EO.Catalog_collision collision) ->
     check bool (label ^ " exact collision") true (collision = expected)
@@ -769,11 +954,13 @@ let test_collision_and_input_hardening () =
     "target case shadow"
     EO.Duplicate_target_identity
     duplicate_target;
+  let hardening_snapshot = snapshot (target_catalog ()) in
   List.iter
     (fun malicious ->
-       match EO.target_ref malicious with
-       | Error _ -> ()
-       | Ok _ -> failf "malicious target ref %S must be rejected" malicious)
+       match EO.admit_target_ref hardening_snapshot malicious with
+       | Error (EO.Target_ref_rejected EO.Invalid_target_ref) -> ()
+       | Ok _ | Error _ ->
+         failf "malicious target ref %S must have the exact typed rejection" malicious)
     [ "../target"; "target?key=secret"; "target\nheader"; "target/child" ]
 ;;
 
@@ -787,17 +974,13 @@ let () =
             `Quick
             test_environment_is_consumed_once_and_snapshot_is_immutable
         ; test_case
-            "typed missing credential"
+            "credential outcomes frozen per target"
             `Quick
-            test_missing_credential_is_per_target_typed_error
+            test_credential_outcomes_are_frozen_per_target
         ; test_case
             "full replacement path suppresses embedded"
             `Quick
             test_full_replacement_path_is_frozen_and_suppresses_embedded
-        ; test_case
-            "overlay and replacement inputs are mutually exclusive"
-            `Quick
-            test_catalog_input_keeps_overlay_and_replacement_mutually_exclusive
         ; test_case
             "invalid full replacement has no fallback"
             `Quick
@@ -819,14 +1002,15 @@ let () =
             `Quick
             test_every_functional_projection_field_changes_generation
         ; test_case
-            "old/new whole-tuple concurrent separation"
+            "one fresh handle is immutable across Domains"
             `Quick
-            test_old_and_new_whole_tuples_never_mix_across_fibers
-        ; test_case "endpoint exact-cause table" `Quick test_endpoint_error_cause_table
+            test_one_fresh_handle_is_immutably_shareable_across_domains
         ; test_case
-            "caller headers and CRLF credential rejected"
+            "old/new whole-tuple Domain and fiber separation"
             `Quick
-            test_caller_headers_and_crlf_credential_fail_closed
+            test_old_and_new_whole_tuples_never_mix_across_domains_and_fibers
+        ; test_case "endpoint exact-cause table" `Quick test_endpoint_error_cause_table
+        ; test_case "caller headers rejected" `Quick test_caller_headers_fail_closed
         ; test_case
             "collision and input hardening"
             `Quick

--- a/test/test_exact_output_resolver_snapshot.ml
+++ b/test/test_exact_output_resolver_snapshot.ml
@@ -107,7 +107,7 @@ let target_catalog
 let snapshot ?(getenv = fun _ -> Ok None) contents =
   let io : EO.resolver_io = { getenv } in
   let overlay : EO.catalog_overlay = { source = "resolver snapshot fixture"; contents } in
-  match EO.load_resolver_snapshot ~io ~overlay () with
+  match EO.load_resolver_snapshot ~io ~catalog:(EO.Embedded_with_overlay overlay) () with
   | Ok snapshot -> snapshot
   | Error _ -> fail "snapshot should load"
 ;;
@@ -316,12 +316,131 @@ let test_environment_is_consumed_once_and_snapshot_is_immutable () =
 
 let test_missing_credential_is_per_target_typed_error () =
   let snapshot = snapshot (target_catalog ~api_key_env:"MISSING_FIXTURE_KEY" ()) in
-  match EO.resolve_target snapshot (target_ref "snapshot-target") with
-  | Error
-      (EO.Missing_target_credential
-         { target_ref = "snapshot-target"; environment_variable = "MISSING_FIXTURE_KEY" })
-    -> ()
-  | Ok _ | Error _ -> fail "missing credential must not invalidate the whole snapshot"
+  let admitted =
+    match EO.admit_target_ref snapshot "snapshot-target" with
+    | Ok target_ref -> target_ref
+    | Error _ -> fail "catalog membership must not require a credential"
+  in
+  (match EO.resolve_target snapshot admitted with
+   | Error
+       (EO.Missing_target_credential
+          { target_ref = "snapshot-target"; environment_variable = "MISSING_FIXTURE_KEY" })
+     -> ()
+   | Ok _ | Error _ -> fail "missing credential must remain a typed resolution error");
+  (match EO.admit_target_ref snapshot "missing-target" with
+   | Error (EO.Target_not_in_catalog "missing-target") -> ()
+   | Ok _ | Error _ -> fail "unknown catalog membership must remain typed");
+  match EO.admit_target_ref snapshot "../invalid-target" with
+  | Error (EO.Target_ref_rejected EO.Invalid_target_ref) -> ()
+  | Ok _ | Error _ -> fail "target syntax rejection must remain typed"
+;;
+
+let with_temp_catalog contents f =
+  let path = Filename.temp_file "exact-output-full-replacement-" ".toml" in
+  Fun.protect
+    ~finally:(fun () -> if Sys.file_exists path then Sys.remove path)
+    (fun () ->
+       Out_channel.with_open_bin path (fun channel ->
+         Out_channel.output_string channel contents);
+       f path)
+;;
+
+let replacement_snapshot contents =
+  let io : EO.resolver_io = { getenv = (fun _ -> Ok None) } in
+  let document : EO.catalog_document =
+    { source = "in-memory full replacement"; contents }
+  in
+  match EO.load_resolver_snapshot ~io ~catalog:(EO.Full_replacement document) () with
+  | Ok snapshot -> snapshot
+  | Error _ -> fail "full replacement snapshot should load"
+;;
+
+let test_full_replacement_path_is_frozen_and_suppresses_embedded () =
+  let contents =
+    target_catalog
+      ~provider:"replacement-provider"
+      ~model:"replacement-model"
+      ~target:"replacement-only-target"
+      ()
+  in
+  with_temp_catalog contents
+  @@ fun path ->
+  let io : EO.resolver_io = { getenv = (fun _ -> Ok None) } in
+  let snapshot =
+    match EO.load_resolver_snapshot ~io ~catalog:(EO.Full_replacement_file path) () with
+    | Ok snapshot -> snapshot
+    | Error _ -> fail "full replacement path should load"
+  in
+  let admitted =
+    match EO.admit_target_ref snapshot "replacement-only-target" with
+    | Ok target_ref -> target_ref
+    | Error _ -> fail "replacement-only target must be admitted"
+  in
+  ignore (EO.resolve_target snapshot admitted : (EO.selected_target, _) result);
+  match EO.admit_target_ref snapshot "ollama-cloud-minimax-m3-json" with
+  | Error (EO.Target_not_in_catalog "ollama-cloud-minimax-m3-json") -> ()
+  | Ok _ | Error _ -> fail "full replacement must suppress embedded targets"
+;;
+
+let test_catalog_input_keeps_overlay_and_replacement_mutually_exclusive () =
+  let base =
+    target_catalog
+      ~provider:"replacement-provider"
+      ~base_url:"https://base.example"
+      ~model:"replacement-model"
+      ~target:"replacement-target"
+      ()
+  in
+  let overlay : EO.catalog_overlay =
+    { source = "replacement overlay"
+    ; contents =
+        target_catalog
+          ~provider:"replacement-provider"
+          ~base_url:"https://overlay.example"
+          ~model:"replacement-model"
+          ~target:"replacement-target"
+          ()
+    }
+  in
+  let baseline = replacement_snapshot base in
+  let io : EO.resolver_io = { getenv = (fun _ -> Ok None) } in
+  let overlaid =
+    match
+      EO.load_resolver_snapshot ~io ~catalog:(EO.Embedded_with_overlay overlay) ()
+    with
+    | Ok snapshot -> snapshot
+    | Error _ -> fail "embedded overlay snapshot should load"
+  in
+  let baseline_target = resolve baseline "replacement-target" in
+  let overlaid_target = resolve overlaid "replacement-target" in
+  check
+    bool
+    "embedded overlay and full replacement remain separate generations"
+    true
+    (not (String.equal (generation baseline) (generation overlaid)));
+  check
+    bool
+    "embedded overlay cannot mutate the full replacement identity"
+    true
+    (not (String.equal (identity baseline_target) (identity overlaid_target)))
+;;
+
+let test_invalid_full_replacement_inputs_fail_without_fallback () =
+  let io : EO.resolver_io = { getenv = (fun _ -> Ok None) } in
+  let invalid : EO.catalog_document =
+    { source = "invalid full replacement"; contents = "[[providers]" }
+  in
+  (match EO.load_resolver_snapshot ~io ~catalog:(EO.Full_replacement invalid) () with
+   | Error (EO.Catalog_parse_failed { source = EO.Full_replacement_catalog; _ }) -> ()
+   | Ok _ | Error _ -> fail "invalid replacement must not fall back to embedded");
+  let missing_path = Filename.temp_file "missing-exact-output-catalog-" ".toml" in
+  Sys.remove missing_path;
+  match
+    EO.load_resolver_snapshot ~io ~catalog:(EO.Full_replacement_file missing_path) ()
+  with
+  | Error (EO.Catalog_read_failed { path; _ }) ->
+    check string "missing replacement path is preserved" missing_path path
+  | Ok _ | Error _ -> fail "missing replacement file must fail without fallback"
 ;;
 
 let test_credential_rotation_is_not_functional_identity () =
@@ -532,7 +651,7 @@ let test_old_and_new_whole_tuples_never_mix_across_fibers () =
 let expect_endpoint_error label expected_cause contents =
   let io : EO.resolver_io = { getenv = (fun _ -> Ok None) } in
   let overlay : EO.catalog_overlay = { source = label; contents } in
-  match EO.load_resolver_snapshot ~io ~overlay () with
+  match EO.load_resolver_snapshot ~io ~catalog:(EO.Embedded_with_overlay overlay) () with
   | Error (EO.Target_endpoint_invalid { cause; _ }) ->
     check bool (label ^ " exact typed cause") true (cause = expected_cause)
   | Error _ -> fail (label ^ " returned the wrong resolver error class")
@@ -595,7 +714,7 @@ let test_caller_headers_and_crlf_credential_fail_closed () =
   in
   let io : EO.resolver_io = { getenv = (fun _ -> Ok None) } in
   let overlay : EO.catalog_overlay = { source = "caller header"; contents } in
-  (match EO.load_resolver_snapshot ~io ~overlay () with
+  (match EO.load_resolver_snapshot ~io ~catalog:(EO.Embedded_with_overlay overlay) () with
    | Error (EO.Target_catalog_invalid { detail; _ }) ->
      check
        bool
@@ -616,7 +735,7 @@ let test_caller_headers_and_crlf_credential_fail_closed () =
     ; contents = target_catalog ~api_key_env:"CRLF_FIXTURE_KEY" ()
     }
   in
-  match EO.load_resolver_snapshot ~io ~overlay () with
+  match EO.load_resolver_snapshot ~io ~catalog:(EO.Embedded_with_overlay overlay) () with
   | Error (EO.Target_credential_invalid { environment_variable = "CRLF_FIXTURE_KEY"; _ })
     -> ()
   | Error _ -> fail "CRLF credential returned the wrong resolver error class"
@@ -626,7 +745,7 @@ let test_caller_headers_and_crlf_credential_fail_closed () =
 let expect_collision_error label expected contents =
   let io : EO.resolver_io = { getenv = (fun _ -> Ok None) } in
   let overlay : EO.catalog_overlay = { source = label; contents } in
-  match EO.load_resolver_snapshot ~io ~overlay () with
+  match EO.load_resolver_snapshot ~io ~catalog:(EO.Embedded_with_overlay overlay) () with
   | Error (EO.Catalog_collision collision) ->
     check bool (label ^ " exact collision") true (collision = expected)
   | Error _ -> fail (label ^ " returned the wrong resolver error class")
@@ -671,6 +790,18 @@ let () =
             "typed missing credential"
             `Quick
             test_missing_credential_is_per_target_typed_error
+        ; test_case
+            "full replacement path suppresses embedded"
+            `Quick
+            test_full_replacement_path_is_frozen_and_suppresses_embedded
+        ; test_case
+            "overlay and replacement inputs are mutually exclusive"
+            `Quick
+            test_catalog_input_keeps_overlay_and_replacement_mutually_exclusive
+        ; test_case
+            "invalid full replacement has no fallback"
+            `Quick
+            test_invalid_full_replacement_inputs_fail_without_fallback
         ; test_case
             "credential rotation is nonfunctional"
             `Quick

--- a/test/test_exact_output_single_surface.ml
+++ b/test/test_exact_output_single_surface.ml
@@ -125,7 +125,7 @@ let with_catalog ?(getenv = fun _ -> Ok None) entries f =
     }
   in
   let io : EO.resolver_io = { getenv } in
-  match EO.load_resolver_snapshot ~io ~overlay () with
+  match EO.load_resolver_snapshot ~io ~catalog:(EO.Embedded_with_overlay overlay) () with
   | Error _ -> fail "resolver snapshot should load"
   | Ok snapshot -> f snapshot
 ;;
@@ -330,7 +330,7 @@ let test_deepseek_catalog_is_json_only_before_dispatch () =
       (if String.equal name "DEEPSEEK_API_KEY" then Some "deepseek-fixture-key" else None)
   in
   let io : EO.resolver_io = { getenv } in
-  match EO.load_resolver_snapshot ~io ~overlay () with
+  match EO.load_resolver_snapshot ~io ~catalog:(EO.Embedded_with_overlay overlay) () with
   | Error _ -> fail "DeepSeek exact-output target should resolve"
   | Ok snapshot ->
     let selected = target snapshot target_id in
@@ -1381,7 +1381,7 @@ let test_gemini_nonempty_request_path_rejected_before_resolution () =
         catalog_fixture_toml (gemini_exact_entry ~id ~request_path:"/interactions")
     }
   in
-  match EO.load_resolver_snapshot ~io ~overlay () with
+  match EO.load_resolver_snapshot ~io ~catalog:(EO.Embedded_with_overlay overlay) () with
   | Error
       (EO.Target_endpoint_invalid
          { target_ref; cause = EO.Unsupported_gemini_request_path }) ->

--- a/test/test_exact_output_single_surface.ml
+++ b/test/test_exact_output_single_surface.ml
@@ -119,7 +119,7 @@ let catalog_fixture_toml entry =
 ;;
 
 let with_catalog ?(getenv = fun _ -> Ok None) entries f =
-  let overlay : EO.catalog_overlay =
+  let overlay : EO.catalog_document =
     { source = "exact-output single-surface fixture"
     ; contents = String.concat "\n" (List.map catalog_fixture_toml entries)
     }
@@ -131,12 +131,12 @@ let with_catalog ?(getenv = fun _ -> Ok None) entries f =
 ;;
 
 let target snapshot selector =
-  let target_ref =
-    match EO.target_ref selector with
-    | Ok target_ref -> target_ref
-    | Error _ -> failf "target ref %s was invalid" selector
+  let admitted =
+    match EO.admit_target_ref snapshot selector with
+    | Ok admitted -> admitted
+    | Error _ -> failf "target ref %s was not admitted" selector
   in
-  match EO.resolve_target snapshot target_ref with
+  match EO.resolve_target admitted with
   | Ok target -> target
   | Error _ -> failf "target %s did not resolve" selector
 ;;
@@ -314,7 +314,7 @@ let test_tier_table_and_provider_schema_rejection () =
 
 let test_deepseek_catalog_is_json_only_before_dispatch () =
   let target_id = "deepseek-json-only-surface" in
-  let overlay : EO.catalog_overlay =
+  let overlay : EO.catalog_document =
     { source = "DeepSeek exact-output capability fixture"
     ; contents =
         Printf.sprintf
@@ -1199,16 +1199,20 @@ let test_overlay_endpoint_and_credential_are_materialized () =
         ~capabilities:(capabilities ~native:true ~json:true)
         ()
     in
+    let frozen_base_url = ref base_url in
+    let frozen_credential = ref "  frozen-surface-secret  " in
     let getenv name =
       Ok
         (if String.equal name "EXACT_SURFACE_BASE_URL"
-         then Some base_url
+         then Some !frozen_base_url
          else if String.equal name "EXACT_SURFACE_API_KEY"
-         then Some "frozen-surface-secret"
+         then Some !frozen_credential
          else None)
     in
     with_catalog ~getenv [ entry ]
     @@ fun snapshot ->
+    frozen_base_url := "https://rotated.invalid";
+    frozen_credential := "rotated-surface-secret";
     let selected = target snapshot "environment-surface" in
     let ready =
       match
@@ -1241,6 +1245,101 @@ let test_overlay_endpoint_and_credential_are_materialized () =
     "exact request owns exactly one JSON content type"
     [ "application/json" ]
     (header_values "content-type" capture.headers)
+;;
+
+let test_credential_rotation_keeps_snapshot_bound_wire_authority () =
+  let response = openai_response {|{"name":"accepted"}|} in
+  let (result_a, result_b), posts, token_posts, captures =
+    with_server ~response
+    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
+    let entry =
+      catalog_entry
+        ~id:"credential-rotation-surface"
+        ~kind:Provider_config.OpenAI_compat
+        ~base_url
+        ~api_key_env:"ROTATING_SURFACE_API_KEY"
+        ~request_path:"/v1/chat/completions"
+        ~capabilities:(capabilities ~native:true ~json:true)
+        ()
+    in
+    let credential = ref "snapshot-secret-a" in
+    let getenv name =
+      Ok (if String.equal name "ROTATING_SURFACE_API_KEY" then Some !credential else None)
+    in
+    let snapshot_a = with_catalog ~getenv [ entry ] Fun.id in
+    let handle_a =
+      match EO.admit_target_ref snapshot_a "credential-rotation-surface" with
+      | Ok admitted -> admitted
+      | Error _ -> fail "snapshot A target should admit"
+    in
+    credential := "snapshot-secret-b";
+    let snapshot_b = with_catalog ~getenv [ entry ] Fun.id in
+    let handle_b =
+      match EO.admit_target_ref snapshot_b "credential-rotation-surface" with
+      | Ok admitted -> admitted
+      | Error _ -> fail "snapshot B target should admit"
+    in
+    check
+      string
+      "credential rotation leaves catalog generation unchanged"
+      (EO.resolver_catalog_generation snapshot_a |> EO.catalog_generation_fingerprint)
+      (EO.resolver_catalog_generation snapshot_b |> EO.catalog_generation_fingerprint);
+    check
+      string
+      "credential rotation leaves catalog evidence unchanged"
+      (EO.resolver_catalog_evidence snapshot_a |> EO.catalog_evidence_sha256)
+      (EO.resolver_catalog_evidence snapshot_b |> EO.catalog_evidence_sha256);
+    let domain_a = Domain.spawn (fun () -> EO.resolve_target handle_a) in
+    let domain_b = Domain.spawn (fun () -> EO.resolve_target handle_b) in
+    let target_a =
+      match Domain.join domain_a with
+      | Ok target -> target
+      | Error _ -> fail "snapshot A handle should resolve across a Domain"
+    in
+    let target_b =
+      match Domain.join domain_b with
+      | Ok target -> target
+      | Error _ -> fail "snapshot B handle should resolve across a Domain"
+    in
+    check
+      string
+      "credential rotation leaves target identity unchanged"
+      (EO.selected_target_identity target_a |> EO.target_identity_fingerprint)
+      (EO.selected_target_identity target_b |> EO.target_identity_fingerprint);
+    let ready target =
+      match
+        EO.admit
+          ~target
+          ~messages:[ msg "credential rotation" ]
+          (requirement EO.Json_syntax)
+      with
+      | Ok ready -> ready
+      | Error _ -> fail "credential rotation target should admit a request"
+    in
+    let result_a = EO.execute_once ~net (ready target_a) in
+    let result_b = EO.execute_once ~net (ready target_b) in
+    result_a, result_b
+  in
+  check int "two frozen credential plans dispatch once each" 2 posts;
+  check int "credential rotation performs no token measurement" 0 token_posts;
+  List.iter
+    (function
+      | Ok _ -> ()
+      | Error _ -> fail "both frozen credential plans should execute")
+    [ result_a; result_b ];
+  match captures with
+  | [ capture_a; capture_b ] ->
+    check
+      (option string)
+      "snapshot A retains credential A after snapshot B exists"
+      (Some "Bearer snapshot-secret-a")
+      (header_value "authorization" capture_a.headers);
+    check
+      (option string)
+      "snapshot B retains credential B"
+      (Some "Bearer snapshot-secret-b")
+      (header_value "authorization" capture_b.headers)
+  | _ -> fail "credential rotation should produce exactly two ordered captures"
 ;;
 
 let test_identity_survives_success_error_and_cancellation () =
@@ -1375,7 +1474,7 @@ let test_gemini_nested_unsupported_schema_keyword_rejected () =
 let test_gemini_nonempty_request_path_rejected_before_resolution () =
   let id = "gemini-interactions-surface" in
   let io : EO.resolver_io = { getenv = (fun _ -> Ok None) } in
-  let overlay : EO.catalog_overlay =
+  let overlay : EO.catalog_document =
     { source = "Gemini endpoint surface fixture"
     ; contents =
         catalog_fixture_toml (gemini_exact_entry ~id ~request_path:"/interactions")
@@ -1385,7 +1484,7 @@ let test_gemini_nonempty_request_path_rejected_before_resolution () =
   | Error
       (EO.Target_endpoint_invalid
          { target_ref; cause = EO.Unsupported_gemini_request_path }) ->
-    check string "rejected Gemini target" id (EO.target_ref_id target_ref)
+    check string "rejected Gemini target" id target_ref
   | Ok _ | Error _ -> fail "nonempty Gemini request_path must fail before resolution"
 ;;
 
@@ -1463,6 +1562,10 @@ let () =
             "overlay endpoint and credential"
             `Quick
             test_overlay_endpoint_and_credential_are_materialized
+        ; test_case
+            "credential rotation keeps snapshot-bound wire authority"
+            `Quick
+            test_credential_rotation_keeps_snapshot_bound_wire_authority
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

- replace optional overlay/path inputs with one closed `resolver_catalog_input` variant
- make catalog membership admission return an opaque, snapshot-bound `admitted_target`
- remove the public raw target-ref constructor and make `resolve_target` accept only the admitted handle
- freeze target, generation, evidence, and credential outcome in the immutable handle path
- keep catalog publication and membership admission independent of missing, invalid, or unreadable target credentials
- materialize a canonical trimmed `Secret.t` only during resolution
- keep resolver, catalog binding, plan, and execution modules private behind `Exact_output`

## Catalog input

The loader accepts exactly one of:

- `Embedded_default`
- `Embedded_with_overlay document`
- `Full_replacement document`
- `Full_replacement_file path`

Invalid full replacement never falls back to the embedded catalog. File inputs are fully loaded and frozen; later overwrite or deletion cannot change an existing snapshot or admitted handle.

## Admission and resolution

```ocaml
admit_target_ref : resolver_snapshot -> string -> (admitted_target, ...) result
resolve_target : admitted_target -> (selected_target, ...) result
```

The admitted handle owns the exact frozen target plus generation/evidence. There is no second snapshot argument and no resolution-time catalog lookup, so admission cannot be bypassed or rebound across snapshots.

Credential environment names are observed once per snapshot, deduplicated across sibling targets. Missing, invalid, and read-failed credentials are stored as typed per-target outcomes: snapshot load and membership admission succeed, while resolution returns the exact typed selection error. Structural base-URL environment errors remain loader failures.

## Proofs

- one fresh handle resolves coherently from multiple OCaml Domains
- same-ID A/B snapshot handles never mix generation, identity, provenance, receipt, endpoint, or credential
- old/new retained handles dispatch their own frozen Authorization headers after credential rotation
- shared credential environment names are read exactly once
- padded credentials use canonical trim; control bytes fail closed
- full-replacement file snapshots survive overwrite and deletion
- Cloud capability truth and exact `supported_models` admission remain unchanged

## Validation

- CI run 29966465362 passed OCaml 5.4.1, OCaml 5.5.0, lint, format, and all applicable boundary gates
- Code Smell Ratchet run 29966465369 passed
- local build/tests intentionally not run per operator instruction; GitHub Actions are the validation authority

## Breaking change

- removed `catalog_overlay`
- removed the public raw `target_ref` constructor/surface and `Unknown_target`
- `admit_target_ref` now accepts a string and returns opaque `admitted_target`
- `resolve_target` now accepts only `admitted_target`
- removed secondary target-identity scalar projection

BREAKING CHANGE: exact-output target resolution now requires an opaque snapshot-bound handle returned by `admit_target_ref`; raw target references, legacy overlay terminology, cross-snapshot resolution, and secondary identity projection are removed.
