### PR TITLE
refactor!: hard-cut exact-output admission

### DIFF
--- a/lib/agent/agent_execution_projection.ml
+++ b/lib/agent/agent_execution_projection.ml
@@ -1,7 +1,7 @@
 open Result_syntax
 module Event = Execution_event
 module Journal = Execution_journal
-module Store = Execution_event_store
+module Durable = Journal.Durable_read
 module Sequence_map = Map.Make (Int)
 
 module type ID = sig
@@ -119,7 +119,7 @@ type event =
   }
 
 type cursor =
-  { scope_id : Store.Scope_id.t
+  { scope_id : Durable.Scope_id.t
   ; seq : int
   }
 
@@ -142,7 +142,7 @@ type cursor_decode_error =
       ; actual : int
       }
 
-type unexpected_store_error =
+type unexpected_store_error = Durable.unexpected_store_error =
   | Writer_already_active
   | Store_already_attached
   | Store_released
@@ -158,7 +158,7 @@ type unexpected_store_error =
   | Store_poisoned
   | Commit_outcome_unknown
 
-type storage_failure =
+type storage_failure = Durable.storage_failure =
   | Invalid_store_argument of string
   | Store_identity_failure of string
   | Store_io_failure of
@@ -217,7 +217,7 @@ type page =
   }
 
 type validated_snapshot =
-  { durable : Store.read_only_snapshot
+  { durable : Durable.snapshot
   ; reducer : Journal.Reducer.t
   ; events : event Sequence_map.t
   }
@@ -239,7 +239,7 @@ type t =
   { codec : Execution_codec_executor.t
   ; dir : Eio.Fs.dir_ty Eio.Path.t
   ; locator_run_id : Run_id.t
-  ; scope_id : Store.Scope_id.t
+  ; scope_id : Durable.Scope_id.t
   ; mu : Eio.Mutex.t
   ; mutable snapshot : validated_snapshot
   ; mutable in_flight_refresh : in_flight_refresh option
@@ -250,7 +250,7 @@ let cursor_version = 1
 let cursor_to_yojson (cursor : cursor) =
   `Assoc
     [ "version", `Int cursor_version
-    ; "scope_id", `String (Store.Scope_id.to_string cursor.scope_id)
+    ; "scope_id", `String (Durable.Scope_id.to_string cursor.scope_id)
     ; "sequence", `Int cursor.seq
     ]
 ;;
@@ -327,7 +327,7 @@ let cursor_of_yojson json =
     match scope_id with
     | None -> Error (Missing_cursor_field Scope_id)
     | Some (`String value) ->
-      Store.Scope_id.of_string value
+      Durable.Scope_id.of_string value
       |> Result.map_error (fun detail ->
         Invalid_cursor_field { field = Scope_id; detail })
     | Some _ ->
@@ -437,62 +437,6 @@ let event value =
   }
 ;;
 
-let unexpected_store_failure kind error =
-  Unexpected_store_failure { kind; detail = Store.error_to_string error }
-;;
-
-let storage_failure error =
-  match error with
-  | Store.Invalid_argument detail -> Invalid_store_argument detail
-  | Store.Identity_failure detail -> Store_identity_failure detail
-  | Store.Io_failure { operation; detail } -> Store_io_failure { operation; detail }
-  | Store.Codec_failure failure ->
-    Store_codec_failure (Execution_codec_executor.failure_to_string failure)
-  | Store.Store_not_found -> Store_not_found
-  | Store.Store_initialization_incomplete -> Store_initialization_incomplete
-  | Store.Store_initialization_conflict -> Store_initialization_conflict
-  | Store.Unsupported_store_version { expected; actual } ->
-    Unsupported_store_version { expected; actual }
-  | Store.Corrupt_store { offset; detail } -> Corrupt_store { offset; detail }
-  | Store.Commit_authority_identity_changed -> Commit_authority_identity_changed
-  | Store.Commit_authority_regressed
-      { previous_committed_offset
-      ; actual_committed_offset
-      ; previous_last_seq
-      ; actual_last_seq
-      } ->
-    Commit_authority_regressed
-      { previous_committed_offset
-      ; actual_committed_offset
-      ; previous_last_seq
-      ; actual_last_seq
-      }
-  | Store.Writer_already_active as error ->
-    unexpected_store_failure Writer_already_active error
-  | Store.Store_already_attached as error ->
-    unexpected_store_failure Store_already_attached error
-  | Store.Store_released as error -> unexpected_store_failure Store_released error
-  | Store.Store_release_forbidden as error ->
-    unexpected_store_failure Store_release_forbidden error
-  | Store.Resource_cleanup_failed _ as error ->
-    unexpected_store_failure Resource_cleanup_failed error
-  | Store.Construction_cleanup_failed _ as error ->
-    unexpected_store_failure Construction_cleanup_failed error
-  | Store.Store_already_exists as error ->
-    unexpected_store_failure Store_already_exists error
-  | Store.Correlation_mismatch as error ->
-    unexpected_store_failure Correlation_mismatch error
-  | Store.Sequence_conflict _ as error -> unexpected_store_failure Sequence_conflict error
-  | Store.Committed_content_conflict _ as error ->
-    unexpected_store_failure Committed_content_conflict error
-  | Store.Cursor_scope_mismatch as error ->
-    unexpected_store_failure Cursor_scope_mismatch error
-  | Store.Cursor_ahead _ as error -> unexpected_store_failure Cursor_ahead error
-  | Store.Store_poisoned _ as error -> unexpected_store_failure Store_poisoned error
-  | Store.Commit_outcome_unknown _ as error ->
-    unexpected_store_failure Commit_outcome_unknown error
-;;
-
 let storage_failure_to_string = function
   | Invalid_store_argument detail -> "invalid store argument: " ^ detail
   | Store_identity_failure detail -> "store identity failure: " ^ detail
@@ -547,7 +491,7 @@ let error_to_string = function
   | Storage_failure failure -> storage_failure_to_string failure
 ;;
 
-let validate_snapshot ~locator_run_id ?previous (durable : Store.read_only_snapshot) =
+let validate_snapshot ~locator_run_id ?previous (durable : Durable.snapshot) =
   let reducer, events =
     match previous with
     | None -> Journal.Reducer.empty, Sequence_map.empty
@@ -573,7 +517,7 @@ let validate_snapshot ~locator_run_id ?previous (durable : Store.read_only_snaps
               ; detail = Journal.show_invariant_violation violation
               }))
   in
-  let* reducer, events = reduce reducer events durable.Store.appended_events in
+  let* reducer, events = reduce reducer events (Durable.appended_events durable) in
   let* () =
     match Journal.Reducer.find_run reducer locator_run_id with
     | None -> Error (Locator_not_found locator_run_id)
@@ -582,12 +526,12 @@ let validate_snapshot ~locator_run_id ?previous (durable : Store.read_only_snaps
        | None -> Ok ()
        | Some _ -> Error (Locator_not_top_level locator_run_id))
   in
-  if Journal.Reducer.last_seq reducer = durable.last_seq
+  if Journal.Reducer.last_seq reducer = Durable.last_seq durable
   then Ok { durable; reducer; events }
   else
     Error
       (Semantic_failure
-         { seq = durable.last_seq
+         { seq = Durable.last_seq durable
          ; detail = "committed sequence does not equal the projected event count"
          })
 ;;
@@ -595,11 +539,11 @@ let validate_snapshot ~locator_run_id ?previous (durable : Store.read_only_snaps
 let load_snapshot ~codec ~dir ~locator_run_id ?previous () =
   let previous_durable = Option.map (fun value -> value.durable) previous in
   let* durable =
-    Store.read_only_snapshot ~codec ~dir ?previous:previous_durable ()
-    |> Result.map_error (fun error -> Storage_failure (storage_failure error))
+    Durable.read_snapshot ~codec ~dir ?previous:previous_durable ()
+    |> Result.map_error (fun failure -> Storage_failure failure)
   in
   match previous with
-  | Some previous when previous.durable == durable -> Ok previous
+  | Some previous when Durable.same_snapshot previous.durable durable -> Ok previous
   | None -> validate_snapshot ~locator_run_id durable
   | Some previous -> validate_snapshot ~locator_run_id ~previous durable
 ;;
@@ -610,7 +554,7 @@ let open_durable ~codec ~dir ~locator_run_id () =
     { codec
     ; dir
     ; locator_run_id
-    ; scope_id = snapshot.durable.scope_id
+    ; scope_id = Durable.scope_id snapshot.durable
     ; mu = Eio.Mutex.create ()
     ; snapshot
     ; in_flight_refresh = None
@@ -646,10 +590,10 @@ let publish_snapshot t ~base candidate =
       t.snapshot <- candidate;
       Ok candidate)
     else (
-      let current_offset = current.durable.committed_offset in
-      let candidate_offset = candidate.durable.committed_offset in
-      let current_seq = current.durable.last_seq in
-      let candidate_seq = candidate.durable.last_seq in
+      let current_offset = Durable.committed_offset current.durable in
+      let candidate_offset = Durable.committed_offset candidate.durable in
+      let current_seq = Durable.last_seq current.durable in
+      let candidate_seq = Durable.last_seq candidate.durable in
       let offset_order = Int64.compare candidate_offset current_offset in
       if offset_order <= 0 && candidate_seq <= current_seq
       then Ok current
@@ -702,11 +646,11 @@ let beginning_cursor t = { scope_id = t.scope_id; seq = 0 }
 
 let current_cursor t =
   let+ snapshot = refresh t in
-  { scope_id = t.scope_id; seq = snapshot.durable.last_seq }
+  { scope_id = t.scope_id; seq = Durable.last_seq snapshot.durable }
 ;;
 
 let cursor_matches scope_id (cursor : cursor) =
-  Store.Scope_id.equal scope_id cursor.scope_id
+  Durable.Scope_id.equal scope_id cursor.scope_id
 ;;
 
 let events_slice events ~first_seq ~count =
@@ -739,21 +683,21 @@ let read_page t ~after ?through ~limit () =
       match through with
       | Some cursor ->
         let cached = cached_snapshot t in
-        if cursor.seq <= cached.durable.last_seq then Ok cached else refresh t
+        if cursor.seq <= Durable.last_seq cached.durable then Ok cached else refresh t
       | None -> refresh t
     in
     let high_watermark =
       match through with
-      | None -> snapshot.durable.last_seq
+      | None -> Durable.last_seq snapshot.durable
       | Some cursor -> cursor.seq
     in
-    if high_watermark > snapshot.durable.last_seq
+    if high_watermark > Durable.last_seq snapshot.durable
     then
       Error
         (Cursor_ahead
            { cursor_role = Through
            ; cursor_seq = high_watermark
-           ; high_watermark = snapshot.durable.last_seq
+           ; high_watermark = Durable.last_seq snapshot.durable
            })
     else if after.seq > high_watermark
     then

--- a/lib/agent/agent_execution_runner.ml
+++ b/lib/agent/agent_execution_runner.ml
@@ -108,37 +108,70 @@ let reraise_after_abort_failure exn backtrace abort_detail =
     Printexc.raise_with_backtrace reserved backtrace
 ;;
 
-let%expect_test "abort failure preserves cancellation class" =
-  (try
-     match
-       reraise_after_abort_failure
-         (Eio.Cancel.Cancelled Exit)
-         (Printexc.get_callstack 8)
-         "injected abort failure"
-     with
-     | () -> failwith "expected cancellation to be re-raised"
-   with
-   | Eio.Cancel.Cancelled Exit -> ()
-   | Eio.Cancel.Cancelled _ | Abort_failed_after_exception _ ->
-     failwith "expected the original cancellation class");
-  [%expect
-    {| durable execution cleanup failed while preserving reserved exception: injected abort failure |}]
+let capture_traceln_for_inline_test f =
+  let buffer = Buffer.create 256 in
+  let original_out, original_flush =
+    Format.pp_get_formatter_output_functions Format.err_formatter ()
+  in
+  Format.pp_set_formatter_output_functions
+    Format.err_formatter
+    (fun text offset length -> Buffer.add_substring buffer text offset length)
+    (fun () -> ());
+  Fun.protect
+    ~finally:(fun () ->
+      Format.pp_print_flush Format.err_formatter ();
+      Format.pp_set_formatter_output_functions
+        Format.err_formatter
+        original_out
+        original_flush)
+    (fun () ->
+       let result = f () in
+       Format.pp_print_flush Format.err_formatter ();
+       result, Buffer.contents buffer)
 ;;
 
-let%expect_test "abort failure preserves reserved runtime exception" =
-  (try
-     match
-       reraise_after_abort_failure
-         Sys.Break
-         (Printexc.get_callstack 8)
-         "injected abort failure"
-     with
-     | () -> failwith "expected Sys.Break to be re-raised"
-   with
-   | Sys.Break -> ()
-   | Abort_failed_after_exception _ -> failwith "expected the original Sys.Break");
-  [%expect
-    {| durable execution cleanup failed while preserving reserved exception: injected abort failure |}]
+let%test "abort failure preserves cancellation class" =
+  let preserved, diagnostic =
+    capture_traceln_for_inline_test (fun () ->
+      try
+        match
+          reraise_after_abort_failure
+            (Eio.Cancel.Cancelled Exit)
+            (Printexc.get_callstack 8)
+            "injected abort failure"
+        with
+        | () -> false
+      with
+      | Eio.Cancel.Cancelled Exit -> true
+      | Eio.Cancel.Cancelled _ | Abort_failed_after_exception _ -> false)
+  in
+  preserved
+  && String.equal
+       (String.trim diagnostic)
+       "durable execution cleanup failed while preserving reserved exception: injected \
+        abort failure"
+;;
+
+let%test "abort failure preserves reserved runtime exception" =
+  let preserved, diagnostic =
+    capture_traceln_for_inline_test (fun () ->
+      try
+        match
+          reraise_after_abort_failure
+            Sys.Break
+            (Printexc.get_callstack 8)
+            "injected abort failure"
+        with
+        | () -> false
+      with
+      | Sys.Break -> true
+      | Abort_failed_after_exception _ -> false)
+  in
+  preserved
+  && String.equal
+       (String.trim diagnostic)
+       "durable execution cleanup failed while preserving reserved exception: injected \
+        abort failure"
 ;;
 
 let abort_after_exception scope on_terminal_disposition exn backtrace =

--- a/lib/agent/agent_execution_runner.ml
+++ b/lib/agent/agent_execution_runner.ml
@@ -108,32 +108,37 @@ let reraise_after_abort_failure exn backtrace abort_detail =
     Printexc.raise_with_backtrace reserved backtrace
 ;;
 
-let%test "abort failure preserves cancellation class" =
-  try
-    match
-      reraise_after_abort_failure
-        (Eio.Cancel.Cancelled Exit)
-        (Printexc.get_callstack 8)
-        "injected abort failure"
-    with
-    | () -> false
-  with
-  | Eio.Cancel.Cancelled Exit -> true
-  | Eio.Cancel.Cancelled _ | Abort_failed_after_exception _ -> false
+let%expect_test "abort failure preserves cancellation class" =
+  (try
+     match
+       reraise_after_abort_failure
+         (Eio.Cancel.Cancelled Exit)
+         (Printexc.get_callstack 8)
+         "injected abort failure"
+     with
+     | () -> failwith "expected cancellation to be re-raised"
+   with
+   | Eio.Cancel.Cancelled Exit -> ()
+   | Eio.Cancel.Cancelled _ | Abort_failed_after_exception _ ->
+     failwith "expected the original cancellation class");
+  [%expect
+    {| durable execution cleanup failed while preserving reserved exception: injected abort failure |}]
 ;;
 
-let%test "abort failure preserves reserved runtime exception" =
-  try
-    match
-      reraise_after_abort_failure
-        Sys.Break
-        (Printexc.get_callstack 8)
-        "injected abort failure"
-    with
-    | () -> false
-  with
-  | Sys.Break -> true
-  | Abort_failed_after_exception _ -> false
+let%expect_test "abort failure preserves reserved runtime exception" =
+  (try
+     match
+       reraise_after_abort_failure
+         Sys.Break
+         (Printexc.get_callstack 8)
+         "injected abort failure"
+     with
+     | () -> failwith "expected Sys.Break to be re-raised"
+   with
+   | Sys.Break -> ()
+   | Abort_failed_after_exception _ -> failwith "expected the original Sys.Break");
+  [%expect
+    {| durable execution cleanup failed while preserving reserved exception: injected abort failure |}]
 ;;
 
 let abort_after_exception scope on_terminal_disposition exn backtrace =

--- a/lib/agent/agent_execution_runner.ml
+++ b/lib/agent/agent_execution_runner.ml
@@ -109,25 +109,22 @@ let reraise_after_abort_failure exn backtrace abort_detail =
 ;;
 
 let capture_traceln_for_inline_test f =
+  Eio_main.run
+  @@ fun env ->
   let buffer = Buffer.create 256 in
-  let original_out, original_flush =
-    Format.pp_get_formatter_output_functions Format.err_formatter ()
+  let captured_traceln =
+    { Eio.Debug.traceln =
+        (fun ?__POS__:_ format ->
+          Format.kasprintf
+            (fun message ->
+               Buffer.add_string buffer message;
+               Buffer.add_char buffer '\n')
+            format)
+    }
   in
-  Format.pp_set_formatter_output_functions
-    Format.err_formatter
-    (fun text offset length -> Buffer.add_substring buffer text offset length)
-    (fun () -> ());
-  Fun.protect
-    ~finally:(fun () ->
-      Format.pp_print_flush Format.err_formatter ();
-      Format.pp_set_formatter_output_functions
-        Format.err_formatter
-        original_out
-        original_flush)
-    (fun () ->
-       let result = f () in
-       Format.pp_print_flush Format.err_formatter ();
-       result, Buffer.contents buffer)
+  Eio.Fiber.with_binding (Eio.Stdenv.debug env)#traceln captured_traceln (fun () ->
+    let result = f () in
+    result, Buffer.contents buffer)
 ;;
 
 let%test "abort failure preserves cancellation class" =

--- a/lib/base/hooks.ml
+++ b/lib/base/hooks.ml
@@ -410,28 +410,6 @@ let compose ~outer ~inner =
 
 (* ── Hook exception safety regression tests ─────────────────── *)
 
-let capture_traceln_for_inline_test f =
-  let buffer = Buffer.create 256 in
-  let original_out, original_flush =
-    Format.pp_get_formatter_output_functions Format.err_formatter ()
-  in
-  Format.pp_set_formatter_output_functions
-    Format.err_formatter
-    (fun text offset length -> Buffer.add_substring buffer text offset length)
-    (fun () -> ());
-  Fun.protect
-    ~finally:(fun () ->
-      Format.pp_print_flush Format.err_formatter ();
-      Format.pp_set_formatter_output_functions
-        Format.err_formatter
-        original_out
-        original_flush)
-    (fun () ->
-       let result = f () in
-       Format.pp_print_flush Format.err_formatter ();
-       result, Buffer.contents buffer)
-;;
-
 let%test "invoke_validated: hook returning Continue propagates" =
   let event = BeforeTurn { turn = 0; messages = [] } in
   match invoke_validated (Some (fun _ -> Continue)) event with
@@ -446,43 +424,12 @@ let%test "invoke_validated: None hook returns Continue" =
   | _ -> false
 ;;
 
-let%test "invoke_validated: raising hook is caught and returns HookFailed" =
-  let event = BeforeTurn { turn = 0; messages = [] } in
-  let raising _ = failwith "kaboom" in
-  let semantic_ok, diagnostic =
-    capture_traceln_for_inline_test (fun () ->
-      match invoke_validated (Some raising) event with
-      | HookFailed { stage = Before_turn; detail } -> String.length detail > 0
-      | _ -> false)
-  in
-  semantic_ok
-  && String.equal
-       (String.trim diagnostic)
-       {|[warn] [hooks] user hook for before_turn raised Failure("kaboom")|}
-;;
-
 let%test "invoke_validated: Sys.Break remains reserved" =
   let event = BeforeTurn { turn = 0; messages = [] } in
   match invoke_validated (Some (fun _ -> raise Sys.Break)) event with
   | exception Sys.Break -> true
   | (exception _)
   | Continue | AdjustParams _ | ElicitInput _ | Nudge _ | HookFailed _ | Block _ -> false
-;;
-
-let%test "invoke_validated: on_illegal is NOT invoked when hook raises" =
-  let event = BeforeTurn { turn = 0; messages = [] } in
-  let raising _ = failwith "kaboom" in
-  let illegal_called = ref false in
-  let on_illegal ~stage:_ ~decision:_ ~msg:_ = illegal_called := true in
-  let semantic_ok, diagnostic =
-    capture_traceln_for_inline_test (fun () ->
-      let _ = invoke_validated ~on_illegal (Some raising) event in
-      not !illegal_called)
-  in
-  semantic_ok
-  && String.equal
-       (String.trim diagnostic)
-       {|[warn] [hooks] user hook for before_turn raised Failure("kaboom")|}
 ;;
 
 (* ── Block variant (RFC-0321) regression tests ─────────────── *)
@@ -508,20 +455,4 @@ let%test "Block: validate_decision rejects at after_turn" =
   match validate_decision ~stage:After_turn (Block "nope") with
   | Error msg -> String.length msg > 0
   | Ok _ -> false
-;;
-
-let%test "Block: invoke_validated coerces illegal Block to HookFailed" =
-  let event = BeforeTurn { turn = 0; messages = [] } in
-  let blocking _ = Block "forbidden" in
-  let semantic_ok, diagnostic =
-    capture_traceln_for_inline_test (fun () ->
-      match invoke_validated (Some blocking) event with
-      | HookFailed { stage = Before_turn; detail } -> String.length detail > 0
-      | HookFailed _ | Continue | AdjustParams _ | ElicitInput _ | Nudge _ | Block _ ->
-        false)
-  in
-  semantic_ok
-  && String.equal
-       (String.trim diagnostic)
-       {|[warn] [hooks] illegal hook decision Block at stage before_turn; legal: [Continue, ElicitInput, Nudge]|}
 ;;

--- a/lib/base/hooks.ml
+++ b/lib/base/hooks.ml
@@ -410,6 +410,28 @@ let compose ~outer ~inner =
 
 (* ── Hook exception safety regression tests ─────────────────── *)
 
+let capture_traceln_for_inline_test f =
+  let buffer = Buffer.create 256 in
+  let original_out, original_flush =
+    Format.pp_get_formatter_output_functions Format.err_formatter ()
+  in
+  Format.pp_set_formatter_output_functions
+    Format.err_formatter
+    (fun text offset length -> Buffer.add_substring buffer text offset length)
+    (fun () -> ());
+  Fun.protect
+    ~finally:(fun () ->
+      Format.pp_print_flush Format.err_formatter ();
+      Format.pp_set_formatter_output_functions
+        Format.err_formatter
+        original_out
+        original_flush)
+    (fun () ->
+       let result = f () in
+       Format.pp_print_flush Format.err_formatter ();
+       result, Buffer.contents buffer)
+;;
+
 let%test "invoke_validated: hook returning Continue propagates" =
   let event = BeforeTurn { turn = 0; messages = [] } in
   match invoke_validated (Some (fun _ -> Continue)) event with
@@ -424,14 +446,19 @@ let%test "invoke_validated: None hook returns Continue" =
   | _ -> false
 ;;
 
-let%expect_test "invoke_validated: raising hook is caught and returns HookFailed" =
+let%test "invoke_validated: raising hook is caught and returns HookFailed" =
   let event = BeforeTurn { turn = 0; messages = [] } in
   let raising _ = failwith "kaboom" in
-  (match invoke_validated (Some raising) event with
-   | HookFailed { stage = Before_turn; detail } ->
-     if String.length detail = 0 then failwith "expected non-empty hook failure detail"
-   | _ -> failwith "expected before_turn HookFailed");
-  [%expect {| [warn] [hooks] user hook for before_turn raised Failure("kaboom") |}]
+  let semantic_ok, diagnostic =
+    capture_traceln_for_inline_test (fun () ->
+      match invoke_validated (Some raising) event with
+      | HookFailed { stage = Before_turn; detail } -> String.length detail > 0
+      | _ -> false)
+  in
+  semantic_ok
+  && String.equal
+       (String.trim diagnostic)
+       {|[warn] [hooks] user hook for before_turn raised Failure("kaboom")|}
 ;;
 
 let%test "invoke_validated: Sys.Break remains reserved" =
@@ -442,14 +469,20 @@ let%test "invoke_validated: Sys.Break remains reserved" =
   | Continue | AdjustParams _ | ElicitInput _ | Nudge _ | HookFailed _ | Block _ -> false
 ;;
 
-let%expect_test "invoke_validated: on_illegal is NOT invoked when hook raises" =
+let%test "invoke_validated: on_illegal is NOT invoked when hook raises" =
   let event = BeforeTurn { turn = 0; messages = [] } in
   let raising _ = failwith "kaboom" in
   let illegal_called = ref false in
   let on_illegal ~stage:_ ~decision:_ ~msg:_ = illegal_called := true in
-  let _ = invoke_validated ~on_illegal (Some raising) event in
-  if !illegal_called then failwith "on_illegal must not be invoked when the hook raises";
-  [%expect {| [warn] [hooks] user hook for before_turn raised Failure("kaboom") |}]
+  let semantic_ok, diagnostic =
+    capture_traceln_for_inline_test (fun () ->
+      let _ = invoke_validated ~on_illegal (Some raising) event in
+      not !illegal_called)
+  in
+  semantic_ok
+  && String.equal
+       (String.trim diagnostic)
+       {|[warn] [hooks] user hook for before_turn raised Failure("kaboom")|}
 ;;
 
 (* ── Block variant (RFC-0321) regression tests ─────────────── *)
@@ -477,16 +510,18 @@ let%test "Block: validate_decision rejects at after_turn" =
   | Ok _ -> false
 ;;
 
-let%expect_test "Block: invoke_validated coerces illegal Block to HookFailed" =
+let%test "Block: invoke_validated coerces illegal Block to HookFailed" =
   let event = BeforeTurn { turn = 0; messages = [] } in
   let blocking _ = Block "forbidden" in
-  (match invoke_validated (Some blocking) event with
-   | HookFailed { stage = Before_turn; detail } ->
-     if String.length detail = 0
-     then failwith "expected non-empty illegal-decision detail"
-   | HookFailed _ -> failwith "expected before_turn HookFailed"
-   | Continue | AdjustParams _ | ElicitInput _ | Nudge _ | Block _ ->
-     failwith "expected illegal Block to become HookFailed");
-  [%expect
-    {| [warn] [hooks] illegal hook decision Block at stage before_turn; legal: [Continue, ElicitInput, Nudge] |}]
+  let semantic_ok, diagnostic =
+    capture_traceln_for_inline_test (fun () ->
+      match invoke_validated (Some blocking) event with
+      | HookFailed { stage = Before_turn; detail } -> String.length detail > 0
+      | HookFailed _ | Continue | AdjustParams _ | ElicitInput _ | Nudge _ | Block _ ->
+        false)
+  in
+  semantic_ok
+  && String.equal
+       (String.trim diagnostic)
+       {|[warn] [hooks] illegal hook decision Block at stage before_turn; legal: [Continue, ElicitInput, Nudge]|}
 ;;

--- a/lib/base/hooks.ml
+++ b/lib/base/hooks.ml
@@ -424,12 +424,14 @@ let%test "invoke_validated: None hook returns Continue" =
   | _ -> false
 ;;
 
-let%test "invoke_validated: raising hook is caught and returns HookFailed" =
+let%expect_test "invoke_validated: raising hook is caught and returns HookFailed" =
   let event = BeforeTurn { turn = 0; messages = [] } in
   let raising _ = failwith "kaboom" in
-  match invoke_validated (Some raising) event with
-  | HookFailed { stage = Before_turn; detail } -> String.length detail > 0
-  | _ -> false
+  (match invoke_validated (Some raising) event with
+   | HookFailed { stage = Before_turn; detail } ->
+     if String.length detail = 0 then failwith "expected non-empty hook failure detail"
+   | _ -> failwith "expected before_turn HookFailed");
+  [%expect {| [warn] [hooks] user hook for before_turn raised Failure("kaboom") |}]
 ;;
 
 let%test "invoke_validated: Sys.Break remains reserved" =
@@ -440,13 +442,14 @@ let%test "invoke_validated: Sys.Break remains reserved" =
   | Continue | AdjustParams _ | ElicitInput _ | Nudge _ | HookFailed _ | Block _ -> false
 ;;
 
-let%test "invoke_validated: on_illegal is NOT invoked when hook raises" =
+let%expect_test "invoke_validated: on_illegal is NOT invoked when hook raises" =
   let event = BeforeTurn { turn = 0; messages = [] } in
   let raising _ = failwith "kaboom" in
   let illegal_called = ref false in
   let on_illegal ~stage:_ ~decision:_ ~msg:_ = illegal_called := true in
   let _ = invoke_validated ~on_illegal (Some raising) event in
-  not !illegal_called
+  if !illegal_called then failwith "on_illegal must not be invoked when the hook raises";
+  [%expect {| [warn] [hooks] user hook for before_turn raised Failure("kaboom") |}]
 ;;
 
 (* ── Block variant (RFC-0321) regression tests ─────────────── *)
@@ -474,11 +477,16 @@ let%test "Block: validate_decision rejects at after_turn" =
   | Ok _ -> false
 ;;
 
-let%test "Block: invoke_validated coerces illegal Block to HookFailed" =
+let%expect_test "Block: invoke_validated coerces illegal Block to HookFailed" =
   let event = BeforeTurn { turn = 0; messages = [] } in
   let blocking _ = Block "forbidden" in
-  match invoke_validated (Some blocking) event with
-  | HookFailed { stage = Before_turn; detail } -> String.length detail > 0
-  | HookFailed _ -> false
-  | Continue | AdjustParams _ | ElicitInput _ | Nudge _ | Block _ -> false
+  (match invoke_validated (Some blocking) event with
+   | HookFailed { stage = Before_turn; detail } ->
+     if String.length detail = 0
+     then failwith "expected non-empty illegal-decision detail"
+   | HookFailed _ -> failwith "expected before_turn HookFailed"
+   | Continue | AdjustParams _ | ElicitInput _ | Nudge _ | Block _ ->
+     failwith "expected illegal Block to become HookFailed");
+  [%expect
+    {| [warn] [hooks] illegal hook decision Block at stage before_turn; legal: [Continue, ElicitInput, Nudge] |}]
 ;;

--- a/lib/execution_journal.ml
+++ b/lib/execution_journal.ml
@@ -344,6 +344,126 @@ let commit_error_disposition = function
   | Invariant_violation _ -> Final_failure
 ;;
 
+module Durable_read = struct
+  module Scope_id = Store.Scope_id
+
+  type unexpected_store_error =
+    | Writer_already_active
+    | Store_already_attached
+    | Store_released
+    | Store_release_forbidden
+    | Resource_cleanup_failed
+    | Construction_cleanup_failed
+    | Store_already_exists
+    | Correlation_mismatch
+    | Sequence_conflict
+    | Committed_content_conflict
+    | Cursor_scope_mismatch
+    | Cursor_ahead
+    | Store_poisoned
+    | Commit_outcome_unknown
+
+  type storage_failure =
+    | Invalid_store_argument of string
+    | Store_identity_failure of string
+    | Store_io_failure of
+        { operation : string
+        ; detail : string
+        }
+    | Store_codec_failure of string
+    | Store_not_found
+    | Store_initialization_incomplete
+    | Store_initialization_conflict
+    | Unsupported_store_version of
+        { expected : int
+        ; actual : int
+        }
+    | Corrupt_store of
+        { offset : int64
+        ; detail : string
+        }
+    | Commit_authority_identity_changed
+    | Commit_authority_regressed of
+        { previous_committed_offset : int64
+        ; actual_committed_offset : int64
+        ; previous_last_seq : int
+        ; actual_last_seq : int
+        }
+    | Unexpected_store_failure of
+        { kind : unexpected_store_error
+        ; detail : string
+        }
+
+  type snapshot = Store.read_only_snapshot
+
+  let unexpected_store_failure (kind : unexpected_store_error) error =
+    Unexpected_store_failure { kind; detail = Store.error_to_string error }
+  ;;
+
+  let storage_failure (error : Store.error) : storage_failure =
+    match error with
+    | Store.Invalid_argument detail -> Invalid_store_argument detail
+    | Store.Identity_failure detail -> Store_identity_failure detail
+    | Store.Io_failure { operation; detail } -> Store_io_failure { operation; detail }
+    | Store.Codec_failure failure ->
+      Store_codec_failure (Execution_codec_executor.failure_to_string failure)
+    | Store.Store_not_found -> Store_not_found
+    | Store.Store_initialization_incomplete -> Store_initialization_incomplete
+    | Store.Store_initialization_conflict -> Store_initialization_conflict
+    | Store.Unsupported_store_version { expected; actual } ->
+      Unsupported_store_version { expected; actual }
+    | Store.Corrupt_store { offset; detail } -> Corrupt_store { offset; detail }
+    | Store.Commit_authority_identity_changed -> Commit_authority_identity_changed
+    | Store.Commit_authority_regressed
+        { previous_committed_offset
+        ; actual_committed_offset
+        ; previous_last_seq
+        ; actual_last_seq
+        } ->
+      Commit_authority_regressed
+        { previous_committed_offset
+        ; actual_committed_offset
+        ; previous_last_seq
+        ; actual_last_seq
+        }
+    | Store.Writer_already_active as error ->
+      unexpected_store_failure Writer_already_active error
+    | Store.Store_already_attached as error ->
+      unexpected_store_failure Store_already_attached error
+    | Store.Store_released as error -> unexpected_store_failure Store_released error
+    | Store.Store_release_forbidden as error ->
+      unexpected_store_failure Store_release_forbidden error
+    | Store.Resource_cleanup_failed _ as error ->
+      unexpected_store_failure Resource_cleanup_failed error
+    | Store.Construction_cleanup_failed _ as error ->
+      unexpected_store_failure Construction_cleanup_failed error
+    | Store.Store_already_exists as error ->
+      unexpected_store_failure Store_already_exists error
+    | Store.Correlation_mismatch as error ->
+      unexpected_store_failure Correlation_mismatch error
+    | Store.Sequence_conflict _ as error ->
+      unexpected_store_failure Sequence_conflict error
+    | Store.Committed_content_conflict _ as error ->
+      unexpected_store_failure Committed_content_conflict error
+    | Store.Cursor_scope_mismatch as error ->
+      unexpected_store_failure Cursor_scope_mismatch error
+    | Store.Cursor_ahead _ as error -> unexpected_store_failure Cursor_ahead error
+    | Store.Store_poisoned _ as error -> unexpected_store_failure Store_poisoned error
+    | Store.Commit_outcome_unknown _ as error ->
+      unexpected_store_failure Commit_outcome_unknown error
+  ;;
+
+  let read_snapshot ~codec ~dir ?previous () =
+    Store.read_only_snapshot ~codec ~dir ?previous () |> Result.map_error storage_failure
+  ;;
+
+  let same_snapshot left right = left == right
+  let scope_id (snapshot : snapshot) = snapshot.scope_id
+  let committed_offset (snapshot : snapshot) = snapshot.committed_offset
+  let last_seq (snapshot : snapshot) = snapshot.last_seq
+  let appended_events (snapshot : snapshot) = snapshot.appended_events
+end
+
 module Reducer = struct
   type node_record =
     { node : Event.node

--- a/lib/execution_journal.mli
+++ b/lib/execution_journal.mli
@@ -195,6 +195,80 @@ type commit_error_disposition =
     callers never inspect store errors or error strings. *)
 val commit_error_disposition : error -> commit_error_disposition
 
+(** Narrow read-only durable source for execution projections. Physical store
+    ownership and store-error translation remain inside this journal boundary. *)
+module Durable_read : sig
+  module Scope_id : sig
+    type t
+
+    val of_string : string -> (t, string) result
+    val to_string : t -> string
+    val equal : t -> t -> bool
+  end
+
+  type unexpected_store_error =
+    | Writer_already_active
+    | Store_already_attached
+    | Store_released
+    | Store_release_forbidden
+    | Resource_cleanup_failed
+    | Construction_cleanup_failed
+    | Store_already_exists
+    | Correlation_mismatch
+    | Sequence_conflict
+    | Committed_content_conflict
+    | Cursor_scope_mismatch
+    | Cursor_ahead
+    | Store_poisoned
+    | Commit_outcome_unknown
+
+  type storage_failure =
+    | Invalid_store_argument of string
+    | Store_identity_failure of string
+    | Store_io_failure of
+        { operation : string
+        ; detail : string
+        }
+    | Store_codec_failure of string
+    | Store_not_found
+    | Store_initialization_incomplete
+    | Store_initialization_conflict
+    | Unsupported_store_version of
+        { expected : int
+        ; actual : int
+        }
+    | Corrupt_store of
+        { offset : int64
+        ; detail : string
+        }
+    | Commit_authority_identity_changed
+    | Commit_authority_regressed of
+        { previous_committed_offset : int64
+        ; actual_committed_offset : int64
+        ; previous_last_seq : int
+        ; actual_last_seq : int
+        }
+    | Unexpected_store_failure of
+        { kind : unexpected_store_error
+        ; detail : string
+        }
+
+  type snapshot
+
+  val read_snapshot
+    :  codec:Execution_codec_executor.t
+    -> dir:Eio.Fs.dir_ty Eio.Path.t
+    -> ?previous:snapshot
+    -> unit
+    -> (snapshot, storage_failure) result
+
+  val same_snapshot : snapshot -> snapshot -> bool
+  val scope_id : snapshot -> Scope_id.t
+  val committed_offset : snapshot -> int64
+  val last_seq : snapshot -> int
+  val appended_events : snapshot -> Execution_event.t list
+end
+
 (** Pure immutable reducer used to validate and project the event stream. *)
 module Reducer : sig
   type t

--- a/lib/llm_provider/backend_openai.ml
+++ b/lib/llm_provider/backend_openai.ml
@@ -23,7 +23,6 @@ let build_openai_tool_json = Backend_openai_serialize.build_openai_tool_json
 
 (* ── Re-exports from parsing ──────────────────────────── *)
 
-let strip_json_markdown_fences = Backend_openai_parse.strip_json_markdown_fences
 let usage_of_openai_json = Backend_openai_parse.usage_of_openai_json
 let parse_openai_response_result = Backend_openai_parse.parse_openai_response_result
 
@@ -232,24 +231,6 @@ let%test "ollama preserves min_p (llama.cpp supports it)" =
   match json |> member "min_p" with
   | `Float f -> Float.abs (f -. 0.05) < 1e-6
   | _ -> false
-;;
-
-let%test "strip_json_markdown_fences plain text unchanged" =
-  strip_json_markdown_fences "{\"key\":\"value\"}" = "{\"key\":\"value\"}"
-;;
-
-let%test "strip_json_markdown_fences strips json fences" =
-  let input = "```json\n{\"key\":\"value\"}\n```" in
-  strip_json_markdown_fences input = "{\"key\":\"value\"}"
-;;
-
-let%test "strip_json_markdown_fences strips plain fences" =
-  let input = "```\n{\"key\":\"value\"}\n```" in
-  strip_json_markdown_fences input = "{\"key\":\"value\"}"
-;;
-
-let%test "strip_json_markdown_fences short string unchanged" =
-  strip_json_markdown_fences "hi" = "hi"
 ;;
 
 let%test "tool_calls_to_openai_json extracts ToolUse blocks" =
@@ -846,13 +827,6 @@ let%test "response_format_to_openai_json preserves named schema envelope" =
        = "object"
   | None -> false
 ;;
-
-let%test "strip_json_markdown_fences no closing fence" =
-  let input = "```json\n{\"key\":\"value\"}" in
-  strip_json_markdown_fences input = input
-;;
-
-let%test "strip_json_markdown_fences empty content" = strip_json_markdown_fences "" = ""
 
 let%test "parse_openai_response_result unknown finish_reason" =
   let json_str =

--- a/lib/llm_provider/backend_openai.mli
+++ b/lib/llm_provider/backend_openai.mli
@@ -8,7 +8,6 @@
 val tool_calls_to_openai_json : Types.content_block list -> Yojson.Safe.t list
 val openai_content_parts_of_blocks : Types.content_block list -> Yojson.Safe.t list
 val openai_messages_of_message : Types.message -> Yojson.Safe.t list
-val strip_json_markdown_fences : string -> string
 val tool_choice_to_openai_json : Types.tool_choice -> Yojson.Safe.t
 val build_openai_tool_json : Yojson.Safe.t -> Yojson.Safe.t
 val response_format_to_openai_json : Types.response_format -> Yojson.Safe.t option

--- a/lib/llm_provider/backend_openai_parse.ml
+++ b/lib/llm_provider/backend_openai_parse.ml
@@ -212,26 +212,6 @@ let derive_ms token_count tok_per_sec =
   | Some _, Some _ | Some _, None | None, Some _ | None, None -> None
 ;;
 
-let strip_json_markdown_fences text =
-  let trimmed = String.trim text in
-  if String.length trimmed < 7 || String.sub trimmed 0 3 <> "```"
-  then trimmed
-  else (
-    match String.split_on_char '\n' trimmed with
-    | [] -> trimmed
-    | first :: rest ->
-      if String.length first < 3
-      then trimmed
-      else (
-        match List.rev rest with
-        | [] -> trimmed
-        | last :: middle_rev when String.trim last = "```" ->
-          String.concat "\n" (List.rev middle_rev) |> String.trim
-        | last :: _middle_rev ->
-          let (_ : string) = last in
-          trimmed))
-;;
-
 let usage_of_openai_json json =
   let open Yojson.Safe.Util in
   let usage = json |> member "usage" in
@@ -361,17 +341,6 @@ let parse_openai_response_result_json_raw (raw_json : Yojson.Safe.t) =
       choice |> member "finish_reason" |> to_string_option |> Option.value ~default:"stop"
     in
     let text_content = text_content_of_openai_content (msg |> member "content") in
-    let text_content =
-      let stripped = strip_json_markdown_fences text_content in
-      if stripped = text_content
-      then text_content
-      else (
-        try
-          let (_ : Yojson.Safe.t) = Yojson.Safe.from_string stripped in
-          stripped
-        with
-        | Yojson.Json_error _ -> text_content)
-    in
     let* tool_blocks = parse_tool_calls_field (msg |> member "tool_calls") in
     (* Ollama uses "reasoning"; OpenAI-compatible providers commonly use
        "reasoning_content"; MiniMax split mode may return "reasoning_details".

--- a/lib/llm_provider/backend_openai_parse.mli
+++ b/lib/llm_provider/backend_openai_parse.mli
@@ -5,7 +5,6 @@
     @stability Internal
     @since 0.93.1 *)
 
-val strip_json_markdown_fences : string -> string
 val usage_of_openai_json : Yojson.Safe.t -> Types.api_usage option
 
 (** Identity of an all-empty completion (oas#2483): a 200 that carried no

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -1436,6 +1436,7 @@ let test_catalog_entry id_prefix : Model_catalog.model_entry =
   ; supports_document_input = None
   ; modality_priority = None
   ; task = None
+  ; supported_models = None
   ; supports_native_streaming = None
   ; supports_system_prompt = None
   ; supports_caching = None

--- a/lib/llm_provider/exact_output.ml
+++ b/lib/llm_provider/exact_output.ml
@@ -377,7 +377,7 @@ let wire_admission_error = function
 
 let admit ~target ~messages requirement =
   let* () =
-    if Resolver.selected_target_model_admitted target
+    if Exact_output_resolver.selected_target_model_admitted target
     then Ok ()
     else
       Error

--- a/lib/llm_provider/exact_output.ml
+++ b/lib/llm_provider/exact_output.ml
@@ -65,6 +65,7 @@ type wire_admission_error =
   | Unsupported_document_input
   | Unsupported_audio_input
   | Unsupported_system_prompt
+  | Unsupported_target_model of { model_id : string }
   | Target_request_rejected
   | Request_serialization_rejected
 
@@ -375,6 +376,15 @@ let wire_admission_error = function
 ;;
 
 let admit ~target ~messages requirement =
+  let* () =
+    match target.capabilities.supported_models with
+    | None -> Ok ()
+    | Some models when List.exists (String.equal target.config.model_id) models -> Ok ()
+    | Some _ ->
+      Error
+        (Wire_admission_rejected
+           (Unsupported_target_model { model_id = target.config.model_id }))
+  in
   let* response_format, actual_assurance, effective_schema_fingerprint =
     response_format target requirement
   in

--- a/lib/llm_provider/exact_output.ml
+++ b/lib/llm_provider/exact_output.ml
@@ -377,10 +377,9 @@ let wire_admission_error = function
 
 let admit ~target ~messages requirement =
   let* () =
-    match target.capabilities.supported_models with
-    | None -> Ok ()
-    | Some models when List.exists (String.equal target.config.model_id) models -> Ok ()
-    | Some _ ->
+    if Resolver.selected_target_model_admitted target
+    then Ok ()
+    else
       Error
         (Wire_admission_rejected
            (Unsupported_target_model { model_id = target.config.model_id }))

--- a/lib/llm_provider/exact_output.mli
+++ b/lib/llm_provider/exact_output.mli
@@ -108,6 +108,7 @@ type wire_admission_error =
   | Unsupported_document_input
   | Unsupported_audio_input
   | Unsupported_system_prompt
+  | Unsupported_target_model of { model_id : string }
   | Target_request_rejected
   | Request_serialization_rejected
 

--- a/lib/llm_provider/exact_output_catalog_binding.ml
+++ b/lib/llm_provider/exact_output_catalog_binding.ml
@@ -129,6 +129,7 @@ let merge_exact_model_entry
       prefer_overlay overlay.supports_document_input base.supports_document_input
   ; modality_priority = prefer_overlay overlay.modality_priority base.modality_priority
   ; task = prefer_overlay overlay.task base.task
+  ; supported_models = prefer_overlay overlay.supported_models base.supported_models
   ; supports_native_streaming =
       prefer_overlay overlay.supports_native_streaming base.supports_native_streaming
   ; supports_system_prompt =
@@ -298,7 +299,65 @@ let capabilities_of_catalog_binding
   ; supports_system_prompt =
       bool_or base.supports_system_prompt model.supports_system_prompt
   ; task = prefer_overlay model.task base.task
+  ; supported_models = prefer_overlay model.supported_models base.supported_models
   }
+;;
+
+let%test "exact pricing-only overlay preserves functional fields" =
+  let base =
+    Model_catalog.of_toml_string
+      ~source:"exact pricing base"
+      "[[providers]]\n\
+       id = \"pricing-provider\"\n\
+       kind = \"openai_compat\"\n\
+       base_url = \"https://pricing.example\"\n\
+       request_path = \"/v1/chat/completions\"\n\
+       api_key_env = \"\"\n\
+       capabilities_base = \"openai_chat\"\n\
+       [[models]]\n\
+       id_prefix = \"pricing-model\"\n\
+       provider_name = \"pricing-provider\"\n\
+       max_context_tokens = 100\n\
+       supports_response_format_json = true\n\
+       supports_document_input = true\n\
+       supported_models = [\"pricing-model\"]\n\
+       input_per_million = 1.0\n"
+  in
+  let overlay =
+    Model_catalog.of_toml_string
+      ~source:"exact pricing overlay"
+      "[[models]]\n\
+       id_prefix = \"pricing-model\"\n\
+       provider_name = \"pricing-provider\"\n\
+       input_per_million = 99.0\n"
+  in
+  match base, overlay with
+  | Ok base, Ok overlay ->
+    (match
+       ( Model_catalog.provider_entries base
+       , Model_catalog.model_entries base
+       , merge_exact_model_entries
+           ~base:(Model_catalog.model_entries base)
+           ~overlay:(Model_catalog.model_entries overlay) )
+     with
+     | [ provider ], [ base_model ], [ merged_model ] ->
+       let base_capabilities = capabilities_of_catalog_binding provider base_model in
+       let merged_capabilities = capabilities_of_catalog_binding provider merged_model in
+       functional_capability_projection
+         base_capabilities
+         ~anthropic_thinking_control:
+           (catalog_anthropic_thinking_control base_model.anthropic_thinking_control)
+       = functional_capability_projection
+           merged_capabilities
+           ~anthropic_thinking_control:
+             (catalog_anthropic_thinking_control merged_model.anthropic_thinking_control)
+       && merged_model.max_context_tokens = Some 100
+       && merged_model.supports_response_format_json = Some true
+       && merged_model.supports_document_input = Some true
+       && merged_model.supported_models = Some [ "pricing-model" ]
+       && merged_model.input_per_million = Some 99.0
+     | _ -> false)
+  | Error _, _ | _, Error _ -> false
 ;;
 
 let%test "exact functional capability projection has a stable golden" =

--- a/lib/llm_provider/exact_output_catalog_binding.ml
+++ b/lib/llm_provider/exact_output_catalog_binding.ml
@@ -226,6 +226,12 @@ let anthropic_thinking_control_string = function
   | Some Caps.Anthropic_always_adaptive -> "always_adaptive"
 ;;
 
+let target_model_admitted (caps : Caps.capabilities) ~model_id =
+  match caps.supported_models with
+  | None -> true
+  | Some models -> List.exists (String.equal model_id) models
+;;
+
 let supported_models_string = function
   | None -> "none"
   | Some models -> "some:" ^ String.concat "," (List.sort_uniq String.compare models)

--- a/lib/llm_provider/exact_output_catalog_binding.mli
+++ b/lib/llm_provider/exact_output_catalog_binding.mli
@@ -32,6 +32,8 @@ val anthropic_thinking_control_string
   :  Capabilities.anthropic_thinking_control option
   -> string
 
+val target_model_admitted : Capabilities.capabilities -> model_id:string -> bool
+
 val catalog_anthropic_thinking_control
   :  Capability_vocab.anthropic_thinking_control option
   -> Capabilities.anthropic_thinking_control option

--- a/lib/llm_provider/exact_output_plan.ml
+++ b/lib/llm_provider/exact_output_plan.ml
@@ -432,9 +432,38 @@ let structured_text content =
   loop [] content
 ;;
 
-let stop_is_terminal = function
-  | Types.EndTurn | Types.StopSequence -> true
-  | Types.StopToolUse
+let normalize_text response_format text =
+  match response_format with
+  | Types.Off -> Ok (Text_output text)
+  | (Types.JsonMode | Types.JsonSchema _) as response_format ->
+    (try
+       let value = Yojson.Safe.from_string text in
+       let validation =
+         match response_format with
+         | Types.JsonMode -> Json_syntax_validated
+         | Types.JsonSchema _ -> Provider_schema_requested_client_validation_required
+         | Types.Off -> assert false
+       in
+       Ok (Json_output { value; validation })
+     with
+     | Yojson.Json_error detail -> Error (Invalid_json detail))
+;;
+
+let normalize_response response_format (response : Types.api_response) =
+  match response.stop_reason with
+  | Types.EndTurn | Types.StopSequence ->
+    (match structured_text response.content with
+     | Error _ as error -> error
+     | Ok text -> normalize_text response_format text)
+  | Types.StopToolUse ->
+    (match structured_text response.content with
+     | Error Unexpected_structured_content as error -> error
+     | Ok _
+     | Error Missing_structured_text
+     | Error (Ambiguous_structured_text _)
+     | Error (Incomplete_structured_response _)
+     | Error (Invalid_json _) ->
+       Error (Incomplete_structured_response response.stop_reason))
   | Types.MaxTokens
   | Types.Refusal
   | Types.ContentFilter
@@ -443,30 +472,7 @@ let stop_is_terminal = function
   | Types.Compaction
   | Types.ContextWindowExceeded
   | Types.UnmatchedToolCalls
-  | Types.Unknown _ -> false
-;;
-
-let normalize_response response_format (response : Types.api_response) =
-  if not (stop_is_terminal response.stop_reason)
-  then Error (Incomplete_structured_response response.stop_reason)
-  else (
-    match structured_text response.content with
-    | Error _ as error -> error
-    | Ok text ->
-      (match response_format with
-       | Types.Off -> Ok (Text_output text)
-       | (Types.JsonMode | Types.JsonSchema _) as response_format ->
-         (try
-            let value = Yojson.Safe.from_string text in
-            let validation =
-              match response_format with
-              | Types.JsonMode -> Json_syntax_validated
-              | Types.JsonSchema _ -> Provider_schema_requested_client_validation_required
-              | Types.Off -> assert false
-            in
-            Ok (Json_output { value; validation })
-          with
-          | Yojson.Json_error detail -> Error (Invalid_json detail))))
+  | Types.Unknown _ -> Error (Incomplete_structured_response response.stop_reason)
 ;;
 
 let normalize plan response = normalize_response plan.response_format response

--- a/lib/llm_provider/exact_output_resolver.ml
+++ b/lib/llm_provider/exact_output_resolver.ml
@@ -160,9 +160,7 @@ let selected_target_catalog_generation (target : selected_target) = target.gener
 let selected_target_catalog_evidence (target : selected_target) = target.evidence
 
 let selected_target_model_admitted (target : selected_target) =
-  match target.capabilities.supported_models with
-  | None -> true
-  | Some models -> List.exists (String.equal target.config.model_id) models
+  Binding.target_model_admitted target.capabilities ~model_id:target.config.model_id
 ;;
 
 let has_control value =

--- a/lib/llm_provider/exact_output_resolver.ml
+++ b/lib/llm_provider/exact_output_resolver.ml
@@ -391,6 +391,95 @@ let merge_target_declarations ~base ~overlay =
       base
 ;;
 
+let%test "exact target id overlay replaces the complete base declaration" =
+  let fixture ~model_id ~target_id =
+    Printf.sprintf
+      "[[providers]]\n\
+       id = \"inline-provider\"\n\
+       kind = \"openai_compat\"\n\
+       base_url = \"https://inline.example\"\n\
+       request_path = \"/v1/chat/completions\"\n\
+       api_key_env = \"\"\n\n\
+       [[models]]\n\
+       id_prefix = %S\n\
+       provider_name = \"inline-provider\"\n\
+       supports_response_format_json = true\n\n\
+       [[targets]]\n\
+       id = %S\n\
+       provider_ref = \"inline-provider\"\n\
+       model_id = %S\n"
+      model_id
+      target_id
+      model_id
+  in
+  let parse source contents =
+    match
+      ( Model_catalog.of_toml_string
+          ~source:"exact target replacement inline test"
+          contents
+      , parse_target_catalog ~source contents )
+    with
+    | Ok catalog, Ok targets ->
+      (match validate_catalog_source catalog targets with
+       | Ok () -> Some (catalog, targets)
+       | Error _ -> None)
+    | Error _, _ | _, Error _ -> None
+  in
+  match
+    ( parse Embedded_catalog (fixture ~model_id:"base-model" ~target_id:"inline-target")
+    , parse Overlay_catalog (fixture ~model_id:"overlay-model" ~target_id:"inline-target")
+    )
+  with
+  | Some (base, base_targets), Some (overlay, overlay_targets) ->
+    (match validate_overlay_collisions ~base ~base_targets ~overlay ~overlay_targets with
+     | Ok () ->
+       merge_target_declarations ~base:base_targets ~overlay:overlay_targets
+       = overlay_targets
+     | Error _ -> false)
+  | None, _ | _, None -> false
+;;
+
+let%test "case-only target overlay shadow fails closed" =
+  let fixture target_id =
+    Printf.sprintf
+      "[[providers]]\n\
+       id = \"inline-provider\"\n\
+       kind = \"openai_compat\"\n\
+       base_url = \"https://inline.example\"\n\
+       request_path = \"/v1/chat/completions\"\n\
+       api_key_env = \"\"\n\n\
+       [[models]]\n\
+       id_prefix = \"inline-model\"\n\
+       provider_name = \"inline-provider\"\n\
+       supports_response_format_json = true\n\n\
+       [[targets]]\n\
+       id = %S\n\
+       provider_ref = \"inline-provider\"\n\
+       model_id = \"inline-model\"\n"
+      target_id
+  in
+  let parse source contents =
+    match
+      ( Model_catalog.of_toml_string ~source:"target shadow inline test" contents
+      , parse_target_catalog ~source contents )
+    with
+    | Ok catalog, Ok targets ->
+      (match validate_catalog_source catalog targets with
+       | Ok () -> Some (catalog, targets)
+       | Error _ -> None)
+    | Error _, _ | _, Error _ -> None
+  in
+  match
+    ( parse Embedded_catalog (fixture "inline-target")
+    , parse Overlay_catalog (fixture "INLINE-TARGET") )
+  with
+  | Some (base, base_targets), Some (overlay, overlay_targets) ->
+    (match validate_overlay_collisions ~base ~base_targets ~overlay ~overlay_targets with
+     | Error (Catalog_collision Target_identity_shadow) -> true
+     | Ok () | Error _ -> false)
+  | None, _ | _, None -> false
+;;
+
 let validate_base_url ~target_ref value =
   if has_control value
   then Error (Target_endpoint_invalid { target_ref; cause = Malformed_base_url })
@@ -545,6 +634,7 @@ let canonical_catalog_evidence catalog model_entries target_declarations =
       ; (match model.task with
          | None -> "none"
          | Some task -> Binding.task_string (Some task))
+      ; "supported_models=" ^ Binding.supported_models_string model.supported_models
       ; option_bool model.supports_system_prompt
       ; Binding.anthropic_thinking_control_string
           (Binding.catalog_anthropic_thinking_control model.anthropic_thinking_control)

--- a/lib/llm_provider/exact_output_resolver.ml
+++ b/lib/llm_provider/exact_output_resolver.ml
@@ -159,6 +159,12 @@ let selected_target_identity (target : selected_target) = target.identity
 let selected_target_catalog_generation (target : selected_target) = target.generation
 let selected_target_catalog_evidence (target : selected_target) = target.evidence
 
+let selected_target_model_admitted (target : selected_target) =
+  match target.capabilities.supported_models with
+  | None -> true
+  | Some models -> List.exists (String.equal target.config.model_id) models
+;;
+
 let has_control value =
   String.exists
     (fun character -> Char.code character < 0x20 || Char.code character = 0x7f)

--- a/lib/llm_provider/exact_output_resolver.ml
+++ b/lib/llm_provider/exact_output_resolver.ml
@@ -582,6 +582,11 @@ let option_bool = function
   | Some value -> "some:" ^ Binding.bool_string value
 ;;
 
+let canonical_supported_models = function
+  | None -> "none"
+  | Some models -> "some:" ^ String.concat "," (List.sort_uniq String.compare models)
+;;
+
 let option_price = function
   | None -> "none"
   | Some value -> Printf.sprintf "some:%.17g" value
@@ -634,7 +639,7 @@ let canonical_catalog_evidence catalog model_entries target_declarations =
       ; (match model.task with
          | None -> "none"
          | Some task -> Binding.task_string (Some task))
-      ; "supported_models=" ^ Binding.supported_models_string model.supported_models
+      ; "supported_models=" ^ canonical_supported_models model.supported_models
       ; option_bool model.supports_system_prompt
       ; Binding.anthropic_thinking_control_string
           (Binding.catalog_anthropic_thinking_control model.anthropic_thinking_control)

--- a/lib/llm_provider/exact_output_resolver.mli
+++ b/lib/llm_provider/exact_output_resolver.mli
@@ -91,6 +91,7 @@ val target_identity_fingerprint : target_identity -> string
 val selected_target_identity : selected_target -> target_identity
 val selected_target_catalog_generation : selected_target -> catalog_generation
 val selected_target_catalog_evidence : selected_target -> catalog_evidence
+val selected_target_model_admitted : selected_target -> bool
 val hash_parts : string list -> string
 val option_float : float option -> string
 

--- a/lib/llm_provider/model_catalog.ml
+++ b/lib/llm_provider/model_catalog.ml
@@ -31,6 +31,7 @@ type model_entry =
   ; supports_document_input : bool option
   ; modality_priority : string option
   ; task : Capability_vocab.task option
+  ; supported_models : string list option
   ; supports_native_streaming : bool option
   ; supports_system_prompt : bool option
   ; supports_caching : bool option
@@ -141,6 +142,49 @@ let float_field ~entry_id = optional_field ~entry_id ~expected:"float" Otoml.get
 
 let string_list_field ~entry_id =
   optional_field ~entry_id ~expected:"string array" (Otoml.get_array Otoml.get_string)
+;;
+
+let exact_non_empty_string_list_opt ~entry_id key toml =
+  match string_list_field ~entry_id key toml with
+  | Error _ as error -> error
+  | Ok None -> Ok None
+  | Ok (Some []) ->
+    Error
+      (Printf.sprintf
+         "model entry %S field %S must contain at least one value"
+         entry_id
+         key)
+  | Ok (Some values) ->
+    let rec validate seen = function
+      | [] -> Ok (Some values)
+      | raw :: rest ->
+        let trimmed = String.trim raw in
+        if trimmed = ""
+        then
+          Error
+            (Printf.sprintf
+               "model entry %S field %S values must not be empty"
+               entry_id
+               key)
+        else if raw <> trimmed
+        then
+          Error
+            (Printf.sprintf
+               "model entry %S field %S values must not have leading or trailing \
+                whitespace"
+               entry_id
+               key)
+        else if List.mem raw seen
+        then
+          Error
+            (Printf.sprintf
+               "model entry %S field %S contains duplicate value %S"
+               entry_id
+               key
+               raw)
+        else validate (raw :: seen) rest
+    in
+    validate [] values
 ;;
 
 let canonical_string_list_opt ~entry_id key ~allowed toml =
@@ -286,6 +330,7 @@ let known_entry_keys =
   ; "supports_document_input"
   ; "modality_priority"
   ; "task"
+  ; "supported_models"
   ; "supports_native_streaming"
   ; "supports_system_prompt"
   ; "supports_caching"
@@ -419,6 +464,9 @@ let parse_entry entry_toml =
       entry_toml
   in
   let* task = task_opt ~entry_id:id_prefix "task" entry_toml in
+  let* supported_models =
+    exact_non_empty_string_list_opt ~entry_id:id_prefix "supported_models" entry_toml
+  in
   let* supports_native_streaming =
     bool_field ~entry_id:id_prefix "supports_native_streaming" entry_toml
   in
@@ -527,6 +575,7 @@ let parse_entry entry_toml =
     ; supports_document_input
     ; modality_priority
     ; task
+    ; supported_models
     ; supports_native_streaming
     ; supports_system_prompt
     ; supports_caching
@@ -564,6 +613,32 @@ let%test "parse_entry accepts an entry whose fields are all known" =
   match parse_entry entry with
   | Ok _ -> true
   | Error _ -> false
+;;
+
+let%test "parse_entry rejects empty supported_models list" =
+  let entry = Otoml.Parser.from_string "id_prefix = \"m\"\nsupported_models = []" in
+  match parse_entry entry with
+  | Error _ -> true
+  | Ok _ -> false
+;;
+
+let%test "parse_entry rejects whitespace-only supported_models item" =
+  let entry =
+    Otoml.Parser.from_string "id_prefix = \"m\"\nsupported_models = [\"   \"]"
+  in
+  match parse_entry entry with
+  | Error _ -> true
+  | Ok _ -> false
+;;
+
+let%test "parse_entry rejects duplicate supported_models" =
+  let entry =
+    Otoml.Parser.from_string
+      "id_prefix = \"m\"\nsupported_models = [\"model-a\", \"model-a\"]"
+  in
+  match parse_entry entry with
+  | Error _ -> true
+  | Ok _ -> false
 ;;
 
 let%test "parse_entry parses a canonical task value into the closed variant" =

--- a/lib/llm_provider/model_catalog.mli
+++ b/lib/llm_provider/model_catalog.mli
@@ -35,6 +35,10 @@ type model_entry =
         speech, image/video generation). Parsed fail-closed against
         {!Capability_vocab.task_values}; [None] means the entry declares no
         task — it is never inferred from the model id. *)
+  ; supported_models : string list option
+    (** Explicit exact model identities supported by this catalog row. A
+        declaration must be a non-empty array of non-empty, exactly trimmed,
+        unique strings. *)
   ; supports_native_streaming : bool option
   ; supports_system_prompt : bool option
   ; supports_caching : bool option

--- a/lib/llm_provider/pricing.ml
+++ b/lib/llm_provider/pricing.ml
@@ -159,6 +159,7 @@ let test_catalog_entry ?provider_name ?input ?output ?cache_write ?cache_read id
   ; supports_document_input = None
   ; modality_priority = None
   ; task = None
+  ; supported_models = None
   ; supports_native_streaming = None
   ; supports_system_prompt = None
   ; supports_caching = None

--- a/lib/structured.ml
+++ b/lib/structured.ml
@@ -88,10 +88,7 @@ type response_json_shape =
   | Object_json
 
 let text_json_of_response (response : api_response) =
-  response
-  |> Types.text_of_response
-  |> Llm_provider.Backend_openai.strip_json_markdown_fences
-  |> String.trim
+  response |> Types.text_of_response |> String.trim
 ;;
 
 let extract_response_json ?(shape = Any_json) (response : api_response)

--- a/models.toml
+++ b/models.toml
@@ -365,7 +365,7 @@ supports_reasoning_budget = false
 accepted_reasoning_efforts = ["high", "max"]
 thinking_control_format = "thinking_object"
 supports_response_format_json = true
-supports_structured_output = false
+supports_structured_output = true
 supports_native_streaming = true
 supports_caching = true
 supports_prompt_caching = false
@@ -618,6 +618,7 @@ supports_reasoning = true
 supports_extended_thinking = true
 supports_reasoning_budget = true
 thinking_control_format = "ollama_think"
+supports_response_format_json = true
 supports_multimodal_inputs = true
 supports_image_input = true
 modality_priority = "visual_first"
@@ -748,6 +749,7 @@ thinking_control_format = "ollama_think"
 # Kimi K2 docs: reasoning content must be replayed (hard-required on tool turns,
 # recommended on all turns). Without this, the base replay policy is no_replay.
 reasoning_replay = "preserve_always"
+supports_response_format_json = true
 supports_multimodal_inputs = true
 supports_image_input = true
 modality_priority = "visual_first"

--- a/scripts/check-exact-output-resolver-boundary.sh
+++ b/scripts/check-exact-output-resolver-boundary.sh
@@ -316,8 +316,18 @@ require_code_pattern \
   'Complete_common\.serialize_http_request_with_thinking_control' \
   "$exact_output_plan_source"
 require_named_function_pattern \
-  "Complete_common exact serializer no longer calls the frozen Anthropic artifact entrypoint" \
+  "Complete_common serialization policy lost the frozen Anthropic artifact entrypoint" \
   'Backend_anthropic\.build_request_artifact_with_thinking_control' \
+  "$(dirname "$exact_output_source")/complete_common.ml" \
+  'serialize_http_request_with_policy'
+require_named_function_pattern \
+  "Complete_common exact serializer no longer delegates to the serialization policy" \
+  'serialize_http_request_with_policy' \
+  "$(dirname "$exact_output_source")/complete_common.ml" \
+  'serialize_http_request_with_thinking_control'
+require_named_function_pattern \
+  "Complete_common exact serializer no longer selects the frozen Anthropic policy" \
+  'Frozen_anthropic_thinking_control[[:space:]]+anthropic_thinking_control' \
   "$(dirname "$exact_output_source")/complete_common.ml" \
   'serialize_http_request_with_thinking_control'
 require_named_function_pattern \

--- a/scripts/check-exact-output-resolver-boundary.sh
+++ b/scripts/check-exact-output-resolver-boundary.sh
@@ -157,7 +157,7 @@ extract_named_functions() {
       sub(/^let[[:space:]]+(rec[[:space:]]+)?/, "", declaration)
       name = declaration
       sub(/[[:space:](].*$/, "", name)
-      capture = required[name]
+      capture = (name in required)
       if (capture) found[name] = 1
     }
     {

--- a/scripts/check-exact-output-resolver-boundary.sh
+++ b/scripts/check-exact-output-resolver-boundary.sh
@@ -393,6 +393,7 @@ scan_code \
 
 for private_module in \
   exact_output_plan \
+  exact_output_execution \
   exact_output_resolver \
   exact_output_catalog_binding
 do

--- a/scripts/check-exact-output-resolver-boundary.sh
+++ b/scripts/check-exact-output-resolver-boundary.sh
@@ -152,6 +152,9 @@ extract_named_functions() {
       }
       capture = 0
     }
+    /^let%[[:alnum:]_]+[[:space:]]/ {
+      capture = 0
+    }
     /^let[[:space:]]/ {
       declaration = $0
       sub(/^let[[:space:]]+(rec[[:space:]]+)?/, "", declaration)

--- a/scripts/check-exact-output-resolver-boundary.sh
+++ b/scripts/check-exact-output-resolver-boundary.sh
@@ -397,7 +397,7 @@ for private_module in \
   exact_output_catalog_binding
 do
   if ! sed -n '/(private_modules/,/)/p' "$module_dir/dune" \
-    | grep -E "^[[:space:]]*$private_module([[:space:]]|\))" >/dev/null; then
+    | grep -E "^[[:space:]]*$private_module([[:space:]]|\)|$)" >/dev/null; then
     echo "exact-output public facade violation: $private_module is not private" >&2
     exit 1
   fi

--- a/scripts/check-exact-output-resolver-boundary.sh
+++ b/scripts/check-exact-output-resolver-boundary.sh
@@ -204,7 +204,7 @@ require_code_pattern() {
   local description="$1"
   local pattern="$2"
   local source_file="$3"
-  if ! strip_ocaml_noncode < "$source_file" | grep -Eq -- "$pattern"; then
+  if ! strip_ocaml_noncode < "$source_file" | grep -E -- "$pattern" >/dev/null; then
     echo "exact-output boundary violation: $description" >&2
     return 1
   fi
@@ -222,7 +222,7 @@ require_named_function_pattern() {
     echo "exact-output boundary violation: $description" >&2
     return 1
   fi
-  if ! strip_ocaml_noncode < "$extracted" | grep -Eq -- "$pattern"; then
+  if ! strip_ocaml_noncode < "$extracted" | grep -E -- "$pattern" >/dev/null; then
     rm -f "$extracted"
     echo "exact-output boundary violation: $description" >&2
     return 1
@@ -384,7 +384,7 @@ for private_module in \
   exact_output_catalog_binding
 do
   if ! sed -n '/(private_modules/,/)/p' "$module_dir/dune" \
-    | grep -Eq "^[[:space:]]*$private_module([[:space:]]|\))"; then
+    | grep -E "^[[:space:]]*$private_module([[:space:]]|\))" >/dev/null; then
     echo "exact-output public facade violation: $private_module is not private" >&2
     exit 1
   fi

--- a/scripts/check-execution-store-boundary.sh
+++ b/scripts/check-execution-store-boundary.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
 
+source_list="$(mktemp)"
+trap 'rm -f "$source_list"' EXIT
+find lib -type f \( -name '*.ml' -o -name '*.mli' \) -print \
+  | LC_ALL=C sort >"$source_list"
+
 failed=0
 while IFS= read -r source; do
   case "$source" in
@@ -22,7 +27,7 @@ while IFS= read -r source; do
       failed=1
     fi
   done
-done < <(rg --files lib -g '*.ml' -g '*.mli' | LC_ALL=C sort)
+done <"$source_list"
 
 if ((failed != 0)); then
   printf '%s\n' \

--- a/test/test_api.ml
+++ b/test/test_api.ml
@@ -255,7 +255,7 @@ let test_parse_response_unknown_stop () =
   | sr -> fail (Printf.sprintf "expected Unknown, got %s" (Types.show_stop_reason sr))
 ;;
 
-let test_parse_openai_response_strips_fenced_json () =
+let test_parse_openai_response_preserves_fenced_json () =
   let json_str =
     {|{
     "id": "chatcmpl_test",
@@ -278,10 +278,10 @@ let test_parse_openai_response_strips_fenced_json () =
     (match resp.content with
      | [ Types.Text text ] ->
        Alcotest.(check string)
-         "stripped json"
-         "{\"engine\":\"default\",\"tool_calling\":false}"
+         "fenced JSON preserved"
+         "```json\n{\"engine\":\"default\",\"tool_calling\":false}\n```"
          text
-     | _ -> Alcotest.fail "expected stripped text block")
+     | _ -> Alcotest.fail "expected raw fenced text block")
 ;;
 
 let test_parse_openai_response_reasoning_content () =
@@ -859,9 +859,9 @@ let () =
         ; test_case "tool_use response" `Quick test_parse_response_tool_use
         ; test_case "unknown stop_reason" `Quick test_parse_response_unknown_stop
         ; test_case
-            "strip fenced json"
+            "preserve fenced json"
             `Quick
-            test_parse_openai_response_strips_fenced_json
+            test_parse_openai_response_preserves_fenced_json
         ; test_case "cache tokens in usage" `Quick test_parse_response_with_cache_tokens
         ; test_case
             "reasoning_content"

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -1140,18 +1140,6 @@ let test_tool_schema_defaults_and_legacy_edge_params () =
     (member "required" params |> as_list "required" |> List.length)
 ;;
 
-let test_strip_json_markdown_fences_variants () =
-  check_string "plain" "plain" (Parse.strip_json_markdown_fences " plain ");
-  check_string
-    "json fence"
-    {|{"a":1}|}
-    (Parse.strip_json_markdown_fences "```json\n{\"a\":1}\n```");
-  check_string
-    "unterminated fence"
-    "```\n{\"a\":1}"
-    (Parse.strip_json_markdown_fences "```\n{\"a\":1}")
-;;
-
 let test_usage_openai_fallbacks () =
   let usage =
     Parse.usage_of_openai_json
@@ -1246,7 +1234,7 @@ let test_parse_text_list_reasoning_and_reported_telemetry () =
   | _ -> Alcotest.fail "expected telemetry"
 ;;
 
-let test_parse_reasoning_without_reported_tokens_and_fenced_json () =
+let test_parse_reasoning_without_reported_tokens_preserves_fenced_json () =
   let json =
     response_json
       ~content:(`String "```json\n{\"ok\":true}\n```")
@@ -1255,8 +1243,8 @@ let test_parse_reasoning_without_reported_tokens_and_fenced_json () =
   in
   let response = parse_ok json in
   (match response.content with
-   | [ Thinking { content = "abcdefghij"; _ }; Text {|{"ok":true}|} ] -> ()
-   | _ -> Alcotest.fail "expected reasoning and stripped JSON text");
+   | [ Thinking { content = "abcdefghij"; _ }; Text "```json\n{\"ok\":true}\n```" ] -> ()
+   | _ -> Alcotest.fail "expected reasoning and lossless fenced JSON text");
   match response.telemetry with
   | Some { timings = None; reasoning_tokens = None; _ } -> ()
   | _ -> Alcotest.fail "reasoning tokens must remain absent when provider omits them"
@@ -2259,19 +2247,15 @@ let () =
             test_parallel_tool_calls_fields
         ] )
     ; ( "parse"
-      , [ Alcotest.test_case
-            "strip markdown fences variants"
-            `Quick
-            test_strip_json_markdown_fences_variants
-        ; Alcotest.test_case "usage fallbacks" `Quick test_usage_openai_fallbacks
+      , [ Alcotest.test_case "usage fallbacks" `Quick test_usage_openai_fallbacks
         ; Alcotest.test_case
             "text list reasoning and reported telemetry"
             `Quick
             test_parse_text_list_reasoning_and_reported_telemetry
         ; Alcotest.test_case
-            "reasoning without token estimate and fenced JSON"
+            "reasoning without token estimate preserves fenced JSON"
             `Quick
-            test_parse_reasoning_without_reported_tokens_and_fenced_json
+            test_parse_reasoning_without_reported_tokens_preserves_fenced_json
         ; Alcotest.test_case
             "tool calls reject malformed"
             `Quick

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -856,14 +856,14 @@ let test_ollama_cloud_grouped_rows_have_required_axes () =
   let cases =
     [ "qwen3.5:397b", false
     ; "gemma4:31b", true
-    ; "kimi-k2.7-code", true
+    ; "kimi-k2.7-code", false
     ; "minimax-m3", true
-    ; "nemotron-3-ultra", true
-    ; "deepseek-v4-flash", true
-    ; "deepseek-v4-pro", true
-    ; "glm-5.2", true
-    ; "gpt-oss:20b", true
-    ; "gpt-oss:120b", true
+    ; "nemotron-3-ultra", false
+    ; "deepseek-v4-flash", false
+    ; "deepseek-v4-pro", false
+    ; "glm-5.2", false
+    ; "gpt-oss:20b", false
+    ; "gpt-oss:120b", false
     ]
   in
   List.iter
@@ -893,24 +893,24 @@ let test_ollama_cloud_grouped_rows_have_required_axes () =
 ;;
 
 let test_ollama_cloud_grouped_rows_follow_exact_output_contract () =
-  (* Exact-output support is model-specific. Rows without affirmative evidence
-     stay fail-closed; supported rows retain both catalog capability axes. *)
+  (* JSON response-format support is model-specific. Native structured output
+     remains disabled by the Ollama Cloud provider contract. *)
   let cases =
-    [ "kimi-k2.5", false, false
-    ; "kimi-k2.6", true, true
-    ; "kimi-k2.7-code", true, true
-    ; "minimax-m3", true, true
-    ; "deepseek-v4-pro", true, true
-    ; "deepseek-v4-flash", true, true
-    ; "glm-5.2", true, true
-    ; "gpt-oss:20b", true, true
-    ; "gpt-oss:120b", true, true
-    ; "nemotron-3-ultra", true, true
-    ; "qwen3.5:397b", false, false
+    [ "kimi-k2.5", false
+    ; "kimi-k2.6", true
+    ; "kimi-k2.7-code", false
+    ; "minimax-m3", true
+    ; "deepseek-v4-pro", false
+    ; "deepseek-v4-flash", false
+    ; "glm-5.2", false
+    ; "gpt-oss:20b", false
+    ; "gpt-oss:120b", false
+    ; "nemotron-3-ultra", false
+    ; "qwen3.5:397b", false
     ]
   in
   List.iter
-    (fun (model_id, expected_json, expected_so) ->
+    (fun (model_id, expected_json) ->
        match
          Capabilities.for_provider_model_id
            ~allow_bare_fallback:false
@@ -924,11 +924,7 @@ let test_ollama_cloud_grouped_rows_follow_exact_output_contract () =
            (model_id ^ " json response format")
            expected_json
            c.supports_response_format_json;
-         check
-           bool
-           (model_id ^ " structured output")
-           expected_so
-           c.supports_structured_output)
+         check bool (model_id ^ " structured output") false c.supports_structured_output)
     cases
 ;;
 
@@ -1399,63 +1395,63 @@ let test_frontier_grouped_tool_thinking_provider_contracts () =
       , Provider_qualified "ollama_cloud"
       , "gemma4:31b"
       , Extended_thinking
-      , Response_format_json_schema
+      , Response_format_json
       , Replay_not_required
       , Delta_stream "thinking" )
     ; ( "Ollama Cloud Kimi K2.7 Code"
       , Provider_qualified "ollama_cloud"
       , "kimi-k2.7-code"
       , Extended_thinking
-      , Response_format_json_schema
+      , No_structured_output
       , Replay_every_turn
       , Delta_stream "thinking" )
     ; ( "Ollama Cloud MiniMax M3"
       , Provider_qualified "ollama_cloud"
       , "minimax-m3"
       , Extended_thinking
-      , Response_format_json_schema
+      , Response_format_json
       , Replay_not_required
       , Delta_stream "reasoning" )
     ; ( "Ollama Cloud Nemotron 3 Ultra"
       , Provider_qualified "ollama_cloud"
       , "nemotron-3-ultra"
       , Extended_thinking
-      , Response_format_json_schema
+      , No_structured_output
       , Replay_not_required
       , Delta_stream "thinking" )
     ; ( "Ollama Cloud DeepSeek V4 Pro"
       , Provider_qualified "ollama_cloud"
       , "deepseek-v4-pro"
       , Extended_thinking
-      , Response_format_json_schema
+      , No_structured_output
       , Replay_not_required
       , Delta_stream "thinking" )
     ; ( "Ollama Cloud DeepSeek V4 Flash"
       , Provider_qualified "ollama_cloud"
       , "deepseek-v4-flash"
       , Extended_thinking
-      , Response_format_json_schema
+      , No_structured_output
       , Replay_not_required
       , Delta_stream "thinking" )
     ; ( "Ollama Cloud GLM 5.2"
       , Provider_qualified "ollama_cloud"
       , "glm-5.2"
       , Extended_thinking
-      , Response_format_json_schema
+      , No_structured_output
       , Replay_not_required
       , Delta_stream "thinking" )
     ; ( "Ollama Cloud GPT-OSS 20B"
       , Provider_qualified "ollama_cloud"
       , "gpt-oss:20b"
       , Extended_thinking
-      , Response_format_json_schema
+      , No_structured_output
       , Replay_not_required
       , Delta_stream "thinking" )
     ; ( "Ollama Cloud GPT-OSS 120B"
       , Provider_qualified "ollama_cloud"
       , "gpt-oss:120b"
       , Extended_thinking
-      , Response_format_json_schema
+      , No_structured_output
       , Replay_not_required
       , Delta_stream "thinking" )
     ]

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -1086,6 +1086,7 @@ let test_ollama_cloud_provider_qualified_preserves_shared_bare_family () =
 
 type structured_contract =
   | Response_format_json_schema
+  | Response_format_json
   | Native_structured_output
   | No_structured_output
 
@@ -1180,6 +1181,13 @@ let check_frontier_model
        check
          bool
          (label ^ " supports response_format/json_schema")
+         true
+         c.supports_response_format_json
+     | Response_format_json ->
+       check bool (label ^ " no structured output") false c.supports_structured_output;
+       check
+         bool
+         (label ^ " supports response_format/json")
          true
          c.supports_response_format_json
      | Native_structured_output ->

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -851,24 +851,23 @@ let test_ollama_cloud_grouped_rows_have_required_axes () =
   (* Live grouped smokes for these Ollama Cloud rows exercise the same
      production workflow: tool call -> tool_result replay -> final answer while
      reasoning may stream on a side channel. The catalog must not regress any
-     one of these axes to a generic text-only profile. Structured output is
-     checked separately and remains fail-closed because Ollama Cloud does not
-     expose a structured-output contract. *)
+     one of these axes to a generic text-only profile. JSON response-format
+     support is an exact per-model contract rather than a provider-wide rule. *)
   let cases =
-    [ "qwen3.5:397b"
-    ; "gemma4:31b"
-    ; "kimi-k2.7-code"
-    ; "minimax-m3"
-    ; "nemotron-3-ultra"
-    ; "deepseek-v4-flash"
-    ; "deepseek-v4-pro"
-    ; "glm-5.2"
-    ; "gpt-oss:20b"
-    ; "gpt-oss:120b"
+    [ "qwen3.5:397b", false
+    ; "gemma4:31b", true
+    ; "kimi-k2.7-code", true
+    ; "minimax-m3", true
+    ; "nemotron-3-ultra", true
+    ; "deepseek-v4-flash", true
+    ; "deepseek-v4-pro", true
+    ; "glm-5.2", true
+    ; "gpt-oss:20b", true
+    ; "gpt-oss:120b", true
     ]
   in
   List.iter
-    (fun model_id ->
+    (fun (model_id, expected_json) ->
        match
          Capabilities.for_provider_model_id
            ~allow_bare_fallback:false
@@ -884,7 +883,7 @@ let test_ollama_cloud_grouped_rows_have_required_axes () =
          check
            bool
            (model_id ^ " json response format")
-           false
+           expected_json
            c.supports_response_format_json;
          check_thinking_control
            (model_id ^ " uses Ollama native think")
@@ -893,25 +892,25 @@ let test_ollama_cloud_grouped_rows_have_required_axes () =
     cases
 ;;
 
-let test_ollama_cloud_grouped_non_so_rows_do_not_advertise_so () =
-  (* Ollama Cloud exposes neither JSON response-format mode nor native schema
-     enforcement. Both exact-output capability axes must stay fail-closed. *)
+let test_ollama_cloud_grouped_rows_follow_exact_output_contract () =
+  (* Exact-output support is model-specific. Rows without affirmative evidence
+     stay fail-closed; supported rows retain both catalog capability axes. *)
   let cases =
-    [ "kimi-k2.5"
-    ; "kimi-k2.6"
-    ; "kimi-k2.7-code"
-    ; "minimax-m3"
-    ; "deepseek-v4-pro"
-    ; "deepseek-v4-flash"
-    ; "glm-5.2"
-    ; "gpt-oss:20b"
-    ; "gpt-oss:120b"
-    ; "nemotron-3-ultra"
-    ; "qwen3.5:397b"
+    [ "kimi-k2.5", false, false
+    ; "kimi-k2.6", true, true
+    ; "kimi-k2.7-code", true, true
+    ; "minimax-m3", true, true
+    ; "deepseek-v4-pro", true, true
+    ; "deepseek-v4-flash", true, true
+    ; "glm-5.2", true, true
+    ; "gpt-oss:20b", true, true
+    ; "gpt-oss:120b", true, true
+    ; "nemotron-3-ultra", true, true
+    ; "qwen3.5:397b", false, false
     ]
   in
   List.iter
-    (fun model_id ->
+    (fun (model_id, expected_json, expected_so) ->
        match
          Capabilities.for_provider_model_id
            ~allow_bare_fallback:false
@@ -923,12 +922,12 @@ let test_ollama_cloud_grouped_non_so_rows_do_not_advertise_so () =
          check
            bool
            (model_id ^ " json response format")
-           false
+           expected_json
            c.supports_response_format_json;
          check
            bool
-           (model_id ^ " no structured output")
-           false
+           (model_id ^ " structured output")
+           expected_so
            c.supports_structured_output)
     cases
 ;;
@@ -1322,7 +1321,7 @@ let test_frontier_grouped_tool_thinking_provider_contracts () =
       , Provider_qualified "deepseek"
       , "deepseek-v4-pro"
       , Extended_thinking
-      , Response_format_json_schema
+      , Response_format_json
       , Replay_tool_turn_only
       , Delta_stream "reasoning_content" )
     ; ( "DeepSeek V4 Flash"
@@ -1392,63 +1391,63 @@ let test_frontier_grouped_tool_thinking_provider_contracts () =
       , Provider_qualified "ollama_cloud"
       , "gemma4:31b"
       , Extended_thinking
-      , No_structured_output
+      , Response_format_json_schema
       , Replay_not_required
       , Delta_stream "thinking" )
     ; ( "Ollama Cloud Kimi K2.7 Code"
       , Provider_qualified "ollama_cloud"
       , "kimi-k2.7-code"
       , Extended_thinking
-      , No_structured_output
+      , Response_format_json_schema
       , Replay_every_turn
       , Delta_stream "thinking" )
     ; ( "Ollama Cloud MiniMax M3"
       , Provider_qualified "ollama_cloud"
       , "minimax-m3"
       , Extended_thinking
-      , No_structured_output
+      , Response_format_json_schema
       , Replay_not_required
       , Delta_stream "reasoning" )
     ; ( "Ollama Cloud Nemotron 3 Ultra"
       , Provider_qualified "ollama_cloud"
       , "nemotron-3-ultra"
       , Extended_thinking
-      , No_structured_output
+      , Response_format_json_schema
       , Replay_not_required
       , Delta_stream "thinking" )
     ; ( "Ollama Cloud DeepSeek V4 Pro"
       , Provider_qualified "ollama_cloud"
       , "deepseek-v4-pro"
       , Extended_thinking
-      , No_structured_output
+      , Response_format_json_schema
       , Replay_not_required
       , Delta_stream "thinking" )
     ; ( "Ollama Cloud DeepSeek V4 Flash"
       , Provider_qualified "ollama_cloud"
       , "deepseek-v4-flash"
       , Extended_thinking
-      , No_structured_output
+      , Response_format_json_schema
       , Replay_not_required
       , Delta_stream "thinking" )
     ; ( "Ollama Cloud GLM 5.2"
       , Provider_qualified "ollama_cloud"
       , "glm-5.2"
       , Extended_thinking
-      , No_structured_output
+      , Response_format_json_schema
       , Replay_not_required
       , Delta_stream "thinking" )
     ; ( "Ollama Cloud GPT-OSS 20B"
       , Provider_qualified "ollama_cloud"
       , "gpt-oss:20b"
       , Extended_thinking
-      , No_structured_output
+      , Response_format_json_schema
       , Replay_not_required
       , Delta_stream "thinking" )
     ; ( "Ollama Cloud GPT-OSS 120B"
       , Provider_qualified "ollama_cloud"
       , "gpt-oss:120b"
       , Extended_thinking
-      , No_structured_output
+      , Response_format_json_schema
       , Replay_not_required
       , Delta_stream "thinking" )
     ]
@@ -2776,9 +2775,9 @@ let () =
             `Quick
             test_ollama_cloud_grouped_rows_have_required_axes
         ; test_case
-            "ollama cloud grouped non-SO rows do not advertise SO"
+            "ollama cloud grouped rows follow exact-output contract"
             `Quick
-            test_ollama_cloud_grouped_non_so_rows_do_not_advertise_so
+            test_ollama_cloud_grouped_rows_follow_exact_output_contract
         ; test_case
             "ollama cloud Kimi preserves historical reasoning"
             `Quick

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -852,8 +852,8 @@ let test_ollama_cloud_grouped_rows_have_required_axes () =
      production workflow: tool call -> tool_result replay -> final answer while
      reasoning may stream on a side channel. The catalog must not regress any
      one of these axes to a generic text-only profile. Structured output is
-     checked separately because the OpenAI-compatible /v1 transport does not
-     guarantee schema-shaped output for every model. *)
+     checked separately and remains fail-closed because Ollama Cloud does not
+     expose a structured-output contract. *)
   let cases =
     [ "qwen3.5:397b"
     ; "gemma4:31b"
@@ -884,7 +884,7 @@ let test_ollama_cloud_grouped_rows_have_required_axes () =
          check
            bool
            (model_id ^ " json response format")
-           true
+           false
            c.supports_response_format_json;
          check_thinking_control
            (model_id ^ " uses Ollama native think")
@@ -894,10 +894,8 @@ let test_ollama_cloud_grouped_rows_have_required_axes () =
 ;;
 
 let test_ollama_cloud_grouped_non_so_rows_do_not_advertise_so () =
-  (* The OpenAI-compatible /v1 transport used by the ollama_cloud provider
-     identity keeps JSON response-format requests available but does not enforce
-     schema-shaped output for these models. They must preserve JSON mode while
-     not advertising native structured output. *)
+  (* Ollama Cloud exposes neither JSON response-format mode nor native schema
+     enforcement. Both exact-output capability axes must stay fail-closed. *)
   let cases =
     [ "kimi-k2.5"
     ; "kimi-k2.6"
@@ -925,7 +923,7 @@ let test_ollama_cloud_grouped_non_so_rows_do_not_advertise_so () =
          check
            bool
            (model_id ^ " json response format")
-           true
+           false
            c.supports_response_format_json;
          check
            bool

--- a/test/test_exact_output_resolver_snapshot.ml
+++ b/test/test_exact_output_resolver_snapshot.ml
@@ -401,6 +401,42 @@ let test_pricing_and_formatting_are_nonfunctional () =
     (evidence first = evidence formatted)
 ;;
 
+let test_supported_models_order_is_canonical () =
+  let first =
+    snapshot
+      (target_catalog
+         ~model_extra:"supported_models = [\"snapshot-model\", \"secondary-model\"]\n"
+         ())
+  in
+  let reordered =
+    snapshot
+      (target_catalog
+         ~model_extra:"supported_models = [\"secondary-model\", \"snapshot-model\"]\n"
+         ())
+  in
+  let changed =
+    snapshot
+      (target_catalog
+         ~model_extra:"supported_models = [\"snapshot-model\", \"different-model\"]\n"
+         ())
+  in
+  check
+    string
+    "supported_models order leaves generation unchanged"
+    (generation first)
+    (generation reordered);
+  check
+    string
+    "supported_models order leaves canonical evidence unchanged"
+    (evidence first)
+    (evidence reordered);
+  check
+    bool
+    "supported_models value changes canonical evidence"
+    true
+    (evidence first <> evidence changed)
+;;
+
 let test_every_functional_projection_field_changes_generation () =
   let base = snapshot (target_catalog ()) in
   let variants =
@@ -412,7 +448,7 @@ let test_every_functional_projection_field_changes_generation () =
     ; ( "document capability"
       , target_catalog ~model_extra:"supports_document_input = true\n" () )
     ; "audio capability", target_catalog ~model_extra:"supports_audio_input = true\n" ()
-    ; ( "supported-model restriction"
+    ; ( "supported models"
       , target_catalog ~model_extra:"supported_models = [\"snapshot-model\"]\n" () )
     ; "codec", target_catalog ~kind:"ollama" ~request_path:"/api/chat" ()
     ]
@@ -493,14 +529,6 @@ let test_old_and_new_whole_tuples_never_mix_across_fibers () =
   check bool "A and B whole tuples differ" true (old_observation <> new_observation)
 ;;
 
-let expect_load_error label contents =
-  let io : EO.resolver_io = { getenv = (fun _ -> Ok None) } in
-  let overlay : EO.catalog_overlay = { source = label; contents } in
-  match EO.load_resolver_snapshot ~io ~overlay () with
-  | Error _ -> ()
-  | Ok _ -> fail (label ^ " must fail closed")
-;;
-
 let expect_endpoint_error label expected_cause contents =
   let io : EO.resolver_io = { getenv = (fun _ -> Ok None) } in
   let overlay : EO.catalog_overlay = { source = label; contents } in
@@ -549,15 +577,10 @@ let test_endpoint_error_cause_table () =
       , target_catalog ~request_path:"/v1/chat\r\nX-Secret: hidden" () )
     ; ( "Gemini slash segment"
       , EO.Invalid_gemini_model_path
-      , target_catalog ~kind:"gemini" ~request_path:"/v1beta/models" ~model:"bad/model" ()
-      )
+      , target_catalog ~kind:"gemini" ~request_path:"" ~model:"bad/model" () )
     ; ( "Gemini encoded segment"
       , EO.Invalid_gemini_model_path
-      , target_catalog
-          ~kind:"gemini"
-          ~request_path:"/v1beta/models"
-          ~model:"bad%2Fmodel"
-          () )
+      , target_catalog ~kind:"gemini" ~request_path:"" ~model:"bad%2Fmodel" () )
     ]
   in
   List.iter
@@ -582,90 +605,57 @@ let test_caller_headers_and_crlf_credential_fail_closed () =
    | Error _ -> fail "caller target headers returned the wrong resolver error class"
    | Ok _ -> fail "caller target headers must be rejected");
   let credential = "secret\r\nX-Leak: yes" in
-  let snapshot =
-    snapshot
-      ~getenv:(fun name ->
-        Ok (if String.equal name "CRLF_FIXTURE_KEY" then Some credential else None))
-      (target_catalog ~api_key_env:"CRLF_FIXTURE_KEY" ())
+  let io : EO.resolver_io =
+    { getenv =
+        (fun name ->
+          Ok (if String.equal name "CRLF_FIXTURE_KEY" then Some credential else None))
+    }
   in
-  let target = resolve snapshot "snapshot-target" in
-  let requirement =
-    EO.make_output_requirement ~schema ~minimum_guarantee:EO.Json_syntax
+  let overlay : EO.catalog_overlay =
+    { source = "CRLF credential"
+    ; contents = target_catalog ~api_key_env:"CRLF_FIXTURE_KEY" ()
+    }
   in
-  (match EO.admit ~target ~messages:[ message ] requirement with
-   | Error (EO.Wire_admission_rejected EO.Target_request_rejected) -> ()
-   | Error _ -> fail "CRLF credential returned the wrong typed admission cause"
-   | Ok _ -> fail "CRLF credential must fail before dispatch");
-  List.iter
-    (fun public_fingerprint ->
-       check
-         bool
-         "CRLF credential is absent from public fingerprints"
-         false
-         (string_contains ~haystack:public_fingerprint ~needle:credential))
-    [ generation snapshot; evidence snapshot; identity target ]
+  match EO.load_resolver_snapshot ~io ~overlay () with
+  | Error (EO.Target_credential_invalid { environment_variable = "CRLF_FIXTURE_KEY"; _ })
+    -> ()
+  | Error _ -> fail "CRLF credential returned the wrong resolver error class"
+  | Ok _ -> fail "CRLF credential must be rejected while freezing the snapshot"
+;;
+
+let expect_collision_error label expected contents =
+  let io : EO.resolver_io = { getenv = (fun _ -> Ok None) } in
+  let overlay : EO.catalog_overlay = { source = label; contents } in
+  match EO.load_resolver_snapshot ~io ~overlay () with
+  | Error (EO.Catalog_collision collision) ->
+    check bool (label ^ " exact collision") true (collision = expected)
+  | Error _ -> fail (label ^ " returned the wrong resolver error class")
+  | Ok _ -> fail (label ^ " must fail closed")
 ;;
 
 let test_collision_and_input_hardening () =
-  expect_load_error
+  expect_collision_error
     "alias shadow"
+    EO.Provider_alias_shadow
     (target_catalog ~provider:"attacker" ~aliases:[ "ollama_cloud" ] ());
-  expect_load_error
+  let duplicate_target =
+    target_catalog ~provider:"case-provider" ~model:"case-model" ~target:"case-target" ()
+    ^ "\n\
+       [[targets]]\n\
+       id = \"CASE-TARGET\"\n\
+       provider_ref = \"case-provider\"\n\
+       model_id = \"case-model\"\n"
+  in
+  expect_collision_error
     "target case shadow"
-    (target_catalog
-       ~provider:"case-provider"
-       ~model:"minimax-m3"
-       ~target:"OLLAMA-CLOUD-MINIMAX-M3-JSON"
-       ());
+    EO.Duplicate_target_identity
+    duplicate_target;
   List.iter
     (fun malicious ->
        match EO.target_ref malicious with
        | Error _ -> ()
        | Ok _ -> failf "malicious target ref %S must be rejected" malicious)
     [ "../target"; "target?key=secret"; "target\nheader"; "target/child" ]
-;;
-
-let test_same_primary_id_overlay_replacement_is_allowed () =
-  let io : EO.resolver_io =
-    { getenv =
-        (fun name ->
-          Ok (if String.equal name "OLLAMA_CLOUD_API_KEY" then Some "fixture" else None))
-    }
-  in
-  let baseline =
-    match EO.load_resolver_snapshot ~io () with
-    | Ok snapshot -> snapshot
-    | Error _ -> fail "embedded baseline should load"
-  in
-  let overlay : EO.catalog_overlay =
-    { source = "same-primary replacement"
-    ; contents =
-        target_catalog
-          ~provider:"ollama_cloud"
-          ~kind:"ollama"
-          ~base_url:"https://replacement.example"
-          ~request_path:"/api/chat"
-          ~api_key_env:"OLLAMA_CLOUD_API_KEY"
-          ~model:"minimax-m3"
-          ~target:"ollama-cloud-minimax-m3-json"
-          ()
-    }
-  in
-  match EO.load_resolver_snapshot ~io ~overlay () with
-  | Error _ -> fail "same primary id replacement should load"
-  | Ok snapshot ->
-    let baseline_target = resolve baseline "ollama-cloud-minimax-m3-json" in
-    let target = resolve snapshot "ollama-cloud-minimax-m3-json" in
-    check
-      bool
-      "replacement changes functional generation"
-      true
-      (generation baseline <> generation snapshot);
-    check
-      bool
-      "replacement changes frozen identity"
-      true
-      (identity baseline_target <> identity target)
 ;;
 
 let () =
@@ -690,6 +680,10 @@ let () =
             `Quick
             test_pricing_and_formatting_are_nonfunctional
         ; test_case
+            "supported_models canonical order"
+            `Quick
+            test_supported_models_order_is_canonical
+        ; test_case
             "functional projection sensitivity"
             `Quick
             test_every_functional_projection_field_changes_generation
@@ -706,10 +700,6 @@ let () =
             "collision and input hardening"
             `Quick
             test_collision_and_input_hardening
-        ; test_case
-            "same primary replacement"
-            `Quick
-            test_same_primary_id_overlay_replacement_is_allowed
         ] )
     ]
 ;;

--- a/test/test_exact_output_single_surface.ml
+++ b/test/test_exact_output_single_surface.ml
@@ -24,7 +24,7 @@ let schema =
     ]
 ;;
 
-let capabilities ?supported_models ~native ~json =
+let capabilities_with_supported_models ~supported_models ~native ~json =
   { Capabilities.default_capabilities with
     max_context_tokens = Some 8192
   ; max_output_tokens = Some 1024
@@ -32,6 +32,10 @@ let capabilities ?supported_models ~native ~json =
   ; supports_structured_output = native
   ; supported_models
   }
+;;
+
+let capabilities ~native ~json =
+  capabilities_with_supported_models ~supported_models:None ~native ~json
 ;;
 
 type catalog_fixture =
@@ -362,7 +366,11 @@ let test_supported_models_membership_is_exact_and_pre_dispatch () =
         ~kind:Provider_config.OpenAI_compat
         ~base_url
         ~request_path:"/v1/chat/completions"
-        ~capabilities:(capabilities ~native:true ~json:true ~supported_models)
+        ~capabilities:
+          (capabilities_with_supported_models
+             ~native:true
+             ~json:true
+             ~supported_models:(Some supported_models))
         ()
     in
     with_catalog

--- a/test/test_exact_output_single_surface.ml
+++ b/test/test_exact_output_single_surface.ml
@@ -24,12 +24,13 @@ let schema =
     ]
 ;;
 
-let capabilities ~native ~json =
+let capabilities ?supported_models ~native ~json =
   { Capabilities.default_capabilities with
     max_context_tokens = Some 8192
   ; max_output_tokens = Some 1024
   ; supports_response_format_json = json
   ; supports_structured_output = native
+  ; supported_models
   }
 ;;
 
@@ -41,11 +42,13 @@ type catalog_fixture =
   ; request_path : string
   ; api_key_env : string
   ; capabilities : Capabilities.capabilities
+  ; body_timeout_s : float option
   }
 
 let catalog_entry
       ?base_url_env
       ?(api_key_env = "")
+      ?body_timeout_s
       ~id
       ~kind
       ~base_url
@@ -53,7 +56,15 @@ let catalog_entry
       ~capabilities
       ()
   =
-  { id; kind; base_url; base_url_env; request_path; api_key_env; capabilities }
+  { id
+  ; kind
+  ; base_url
+  ; base_url_env
+  ; request_path
+  ; api_key_env
+  ; capabilities
+  ; body_timeout_s
+  }
 ;;
 
 let catalog_fixture_toml entry =
@@ -70,11 +81,13 @@ let catalog_fixture_toml entry =
      max_context_tokens = 8192\n\
      max_output_tokens = 1024\n\
      supports_response_format_json = %b\n\
-     supports_structured_output = %b\n\n\
+     supports_structured_output = %b\n\
+     %s\n\
      [[targets]]\n\
      id = %S\n\
      provider_ref = %S\n\
-     model_id = %S\n"
+     model_id = %S\n\
+     %s"
     entry.id
     (Provider_config.string_of_provider_kind entry.kind)
     entry.base_url
@@ -87,9 +100,18 @@ let catalog_fixture_toml entry =
     entry.id
     entry.capabilities.supports_response_format_json
     entry.capabilities.supports_structured_output
+    (match entry.capabilities.supported_models with
+     | None -> ""
+     | Some models ->
+       Printf.sprintf
+         "supported_models = [%s]\n"
+         (String.concat ", " (List.map (Printf.sprintf "%S") models)))
     entry.id
     entry.id
     (entry.id ^ "-model")
+    (match entry.body_timeout_s with
+     | None -> ""
+     | Some seconds -> Printf.sprintf "body_timeout_s = %.17g\n" seconds)
 ;;
 
 let with_catalog ?(getenv = fun _ -> Ok None) entries f =
@@ -326,6 +348,47 @@ let test_deepseek_catalog_is_json_only_before_dispatch () =
      with
      | Error EO.Provider_schema_unavailable -> ()
      | Ok _ | Error _ -> fail "DeepSeek provider schema must reject before dispatch")
+;;
+
+let test_supported_models_membership_is_exact_and_pre_dispatch () =
+  let allowed_id = "membership-allowed" in
+  let rejected_id = "membership-rejected" in
+  let (allowed, rejected), completion_posts, token_posts, captures =
+    with_server ~response:(openai_response {|{"name":"unused"}|})
+    @@ fun ~sw:_ ~net:_ ~clock:_ ~base_url ->
+    let entry id supported_models =
+      catalog_entry
+        ~id
+        ~kind:Provider_config.OpenAI_compat
+        ~base_url
+        ~request_path:"/v1/chat/completions"
+        ~capabilities:(capabilities ~native:true ~json:true ~supported_models)
+        ()
+    in
+    with_catalog
+      [ entry allowed_id [ allowed_id ^ "-model" ]
+      ; entry rejected_id [ "MEMBERSHIP-REJECTED-MODEL" ]
+      ]
+    @@ fun snapshot ->
+    let admit id =
+      EO.admit
+        ~target:(target snapshot id)
+        ~messages:[ msg "membership" ]
+        (requirement EO.Json_syntax)
+    in
+    admit allowed_id, admit rejected_id
+  in
+  (match allowed with
+   | Ok _ -> ()
+   | Error _ -> fail "exact supported model must admit");
+  (match rejected with
+   | Error
+       (EO.Wire_admission_rejected
+          (EO.Unsupported_target_model { model_id = "membership-rejected-model" })) -> ()
+   | Ok _ | Error _ -> fail "case-only non-member must return the typed rejection");
+  check int "membership rejection completion posts" 0 completion_posts;
+  check int "membership rejection token posts" 0 token_posts;
+  check int "membership rejection captures" 0 (List.length captures)
 ;;
 
 let test_wire_envelope_and_cross_feature_injection_rejected () =
@@ -611,14 +674,15 @@ let check_receipt label ~phase ~dispatch_count ~http_status receipt =
 let test_public_receipt_phase_matrix () =
   let pre_result, pre_posts, _, _ =
     with_server ~response:"unused"
-    @@ fun ~sw:_ ~net ~clock:_ ~base_url:_ ->
+    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
     let entry =
       catalog_entry
         ~id:"pre-dispatch-surface"
         ~kind:Provider_config.OpenAI_compat
-        ~base_url:"ftp://surface.invalid"
+        ~base_url
         ~request_path:"/v1/chat/completions"
         ~capabilities:(capabilities ~native:true ~json:true)
+        ~body_timeout_s:1.0
         ()
     in
     with_catalog [ entry ]
@@ -627,7 +691,7 @@ let test_public_receipt_phase_matrix () =
   in
   check int "pre-dispatch has zero POSTs" 0 pre_posts;
   (match pre_result with
-   | Error { EO.receipt; cause = EO.Completion_failed; raw_response = None } ->
+   | Error { EO.receipt; cause = EO.Clock_required_for_timeout; raw_response = None } ->
      check_receipt
        "pre-dispatch"
        ~phase:EO.Before_dispatch
@@ -1329,6 +1393,10 @@ let () =
             "DeepSeek catalog is JSON-only before dispatch"
             `Quick
             test_deepseek_catalog_is_json_only_before_dispatch
+        ; test_case
+            "supported_models exact membership"
+            `Quick
+            test_supported_models_membership_is_exact_and_pre_dispatch
         ; test_case
             "injection rejected"
             `Quick

--- a/test/test_hooks.ml
+++ b/test/test_hooks.ml
@@ -344,6 +344,82 @@ let contains_substring ~needle haystack =
   n = 0 || loop 0
 ;;
 
+let capture_traceln f =
+  Eio_main.run
+  @@ fun env ->
+  let buffer = Buffer.create 256 in
+  let captured_traceln =
+    { Eio.Debug.traceln =
+        (fun ?__POS__:_ format ->
+          Format.kasprintf
+            (fun message ->
+               Buffer.add_string buffer message;
+               Buffer.add_char buffer '\n')
+            format)
+    }
+  in
+  Eio.Fiber.with_binding (Eio.Stdenv.debug env)#traceln captured_traceln (fun () ->
+    let result = f () in
+    result, Buffer.contents buffer)
+;;
+
+let test_invoke_validated_raising_hook_returns_hook_failed () =
+  let event = Hooks.BeforeTurn { turn = 0; messages = [] } in
+  let raising _ = failwith "kaboom" in
+  let semantic_ok, diagnostic =
+    capture_traceln (fun () ->
+      match Hooks.invoke_validated (Some raising) event with
+      | Hooks.HookFailed { stage = Hooks.Before_turn; detail } -> String.length detail > 0
+      | _ -> false)
+  in
+  check bool "raising hook returns before_turn HookFailed" true semantic_ok;
+  check
+    string
+    "raising hook warning"
+    {|[warn] [hooks] user hook for before_turn raised Failure("kaboom")|}
+    (String.trim diagnostic)
+;;
+
+let test_invoke_validated_raising_hook_skips_on_illegal () =
+  let event = Hooks.BeforeTurn { turn = 0; messages = [] } in
+  let raising _ = failwith "kaboom" in
+  let illegal_called = ref false in
+  let on_illegal ~stage:_ ~decision:_ ~msg:_ = illegal_called := true in
+  let semantic_ok, diagnostic =
+    capture_traceln (fun () ->
+      let _ = Hooks.invoke_validated ~on_illegal (Some raising) event in
+      not !illegal_called)
+  in
+  check bool "raising hook does not call on_illegal" true semantic_ok;
+  check
+    string
+    "raising hook warning"
+    {|[warn] [hooks] user hook for before_turn raised Failure("kaboom")|}
+    (String.trim diagnostic)
+;;
+
+let test_invoke_validated_illegal_block_returns_hook_failed_with_warning () =
+  let event = Hooks.BeforeTurn { turn = 0; messages = [] } in
+  let blocking _ = Hooks.Block "forbidden" in
+  let semantic_ok, diagnostic =
+    capture_traceln (fun () ->
+      match Hooks.invoke_validated (Some blocking) event with
+      | Hooks.HookFailed { stage = Hooks.Before_turn; detail } -> String.length detail > 0
+      | Hooks.HookFailed _
+      | Hooks.Continue
+      | Hooks.AdjustParams _
+      | Hooks.ElicitInput _
+      | Hooks.Nudge _
+      | Hooks.Block _ -> false)
+  in
+  check bool "illegal Block returns before_turn HookFailed" true semantic_ok;
+  check
+    string
+    "illegal Block warning"
+    {|[warn] [hooks] illegal hook decision Block at stage before_turn; legal: [Continue, ElicitInput, Nudge]|}
+    (String.trim diagnostic)
+;;
+
 (** Test invoke_validated returns HookFailed on illegal decision. *)
 let test_invoke_validated_illegal_returns_hook_failed () =
   let hook _event = Hooks.Block "blocked" in
@@ -504,6 +580,18 @@ let () =
             "illegal returns HookFailed"
             `Quick
             test_invoke_validated_illegal_returns_hook_failed
+        ; test_case
+            "raising hook returns HookFailed"
+            `Quick
+            test_invoke_validated_raising_hook_returns_hook_failed
+        ; test_case
+            "raising hook skips on_illegal"
+            `Quick
+            test_invoke_validated_raising_hook_skips_on_illegal
+        ; test_case
+            "illegal Block logs and returns HookFailed"
+            `Quick
+            test_invoke_validated_illegal_block_returns_hook_failed_with_warning
         ; test_case "None returns Continue" `Quick test_invoke_validated_none
         ; test_case
             "observe-only Continue passes"

--- a/test/test_model_catalog_overlay.ml
+++ b/test/test_model_catalog_overlay.ml
@@ -95,51 +95,6 @@ let test_merge_overlay_row_replaces_same_key () =
     (List.length (Model_catalog.model_entries merged))
 ;;
 
-let test_sparse_pricing_row_inherits_functional_fields () =
-  let suite = "sparse pricing merge" in
-  let base =
-    catalog_of
-      ~suite
-      (scoped_row
-         ~provider:"prov-a"
-         ~model:"model-1"
-         ~max_context:100
-         ~extra:
-           "supports_response_format_json = true\n\
-            supports_document_input = true\n\
-            input_per_million = 1.0\n"
-         ())
-  in
-  let overlay =
-    catalog_of
-      ~suite
-      "[[models]]\n\
-       id_prefix = \"model-1\"\n\
-       provider_name = \"prov-a\"\n\
-       input_per_million = 99.0\n"
-  in
-  let merged = Model_catalog.merge ~base ~overlay in
-  let entry =
-    match
-      Model_catalog.lookup_for_provider merged ~provider_name:"prov-a" ~model_id:"model-1"
-    with
-    | None -> fail "sparse pricing merge should preserve the model row"
-    | Some entry -> entry
-  in
-  check (option int) "context limit inherited" (Some 100) entry.max_context_tokens;
-  check
-    (option bool)
-    "JSON capability inherited"
-    (Some true)
-    entry.supports_response_format_json;
-  check
-    (option bool)
-    "document capability inherited"
-    (Some true)
-    entry.supports_document_input;
-  check (option (float 0.)) "pricing field replaced" (Some 99.0) entry.input_per_million
-;;
-
 let test_merge_keeps_bare_and_scoped_rows_distinct () =
   let suite = "merge bare vs scoped" in
   let base = catalog_of ~suite (bare_row ~model:"model-1" ~max_context:100) in
@@ -455,10 +410,6 @@ let () =
             "bare and scoped rows stay distinct"
             `Quick
             test_merge_keeps_bare_and_scoped_rows_distinct
-        ; test_case
-            "sparse pricing inherits functional fields"
-            `Quick
-            test_sparse_pricing_row_inherits_functional_fields
         ; test_case
             "provider entries replace by id"
             `Quick

--- a/test/test_structured.ml
+++ b/test/test_structured.ml
@@ -427,14 +427,12 @@ let test_response_json_extractor_object_success () =
   | Error e -> Alcotest.fail e
 ;;
 
-let test_response_json_extractor_fenced_object () =
+let test_response_json_extractor_rejects_fenced_object () =
   let extract = Structured.response_json_extractor ~shape:Structured.Object_json () in
   let resp = make_response [ Text "```json\n{\"ok\":true}\n```" ] in
   match extract resp with
-  | Ok (`Assoc fields) ->
-    Alcotest.(check bool) "ok field present" true (List.mem_assoc "ok" fields)
-  | Ok _ -> Alcotest.fail "expected JSON object"
-  | Error e -> Alcotest.fail e
+  | Error e -> Alcotest.(check bool) "has parse error text" true (String.length e > 0)
+  | Ok _ -> Alcotest.fail "expected fenced JSON rejection"
 ;;
 
 let test_response_json_extractor_any_accepts_array () =
@@ -475,7 +473,7 @@ let test_text_extractor_none () =
 
 let test_schema_extractor_success () =
   let extract = Structured.schema_extractor person_schema in
-  let resp = make_response [ Text "```json\n{\"name\":\"Dana\",\"age\":42}\n```" ] in
+  let resp = make_response [ Text "{\"name\":\"Dana\",\"age\":42}" ] in
   match extract resp with
   | Ok (name, age) ->
     Alcotest.(check string) "name" "Dana" name;
@@ -565,9 +563,9 @@ let () =
             `Quick
             test_response_json_extractor_object_success
         ; Alcotest.test_case
-            "response_json_extractor fenced object"
+            "response_json_extractor rejects fenced object"
             `Quick
-            test_response_json_extractor_fenced_object
+            test_response_json_extractor_rejects_fenced_object
         ; Alcotest.test_case
             "response_json_extractor any array"
             `Quick


### PR DESCRIPTION
## Context\n\nStacked on #2778. The cache lifecycle deadlock on current main prevented dune runtest from terminating and hid deterministic exact-output baseline failures introduced before this branch.\n\n## Summary\n\n- remove markdown-fence stripping from provider and Structured parsing, including the public legacy helpers and re-exports\n- preserve raw provider text and classify exact-output content without heuristic repair\n- apply constructor-specific stop precedence so incomplete transport outcomes remain incomplete while tool content remains unexpected\n- add typed supported_models catalog parsing, sparse exact merge, canonical evidence, and before-dispatch membership admission\n- repair resolver, receipt, collision, capability, and catalog proofs against the current fail-closed contracts\n- make the resolver boundary ratchet consume grep pipelines fully under pipefail\n\n## Boundary\n\n- MASC/domain callers own schema and semantic decoding\n- OAS owns target admission, exact wire behavior, normalized JSON, and receipt evidence\n- pricing remains observation metadata only; generic Model_catalog.merge remains whole-row replacement\n- pricing does not affect admission, routing, retry, failover, limits, or functional generation\n- unsupported model membership fails before response-format selection, plan creation, or dispatch\n\n## Breaking changes\n\n- remove Backend_openai_parse.strip_json_markdown_fences\n- remove Backend_openai.strip_json_markdown_fences\n- add supported_models to Model_catalog.model_entry\n- add Unsupported_target_model to wire_admission_error\n- fenced JSON is no longer repaired automatically\n\n## Proofs\n\n- parser rejects empty, whitespace-only, and duplicate supported_models entries\n- exact pricing-only overlays preserve functional fields and supported_models while changing price evidence only\n- canonical evidence is order-invariant and value-sensitive\n- allowed model admission succeeds; unsupported membership returns a typed error with zero completion, capture, token, or dispatch effects\n- exact target replacement and case-shadow rejection are proven independently\n\n## Validation\n\n- ocamlformat applied to changed OCaml files\n- two independent static P0/P1 reviews completed with no remaining findings\n- local build/tests intentionally not run per operator instruction; GitHub Actions is the validation authority