### PR TITLE
feat(exact-output): add affine outer flow

### DIFF
--- a/docs/design/exact-output-flow-boundary.md
+++ b/docs/design/exact-output-flow-boundary.md
@@ -1,0 +1,89 @@
+# Exact-output outer-flow boundary
+
+Status: active pre-1.0 contract  
+Effective: 2026-07-23
+
+## Ownership
+
+`Agent_sdk.Exact_output` is the single public surface for exact structured
+output. OAS owns:
+
+- immutable resolver and target snapshots;
+- provider-wire admission and separately frozen candidate plans;
+- fresh, non-shared attempt identities;
+- one-plan, at-most-one-dispatch `execute_once`;
+- monotonic phase, dispatch-count, response, and provenance receipts;
+- the ordered outer-flow transition to a predetermined successor.
+
+The caller owns:
+
+- domain input construction;
+- domain schema, codec, and content validation;
+- durable business-state binding, release, quarantine, and completion;
+- operator configuration that names opaque candidate references.
+
+The outer flow is generic. It contains no coordinator vocabulary and no
+provider, model, tier, price, query-intent, or error-string policy.
+
+## Immutable admission
+
+An outer flow is a nonempty ordered snapshot. OAS admits every candidate and
+freezes every successful exact plan before it creates an attempt or performs a
+network effect. The ordered admission evidence retains both successes and typed
+rejections. A flow can start only when at least one candidate admitted.
+
+Starting a ready flow creates one fresh exact attempt per admitted candidate.
+Attempts are never shared between candidates or between two starts of the same
+ready flow.
+
+## Execution
+
+`execute_flow_once` is affine. A duplicate or concurrent invocation cannot
+dispatch. For each predetermined candidate:
+
+1. The caller's `before_dispatch` callback must confirm its durable binding.
+2. OAS invokes the unchanged single-plan `execute_once`.
+3. OAS may select the next admitted candidate only for a first-use transport
+   failure whose exact receipt is `Before_dispatch` with `dispatch_count = 0`.
+4. The caller's `before_advance` callback must durably confirm release before
+   OAS enters that already-selected successor.
+
+Callbacks can stop a transition but cannot select, replace, or reorder a
+candidate.
+
+The following outcomes are terminal:
+
+- callback failure or exception;
+- duplicate/replayed execution;
+- cancellation;
+- a missing execution prerequisite or frozen-request invariant failure;
+- any receipt with `dispatch_count > 0`;
+- response, partial, tool, structural-output, or normalization exposure;
+- success.
+
+Domain validation occurs only after an OAS success. A caller-side domain
+rejection therefore cannot trigger another provider dispatch.
+
+## Evidence
+
+Every terminal result carries:
+
+- the original ordered admission outcomes;
+- the immutable candidate identities and plan provenance;
+- every non-shared attempt receipt, including unstarted successors;
+- the exact success or execution failure for the terminal candidate.
+
+After cancellation escapes, the same aggregate evidence remains queryable from
+the opaque flow attempt.
+
+## Explicit exclusions
+
+- `execute_once` never retries and never changes plans.
+- The outer flow performs no weighted, health, cost, or latency routing.
+- Pricing is measurement evidence only and is absent from all decisions.
+- There is no legacy cascade API, compatibility wrapper, or persisted runtime
+  JSON migration.
+- Before 1.0, obsolete runtime assets are reset rather than reconciled.
+
+Archived cascade documents describe an earlier ownership decision and are not
+the active exact-output contract.

--- a/lib/llm_provider/dune
+++ b/lib/llm_provider/dune
@@ -16,6 +16,7 @@
   exact_output_call_id
   exact_output_resolver
   exact_output_execution
+  exact_output_flow
   exact_output_plan)
  (libraries
   yojson

--- a/lib/llm_provider/exact_output.ml
+++ b/lib/llm_provider/exact_output.ml
@@ -1,5 +1,6 @@
 module Plan = Exact_output_plan
 module Exec = Exact_output_execution
+module Flow_state = Exact_output_flow
 module Caps = Capabilities
 module PC = Provider_config
 include Exact_output_resolver
@@ -127,6 +128,109 @@ type success =
   ; provenance : plan_provenance
   ; raw_response : raw_response
   }
+
+type flow_candidate_identity =
+  { candidate_id : string
+  ; catalog_generation : catalog_generation
+  ; catalog_evidence : catalog_evidence
+  ; target_identity : target_identity
+  }
+
+type flow_candidate =
+  { identity : flow_candidate_identity
+  ; target : selected_target
+  }
+
+type admitted_flow_candidate =
+  { identity : flow_candidate_identity
+  ; plan_fingerprint : string
+  ; request_body_sha256 : string
+  ; provenance : plan_provenance
+  }
+
+type candidate_admission =
+  | Candidate_admitted of admitted_flow_candidate
+  | Candidate_rejected of
+      { identity : flow_candidate_identity
+      ; cause : admission_error
+      }
+
+type ready_flow_candidate =
+  { evidence : admitted_flow_candidate
+  ; plan : ready_plan
+  }
+
+type ready_flow =
+  { admissions : candidate_admission list
+  ; candidates : ready_flow_candidate list
+  }
+
+type flow_attempt_candidate =
+  { evidence : admitted_flow_candidate
+  ; attempt : attempt
+  }
+
+type flow_attempt =
+  { execution : Flow_state.t
+  ; admissions : candidate_admission list
+  ; candidates : flow_attempt_candidate list
+  }
+
+type flow_candidate_error = Blank_flow_candidate_id
+
+type flow_admission_error =
+  | Duplicate_flow_candidate_id of
+      { candidate_id : string
+      ; first_position : int
+      ; duplicate_position : int
+      }
+  | No_admitted_flow_candidates of candidate_admission list
+
+type start_attempt_error = Call_id_generation_failed of string
+
+type flow_start_error =
+  | Flow_candidate_attempt_start_failed of
+      { identity : flow_candidate_identity
+      ; position : int
+      ; cause : start_attempt_error
+      ; admissions : candidate_admission list
+      }
+
+type flow_attempt_receipt =
+  { identity : flow_candidate_identity
+  ; receipt : receipt
+  }
+
+type flow_evidence =
+  { admissions : candidate_admission list
+  ; attempts : flow_attempt_receipt list
+  }
+
+type flow_success =
+  { candidate : flow_attempt_receipt
+  ; success : success
+  ; evidence : flow_evidence
+  }
+
+type 'callback_error flow_execution_error =
+  | Flow_attempt_already_started of flow_evidence
+  | Flow_before_dispatch_callback_failed of
+      { candidate : flow_attempt_receipt
+      ; cause : 'callback_error
+      ; evidence : flow_evidence
+      }
+  | Flow_before_advance_callback_failed of
+      { failed : flow_attempt_receipt
+      ; failure : execution_error
+      ; next : flow_attempt_receipt
+      ; cause : 'callback_error
+      ; evidence : flow_evidence
+      }
+  | Flow_exact_execution_failed of
+      { candidate : flow_attempt_receipt
+      ; cause : execution_error
+      ; evidence : flow_evidence
+      }
 
 let ( let* ) = Result.bind
 
@@ -442,7 +546,70 @@ let admit ~target ~messages requirement =
 let plan_provenance (ready : ready_plan) = ready.provenance
 let plan_fingerprint (ready : ready_plan) = ready.plan_fingerprint
 
-type start_attempt_error = Call_id_generation_failed of string
+let make_flow_candidate ~id ~target =
+  let id = String.trim id in
+  if String.equal id ""
+  then Error Blank_flow_candidate_id
+  else
+    Ok
+      { identity =
+          { candidate_id = id
+          ; catalog_generation = selected_target_catalog_generation target
+          ; catalog_evidence = selected_target_catalog_evidence target
+          ; target_identity = selected_target_identity target
+          }
+      ; target
+      }
+;;
+
+let flow_candidate_identity candidate = candidate.identity
+
+let duplicate_flow_candidate_id candidates =
+  let rec find position seen = function
+    | [] -> None
+    | candidate :: rest ->
+      let candidate_id = candidate.identity.candidate_id in
+      (match
+         List.find_opt (fun (seen_id, _) -> String.equal seen_id candidate_id) seen
+       with
+       | Some (_, first_position) ->
+         Some { candidate_id; first_position; duplicate_position = position }
+       | None -> find (position + 1) ((candidate_id, position) :: seen) rest)
+  in
+  find 1 [] candidates
+;;
+
+let admit_flow ~first ~rest ~messages requirement =
+  let candidates = first :: rest in
+  match duplicate_flow_candidate_id candidates with
+  | Some duplicate -> Error (Duplicate_flow_candidate_id duplicate)
+  | None ->
+    let admissions, admitted =
+      List.fold_left
+        (fun (admissions, admitted) candidate ->
+           match admit ~target:candidate.target ~messages requirement with
+           | Error cause ->
+             ( Candidate_rejected { identity = candidate.identity; cause } :: admissions
+             , admitted )
+           | Ok plan ->
+             let evidence =
+               { identity = candidate.identity
+               ; plan_fingerprint = plan.plan_fingerprint
+               ; request_body_sha256 = plan.request_body_sha256
+               ; provenance = plan.provenance
+               }
+             in
+             Candidate_admitted evidence :: admissions, { evidence; plan } :: admitted)
+        ([], [])
+        candidates
+    in
+    let admissions = List.rev admissions in
+    (match List.rev admitted with
+     | [] -> Error (No_admitted_flow_candidates admissions)
+     | candidates -> Ok { admissions; candidates })
+;;
+
+let ready_flow_admissions ready = ready.admissions
 
 let start_attempt (ready : ready_plan) =
   match Exact_output_call_id.create () with
@@ -459,6 +626,30 @@ let start_attempt (ready : ready_plan) =
       }
     in
     Ok { ready; receipt }
+;;
+
+let start_flow ready =
+  let rec start position started = function
+    | [] ->
+      Ok
+        { execution = Flow_state.create ()
+        ; admissions = ready.admissions
+        ; candidates = List.rev started
+        }
+    | candidate :: rest ->
+      (match start_attempt candidate.plan with
+       | Error cause ->
+         Error
+           (Flow_candidate_attempt_start_failed
+              { identity = candidate.evidence.identity
+              ; position
+              ; cause
+              ; admissions = ready.admissions
+              })
+       | Ok attempt ->
+         start (position + 1) ({ evidence = candidate.evidence; attempt } :: started) rest)
+  in
+  start 1 [] ready.candidates
 ;;
 
 let call_id_to_string (Call_id id) = id
@@ -492,6 +683,16 @@ let receipt_request_body_sha256 (receipt : receipt) = receipt.request_body_sha25
 let receipt_catalog_generation (receipt : receipt) = receipt.catalog_generation
 let receipt_catalog_evidence (receipt : receipt) = receipt.catalog_evidence
 let receipt_target_identity (receipt : receipt) = receipt.target_identity
+
+let flow_attempt_receipt candidate =
+  { identity = candidate.evidence.identity; receipt = attempt_receipt candidate.attempt }
+;;
+
+let flow_attempt_evidence flow =
+  { admissions = flow.admissions
+  ; attempts = List.map flow_attempt_receipt flow.candidates
+  }
+;;
 
 let state_rank = function
   | Not_started_state -> 0
@@ -599,4 +800,61 @@ let execute_once ~net ?clock (attempt : attempt) =
            ; cause = Internal_non_json_output
            ; raw_response = Some (raw_response evidence)
            }))
+;;
+
+let execution_failure_may_advance (error : execution_error) =
+  match error.cause with
+  | Completion_failed ->
+    (match receipt_phase error.receipt with
+     | Before_dispatch -> receipt_dispatch_count error.receipt = 0
+     | Not_started | Dispatch_started | Response_received | Terminal -> false)
+  | Attempt_already_started
+  | Clock_required_for_timeout
+  | Frozen_request_mismatch
+  | Incomplete_output
+  | Missing_output
+  | Ambiguous_output _
+  | Unexpected_output_content
+  | Invalid_json_output
+  | Internal_non_json_output -> false
+;;
+
+let execute_flow_once ~net ?clock ~before_dispatch ~before_advance flow =
+  let public_candidate = flow_attempt_receipt in
+  let outcome =
+    Flow_state.execute_once
+      flow.execution
+      ~candidates:flow.candidates
+      ~before_dispatch:(fun candidate -> before_dispatch (public_candidate candidate))
+      ~execute:(fun candidate -> execute_once ~net ?clock candidate.attempt)
+      ~can_advance:execution_failure_may_advance
+      ~before_advance:(fun ~failed ~failure ~next ->
+        before_advance
+          ~failed:(public_candidate failed)
+          ~failure
+          ~next:(public_candidate next))
+  in
+  let evidence = flow_attempt_evidence flow in
+  match outcome with
+  | Flow_state.Succeeded { candidate; success } ->
+    Ok { candidate = public_candidate candidate; success; evidence }
+  | Flow_state.Attempt_already_started -> Error (Flow_attempt_already_started evidence)
+  | Flow_state.Before_dispatch_callback_failed { candidate; cause } ->
+    Error
+      (Flow_before_dispatch_callback_failed
+         { candidate = public_candidate candidate; cause; evidence })
+  | Flow_state.Before_advance_callback_failed
+      { failed_candidate; failure; next_candidate; cause } ->
+    Error
+      (Flow_before_advance_callback_failed
+         { failed = public_candidate failed_candidate
+         ; failure
+         ; next = public_candidate next_candidate
+         ; cause
+         ; evidence
+         })
+  | Flow_state.Execution_failed { candidate; cause } ->
+    Error
+      (Flow_exact_execution_failed
+         { candidate = public_candidate candidate; cause; evidence })
 ;;

--- a/lib/llm_provider/exact_output.ml
+++ b/lib/llm_provider/exact_output.ml
@@ -562,12 +562,12 @@ let make_flow_candidate ~id ~target =
       }
 ;;
 
-let flow_candidate_identity candidate = candidate.identity
+let flow_candidate_identity (candidate : flow_candidate) = candidate.identity
 
-let duplicate_flow_candidate_id candidates =
+let duplicate_flow_candidate_id (candidates : flow_candidate list) =
   let rec find position seen = function
     | [] -> None
-    | candidate :: rest ->
+    | (candidate : flow_candidate) :: rest ->
       let candidate_id = candidate.identity.candidate_id in
       (match
          List.find_opt (fun (seen_id, _) -> String.equal seen_id candidate_id) seen
@@ -611,7 +611,7 @@ let admit_flow ~first ~rest ~messages requirement =
      | candidates -> Ok { admissions; candidates })
 ;;
 
-let ready_flow_admissions ready = ready.admissions
+let ready_flow_admissions (ready : ready_flow) = ready.admissions
 
 let start_attempt (ready : ready_plan) =
   match Exact_output_call_id.create () with
@@ -630,7 +630,7 @@ let start_attempt (ready : ready_plan) =
     Ok { ready; receipt }
 ;;
 
-let start_flow ready =
+let start_flow (ready : ready_flow) =
   let rec start position started = function
     | [] ->
       Ok
@@ -686,11 +686,11 @@ let receipt_catalog_generation (receipt : receipt) = receipt.catalog_generation
 let receipt_catalog_evidence (receipt : receipt) = receipt.catalog_evidence
 let receipt_target_identity (receipt : receipt) = receipt.target_identity
 
-let flow_attempt_receipt candidate =
+let flow_attempt_receipt (candidate : flow_attempt_candidate) =
   { identity = candidate.evidence.identity; receipt = attempt_receipt candidate.attempt }
 ;;
 
-let flow_attempt_evidence flow =
+let flow_attempt_evidence (flow : flow_attempt) =
   { admissions = flow.admissions
   ; attempts = List.map flow_attempt_receipt flow.candidates
   }

--- a/lib/llm_provider/exact_output.ml
+++ b/lib/llm_provider/exact_output.ml
@@ -573,7 +573,9 @@ let duplicate_flow_candidate_id candidates =
          List.find_opt (fun (seen_id, _) -> String.equal seen_id candidate_id) seen
        with
        | Some (_, first_position) ->
-         Some { candidate_id; first_position; duplicate_position = position }
+         Some
+           (Duplicate_flow_candidate_id
+              { candidate_id; first_position; duplicate_position = position })
        | None -> find (position + 1) ((candidate_id, position) :: seen) rest)
   in
   find 1 [] candidates
@@ -582,7 +584,7 @@ let duplicate_flow_candidate_id candidates =
 let admit_flow ~first ~rest ~messages requirement =
   let candidates = first :: rest in
   match duplicate_flow_candidate_id candidates with
-  | Some duplicate -> Error (Duplicate_flow_candidate_id duplicate)
+  | Some duplicate -> Error duplicate
   | None ->
     let admissions, admitted =
       List.fold_left

--- a/lib/llm_provider/exact_output.mli
+++ b/lib/llm_provider/exact_output.mli
@@ -22,6 +22,9 @@ type attempt
 type receipt
 type call_id
 type schema_fingerprint
+type flow_candidate
+type ready_flow
+type flow_attempt
 type resolver_io = { getenv : string -> (string option, unit) result }
 
 type catalog_document =
@@ -188,6 +191,62 @@ type success =
   ; raw_response : raw_response
   }
 
+(** Provider-neutral identity for one caller-labelled candidate in a frozen
+    exact flow. The target fields remain opaque and can only be projected to
+    their stable fingerprints. *)
+type flow_candidate_identity =
+  { candidate_id : string
+  ; catalog_generation : catalog_generation
+  ; catalog_evidence : catalog_evidence
+  ; target_identity : target_identity
+  }
+
+type admitted_flow_candidate =
+  { identity : flow_candidate_identity
+  ; plan_fingerprint : string
+  ; request_body_sha256 : string
+  ; provenance : plan_provenance
+  }
+
+type candidate_admission =
+  | Candidate_admitted of admitted_flow_candidate
+  | Candidate_rejected of
+      { identity : flow_candidate_identity
+      ; cause : admission_error
+      }
+
+type flow_candidate_error = Blank_flow_candidate_id
+
+type flow_admission_error =
+  | Duplicate_flow_candidate_id of
+      { candidate_id : string
+      ; first_position : int
+      ; duplicate_position : int
+      }
+  | No_admitted_flow_candidates of candidate_admission list
+
+(** Construct one provider-neutral candidate. The trimmed caller identity must
+    be nonempty; it is evidence only and never drives provider policy. *)
+val make_flow_candidate
+  :  id:string
+  -> target:selected_target
+  -> (flow_candidate, flow_candidate_error) result
+
+val flow_candidate_identity : flow_candidate -> flow_candidate_identity
+
+(** Admit every candidate in the immutable, nonempty ordered snapshot before
+    any attempt or network effect exists. Rejected candidates remain in ordered
+    admission evidence; admitted candidates retain separately frozen plans.
+    Execution is possible when at least one candidate admitted. *)
+val admit_flow
+  :  first:flow_candidate
+  -> rest:flow_candidate list
+  -> messages:Types.message list
+  -> output_requirement
+  -> (ready_flow, flow_admission_error) result
+
+val ready_flow_admissions : ready_flow -> candidate_admission list
+
 (** Parse exactly one typed catalog input and freeze a private immutable target
     map. The default input is the embedded OAS catalog. [Embedded_with_overlay]
     applies the existing sparse exact-output overlay precedence to that
@@ -257,6 +316,18 @@ type start_attempt_error = Call_id_generation_failed of string
     Each attempt owns an opaque call identity and affine execution state. *)
 val start_attempt : ready_plan -> (attempt, start_attempt_error) result
 
+type flow_start_error =
+  | Flow_candidate_attempt_start_failed of
+      { identity : flow_candidate_identity
+      ; position : int
+      ; cause : start_attempt_error
+      ; admissions : candidate_admission list
+      }
+
+(** Allocate a fresh, non-shared exact attempt for every admitted candidate.
+    No attempt is exposed separately and no network effect occurs. *)
+val start_flow : ready_flow -> (flow_attempt, flow_start_error) result
+
 val call_id_to_string : call_id -> string
 val attempt_receipt : attempt -> receipt
 val receipt_call_id : receipt -> call_id
@@ -269,6 +340,47 @@ val receipt_catalog_generation : receipt -> catalog_generation
 val receipt_catalog_evidence : receipt -> catalog_evidence
 val receipt_target_identity : receipt -> target_identity
 
+type flow_attempt_receipt =
+  { identity : flow_candidate_identity
+  ; receipt : receipt
+  }
+
+type flow_evidence =
+  { admissions : candidate_admission list
+  ; attempts : flow_attempt_receipt list
+  }
+
+type flow_success =
+  { candidate : flow_attempt_receipt
+  ; success : success
+  ; evidence : flow_evidence
+  }
+
+type 'callback_error flow_execution_error =
+  | Flow_attempt_already_started of flow_evidence
+  | Flow_before_dispatch_callback_failed of
+      { candidate : flow_attempt_receipt
+      ; cause : 'callback_error
+      ; evidence : flow_evidence
+      }
+  | Flow_before_advance_callback_failed of
+      { failed : flow_attempt_receipt
+      ; failure : execution_error
+      ; next : flow_attempt_receipt
+      ; cause : 'callback_error
+      ; evidence : flow_evidence
+      }
+  | Flow_exact_execution_failed of
+      { candidate : flow_attempt_receipt
+      ; cause : execution_error
+      ; evidence : flow_evidence
+      }
+
+(** Point-in-time aggregate evidence. Receipts are the same monotonic handles
+    owned by the non-shared candidate attempts, including candidates that have
+    not started. This remains queryable after cancellation escapes. *)
+val flow_attempt_evidence : flow_attempt -> flow_evidence
+
 (** Execute the frozen request once. The attempt is single-use: duplicate or
     concurrent invocation of the same attempt is rejected before a second dispatch.
     Obtain {!attempt_receipt} before entering a cancellation scope; its phase is
@@ -280,3 +392,30 @@ val execute_once
   -> ?clock:_ Eio.Time.clock
   -> attempt
   -> (success, execution_error) result
+
+(** Execute one affine outer flow.
+
+    [before_dispatch] must durably bind the predetermined candidate before its
+    sole {!execute_once} call. A typed pre-dispatch transport failure may move
+    to the next admitted candidate only when its receipt is exactly
+    [Before_dispatch] with [dispatch_count = 0] and [before_advance] durably
+    confirms that predetermined transition. Callbacks cannot select, replace,
+    or reorder candidates.
+
+    Callback errors, replay, missing execution prerequisites, frozen-request
+    corruption, cancellation, every post-dispatch outcome, and success are
+    terminal. Cancellation is re-raised after the flow is terminalized; inspect
+    {!flow_attempt_evidence} for its monotonic receipts. Domain validation occurs
+    after an OAS success and is therefore outside this API and never failover
+    eligible. *)
+val execute_flow_once
+  :  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> ?clock:_ Eio.Time.clock
+  -> before_dispatch:(flow_attempt_receipt -> (unit, 'callback_error) result)
+  -> before_advance:
+       (failed:flow_attempt_receipt
+        -> failure:execution_error
+        -> next:flow_attempt_receipt
+        -> (unit, 'callback_error) result)
+  -> flow_attempt
+  -> (flow_success, 'callback_error flow_execution_error) result

--- a/lib/llm_provider/exact_output_flow.ml
+++ b/lib/llm_provider/exact_output_flow.ml
@@ -1,0 +1,61 @@
+type state =
+  | Not_started
+  | Running
+  | Terminal
+
+type t = state Atomic.t
+
+type ('candidate, 'success, 'execution_error, 'callback_error) outcome =
+  | Succeeded of
+      { candidate : 'candidate
+      ; success : 'success
+      }
+  | Attempt_already_started
+  | Before_dispatch_callback_failed of
+      { candidate : 'candidate
+      ; cause : 'callback_error
+      }
+  | Before_advance_callback_failed of
+      { failed_candidate : 'candidate
+      ; failure : 'execution_error
+      ; next_candidate : 'candidate
+      ; cause : 'callback_error
+      }
+  | Execution_failed of
+      { candidate : 'candidate
+      ; cause : 'execution_error
+      }
+
+let create () = Atomic.make Not_started
+
+let execute_once state ~candidates ~before_dispatch ~execute ~can_advance ~before_advance =
+  if not (Atomic.compare_and_set state Not_started Running)
+  then Attempt_already_started
+  else
+    Fun.protect
+      ~finally:(fun () -> Atomic.set state Terminal)
+      (fun () ->
+         let rec execute_candidates = function
+           | [] -> invalid_arg "Exact_output_flow: empty candidate snapshot"
+           | candidate :: rest ->
+             (match before_dispatch candidate with
+              | Error cause -> Before_dispatch_callback_failed { candidate; cause }
+              | Ok () ->
+                (match execute candidate with
+                 | Ok success -> Succeeded { candidate; success }
+                 | Error failure ->
+                   (match rest with
+                    | next :: _ when can_advance failure ->
+                      (match before_advance ~failed:candidate ~failure ~next with
+                       | Ok () -> execute_candidates rest
+                       | Error cause ->
+                         Before_advance_callback_failed
+                           { failed_candidate = candidate
+                           ; failure
+                           ; next_candidate = next
+                           ; cause
+                           })
+                    | [] | _ :: _ -> Execution_failed { candidate; cause = failure })))
+         in
+         execute_candidates candidates)
+;;

--- a/lib/llm_provider/exact_output_flow.mli
+++ b/lib/llm_provider/exact_output_flow.mli
@@ -1,0 +1,54 @@
+(** Private affine executor for an ordered exact-output flow.
+
+    The public contract is exposed only through {!Exact_output}. This module is
+    generic so it can own orchestration without depending back on the facade
+    types that wrap the private exact plan and execution modules. *)
+
+type t
+
+type ('candidate, 'success, 'execution_error, 'callback_error) outcome =
+  | Succeeded of
+      { candidate : 'candidate
+      ; success : 'success
+      }
+  | Attempt_already_started
+  | Before_dispatch_callback_failed of
+      { candidate : 'candidate
+      ; cause : 'callback_error
+      }
+  | Before_advance_callback_failed of
+      { failed_candidate : 'candidate
+      ; failure : 'execution_error
+      ; next_candidate : 'candidate
+      ; cause : 'callback_error
+      }
+  | Execution_failed of
+      { candidate : 'candidate
+      ; cause : 'execution_error
+      }
+
+val create : unit -> t
+
+(** Execute an immutable, nonempty candidate snapshot once.
+
+    [before_dispatch] must confirm the caller's durable binding before
+    [execute] is entered. [before_advance] receives the already-selected
+    successor and can only confirm or reject its durable transition; it cannot
+    replace or reorder that successor. [can_advance] is supplied exclusively by
+    the private facade adapter.
+
+    The outer attempt is affine. A duplicate or concurrent invocation returns
+    [Attempt_already_started]. Any exception, including Eio cancellation,
+    terminalizes the outer attempt before the exception is re-raised. *)
+val execute_once
+  :  t
+  -> candidates:'candidate list
+  -> before_dispatch:('candidate -> (unit, 'callback_error) result)
+  -> execute:('candidate -> ('success, 'execution_error) result)
+  -> can_advance:('execution_error -> bool)
+  -> before_advance:
+       (failed:'candidate
+        -> failure:'execution_error
+        -> next:'candidate
+        -> (unit, 'callback_error) result)
+  -> ('candidate, 'success, 'execution_error, 'callback_error) outcome

--- a/scripts/check-exact-output-resolver-boundary.sh
+++ b/scripts/check-exact-output-resolver-boundary.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 required_basenames=(
   exact_output.ml
+  exact_output_flow.ml
   exact_output_resolver.ml
   exact_output_catalog_binding.ml
   exact_output_plan.ml
@@ -346,6 +347,7 @@ require_named_function_pattern() {
 }
 
 exact_output_source=""
+exact_output_flow_source=""
 resolver_source=""
 catalog_binding_source=""
 exact_output_plan_source=""
@@ -354,6 +356,10 @@ downstream_sources=()
 for source_file in "${source_files[@]}"; do
   case "$(basename "$source_file")" in
     exact_output.ml) exact_output_source="$source_file" ;;
+    exact_output_flow.ml)
+      exact_output_flow_source="$source_file"
+      downstream_sources+=("$source_file")
+      ;;
     exact_output_resolver.ml) resolver_source="$source_file" ;;
     exact_output_catalog_binding.ml) catalog_binding_source="$source_file" ;;
     exact_output_plan.ml)
@@ -591,6 +597,7 @@ scan_code \
 for private_module in \
   exact_output_plan \
   exact_output_execution \
+  exact_output_flow \
   exact_output_resolver \
   exact_output_catalog_binding
 do
@@ -600,3 +607,26 @@ do
     exit 1
   fi
 done
+
+# The generic outer executor is private, affine, and policy-free. The facade is
+# the only place allowed to interpret exact receipt/cause types.
+require_code_pattern \
+  "private exact-output flow lost its affine execution gate" \
+  'Atomic\.compare_and_set' \
+  "$exact_output_flow_source"
+require_code_pattern \
+  "private exact-output flow no longer terminalizes exceptions and cancellation" \
+  'Fun\.protect' \
+  "$exact_output_flow_source"
+scan_code \
+  "private exact-output flow acquired provider, model, tier, pricing, retry, cascade, or string policy" \
+  'Provider|provider|Model|model|Tier|tier|Pricing|pricing|Retry|retry|Cascade|cascade|String\.|Str\.|Re\.' \
+  "$exact_output_flow_source"
+require_code_pattern \
+  "canonical facade lost outer exact-flow execution" \
+  '^[[:space:]]*val[[:space:]]+execute_flow_once[[:space:]]*:' \
+  "$exact_output_interface"
+scan_code \
+  "parallel public exact-output flow module escaped the single facade" \
+  '^[[:space:]]*module[[:space:]]+(Flow|Exact_output_flow)' \
+  "$exact_output_interface"

--- a/scripts/check-exact-output-resolver-boundary.sh
+++ b/scripts/check-exact-output-resolver-boundary.sh
@@ -622,9 +622,9 @@ scan_code \
   "private exact-output flow acquired provider, model, tier, pricing, retry, cascade, or string policy" \
   'Provider|provider|Model|model|Tier|tier|Pricing|pricing|Retry|retry|Cascade|cascade|String\.|Str\.|Re\.' \
   "$exact_output_flow_source"
-require_code_pattern \
+require_code_sequence \
   "canonical facade lost outer exact-flow execution" \
-  '^[[:space:]]*val[[:space:]]+execute_flow_once[[:space:]]*:' \
+  'val[[:space:]]+execute_flow_once[[:space:]]*:' \
   "$exact_output_interface"
 scan_code \
   "parallel public exact-output flow module escaped the single facade" \

--- a/test/dune
+++ b/test/dune
@@ -423,6 +423,11 @@
  (libraries agent_sdk llm_provider alcotest eio_main))
 
 (test
+ (name test_exact_output_flow)
+ (modules test_exact_output_flow)
+ (libraries agent_sdk llm_provider alcotest eio_main))
+
+(test
  (name test_exact_output_resolver_snapshot)
  (modules test_exact_output_resolver_snapshot)
  (libraries agent_sdk llm_provider alcotest eio_main))
@@ -433,6 +438,8 @@
   ../scripts/check-exact-output-resolver-boundary.sh
   ../lib/llm_provider/exact_output.ml
   ../lib/llm_provider/exact_output.mli
+  ../lib/llm_provider/exact_output_flow.ml
+  ../lib/llm_provider/exact_output_flow.mli
   ../lib/llm_provider/exact_output_resolver.ml
   ../lib/llm_provider/exact_output_resolver.mli
   ../lib/llm_provider/exact_output_catalog_binding.ml
@@ -454,6 +461,7 @@
    bash
    %{dep:../scripts/check-exact-output-resolver-boundary.sh}
    %{dep:../lib/llm_provider/exact_output.ml}
+   %{dep:../lib/llm_provider/exact_output_flow.ml}
    %{dep:../lib/llm_provider/exact_output_resolver.ml}
    %{dep:../lib/llm_provider/exact_output_catalog_binding.ml}
    %{dep:../lib/llm_provider/exact_output_plan.ml}

--- a/test/test_exact_output_flow.ml
+++ b/test/test_exact_output_flow.ml
@@ -1,0 +1,610 @@
+open Alcotest
+open Llm_provider
+module EO = Agent_sdk.Exact_output
+
+let msg text : Types.message =
+  { role = Types.User
+  ; content = [ Types.Text text ]
+  ; name = None
+  ; tool_call_id = None
+  ; metadata = []
+  }
+;;
+
+let schema =
+  `Assoc
+    [ "type", `String "object"
+    ; "properties", `Assoc [ "name", `Assoc [ "type", `String "string" ] ]
+    ; "required", `List [ `String "name" ]
+    ; "additionalProperties", `Bool false
+    ]
+;;
+
+type catalog_fixture =
+  { id : string
+  ; base_url : string
+  ; native : bool
+  ; json : bool
+  ; body_timeout_s : float option
+  }
+
+let catalog_entry ?body_timeout_s ~id ~base_url ~native ~json () =
+  { id; base_url; native; json; body_timeout_s }
+;;
+
+let catalog_fixture_toml entry =
+  Printf.sprintf
+    "[[providers]]\n\
+     id = %S\n\
+     kind = \"openai_compat\"\n\
+     base_url = %S\n\
+     request_path = \"/v1/chat/completions\"\n\
+     api_key_env = \"\"\n\n\
+     [[models]]\n\
+     id_prefix = %S\n\
+     provider_name = %S\n\
+     max_context_tokens = 8192\n\
+     max_output_tokens = 1024\n\
+     supports_response_format_json = %b\n\
+     supports_structured_output = %b\n\n\
+     [[targets]]\n\
+     id = %S\n\
+     provider_ref = %S\n\
+     model_id = %S\n\
+     %s"
+    entry.id
+    entry.base_url
+    (entry.id ^ "-model")
+    entry.id
+    entry.json
+    entry.native
+    entry.id
+    entry.id
+    (entry.id ^ "-model")
+    (match entry.body_timeout_s with
+     | None -> ""
+     | Some seconds -> Printf.sprintf "body_timeout_s = %.17g\n" seconds)
+;;
+
+let with_catalog entries f =
+  let document : EO.catalog_document =
+    { source = "exact-output outer-flow fixture"
+    ; contents = String.concat "\n" (List.map catalog_fixture_toml entries)
+    }
+  in
+  let io : EO.resolver_io = { getenv = (fun _ -> Ok None) } in
+  match EO.load_resolver_snapshot ~io ~catalog:(EO.Embedded_with_overlay document) () with
+  | Error _ -> fail "outer-flow resolver snapshot should load"
+  | Ok snapshot -> f snapshot
+;;
+
+let target snapshot selector =
+  match EO.admit_target_ref snapshot selector with
+  | Error _ -> failf "target ref %s was not admitted" selector
+  | Ok admitted ->
+    (match EO.resolve_target admitted with
+     | Ok target -> target
+     | Error _ -> failf "target %s did not resolve" selector)
+;;
+
+let flow_candidate snapshot id =
+  match EO.make_flow_candidate ~id ~target:(target snapshot id) with
+  | Ok candidate -> candidate
+  | Error EO.Blank_flow_candidate_id -> fail "fixture candidate id was blank"
+;;
+
+let ready_flow snapshot ids =
+  match List.map (flow_candidate snapshot) ids with
+  | [] -> fail "flow fixture must be nonempty"
+  | first :: rest ->
+    (match
+       EO.admit_flow
+         ~first
+         ~rest
+         ~messages:[ msg "return one exact object" ]
+         (EO.make_output_requirement ~schema ~minimum_guarantee:EO.Json_syntax)
+     with
+     | Ok ready -> ready
+     | Error _ -> fail "flow fixture did not admit")
+;;
+
+let start_flow ready =
+  match EO.start_flow ready with
+  | Ok flow -> flow
+  | Error (EO.Flow_candidate_attempt_start_failed _) ->
+    fail "flow attempt identity allocation failed"
+;;
+
+let fresh_port () =
+  let socket = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+  Unix.setsockopt socket Unix.SO_REUSEADDR true;
+  Unix.bind socket (Unix.ADDR_INET (Unix.inet_addr_loopback, 0));
+  let port =
+    match Unix.getsockname socket with
+    | Unix.ADDR_INET (_, port) -> port
+    | _ -> fail "loopback socket did not expose a TCP port"
+  in
+  Unix.close socket;
+  port
+;;
+
+let openai_response content =
+  let encoded_content = Yojson.Safe.to_string (`String content) in
+  Printf.sprintf
+    {|{"id":"resp-flow","model":"flow","choices":[{"index":0,"message":{"role":"assistant","content":%s},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}|}
+    encoded_content
+;;
+
+let tool_response =
+  {|{"id":"resp-tool","model":"flow","choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":[{"id":"call-1","type":"function","function":{"name":"forbidden","arguments":"{}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}|}
+;;
+
+let with_server ?response_delay_s ?(status = `OK) ?(abort_completion = false) ~response f =
+  let completion_posts = Atomic.make 0 in
+  let result =
+    Eio_main.run
+    @@ fun env ->
+    Eio.Switch.run
+    @@ fun sw ->
+    let net = Eio.Stdenv.net env in
+    let clock = Eio.Stdenv.clock env in
+    let port = fresh_port () in
+    let handler _conn _request body =
+      ignore (Eio.Buf_read.(of_flow ~max_size:max_int body |> take_all) : string);
+      Atomic.incr completion_posts;
+      if abort_completion then raise Exit;
+      Option.iter (Eio.Time.sleep clock) response_delay_s;
+      Cohttp_eio.Server.respond_string ~status ~body:response ()
+    in
+    let socket =
+      Eio.Net.listen
+        net
+        ~sw
+        ~backlog:8
+        ~reuse_addr:true
+        (`Tcp (Eio.Net.Ipaddr.V4.loopback, port))
+    in
+    let server = Cohttp_eio.Server.make ~callback:handler () in
+    Eio.Fiber.fork_daemon ~sw (fun () ->
+      Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()));
+    f ~sw ~net ~clock ~base_url:(Printf.sprintf "http://127.0.0.1:%d" port)
+  in
+  result, Atomic.get completion_posts
+;;
+
+let candidate_id (candidate : EO.flow_attempt_receipt) = candidate.identity.candidate_id
+
+let attempt_for evidence id =
+  match
+    List.find_opt
+      (fun (attempt : EO.flow_attempt_receipt) ->
+         String.equal attempt.identity.candidate_id id)
+      evidence.EO.attempts
+  with
+  | Some attempt -> attempt
+  | None -> failf "missing attempt evidence for %s" id
+;;
+
+let execute_ok ~net flow =
+  EO.execute_flow_once
+    ~net
+    ~before_dispatch:(fun _ -> Ok ())
+    ~before_advance:(fun ~failed:_ ~failure:_ ~next:_ -> Ok ())
+    flow
+;;
+
+let test_admission_freezes_all_candidates_before_network () =
+  let (admissions, evidence_a, evidence_b), posts =
+    with_server ~response:(openai_response {|{"name":"unused"}|})
+    @@ fun ~sw:_ ~net:_ ~clock:_ ~base_url ->
+    let entry id native json = catalog_entry ~id ~base_url ~native ~json () in
+    with_catalog
+      [ entry "flow-good-a" true true
+      ; entry "flow-rejected" false false
+      ; entry "flow-good-b" true true
+      ]
+    @@ fun snapshot ->
+    let candidates =
+      List.map (flow_candidate snapshot) [ "flow-good-a"; "flow-rejected"; "flow-good-b" ]
+    in
+    let ready =
+      match candidates with
+      | first :: rest ->
+        (match
+           EO.admit_flow
+             ~first
+             ~rest
+             ~messages:[ msg "freeze all" ]
+             (EO.make_output_requirement ~schema ~minimum_guarantee:EO.Json_syntax)
+         with
+         | Ok ready -> ready
+         | Error _ -> fail "partially admissible flow should be ready")
+      | [] -> assert false
+    in
+    let flow_a = start_flow ready in
+    let flow_b = start_flow ready in
+    ( EO.ready_flow_admissions ready
+    , EO.flow_attempt_evidence flow_a
+    , EO.flow_attempt_evidence flow_b )
+  in
+  check int "admission and attempt allocation make no POST" 0 posts;
+  check int "all admission outcomes retained" 3 (List.length admissions);
+  (match admissions with
+   | [ EO.Candidate_admitted admitted_a
+     ; EO.Candidate_rejected { identity = rejected; cause = EO.Json_syntax_unavailable }
+     ; EO.Candidate_admitted admitted_b
+     ] ->
+     check
+       string
+       "first admission identity"
+       "flow-good-a"
+       admitted_a.identity.candidate_id;
+     check string "rejection identity" "flow-rejected" rejected.candidate_id;
+     check string "last admission identity" "flow-good-b" admitted_b.identity.candidate_id
+   | _ -> fail "ordered admission evidence was incomplete");
+  check int "only admitted candidates get attempts" 2 (List.length evidence_a.attempts);
+  List.iter
+    (fun (attempt : EO.flow_attempt_receipt) ->
+       check
+         bool
+         "candidate remains not started"
+         true
+         (EO.receipt_phase attempt.receipt = EO.Not_started))
+    evidence_a.attempts;
+  List.iter2
+    (fun (left : EO.flow_attempt_receipt) (right : EO.flow_attempt_receipt) ->
+       check
+         bool
+         "separate flows do not share call identity"
+         true
+         (not
+            (String.equal
+               (EO.receipt_call_id left.receipt |> EO.call_id_to_string)
+               (EO.receipt_call_id right.receipt |> EO.call_id_to_string))))
+    evidence_a.attempts
+    evidence_b.attempts
+;;
+
+let test_predispatch_transport_failure_advances_after_durable_callback () =
+  let (result, bound, advanced), posts =
+    with_server ~response:(openai_response {|{"name":"accepted"}|})
+    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
+    let dead_url = Printf.sprintf "http://127.0.0.1:%d" (fresh_port ()) in
+    with_catalog
+      [ catalog_entry ~id:"flow-dead" ~base_url:dead_url ~native:true ~json:true ()
+      ; catalog_entry ~id:"flow-live" ~base_url ~native:true ~json:true ()
+      ]
+    @@ fun snapshot ->
+    let flow = start_flow (ready_flow snapshot [ "flow-dead"; "flow-live" ]) in
+    let bound = ref [] in
+    let advanced = ref [] in
+    let result =
+      EO.execute_flow_once
+        ~net
+        ~before_dispatch:(fun candidate ->
+          bound := candidate_id candidate :: !bound;
+          Ok ())
+        ~before_advance:(fun ~failed ~failure ~next ->
+          check
+            bool
+            "advance failure is pre-dispatch"
+            true
+            (EO.receipt_phase failure.EO.receipt = EO.Before_dispatch);
+          check
+            int
+            "advance failure has zero dispatch"
+            0
+            (EO.receipt_dispatch_count failure.receipt);
+          advanced := (candidate_id failed, candidate_id next) :: !advanced;
+          Ok ())
+        flow
+    in
+    result, List.rev !bound, List.rev !advanced
+  in
+  check int "only live successor posts" 1 posts;
+  check (list string) "bind order" [ "flow-dead"; "flow-live" ] bound;
+  check
+    (list (pair string string))
+    "predetermined successor"
+    [ "flow-dead", "flow-live" ]
+    advanced;
+  match result with
+  | Ok success ->
+    check string "successor succeeds" "flow-live" (candidate_id success.candidate);
+    let failed = attempt_for success.evidence "flow-dead" in
+    check
+      bool
+      "failed receipt remains before dispatch"
+      true
+      (EO.receipt_phase failed.receipt = EO.Before_dispatch);
+    check
+      int
+      "failed receipt remains zero dispatch"
+      0
+      (EO.receipt_dispatch_count failed.receipt)
+  | Error _ -> fail "eligible pre-dispatch failure did not advance"
+;;
+
+let test_callback_failures_are_terminal () =
+  let before_dispatch_result, before_dispatch_posts =
+    with_server ~response:(openai_response {|{"name":"unused"}|})
+    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
+    with_catalog
+      [ catalog_entry ~id:"bind-a" ~base_url ~native:true ~json:true ()
+      ; catalog_entry ~id:"bind-b" ~base_url ~native:true ~json:true ()
+      ]
+    @@ fun snapshot ->
+    EO.execute_flow_once
+      ~net
+      ~before_dispatch:(fun _ -> Error "bind-not-durable")
+      ~before_advance:(fun ~failed:_ ~failure:_ ~next:_ -> Ok ())
+      (start_flow (ready_flow snapshot [ "bind-a"; "bind-b" ]))
+  in
+  check int "failed bind dispatches nothing" 0 before_dispatch_posts;
+  (match before_dispatch_result with
+   | Error
+       (EO.Flow_before_dispatch_callback_failed
+          { candidate; cause = "bind-not-durable"; evidence }) ->
+     check string "failed bind candidate" "bind-a" (candidate_id candidate);
+     check
+       bool
+       "failed bind leaves receipt not started"
+       true
+       (EO.receipt_phase candidate.receipt = EO.Not_started);
+     check
+       bool
+       "successor remains not started"
+       true
+       (EO.receipt_phase (attempt_for evidence "bind-b").receipt = EO.Not_started)
+   | Ok _ | Error _ -> fail "failed bind did not return typed terminal evidence");
+  let before_advance_result, before_advance_posts =
+    with_server ~response:(openai_response {|{"name":"unused"}|})
+    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
+    let dead_url = Printf.sprintf "http://127.0.0.1:%d" (fresh_port ()) in
+    with_catalog
+      [ catalog_entry ~id:"advance-a" ~base_url:dead_url ~native:true ~json:true ()
+      ; catalog_entry ~id:"advance-b" ~base_url ~native:true ~json:true ()
+      ]
+    @@ fun snapshot ->
+    EO.execute_flow_once
+      ~net
+      ~before_dispatch:(fun _ -> Ok ())
+      ~before_advance:(fun ~failed:_ ~failure:_ ~next:_ -> Error "release-not-durable")
+      (start_flow (ready_flow snapshot [ "advance-a"; "advance-b" ]))
+  in
+  check int "failed advance dispatches no successor" 0 before_advance_posts;
+  match before_advance_result with
+  | Error
+      (EO.Flow_before_advance_callback_failed
+         { failed; next; cause = "release-not-durable"; evidence; _ }) ->
+    check string "failed attempt identity" "advance-a" (candidate_id failed);
+    check string "withheld successor identity" "advance-b" (candidate_id next);
+    check
+      bool
+      "withheld successor remains not started"
+      true
+      (EO.receipt_phase (attempt_for evidence "advance-b").receipt = EO.Not_started)
+  | Ok _ | Error _ -> fail "failed advance did not return typed terminal evidence"
+;;
+
+let test_postdispatch_and_structural_outcomes_never_advance () =
+  let run ?(status = `OK) ?(abort_completion = false) label response =
+    let (result, advances), posts =
+      with_server ~status ~abort_completion ~response
+      @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
+      with_catalog
+        [ catalog_entry ~id:(label ^ "-a") ~base_url ~native:true ~json:true ()
+        ; catalog_entry ~id:(label ^ "-b") ~base_url ~native:true ~json:true ()
+        ]
+      @@ fun snapshot ->
+      let advances = ref 0 in
+      let result =
+        EO.execute_flow_once
+          ~net
+          ~before_dispatch:(fun _ -> Ok ())
+          ~before_advance:(fun ~failed:_ ~failure:_ ~next:_ ->
+            incr advances;
+            Ok ())
+          (start_flow (ready_flow snapshot [ label ^ "-a"; label ^ "-b" ]))
+      in
+      result, !advances
+    in
+    check int (label ^ " dispatches exactly once") 1 posts;
+    check int (label ^ " does not request advance") 0 advances;
+    match result with
+    | Error (EO.Flow_exact_execution_failed { candidate; cause; evidence }) ->
+      check string (label ^ " terminal candidate") (label ^ "-a") (candidate_id candidate);
+      check
+        int
+        (label ^ " terminal dispatch count")
+        1
+        (EO.receipt_dispatch_count cause.receipt);
+      check
+        bool
+        (label ^ " successor remains not started")
+        true
+        (EO.receipt_phase (attempt_for evidence (label ^ "-b")).receipt = EO.Not_started)
+    | Ok _ | Error _ -> fail (label ^ " did not remain terminal")
+  in
+  run ~abort_completion:true "partial" "unused";
+  run ~status:`Too_many_requests "response" "rate limited";
+  run "structural" (openai_response "not-json");
+  run "tool" tool_response
+;;
+
+let test_success_and_later_domain_rejection_are_terminal () =
+  let result, posts =
+    with_server ~response:(openai_response {|{"name":"accepted"}|})
+    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
+    with_catalog
+      [ catalog_entry ~id:"success-a" ~base_url ~native:true ~json:true ()
+      ; catalog_entry ~id:"success-b" ~base_url ~native:true ~json:true ()
+      ]
+    @@ fun snapshot ->
+    execute_ok ~net (start_flow (ready_flow snapshot [ "success-a"; "success-b" ]))
+  in
+  check int "success dispatches exactly once" 1 posts;
+  match result with
+  | Ok success ->
+    check string "first candidate succeeds" "success-a" (candidate_id success.candidate);
+    check
+      bool
+      "successor remains unavailable to later domain rejection"
+      true
+      (EO.receipt_phase (attempt_for success.evidence "success-b").receipt
+       = EO.Not_started)
+  | Error _ -> fail "terminal success fixture failed"
+;;
+
+let test_structural_predispatch_failure_does_not_advance () =
+  let (result, advances), posts =
+    with_server ~response:(openai_response {|{"name":"unused"}|})
+    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
+    with_catalog
+      [ catalog_entry
+          ~body_timeout_s:1.0
+          ~id:"clock-a"
+          ~base_url
+          ~native:true
+          ~json:true
+          ()
+      ; catalog_entry ~id:"clock-b" ~base_url ~native:true ~json:true ()
+      ]
+    @@ fun snapshot ->
+    let advances = ref 0 in
+    let result =
+      EO.execute_flow_once
+        ~net
+        ~before_dispatch:(fun _ -> Ok ())
+        ~before_advance:(fun ~failed:_ ~failure:_ ~next:_ ->
+          incr advances;
+          Ok ())
+        (start_flow (ready_flow snapshot [ "clock-a"; "clock-b" ]))
+    in
+    result, !advances
+  in
+  check int "missing clock dispatches nothing" 0 posts;
+  check int "missing clock cannot advance" 0 advances;
+  match result with
+  | Error
+      (EO.Flow_exact_execution_failed
+         { cause = { cause = EO.Clock_required_for_timeout; receipt; _ }; evidence; _ })
+    ->
+    check
+      int
+      "structural failure remains zero dispatch"
+      0
+      (EO.receipt_dispatch_count receipt);
+    check
+      bool
+      "structural successor remains not started"
+      true
+      (EO.receipt_phase (attempt_for evidence "clock-b").receipt = EO.Not_started)
+  | Ok _ | Error _ -> fail "missing clock was not terminal"
+;;
+
+let test_concurrent_duplicate_flow_does_not_double_dispatch () =
+  let (left, right), posts =
+    with_server ~response_delay_s:0.1 ~response:(openai_response {|{"name":"accepted"}|})
+    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
+    with_catalog
+      [ catalog_entry ~id:"concurrent-flow" ~base_url ~native:true ~json:true () ]
+    @@ fun snapshot ->
+    let flow = start_flow (ready_flow snapshot [ "concurrent-flow" ]) in
+    let execute () : (EO.flow_success, string EO.flow_execution_error) result =
+      EO.execute_flow_once
+        ~net
+        ~before_dispatch:(fun _ -> Ok ())
+        ~before_advance:(fun ~failed:_ ~failure:_ ~next:_ -> Ok ())
+        flow
+    in
+    Eio.Fiber.both execute execute
+  in
+  check int "concurrent duplicate makes one POST" 1 posts;
+  let is_success = function
+    | Ok _ -> true
+    | Error _ -> false
+  in
+  let is_replay = function
+    | Error (EO.Flow_attempt_already_started _) -> true
+    | Ok _ | Error _ -> false
+  in
+  check
+    bool
+    "one concurrent invocation succeeds"
+    true
+    (is_success left <> is_success right);
+  check
+    bool
+    "one concurrent invocation is rejected"
+    true
+    (is_replay left <> is_replay right)
+;;
+
+let test_cancellation_terminalizes_outer_attempt () =
+  let (timed_out, replay, evidence), posts =
+    with_server ~response_delay_s:0.1 ~response:(openai_response {|{"name":"accepted"}|})
+    @@ fun ~sw:_ ~net ~clock ~base_url ->
+    with_catalog [ catalog_entry ~id:"cancel-flow" ~base_url ~native:true ~json:true () ]
+    @@ fun snapshot ->
+    let flow = start_flow (ready_flow snapshot [ "cancel-flow" ]) in
+    let timed_out =
+      try
+        ignore
+          (Eio.Time.with_timeout_exn clock 0.01 (fun () -> execute_ok ~net flow)
+           : (EO.flow_success, _ EO.flow_execution_error) result);
+        false
+      with
+      | Eio.Time.Timeout -> true
+    in
+    let replay = execute_ok ~net flow in
+    timed_out, replay, EO.flow_attempt_evidence flow
+  in
+  check bool "cancellation escaped" true timed_out;
+  check int "cancellation dispatched at most once" 1 posts;
+  (match replay with
+   | Error (EO.Flow_attempt_already_started _) -> ()
+   | Ok _ | Error _ -> fail "cancelled flow was not terminal");
+  let receipt = (attempt_for evidence "cancel-flow").receipt in
+  check int "cancelled receipt records dispatch" 1 (EO.receipt_dispatch_count receipt)
+;;
+
+let () =
+  run
+    "exact-output-flow"
+    [ ( "outer-flow"
+      , [ test_case
+            "all admissions freeze before network"
+            `Quick
+            test_admission_freezes_all_candidates_before_network
+        ; test_case
+            "predispatch transport failure advances durably"
+            `Quick
+            test_predispatch_transport_failure_advances_after_durable_callback
+        ; test_case
+            "callback failures are terminal"
+            `Quick
+            test_callback_failures_are_terminal
+        ; test_case
+            "postdispatch and structural outcomes stop"
+            `Quick
+            test_postdispatch_and_structural_outcomes_never_advance
+        ; test_case
+            "success and domain rejection stop"
+            `Quick
+            test_success_and_later_domain_rejection_are_terminal
+        ; test_case
+            "predispatch structural failure stops"
+            `Quick
+            test_structural_predispatch_failure_does_not_advance
+        ; test_case
+            "concurrent duplicate makes one dispatch"
+            `Quick
+            test_concurrent_duplicate_flow_does_not_double_dispatch
+        ; test_case
+            "cancellation terminalizes outer attempt"
+            `Quick
+            test_cancellation_terminalizes_outer_attempt
+        ] )
+    ]
+;;

--- a/test/test_exact_output_flow.ml
+++ b/test/test_exact_output_flow.ml
@@ -266,7 +266,7 @@ let test_admission_freezes_all_candidates_before_network () =
 ;;
 
 let test_predispatch_transport_failure_advances_after_durable_callback () =
-  let (result, bound, advanced), posts =
+  let (result, bound, advanced, events), posts =
     with_server ~response:(openai_response {|{"name":"accepted"}|})
     @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
     let dead_url = Printf.sprintf "http://127.0.0.1:%d" (fresh_port ()) in
@@ -278,10 +278,12 @@ let test_predispatch_transport_failure_advances_after_durable_callback () =
     let flow = start_flow (ready_flow snapshot [ "flow-dead"; "flow-live" ]) in
     let bound = ref [] in
     let advanced = ref [] in
+    let events = ref [] in
     let result =
       EO.execute_flow_once
         ~net
         ~before_dispatch:(fun candidate ->
+          events := ("bind:" ^ candidate_id candidate) :: !events;
           bound := candidate_id candidate :: !bound;
           Ok ())
         ~before_advance:(fun ~failed ~failure ~next ->
@@ -295,11 +297,14 @@ let test_predispatch_transport_failure_advances_after_durable_callback () =
             "advance failure has zero dispatch"
             0
             (EO.receipt_dispatch_count failure.receipt);
+          events
+          := Printf.sprintf "advance:%s->%s" (candidate_id failed) (candidate_id next)
+             :: !events;
           advanced := (candidate_id failed, candidate_id next) :: !advanced;
           Ok ())
         flow
     in
-    result, List.rev !bound, List.rev !advanced
+    result, List.rev !bound, List.rev !advanced, List.rev !events
   in
   check int "only live successor posts" 1 posts;
   check (list string) "bind order" [ "flow-dead"; "flow-live" ] bound;
@@ -308,6 +313,11 @@ let test_predispatch_transport_failure_advances_after_durable_callback () =
     "predetermined successor"
     [ "flow-dead", "flow-live" ]
     advanced;
+  check
+    (list string)
+    "durable advance precedes successor bind"
+    [ "bind:flow-dead"; "advance:flow-dead->flow-live"; "bind:flow-live" ]
+    events;
   match result with
   | Ok success ->
     check string "successor succeeds" "flow-live" (candidate_id success.candidate);
@@ -518,7 +528,12 @@ let test_concurrent_duplicate_flow_does_not_double_dispatch () =
         ~before_advance:(fun ~failed:_ ~failure:_ ~next:_ -> Ok ())
         flow
     in
-    Eio.Fiber.both execute execute
+    let left_promise, left_resolver = Eio.Promise.create () in
+    let right_promise, right_resolver = Eio.Promise.create () in
+    Eio.Fiber.both
+      (fun () -> Eio.Promise.resolve left_resolver (execute ()))
+      (fun () -> Eio.Promise.resolve right_resolver (execute ()));
+    Eio.Promise.await left_promise, Eio.Promise.await right_promise
   in
   check int "concurrent duplicate makes one POST" 1 posts;
   let is_success = function


### PR DESCRIPTION
## Summary

- add one canonical provider-neutral outer exact-flow behind `Agent_sdk.Exact_output`
- freeze every ordered candidate admission before network activity and retain admitted/rejected aggregate evidence
- allocate fresh non-shared attempts for every admitted candidate under one affine outer attempt
- let OAS own the predetermined successor transition while caller callbacks only confirm durable bind/release effects
- retain the existing single-plan `execute_once` unchanged

## Boundary

- OAS owns immutable candidate plans, attempt identity, exact receipts, and next-candidate selection
- callers own domain input/schema/codec/content validation and durable business-state effects
- only `Completion_failed` with receipt `Before_dispatch && dispatch_count = 0` can advance
- advance additionally requires a successful durable `before_advance` callback
- callback failure, replay, cancellation, missing clock, frozen-request mismatch, every post-dispatch outcome, structural output failure, success, and later caller domain rejection are terminal
- callbacks cannot select, replace, or reorder candidates

## Evidence

- ordered candidate identities and every admission outcome
- plan/request/catalog/target provenance for admitted candidates
- every per-candidate receipt, including unstarted successors
- terminal success or exact execution failure
- cancellation leaves aggregate receipts queryable after it escapes

## Conformance

- all candidates admitted/frozen before network
- rejected admissions retained while usable candidates remain executable
- two starts share neither call identity nor attempt state
- pre-dispatch transport failure advances only after durable confirmation
- bind/release callback failure prevents dispatch/advance
- dispatch-started, response-received, tool/structural output, success, and missing prerequisites never advance
- concurrent duplicate outer execution performs one dispatch
- cancellation terminalizes the outer attempt
- boundary ratchet keeps the flow private and free of provider/model/tier/Pricing/retry/cascade/string policy

## Pre-1.0 policy

No legacy cascade API, compatibility wrapper, persisted JSON decoder, reconciliation, or migration is added. Obsolete runtime assets are reset rather than migrated before 1.0.

## Validation

- `ocamlformat -i` applied to the five changed OCaml source/interface files
- local builds/tests intentionally not run per operator instruction; PR CI is the compile and behavioral authority

## Dependency

This OAS PR and its release precede the MASC HITL consumer restack. MASC PR #25623 must remove its local candidate loop/next-slot decision before merge.
