### PR TITLE
refactor(agent): purge unused internal helpers replace_projected_error and persist_turn_checkpoint

### DIFF
--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -66,10 +66,6 @@ let open_execution_projection ~runtime ~dir locator =
     ()
 ;;
 
-let replace_projected_error error detailed =
-  { detailed with Provider_failure_attribution.error }
-;;
-
 let project_detailed_error result =
   Result.map_error (fun detailed -> detailed.error) result
 ;;

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -30,7 +30,6 @@ type turn_outcome = Pipeline_terminal_tool.turn_outcome =
   | TerminalToolCompleted of Terminal_tool_receipt.t
 
 let persist_turn_checkpoint_for_state = Pipeline_checkpoint.persist_for_state
-;;
 
 (** Set lifecycle to Ready, invoke BeforeTurn hook, handle elicitation. *)
 let stage_input = Pipeline_stage_prepare.stage_input

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -30,9 +30,6 @@ type turn_outcome = Pipeline_terminal_tool.turn_outcome =
   | TerminalToolCompleted of Terminal_tool_receipt.t
 
 let persist_turn_checkpoint_for_state = Pipeline_checkpoint.persist_for_state
-
-let persist_turn_checkpoint agent stage =
-  persist_turn_checkpoint_for_state agent stage agent.state
 ;;
 
 (** Set lifecycle to Ready, invoke BeforeTurn hook, handle elicitation. *)

--- a/specs/TurnDurability.tla
+++ b/specs/TurnDurability.tla
@@ -3,7 +3,7 @@
 \*
 \* Concrete code:
 \*   - Agent_types.checkpoint_sink
-\*   - Pipeline.persist_turn_checkpoint
+\*   - Pipeline.persist_turn_checkpoint_for_state
 \*   - stage_collect / stage_execute / required-tool retry feedback append
 \*
 \* The key safety rule is that once an in-memory mutation that changes


### PR DESCRIPTION
### Summary
Purged unused top-level internal helper functions identified during 10-pass Blast Radius dead code analysis:
- `lib/agent/agent.ml`: Remove `replace_projected_error` (0 calls across the codebase).
- `lib/pipeline/pipeline.ml`: Remove `persist_turn_checkpoint` (0 callers; callers use `persist_turn_checkpoint_for_state` directly).

### Verification
- Focused local dune build: `scripts/dune-local.sh build` passed clean.
- Unit & integration tests: `scripts/dune-local.sh runtest` (all tests passed).