### PR TITLE
feat(exact-output): anchor opaque provider trace

### DIFF
--- a/lib/llm_provider/exact_output.ml
+++ b/lib/llm_provider/exact_output.ml
@@ -40,8 +40,18 @@ type attempt_state =
 
 type call_id = Call_id of string
 
+type provider_trace =
+  { fingerprint : string
+  ; http_status : int
+  ; response_header_evidence_fingerprint : string
+  ; raw_response_body_sha256 : string
+  ; response_id : string option
+  ; response_model : string option
+  }
+
 type receipt =
   { state : attempt_state Atomic.t
+  ; provider_trace_state : provider_trace option Atomic.t
   ; call_id : call_id
   ; plan_fingerprint : string
   ; request_body_sha256 : string
@@ -619,6 +629,7 @@ let start_attempt (ready : ready_plan) =
   | Ok id ->
     let receipt =
       { state = Atomic.make Not_started_state
+      ; provider_trace_state = Atomic.make None
       ; call_id = Call_id id
       ; plan_fingerprint = ready.plan_fingerprint
       ; request_body_sha256 = ready.request_body_sha256
@@ -680,6 +691,8 @@ let receipt_http_status receipt =
   | Not_started_state | Before_dispatch_state | Dispatch_started_state -> None
 ;;
 
+let receipt_provider_trace receipt = Atomic.get receipt.provider_trace_state
+let provider_trace_fingerprint trace = trace.fingerprint
 let receipt_plan_fingerprint (receipt : receipt) = receipt.plan_fingerprint
 let receipt_request_body_sha256 (receipt : receipt) = receipt.request_body_sha256
 let receipt_catalog_generation (receipt : receipt) = receipt.catalog_generation
@@ -741,6 +754,65 @@ let raw_response (evidence : Exec.raw_response_evidence) =
   { body = evidence.raw_body; body_sha256 = evidence.raw_body_sha256 }
 ;;
 
+let provider_trace_of_evidence
+      ?response
+      complete_receipt
+      (evidence : Exec.raw_response_evidence)
+  =
+  let http_status =
+    match Exec.receipt_http_status complete_receipt with
+    | Some status -> status
+    | None -> invalid_arg "Exact_output: response evidence without HTTP status"
+  in
+  let response_id, response_model =
+    match response with
+    | None -> None, None
+    | Some (response : Types.api_response) -> Some response.id, Some response.model
+  in
+  let response_header_evidence_fingerprint =
+    Http_client.response_header_evidence_fingerprint evidence.response_header_evidence
+  in
+  let payload =
+    `Assoc
+      [ "version", `Int 1
+      ; "http_status", `Int http_status
+      ; ( "response_header_evidence_fingerprint"
+        , `String response_header_evidence_fingerprint )
+      ; "raw_response_body_sha256", `String evidence.raw_body_sha256
+      ; ( "response_id"
+        , match response_id with
+          | None -> `Null
+          | Some value -> `String value )
+      ; ( "response_model"
+        , match response_model with
+          | None -> `Null
+          | Some value -> `String value )
+      ]
+  in
+  let fingerprint =
+    payload
+    |> Yojson.Safe.to_string
+    |> Digestif.SHA256.digest_string
+    |> Digestif.SHA256.to_hex
+  in
+  { fingerprint
+  ; http_status
+  ; response_header_evidence_fingerprint
+  ; raw_response_body_sha256 = evidence.raw_body_sha256
+  ; response_id
+  ; response_model
+  }
+;;
+
+let rec record_provider_trace receipt trace =
+  match Atomic.get receipt.provider_trace_state with
+  | Some existing when String.equal existing.fingerprint trace.fingerprint -> ()
+  | Some _ -> invalid_arg "Exact_output: provider trace changed after installation"
+  | None ->
+    if not (Atomic.compare_and_set receipt.provider_trace_state None (Some trace))
+    then record_provider_trace receipt trace
+;;
+
 let execution_error_cause = function
   | Exec.Clock_required_for_timeout -> Clock_required_for_timeout
   | Exec.Frozen_request_mismatch -> Frozen_request_mismatch
@@ -778,6 +850,12 @@ let execute_once ~net ?clock (attempt : attempt) =
         ({ receipt = complete_receipt; cause; raw_response = evidence } :
           Exec.execute_once_error_with_evidence) ->
       synchronize_receipt receipt complete_receipt;
+      Option.iter
+        (fun response_evidence ->
+           response_evidence
+           |> provider_trace_of_evidence complete_receipt
+           |> record_provider_trace receipt)
+        evidence;
       Error
         { call_id = receipt.call_id
         ; receipt
@@ -786,6 +864,10 @@ let execute_once ~net ?clock (attempt : attempt) =
         }
     | Ok { outcome; raw_response = evidence } ->
       synchronize_receipt receipt outcome.receipt;
+      let provider_trace =
+        provider_trace_of_evidence ~response:outcome.response outcome.receipt evidence
+      in
+      record_provider_trace receipt provider_trace;
       (match outcome.output with
        | Exec.Json_output { value; _ } ->
          Ok

--- a/lib/llm_provider/exact_output.mli
+++ b/lib/llm_provider/exact_output.mli
@@ -159,6 +159,10 @@ type effect_phase =
   | Response_received
   | Terminal
 
+(** Provider-neutral response evidence owned by OAS. Detailed headers and
+    provider metadata remain opaque; consumers compare only its fingerprint. *)
+type provider_trace
+
 type raw_response =
   { body : string
   ; body_sha256 : string
@@ -334,6 +338,8 @@ val receipt_call_id : receipt -> call_id
 val receipt_phase : receipt -> effect_phase
 val receipt_dispatch_count : receipt -> int
 val receipt_http_status : receipt -> int option
+val receipt_provider_trace : receipt -> provider_trace option
+val provider_trace_fingerprint : provider_trace -> string
 val receipt_plan_fingerprint : receipt -> string
 val receipt_request_body_sha256 : receipt -> string
 val receipt_catalog_generation : receipt -> catalog_generation
@@ -385,8 +391,11 @@ val flow_attempt_evidence : flow_attempt -> flow_evidence
     concurrent invocation of the same attempt is rejected before a second dispatch.
     Obtain {!attempt_receipt} before entering a cancellation scope; its phase is
     monotonic and remains queryable if cancellation escapes this function. The
-    sole invocation performs at most one outward completion POST and never
-    retries or falls back. *)
+    sole invocation performs at most one outward completion HTTP POST. It calls
+    the direct one-dispatch transport rather than a provider SDK or the generic
+    retry layer; internal model rotation and requested server-side fallback are
+    disabled. This is an outward-dispatch guarantee, not a claim about opaque
+    physical execution inside a provider service. *)
 val execute_once
   :  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> ?clock:_ Eio.Time.clock

--- a/lib/llm_provider/exact_output_execution.ml
+++ b/lib/llm_provider/exact_output_execution.ml
@@ -137,7 +137,7 @@ let execute_once_with_evidence ~net ?clock ?on_phase plan =
       error (before_dispatch_receipt ()) Clock_required_for_timeout
     | connect_timeout_s, body_timeout_s, _ ->
       let post_once () =
-      Http_client.post_sync_once_with_evidence
+        Http_client.post_sync_once_with_evidence
           ?clock
           ?connect_timeout_s
           ?body_timeout_s
@@ -156,8 +156,8 @@ let execute_once_with_evidence ~net ?clock ?on_phase plan =
        | Error transport_error ->
          let receipt, provider_error = transport_error_receipt transport_error in
          error receipt (Provider_error provider_error)
-      | Ok (raw, response_header_evidence) when raw.status < 200 || raw.status >= 300 ->
-        let raw_response = raw_response_evidence raw response_header_evidence in
+       | Ok (raw, response_header_evidence) when raw.status < 200 || raw.status >= 300 ->
+         let raw_response = raw_response_evidence raw response_header_evidence in
          error
            ~raw_response
            (response_received_receipt raw.status)
@@ -165,7 +165,7 @@ let execute_once_with_evidence ~net ?clock ?on_phase plan =
               (Http_client.HttpError
                  { code = raw.status
                  ; body = raw.body
-                ; retry_after_header = raw.retry_after_header
+                 ; retry_after_header = raw.retry_after_header
                 }))
       | Ok (raw, response_header_evidence) ->
         let raw_response = raw_response_evidence raw response_header_evidence in

--- a/lib/llm_provider/exact_output_execution.ml
+++ b/lib/llm_provider/exact_output_execution.ml
@@ -55,6 +55,7 @@ type normalized_outcome =
 type raw_response_evidence =
   { raw_body : string
   ; raw_body_sha256 : string
+  ; response_header_evidence : Http_client.response_header_evidence
   }
 
 type normalized_outcome_with_evidence =
@@ -94,8 +95,14 @@ let receipt_identity = function
 let receipt_fingerprint receipt = (receipt_identity receipt).fingerprint
 let receipt_request_body_sha256 receipt = (receipt_identity receipt).request_body_sha256
 
-let raw_response_evidence raw_body =
-  { raw_body; raw_body_sha256 = Digestif.SHA256.(to_hex (digest_string raw_body)) }
+let raw_response_evidence
+      (raw : Http_client.raw_sync_response)
+      response_header_evidence
+  =
+  { raw_body = raw.body
+  ; raw_body_sha256 = Digestif.SHA256.(to_hex (digest_string raw.body))
+  ; response_header_evidence
+  }
 ;;
 
 let execute_once_with_evidence ~net ?clock ?on_phase plan =
@@ -130,7 +137,7 @@ let execute_once_with_evidence ~net ?clock ?on_phase plan =
       error (before_dispatch_receipt ()) Clock_required_for_timeout
     | connect_timeout_s, body_timeout_s, _ ->
       let post_once () =
-        Http_client.post_sync_once
+      Http_client.post_sync_once_with_evidence
           ?clock
           ?connect_timeout_s
           ?body_timeout_s
@@ -149,8 +156,8 @@ let execute_once_with_evidence ~net ?clock ?on_phase plan =
        | Error transport_error ->
          let receipt, provider_error = transport_error_receipt transport_error in
          error receipt (Provider_error provider_error)
-       | Ok raw when raw.status < 200 || raw.status >= 300 ->
-         let raw_response = raw_response_evidence raw.body in
+      | Ok (raw, response_header_evidence) when raw.status < 200 || raw.status >= 300 ->
+        let raw_response = raw_response_evidence raw response_header_evidence in
          error
            ~raw_response
            (response_received_receipt raw.status)
@@ -158,10 +165,10 @@ let execute_once_with_evidence ~net ?clock ?on_phase plan =
               (Http_client.HttpError
                  { code = raw.status
                  ; body = raw.body
-                 ; retry_after_header = raw.retry_after_header
-                 }))
-       | Ok raw ->
-         let raw_response = raw_response_evidence raw.body in
+                ; retry_after_header = raw.retry_after_header
+                }))
+      | Ok (raw, response_header_evidence) ->
+        let raw_response = raw_response_evidence raw response_header_evidence in
          (match
             Complete_sync.parse_sync_response
               ~http_codec:(Exact_output_plan.response_codec plan)

--- a/lib/llm_provider/exact_output_execution.ml
+++ b/lib/llm_provider/exact_output_execution.ml
@@ -95,10 +95,7 @@ let receipt_identity = function
 let receipt_fingerprint receipt = (receipt_identity receipt).fingerprint
 let receipt_request_body_sha256 receipt = (receipt_identity receipt).request_body_sha256
 
-let raw_response_evidence
-      (raw : Http_client.raw_sync_response)
-      response_header_evidence
-  =
+let raw_response_evidence (raw : Http_client.raw_sync_response) response_header_evidence =
   { raw_body = raw.body
   ; raw_body_sha256 = Digestif.SHA256.(to_hex (digest_string raw.body))
   ; response_header_evidence
@@ -166,9 +163,9 @@ let execute_once_with_evidence ~net ?clock ?on_phase plan =
                  { code = raw.status
                  ; body = raw.body
                  ; retry_after_header = raw.retry_after_header
-                }))
-      | Ok (raw, response_header_evidence) ->
-        let raw_response = raw_response_evidence raw response_header_evidence in
+                 }))
+       | Ok (raw, response_header_evidence) ->
+         let raw_response = raw_response_evidence raw response_header_evidence in
          (match
             Complete_sync.parse_sync_response
               ~http_codec:(Exact_output_plan.response_codec plan)

--- a/lib/llm_provider/exact_output_execution.mli
+++ b/lib/llm_provider/exact_output_execution.mli
@@ -55,6 +55,7 @@ type normalized_outcome =
 type raw_response_evidence =
   { raw_body : string
   ; raw_body_sha256 : string
+  ; response_header_evidence : Http_client.response_header_evidence
   }
 
 type normalized_outcome_with_evidence =

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -2010,7 +2010,7 @@ let post_sync_once_with_evidence
                        ; body = response_body
                        ; retry_after_header
                        }
-                     , response_header_evidence )))))
+                     , response_header_evidence ))))))
 ;;
 
 let post_sync_once

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -1166,10 +1166,10 @@ let capture_response_header_evidence headers =
     match
       List.filter
         (fun (name, _) ->
-           String.equal (String.lowercase_ascii (String.trim name)) "retry-after")
-        raw_headers
-    with
-    | [ _, value ] ->
+            String.equal (String.lowercase_ascii (String.trim name)) "retry-after")
+         raw_headers
+     with
+    | [ (_, value) ] ->
       Http.Header.of_list [ "retry-after", value ]
       |> retry_after_header_of_response_headers
     | [] | _ :: _ :: _ -> None
@@ -1178,9 +1178,7 @@ let capture_response_header_evidence headers =
     raw_headers
     |> normalize_response_headers
     |> List.map (fun (name, value) ->
-      if response_header_name_is_sensitive name
-      then name, "[REDACTED]"
-      else name, value)
+      if response_header_name_is_sensitive name then name, "[REDACTED]" else name, value)
   in
   let fingerprint =
     `Assoc
@@ -1208,19 +1206,14 @@ let header_evidence_fingerprint_for_test headers =
 
 let%test "response header evidence is canonical, multiplicity-sensitive, and redacted" =
   let first =
-    header_evidence_fingerprint_for_test
-      [ "X-Trace-B", " beta "; "X-Trace-A", "alpha" ]
+    header_evidence_fingerprint_for_test [ "X-Trace-B", " beta "; "X-Trace-A", "alpha" ]
   in
   let reordered =
-    header_evidence_fingerprint_for_test
-      [ "x-trace-a", "alpha"; "x-trace-b", "beta" ]
+    header_evidence_fingerprint_for_test [ "x-trace-a", "alpha"; "x-trace-b", "beta" ]
   in
-  let one =
-    header_evidence_fingerprint_for_test [ "x-trace", "same" ]
-  in
+  let one = header_evidence_fingerprint_for_test [ "x-trace", "same" ] in
   let duplicate =
-    header_evidence_fingerprint_for_test
-      [ "x-trace", "same"; "X-Trace", "same" ]
+    header_evidence_fingerprint_for_test [ "x-trace", "same"; "X-Trace", "same" ]
   in
   let secret_one =
     header_evidence_fingerprint_for_test [ "set-cookie", "session=secret-one" ]
@@ -1229,7 +1222,7 @@ let%test "response header evidence is canonical, multiplicity-sensitive, and red
     header_evidence_fingerprint_for_test [ "Set-Cookie", "session=secret-two" ]
   in
   String.equal first reordered
-  && not (String.equal one duplicate)
+  && (not (String.equal one duplicate))
   && String.equal secret_one secret_two
 ;;
 
@@ -1241,16 +1234,11 @@ type raw_sync_response =
 
 let%test "Retry-After is captured once with explicit duplicate ambiguity" =
   let capture headers =
-    headers
-    |> Http.Header.of_list
-    |> capture_response_header_evidence
-    |> snd
+    headers |> Http.Header.of_list |> capture_response_header_evidence |> snd
   in
   let retry_after_header = capture [ "Retry-After", "7" ] in
   let response = { status = 429; body = "rate limited"; retry_after_header } in
-  let duplicate =
-    capture [ "Retry-After", "7"; "retry-after", "8" ]
-  in
+  let duplicate = capture [ "Retry-After", "7"; "retry-after", "8" ] in
   response.retry_after_header = Some 7.0
   && response.retry_after_header = retry_after_header
   && duplicate = None
@@ -1921,11 +1909,10 @@ let post_sync_once_with_evidence
                 in
                 let response_status =
                   Cohttp.Response.status response |> Cohttp.Code.code_of_status
-                in
-                let response_header_evidence, retry_after_header =
-                  Cohttp.Response.headers response
-                  |> capture_response_header_evidence
-                in
+                 in
+                 let response_header_evidence, retry_after_header =
+                  Cohttp.Response.headers response |> capture_response_header_evidence
+                 in
                 phase := Response_received;
                 status := Some response_status;
                 Http_client_phase_observer.observe

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -1163,9 +1163,9 @@ let response_header_name_is_sensitive = function
 let capture_response_header_evidence headers =
   let raw_headers = Http.Header.to_list headers in
   let retry_after_header =
-     match
-       List.filter
-         (fun (name, _) ->
+    match
+      List.filter
+        (fun (name, _) ->
            String.equal (String.lowercase_ascii (String.trim name)) "retry-after")
         raw_headers
     with
@@ -1907,11 +1907,11 @@ let post_sync_once_with_evidence
                     ~body:(Cohttp_eio.Body.of_string body)
                     uri
                 in
-                 let response_status =
-                   Cohttp.Response.status response |> Cohttp.Code.code_of_status
+                let response_status =
+                  Cohttp.Response.status response |> Cohttp.Code.code_of_status
                 in
                 let response_header_evidence, retry_after_header =
-                   Cohttp.Response.headers response |> capture_response_header_evidence
+                  Cohttp.Response.headers response |> capture_response_header_evidence
                 in
                 phase := Response_received;
                 status := Some response_status;

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -1130,11 +1130,131 @@ type one_dispatch_phase =
   | Dispatch_started
   | Response_received
 
+type response_header_evidence = Response_header_evidence of string
+
+let response_header_evidence_fingerprint (Response_header_evidence fingerprint) =
+  fingerprint
+;;
+
+let normalize_response_headers headers =
+  headers
+  |> List.map (fun (name, value) ->
+    String.lowercase_ascii (String.trim name), String.trim value)
+  |> List.sort (fun (left_name, left_value) (right_name, right_value) ->
+    match String.compare left_name right_name with
+    | 0 -> String.compare left_value right_value
+    | order -> order)
+;;
+
+let response_header_name_is_sensitive = function
+  | "authorization"
+  | "proxy-authorization"
+  | "cookie"
+  | "set-cookie"
+  | "www-authenticate"
+  | "proxy-authenticate"
+  | "authentication-info"
+  | "proxy-authentication-info"
+  | "api-key"
+  | "x-api-key" -> true
+  | _ -> false
+;;
+
+let capture_response_header_evidence headers =
+  let raw_headers = Http.Header.to_list headers in
+  let retry_after_header =
+    match
+      List.filter
+        (fun (name, _) ->
+           String.equal (String.lowercase_ascii (String.trim name)) "retry-after")
+        raw_headers
+    with
+    | [ _, value ] ->
+      Http.Header.of_list [ "retry-after", value ]
+      |> retry_after_header_of_response_headers
+    | [] | _ :: _ :: _ -> None
+  in
+  let redacted_headers =
+    raw_headers
+    |> normalize_response_headers
+    |> List.map (fun (name, value) ->
+      if response_header_name_is_sensitive name
+      then name, "[REDACTED]"
+      else name, value)
+  in
+  let fingerprint =
+    `Assoc
+      [ "version", `Int 1
+      ; ( "headers"
+        , `List
+            (List.map
+               (fun (name, value) -> `List [ `String name; `String value ])
+               redacted_headers) )
+      ]
+    |> Yojson.Safe.to_string
+    |> Digestif.SHA256.digest_string
+    |> Digestif.SHA256.to_hex
+  in
+  Response_header_evidence fingerprint, retry_after_header
+;;
+
+let header_evidence_fingerprint_for_test headers =
+  headers
+  |> Http.Header.of_list
+  |> capture_response_header_evidence
+  |> fst
+  |> response_header_evidence_fingerprint
+;;
+
+let%test "response header evidence is canonical, multiplicity-sensitive, and redacted" =
+  let first =
+    header_evidence_fingerprint_for_test
+      [ "X-Trace-B", " beta "; "X-Trace-A", "alpha" ]
+  in
+  let reordered =
+    header_evidence_fingerprint_for_test
+      [ "x-trace-a", "alpha"; "x-trace-b", "beta" ]
+  in
+  let one =
+    header_evidence_fingerprint_for_test [ "x-trace", "same" ]
+  in
+  let duplicate =
+    header_evidence_fingerprint_for_test
+      [ "x-trace", "same"; "X-Trace", "same" ]
+  in
+  let secret_one =
+    header_evidence_fingerprint_for_test [ "set-cookie", "session=secret-one" ]
+  in
+  let secret_two =
+    header_evidence_fingerprint_for_test [ "Set-Cookie", "session=secret-two" ]
+  in
+  String.equal first reordered
+  && not (String.equal one duplicate)
+  && String.equal secret_one secret_two
+;;
+
 type raw_sync_response =
   { status : int
   ; body : string
   ; retry_after_header : float option
   }
+
+let%test "Retry-After is captured once with explicit duplicate ambiguity" =
+  let capture headers =
+    headers
+    |> Http.Header.of_list
+    |> capture_response_header_evidence
+    |> snd
+  in
+  let retry_after_header = capture [ "Retry-After", "7" ] in
+  let response = { status = 429; body = "rate limited"; retry_after_header } in
+  let duplicate =
+    capture [ "Retry-After", "7"; "retry-after", "8" ]
+  in
+  response.retry_after_header = Some 7.0
+  && response.retry_after_header = retry_after_header
+  && duplicate = None
+;;
 
 type post_sync_once_error =
   | Before_dispatch_error of http_error
@@ -1642,7 +1762,7 @@ let post_sync ?cache ?clock ?timeout_s ~sw ~net ~url ~headers ~body () =
         Ok (code, body_str))))
 ;;
 
-let post_sync_once
+let post_sync_once_with_evidence
       ?cache
       ?clock
       ?connect_timeout_s
@@ -1802,11 +1922,20 @@ let post_sync_once
                 let response_status =
                   Cohttp.Response.status response |> Cohttp.Code.code_of_status
                 in
+                let response_header_evidence, retry_after_header =
+                  Cohttp.Response.headers response
+                  |> capture_response_header_evidence
+                in
                 phase := Response_received;
                 status := Some response_status;
                 Http_client_phase_observer.observe
                   (Http_client_phase_observer.Response_received response_status);
-                Ok (conn, response, response_body))
+                Ok
+                  ( conn
+                  , response
+                  , response_body
+                  , response_header_evidence
+                  , retry_after_header ))
             with
             | Eio.Time.Timeout as exn ->
               release_connection ();
@@ -1817,7 +1946,12 @@ let post_sync_once
            | Error error ->
              release_connection ();
              fail error
-           | Ok (conn, response, response_body) ->
+           | Ok
+               ( conn
+               , response
+               , response_body
+               , response_header_evidence
+               , retry_after_header ) ->
              let body_result =
                try
                  match body_deadline, total_started_at with
@@ -1848,10 +1982,6 @@ let post_sync_once
                 release_connection ();
                 fail error
               | Ok response_body ->
-                let retry_after_header =
-                  Cohttp.Response.headers response
-                  |> retry_after_header_of_response_headers
-                in
                 let release_result =
                   match
                     ( cache
@@ -1876,10 +2006,38 @@ let post_sync_once
                    fail error
                  | Ok () ->
                    Ok
-                     { status = Option.get !status
-                     ; body = response_body
-                     ; retry_after_header
-                     })))))
+                     ( { status = Option.get !status
+                       ; body = response_body
+                       ; retry_after_header
+                       }
+                     , response_header_evidence )))))
+;;
+
+let post_sync_once
+      ?cache
+      ?clock
+      ?connect_timeout_s
+      ?body_timeout_s
+      ~net
+      ~url
+      ~headers
+      ~body
+      ()
+  =
+  match
+    post_sync_once_with_evidence
+      ?cache
+      ?clock
+      ?connect_timeout_s
+      ?body_timeout_s
+      ~net
+      ~url
+      ~headers
+      ~body
+      ()
+  with
+  | Ok (response, _) -> Ok response
+  | Error error -> Error error
 ;;
 
 let post_stream ?cache ?clock ?connect_timeout_s ~sw ~net ~url ~headers ~body () =

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -1163,12 +1163,12 @@ let response_header_name_is_sensitive = function
 let capture_response_header_evidence headers =
   let raw_headers = Http.Header.to_list headers in
   let retry_after_header =
-    match
-      List.filter
-        (fun (name, _) ->
-            String.equal (String.lowercase_ascii (String.trim name)) "retry-after")
-         raw_headers
-     with
+     match
+       List.filter
+         (fun (name, _) ->
+           String.equal (String.lowercase_ascii (String.trim name)) "retry-after")
+        raw_headers
+    with
     | [ (_, value) ] ->
       Http.Header.of_list [ "retry-after", value ]
       |> retry_after_header_of_response_headers
@@ -1907,12 +1907,12 @@ let post_sync_once_with_evidence
                     ~body:(Cohttp_eio.Body.of_string body)
                     uri
                 in
-                let response_status =
-                  Cohttp.Response.status response |> Cohttp.Code.code_of_status
-                 in
-                 let response_header_evidence, retry_after_header =
-                  Cohttp.Response.headers response |> capture_response_header_evidence
-                 in
+                 let response_status =
+                   Cohttp.Response.status response |> Cohttp.Code.code_of_status
+                in
+                let response_header_evidence, retry_after_header =
+                   Cohttp.Response.headers response |> capture_response_header_evidence
+                in
                 phase := Response_received;
                 status := Some response_status;
                 Http_client_phase_observer.observe

--- a/lib/llm_provider/http_client.mli
+++ b/lib/llm_provider/http_client.mli
@@ -369,6 +369,12 @@ type one_dispatch_phase =
   | Dispatch_started
   | Response_received
 
+type response_header_evidence
+
+(** Stable fingerprint of canonical, redacted response-header evidence. Header
+    names, values, and provider-specific semantics are deliberately opaque. *)
+val response_header_evidence_fingerprint : response_header_evidence -> string
+
 (** Raw response from {!post_sync_once}. No provider-specific body parsing or
     retry policy has run. *)
 type raw_sync_response =
@@ -413,6 +419,22 @@ val post_sync_once
   -> body:string
   -> unit
   -> (raw_sync_response, post_sync_once_error) result
+
+(** Exact-output transport variant. It performs the same sole POST as
+    {!post_sync_once}, while also returning opaque canonical response-header
+    evidence. The public wrapper calls this function once and discards that
+    evidence; neither path retries. *)
+val post_sync_once_with_evidence
+  :  ?cache:cache
+  -> ?clock:_ Eio.Time.clock
+  -> ?connect_timeout_s:float
+  -> ?body_timeout_s:float
+  -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> url:string
+  -> headers:(string * string) list
+  -> body:string
+  -> unit
+  -> ((raw_sync_response * response_header_evidence), post_sync_once_error) result
 
 (** POST JSON body for SSE/NDJSON streaming.
     Returns [Ok reader] on HTTP 200 (10 MB buffer).

--- a/lib/llm_provider/http_client.mli
+++ b/lib/llm_provider/http_client.mli
@@ -434,7 +434,7 @@ val post_sync_once_with_evidence
   -> headers:(string * string) list
   -> body:string
   -> unit
-  -> ((raw_sync_response * response_header_evidence), post_sync_once_error) result
+  -> (raw_sync_response * response_header_evidence, post_sync_once_error) result
 
 (** POST JSON body for SSE/NDJSON streaming.
     Returns [Ok reader] on HTTP 200 (10 MB buffer).

--- a/test/test_exact_output_single_surface.ml
+++ b/test/test_exact_output_single_surface.ml
@@ -588,16 +588,14 @@ let test_no_measure_one_post_and_wire_authority () =
       bool
       (id ^ " server-side fallback header absent")
       false
-      (List.exists
-         (fun (name, value) ->
-            String.equal (String.lowercase_ascii name) "anthropic-beta"
-            && (value
-                |> String.split_on_char ','
-                |> List.exists (fun beta ->
-                  String.equal
-                    (String.trim beta)
-                    "server-side-fallback-2026-06-01")))
-         capture.headers);
+       (List.exists
+          (fun (name, value) ->
+             String.equal (String.lowercase_ascii name) "anthropic-beta"
+            && value
+               |> String.split_on_char ','
+               |> List.exists (fun beta ->
+                 String.equal (String.trim beta) "server-side-fallback-2026-06-01"))
+          capture.headers);
     inspect provenance body;
     match result with
     | Ok (success : EO.success) ->
@@ -671,20 +669,18 @@ let test_no_measure_one_post_and_wire_authority () =
     ~path:"/api/chat"
     ~response:(ollama_response content)
     (fun _provenance body ->
-       check
-         bool
-         "Ollama receives raw schema"
-       true
-       Yojson.Safe.Util.(
-         body |> member "format" |> member "type" |> to_string = "object"));
+        check
+          bool
+          "Ollama receives raw schema"
+         true
+         Yojson.Safe.Util.(
+           body |> member "format" |> member "type" |> to_string = "object"));
   run
     ~id:"anthropic-surface"
-    ~kind:Provider_config.Anthropic
-    ~path:"/v1/messages"
-    ~response:
-      (anthropic_response
-         {|[{"type":"text","text":"{\"name\":\"accepted\"}"}]|})
-    (fun _provenance _body -> ())
+     ~kind:Provider_config.Anthropic
+     ~path:"/v1/messages"
+    ~response:(anthropic_response {|[{"type":"text","text":"{\"name\":\"accepted\"}"}]|})
+     (fun _provenance _body -> ())
 ;;
 
 let test_provider_trace_fingerprint_anchors_normalized_headers_and_body () =
@@ -717,20 +713,14 @@ let test_provider_trace_fingerprint_anchors_normalized_headers_and_body () =
   in
   let response = openai_response {|{"name":"accepted"}|} in
   let first =
-    run
-      ~response_headers:[ "X-Trace-B", " beta "; "X-Trace-A", "alpha" ]
-      response
+    run ~response_headers:[ "X-Trace-B", " beta "; "X-Trace-A", "alpha" ] response
   in
   let reordered =
-    run
-      ~response_headers:[ "x-trace-a", "alpha"; "x-trace-b", "beta" ]
-      response
+    run ~response_headers:[ "x-trace-a", "alpha"; "x-trace-b", "beta" ] response
   in
   check string "header normalization is deterministic" first reordered;
   let changed_header =
-    run
-      ~response_headers:[ "x-trace-a", "changed"; "x-trace-b", "beta" ]
-      response
+    run ~response_headers:[ "x-trace-a", "changed"; "x-trace-b", "beta" ] response
   in
   check
     bool

--- a/test/test_exact_output_single_surface.ml
+++ b/test/test_exact_output_single_surface.ml
@@ -2,6 +2,19 @@ open Alcotest
 open Llm_provider
 module EO = Agent_sdk.Exact_output
 
+let _preserve_public_raw_sync_response_surface
+      ({ status = _; body = _; retry_after_header = _ } : Http_client.raw_sync_response)
+  =
+  ()
+;;
+
+let _preserve_public_success_surface
+      ({ call_id = _; receipt = _; output = _; provenance = _; raw_response = _ } :
+        EO.success)
+  =
+  ()
+;;
+
 let msg text : Types.message =
   { role = Types.User
   ; content = [ Types.Text text ]
@@ -202,7 +215,14 @@ let anthropic_response ?(stop_reason = "end_turn") content =
     stop_reason
 ;;
 
-let with_server ?response_delay_s ?(status = `OK) ?(abort_completion = false) ~response f =
+let with_server
+      ?response_delay_s
+      ?(status = `OK)
+      ?(abort_completion = false)
+      ?(response_headers = [])
+      ~response
+      f
+  =
   let completion_posts = Atomic.make 0 in
   let token_posts = Atomic.make 0 in
   let captures = Atomic.make [] in
@@ -232,7 +252,11 @@ let with_server ?response_delay_s ?(status = `OK) ?(abort_completion = false) ~r
            :: Atomic.get captures);
         if abort_completion then raise Exit;
         Option.iter (Eio.Time.sleep clock) response_delay_s;
-        Cohttp_eio.Server.respond_string ~status ~body:response ())
+        Cohttp_eio.Server.respond_string
+          ~headers:(Cohttp.Header.of_list response_headers)
+          ~status
+          ~body:response
+          ())
     in
     let socket =
       Eio.Net.listen
@@ -554,7 +578,26 @@ let test_no_measure_one_post_and_wire_authority () =
       ; "reasoning_effort"
       ; "thinking"
       ; "pricing"
+      ; "retry"
+      ; "retries"
+      ; "max_retries"
+      ; "fallbacks"
+      ; "internal_model_rotation_count"
       ];
+    check
+      bool
+      (id ^ " server-side fallback header absent")
+      false
+      (List.exists
+         (fun (name, value) ->
+            String.equal (String.lowercase_ascii name) "anthropic-beta"
+            && (value
+                |> String.split_on_char ','
+                |> List.exists (fun beta ->
+                  String.equal
+                    (String.trim beta)
+                    "server-side-fallback-2026-06-01")))
+         capture.headers);
     inspect provenance body;
     match result with
     | Ok (success : EO.success) ->
@@ -631,9 +674,79 @@ let test_no_measure_one_post_and_wire_authority () =
        check
          bool
          "Ollama receives raw schema"
-         true
-         Yojson.Safe.Util.(
-           body |> member "format" |> member "type" |> to_string = "object"))
+       true
+       Yojson.Safe.Util.(
+         body |> member "format" |> member "type" |> to_string = "object"));
+  run
+    ~id:"anthropic-surface"
+    ~kind:Provider_config.Anthropic
+    ~path:"/v1/messages"
+    ~response:
+      (anthropic_response
+         {|[{"type":"text","text":"{\"name\":\"accepted\"}"}]|})
+    (fun _provenance _body -> ())
+;;
+
+let test_provider_trace_fingerprint_anchors_normalized_headers_and_body () =
+  let run ~response_headers response =
+    let result, posts, _, _ =
+      with_server ~response_headers ~response
+      @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
+      let entry =
+        catalog_entry
+          ~id:"provider-trace-surface"
+          ~kind:Provider_config.OpenAI_compat
+          ~base_url
+          ~request_path:"/v1/chat/completions"
+          ~capabilities:(capabilities ~native:true ~json:true)
+          ()
+      in
+      with_catalog [ entry ]
+      @@ fun snapshot ->
+      EO.execute_once
+        ~net
+        (attempt (plan snapshot "provider-trace-surface" EO.Json_syntax))
+    in
+    check int "provider trace uses one POST" 1 posts;
+    match result with
+    | Error _ -> fail "provider trace fixture failed"
+    | Ok success ->
+      (match EO.receipt_provider_trace success.receipt with
+       | None -> fail "success receipt lost provider trace"
+       | Some trace -> EO.provider_trace_fingerprint trace)
+  in
+  let response = openai_response {|{"name":"accepted"}|} in
+  let first =
+    run
+      ~response_headers:[ "X-Trace-B", " beta "; "X-Trace-A", "alpha" ]
+      response
+  in
+  let reordered =
+    run
+      ~response_headers:[ "x-trace-a", "alpha"; "x-trace-b", "beta" ]
+      response
+  in
+  check string "header normalization is deterministic" first reordered;
+  let changed_header =
+    run
+      ~response_headers:[ "x-trace-a", "changed"; "x-trace-b", "beta" ]
+      response
+  in
+  check
+    bool
+    "provider trace is header-sensitive"
+    true
+    (not (String.equal first changed_header));
+  let changed_body =
+    run
+      ~response_headers:[ "x-trace-a", "alpha"; "x-trace-b", "beta" ]
+      (openai_response {|{"name":"different"}|})
+  in
+  check
+    bool
+    "provider trace is body-sensitive"
+    true
+    (not (String.equal first changed_body))
 ;;
 
 let test_response_received_error_evidence_matrix () =
@@ -672,9 +785,14 @@ let test_response_received_error_evidence_matrix () =
       check
         (option int)
         (label ^ " response status")
-        (Some 200)
-        (EO.receipt_http_status receipt)
-    | Ok _ | Error _ -> fail (label ^ " lost response-received evidence")
+    (Some 200)
+    (EO.receipt_http_status receipt);
+  check
+    bool
+    (label ^ " typed error receipt trace")
+    true
+    (Option.is_some (EO.receipt_provider_trace receipt))
+| Ok _ | Error _ -> fail (label ^ " lost response-received evidence")
   in
   let completion_failed = function
     | EO.Completion_failed -> true
@@ -1634,6 +1752,10 @@ let () =
             "no measure and one post"
             `Quick
             test_no_measure_one_post_and_wire_authority
+        ; test_case
+            "provider trace fingerprint"
+            `Quick
+            test_provider_trace_fingerprint_anchors_normalized_headers_and_body
         ; test_case
             "response-received error evidence"
             `Quick

--- a/test/test_exact_output_single_surface.ml
+++ b/test/test_exact_output_single_surface.ml
@@ -584,10 +584,10 @@ let test_no_measure_one_post_and_wire_authority () =
       ; "fallbacks"
       ; "internal_model_rotation_count"
       ];
-    check
-       bool
-       (id ^ " server-side fallback header absent")
-       false
+     check
+      bool
+      (id ^ " server-side fallback header absent")
+      false
       (List.exists
          (fun (name, value) ->
             String.equal (String.lowercase_ascii name) "anthropic-beta"
@@ -666,9 +666,9 @@ let test_no_measure_one_post_and_wire_authority () =
   run
     ~id:"ollama-surface"
     ~kind:Provider_config.Ollama
-     ~path:"/api/chat"
-     ~response:(ollama_response content)
-     (fun _provenance body ->
+    ~path:"/api/chat"
+    ~response:(ollama_response content)
+    (fun _provenance body ->
        check
          bool
          "Ollama receives raw schema"
@@ -679,7 +679,7 @@ let test_no_measure_one_post_and_wire_authority () =
     ~id:"anthropic-surface"
     ~kind:Provider_config.Anthropic
     ~path:"/v1/messages"
-     ~response:(anthropic_response {|[{"type":"text","text":"{\"name\":\"accepted\"}"}]|})
+    ~response:(anthropic_response {|[{"type":"text","text":"{\"name\":\"accepted\"}"}]|})
     (fun _provenance _body -> ())
 ;;
 

--- a/test/test_exact_output_single_surface.ml
+++ b/test/test_exact_output_single_surface.ml
@@ -785,14 +785,14 @@ let test_response_received_error_evidence_matrix () =
       check
         (option int)
         (label ^ " response status")
-    (Some 200)
-    (EO.receipt_http_status receipt);
-  check
-    bool
-    (label ^ " typed error receipt trace")
-    true
-    (Option.is_some (EO.receipt_provider_trace receipt))
-| Ok _ | Error _ -> fail (label ^ " lost response-received evidence")
+        (Some 200)
+        (EO.receipt_http_status receipt);
+      check
+        bool
+        (label ^ " typed error receipt trace")
+        true
+        (Option.is_some (EO.receipt_provider_trace receipt))
+    | Ok _ | Error _ -> fail (label ^ " lost response-received evidence")
   in
   let completion_failed = function
     | EO.Completion_failed -> true

--- a/test/test_exact_output_single_surface.ml
+++ b/test/test_exact_output_single_surface.ml
@@ -585,17 +585,17 @@ let test_no_measure_one_post_and_wire_authority () =
       ; "internal_model_rotation_count"
       ];
     check
-      bool
-      (id ^ " server-side fallback header absent")
-      false
-       (List.exists
-          (fun (name, value) ->
-             String.equal (String.lowercase_ascii name) "anthropic-beta"
+       bool
+       (id ^ " server-side fallback header absent")
+       false
+      (List.exists
+         (fun (name, value) ->
+            String.equal (String.lowercase_ascii name) "anthropic-beta"
             && value
                |> String.split_on_char ','
                |> List.exists (fun beta ->
                  String.equal (String.trim beta) "server-side-fallback-2026-06-01"))
-          capture.headers);
+         capture.headers);
     inspect provenance body;
     match result with
     | Ok (success : EO.success) ->
@@ -666,21 +666,21 @@ let test_no_measure_one_post_and_wire_authority () =
   run
     ~id:"ollama-surface"
     ~kind:Provider_config.Ollama
-    ~path:"/api/chat"
-    ~response:(ollama_response content)
-    (fun _provenance body ->
-        check
-          bool
-          "Ollama receives raw schema"
+     ~path:"/api/chat"
+     ~response:(ollama_response content)
+     (fun _provenance body ->
+       check
+         bool
+         "Ollama receives raw schema"
          true
          Yojson.Safe.Util.(
            body |> member "format" |> member "type" |> to_string = "object"));
   run
     ~id:"anthropic-surface"
-     ~kind:Provider_config.Anthropic
-     ~path:"/v1/messages"
-    ~response:(anthropic_response {|[{"type":"text","text":"{\"name\":\"accepted\"}"}]|})
-     (fun _provenance _body -> ())
+    ~kind:Provider_config.Anthropic
+    ~path:"/v1/messages"
+     ~response:(anthropic_response {|[{"type":"text","text":"{\"name\":\"accepted\"}"}]|})
+    (fun _provenance _body -> ())
 ;;
 
 let test_provider_trace_fingerprint_anchors_normalized_headers_and_body () =

--- a/test/test_exact_output_single_surface.ml
+++ b/test/test_exact_output_single_surface.ml
@@ -584,7 +584,7 @@ let test_no_measure_one_post_and_wire_authority () =
       ; "fallbacks"
       ; "internal_model_rotation_count"
       ];
-     check
+    check
       bool
       (id ^ " server-side fallback header absent")
       false


### PR DESCRIPTION
## Summary
- capture normalized response-header evidence and Retry-After exactly once when the HTTP response arrives
- anchor status, redacted header evidence, body digest, and typed response identity in a write-once exact-output receipt trace
- expose only an opaque provider-neutral trace fingerprint while preserving existing public record shapes
- define execute-once precisely as at most one outward HTTP completion POST with no retry, fallback, or internal rotation

## Safety properties
- raw response headers and provider/model values are not exposed downstream
- sensitive header values are redacted before fingerprint input
- duplicate Retry-After values are treated as ambiguous instead of depending on ordering
- full-body success and typed errors retain trace evidence; body-read cancellation retains phase/status without fabricating a body-backed trace

## Evidence
- independent static hostile review: P0/P1/P2 = 0
- source-compatibility and one-POST surfaces reviewed against current main
- local build/tests intentionally not run; PR CI is the build authority
