### PR TITLE
feat: add evidence-backed token serving admission

### DIFF
--- a/lib/error_domain.ml
+++ b/lib/error_domain.ml
@@ -15,6 +15,8 @@ type provider_error =
   | `Invalid_request of string
   | `Not_found of string
   | `Context_overflow of string * int option
+  | `Input_capacity of
+      Retry.input_capacity_reason * Llm_provider.Serving_constraint.t * string
   | `Payment_required of string
   ]
 
@@ -92,6 +94,7 @@ let of_api_error (err : Retry.api_error) : provider_error =
   | Retry.InvalidRequest r -> `Invalid_request r.message
   | Retry.NotFound r -> `Not_found r.message
   | Retry.ContextOverflow r -> `Context_overflow (r.message, r.limit)
+  | Retry.InputCapacity r -> `Input_capacity (r.reason, r.constraint_, r.message)
   | Retry.PaymentRequired r -> `Payment_required r.message
 ;;
 
@@ -172,6 +175,8 @@ let provider_to_sdk : provider_error -> Error.sdk_error = function
   | `Not_found msg -> Error.Api (Retry.NotFound { message = msg })
   | `Context_overflow (msg, limit) ->
     Error.Api (Retry.ContextOverflow { message = msg; limit })
+  | `Input_capacity (reason, constraint_, message) ->
+    Error.Api (Retry.InputCapacity { message; constraint_; reason })
   | `Payment_required msg -> Error.Api (Retry.PaymentRequired { message = msg })
 ;;
 
@@ -258,6 +263,7 @@ let is_retryable (err : [< sdk_error_poly ]) : bool =
   | `Invalid_request _
   | `Not_found _
   | `Context_overflow _
+  | `Input_capacity _
   | `Payment_required _
   | `Tool_exec_failed _
   | `Tool_timeout _

--- a/lib/error_domain.mli
+++ b/lib/error_domain.mli
@@ -33,6 +33,10 @@ type provider_error =
   | `Invalid_request of string
   | `Not_found of string
   | `Context_overflow of string * int option
+  | `Input_capacity of
+      Llm_provider.Retry.input_capacity_reason
+      * Llm_provider.Serving_constraint.t
+      * string
   | `Payment_required of string
     (** HTTP 402 — hard billing/quota exhaustion, distinct from
         [`Invalid_request]. Always non-retryable. *)

--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -118,6 +118,7 @@ let anthropic_thinking_control_of_vocab_value = function
 type capabilities =
   { (* ── Numeric limits ────────────────────────────────── *)
     max_context_tokens : int option (** Model's context window. None = unknown. *)
+  ; serving_constraint : Serving_constraint.t option
   ; max_output_tokens : int option (** Model's max output. None = unknown. *)
   ; (* ── Tool use ──────────────────────────────────────── *)
     supports_tools : bool
@@ -229,6 +230,7 @@ type capabilities =
 
 let default_capabilities =
   { max_context_tokens = None
+  ; serving_constraint = None
   ; max_output_tokens = None
   ; supports_tools = false
   ; supports_tool_choice = false
@@ -843,6 +845,7 @@ let reasoning_efforts_of_catalog_strings ~field values =
 type declarative_capability_overrides =
   { base_label : string option
   ; max_context_tokens : int option
+  ; serving_constraint : Serving_constraint.t option
   ; max_output_tokens : int option
   ; supports_tools : bool option
   ; supports_tool_choice : bool option
@@ -885,6 +888,7 @@ type declarative_capability_overrides =
 let overrides_of_manifest_entry (entry : Capability_manifest.entry) =
   { base_label = Option.map Capability_manifest.base_label_to_string entry.base_label
   ; max_context_tokens = entry.max_context_tokens
+  ; serving_constraint = None
   ; max_output_tokens = entry.max_output_tokens
   ; supports_tools = entry.supports_tools
   ; supports_tool_choice = entry.supports_tool_choice
@@ -960,6 +964,10 @@ let apply_declarative_capability_overrides overrides =
   { base with
     max_context_tokens =
       override_int_opt base.max_context_tokens overrides.max_context_tokens
+  ; serving_constraint =
+      (match overrides.serving_constraint with
+       | Some _ as constraint_ -> constraint_
+       | None -> base.serving_constraint)
   ; max_output_tokens =
       override_int_opt base.max_output_tokens overrides.max_output_tokens
   ; supports_tools = override_bool base.supports_tools overrides.supports_tools
@@ -1162,6 +1170,7 @@ let%test "reasoning_replay_override_of_catalog_string parses vocabulary" =
 let overrides_of_catalog_entry (entry : Model_catalog.model_entry) =
   { base_label = entry.base_label
   ; max_context_tokens = entry.max_context_tokens
+  ; serving_constraint = entry.serving_constraint
   ; max_output_tokens = entry.max_output_tokens
   ; supports_tools = entry.supports_tools
   ; supports_tool_choice = entry.supports_tool_choice
@@ -1416,6 +1425,7 @@ let test_catalog_entry id_prefix : Model_catalog.model_entry =
   ; base_label = None
   ; provider_name = None
   ; max_context_tokens = None
+  ; serving_constraint = None
   ; max_output_tokens = None
   ; supports_tools = None
   ; supports_tool_choice = None

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -92,6 +92,9 @@ type anthropic_thinking_control =
 type capabilities =
   { (* Numeric limits *)
     max_context_tokens : int option
+  ; serving_constraint : Serving_constraint.t option
+    (** Evidence-backed input-token serving interval for the exact resolved
+        runtime row. This is not inferred from [max_context_tokens]. *)
   ; max_output_tokens : int option
   ; (* Tool use *)
     supports_tools : bool

--- a/lib/llm_provider/capabilities.mli
+++ b/lib/llm_provider/capabilities.mli
@@ -308,6 +308,10 @@ val with_tool_support : capabilities -> supports_tools:bool -> capabilities
     back to {!default_capabilities}.  Each [Some] field in [entry] overrides the
     corresponding field; [None] fields inherit from the base.
 
+    Capability manifests do not carry evidence-backed serving constraints.
+    Those constraints require provenance and validity fields and are therefore
+    accepted only through the model catalog declaration path.
+
     @since 0.188.0 *)
 val apply_manifest_entry : Capability_manifest.entry -> capabilities
 

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -30,11 +30,17 @@ type fit_error = Prepared_completion_request.fit_error =
       }
   | Output_reservation_unknown of { model_id : string }
   | Context_window_exceeded of context_fit
+  | Serving_constraint_rejected of
+      { constraint_ : Serving_constraint.t
+      ; reason : Serving_constraint.admission_error
+      }
 
 let prepare_request = Prepared_completion_request.prepare
 let measure_request = Prepared_completion_request.measure
 let request_measurement = Prepared_completion_request.measurement
 let resolve_context_limit = Prepared_completion_request.resolve_context_limit
+let requires_token_measurement = Prepared_completion_request.requires_token_measurement
+let serving_constraint = Prepared_completion_request.serving_constraint
 let admit_request = Prepared_completion_request.admit
 let admitted_fit = Prepared_completion_request.admitted_fit
 

--- a/lib/llm_provider/complete.mli
+++ b/lib/llm_provider/complete.mli
@@ -90,7 +90,7 @@ val serving_constraint : prepared_request -> Serving_constraint.t option
     carried by the same provider request artifact. A missing reservation and
     context overflow are explicit. *)
 val admit_request
-  :  ?now_unix_s:int
+  :  now_unix_s:int
   -> max_context_tokens:int
   -> measured_request
   -> (admitted_request, fit_error) result

--- a/lib/llm_provider/complete.mli
+++ b/lib/llm_provider/complete.mli
@@ -36,6 +36,10 @@ type fit_error =
       }
   | Output_reservation_unknown of { model_id : string }
   | Context_window_exceeded of context_fit
+  | Serving_constraint_rejected of
+      { constraint_ : Serving_constraint.t
+      ; reason : Serving_constraint.admission_error
+      }
 
 (** Build the single request value used by measurement and dispatch. Existing
     [complete] and [complete_stream] calls are compatibility wrappers over this
@@ -78,12 +82,16 @@ val request_measurement
     count round-trip. *)
 val resolve_context_limit : prepared_request -> (int, fit_error) result
 
+val requires_token_measurement : prepared_request -> bool
+val serving_constraint : prepared_request -> Serving_constraint.t option
+
 (** Admit the measured request against the [max_context_tokens] resolved by
     {!resolve_context_limit}. The output-token reservation is the effective value
     carried by the same provider request artifact. A missing reservation and
     context overflow are explicit. *)
 val admit_request
-  :  max_context_tokens:int
+  :  ?now_unix_s:int
+  -> max_context_tokens:int
   -> measured_request
   -> (admitted_request, fit_error) result
 

--- a/lib/llm_provider/error.ml
+++ b/lib/llm_provider/error.ml
@@ -206,6 +206,8 @@ let of_retry_api_error ?provider err =
   | Retry.NotFound r -> NotFound { provider; detail = r.message }
   | Retry.ContextOverflow r ->
     InvalidRequest { provider; reason = Retry.error_message (Retry.ContextOverflow r) }
+  | Retry.InputCapacity r ->
+    InvalidRequest { provider; reason = Retry.error_message (Retry.InputCapacity r) }
   | Retry.NetworkError r ->
     NetworkError { provider; kind = r.kind; timeout_phase = None; detail = r.message }
   (* Preserve the transport phase carried by Retry.Timeout so a retried

--- a/lib/llm_provider/error.ml
+++ b/lib/llm_provider/error.ml
@@ -207,6 +207,9 @@ let of_retry_api_error ?provider err =
   | Retry.ContextOverflow r ->
     InvalidRequest { provider; reason = Retry.error_message (Retry.ContextOverflow r) }
   | Retry.InputCapacity r ->
+    (* [Error.t] is the legacy provider-only surface and cannot preserve the
+       constraint evidence. The Agent SDK [Error.Api] / error-domain path keeps
+       [Retry.InputCapacity] typed end to end; new consumers must use it. *)
     InvalidRequest { provider; reason = Retry.error_message (Retry.InputCapacity r) }
   | Retry.NetworkError r ->
     NetworkError { provider; kind = r.kind; timeout_phase = None; detail = r.message }

--- a/lib/llm_provider/exact_output.ml
+++ b/lib/llm_provider/exact_output.ml
@@ -88,6 +88,7 @@ type wire_admission_error =
   | Unsupported_document_input
   | Unsupported_audio_input
   | Unsupported_system_prompt
+  | Token_measurement_required of Serving_constraint.t
   | Unsupported_target_model of { model_id : string }
   | Target_request_rejected
   | Request_body_too_large of
@@ -503,6 +504,7 @@ let wire_admission_error = function
   | Plan.Unsupported_document_input -> Unsupported_document_input
   | Plan.Unsupported_audio_input -> Unsupported_audio_input
   | Plan.Unsupported_system_prompt -> Unsupported_system_prompt
+  | Plan.Token_measurement_required constraint_ -> Token_measurement_required constraint_
   | Plan.Provider_request_rejected _ -> Target_request_rejected
   | Plan.Request_body_too_large { actual_bytes; limit_bytes } ->
     Request_body_too_large { actual_bytes; limit_bytes }

--- a/lib/llm_provider/exact_output.mli
+++ b/lib/llm_provider/exact_output.mli
@@ -131,6 +131,7 @@ type wire_admission_error =
   | Unsupported_document_input
   | Unsupported_audio_input
   | Unsupported_system_prompt
+  | Token_measurement_required of Serving_constraint.t
   | Unsupported_target_model of { model_id : string }
   | Target_request_rejected
   | Request_body_too_large of

--- a/lib/llm_provider/exact_output_catalog_binding.ml
+++ b/lib/llm_provider/exact_output_catalog_binding.ml
@@ -439,8 +439,9 @@ let%test "exact functional capability projection has a stable golden" =
   functional_capability_projection
     fixture
     ~anthropic_thinking_control:(Some Caps.Anthropic_adaptive_preferred)
-  = [ "oas-exact-output-functional-capabilities-v1"
+  = [ "oas-exact-output-functional-capabilities-v2"
     ; "max_context=some:8"
+    ; "serving_constraint=none"
     ; "max_output=some:3"
     ; "json_mode=1"
     ; "native_schema=0"

--- a/lib/llm_provider/exact_output_catalog_binding.ml
+++ b/lib/llm_provider/exact_output_catalog_binding.ml
@@ -125,6 +125,7 @@ let merge_exact_model_entry
   ; base_label = prefer_overlay overlay.base_label base.base_label
   ; provider_name = overlay.provider_name
   ; max_context_tokens = prefer_overlay overlay.max_context_tokens base.max_context_tokens
+  ; serving_constraint = prefer_overlay overlay.serving_constraint base.serving_constraint
   ; max_output_tokens = prefer_overlay overlay.max_output_tokens base.max_output_tokens
   ; supports_tools = prefer_overlay overlay.supports_tools base.supports_tools
   ; supports_tool_choice =
@@ -280,22 +281,33 @@ let functional_capability_projection
       (caps : Caps.capabilities)
       ~anthropic_thinking_control
   =
-  [ "oas-exact-output-functional-capabilities-v1"
+  let serving_constraint =
+    match caps.serving_constraint with
+    | None -> [ "serving_constraint=none" ]
+    | Some constraint_ ->
+      "serving_constraint=some"
+      :: List.map
+           (fun part -> "serving_constraint." ^ part)
+           (Serving_constraint.fingerprint_parts constraint_)
+  in
+  [ "oas-exact-output-functional-capabilities-v2"
   ; "max_context=" ^ option_int caps.max_context_tokens
-  ; "max_output=" ^ option_int caps.max_output_tokens
-  ; "json_mode=" ^ bool_string caps.supports_response_format_json
-  ; "native_schema=" ^ bool_string caps.supports_structured_output
-  ; "multimodal=" ^ bool_string caps.supports_multimodal_inputs
-  ; "image=" ^ bool_string caps.supports_image_input
-  ; "audio=" ^ bool_string caps.supports_audio_input
-  ; "video=" ^ bool_string caps.supports_video_input
-  ; "document=" ^ bool_string caps.supports_document_input
-  ; "modality_priority=" ^ modality_priority_string caps.modality_priority
-  ; "system_prompt=" ^ bool_string caps.supports_system_prompt
-  ; "task=" ^ task_string caps.task
-  ; "supported_models=" ^ supported_models_string caps.supported_models
-  ; "anthropic_thinking=" ^ anthropic_thinking_control_string anthropic_thinking_control
   ]
+  @ serving_constraint
+  @ [ "max_output=" ^ option_int caps.max_output_tokens
+    ; "json_mode=" ^ bool_string caps.supports_response_format_json
+    ; "native_schema=" ^ bool_string caps.supports_structured_output
+    ; "multimodal=" ^ bool_string caps.supports_multimodal_inputs
+    ; "image=" ^ bool_string caps.supports_image_input
+    ; "audio=" ^ bool_string caps.supports_audio_input
+    ; "video=" ^ bool_string caps.supports_video_input
+    ; "document=" ^ bool_string caps.supports_document_input
+    ; "modality_priority=" ^ modality_priority_string caps.modality_priority
+    ; "system_prompt=" ^ bool_string caps.supports_system_prompt
+    ; "task=" ^ task_string caps.task
+    ; "supported_models=" ^ supported_models_string caps.supported_models
+    ; "anthropic_thinking=" ^ anthropic_thinking_control_string anthropic_thinking_control
+    ]
 ;;
 
 let catalog_anthropic_thinking_control = function
@@ -327,6 +339,7 @@ let capabilities_of_catalog_binding
   let bool_or fallback = Option.value ~default:fallback in
   { base with
     max_context_tokens = prefer_overlay model.max_context_tokens base.max_context_tokens
+  ; serving_constraint = prefer_overlay model.serving_constraint base.serving_constraint
   ; max_output_tokens = prefer_overlay model.max_output_tokens base.max_output_tokens
   ; supports_response_format_json =
       bool_or base.supports_response_format_json model.supports_response_format_json

--- a/lib/llm_provider/exact_output_plan.ml
+++ b/lib/llm_provider/exact_output_plan.ml
@@ -19,6 +19,7 @@ type output_admission_error =
   | Unsupported_document_input
   | Unsupported_audio_input
   | Unsupported_system_prompt
+  | Token_measurement_required of Serving_constraint.t
   | Provider_request_rejected of Http_client.http_error
   | Request_body_too_large of
       { actual_bytes : int
@@ -406,10 +407,16 @@ let admit = function
       ~anthropic_thinking_control:None
       (Prepared_completion_request.admitted_request admitted)
   | Unmeasured { config; messages; body_timeout_s; anthropic_thinking_control } ->
-    Prepared_completion_request.prepare ~config ~messages ?body_timeout_s ()
-    |> admit_prepared
+    let prepared =
+      Prepared_completion_request.prepare ~config ~messages ?body_timeout_s ()
+    in
+    (match Prepared_completion_request.serving_constraint prepared with
+     | Some constraint_ -> Error (Token_measurement_required constraint_)
+     | None ->
+       admit_prepared
          ~admission_basis:Token_measurement_not_required
          ~anthropic_thinking_control
+         prepared)
 ;;
 
 let fingerprint plan = plan.fingerprint

--- a/lib/llm_provider/exact_output_plan.mli
+++ b/lib/llm_provider/exact_output_plan.mli
@@ -33,6 +33,7 @@ type output_admission_error =
   | Unsupported_document_input
   | Unsupported_audio_input
   | Unsupported_system_prompt
+  | Token_measurement_required of Serving_constraint.t
   | Provider_request_rejected of Http_client.http_error
   | Request_body_too_large of
       { actual_bytes : int

--- a/lib/llm_provider/model_catalog.ml
+++ b/lib/llm_provider/model_catalog.ml
@@ -11,6 +11,7 @@ type model_entry =
   ; base_label : string option
   ; provider_name : string option
   ; max_context_tokens : int option
+  ; serving_constraint : Serving_constraint.t option
   ; max_output_tokens : int option
   ; supports_tools : bool option
   ; supports_tool_choice : bool option
@@ -139,6 +140,91 @@ let optional_field ~entry_id ~expected getter key toml =
 let bool_field ~entry_id = optional_field ~entry_id ~expected:"bool" Otoml.get_boolean
 let int_field ~entry_id = optional_field ~entry_id ~expected:"integer" Otoml.get_integer
 let float_field ~entry_id = optional_field ~entry_id ~expected:"float" Otoml.get_float
+
+let serving_constraint_opt ~entry_id toml =
+  let* source_kind_raw =
+    find_string_field ~entry_id "serving_constraint_source_kind" toml
+  in
+  let* source_ref = find_string_field ~entry_id "serving_constraint_source" toml in
+  let* checked_at_unix_s =
+    int_field ~entry_id "serving_constraint_checked_at_unix_s" toml
+  in
+  let* confidence_raw =
+    find_string_field ~entry_id "serving_constraint_confidence" toml
+  in
+  let* expires_at_unix_s =
+    int_field ~entry_id "serving_constraint_expires_at_unix_s" toml
+  in
+  let* accepted_through =
+    int_field ~entry_id "serving_constraint_accepted_through_tokens" toml
+  in
+  let* rejected_from =
+    int_field ~entry_id "serving_constraint_rejected_from_tokens" toml
+  in
+  match
+    ( source_kind_raw
+    , source_ref
+    , checked_at_unix_s
+    , confidence_raw
+    , expires_at_unix_s
+    , accepted_through
+    , rejected_from )
+  with
+  | None, None, None, None, None, None, None -> Ok None
+  | ( Some source_kind_raw
+    , Some source_ref
+    , Some checked_at_unix_s
+    , Some confidence_raw
+    , expires_at_unix_s
+    , Some accepted_through
+    , rejected_from ) ->
+    let source_kind_raw = String.lowercase_ascii (String.trim source_kind_raw) in
+    let confidence_raw = String.lowercase_ascii (String.trim confidence_raw) in
+    let* source_kind =
+      match Serving_constraint.source_kind_of_string source_kind_raw with
+      | Some value -> Ok value
+      | None ->
+        Error
+          (Printf.sprintf
+             "model entry %S field %S has unknown value %S (canonical: declaration, \
+              probe)"
+             entry_id
+             "serving_constraint_source_kind"
+             source_kind_raw)
+    in
+    let* confidence =
+      match Serving_constraint.confidence_of_string confidence_raw with
+      | Some value -> Ok value
+      | None ->
+        Error
+          (Printf.sprintf
+             "model entry %S field %S has unknown value %S (canonical: low, medium, high)"
+             entry_id
+             "serving_constraint_confidence"
+             confidence_raw)
+    in
+    Serving_constraint.make
+      ~source_kind
+      ~source_ref
+      ~checked_at_unix_s
+      ~confidence
+      ?expires_at_unix_s
+      ~accepted_through
+      ?rejected_from
+      ()
+    |> Result.map Option.some
+    |> Result.map_error (fun error ->
+      Printf.sprintf
+        "model entry %S has invalid serving constraint: %s"
+        entry_id
+        (Serving_constraint.show_validation_error error))
+  | _ ->
+    Error
+      (Printf.sprintf
+         "model entry %S serving constraint requires source_kind, source, checked_at, \
+          confidence, and accepted_through"
+         entry_id)
+;;
 
 let string_list_field ~entry_id =
   optional_field ~entry_id ~expected:"string array" (Otoml.get_array Otoml.get_string)
@@ -310,6 +396,13 @@ let known_entry_keys =
   ; "base"
   ; "provider_name"
   ; "max_context_tokens"
+  ; "serving_constraint_source_kind"
+  ; "serving_constraint_source"
+  ; "serving_constraint_checked_at_unix_s"
+  ; "serving_constraint_confidence"
+  ; "serving_constraint_expires_at_unix_s"
+  ; "serving_constraint_accepted_through_tokens"
+  ; "serving_constraint_rejected_from_tokens"
   ; "max_output_tokens"
   ; "supports_tools"
   ; "supports_tool_choice"
@@ -398,6 +491,7 @@ let parse_entry entry_toml =
   let* max_context_tokens =
     int_field ~entry_id:id_prefix "max_context_tokens" entry_toml
   in
+  let* serving_constraint = serving_constraint_opt ~entry_id:id_prefix entry_toml in
   let* max_output_tokens = int_field ~entry_id:id_prefix "max_output_tokens" entry_toml in
   let* supports_tools = bool_field ~entry_id:id_prefix "supports_tools" entry_toml in
   let* supports_tool_choice =
@@ -555,6 +649,7 @@ let parse_entry entry_toml =
     ; base_label
     ; provider_name
     ; max_context_tokens
+    ; serving_constraint
     ; max_output_tokens
     ; supports_tools
     ; supports_tool_choice

--- a/lib/llm_provider/model_catalog.ml
+++ b/lib/llm_provider/model_catalog.ml
@@ -141,91 +141,6 @@ let bool_field ~entry_id = optional_field ~entry_id ~expected:"bool" Otoml.get_b
 let int_field ~entry_id = optional_field ~entry_id ~expected:"integer" Otoml.get_integer
 let float_field ~entry_id = optional_field ~entry_id ~expected:"float" Otoml.get_float
 
-let serving_constraint_opt ~entry_id toml =
-  let* source_kind_raw =
-    find_string_field ~entry_id "serving_constraint_source_kind" toml
-  in
-  let* source_ref = find_string_field ~entry_id "serving_constraint_source" toml in
-  let* checked_at_unix_s =
-    int_field ~entry_id "serving_constraint_checked_at_unix_s" toml
-  in
-  let* confidence_raw =
-    find_string_field ~entry_id "serving_constraint_confidence" toml
-  in
-  let* expires_at_unix_s =
-    int_field ~entry_id "serving_constraint_expires_at_unix_s" toml
-  in
-  let* accepted_through =
-    int_field ~entry_id "serving_constraint_accepted_through_tokens" toml
-  in
-  let* rejected_from =
-    int_field ~entry_id "serving_constraint_rejected_from_tokens" toml
-  in
-  match
-    ( source_kind_raw
-    , source_ref
-    , checked_at_unix_s
-    , confidence_raw
-    , expires_at_unix_s
-    , accepted_through
-    , rejected_from )
-  with
-  | None, None, None, None, None, None, None -> Ok None
-  | ( Some source_kind_raw
-    , Some source_ref
-    , Some checked_at_unix_s
-    , Some confidence_raw
-    , expires_at_unix_s
-    , Some accepted_through
-    , rejected_from ) ->
-    let source_kind_raw = String.lowercase_ascii (String.trim source_kind_raw) in
-    let confidence_raw = String.lowercase_ascii (String.trim confidence_raw) in
-    let* source_kind =
-      match Serving_constraint.source_kind_of_string source_kind_raw with
-      | Some value -> Ok value
-      | None ->
-        Error
-          (Printf.sprintf
-             "model entry %S field %S has unknown value %S (canonical: declaration, \
-              probe)"
-             entry_id
-             "serving_constraint_source_kind"
-             source_kind_raw)
-    in
-    let* confidence =
-      match Serving_constraint.confidence_of_string confidence_raw with
-      | Some value -> Ok value
-      | None ->
-        Error
-          (Printf.sprintf
-             "model entry %S field %S has unknown value %S (canonical: low, medium, high)"
-             entry_id
-             "serving_constraint_confidence"
-             confidence_raw)
-    in
-    Serving_constraint.make
-      ~source_kind
-      ~source_ref
-      ~checked_at_unix_s
-      ~confidence
-      ?expires_at_unix_s
-      ~accepted_through
-      ?rejected_from
-      ()
-    |> Result.map Option.some
-    |> Result.map_error (fun error ->
-      Printf.sprintf
-        "model entry %S has invalid serving constraint: %s"
-        entry_id
-        (Serving_constraint.show_validation_error error))
-  | _ ->
-    Error
-      (Printf.sprintf
-         "model entry %S serving constraint requires source_kind, source, checked_at, \
-          confidence, and accepted_through"
-         entry_id)
-;;
-
 let string_list_field ~entry_id =
   optional_field ~entry_id ~expected:"string array" (Otoml.get_array Otoml.get_string)
 ;;
@@ -491,7 +406,9 @@ let parse_entry entry_toml =
   let* max_context_tokens =
     int_field ~entry_id:id_prefix "max_context_tokens" entry_toml
   in
-  let* serving_constraint = serving_constraint_opt ~entry_id:id_prefix entry_toml in
+  let* serving_constraint =
+    Serving_constraint_catalog.parse ~entry_id:id_prefix entry_toml
+  in
   let* max_output_tokens = int_field ~entry_id:id_prefix "max_output_tokens" entry_toml in
   let* supports_tools = bool_field ~entry_id:id_prefix "supports_tools" entry_toml in
   let* supports_tool_choice =

--- a/lib/llm_provider/model_catalog.mli
+++ b/lib/llm_provider/model_catalog.mli
@@ -11,6 +11,9 @@ type model_entry =
         not a capability preset; [base_label] remains the capability base. *)
   ; provider_name : string option
   ; max_context_tokens : int option
+  ; serving_constraint : Serving_constraint.t option
+    (** Evidence-backed input-token admission interval for this exact catalog
+        row. It remains distinct from the declared model context window. *)
   ; max_output_tokens : int option
   ; supports_tools : bool option
   ; supports_tool_choice : bool option

--- a/lib/llm_provider/prepared_completion_request.ml
+++ b/lib/llm_provider/prepared_completion_request.ml
@@ -19,6 +19,10 @@ type fit_error =
       }
   | Output_reservation_unknown of { model_id : string }
   | Context_window_exceeded of context_fit
+  | Serving_constraint_rejected of
+      { constraint_ : Serving_constraint.t
+      ; reason : Serving_constraint.admission_error
+      }
 
 type admitted =
   { measured : measured
@@ -94,7 +98,15 @@ let resolve_context_limit prepared =
   | Some max_context_tokens -> Ok max_context_tokens
 ;;
 
-let admit ~max_context_tokens measured =
+let serving_constraint prepared =
+  Option.bind
+    (Provider_config.capabilities_for_config_model prepared.request.config)
+    (fun capabilities -> capabilities.Capabilities.serving_constraint)
+;;
+
+let requires_token_measurement prepared = Option.is_some (serving_constraint prepared)
+
+let admit ?now_unix_s ~max_context_tokens measured =
   let request = measured.prepared.request in
   let input_tokens = measured.measurement.input_count.input_tokens in
   let reserved_output_tokens =
@@ -112,7 +124,16 @@ let admit ~max_context_tokens measured =
       reserved_output_tokens > max_context_tokens
       || input_tokens > max_context_tokens - reserved_output_tokens
     then Error (Context_window_exceeded fit)
-    else Ok { measured; fit }
+    else (
+      match serving_constraint measured.prepared with
+      | None -> Ok { measured; fit }
+      | Some constraint_ ->
+        let now_unix_s =
+          Option.value now_unix_s ~default:(int_of_float (Unix.gettimeofday ()))
+        in
+        (match Serving_constraint.admit ~now_unix_s ~input_tokens constraint_ with
+         | Ok () -> Ok { measured; fit }
+         | Error reason -> Error (Serving_constraint_rejected { constraint_; reason })))
 ;;
 
 let admitted_request admitted = admitted.measured.prepared

--- a/lib/llm_provider/prepared_completion_request.ml
+++ b/lib/llm_provider/prepared_completion_request.ml
@@ -106,7 +106,7 @@ let serving_constraint prepared =
 
 let requires_token_measurement prepared = Option.is_some (serving_constraint prepared)
 
-let admit ?now_unix_s ~max_context_tokens measured =
+let admit ~now_unix_s ~max_context_tokens measured =
   let request = measured.prepared.request in
   let input_tokens = measured.measurement.input_count.input_tokens in
   let reserved_output_tokens =
@@ -128,9 +128,6 @@ let admit ?now_unix_s ~max_context_tokens measured =
       match serving_constraint measured.prepared with
       | None -> Ok { measured; fit }
       | Some constraint_ ->
-        let now_unix_s =
-          Option.value now_unix_s ~default:(int_of_float (Unix.gettimeofday ()))
-        in
         (match Serving_constraint.admit ~now_unix_s ~input_tokens constraint_ with
          | Ok () -> Ok { measured; fit }
          | Error reason -> Error (Serving_constraint_rejected { constraint_; reason })))

--- a/lib/llm_provider/prepared_completion_request.mli
+++ b/lib/llm_provider/prepared_completion_request.mli
@@ -22,6 +22,10 @@ type fit_error =
       }
   | Output_reservation_unknown of { model_id : string }
   | Context_window_exceeded of context_fit
+  | Serving_constraint_rejected of
+      { constraint_ : Serving_constraint.t
+      ; reason : Serving_constraint.admission_error
+      }
 
 val prepare
   :  config:Provider_config.t
@@ -54,6 +58,17 @@ val measurement : measured -> Count_tokens_sync.completion_request_measurement
     limit is declared, [Invalid_context_limit] when it is non-positive. *)
 val resolve_context_limit : t -> (int, fit_error) result
 
-val admit : max_context_tokens:int -> measured -> (admitted, fit_error) result
+(** [true] when the exact resolved capability carries a serving constraint and
+    therefore cannot use an unmeasured compatibility dispatch. *)
+val requires_token_measurement : t -> bool
+
+val serving_constraint : t -> Serving_constraint.t option
+
+val admit
+  :  ?now_unix_s:int
+  -> max_context_tokens:int
+  -> measured
+  -> (admitted, fit_error) result
+
 val admitted_request : admitted -> t
 val admitted_fit : admitted -> context_fit

--- a/lib/llm_provider/prepared_completion_request.mli
+++ b/lib/llm_provider/prepared_completion_request.mli
@@ -65,7 +65,7 @@ val requires_token_measurement : t -> bool
 val serving_constraint : t -> Serving_constraint.t option
 
 val admit
-  :  ?now_unix_s:int
+  :  now_unix_s:int
   -> max_context_tokens:int
   -> measured
   -> (admitted, fit_error) result

--- a/lib/llm_provider/pricing.ml
+++ b/lib/llm_provider/pricing.ml
@@ -139,6 +139,7 @@ let test_catalog_entry ?provider_name ?input ?output ?cache_write ?cache_read id
   ; base_label = None
   ; provider_name
   ; max_context_tokens = None
+  ; serving_constraint = None
   ; max_output_tokens = None
   ; supports_tools = None
   ; supports_tool_choice = None

--- a/lib/llm_provider/retry.ml
+++ b/lib/llm_provider/retry.ml
@@ -8,6 +8,10 @@ type invalid_request_reason =
       }
   | Unknown_invalid_request
 
+type input_capacity_reason =
+  | Serving_constraint_rejected of Serving_constraint.admission_error
+  | Token_measurement_unavailable of Input_token_count.protocol
+
 type api_error =
   | RateLimited of
       { retry_after : float option
@@ -29,6 +33,11 @@ type api_error =
   | ContextOverflow of
       { message : string
       ; limit : int option
+      }
+  | InputCapacity of
+      { message : string
+      ; constraint_ : Serving_constraint.t
+      ; reason : input_capacity_reason
       }
   | NetworkError of
       { message : string
@@ -76,6 +85,15 @@ let error_message = function
       | None -> ""
     in
     Printf.sprintf "Context overflow%s: %s" limit_str r.message
+  | InputCapacity r ->
+    let reason =
+      match r.reason with
+      | Serving_constraint_rejected reason ->
+        Serving_constraint.show_admission_error reason
+      | Token_measurement_unavailable protocol ->
+        "token_measurement_unavailable(" ^ Input_token_count.show_protocol protocol ^ ")"
+    in
+    Printf.sprintf "Input capacity (%s): %s" reason r.message
   | NetworkError { message; kind = Unknown } -> Printf.sprintf "Network error: %s" message
   | NetworkError { message; kind } ->
     Printf.sprintf "Network error (%s): %s" (network_error_kind_label kind) message
@@ -101,7 +119,8 @@ let is_retryable = function
     (* Malformed JSON from model output is transient — retry may produce valid JSON. *)
     true
   | InvalidRequest _ -> false
-  | AuthError _ | AuthorizationError _ | ContextOverflow _ | NotFound _ -> false
+  | AuthError _ | AuthorizationError _ | ContextOverflow _ | InputCapacity _ | NotFound _
+    -> false
   | PaymentRequired _ -> false
 ;;
 
@@ -357,6 +376,7 @@ let%test "is_retryable: flat Ollama provider prose is not retryable" =
   | PaymentRequired _
   | NotFound _
   | ContextOverflow _
+  | InputCapacity _
   | NetworkError _
   | Timeout _ -> false
 ;;
@@ -369,6 +389,7 @@ let%test "HTTP 400 prose does not synthesize ContextOverflow" =
   | InvalidRequest { reason = Unknown_invalid_request; _ } -> true
   | InvalidRequest { reason = Json_parse_error | Request_body_too_large _; _ }
   | ContextOverflow _
+  | InputCapacity _
   | RateLimited _
   | Overloaded _
   | ServerError _
@@ -393,6 +414,7 @@ let%test "classify_error returns Unknown InvalidRequest for non-overflow 400" =
   | PaymentRequired _
   | NotFound _
   | ContextOverflow _
+  | InputCapacity _
   | NetworkError _
   | Timeout _ -> false
 ;;
@@ -503,6 +525,7 @@ let%test "classify_error 429 preserves structured retry_after regardless of pros
   | InvalidRequest _
   | NotFound _
   | ContextOverflow _
+  | InputCapacity _
   | NetworkError _
   | Timeout _ -> false
 ;;
@@ -522,6 +545,7 @@ let%test "classify_error 429 transient preserves retry_after" =
   | InvalidRequest _
   | NotFound _
   | ContextOverflow _
+  | InputCapacity _
   | NetworkError _
   | Timeout _ -> false
 ;;
@@ -547,6 +571,7 @@ let%test "classify_error 429: body retry_after wins over header" =
   | InvalidRequest _
   | NotFound _
   | ContextOverflow _
+  | InputCapacity _
   | NetworkError _
   | Timeout _ -> false
 ;;
@@ -565,6 +590,7 @@ let%test "classify_error 429: header-only (flat provider body) works" =
   | InvalidRequest _
   | NotFound _
   | ContextOverflow _
+  | InputCapacity _
   | NetworkError _
   | Timeout _ -> false
 ;;
@@ -583,6 +609,7 @@ let%test "classify_error 429: neither body nor header yields None, message prese
   | InvalidRequest _
   | NotFound _
   | ContextOverflow _
+  | InputCapacity _
   | NetworkError _
   | Timeout _ -> false
 ;;
@@ -601,6 +628,7 @@ let%test "classify_error 402 maps to PaymentRequired" =
   | InvalidRequest _
   | NotFound _
   | ContextOverflow _
+  | InputCapacity _
   | NetworkError _
   | Timeout _ -> false
 ;;
@@ -619,6 +647,7 @@ let%test "classify_error 402 is not retryable" =
   | InvalidRequest _
   | NotFound _
   | ContextOverflow _
+  | InputCapacity _
   | NetworkError _
   | Timeout _ -> false
 ;;

--- a/lib/llm_provider/retry.mli
+++ b/lib/llm_provider/retry.mli
@@ -13,6 +13,10 @@ type invalid_request_reason =
       }
   | Unknown_invalid_request
 
+type input_capacity_reason =
+  | Serving_constraint_rejected of Serving_constraint.admission_error
+  | Token_measurement_unavailable of Input_token_count.protocol
+
 type api_error =
   | RateLimited of
       { retry_after : float option
@@ -35,6 +39,11 @@ type api_error =
   | ContextOverflow of
       { message : string
       ; limit : int option
+      }
+  | InputCapacity of
+      { message : string
+      ; constraint_ : Serving_constraint.t
+      ; reason : input_capacity_reason
       }
   | NetworkError of
       { message : string

--- a/lib/llm_provider/serving_constraint.ml
+++ b/lib/llm_provider/serving_constraint.ml
@@ -33,6 +33,7 @@ type t =
 type validation_error =
   | Invalid_source_ref
   | Invalid_checked_at of int
+  | Missing_probe_expiry
   | Invalid_expiry of
       { checked_at_unix_s : int
       ; expires_at_unix_s : int
@@ -60,6 +61,8 @@ let make
   then Error (Invalid_checked_at checked_at_unix_s)
   else if accepted_through < 0
   then Error (Invalid_accepted_through accepted_through)
+  else if source_kind = Probe && Option.is_none expires_at_unix_s
+  then Error Missing_probe_expiry
   else (
     match expires_at_unix_s, rejected_from with
     | Some expires_at_unix_s, _ when expires_at_unix_s <= checked_at_unix_s ->

--- a/lib/llm_provider/serving_constraint.ml
+++ b/lib/llm_provider/serving_constraint.ml
@@ -1,0 +1,177 @@
+type source_kind =
+  | Declaration
+  | Probe
+[@@deriving show, eq]
+
+type confidence =
+  | Low
+  | Medium
+  | High
+[@@deriving show, eq]
+
+type evidence =
+  { source_kind : source_kind
+  ; source_ref : string
+  ; checked_at_unix_s : int
+  ; confidence : confidence
+  ; expires_at_unix_s : int option
+  }
+[@@deriving show, eq]
+
+type observation =
+  { accepted_through : int
+  ; rejected_from : int option
+  }
+[@@deriving show, eq]
+
+type t =
+  { observation : observation
+  ; evidence : evidence
+  }
+[@@deriving show, eq]
+
+type validation_error =
+  | Invalid_source_ref
+  | Invalid_checked_at of int
+  | Invalid_expiry of
+      { checked_at_unix_s : int
+      ; expires_at_unix_s : int
+      }
+  | Invalid_accepted_through of int
+  | Invalid_rejected_from of
+      { accepted_through : int
+      ; rejected_from : int
+      }
+[@@deriving show, eq]
+
+let make
+      ~source_kind
+      ~source_ref
+      ~checked_at_unix_s
+      ~confidence
+      ?expires_at_unix_s
+      ~accepted_through
+      ?rejected_from
+      ()
+  =
+  if source_ref = "" || String.trim source_ref <> source_ref
+  then Error Invalid_source_ref
+  else if checked_at_unix_s < 0
+  then Error (Invalid_checked_at checked_at_unix_s)
+  else if accepted_through < 0
+  then Error (Invalid_accepted_through accepted_through)
+  else (
+    match expires_at_unix_s, rejected_from with
+    | Some expires_at_unix_s, _ when expires_at_unix_s <= checked_at_unix_s ->
+      Error (Invalid_expiry { checked_at_unix_s; expires_at_unix_s })
+    | _, Some rejected_from when rejected_from <= accepted_through ->
+      Error (Invalid_rejected_from { accepted_through; rejected_from })
+    | _ ->
+      Ok
+        { observation = { accepted_through; rejected_from }
+        ; evidence =
+            { source_kind; source_ref; checked_at_unix_s; confidence; expires_at_unix_s }
+        })
+;;
+
+type admission_error =
+  | Evidence_not_yet_valid of
+      { now_unix_s : int
+      ; checked_at_unix_s : int
+      }
+  | Evidence_expired of
+      { now_unix_s : int
+      ; expires_at_unix_s : int
+      }
+  | Boundary_unknown of
+      { input_tokens : int
+      ; accepted_through : int
+      ; rejected_from : int option
+      }
+  | Input_rejected of
+      { input_tokens : int
+      ; accepted_through : int
+      ; rejected_from : int
+      }
+[@@deriving show, eq]
+
+let check_evidence ~now_unix_s constraint_ =
+  let evidence = constraint_.evidence in
+  if now_unix_s < evidence.checked_at_unix_s
+  then
+    Error
+      (Evidence_not_yet_valid
+         { now_unix_s; checked_at_unix_s = evidence.checked_at_unix_s })
+  else (
+    match evidence.expires_at_unix_s with
+    | Some expires_at_unix_s when now_unix_s >= expires_at_unix_s ->
+      Error (Evidence_expired { now_unix_s; expires_at_unix_s })
+    | Some _ | None -> Ok ())
+;;
+
+let admit ~now_unix_s ~input_tokens constraint_ =
+  match check_evidence ~now_unix_s constraint_ with
+  | Error error -> Error error
+  | Ok () ->
+    let observation = constraint_.observation in
+    if input_tokens <= observation.accepted_through
+    then Ok ()
+    else (
+      match observation.rejected_from with
+      | Some rejected_from when input_tokens >= rejected_from ->
+        Error
+          (Input_rejected
+             { input_tokens
+             ; accepted_through = observation.accepted_through
+             ; rejected_from
+             })
+      | rejected_from ->
+        Error
+          (Boundary_unknown
+             { input_tokens
+             ; accepted_through = observation.accepted_through
+             ; rejected_from
+             }))
+;;
+
+let source_kind_of_string = function
+  | "declaration" -> Some Declaration
+  | "probe" -> Some Probe
+  | _ -> None
+;;
+
+let source_kind_to_string = function
+  | Declaration -> "declaration"
+  | Probe -> "probe"
+;;
+
+let confidence_of_string = function
+  | "low" -> Some Low
+  | "medium" -> Some Medium
+  | "high" -> Some High
+  | _ -> None
+;;
+
+let confidence_to_string = function
+  | Low -> "low"
+  | Medium -> "medium"
+  | High -> "high"
+;;
+
+let option_int = function
+  | None -> "none"
+  | Some value -> "some:" ^ string_of_int value
+;;
+
+let fingerprint_parts constraint_ =
+  let evidence = constraint_.evidence in
+  let observation = constraint_.observation in
+  [ "source_kind=" ^ source_kind_to_string evidence.source_kind
+  ; "source_ref=" ^ evidence.source_ref
+  ; "checked_at_unix_s=" ^ string_of_int evidence.checked_at_unix_s
+  ; "confidence=" ^ confidence_to_string evidence.confidence
+  ; "expires_at_unix_s=" ^ option_int evidence.expires_at_unix_s
+  ; "accepted_through=" ^ string_of_int observation.accepted_through
+  ; "rejected_from=" ^ option_int observation.rejected_from
+  ]
+;;

--- a/lib/llm_provider/serving_constraint.mli
+++ b/lib/llm_provider/serving_constraint.mli
@@ -97,6 +97,9 @@ val source_kind_to_string : source_kind -> string
 val confidence_of_string : string -> confidence option
 val confidence_to_string : confidence -> string
 
-(** Stable functional projection used by immutable catalog and ready-plan
-    fingerprints. *)
+(** Stable projection used by immutable catalog and ready-plan fingerprints.
+    This deliberately includes the full evidence identity, not only the
+    observed interval: refreshing [checked_at], [expires_at], [source_ref], or
+    confidence creates a new ready-plan generation instead of mutating the
+    meaning or validity window of an already-frozen plan. *)
 val fingerprint_parts : t -> string list

--- a/lib/llm_provider/serving_constraint.mli
+++ b/lib/llm_provider/serving_constraint.mli
@@ -1,0 +1,102 @@
+(** Evidence-backed token-serving boundaries for one resolved runtime target.
+
+    A declaration or probe records only what it established: requests at or
+    below [accepted_through] are known admitted, requests at or above
+    [rejected_from] are known rejected, and any gap remains explicitly unknown.
+    No provider, model, endpoint, or error prose is interpreted here. *)
+
+type source_kind =
+  | Declaration
+  | Probe
+[@@deriving show, eq]
+
+type confidence =
+  | Low
+  | Medium
+  | High
+[@@deriving show, eq]
+
+type evidence =
+  { source_kind : source_kind
+  ; source_ref : string
+  ; checked_at_unix_s : int
+  ; confidence : confidence
+  ; expires_at_unix_s : int option
+  }
+[@@deriving show, eq]
+
+type observation =
+  { accepted_through : int
+  ; rejected_from : int option
+  }
+[@@deriving show, eq]
+
+type t =
+  { observation : observation
+  ; evidence : evidence
+  }
+[@@deriving show, eq]
+
+type validation_error =
+  | Invalid_source_ref
+  | Invalid_checked_at of int
+  | Invalid_expiry of
+      { checked_at_unix_s : int
+      ; expires_at_unix_s : int
+      }
+  | Invalid_accepted_through of int
+  | Invalid_rejected_from of
+      { accepted_through : int
+      ; rejected_from : int
+      }
+[@@deriving show, eq]
+
+val make
+  :  source_kind:source_kind
+  -> source_ref:string
+  -> checked_at_unix_s:int
+  -> confidence:confidence
+  -> ?expires_at_unix_s:int
+  -> accepted_through:int
+  -> ?rejected_from:int
+  -> unit
+  -> (t, validation_error) result
+
+type admission_error =
+  | Evidence_not_yet_valid of
+      { now_unix_s : int
+      ; checked_at_unix_s : int
+      }
+  | Evidence_expired of
+      { now_unix_s : int
+      ; expires_at_unix_s : int
+      }
+  | Boundary_unknown of
+      { input_tokens : int
+      ; accepted_through : int
+      ; rejected_from : int option
+      }
+  | Input_rejected of
+      { input_tokens : int
+      ; accepted_through : int
+      ; rejected_from : int
+      }
+[@@deriving show, eq]
+
+(** Check whether the evidence is current without requiring a token
+    measurement. This permits stale or future-dated evidence to fail before any
+    provider request. *)
+val check_evidence : now_unix_s:int -> t -> (unit, admission_error) result
+
+(** Admit one exact provider-native input-token measurement. Evidence is
+    current only in [[checked_at, expires_at)] when an expiry exists. *)
+val admit : now_unix_s:int -> input_tokens:int -> t -> (unit, admission_error) result
+
+val source_kind_of_string : string -> source_kind option
+val source_kind_to_string : source_kind -> string
+val confidence_of_string : string -> confidence option
+val confidence_to_string : confidence -> string
+
+(** Stable functional projection used by immutable catalog and ready-plan
+    fingerprints. *)
+val fingerprint_parts : t -> string list

--- a/lib/llm_provider/serving_constraint.mli
+++ b/lib/llm_provider/serving_constraint.mli
@@ -40,6 +40,7 @@ type t =
 type validation_error =
   | Invalid_source_ref
   | Invalid_checked_at of int
+  | Missing_probe_expiry
   | Invalid_expiry of
       { checked_at_unix_s : int
       ; expires_at_unix_s : int
@@ -51,6 +52,9 @@ type validation_error =
       }
 [@@deriving show, eq]
 
+(** Probe evidence must carry an explicit expiry. The boundary never invents a
+    default TTL; the catalog owner chooses the validity window. Declarations
+    may omit expiry when their source contract is itself durable. *)
 val make
   :  source_kind:source_kind
   -> source_ref:string

--- a/lib/llm_provider/serving_constraint_catalog.ml
+++ b/lib/llm_provider/serving_constraint_catalog.ml
@@ -1,0 +1,91 @@
+let ( let* ) = Result.bind
+
+let field ~entry_id ~expected getter key toml =
+  try Ok (Otoml.find_opt toml getter [ key ]) with
+  | Otoml.Type_error _ ->
+    Error (Printf.sprintf "model entry %S field %S expected %s" entry_id key expected)
+;;
+
+let string_field ~entry_id = field ~entry_id ~expected:"string" Otoml.get_string
+let int_field ~entry_id = field ~entry_id ~expected:"integer" Otoml.get_integer
+
+let parse ~entry_id toml =
+  let* source_kind_raw = string_field ~entry_id "serving_constraint_source_kind" toml in
+  let* source_ref = string_field ~entry_id "serving_constraint_source" toml in
+  let* checked_at_unix_s =
+    int_field ~entry_id "serving_constraint_checked_at_unix_s" toml
+  in
+  let* confidence_raw = string_field ~entry_id "serving_constraint_confidence" toml in
+  let* expires_at_unix_s =
+    int_field ~entry_id "serving_constraint_expires_at_unix_s" toml
+  in
+  let* accepted_through =
+    int_field ~entry_id "serving_constraint_accepted_through_tokens" toml
+  in
+  let* rejected_from =
+    int_field ~entry_id "serving_constraint_rejected_from_tokens" toml
+  in
+  match
+    ( source_kind_raw
+    , source_ref
+    , checked_at_unix_s
+    , confidence_raw
+    , expires_at_unix_s
+    , accepted_through
+    , rejected_from )
+  with
+  | None, None, None, None, None, None, None -> Ok None
+  | ( Some source_kind_raw
+    , Some source_ref
+    , Some checked_at_unix_s
+    , Some confidence_raw
+    , expires_at_unix_s
+    , Some accepted_through
+    , rejected_from ) ->
+    let source_kind_raw = String.lowercase_ascii (String.trim source_kind_raw) in
+    let confidence_raw = String.lowercase_ascii (String.trim confidence_raw) in
+    let* source_kind =
+      match Serving_constraint.source_kind_of_string source_kind_raw with
+      | Some value -> Ok value
+      | None ->
+        Error
+          (Printf.sprintf
+             "model entry %S field %S has unknown value %S (canonical: declaration, \
+              probe)"
+             entry_id
+             "serving_constraint_source_kind"
+             source_kind_raw)
+    in
+    let* confidence =
+      match Serving_constraint.confidence_of_string confidence_raw with
+      | Some value -> Ok value
+      | None ->
+        Error
+          (Printf.sprintf
+             "model entry %S field %S has unknown value %S (canonical: low, medium, high)"
+             entry_id
+             "serving_constraint_confidence"
+             confidence_raw)
+    in
+    Serving_constraint.make
+      ~source_kind
+      ~source_ref
+      ~checked_at_unix_s
+      ~confidence
+      ?expires_at_unix_s
+      ~accepted_through
+      ?rejected_from
+      ()
+    |> Result.map Option.some
+    |> Result.map_error (fun error ->
+      Printf.sprintf
+        "model entry %S has invalid serving constraint: %s"
+        entry_id
+        (Serving_constraint.show_validation_error error))
+  | _ ->
+    Error
+      (Printf.sprintf
+         "model entry %S serving constraint requires source_kind, source, checked_at, \
+          confidence, and accepted_through"
+         entry_id)
+;;

--- a/lib/llm_provider/serving_constraint_catalog.mli
+++ b/lib/llm_provider/serving_constraint_catalog.mli
@@ -1,0 +1,5 @@
+(** Decode one optional evidence-backed serving constraint from a model catalog
+    row. The grouped fields are all-or-nothing except the observed rejection
+    and explicit expiry bounds. *)
+
+val parse : entry_id:string -> Otoml.t -> (Serving_constraint.t option, string) result

--- a/lib/pipeline/pipeline_stage_route.ml
+++ b/lib/pipeline/pipeline_stage_route.ml
@@ -26,6 +26,12 @@ let invalid_request message =
        { message; reason = Llm_provider.Retry.Unknown_invalid_request })
 ;;
 
+let input_capacity_error ~binding ~message ~constraint_ ~reason =
+  Provider_failure_attribution.of_request_validation_error
+    ~binding
+    (Error.Api (Llm_provider.Retry.InputCapacity { message; constraint_; reason }))
+;;
+
 let measurement_error ~binding ~constraint_ = function
   | Llm_provider.Count_tokens_sync.Input_count_failed
       (Llm_provider.Input_token_count.Transport http_error) ->
@@ -34,19 +40,16 @@ let measurement_error ~binding ~constraint_ = function
       (Llm_provider.Input_token_count.Unsupported { protocol; model_id }) ->
     (match constraint_ with
      | Some constraint_ ->
-       Provider_failure_attribution.of_request_validation_error
+       input_capacity_error
          ~binding
-         (Error.Api
-            (Llm_provider.Retry.InputCapacity
-               { message =
-                   Printf.sprintf
-                     "provider-native input measurement %s is unavailable for \
-                      constrained model %s"
-                     (Llm_provider.Input_token_count.show_protocol protocol)
-                     model_id
-               ; constraint_
-               ; reason = Llm_provider.Retry.Token_measurement_unavailable protocol
-               }))
+         ~message:
+           (Printf.sprintf
+              "provider-native input measurement %s is unavailable for constrained model \
+               %s"
+              (Llm_provider.Input_token_count.show_protocol protocol)
+              model_id)
+         ~constraint_
+         ~reason:(Llm_provider.Retry.Token_measurement_unavailable protocol)
      | None ->
        Provider_failure_attribution.of_request_validation_error
          ~binding
@@ -122,14 +125,11 @@ let fit_error ~binding = function
             ; limit = Some max_context_tokens
             }))
   | Llm_provider.Complete.Serving_constraint_rejected { constraint_; reason } ->
-    Provider_failure_attribution.of_request_validation_error
+    input_capacity_error
       ~binding
-      (Error.Api
-         (Llm_provider.Retry.InputCapacity
-            { message = "prepared request rejected by resolved serving constraint"
-            ; constraint_
-            ; reason = Llm_provider.Retry.Serving_constraint_rejected reason
-            }))
+      ~message:"prepared request rejected by resolved serving constraint"
+      ~constraint_
+      ~reason:(Llm_provider.Retry.Serving_constraint_rejected reason)
 ;;
 
 let preflight_serving_constraint ~binding ~now_unix_s prepared =
@@ -140,14 +140,11 @@ let preflight_serving_constraint ~binding ~now_unix_s prepared =
      | Ok () -> Ok ()
      | Error reason ->
        Error
-         (Provider_failure_attribution.of_request_validation_error
+         (input_capacity_error
             ~binding
-            (Error.Api
-               (Llm_provider.Retry.InputCapacity
-                  { message = "resolved serving-constraint evidence is not current"
-                  ; constraint_
-                  ; reason = Llm_provider.Retry.Serving_constraint_rejected reason
-                  }))))
+            ~message:"resolved serving-constraint evidence is not current"
+            ~constraint_
+            ~reason:(Llm_provider.Retry.Serving_constraint_rejected reason)))
 ;;
 
 let enforce_context_fit agent (provider_config : Llm_provider.Provider_config.t) =

--- a/lib/pipeline/pipeline_stage_route.ml
+++ b/lib/pipeline/pipeline_stage_route.ml
@@ -26,19 +26,35 @@ let invalid_request message =
        { message; reason = Llm_provider.Retry.Unknown_invalid_request })
 ;;
 
-let measurement_error ~binding = function
+let measurement_error ~binding ~constraint_ = function
   | Llm_provider.Count_tokens_sync.Input_count_failed
       (Llm_provider.Input_token_count.Transport http_error) ->
     Provider_failure_attribution.of_http_error ~binding http_error
   | Llm_provider.Count_tokens_sync.Input_count_failed
       (Llm_provider.Input_token_count.Unsupported { protocol; model_id }) ->
-    Provider_failure_attribution.of_request_validation_error
-      ~binding
-      (invalid_request
-         (Printf.sprintf
-            "provider-native input measurement %s is unsupported for model %s"
-            (Llm_provider.Input_token_count.show_protocol protocol)
-            model_id))
+    (match constraint_ with
+     | Some constraint_ ->
+       Provider_failure_attribution.of_request_validation_error
+         ~binding
+         (Error.Api
+            (Llm_provider.Retry.InputCapacity
+               { message =
+                   Printf.sprintf
+                     "provider-native input measurement %s is unavailable for \
+                      constrained model %s"
+                     (Llm_provider.Input_token_count.show_protocol protocol)
+                     model_id
+               ; constraint_
+               ; reason = Llm_provider.Retry.Token_measurement_unavailable protocol
+               }))
+     | None ->
+       Provider_failure_attribution.of_request_validation_error
+         ~binding
+         (invalid_request
+            (Printf.sprintf
+               "provider-native input measurement %s is unsupported for model %s"
+               (Llm_provider.Input_token_count.show_protocol protocol)
+               model_id)))
   | Llm_provider.Count_tokens_sync.Input_count_failed
       (Llm_provider.Input_token_count.Invalid_response { protocol; model_id; detail }) ->
     Provider_failure_attribution.of_response_parse_error
@@ -105,6 +121,37 @@ let fit_error ~binding = function
                   max_context_tokens
             ; limit = Some max_context_tokens
             }))
+  | Llm_provider.Complete.Serving_constraint_rejected { constraint_; reason } ->
+    Provider_failure_attribution.of_request_validation_error
+      ~binding
+      (Error.Api
+         (Llm_provider.Retry.InputCapacity
+            { message = "prepared request rejected by resolved serving constraint"
+            ; constraint_
+            ; reason = Llm_provider.Retry.Serving_constraint_rejected reason
+            }))
+;;
+
+let preflight_serving_constraint ~binding prepared =
+  match Llm_provider.Complete.serving_constraint prepared with
+  | None -> Ok ()
+  | Some constraint_ ->
+    (match
+       Llm_provider.Serving_constraint.check_evidence
+         ~now_unix_s:(int_of_float (Unix.gettimeofday ()))
+         constraint_
+     with
+     | Ok () -> Ok ()
+     | Error reason ->
+       Error
+         (Provider_failure_attribution.of_request_validation_error
+            ~binding
+            (Error.Api
+               (Llm_provider.Retry.InputCapacity
+                  { message = "resolved serving-constraint evidence is not current"
+                  ; constraint_
+                  ; reason = Llm_provider.Retry.Serving_constraint_rejected reason
+                  }))))
 ;;
 
 let enforce_context_fit agent (provider_config : Llm_provider.Provider_config.t) =
@@ -112,6 +159,12 @@ let enforce_context_fit agent (provider_config : Llm_provider.Provider_config.t)
   | Disabled -> false
   | Enforce_when_supported ->
     Llm_provider.Count_tokens_sync.supports_completion_request_measurement provider_config
+    ||
+      (match
+         Llm_provider.Provider_config.capabilities_for_config_model provider_config
+       with
+      | Some { Llm_provider.Capabilities.serving_constraint = Some _; _ } -> true
+      | Some _ | None -> false)
 ;;
 
 let finish_call ?on_provider_failure = function
@@ -186,33 +239,41 @@ let dispatch_sync
           ~trace_context
           ()
       in
-      (* Resolve the context limit first: it needs no network, so a pre-knowable
-         limit failure surfaces without wasting a [measure_request] round-trip. *)
-      match Llm_provider.Complete.resolve_context_limit prepared with
-      | Error error -> Error (fit_error ~binding error)
-      | Ok max_context_tokens ->
-        (match
-           Llm_provider.Complete.measure_request
-             ~sw
-             ~net:agent.net
-             ?clock
-             ?timeout_s:agent.options.body_timeout_s
-             prepared
-         with
-         | Error error -> Error (measurement_error ~binding error)
-         | Ok measured ->
-           (match Llm_provider.Complete.admit_request ~max_context_tokens measured with
-            | Error error -> Error (fit_error ~binding error)
-            | Ok admitted ->
-              Llm_provider.Complete.complete_admitted
+      (* Reject stale or future-dated evidence, then resolve the context limit.
+         Both are network-free and therefore precede token measurement. *)
+      match preflight_serving_constraint ~binding prepared with
+      | Error error -> Error error
+      | Ok () ->
+        (match Llm_provider.Complete.resolve_context_limit prepared with
+         | Error error -> Error (fit_error ~binding error)
+         | Ok max_context_tokens ->
+           (match
+              Llm_provider.Complete.measure_request
                 ~sw
                 ~net:agent.net
                 ?clock
-                ?transport:agent.options.transport
-                admitted
-                ?body_timeout_s:agent.options.body_timeout_s
-                ()
-              |> Result.map_error (Provider_failure_attribution.of_http_error ~binding)))
+                ?timeout_s:agent.options.body_timeout_s
+                prepared
+            with
+            | Error error ->
+              Error
+                (measurement_error
+                   ~binding
+                   ~constraint_:(Llm_provider.Complete.serving_constraint prepared)
+                   error)
+            | Ok measured ->
+              (match Llm_provider.Complete.admit_request ~max_context_tokens measured with
+               | Error error -> Error (fit_error ~binding error)
+               | Ok admitted ->
+                 Llm_provider.Complete.complete_admitted
+                   ~sw
+                   ~net:agent.net
+                   ?clock
+                   ?transport:agent.options.transport
+                   admitted
+                   ?body_timeout_s:agent.options.body_timeout_s
+                   ()
+                 |> Result.map_error (Provider_failure_attribution.of_http_error ~binding))))
     in
     if enforce_context_fit agent pc
     then finish_call ?on_provider_failure (admitted_call ())
@@ -278,34 +339,42 @@ let dispatch_stream
           ?body_timeout_s:agent.options.body_timeout_s
           ()
       in
-      (* Resolve the context limit first: it needs no network, so a pre-knowable
-         limit failure surfaces without wasting a [measure_request] round-trip. *)
-      match Llm_provider.Complete.resolve_context_limit prepared with
-      | Error error -> Error (fit_error ~binding error)
-      | Ok max_context_tokens ->
-        (match
-           Llm_provider.Complete.measure_request
-             ~sw
-             ~net:agent.net
-             ?clock
-             ?timeout_s:agent.options.body_timeout_s
-             prepared
-         with
-         | Error error -> Error (measurement_error ~binding error)
-         | Ok measured ->
-           (match Llm_provider.Complete.admit_request ~max_context_tokens measured with
-            | Error error -> Error (fit_error ~binding error)
-            | Ok admitted ->
-              Llm_provider.Complete.complete_stream_admitted
+      (* Reject stale or future-dated evidence, then resolve the context limit.
+         Both are network-free and therefore precede token measurement. *)
+      match preflight_serving_constraint ~binding prepared with
+      | Error error -> Error error
+      | Ok () ->
+        (match Llm_provider.Complete.resolve_context_limit prepared with
+         | Error error -> Error (fit_error ~binding error)
+         | Ok max_context_tokens ->
+           (match
+              Llm_provider.Complete.measure_request
                 ~sw
                 ~net:agent.net
                 ?clock
-                ?transport:agent.options.transport
-                admitted
-                ~on_event
-                ?on_telemetry
-                ()
-              |> Result.map_error (Provider_failure_attribution.of_http_error ~binding)))
+                ?timeout_s:agent.options.body_timeout_s
+                prepared
+            with
+            | Error error ->
+              Error
+                (measurement_error
+                   ~binding
+                   ~constraint_:(Llm_provider.Complete.serving_constraint prepared)
+                   error)
+            | Ok measured ->
+              (match Llm_provider.Complete.admit_request ~max_context_tokens measured with
+               | Error error -> Error (fit_error ~binding error)
+               | Ok admitted ->
+                 Llm_provider.Complete.complete_stream_admitted
+                   ~sw
+                   ~net:agent.net
+                   ?clock
+                   ?transport:agent.options.transport
+                   admitted
+                   ~on_event
+                   ?on_telemetry
+                   ()
+                 |> Result.map_error (Provider_failure_attribution.of_http_error ~binding))))
     in
     if enforce_context_fit agent pc
     then finish_call ?on_provider_failure (admitted_call ())

--- a/lib/pipeline/pipeline_stage_route.ml
+++ b/lib/pipeline/pipeline_stage_route.ml
@@ -132,15 +132,11 @@ let fit_error ~binding = function
             }))
 ;;
 
-let preflight_serving_constraint ~binding prepared =
+let preflight_serving_constraint ~binding ~now_unix_s prepared =
   match Llm_provider.Complete.serving_constraint prepared with
   | None -> Ok ()
   | Some constraint_ ->
-    (match
-       Llm_provider.Serving_constraint.check_evidence
-         ~now_unix_s:(int_of_float (Unix.gettimeofday ()))
-         constraint_
-     with
+    (match Llm_provider.Serving_constraint.check_evidence ~now_unix_s constraint_ with
      | Ok () -> Ok ()
      | Error reason ->
        Error
@@ -231,6 +227,7 @@ let dispatch_sync
       |> Result.map_error (Provider_failure_attribution.of_http_error ~binding)
     in
     let admitted_call () =
+      let now_unix_s = int_of_float (Unix.gettimeofday ()) in
       let prepared =
         Llm_provider.Complete.prepare_request
           ~config:pc
@@ -241,7 +238,7 @@ let dispatch_sync
       in
       (* Reject stale or future-dated evidence, then resolve the context limit.
          Both are network-free and therefore precede token measurement. *)
-      match preflight_serving_constraint ~binding prepared with
+      match preflight_serving_constraint ~binding ~now_unix_s prepared with
       | Error error -> Error error
       | Ok () ->
         (match Llm_provider.Complete.resolve_context_limit prepared with
@@ -262,7 +259,12 @@ let dispatch_sync
                    ~constraint_:(Llm_provider.Complete.serving_constraint prepared)
                    error)
             | Ok measured ->
-              (match Llm_provider.Complete.admit_request ~max_context_tokens measured with
+              (match
+                 Llm_provider.Complete.admit_request
+                   ~now_unix_s
+                   ~max_context_tokens
+                   measured
+               with
                | Error error -> Error (fit_error ~binding error)
                | Ok admitted ->
                  Llm_provider.Complete.complete_admitted
@@ -327,6 +329,7 @@ let dispatch_stream
       |> Result.map_error (Provider_failure_attribution.of_http_error ~binding)
     in
     let admitted_call () =
+      let now_unix_s = int_of_float (Unix.gettimeofday ()) in
       let prepared =
         Llm_provider.Complete.prepare_request
           ~config:pc
@@ -341,7 +344,7 @@ let dispatch_stream
       in
       (* Reject stale or future-dated evidence, then resolve the context limit.
          Both are network-free and therefore precede token measurement. *)
-      match preflight_serving_constraint ~binding prepared with
+      match preflight_serving_constraint ~binding ~now_unix_s prepared with
       | Error error -> Error error
       | Ok () ->
         (match Llm_provider.Complete.resolve_context_limit prepared with
@@ -362,7 +365,12 @@ let dispatch_stream
                    ~constraint_:(Llm_provider.Complete.serving_constraint prepared)
                    error)
             | Ok measured ->
-              (match Llm_provider.Complete.admit_request ~max_context_tokens measured with
+              (match
+                 Llm_provider.Complete.admit_request
+                   ~now_unix_s
+                   ~max_context_tokens
+                   measured
+               with
                | Error error -> Error (fit_error ~binding error)
                | Ok admitted ->
                  Llm_provider.Complete.complete_stream_admitted

--- a/lib/provider.mli
+++ b/lib/provider.mli
@@ -124,6 +124,7 @@ type task = Llm_provider.Capabilities.task =
    is checked against the source record by the compiler. *)
 type capabilities = Llm_provider.Capabilities.capabilities =
   { max_context_tokens : int option
+  ; serving_constraint : Llm_provider.Serving_constraint.t option
   ; max_output_tokens : int option
   ; supports_tools : bool
   ; supports_tool_choice : bool

--- a/lib/provider_runtime_binding.ml
+++ b/lib/provider_runtime_binding.ml
@@ -51,6 +51,7 @@ let public_capabilities (caps : Llm_provider.Capabilities.capabilities)
   : Provider.capabilities
   =
   { max_context_tokens = caps.max_context_tokens
+  ; serving_constraint = caps.serving_constraint
   ; max_output_tokens = caps.max_output_tokens
   ; supports_tools = caps.supports_tools
   ; supports_tool_choice = caps.supports_tool_choice

--- a/test/test_anthropic_input_token_count.ml
+++ b/test/test_anthropic_input_token_count.ml
@@ -492,8 +492,13 @@ let dispatch_tripwire dispatched =
 ;;
 
 let serving_constraint ?expires_at_unix_s () =
+  let source_kind =
+    match expires_at_unix_s with
+    | Some _ -> Serving_constraint.Probe
+    | None -> Serving_constraint.Declaration
+  in
   Serving_constraint.make
-    ~source_kind:Serving_constraint.Probe
+    ~source_kind
     ~source_ref:"probe://incident/2793"
     ~checked_at_unix_s:0
     ~confidence:Serving_constraint.High

--- a/test/test_anthropic_input_token_count.ml
+++ b/test/test_anthropic_input_token_count.ml
@@ -55,6 +55,7 @@ let config
       ?(request_path = "/proxy/messages")
       ?max_context
       ?max_concurrent_requests
+      ?model_capabilities_override
       base_url
   =
   Provider_config.make
@@ -76,6 +77,7 @@ let config
     ~supports_tool_choice_override:true
     ~output_schema:(`Assoc [ "type", `String "object" ])
     ?max_concurrent_requests
+    ?model_capabilities_override
     ()
 ;;
 
@@ -486,6 +488,157 @@ let dispatch_tripwire dispatched =
         dispatched := true;
         Ok response)
   }
+;;
+
+let serving_constraint ?expires_at_unix_s () =
+  Serving_constraint.make
+    ~source_kind:Serving_constraint.Probe
+    ~source_ref:"probe://incident/2793"
+    ~checked_at_unix_s:0
+    ~confidence:Serving_constraint.High
+    ?expires_at_unix_s
+    ~accepted_through:524298
+    ~rejected_from:524299
+    ()
+  |> Result.get_ok
+;;
+
+let constrained_capabilities base constraint_ =
+  { base with Capabilities.serving_constraint = Some constraint_ }
+;;
+
+let run_constrained_anthropic_count input_tokens =
+  let response = Printf.sprintf {|{"input_tokens":%d}|} input_tokens in
+  with_mock ~status:`OK ~response
+  @@ fun ~sw ~net ~base_url ->
+  let provider_config =
+    config
+      ~max_context:1048576
+      ~model_capabilities_override:
+        (constrained_capabilities
+           Capabilities.anthropic_capabilities
+           (serving_constraint ()))
+      base_url
+  in
+  let dispatched = ref false in
+  let transport = dispatch_tripwire dispatched in
+  let result =
+    Agent_sdk.Agent.run
+      ~sw
+      (build_admission_agent ~net ~provider_config ~transport ())
+      "same exact provider request"
+  in
+  result, !dispatched
+;;
+
+let test_serving_constraint_uses_exact_provider_count () =
+  let (accepted, accepted_dispatched), (_, _, accepted_body) =
+    run_constrained_anthropic_count 524298
+  in
+  let (rejected, rejected_dispatched), (_, _, rejected_body) =
+    run_constrained_anthropic_count 524299
+  in
+  check
+    string
+    "the measured provider request is byte-identical"
+    accepted_body
+    rejected_body;
+  (match accepted with
+   | Ok _ -> check bool "accepted observation dispatches" true accepted_dispatched
+   | Error error -> fail (Agent_sdk.Error.to_string error));
+  match rejected with
+  | Error
+      (Agent_sdk.Error.Api
+         (Retry.InputCapacity
+            { reason =
+                Retry.Serving_constraint_rejected
+                  (Serving_constraint.Input_rejected
+                     { input_tokens = 524299
+                     ; accepted_through = 524298
+                     ; rejected_from = 524299
+                     })
+            ; _
+            })) ->
+    check bool "rejected observation is zero-dispatch" false rejected_dispatched
+  | Error error -> fail (Agent_sdk.Error.to_string error)
+  | Ok _ -> fail "rejected exact token observation was dispatched"
+;;
+
+let test_stale_serving_constraint_fails_before_measurement () =
+  let dispatched = ref false in
+  let result, posts =
+    with_post_counter
+    @@ fun ~sw ~net ~base_url ->
+    let provider_config =
+      config
+        ~max_context:1048576
+        ~model_capabilities_override:
+          (constrained_capabilities
+             Capabilities.anthropic_capabilities
+             (serving_constraint ~expires_at_unix_s:1 ()))
+        base_url
+    in
+    Agent_sdk.Agent.run
+      ~sw
+      (build_admission_agent
+         ~net
+         ~provider_config
+         ~transport:(dispatch_tripwire dispatched)
+         ())
+      "stale evidence"
+  in
+  (match result with
+   | Error
+       (Agent_sdk.Error.Api
+          (Retry.InputCapacity
+             { reason =
+                 Retry.Serving_constraint_rejected (Serving_constraint.Evidence_expired _)
+             ; _
+             })) -> ()
+   | Error error -> fail (Agent_sdk.Error.to_string error)
+   | Ok _ -> fail "stale serving evidence was admitted");
+  check int "stale evidence makes no count request" 0 posts;
+  check bool "stale evidence makes no completion request" false !dispatched
+;;
+
+let test_unmeasurable_constraint_fails_typed_without_dispatch () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let dispatched = ref false in
+  let provider_config =
+    { (config
+         ~kind:Provider_config.OpenAI_compat
+         ~max_context:1048576
+         ~model_capabilities_override:
+           (constrained_capabilities
+              Capabilities.openai_compat_chat_capabilities
+              (serving_constraint ()))
+         "not-used")
+      with
+      output_schema = None
+    ; response_format = Off
+    }
+  in
+  let result =
+    Agent_sdk.Agent.run
+      ~sw
+      (build_admission_agent
+         ~net:(Eio.Stdenv.net env)
+         ~provider_config
+         ~transport:(dispatch_tripwire dispatched)
+         ())
+      "provider-native measurement is unavailable"
+  in
+  (match result with
+   | Error
+       (Agent_sdk.Error.Api
+          (Retry.InputCapacity { reason = Retry.Token_measurement_unavailable _; _ })) ->
+     ()
+   | Error error -> fail (Agent_sdk.Error.to_string error)
+   | Ok _ -> fail "unmeasurable constrained request was dispatched");
+  check bool "unmeasurable constraint is zero-dispatch" false !dispatched
 ;;
 
 (* Regression for #2678: [Pipeline_stage_route.dispatch_sync] /
@@ -986,6 +1139,18 @@ let () =
             "resolve before measure skips count round-trip (stream)"
             `Quick
             test_resolve_before_measure_skips_count_roundtrip_stream
+        ; test_case
+            "serving boundary uses exact provider count"
+            `Quick
+            test_serving_constraint_uses_exact_provider_count
+        ; test_case
+            "stale serving evidence is zero-I/O"
+            `Quick
+            test_stale_serving_constraint_fails_before_measurement
+        ; test_case
+            "unmeasurable serving constraint is typed zero-dispatch"
+            `Quick
+            test_unmeasurable_constraint_fails_typed_without_dispatch
         ; test_case
             "measurement validates before I/O"
             `Quick

--- a/test/test_anthropic_input_token_count.ml
+++ b/test/test_anthropic_input_token_count.ml
@@ -349,7 +349,7 @@ let test_prepared_measure_admit_dispatch () =
       | Error _ -> fail "expected resolved context limit"
     in
     let admitted =
-      match Complete.admit_request ~max_context_tokens measured with
+      match Complete.admit_request ~now_unix_s:0 ~max_context_tokens measured with
       | Ok admitted -> admitted
       | Error _ -> fail "expected prepared request admission"
     in
@@ -403,7 +403,8 @@ let test_prepared_context_overflow_is_typed () =
     | Ok measured ->
       (match Complete.resolve_context_limit prepared with
        | Error _ -> fail "expected resolved context limit"
-       | Ok max_context_tokens -> Complete.admit_request ~max_context_tokens measured)
+       | Ok max_context_tokens ->
+         Complete.admit_request ~now_unix_s:0 ~max_context_tokens measured)
   in
   match result with
   | Error
@@ -426,7 +427,7 @@ let test_prepared_admission_resolves_catalog_context_limit () =
     let prepared = Complete.prepare_request ~config:cfg ~messages ~tools:[ tool ] () in
     let measured = Complete.measure_request ~sw ~net prepared |> Result.get_ok in
     let max_context_tokens = Complete.resolve_context_limit prepared |> Result.get_ok in
-    Complete.admit_request ~max_context_tokens measured, expected
+    Complete.admit_request ~now_unix_s:0 ~max_context_tokens measured, expected
   in
   match result with
   | Error _, _ -> fail "catalog-backed context admission unexpectedly failed"

--- a/test/test_exact_output_flow.ml
+++ b/test/test_exact_output_flow.ml
@@ -28,10 +28,19 @@ type catalog_fixture =
   ; native : bool
   ; json : bool
   ; body_timeout_s : float option
+  ; serving_constraint : bool
   }
 
-let catalog_entry ?body_timeout_s ~id ~base_url ~native ~json () =
-  { id; base_url; native; json; body_timeout_s }
+let catalog_entry
+      ?body_timeout_s
+      ?(serving_constraint = false)
+      ~id
+      ~base_url
+      ~native
+      ~json
+      ()
+  =
+  { id; base_url; native; json; body_timeout_s; serving_constraint }
 ;;
 
 let catalog_fixture_toml entry =
@@ -47,7 +56,7 @@ let catalog_fixture_toml entry =
      provider_name = %S\n\
      max_context_tokens = 8192\n\
      max_output_tokens = 1024\n\
-     supports_response_format_json = %b\n\
+     %ssupports_response_format_json = %b\n\
      supports_structured_output = %b\n\n\
      [[targets]]\n\
      id = %S\n\
@@ -58,6 +67,15 @@ let catalog_fixture_toml entry =
     entry.base_url
     (entry.id ^ "-model")
     entry.id
+    (if entry.serving_constraint
+     then
+       "serving_constraint_source_kind = \"probe\"\n\
+        serving_constraint_source = \"probe://incident/2793\"\n\
+        serving_constraint_checked_at_unix_s = 0\n\
+        serving_constraint_confidence = \"high\"\n\
+        serving_constraint_accepted_through_tokens = 524298\n\
+        serving_constraint_rejected_from_tokens = 524299\n"
+     else "")
     entry.json
     entry.native
     entry.id
@@ -265,6 +283,46 @@ let test_admission_freezes_all_candidates_before_network () =
                (EO.receipt_call_id right.receipt |> EO.call_id_to_string))))
     evidence_a.attempts
     evidence_b.attempts
+;;
+
+let test_unmeasured_constraint_rejects_exact_candidate_before_network () =
+  let admissions, posts =
+    with_server ~response:(openai_response {|{"name":"unused"}|})
+    @@ fun ~sw:_ ~net:_ ~clock:_ ~base_url ->
+    with_catalog
+      [ catalog_entry
+          ~id:"constrained-exact"
+          ~base_url
+          ~native:true
+          ~json:true
+          ~serving_constraint:true
+          ()
+      ; catalog_entry ~id:"unconstrained-exact" ~base_url ~native:true ~json:true ()
+      ]
+    @@ fun snapshot ->
+    let ready = ready_flow snapshot [ "constrained-exact"; "unconstrained-exact" ] in
+    EO.ready_flow_admissions ready
+  in
+  check int "exact admission makes no POST" 0 posts;
+  match admissions with
+  | [ EO.Candidate_rejected
+        { identity
+        ; cause = EO.Wire_admission_rejected (EO.Token_measurement_required constraint_)
+        }
+    ; EO.Candidate_admitted admitted
+    ] ->
+    check string "constrained identity" "constrained-exact" identity.candidate_id;
+    check
+      int
+      "constraint remains exact"
+      524298
+      constraint_.Serving_constraint.observation.accepted_through;
+    check
+      string
+      "unconstrained successor remains available"
+      "unconstrained-exact"
+      admitted.identity.candidate_id
+  | _ -> fail "unmeasured exact candidate did not fail closed before its successor"
 ;;
 
 let test_predispatch_transport_failure_advances_after_durable_callback () =
@@ -782,6 +840,10 @@ let () =
             "all admissions freeze before network"
             `Quick
             test_admission_freezes_all_candidates_before_network
+        ; test_case
+            "unmeasured constraint rejects before network"
+            `Quick
+            test_unmeasured_constraint_rejects_exact_candidate_before_network
         ; test_case
             "predispatch transport failure advances durably"
             `Quick

--- a/test/test_exact_output_flow.ml
+++ b/test/test_exact_output_flow.ml
@@ -73,6 +73,7 @@ let catalog_fixture_toml entry =
         serving_constraint_source = \"probe://incident/2793\"\n\
         serving_constraint_checked_at_unix_s = 0\n\
         serving_constraint_confidence = \"high\"\n\
+        serving_constraint_expires_at_unix_s = 2000000000\n\
         serving_constraint_accepted_through_tokens = 524298\n\
         serving_constraint_rejected_from_tokens = 524299\n"
      else "")

--- a/test/test_model_catalog_default.ml
+++ b/test/test_model_catalog_default.ml
@@ -1,6 +1,7 @@
 open Alcotest
 module Capabilities = Llm_provider.Capabilities
 module Model_catalog = Llm_provider.Model_catalog
+module Serving_constraint = Llm_provider.Serving_constraint
 
 let first_id_prefix ~suite catalog =
   match Model_catalog.model_entries catalog with
@@ -62,6 +63,107 @@ let test_global_loads_default_catalog_for_capabilities () =
         model_id)
 ;;
 
+let constraint_catalog ?expires_at ?rejected_from () =
+  Printf.sprintf
+    "[[models]]\n\
+     id_prefix = \"evidence-model\"\n\
+     provider_name = \"evidence-runtime\"\n\
+     max_context_tokens = 1048576\n\
+     serving_constraint_source_kind = \"probe\"\n\
+     serving_constraint_source = \"probe://incident/2793\"\n\
+     serving_constraint_checked_at_unix_s = 100\n\
+     serving_constraint_confidence = \"high\"\n\
+     %sserving_constraint_accepted_through_tokens = 524298\n\
+     %s"
+    (Option.fold
+       ~none:""
+       ~some:(Printf.sprintf "serving_constraint_expires_at_unix_s = %d\n")
+       expires_at)
+    (Option.fold
+       ~none:""
+       ~some:(Printf.sprintf "serving_constraint_rejected_from_tokens = %d\n")
+       rejected_from)
+;;
+
+let parsed_constraint toml =
+  match Model_catalog.of_toml_string ~source:"serving constraint fixture" toml with
+  | Error message -> fail message
+  | Ok catalog ->
+    (match Model_catalog.model_entries catalog with
+     | [ { Model_catalog.serving_constraint = Some constraint_; _ } ] -> constraint_
+     | _ -> fail "expected exactly one model with one serving constraint")
+;;
+
+let test_serving_constraint_projects_exact_interval () =
+  let constraint_ =
+    parsed_constraint (constraint_catalog ~expires_at:200 ~rejected_from:524299 ())
+  in
+  check
+    bool
+    "accepted observation is admitted"
+    true
+    (Serving_constraint.admit ~now_unix_s:150 ~input_tokens:524298 constraint_ = Ok ());
+  match Serving_constraint.admit ~now_unix_s:150 ~input_tokens:524299 constraint_ with
+  | Error
+      (Serving_constraint.Input_rejected
+         { input_tokens = 524299; accepted_through = 524298; rejected_from = 524299 }) ->
+    ()
+  | Ok () | Error _ -> fail "rejected observation did not remain exact"
+;;
+
+let test_serving_constraint_stale_evidence_fails_closed () =
+  let constraint_ =
+    parsed_constraint (constraint_catalog ~expires_at:200 ~rejected_from:524299 ())
+  in
+  match Serving_constraint.check_evidence ~now_unix_s:200 constraint_ with
+  | Error
+      (Serving_constraint.Evidence_expired { now_unix_s = 200; expires_at_unix_s = 200 })
+    -> ()
+  | Ok () | Error _ -> fail "expired serving evidence was accepted"
+;;
+
+let test_catalog_only_runtime_projects_serving_constraint () =
+  let catalog =
+    Model_catalog.of_toml_string
+      ~source:"catalog-only serving constraint fixture"
+      (constraint_catalog ~expires_at:200 ~rejected_from:524299 ())
+    |> Result.get_ok
+  in
+  with_clean_model_catalog_override (fun () ->
+    Model_catalog.set_global catalog;
+    match
+      Capabilities.for_provider_model_id
+        ~allow_bare_fallback:false
+        ~provider_label:"evidence-runtime"
+        ~model_id:"evidence-model"
+    with
+    | Some { Capabilities.serving_constraint = Some constraint_; _ } ->
+      check
+        int
+        "resolved runtime preserves observed acceptance"
+        524298
+        constraint_.Serving_constraint.observation.accepted_through
+    | Some _ | None -> fail "catalog-only normal runtime lost its serving constraint")
+;;
+
+let test_serving_constraint_partial_group_fails_closed () =
+  match
+    Model_catalog.of_toml_string
+      ~source:"partial serving constraint fixture"
+      "[[models]]\n\
+       id_prefix = \"partial-evidence\"\n\
+       serving_constraint_source_kind = \"probe\"\n\
+       serving_constraint_accepted_through_tokens = 524298\n"
+  with
+  | Error message ->
+    check
+      bool
+      "diagnostic identifies the grouped declaration"
+      true
+      (String.starts_with ~prefix:"model entry \"partial-evidence\"" message)
+  | Ok _ -> fail "partial serving-constraint declaration must fail closed"
+;;
+
 let () =
   run
     "model catalog default"
@@ -75,6 +177,22 @@ let () =
             "global uses embedded default"
             `Quick
             test_global_loads_default_catalog_for_capabilities
+        ; test_case
+            "serving constraint preserves exact interval"
+            `Quick
+            test_serving_constraint_projects_exact_interval
+        ; test_case
+            "stale serving evidence fails closed"
+            `Quick
+            test_serving_constraint_stale_evidence_fails_closed
+        ; test_case
+            "catalog-only runtime projects serving evidence"
+            `Quick
+            test_catalog_only_runtime_projects_serving_constraint
+        ; test_case
+            "partial serving evidence fails closed"
+            `Quick
+            test_serving_constraint_partial_group_fails_closed
         ] )
     ]
 ;;

--- a/test/test_model_catalog_default.ml
+++ b/test/test_model_catalog_default.ml
@@ -122,6 +122,21 @@ let test_serving_constraint_stale_evidence_fails_closed () =
   | Ok () | Error _ -> fail "expired serving evidence was accepted"
 ;;
 
+let test_probe_serving_constraint_requires_expiry () =
+  match
+    Serving_constraint.make
+      ~source_kind:Serving_constraint.Probe
+      ~source_ref:"probe://incident/2793"
+      ~checked_at_unix_s:100
+      ~confidence:Serving_constraint.Medium
+      ~accepted_through:524298
+      ~rejected_from:524299
+      ()
+  with
+  | Error Serving_constraint.Missing_probe_expiry -> ()
+  | Error _ | Ok _ -> fail "probe evidence without explicit expiry was accepted"
+;;
+
 let test_catalog_only_runtime_projects_serving_constraint () =
   let catalog =
     Model_catalog.of_toml_string
@@ -185,6 +200,10 @@ let () =
             "stale serving evidence fails closed"
             `Quick
             test_serving_constraint_stale_evidence_fails_closed
+        ; test_case
+            "probe serving evidence requires expiry"
+            `Quick
+            test_probe_serving_constraint_requires_expiry
         ; test_case
             "catalog-only runtime projects serving evidence"
             `Quick


### PR DESCRIPTION
## Summary

- add a provider/model-neutral `Serving_constraint` with exact observed interval, provenance, confidence, checked time, and declaration-optional expiry
- require every `Probe` observation to declare its own expiry; OAS invents no default TTL
- project the immutable constraint through catalog capabilities, normal Agent runtime admission, error-domain evidence, and exact-output catalog fingerprints
- return typed zero-dispatch `InputCapacity` for rejected/stale/unknown measurements; never infer capacity from provider/model/URL/error prose
- fail closed when a constrained runtime has no provider-native token measurement contract, preserving the typed reason for outer failover
- reject an unmeasured constrained exact-output candidate before network while leaving later flow candidates available

## Important boundary

This PR does **not** pretend Ollama/OpenAI-compatible endpoints expose an exact preflight token counter. A constrained target without such a contract returns typed `Token_measurement_unavailable` before completion dispatch. The MASC follow-up consumes that typed outcome for lane failover. This avoids the unnamed 400 without inventing tokenizer math.

`source_kind = Probe` does not imply an automatic re-probe daemon. Probe evidence is rejected at catalog construction unless it has an explicit expiry. The catalog owner that publishes it owns replacing it with a new checked observation before expiry. Expired evidence deliberately becomes typed zero-dispatch `Evidence_expired`; it never silently extends itself. This PR therefore adds no flash constraint row and invents no TTL policy.

Capability manifests intentionally cannot declare a serving constraint: they lack the required provenance and validity fields. Evidence-backed constraints enter through the model catalog path only.

## Rollout order

1. Merge and release this OAS typed boundary.
2. Pin that release in MASC and deploy the typed compaction/lane-failover consumer.
3. Only then publish an endpoint/model-scoped serving-constraint row with explicit source, checked time, confidence, and operator-chosen expiry.
4. Resolve a fresh ready plan and verify zero completion dispatch plus next-lane progress before enabling the row broadly.

Publishing a constraint before step 2 can intentionally fail closed an unmeasurable lane without giving the downstream keeper a continuation path, so the order is part of the operational contract.

## Compatibility

- the exact functional capability projection moves to v2 because serving-constraint evidence changes admission behavior
- the full evidence identity is fingerprinted: refreshing checked time, expiry, source, or confidence creates a new immutable ready-plan generation; an already-frozen plan is not mutated
- normal route preflight and final admission receive the same request-scoped Unix timestamp; pure admission requires the timestamp explicitly
- legacy provider-only `Error.t` cannot preserve `InputCapacity`; the Agent SDK API/error-domain path remains the typed consumer surface

## Proof

- `scripts/dune-local.sh build @check test/test_model_catalog_default.exe test/test_anthropic_input_token_count.exe test/test_exact_output_flow.exe`
- `scripts/dune-local.sh exec test/test_model_catalog_default.exe` (8 tests)
- `scripts/dune-local.sh exec test/test_anthropic_input_token_count.exe` (28 tests)
- `scripts/dune-local.sh exec test/test_exact_output_flow.exe` (10 tests)
- focused exact catalog inline partition: 3 tests
- adjacent error/retry/capability/runtime-binding/catalog/exact-resolver suites: 244 tests passed
- `scripts/hardening-ratchet.sh`
- `scripts/ci-code-smell-ratchet.sh`

## Acceptance evidence

- catalog-only normal runtime projects the constraint
- byte-identical count requests returning 524,298 vs 524,299 produce admitted vs typed zero-dispatch outcomes
- probe evidence without explicit expiry is rejected at construction
- expired evidence performs zero count requests and zero completion dispatches
- unsupported token measurement performs zero completion dispatches
- exact-output constrained candidate is rejected before network and the next candidate remains admitted

Refs jeong-sik/masc#27864