### PR TITLE
fix(exact-output): settle current-candidate admission

### DIFF
--- a/docs/design/exact-output-flow-boundary.md
+++ b/docs/design/exact-output-flow-boundary.md
@@ -25,28 +25,36 @@ The caller owns:
 The outer flow is generic. It contains no coordinator vocabulary and no
 provider, model, tier, price, query-intent, or error-string policy.
 
-## Immutable admission
+## Immutable flow snapshot
 
-An outer flow is a nonempty ordered snapshot. OAS admits every candidate and
-freezes every successful exact plan before it creates an attempt or performs a
-network effect. The ordered admission evidence retains both successes and typed
-rejections. A flow can start only when at least one candidate admitted.
+An outer flow freezes one nonempty ordered candidate snapshot and one immutable
+domain input. It does not prepare every candidate speculatively. Starting the
+flow creates only the affine flow handle; it performs no target admission, call
+identity allocation, or network effect.
 
-Starting a ready flow creates one fresh exact attempt per admitted candidate.
-Attempts are never shared between candidates or between two starts of the same
-ready flow.
+During execution, OAS prepares only the current candidate. Successful
+preparation freezes one ready plan and receives one fresh non-shared attempt.
+Rejected candidates receive no plan, call ID, or execution receipt.
 
 ## Execution
 
 `execute_flow_once` is affine. A duplicate or concurrent invocation cannot
 dispatch. For each predetermined candidate:
 
-1. The caller's `before_dispatch` callback must confirm its durable binding.
-2. OAS invokes the unchanged single-plan `execute_once`.
-3. OAS may select the next admitted candidate only for a first-use transport
-   failure whose exact receipt is `Before_dispatch` with `dispatch_count = 0`.
-4. The caller's `before_advance` callback must durably confirm release before
-   OAS enters that already-selected successor.
+1. OAS increments the typed candidate-attempt count and prepares the current
+   exact target and contract.
+2. A typed admission rejection receives an immutable admission receipt fixed at
+   `Before_dispatch` and `dispatch_count = 0`; it does not enter
+   `before_dispatch`.
+3. For an admitted candidate, the caller's `before_dispatch` callback must
+   confirm its durable binding before OAS invokes the unchanged single-plan
+   `execute_once`.
+4. OAS may select the next frozen candidate only after either that admission
+   receipt or a first-use transport failure whose exact execution receipt is
+   `Before_dispatch` with `dispatch_count = 0`.
+5. The caller's `before_advance` callback receives the settled typed failure and
+   the next frozen candidate identity, and must durably confirm release before
+   OAS prepares that successor.
 
 Callbacks can stop a transition but cannot select, replace, or reorder a
 candidate.
@@ -59,6 +67,7 @@ The following outcomes are terminal:
 - a missing execution prerequisite or frozen-request invariant failure;
 - any receipt with `dispatch_count > 0`;
 - response, partial, tool, structural-output, or normalization exposure;
+- a final typed admission rejection;
 - success.
 
 Domain validation occurs only after an OAS success. A caller-side domain
@@ -68,10 +77,13 @@ rejection therefore cannot trigger another provider dispatch.
 
 Every terminal result carries:
 
-- the original ordered admission outcomes;
-- the immutable candidate identities and plan provenance;
-- every non-shared attempt receipt, including unstarted successors;
-- the exact success or execution failure for the terminal candidate.
+- the original immutable candidate identity snapshot;
+- the monotonic typed candidate-attempt count;
+- ordered admission outcomes only for candidates reached so far;
+- every non-shared execution receipt allocated for an admitted current
+  candidate;
+- the exact admission rejection, success, or execution failure for the
+  terminal candidate.
 
 After cancellation escapes, the same aggregate evidence remains queryable from
 the opaque flow attempt.

--- a/docs/design/exact-output-flow-boundary.md
+++ b/docs/design/exact-output-flow-boundary.md
@@ -8,8 +8,9 @@ Effective: 2026-07-23
 `Agent_sdk.Exact_output` is the single public surface for exact structured
 output. OAS owns:
 
-- immutable resolver and target snapshots;
+- immutable resolver snapshots and catalog-admitted opaque target handles;
 - provider-wire admission and separately frozen candidate plans;
+- one fresh outer-flow identity with immutable, preordered candidate visits;
 - fresh, non-shared attempt identities;
 - one-plan, at-most-one-dispatch `execute_once`;
 - monotonic phase, dispatch-count, response, and provenance receipts;
@@ -27,45 +28,50 @@ provider, model, tier, price, query-intent, or error-string policy.
 
 ## Immutable flow snapshot
 
-An outer flow freezes one nonempty ordered candidate snapshot and one immutable
-domain input. It does not prepare every candidate speculatively. Starting the
-flow creates only the affine flow handle; it performs no target admission, call
-identity allocation, or network effect.
+An outer flow freezes one nonempty ordered candidate snapshot, its
+catalog-admitted opaque target handles, and one immutable domain input. Catalog
+membership and credential outcomes are frozen, but credentials remain
+unselected. Starting the flow allocates one OAS-owned outer-flow identity and
+precomputes one immutable visit `(flow ID, 1-based ordinal, candidate identity)`
+for every frozen candidate. This performs no credential selection, request
+admission, call identity allocation, callback, or network effect.
 
-During execution, OAS prepares only the current candidate. Successful
-preparation freezes one ready plan and receives one fresh non-shared attempt.
-Rejected candidates receive no plan, call ID, or execution receipt.
+During execution, OAS resolves the frozen credential outcome and prepares only
+the current candidate. Successful request admission freezes one ready plan and
+receives one fresh non-shared attempt. A target-selection or request-admission
+rejection receives no plan, call ID, or execution receipt.
 
 ## Execution
 
 `execute_flow_once` is affine. A duplicate or concurrent invocation cannot
 dispatch. For each predetermined candidate:
 
-1. OAS increments the typed candidate-attempt count and prepares the current
-   exact target and contract.
-2. A typed admission rejection receives an immutable admission receipt fixed at
-   `Before_dispatch` and `dispatch_count = 0`; it does not enter
+1. OAS resolves only the current precomputed visit's frozen target and admits
+   its exact request contract.
+2. A typed target-selection or request-admission rejection receives an
+   immutable candidate-rejection receipt fixed at `Before_dispatch` and
+   `dispatch_count = 0`; it does not enter
    `before_dispatch`.
 3. For an admitted candidate, the caller's `before_dispatch` callback must
    confirm its durable binding before OAS invokes the unchanged single-plan
    `execute_once`.
-4. OAS may select the next frozen candidate only after either that admission
-   receipt or a first-use transport failure whose exact execution receipt is
-   `Before_dispatch` with `dispatch_count = 0`.
+4. OAS may select the next frozen candidate only after either that candidate
+   rejection receipt or a first-use transport failure whose exact execution
+   receipt is `Before_dispatch` with `dispatch_count = 0`.
 5. The caller's `before_advance` callback receives the settled typed failure and
-   the next frozen candidate identity, and must durably confirm release before
+   the predetermined successor visit, and must durably confirm release before
    OAS prepares that successor.
 
 Callbacks can stop a transition but cannot select, replace, or reorder a
 candidate.
 
-Advance eligibility is effect-based, not a classifier over admission-error
-causes. Every typed admission rejection is pre-dispatch and zero-dispatch, so
-it is eligible for the predetermined successor. OAS does not infer that a
-schema or requirement rejection must behave identically across opaque targets.
-Target-specific schema validators and capability admission can emit the same
-public error variant, so the cause alone is not proof that an unvisited
-candidate must reject the contract.
+Advance eligibility is effect-based, not a classifier over rejection causes.
+Every typed target-selection or request-admission rejection is pre-dispatch and
+zero-dispatch, so it is eligible for the predetermined successor. OAS does not
+infer that a credential, schema, or requirement rejection must behave
+identically across opaque targets. Target-specific credential outcomes, schema
+validators, and capability admission are evidence about the visited candidate,
+not proof that an unvisited candidate must reject the contract.
 
 The following outcomes are terminal:
 
@@ -75,7 +81,7 @@ The following outcomes are terminal:
 - a missing execution prerequisite or frozen-request invariant failure;
 - any receipt with `dispatch_count > 0`;
 - response, partial, tool, structural-output, or normalization exposure;
-- a final typed admission rejection;
+- a final typed candidate rejection, reported as `Flow_candidates_exhausted`;
 - success.
 
 Domain validation occurs only after an OAS success. A caller-side domain
@@ -83,29 +89,44 @@ rejection therefore cannot trigger another provider dispatch.
 
 ## Evidence
 
-Every terminal result carries:
+Every flow evidence projection carries:
 
+- the fresh outer-flow identity;
 - the original immutable candidate identity snapshot;
-- the monotonic typed candidate-attempt count;
+- the monotonic typed candidate-visit count;
 - ordered admission outcomes only for candidates reached so far;
 - every non-shared execution receipt allocated for an admitted current
   candidate;
-- the exact admission rejection, success, or execution failure for the
-  terminal candidate.
+
+Terminal variants that settle a candidate additionally carry its exact
+rejection, success, or execution failure. The `admitted_flow_candidate` and
+`flow_attempt_receipt` wrappers embed the same precomputed visit; a rejection
+embeds that visit without fabricating a plan, call ID, or execution receipt. A
+new `start_flow` always allocates a new flow identity; restart resume is
+unsupported here and belongs to the caller's authenticated lease or operation
+journal.
 
 After cancellation escapes, the same aggregate evidence remains queryable from
 the opaque flow attempt.
 
 The affine executor is the sole progress writer. Concurrent evidence readers
-may observe the exact intermediate point after admission is recorded and before
-an admitted candidate receives its fresh attempt. Such a snapshot is
-point-in-time evidence, not a fabricated attempt or a terminal state.
+may observe the exact intermediate point after a successful request admission
+is recorded and before that candidate receives its fresh attempt. Such a
+snapshot is point-in-time evidence, not a fabricated attempt or a terminal
+state.
 
 ## Explicit exclusions
 
 - `execute_once` never retries and never changes plans.
 - The outer flow performs no weighted, health, cost, or latency routing.
 - Pricing is measurement evidence only and is absent from all decisions.
+- Public flow rejections expose provider-neutral dispositions and capacity
+  bounds only; provider, model, endpoint, credential environment, schema path,
+  and raw serving-evidence source remain private to OAS.
+- Resolver bootstrap and direct-execution diagnostics remain OAS integration
+  surfaces, not MASC control inputs. MASC consumers may import only the outer
+  flow's provider-neutral visit, disposition, receipt, and provenance
+  projections.
 - There is no legacy cascade API, compatibility wrapper, or persisted runtime
   JSON migration.
 - Before 1.0, obsolete runtime assets are reset rather than reconciled.

--- a/docs/design/exact-output-flow-boundary.md
+++ b/docs/design/exact-output-flow-boundary.md
@@ -59,6 +59,14 @@ dispatch. For each predetermined candidate:
 Callbacks can stop a transition but cannot select, replace, or reorder a
 candidate.
 
+Advance eligibility is effect-based, not a classifier over admission-error
+causes. Every typed admission rejection is pre-dispatch and zero-dispatch, so
+it is eligible for the predetermined successor. OAS does not infer that a
+schema or requirement rejection must behave identically across opaque targets.
+Target-specific schema validators and capability admission can emit the same
+public error variant, so the cause alone is not proof that an unvisited
+candidate must reject the contract.
+
 The following outcomes are terminal:
 
 - callback failure or exception;
@@ -87,6 +95,11 @@ Every terminal result carries:
 
 After cancellation escapes, the same aggregate evidence remains queryable from
 the opaque flow attempt.
+
+The affine executor is the sole progress writer. Concurrent evidence readers
+may observe the exact intermediate point after admission is recorded and before
+an admitted candidate receives its fresh attempt. Such a snapshot is
+point-in-time evidence, not a fabricated attempt or a terminal state.
 
 ## Explicit exclusions
 

--- a/lib/llm_provider/dune
+++ b/lib/llm_provider/dune
@@ -16,6 +16,7 @@
   exact_output_call_id
   exact_output_resolver
   exact_output_execution
+  exact_output_gemini_schema
   exact_output_flow
   exact_output_plan)
  (libraries

--- a/lib/llm_provider/exact_output.ml
+++ b/lib/llm_provider/exact_output.ml
@@ -865,7 +865,13 @@ let record_candidate_rejection flow visit cause =
   rejection
 ;;
 
-let execute_flow_candidate ~net ?clock ~before_dispatch flow candidate =
+let execute_flow_candidate
+      ~net
+      ?clock
+      ~before_dispatch
+      flow
+      (candidate : flow_candidate_step)
+  =
   let reject cause =
     let rejection = record_candidate_rejection flow candidate.visit cause in
     Error (Flow_step_candidate_rejected rejection)

--- a/lib/llm_provider/exact_output.ml
+++ b/lib/llm_provider/exact_output.ml
@@ -156,6 +156,14 @@ type flow_candidate =
   ; target : selected_target
   }
 
+type candidate_attempt_count = Candidate_attempt_count of int
+
+type admission_rejection_receipt =
+  { identity : flow_candidate_identity
+  ; cause : admission_error
+  ; candidate_attempt_count : candidate_attempt_count
+  }
+
 type admitted_flow_candidate =
   { identity : flow_candidate_identity
   ; plan_fingerprint : string
@@ -165,59 +173,43 @@ type admitted_flow_candidate =
 
 type candidate_admission =
   | Candidate_admitted of admitted_flow_candidate
-  | Candidate_rejected of
-      { identity : flow_candidate_identity
-      ; cause : admission_error
-      }
+  | Candidate_rejected of admission_rejection_receipt
 
-type ready_flow_candidate =
-  { evidence : admitted_flow_candidate
-  ; plan : ready_plan
+type flow_snapshot =
+  { candidates : flow_candidate list
+  ; messages : Types.message list
+  ; requirement : output_requirement
   }
-
-type ready_flow =
-  { admissions : candidate_admission list
-  ; candidates : ready_flow_candidate list
-  }
-
-type flow_attempt_candidate =
-  { evidence : admitted_flow_candidate
-  ; attempt : attempt
-  }
-
-type flow_attempt =
-  { execution : Flow_state.t
-  ; admissions : candidate_admission list
-  ; candidates : flow_attempt_candidate list
-  }
-
-type flow_candidate_error = Blank_flow_candidate_id
-
-type flow_admission_error =
-  | Duplicate_flow_candidate_id of
-      { candidate_id : string
-      ; first_position : int
-      ; duplicate_position : int
-      }
-  | No_admitted_flow_candidates of candidate_admission list
-
-type start_attempt_error = Call_id_generation_failed of string
-
-type flow_start_error =
-  | Flow_candidate_attempt_start_failed of
-      { identity : flow_candidate_identity
-      ; position : int
-      ; cause : start_attempt_error
-      ; admissions : candidate_admission list
-      }
 
 type flow_attempt_receipt =
   { identity : flow_candidate_identity
   ; receipt : receipt
   }
 
+type flow_attempt =
+  { execution : Flow_state.t
+  ; candidate_snapshot : flow_candidate_identity list
+  ; candidates : flow_candidate list
+  ; messages : Types.message list
+  ; requirement : output_requirement
+  ; progress : (candidate_admission, flow_attempt_receipt) Flow_state.progress
+  }
+
+type flow_candidate_error = Blank_flow_candidate_id
+
+type flow_snapshot_error =
+  | Duplicate_flow_candidate_id of
+      { candidate_id : string
+      ; first_position : int
+      ; duplicate_position : int
+      }
+
+type start_attempt_error = Call_id_generation_failed of string
+
 type flow_evidence =
-  { admissions : candidate_admission list
+  { candidate_snapshot : flow_candidate_identity list
+  ; candidate_attempt_count : candidate_attempt_count
+  ; admissions : candidate_admission list
   ; attempts : flow_attempt_receipt list
   }
 
@@ -227,18 +219,34 @@ type flow_success =
   ; evidence : flow_evidence
   }
 
+type flow_candidate_failure =
+  | Flow_candidate_admission_rejected of admission_rejection_receipt
+  | Flow_candidate_execution_failed of
+      { candidate : flow_attempt_receipt
+      ; cause : execution_error
+      ; candidate_attempt_count : candidate_attempt_count
+      }
+
 type 'callback_error flow_execution_error =
   | Flow_attempt_already_started of flow_evidence
+  | Flow_attempt_start_failed of
+      { candidate : flow_candidate_identity
+      ; cause : start_attempt_error
+      ; evidence : flow_evidence
+      }
   | Flow_before_dispatch_callback_failed of
       { candidate : flow_attempt_receipt
       ; cause : 'callback_error
       ; evidence : flow_evidence
       }
   | Flow_before_advance_callback_failed of
-      { failed : flow_attempt_receipt
-      ; failure : execution_error
-      ; next : flow_attempt_receipt
+      { failed : flow_candidate_failure
+      ; next : flow_candidate_identity
       ; cause : 'callback_error
+      ; evidence : flow_evidence
+      }
+  | Flow_admission_failed of
+      { rejection : admission_rejection_receipt
       ; evidence : flow_evidence
       }
   | Flow_exact_execution_failed of
@@ -246,6 +254,12 @@ type 'callback_error flow_execution_error =
       ; cause : execution_error
       ; evidence : flow_evidence
       }
+
+type 'callback_error flow_step_failure =
+  | Flow_step_admission_rejected of admission_rejection_receipt
+  | Flow_step_attempt_start_failed of flow_candidate_identity * start_attempt_error
+  | Flow_step_before_dispatch_callback_failed of flow_attempt_receipt * 'callback_error
+  | Flow_step_execution_failed of flow_candidate_failure
 
 let ( let* ) = Result.bind
 
@@ -583,53 +597,20 @@ let make_flow_candidate ~id ~target =
 let flow_candidate_identity (candidate : flow_candidate) = candidate.identity
 
 let duplicate_flow_candidate_id (candidates : flow_candidate list) =
-  let rec find position seen = function
-    | [] -> None
-    | (candidate : flow_candidate) :: rest ->
-      let candidate_id = candidate.identity.candidate_id in
-      (match
-         List.find_opt (fun (seen_id, _) -> String.equal seen_id candidate_id) seen
-       with
-       | Some (_, first_position) ->
-         Some
-           (Duplicate_flow_candidate_id
-              { candidate_id; first_position; duplicate_position = position })
-       | None -> find (position + 1) ((candidate_id, position) :: seen) rest)
-  in
-  find 1 [] candidates
+  Flow_state.duplicate_key
+    ~equal:String.equal
+    ~key:(fun (candidate : flow_candidate) -> candidate.identity.candidate_id)
+    candidates
+  |> Option.map (fun (candidate_id, first_position, duplicate_position) ->
+    Duplicate_flow_candidate_id { candidate_id; first_position; duplicate_position })
 ;;
 
-let admit_flow ~first ~rest ~messages requirement =
+let snapshot_flow ~first ~rest ~messages requirement =
   let candidates = first :: rest in
   match duplicate_flow_candidate_id candidates with
   | Some duplicate -> Error duplicate
-  | None ->
-    let admissions, admitted =
-      List.fold_left
-        (fun (admissions, admitted) candidate ->
-           match admit ~target:candidate.target ~messages requirement with
-           | Error cause ->
-             ( Candidate_rejected { identity = candidate.identity; cause } :: admissions
-             , admitted )
-           | Ok plan ->
-             let evidence =
-               { identity = candidate.identity
-               ; plan_fingerprint = plan.plan_fingerprint
-               ; request_body_sha256 = plan.request_body_sha256
-               ; provenance = plan.provenance
-               }
-             in
-             Candidate_admitted evidence :: admissions, { evidence; plan } :: admitted)
-        ([], [])
-        candidates
-    in
-    let admissions = List.rev admissions in
-    (match List.rev admitted with
-     | [] -> Error (No_admitted_flow_candidates admissions)
-     | candidates -> Ok { admissions; candidates })
+  | None -> Ok { candidates; messages; requirement }
 ;;
-
-let ready_flow_admissions (ready : ready_flow) = ready.admissions
 
 let start_attempt (ready : ready_plan) =
   match Exact_output_call_id.create () with
@@ -649,28 +630,14 @@ let start_attempt (ready : ready_plan) =
     Ok { ready; receipt }
 ;;
 
-let start_flow (ready : ready_flow) =
-  let rec start position started = function
-    | [] ->
-      Ok
-        { execution = Flow_state.create ()
-        ; admissions = ready.admissions
-        ; candidates = List.rev started
-        }
-    | candidate :: rest ->
-      (match start_attempt candidate.plan with
-       | Error cause ->
-         Error
-           (Flow_candidate_attempt_start_failed
-              { identity = candidate.evidence.identity
-              ; position
-              ; cause
-              ; admissions = ready.admissions
-              })
-       | Ok attempt ->
-         start (position + 1) ({ evidence = candidate.evidence; attempt } :: started) rest)
-  in
-  start 1 [] ready.candidates
+let start_flow (ready : flow_snapshot) =
+  { execution = Flow_state.create ()
+  ; candidate_snapshot = List.map flow_candidate_identity ready.candidates
+  ; candidates = ready.candidates
+  ; messages = ready.messages
+  ; requirement = ready.requirement
+  ; progress = Flow_state.create_progress ()
+  }
 ;;
 
 let call_id_to_string (Call_id id) = id
@@ -706,16 +673,30 @@ let receipt_request_body_sha256 (receipt : receipt) = receipt.request_body_sha25
 let receipt_catalog_generation (receipt : receipt) = receipt.catalog_generation
 let receipt_catalog_evidence (receipt : receipt) = receipt.catalog_evidence
 let receipt_target_identity (receipt : receipt) = receipt.target_identity
+let candidate_attempt_count_to_int (Candidate_attempt_count count) = count
 
-let flow_attempt_receipt (candidate : flow_attempt_candidate) =
-  { identity = candidate.evidence.identity; receipt = attempt_receipt candidate.attempt }
+let admission_rejection_identity (receipt : admission_rejection_receipt) =
+  receipt.identity
+;;
+
+let admission_rejection_cause receipt = receipt.cause
+let admission_rejection_phase _ = Before_dispatch
+let admission_rejection_dispatch_count _ = 0
+
+let admission_rejection_candidate_attempt_count (receipt : admission_rejection_receipt) =
+  receipt.candidate_attempt_count
 ;;
 
 let flow_attempt_evidence (flow : flow_attempt) =
-  { admissions = flow.admissions
-  ; attempts = List.map flow_attempt_receipt flow.candidates
+  let progress = Flow_state.progress_snapshot flow.progress in
+  { candidate_snapshot = flow.candidate_snapshot
+  ; candidate_attempt_count = Candidate_attempt_count progress.candidate_attempt_count
+  ; admissions = progress.admissions
+  ; attempts = progress.attempts
   }
 ;;
+
+let record_attempt flow = Flow_state.record_attempt flow.progress
 
 let state_rank = function
   | Not_started_state -> 0
@@ -895,58 +876,117 @@ let execute_once ~net ?clock (attempt : attempt) =
 ;;
 
 let execution_failure_may_advance (error : execution_error) =
-  match error.cause with
-  | Completion_failed ->
-    (match receipt_phase error.receipt with
-     | Before_dispatch -> receipt_dispatch_count error.receipt = 0
-     | Not_started | Dispatch_started | Response_received | Terminal -> false)
-  | Attempt_already_started
-  | Clock_required_for_timeout
-  | Frozen_request_mismatch
-  | Incomplete_output
-  | Missing_output
-  | Ambiguous_output _
-  | Unexpected_output_content
-  | Invalid_json_output
-  | Internal_non_json_output -> false
+  match error.cause, receipt_phase error.receipt with
+  | Completion_failed, Before_dispatch -> receipt_dispatch_count error.receipt = 0
+  | Completion_failed, (Not_started | Dispatch_started | Response_received | Terminal)
+  | ( ( Attempt_already_started
+      | Clock_required_for_timeout
+      | Frozen_request_mismatch
+      | Incomplete_output
+      | Missing_output
+      | Ambiguous_output _
+      | Unexpected_output_content
+      | Invalid_json_output
+      | Internal_non_json_output )
+    , _ ) -> false
+;;
+
+let admitted_flow_candidate identity (plan : ready_plan) =
+  { identity
+  ; plan_fingerprint = plan.plan_fingerprint
+  ; request_body_sha256 = plan.request_body_sha256
+  ; provenance = plan.provenance
+  }
+;;
+
+let record_admission_rejection flow identity cause =
+  Flow_state.record_admission flow.progress (fun ~candidate_attempt_count ->
+    let candidate_attempt_count = Candidate_attempt_count candidate_attempt_count in
+    let rejection = { identity; cause; candidate_attempt_count } in
+    Candidate_rejected rejection, rejection)
+;;
+
+let execute_flow_candidate ~net ?clock ~before_dispatch flow candidate =
+  match admit ~target:candidate.target ~messages:flow.messages flow.requirement with
+  | Error cause ->
+    let rejection = record_admission_rejection flow candidate.identity cause in
+    Error (Flow_step_admission_rejected rejection)
+  | Ok plan ->
+    let admitted = admitted_flow_candidate candidate.identity plan in
+    let candidate_attempt_count =
+      Flow_state.record_admission flow.progress (fun ~candidate_attempt_count ->
+        Candidate_admitted admitted, Candidate_attempt_count candidate_attempt_count)
+    in
+    (match start_attempt plan with
+     | Error cause -> Error (Flow_step_attempt_start_failed (candidate.identity, cause))
+     | Ok attempt ->
+       let candidate_receipt =
+         { identity = candidate.identity; receipt = attempt_receipt attempt }
+       in
+       record_attempt flow candidate_receipt;
+       (match before_dispatch candidate_receipt with
+        | Error cause ->
+          Error (Flow_step_before_dispatch_callback_failed (candidate_receipt, cause))
+        | Ok () ->
+          (match execute_once ~net ?clock attempt with
+           | Ok success -> Ok (candidate_receipt, success)
+           | Error cause ->
+             Error
+               (Flow_step_execution_failed
+                  (Flow_candidate_execution_failed
+                     { candidate = candidate_receipt; cause; candidate_attempt_count })))))
+;;
+
+let flow_step_failure_may_advance = function
+  | Flow_step_admission_rejected _ -> true
+  | Flow_step_execution_failed (Flow_candidate_execution_failed { cause; _ }) ->
+    execution_failure_may_advance cause
+  | Flow_step_execution_failed (Flow_candidate_admission_rejected _)
+  | Flow_step_attempt_start_failed _ | Flow_step_before_dispatch_callback_failed _ ->
+    false
+;;
+
+let advanceable_flow_failure = function
+  | Flow_step_admission_rejected receipt -> Flow_candidate_admission_rejected receipt
+  | Flow_step_execution_failed failure -> failure
+  | Flow_step_attempt_start_failed _ | Flow_step_before_dispatch_callback_failed _ ->
+    invalid_arg "Exact_output: terminal flow failure reached before_advance"
 ;;
 
 let execute_flow_once ~net ?clock ~before_dispatch ~before_advance flow =
-  let public_candidate = flow_attempt_receipt in
   let outcome =
     Flow_state.execute_once
       flow.execution
       ~candidates:flow.candidates
-      ~before_dispatch:(fun candidate -> before_dispatch (public_candidate candidate))
-      ~execute:(fun candidate -> execute_once ~net ?clock candidate.attempt)
-      ~can_advance:execution_failure_may_advance
-      ~before_advance:(fun ~failed ~failure ~next ->
-        before_advance
-          ~failed:(public_candidate failed)
-          ~failure
-          ~next:(public_candidate next))
+      ~execute:(execute_flow_candidate ~net ?clock ~before_dispatch flow)
+      ~can_advance:flow_step_failure_may_advance
+      ~before_advance:(fun ~failed:_ ~failure ~next ->
+        before_advance ~failed:(advanceable_flow_failure failure) ~next:next.identity)
   in
   let evidence = flow_attempt_evidence flow in
   match outcome with
-  | Flow_state.Succeeded { candidate; success } ->
-    Ok { candidate = public_candidate candidate; success; evidence }
+  | Flow_state.Succeeded { success = candidate, success; _ } ->
+    Ok { candidate; success; evidence }
   | Flow_state.Attempt_already_started -> Error (Flow_attempt_already_started evidence)
-  | Flow_state.Before_dispatch_callback_failed { candidate; cause } ->
-    Error
-      (Flow_before_dispatch_callback_failed
-         { candidate = public_candidate candidate; cause; evidence })
-  | Flow_state.Before_advance_callback_failed
-      { failed_candidate; failure; next_candidate; cause } ->
+  | Flow_state.Before_advance_callback_failed { failure; next_candidate; cause; _ } ->
     Error
       (Flow_before_advance_callback_failed
-         { failed = public_candidate failed_candidate
-         ; failure
-         ; next = public_candidate next_candidate
+         { failed = advanceable_flow_failure failure
+         ; next = next_candidate.identity
          ; cause
          ; evidence
          })
-  | Flow_state.Execution_failed { candidate; cause } ->
-    Error
-      (Flow_exact_execution_failed
-         { candidate = public_candidate candidate; cause; evidence })
+  | Flow_state.Execution_failed { cause; _ } ->
+    (match cause with
+     | Flow_step_admission_rejected rejection ->
+       Error (Flow_admission_failed { rejection; evidence })
+     | Flow_step_attempt_start_failed (candidate, cause) ->
+       Error (Flow_attempt_start_failed { candidate; cause; evidence })
+     | Flow_step_before_dispatch_callback_failed (candidate, cause) ->
+       Error (Flow_before_dispatch_callback_failed { candidate; cause; evidence })
+     | Flow_step_execution_failed
+         (Flow_candidate_execution_failed { candidate; cause; _ }) ->
+       Error (Flow_exact_execution_failed { candidate; cause; evidence })
+     | Flow_step_execution_failed (Flow_candidate_admission_rejected _) ->
+       invalid_arg "Exact_output: admission rejection used an execution-failure step")
 ;;

--- a/lib/llm_provider/exact_output.ml
+++ b/lib/llm_provider/exact_output.ml
@@ -259,7 +259,11 @@ type 'callback_error flow_step_failure =
   | Flow_step_admission_rejected of admission_rejection_receipt
   | Flow_step_attempt_start_failed of flow_candidate_identity * start_attempt_error
   | Flow_step_before_dispatch_callback_failed of flow_attempt_receipt * 'callback_error
-  | Flow_step_execution_failed of flow_candidate_failure
+  | Flow_step_execution_failed of
+      { candidate : flow_attempt_receipt
+      ; cause : execution_error
+      ; candidate_attempt_count : candidate_attempt_count
+      }
 
 let ( let* ) = Result.bind
 
@@ -933,24 +937,23 @@ let execute_flow_candidate ~net ?clock ~before_dispatch flow candidate =
            | Error cause ->
              Error
                (Flow_step_execution_failed
-                  (Flow_candidate_execution_failed
-                     { candidate = candidate_receipt; cause; candidate_attempt_count })))))
-;;
-
-let flow_step_failure_may_advance = function
-  | Flow_step_admission_rejected _ -> true
-  | Flow_step_execution_failed (Flow_candidate_execution_failed { cause; _ }) ->
-    execution_failure_may_advance cause
-  | Flow_step_execution_failed (Flow_candidate_admission_rejected _)
-  | Flow_step_attempt_start_failed _ | Flow_step_before_dispatch_callback_failed _ ->
-    false
+                  { candidate = candidate_receipt; cause; candidate_attempt_count }))))
 ;;
 
 let advanceable_flow_failure = function
-  | Flow_step_admission_rejected receipt -> Flow_candidate_admission_rejected receipt
-  | Flow_step_execution_failed failure -> failure
-  | Flow_step_attempt_start_failed _ | Flow_step_before_dispatch_callback_failed _ ->
-    invalid_arg "Exact_output: terminal flow failure reached before_advance"
+  | Flow_step_admission_rejected receipt ->
+    Some (Flow_candidate_admission_rejected receipt)
+  | Flow_step_execution_failed ({ cause; _ } as failure)
+    when execution_failure_may_advance cause ->
+    Some
+      (Flow_candidate_execution_failed
+         { candidate = failure.candidate
+         ; cause = failure.cause
+         ; candidate_attempt_count = failure.candidate_attempt_count
+         })
+  | Flow_step_execution_failed _
+  | Flow_step_attempt_start_failed _
+  | Flow_step_before_dispatch_callback_failed _ -> None
 ;;
 
 let execute_flow_once ~net ?clock ~before_dispatch ~before_advance flow =
@@ -959,9 +962,9 @@ let execute_flow_once ~net ?clock ~before_dispatch ~before_advance flow =
       flow.execution
       ~candidates:flow.candidates
       ~execute:(execute_flow_candidate ~net ?clock ~before_dispatch flow)
-      ~can_advance:flow_step_failure_may_advance
+      ~advanceable:advanceable_flow_failure
       ~before_advance:(fun ~failed:_ ~failure ~next ->
-        before_advance ~failed:(advanceable_flow_failure failure) ~next:next.identity)
+        before_advance ~failed:failure ~next:next.identity)
   in
   let evidence = flow_attempt_evidence flow in
   match outcome with
@@ -971,11 +974,7 @@ let execute_flow_once ~net ?clock ~before_dispatch ~before_advance flow =
   | Flow_state.Before_advance_callback_failed { failure; next_candidate; cause; _ } ->
     Error
       (Flow_before_advance_callback_failed
-         { failed = advanceable_flow_failure failure
-         ; next = next_candidate.identity
-         ; cause
-         ; evidence
-         })
+         { failed = failure; next = next_candidate.identity; cause; evidence })
   | Flow_state.Execution_failed { cause; _ } ->
     (match cause with
      | Flow_step_admission_rejected rejection ->
@@ -984,9 +983,6 @@ let execute_flow_once ~net ?clock ~before_dispatch ~before_advance flow =
        Error (Flow_attempt_start_failed { candidate; cause; evidence })
      | Flow_step_before_dispatch_callback_failed (candidate, cause) ->
        Error (Flow_before_dispatch_callback_failed { candidate; cause; evidence })
-     | Flow_step_execution_failed
-         (Flow_candidate_execution_failed { candidate; cause; _ }) ->
-       Error (Flow_exact_execution_failed { candidate; cause; evidence })
-     | Flow_step_execution_failed (Flow_candidate_admission_rejected _) ->
-       invalid_arg "Exact_output: admission rejection used an execution-failure step")
+     | Flow_step_execution_failed { candidate; cause; _ } ->
+       Error (Flow_exact_execution_failed { candidate; cause; evidence }))
 ;;

--- a/lib/llm_provider/exact_output.ml
+++ b/lib/llm_provider/exact_output.ml
@@ -1,6 +1,7 @@
 module Plan = Exact_output_plan
 module Exec = Exact_output_execution
 module Flow_state = Exact_output_flow
+module Gemini_schema = Exact_output_gemini_schema
 module Caps = Capabilities
 module PC = Provider_config
 include Exact_output_resolver
@@ -329,159 +330,14 @@ let make_output_requirement ~schema ~minimum_guarantee =
   }
 ;;
 
-let gemini_schema_keywords =
-  [ "type"
-  ; "title"
-  ; "description"
-  ; "properties"
-  ; "required"
-  ; "additionalProperties"
-  ; "enum"
-  ; "format"
-  ; "minimum"
-  ; "maximum"
-  ; "items"
-  ; "prefixItems"
-  ; "minItems"
-  ; "maxItems"
-  ]
-;;
-
-let gemini_keywords_for_type = function
-  | "object" ->
-    [ "type"; "title"; "description"; "properties"; "required"; "additionalProperties" ]
-  | "string" -> [ "type"; "title"; "description"; "enum"; "format" ]
-  | "number" | "integer" ->
-    [ "type"; "title"; "description"; "enum"; "minimum"; "maximum" ]
-  | "array" ->
-    [ "type"; "title"; "description"; "items"; "prefixItems"; "minItems"; "maxItems" ]
-  | "boolean" | "null" -> [ "type"; "title"; "description" ]
-  | type_name -> raise_notrace (Invalid_argument type_name)
-;;
-
-let assoc_keys_are_unique fields =
-  let keys = List.map fst fields in
-  List.length keys = List.length (List.sort_uniq String.compare keys)
-;;
-
-let json_number = function
-  | `Int _ | `Intlit _ | `Float _ -> true
-  | `Null | `Bool _ | `String _ | `Assoc _ | `List _ -> false
-;;
-
-let json_integer = function
-  | `Int _ | `Intlit _ -> true
-  | `Null | `Bool _ | `Float _ | `String _ | `Assoc _ | `List _ -> false
-;;
-
-let gemini_non_null_schema_types =
-  [ "string"; "number"; "integer"; "boolean"; "object"; "array" ]
-;;
-
-let gemini_schema_base_type = function
-  | Some (`String type_name)
-    when String.equal type_name "null" || List.mem type_name gemini_non_null_schema_types
-    -> Ok type_name
-  | Some (`String type_name) -> Error (Unsupported_schema_type type_name)
-  | Some (`List [ `String left; `String right ])
-    when String.equal left "null" && List.mem right gemini_non_null_schema_types ->
-    Ok right
-  | Some (`List [ `String left; `String right ])
-    when String.equal right "null" && List.mem left gemini_non_null_schema_types ->
-    Ok left
-  | Some (`List _) | Some _ | None -> Error Invalid_schema
-;;
-
-let rec validate_gemini_schema ~path = function
-  | `Assoc fields when assoc_keys_are_unique fields ->
-    (match
-       List.find_opt
-         (fun (keyword, _) -> not (List.mem keyword gemini_schema_keywords))
-         fields
-     with
-     | Some (keyword, _) -> Error (Unsupported_schema_keyword (path ^ "." ^ keyword))
-     | None ->
-       (match gemini_schema_base_type (List.assoc_opt "type" fields) with
-        | Ok type_name ->
-          let supported = gemini_keywords_for_type type_name in
-          (match
-             List.find_opt (fun (keyword, _) -> not (List.mem keyword supported)) fields
-           with
-           | Some (keyword, _) ->
-             Error (Unsupported_schema_keyword (path ^ "." ^ keyword))
-           | None -> validate_gemini_schema_fields ~path ~type_name fields)
-        | Error _ as error -> error))
-  | `Assoc _ | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ ->
-    Error Invalid_schema
-
-and validate_gemini_schema_fields ~path ~type_name fields =
-  let rec validate_all = function
-    | [] -> Ok ()
-    | field :: rest ->
-      let* () = validate_gemini_schema_field ~path ~type_name field in
-      validate_all rest
-  in
-  validate_all fields
-
-and validate_gemini_schema_field ~path ~type_name = function
-  | "type", (`String _ | `List _) -> Ok ()
-  | ("title" | "description"), `String _ -> Ok ()
-  | "properties", `Assoc properties
-    when String.equal type_name "object" && assoc_keys_are_unique properties ->
-    let rec validate = function
-      | [] -> Ok ()
-      | (name, schema) :: rest ->
-        let* () = validate_gemini_schema ~path:(path ^ ".properties." ^ name) schema in
-        validate rest
-    in
-    validate properties
-  | "required", `List names
-    when String.equal type_name "object"
-         && List.for_all
-              (function
-                | `String _ -> true
-                | _ -> false)
-              names -> Ok ()
-  | "additionalProperties", `Bool _ when String.equal type_name "object" -> Ok ()
-  | "additionalProperties", schema when String.equal type_name "object" ->
-    validate_gemini_schema ~path:(path ^ ".additionalProperties") schema
-  | "enum", `List values
-    when values <> []
-         && String.equal type_name "string"
-         && List.for_all
-              (function
-                | `String _ -> true
-                | _ -> false)
-              values -> Ok ()
-  | "enum", `List values
-    when values <> []
-         && String.equal type_name "number"
-         && List.for_all json_number values -> Ok ()
-  | "enum", `List values
-    when values <> []
-         && String.equal type_name "integer"
-         && List.for_all json_integer values -> Ok ()
-  | "format", `String _ when String.equal type_name "string" -> Ok ()
-  | ("minimum" | "maximum"), value
-    when (String.equal type_name "number" || String.equal type_name "integer")
-         && json_number value -> Ok ()
-  | "items", schema when String.equal type_name "array" ->
-    validate_gemini_schema ~path:(path ^ ".items") schema
-  | "prefixItems", `List schemas when String.equal type_name "array" ->
-    let rec validate index = function
-      | [] -> Ok ()
-      | schema :: rest ->
-        let* () =
-          validate_gemini_schema
-            ~path:(Printf.sprintf "%s.prefixItems[%d]" path index)
-            schema
-        in
-        validate (index + 1) rest
-    in
-    validate 0 schemas
-  | ("minItems" | "maxItems"), `Int value
-    when String.equal type_name "array" && value >= 0 -> Ok ()
-  | _ -> Error Invalid_schema
+let validate_gemini_schema ~path schema =
+  match Gemini_schema.validate ~path schema with
+  | Ok () -> Ok ()
+  | Error (Gemini_schema.Unsupported_keyword keyword) ->
+    Error (Unsupported_schema_keyword keyword)
+  | Error (Gemini_schema.Unsupported_type type_name) ->
+    Error (Unsupported_schema_type type_name)
+  | Error Gemini_schema.Invalid_schema -> Error Invalid_schema
 ;;
 
 let schema_for_wire target (Domain_schema domain_schema) =

--- a/lib/llm_provider/exact_output.ml
+++ b/lib/llm_provider/exact_output.ml
@@ -893,8 +893,7 @@ let execute_flow_candidate ~net ?clock ~before_dispatch flow candidate =
               | Ok success -> Ok (candidate_receipt, success)
               | Error cause ->
                 Error
-                  (Flow_step_execution_failed
-                     { candidate = candidate_receipt; cause })))))
+                  (Flow_step_execution_failed { candidate = candidate_receipt; cause })))))
 ;;
 
 let advanceable_flow_failure = function
@@ -903,9 +902,7 @@ let advanceable_flow_failure = function
     when execution_failure_may_advance cause ->
     Some
       (Flow_candidate_execution_failed
-         { candidate = failure.candidate
-         ; cause = failure.cause
-         })
+         { candidate = failure.candidate; cause = failure.cause })
   | Flow_step_execution_failed _
   | Flow_step_attempt_start_failed _
   | Flow_step_before_dispatch_callback_failed _ -> None

--- a/lib/llm_provider/exact_output.ml
+++ b/lib/llm_provider/exact_output.ml
@@ -105,6 +105,24 @@ type admission_error =
   | Invalid_schema
   | Wire_admission_rejected of wire_admission_error
 
+type input_capacity_disposition =
+  | Token_measurement_required of
+      { accepted_through_tokens : int
+      ; rejected_from_tokens : int option
+      }
+  | Serialized_request_body_too_large of
+      { actual_bytes : int
+      ; limit_bytes : int
+      }
+
+type candidate_rejection_disposition =
+  | Runtime_slot_unavailable
+  | Runtime_contract_rejected
+  | Input_contract_rejected
+  | Output_requirement_rejected
+  | Input_capacity of input_capacity_disposition
+  | Request_preparation_failed
+
 type effect_phase =
   | Not_started
   | Before_dispatch
@@ -153,19 +171,35 @@ type flow_candidate_identity =
 
 type flow_candidate =
   { identity : flow_candidate_identity
-  ; target : selected_target
+  ; admitted_target : admitted_target
   }
 
-type candidate_attempt_count = Candidate_attempt_count of int
+type flow_id = Flow_id of string
+type flow_visit_ordinal = Flow_visit_ordinal of int
+type candidate_visit_count = Candidate_visit_count of int
 
-type admission_rejection_receipt =
-  { identity : flow_candidate_identity
-  ; cause : admission_error
-  ; candidate_attempt_count : candidate_attempt_count
+type flow_candidate_visit =
+  { flow_id : flow_id
+  ; ordinal : flow_visit_ordinal
+  ; identity : flow_candidate_identity
+  }
+
+type flow_candidate_step =
+  { visit : flow_candidate_visit
+  ; admitted_target : admitted_target
+  }
+
+type candidate_rejection_cause =
+  | Target_selection_rejected of target_selection_error
+  | Request_admission_rejected of admission_error
+
+type candidate_rejection_receipt =
+  { visit : flow_candidate_visit
+  ; cause : candidate_rejection_cause
   }
 
 type admitted_flow_candidate =
-  { identity : flow_candidate_identity
+  { visit : flow_candidate_visit
   ; plan_fingerprint : string
   ; request_body_sha256 : string
   ; provenance : plan_provenance
@@ -173,7 +207,7 @@ type admitted_flow_candidate =
 
 type candidate_admission =
   | Candidate_admitted of admitted_flow_candidate
-  | Candidate_rejected of admission_rejection_receipt
+  | Candidate_rejected of candidate_rejection_receipt
 
 type flow_snapshot =
   { candidates : flow_candidate list
@@ -182,14 +216,15 @@ type flow_snapshot =
   }
 
 type flow_attempt_receipt =
-  { identity : flow_candidate_identity
+  { visit : flow_candidate_visit
   ; receipt : receipt
   }
 
 type flow_attempt =
   { execution : Flow_state.t
+  ; flow_id : flow_id
   ; candidate_snapshot : flow_candidate_identity list
-  ; candidates : flow_candidate list
+  ; candidates : flow_candidate_step list
   ; messages : Types.message list
   ; requirement : output_requirement
   ; progress : (candidate_admission, flow_attempt_receipt) Flow_state.progress
@@ -205,10 +240,12 @@ type flow_snapshot_error =
       }
 
 type start_attempt_error = Call_id_generation_failed of string
+type flow_start_error = Flow_id_generation_failed of string
 
 type flow_evidence =
-  { candidate_snapshot : flow_candidate_identity list
-  ; candidate_attempt_count : candidate_attempt_count
+  { flow_id : flow_id
+  ; candidate_snapshot : flow_candidate_identity list
+  ; candidate_visit_count : candidate_visit_count
   ; admissions : candidate_admission list
   ; attempts : flow_attempt_receipt list
   }
@@ -220,17 +257,16 @@ type flow_success =
   }
 
 type flow_candidate_failure =
-  | Flow_candidate_admission_rejected of admission_rejection_receipt
+  | Flow_candidate_rejected of candidate_rejection_receipt
   | Flow_candidate_execution_failed of
       { candidate : flow_attempt_receipt
       ; cause : execution_error
-      ; candidate_attempt_count : candidate_attempt_count
       }
 
 type 'callback_error flow_execution_error =
   | Flow_attempt_already_started of flow_evidence
   | Flow_attempt_start_failed of
-      { candidate : flow_candidate_identity
+      { candidate : flow_candidate_visit
       ; cause : start_attempt_error
       ; evidence : flow_evidence
       }
@@ -241,12 +277,12 @@ type 'callback_error flow_execution_error =
       }
   | Flow_before_advance_callback_failed of
       { failed : flow_candidate_failure
-      ; next : flow_candidate_identity
+      ; next : flow_candidate_visit
       ; cause : 'callback_error
       ; evidence : flow_evidence
       }
-  | Flow_admission_failed of
-      { rejection : admission_rejection_receipt
+  | Flow_candidates_exhausted of
+      { rejection : candidate_rejection_receipt
       ; evidence : flow_evidence
       }
   | Flow_exact_execution_failed of
@@ -256,13 +292,12 @@ type 'callback_error flow_execution_error =
       }
 
 type 'callback_error flow_step_failure =
-  | Flow_step_admission_rejected of admission_rejection_receipt
-  | Flow_step_attempt_start_failed of flow_candidate_identity * start_attempt_error
+  | Flow_step_candidate_rejected of candidate_rejection_receipt
+  | Flow_step_attempt_start_failed of flow_candidate_visit * start_attempt_error
   | Flow_step_before_dispatch_callback_failed of flow_attempt_receipt * 'callback_error
   | Flow_step_execution_failed of
       { candidate : flow_attempt_receipt
       ; cause : execution_error
-      ; candidate_attempt_count : candidate_attempt_count
       }
 
 let ( let* ) = Result.bind
@@ -582,7 +617,7 @@ let admit ~target ~messages requirement =
 let plan_provenance (ready : ready_plan) = ready.provenance
 let plan_fingerprint (ready : ready_plan) = ready.plan_fingerprint
 
-let make_flow_candidate ~id ~target =
+let make_flow_candidate ~id ~admitted_target =
   let id = String.trim id in
   if String.equal id ""
   then Error Blank_flow_candidate_id
@@ -590,11 +625,11 @@ let make_flow_candidate ~id ~target =
     Ok
       { identity =
           { candidate_id = id
-          ; catalog_generation = selected_target_catalog_generation target
-          ; catalog_evidence = selected_target_catalog_evidence target
-          ; target_identity = selected_target_identity target
+          ; catalog_generation = admitted_target_catalog_generation admitted_target
+          ; catalog_evidence = admitted_target_catalog_evidence admitted_target
+          ; target_identity = admitted_target_identity admitted_target
           }
-      ; target
+      ; admitted_target
       }
 ;;
 
@@ -635,16 +670,37 @@ let start_attempt (ready : ready_plan) =
 ;;
 
 let start_flow (ready : flow_snapshot) =
-  { execution = Flow_state.create ()
-  ; candidate_snapshot = List.map flow_candidate_identity ready.candidates
-  ; candidates = ready.candidates
-  ; messages = ready.messages
-  ; requirement = ready.requirement
-  ; progress = Flow_state.create_progress ()
-  }
+  match Exact_output_call_id.create () with
+  | Error detail -> Error (Flow_id_generation_failed detail)
+  | Ok raw_flow_id ->
+    let flow_id = Flow_id raw_flow_id in
+    let candidates =
+      List.mapi
+        (fun index (candidate : flow_candidate) ->
+           { visit =
+               { flow_id
+               ; ordinal = Flow_visit_ordinal (index + 1)
+               ; identity = candidate.identity
+               }
+           ; admitted_target = candidate.admitted_target
+           })
+        ready.candidates
+    in
+    Ok
+      { execution = Flow_state.create ()
+      ; flow_id
+      ; candidate_snapshot = List.map flow_candidate_identity ready.candidates
+      ; candidates
+      ; messages = ready.messages
+      ; requirement = ready.requirement
+      ; progress = Flow_state.create_progress ()
+      }
 ;;
 
 let call_id_to_string (Call_id id) = id
+let flow_id_to_string (Flow_id id) = id
+let flow_visit_ordinal_to_int (Flow_visit_ordinal ordinal) = ordinal
+let flow_attempt_id (flow : flow_attempt) = flow.flow_id
 let attempt_receipt (attempt : attempt) = attempt.receipt
 let receipt_call_id (receipt : receipt) = receipt.call_id
 
@@ -677,24 +733,68 @@ let receipt_request_body_sha256 (receipt : receipt) = receipt.request_body_sha25
 let receipt_catalog_generation (receipt : receipt) = receipt.catalog_generation
 let receipt_catalog_evidence (receipt : receipt) = receipt.catalog_evidence
 let receipt_target_identity (receipt : receipt) = receipt.target_identity
-let candidate_attempt_count_to_int (Candidate_attempt_count count) = count
+let candidate_visit_count_to_int (Candidate_visit_count count) = count
 
-let admission_rejection_identity (receipt : admission_rejection_receipt) =
-  receipt.identity
+let candidate_rejection_identity (receipt : candidate_rejection_receipt) =
+  receipt.visit.identity
 ;;
 
-let admission_rejection_cause receipt = receipt.cause
-let admission_rejection_phase _ = Before_dispatch
-let admission_rejection_dispatch_count _ = 0
+let candidate_rejection_visit (receipt : candidate_rejection_receipt) = receipt.visit
+let candidate_rejection_phase _ = Before_dispatch
+let candidate_rejection_dispatch_count _ = 0
 
-let admission_rejection_candidate_attempt_count (receipt : admission_rejection_receipt) =
-  receipt.candidate_attempt_count
+let target_selection_error_disposition = function
+  | Missing_target_credential _
+  | Target_credential_invalid _
+  | Target_credential_read_failed _ -> Runtime_slot_unavailable
+;;
+
+let wire_admission_error_disposition = function
+  | Capability_snapshot_missing
+  | Inconsistent_output_contract
+  | Global_admission_not_allowed
+  | Invalid_connect_timeout
+  | Invalid_body_timeout
+  | Unsupported_target_model _ -> Runtime_contract_rejected
+  | Output_contract_unavailable -> Output_requirement_rejected
+  | Cross_feature_not_allowed
+  | Caller_supplied_header_not_allowed
+  | Unsupported_image_input
+  | Unsupported_document_input
+  | Unsupported_audio_input
+  | Unsupported_system_prompt -> Input_contract_rejected
+  | Token_measurement_required constraint_ ->
+    Input_capacity
+      (Token_measurement_required
+         { accepted_through_tokens =
+             constraint_.Serving_constraint.observation.accepted_through
+         ; rejected_from_tokens = constraint_.observation.rejected_from
+         })
+  | Request_body_too_large { actual_bytes; limit_bytes } ->
+    Input_capacity (Serialized_request_body_too_large { actual_bytes; limit_bytes })
+  | Target_request_rejected | Request_serialization_rejected -> Request_preparation_failed
+;;
+
+let admission_error_disposition = function
+  | Provider_schema_unavailable
+  | Json_syntax_unavailable
+  | Unsupported_schema_keyword _
+  | Unsupported_schema_type _
+  | Invalid_schema -> Output_requirement_rejected
+  | Wire_admission_rejected cause -> wire_admission_error_disposition cause
+;;
+
+let candidate_rejection_disposition (receipt : candidate_rejection_receipt) =
+  match receipt.cause with
+  | Target_selection_rejected cause -> target_selection_error_disposition cause
+  | Request_admission_rejected cause -> admission_error_disposition cause
 ;;
 
 let flow_attempt_evidence (flow : flow_attempt) =
   let progress = Flow_state.progress_snapshot flow.progress in
-  { candidate_snapshot = flow.candidate_snapshot
-  ; candidate_attempt_count = Candidate_attempt_count progress.candidate_attempt_count
+  { flow_id = flow.flow_id
+  ; candidate_snapshot = flow.candidate_snapshot
+  ; candidate_visit_count = Candidate_visit_count progress.candidate_visit_count
   ; admissions = progress.admissions
   ; attempts = progress.attempts
   }
@@ -895,61 +995,60 @@ let execution_failure_may_advance (error : execution_error) =
     , _ ) -> false
 ;;
 
-let admitted_flow_candidate identity (plan : ready_plan) =
-  { identity
+let admitted_flow_candidate visit (plan : ready_plan) =
+  { visit
   ; plan_fingerprint = plan.plan_fingerprint
   ; request_body_sha256 = plan.request_body_sha256
   ; provenance = plan.provenance
   }
 ;;
 
-let record_admission_rejection flow identity cause =
-  Flow_state.record_admission flow.progress (fun ~candidate_attempt_count ->
-    let candidate_attempt_count = Candidate_attempt_count candidate_attempt_count in
-    let rejection = { identity; cause; candidate_attempt_count } in
-    Candidate_rejected rejection, rejection)
+let record_candidate_rejection flow visit cause =
+  let rejection = { visit; cause } in
+  Flow_state.record_admission flow.progress (Candidate_rejected rejection);
+  rejection
 ;;
 
 let execute_flow_candidate ~net ?clock ~before_dispatch flow candidate =
-  match admit ~target:candidate.target ~messages:flow.messages flow.requirement with
-  | Error cause ->
-    let rejection = record_admission_rejection flow candidate.identity cause in
-    Error (Flow_step_admission_rejected rejection)
-  | Ok plan ->
-    let admitted = admitted_flow_candidate candidate.identity plan in
-    let candidate_attempt_count =
-      Flow_state.record_admission flow.progress (fun ~candidate_attempt_count ->
-        Candidate_admitted admitted, Candidate_attempt_count candidate_attempt_count)
-    in
-    (match start_attempt plan with
-     | Error cause -> Error (Flow_step_attempt_start_failed (candidate.identity, cause))
-     | Ok attempt ->
-       let candidate_receipt =
-         { identity = candidate.identity; receipt = attempt_receipt attempt }
-       in
-       record_attempt flow candidate_receipt;
-       (match before_dispatch candidate_receipt with
-        | Error cause ->
-          Error (Flow_step_before_dispatch_callback_failed (candidate_receipt, cause))
-        | Ok () ->
-          (match execute_once ~net ?clock attempt with
-           | Ok success -> Ok (candidate_receipt, success)
+  let reject cause =
+    let rejection = record_candidate_rejection flow candidate.visit cause in
+    Error (Flow_step_candidate_rejected rejection)
+  in
+  match resolve_target candidate.admitted_target with
+  | Error cause -> reject (Target_selection_rejected cause)
+  | Ok target ->
+    (match admit ~target ~messages:flow.messages flow.requirement with
+     | Error cause -> reject (Request_admission_rejected cause)
+     | Ok plan ->
+       let admitted = admitted_flow_candidate candidate.visit plan in
+       Flow_state.record_admission flow.progress (Candidate_admitted admitted);
+       (match start_attempt plan with
+        | Error cause -> Error (Flow_step_attempt_start_failed (candidate.visit, cause))
+        | Ok attempt ->
+          let candidate_receipt =
+            { visit = candidate.visit; receipt = attempt_receipt attempt }
+          in
+          record_attempt flow candidate_receipt;
+          (match before_dispatch candidate_receipt with
            | Error cause ->
-             Error
-               (Flow_step_execution_failed
-                  { candidate = candidate_receipt; cause; candidate_attempt_count }))))
+             Error (Flow_step_before_dispatch_callback_failed (candidate_receipt, cause))
+           | Ok () ->
+             (match execute_once ~net ?clock attempt with
+              | Ok success -> Ok (candidate_receipt, success)
+              | Error cause ->
+                Error
+                  (Flow_step_execution_failed
+                     { candidate = candidate_receipt; cause })))))
 ;;
 
 let advanceable_flow_failure = function
-  | Flow_step_admission_rejected receipt ->
-    Some (Flow_candidate_admission_rejected receipt)
+  | Flow_step_candidate_rejected receipt -> Some (Flow_candidate_rejected receipt)
   | Flow_step_execution_failed ({ cause; _ } as failure)
     when execution_failure_may_advance cause ->
     Some
       (Flow_candidate_execution_failed
          { candidate = failure.candidate
          ; cause = failure.cause
-         ; candidate_attempt_count = failure.candidate_attempt_count
          })
   | Flow_step_execution_failed _
   | Flow_step_attempt_start_failed _
@@ -964,7 +1063,7 @@ let execute_flow_once ~net ?clock ~before_dispatch ~before_advance flow =
       ~execute:(execute_flow_candidate ~net ?clock ~before_dispatch flow)
       ~advanceable:advanceable_flow_failure
       ~before_advance:(fun ~failed:_ ~failure ~next ->
-        before_advance ~failed:failure ~next:next.identity)
+        before_advance ~failed:failure ~next:next.visit)
   in
   let evidence = flow_attempt_evidence flow in
   match outcome with
@@ -974,11 +1073,11 @@ let execute_flow_once ~net ?clock ~before_dispatch ~before_advance flow =
   | Flow_state.Before_advance_callback_failed { failure; next_candidate; cause; _ } ->
     Error
       (Flow_before_advance_callback_failed
-         { failed = failure; next = next_candidate.identity; cause; evidence })
+         { failed = failure; next = next_candidate.visit; cause; evidence })
   | Flow_state.Execution_failed { cause; _ } ->
     (match cause with
-     | Flow_step_admission_rejected rejection ->
-       Error (Flow_admission_failed { rejection; evidence })
+     | Flow_step_candidate_rejected rejection ->
+       Error (Flow_candidates_exhausted { rejection; evidence })
      | Flow_step_attempt_start_failed (candidate, cause) ->
        Error (Flow_attempt_start_failed { candidate; cause; evidence })
      | Flow_step_before_dispatch_callback_failed (candidate, cause) ->

--- a/lib/llm_provider/exact_output.mli
+++ b/lib/llm_provider/exact_output.mli
@@ -408,7 +408,9 @@ type 'callback_error flow_execution_error =
     immutable order. [candidate_attempt_count], [admissions], and [attempts]
     contain only candidates reached so far. Attempts are allocated only after
     current-candidate admission succeeds. This remains queryable after
-    cancellation escapes. *)
+    cancellation escapes. The affine executor is the sole writer. A concurrent
+    reader may observe the exact point after an admitted outcome is recorded
+    and before its fresh attempt is allocated. *)
 val flow_attempt_evidence : flow_attempt -> flow_evidence
 
 (** Execute the frozen request once. The attempt is single-use: duplicate or

--- a/lib/llm_provider/exact_output.mli
+++ b/lib/llm_provider/exact_output.mli
@@ -100,53 +100,32 @@ type actual_assurance =
   | Json_syntax_only
   | Provider_schema_requested
 
-type target_selection_error =
-  | Missing_target_credential of
-      { target_ref : string
-      ; environment_variable : string
-      }
-  | Target_credential_invalid of
-      { target_ref : string
-      ; environment_variable : string
-      }
-  | Target_credential_read_failed of
-      { target_ref : string
-      ; environment_variable : string
-      }
+type target_selection_error
 
 type target_catalog_admission_error =
   | Target_ref_rejected of target_ref_error
   | Target_not_in_catalog of string
 
-type wire_admission_error =
-  | Capability_snapshot_missing
-  | Inconsistent_output_contract
-  | Output_contract_unavailable
-  | Cross_feature_not_allowed
-  | Global_admission_not_allowed
-  | Invalid_connect_timeout
-  | Invalid_body_timeout
-  | Caller_supplied_header_not_allowed
-  | Unsupported_image_input
-  | Unsupported_document_input
-  | Unsupported_audio_input
-  | Unsupported_system_prompt
-  | Token_measurement_required of Serving_constraint.t
-  | Unsupported_target_model of { model_id : string }
-  | Target_request_rejected
-  | Request_body_too_large of
+type wire_admission_error
+type admission_error
+
+type input_capacity_disposition =
+  | Token_measurement_required of
+      { accepted_through_tokens : int
+      ; rejected_from_tokens : int option
+      }
+  | Serialized_request_body_too_large of
       { actual_bytes : int
       ; limit_bytes : int
       }
-  | Request_serialization_rejected
 
-type admission_error =
-  | Provider_schema_unavailable
-  | Json_syntax_unavailable
-  | Unsupported_schema_keyword of string
-  | Unsupported_schema_type of string
-  | Invalid_schema
-  | Wire_admission_rejected of wire_admission_error
+type candidate_rejection_disposition =
+  | Runtime_slot_unavailable
+  | Runtime_contract_rejected
+  | Input_contract_rejected
+  | Output_requirement_rejected
+  | Input_capacity of input_capacity_disposition
+  | Request_preparation_failed
 
 type plan_provenance =
   { source_schema_fingerprint : schema_fingerprint
@@ -210,11 +189,20 @@ type flow_candidate_identity =
   ; target_identity : target_identity
   }
 
-type candidate_attempt_count
-type admission_rejection_receipt
+type flow_id
+type flow_visit_ordinal
+type candidate_visit_count
+
+type flow_candidate_visit = private
+  { flow_id : flow_id
+  ; ordinal : flow_visit_ordinal
+  ; identity : flow_candidate_identity
+  }
+
+type candidate_rejection_receipt
 
 type admitted_flow_candidate =
-  { identity : flow_candidate_identity
+  { visit : flow_candidate_visit
   ; plan_fingerprint : string
   ; request_body_sha256 : string
   ; provenance : plan_provenance
@@ -222,7 +210,7 @@ type admitted_flow_candidate =
 
 type candidate_admission =
   | Candidate_admitted of admitted_flow_candidate
-  | Candidate_rejected of admission_rejection_receipt
+  | Candidate_rejected of candidate_rejection_receipt
 
 type flow_candidate_error = Blank_flow_candidate_id
 
@@ -233,19 +221,22 @@ type flow_snapshot_error =
       ; duplicate_position : int
       }
 
-(** Construct one provider-neutral candidate. The trimmed caller identity must
-    be nonempty; it is evidence only and never drives provider policy. *)
+(** Construct one provider-neutral candidate from a catalog-admitted target.
+    Credential selection remains frozen but unresolved until this candidate is
+    reached by {!execute_flow_once}. The trimmed caller identity must be
+    nonempty; it is evidence only and never drives provider policy. *)
 val make_flow_candidate
   :  id:string
-  -> target:selected_target
+  -> admitted_target:admitted_target
   -> (flow_candidate, flow_candidate_error) result
 
 val flow_candidate_identity : flow_candidate -> flow_candidate_identity
 
 (** Freeze one nonempty ordered candidate snapshot and its immutable domain
-    input. This validates only flow topology. Exact target admission is deferred
-    to the current candidate during {!execute_flow_once}; later candidates are
-    neither prepared nor assigned attempts speculatively. *)
+    input. This validates only flow topology. Credential selection and exact
+    request admission are deferred to the current candidate during
+    {!execute_flow_once}; later candidates are neither selected, prepared, nor
+    assigned attempts speculatively. *)
 val snapshot_flow
   :  first:flow_candidate
   -> rest:flow_candidate list
@@ -316,17 +307,24 @@ val plan_fingerprint : ready_plan -> string
 val schema_fingerprint_to_string : schema_fingerprint -> string
 
 type start_attempt_error = Call_id_generation_failed of string
+type flow_start_error = Flow_id_generation_failed of string
 
 (** Allocate a fresh, independent execution attempt for an admitted plan.
     [admit] remains pure and the same immutable plan may start multiple attempts.
     Each attempt owns an opaque call identity and affine execution state. *)
 val start_attempt : ready_plan -> (attempt, start_attempt_error) result
 
-(** Create one affine execution handle over the frozen snapshot. This performs
-    no target admission, identity allocation, or network effect. *)
-val start_flow : flow_snapshot -> flow_attempt
+(** Allocate one fresh outer-flow identity and precompute one immutable visit
+    for each frozen candidate. This performs no credential selection, request
+    admission, call identity allocation, callback, or network effect. A new
+    invocation always creates a new flow; restart resume belongs to the
+    caller's authenticated durable journal. *)
+val start_flow : flow_snapshot -> (flow_attempt, flow_start_error) result
 
 val call_id_to_string : call_id -> string
+val flow_id_to_string : flow_id -> string
+val flow_visit_ordinal_to_int : flow_visit_ordinal -> int
+val flow_attempt_id : flow_attempt -> flow_id
 val attempt_receipt : attempt -> receipt
 val receipt_call_id : receipt -> call_id
 val receipt_phase : receipt -> effect_phase
@@ -341,23 +339,28 @@ val receipt_catalog_evidence : receipt -> catalog_evidence
 val receipt_target_identity : receipt -> target_identity
 
 type flow_attempt_receipt =
-  { identity : flow_candidate_identity
+  { visit : flow_candidate_visit
   ; receipt : receipt
   }
 
-val candidate_attempt_count_to_int : candidate_attempt_count -> int
-val admission_rejection_identity : admission_rejection_receipt -> flow_candidate_identity
-val admission_rejection_cause : admission_rejection_receipt -> admission_error
-val admission_rejection_phase : admission_rejection_receipt -> effect_phase
-val admission_rejection_dispatch_count : admission_rejection_receipt -> int
+val candidate_visit_count_to_int : candidate_visit_count -> int
+val target_selection_error_disposition
+  :  target_selection_error
+  -> candidate_rejection_disposition
 
-val admission_rejection_candidate_attempt_count
-  :  admission_rejection_receipt
-  -> candidate_attempt_count
+val admission_error_disposition : admission_error -> candidate_rejection_disposition
+val candidate_rejection_identity : candidate_rejection_receipt -> flow_candidate_identity
+val candidate_rejection_visit : candidate_rejection_receipt -> flow_candidate_visit
+val candidate_rejection_disposition
+  :  candidate_rejection_receipt
+  -> candidate_rejection_disposition
+val candidate_rejection_phase : candidate_rejection_receipt -> effect_phase
+val candidate_rejection_dispatch_count : candidate_rejection_receipt -> int
 
 type flow_evidence =
-  { candidate_snapshot : flow_candidate_identity list
-  ; candidate_attempt_count : candidate_attempt_count
+  { flow_id : flow_id
+  ; candidate_snapshot : flow_candidate_identity list
+  ; candidate_visit_count : candidate_visit_count
   ; admissions : candidate_admission list
   ; attempts : flow_attempt_receipt list
   }
@@ -369,17 +372,16 @@ type flow_success =
   }
 
 type flow_candidate_failure =
-  | Flow_candidate_admission_rejected of admission_rejection_receipt
+  | Flow_candidate_rejected of candidate_rejection_receipt
   | Flow_candidate_execution_failed of
       { candidate : flow_attempt_receipt
       ; cause : execution_error
-      ; candidate_attempt_count : candidate_attempt_count
       }
 
 type 'callback_error flow_execution_error =
   | Flow_attempt_already_started of flow_evidence
   | Flow_attempt_start_failed of
-      { candidate : flow_candidate_identity
+      { candidate : flow_candidate_visit
       ; cause : start_attempt_error
       ; evidence : flow_evidence
       }
@@ -390,12 +392,12 @@ type 'callback_error flow_execution_error =
       }
   | Flow_before_advance_callback_failed of
       { failed : flow_candidate_failure
-      ; next : flow_candidate_identity
+      ; next : flow_candidate_visit
       ; cause : 'callback_error
       ; evidence : flow_evidence
       }
-  | Flow_admission_failed of
-      { rejection : admission_rejection_receipt
+  | Flow_candidates_exhausted of
+      { rejection : candidate_rejection_receipt
       ; evidence : flow_evidence
       }
   | Flow_exact_execution_failed of
@@ -405,12 +407,12 @@ type 'callback_error flow_execution_error =
       }
 
 (** Point-in-time aggregate evidence. [candidate_snapshot] is the original
-    immutable order. [candidate_attempt_count], [admissions], and [attempts]
+    immutable order. [candidate_visit_count], [admissions], and [attempts]
     contain only candidates reached so far. Attempts are allocated only after
-    current-candidate admission succeeds. This remains queryable after
-    cancellation escapes. The affine executor is the sole writer. A concurrent
-    reader may observe the exact point after an admitted outcome is recorded
-    and before its fresh attempt is allocated. *)
+    current-candidate target selection and request admission succeed. This
+    remains queryable after cancellation escapes. The affine executor is the
+    sole writer. A concurrent reader may observe the exact point after an
+    admitted outcome is recorded and before its fresh attempt is allocated. *)
 val flow_attempt_evidence : flow_attempt -> flow_evidence
 
 (** Execute the frozen request once. The attempt is single-use: duplicate or
@@ -430,33 +432,33 @@ val execute_once
 
 (** Execute one affine outer flow.
 
-    OAS prepares only the current frozen candidate. A successful preparation
-    receives one fresh attempt identity, then [before_dispatch] must durably bind
-    that attempt before its sole {!execute_once} call. A typed admission
-    rejection receives a real [admission_rejection_receipt] whose phase is
+    OAS resolves credentials and prepares the request only for the current
+    frozen candidate. A successful preparation receives one fresh attempt
+    identity, then [before_dispatch] must durably bind that attempt before its
+    sole {!execute_once} call. A typed target-selection or request-admission
+    rejection receives a real [candidate_rejection_receipt] whose phase is
     [Before_dispatch] and dispatch count is zero, but no plan, call ID, or
     execution receipt.
 
     [before_advance] receives the settled typed failure and the predetermined
-    next candidate identity. OAS may call it only for an admission rejection or
-    an execution receipt that is exactly [Before_dispatch] with zero dispatch.
-    The callback can stop but cannot select, replace, skip, or reorder the
-    successor.
+    next candidate visit. OAS may call it only for a candidate rejection or an
+    execution receipt that is exactly [Before_dispatch] with zero dispatch. The
+    callback can stop but cannot select, replace, skip, or reorder the successor.
 
-    A final admission rejection returns [Flow_admission_failed]. Callback errors,
-    replay, identity-allocation failure, missing execution prerequisites,
+    A final candidate rejection returns [Flow_candidates_exhausted]. Callback
+    errors, replay, identity-allocation failure, missing execution prerequisites,
     frozen-request corruption, cancellation, every post-dispatch outcome, and
     success are terminal. Cancellation is re-raised after the flow is
-    terminalized; inspect {!flow_attempt_evidence} for monotonic progress.
-    Domain validation occurs after an OAS success and is therefore outside this
-    API and never failover eligible. *)
+    terminalized; inspect {!flow_attempt_evidence} for monotonic progress. Domain
+    validation occurs after an OAS success and is therefore outside this API and
+    never failover eligible. *)
 val execute_flow_once
   :  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> ?clock:_ Eio.Time.clock
   -> before_dispatch:(flow_attempt_receipt -> (unit, 'callback_error) result)
   -> before_advance:
        (failed:flow_candidate_failure
-        -> next:flow_candidate_identity
+        -> next:flow_candidate_visit
         -> (unit, 'callback_error) result)
   -> flow_attempt
   -> (flow_success, 'callback_error flow_execution_error) result

--- a/lib/llm_provider/exact_output.mli
+++ b/lib/llm_provider/exact_output.mli
@@ -344,6 +344,7 @@ type flow_attempt_receipt =
   }
 
 val candidate_visit_count_to_int : candidate_visit_count -> int
+
 val target_selection_error_disposition
   :  target_selection_error
   -> candidate_rejection_disposition
@@ -351,9 +352,11 @@ val target_selection_error_disposition
 val admission_error_disposition : admission_error -> candidate_rejection_disposition
 val candidate_rejection_identity : candidate_rejection_receipt -> flow_candidate_identity
 val candidate_rejection_visit : candidate_rejection_receipt -> flow_candidate_visit
+
 val candidate_rejection_disposition
   :  candidate_rejection_receipt
   -> candidate_rejection_disposition
+
 val candidate_rejection_phase : candidate_rejection_receipt -> effect_phase
 val candidate_rejection_dispatch_count : candidate_rejection_receipt -> int
 

--- a/lib/llm_provider/exact_output.mli
+++ b/lib/llm_provider/exact_output.mli
@@ -23,7 +23,7 @@ type receipt
 type call_id
 type schema_fingerprint
 type flow_candidate
-type ready_flow
+type flow_snapshot
 type flow_attempt
 type resolver_io = { getenv : string -> (string option, unit) result }
 
@@ -210,6 +210,9 @@ type flow_candidate_identity =
   ; target_identity : target_identity
   }
 
+type candidate_attempt_count
+type admission_rejection_receipt
+
 type admitted_flow_candidate =
   { identity : flow_candidate_identity
   ; plan_fingerprint : string
@@ -219,20 +222,16 @@ type admitted_flow_candidate =
 
 type candidate_admission =
   | Candidate_admitted of admitted_flow_candidate
-  | Candidate_rejected of
-      { identity : flow_candidate_identity
-      ; cause : admission_error
-      }
+  | Candidate_rejected of admission_rejection_receipt
 
 type flow_candidate_error = Blank_flow_candidate_id
 
-type flow_admission_error =
+type flow_snapshot_error =
   | Duplicate_flow_candidate_id of
       { candidate_id : string
       ; first_position : int
       ; duplicate_position : int
       }
-  | No_admitted_flow_candidates of candidate_admission list
 
 (** Construct one provider-neutral candidate. The trimmed caller identity must
     be nonempty; it is evidence only and never drives provider policy. *)
@@ -243,18 +242,16 @@ val make_flow_candidate
 
 val flow_candidate_identity : flow_candidate -> flow_candidate_identity
 
-(** Admit every candidate in the immutable, nonempty ordered snapshot before
-    any attempt or network effect exists. Rejected candidates remain in ordered
-    admission evidence; admitted candidates retain separately frozen plans.
-    Execution is possible when at least one candidate admitted. *)
-val admit_flow
+(** Freeze one nonempty ordered candidate snapshot and its immutable domain
+    input. This validates only flow topology. Exact target admission is deferred
+    to the current candidate during {!execute_flow_once}; later candidates are
+    neither prepared nor assigned attempts speculatively. *)
+val snapshot_flow
   :  first:flow_candidate
   -> rest:flow_candidate list
   -> messages:Types.message list
   -> output_requirement
-  -> (ready_flow, flow_admission_error) result
-
-val ready_flow_admissions : ready_flow -> candidate_admission list
+  -> (flow_snapshot, flow_snapshot_error) result
 
 (** Parse exactly one typed catalog input and freeze a private immutable target
     map. The default input is the embedded OAS catalog. [Embedded_with_overlay]
@@ -325,17 +322,9 @@ type start_attempt_error = Call_id_generation_failed of string
     Each attempt owns an opaque call identity and affine execution state. *)
 val start_attempt : ready_plan -> (attempt, start_attempt_error) result
 
-type flow_start_error =
-  | Flow_candidate_attempt_start_failed of
-      { identity : flow_candidate_identity
-      ; position : int
-      ; cause : start_attempt_error
-      ; admissions : candidate_admission list
-      }
-
-(** Allocate a fresh, non-shared exact attempt for every admitted candidate.
-    No attempt is exposed separately and no network effect occurs. *)
-val start_flow : ready_flow -> (flow_attempt, flow_start_error) result
+(** Create one affine execution handle over the frozen snapshot. This performs
+    no target admission, identity allocation, or network effect. *)
+val start_flow : flow_snapshot -> flow_attempt
 
 val call_id_to_string : call_id -> string
 val attempt_receipt : attempt -> receipt
@@ -356,8 +345,20 @@ type flow_attempt_receipt =
   ; receipt : receipt
   }
 
+val candidate_attempt_count_to_int : candidate_attempt_count -> int
+val admission_rejection_identity : admission_rejection_receipt -> flow_candidate_identity
+val admission_rejection_cause : admission_rejection_receipt -> admission_error
+val admission_rejection_phase : admission_rejection_receipt -> effect_phase
+val admission_rejection_dispatch_count : admission_rejection_receipt -> int
+
+val admission_rejection_candidate_attempt_count
+  :  admission_rejection_receipt
+  -> candidate_attempt_count
+
 type flow_evidence =
-  { admissions : candidate_admission list
+  { candidate_snapshot : flow_candidate_identity list
+  ; candidate_attempt_count : candidate_attempt_count
+  ; admissions : candidate_admission list
   ; attempts : flow_attempt_receipt list
   }
 
@@ -367,18 +368,34 @@ type flow_success =
   ; evidence : flow_evidence
   }
 
+type flow_candidate_failure =
+  | Flow_candidate_admission_rejected of admission_rejection_receipt
+  | Flow_candidate_execution_failed of
+      { candidate : flow_attempt_receipt
+      ; cause : execution_error
+      ; candidate_attempt_count : candidate_attempt_count
+      }
+
 type 'callback_error flow_execution_error =
   | Flow_attempt_already_started of flow_evidence
+  | Flow_attempt_start_failed of
+      { candidate : flow_candidate_identity
+      ; cause : start_attempt_error
+      ; evidence : flow_evidence
+      }
   | Flow_before_dispatch_callback_failed of
       { candidate : flow_attempt_receipt
       ; cause : 'callback_error
       ; evidence : flow_evidence
       }
   | Flow_before_advance_callback_failed of
-      { failed : flow_attempt_receipt
-      ; failure : execution_error
-      ; next : flow_attempt_receipt
+      { failed : flow_candidate_failure
+      ; next : flow_candidate_identity
       ; cause : 'callback_error
+      ; evidence : flow_evidence
+      }
+  | Flow_admission_failed of
+      { rejection : admission_rejection_receipt
       ; evidence : flow_evidence
       }
   | Flow_exact_execution_failed of
@@ -387,9 +404,11 @@ type 'callback_error flow_execution_error =
       ; evidence : flow_evidence
       }
 
-(** Point-in-time aggregate evidence. Receipts are the same monotonic handles
-    owned by the non-shared candidate attempts, including candidates that have
-    not started. This remains queryable after cancellation escapes. *)
+(** Point-in-time aggregate evidence. [candidate_snapshot] is the original
+    immutable order. [candidate_attempt_count], [admissions], and [attempts]
+    contain only candidates reached so far. Attempts are allocated only after
+    current-candidate admission succeeds. This remains queryable after
+    cancellation escapes. *)
 val flow_attempt_evidence : flow_attempt -> flow_evidence
 
 (** Execute the frozen request once. The attempt is single-use: duplicate or
@@ -409,27 +428,33 @@ val execute_once
 
 (** Execute one affine outer flow.
 
-    [before_dispatch] must durably bind the predetermined candidate before its
-    sole {!execute_once} call. A typed pre-dispatch transport failure may move
-    to the next admitted candidate only when its receipt is exactly
-    [Before_dispatch] with [dispatch_count = 0] and [before_advance] durably
-    confirms that predetermined transition. Callbacks cannot select, replace,
-    or reorder candidates.
+    OAS prepares only the current frozen candidate. A successful preparation
+    receives one fresh attempt identity, then [before_dispatch] must durably bind
+    that attempt before its sole {!execute_once} call. A typed admission
+    rejection receives a real [admission_rejection_receipt] whose phase is
+    [Before_dispatch] and dispatch count is zero, but no plan, call ID, or
+    execution receipt.
 
-    Callback errors, replay, missing execution prerequisites, frozen-request
-    corruption, cancellation, every post-dispatch outcome, and success are
-    terminal. Cancellation is re-raised after the flow is terminalized; inspect
-    {!flow_attempt_evidence} for its monotonic receipts. Domain validation occurs
-    after an OAS success and is therefore outside this API and never failover
-    eligible. *)
+    [before_advance] receives the settled typed failure and the predetermined
+    next candidate identity. OAS may call it only for an admission rejection or
+    an execution receipt that is exactly [Before_dispatch] with zero dispatch.
+    The callback can stop but cannot select, replace, skip, or reorder the
+    successor.
+
+    A final admission rejection returns [Flow_admission_failed]. Callback errors,
+    replay, identity-allocation failure, missing execution prerequisites,
+    frozen-request corruption, cancellation, every post-dispatch outcome, and
+    success are terminal. Cancellation is re-raised after the flow is
+    terminalized; inspect {!flow_attempt_evidence} for monotonic progress.
+    Domain validation occurs after an OAS success and is therefore outside this
+    API and never failover eligible. *)
 val execute_flow_once
   :  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> ?clock:_ Eio.Time.clock
   -> before_dispatch:(flow_attempt_receipt -> (unit, 'callback_error) result)
   -> before_advance:
-       (failed:flow_attempt_receipt
-        -> failure:execution_error
-        -> next:flow_attempt_receipt
+       (failed:flow_candidate_failure
+        -> next:flow_candidate_identity
         -> (unit, 'callback_error) result)
   -> flow_attempt
   -> (flow_success, 'callback_error flow_execution_error) result

--- a/lib/llm_provider/exact_output_call_id.ml
+++ b/lib/llm_provider/exact_output_call_id.ml
@@ -1,4 +1,4 @@
-(** Private exact-output call identity generation.
+(** Private exact-output call and outer-flow identity generation.
 
     Every identifier is sampled independently from 128 bits of operating-system
     entropy. Entropy failure is explicit and never falls back to clocks,

--- a/lib/llm_provider/exact_output_catalog_binding.ml
+++ b/lib/llm_provider/exact_output_catalog_binding.ml
@@ -1,4 +1,5 @@
 module Caps = Capabilities
+module PC = Provider_config
 module String_map = Map.Make (String)
 module String_set = Set.Make (String)
 
@@ -6,10 +7,96 @@ type exact_binding_error =
   | Provider_missing
   | Model_missing
 
+type endpoint_error =
+  | Malformed_base_url
+  | Base_url_userinfo_not_allowed
+  | Base_url_query_not_allowed
+  | Base_url_fragment_not_allowed
+  | Invalid_request_path
+  | Unsupported_gemini_request_path
+  | Invalid_gemini_model_path
+
 let has_control value =
   String.exists
     (fun character -> Char.code character < 0x20 || Char.code character = 0x7f)
     value
+;;
+
+let validate_base_url value =
+  if has_control value
+  then Error Malformed_base_url
+  else if String.contains value '?'
+  then Error Base_url_query_not_allowed
+  else if String.contains value '#'
+  then Error Base_url_fragment_not_allowed
+  else (
+    let uri = Uri.of_string value in
+    match Uri.scheme uri, Uri.host uri with
+    | Some ("http" | "https"), Some host when host <> "" ->
+      if Option.is_some (Uri.userinfo uri)
+      then Error Base_url_userinfo_not_allowed
+      else if Uri.query uri <> []
+      then Error Base_url_query_not_allowed
+      else if Option.is_some (Uri.fragment uri)
+      then Error Base_url_fragment_not_allowed
+      else Ok ()
+    | _ -> Error Malformed_base_url)
+;;
+
+let contains_encoded_control value =
+  let value = String.lowercase_ascii value in
+  List.exists
+    (fun encoded ->
+       let encoded_length = String.length encoded in
+       let rec loop offset =
+         offset + encoded_length <= String.length value
+         && (String.sub value offset encoded_length = encoded || loop (offset + 1))
+       in
+       loop 0)
+    [ "%00"; "%0a"; "%0d" ]
+;;
+
+let validate_request_path ~kind value =
+  match kind with
+  | PC.Gemini ->
+    if value = "" then Ok () else Error Unsupported_gemini_request_path
+  | PC.Anthropic | PC.Kimi | PC.OpenAI_compat | PC.Ollama | PC.Glm | PC.DashScope ->
+    let path_segments = String.split_on_char '/' value in
+    if
+      value = ""
+      || value.[0] <> '/'
+      || has_control value
+      || contains_encoded_control value
+      || String.contains value '%'
+      || String.contains value '\\'
+      || String.contains value '?'
+      || String.contains value '#'
+      || List.exists (fun segment -> segment = "." || segment = "..") path_segments
+      || List.exists (fun segment -> segment = "") (List.tl path_segments)
+    then Error Invalid_request_path
+    else Ok ()
+;;
+
+let validate_model_path kind model_id =
+  match kind with
+  | PC.Gemini
+    when model_id = ""
+         || model_id = "."
+         || model_id = ".."
+         || not
+              (String.for_all
+                 (function
+                   | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '-' | '_' | '.' | '~' -> true
+                   | _ -> false)
+                 model_id) ->
+    Error Invalid_gemini_model_path
+  | PC.Gemini
+  | PC.Anthropic
+  | PC.Kimi
+  | PC.OpenAI_compat
+  | PC.Ollama
+  | PC.Glm
+  | PC.DashScope -> Ok ()
 ;;
 
 let target_string_field ~target_label ~field toml =

--- a/lib/llm_provider/exact_output_catalog_binding.ml
+++ b/lib/llm_provider/exact_output_catalog_binding.ml
@@ -58,8 +58,7 @@ let contains_encoded_control value =
 
 let validate_request_path ~kind value =
   match kind with
-  | PC.Gemini ->
-    if value = "" then Ok () else Error Unsupported_gemini_request_path
+  | PC.Gemini -> if value = "" then Ok () else Error Unsupported_gemini_request_path
   | PC.Anthropic | PC.Kimi | PC.OpenAI_compat | PC.Ollama | PC.Glm | PC.DashScope ->
     let path_segments = String.split_on_char '/' value in
     if
@@ -88,8 +87,7 @@ let validate_model_path kind model_id =
                  (function
                    | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '-' | '_' | '.' | '~' -> true
                    | _ -> false)
-                 model_id) ->
-    Error Invalid_gemini_model_path
+                 model_id) -> Error Invalid_gemini_model_path
   | PC.Gemini
   | PC.Anthropic
   | PC.Kimi

--- a/lib/llm_provider/exact_output_catalog_binding.mli
+++ b/lib/llm_provider/exact_output_catalog_binding.mli
@@ -12,7 +12,6 @@ type endpoint_error =
   | Invalid_gemini_model_path
 
 val has_control : string -> bool
-
 val validate_base_url : string -> (unit, endpoint_error) result
 
 val validate_request_path

--- a/lib/llm_provider/exact_output_catalog_binding.mli
+++ b/lib/llm_provider/exact_output_catalog_binding.mli
@@ -2,7 +2,28 @@ type exact_binding_error =
   | Provider_missing
   | Model_missing
 
+type endpoint_error =
+  | Malformed_base_url
+  | Base_url_userinfo_not_allowed
+  | Base_url_query_not_allowed
+  | Base_url_fragment_not_allowed
+  | Invalid_request_path
+  | Unsupported_gemini_request_path
+  | Invalid_gemini_model_path
+
 val has_control : string -> bool
+
+val validate_base_url : string -> (unit, endpoint_error) result
+
+val validate_request_path
+  :  kind:Provider_config.provider_kind
+  -> string
+  -> (unit, endpoint_error) result
+
+val validate_model_path
+  :  Provider_config.provider_kind
+  -> string
+  -> (unit, endpoint_error) result
 
 val target_string_field
   :  target_label:string

--- a/lib/llm_provider/exact_output_flow.ml
+++ b/lib/llm_provider/exact_output_flow.ml
@@ -19,7 +19,7 @@ type ('admission, 'attempt) progress_state =
 
 type ('admission, 'attempt) progress = ('admission, 'attempt) progress_state Atomic.t
 
-type ('candidate, 'success, 'execution_error, 'callback_error) outcome =
+type ('candidate, 'success, 'execution_error, 'advanceable_error, 'callback_error) outcome =
   | Succeeded of
       { candidate : 'candidate
       ; success : 'success
@@ -27,7 +27,7 @@ type ('candidate, 'success, 'execution_error, 'callback_error) outcome =
   | Attempt_already_started
   | Before_advance_callback_failed of
       { failed_candidate : 'candidate
-      ; failure : 'execution_error
+      ; failure : 'advanceable_error
       ; next_candidate : 'candidate
       ; cause : 'callback_error
       }
@@ -80,7 +80,7 @@ let duplicate_key ~equal ~key candidates =
   find 1 [] candidates
 ;;
 
-let execute_once state ~candidates ~execute ~can_advance ~before_advance =
+let execute_once state ~candidates ~execute ~advanceable ~before_advance =
   if not (Atomic.compare_and_set state Not_started Running)
   then Attempt_already_started
   else
@@ -93,18 +93,20 @@ let execute_once state ~candidates ~execute ~can_advance ~before_advance =
              (match execute candidate with
               | Ok success -> Succeeded { candidate; success }
               | Error failure ->
-                (match rest with
-                 | next :: _ when can_advance failure ->
-                   (match before_advance ~failed:candidate ~failure ~next with
+                (match rest, advanceable failure with
+                 | next :: _, Some advanceable_failure ->
+                   (match
+                      before_advance ~failed:candidate ~failure:advanceable_failure ~next
+                    with
                     | Ok () -> execute_candidates rest
                     | Error cause ->
                       Before_advance_callback_failed
                         { failed_candidate = candidate
-                        ; failure
+                        ; failure = advanceable_failure
                         ; next_candidate = next
                         ; cause
                         })
-                 | [] | _ :: _ -> Execution_failed { candidate; cause = failure }))
+                 | [], _ | _ :: _, None -> Execution_failed { candidate; cause = failure }))
          in
          execute_candidates candidates)
 ;;

--- a/lib/llm_provider/exact_output_flow.ml
+++ b/lib/llm_provider/exact_output_flow.ml
@@ -5,16 +5,26 @@ type state =
 
 type t = state Atomic.t
 
+type ('admission, 'attempt) progress_snapshot =
+  { candidate_attempt_count : int
+  ; admissions : 'admission list
+  ; attempts : 'attempt list
+  }
+
+type ('admission, 'attempt) progress_state =
+  { candidate_attempt_count : int
+  ; admissions_rev : 'admission list
+  ; attempts_rev : 'attempt list
+  }
+
+type ('admission, 'attempt) progress = ('admission, 'attempt) progress_state Atomic.t
+
 type ('candidate, 'success, 'execution_error, 'callback_error) outcome =
   | Succeeded of
       { candidate : 'candidate
       ; success : 'success
       }
   | Attempt_already_started
-  | Before_dispatch_callback_failed of
-      { candidate : 'candidate
-      ; cause : 'callback_error
-      }
   | Before_advance_callback_failed of
       { failed_candidate : 'candidate
       ; failure : 'execution_error
@@ -28,7 +38,49 @@ type ('candidate, 'success, 'execution_error, 'callback_error) outcome =
 
 let create () = Atomic.make Not_started
 
-let execute_once state ~candidates ~before_dispatch ~execute ~can_advance ~before_advance =
+let create_progress () =
+  Atomic.make { candidate_attempt_count = 0; admissions_rev = []; attempts_rev = [] }
+;;
+
+let record_admission progress make_admission =
+  let current = Atomic.get progress in
+  let candidate_attempt_count = current.candidate_attempt_count + 1 in
+  let admission, result = make_admission ~candidate_attempt_count in
+  Atomic.set
+    progress
+    { current with
+      candidate_attempt_count
+    ; admissions_rev = admission :: current.admissions_rev
+    };
+  result
+;;
+
+let record_attempt progress attempt =
+  let current = Atomic.get progress in
+  Atomic.set progress { current with attempts_rev = attempt :: current.attempts_rev }
+;;
+
+let progress_snapshot progress =
+  let current = Atomic.get progress in
+  { candidate_attempt_count = current.candidate_attempt_count
+  ; admissions = List.rev current.admissions_rev
+  ; attempts = List.rev current.attempts_rev
+  }
+;;
+
+let duplicate_key ~equal ~key candidates =
+  let rec find position seen = function
+    | [] -> None
+    | candidate :: rest ->
+      let value = key candidate in
+      (match List.find_opt (fun (seen_value, _) -> equal seen_value value) seen with
+       | Some (_, first_position) -> Some (value, first_position, position)
+       | None -> find (position + 1) ((value, position) :: seen) rest)
+  in
+  find 1 [] candidates
+;;
+
+let execute_once state ~candidates ~execute ~can_advance ~before_advance =
   if not (Atomic.compare_and_set state Not_started Running)
   then Attempt_already_started
   else
@@ -38,24 +90,21 @@ let execute_once state ~candidates ~before_dispatch ~execute ~can_advance ~befor
          let rec execute_candidates = function
            | [] -> invalid_arg "Exact_output_flow: empty candidate snapshot"
            | candidate :: rest ->
-             (match before_dispatch candidate with
-              | Error cause -> Before_dispatch_callback_failed { candidate; cause }
-              | Ok () ->
-                (match execute candidate with
-                 | Ok success -> Succeeded { candidate; success }
-                 | Error failure ->
-                   (match rest with
-                    | next :: _ when can_advance failure ->
-                      (match before_advance ~failed:candidate ~failure ~next with
-                       | Ok () -> execute_candidates rest
-                       | Error cause ->
-                         Before_advance_callback_failed
-                           { failed_candidate = candidate
-                           ; failure
-                           ; next_candidate = next
-                           ; cause
-                           })
-                    | [] | _ :: _ -> Execution_failed { candidate; cause = failure })))
+             (match execute candidate with
+              | Ok success -> Succeeded { candidate; success }
+              | Error failure ->
+                (match rest with
+                 | next :: _ when can_advance failure ->
+                   (match before_advance ~failed:candidate ~failure ~next with
+                    | Ok () -> execute_candidates rest
+                    | Error cause ->
+                      Before_advance_callback_failed
+                        { failed_candidate = candidate
+                        ; failure
+                        ; next_candidate = next
+                        ; cause
+                        })
+                 | [] | _ :: _ -> Execution_failed { candidate; cause = failure }))
          in
          execute_candidates candidates)
 ;;

--- a/lib/llm_provider/exact_output_flow.ml
+++ b/lib/llm_provider/exact_output_flow.ml
@@ -6,13 +6,13 @@ type state =
 type t = state Atomic.t
 
 type ('admission, 'attempt) progress_snapshot =
-  { candidate_attempt_count : int
+  { candidate_visit_count : int
   ; admissions : 'admission list
   ; attempts : 'attempt list
   }
 
 type ('admission, 'attempt) progress_state =
-  { candidate_attempt_count : int
+  { candidate_visit_count : int
   ; admissions_rev : 'admission list
   ; attempts_rev : 'attempt list
   }
@@ -39,20 +39,18 @@ type ('candidate, 'success, 'execution_error, 'advanceable_error, 'callback_erro
 let create () = Atomic.make Not_started
 
 let create_progress () =
-  Atomic.make { candidate_attempt_count = 0; admissions_rev = []; attempts_rev = [] }
+  Atomic.make { candidate_visit_count = 0; admissions_rev = []; attempts_rev = [] }
 ;;
 
-let record_admission progress make_admission =
+let record_admission progress admission =
   let current = Atomic.get progress in
-  let candidate_attempt_count = current.candidate_attempt_count + 1 in
-  let admission, result = make_admission ~candidate_attempt_count in
+  let candidate_visit_count = current.candidate_visit_count + 1 in
   Atomic.set
     progress
     { current with
-      candidate_attempt_count
+      candidate_visit_count
     ; admissions_rev = admission :: current.admissions_rev
-    };
-  result
+    }
 ;;
 
 let record_attempt progress attempt =
@@ -62,7 +60,7 @@ let record_attempt progress attempt =
 
 let progress_snapshot progress =
   let current = Atomic.get progress in
-  { candidate_attempt_count = current.candidate_attempt_count
+  { candidate_visit_count = current.candidate_visit_count
   ; admissions = List.rev current.admissions_rev
   ; attempts = List.rev current.attempts_rev
   }

--- a/lib/llm_provider/exact_output_flow.mli
+++ b/lib/llm_provider/exact_output_flow.mli
@@ -5,6 +5,13 @@
     types that wrap the private exact plan and execution modules. *)
 
 type t
+type ('admission, 'attempt) progress
+
+type ('admission, 'attempt) progress_snapshot =
+  { candidate_attempt_count : int
+  ; admissions : 'admission list
+  ; attempts : 'attempt list
+  }
 
 type ('candidate, 'success, 'execution_error, 'callback_error) outcome =
   | Succeeded of
@@ -12,10 +19,6 @@ type ('candidate, 'success, 'execution_error, 'callback_error) outcome =
       ; success : 'success
       }
   | Attempt_already_started
-  | Before_dispatch_callback_failed of
-      { candidate : 'candidate
-      ; cause : 'callback_error
-      }
   | Before_advance_callback_failed of
       { failed_candidate : 'candidate
       ; failure : 'execution_error
@@ -28,14 +31,32 @@ type ('candidate, 'success, 'execution_error, 'callback_error) outcome =
       }
 
 val create : unit -> t
+val create_progress : unit -> ('admission, 'attempt) progress
+
+val record_admission
+  :  ('admission, 'attempt) progress
+  -> (candidate_attempt_count:int -> 'admission * 'result)
+  -> 'result
+
+val record_attempt : ('admission, 'attempt) progress -> 'attempt -> unit
+
+val progress_snapshot
+  :  ('admission, 'attempt) progress
+  -> ('admission, 'attempt) progress_snapshot
+
+val duplicate_key
+  :  equal:('key -> 'key -> bool)
+  -> key:('candidate -> 'key)
+  -> 'candidate list
+  -> ('key * int * int) option
 
 (** Execute an immutable, nonempty candidate snapshot once.
 
-    [before_dispatch] must confirm the caller's durable binding before
-    [execute] is entered. [before_advance] receives the already-selected
-    successor and can only confirm or reject its durable transition; it cannot
-    replace or reorder that successor. [can_advance] is supplied exclusively by
-    the private facade adapter.
+    [execute] owns preparation, durable pre-dispatch binding, and one-shot
+    execution for the current candidate. [before_advance] receives the
+    already-selected successor and can only confirm or reject its durable
+    transition; it cannot replace or reorder that successor. [can_advance] is
+    supplied exclusively by the private facade adapter.
 
     The outer attempt is affine. A duplicate or concurrent invocation returns
     [Attempt_already_started]. Any exception, including Eio cancellation,
@@ -43,7 +64,6 @@ val create : unit -> t
 val execute_once
   :  t
   -> candidates:'candidate list
-  -> before_dispatch:('candidate -> (unit, 'callback_error) result)
   -> execute:('candidate -> ('success, 'execution_error) result)
   -> can_advance:('execution_error -> bool)
   -> before_advance:

--- a/lib/llm_provider/exact_output_flow.mli
+++ b/lib/llm_provider/exact_output_flow.mli
@@ -8,7 +8,7 @@ type t
 type ('admission, 'attempt) progress
 
 type ('admission, 'attempt) progress_snapshot =
-  { candidate_attempt_count : int
+  { candidate_visit_count : int
   ; admissions : 'admission list
   ; attempts : 'attempt list
   }
@@ -39,8 +39,8 @@ val create_progress : unit -> ('admission, 'attempt) progress
 
 val record_admission
   :  ('admission, 'attempt) progress
-  -> (candidate_attempt_count:int -> 'admission * 'result)
-  -> 'result
+  -> 'admission
+  -> unit
 
 val record_attempt : ('admission, 'attempt) progress -> 'attempt -> unit
 

--- a/lib/llm_provider/exact_output_flow.mli
+++ b/lib/llm_provider/exact_output_flow.mli
@@ -37,11 +37,7 @@ val create : unit -> t
     recorded admission and its subsequently allocated attempt. *)
 val create_progress : unit -> ('admission, 'attempt) progress
 
-val record_admission
-  :  ('admission, 'attempt) progress
-  -> 'admission
-  -> unit
-
+val record_admission : ('admission, 'attempt) progress -> 'admission -> unit
 val record_attempt : ('admission, 'attempt) progress -> 'attempt -> unit
 
 val progress_snapshot

--- a/lib/llm_provider/exact_output_flow.mli
+++ b/lib/llm_provider/exact_output_flow.mli
@@ -13,7 +13,7 @@ type ('admission, 'attempt) progress_snapshot =
   ; attempts : 'attempt list
   }
 
-type ('candidate, 'success, 'execution_error, 'callback_error) outcome =
+type ('candidate, 'success, 'execution_error, 'advanceable_error, 'callback_error) outcome =
   | Succeeded of
       { candidate : 'candidate
       ; success : 'success
@@ -21,7 +21,7 @@ type ('candidate, 'success, 'execution_error, 'callback_error) outcome =
   | Attempt_already_started
   | Before_advance_callback_failed of
       { failed_candidate : 'candidate
-      ; failure : 'execution_error
+      ; failure : 'advanceable_error
       ; next_candidate : 'candidate
       ; cause : 'callback_error
       }
@@ -31,6 +31,10 @@ type ('candidate, 'success, 'execution_error, 'callback_error) outcome =
       }
 
 val create : unit -> t
+
+(** Progress has exactly one writer: the invocation that wins [execute_once]'s
+    affine gate. Concurrent readers may observe the honest point between a
+    recorded admission and its subsequently allocated attempt. *)
 val create_progress : unit -> ('admission, 'attempt) progress
 
 val record_admission
@@ -55,8 +59,9 @@ val duplicate_key
     [execute] owns preparation, durable pre-dispatch binding, and one-shot
     execution for the current candidate. [before_advance] receives the
     already-selected successor and can only confirm or reject its durable
-    transition; it cannot replace or reorder that successor. [can_advance] is
-    supplied exclusively by the private facade adapter.
+    transition; it cannot replace or reorder that successor. [advanceable]
+    refines an execution error into the only error type accepted by
+    [before_advance]; terminal errors cannot reach that callback.
 
     The outer attempt is affine. A duplicate or concurrent invocation returns
     [Attempt_already_started]. Any exception, including Eio cancellation,
@@ -65,10 +70,10 @@ val execute_once
   :  t
   -> candidates:'candidate list
   -> execute:('candidate -> ('success, 'execution_error) result)
-  -> can_advance:('execution_error -> bool)
+  -> advanceable:('execution_error -> 'advanceable_error option)
   -> before_advance:
        (failed:'candidate
-        -> failure:'execution_error
+        -> failure:'advanceable_error
         -> next:'candidate
         -> (unit, 'callback_error) result)
-  -> ('candidate, 'success, 'execution_error, 'callback_error) outcome
+  -> ('candidate, 'success, 'execution_error, 'advanceable_error, 'callback_error) outcome

--- a/lib/llm_provider/exact_output_gemini_schema.ml
+++ b/lib/llm_provider/exact_output_gemini_schema.ml
@@ -1,0 +1,156 @@
+type error =
+  | Unsupported_keyword of string
+  | Unsupported_type of string
+  | Invalid_schema
+
+let ( let* ) = Result.bind
+
+let schema_keywords =
+  [ "type"
+  ; "title"
+  ; "description"
+  ; "properties"
+  ; "required"
+  ; "additionalProperties"
+  ; "enum"
+  ; "format"
+  ; "minimum"
+  ; "maximum"
+  ; "items"
+  ; "prefixItems"
+  ; "minItems"
+  ; "maxItems"
+  ]
+;;
+
+let keywords_for_type = function
+  | "object" ->
+    [ "type"; "title"; "description"; "properties"; "required"; "additionalProperties" ]
+  | "string" -> [ "type"; "title"; "description"; "enum"; "format" ]
+  | "number" | "integer" ->
+    [ "type"; "title"; "description"; "enum"; "minimum"; "maximum" ]
+  | "array" ->
+    [ "type"; "title"; "description"; "items"; "prefixItems"; "minItems"; "maxItems" ]
+  | "boolean" | "null" -> [ "type"; "title"; "description" ]
+  | type_name -> raise_notrace (Invalid_argument type_name)
+;;
+
+let assoc_keys_are_unique fields =
+  let keys = List.map fst fields in
+  List.length keys = List.length (List.sort_uniq String.compare keys)
+;;
+
+let json_number = function
+  | `Int _ | `Intlit _ | `Float _ -> true
+  | `Null | `Bool _ | `String _ | `Assoc _ | `List _ -> false
+;;
+
+let json_integer = function
+  | `Int _ | `Intlit _ -> true
+  | `Null | `Bool _ | `Float _ | `String _ | `Assoc _ | `List _ -> false
+;;
+
+let non_null_schema_types =
+  [ "string"; "number"; "integer"; "boolean"; "object"; "array" ]
+;;
+
+let schema_base_type = function
+  | Some (`String type_name)
+    when String.equal type_name "null" || List.mem type_name non_null_schema_types ->
+    Ok type_name
+  | Some (`String type_name) -> Error (Unsupported_type type_name)
+  | Some (`List [ `String left; `String right ])
+    when String.equal left "null" && List.mem right non_null_schema_types ->
+    Ok right
+  | Some (`List [ `String left; `String right ])
+    when String.equal right "null" && List.mem left non_null_schema_types ->
+    Ok left
+  | Some (`List _) | Some _ | None -> Error Invalid_schema
+;;
+
+let rec validate ~path = function
+  | `Assoc fields when assoc_keys_are_unique fields ->
+    (match
+       List.find_opt (fun (keyword, _) -> not (List.mem keyword schema_keywords)) fields
+     with
+     | Some (keyword, _) -> Error (Unsupported_keyword (path ^ "." ^ keyword))
+     | None ->
+       (match schema_base_type (List.assoc_opt "type" fields) with
+        | Ok type_name ->
+          let supported = keywords_for_type type_name in
+          (match
+             List.find_opt (fun (keyword, _) -> not (List.mem keyword supported)) fields
+           with
+           | Some (keyword, _) -> Error (Unsupported_keyword (path ^ "." ^ keyword))
+           | None -> validate_fields ~path ~type_name fields)
+        | Error _ as error -> error))
+  | `Assoc _ | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ ->
+    Error Invalid_schema
+
+and validate_fields ~path ~type_name fields =
+  let rec validate_all = function
+    | [] -> Ok ()
+    | field :: rest ->
+      let* () = validate_field ~path ~type_name field in
+      validate_all rest
+  in
+  validate_all fields
+
+and validate_field ~path ~type_name = function
+  | "type", (`String _ | `List _) -> Ok ()
+  | ("title" | "description"), `String _ -> Ok ()
+  | "properties", `Assoc properties
+    when String.equal type_name "object" && assoc_keys_are_unique properties ->
+    let rec validate_properties = function
+      | [] -> Ok ()
+      | (name, schema) :: rest ->
+        let* () = validate ~path:(path ^ ".properties." ^ name) schema in
+        validate_properties rest
+    in
+    validate_properties properties
+  | "required", `List names
+    when String.equal type_name "object"
+         && List.for_all
+              (function
+                | `String _ -> true
+                | _ -> false)
+              names -> Ok ()
+  | "additionalProperties", `Bool _ when String.equal type_name "object" -> Ok ()
+  | "additionalProperties", schema when String.equal type_name "object" ->
+    validate ~path:(path ^ ".additionalProperties") schema
+  | "enum", `List values
+    when values <> []
+         && String.equal type_name "string"
+         && List.for_all
+              (function
+                | `String _ -> true
+                | _ -> false)
+              values -> Ok ()
+  | "enum", `List values
+    when values <> []
+         && String.equal type_name "number"
+         && List.for_all json_number values -> Ok ()
+  | "enum", `List values
+    when values <> []
+         && String.equal type_name "integer"
+         && List.for_all json_integer values -> Ok ()
+  | "format", `String _ when String.equal type_name "string" -> Ok ()
+  | ("minimum" | "maximum"), value
+    when (String.equal type_name "number" || String.equal type_name "integer")
+         && json_number value -> Ok ()
+  | "items", schema when String.equal type_name "array" ->
+    validate ~path:(path ^ ".items") schema
+  | "prefixItems", `List schemas when String.equal type_name "array" ->
+    let rec validate_prefix_items index = function
+      | [] -> Ok ()
+      | schema :: rest ->
+        let* () =
+          validate ~path:(Printf.sprintf "%s.prefixItems[%d]" path index) schema
+        in
+        validate_prefix_items (index + 1) rest
+    in
+    validate_prefix_items 0 schemas
+  | ("minItems" | "maxItems"), `Int value
+    when String.equal type_name "array" && value >= 0 -> Ok ()
+  | _ -> Error Invalid_schema
+;;

--- a/lib/llm_provider/exact_output_gemini_schema.ml
+++ b/lib/llm_provider/exact_output_gemini_schema.ml
@@ -60,11 +60,9 @@ let schema_base_type = function
     Ok type_name
   | Some (`String type_name) -> Error (Unsupported_type type_name)
   | Some (`List [ `String left; `String right ])
-    when String.equal left "null" && List.mem right non_null_schema_types ->
-    Ok right
+    when String.equal left "null" && List.mem right non_null_schema_types -> Ok right
   | Some (`List [ `String left; `String right ])
-    when String.equal right "null" && List.mem left non_null_schema_types ->
-    Ok left
+    when String.equal right "null" && List.mem left non_null_schema_types -> Ok left
   | Some (`List _) | Some _ | None -> Error Invalid_schema
 ;;
 

--- a/lib/llm_provider/exact_output_gemini_schema.mli
+++ b/lib/llm_provider/exact_output_gemini_schema.mli
@@ -1,0 +1,6 @@
+type error =
+  | Unsupported_keyword of string
+  | Unsupported_type of string
+  | Invalid_schema
+
+val validate : path:string -> Yojson.Safe.t -> (unit, error) result

--- a/lib/llm_provider/exact_output_resolver.ml
+++ b/lib/llm_provider/exact_output_resolver.ml
@@ -965,6 +965,14 @@ let admit_target_ref snapshot value =
        Ok { target; generation = snapshot.generation; evidence = snapshot.evidence })
 ;;
 
+let admitted_target_identity (admitted : admitted_target) = admitted.target.identity
+
+let admitted_target_catalog_generation (admitted : admitted_target) =
+  admitted.generation
+;;
+
+let admitted_target_catalog_evidence (admitted : admitted_target) = admitted.evidence
+
 let resolve_target (admitted : admitted_target) =
   let target = admitted.target in
   let target_ref = target_ref_id target.identity.target_ref in

--- a/lib/llm_provider/exact_output_resolver.ml
+++ b/lib/llm_provider/exact_output_resolver.ml
@@ -893,11 +893,7 @@ let admit_target_ref snapshot value =
 ;;
 
 let admitted_target_identity (admitted : admitted_target) = admitted.target.identity
-
-let admitted_target_catalog_generation (admitted : admitted_target) =
-  admitted.generation
-;;
-
+let admitted_target_catalog_generation (admitted : admitted_target) = admitted.generation
 let admitted_target_catalog_evidence (admitted : admitted_target) = admitted.evidence
 
 let resolve_target (admitted : admitted_target) =

--- a/lib/llm_provider/exact_output_resolver.ml
+++ b/lib/llm_provider/exact_output_resolver.ml
@@ -51,7 +51,7 @@ type resolver_binding_component =
   | Target_provider
   | Target_model
 
-type resolver_endpoint_error =
+type resolver_endpoint_error = Binding.endpoint_error =
   | Malformed_base_url
   | Base_url_userinfo_not_allowed
   | Base_url_query_not_allowed
@@ -514,94 +514,21 @@ let%test "case-only target overlay shadow fails closed" =
   | None, _ | _, None -> false
 ;;
 
-let validate_base_url ~target_ref value =
-  let target_ref = target_ref_id target_ref in
-  if Binding.has_control value
-  then Error (Target_endpoint_invalid { target_ref; cause = Malformed_base_url })
-  else if String.contains value '?'
-  then Error (Target_endpoint_invalid { target_ref; cause = Base_url_query_not_allowed })
-  else if String.contains value '#'
-  then
-    Error (Target_endpoint_invalid { target_ref; cause = Base_url_fragment_not_allowed })
-  else (
-    let uri = Uri.of_string value in
-    match Uri.scheme uri, Uri.host uri with
-    | Some ("http" | "https"), Some host when host <> "" ->
-      if Option.is_some (Uri.userinfo uri)
-      then
-        Error
-          (Target_endpoint_invalid { target_ref; cause = Base_url_userinfo_not_allowed })
-      else if Uri.query uri <> []
-      then
-        Error (Target_endpoint_invalid { target_ref; cause = Base_url_query_not_allowed })
-      else if Option.is_some (Uri.fragment uri)
-      then
-        Error
-          (Target_endpoint_invalid { target_ref; cause = Base_url_fragment_not_allowed })
-      else Ok ()
-    | _ -> Error (Target_endpoint_invalid { target_ref; cause = Malformed_base_url }))
+let endpoint_result ~target_ref =
+  Result.map_error (fun cause ->
+    Target_endpoint_invalid { target_ref = target_ref_id target_ref; cause })
 ;;
 
-let contains_encoded_control value =
-  let value = String.lowercase_ascii value in
-  List.exists
-    (fun encoded ->
-       let encoded_length = String.length encoded in
-       let rec loop offset =
-         offset + encoded_length <= String.length value
-         && (String.sub value offset encoded_length = encoded || loop (offset + 1))
-       in
-       loop 0)
-    [ "%00"; "%0a"; "%0d" ]
+let validate_base_url ~target_ref value =
+  Binding.validate_base_url value |> endpoint_result ~target_ref
 ;;
 
 let validate_request_path ~target_ref ~kind value =
-  let target_ref = target_ref_id target_ref in
-  match kind with
-  | PC.Gemini ->
-    if value = ""
-    then Ok ()
-    else
-      Error
-        (Target_endpoint_invalid { target_ref; cause = Unsupported_gemini_request_path })
-  | PC.Anthropic | PC.Kimi | PC.OpenAI_compat | PC.Ollama | PC.Glm | PC.DashScope ->
-    let path_segments = String.split_on_char '/' value in
-    if
-      value = ""
-      || value.[0] <> '/'
-      || Binding.has_control value
-      || contains_encoded_control value
-      || String.contains value '%'
-      || String.contains value '\\'
-      || String.contains value '?'
-      || String.contains value '#'
-      || List.exists (fun segment -> segment = "." || segment = "..") path_segments
-      || List.exists (fun segment -> segment = "") (List.tl path_segments)
-    then Error (Target_endpoint_invalid { target_ref; cause = Invalid_request_path })
-    else Ok ()
+  Binding.validate_request_path ~kind value |> endpoint_result ~target_ref
 ;;
 
 let validate_model_path ~target_ref kind model_id =
-  let target_ref = target_ref_id target_ref in
-  match kind with
-  | PC.Gemini
-    when model_id = ""
-         || model_id = "."
-         || model_id = ".."
-         || not
-              (String.for_all
-                 (function
-                   | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '-' | '_' | '.' | '~' -> true
-                   | _ -> false)
-                 model_id) ->
-    Error (Target_endpoint_invalid { target_ref; cause = Invalid_gemini_model_path })
-  | PC.Gemini
-  | PC.Anthropic
-  | PC.Kimi
-  | PC.OpenAI_compat
-  | PC.Ollama
-  | PC.Glm
-  | PC.DashScope -> Ok ()
+  Binding.validate_model_path kind model_id |> endpoint_result ~target_ref
 ;;
 
 let option_float = function

--- a/lib/llm_provider/exact_output_resolver.mli
+++ b/lib/llm_provider/exact_output_resolver.mli
@@ -103,6 +103,9 @@ val catalog_evidence_sha256 : catalog_evidence -> string
 val resolver_catalog_generation : resolver_snapshot -> catalog_generation
 val resolver_catalog_evidence : resolver_snapshot -> catalog_evidence
 val target_identity_fingerprint : target_identity -> string
+val admitted_target_identity : admitted_target -> target_identity
+val admitted_target_catalog_generation : admitted_target -> catalog_generation
+val admitted_target_catalog_evidence : admitted_target -> catalog_evidence
 val selected_target_identity : selected_target -> target_identity
 val selected_target_catalog_generation : selected_target -> catalog_generation
 val selected_target_catalog_evidence : selected_target -> catalog_evidence

--- a/scripts/check-exact-output-resolver-boundary.sh
+++ b/scripts/check-exact-output-resolver-boundary.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -eEuo pipefail
+
+trap 'status=$?; printf "exact-output resolver boundary ratchet aborted at line %s: %s\n" "$LINENO" "$BASH_COMMAND" >&2; exit "$status"' ERR
 
 required_basenames=(
   exact_output.ml
@@ -1043,3 +1045,5 @@ scan_code \
   "parallel public exact-output flow module escaped the single facade" \
   '^[[:space:]]*module[[:space:]]+(Flow|Exact_output_flow)' \
   "$exact_output_interface"
+
+echo "exact-output resolver boundary: OK"

--- a/scripts/check-exact-output-resolver-boundary.sh
+++ b/scripts/check-exact-output-resolver-boundary.sh
@@ -650,6 +650,15 @@ require_code_pattern \
   "outer exact flow no longer prepares only the executing candidate" \
   'let[[:space:]]+execute_flow_candidate[[:space:]]' \
   "$exact_output_source"
+require_code_sequence \
+  "private exact-output flow lost typed advance-error refinement" \
+  'advanceable:.*option.*failure:.*advanceable_error' \
+  "$module_dir/exact_output_flow.mli"
+scan_named_functions \
+  "outer exact-flow advance refinement returned to runtime exceptions" \
+  'invalid_arg|failwith' \
+  "$exact_output_source" \
+  "advanceable_flow_failure execute_flow_once"
 scan_code \
   "speculative ready-flow admission projection returned" \
   'type[[:space:]]+ready_flow|val[[:space:]]+(ready_flow_admissions|admit_flow)|let[[:space:]]+(ready_flow_admissions|admit_flow)' \

--- a/scripts/check-exact-output-resolver-boundary.sh
+++ b/scripts/check-exact-output-resolver-boundary.sh
@@ -503,16 +503,10 @@ scan_public_error_accessors() {
   hits="$(
     strip_ocaml_noncode < "$source_file" \
       | awk '
-          match(
-            $0,
-            /^[[:space:]]*val[[:space:]]+(target_selection_error|wire_admission_error|admission_error)_[[:alnum:]_]+/
-          ) {
+          match($0, /^[[:space:]]*val[[:space:]]+(target_selection_error|wire_admission_error|admission_error)_[[:alnum:]_]+/) {
             accessor = substr($0, RSTART, RLENGTH)
             sub(/^[[:space:]]*val[[:space:]]+/, "", accessor)
-            if (
-              accessor != "target_selection_error_disposition"
-              && accessor != "admission_error_disposition"
-            ) {
+            if (accessor != "target_selection_error_disposition" && accessor != "admission_error_disposition") {
               printf "%d:%s\n", NR, $0
             }
           }
@@ -986,7 +980,7 @@ scan_named_functions \
   "make_flow_candidate snapshot_flow start_flow"
 require_code_pattern \
   "outer exact flow no longer prepares only the executing candidate" \
-  'let[[:space:]]+execute_flow_candidate[[:space:]]' \
+  'let[[:space:]]+execute_flow_candidate([^[:alnum:]_]|$)' \
   "$exact_output_source"
 require_named_function_pattern \
   "current exact-flow candidate no longer resolves its frozen target" \

--- a/scripts/check-exact-output-resolver-boundary.sh
+++ b/scripts/check-exact-output-resolver-boundary.sh
@@ -353,9 +353,10 @@ extract_named_type_block() {
   local type_name="$2"
   strip_ocaml_noncode < "$source_file" \
     | awk -v target="$type_name" '
-        BEGIN {
-          capture = 0
-          found = 0
+    BEGIN {
+      capture = 0
+      found = 0
+      done = 0
         }
         function declaration_name(line) {
           sub(/^type[[:space:]]+/, "", line)
@@ -364,14 +365,18 @@ extract_named_type_block() {
         }
         /^type[[:space:]]+/ {
           current = declaration_name($0)
-          if (capture) exit
-          if (current == target) {
+          if (capture) {
+            capture = 0
+            done = 1
+          }
+          if (!done && current == target) {
             capture = 1
             found = 1
           }
         }
         capture && /^(val|module|exception|class|include|external|open)[[:space:]]/ {
-          exit
+          capture = 0
+          done = 1
         }
         capture {
           print

--- a/scripts/check-exact-output-resolver-boundary.sh
+++ b/scripts/check-exact-output-resolver-boundary.sh
@@ -626,6 +626,35 @@ require_code_sequence \
   "canonical facade lost outer exact-flow execution" \
   'val[[:space:]]+execute_flow_once[[:space:]]*:' \
   "$exact_output_interface"
+require_code_sequence \
+  "canonical facade lost immutable flow snapshot construction" \
+  'val[[:space:]]+snapshot_flow[[:space:]]*:' \
+  "$exact_output_interface"
+require_code_sequence \
+  "outer exact flow lost typed candidate-attempt progress" \
+  'type[[:space:]]+candidate_attempt_count' \
+  "$exact_output_interface"
+require_code_sequence \
+  "outer exact flow lost typed admission-rejection receipts" \
+  'type[[:space:]]+admission_rejection_receipt' \
+  "$exact_output_interface"
+require_code_pattern \
+  "admission rejection is no longer fixed at Before_dispatch" \
+  'let[[:space:]]+admission_rejection_phase[[:space:]]+_[[:space:]]*=[[:space:]]*Before_dispatch' \
+  "$exact_output_source"
+require_code_pattern \
+  "admission rejection is no longer fixed at zero dispatch" \
+  'let[[:space:]]+admission_rejection_dispatch_count[[:space:]]+_[[:space:]]*=[[:space:]]*0' \
+  "$exact_output_source"
+require_code_pattern \
+  "outer exact flow no longer prepares only the executing candidate" \
+  'let[[:space:]]+execute_flow_candidate[[:space:]]' \
+  "$exact_output_source"
+scan_code \
+  "speculative ready-flow admission projection returned" \
+  'type[[:space:]]+ready_flow|val[[:space:]]+(ready_flow_admissions|admit_flow)|let[[:space:]]+(ready_flow_admissions|admit_flow)' \
+  "$exact_output_interface" \
+  "$exact_output_source"
 scan_code \
   "parallel public exact-output flow module escaped the single facade" \
   '^[[:space:]]*module[[:space:]]+(Flow|Exact_output_flow)' \

--- a/scripts/check-exact-output-resolver-boundary.sh
+++ b/scripts/check-exact-output-resolver-boundary.sh
@@ -346,6 +346,182 @@ require_named_function_pattern() {
   rm -f "$extracted"
 }
 
+extract_named_type_block() {
+  local source_file="$1"
+  local type_name="$2"
+  strip_ocaml_noncode < "$source_file" \
+    | awk -v target="$type_name" '
+        BEGIN {
+          capture = 0
+          found = 0
+        }
+        function declaration_name(line) {
+          sub(/^type[[:space:]]+/, "", line)
+          sub(/[^[:alnum:]_].*$/, "", line)
+          return line
+        }
+        /^type[[:space:]]+/ {
+          current = declaration_name($0)
+          if (capture) exit
+          if (current == target) {
+            capture = 1
+            found = 1
+          }
+        }
+        capture && /^(val|module|exception|class|include|external|open)[[:space:]]/ {
+          exit
+        }
+        capture {
+          print
+        }
+        END {
+          if (!found) exit 3
+        }
+      '
+}
+
+require_type_block_pattern() {
+  local description="$1"
+  local source_file="$2"
+  local type_name="$3"
+  local pattern="$4"
+  local block compact
+  if ! block="$(extract_named_type_block "$source_file" "$type_name")"; then
+    echo "exact-output boundary violation: $description" >&2
+    return 1
+  fi
+  compact="$(printf '%s\n' "$block" | awk '{ printf "%s ", $0 } END { print "" }')"
+  if ! grep -E -- "$pattern" <<< "$compact" >/dev/null; then
+    echo "exact-output boundary violation: $description" >&2
+    return 1
+  fi
+}
+
+require_opaque_type() {
+  local description="$1"
+  local source_file="$2"
+  local type_name="$3"
+  local block compact
+  if ! block="$(extract_named_type_block "$source_file" "$type_name")"; then
+    echo "exact-output boundary violation: $description" >&2
+    return 1
+  fi
+  compact="$(printf '%s\n' "$block" | awk '{ printf "%s ", $0 } END { print "" }')"
+  if grep -E -- \
+    "type[[:space:]]+${type_name}[[:space:]]*:?[[:space:]]*=" \
+    <<< "$compact" \
+    >/dev/null
+  then
+    echo "exact-output boundary violation: $description" >&2
+    return 1
+  fi
+}
+
+require_type_constructor_set() {
+  local description="$1"
+  local source_file="$2"
+  local type_name="$3"
+  shift 3
+  local block actual expected
+  if ! block="$(extract_named_type_block "$source_file" "$type_name")"; then
+    echo "exact-output boundary violation: $description" >&2
+    return 1
+  fi
+  actual="$(
+    printf '%s\n' "$block" \
+      | awk '
+          {
+            rest = $0
+            while (match(rest, /(^|[=|])[[:space:]]*[A-Z][[:alnum:]_]*/)) {
+              constructor = substr(rest, RSTART, RLENGTH)
+              sub(/^[=|][[:space:]]*/, "", constructor)
+              sub(/^[[:space:]]*/, "", constructor)
+              print constructor
+              rest = substr(rest, RSTART + RLENGTH)
+            }
+          }
+        ' \
+      | sort -u \
+      | paste -s -d ' ' -
+  )"
+  expected="$(printf '%s\n' "$@" | sort -u | paste -s -d ' ' -)"
+  if [[ "$actual" != "$expected" ]]; then
+    echo \
+      "exact-output boundary violation: $description (expected: $expected; actual: $actual)" \
+      >&2
+    return 1
+  fi
+}
+
+require_type_field_set() {
+  local description="$1"
+  local source_file="$2"
+  local type_name="$3"
+  shift 3
+  local block actual expected
+  if ! block="$(extract_named_type_block "$source_file" "$type_name")"; then
+    echo "exact-output boundary violation: $description" >&2
+    return 1
+  fi
+  actual="$(
+    printf '%s\n' "$block" \
+      | awk '
+          {
+            rest = $0
+            while (match(rest, /(^|[;{])[[:space:]]*[a-z][[:alnum:]_]*[[:space:]]*:/)) {
+              field = substr(rest, RSTART, RLENGTH)
+              sub(/^[;{][[:space:]]*/, "", field)
+              sub(/^[[:space:]]*/, "", field)
+              sub(/[[:space:]]*:$/, "", field)
+              print field
+              rest = substr(rest, RSTART + RLENGTH)
+            }
+          }
+        ' \
+      | sort -u \
+      | paste -s -d ' ' -
+  )"
+  expected="$(printf '%s\n' "$@" | sort -u | paste -s -d ' ' -)"
+  if [[ "$actual" != "$expected" ]]; then
+    echo \
+      "exact-output boundary violation: $description (expected: $expected; actual: $actual)" \
+      >&2
+    return 1
+  fi
+}
+
+scan_public_error_accessors() {
+  local source_file="$1"
+  local hits
+  hits="$(
+    strip_ocaml_noncode < "$source_file" \
+      | awk '
+          match(
+            $0,
+            /^[[:space:]]*val[[:space:]]+(target_selection_error|wire_admission_error|admission_error)_[[:alnum:]_]+/
+          ) {
+            accessor = substr($0, RSTART, RLENGTH)
+            sub(/^[[:space:]]*val[[:space:]]+/, "", accessor)
+            if (
+              accessor != "target_selection_error_disposition"
+              && accessor != "admission_error_disposition"
+            ) {
+              printf "%d:%s\n", NR, $0
+            }
+          }
+        '
+  )"
+  if [[ -n "$hits" ]]; then
+    while IFS= read -r hit; do
+      printf '%s:%s\n' "$source_file" "$hit" >&2
+    done <<< "$hits"
+    echo \
+      "exact-output boundary violation: detailed exact-output error accessor escaped" \
+      >&2
+    return 1
+  fi
+}
+
 exact_output_source=""
 exact_output_flow_source=""
 resolver_source=""
@@ -631,25 +807,199 @@ require_code_sequence \
   'val[[:space:]]+snapshot_flow[[:space:]]*:' \
   "$exact_output_interface"
 require_code_sequence \
-  "outer exact flow lost typed candidate-attempt progress" \
-  'type[[:space:]]+candidate_attempt_count' \
+  "outer exact flow lost typed candidate-visit progress" \
+  'type[[:space:]]+candidate_visit_count([[:space:]]|$)' \
+  "$exact_output_interface"
+require_type_constructor_set \
+  "outer exact flow lost provider-neutral rejection projection" \
+  "$exact_output_interface" \
+  candidate_rejection_disposition \
+  Runtime_slot_unavailable \
+  Runtime_contract_rejected \
+  Input_contract_rejected \
+  Output_requirement_rejected \
+  Input_capacity \
+  Request_preparation_failed
+require_type_block_pattern \
+  "outer exact flow lost the typed input-capacity payload" \
+  "$exact_output_interface" \
+  candidate_rejection_disposition \
+  'Input_capacity[[:space:]]+of[[:space:]]+input_capacity_disposition([^[:alnum:]_]|$)'
+require_type_constructor_set \
+  "outer exact flow lost the closed token/byte capacity projection" \
+  "$exact_output_interface" \
+  input_capacity_disposition \
+  Token_measurement_required \
+  Serialized_request_body_too_large
+require_type_field_set \
+  "outer exact flow changed the closed token/byte capacity fields" \
+  "$exact_output_interface" \
+  input_capacity_disposition \
+  accepted_through_tokens \
+  rejected_from_tokens \
+  actual_bytes \
+  limit_bytes
+require_type_block_pattern \
+  "token measurement disposition lost accepted-through token evidence" \
+  "$exact_output_interface" \
+  input_capacity_disposition \
+  'Token_measurement_required[[:space:]]+of[[:space:]]*\{[^}]*accepted_through_tokens[[:space:]]*:'
+require_type_block_pattern \
+  "token measurement disposition lost rejected-from token evidence" \
+  "$exact_output_interface" \
+  input_capacity_disposition \
+  'Token_measurement_required[[:space:]]+of[[:space:]]*\{[^}]*rejected_from_tokens[[:space:]]*:'
+require_type_block_pattern \
+  "serialized request disposition lost actual-byte evidence" \
+  "$exact_output_interface" \
+  input_capacity_disposition \
+  'Serialized_request_body_too_large[[:space:]]+of[[:space:]]*\{[^}]*actual_bytes[[:space:]]*:'
+require_type_block_pattern \
+  "serialized request disposition lost byte-limit evidence" \
+  "$exact_output_interface" \
+  input_capacity_disposition \
+  'Serialized_request_body_too_large[[:space:]]+of[[:space:]]*\{[^}]*limit_bytes[[:space:]]*:'
+require_type_block_pattern \
+  "outer exact flow changed accepted-through token evidence" \
+  "$exact_output_interface" \
+  input_capacity_disposition \
+  'accepted_through_tokens[[:space:]]*:[[:space:]]*int([^[:alnum:]_]|$)'
+require_type_block_pattern \
+  "outer exact flow changed rejected-from token evidence" \
+  "$exact_output_interface" \
+  input_capacity_disposition \
+  'rejected_from_tokens[[:space:]]*:[[:space:]]*int[[:space:]]+option([^[:alnum:]_]|$)'
+require_type_block_pattern \
+  "outer exact flow changed serialized request byte evidence" \
+  "$exact_output_interface" \
+  input_capacity_disposition \
+  'actual_bytes[[:space:]]*:[[:space:]]*int([^[:alnum:]_]|$)'
+require_type_block_pattern \
+  "outer exact flow changed serialized request byte limit" \
+  "$exact_output_interface" \
+  input_capacity_disposition \
+  'limit_bytes[[:space:]]*:[[:space:]]*int([^[:alnum:]_]|$)'
+require_opaque_type \
+  "target-selection errors stopped being opaque" \
+  "$exact_output_interface" \
+  target_selection_error
+require_opaque_type \
+  "wire-admission errors stopped being opaque" \
+  "$exact_output_interface" \
+  wire_admission_error
+require_opaque_type \
+  "request-admission errors stopped being opaque" \
+  "$exact_output_interface" \
+  admission_error
+require_code_sequence \
+  "outer exact flow lost its OAS-owned identity" \
+  'type[[:space:]]+flow_id([[:space:]]|$)' \
+  "$exact_output_interface"
+require_type_block_pattern \
+  "outer exact flow lost immutable candidate visits" \
+  "$exact_output_interface" \
+  flow_candidate_visit \
+  'type[[:space:]]+flow_candidate_visit[[:space:]]*=[[:space:]]*private[[:space:]]*\{'
+require_type_field_set \
+  "outer exact flow changed immutable candidate-visit fields" \
+  "$exact_output_interface" \
+  flow_candidate_visit \
+  flow_id \
+  ordinal \
+  identity
+require_type_block_pattern \
+  "outer exact flow changed candidate-visit flow identity" \
+  "$exact_output_interface" \
+  flow_candidate_visit \
+  'flow_id[[:space:]]*:[[:space:]]*flow_id([^[:alnum:]_]|$)'
+require_type_block_pattern \
+  "outer exact flow changed candidate-visit ordinal" \
+  "$exact_output_interface" \
+  flow_candidate_visit \
+  'ordinal[[:space:]]*:[[:space:]]*flow_visit_ordinal([^[:alnum:]_]|$)'
+require_type_block_pattern \
+  "outer exact flow changed candidate-visit identity" \
+  "$exact_output_interface" \
+  flow_candidate_visit \
+  'identity[[:space:]]*:[[:space:]]*flow_candidate_identity([^[:alnum:]_]|$)'
+require_code_sequence \
+  "candidate rejection no longer stores the immutable visit" \
+  'val[[:space:]]+candidate_rejection_visit[[:space:]]*:[[:space:]]*candidate_rejection_receipt[[:space:]]*->[[:space:]]*flow_candidate_visit' \
   "$exact_output_interface"
 require_code_sequence \
-  "outer exact flow lost typed admission-rejection receipts" \
-  'type[[:space:]]+admission_rejection_receipt' \
+  "admitted candidate no longer stores the immutable visit" \
+  'type[[:space:]]+admitted_flow_candidate[[:space:]]*=[[:space:]]*\{[^}]*visit[[:space:]]*:[[:space:]]*flow_candidate_visit' \
   "$exact_output_interface"
+require_code_sequence \
+  "execution receipt no longer stores the immutable visit" \
+  'type[[:space:]]+flow_attempt_receipt[[:space:]]*=[[:space:]]*\{[^}]*visit[[:space:]]*:[[:space:]]*flow_candidate_visit' \
+  "$exact_output_interface"
+require_code_sequence \
+  "outer exact flow start stopped failing closed on identity allocation" \
+  'val[[:space:]]+start_flow[[:space:]]*:[[:space:]]*flow_snapshot[[:space:]]*->[[:space:]]*\(flow_attempt,[[:space:]]*flow_start_error\)[[:space:]]*result' \
+  "$exact_output_interface"
+require_named_function_pattern \
+  "outer exact flow start stopped allocating one OAS-owned identity" \
+  'Exact_output_call_id[.]create' \
+  "$exact_output_source" \
+  "start_flow"
+require_named_function_pattern \
+  "outer exact flow start stopped precomputing immutable visits" \
+  'List[.]mapi' \
+  "$exact_output_source" \
+  "start_flow"
+require_opaque_type \
+  "outer exact flow lost typed candidate-rejection receipts" \
+  "$exact_output_interface" \
+  candidate_rejection_receipt
 require_code_pattern \
-  "admission rejection is no longer fixed at Before_dispatch" \
-  'let[[:space:]]+admission_rejection_phase[[:space:]]+_[[:space:]]*=[[:space:]]*Before_dispatch' \
+  "candidate rejection is no longer fixed at Before_dispatch" \
+  'let[[:space:]]+candidate_rejection_phase[[:space:]]+_[[:space:]]*=[[:space:]]*Before_dispatch' \
   "$exact_output_source"
 require_code_pattern \
-  "admission rejection is no longer fixed at zero dispatch" \
-  'let[[:space:]]+admission_rejection_dispatch_count[[:space:]]+_[[:space:]]*=[[:space:]]*0' \
+  "candidate rejection is no longer fixed at zero dispatch" \
+  'let[[:space:]]+candidate_rejection_dispatch_count[[:space:]]+_[[:space:]]*=[[:space:]]*0' \
   "$exact_output_source"
+require_code_sequence \
+  "outer flow candidate no longer accepts a catalog-admitted target" \
+  'val[[:space:]]+make_flow_candidate[[:space:]]*:[[:space:]]*id:string[[:space:]]*->[[:space:]]*admitted_target:admitted_target' \
+  "$exact_output_interface"
+scan_code \
+  "outer flow catalog-admitted target label was rebound to a selected target" \
+  'admitted_target[[:space:]]*:[[:space:]]*selected_target' \
+  "$exact_output_interface"
+require_code_sequence \
+  "outer flow candidate no longer stores its catalog-admitted target" \
+  'type[[:space:]]+flow_candidate[[:space:]]*=[[:space:]]*\{[^}]*admitted_target[[:space:]]*:[[:space:]]*admitted_target' \
+  "$exact_output_source"
+scan_named_functions \
+  "outer flow selected credentials before current-candidate execution" \
+  'resolve_target' \
+  "$exact_output_source" \
+  "make_flow_candidate snapshot_flow start_flow"
 require_code_pattern \
   "outer exact flow no longer prepares only the executing candidate" \
   'let[[:space:]]+execute_flow_candidate[[:space:]]' \
   "$exact_output_source"
+require_named_function_pattern \
+  "current exact-flow candidate no longer resolves its frozen target" \
+  'resolve_target[[:space:]]+candidate[.]admitted_target' \
+  "$exact_output_source" \
+  "execute_flow_candidate"
+require_named_function_pattern \
+  "current exact-flow candidate lost typed target-selection rejection" \
+  'Target_selection_rejected' \
+  "$exact_output_source" \
+  "execute_flow_candidate"
+require_named_function_pattern \
+  "current exact-flow candidate lost typed request-admission rejection" \
+  'Request_admission_rejected' \
+  "$exact_output_source" \
+  "execute_flow_candidate"
+require_code_sequence \
+  "outer exact flow lost typed candidate exhaustion" \
+  'Flow_candidates_exhausted[[:space:]]+of' \
+  "$exact_output_interface"
 require_code_sequence \
   "private exact-output flow lost typed advance-error refinement" \
   'advanceable:.*option.*failure:.*advanceable_error' \
@@ -664,6 +1014,31 @@ scan_code \
   'type[[:space:]]+ready_flow|val[[:space:]]+(ready_flow_admissions|admit_flow)|let[[:space:]]+(ready_flow_admissions|admit_flow)' \
   "$exact_output_interface" \
   "$exact_output_source"
+scan_code \
+  "obsolete outer-flow admission or attempt-count surface returned" \
+  'candidate_attempt_count|admission_rejection|Flow_admission_failed|Flow_candidate_admission_rejected|Flow_step_admission_rejected' \
+  "$exact_output_interface" \
+  "$exact_output_source" \
+  "$module_dir/exact_output_flow.mli" \
+  "$exact_output_flow_source"
+scan_code \
+  "provider, model, credential, or raw serving evidence escaped the public rejection surface" \
+  'Missing_target_credential|Target_credential_invalid|Target_credential_read_failed|Unsupported_target_model|Target_selection_rejected|Request_admission_rejected|candidate_rejection_cause|Token_measurement_required[[:space:]]+of[[:space:]]+Serving_constraint[.]t' \
+  "$exact_output_interface"
+scan_code \
+  "raw serving-constraint evidence escaped the public exact-output facade" \
+  'Serving_constraint' \
+  "$exact_output_interface"
+scan_public_error_accessors "$exact_output_interface"
+scan_code \
+  "before-advance successor lost its immutable flow visit" \
+  'next:flow_candidate_identity' \
+  "$exact_output_interface"
+scan_named_functions \
+  "candidate rejection fabricated a call or execution attempt identity" \
+  'start_attempt|Call_id|Exact_output_call_id' \
+  "$exact_output_source" \
+  "record_candidate_rejection"
 scan_code \
   "parallel public exact-output flow module escaped the single facade" \
   '^[[:space:]]*module[[:space:]]+(Flow|Exact_output_flow)' \

--- a/test/test_exact_output_flow.ml
+++ b/test/test_exact_output_flow.ml
@@ -29,21 +29,39 @@ type catalog_fixture =
   ; json : bool
   ; body_timeout_s : float option
   ; serving_constraint : bool
+  ; max_request_body_bytes : int option
   }
 
 let catalog_entry
       ?body_timeout_s
       ?(serving_constraint = false)
+      ?max_request_body_bytes
       ~id
       ~base_url
       ~native
       ~json
       ()
   =
-  { id; base_url; native; json; body_timeout_s; serving_constraint }
+  { id
+  ; base_url
+  ; native
+  ; json
+  ; body_timeout_s
+  ; serving_constraint
+  ; max_request_body_bytes
+  }
 ;;
 
 let catalog_fixture_toml entry =
+  let target_options =
+    (match entry.body_timeout_s with
+     | None -> ""
+     | Some seconds -> Printf.sprintf "body_timeout_s = %.17g\n" seconds)
+    ^
+    match entry.max_request_body_bytes with
+    | None -> ""
+    | Some bytes -> Printf.sprintf "max_request_body_bytes = %d\n" bytes
+  in
   Printf.sprintf
     "[[providers]]\n\
      id = %S\n\
@@ -82,9 +100,7 @@ let catalog_fixture_toml entry =
     entry.id
     entry.id
     (entry.id ^ "-model")
-    (match entry.body_timeout_s with
-     | None -> ""
-     | Some seconds -> Printf.sprintf "body_timeout_s = %.17g\n" seconds)
+    target_options
 ;;
 
 let with_catalog entries f =
@@ -114,12 +130,12 @@ let flow_candidate snapshot id =
   | Error EO.Blank_flow_candidate_id -> fail "fixture candidate id was blank"
 ;;
 
-let ready_flow snapshot ids =
+let frozen_flow snapshot ids =
   match List.map (flow_candidate snapshot) ids with
   | [] -> fail "flow fixture must be nonempty"
   | first :: rest ->
     (match
-       EO.admit_flow
+       EO.snapshot_flow
          ~first
          ~rest
          ~messages:[ msg "return one exact object" ]
@@ -129,12 +145,7 @@ let ready_flow snapshot ids =
      | Error _ -> fail "flow fixture did not admit")
 ;;
 
-let start_flow ready =
-  match EO.start_flow ready with
-  | Ok flow -> flow
-  | Error (EO.Flow_candidate_attempt_start_failed _) ->
-    fail "flow attempt identity allocation failed"
-;;
+let start_flow ready = EO.start_flow ready
 
 let fresh_port () =
   let socket = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
@@ -195,6 +206,18 @@ let with_server ?response_delay_s ?(status = `OK) ?(abort_completion = false) ~r
 
 let candidate_id (candidate : EO.flow_attempt_receipt) = candidate.identity.candidate_id
 
+let flow_failure_id = function
+  | EO.Flow_candidate_admission_rejected rejection ->
+    (EO.admission_rejection_identity rejection).candidate_id
+  | EO.Flow_candidate_execution_failed { candidate; _ } -> candidate_id candidate
+;;
+
+let flow_execution_failure = function
+  | EO.Flow_candidate_execution_failed { candidate; cause; _ } -> candidate, cause
+  | EO.Flow_candidate_admission_rejected _ ->
+    fail "expected an execution failure, got an admission rejection"
+;;
+
 let attempt_for evidence id =
   match
     List.find_opt
@@ -210,14 +233,14 @@ let execute_ok ~net flow =
   EO.execute_flow_once
     ~net
     ~before_dispatch:(fun _ -> Ok ())
-    ~before_advance:(fun ~failed:_ ~failure:_ ~next:_ -> Ok ())
+    ~before_advance:(fun ~failed:_ ~next:_ -> Ok ())
     flow
 ;;
 
-let test_admission_freezes_all_candidates_before_network () =
-  let (admissions, evidence_a, evidence_b), posts =
-    with_server ~response:(openai_response {|{"name":"unused"}|})
-    @@ fun ~sw:_ ~net:_ ~clock:_ ~base_url ->
+let test_snapshot_defers_admission_and_allocates_nonshared_current_attempts () =
+  let (before_a, before_b, result_a, result_b), posts =
+    with_server ~response:(openai_response {|{"name":"accepted"}|})
+    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
     let entry id native json = catalog_entry ~id ~base_url ~native ~json () in
     with_catalog
       [ entry "flow-good-a" true true
@@ -232,64 +255,74 @@ let test_admission_freezes_all_candidates_before_network () =
       match candidates with
       | first :: rest ->
         (match
-           EO.admit_flow
+           EO.snapshot_flow
              ~first
              ~rest
              ~messages:[ msg "freeze all" ]
              (EO.make_output_requirement ~schema ~minimum_guarantee:EO.Json_syntax)
          with
          | Ok ready -> ready
-         | Error _ -> fail "partially admissible flow should be ready")
+         | Error _ -> fail "valid flow topology should freeze")
       | [] -> assert false
     in
     let flow_a = start_flow ready in
     let flow_b = start_flow ready in
-    ( EO.ready_flow_admissions ready
-    , EO.flow_attempt_evidence flow_a
-    , EO.flow_attempt_evidence flow_b )
+    let before_a = EO.flow_attempt_evidence flow_a in
+    let before_b = EO.flow_attempt_evidence flow_b in
+    before_a, before_b, execute_ok ~net flow_a, execute_ok ~net flow_b
   in
-  check int "admission and attempt allocation make no POST" 0 posts;
-  check int "all admission outcomes retained" 3 (List.length admissions);
-  (match admissions with
-   | [ EO.Candidate_admitted admitted_a
-     ; EO.Candidate_rejected { identity = rejected; cause = EO.Json_syntax_unavailable }
-     ; EO.Candidate_admitted admitted_b
-     ] ->
-     check
-       string
-       "first admission identity"
-       "flow-good-a"
-       admitted_a.identity.candidate_id;
-     check string "rejection identity" "flow-rejected" rejected.candidate_id;
-     check string "last admission identity" "flow-good-b" admitted_b.identity.candidate_id
-   | _ -> fail "ordered admission evidence was incomplete");
-  check int "only admitted candidates get attempts" 2 (List.length evidence_a.attempts);
+  check int "two independent current attempts make two POSTs" 2 posts;
   List.iter
-    (fun (attempt : EO.flow_attempt_receipt) ->
+    (fun evidence ->
        check
-         bool
-         "candidate remains not started"
-         true
-         (EO.receipt_phase attempt.receipt = EO.Not_started))
-    evidence_a.attempts;
-  List.iter2
-    (fun (left : EO.flow_attempt_receipt) (right : EO.flow_attempt_receipt) ->
+         int
+         "candidate snapshot is complete"
+         3
+         (List.length evidence.EO.candidate_snapshot);
+       check int "no admission is speculative" 0 (List.length evidence.admissions);
+       check int "no attempt is speculative" 0 (List.length evidence.attempts);
        check
-         bool
-         "separate flows do not share call identity"
-         true
-         (not
-            (String.equal
-               (EO.receipt_call_id left.receipt |> EO.call_id_to_string)
-               (EO.receipt_call_id right.receipt |> EO.call_id_to_string))))
-    evidence_a.attempts
-    evidence_b.attempts
+         int
+         "candidate attempt count starts at zero"
+         0
+         (EO.candidate_attempt_count_to_int evidence.candidate_attempt_count))
+    [ before_a; before_b ];
+  match result_a, result_b with
+  | Ok success_a, Ok success_b ->
+    List.iter
+      (fun success ->
+         check
+           int
+           "only current candidate is admitted"
+           1
+           (List.length success.EO.evidence.admissions);
+         check
+           int
+           "only current candidate gets an attempt"
+           1
+           (List.length success.evidence.attempts);
+         check
+           int
+           "candidate attempt count advances once"
+           1
+           (EO.candidate_attempt_count_to_int success.evidence.candidate_attempt_count))
+      [ success_a; success_b ];
+    check
+      bool
+      "separate flows do not share call identity"
+      true
+      (not
+         (String.equal
+            (EO.receipt_call_id success_a.candidate.receipt |> EO.call_id_to_string)
+            (EO.receipt_call_id success_b.candidate.receipt |> EO.call_id_to_string)))
+  | Ok _, Error _ | Error _, Ok _ | Error _, Error _ ->
+    fail "independent current candidates did not both succeed"
 ;;
 
-let test_unmeasured_constraint_rejects_exact_candidate_before_network () =
-  let admissions, posts =
-    with_server ~response:(openai_response {|{"name":"unused"}|})
-    @@ fun ~sw:_ ~net:_ ~clock:_ ~base_url ->
+let test_unmeasured_constraint_advances_only_after_durable_settlement () =
+  let (result, transitions, bound), posts =
+    with_server ~response:(openai_response {|{"name":"accepted"}|})
+    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
     with_catalog
       [ catalog_entry
           ~id:"constrained-exact"
@@ -301,29 +334,246 @@ let test_unmeasured_constraint_rejects_exact_candidate_before_network () =
       ; catalog_entry ~id:"unconstrained-exact" ~base_url ~native:true ~json:true ()
       ]
     @@ fun snapshot ->
-    let ready = ready_flow snapshot [ "constrained-exact"; "unconstrained-exact" ] in
-    EO.ready_flow_admissions ready
+    let ready = frozen_flow snapshot [ "constrained-exact"; "unconstrained-exact" ] in
+    let transitions = ref [] in
+    let bound = ref [] in
+    let result =
+      EO.execute_flow_once
+        ~net
+        ~before_dispatch:(fun candidate ->
+          bound := candidate_id candidate :: !bound;
+          Ok ())
+        ~before_advance:(fun ~failed ~next ->
+          match failed with
+          | EO.Flow_candidate_admission_rejected rejection ->
+            let identity = EO.admission_rejection_identity rejection in
+            let constraint_ =
+              match EO.admission_rejection_cause rejection with
+              | EO.Wire_admission_rejected (EO.Token_measurement_required constraint_) ->
+                constraint_
+              | _ -> fail "capacity rejection lost its typed cause"
+            in
+            check
+              string
+              "settled rejected identity"
+              "constrained-exact"
+              identity.candidate_id;
+            check
+              int
+              "settled constraint remains exact"
+              524298
+              constraint_.Serving_constraint.observation.accepted_through;
+            check
+              bool
+              "admission receipt is pre-dispatch"
+              true
+              (EO.admission_rejection_phase rejection = EO.Before_dispatch);
+            check
+              int
+              "admission receipt is zero-dispatch"
+              0
+              (EO.admission_rejection_dispatch_count rejection);
+            transitions := (identity.candidate_id, next.candidate_id) :: !transitions;
+            Ok ()
+          | _ -> fail "capacity rejection lost its typed durable transition")
+        (start_flow ready)
+    in
+    result, List.rev !transitions, List.rev !bound
   in
-  check int "exact admission makes no POST" 0 posts;
-  match admissions with
-  | [ EO.Candidate_rejected
-        { identity
-        ; cause = EO.Wire_admission_rejected (EO.Token_measurement_required constraint_)
-        }
-    ; EO.Candidate_admitted admitted
-    ] ->
-    check string "constrained identity" "constrained-exact" identity.candidate_id;
-    check
-      int
-      "constraint remains exact"
-      524298
-      constraint_.Serving_constraint.observation.accepted_through;
+  check int "only the admitted successor posts" 1 posts;
+  check
+    (list (pair string string))
+    "capacity transition is explicit"
+    [ "constrained-exact", "unconstrained-exact" ]
+    transitions;
+  check
+    (list string)
+    "only the admitted successor reaches before_dispatch"
+    [ "unconstrained-exact" ]
+    bound;
+  match result with
+  | Ok success ->
     check
       string
-      "unconstrained successor remains available"
+      "admitted successor succeeds"
       "unconstrained-exact"
-      admitted.identity.candidate_id
-  | _ -> fail "unmeasured exact candidate did not fail closed before its successor"
+      (candidate_id success.candidate);
+    check
+      int
+      "only reached candidates are admitted"
+      2
+      (List.length success.evidence.admissions);
+    check
+      int
+      "candidate attempt count preserves ordered progress"
+      2
+      (EO.candidate_attempt_count_to_int success.evidence.candidate_attempt_count)
+  | Error _ -> fail "durably settled admission rejection did not reach its successor"
+;;
+
+let test_request_body_capacity_advances_only_after_durable_settlement () =
+  let (result, transition), posts =
+    with_server ~response:(openai_response {|{"name":"accepted"}|})
+    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
+    with_catalog
+      [ catalog_entry
+          ~max_request_body_bytes:1
+          ~id:"body-capped"
+          ~base_url
+          ~native:true
+          ~json:true
+          ()
+      ; catalog_entry ~id:"body-successor" ~base_url ~native:true ~json:true ()
+      ]
+    @@ fun snapshot ->
+    let transition = ref None in
+    let result =
+      EO.execute_flow_once
+        ~net
+        ~before_dispatch:(fun _ -> Ok ())
+        ~before_advance:(fun ~failed ~next ->
+          match failed with
+          | EO.Flow_candidate_admission_rejected rejection ->
+            let actual_bytes, limit_bytes =
+              match EO.admission_rejection_cause rejection with
+              | EO.Wire_admission_rejected
+                  (EO.Request_body_too_large { actual_bytes; limit_bytes }) ->
+                actual_bytes, limit_bytes
+              | _ -> fail "request-body rejection lost its typed cause"
+            in
+            check bool "serialized body exceeds the exact cap" true (actual_bytes > 1);
+            check int "declared cap remains exact" 1 limit_bytes;
+            check
+              int
+              "admission receipt is zero-dispatch"
+              0
+              (EO.admission_rejection_dispatch_count rejection);
+            transition
+            := Some
+                 ( (EO.admission_rejection_identity rejection).candidate_id
+                 , next.candidate_id );
+            Ok ()
+          | _ -> fail "request-body rejection lost its typed durable transition")
+        (start_flow (frozen_flow snapshot [ "body-capped"; "body-successor" ]))
+    in
+    result, !transition
+  in
+  check int "only body-cap successor posts" 1 posts;
+  check
+    (option (pair string string))
+    "request-body transition is explicit"
+    (Some ("body-capped", "body-successor"))
+    transition;
+  match result with
+  | Ok success ->
+    check
+      string
+      "body-cap successor succeeds"
+      "body-successor"
+      (candidate_id success.candidate)
+  | Error _ -> fail "durably settled body-cap rejection did not reach its successor"
+;;
+
+let test_all_admission_rejections_return_typed_zero_dispatch_terminal () =
+  let (result, transitions, evidence), posts =
+    with_server ~response:(openai_response {|{"name":"unused"}|})
+    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
+    with_catalog
+      [ catalog_entry
+          ~serving_constraint:true
+          ~id:"rejected-a"
+          ~base_url
+          ~native:true
+          ~json:true
+          ()
+      ; catalog_entry
+          ~max_request_body_bytes:1
+          ~id:"rejected-b"
+          ~base_url
+          ~native:true
+          ~json:true
+          ()
+      ]
+    @@ fun snapshot ->
+    let transitions = ref [] in
+    let flow = start_flow (frozen_flow snapshot [ "rejected-a"; "rejected-b" ]) in
+    let result =
+      EO.execute_flow_once
+        ~net
+        ~before_dispatch:(fun candidate ->
+          failf "rejected candidate %s reached before_dispatch" (candidate_id candidate))
+        ~before_advance:(fun ~failed ~next ->
+          transitions := (flow_failure_id failed, next.candidate_id) :: !transitions;
+          Ok ())
+        flow
+    in
+    result, List.rev !transitions, EO.flow_attempt_evidence flow
+  in
+  check int "all-rejected flow performs zero completion POSTs" 0 posts;
+  check
+    (list (pair string string))
+    "all-rejected flow settles the ordered transition"
+    [ "rejected-a", "rejected-b" ]
+    transitions;
+  check int "all-rejected flow fabricates no attempts" 0 (List.length evidence.attempts);
+  check int "all rejection evidence remains ordered" 2 (List.length evidence.admissions);
+  (match evidence.admissions with
+   | [ EO.Candidate_rejected first; EO.Candidate_rejected second ] ->
+     check
+       string
+       "first retained rejection"
+       "rejected-a"
+       (EO.admission_rejection_identity first).candidate_id;
+     check
+       int
+       "first retained candidate count"
+       1
+       (EO.admission_rejection_candidate_attempt_count first
+        |> EO.candidate_attempt_count_to_int);
+     check
+       string
+       "second retained rejection"
+       "rejected-b"
+       (EO.admission_rejection_identity second).candidate_id;
+     check
+       int
+       "second retained candidate count"
+       2
+       (EO.admission_rejection_candidate_attempt_count second
+        |> EO.candidate_attempt_count_to_int);
+     List.iter
+       (fun rejection ->
+          check
+            bool
+            "retained rejection remains pre-dispatch"
+            true
+            (EO.admission_rejection_phase rejection = EO.Before_dispatch);
+          check
+            int
+            "retained rejection remains zero-dispatch"
+            0
+            (EO.admission_rejection_dispatch_count rejection))
+       [ first; second ]
+   | _ -> fail "flow evidence did not retain typed admission receipts");
+  match result with
+  | Error (EO.Flow_admission_failed { rejection; evidence = terminal_evidence }) ->
+    check
+      string
+      "terminal rejected candidate"
+      "rejected-b"
+      (EO.admission_rejection_identity rejection).candidate_id;
+    (match EO.admission_rejection_cause rejection with
+     | EO.Wire_admission_rejected
+         (EO.Request_body_too_large { actual_bytes; limit_bytes }) ->
+       check bool "terminal body remains over cap" true (actual_bytes > limit_bytes)
+     | _ -> fail "terminal admission receipt lost its body-cap cause");
+    check int "terminal retains zero attempts" 0 (List.length terminal_evidence.attempts);
+    check
+      int
+      "terminal candidate count is exact"
+      2
+      (EO.candidate_attempt_count_to_int terminal_evidence.candidate_attempt_count)
+  | Ok _ | Error _ -> fail "all-rejected flow lost its typed terminal admission failure"
 ;;
 
 let test_predispatch_transport_failure_advances_after_durable_callback () =
@@ -336,7 +586,7 @@ let test_predispatch_transport_failure_advances_after_durable_callback () =
       ; catalog_entry ~id:"flow-live" ~base_url ~native:true ~json:true ()
       ]
     @@ fun snapshot ->
-    let flow = start_flow (ready_flow snapshot [ "flow-dead"; "flow-live" ]) in
+    let flow = start_flow (frozen_flow snapshot [ "flow-dead"; "flow-live" ]) in
     let bound = ref [] in
     let advanced = ref [] in
     let events = ref [] in
@@ -347,7 +597,8 @@ let test_predispatch_transport_failure_advances_after_durable_callback () =
           events := ("bind:" ^ candidate_id candidate) :: !events;
           bound := candidate_id candidate :: !bound;
           Ok ())
-        ~before_advance:(fun ~failed ~failure ~next ->
+        ~before_advance:(fun ~failed ~next ->
+          let failed_candidate, failure = flow_execution_failure failed in
           check
             bool
             "advance failure is pre-dispatch"
@@ -359,9 +610,12 @@ let test_predispatch_transport_failure_advances_after_durable_callback () =
             0
             (EO.receipt_dispatch_count failure.receipt);
           events
-          := Printf.sprintf "advance:%s->%s" (candidate_id failed) (candidate_id next)
+          := Printf.sprintf
+               "advance:%s->%s"
+               (candidate_id failed_candidate)
+               next.candidate_id
              :: !events;
-          advanced := (candidate_id failed, candidate_id next) :: !advanced;
+          advanced := (candidate_id failed_candidate, next.candidate_id) :: !advanced;
           Ok ())
         flow
     in
@@ -433,7 +687,7 @@ let test_exception_after_durable_advance_stops_before_successor () =
          @@ fun snapshot ->
          let flow =
            start_flow
-             (ready_flow snapshot [ "advance-committed-dead"; "advance-withheld-live" ])
+             (frozen_flow snapshot [ "advance-committed-dead"; "advance-withheld-live" ])
          in
          let bound = ref [] in
          let raised =
@@ -444,7 +698,8 @@ let test_exception_after_durable_advance_stops_before_successor () =
                   ~before_dispatch:(fun candidate ->
                     bound := candidate_id candidate :: !bound;
                     Ok ())
-                  ~before_advance:(fun ~failed ~failure ~next ->
+                  ~before_advance:(fun ~failed ~next ->
+                    let failed, failure = flow_execution_failure failed in
                     (match failure.EO.cause with
                      | EO.Completion_failed -> ()
                      | _ ->
@@ -463,19 +718,13 @@ let test_exception_after_durable_advance_stops_before_successor () =
                     persist_advance
                       (`Assoc
                           [ "failed_candidate_id", `String (candidate_id failed)
-                          ; "next_candidate_id", `String (candidate_id next)
+                          ; "next_candidate_id", `String next.candidate_id
                           ; ( "failed_call_id"
                             , `String
                                 (EO.receipt_call_id failed.receipt |> EO.call_id_to_string)
                             )
-                          ; ( "next_call_id"
-                            , `String
-                                (EO.receipt_call_id next.receipt |> EO.call_id_to_string)
-                            )
                           ; ( "failed_plan_fingerprint"
                             , `String (EO.receipt_plan_fingerprint failed.receipt) )
-                          ; ( "next_plan_fingerprint"
-                            , `String (EO.receipt_plan_fingerprint next.receipt) )
                           ; "failure_cause", `String "completion_failed"
                           ; "failure_phase", `String "before_dispatch"
                           ; "failure_dispatch_count", `Int 0
@@ -505,15 +754,12 @@ let test_exception_after_durable_advance_stops_before_successor () =
        (match replay with
         | Error (EO.Flow_attempt_already_started replay_evidence) ->
           check
-            bool
-            "replay evidence keeps successor not started"
-            true
-            (EO.receipt_phase
-               (attempt_for replay_evidence "advance-withheld-live").receipt
-             = EO.Not_started)
+            int
+            "replay evidence keeps successor unprepared"
+            1
+            (List.length replay_evidence.attempts)
         | Ok _ | Error _ -> fail "flow was replayable after committed advance exception");
        let failed = attempt_for evidence "advance-committed-dead" in
-       let next = attempt_for evidence "advance-withheld-live" in
        check
          bool
          "failed attempt evidence remains before dispatch"
@@ -524,16 +770,12 @@ let test_exception_after_durable_advance_stops_before_successor () =
          "failed attempt evidence remains zero dispatch"
          0
          (EO.receipt_dispatch_count failed.receipt);
-       check
-         bool
-         "successor evidence remains not started"
-         true
-         (EO.receipt_phase next.receipt = EO.Not_started);
+       check int "successor has no speculative attempt" 1 (List.length evidence.attempts);
        check
          int
-         "successor evidence remains zero dispatch"
-         0
-         (EO.receipt_dispatch_count next.receipt);
+         "only the failed candidate was attempted"
+         1
+         (EO.candidate_attempt_count_to_int evidence.candidate_attempt_count);
        let open Yojson.Safe.Util in
        let committed_string field = committed |> member field |> to_string in
        let committed_int field = committed |> member field |> to_int in
@@ -545,7 +787,7 @@ let test_exception_after_durable_advance_stops_before_successor () =
        check
          string
          "committed successor joins retained evidence"
-         (candidate_id next)
+         "advance-withheld-live"
          (committed_string "next_candidate_id");
        check
          string
@@ -554,19 +796,9 @@ let test_exception_after_durable_advance_stops_before_successor () =
          (committed_string "failed_call_id");
        check
          string
-         "committed successor call joins retained evidence"
-         (EO.receipt_call_id next.receipt |> EO.call_id_to_string)
-         (committed_string "next_call_id");
-       check
-         string
          "committed failed plan joins retained evidence"
          (EO.receipt_plan_fingerprint failed.receipt)
          (committed_string "failed_plan_fingerprint");
-       check
-         string
-         "committed successor plan joins retained evidence"
-         (EO.receipt_plan_fingerprint next.receipt)
-         (committed_string "next_plan_fingerprint");
        check
          string
          "caller reconciliation retains typed cause"
@@ -596,8 +828,8 @@ let test_callback_failures_are_terminal () =
     EO.execute_flow_once
       ~net
       ~before_dispatch:(fun _ -> Error "bind-not-durable")
-      ~before_advance:(fun ~failed:_ ~failure:_ ~next:_ -> Ok ())
-      (start_flow (ready_flow snapshot [ "bind-a"; "bind-b" ]))
+      ~before_advance:(fun ~failed:_ ~next:_ -> Ok ())
+      (start_flow (frozen_flow snapshot [ "bind-a"; "bind-b" ]))
   in
   check int "failed bind dispatches nothing" 0 before_dispatch_posts;
   (match before_dispatch_result with
@@ -610,11 +842,7 @@ let test_callback_failures_are_terminal () =
        "failed bind leaves receipt not started"
        true
        (EO.receipt_phase candidate.receipt = EO.Not_started);
-     check
-       bool
-       "successor remains not started"
-       true
-       (EO.receipt_phase (attempt_for evidence "bind-b").receipt = EO.Not_started)
+     check int "successor remains unprepared" 1 (List.length evidence.attempts)
    | Ok _ | Error _ -> fail "failed bind did not return typed terminal evidence");
   let before_advance_result, before_advance_posts =
     with_server ~response:(openai_response {|{"name":"unused"}|})
@@ -628,21 +856,17 @@ let test_callback_failures_are_terminal () =
     EO.execute_flow_once
       ~net
       ~before_dispatch:(fun _ -> Ok ())
-      ~before_advance:(fun ~failed:_ ~failure:_ ~next:_ -> Error "release-not-durable")
-      (start_flow (ready_flow snapshot [ "advance-a"; "advance-b" ]))
+      ~before_advance:(fun ~failed:_ ~next:_ -> Error "release-not-durable")
+      (start_flow (frozen_flow snapshot [ "advance-a"; "advance-b" ]))
   in
   check int "failed advance dispatches no successor" 0 before_advance_posts;
   match before_advance_result with
   | Error
       (EO.Flow_before_advance_callback_failed
          { failed; next; cause = "release-not-durable"; evidence; _ }) ->
-    check string "failed attempt identity" "advance-a" (candidate_id failed);
-    check string "withheld successor identity" "advance-b" (candidate_id next);
-    check
-      bool
-      "withheld successor remains not started"
-      true
-      (EO.receipt_phase (attempt_for evidence "advance-b").receipt = EO.Not_started)
+    check string "failed attempt identity" "advance-a" (flow_failure_id failed);
+    check string "withheld successor identity" "advance-b" next.candidate_id;
+    check int "withheld successor remains unprepared" 1 (List.length evidence.attempts)
   | Ok _ | Error _ -> fail "failed advance did not return typed terminal evidence"
 ;;
 
@@ -661,10 +885,10 @@ let test_postdispatch_and_structural_outcomes_never_advance () =
         EO.execute_flow_once
           ~net
           ~before_dispatch:(fun _ -> Ok ())
-          ~before_advance:(fun ~failed:_ ~failure:_ ~next:_ ->
+          ~before_advance:(fun ~failed:_ ~next:_ ->
             incr advances;
             Ok ())
-          (start_flow (ready_flow snapshot [ label ^ "-a"; label ^ "-b" ]))
+          (start_flow (frozen_flow snapshot [ label ^ "-a"; label ^ "-b" ]))
       in
       result, !advances
     in
@@ -679,10 +903,10 @@ let test_postdispatch_and_structural_outcomes_never_advance () =
         1
         (EO.receipt_dispatch_count cause.receipt);
       check
-        bool
-        (label ^ " successor remains not started")
-        true
-        (EO.receipt_phase (attempt_for evidence (label ^ "-b")).receipt = EO.Not_started)
+        int
+        (label ^ " successor remains unprepared")
+        1
+        (List.length evidence.attempts)
     | Ok _ | Error _ -> fail (label ^ " did not remain terminal")
   in
   run ~abort_completion:true "partial" "unused";
@@ -700,18 +924,17 @@ let test_success_and_later_domain_rejection_are_terminal () =
       ; catalog_entry ~id:"success-b" ~base_url ~native:true ~json:true ()
       ]
     @@ fun snapshot ->
-    execute_ok ~net (start_flow (ready_flow snapshot [ "success-a"; "success-b" ]))
+    execute_ok ~net (start_flow (frozen_flow snapshot [ "success-a"; "success-b" ]))
   in
   check int "success dispatches exactly once" 1 posts;
   match result with
   | Ok success ->
     check string "first candidate succeeds" "success-a" (candidate_id success.candidate);
     check
-      bool
+      int
       "successor remains unavailable to later domain rejection"
-      true
-      (EO.receipt_phase (attempt_for success.evidence "success-b").receipt
-       = EO.Not_started)
+      1
+      (List.length success.evidence.attempts)
   | Error _ -> fail "terminal success fixture failed"
 ;;
 
@@ -735,10 +958,10 @@ let test_structural_predispatch_failure_does_not_advance () =
       EO.execute_flow_once
         ~net
         ~before_dispatch:(fun _ -> Ok ())
-        ~before_advance:(fun ~failed:_ ~failure:_ ~next:_ ->
+        ~before_advance:(fun ~failed:_ ~next:_ ->
           incr advances;
           Ok ())
-        (start_flow (ready_flow snapshot [ "clock-a"; "clock-b" ]))
+        (start_flow (frozen_flow snapshot [ "clock-a"; "clock-b" ]))
     in
     result, !advances
   in
@@ -754,11 +977,7 @@ let test_structural_predispatch_failure_does_not_advance () =
       "structural failure remains zero dispatch"
       0
       (EO.receipt_dispatch_count receipt);
-    check
-      bool
-      "structural successor remains not started"
-      true
-      (EO.receipt_phase (attempt_for evidence "clock-b").receipt = EO.Not_started)
+    check int "structural successor remains unprepared" 1 (List.length evidence.attempts)
   | Ok _ | Error _ -> fail "missing clock was not terminal"
 ;;
 
@@ -769,12 +988,12 @@ let test_concurrent_duplicate_flow_does_not_double_dispatch () =
     with_catalog
       [ catalog_entry ~id:"concurrent-flow" ~base_url ~native:true ~json:true () ]
     @@ fun snapshot ->
-    let flow = start_flow (ready_flow snapshot [ "concurrent-flow" ]) in
+    let flow = start_flow (frozen_flow snapshot [ "concurrent-flow" ]) in
     let execute () : (EO.flow_success, string EO.flow_execution_error) result =
       EO.execute_flow_once
         ~net
         ~before_dispatch:(fun _ -> Ok ())
-        ~before_advance:(fun ~failed:_ ~failure:_ ~next:_ -> Ok ())
+        ~before_advance:(fun ~failed:_ ~next:_ -> Ok ())
         flow
     in
     let left_promise, left_resolver = Eio.Promise.create () in
@@ -811,7 +1030,7 @@ let test_cancellation_terminalizes_outer_attempt () =
     @@ fun ~sw:_ ~net ~clock ~base_url ->
     with_catalog [ catalog_entry ~id:"cancel-flow" ~base_url ~native:true ~json:true () ]
     @@ fun snapshot ->
-    let flow = start_flow (ready_flow snapshot [ "cancel-flow" ]) in
+    let flow = start_flow (frozen_flow snapshot [ "cancel-flow" ]) in
     let timed_out =
       try
         ignore
@@ -838,13 +1057,21 @@ let () =
     "exact-output-flow"
     [ ( "outer-flow"
       , [ test_case
-            "all admissions freeze before network"
+            "snapshot defers admission and current attempts do not share"
             `Quick
-            test_admission_freezes_all_candidates_before_network
+            test_snapshot_defers_admission_and_allocates_nonshared_current_attempts
         ; test_case
-            "unmeasured constraint rejects before network"
+            "unmeasured constraint advances after durable settlement"
             `Quick
-            test_unmeasured_constraint_rejects_exact_candidate_before_network
+            test_unmeasured_constraint_advances_only_after_durable_settlement
+        ; test_case
+            "request body cap advances after durable settlement"
+            `Quick
+            test_request_body_capacity_advances_only_after_durable_settlement
+        ; test_case
+            "all admission rejections return zero-dispatch terminal"
+            `Quick
+            test_all_admission_rejections_return_typed_zero_dispatch_terminal
         ; test_case
             "predispatch transport failure advances durably"
             `Quick

--- a/test/test_exact_output_flow.ml
+++ b/test/test_exact_output_flow.ml
@@ -25,6 +25,7 @@ let schema =
 type catalog_fixture =
   { id : string
   ; base_url : string
+  ; api_key_env : string
   ; native : bool
   ; json : bool
   ; body_timeout_s : float option
@@ -36,6 +37,7 @@ let catalog_entry
       ?body_timeout_s
       ?(serving_constraint = false)
       ?max_request_body_bytes
+      ?(api_key_env = "")
       ~id
       ~base_url
       ~native
@@ -44,6 +46,7 @@ let catalog_entry
   =
   { id
   ; base_url
+  ; api_key_env
   ; native
   ; json
   ; body_timeout_s
@@ -68,7 +71,7 @@ let catalog_fixture_toml entry =
      kind = \"openai_compat\"\n\
      base_url = %S\n\
      request_path = \"/v1/chat/completions\"\n\
-     api_key_env = \"\"\n\n\
+     api_key_env = %S\n\n\
      [[models]]\n\
      id_prefix = %S\n\
      provider_name = %S\n\
@@ -83,6 +86,7 @@ let catalog_fixture_toml entry =
      %s"
     entry.id
     entry.base_url
+    entry.api_key_env
     (entry.id ^ "-model")
     entry.id
     (if entry.serving_constraint
@@ -103,31 +107,35 @@ let catalog_fixture_toml entry =
     target_options
 ;;
 
-let with_catalog entries f =
+let with_catalog ?(getenv = fun _ -> Ok None) entries f =
   let document : EO.catalog_document =
     { source = "exact-output outer-flow fixture"
     ; contents = String.concat "\n" (List.map catalog_fixture_toml entries)
     }
   in
-  let io : EO.resolver_io = { getenv = (fun _ -> Ok None) } in
+  let io : EO.resolver_io = { getenv } in
   match EO.load_resolver_snapshot ~io ~catalog:(EO.Embedded_with_overlay document) () with
   | Error _ -> fail "outer-flow resolver snapshot should load"
   | Ok snapshot -> f snapshot
 ;;
 
-let target snapshot selector =
+let admitted_target snapshot selector =
   match EO.admit_target_ref snapshot selector with
   | Error _ -> failf "target ref %s was not admitted" selector
-  | Ok admitted ->
-    (match EO.resolve_target admitted with
-     | Ok target -> target
-     | Error _ -> failf "target %s did not resolve" selector)
+  | Ok admitted -> admitted
 ;;
 
 let flow_candidate snapshot id =
-  match EO.make_flow_candidate ~id ~target:(target snapshot id) with
+  match EO.make_flow_candidate ~id ~admitted_target:(admitted_target snapshot id) with
   | Ok candidate -> candidate
   | Error EO.Blank_flow_candidate_id -> fail "fixture candidate id was blank"
+;;
+
+let credential_getenv = function
+  | "MISSING_FLOW_KEY" -> Ok None
+  | "INVALID_FLOW_KEY" -> Ok (Some "secret\r\nX-Leak: yes")
+  | "READ_FAILED_FLOW_KEY" -> Error ()
+  | _ -> Ok None
 ;;
 
 let frozen_flow snapshot ids =
@@ -145,7 +153,12 @@ let frozen_flow snapshot ids =
      | Error _ -> fail "flow fixture did not admit")
 ;;
 
-let start_flow ready = EO.start_flow ready
+let start_flow ready =
+  match EO.start_flow ready with
+  | Ok flow -> flow
+  | Error (EO.Flow_id_generation_failed detail) ->
+    failf "flow identity allocation failed: %s" detail
+;;
 
 let fresh_port () =
   let socket = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
@@ -204,25 +217,25 @@ let with_server ?response_delay_s ?(status = `OK) ?(abort_completion = false) ~r
   result, Atomic.get completion_posts
 ;;
 
-let candidate_id (candidate : EO.flow_attempt_receipt) = candidate.identity.candidate_id
+let candidate_id (candidate : EO.flow_attempt_receipt) = candidate.visit.identity.candidate_id
 
 let flow_failure_id = function
-  | EO.Flow_candidate_admission_rejected rejection ->
-    (EO.admission_rejection_identity rejection).candidate_id
+  | EO.Flow_candidate_rejected rejection ->
+    (EO.candidate_rejection_identity rejection).candidate_id
   | EO.Flow_candidate_execution_failed { candidate; _ } -> candidate_id candidate
 ;;
 
 let flow_execution_failure = function
   | EO.Flow_candidate_execution_failed { candidate; cause; _ } -> candidate, cause
-  | EO.Flow_candidate_admission_rejected _ ->
-    fail "expected an execution failure, got an admission rejection"
+  | EO.Flow_candidate_rejected _ ->
+    fail "expected an execution failure, got a candidate rejection"
 ;;
 
 let attempt_for evidence id =
   match
     List.find_opt
       (fun (attempt : EO.flow_attempt_receipt) ->
-         String.equal attempt.identity.candidate_id id)
+         String.equal attempt.visit.identity.candidate_id id)
       evidence.EO.attempts
   with
   | Some attempt -> attempt
@@ -269,9 +282,27 @@ let test_snapshot_defers_admission_and_allocates_nonshared_current_attempts () =
     let flow_b = start_flow ready in
     let before_a = EO.flow_attempt_evidence flow_a in
     let before_b = EO.flow_attempt_evidence flow_b in
+    check
+      string
+      "flow A handle and evidence share one identity"
+      (EO.flow_id_to_string before_a.flow_id)
+      (EO.flow_id_to_string (EO.flow_attempt_id flow_a));
+    check
+      string
+      "flow B handle and evidence share one identity"
+      (EO.flow_id_to_string before_b.flow_id)
+      (EO.flow_id_to_string (EO.flow_attempt_id flow_b));
     before_a, before_b, execute_ok ~net flow_a, execute_ok ~net flow_b
   in
   check int "two independent current attempts make two POSTs" 2 posts;
+  check
+    bool
+    "independent flow starts do not share outer identity"
+    true
+    (not
+       (String.equal
+          (EO.flow_id_to_string before_a.flow_id)
+          (EO.flow_id_to_string before_b.flow_id)));
   List.iter
     (fun evidence ->
        check
@@ -283,9 +314,9 @@ let test_snapshot_defers_admission_and_allocates_nonshared_current_attempts () =
        check int "no attempt is speculative" 0 (List.length evidence.attempts);
        check
          int
-         "candidate attempt count starts at zero"
+         "candidate visit count starts at zero"
          0
-         (EO.candidate_attempt_count_to_int evidence.candidate_attempt_count))
+         (EO.candidate_visit_count_to_int evidence.candidate_visit_count))
     [ before_a; before_b ];
   match result_a, result_b with
   | Ok success_a, Ok success_b ->
@@ -303,9 +334,9 @@ let test_snapshot_defers_admission_and_allocates_nonshared_current_attempts () =
            (List.length success.evidence.attempts);
          check
            int
-           "candidate attempt count advances once"
+           "candidate visit count advances once"
            1
-           (EO.candidate_attempt_count_to_int success.evidence.candidate_attempt_count))
+           (EO.candidate_visit_count_to_int success.evidence.candidate_visit_count))
       [ success_a; success_b ];
     check
       bool
@@ -314,9 +345,357 @@ let test_snapshot_defers_admission_and_allocates_nonshared_current_attempts () =
       (not
          (String.equal
             (EO.receipt_call_id success_a.candidate.receipt |> EO.call_id_to_string)
-            (EO.receipt_call_id success_b.candidate.receipt |> EO.call_id_to_string)))
+            (EO.receipt_call_id success_b.candidate.receipt |> EO.call_id_to_string)));
+    List.iter
+      (fun success ->
+         check
+           string
+           "attempt visit remains bound to its outer flow"
+           (EO.flow_id_to_string success.EO.evidence.flow_id)
+           (EO.flow_id_to_string success.candidate.visit.flow_id);
+         check
+           int
+           "current candidate visit ordinal is one"
+           1
+           (EO.flow_visit_ordinal_to_int success.candidate.visit.ordinal))
+      [ success_a; success_b ]
   | Ok _, Error _ | Error _, Ok _ | Error _, Error _ ->
     fail "independent current candidates did not both succeed"
+;;
+
+let test_later_missing_credential_does_not_block_current_success () =
+  let (result, advances), posts =
+    with_server ~response:(openai_response {|{"name":"accepted"}|})
+    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
+    with_catalog
+      ~getenv:credential_getenv
+      [ catalog_entry ~id:"current-good" ~base_url ~native:true ~json:true ()
+      ; catalog_entry
+          ~api_key_env:"MISSING_FLOW_KEY"
+          ~id:"later-missing"
+          ~base_url
+          ~native:true
+          ~json:true
+          ()
+      ]
+    @@ fun snapshot ->
+    let advances = ref 0 in
+    let result =
+      EO.execute_flow_once
+        ~net
+        ~before_dispatch:(fun _ -> Ok ())
+        ~before_advance:(fun ~failed:_ ~next:_ ->
+          incr advances;
+          Ok ())
+        (start_flow (frozen_flow snapshot [ "current-good"; "later-missing" ]))
+    in
+    result, !advances
+  in
+  check int "only the current candidate posts" 1 posts;
+  check int "unvisited missing credential does not advance" 0 advances;
+  match result with
+  | Ok success ->
+    check string "current candidate succeeds" "current-good" (candidate_id success.candidate);
+    check
+      int
+      "full candidate snapshot remains frozen"
+      2
+      (List.length success.evidence.candidate_snapshot);
+    check
+      int
+      "only current admission is recorded"
+      1
+      (List.length success.evidence.admissions);
+    check int "only current attempt is allocated" 1 (List.length success.evidence.attempts);
+    check
+      int
+      "only current candidate is visited"
+      1
+      (EO.candidate_visit_count_to_int success.evidence.candidate_visit_count)
+  | Error _ -> fail "later missing credential blocked the current candidate"
+;;
+
+let test_missing_current_credential_advances_after_durable_settlement () =
+  let (result, transitions, bound, next_visit), posts =
+    with_server ~response:(openai_response {|{"name":"accepted"}|})
+    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
+    with_catalog
+      ~getenv:credential_getenv
+      [ catalog_entry
+          ~api_key_env:"MISSING_FLOW_KEY"
+          ~id:"current-missing"
+          ~base_url
+          ~native:true
+          ~json:true
+          ()
+      ; catalog_entry ~id:"next-good" ~base_url ~native:true ~json:true ()
+      ]
+    @@ fun snapshot ->
+    let transitions = ref [] in
+    let bound = ref [] in
+    let next_visit = ref None in
+    let result =
+      EO.execute_flow_once
+        ~net
+        ~before_dispatch:(fun candidate ->
+          bound := candidate_id candidate :: !bound;
+          Ok ())
+        ~before_advance:(fun ~failed ~next ->
+          match failed with
+          | EO.Flow_candidate_rejected rejection ->
+            let identity = EO.candidate_rejection_identity rejection in
+            (match EO.candidate_rejection_disposition rejection with
+             | EO.Runtime_slot_unavailable -> ()
+             | _ -> fail "missing credential lost its neutral slot disposition");
+            check string "rejected current identity" "current-missing" identity.candidate_id;
+            check
+              bool
+              "selection rejection is pre-dispatch"
+              true
+              (EO.candidate_rejection_phase rejection = EO.Before_dispatch);
+            check
+              int
+              "selection rejection is zero-dispatch"
+              0
+              (EO.candidate_rejection_dispatch_count rejection);
+            check
+              int
+              "selection rejection is first visit"
+              1
+              (EO.flow_visit_ordinal_to_int
+                 (EO.candidate_rejection_visit rejection).ordinal);
+            check
+              string
+              "rejection and successor share one outer flow"
+              (EO.flow_id_to_string (EO.candidate_rejection_visit rejection).flow_id)
+              (EO.flow_id_to_string next.flow_id);
+            check int "successor visit is second" 2 (EO.flow_visit_ordinal_to_int next.ordinal);
+            next_visit := Some next;
+            transitions := (identity.candidate_id, next.identity.candidate_id) :: !transitions;
+            Ok ()
+          | EO.Flow_candidate_execution_failed _ ->
+            fail "missing credential became an execution failure")
+        (start_flow (frozen_flow snapshot [ "current-missing"; "next-good" ]))
+    in
+    result, List.rev !transitions, List.rev !bound, !next_visit
+  in
+  check int "only resolved successor posts" 1 posts;
+  check
+    (list (pair string string))
+    "selection rejection advances to predetermined successor"
+    [ "current-missing", "next-good" ]
+    transitions;
+  check (list string) "only successor reaches before_dispatch" [ "next-good" ] bound;
+  match result with
+  | Ok success ->
+    check string "resolved successor succeeds" "next-good" (candidate_id success.candidate);
+    check
+      int
+      "both candidate outcomes remain ordered"
+      2
+      (List.length success.evidence.admissions);
+    check int "only successor gets an attempt" 1 (List.length success.evidence.attempts);
+    (match next_visit with
+     | Some next ->
+       check
+         string
+         "settled successor visit becomes the successful attempt visit"
+         (EO.flow_id_to_string next.flow_id)
+         (EO.flow_id_to_string success.candidate.visit.flow_id);
+       check
+         int
+         "settled successor ordinal is retained by the attempt"
+         (EO.flow_visit_ordinal_to_int next.ordinal)
+         (EO.flow_visit_ordinal_to_int success.candidate.visit.ordinal);
+       check
+         string
+         "settled successor identity is retained by the attempt"
+         next.identity.candidate_id
+         success.candidate.visit.identity.candidate_id
+     | None -> fail "successful successor had no settled visit");
+    check
+      int
+      "both candidates are visited"
+      2
+      (EO.candidate_visit_count_to_int success.evidence.candidate_visit_count)
+  | Error _ -> fail "durably settled selection rejection did not reach successor"
+;;
+
+let test_read_failed_current_credential_advances_to_good_successor () =
+  let (result, advances), posts =
+    with_server ~response:(openai_response {|{"name":"accepted"}|})
+    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
+    with_catalog
+      ~getenv:credential_getenv
+      [ catalog_entry
+          ~api_key_env:"READ_FAILED_FLOW_KEY"
+          ~id:"read-failed-current"
+          ~base_url
+          ~native:true
+          ~json:true
+          ()
+      ; catalog_entry ~id:"read-failed-successor" ~base_url ~native:true ~json:true ()
+      ]
+    @@ fun snapshot ->
+    let advances = ref [] in
+    let result =
+      EO.execute_flow_once
+        ~net
+        ~before_dispatch:(fun _ -> Ok ())
+        ~before_advance:(fun ~failed ~next ->
+          match failed with
+          | EO.Flow_candidate_rejected rejection ->
+            (match EO.candidate_rejection_disposition rejection with
+             | EO.Runtime_slot_unavailable -> ()
+             | _ -> fail "read-failed credential lost its neutral slot disposition");
+            check
+              int
+              "read-failed credential is zero-dispatch"
+              0
+              (EO.candidate_rejection_dispatch_count rejection);
+            advances
+            := ( (EO.candidate_rejection_identity rejection).candidate_id
+               , next.identity.candidate_id )
+               :: !advances;
+            Ok ()
+          | EO.Flow_candidate_execution_failed _ ->
+            fail "read-failed credential became an execution attempt")
+        (start_flow
+           (frozen_flow snapshot [ "read-failed-current"; "read-failed-successor" ]))
+    in
+    result, List.rev !advances
+  in
+  check int "only the read-failed successor posts" 1 posts;
+  check
+    (list (pair string string))
+    "read-failed credential advances in frozen order"
+    [ "read-failed-current", "read-failed-successor" ]
+    advances;
+  match result with
+  | Ok success ->
+    check
+      string
+      "read-failed successor succeeds"
+      "read-failed-successor"
+      (candidate_id success.candidate)
+  | Error _ -> fail "read-failed current candidate blocked its good successor"
+;;
+
+let test_credential_rejections_are_ordered_zero_dispatch_terminal () =
+  let (result, transitions, evidence), posts =
+    with_server ~response:(openai_response {|{"name":"unused"}|})
+    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
+    with_catalog
+      ~getenv:credential_getenv
+      [ catalog_entry
+          ~api_key_env:"MISSING_FLOW_KEY"
+          ~id:"credential-missing"
+          ~base_url
+          ~native:true
+          ~json:true
+          ()
+      ; catalog_entry
+          ~api_key_env:"INVALID_FLOW_KEY"
+          ~id:"credential-invalid"
+          ~base_url
+          ~native:true
+          ~json:true
+          ()
+      ; catalog_entry
+          ~api_key_env:"READ_FAILED_FLOW_KEY"
+          ~id:"credential-read-failed"
+          ~base_url
+          ~native:true
+          ~json:true
+          ()
+      ]
+    @@ fun snapshot ->
+    let transitions = ref [] in
+    let flow =
+      start_flow
+        (frozen_flow
+           snapshot
+           [ "credential-missing"; "credential-invalid"; "credential-read-failed" ])
+    in
+    let result =
+      EO.execute_flow_once
+        ~net
+        ~before_dispatch:(fun candidate ->
+          failf "credential rejection %s reached before_dispatch" (candidate_id candidate))
+        ~before_advance:(fun ~failed ~next ->
+          transitions := (flow_failure_id failed, next.identity.candidate_id) :: !transitions;
+          Ok ())
+        flow
+    in
+    result, List.rev !transitions, EO.flow_attempt_evidence flow
+  in
+  check int "credential rejections perform zero completion POSTs" 0 posts;
+  check
+    (list (pair string string))
+    "credential rejection transitions remain ordered"
+    [ "credential-missing", "credential-invalid"
+    ; "credential-invalid", "credential-read-failed"
+    ]
+    transitions;
+  check int "credential rejections fabricate no attempts" 0 (List.length evidence.attempts);
+  check int "all credential outcomes remain ordered" 3 (List.length evidence.admissions);
+  let check_rejection ~id ~visit rejection =
+    check
+      string
+      "credential rejection identity"
+      id
+      (EO.candidate_rejection_identity rejection).candidate_id;
+    check
+      bool
+      "credential rejection remains pre-dispatch"
+      true
+      (EO.candidate_rejection_phase rejection = EO.Before_dispatch);
+    check
+      int
+      "credential rejection remains zero-dispatch"
+      0
+      (EO.candidate_rejection_dispatch_count rejection);
+    check
+      int
+      "credential rejection visit is exact"
+      visit
+      (EO.flow_visit_ordinal_to_int (EO.candidate_rejection_visit rejection).ordinal);
+    match EO.candidate_rejection_disposition rejection with
+    | EO.Runtime_slot_unavailable -> ()
+    | _ -> fail "credential rejection leaked a non-neutral disposition"
+  in
+  (match evidence.admissions with
+   | [ EO.Candidate_rejected missing
+     ; EO.Candidate_rejected invalid
+     ; EO.Candidate_rejected read_failed
+     ] ->
+      check_rejection
+        ~id:"credential-missing"
+        ~visit:1
+        missing;
+      check_rejection
+        ~id:"credential-invalid"
+        ~visit:2
+        invalid;
+      check_rejection
+        ~id:"credential-read-failed"
+        ~visit:3
+        read_failed
+   | _ -> fail "credential evidence did not retain three typed rejections");
+  match result with
+  | Error (EO.Flow_candidates_exhausted { rejection; evidence = terminal_evidence }) ->
+    check
+      string
+      "last rejected candidate is terminal"
+      "credential-read-failed"
+      (EO.candidate_rejection_identity rejection).candidate_id;
+    check int "terminal retains zero attempts" 0 (List.length terminal_evidence.attempts);
+    check
+      int
+      "terminal candidate visit count is exact"
+      3
+      (EO.candidate_visit_count_to_int terminal_evidence.candidate_visit_count)
+  | Ok _ | Error _ -> fail "credential exhaustion lost its typed terminal rejection"
 ;;
 
 let test_unmeasured_constraint_advances_only_after_durable_settlement () =
@@ -345,13 +724,13 @@ let test_unmeasured_constraint_advances_only_after_durable_settlement () =
           Ok ())
         ~before_advance:(fun ~failed ~next ->
           match failed with
-          | EO.Flow_candidate_admission_rejected rejection ->
-            let identity = EO.admission_rejection_identity rejection in
+          | EO.Flow_candidate_rejected rejection ->
+            let identity = EO.candidate_rejection_identity rejection in
             let constraint_ =
-              match EO.admission_rejection_cause rejection with
-              | EO.Wire_admission_rejected (EO.Token_measurement_required constraint_) ->
-                constraint_
-              | _ -> fail "capacity rejection lost its typed cause"
+              match EO.candidate_rejection_disposition rejection with
+              | EO.Input_capacity (EO.Token_measurement_required observation) ->
+                observation
+              | _ -> fail "capacity rejection lost its neutral disposition"
             in
             check
               string
@@ -362,18 +741,18 @@ let test_unmeasured_constraint_advances_only_after_durable_settlement () =
               int
               "settled constraint remains exact"
               524298
-              constraint_.Serving_constraint.observation.accepted_through;
+              constraint_.accepted_through_tokens;
             check
               bool
               "admission receipt is pre-dispatch"
               true
-              (EO.admission_rejection_phase rejection = EO.Before_dispatch);
+              (EO.candidate_rejection_phase rejection = EO.Before_dispatch);
             check
               int
               "admission receipt is zero-dispatch"
               0
-              (EO.admission_rejection_dispatch_count rejection);
-            transitions := (identity.candidate_id, next.candidate_id) :: !transitions;
+              (EO.candidate_rejection_dispatch_count rejection);
+            transitions := (identity.candidate_id, next.identity.candidate_id) :: !transitions;
             Ok ()
           | _ -> fail "capacity rejection lost its typed durable transition")
         (start_flow ready)
@@ -405,9 +784,9 @@ let test_unmeasured_constraint_advances_only_after_durable_settlement () =
       (List.length success.evidence.admissions);
     check
       int
-      "candidate attempt count preserves ordered progress"
+      "candidate visit count preserves ordered progress"
       2
-      (EO.candidate_attempt_count_to_int success.evidence.candidate_attempt_count)
+      (EO.candidate_visit_count_to_int success.evidence.candidate_visit_count)
   | Error _ -> fail "durably settled admission rejection did not reach its successor"
 ;;
 
@@ -433,13 +812,13 @@ let test_request_body_capacity_advances_only_after_durable_settlement () =
         ~before_dispatch:(fun _ -> Ok ())
         ~before_advance:(fun ~failed ~next ->
           match failed with
-          | EO.Flow_candidate_admission_rejected rejection ->
+          | EO.Flow_candidate_rejected rejection ->
             let actual_bytes, limit_bytes =
-              match EO.admission_rejection_cause rejection with
-              | EO.Wire_admission_rejected
-                  (EO.Request_body_too_large { actual_bytes; limit_bytes }) ->
+              match EO.candidate_rejection_disposition rejection with
+              | EO.Input_capacity
+                  (EO.Serialized_request_body_too_large { actual_bytes; limit_bytes }) ->
                 actual_bytes, limit_bytes
-              | _ -> fail "request-body rejection lost its typed cause"
+              | _ -> fail "request-body rejection lost its neutral disposition"
             in
             check bool "serialized body exceeds the exact cap" true (actual_bytes > 1);
             check int "declared cap remains exact" 1 limit_bytes;
@@ -447,11 +826,11 @@ let test_request_body_capacity_advances_only_after_durable_settlement () =
               int
               "admission receipt is zero-dispatch"
               0
-              (EO.admission_rejection_dispatch_count rejection);
+              (EO.candidate_rejection_dispatch_count rejection);
             transition
             := Some
-                 ( (EO.admission_rejection_identity rejection).candidate_id
-                 , next.candidate_id );
+                 ( (EO.candidate_rejection_identity rejection).candidate_id
+                 , next.identity.candidate_id );
             Ok ()
           | _ -> fail "request-body rejection lost its typed durable transition")
         (start_flow (frozen_flow snapshot [ "body-capped"; "body-successor" ]))
@@ -474,7 +853,7 @@ let test_request_body_capacity_advances_only_after_durable_settlement () =
   | Error _ -> fail "durably settled body-cap rejection did not reach its successor"
 ;;
 
-let test_all_admission_rejections_return_typed_zero_dispatch_terminal () =
+let test_all_candidate_rejections_return_typed_zero_dispatch_terminal () =
   let (result, transitions, evidence), posts =
     with_server ~response:(openai_response {|{"name":"unused"}|})
     @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
@@ -503,7 +882,7 @@ let test_all_admission_rejections_return_typed_zero_dispatch_terminal () =
         ~before_dispatch:(fun candidate ->
           failf "rejected candidate %s reached before_dispatch" (candidate_id candidate))
         ~before_advance:(fun ~failed ~next ->
-          transitions := (flow_failure_id failed, next.candidate_id) :: !transitions;
+          transitions := (flow_failure_id failed, next.identity.candidate_id) :: !transitions;
           Ok ())
         flow
     in
@@ -523,57 +902,161 @@ let test_all_admission_rejections_return_typed_zero_dispatch_terminal () =
        string
        "first retained rejection"
        "rejected-a"
-       (EO.admission_rejection_identity first).candidate_id;
+       (EO.candidate_rejection_identity first).candidate_id;
      check
        int
        "first retained candidate count"
        1
-       (EO.admission_rejection_candidate_attempt_count first
-        |> EO.candidate_attempt_count_to_int);
+       (EO.flow_visit_ordinal_to_int (EO.candidate_rejection_visit first).ordinal);
      check
        string
        "second retained rejection"
        "rejected-b"
-       (EO.admission_rejection_identity second).candidate_id;
+       (EO.candidate_rejection_identity second).candidate_id;
      check
        int
        "second retained candidate count"
        2
-       (EO.admission_rejection_candidate_attempt_count second
-        |> EO.candidate_attempt_count_to_int);
+       (EO.flow_visit_ordinal_to_int (EO.candidate_rejection_visit second).ordinal);
      List.iter
        (fun rejection ->
           check
             bool
             "retained rejection remains pre-dispatch"
             true
-            (EO.admission_rejection_phase rejection = EO.Before_dispatch);
+            (EO.candidate_rejection_phase rejection = EO.Before_dispatch);
           check
             int
             "retained rejection remains zero-dispatch"
             0
-            (EO.admission_rejection_dispatch_count rejection))
+            (EO.candidate_rejection_dispatch_count rejection))
        [ first; second ]
    | _ -> fail "flow evidence did not retain typed admission receipts");
   match result with
-  | Error (EO.Flow_admission_failed { rejection; evidence = terminal_evidence }) ->
+  | Error (EO.Flow_candidates_exhausted { rejection; evidence = terminal_evidence }) ->
     check
       string
       "terminal rejected candidate"
       "rejected-b"
-      (EO.admission_rejection_identity rejection).candidate_id;
-    (match EO.admission_rejection_cause rejection with
-     | EO.Wire_admission_rejected
-         (EO.Request_body_too_large { actual_bytes; limit_bytes }) ->
+      (EO.candidate_rejection_identity rejection).candidate_id;
+    (match EO.candidate_rejection_disposition rejection with
+     | EO.Input_capacity
+         (EO.Serialized_request_body_too_large { actual_bytes; limit_bytes }) ->
        check bool "terminal body remains over cap" true (actual_bytes > limit_bytes)
-     | _ -> fail "terminal admission receipt lost its body-cap cause");
+     | _ -> fail "terminal admission receipt lost its neutral body-cap disposition");
     check int "terminal retains zero attempts" 0 (List.length terminal_evidence.attempts);
     check
       int
       "terminal candidate count is exact"
       2
-      (EO.candidate_attempt_count_to_int terminal_evidence.candidate_attempt_count)
+      (EO.candidate_visit_count_to_int terminal_evidence.candidate_visit_count)
   | Ok _ | Error _ -> fail "all-rejected flow lost its typed terminal admission failure"
+;;
+
+exception Rejection_advance_committed_before_successor
+
+let test_exception_after_durable_rejection_stops_before_successor () =
+  let durable_path = Filename.temp_file "oas-rejection-advance-" ".json" in
+  Fun.protect
+    ~finally:(fun () -> Sys.remove durable_path)
+    (fun () ->
+       let (raised, replay, evidence, observed), posts =
+         with_server ~response:(openai_response {|{"name":"must-not-dispatch"}|})
+         @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
+         with_catalog
+           ~getenv:credential_getenv
+           [ catalog_entry
+               ~api_key_env:"MISSING_FLOW_KEY"
+               ~id:"rejection-committed"
+               ~base_url
+               ~native:true
+               ~json:true
+               ()
+           ; catalog_entry
+               ~id:"rejection-withheld-successor"
+               ~base_url
+               ~native:true
+               ~json:true
+               ()
+           ]
+         @@ fun snapshot ->
+         let flow =
+           start_flow
+             (frozen_flow
+                snapshot
+                [ "rejection-committed"; "rejection-withheld-successor" ])
+         in
+         let observed = ref None in
+         let raised =
+           try
+             ignore
+               (EO.execute_flow_once
+                  ~net
+                  ~before_dispatch:(fun candidate ->
+                    failf
+                      "zero-dispatch rejection unexpectedly prepared %s"
+                      (candidate_id candidate))
+                  ~before_advance:(fun ~failed ~next ->
+                    match failed with
+                    | EO.Flow_candidate_rejected rejection ->
+                      let failed_visit = EO.candidate_rejection_visit rejection in
+                      let payload =
+                        `Assoc
+                          [ "flow_id", `String (EO.flow_id_to_string failed_visit.flow_id)
+                          ; ( "failed_ordinal"
+                            , `Int (EO.flow_visit_ordinal_to_int failed_visit.ordinal) )
+                          ; "next_ordinal", `Int (EO.flow_visit_ordinal_to_int next.ordinal)
+                          ; "failed_candidate_id", `String failed_visit.identity.candidate_id
+                          ; "next_candidate_id", `String next.identity.candidate_id
+                          ]
+                      in
+                      Out_channel.with_open_bin durable_path (fun channel ->
+                        output_string channel (Yojson.Safe.to_string payload);
+                        flush channel;
+                        Unix.fsync (Unix.descr_of_out_channel channel));
+                      observed := Some (failed_visit, next);
+                      raise Rejection_advance_committed_before_successor
+                    | EO.Flow_candidate_execution_failed _ ->
+                      fail "credential rejection allocated an execution attempt")
+                  flow
+                : (EO.flow_success, unit EO.flow_execution_error) result);
+             false
+           with
+           | Rejection_advance_committed_before_successor -> true
+         in
+         raised, execute_ok ~net flow, EO.flow_attempt_evidence flow, !observed
+       in
+       check bool "exception escaped after durable rejection settlement" true raised;
+       check int "rejection and withheld successor dispatch nothing" 0 posts;
+       check int "only rejected admission is recorded" 1 (List.length evidence.admissions);
+       check int "rejection fabricates no attempt" 0 (List.length evidence.attempts);
+       check
+         int
+         "only rejected candidate is visited"
+         1
+         (EO.candidate_visit_count_to_int evidence.candidate_visit_count);
+       (match replay with
+        | Error (EO.Flow_attempt_already_started _) -> ()
+        | Ok _ | Error _ -> fail "rejection callback exception left flow replayable");
+       (match observed with
+        | Some (failed_visit, next) ->
+          check
+            string
+            "rejection and withheld successor share a flow"
+            (EO.flow_id_to_string failed_visit.flow_id)
+            (EO.flow_id_to_string next.flow_id);
+          check
+            int
+            "rejected visit ordinal"
+            1
+            (EO.flow_visit_ordinal_to_int failed_visit.ordinal);
+          check int "withheld visit ordinal" 2 (EO.flow_visit_ordinal_to_int next.ordinal)
+        | None -> fail "durable rejection visit was not observed");
+       check
+         bool
+         "durable visit settlement was written"
+         true
+         (In_channel.with_open_bin durable_path In_channel.input_all <> ""))
 ;;
 
 let test_predispatch_transport_failure_advances_after_durable_callback () =
@@ -613,9 +1096,9 @@ let test_predispatch_transport_failure_advances_after_durable_callback () =
           := Printf.sprintf
                "advance:%s->%s"
                (candidate_id failed_candidate)
-               next.candidate_id
+               next.identity.candidate_id
              :: !events;
-          advanced := (candidate_id failed_candidate, next.candidate_id) :: !advanced;
+          advanced := (candidate_id failed_candidate, next.identity.candidate_id) :: !advanced;
           Ok ())
         flow
     in
@@ -718,7 +1201,7 @@ let test_exception_after_durable_advance_stops_before_successor () =
                     persist_advance
                       (`Assoc
                           [ "failed_candidate_id", `String (candidate_id failed)
-                          ; "next_candidate_id", `String next.candidate_id
+                          ; "next_candidate_id", `String next.identity.candidate_id
                           ; ( "failed_call_id"
                             , `String
                                 (EO.receipt_call_id failed.receipt |> EO.call_id_to_string)
@@ -775,7 +1258,7 @@ let test_exception_after_durable_advance_stops_before_successor () =
          int
          "only the failed candidate was attempted"
          1
-         (EO.candidate_attempt_count_to_int evidence.candidate_attempt_count);
+         (EO.candidate_visit_count_to_int evidence.candidate_visit_count);
        let open Yojson.Safe.Util in
        let committed_string field = committed |> member field |> to_string in
        let committed_int field = committed |> member field |> to_int in
@@ -865,7 +1348,7 @@ let test_callback_failures_are_terminal () =
       (EO.Flow_before_advance_callback_failed
          { failed; next; cause = "release-not-durable"; evidence; _ }) ->
     check string "failed attempt identity" "advance-a" (flow_failure_id failed);
-    check string "withheld successor identity" "advance-b" next.candidate_id;
+    check string "withheld successor identity" "advance-b" next.identity.candidate_id;
     check int "withheld successor remains unprepared" 1 (List.length evidence.attempts)
   | Ok _ | Error _ -> fail "failed advance did not return typed terminal evidence"
 ;;
@@ -1061,6 +1544,22 @@ let () =
             `Quick
             test_snapshot_defers_admission_and_allocates_nonshared_current_attempts
         ; test_case
+            "later missing credential does not block current success"
+            `Quick
+            test_later_missing_credential_does_not_block_current_success
+        ; test_case
+            "missing current credential advances after durable settlement"
+            `Quick
+            test_missing_current_credential_advances_after_durable_settlement
+        ; test_case
+            "read-failed current credential advances to good successor"
+            `Quick
+            test_read_failed_current_credential_advances_to_good_successor
+        ; test_case
+            "credential rejections remain ordered zero-dispatch terminal"
+            `Quick
+            test_credential_rejections_are_ordered_zero_dispatch_terminal
+        ; test_case
             "unmeasured constraint advances after durable settlement"
             `Quick
             test_unmeasured_constraint_advances_only_after_durable_settlement
@@ -1069,9 +1568,9 @@ let () =
             `Quick
             test_request_body_capacity_advances_only_after_durable_settlement
         ; test_case
-            "all admission rejections return zero-dispatch terminal"
+            "all candidate rejections return zero-dispatch terminal"
             `Quick
-            test_all_admission_rejections_return_typed_zero_dispatch_terminal
+            test_all_candidate_rejections_return_typed_zero_dispatch_terminal
         ; test_case
             "predispatch transport failure advances durably"
             `Quick
@@ -1080,6 +1579,10 @@ let () =
             "exception after durable advance stops successor"
             `Quick
             test_exception_after_durable_advance_stops_before_successor
+        ; test_case
+            "exception after durable rejection stops successor"
+            `Quick
+            test_exception_after_durable_rejection_stops_before_successor
         ; test_case
             "callback failures are terminal"
             `Quick

--- a/test/test_exact_output_flow.ml
+++ b/test/test_exact_output_flow.ml
@@ -217,7 +217,9 @@ let with_server ?response_delay_s ?(status = `OK) ?(abort_completion = false) ~r
   result, Atomic.get completion_posts
 ;;
 
-let candidate_id (candidate : EO.flow_attempt_receipt) = candidate.visit.identity.candidate_id
+let candidate_id (candidate : EO.flow_attempt_receipt) =
+  candidate.visit.identity.candidate_id
+;;
 
 let flow_failure_id = function
   | EO.Flow_candidate_rejected rejection ->
@@ -395,7 +397,11 @@ let test_later_missing_credential_does_not_block_current_success () =
   check int "unvisited missing credential does not advance" 0 advances;
   match result with
   | Ok success ->
-    check string "current candidate succeeds" "current-good" (candidate_id success.candidate);
+    check
+      string
+      "current candidate succeeds"
+      "current-good"
+      (candidate_id success.candidate);
     check
       int
       "full candidate snapshot remains frozen"
@@ -406,7 +412,11 @@ let test_later_missing_credential_does_not_block_current_success () =
       "only current admission is recorded"
       1
       (List.length success.evidence.admissions);
-    check int "only current attempt is allocated" 1 (List.length success.evidence.attempts);
+    check
+      int
+      "only current attempt is allocated"
+      1
+      (List.length success.evidence.attempts);
     check
       int
       "only current candidate is visited"
@@ -447,7 +457,11 @@ let test_missing_current_credential_advances_after_durable_settlement () =
             (match EO.candidate_rejection_disposition rejection with
              | EO.Runtime_slot_unavailable -> ()
              | _ -> fail "missing credential lost its neutral slot disposition");
-            check string "rejected current identity" "current-missing" identity.candidate_id;
+            check
+              string
+              "rejected current identity"
+              "current-missing"
+              identity.candidate_id;
             check
               bool
               "selection rejection is pre-dispatch"
@@ -469,9 +483,14 @@ let test_missing_current_credential_advances_after_durable_settlement () =
               "rejection and successor share one outer flow"
               (EO.flow_id_to_string (EO.candidate_rejection_visit rejection).flow_id)
               (EO.flow_id_to_string next.flow_id);
-            check int "successor visit is second" 2 (EO.flow_visit_ordinal_to_int next.ordinal);
+            check
+              int
+              "successor visit is second"
+              2
+              (EO.flow_visit_ordinal_to_int next.ordinal);
             next_visit := Some next;
-            transitions := (identity.candidate_id, next.identity.candidate_id) :: !transitions;
+            transitions
+            := (identity.candidate_id, next.identity.candidate_id) :: !transitions;
             Ok ()
           | EO.Flow_candidate_execution_failed _ ->
             fail "missing credential became an execution failure")
@@ -488,7 +507,11 @@ let test_missing_current_credential_advances_after_durable_settlement () =
   check (list string) "only successor reaches before_dispatch" [ "next-good" ] bound;
   match result with
   | Ok success ->
-    check string "resolved successor succeeds" "next-good" (candidate_id success.candidate);
+    check
+      string
+      "resolved successor succeeds"
+      "next-good"
+      (candidate_id success.candidate);
     check
       int
       "both candidate outcomes remain ordered"
@@ -623,7 +646,8 @@ let test_credential_rejections_are_ordered_zero_dispatch_terminal () =
         ~before_dispatch:(fun candidate ->
           failf "credential rejection %s reached before_dispatch" (candidate_id candidate))
         ~before_advance:(fun ~failed ~next ->
-          transitions := (flow_failure_id failed, next.identity.candidate_id) :: !transitions;
+          transitions
+          := (flow_failure_id failed, next.identity.candidate_id) :: !transitions;
           Ok ())
         flow
     in
@@ -637,7 +661,11 @@ let test_credential_rejections_are_ordered_zero_dispatch_terminal () =
     ; "credential-invalid", "credential-read-failed"
     ]
     transitions;
-  check int "credential rejections fabricate no attempts" 0 (List.length evidence.attempts);
+  check
+    int
+    "credential rejections fabricate no attempts"
+    0
+    (List.length evidence.attempts);
   check int "all credential outcomes remain ordered" 3 (List.length evidence.admissions);
   let check_rejection ~id ~visit rejection =
     check
@@ -669,18 +697,9 @@ let test_credential_rejections_are_ordered_zero_dispatch_terminal () =
      ; EO.Candidate_rejected invalid
      ; EO.Candidate_rejected read_failed
      ] ->
-      check_rejection
-        ~id:"credential-missing"
-        ~visit:1
-        missing;
-      check_rejection
-        ~id:"credential-invalid"
-        ~visit:2
-        invalid;
-      check_rejection
-        ~id:"credential-read-failed"
-        ~visit:3
-        read_failed
+     check_rejection ~id:"credential-missing" ~visit:1 missing;
+     check_rejection ~id:"credential-invalid" ~visit:2 invalid;
+     check_rejection ~id:"credential-read-failed" ~visit:3 read_failed
    | _ -> fail "credential evidence did not retain three typed rejections");
   match result with
   | Error (EO.Flow_candidates_exhausted { rejection; evidence = terminal_evidence }) ->
@@ -752,7 +771,8 @@ let test_unmeasured_constraint_advances_only_after_durable_settlement () =
               "admission receipt is zero-dispatch"
               0
               (EO.candidate_rejection_dispatch_count rejection);
-            transitions := (identity.candidate_id, next.identity.candidate_id) :: !transitions;
+            transitions
+            := (identity.candidate_id, next.identity.candidate_id) :: !transitions;
             Ok ()
           | _ -> fail "capacity rejection lost its typed durable transition")
         (start_flow ready)
@@ -882,7 +902,8 @@ let test_all_candidate_rejections_return_typed_zero_dispatch_terminal () =
         ~before_dispatch:(fun candidate ->
           failf "rejected candidate %s reached before_dispatch" (candidate_id candidate))
         ~before_advance:(fun ~failed ~next ->
-          transitions := (flow_failure_id failed, next.identity.candidate_id) :: !transitions;
+          transitions
+          := (flow_failure_id failed, next.identity.candidate_id) :: !transitions;
           Ok ())
         flow
     in
@@ -1005,8 +1026,10 @@ let test_exception_after_durable_rejection_stops_before_successor () =
                           [ "flow_id", `String (EO.flow_id_to_string failed_visit.flow_id)
                           ; ( "failed_ordinal"
                             , `Int (EO.flow_visit_ordinal_to_int failed_visit.ordinal) )
-                          ; "next_ordinal", `Int (EO.flow_visit_ordinal_to_int next.ordinal)
-                          ; "failed_candidate_id", `String failed_visit.identity.candidate_id
+                          ; ( "next_ordinal"
+                            , `Int (EO.flow_visit_ordinal_to_int next.ordinal) )
+                          ; ( "failed_candidate_id"
+                            , `String failed_visit.identity.candidate_id )
                           ; "next_candidate_id", `String next.identity.candidate_id
                           ]
                       in
@@ -1098,7 +1121,8 @@ let test_predispatch_transport_failure_advances_after_durable_callback () =
                (candidate_id failed_candidate)
                next.identity.candidate_id
              :: !events;
-          advanced := (candidate_id failed_candidate, next.identity.candidate_id) :: !advanced;
+          advanced
+          := (candidate_id failed_candidate, next.identity.candidate_id) :: !advanced;
           Ok ())
         flow
     in

--- a/test/test_exact_output_flow.ml
+++ b/test/test_exact_output_flow.ml
@@ -745,10 +745,12 @@ let test_unmeasured_constraint_advances_only_after_durable_settlement () =
           match failed with
           | EO.Flow_candidate_rejected rejection ->
             let identity = EO.candidate_rejection_identity rejection in
-            let constraint_ =
+            let accepted_through_tokens, rejected_from_tokens =
               match EO.candidate_rejection_disposition rejection with
-              | EO.Input_capacity (EO.Token_measurement_required observation) ->
-                observation
+              | EO.Input_capacity
+                  (EO.Token_measurement_required
+                     { accepted_through_tokens; rejected_from_tokens }) ->
+                accepted_through_tokens, rejected_from_tokens
               | _ -> fail "capacity rejection lost its neutral disposition"
             in
             check
@@ -756,11 +758,12 @@ let test_unmeasured_constraint_advances_only_after_durable_settlement () =
               "settled rejected identity"
               "constrained-exact"
               identity.candidate_id;
+            check int "settled constraint remains exact" 524298 accepted_through_tokens;
             check
-              int
-              "settled constraint remains exact"
-              524298
-              constraint_.accepted_through_tokens;
+              (option int)
+              "settled rejected boundary remains exact"
+              (Some 524299)
+              rejected_from_tokens;
             check
               bool
               "admission receipt is pre-dispatch"

--- a/test/test_exact_output_resolver_snapshot.ml
+++ b/test/test_exact_output_resolver_snapshot.ml
@@ -410,30 +410,27 @@ let test_credential_outcomes_are_frozen_per_target () =
   ignore (resolve_admitted shared_available : EO.selected_target);
   let expect_missing admitted =
     match EO.resolve_target admitted with
-    | Error
-        (EO.Missing_target_credential
-           { target_ref = "credential-missing"
-           ; environment_variable = "MISSING_FIXTURE_KEY"
-           }) -> ()
-    | Ok _ | Error _ -> fail "missing credential must remain a typed target outcome"
+    | Error error ->
+      (match EO.target_selection_error_disposition error with
+       | EO.Runtime_slot_unavailable -> ()
+       | _ -> fail "missing credential must remain a runtime-slot outcome")
+    | Ok _ -> fail "missing credential unexpectedly resolved"
   in
   let expect_invalid admitted =
     match EO.resolve_target admitted with
-    | Error
-        (EO.Target_credential_invalid
-           { target_ref = "credential-invalid"
-           ; environment_variable = "INVALID_FIXTURE_KEY"
-           }) -> ()
-    | Ok _ | Error _ -> fail "invalid credential must remain a typed target outcome"
+    | Error error ->
+      (match EO.target_selection_error_disposition error with
+       | EO.Runtime_slot_unavailable -> ()
+       | _ -> fail "invalid credential must remain a runtime-slot outcome")
+    | Ok _ -> fail "invalid credential unexpectedly resolved"
   in
   let expect_read_failed admitted =
     match EO.resolve_target admitted with
-    | Error
-        (EO.Target_credential_read_failed
-           { target_ref = "credential-read-failed"
-           ; environment_variable = "READ_FAILED_FIXTURE_KEY"
-           }) -> ()
-    | Ok _ | Error _ -> fail "credential read failure must remain a typed target outcome"
+    | Error error ->
+      (match EO.target_selection_error_disposition error with
+       | EO.Runtime_slot_unavailable -> ()
+       | _ -> fail "credential read failure must remain a runtime-slot outcome")
+    | Ok _ -> fail "read-failed credential unexpectedly resolved"
   in
   expect_missing missing;
   expect_invalid invalid;

--- a/test/test_exact_output_single_surface.ml
+++ b/test/test_exact_output_single_surface.ml
@@ -427,8 +427,7 @@ let test_request_body_limit_is_typed_and_pre_dispatch () =
           true
           (actual_bytes > limit_bytes)
       | _ -> fail "oversized request lost its neutral byte-cap disposition")
-   | Ok _ -> fail "oversized exact-output request unexpectedly admitted"
-  );
+   | Ok _ -> fail "oversized exact-output request unexpectedly admitted");
   check int "completion POST count" 0 completion_posts;
   check int "token measurement POST count" 0 token_posts;
   check int "captured request count" 0 (List.length captures)

--- a/test/test_exact_output_single_surface.ml
+++ b/test/test_exact_output_single_surface.ml
@@ -330,16 +330,22 @@ let test_tier_table_and_provider_schema_rejection () =
        ~messages:[ msg "json" ]
        (requirement EO.Provider_schema)
    with
-   | Error EO.Provider_schema_unavailable -> ()
-   | Ok _ | Error _ -> fail "provider-schema minimum must fail on JSON-only target");
+   | Error error ->
+     (match EO.admission_error_disposition error with
+      | EO.Output_requirement_rejected -> ()
+      | _ -> fail "provider-schema rejection lost its neutral disposition")
+   | Ok _ -> fail "provider-schema minimum must fail on JSON-only target");
   match
     EO.admit
       ~target:(target snapshot "none")
       ~messages:[ msg "json" ]
       (requirement EO.Json_syntax)
   with
-  | Error EO.Json_syntax_unavailable -> ()
-  | Ok _ | Error _ -> fail "JSON syntax must fail when target declares no JSON tier"
+  | Error error ->
+    (match EO.admission_error_disposition error with
+     | EO.Output_requirement_rejected -> ()
+     | _ -> fail "JSON syntax rejection lost its neutral disposition")
+  | Ok _ -> fail "JSON syntax must fail when target declares no JSON tier"
 ;;
 
 let test_deepseek_catalog_is_json_only_before_dispatch () =
@@ -380,8 +386,11 @@ let test_deepseek_catalog_is_json_only_before_dispatch () =
          ~messages:[ msg "schema" ]
          (requirement EO.Provider_schema)
      with
-     | Error EO.Provider_schema_unavailable -> ()
-     | Ok _ | Error _ -> fail "DeepSeek provider schema must reject before dispatch")
+     | Error error ->
+       (match EO.admission_error_disposition error with
+        | EO.Output_requirement_rejected -> ()
+        | _ -> fail "DeepSeek schema rejection lost its neutral disposition")
+     | Ok _ -> fail "DeepSeek provider schema must reject before dispatch")
 ;;
 
 let test_request_body_limit_is_typed_and_pre_dispatch () =
@@ -407,17 +416,19 @@ let test_request_body_limit_is_typed_and_pre_dispatch () =
       (requirement EO.Json_syntax)
   in
   (match admission with
-   | Error
-       (EO.Wire_admission_rejected
-          (EO.Request_body_too_large { actual_bytes; limit_bytes })) ->
-     check int "resolved exact-target byte limit" 1 limit_bytes;
-     check
-       bool
-       "actual serialized request bytes measured"
-       true
-       (actual_bytes > limit_bytes)
+   | Error error ->
+     (match EO.admission_error_disposition error with
+      | EO.Input_capacity
+          (EO.Serialized_request_body_too_large { actual_bytes; limit_bytes }) ->
+        check int "resolved exact-target byte limit" 1 limit_bytes;
+        check
+          bool
+          "actual serialized request bytes measured"
+          true
+          (actual_bytes > limit_bytes)
+      | _ -> fail "oversized request lost its neutral byte-cap disposition")
    | Ok _ -> fail "oversized exact-output request unexpectedly admitted"
-   | Error _ -> fail "oversized exact-output request lost its typed admission reason");
+  );
   check int "completion POST count" 0 completion_posts;
   check int "token measurement POST count" 0 token_posts;
   check int "captured request count" 0 (List.length captures)
@@ -459,10 +470,11 @@ let test_supported_models_membership_is_exact_and_pre_dispatch () =
    | Ok _ -> ()
    | Error _ -> fail "exact supported model must admit");
   (match rejected with
-   | Error
-       (EO.Wire_admission_rejected
-          (EO.Unsupported_target_model { model_id = "membership-rejected-model" })) -> ()
-   | Ok _ | Error _ -> fail "case-only non-member must return the typed rejection");
+   | Error error ->
+     (match EO.admission_error_disposition error with
+      | EO.Runtime_contract_rejected -> ()
+      | _ -> fail "model membership rejection lost its neutral disposition")
+   | Ok _ -> fail "case-only non-member must return the typed rejection");
   check int "membership rejection completion posts" 0 completion_posts;
   check int "membership rejection token posts" 0 token_posts;
   check int "membership rejection captures" 0 (List.length captures)
@@ -514,8 +526,11 @@ let test_wire_envelope_and_cross_feature_injection_rejected () =
        ~messages:[ wire_phase_message ]
        (requirement EO.Json_syntax)
    with
-   | Error (EO.Wire_admission_rejected EO.Cross_feature_not_allowed) -> ()
-   | Ok _ | Error _ -> fail "reserved wire metadata must reject before dispatch");
+   | Error error ->
+     (match EO.admission_error_disposition error with
+      | EO.Input_contract_rejected -> ()
+      | _ -> fail "reserved wire metadata lost its neutral disposition")
+   | Ok _ -> fail "reserved wire metadata must reject before dispatch");
   let tool_role_message = { (msg "tool role") with role = Types.Tool } in
   (match
      EO.admit
@@ -523,8 +538,11 @@ let test_wire_envelope_and_cross_feature_injection_rejected () =
        ~messages:[ tool_role_message ]
        (requirement EO.Json_syntax)
    with
-   | Error (EO.Wire_admission_rejected EO.Cross_feature_not_allowed) -> ()
-   | Ok _ | Error _ -> fail "tool role must reject before exact dispatch");
+   | Error error ->
+     (match EO.admission_error_disposition error with
+      | EO.Input_contract_rejected -> ()
+      | _ -> fail "tool role rejection lost its neutral disposition")
+   | Ok _ -> fail "tool role must reject before exact dispatch");
   let tool_message : Types.message =
     { role = Types.Assistant
     ; content = [ Types.ToolUse { id = "tool-1"; name = "forbidden"; input = `Assoc [] } ]
@@ -539,8 +557,11 @@ let test_wire_envelope_and_cross_feature_injection_rejected () =
       ~messages:[ tool_message ]
       (requirement EO.Json_syntax)
   with
-  | Error (EO.Wire_admission_rejected EO.Cross_feature_not_allowed) -> ()
-  | Ok _ | Error _ -> fail "tool history must reject before exact dispatch"
+  | Error error ->
+    (match EO.admission_error_disposition error with
+     | EO.Input_contract_rejected -> ()
+     | _ -> fail "tool history rejection lost its neutral disposition")
+  | Ok _ -> fail "tool history must reject before exact dispatch"
 ;;
 
 let test_anthropic_schema_prefill_rejected_before_dispatch () =
@@ -565,8 +586,11 @@ let test_anthropic_schema_prefill_rejected_before_dispatch () =
       (requirement EO.Provider_schema)
   in
   (match admission with
-   | Error (EO.Wire_admission_rejected EO.Cross_feature_not_allowed) -> ()
-   | Ok _ | Error _ -> fail "Anthropic schema prefill must reject during admission");
+   | Error error ->
+     (match EO.admission_error_disposition error with
+      | EO.Input_contract_rejected -> ()
+      | _ -> fail "Anthropic prefill rejection lost its neutral disposition")
+   | Ok _ -> fail "Anthropic schema prefill must reject during admission");
   check int "Anthropic prefill completion posts" 0 completion_posts;
   check int "Anthropic prefill token posts" 0 token_posts;
   check int "Anthropic prefill captures" 0 (List.length captures)
@@ -1726,8 +1750,11 @@ let test_gemini_nested_unsupported_schema_keyword_rejected () =
          ~schema:unsupported_schema
          ~minimum_guarantee:EO.Provider_schema)
   with
-  | Error (EO.Unsupported_schema_keyword "$.properties.name.pattern") -> ()
-  | Ok _ | Error _ -> fail "Gemini unsupported schema keyword must remain typed"
+  | Error error ->
+    (match EO.admission_error_disposition error with
+     | EO.Output_requirement_rejected -> ()
+     | _ -> fail "Gemini schema rejection lost its neutral disposition")
+  | Ok _ -> fail "Gemini unsupported schema keyword must reject"
 ;;
 
 let test_gemini_nonempty_request_path_rejected_before_resolution () =


### PR DESCRIPTION
## What

Align the OAS exact-output outer-flow facade with the current-candidate algorithm in the structured-output/provider-capability audit:

- freeze candidate order and immutable domain input without speculative target resolution or admission;
- allocate one `flow_id` at flow start and precompute branded 1-based candidate visits;
- resolve, prepare, measure, and admit only the current visit;
- allocate call/attempt identity only when a dispatch is actually admitted;
- retain provider-neutral zero-dispatch rejection evidence without creating a call ID;
- require durable `before_advance` settlement before entering the predetermined successor visit;
- retain ordered snapshot, visits, reached admissions, rejection receipts, attempts, and provenance after terminal/cancellation outcomes.

## Pre-1.0 API hard cut

- `admit_flow` becomes `snapshot_flow`;
- `ready_flow` becomes `flow_snapshot`;
- `start_flow` creates the single outer identity and can reject an invalid candidate sequence before admission/network activity;
- `before_advance` receives the settled provider-neutral rejection and the precomputed next visit;
- speculative all-candidate resolution/admission and `ready_flow_admissions` are removed;
- public flow errors are abstract; provider/model/credential/source details remain inside OAS diagnostics.

This is intentionally breaking. Downstream MASC exact-flow consumers must migrate only after this OAS release is pinned.

## Proof

Latest head: `11fd8b0c4`.

- three independent static reviews found no remaining P0/P1 in the flow implementation, public interfaces, private validator extractions, or Dune wiring;
- boundary ratchets cover multiline manifest leaks, detailed error accessors, closed dispositions, private visits, and constructor-specific capacity payloads;
- the previous head exposed a `godfile` regression; Gemini schema admission and endpoint binding validation were moved into private single-responsibility modules rather than waived or line-compressed;
- local build/test/formatter were intentionally not rerun for this head; GitHub Actions is the build authority and is currently pending.

## Rollout

1. Merge and release this OAS boundary only after required checks are green.
2. Pin that release in MASC and migrate every exact-flow consumer.
3. Complete target serving-constraint rows and exact input-token measurement support before enabling affected targets.
4. Verify fresh-state zero-dispatch capacity advancement, next-visit progress, compaction re-admission, and restart recovery.

Refs jeong-sik/masc#27864

BEGIN_COMMIT_OVERRIDE
feat(exact-output)!: settle current-candidate admission

BREAKING CHANGE: Replace admit_flow/ready_flow with snapshot_flow/flow_snapshot and change start_flow/before_advance contracts.
END_COMMIT_OVERRIDE

