### PR TITLE
feat(exact-output): settle scoped domain success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ original tag dates. `0.100.4` was never tagged or released.
 
 ### Breaking Changes
 
+* **exact-output flow settlement:** require an explicit hard capacity when
+  creating a scope-local preference store, add explicit scope removal and typed
+  capacity/released-scope failures, and replace caller-provided success
+  timestamps with an OAS-owned monotonic ordinal frozen at structural success.
+  Domain settlement receipts are now private evidence values, so callers can
+  inspect but cannot construct them.
 * **tool lifecycle:** replace independently writable tool-call id, turn, and
   schedule copies across hooks, events, results, failures, and execution
   callbacks with one run-scoped `Tool.Invocation.t`. The invocation now owns

--- a/docs/design/exact-output-flow-boundary.md
+++ b/docs/design/exact-output-flow-boundary.md
@@ -128,6 +128,12 @@ timestamp, string, or target-specific tie-break. An older observation leaves
 the installed preference unchanged and returns a typed superseded receipt
 containing the retained candidate identity and ordinal.
 
+The per-success settlement gate remains held until domain-valid preference
+publication completes. A losing duplicate therefore cannot return
+`Domain_already_settled` and immediately observe a pre-publication snapshot.
+The only nested lock order is settlement gate then preference store; no path
+acquires those locks in reverse.
+
 No network or filesystem I/O occurs while the preference mutex is held.
 
 ## Evidence

--- a/docs/design/exact-output-flow-boundary.md
+++ b/docs/design/exact-output-flow-boundary.md
@@ -38,8 +38,11 @@ catalog-admitted opaque target handles, and one immutable domain input. Catalog
 membership and credential outcomes are frozen, but credentials remain
 unselected. The caller supplies an explicit preference store and opaque
 nonempty flow scope. OAS performs one exact scope lookup while creating the
-snapshot. If that scope's last domain-valid candidate is present, OAS moves it
-to the front and preserves the relative order of every other candidate.
+snapshot. The store retains the full successful candidate identity. OAS moves
+that candidate to the front only when both its opaque caller slot identity and
+opaque target-identity fingerprint still match. An absent slot or a slot rebound
+to another target is not promoted and remains typed observation evidence.
+The relative order of every other candidate is preserved.
 
 The resulting order is immutable. A later success cannot change an existing
 snapshot, and a preference recorded in one scope cannot affect another scope.
@@ -108,7 +111,8 @@ Neither disposition can trigger another provider dispatch.
 
 An older success time cannot overwrite a newer observation for the same scope.
 OAS uses no string or target-specific tie-break. Equal or older observations
-leave the installed preference unchanged.
+leave the installed preference unchanged and return a typed superseded receipt
+containing the retained candidate identity and success time.
 
 No network or filesystem I/O occurs while the preference mutex is held.
 
@@ -118,7 +122,10 @@ Every flow evidence projection carries:
 
 - the fresh outer-flow identity;
 - the exact opaque flow scope;
+- the caller-declared candidate identity snapshot;
 - the frozen effective candidate identity snapshot;
+- the single frozen preference observation: no record, applied, absent slot, or
+  changed target binding, including the observed success time when present;
 - the monotonic typed candidate-visit count;
 - ordered admission outcomes only for candidates reached so far;
 - every non-shared execution receipt allocated for an admitted current
@@ -134,8 +141,8 @@ journal.
 
 Every admission rejection and allocated outer attempt receipt carries the same
 opaque scope as the flow evidence. The scope, candidate identity, and one-shot
-receipt therefore form one immutable binding; the caller does not reconstruct
-that join from coordinator or target strings.
+receipt therefore form one private immutable record binding; the caller cannot
+construct or splice that join from coordinator or target strings.
 
 After cancellation escapes, the same aggregate evidence remains queryable from
 the opaque flow attempt.

--- a/docs/design/exact-output-flow-boundary.md
+++ b/docs/design/exact-output-flow-boundary.md
@@ -16,6 +16,8 @@ output. OAS owns:
 - monotonic phase, dispatch-count, response, and provenance receipts;
 - the ordered outer-flow transition to a predetermined successor;
 - explicit scope-local last-good preference for future snapshots;
+- an immutable monotonic success ordinal allocated when structural success is
+  created;
 - affine typed settlement of caller-owned domain validation.
 
 The caller owns:
@@ -23,10 +25,10 @@ The caller owns:
 - domain input construction;
 - domain schema, codec, and content validation;
 - durable business-state binding, release, quarantine, and completion;
-- operator configuration that names opaque candidate references.
+- operator configuration that names opaque candidate references;
 - creation and lifetime of each process-local preference store and opaque flow
-  scope;
-- the success time supplied with a domain-valid settlement.
+  scope, including its hard capacity and explicit scope removal;
+- the domain-valid or domain-rejected disposition, but no freshness value.
 
 The outer flow is generic. It contains no coordinator vocabulary and no
 provider, model, tier, price, query-intent, or error-string policy.
@@ -38,16 +40,22 @@ catalog-admitted opaque target handles, and one immutable domain input. Catalog
 membership and credential outcomes are frozen, but credentials remain
 unselected. The caller supplies an explicit preference store and opaque
 nonempty flow scope. OAS performs one exact scope lookup while creating the
-snapshot. The store retains the full successful candidate identity. OAS moves
-that candidate to the front only when both its opaque caller slot identity and
-opaque target-identity fingerprint still match. An absent slot or a slot rebound
-to another target is not promoted and remains typed observation evidence.
-The relative order of every other candidate is preserved.
+snapshot and atomically reserves that scope under the caller-supplied hard
+capacity. A new scope that would exceed the capacity fails with typed capacity
+evidence. Each reservation has a private generation carried by the snapshot,
+attempt, and success; removing and recreating the same textual scope cannot
+allow an older success to write into the new generation. The store retains the
+full successful candidate identity. OAS moves that candidate to the front only
+when both its opaque caller slot identity and opaque target-identity fingerprint
+still match. An absent slot or a slot rebound to another target is not promoted
+and remains typed observation evidence. The relative order of every other
+candidate is preserved.
 
 The resulting order is immutable. A later success cannot change an existing
 snapshot, and a preference recorded in one scope cannot affect another scope.
-The store is caller-owned and process-local; there is no singleton, implicit
-clock, environment policy, expiry, persistence, or refresh daemon.
+The store is caller-owned, bounded, and process-local. Explicit scope removal
+frees one capacity slot. There is no singleton, implicit clock, environment
+policy, expiry, eviction heuristic, persistence, or refresh daemon.
 
 Starting the flow allocates one OAS-owned outer-flow identity and precomputes one
 immutable visit `(flow ID, 1-based ordinal, candidate identity)` for every
@@ -104,15 +112,21 @@ The following outcomes are terminal:
 
 After structural success, the caller submits exactly one typed domain
 disposition. `Domain_rejected` leaves the flow terminal and records no
-preference. `Domain_valid` atomically records the opaque successful candidate
-and caller-supplied success time for future snapshots in the same scope. A
-duplicate or concurrent disposition returns a typed already-settled error.
-Neither disposition can trigger another provider dispatch.
+preference. OAS allocates a monotonic immutable ordinal when it creates each
+structural success. `Domain_valid` carries no caller-provided freshness and
+atomically records the opaque successful candidate and its frozen ordinal for
+future snapshots in the same scope reservation. A duplicate or concurrent
+disposition returns a typed already-settled error. A domain-valid settlement
+whose reservation was explicitly removed, including one whose textual scope
+has since been recreated, returns a typed released-scope error and is still
+consumed exactly once. Neither disposition can trigger another provider
+dispatch.
 
-An older success time cannot overwrite a newer observation for the same scope.
-OAS uses no string or target-specific tie-break. Equal or older observations
-leave the installed preference unchanged and return a typed superseded receipt
-containing the retained candidate identity and success time.
+An older or equal OAS-owned success ordinal cannot overwrite a newer
+observation for the same scope reservation. OAS uses no wall clock, caller
+timestamp, string, or target-specific tie-break. An older observation leaves
+the installed preference unchanged and returns a typed superseded receipt
+containing the retained candidate identity and ordinal.
 
 No network or filesystem I/O occurs while the preference mutex is held.
 
@@ -125,7 +139,8 @@ Every flow evidence projection carries:
 - the caller-declared candidate identity snapshot;
 - the frozen effective candidate identity snapshot;
 - the single frozen preference observation: no record, applied, absent slot, or
-  changed target binding, including the observed success time when present;
+  changed target binding, including the observed OAS-owned success ordinal when
+  present;
 - the monotonic typed candidate-visit count;
 - ordered admission outcomes only for candidates reached so far;
 - every non-shared execution receipt allocated for an admitted current
@@ -169,6 +184,9 @@ state.
   JSON migration.
 - A process-local last-good store is not a capability probe, health score,
   retry budget, or replacement for caller-owned durable state.
+- Preference capacity is caller policy, but exhaustion, reservation
+  invalidation, and success ordering are typed OAS transitions rather than
+  TTL/LRU cleanup or caller-supplied timestamps.
 - Before 1.0, obsolete runtime assets are reset rather than reconciled.
 
 Archived cascade documents describe an earlier ownership decision and are not

--- a/docs/design/exact-output-flow-boundary.md
+++ b/docs/design/exact-output-flow-boundary.md
@@ -14,7 +14,9 @@ output. OAS owns:
 - fresh, non-shared attempt identities;
 - one-plan, at-most-one-dispatch `execute_once`;
 - monotonic phase, dispatch-count, response, and provenance receipts;
-- the ordered outer-flow transition to a predetermined successor.
+- the ordered outer-flow transition to a predetermined successor;
+- explicit scope-local last-good preference for future snapshots;
+- affine typed settlement of caller-owned domain validation.
 
 The caller owns:
 
@@ -22,6 +24,9 @@ The caller owns:
 - domain schema, codec, and content validation;
 - durable business-state binding, release, quarantine, and completion;
 - operator configuration that names opaque candidate references.
+- creation and lifetime of each process-local preference store and opaque flow
+  scope;
+- the success time supplied with a domain-valid settlement.
 
 The outer flow is generic. It contains no coordinator vocabulary and no
 provider, model, tier, price, query-intent, or error-string policy.
@@ -31,10 +36,20 @@ provider, model, tier, price, query-intent, or error-string policy.
 An outer flow freezes one nonempty ordered candidate snapshot, its
 catalog-admitted opaque target handles, and one immutable domain input. Catalog
 membership and credential outcomes are frozen, but credentials remain
-unselected. Starting the flow allocates one OAS-owned outer-flow identity and
-precomputes one immutable visit `(flow ID, 1-based ordinal, candidate identity)`
-for every frozen candidate. This performs no credential selection, request
-admission, call identity allocation, callback, or network effect.
+unselected. The caller supplies an explicit preference store and opaque
+nonempty flow scope. OAS performs one exact scope lookup while creating the
+snapshot. If that scope's last domain-valid candidate is present, OAS moves it
+to the front and preserves the relative order of every other candidate.
+
+The resulting order is immutable. A later success cannot change an existing
+snapshot, and a preference recorded in one scope cannot affect another scope.
+The store is caller-owned and process-local; there is no singleton, implicit
+clock, environment policy, expiry, persistence, or refresh daemon.
+
+Starting the flow allocates one OAS-owned outer-flow identity and precomputes one
+immutable visit `(flow ID, 1-based ordinal, candidate identity)` for every
+frozen candidate. This performs no credential selection, request admission,
+call identity allocation, callback, or network effect.
 
 During execution, OAS resolves the frozen credential outcome and prepares only
 the current candidate. Successful request admission freezes one ready plan and
@@ -82,17 +97,28 @@ The following outcomes are terminal:
 - any receipt with `dispatch_count > 0`;
 - response, partial, tool, structural-output, or normalization exposure;
 - a final typed candidate rejection, reported as `Flow_candidates_exhausted`;
-- success.
+- structural success.
 
-Domain validation occurs only after an OAS success. A caller-side domain
-rejection therefore cannot trigger another provider dispatch.
+After structural success, the caller submits exactly one typed domain
+disposition. `Domain_rejected` leaves the flow terminal and records no
+preference. `Domain_valid` atomically records the opaque successful candidate
+and caller-supplied success time for future snapshots in the same scope. A
+duplicate or concurrent disposition returns a typed already-settled error.
+Neither disposition can trigger another provider dispatch.
+
+An older success time cannot overwrite a newer observation for the same scope.
+OAS uses no string or target-specific tie-break. Equal or older observations
+leave the installed preference unchanged.
+
+No network or filesystem I/O occurs while the preference mutex is held.
 
 ## Evidence
 
 Every flow evidence projection carries:
 
 - the fresh outer-flow identity;
-- the original immutable candidate identity snapshot;
+- the exact opaque flow scope;
+- the frozen effective candidate identity snapshot;
 - the monotonic typed candidate-visit count;
 - ordered admission outcomes only for candidates reached so far;
 - every non-shared execution receipt allocated for an admitted current
@@ -105,6 +131,11 @@ embeds that visit without fabricating a plan, call ID, or execution receipt. A
 new `start_flow` always allocates a new flow identity; restart resume is
 unsupported here and belongs to the caller's authenticated lease or operation
 journal.
+
+Every admission rejection and allocated outer attempt receipt carries the same
+opaque scope as the flow evidence. The scope, candidate identity, and one-shot
+receipt therefore form one immutable binding; the caller does not reconstruct
+that join from coordinator or target strings.
 
 After cancellation escapes, the same aggregate evidence remains queryable from
 the opaque flow attempt.
@@ -129,6 +160,8 @@ state.
   projections.
 - There is no legacy cascade API, compatibility wrapper, or persisted runtime
   JSON migration.
+- A process-local last-good store is not a capability probe, health score,
+  retry budget, or replacement for caller-owned durable state.
 - Before 1.0, obsolete runtime assets are reset rather than reconciled.
 
 Archived cascade documents describe an earlier ownership decision and are not

--- a/lib/llm_provider/dune
+++ b/lib/llm_provider/dune
@@ -18,6 +18,7 @@
   exact_output_execution
   exact_output_gemini_schema
   exact_output_flow
+  exact_output_flow_contract
   exact_output_provider_trace
   exact_output_plan)
  (libraries

--- a/lib/llm_provider/dune
+++ b/lib/llm_provider/dune
@@ -18,6 +18,7 @@
   exact_output_execution
   exact_output_gemini_schema
   exact_output_flow
+  exact_output_provider_trace
   exact_output_plan)
  (libraries
   yojson

--- a/lib/llm_provider/exact_output.ml
+++ b/lib/llm_provider/exact_output.ml
@@ -2,6 +2,7 @@ module Plan = Exact_output_plan
 module Exec = Exact_output_execution
 module Flow_state = Exact_output_flow
 module Gemini_schema = Exact_output_gemini_schema
+module Trace = Exact_output_provider_trace
 module Caps = Capabilities
 module PC = Provider_config
 include Exact_output_resolver
@@ -40,15 +41,7 @@ type attempt_state =
   | Terminal_state of int
 
 type call_id = Call_id of string
-
-type provider_trace =
-  { fingerprint : string
-  ; http_status : int
-  ; response_header_evidence_fingerprint : string
-  ; raw_response_body_sha256 : string
-  ; response_id : string option
-  ; response_model : string option
-  }
+type provider_trace = Trace.t
 
 type receipt =
   { state : attempt_state Atomic.t
@@ -131,7 +124,7 @@ type effect_phase =
   | Response_received
   | Terminal
 
-type raw_response =
+type raw_response = Trace.raw_response =
   { body : string
   ; body_sha256 : string
   }
@@ -178,6 +171,8 @@ type flow_candidate =
 type flow_id = Flow_id of string
 type flow_visit_ordinal = Flow_visit_ordinal of int
 type candidate_visit_count = Candidate_visit_count of int
+type flow_preference_store = (string, string) Flow_state.preference_store
+type flow_scope = Flow_scope of string
 
 type flow_candidate_visit =
   { flow_id : flow_id
@@ -195,7 +190,8 @@ type candidate_rejection_cause =
   | Request_admission_rejected of admission_error
 
 type candidate_rejection_receipt =
-  { visit : flow_candidate_visit
+  { scope : flow_scope
+  ; visit : flow_candidate_visit
   ; cause : candidate_rejection_cause
   }
 
@@ -211,19 +207,24 @@ type candidate_admission =
   | Candidate_rejected of candidate_rejection_receipt
 
 type flow_snapshot =
-  { candidates : flow_candidate list
+  { preferences : flow_preference_store
+  ; scope : flow_scope
+  ; candidates : flow_candidate list
   ; messages : Types.message list
   ; requirement : output_requirement
   }
 
 type flow_attempt_receipt =
-  { visit : flow_candidate_visit
+  { scope : flow_scope
+  ; visit : flow_candidate_visit
   ; receipt : receipt
   }
 
 type flow_attempt =
   { execution : Flow_state.t
   ; flow_id : flow_id
+  ; preferences : flow_preference_store
+  ; scope : flow_scope
   ; candidate_snapshot : flow_candidate_identity list
   ; candidates : flow_candidate_step list
   ; messages : Types.message list
@@ -232,6 +233,7 @@ type flow_attempt =
   }
 
 type flow_candidate_error = Blank_flow_candidate_id
+type flow_scope_error = Blank_flow_scope_id
 
 type flow_snapshot_error =
   | Duplicate_flow_candidate_id of
@@ -245,6 +247,7 @@ type flow_start_error = Flow_id_generation_failed of string
 
 type flow_evidence =
   { flow_id : flow_id
+  ; scope : flow_scope
   ; candidate_snapshot : flow_candidate_identity list
   ; candidate_visit_count : candidate_visit_count
   ; admissions : candidate_admission list
@@ -255,7 +258,16 @@ type flow_success =
   { candidate : flow_attempt_receipt
   ; success : success
   ; evidence : flow_evidence
+  ; domain_settlement : Flow_state.domain_settlement
+  ; preferences : flow_preference_store
+  ; scope : flow_scope
   }
+
+type domain_disposition =
+  | Domain_valid of { success_time_unix_s : int64 }
+  | Domain_rejected
+
+type domain_settlement_error = Domain_already_settled
 
 type flow_candidate_failure =
   | Flow_candidate_rejected of candidate_rejection_receipt
@@ -490,6 +502,14 @@ let make_flow_candidate ~id ~admitted_target =
 ;;
 
 let flow_candidate_identity (candidate : flow_candidate) = candidate.identity
+let create_flow_preference_store () = Flow_state.create_preference_store ()
+
+let make_flow_scope ~id =
+  let id = String.trim id in
+  if String.equal id "" then Error Blank_flow_scope_id else Ok (Flow_scope id)
+;;
+
+let flow_scope_equal (Flow_scope left) (Flow_scope right) = String.equal left right
 
 let duplicate_flow_candidate_id (candidates : flow_candidate list) =
   Flow_state.duplicate_key
@@ -500,11 +520,22 @@ let duplicate_flow_candidate_id (candidates : flow_candidate list) =
     Duplicate_flow_candidate_id { candidate_id; first_position; duplicate_position })
 ;;
 
-let snapshot_flow ~first ~rest ~messages requirement =
+let prefer_last_good preferences (Flow_scope scope) candidates =
+  let preferred = Flow_state.preferred_candidate preferences ~scope |> Option.map fst in
+  Flow_state.promote_candidate
+    ~equal:String.equal
+    ~key:(fun (candidate : flow_candidate) -> candidate.identity.candidate_id)
+    ~preferred
+    candidates
+;;
+
+let snapshot_flow ~preferences ~scope ~first ~rest ~messages requirement =
   let candidates = first :: rest in
   match duplicate_flow_candidate_id candidates with
   | Some duplicate -> Error duplicate
-  | None -> Ok { candidates; messages; requirement }
+  | None ->
+    let candidates = prefer_last_good preferences scope candidates in
+    Ok { preferences; scope; candidates; messages; requirement }
 ;;
 
 let start_attempt (ready : ready_plan) =
@@ -545,12 +576,36 @@ let start_flow (ready : flow_snapshot) =
     Ok
       { execution = Flow_state.create ()
       ; flow_id
+      ; preferences = ready.preferences
+      ; scope = ready.scope
       ; candidate_snapshot = List.map flow_candidate_identity ready.candidates
       ; candidates
       ; messages = ready.messages
       ; requirement = ready.requirement
       ; progress = Flow_state.create_progress ()
       }
+;;
+
+let flow_success_candidate success = success.candidate
+let flow_success_output success = success.success
+let flow_success_evidence success = success.evidence
+
+let settle_flow_domain success disposition =
+  let result =
+    match disposition with
+    | Domain_rejected -> Flow_state.settle_domain_rejected_once success.domain_settlement
+    | Domain_valid { success_time_unix_s } ->
+      let (Flow_scope scope) = success.scope in
+      Flow_state.settle_domain_valid_once
+        success.domain_settlement
+        success.preferences
+        ~scope
+        ~candidate:success.candidate.visit.identity.candidate_id
+        ~time:success_time_unix_s
+  in
+  match result with
+  | Error Flow_state.Already_settled -> Error Domain_already_settled
+  | Ok () -> Ok ()
 ;;
 
 let call_id_to_string (Call_id id) = id
@@ -583,7 +638,7 @@ let receipt_http_status receipt =
 ;;
 
 let receipt_provider_trace receipt = Atomic.get receipt.provider_trace_state
-let provider_trace_fingerprint trace = trace.fingerprint
+let provider_trace_fingerprint = Trace.fingerprint
 let receipt_plan_fingerprint (receipt : receipt) = receipt.plan_fingerprint
 let receipt_request_body_sha256 (receipt : receipt) = receipt.request_body_sha256
 let receipt_catalog_generation (receipt : receipt) = receipt.catalog_generation
@@ -595,6 +650,7 @@ let candidate_rejection_identity (receipt : candidate_rejection_receipt) =
   receipt.visit.identity
 ;;
 
+let candidate_rejection_scope (receipt : candidate_rejection_receipt) = receipt.scope
 let candidate_rejection_visit (receipt : candidate_rejection_receipt) = receipt.visit
 let candidate_rejection_phase _ = Before_dispatch
 let candidate_rejection_dispatch_count _ = 0
@@ -649,6 +705,7 @@ let candidate_rejection_disposition (receipt : candidate_rejection_receipt) =
 let flow_attempt_evidence (flow : flow_attempt) =
   let progress = Flow_state.progress_snapshot flow.progress in
   { flow_id = flow.flow_id
+  ; scope = flow.scope
   ; candidate_snapshot = flow.candidate_snapshot
   ; candidate_visit_count = Candidate_visit_count progress.candidate_visit_count
   ; admissions = progress.admissions
@@ -699,68 +756,8 @@ let synchronize_receipt receipt complete_receipt =
      | None -> invalid_arg "Exact_output: terminal receipt without HTTP status")
 ;;
 
-let raw_response (evidence : Exec.raw_response_evidence) =
-  { body = evidence.raw_body; body_sha256 = evidence.raw_body_sha256 }
-;;
-
-let provider_trace_of_evidence
-      ?response
-      complete_receipt
-      (evidence : Exec.raw_response_evidence)
-  =
-  let http_status =
-    match Exec.receipt_http_status complete_receipt with
-    | Some status -> status
-    | None -> invalid_arg "Exact_output: response evidence without HTTP status"
-  in
-  let response_id, response_model =
-    match response with
-    | None -> None, None
-    | Some (response : Types.api_response) -> Some response.id, Some response.model
-  in
-  let response_header_evidence_fingerprint =
-    Http_client.response_header_evidence_fingerprint evidence.response_header_evidence
-  in
-  let payload =
-    `Assoc
-      [ "version", `Int 1
-      ; "http_status", `Int http_status
-      ; ( "response_header_evidence_fingerprint"
-        , `String response_header_evidence_fingerprint )
-      ; "raw_response_body_sha256", `String evidence.raw_body_sha256
-      ; ( "response_id"
-        , match response_id with
-          | None -> `Null
-          | Some value -> `String value )
-      ; ( "response_model"
-        , match response_model with
-          | None -> `Null
-          | Some value -> `String value )
-      ]
-  in
-  let fingerprint =
-    payload
-    |> Yojson.Safe.to_string
-    |> Digestif.SHA256.digest_string
-    |> Digestif.SHA256.to_hex
-  in
-  { fingerprint
-  ; http_status
-  ; response_header_evidence_fingerprint
-  ; raw_response_body_sha256 = evidence.raw_body_sha256
-  ; response_id
-  ; response_model
-  }
-;;
-
-let rec record_provider_trace receipt trace =
-  match Atomic.get receipt.provider_trace_state with
-  | Some existing when String.equal existing.fingerprint trace.fingerprint -> ()
-  | Some _ -> invalid_arg "Exact_output: provider trace changed after installation"
-  | None ->
-    if not (Atomic.compare_and_set receipt.provider_trace_state None (Some trace))
-    then record_provider_trace receipt trace
-;;
+let raw_response = Trace.raw_response
+let record_provider_trace receipt = Trace.record_once receipt.provider_trace_state
 
 let execution_error_cause = function
   | Exec.Clock_required_for_timeout -> Clock_required_for_timeout
@@ -802,7 +799,7 @@ let execute_once ~net ?clock (attempt : attempt) =
       Option.iter
         (fun response_evidence ->
            response_evidence
-           |> provider_trace_of_evidence complete_receipt
+           |> Trace.of_evidence complete_receipt
            |> record_provider_trace receipt)
         evidence;
       Error
@@ -814,7 +811,7 @@ let execute_once ~net ?clock (attempt : attempt) =
     | Ok { outcome; raw_response = evidence } ->
       synchronize_receipt receipt outcome.receipt;
       let provider_trace =
-        provider_trace_of_evidence ~response:outcome.response outcome.receipt evidence
+        Trace.of_evidence ~response:outcome.response outcome.receipt evidence
       in
       record_provider_trace receipt provider_trace;
       (match outcome.output with
@@ -860,7 +857,7 @@ let admitted_flow_candidate visit (plan : ready_plan) =
 ;;
 
 let record_candidate_rejection flow visit cause =
-  let rejection = { visit; cause } in
+  let rejection = { scope = flow.scope; visit; cause } in
   Flow_state.record_admission flow.progress (Candidate_rejected rejection);
   rejection
 ;;
@@ -885,13 +882,16 @@ let execute_flow_candidate
        let admitted = admitted_flow_candidate candidate.visit plan in
        Flow_state.record_admission flow.progress (Candidate_admitted admitted);
        (match start_attempt plan with
-        | Error cause -> Error (Flow_step_attempt_start_failed (candidate.visit, cause))
-        | Ok attempt ->
-          let candidate_receipt =
-            { visit = candidate.visit; receipt = attempt_receipt attempt }
-          in
-          record_attempt flow candidate_receipt;
-          (match before_dispatch candidate_receipt with
+         | Error cause -> Error (Flow_step_attempt_start_failed (candidate.visit, cause))
+         | Ok attempt ->
+           let candidate_receipt =
+             { scope = flow.scope
+             ; visit = candidate.visit
+             ; receipt = attempt_receipt attempt
+             }
+           in
+           record_attempt flow candidate_receipt;
+           (match before_dispatch candidate_receipt with
            | Error cause ->
              Error (Flow_step_before_dispatch_callback_failed (candidate_receipt, cause))
            | Ok () ->
@@ -927,7 +927,14 @@ let execute_flow_once ~net ?clock ~before_dispatch ~before_advance flow =
   let evidence = flow_attempt_evidence flow in
   match outcome with
   | Flow_state.Succeeded { success = candidate, success; _ } ->
-    Ok { candidate; success; evidence }
+    Ok
+      { candidate
+      ; success
+      ; evidence
+      ; domain_settlement = Flow_state.create_domain_settlement ()
+      ; preferences = flow.preferences
+      ; scope = flow.scope
+      }
   | Flow_state.Attempt_already_started -> Error (Flow_attempt_already_started evidence)
   | Flow_state.Before_advance_callback_failed { failure; next_candidate; cause; _ } ->
     Error

--- a/lib/llm_provider/exact_output.ml
+++ b/lib/llm_provider/exact_output.ml
@@ -856,7 +856,7 @@ let admitted_flow_candidate visit (plan : ready_plan) =
   }
 ;;
 
-let record_candidate_rejection flow visit cause =
+let record_candidate_rejection (flow : flow_attempt) visit cause =
   let rejection = { scope = flow.scope; visit; cause } in
   Flow_state.record_admission flow.progress (Candidate_rejected rejection);
   rejection
@@ -882,16 +882,16 @@ let execute_flow_candidate
        let admitted = admitted_flow_candidate candidate.visit plan in
        Flow_state.record_admission flow.progress (Candidate_admitted admitted);
        (match start_attempt plan with
-         | Error cause -> Error (Flow_step_attempt_start_failed (candidate.visit, cause))
-         | Ok attempt ->
-           let candidate_receipt =
-             { scope = flow.scope
-             ; visit = candidate.visit
-             ; receipt = attempt_receipt attempt
-             }
-           in
-           record_attempt flow candidate_receipt;
-           (match before_dispatch candidate_receipt with
+        | Error cause -> Error (Flow_step_attempt_start_failed (candidate.visit, cause))
+        | Ok attempt ->
+          let candidate_receipt =
+            { scope = flow.scope
+            ; visit = candidate.visit
+            ; receipt = attempt_receipt attempt
+            }
+          in
+          record_attempt flow candidate_receipt;
+          (match before_dispatch candidate_receipt with
            | Error cause ->
              Error (Flow_step_before_dispatch_callback_failed (candidate_receipt, cause))
            | Ok () ->

--- a/lib/llm_provider/exact_output.ml
+++ b/lib/llm_provider/exact_output.ml
@@ -171,8 +171,24 @@ type flow_candidate =
 type flow_id = Flow_id of string
 type flow_visit_ordinal = Flow_visit_ordinal of int
 type candidate_visit_count = Candidate_visit_count of int
-type flow_preference_store = (string, string) Flow_state.preference_store
+type flow_preference_store = (string, flow_candidate_identity) Flow_state.preference_store
 type flow_scope = Flow_scope of string
+
+type flow_preference_not_applied_reason =
+  | Preference_candidate_absent
+  | Preference_candidate_binding_changed
+
+type flow_preference_observation =
+  | No_preference_recorded
+  | Preference_applied of
+      { candidate : flow_candidate_identity
+      ; success_time_unix_s : int64
+      }
+  | Preference_not_applied of
+      { candidate : flow_candidate_identity
+      ; success_time_unix_s : int64
+      ; reason : flow_preference_not_applied_reason
+      }
 
 type flow_candidate_visit =
   { flow_id : flow_id
@@ -209,6 +225,8 @@ type candidate_admission =
 type flow_snapshot =
   { preferences : flow_preference_store
   ; scope : flow_scope
+  ; declared_candidate_snapshot : flow_candidate_identity list
+  ; preference_observation : flow_preference_observation
   ; candidates : flow_candidate list
   ; messages : Types.message list
   ; requirement : output_requirement
@@ -225,7 +243,9 @@ type flow_attempt =
   ; flow_id : flow_id
   ; preferences : flow_preference_store
   ; scope : flow_scope
+  ; declared_candidate_snapshot : flow_candidate_identity list
   ; candidate_snapshot : flow_candidate_identity list
+  ; preference_observation : flow_preference_observation
   ; candidates : flow_candidate_step list
   ; messages : Types.message list
   ; requirement : output_requirement
@@ -248,7 +268,9 @@ type flow_start_error = Flow_id_generation_failed of string
 type flow_evidence =
   { flow_id : flow_id
   ; scope : flow_scope
+  ; declared_candidate_snapshot : flow_candidate_identity list
   ; candidate_snapshot : flow_candidate_identity list
+  ; preference_observation : flow_preference_observation
   ; candidate_visit_count : candidate_visit_count
   ; admissions : candidate_admission list
   ; attempts : flow_attempt_receipt list
@@ -266,6 +288,17 @@ type flow_success =
 type domain_disposition =
   | Domain_valid of { success_time_unix_s : int64 }
   | Domain_rejected
+
+type domain_settlement_receipt =
+  | Domain_rejected_recorded
+  | Domain_valid_preference_installed of
+      { candidate : flow_candidate_identity
+      ; success_time_unix_s : int64
+      }
+  | Domain_valid_preference_superseded of
+      { current_candidate : flow_candidate_identity
+      ; current_success_time_unix_s : int64
+      }
 
 type domain_settlement_error = Domain_already_settled
 
@@ -520,13 +553,43 @@ let duplicate_flow_candidate_id (candidates : flow_candidate list) =
     Duplicate_flow_candidate_id { candidate_id; first_position; duplicate_position })
 ;;
 
+let target_binding_equal left right =
+  String.equal
+    (target_identity_fingerprint left.target_identity)
+    (target_identity_fingerprint right.target_identity)
+;;
+
 let prefer_last_good preferences (Flow_scope scope) candidates =
-  let preferred = Flow_state.preferred_candidate preferences ~scope |> Option.map fst in
-  Flow_state.promote_candidate
-    ~equal:String.equal
-    ~key:(fun (candidate : flow_candidate) -> candidate.identity.candidate_id)
-    ~preferred
-    candidates
+  match Flow_state.preferred_candidate preferences ~scope with
+  | None -> candidates, No_preference_recorded
+  | Some (recorded, success_time_unix_s) ->
+    (match
+       List.find_opt
+         (fun (candidate : flow_candidate) ->
+            String.equal candidate.identity.candidate_id recorded.candidate_id)
+         candidates
+     with
+     | None ->
+       ( candidates
+       , Preference_not_applied
+           { candidate = recorded
+           ; success_time_unix_s
+           ; reason = Preference_candidate_absent
+           } )
+     | Some current when not (target_binding_equal recorded current.identity) ->
+       ( candidates
+       , Preference_not_applied
+           { candidate = recorded
+           ; success_time_unix_s
+           ; reason = Preference_candidate_binding_changed
+           } )
+     | Some _ ->
+       ( Flow_state.promote_candidate
+           ~equal:String.equal
+           ~key:(fun (candidate : flow_candidate) -> candidate.identity.candidate_id)
+           ~preferred:(Some recorded.candidate_id)
+           candidates
+       , Preference_applied { candidate = recorded; success_time_unix_s } ))
 ;;
 
 let snapshot_flow ~preferences ~scope ~first ~rest ~messages requirement =
@@ -534,8 +597,19 @@ let snapshot_flow ~preferences ~scope ~first ~rest ~messages requirement =
   match duplicate_flow_candidate_id candidates with
   | Some duplicate -> Error duplicate
   | None ->
-    let candidates = prefer_last_good preferences scope candidates in
-    Ok { preferences; scope; candidates; messages; requirement }
+    let declared_candidate_snapshot = List.map flow_candidate_identity candidates in
+    let candidates, preference_observation =
+      prefer_last_good preferences scope candidates
+    in
+    Ok
+      { preferences
+      ; scope
+      ; declared_candidate_snapshot
+      ; preference_observation
+      ; candidates
+      ; messages
+      ; requirement
+      }
 ;;
 
 let start_attempt (ready : ready_plan) =
@@ -578,7 +652,9 @@ let start_flow (ready : flow_snapshot) =
       ; flow_id
       ; preferences = ready.preferences
       ; scope = ready.scope
+      ; declared_candidate_snapshot = ready.declared_candidate_snapshot
       ; candidate_snapshot = List.map flow_candidate_identity ready.candidates
+      ; preference_observation = ready.preference_observation
       ; candidates
       ; messages = ready.messages
       ; requirement = ready.requirement
@@ -591,21 +667,30 @@ let flow_success_output success = success.success
 let flow_success_evidence success = success.evidence
 
 let settle_flow_domain success disposition =
+  let candidate = success.candidate.visit.identity in
   let result =
     match disposition with
-    | Domain_rejected -> Flow_state.settle_domain_rejected_once success.domain_settlement
+    | Domain_rejected ->
+      Flow_state.settle_domain_rejected_once success.domain_settlement
+      |> Result.map (fun () -> Domain_rejected_recorded)
     | Domain_valid { success_time_unix_s } ->
       let (Flow_scope scope) = success.scope in
       Flow_state.settle_domain_valid_once
         success.domain_settlement
         success.preferences
         ~scope
-        ~candidate:success.candidate.visit.identity.candidate_id
+        ~candidate
         ~time:success_time_unix_s
+      |> Result.map (function
+        | Flow_state.Preference_installed ->
+          Domain_valid_preference_installed { candidate; success_time_unix_s }
+        | Flow_state.Preference_superseded { current_candidate; current_time } ->
+          Domain_valid_preference_superseded
+            { current_candidate; current_success_time_unix_s = current_time })
   in
   match result with
   | Error Flow_state.Already_settled -> Error Domain_already_settled
-  | Ok () -> Ok ()
+  | Ok receipt -> Ok receipt
 ;;
 
 let call_id_to_string (Call_id id) = id
@@ -706,7 +791,9 @@ let flow_attempt_evidence (flow : flow_attempt) =
   let progress = Flow_state.progress_snapshot flow.progress in
   { flow_id = flow.flow_id
   ; scope = flow.scope
+  ; declared_candidate_snapshot = flow.declared_candidate_snapshot
   ; candidate_snapshot = flow.candidate_snapshot
+  ; preference_observation = flow.preference_observation
   ; candidate_visit_count = Candidate_visit_count progress.candidate_visit_count
   ; admissions = progress.admissions
   ; attempts = progress.attempts

--- a/lib/llm_provider/exact_output.ml
+++ b/lib/llm_provider/exact_output.ml
@@ -1,11 +1,13 @@
 module Plan = Exact_output_plan
 module Exec = Exact_output_execution
 module Flow_state = Exact_output_flow
+module Flow_contract = Exact_output_flow_contract
 module Gemini_schema = Exact_output_gemini_schema
 module Trace = Exact_output_provider_trace
 module Caps = Capabilities
 module PC = Provider_config
 include Exact_output_resolver
+include Flow_contract
 
 type schema_fingerprint = Schema_fingerprint of string
 type domain_schema = Domain_schema of Yojson.Safe.t
@@ -156,13 +158,6 @@ type success =
   ; raw_response : raw_response
   }
 
-type flow_candidate_identity =
-  { candidate_id : string
-  ; catalog_generation : catalog_generation
-  ; catalog_evidence : catalog_evidence
-  ; target_identity : target_identity
-  }
-
 type flow_candidate =
   { identity : flow_candidate_identity
   ; admitted_target : admitted_target
@@ -171,24 +166,6 @@ type flow_candidate =
 type flow_id = Flow_id of string
 type flow_visit_ordinal = Flow_visit_ordinal of int
 type candidate_visit_count = Candidate_visit_count of int
-type flow_preference_store = (string, flow_candidate_identity) Flow_state.preference_store
-type flow_scope = Flow_scope of string
-
-type flow_preference_not_applied_reason =
-  | Preference_candidate_absent
-  | Preference_candidate_binding_changed
-
-type flow_preference_observation =
-  | No_preference_recorded
-  | Preference_applied of
-      { candidate : flow_candidate_identity
-      ; success_time_unix_s : int64
-      }
-  | Preference_not_applied of
-      { candidate : flow_candidate_identity
-      ; success_time_unix_s : int64
-      ; reason : flow_preference_not_applied_reason
-      }
 
 type flow_candidate_visit =
   { flow_id : flow_id
@@ -253,7 +230,6 @@ type flow_attempt =
   }
 
 type flow_candidate_error = Blank_flow_candidate_id
-type flow_scope_error = Blank_flow_scope_id
 
 type flow_snapshot_error =
   | Duplicate_flow_candidate_id of
@@ -284,23 +260,6 @@ type flow_success =
   ; preferences : flow_preference_store
   ; scope : flow_scope
   }
-
-type domain_disposition =
-  | Domain_valid of { success_time_unix_s : int64 }
-  | Domain_rejected
-
-type domain_settlement_receipt =
-  | Domain_rejected_recorded
-  | Domain_valid_preference_installed of
-      { candidate : flow_candidate_identity
-      ; success_time_unix_s : int64
-      }
-  | Domain_valid_preference_superseded of
-      { current_candidate : flow_candidate_identity
-      ; current_success_time_unix_s : int64
-      }
-
-type domain_settlement_error = Domain_already_settled
 
 type flow_candidate_failure =
   | Flow_candidate_rejected of candidate_rejection_receipt
@@ -535,71 +494,26 @@ let make_flow_candidate ~id ~admitted_target =
 ;;
 
 let flow_candidate_identity (candidate : flow_candidate) = candidate.identity
-let create_flow_preference_store () = Flow_state.create_preference_store ()
-
-let make_flow_scope ~id =
-  let id = String.trim id in
-  if String.equal id "" then Error Blank_flow_scope_id else Ok (Flow_scope id)
-;;
-
-let flow_scope_equal (Flow_scope left) (Flow_scope right) = String.equal left right
-
-let duplicate_flow_candidate_id (candidates : flow_candidate list) =
-  Flow_state.duplicate_key
-    ~equal:String.equal
-    ~key:(fun (candidate : flow_candidate) -> candidate.identity.candidate_id)
-    candidates
-  |> Option.map (fun (candidate_id, first_position, duplicate_position) ->
-    Duplicate_flow_candidate_id { candidate_id; first_position; duplicate_position })
-;;
-
-let target_binding_equal left right =
-  String.equal
-    (target_identity_fingerprint left.target_identity)
-    (target_identity_fingerprint right.target_identity)
-;;
-
-let prefer_last_good preferences (Flow_scope scope) candidates =
-  match Flow_state.preferred_candidate preferences ~scope with
-  | None -> candidates, No_preference_recorded
-  | Some (recorded, success_time_unix_s) ->
-    (match
-       List.find_opt
-         (fun (candidate : flow_candidate) ->
-            String.equal candidate.identity.candidate_id recorded.candidate_id)
-         candidates
-     with
-     | None ->
-       ( candidates
-       , Preference_not_applied
-           { candidate = recorded
-           ; success_time_unix_s
-           ; reason = Preference_candidate_absent
-           } )
-     | Some current when not (target_binding_equal recorded current.identity) ->
-       ( candidates
-       , Preference_not_applied
-           { candidate = recorded
-           ; success_time_unix_s
-           ; reason = Preference_candidate_binding_changed
-           } )
-     | Some _ ->
-       ( Flow_state.promote_candidate
-           ~equal:String.equal
-           ~key:(fun (candidate : flow_candidate) -> candidate.identity.candidate_id)
-           ~preferred:(Some recorded.candidate_id)
-           candidates
-       , Preference_applied { candidate = recorded; success_time_unix_s } ))
-;;
 
 let snapshot_flow ~preferences ~scope ~first ~rest ~messages requirement =
   let candidates = first :: rest in
-  match duplicate_flow_candidate_id candidates with
-  | Some duplicate -> Error duplicate
+  match
+    Flow_state.duplicate_key
+      ~equal:String.equal
+      ~key:(fun (candidate : flow_candidate) -> candidate.identity.candidate_id)
+      candidates
+  with
+  | Some (candidate_id, first_position, duplicate_position) ->
+    Error
+      (Duplicate_flow_candidate_id { candidate_id; first_position; duplicate_position })
   | None ->
     let declared_candidate_snapshot = List.map flow_candidate_identity candidates in
     let candidates, preference_observation =
-      prefer_last_good preferences scope candidates
+      Flow_contract.prefer_last_good
+        preferences
+        scope
+        ~candidate_identity:flow_candidate_identity
+        candidates
     in
     Ok
       { preferences
@@ -667,30 +581,12 @@ let flow_success_output success = success.success
 let flow_success_evidence success = success.evidence
 
 let settle_flow_domain success disposition =
-  let candidate = success.candidate.visit.identity in
-  let result =
-    match disposition with
-    | Domain_rejected ->
-      Flow_state.settle_domain_rejected_once success.domain_settlement
-      |> Result.map (fun () -> Domain_rejected_recorded)
-    | Domain_valid { success_time_unix_s } ->
-      let (Flow_scope scope) = success.scope in
-      Flow_state.settle_domain_valid_once
-        success.domain_settlement
-        success.preferences
-        ~scope
-        ~candidate
-        ~time:success_time_unix_s
-      |> Result.map (function
-        | Flow_state.Preference_installed ->
-          Domain_valid_preference_installed { candidate; success_time_unix_s }
-        | Flow_state.Preference_superseded { current_candidate; current_time } ->
-          Domain_valid_preference_superseded
-            { current_candidate; current_success_time_unix_s = current_time })
-  in
-  match result with
-  | Error Flow_state.Already_settled -> Error Domain_already_settled
-  | Ok receipt -> Ok receipt
+  Flow_contract.settle_domain
+    success.domain_settlement
+    success.preferences
+    success.scope
+    ~candidate:success.candidate.visit.identity
+    disposition
 ;;
 
 let call_id_to_string (Call_id id) = id

--- a/lib/llm_provider/exact_output.ml
+++ b/lib/llm_provider/exact_output.ml
@@ -202,6 +202,7 @@ type candidate_admission =
 type flow_snapshot =
   { preferences : flow_preference_store
   ; scope : flow_scope
+  ; preference_reservation : Flow_contract.flow_preference_reservation
   ; declared_candidate_snapshot : flow_candidate_identity list
   ; preference_observation : flow_preference_observation
   ; candidates : flow_candidate list
@@ -220,6 +221,7 @@ type flow_attempt =
   ; flow_id : flow_id
   ; preferences : flow_preference_store
   ; scope : flow_scope
+  ; preference_reservation : Flow_contract.flow_preference_reservation
   ; declared_candidate_snapshot : flow_candidate_identity list
   ; candidate_snapshot : flow_candidate_identity list
   ; preference_observation : flow_preference_observation
@@ -237,6 +239,7 @@ type flow_snapshot_error =
       ; first_position : int
       ; duplicate_position : int
       }
+  | Flow_preference_capacity_exhausted of { capacity : int }
 
 type start_attempt_error = Call_id_generation_failed of string
 type flow_start_error = Flow_id_generation_failed of string
@@ -255,10 +258,12 @@ type flow_evidence =
 type flow_success =
   { candidate : flow_attempt_receipt
   ; success : success
+  ; success_ordinal : flow_success_ordinal
   ; evidence : flow_evidence
   ; domain_settlement : Flow_state.domain_settlement
   ; preferences : flow_preference_store
   ; scope : flow_scope
+  ; preference_reservation : Flow_contract.flow_preference_reservation
   }
 
 type flow_candidate_failure =
@@ -270,6 +275,7 @@ type flow_candidate_failure =
 
 type 'callback_error flow_execution_error =
   | Flow_attempt_already_started of flow_evidence
+  | Flow_success_ordinal_exhausted of flow_evidence
   | Flow_attempt_start_failed of
       { candidate : flow_candidate_visit
       ; cause : start_attempt_error
@@ -508,22 +514,26 @@ let snapshot_flow ~preferences ~scope ~first ~rest ~messages requirement =
       (Duplicate_flow_candidate_id { candidate_id; first_position; duplicate_position })
   | None ->
     let declared_candidate_snapshot = List.map flow_candidate_identity candidates in
-    let candidates, preference_observation =
-      Flow_contract.prefer_last_good
-        preferences
-        scope
-        ~candidate_identity:flow_candidate_identity
-        candidates
-    in
-    Ok
-      { preferences
-      ; scope
-      ; declared_candidate_snapshot
-      ; preference_observation
-      ; candidates
-      ; messages
-      ; requirement
-      }
+    (match
+       Flow_contract.prefer_last_good
+         preferences
+         scope
+         ~candidate_identity:flow_candidate_identity
+         candidates
+     with
+     | Error (Preference_capacity_exhausted { capacity }) ->
+       Error (Flow_preference_capacity_exhausted { capacity })
+     | Ok (candidates, preference_observation, preference_reservation) ->
+       Ok
+         { preferences
+         ; scope
+         ; preference_reservation
+         ; declared_candidate_snapshot
+         ; preference_observation
+         ; candidates
+         ; messages
+         ; requirement
+         })
 ;;
 
 let start_attempt (ready : ready_plan) =
@@ -566,6 +576,7 @@ let start_flow (ready : flow_snapshot) =
       ; flow_id
       ; preferences = ready.preferences
       ; scope = ready.scope
+      ; preference_reservation = ready.preference_reservation
       ; declared_candidate_snapshot = ready.declared_candidate_snapshot
       ; candidate_snapshot = List.map flow_candidate_identity ready.candidates
       ; preference_observation = ready.preference_observation
@@ -579,13 +590,16 @@ let start_flow (ready : flow_snapshot) =
 let flow_success_candidate success = success.candidate
 let flow_success_output success = success.success
 let flow_success_evidence success = success.evidence
+let flow_success_ordinal success = success.success_ordinal
 
 let settle_flow_domain success disposition =
   Flow_contract.settle_domain
     success.domain_settlement
     success.preferences
     success.scope
+    ~reservation:success.preference_reservation
     ~candidate:success.candidate.visit.identity
+    ~success_ordinal:success.success_ordinal
     disposition
 ;;
 
@@ -910,14 +924,20 @@ let execute_flow_once ~net ?clock ~before_dispatch ~before_advance flow =
   let evidence = flow_attempt_evidence flow in
   match outcome with
   | Flow_state.Succeeded { success = candidate, success; _ } ->
-    Ok
-      { candidate
-      ; success
-      ; evidence
-      ; domain_settlement = Flow_state.create_domain_settlement ()
-      ; preferences = flow.preferences
-      ; scope = flow.scope
-      }
+    (match Flow_contract.allocate_flow_success_ordinal flow.preferences with
+     | Error Success_ordinal_space_exhausted ->
+       Error (Flow_success_ordinal_exhausted evidence)
+     | Ok success_ordinal ->
+       Ok
+         { candidate
+         ; success
+         ; success_ordinal
+         ; evidence
+         ; domain_settlement = Flow_state.create_domain_settlement ()
+         ; preferences = flow.preferences
+         ; scope = flow.scope
+         ; preference_reservation = flow.preference_reservation
+         })
   | Flow_state.Attempt_already_started -> Error (Flow_attempt_already_started evidence)
   | Flow_state.Before_advance_callback_failed { failure; next_candidate; cause; _ } ->
     Error

--- a/lib/llm_provider/exact_output.mli
+++ b/lib/llm_provider/exact_output.mli
@@ -196,6 +196,22 @@ type flow_id
 type flow_visit_ordinal
 type candidate_visit_count
 
+type flow_preference_not_applied_reason =
+  | Preference_candidate_absent
+  | Preference_candidate_binding_changed
+
+type flow_preference_observation =
+  | No_preference_recorded
+  | Preference_applied of
+      { candidate : flow_candidate_identity
+      ; success_time_unix_s : int64
+      }
+  | Preference_not_applied of
+      { candidate : flow_candidate_identity
+      ; success_time_unix_s : int64
+      ; reason : flow_preference_not_applied_reason
+      }
+
 type flow_candidate_visit = private
   { flow_id : flow_id
   ; ordinal : flow_visit_ordinal
@@ -228,7 +244,10 @@ type flow_snapshot_error =
 (** Construct one provider-neutral candidate from a catalog-admitted target.
     Credential selection remains frozen but unresolved until this candidate is
     reached by {!execute_flow_once}. The trimmed caller identity must be
-    nonempty; it is evidence only and never drives provider policy. *)
+    nonempty. It is an opaque caller slot identity: a domain-valid preference
+    may reorder a future snapshot only when both this exact slot identity and
+    the opaque target-identity fingerprint remain unchanged. OAS does not parse
+    provider, model, tier, or coordinator meaning from it. *)
 val make_flow_candidate
   :  id:string
   -> admitted_target:admitted_target
@@ -254,7 +273,9 @@ val flow_scope_equal : flow_scope -> flow_scope -> bool
     assigned attempts speculatively.
 
     A domain-valid last-good candidate recorded in [preferences] for [scope] is
-    moved to the front if it is present. The remaining candidates retain their
+    moved to the front only when the same caller slot and opaque target binding
+    are both present. An absent slot or changed target binding is retained as a
+    typed non-applied observation. The remaining candidates retain their
     declared relative order. This lookup happens exactly once: existing
     snapshots never change, and preferences from another scope cannot affect
     this snapshot. *)
@@ -364,7 +385,7 @@ val receipt_target_identity : receipt -> target_identity
 (** One immutable outer-flow binding. [scope], opaque candidate identity, and
     the one-shot execution receipt travel together; consumers do not rebuild
     that join from coordinator or target strings. *)
-type flow_attempt_receipt =
+type flow_attempt_receipt = private
   { scope : flow_scope
   ; visit : flow_candidate_visit
   ; receipt : receipt
@@ -388,10 +409,12 @@ val candidate_rejection_disposition
 val candidate_rejection_phase : candidate_rejection_receipt -> effect_phase
 val candidate_rejection_dispatch_count : candidate_rejection_receipt -> int
 
-type flow_evidence =
+type flow_evidence = private
   { flow_id : flow_id
   ; scope : flow_scope
+  ; declared_candidate_snapshot : flow_candidate_identity list
   ; candidate_snapshot : flow_candidate_identity list
+  ; preference_observation : flow_preference_observation
   ; candidate_visit_count : candidate_visit_count
   ; admissions : candidate_admission list
   ; attempts : flow_attempt_receipt list
@@ -405,6 +428,17 @@ type domain_disposition =
   | Domain_valid of { success_time_unix_s : int64 }
   | Domain_rejected
 
+type domain_settlement_receipt =
+  | Domain_rejected_recorded
+  | Domain_valid_preference_installed of
+      { candidate : flow_candidate_identity
+      ; success_time_unix_s : int64
+      }
+  | Domain_valid_preference_superseded of
+      { current_candidate : flow_candidate_identity
+      ; current_success_time_unix_s : int64
+      }
+
 type domain_settlement_error = Domain_already_settled
 
 (** Settle caller-owned domain validation exactly once after structural
@@ -413,11 +447,13 @@ type domain_settlement_error = Domain_already_settled
     [Domain_rejected] records no preference and never resumes or advances the
     terminal flow. Concurrent or duplicate settlement returns
     [Domain_already_settled]. An equal or older success time cannot overwrite
-    a newer preference already recorded by another flow. *)
+    a newer preference already recorded by another flow and returns a typed
+    [Domain_valid_preference_superseded] receipt naming the retained opaque
+    candidate identity and success time. *)
 val settle_flow_domain
   :  flow_success
   -> domain_disposition
-  -> (unit, domain_settlement_error) result
+  -> (domain_settlement_receipt, domain_settlement_error) result
 
 type flow_candidate_failure =
   | Flow_candidate_rejected of candidate_rejection_receipt
@@ -454,8 +490,12 @@ type 'callback_error flow_execution_error =
       ; evidence : flow_evidence
       }
 
-(** Point-in-time aggregate evidence. [scope] is the exact opaque flow scope and
+(** Point-in-time aggregate evidence. [scope] is the exact opaque flow scope,
+    [declared_candidate_snapshot] is the caller-declared order, and
     [candidate_snapshot] is the frozen effective order.
+    [preference_observation] is the single scope lookup frozen when the snapshot
+    was created; it distinguishes no record, an applied binding, an absent
+    recorded slot, and a changed target binding.
     [candidate_visit_count], [admissions], and [attempts] contain only
     candidates reached so far. Attempts are allocated only after
     current-candidate target selection and request admission succeed. This

--- a/lib/llm_provider/exact_output.mli
+++ b/lib/llm_provider/exact_output.mli
@@ -23,8 +23,11 @@ type receipt
 type call_id
 type schema_fingerprint
 type flow_candidate
+type flow_preference_store
+type flow_scope
 type flow_snapshot
 type flow_attempt
+type flow_success
 type resolver_io = { getenv : string -> (string option, unit) result }
 
 type catalog_document =
@@ -213,6 +216,7 @@ type candidate_admission =
   | Candidate_rejected of candidate_rejection_receipt
 
 type flow_candidate_error = Blank_flow_candidate_id
+type flow_scope_error = Blank_flow_scope_id
 
 type flow_snapshot_error =
   | Duplicate_flow_candidate_id of
@@ -232,13 +236,32 @@ val make_flow_candidate
 
 val flow_candidate_identity : flow_candidate -> flow_candidate_identity
 
+(** Create one caller-owned, process-local preference store. The store has no
+    global singleton, environment-derived policy, expiry, clock, persistence,
+    or background refresh. Sharing and lifetime are explicit at the call site. *)
+val create_flow_preference_store : unit -> flow_preference_store
+
+(** Brand one opaque caller scope. OAS compares the trimmed nonempty identity
+    exactly; it does not parse coordinator, tenant, provider, or model fields. *)
+val make_flow_scope : id:string -> (flow_scope, flow_scope_error) result
+
+val flow_scope_equal : flow_scope -> flow_scope -> bool
+
 (** Freeze one nonempty ordered candidate snapshot and its immutable domain
     input. This validates only flow topology. Credential selection and exact
     request admission are deferred to the current candidate during
     {!execute_flow_once}; later candidates are neither selected, prepared, nor
-    assigned attempts speculatively. *)
+    assigned attempts speculatively.
+
+    A domain-valid last-good candidate recorded in [preferences] for [scope] is
+    moved to the front if it is present. The remaining candidates retain their
+    declared relative order. This lookup happens exactly once: existing
+    snapshots never change, and preferences from another scope cannot affect
+    this snapshot. *)
 val snapshot_flow
-  :  first:flow_candidate
+  :  preferences:flow_preference_store
+  -> scope:flow_scope
+  -> first:flow_candidate
   -> rest:flow_candidate list
   -> messages:Types.message list
   -> output_requirement
@@ -338,8 +361,12 @@ val receipt_catalog_generation : receipt -> catalog_generation
 val receipt_catalog_evidence : receipt -> catalog_evidence
 val receipt_target_identity : receipt -> target_identity
 
+(** One immutable outer-flow binding. [scope], opaque candidate identity, and
+    the one-shot execution receipt travel together; consumers do not rebuild
+    that join from coordinator or target strings. *)
 type flow_attempt_receipt =
-  { visit : flow_candidate_visit
+  { scope : flow_scope
+  ; visit : flow_candidate_visit
   ; receipt : receipt
   }
 
@@ -351,6 +378,7 @@ val target_selection_error_disposition
 
 val admission_error_disposition : admission_error -> candidate_rejection_disposition
 val candidate_rejection_identity : candidate_rejection_receipt -> flow_candidate_identity
+val candidate_rejection_scope : candidate_rejection_receipt -> flow_scope
 val candidate_rejection_visit : candidate_rejection_receipt -> flow_candidate_visit
 
 val candidate_rejection_disposition
@@ -362,17 +390,34 @@ val candidate_rejection_dispatch_count : candidate_rejection_receipt -> int
 
 type flow_evidence =
   { flow_id : flow_id
+  ; scope : flow_scope
   ; candidate_snapshot : flow_candidate_identity list
   ; candidate_visit_count : candidate_visit_count
   ; admissions : candidate_admission list
   ; attempts : flow_attempt_receipt list
   }
 
-type flow_success =
-  { candidate : flow_attempt_receipt
-  ; success : success
-  ; evidence : flow_evidence
-  }
+val flow_success_candidate : flow_success -> flow_attempt_receipt
+val flow_success_output : flow_success -> success
+val flow_success_evidence : flow_success -> flow_evidence
+
+type domain_disposition =
+  | Domain_valid of { success_time_unix_s : int64 }
+  | Domain_rejected
+
+type domain_settlement_error = Domain_already_settled
+
+(** Settle caller-owned domain validation exactly once after structural
+    success. [Domain_valid] records the successful opaque candidate and the
+    caller-supplied success time as last-good for this flow's scope.
+    [Domain_rejected] records no preference and never resumes or advances the
+    terminal flow. Concurrent or duplicate settlement returns
+    [Domain_already_settled]. An equal or older success time cannot overwrite
+    a newer preference already recorded by another flow. *)
+val settle_flow_domain
+  :  flow_success
+  -> domain_disposition
+  -> (unit, domain_settlement_error) result
 
 type flow_candidate_failure =
   | Flow_candidate_rejected of candidate_rejection_receipt
@@ -409,9 +454,10 @@ type 'callback_error flow_execution_error =
       ; evidence : flow_evidence
       }
 
-(** Point-in-time aggregate evidence. [candidate_snapshot] is the original
-    immutable order. [candidate_visit_count], [admissions], and [attempts]
-    contain only candidates reached so far. Attempts are allocated only after
+(** Point-in-time aggregate evidence. [scope] is the exact opaque flow scope and
+    [candidate_snapshot] is the frozen effective order.
+    [candidate_visit_count], [admissions], and [attempts] contain only
+    candidates reached so far. Attempts are allocated only after
     current-candidate target selection and request admission succeed. This
     remains queryable after cancellation escapes. The affine executor is the
     sole writer. A concurrent reader may observe the exact point after an
@@ -452,9 +498,11 @@ val execute_once
     errors, replay, identity-allocation failure, missing execution prerequisites,
     frozen-request corruption, cancellation, every post-dispatch outcome, and
     success are terminal. Cancellation is re-raised after the flow is
-    terminalized; inspect {!flow_attempt_evidence} for monotonic progress. Domain
-    validation occurs after an OAS success and is therefore outside this API and
-    never failover eligible. *)
+    terminalized; inspect {!flow_attempt_evidence} for monotonic progress.
+    Domain validation occurs after an OAS success through
+    {!settle_flow_domain}; either disposition remains terminal and is never
+    failover eligible. Only a domain-valid settlement can affect a future
+    snapshot in the same explicit scope. *)
 val execute_flow_once
   :  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> ?clock:_ Eio.Time.clock

--- a/lib/llm_provider/exact_output.mli
+++ b/lib/llm_provider/exact_output.mli
@@ -25,6 +25,7 @@ type schema_fingerprint
 type flow_candidate
 type flow_preference_store
 type flow_scope
+type flow_success_ordinal
 type flow_snapshot
 type flow_attempt
 type flow_success
@@ -204,11 +205,11 @@ type flow_preference_observation =
   | No_preference_recorded
   | Preference_applied of
       { candidate : flow_candidate_identity
-      ; success_time_unix_s : int64
+      ; success_ordinal : flow_success_ordinal
       }
   | Preference_not_applied of
       { candidate : flow_candidate_identity
-      ; success_time_unix_s : int64
+      ; success_ordinal : flow_success_ordinal
       ; reason : flow_preference_not_applied_reason
       }
 
@@ -233,6 +234,11 @@ type candidate_admission =
 
 type flow_candidate_error = Blank_flow_candidate_id
 type flow_scope_error = Blank_flow_scope_id
+type flow_preference_store_error = Invalid_flow_preference_capacity of int
+
+type flow_preference_scope_removal =
+  | Flow_preference_scope_removed
+  | Flow_preference_scope_not_reserved
 
 type flow_snapshot_error =
   | Duplicate_flow_candidate_id of
@@ -240,6 +246,7 @@ type flow_snapshot_error =
       ; first_position : int
       ; duplicate_position : int
       }
+  | Flow_preference_capacity_exhausted of { capacity : int }
 
 (** Construct one provider-neutral candidate from a catalog-admitted target.
     Credential selection remains frozen but unresolved until this candidate is
@@ -255,16 +262,30 @@ val make_flow_candidate
 
 val flow_candidate_identity : flow_candidate -> flow_candidate_identity
 
-(** Create one caller-owned, process-local preference store. The store has no
+(** Create one caller-owned, process-local preference store with an explicit
+    hard scope capacity. Nonpositive capacities fail closed. The store has no
     global singleton, environment-derived policy, expiry, clock, persistence,
-    or background refresh. Sharing and lifetime are explicit at the call site. *)
-val create_flow_preference_store : unit -> flow_preference_store
+    or background refresh. *)
+val create_flow_preference_store
+  :  capacity:int
+  -> (flow_preference_store, flow_preference_store_error) result
 
 (** Brand one opaque caller scope. OAS compares the trimmed nonempty identity
     exactly; it does not parse coordinator, tenant, provider, or model fields. *)
 val make_flow_scope : id:string -> (flow_scope, flow_scope_error) result
 
 val flow_scope_equal : flow_scope -> flow_scope -> bool
+val flow_success_ordinal_to_int64 : flow_success_ordinal -> int64
+
+(** Remove one explicitly reserved scope and free its capacity. Existing frozen
+    snapshots remain immutable, but a later domain-valid settlement from an
+    already-running flow for this reservation fails with
+    [Domain_preference_scope_released], even if the same textual scope has since
+    been reserved again, and is still consumed exactly once. *)
+val remove_flow_preference_scope
+  :  flow_preference_store
+  -> flow_scope
+  -> flow_preference_scope_removal
 
 (** Freeze one nonempty ordered candidate snapshot and its immutable domain
     input. This validates only flow topology. Credential selection and exact
@@ -272,13 +293,14 @@ val flow_scope_equal : flow_scope -> flow_scope -> bool
     {!execute_flow_once}; later candidates are neither selected, prepared, nor
     assigned attempts speculatively.
 
-    A domain-valid last-good candidate recorded in [preferences] for [scope] is
-    moved to the front only when the same caller slot and opaque target binding
-    are both present. An absent slot or changed target binding is retained as a
-    typed non-applied observation. The remaining candidates retain their
-    declared relative order. This lookup happens exactly once: existing
-    snapshots never change, and preferences from another scope cannot affect
-    this snapshot. *)
+    The snapshot atomically reserves [scope] in [preferences]. A new scope fails
+    with [Flow_preference_capacity_exhausted] when the store is full. A
+    domain-valid last-good candidate recorded for the scope is moved to the
+    front only when the same caller slot and opaque target binding are both
+    present. An absent slot or changed target binding is retained as a typed
+    non-applied observation. The remaining candidates retain their declared
+    relative order. This lookup happens exactly once: existing snapshots never
+    change, and preferences from another scope cannot affect this snapshot. *)
 val snapshot_flow
   :  preferences:flow_preference_store
   -> scope:flow_scope
@@ -423,33 +445,40 @@ type flow_evidence = private
 val flow_success_candidate : flow_success -> flow_attempt_receipt
 val flow_success_output : flow_success -> success
 val flow_success_evidence : flow_success -> flow_evidence
+val flow_success_ordinal : flow_success -> flow_success_ordinal
 
 type domain_disposition =
-  | Domain_valid of { success_time_unix_s : int64 }
+  | Domain_valid
   | Domain_rejected
 
-type domain_settlement_receipt =
+type domain_settlement_receipt = private
   | Domain_rejected_recorded
   | Domain_valid_preference_installed of
       { candidate : flow_candidate_identity
-      ; success_time_unix_s : int64
+      ; success_ordinal : flow_success_ordinal
       }
   | Domain_valid_preference_superseded of
       { current_candidate : flow_candidate_identity
-      ; current_success_time_unix_s : int64
+      ; current_success_ordinal : flow_success_ordinal
       }
 
-type domain_settlement_error = Domain_already_settled
+type domain_settlement_error =
+  | Domain_already_settled
+  | Domain_preference_scope_released
 
 (** Settle caller-owned domain validation exactly once after structural
-    success. [Domain_valid] records the successful opaque candidate and the
-    caller-supplied success time as last-good for this flow's scope.
-    [Domain_rejected] records no preference and never resumes or advances the
-    terminal flow. Concurrent or duplicate settlement returns
-    [Domain_already_settled]. An equal or older success time cannot overwrite
-    a newer preference already recorded by another flow and returns a typed
-    [Domain_valid_preference_superseded] receipt naming the retained opaque
-    candidate identity and success time. *)
+    success. OAS freezes an immutable monotonic ordinal when structural success
+    is created; the caller cannot supply or alter freshness. [Domain_valid]
+    records the successful opaque candidate and frozen ordinal as last-good for
+    this flow's scope. [Domain_rejected] records no preference and never resumes
+    or advances the terminal flow. Concurrent or duplicate settlement returns
+    [Domain_already_settled]. A success whose ordinal is not newer cannot
+    overwrite the retained preference and returns a typed
+    [Domain_valid_preference_superseded] receipt. If the caller explicitly
+    removed the scope reservation after snapshot, domain-valid settlement
+    returns [Domain_preference_scope_released]; recreating the same textual
+    scope does not revive the old reservation. Every disposition is consumed
+    exactly once. *)
 val settle_flow_domain
   :  flow_success
   -> domain_disposition
@@ -464,6 +493,7 @@ type flow_candidate_failure =
 
 type 'callback_error flow_execution_error =
   | Flow_attempt_already_started of flow_evidence
+  | Flow_success_ordinal_exhausted of flow_evidence
   | Flow_attempt_start_failed of
       { candidate : flow_candidate_visit
       ; cause : start_attempt_error

--- a/lib/llm_provider/exact_output_flow.ml
+++ b/lib/llm_provider/exact_output_flow.ml
@@ -33,7 +33,11 @@ type ('scope, 'candidate) preference_store =
   ; mutable last_success_ordinal : int64
   }
 
-type domain_settlement = bool Atomic.t
+type domain_settlement =
+  { mutex : Mutex.t
+  ; mutable settled : bool
+  }
+
 type preference_store_error = Invalid_preference_capacity of int
 type preference_reservation_error = Preference_capacity_exhausted of { capacity : int }
 
@@ -91,7 +95,7 @@ let create_preference_store ~capacity =
       }
 ;;
 
-let create_domain_settlement () = Atomic.make false
+let create_domain_settlement () = { mutex = Mutex.create (); settled = false }
 
 let with_preference_lock (store : (_, _) preference_store) f =
   Mutex.lock store.mutex;
@@ -150,11 +154,17 @@ let record_preference store ~scope ~reservation ~candidate ~ordinal =
       Ok Preference_installed)
 ;;
 
-let claim_domain_settlement settlement =
-  if Atomic.compare_and_set settlement false true then Ok () else Error Already_settled
+let settle_domain_rejected_once settlement =
+  Mutex.lock settlement.mutex;
+  Fun.protect
+    ~finally:(fun () -> Mutex.unlock settlement.mutex)
+    (fun () ->
+       if settlement.settled
+       then Error Already_settled
+       else (
+         settlement.settled <- true;
+         Ok ()))
 ;;
-
-let settle_domain_rejected_once = claim_domain_settlement
 
 let settle_domain_valid_once
       settlement
@@ -164,12 +174,21 @@ let settle_domain_valid_once
       ~candidate
       ~ordinal
   =
-  match claim_domain_settlement settlement with
-  | Error Already_settled -> Error Already_settled
-  | Ok () ->
-    (match record_preference preferences ~scope ~reservation ~candidate ~ordinal with
-     | Ok installation -> Ok installation
-     | Error Preference_scope_not_reserved_for_record -> Error Preference_scope_released)
+  Mutex.lock settlement.mutex;
+  Fun.protect
+    ~finally:(fun () -> Mutex.unlock settlement.mutex)
+    (fun () ->
+       if settlement.settled
+       then Error Already_settled
+       else (
+         let installation =
+           record_preference preferences ~scope ~reservation ~candidate ~ordinal
+         in
+         settlement.settled <- true;
+         match installation with
+         | Ok installation -> Ok installation
+         | Error Preference_scope_not_reserved_for_record ->
+           Error Preference_scope_released))
 ;;
 
 let record_admission progress admission =

--- a/lib/llm_provider/exact_output_flow.ml
+++ b/lib/llm_provider/exact_output_flow.ml
@@ -34,7 +34,6 @@ type ('scope, 'candidate) preference_store =
   }
 
 type domain_settlement = bool Atomic.t
-
 type preference_store_error = Invalid_preference_capacity of int
 type preference_reservation_error = Preference_capacity_exhausted of { capacity : int }
 

--- a/lib/llm_provider/exact_output_flow.ml
+++ b/lib/llm_provider/exact_output_flow.ml
@@ -33,10 +33,7 @@ type ('scope, 'candidate) preference_store =
   ; mutable last_success_ordinal : int64
   }
 
-type domain_settlement =
-  { mutex : Mutex.t
-  ; mutable settled : bool
-  }
+type domain_settlement = bool Atomic.t
 
 type preference_store_error = Invalid_preference_capacity of int
 type preference_reservation_error = Preference_capacity_exhausted of { capacity : int }
@@ -95,7 +92,7 @@ let create_preference_store ~capacity =
       }
 ;;
 
-let create_domain_settlement () = { mutex = Mutex.create (); settled = false }
+let create_domain_settlement () = Atomic.make false
 
 let with_preference_lock (store : (_, _) preference_store) f =
   Mutex.lock store.mutex;
@@ -154,17 +151,13 @@ let record_preference store ~scope ~reservation ~candidate ~ordinal =
       Ok Preference_installed)
 ;;
 
-let settle_domain_rejected_once settlement =
-  Mutex.lock settlement.mutex;
-  Fun.protect
-    ~finally:(fun () -> Mutex.unlock settlement.mutex)
-    (fun () ->
-       if settlement.settled
-       then Error Already_settled
-       else (
-         settlement.settled <- true;
-         Ok ()))
+let claim_domain_settlement settlement =
+  if Atomic.compare_and_set settlement false true
+  then Ok ()
+  else Error Already_settled
 ;;
+
+let settle_domain_rejected_once = claim_domain_settlement
 
 let settle_domain_valid_once
       settlement
@@ -174,21 +167,13 @@ let settle_domain_valid_once
       ~candidate
       ~ordinal
   =
-  Mutex.lock settlement.mutex;
-  Fun.protect
-    ~finally:(fun () -> Mutex.unlock settlement.mutex)
-    (fun () ->
-       if settlement.settled
-       then Error Already_settled
-       else (
-         let installation =
-           record_preference preferences ~scope ~reservation ~candidate ~ordinal
-         in
-         settlement.settled <- true;
-         match installation with
-         | Ok installation -> Ok installation
-         | Error Preference_scope_not_reserved_for_record ->
-           Error Preference_scope_released))
+  match claim_domain_settlement settlement with
+  | Error Already_settled -> Error Already_settled
+  | Ok () ->
+    (match record_preference preferences ~scope ~reservation ~candidate ~ordinal with
+     | Ok installation -> Ok installation
+     | Error Preference_scope_not_reserved_for_record ->
+       Error Preference_scope_released)
 ;;
 
 let record_admission progress admission =

--- a/lib/llm_provider/exact_output_flow.ml
+++ b/lib/llm_provider/exact_output_flow.ml
@@ -31,6 +31,13 @@ type domain_settlement =
 
 type domain_settlement_error = Already_settled
 
+type 'candidate preference_installation =
+  | Preference_installed
+  | Preference_superseded of
+      { current_candidate : 'candidate
+      ; current_time : int64
+      }
+
 type ('candidate, 'success, 'execution_error, 'advanceable_error, 'callback_error) outcome =
   | Succeeded of
       { candidate : 'candidate
@@ -69,11 +76,14 @@ let preferred_candidate store ~scope =
 let record_preference store ~scope ~candidate ~time =
   with_preference_lock store (fun () ->
     match Hashtbl.find_opt store.entries scope with
-    | Some (_, current_time) when Int64.compare time current_time <= 0 -> ()
-    | None | Some _ -> Hashtbl.replace store.entries scope (candidate, time))
+    | Some (current_candidate, current_time) when Int64.compare time current_time <= 0 ->
+      Preference_superseded { current_candidate; current_time }
+    | None | Some _ ->
+      Hashtbl.replace store.entries scope (candidate, time);
+      Preference_installed)
 ;;
 
-let settle_domain_once settlement ~commit =
+let settle_domain_rejected_once settlement =
   Mutex.lock settlement.mutex;
   Fun.protect
     ~finally:(fun () -> Mutex.unlock settlement.mutex)
@@ -81,18 +91,21 @@ let settle_domain_once settlement ~commit =
        if settlement.settled
        then Error Already_settled
        else (
-         commit ();
          settlement.settled <- true;
          Ok ()))
 ;;
 
-let settle_domain_rejected_once settlement =
-  settle_domain_once settlement ~commit:(fun () -> ())
-;;
-
 let settle_domain_valid_once settlement preferences ~scope ~candidate ~time =
-  settle_domain_once settlement ~commit:(fun () ->
-    record_preference preferences ~scope ~candidate ~time)
+  Mutex.lock settlement.mutex;
+  Fun.protect
+    ~finally:(fun () -> Mutex.unlock settlement.mutex)
+    (fun () ->
+       if settlement.settled
+       then Error Already_settled
+       else (
+         let installation = record_preference preferences ~scope ~candidate ~time in
+         settlement.settled <- true;
+         Ok installation))
 ;;
 
 let record_admission progress admission =

--- a/lib/llm_provider/exact_output_flow.ml
+++ b/lib/llm_provider/exact_output_flow.ml
@@ -18,10 +18,19 @@ type ('admission, 'attempt) progress_state =
   }
 
 type ('admission, 'attempt) progress = ('admission, 'attempt) progress_state Atomic.t
+type preference_reservation = unit ref
+type success_ordinal = Success_ordinal of int64
+
+type 'candidate preference_entry =
+  { reservation : preference_reservation
+  ; mutable preference : ('candidate * success_ordinal) option
+  }
 
 type ('scope, 'candidate) preference_store =
   { mutex : Mutex.t
-  ; entries : ('scope, 'candidate * int64) Hashtbl.t
+  ; capacity : int
+  ; entries : ('scope, 'candidate preference_entry) Hashtbl.t
+  ; mutable last_success_ordinal : int64
   }
 
 type domain_settlement =
@@ -29,13 +38,26 @@ type domain_settlement =
   ; mutable settled : bool
   }
 
-type domain_settlement_error = Already_settled
+type preference_store_error = Invalid_preference_capacity of int
+type preference_reservation_error = Preference_capacity_exhausted of { capacity : int }
+
+type preference_scope_removal =
+  | Preference_scope_removed
+  | Preference_scope_not_reserved
+
+type success_ordinal_error = Success_ordinal_exhausted
+
+type domain_settlement_error =
+  | Already_settled
+  | Preference_scope_released
+
+type preference_record_error = Preference_scope_not_reserved_for_record
 
 type 'candidate preference_installation =
   | Preference_installed
   | Preference_superseded of
       { current_candidate : 'candidate
-      ; current_time : int64
+      ; current_ordinal : success_ordinal
       }
 
 type ('candidate, 'success, 'execution_error, 'advanceable_error, 'callback_error) outcome =
@@ -61,7 +83,18 @@ let create_progress () =
   Atomic.make { candidate_visit_count = 0; admissions_rev = []; attempts_rev = [] }
 ;;
 
-let create_preference_store () = { mutex = Mutex.create (); entries = Hashtbl.create 8 }
+let create_preference_store ~capacity =
+  if capacity <= 0
+  then Error (Invalid_preference_capacity capacity)
+  else
+    Ok
+      { mutex = Mutex.create ()
+      ; capacity
+      ; entries = Hashtbl.create (Int.min capacity 16)
+      ; last_success_ordinal = 0L
+      }
+;;
+
 let create_domain_settlement () = { mutex = Mutex.create (); settled = false }
 
 let with_preference_lock (store : (_, _) preference_store) f =
@@ -69,18 +102,56 @@ let with_preference_lock (store : (_, _) preference_store) f =
   Fun.protect ~finally:(fun () -> Mutex.unlock store.mutex) f
 ;;
 
-let preferred_candidate store ~scope =
-  with_preference_lock store (fun () -> Hashtbl.find_opt store.entries scope)
-;;
-
-let record_preference store ~scope ~candidate ~time =
+let reserve_preference_scope store ~scope =
   with_preference_lock store (fun () ->
     match Hashtbl.find_opt store.entries scope with
-    | Some (current_candidate, current_time) when Int64.compare time current_time <= 0 ->
-      Preference_superseded { current_candidate; current_time }
-    | None | Some _ ->
-      Hashtbl.replace store.entries scope (candidate, time);
-      Preference_installed)
+    | Some entry -> Ok (entry.reservation, entry.preference)
+    | None ->
+      if Hashtbl.length store.entries >= store.capacity
+      then Error (Preference_capacity_exhausted { capacity = store.capacity })
+      else (
+        let reservation = ref () in
+        Hashtbl.add store.entries scope { reservation; preference = None };
+        Ok (reservation, None)))
+;;
+
+let remove_preference_scope store ~scope =
+  with_preference_lock store (fun () ->
+    if Hashtbl.mem store.entries scope
+    then (
+      Hashtbl.remove store.entries scope;
+      Preference_scope_removed)
+    else Preference_scope_not_reserved)
+;;
+
+let allocate_success_ordinal store =
+  with_preference_lock store (fun () ->
+    if Int64.equal store.last_success_ordinal Int64.max_int
+    then Error Success_ordinal_exhausted
+    else (
+      let ordinal = Int64.succ store.last_success_ordinal in
+      store.last_success_ordinal <- ordinal;
+      Ok (Success_ordinal ordinal)))
+;;
+
+let success_ordinal_to_int64 (Success_ordinal ordinal) = ordinal
+
+let compare_success_ordinal (Success_ordinal left) (Success_ordinal right) =
+  Int64.compare left right
+;;
+
+let record_preference store ~scope ~reservation ~candidate ~ordinal =
+  with_preference_lock store (fun () ->
+    match Hashtbl.find_opt store.entries scope with
+    | None -> Error Preference_scope_not_reserved_for_record
+    | Some entry when entry.reservation != reservation ->
+      Error Preference_scope_not_reserved_for_record
+    | Some { preference = Some (current_candidate, current_ordinal); _ }
+      when compare_success_ordinal ordinal current_ordinal <= 0 ->
+      Ok (Preference_superseded { current_candidate; current_ordinal })
+    | Some entry ->
+      entry.preference <- Some (candidate, ordinal);
+      Ok Preference_installed)
 ;;
 
 let settle_domain_rejected_once settlement =
@@ -95,7 +166,14 @@ let settle_domain_rejected_once settlement =
          Ok ()))
 ;;
 
-let settle_domain_valid_once settlement preferences ~scope ~candidate ~time =
+let settle_domain_valid_once
+      settlement
+      preferences
+      ~scope
+      ~reservation
+      ~candidate
+      ~ordinal
+  =
   Mutex.lock settlement.mutex;
   Fun.protect
     ~finally:(fun () -> Mutex.unlock settlement.mutex)
@@ -103,9 +181,14 @@ let settle_domain_valid_once settlement preferences ~scope ~candidate ~time =
        if settlement.settled
        then Error Already_settled
        else (
-         let installation = record_preference preferences ~scope ~candidate ~time in
+         let installation =
+           record_preference preferences ~scope ~reservation ~candidate ~ordinal
+         in
          settlement.settled <- true;
-         Ok installation))
+         match installation with
+         | Ok installation -> Ok installation
+         | Error Preference_scope_not_reserved_for_record ->
+           Error Preference_scope_released))
 ;;
 
 let record_admission progress admission =

--- a/lib/llm_provider/exact_output_flow.ml
+++ b/lib/llm_provider/exact_output_flow.ml
@@ -19,6 +19,18 @@ type ('admission, 'attempt) progress_state =
 
 type ('admission, 'attempt) progress = ('admission, 'attempt) progress_state Atomic.t
 
+type ('scope, 'candidate) preference_store =
+  { mutex : Mutex.t
+  ; entries : ('scope, 'candidate * int64) Hashtbl.t
+  }
+
+type domain_settlement =
+  { mutex : Mutex.t
+  ; mutable settled : bool
+  }
+
+type domain_settlement_error = Already_settled
+
 type ('candidate, 'success, 'execution_error, 'advanceable_error, 'callback_error) outcome =
   | Succeeded of
       { candidate : 'candidate
@@ -40,6 +52,47 @@ let create () = Atomic.make Not_started
 
 let create_progress () =
   Atomic.make { candidate_visit_count = 0; admissions_rev = []; attempts_rev = [] }
+;;
+
+let create_preference_store () = { mutex = Mutex.create (); entries = Hashtbl.create 8 }
+let create_domain_settlement () = { mutex = Mutex.create (); settled = false }
+
+let with_preference_lock (store : (_, _) preference_store) f =
+  Mutex.lock store.mutex;
+  Fun.protect ~finally:(fun () -> Mutex.unlock store.mutex) f
+;;
+
+let preferred_candidate store ~scope =
+  with_preference_lock store (fun () -> Hashtbl.find_opt store.entries scope)
+;;
+
+let record_preference store ~scope ~candidate ~time =
+  with_preference_lock store (fun () ->
+    match Hashtbl.find_opt store.entries scope with
+    | Some (_, current_time) when Int64.compare time current_time <= 0 -> ()
+    | None | Some _ -> Hashtbl.replace store.entries scope (candidate, time))
+;;
+
+let settle_domain_once settlement ~commit =
+  Mutex.lock settlement.mutex;
+  Fun.protect
+    ~finally:(fun () -> Mutex.unlock settlement.mutex)
+    (fun () ->
+       if settlement.settled
+       then Error Already_settled
+       else (
+         commit ();
+         settlement.settled <- true;
+         Ok ()))
+;;
+
+let settle_domain_rejected_once settlement =
+  settle_domain_once settlement ~commit:(fun () -> ())
+;;
+
+let settle_domain_valid_once settlement preferences ~scope ~candidate ~time =
+  settle_domain_once settlement ~commit:(fun () ->
+    record_preference preferences ~scope ~candidate ~time)
 ;;
 
 let record_admission progress admission =
@@ -76,6 +129,16 @@ let duplicate_key ~equal ~key candidates =
        | None -> find (position + 1) ((value, position) :: seen) rest)
   in
   find 1 [] candidates
+;;
+
+let promote_candidate ~equal ~key ~preferred candidates =
+  match preferred with
+  | None -> candidates
+  | Some preferred ->
+    let selected, remaining =
+      List.partition (fun candidate -> equal (key candidate) preferred) candidates
+    in
+    selected @ remaining
 ;;
 
 let execute_once state ~candidates ~execute ~advanceable ~before_advance =

--- a/lib/llm_provider/exact_output_flow.ml
+++ b/lib/llm_provider/exact_output_flow.ml
@@ -152,9 +152,7 @@ let record_preference store ~scope ~reservation ~candidate ~ordinal =
 ;;
 
 let claim_domain_settlement settlement =
-  if Atomic.compare_and_set settlement false true
-  then Ok ()
-  else Error Already_settled
+  if Atomic.compare_and_set settlement false true then Ok () else Error Already_settled
 ;;
 
 let settle_domain_rejected_once = claim_domain_settlement
@@ -172,8 +170,7 @@ let settle_domain_valid_once
   | Ok () ->
     (match record_preference preferences ~scope ~reservation ~candidate ~ordinal with
      | Ok installation -> Ok installation
-     | Error Preference_scope_not_reserved_for_record ->
-       Error Preference_scope_released)
+     | Error Preference_scope_not_reserved_for_record -> Error Preference_scope_released)
 ;;
 
 let record_admission progress admission =

--- a/lib/llm_provider/exact_output_flow.mli
+++ b/lib/llm_provider/exact_output_flow.mli
@@ -6,6 +6,9 @@
 
 type t
 type ('admission, 'attempt) progress
+type ('scope, 'candidate) preference_store
+type domain_settlement
+type domain_settlement_error = Already_settled
 
 type ('admission, 'attempt) progress_snapshot =
   { candidate_visit_count : int
@@ -37,6 +40,26 @@ val create : unit -> t
     recorded admission and its subsequently allocated attempt. *)
 val create_progress : unit -> ('admission, 'attempt) progress
 
+val create_preference_store : unit -> ('scope, 'candidate) preference_store
+val create_domain_settlement : unit -> domain_settlement
+
+val preferred_candidate
+  :  ('scope, 'candidate) preference_store
+  -> scope:'scope
+  -> ('candidate * int64) option
+
+val settle_domain_rejected_once
+  :  domain_settlement
+  -> (unit, domain_settlement_error) result
+
+val settle_domain_valid_once
+  :  domain_settlement
+  -> ('scope, 'candidate) preference_store
+  -> scope:'scope
+  -> candidate:'candidate
+  -> time:int64
+  -> (unit, domain_settlement_error) result
+
 val record_admission : ('admission, 'attempt) progress -> 'admission -> unit
 val record_attempt : ('admission, 'attempt) progress -> 'attempt -> unit
 
@@ -49,6 +72,13 @@ val duplicate_key
   -> key:('candidate -> 'key)
   -> 'candidate list
   -> ('key * int * int) option
+
+val promote_candidate
+  :  equal:('key -> 'key -> bool)
+  -> key:('candidate -> 'key)
+  -> preferred:'key option
+  -> 'candidate list
+  -> 'candidate list
 
 (** Execute an immutable, nonempty candidate snapshot once.
 

--- a/lib/llm_provider/exact_output_flow.mli
+++ b/lib/llm_provider/exact_output_flow.mli
@@ -7,14 +7,27 @@
 type t
 type ('admission, 'attempt) progress
 type ('scope, 'candidate) preference_store
+type preference_reservation
+type success_ordinal
 type domain_settlement
-type domain_settlement_error = Already_settled
+type preference_store_error = Invalid_preference_capacity of int
+type preference_reservation_error = Preference_capacity_exhausted of { capacity : int }
+
+type preference_scope_removal =
+  | Preference_scope_removed
+  | Preference_scope_not_reserved
+
+type success_ordinal_error = Success_ordinal_exhausted
+
+type domain_settlement_error =
+  | Already_settled
+  | Preference_scope_released
 
 type 'candidate preference_installation =
   | Preference_installed
   | Preference_superseded of
       { current_candidate : 'candidate
-      ; current_time : int64
+      ; current_ordinal : success_ordinal
       }
 
 type ('admission, 'attempt) progress_snapshot =
@@ -47,13 +60,29 @@ val create : unit -> t
     recorded admission and its subsequently allocated attempt. *)
 val create_progress : unit -> ('admission, 'attempt) progress
 
-val create_preference_store : unit -> ('scope, 'candidate) preference_store
+val create_preference_store
+  :  capacity:int
+  -> (('scope, 'candidate) preference_store, preference_store_error) result
+
 val create_domain_settlement : unit -> domain_settlement
 
-val preferred_candidate
+val reserve_preference_scope
   :  ('scope, 'candidate) preference_store
   -> scope:'scope
-  -> ('candidate * int64) option
+  -> ( preference_reservation * ('candidate * success_ordinal) option
+       , preference_reservation_error )
+       result
+
+val remove_preference_scope
+  :  ('scope, 'candidate) preference_store
+  -> scope:'scope
+  -> preference_scope_removal
+
+val allocate_success_ordinal
+  :  ('scope, 'candidate) preference_store
+  -> (success_ordinal, success_ordinal_error) result
+
+val success_ordinal_to_int64 : success_ordinal -> int64
 
 val settle_domain_rejected_once
   :  domain_settlement
@@ -63,8 +92,9 @@ val settle_domain_valid_once
   :  domain_settlement
   -> ('scope, 'candidate) preference_store
   -> scope:'scope
+  -> reservation:preference_reservation
   -> candidate:'candidate
-  -> time:int64
+  -> ordinal:success_ordinal
   -> ('candidate preference_installation, domain_settlement_error) result
 
 val record_admission : ('admission, 'attempt) progress -> 'admission -> unit

--- a/lib/llm_provider/exact_output_flow.mli
+++ b/lib/llm_provider/exact_output_flow.mli
@@ -10,6 +10,13 @@ type ('scope, 'candidate) preference_store
 type domain_settlement
 type domain_settlement_error = Already_settled
 
+type 'candidate preference_installation =
+  | Preference_installed
+  | Preference_superseded of
+      { current_candidate : 'candidate
+      ; current_time : int64
+      }
+
 type ('admission, 'attempt) progress_snapshot =
   { candidate_visit_count : int
   ; admissions : 'admission list
@@ -58,7 +65,7 @@ val settle_domain_valid_once
   -> scope:'scope
   -> candidate:'candidate
   -> time:int64
-  -> (unit, domain_settlement_error) result
+  -> ('candidate preference_installation, domain_settlement_error) result
 
 val record_admission : ('admission, 'attempt) progress -> 'admission -> unit
 val record_attempt : ('admission, 'attempt) progress -> 'attempt -> unit

--- a/lib/llm_provider/exact_output_flow.mli
+++ b/lib/llm_provider/exact_output_flow.mli
@@ -88,6 +88,10 @@ val settle_domain_rejected_once
   :  domain_settlement
   -> (unit, domain_settlement_error) result
 
+(** The per-success settlement gate remains held through preference
+    publication. A losing duplicate therefore returns only after the winning
+    domain-valid record is visible. Lock acquisition is strictly settlement
+    gate then preference store; no operation acquires them in reverse order. *)
 val settle_domain_valid_once
   :  domain_settlement
   -> ('scope, 'candidate) preference_store

--- a/lib/llm_provider/exact_output_flow_contract.ml
+++ b/lib/llm_provider/exact_output_flow_contract.ml
@@ -1,0 +1,121 @@
+module Flow_state = Exact_output_flow
+module Resolver = Exact_output_resolver
+
+type flow_candidate_identity =
+  { candidate_id : string
+  ; catalog_generation : Resolver.catalog_generation
+  ; catalog_evidence : Resolver.catalog_evidence
+  ; target_identity : Resolver.target_identity
+  }
+
+type flow_preference_store = (string, flow_candidate_identity) Flow_state.preference_store
+type flow_scope = Flow_scope of string
+
+type flow_preference_not_applied_reason =
+  | Preference_candidate_absent
+  | Preference_candidate_binding_changed
+
+type flow_preference_observation =
+  | No_preference_recorded
+  | Preference_applied of
+      { candidate : flow_candidate_identity
+      ; success_time_unix_s : int64
+      }
+  | Preference_not_applied of
+      { candidate : flow_candidate_identity
+      ; success_time_unix_s : int64
+      ; reason : flow_preference_not_applied_reason
+      }
+
+type flow_scope_error = Blank_flow_scope_id
+
+type domain_disposition =
+  | Domain_valid of { success_time_unix_s : int64 }
+  | Domain_rejected
+
+type domain_settlement_receipt =
+  | Domain_rejected_recorded
+  | Domain_valid_preference_installed of
+      { candidate : flow_candidate_identity
+      ; success_time_unix_s : int64
+      }
+  | Domain_valid_preference_superseded of
+      { current_candidate : flow_candidate_identity
+      ; current_success_time_unix_s : int64
+      }
+
+type domain_settlement_error = Domain_already_settled
+
+let create_flow_preference_store () = Flow_state.create_preference_store ()
+
+let make_flow_scope ~id =
+  let id = String.trim id in
+  if String.equal id "" then Error Blank_flow_scope_id else Ok (Flow_scope id)
+;;
+
+let flow_scope_equal (Flow_scope left) (Flow_scope right) = String.equal left right
+
+let target_binding_equal left right =
+  String.equal
+    (Resolver.target_identity_fingerprint left.target_identity)
+    (Resolver.target_identity_fingerprint right.target_identity)
+;;
+
+let prefer_last_good preferences (Flow_scope scope) ~candidate_identity candidates =
+  match Flow_state.preferred_candidate preferences ~scope with
+  | None -> candidates, No_preference_recorded
+  | Some (recorded, success_time_unix_s) ->
+    (match
+       List.find_opt
+         (fun candidate ->
+            String.equal (candidate_identity candidate).candidate_id recorded.candidate_id)
+         candidates
+     with
+     | None ->
+       ( candidates
+       , Preference_not_applied
+           { candidate = recorded
+           ; success_time_unix_s
+           ; reason = Preference_candidate_absent
+           } )
+     | Some current when not (target_binding_equal recorded (candidate_identity current))
+       ->
+       ( candidates
+       , Preference_not_applied
+           { candidate = recorded
+           ; success_time_unix_s
+           ; reason = Preference_candidate_binding_changed
+           } )
+     | Some _ ->
+       ( Flow_state.promote_candidate
+           ~equal:String.equal
+           ~key:(fun candidate -> (candidate_identity candidate).candidate_id)
+           ~preferred:(Some recorded.candidate_id)
+           candidates
+       , Preference_applied { candidate = recorded; success_time_unix_s } ))
+;;
+
+let settle_domain settlement preferences (Flow_scope scope) ~candidate disposition =
+  let result =
+    match disposition with
+    | Domain_rejected ->
+      Flow_state.settle_domain_rejected_once settlement
+      |> Result.map (fun () -> Domain_rejected_recorded)
+    | Domain_valid { success_time_unix_s } ->
+      Flow_state.settle_domain_valid_once
+        settlement
+        preferences
+        ~scope
+        ~candidate
+        ~time:success_time_unix_s
+      |> Result.map (function
+        | Flow_state.Preference_installed ->
+          Domain_valid_preference_installed { candidate; success_time_unix_s }
+        | Flow_state.Preference_superseded { current_candidate; current_time } ->
+          Domain_valid_preference_superseded
+            { current_candidate; current_success_time_unix_s = current_time })
+  in
+  match result with
+  | Error Flow_state.Already_settled -> Error Domain_already_settled
+  | Ok receipt -> Ok receipt
+;;

--- a/lib/llm_provider/exact_output_flow_contract.ml
+++ b/lib/llm_provider/exact_output_flow_contract.ml
@@ -10,6 +10,18 @@ type flow_candidate_identity =
 
 type flow_preference_store = (string, flow_candidate_identity) Flow_state.preference_store
 type flow_scope = Flow_scope of string
+type flow_preference_reservation = Flow_state.preference_reservation
+type flow_success_ordinal = Flow_state.success_ordinal
+type flow_preference_store_error = Invalid_flow_preference_capacity of int
+
+type flow_preference_reservation_error =
+  | Preference_capacity_exhausted of { capacity : int }
+
+type flow_preference_scope_removal =
+  | Flow_preference_scope_removed
+  | Flow_preference_scope_not_reserved
+
+type flow_success_ordinal_error = Success_ordinal_space_exhausted
 
 type flow_preference_not_applied_reason =
   | Preference_candidate_absent
@@ -19,34 +31,41 @@ type flow_preference_observation =
   | No_preference_recorded
   | Preference_applied of
       { candidate : flow_candidate_identity
-      ; success_time_unix_s : int64
+      ; success_ordinal : flow_success_ordinal
       }
   | Preference_not_applied of
       { candidate : flow_candidate_identity
-      ; success_time_unix_s : int64
+      ; success_ordinal : flow_success_ordinal
       ; reason : flow_preference_not_applied_reason
       }
 
 type flow_scope_error = Blank_flow_scope_id
 
 type domain_disposition =
-  | Domain_valid of { success_time_unix_s : int64 }
+  | Domain_valid
   | Domain_rejected
 
 type domain_settlement_receipt =
   | Domain_rejected_recorded
   | Domain_valid_preference_installed of
       { candidate : flow_candidate_identity
-      ; success_time_unix_s : int64
+      ; success_ordinal : flow_success_ordinal
       }
   | Domain_valid_preference_superseded of
       { current_candidate : flow_candidate_identity
-      ; current_success_time_unix_s : int64
+      ; current_success_ordinal : flow_success_ordinal
       }
 
-type domain_settlement_error = Domain_already_settled
+type domain_settlement_error =
+  | Domain_already_settled
+  | Domain_preference_scope_released
 
-let create_flow_preference_store () = Flow_state.create_preference_store ()
+let create_flow_preference_store ~capacity =
+  match Flow_state.create_preference_store ~capacity with
+  | Ok store -> Ok store
+  | Error (Flow_state.Invalid_preference_capacity capacity) ->
+    Error (Invalid_flow_preference_capacity capacity)
+;;
 
 let make_flow_scope ~id =
   let id = String.trim id in
@@ -54,6 +73,19 @@ let make_flow_scope ~id =
 ;;
 
 let flow_scope_equal (Flow_scope left) (Flow_scope right) = String.equal left right
+let flow_success_ordinal_to_int64 = Flow_state.success_ordinal_to_int64
+
+let remove_flow_preference_scope preferences (Flow_scope scope) =
+  match Flow_state.remove_preference_scope preferences ~scope with
+  | Flow_state.Preference_scope_removed -> Flow_preference_scope_removed
+  | Flow_state.Preference_scope_not_reserved -> Flow_preference_scope_not_reserved
+;;
+
+let allocate_flow_success_ordinal preferences =
+  match Flow_state.allocate_success_ordinal preferences with
+  | Ok ordinal -> Ok ordinal
+  | Error Flow_state.Success_ordinal_exhausted -> Error Success_ordinal_space_exhausted
+;;
 
 let target_binding_equal left right =
   String.equal
@@ -62,9 +94,11 @@ let target_binding_equal left right =
 ;;
 
 let prefer_last_good preferences (Flow_scope scope) ~candidate_identity candidates =
-  match Flow_state.preferred_candidate preferences ~scope with
-  | None -> candidates, No_preference_recorded
-  | Some (recorded, success_time_unix_s) ->
+  match Flow_state.reserve_preference_scope preferences ~scope with
+  | Error (Flow_state.Preference_capacity_exhausted { capacity }) ->
+    Error (Preference_capacity_exhausted { capacity })
+  | Ok (reservation, None) -> Ok (candidates, No_preference_recorded, reservation)
+  | Ok (reservation, Some (recorded, success_ordinal)) ->
     (match
        List.find_opt
          (fun candidate ->
@@ -72,50 +106,66 @@ let prefer_last_good preferences (Flow_scope scope) ~candidate_identity candidat
          candidates
      with
      | None ->
-       ( candidates
-       , Preference_not_applied
-           { candidate = recorded
-           ; success_time_unix_s
-           ; reason = Preference_candidate_absent
-           } )
+       Ok
+         ( candidates
+         , Preference_not_applied
+             { candidate = recorded
+             ; success_ordinal
+             ; reason = Preference_candidate_absent
+             }
+         , reservation )
      | Some current when not (target_binding_equal recorded (candidate_identity current))
        ->
-       ( candidates
-       , Preference_not_applied
-           { candidate = recorded
-           ; success_time_unix_s
-           ; reason = Preference_candidate_binding_changed
-           } )
+       Ok
+         ( candidates
+         , Preference_not_applied
+             { candidate = recorded
+             ; success_ordinal
+             ; reason = Preference_candidate_binding_changed
+             }
+         , reservation )
      | Some _ ->
-       ( Flow_state.promote_candidate
-           ~equal:String.equal
-           ~key:(fun candidate -> (candidate_identity candidate).candidate_id)
-           ~preferred:(Some recorded.candidate_id)
-           candidates
-       , Preference_applied { candidate = recorded; success_time_unix_s } ))
+       Ok
+         ( Flow_state.promote_candidate
+             ~equal:String.equal
+             ~key:(fun candidate -> (candidate_identity candidate).candidate_id)
+             ~preferred:(Some recorded.candidate_id)
+             candidates
+         , Preference_applied { candidate = recorded; success_ordinal }
+         , reservation ))
 ;;
 
-let settle_domain settlement preferences (Flow_scope scope) ~candidate disposition =
+let settle_domain
+      settlement
+      preferences
+      (Flow_scope scope)
+      ~reservation
+      ~candidate
+      ~success_ordinal
+      disposition
+  =
   let result =
     match disposition with
     | Domain_rejected ->
       Flow_state.settle_domain_rejected_once settlement
       |> Result.map (fun () -> Domain_rejected_recorded)
-    | Domain_valid { success_time_unix_s } ->
+    | Domain_valid ->
       Flow_state.settle_domain_valid_once
         settlement
         preferences
         ~scope
+        ~reservation
         ~candidate
-        ~time:success_time_unix_s
+        ~ordinal:success_ordinal
       |> Result.map (function
         | Flow_state.Preference_installed ->
-          Domain_valid_preference_installed { candidate; success_time_unix_s }
-        | Flow_state.Preference_superseded { current_candidate; current_time } ->
+          Domain_valid_preference_installed { candidate; success_ordinal }
+        | Flow_state.Preference_superseded { current_candidate; current_ordinal } ->
           Domain_valid_preference_superseded
-            { current_candidate; current_success_time_unix_s = current_time })
+            { current_candidate; current_success_ordinal = current_ordinal })
   in
   match result with
   | Error Flow_state.Already_settled -> Error Domain_already_settled
+  | Error Flow_state.Preference_scope_released -> Error Domain_preference_scope_released
   | Ok receipt -> Ok receipt
 ;;

--- a/lib/llm_provider/exact_output_flow_contract.mli
+++ b/lib/llm_provider/exact_output_flow_contract.mli
@@ -13,6 +13,18 @@ type flow_candidate_identity =
 
 type flow_preference_store
 type flow_scope
+type flow_preference_reservation
+type flow_success_ordinal
+type flow_preference_store_error = Invalid_flow_preference_capacity of int
+
+type flow_preference_reservation_error =
+  | Preference_capacity_exhausted of { capacity : int }
+
+type flow_preference_scope_removal =
+  | Flow_preference_scope_removed
+  | Flow_preference_scope_not_reserved
+
+type flow_success_ordinal_error = Success_ordinal_space_exhausted
 
 type flow_preference_not_applied_reason =
   | Preference_candidate_absent
@@ -22,48 +34,67 @@ type flow_preference_observation =
   | No_preference_recorded
   | Preference_applied of
       { candidate : flow_candidate_identity
-      ; success_time_unix_s : int64
+      ; success_ordinal : flow_success_ordinal
       }
   | Preference_not_applied of
       { candidate : flow_candidate_identity
-      ; success_time_unix_s : int64
+      ; success_ordinal : flow_success_ordinal
       ; reason : flow_preference_not_applied_reason
       }
 
 type flow_scope_error = Blank_flow_scope_id
 
 type domain_disposition =
-  | Domain_valid of { success_time_unix_s : int64 }
+  | Domain_valid
   | Domain_rejected
 
-type domain_settlement_receipt =
+type domain_settlement_receipt = private
   | Domain_rejected_recorded
   | Domain_valid_preference_installed of
       { candidate : flow_candidate_identity
-      ; success_time_unix_s : int64
+      ; success_ordinal : flow_success_ordinal
       }
   | Domain_valid_preference_superseded of
       { current_candidate : flow_candidate_identity
-      ; current_success_time_unix_s : int64
+      ; current_success_ordinal : flow_success_ordinal
       }
 
-type domain_settlement_error = Domain_already_settled
+type domain_settlement_error =
+  | Domain_already_settled
+  | Domain_preference_scope_released
 
-val create_flow_preference_store : unit -> flow_preference_store
+val create_flow_preference_store
+  :  capacity:int
+  -> (flow_preference_store, flow_preference_store_error) result
+
 val make_flow_scope : id:string -> (flow_scope, flow_scope_error) result
 val flow_scope_equal : flow_scope -> flow_scope -> bool
+val flow_success_ordinal_to_int64 : flow_success_ordinal -> int64
+
+val remove_flow_preference_scope
+  :  flow_preference_store
+  -> flow_scope
+  -> flow_preference_scope_removal
+
+val allocate_flow_success_ordinal
+  :  flow_preference_store
+  -> (flow_success_ordinal, flow_success_ordinal_error) result
 
 val prefer_last_good
   :  flow_preference_store
   -> flow_scope
   -> candidate_identity:('candidate -> flow_candidate_identity)
   -> 'candidate list
-  -> 'candidate list * flow_preference_observation
+  -> ( 'candidate list * flow_preference_observation * flow_preference_reservation
+       , flow_preference_reservation_error )
+       result
 
 val settle_domain
   :  Exact_output_flow.domain_settlement
   -> flow_preference_store
   -> flow_scope
+  -> reservation:flow_preference_reservation
   -> candidate:flow_candidate_identity
+  -> success_ordinal:flow_success_ordinal
   -> domain_disposition
   -> (domain_settlement_receipt, domain_settlement_error) result

--- a/lib/llm_provider/exact_output_flow_contract.mli
+++ b/lib/llm_provider/exact_output_flow_contract.mli
@@ -1,0 +1,69 @@
+(** Private typed contract for scope-local exact-output preferences.
+
+    The public surface is re-exported by {!Exact_output}. Keeping the state
+    transition and its evidence types together prevents the facade from
+    reimplementing preference ordering or domain settlement. *)
+
+type flow_candidate_identity =
+  { candidate_id : string
+  ; catalog_generation : Exact_output_resolver.catalog_generation
+  ; catalog_evidence : Exact_output_resolver.catalog_evidence
+  ; target_identity : Exact_output_resolver.target_identity
+  }
+
+type flow_preference_store
+type flow_scope
+
+type flow_preference_not_applied_reason =
+  | Preference_candidate_absent
+  | Preference_candidate_binding_changed
+
+type flow_preference_observation =
+  | No_preference_recorded
+  | Preference_applied of
+      { candidate : flow_candidate_identity
+      ; success_time_unix_s : int64
+      }
+  | Preference_not_applied of
+      { candidate : flow_candidate_identity
+      ; success_time_unix_s : int64
+      ; reason : flow_preference_not_applied_reason
+      }
+
+type flow_scope_error = Blank_flow_scope_id
+
+type domain_disposition =
+  | Domain_valid of { success_time_unix_s : int64 }
+  | Domain_rejected
+
+type domain_settlement_receipt =
+  | Domain_rejected_recorded
+  | Domain_valid_preference_installed of
+      { candidate : flow_candidate_identity
+      ; success_time_unix_s : int64
+      }
+  | Domain_valid_preference_superseded of
+      { current_candidate : flow_candidate_identity
+      ; current_success_time_unix_s : int64
+      }
+
+type domain_settlement_error = Domain_already_settled
+
+val create_flow_preference_store : unit -> flow_preference_store
+val make_flow_scope : id:string -> (flow_scope, flow_scope_error) result
+val flow_scope_equal : flow_scope -> flow_scope -> bool
+
+val prefer_last_good
+  :  flow_preference_store
+  -> flow_scope
+  -> candidate_identity:('candidate -> flow_candidate_identity)
+  -> 'candidate list
+  -> 'candidate list * flow_preference_observation
+
+val settle_domain
+  :  Exact_output_flow.domain_settlement
+  -> flow_preference_store
+  -> flow_scope
+  -> candidate:flow_candidate_identity
+  -> domain_disposition
+  -> (domain_settlement_receipt, domain_settlement_error) result

--- a/lib/llm_provider/exact_output_provider_trace.ml
+++ b/lib/llm_provider/exact_output_provider_trace.ml
@@ -1,0 +1,76 @@
+module Exec = Exact_output_execution
+
+type t =
+  { fingerprint : string
+  ; http_status : int
+  ; response_header_evidence_fingerprint : string
+  ; raw_response_body_sha256 : string
+  ; response_id : string option
+  ; response_model : string option
+  }
+
+type raw_response =
+  { body : string
+  ; body_sha256 : string
+  }
+
+let fingerprint trace = trace.fingerprint
+let equal left right = String.equal left.fingerprint right.fingerprint
+
+let rec record_once state trace =
+  match Atomic.get state with
+  | Some existing when equal existing trace -> ()
+  | Some _ -> invalid_arg "Exact_output: provider trace changed after installation"
+  | None ->
+    if not (Atomic.compare_and_set state None (Some trace)) then record_once state trace
+;;
+
+let raw_response (evidence : Exec.raw_response_evidence) =
+  { body = evidence.raw_body; body_sha256 = evidence.raw_body_sha256 }
+;;
+
+let of_evidence ?response receipt (evidence : Exec.raw_response_evidence) =
+  let http_status =
+    match Exec.receipt_http_status receipt with
+    | Some status -> status
+    | None -> invalid_arg "Exact_output: response evidence without HTTP status"
+  in
+  let response_id, response_model =
+    match response with
+    | None -> None, None
+    | Some (response : Types.api_response) -> Some response.id, Some response.model
+  in
+  let response_header_evidence_fingerprint =
+    Http_client.response_header_evidence_fingerprint evidence.response_header_evidence
+  in
+  let payload =
+    `Assoc
+      [ "version", `Int 1
+      ; "http_status", `Int http_status
+      ; ( "response_header_evidence_fingerprint"
+        , `String response_header_evidence_fingerprint )
+      ; "raw_response_body_sha256", `String evidence.raw_body_sha256
+      ; ( "response_id"
+        , match response_id with
+          | None -> `Null
+          | Some value -> `String value )
+      ; ( "response_model"
+        , match response_model with
+          | None -> `Null
+          | Some value -> `String value )
+      ]
+  in
+  let fingerprint =
+    payload
+    |> Yojson.Safe.to_string
+    |> Digestif.SHA256.digest_string
+    |> Digestif.SHA256.to_hex
+  in
+  { fingerprint
+  ; http_status
+  ; response_header_evidence_fingerprint
+  ; raw_response_body_sha256 = evidence.raw_body_sha256
+  ; response_id
+  ; response_model
+  }
+;;

--- a/lib/llm_provider/exact_output_provider_trace.mli
+++ b/lib/llm_provider/exact_output_provider_trace.mli
@@ -1,0 +1,19 @@
+(** Private construction of immutable exact-output response provenance. *)
+
+type t
+
+type raw_response =
+  { body : string
+  ; body_sha256 : string
+  }
+
+val of_evidence
+  :  ?response:Types.api_response
+  -> Exact_output_execution.one_dispatch_receipt
+  -> Exact_output_execution.raw_response_evidence
+  -> t
+
+val fingerprint : t -> string
+val equal : t -> t -> bool
+val raw_response : Exact_output_execution.raw_response_evidence -> raw_response
+val record_once : t option Atomic.t -> t -> unit

--- a/scripts/check-exact-output-resolver-boundary.sh
+++ b/scripts/check-exact-output-resolver-boundary.sh
@@ -180,7 +180,8 @@ scan_cli_common_env_usage() {
 extract_named_functions() {
   local source_file="$1"
   local names="$2"
-  awk -v names="$names" '
+  strip_ocaml_noncode < "$source_file" \
+    | awk -v names="$names" '
     BEGIN {
       count = split(names, requested, /[[:space:]]+/)
       for (i = 1; i <= count; i++) {
@@ -213,7 +214,7 @@ extract_named_functions() {
       }
       if (missing) exit 3
     }
-  ' "$source_file"
+  '
 }
 
 scan_named_functions() {
@@ -245,7 +246,8 @@ scan_named_functions() {
 exclude_named_functions() {
   local source_file="$1"
   local names="$2"
-  awk -v names="$names" '
+  strip_ocaml_noncode < "$source_file" \
+    | awk -v names="$names" '
     BEGIN {
       count = split(names, requested, /[[:space:]]+/)
       for (i = 1; i <= count; i++) {
@@ -278,7 +280,7 @@ exclude_named_functions() {
       }
       if (missing) exit 3
     }
-  ' "$source_file"
+  '
 }
 
 scan_outside_named_functions() {
@@ -334,14 +336,15 @@ require_named_function_pattern() {
   local pattern="$2"
   local source_file="$3"
   local name="$4"
-  local extracted
+  local extracted compact
   extracted="$(mktemp)"
   if ! extract_named_functions "$source_file" "$name" > "$extracted"; then
     rm -f "$extracted"
     echo "exact-output boundary violation: $description" >&2
     return 1
   fi
-  if ! strip_ocaml_noncode < "$extracted" | grep -E -- "$pattern" >/dev/null; then
+  compact="$(awk '{ printf "%s ", $0 } END { print "" }' "$extracted")"
+  if ! grep -E -- "$pattern" <<< "$compact" >/dev/null; then
     rm -f "$extracted"
     echo "exact-output boundary violation: $description" >&2
     return 1

--- a/scripts/check-exact-output-resolver-boundary.sh
+++ b/scripts/check-exact-output-resolver-boundary.sh
@@ -965,6 +965,18 @@ require_code_sequence \
   'type[[:space:]]+flow_preference_store.*type[[:space:]]+flow_scope' \
   "$exact_output_interface"
 require_code_sequence \
+  "outer exact-flow preference store lost its mandatory hard capacity" \
+  'val[[:space:]]+create_flow_preference_store[[:space:]]*:[[:space:]]*capacity:int[[:space:]]*->[[:space:]]*\(flow_preference_store,[[:space:]]*flow_preference_store_error\)[[:space:]]*result' \
+  "$exact_output_interface"
+require_code_sequence \
+  "outer exact-flow snapshot lost typed capacity exhaustion" \
+  'type[[:space:]]+flow_snapshot_error.*Flow_preference_capacity_exhausted[[:space:]]+of[[:space:]]*\{[[:space:]]*capacity[[:space:]]*:[[:space:]]*int' \
+  "$exact_output_interface"
+require_code_sequence \
+  "outer exact-flow preference lost explicit scope removal" \
+  'val[[:space:]]+remove_flow_preference_scope[[:space:]]*:[[:space:]]*flow_preference_store[[:space:]]*->[[:space:]]*flow_scope[[:space:]]*->[[:space:]]*flow_preference_scope_removal' \
+  "$exact_output_interface"
+require_code_sequence \
   "outer exact-flow attempt receipt lost its opaque scope binding" \
   'type[[:space:]]+flow_attempt_receipt[[:space:]]*=[[:space:]]*private.*scope[[:space:]]*:.*flow_scope.*visit.*receipt' \
   "$exact_output_interface"
@@ -987,15 +999,45 @@ require_code_sequence \
   "$exact_output_interface"
 require_code_sequence \
   "outer exact flow lost typed domain settlement" \
-  'type[[:space:]]+domain_disposition.*type[[:space:]]+domain_settlement_receipt.*Domain_rejected_recorded.*Domain_valid_preference_installed.*Domain_valid_preference_superseded.*val[[:space:]]+settle_flow_domain' \
+  'type[[:space:]]+domain_disposition.*type[[:space:]]+domain_settlement_receipt[[:space:]]*=[[:space:]]*private.*Domain_rejected_recorded.*Domain_valid_preference_installed.*Domain_valid_preference_superseded.*val[[:space:]]+settle_flow_domain' \
   "$exact_output_interface"
+require_code_sequence \
+  "private exact-flow contract exposed forgeable domain settlement receipts" \
+  'type[[:space:]]+domain_settlement_receipt[[:space:]]*=[[:space:]]*private' \
+  "$module_dir/exact_output_flow_contract.mli"
+scan_code \
+  "domain-valid settlement regained caller-forgeable freshness" \
+  'Domain_valid[[:space:]]+of|success_time_unix_s|current_success_time_unix_s' \
+  "$exact_output_source" \
+  "$exact_output_interface" \
+  "$exact_output_flow_source" \
+  "$module_dir/exact_output_flow.mli" \
+  "$exact_output_flow_contract_source" \
+  "$module_dir/exact_output_flow_contract.mli"
+require_code_sequence \
+  "outer exact-flow structural success lost its opaque OAS-owned ordinal" \
+  'type[[:space:]]+flow_success_ordinal.*val[[:space:]]+flow_success_ordinal[[:space:]]*:[[:space:]]*flow_success[[:space:]]*->[[:space:]]*flow_success_ordinal' \
+  "$exact_output_interface"
+require_named_function_pattern \
+  "outer exact-flow structural success stopped allocating its OAS-owned ordinal" \
+  'allocate_flow_success_ordinal[[:space:]]+flow[.]preferences' \
+  "$exact_output_source" \
+  "execute_flow_once"
 scan_code \
   "outer exact flow exposed forgeable structural success settlement state" \
   'type[[:space:]]+flow_success[[:space:]]*=' \
   "$exact_output_interface"
 require_code_sequence \
-  "scope-local preference can be overwritten by stale success evidence" \
-  'Int64\.compare[[:space:]]+time[[:space:]]+current_time[[:space:]]*<=[[:space:]]*0' \
+  "scope-local preference can be overwritten by an older success ordinal" \
+  'compare_success_ordinal[[:space:]]+ordinal[[:space:]]+current_ordinal[[:space:]]*<=[[:space:]]*0' \
+  "$exact_output_flow_source"
+require_code_sequence \
+  "scope-local preference lost snapshot reservation generation validation" \
+  'entry[.]reservation[[:space:]]*!=[[:space:]]*reservation' \
+  "$exact_output_flow_source"
+require_code_sequence \
+  "scope-local preference stopped failing closed on ordinal exhaustion" \
+  'let[[:space:]]+allocate_success_ordinal.*Int64[.]max_int.*Int64[.]succ' \
   "$exact_output_flow_source"
 require_code_sequence \
   "domain settlement lost its linearized commit-before-publication gate" \

--- a/scripts/check-exact-output-resolver-boundary.sh
+++ b/scripts/check-exact-output-resolver-boundary.sh
@@ -1048,10 +1048,20 @@ require_named_function_pattern \
   'claim_domain_settlement[[:space:]]+settlement.*record_preference' \
   "$exact_output_flow_source" \
   "settle_domain_valid_once"
+scan_named_functions \
+  "domain settlement regained a blocking mutex" \
+  'Mutex[.]' \
+  "$exact_output_flow_source" \
+  "claim_domain_settlement settle_domain_rejected_once settle_domain_valid_once"
 scan_code \
   "domain settlement regained a per-success blocking mutex" \
   'settlement[.]mutex|type[[:space:]]+domain_settlement[[:space:]]*=[[:space:]]*\{[^}]*Mutex[.]t' \
   "$exact_output_flow_source"
+require_named_function_pattern \
+  "preference capacity check and reservation add are no longer atomic" \
+  'with_preference_lock[[:space:]]+store.*Hashtbl[.]length[[:space:]]+store[.]entries.*Hashtbl[.]add[[:space:]]+store[.]entries' \
+  "$exact_output_flow_source" \
+  "reserve_preference_scope"
 scan_code \
   "outer exact flow revived a legacy attempt or admission alias" \
   'candidate_attempt_count|admission_rejection|ready_flow|admit_flow' \

--- a/scripts/check-exact-output-resolver-boundary.sh
+++ b/scripts/check-exact-output-resolver-boundary.sh
@@ -6,6 +6,7 @@ trap 'status=$?; printf "exact-output resolver boundary ratchet aborted at line 
 required_basenames=(
   exact_output.ml
   exact_output_flow.ml
+  exact_output_flow_contract.ml
   exact_output_resolver.ml
   exact_output_catalog_binding.ml
   exact_output_plan.ml

--- a/scripts/check-exact-output-resolver-boundary.sh
+++ b/scripts/check-exact-output-resolver-boundary.sh
@@ -775,6 +775,7 @@ for private_module in \
   exact_output_plan \
   exact_output_execution \
   exact_output_flow \
+  exact_output_provider_trace \
   exact_output_resolver \
   exact_output_catalog_binding
 do
@@ -933,7 +934,7 @@ require_code_sequence \
   "$exact_output_interface"
 require_code_sequence \
   "execution receipt no longer stores the immutable visit" \
-  'type[[:space:]]+flow_attempt_receipt[[:space:]]*=[[:space:]]*\{[^}]*visit[[:space:]]*:[[:space:]]*flow_candidate_visit' \
+  'type[[:space:]]+flow_attempt_receipt[[:space:]]*=[[:space:]]*\{[^}]*scope[[:space:]]*:[[:space:]]*flow_scope[^}]*visit[[:space:]]*:[[:space:]]*flow_candidate_visit' \
   "$exact_output_interface"
 require_code_sequence \
   "outer exact flow start stopped failing closed on identity allocation" \
@@ -953,6 +954,43 @@ require_opaque_type \
   "outer exact flow lost typed candidate-rejection receipts" \
   "$exact_output_interface" \
   candidate_rejection_receipt
+require_code_sequence \
+  "outer exact flow lost explicit scope-local preference ownership" \
+  'type[[:space:]]+flow_preference_store.*type[[:space:]]+flow_scope' \
+  "$exact_output_interface"
+require_code_sequence \
+  "outer exact-flow attempt receipt lost its opaque scope binding" \
+  'type[[:space:]]+flow_attempt_receipt.*scope[[:space:]]*:.*flow_scope.*visit.*receipt' \
+  "$exact_output_interface"
+require_code_sequence \
+  "outer exact-flow evidence lost its opaque scope binding" \
+  'type[[:space:]]+flow_evidence.*flow_id[[:space:]]*:.*scope[[:space:]]*:.*flow_scope.*candidate_snapshot' \
+  "$exact_output_interface"
+require_code_sequence \
+  "candidate rejection lost its opaque scope projection" \
+  'val[[:space:]]+candidate_rejection_scope[[:space:]]*:' \
+  "$exact_output_interface"
+require_code_sequence \
+  "outer exact flow lost typed domain settlement" \
+  'type[[:space:]]+domain_disposition.*val[[:space:]]+settle_flow_domain' \
+  "$exact_output_interface"
+scan_code \
+  "outer exact flow exposed forgeable structural success settlement state" \
+  'type[[:space:]]+flow_success[[:space:]]*=' \
+  "$exact_output_interface"
+require_code_sequence \
+  "scope-local preference can be overwritten by stale success evidence" \
+  'Int64\.compare[[:space:]]+time[[:space:]]+current_time[[:space:]]*<=[[:space:]]*0' \
+  "$exact_output_flow_source"
+require_code_sequence \
+  "domain settlement lost its linearized commit-before-publication gate" \
+  'let[[:space:]]+settle_domain_once.*Mutex\.lock.*commit[[:space:]]*\(\).*settled[[:space:]]*<-[[:space:]]*true' \
+  "$exact_output_flow_source"
+scan_code \
+  "outer exact-flow preference acquired an implicit clock or environment policy" \
+  'Unix\.gettimeofday|Sys\.getenv|Eio\.Time\.now' \
+  "$exact_output_source" \
+  "$exact_output_flow_source"
 require_code_pattern \
   "candidate rejection is no longer fixed at Before_dispatch" \
   'let[[:space:]]+candidate_rejection_phase[[:space:]]+_[[:space:]]*=[[:space:]]*Before_dispatch' \

--- a/scripts/check-exact-output-resolver-boundary.sh
+++ b/scripts/check-exact-output-resolver-boundary.sh
@@ -526,6 +526,7 @@ scan_public_error_accessors() {
 
 exact_output_source=""
 exact_output_flow_source=""
+exact_output_flow_contract_source=""
 resolver_source=""
 catalog_binding_source=""
 exact_output_plan_source=""
@@ -536,6 +537,10 @@ for source_file in "${source_files[@]}"; do
     exact_output.ml) exact_output_source="$source_file" ;;
     exact_output_flow.ml)
       exact_output_flow_source="$source_file"
+      downstream_sources+=("$source_file")
+      ;;
+    exact_output_flow_contract.ml)
+      exact_output_flow_contract_source="$source_file"
       downstream_sources+=("$source_file")
       ;;
     exact_output_resolver.ml) resolver_source="$source_file" ;;
@@ -935,7 +940,7 @@ require_code_sequence \
   "$exact_output_interface"
 require_code_sequence \
   "execution receipt no longer stores the immutable visit" \
-  'type[[:space:]]+flow_attempt_receipt[[:space:]]*=[[:space:]]*\{[^}]*scope[[:space:]]*:[[:space:]]*flow_scope[^}]*visit[[:space:]]*:[[:space:]]*flow_candidate_visit' \
+  'type[[:space:]]+flow_attempt_receipt[[:space:]]*=[[:space:]]*private[[:space:]]*\{[^}]*scope[[:space:]]*:[[:space:]]*flow_scope[^}]*visit[[:space:]]*:[[:space:]]*flow_candidate_visit' \
   "$exact_output_interface"
 require_code_sequence \
   "outer exact flow start stopped failing closed on identity allocation" \
@@ -974,7 +979,7 @@ require_code_sequence \
 require_named_function_pattern \
   "scope-local preference stopped requiring opaque target binding equality" \
   'target_identity_fingerprint' \
-  "$exact_output_source" \
+  "$exact_output_flow_contract_source" \
   "target_binding_equal"
 require_code_sequence \
   "candidate rejection lost its opaque scope projection" \
@@ -1001,12 +1006,14 @@ scan_code \
   'candidate_attempt_count|admission_rejection|ready_flow|admit_flow' \
   "$exact_output_source" \
   "$exact_output_interface" \
-  "$exact_output_flow_source"
+  "$exact_output_flow_source" \
+  "$exact_output_flow_contract_source"
 scan_code \
   "outer exact-flow preference acquired an implicit clock or environment policy" \
   'Unix\.gettimeofday|Sys\.getenv|Eio\.Time\.now' \
   "$exact_output_source" \
-  "$exact_output_flow_source"
+  "$exact_output_flow_source" \
+  "$exact_output_flow_contract_source"
 require_code_pattern \
   "candidate rejection is no longer fixed at Before_dispatch" \
   'let[[:space:]]+candidate_rejection_phase[[:space:]]+_[[:space:]]*=[[:space:]]*Before_dispatch' \

--- a/scripts/check-exact-output-resolver-boundary.sh
+++ b/scripts/check-exact-output-resolver-boundary.sh
@@ -960,19 +960,28 @@ require_code_sequence \
   "$exact_output_interface"
 require_code_sequence \
   "outer exact-flow attempt receipt lost its opaque scope binding" \
-  'type[[:space:]]+flow_attempt_receipt.*scope[[:space:]]*:.*flow_scope.*visit.*receipt' \
+  'type[[:space:]]+flow_attempt_receipt[[:space:]]*=[[:space:]]*private.*scope[[:space:]]*:.*flow_scope.*visit.*receipt' \
   "$exact_output_interface"
 require_code_sequence \
   "outer exact-flow evidence lost its opaque scope binding" \
-  'type[[:space:]]+flow_evidence.*flow_id[[:space:]]*:.*scope[[:space:]]*:.*flow_scope.*candidate_snapshot' \
+  'type[[:space:]]+flow_evidence[[:space:]]*=[[:space:]]*private.*flow_id[[:space:]]*:.*scope[[:space:]]*:.*flow_scope.*declared_candidate_snapshot.*candidate_snapshot.*preference_observation' \
   "$exact_output_interface"
+require_code_sequence \
+  "outer exact flow lost its closed preference observation" \
+  'type[[:space:]]+flow_preference_observation.*No_preference_recorded.*Preference_applied.*Preference_not_applied' \
+  "$exact_output_interface"
+require_named_function_pattern \
+  "scope-local preference stopped requiring opaque target binding equality" \
+  'target_identity_fingerprint' \
+  "$exact_output_source" \
+  "target_binding_equal"
 require_code_sequence \
   "candidate rejection lost its opaque scope projection" \
   'val[[:space:]]+candidate_rejection_scope[[:space:]]*:' \
   "$exact_output_interface"
 require_code_sequence \
   "outer exact flow lost typed domain settlement" \
-  'type[[:space:]]+domain_disposition.*val[[:space:]]+settle_flow_domain' \
+  'type[[:space:]]+domain_disposition.*type[[:space:]]+domain_settlement_receipt.*Domain_rejected_recorded.*Domain_valid_preference_installed.*Domain_valid_preference_superseded.*val[[:space:]]+settle_flow_domain' \
   "$exact_output_interface"
 scan_code \
   "outer exact flow exposed forgeable structural success settlement state" \
@@ -984,7 +993,13 @@ require_code_sequence \
   "$exact_output_flow_source"
 require_code_sequence \
   "domain settlement lost its linearized commit-before-publication gate" \
-  'let[[:space:]]+settle_domain_once.*Mutex\.lock.*commit[[:space:]]*\(\).*settled[[:space:]]*<-[[:space:]]*true' \
+  'let[[:space:]]+settle_domain_valid_once.*Mutex\.lock.*record_preference.*settled[[:space:]]*<-[[:space:]]*true' \
+  "$exact_output_flow_source"
+scan_code \
+  "outer exact flow revived a legacy attempt or admission alias" \
+  'candidate_attempt_count|admission_rejection|ready_flow|admit_flow' \
+  "$exact_output_source" \
+  "$exact_output_interface" \
   "$exact_output_flow_source"
 scan_code \
   "outer exact-flow preference acquired an implicit clock or environment policy" \

--- a/scripts/check-exact-output-resolver-boundary.sh
+++ b/scripts/check-exact-output-resolver-boundary.sh
@@ -1040,8 +1040,17 @@ require_code_sequence \
   'let[[:space:]]+allocate_success_ordinal.*Int64[.]max_int.*Int64[.]succ' \
   "$exact_output_flow_source"
 require_code_sequence \
-  "domain settlement lost its linearized commit-before-publication gate" \
-  'let[[:space:]]+settle_domain_valid_once.*Mutex\.lock.*record_preference.*settled[[:space:]]*<-[[:space:]]*true' \
+  "domain settlement lost its affine atomic gate" \
+  'type[[:space:]]+domain_settlement[[:space:]]*=[[:space:]]*bool[[:space:]]+Atomic[.]t.*let[[:space:]]+claim_domain_settlement.*Atomic[.]compare_and_set[[:space:]]+settlement[[:space:]]+false[[:space:]]+true' \
+  "$exact_output_flow_source"
+require_named_function_pattern \
+  "domain-valid settlement stopped consuming its affine gate before recording preference" \
+  'claim_domain_settlement[[:space:]]+settlement.*record_preference' \
+  "$exact_output_flow_source" \
+  "settle_domain_valid_once"
+scan_code \
+  "domain settlement regained a per-success blocking mutex" \
+  'settlement[.]mutex|type[[:space:]]+domain_settlement[[:space:]]*=[[:space:]]*\{[^}]*Mutex[.]t' \
   "$exact_output_flow_source"
 scan_code \
   "outer exact flow revived a legacy attempt or admission alias" \

--- a/scripts/check-exact-output-resolver-boundary.sh
+++ b/scripts/check-exact-output-resolver-boundary.sh
@@ -1042,24 +1042,11 @@ require_code_sequence \
   "scope-local preference stopped failing closed on ordinal exhaustion" \
   'let[[:space:]]+allocate_success_ordinal.*Int64[.]max_int.*Int64[.]succ' \
   "$exact_output_flow_source"
-require_code_sequence \
-  "domain settlement lost its affine atomic gate" \
-  'type[[:space:]]+domain_settlement[[:space:]]*=[[:space:]]*bool[[:space:]]+Atomic[.]t.*let[[:space:]]+claim_domain_settlement.*Atomic[.]compare_and_set[[:space:]]+settlement[[:space:]]+false[[:space:]]+true' \
-  "$exact_output_flow_source"
 require_named_function_pattern \
-  "domain-valid settlement stopped consuming its affine gate before recording preference" \
-  'claim_domain_settlement[[:space:]]+settlement.*record_preference' \
+  "domain settlement lost its synchronized commit-before-publication gate" \
+  'Mutex[.]lock[[:space:]]+settlement[.]mutex.*Fun[.]protect.*Mutex[.]unlock[[:space:]]+settlement[.]mutex.*record_preference.*settled[[:space:]]*<-[[:space:]]*true' \
   "$exact_output_flow_source" \
   "settle_domain_valid_once"
-scan_named_functions \
-  "domain settlement regained a blocking mutex" \
-  'Mutex[.]' \
-  "$exact_output_flow_source" \
-  "claim_domain_settlement settle_domain_rejected_once settle_domain_valid_once"
-scan_code \
-  "domain settlement regained a per-success blocking mutex" \
-  'settlement[.]mutex|type[[:space:]]+domain_settlement[[:space:]]*=[[:space:]]*\{[^}]*Mutex[.]t' \
-  "$exact_output_flow_source"
 require_named_function_pattern \
   "preference capacity check and reservation add are no longer atomic" \
   'with_preference_lock[[:space:]]+store.*Hashtbl[.]length[[:space:]]+store[.]entries.*Hashtbl[.]add[[:space:]]+store[.]entries' \

--- a/test/dune
+++ b/test/dune
@@ -440,6 +440,8 @@
   ../lib/llm_provider/exact_output.mli
   ../lib/llm_provider/exact_output_flow.ml
   ../lib/llm_provider/exact_output_flow.mli
+  ../lib/llm_provider/exact_output_flow_contract.ml
+  ../lib/llm_provider/exact_output_flow_contract.mli
   ../lib/llm_provider/exact_output_resolver.ml
   ../lib/llm_provider/exact_output_resolver.mli
   ../lib/llm_provider/exact_output_catalog_binding.ml
@@ -462,6 +464,7 @@
    %{dep:../scripts/check-exact-output-resolver-boundary.sh}
    %{dep:../lib/llm_provider/exact_output.ml}
    %{dep:../lib/llm_provider/exact_output_flow.ml}
+   %{dep:../lib/llm_provider/exact_output_flow_contract.ml}
    %{dep:../lib/llm_provider/exact_output_resolver.ml}
    %{dep:../lib/llm_provider/exact_output_catalog_binding.ml}
    %{dep:../lib/llm_provider/exact_output_plan.ml}

--- a/test/test_exact_output_flow.ml
+++ b/test/test_exact_output_flow.ml
@@ -614,12 +614,18 @@ let test_concurrent_domain_settlement_has_one_winner () =
     let left, right, future_order = result in
     left, right, future_order, posts
   in
-  let settled = function
-    | Ok (EO.Domain_valid_preference_installed _) -> true
-    | Ok (EO.Domain_rejected_recorded | EO.Domain_valid_preference_superseded _) -> false
-    | Error (EO.Domain_already_settled | EO.Domain_preference_scope_released) -> false
+  let settlement_class = function
+    | Ok (EO.Domain_valid_preference_installed _) -> `Installed
+    | Error EO.Domain_already_settled -> `Already_settled
+    | Ok EO.Domain_rejected_recorded -> `Rejected
+    | Ok (EO.Domain_valid_preference_superseded _) -> `Superseded
+    | Error EO.Domain_preference_scope_released -> `Scope_released
   in
-  check bool "exactly one concurrent settlement wins" true (settled left <> settled right);
+  (match settlement_class left, settlement_class right with
+   | `Installed, `Already_settled | `Already_settled, `Installed -> ()
+   | _ ->
+     fail
+       "concurrent settlement did not return exactly one installed receipt and one already-settled error");
   check
     (list string)
     "winning settlement updates future snapshot once"

--- a/test/test_exact_output_flow.ml
+++ b/test/test_exact_output_flow.ml
@@ -148,25 +148,34 @@ let flow_scope id =
   | Error EO.Blank_flow_scope_id -> fail "fixture flow scope was blank"
 ;;
 
-let frozen_candidates
-      ?(preferences = EO.create_flow_preference_store ())
-      ?(scope = flow_scope "test-default")
-      candidates
-  =
+let preference_store ?(capacity = 16) () =
+  match EO.create_flow_preference_store ~capacity with
+  | Ok preferences -> preferences
+  | Error (EO.Invalid_flow_preference_capacity invalid) ->
+    failf "fixture preference capacity was invalid: %d" invalid
+;;
+
+let snapshot_candidates ~preferences ~scope candidates =
   match candidates with
   | [] -> fail "flow fixture must be nonempty"
   | first :: rest ->
-    (match
-       EO.snapshot_flow
-         ~preferences
-         ~scope
-         ~first
-         ~rest
-         ~messages:[ msg "return one exact object" ]
-         (EO.make_output_requirement ~schema ~minimum_guarantee:EO.Json_syntax)
-     with
-     | Ok ready -> ready
-     | Error _ -> fail "flow fixture did not admit")
+    EO.snapshot_flow
+      ~preferences
+      ~scope
+      ~first
+      ~rest
+      ~messages:[ msg "return one exact object" ]
+      (EO.make_output_requirement ~schema ~minimum_guarantee:EO.Json_syntax)
+;;
+
+let frozen_candidates
+      ?(preferences = preference_store ())
+      ?(scope = flow_scope "test-default")
+      candidates
+  =
+  match snapshot_candidates ~preferences ~scope candidates with
+  | Ok ready -> ready
+  | Error _ -> fail "flow fixture did not admit"
 ;;
 
 let frozen_flow ?preferences ?scope snapshot ids =
@@ -294,7 +303,7 @@ let test_scope_local_domain_valid_preference_changes_only_future_snapshots () =
       ; catalog_entry ~id:"preferred-b" ~base_url ~native:true ~json:true ()
       ]
     @@ fun snapshot ->
-    let preferences = EO.create_flow_preference_store () in
+    let preferences = preference_store () in
     let primary_scope = flow_scope "/runtime/keeper-primary" in
     let other_scope = flow_scope "/runtime/keeper-other" in
     let existing =
@@ -318,6 +327,7 @@ let test_scope_local_domain_valid_preference_changes_only_future_snapshots () =
     | Ok success ->
       let candidate = EO.flow_success_candidate success in
       let evidence = EO.flow_success_evidence success in
+      let success_ordinal = EO.flow_success_ordinal success in
       check
         bool
         "success receipt carries primary scope"
@@ -329,18 +339,23 @@ let test_scope_local_domain_valid_preference_changes_only_future_snapshots () =
         true
         (EO.flow_scope_equal primary_scope evidence.scope);
       let success_id = candidate_id candidate in
-      let settlement =
-        EO.settle_flow_domain success (EO.Domain_valid { success_time_unix_s = 42L })
-      in
+      let settlement = EO.settle_flow_domain success EO.Domain_valid in
       (match settlement with
        | Ok
-           (EO.Domain_valid_preference_installed { candidate; success_time_unix_s = 42L })
-         ->
+           (EO.Domain_valid_preference_installed
+              { candidate; success_ordinal = installed_ordinal }) ->
          check
            string
            "installed preference candidate"
            "preferred-b"
-           candidate.candidate_id
+           candidate.candidate_id;
+         check
+           bool
+           "installed preference carries OAS-owned success ordinal"
+           true
+           (Int64.equal
+              (EO.flow_success_ordinal_to_int64 success_ordinal)
+              (EO.flow_success_ordinal_to_int64 installed_ordinal))
        | Ok _ | Error _ -> fail "domain-valid preference was not installed exactly");
       let future =
         frozen_flow
@@ -369,10 +384,17 @@ let test_scope_local_domain_valid_preference_changes_only_future_snapshots () =
        | EO.Preference_applied _ | EO.Preference_not_applied _ ->
          fail "pre-existing snapshot observed a later preference");
       (match future_evidence.preference_observation with
-       | EO.Preference_applied { candidate; success_time_unix_s = 42L } ->
-         check string "applied observation candidate" "preferred-b" candidate.candidate_id
-       | EO.No_preference_recorded | EO.Preference_not_applied _ | EO.Preference_applied _
-         -> fail "future snapshot did not freeze the applied preference");
+       | EO.Preference_applied { candidate; success_ordinal = observed_ordinal } ->
+         check string "applied observation candidate" "preferred-b" candidate.candidate_id;
+         check
+           bool
+           "applied observation freezes the successful ordinal"
+           true
+           (Int64.equal
+              (EO.flow_success_ordinal_to_int64 success_ordinal)
+              (EO.flow_success_ordinal_to_int64 observed_ordinal))
+       | EO.No_preference_recorded | EO.Preference_not_applied _ ->
+         fail "future snapshot did not freeze the applied preference");
       (match other_scope_evidence.preference_observation with
        | EO.No_preference_recorded -> ()
        | EO.Preference_applied _ | EO.Preference_not_applied _ ->
@@ -411,7 +433,7 @@ let test_concurrent_flow_scopes_isolate_attempts_and_future_preferences () =
         ; catalog_entry ~id:"scope-b" ~base_url ~native:true ~json:true ()
         ]
       @@ fun snapshot ->
-      let preferences = EO.create_flow_preference_store () in
+      let preferences = preference_store () in
       let scope_a = flow_scope "/runtime/concurrent-a" in
       let scope_b = flow_scope "/runtime/concurrent-b" in
       let flow_a =
@@ -445,16 +467,15 @@ let test_concurrent_flow_scopes_isolate_attempts_and_future_preferences () =
         "second attempt stays in second scope"
         true
         (EO.flow_scope_equal scope_b candidate_b.scope);
-      let settle success time =
-        match
-          EO.settle_flow_domain success (EO.Domain_valid { success_time_unix_s = time })
-        with
+      let settle success =
+        match EO.settle_flow_domain success EO.Domain_valid with
         | Ok (EO.Domain_valid_preference_installed _) -> ()
         | Ok (EO.Domain_rejected_recorded | EO.Domain_valid_preference_superseded _) ->
           fail "fresh scoped success returned the wrong settlement receipt"
-        | Error EO.Domain_already_settled -> fail "fresh scoped success was settled twice"
+        | Error (EO.Domain_already_settled | EO.Domain_preference_scope_released) ->
+          fail "fresh scoped success could not settle"
       in
-      Eio.Fiber.both (fun () -> settle success_a 200L) (fun () -> settle success_b 200L);
+      Eio.Fiber.both (fun () -> settle success_a) (fun () -> settle success_b);
       let call_id candidate =
         EO.receipt_call_id candidate.EO.receipt |> EO.call_id_to_string
       in
@@ -491,7 +512,7 @@ let test_domain_rejection_never_updates_preference_and_settlement_is_affine () =
         ; catalog_entry ~id:"declared-b" ~base_url ~native:true ~json:true ()
         ]
       @@ fun snapshot ->
-      let preferences = EO.create_flow_preference_store () in
+      let preferences = preference_store () in
       let scope = flow_scope "/runtime/domain-rejected" in
       match
         frozen_flow ~preferences ~scope snapshot [ "rejected-a"; "declared-b" ]
@@ -505,9 +526,7 @@ let test_domain_rejection_never_updates_preference_and_settlement_is_affine () =
           |> flow_snapshot_ids
         in
         let first_settlement = EO.settle_flow_domain success EO.Domain_rejected in
-        let duplicate_settlement =
-          EO.settle_flow_domain success (EO.Domain_valid { success_time_unix_s = 43L })
-        in
+        let duplicate_settlement = EO.settle_flow_domain success EO.Domain_valid in
         let after_settlement =
           frozen_flow ~preferences ~scope snapshot [ "declared-b"; "rejected-a" ]
           |> flow_snapshot_ids
@@ -530,13 +549,14 @@ let test_domain_rejection_never_updates_preference_and_settlement_is_affine () =
      | Ok EO.Domain_rejected_recorded -> true
      | Ok
          (EO.Domain_valid_preference_installed _ | EO.Domain_valid_preference_superseded _)
-     | Error EO.Domain_already_settled -> false);
+     | Error (EO.Domain_already_settled | EO.Domain_preference_scope_released) -> false);
   check
     bool
     "duplicate settlement is typed"
     true
     (match duplicate_settlement with
      | Error EO.Domain_already_settled -> true
+     | Error EO.Domain_preference_scope_released -> false
      | Ok
          ( EO.Domain_rejected_recorded
          | EO.Domain_valid_preference_installed _
@@ -559,7 +579,7 @@ let test_concurrent_domain_settlement_has_one_winner () =
         ; catalog_entry ~id:"declared-b" ~base_url ~native:true ~json:true ()
         ]
       @@ fun snapshot ->
-      let preferences = EO.create_flow_preference_store () in
+      let preferences = preference_store () in
       let scope = flow_scope "/runtime/concurrent-settlement" in
       match
         frozen_flow ~preferences ~scope snapshot [ "winner-a"; "declared-b" ]
@@ -570,15 +590,15 @@ let test_concurrent_domain_settlement_has_one_winner () =
       | Ok success ->
         let ready = Atomic.make 0 in
         let start = Atomic.make false in
-        let contend success_time_unix_s =
+        let contend () =
           ignore (Atomic.fetch_and_add ready 1);
           while not (Atomic.get start) do
             Domain.cpu_relax ()
           done;
-          EO.settle_flow_domain success (EO.Domain_valid { success_time_unix_s })
+          EO.settle_flow_domain success EO.Domain_valid
         in
-        let left_domain = Domain.spawn (fun () -> contend 44L) in
-        let right_domain = Domain.spawn (fun () -> contend 45L) in
+        let left_domain = Domain.spawn contend in
+        let right_domain = Domain.spawn contend in
         while Atomic.get ready <> 2 do
           Domain.cpu_relax ()
         done;
@@ -597,7 +617,7 @@ let test_concurrent_domain_settlement_has_one_winner () =
   let settled = function
     | Ok (EO.Domain_valid_preference_installed _) -> true
     | Ok (EO.Domain_rejected_recorded | EO.Domain_valid_preference_superseded _) -> false
-    | Error EO.Domain_already_settled -> false
+    | Error (EO.Domain_already_settled | EO.Domain_preference_scope_released) -> false
   in
   check bool "exactly one concurrent settlement wins" true (settled left <> settled right);
   check
@@ -608,65 +628,117 @@ let test_concurrent_domain_settlement_has_one_winner () =
   check int "concurrent-settlement proof dispatches once" 1 posts
 ;;
 
-let test_stale_domain_success_cannot_overwrite_newer_last_good () =
-  let (future_order, newer_receipt, stale_receipt), posts =
+let test_older_success_cannot_overwrite_newer_after_reversed_domain_settlement () =
+  let (future_order, newer_receipt, older_receipt, older_ordinal, newer_ordinal), posts =
     with_server ~response:(openai_response {|{"name":"accepted"}|})
     @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
     with_catalog
-      [ catalog_entry ~id:"stale-a" ~base_url ~native:true ~json:true ()
+      [ catalog_entry ~id:"older-a" ~base_url ~native:true ~json:true ()
       ; catalog_entry ~id:"newer-b" ~base_url ~native:true ~json:true ()
       ]
     @@ fun snapshot ->
-    let preferences = EO.create_flow_preference_store () in
+    let preferences = preference_store () in
     let scope = flow_scope "/runtime/out-of-order-success" in
-    let newer_flow =
-      frozen_flow ~preferences ~scope snapshot [ "newer-b"; "stale-a" ] |> start_flow
+    let older_flow =
+      frozen_flow ~preferences ~scope snapshot [ "older-a"; "newer-b" ] |> start_flow
     in
-    let stale_flow =
-      frozen_flow ~preferences ~scope snapshot [ "stale-a"; "newer-b" ] |> start_flow
+    let newer_flow =
+      frozen_flow ~preferences ~scope snapshot [ "newer-b"; "older-a" ] |> start_flow
     in
     let execute flow =
       match execute_ok ~net flow with
       | Error _ -> fail "out-of-order settlement fixture did not succeed"
       | Ok success -> success
     in
+    let older_success = execute older_flow in
     let newer_success = execute newer_flow in
-    let stale_success = execute stale_flow in
-    let newer_receipt =
-      EO.settle_flow_domain newer_success (EO.Domain_valid { success_time_unix_s = 100L })
+    let older_ordinal = EO.flow_success_ordinal older_success in
+    let newer_ordinal = EO.flow_success_ordinal newer_success in
+    let ready = Atomic.make 0 in
+    let start = Atomic.make false in
+    let newer_settled = Atomic.make false in
+    let await_start () =
+      ignore (Atomic.fetch_and_add ready 1);
+      while not (Atomic.get start) do
+        Domain.cpu_relax ()
+      done
     in
-    let stale_receipt =
-      EO.settle_flow_domain stale_success (EO.Domain_valid { success_time_unix_s = 99L })
+    let newer_domain =
+      Domain.spawn (fun () ->
+        await_start ();
+        let receipt = EO.settle_flow_domain newer_success EO.Domain_valid in
+        Atomic.set newer_settled true;
+        receipt)
     in
-    ( frozen_flow ~preferences ~scope snapshot [ "stale-a"; "newer-b" ]
+    let older_domain =
+      Domain.spawn (fun () ->
+        await_start ();
+        while not (Atomic.get newer_settled) do
+          Domain.cpu_relax ()
+        done;
+        EO.settle_flow_domain older_success EO.Domain_valid)
+    in
+    while Atomic.get ready <> 2 do
+      Domain.cpu_relax ()
+    done;
+    Atomic.set start true;
+    let newer_receipt = Domain.join newer_domain in
+    let older_receipt = Domain.join older_domain in
+    ( frozen_flow ~preferences ~scope snapshot [ "older-a"; "newer-b" ]
       |> flow_snapshot_ids
     , newer_receipt
-    , stale_receipt )
+    , older_receipt
+    , older_ordinal
+    , newer_ordinal )
   in
   check int "out-of-order settlement proof dispatches twice" 2 posts;
   check
+    bool
+    "structural success allocates strictly increasing OAS ordinals"
+    true
+    (Int64.compare
+       (EO.flow_success_ordinal_to_int64 older_ordinal)
+       (EO.flow_success_ordinal_to_int64 newer_ordinal)
+     < 0);
+  check
     (list string)
-    "older success time cannot overwrite newer last-good"
-    [ "newer-b"; "stale-a" ]
+    "later structural success survives reversed cross-domain settlement"
+    [ "newer-b"; "older-a" ]
     future_order;
   (match newer_receipt with
-   | Ok (EO.Domain_valid_preference_installed { candidate; success_time_unix_s = 100L })
-     -> check string "newer preference receipt candidate" "newer-b" candidate.candidate_id
+   | Ok
+       (EO.Domain_valid_preference_installed
+          { candidate; success_ordinal = installed_ordinal }) ->
+     check string "newer preference receipt candidate" "newer-b" candidate.candidate_id;
+     check
+       bool
+       "newer receipt carries its frozen ordinal"
+       true
+       (Int64.equal
+          (EO.flow_success_ordinal_to_int64 newer_ordinal)
+          (EO.flow_success_ordinal_to_int64 installed_ordinal))
    | Ok _ | Error _ -> fail "newer success did not install its preference");
-  match stale_receipt with
+  match older_receipt with
   | Ok
       (EO.Domain_valid_preference_superseded
-         { current_candidate; current_success_time_unix_s = 100L }) ->
+         { current_candidate; current_success_ordinal }) ->
     check
       string
-      "stale receipt names retained candidate"
+      "older receipt names retained candidate"
       "newer-b"
-      current_candidate.candidate_id
-  | Ok _ | Error _ -> fail "stale success was not reported as superseded"
+      current_candidate.candidate_id;
+    check
+      bool
+      "superseded receipt carries the retained ordinal"
+      true
+      (Int64.equal
+         (EO.flow_success_ordinal_to_int64 newer_ordinal)
+         (EO.flow_success_ordinal_to_int64 current_success_ordinal))
+  | Ok _ | Error _ -> fail "older success was not reported as superseded"
 ;;
 
 let test_rebound_preference_is_not_promoted_and_observation_is_typed () =
-  let (rebound_evidence, absent_evidence), posts =
+  let (success_ordinal, rebound_evidence, absent_evidence), posts =
     with_server ~response:(openai_response {|{"name":"accepted"}|})
     @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
     with_catalog
@@ -674,7 +746,7 @@ let test_rebound_preference_is_not_promoted_and_observation_is_typed () =
       ; catalog_entry ~id:"binding-b" ~base_url ~native:true ~json:true ()
       ]
     @@ fun snapshot ->
-    let preferences = EO.create_flow_preference_store () in
+    let preferences = preference_store () in
     let scope = flow_scope "/runtime/rebound-preference" in
     let successful =
       flow_candidate_as snapshot ~id:"stable-slot" ~target_ref:"binding-a"
@@ -686,11 +758,10 @@ let test_rebound_preference_is_not_promoted_and_observation_is_typed () =
       | Ok success -> success
       | Error _ -> fail "binding fixture did not structurally succeed"
     in
-    (match
-       EO.settle_flow_domain success (EO.Domain_valid { success_time_unix_s = 77L })
-     with
+    (match EO.settle_flow_domain success EO.Domain_valid with
      | Ok (EO.Domain_valid_preference_installed _) -> ()
      | Ok _ | Error _ -> fail "binding fixture did not install its preference");
+    let success_ordinal = EO.flow_success_ordinal success in
     let fallback = flow_candidate_as snapshot ~id:"fallback" ~target_ref:"binding-a" in
     let rebound = flow_candidate_as snapshot ~id:"stable-slot" ~target_ref:"binding-b" in
     let rebound_evidence =
@@ -700,7 +771,7 @@ let test_rebound_preference_is_not_promoted_and_observation_is_typed () =
     let absent_evidence =
       frozen_candidates ~preferences ~scope [ fallback ] |> flow_snapshot_evidence
     in
-    rebound_evidence, absent_evidence
+    success_ordinal, rebound_evidence, absent_evidence
   in
   check int "binding observation proof dispatches once" 1 posts;
   check
@@ -716,16 +787,33 @@ let test_rebound_preference_is_not_promoted_and_observation_is_typed () =
   (match rebound_evidence.preference_observation with
    | EO.Preference_not_applied
        { candidate
-       ; success_time_unix_s = 77L
+       ; success_ordinal = rebound_ordinal
        ; reason = EO.Preference_candidate_binding_changed
        } ->
-     check string "binding-changed observation slot" "stable-slot" candidate.candidate_id
+     check string "binding-changed observation slot" "stable-slot" candidate.candidate_id;
+     check
+       bool
+       "binding-changed observation keeps successful ordinal"
+       true
+       (Int64.equal
+          (EO.flow_success_ordinal_to_int64 success_ordinal)
+          (EO.flow_success_ordinal_to_int64 rebound_ordinal))
    | EO.No_preference_recorded | EO.Preference_applied _ | EO.Preference_not_applied _ ->
      fail "rebound target did not produce binding-changed evidence");
   match absent_evidence.preference_observation with
   | EO.Preference_not_applied
-      { candidate; success_time_unix_s = 77L; reason = EO.Preference_candidate_absent } ->
-    check string "absent observation slot" "stable-slot" candidate.candidate_id
+      { candidate
+      ; success_ordinal = absent_ordinal
+      ; reason = EO.Preference_candidate_absent
+      } ->
+    check string "absent observation slot" "stable-slot" candidate.candidate_id;
+    check
+      bool
+      "absent observation keeps successful ordinal"
+      true
+      (Int64.equal
+         (EO.flow_success_ordinal_to_int64 success_ordinal)
+         (EO.flow_success_ordinal_to_int64 absent_ordinal))
   | EO.No_preference_recorded | EO.Preference_applied _ | EO.Preference_not_applied _ ->
     fail "absent target did not produce typed evidence"
 ;;
@@ -734,6 +822,127 @@ let test_blank_flow_scope_is_rejected () =
   match EO.make_flow_scope ~id:" \n\t " with
   | Error EO.Blank_flow_scope_id -> ()
   | Ok _ -> fail "blank flow scope was accepted"
+;;
+
+let test_preference_store_capacity_is_typed_and_reusable_after_removal () =
+  (match EO.create_flow_preference_store ~capacity:0 with
+   | Error (EO.Invalid_flow_preference_capacity 0) -> ()
+   | Error (EO.Invalid_flow_preference_capacity invalid) ->
+     failf "zero capacity reported the wrong value: %d" invalid
+   | Ok _ -> fail "zero-capacity preference store was accepted");
+  with_catalog
+    [ catalog_entry
+        ~id:"capacity-candidate"
+        ~base_url:"http://127.0.0.1:1"
+        ~native:true
+        ~json:true
+        ()
+    ]
+  @@ fun snapshot ->
+  let preferences = preference_store ~capacity:1 () in
+  let scope_a = flow_scope "/runtime/capacity-a" in
+  let scope_b = flow_scope "/runtime/capacity-b" in
+  let candidates = [ flow_candidate snapshot "capacity-candidate" ] in
+  (match snapshot_candidates ~preferences ~scope:scope_a candidates with
+   | Ok _ -> ()
+   | Error _ -> fail "first scope did not reserve the only capacity slot");
+  (match snapshot_candidates ~preferences ~scope:scope_b candidates with
+   | Error (EO.Flow_preference_capacity_exhausted { capacity = 1 }) -> ()
+   | Error (EO.Flow_preference_capacity_exhausted { capacity }) ->
+     failf "capacity exhaustion reported the wrong bound: %d" capacity
+   | Error (EO.Duplicate_flow_candidate_id _) ->
+     fail "capacity exhaustion was reported as a duplicate candidate"
+   | Ok _ -> fail "second scope exceeded the hard preference capacity");
+  (match EO.remove_flow_preference_scope preferences scope_a with
+   | EO.Flow_preference_scope_removed -> ()
+   | EO.Flow_preference_scope_not_reserved ->
+     fail "reserved preference scope was not removable");
+  (match EO.remove_flow_preference_scope preferences scope_a with
+   | EO.Flow_preference_scope_not_reserved -> ()
+   | EO.Flow_preference_scope_removed -> fail "preference scope was removed twice");
+  match snapshot_candidates ~preferences ~scope:scope_b candidates with
+  | Ok _ -> ()
+  | Error _ -> fail "released capacity was not reusable by a new scope"
+;;
+
+let test_removed_scope_consumes_domain_valid_settlement_as_typed_failure () =
+  let settlement, duplicate, replacement_order, posts =
+    let result, posts =
+      with_server ~response:(openai_response {|{"name":"accepted"}|})
+      @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
+      with_catalog
+        [ catalog_entry ~id:"released-a" ~base_url ~native:true ~json:true ()
+        ; catalog_entry ~id:"replacement-b" ~base_url ~native:true ~json:true ()
+        ]
+      @@ fun snapshot ->
+      let preferences = preference_store ~capacity:1 () in
+      let released_scope = flow_scope "/runtime/released" in
+      let success =
+        match
+          frozen_flow
+            ~preferences
+            ~scope:released_scope
+            snapshot
+            [ "released-a"; "replacement-b" ]
+          |> start_flow
+          |> execute_ok ~net
+        with
+        | Ok success -> success
+        | Error _ -> fail "released-scope fixture did not structurally succeed"
+      in
+      (match EO.remove_flow_preference_scope preferences released_scope with
+       | EO.Flow_preference_scope_removed -> ()
+       | EO.Flow_preference_scope_not_reserved ->
+         fail "running flow's preference scope was not reserved");
+      let _replacement_generation =
+        frozen_flow
+          ~preferences
+          ~scope:released_scope
+          snapshot
+          [ "replacement-b"; "released-a" ]
+      in
+      let settlement = EO.settle_flow_domain success EO.Domain_valid in
+      let duplicate = EO.settle_flow_domain success EO.Domain_valid in
+      let after_stale_settlement =
+        frozen_flow
+          ~preferences
+          ~scope:released_scope
+          snapshot
+          [ "replacement-b"; "released-a" ]
+      in
+      settlement, duplicate, flow_snapshot_ids after_stale_settlement
+    in
+    let settlement, duplicate, replacement_order = result in
+    settlement, duplicate, replacement_order, posts
+  in
+  check int "released-scope proof dispatches once" 1 posts;
+  check
+    bool
+    "domain-valid settlement reports released scope"
+    true
+    (match settlement with
+     | Error EO.Domain_preference_scope_released -> true
+     | Error EO.Domain_already_settled
+     | Ok
+         ( EO.Domain_rejected_recorded
+         | EO.Domain_valid_preference_installed _
+         | EO.Domain_valid_preference_superseded _ ) -> false);
+  check
+    bool
+    "released-scope failure still consumes settlement"
+    true
+    (match duplicate with
+     | Error EO.Domain_already_settled -> true
+     | Error EO.Domain_preference_scope_released
+     | Ok
+         ( EO.Domain_rejected_recorded
+         | EO.Domain_valid_preference_installed _
+         | EO.Domain_valid_preference_superseded _ ) -> false);
+  check
+    (list string)
+    "same scope reuses capacity without accepting stale generation"
+    [ "replacement-b"; "released-a" ]
+    replacement_order
 ;;
 
 let test_snapshot_defers_admission_and_allocates_nonshared_current_attempts () =
@@ -755,7 +964,7 @@ let test_snapshot_defers_admission_and_allocates_nonshared_current_attempts () =
       | first :: rest ->
         (match
            EO.snapshot_flow
-             ~preferences:(EO.create_flow_preference_store ())
+             ~preferences:(preference_store ())
              ~scope:(flow_scope "nonsharing")
              ~first
              ~rest
@@ -2093,9 +2302,9 @@ let () =
             `Quick
             test_concurrent_domain_settlement_has_one_winner
         ; test_case
-            "stale domain success cannot overwrite newer last-good"
+            "older success cannot overwrite newer after reversed domain settlement"
             `Quick
-            test_stale_domain_success_cannot_overwrite_newer_last_good
+            test_older_success_cannot_overwrite_newer_after_reversed_domain_settlement
         ; test_case
             "rebound preference is not promoted and observation is typed"
             `Quick
@@ -2104,6 +2313,14 @@ let () =
             "blank flow scope is rejected"
             `Quick
             test_blank_flow_scope_is_rejected
+        ; test_case
+            "preference capacity is typed and reusable after removal"
+            `Quick
+            test_preference_store_capacity_is_typed_and_reusable_after_removal
+        ; test_case
+            "removed scope consumes domain-valid settlement as typed failure"
+            `Quick
+            test_removed_scope_consumes_domain_valid_settlement_as_typed_failure
         ; test_case
             "snapshot defers admission and current attempts do not share"
             `Quick

--- a/test/test_exact_output_flow.ml
+++ b/test/test_exact_output_flow.ml
@@ -777,7 +777,8 @@ let test_later_missing_credential_does_not_block_current_success () =
       int
       "only current candidate is visited"
       1
-      (EO.candidate_visit_count_to_int (EO.flow_success_evidence success).candidate_visit_count)
+      (EO.candidate_visit_count_to_int
+         (EO.flow_success_evidence success).candidate_visit_count)
   | Error _ -> fail "later missing credential blocked the current candidate"
 ;;
 
@@ -873,7 +874,11 @@ let test_missing_current_credential_advances_after_durable_settlement () =
       "both candidate outcomes remain ordered"
       2
       (List.length (EO.flow_success_evidence success).admissions);
-    check int "only successor gets an attempt" 1 (List.length (EO.flow_success_evidence success).attempts);
+    check
+      int
+      "only successor gets an attempt"
+      1
+      (List.length (EO.flow_success_evidence success).attempts);
     (match next_visit with
      | Some next ->
        check
@@ -896,7 +901,8 @@ let test_missing_current_credential_advances_after_durable_settlement () =
       int
       "both candidates are visited"
       2
-      (EO.candidate_visit_count_to_int (EO.flow_success_evidence success).candidate_visit_count)
+      (EO.candidate_visit_count_to_int
+         (EO.flow_success_evidence success).candidate_visit_count)
   | Error _ -> fail "durably settled selection rejection did not reach successor"
 ;;
 

--- a/test/test_exact_output_flow.ml
+++ b/test/test_exact_output_flow.ml
@@ -125,11 +125,15 @@ let admitted_target snapshot selector =
   | Ok admitted -> admitted
 ;;
 
-let flow_candidate snapshot id =
-  match EO.make_flow_candidate ~id ~admitted_target:(admitted_target snapshot id) with
+let flow_candidate_as snapshot ~id ~target_ref =
+  match
+    EO.make_flow_candidate ~id ~admitted_target:(admitted_target snapshot target_ref)
+  with
   | Ok candidate -> candidate
   | Error EO.Blank_flow_candidate_id -> fail "fixture candidate id was blank"
 ;;
+
+let flow_candidate snapshot id = flow_candidate_as snapshot ~id ~target_ref:id
 
 let credential_getenv = function
   | "MISSING_FLOW_KEY" -> Ok None
@@ -144,13 +148,12 @@ let flow_scope id =
   | Error EO.Blank_flow_scope_id -> fail "fixture flow scope was blank"
 ;;
 
-let frozen_flow
+let frozen_candidates
       ?(preferences = EO.create_flow_preference_store ())
       ?(scope = flow_scope "test-default")
-      snapshot
-      ids
+      candidates
   =
-  match List.map (flow_candidate snapshot) ids with
+  match candidates with
   | [] -> fail "flow fixture must be nonempty"
   | first :: rest ->
     (match
@@ -164,6 +167,11 @@ let frozen_flow
      with
      | Ok ready -> ready
      | Error _ -> fail "flow fixture did not admit")
+;;
+
+let frozen_flow ?preferences ?scope snapshot ids =
+  List.map (flow_candidate snapshot) ids
+  |> frozen_candidates ?preferences ?scope
 ;;
 
 let start_flow ready =
@@ -265,16 +273,20 @@ let execute_ok ~net flow =
     flow
 ;;
 
-let flow_snapshot_ids ready =
-  EO.flow_attempt_evidence (start_flow ready)
-  |> fun evidence ->
+let candidate_ids identities =
   List.map
     (fun (identity : EO.flow_candidate_identity) -> identity.candidate_id)
-    evidence.candidate_snapshot
+    identities
+;;
+
+let flow_snapshot_evidence ready = EO.flow_attempt_evidence (start_flow ready)
+
+let flow_snapshot_ids ready =
+  flow_snapshot_evidence ready |> fun evidence -> candidate_ids evidence.candidate_snapshot
 ;;
 
 let test_scope_local_domain_valid_preference_changes_only_future_snapshots () =
-  let (success_id, settlement, existing_order, future_order, other_scope_order), posts =
+  let (success_id, existing_order, future_order, other_scope_order), posts =
     with_server ~response:(openai_response {|{"name":"accepted"}|})
     @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
     with_catalog
@@ -320,6 +332,12 @@ let test_scope_local_domain_valid_preference_changes_only_future_snapshots () =
       let settlement =
         EO.settle_flow_domain success (EO.Domain_valid { success_time_unix_s = 42L })
       in
+      (match settlement with
+       | Ok
+           (EO.Domain_valid_preference_installed
+              { candidate; success_time_unix_s = 42L }) ->
+         check string "installed preference candidate" "preferred-b" candidate.candidate_id
+       | Ok _ | Error _ -> fail "domain-valid preference was not installed exactly");
       let future =
         frozen_flow
           ~preferences
@@ -334,15 +352,34 @@ let test_scope_local_domain_valid_preference_changes_only_future_snapshots () =
           snapshot
           [ "preferred-a"; "preferred-b" ]
       in
+      let existing_evidence = flow_snapshot_evidence existing in
+      let future_evidence = flow_snapshot_evidence future in
+      let other_scope_evidence = flow_snapshot_evidence other_scope in
+      check
+        (list string)
+        "future evidence preserves declared order"
+        [ "preferred-a"; "preferred-b" ]
+        (candidate_ids future_evidence.declared_candidate_snapshot);
+      (match existing_evidence.preference_observation with
+       | EO.No_preference_recorded -> ()
+       | EO.Preference_applied _ | EO.Preference_not_applied _ ->
+         fail "pre-existing snapshot observed a later preference");
+      (match future_evidence.preference_observation with
+       | EO.Preference_applied { candidate; success_time_unix_s = 42L } ->
+         check string "applied observation candidate" "preferred-b" candidate.candidate_id
+       | EO.No_preference_recorded | EO.Preference_not_applied _ | EO.Preference_applied _ ->
+         fail "future snapshot did not freeze the applied preference");
+      (match other_scope_evidence.preference_observation with
+       | EO.No_preference_recorded -> ()
+       | EO.Preference_applied _ | EO.Preference_not_applied _ ->
+         fail "other scope observed the primary preference");
       ( success_id
-      , settlement
-      , flow_snapshot_ids existing
-      , flow_snapshot_ids future
-      , flow_snapshot_ids other_scope )
+      , candidate_ids existing_evidence.candidate_snapshot
+      , candidate_ids future_evidence.candidate_snapshot
+      , candidate_ids other_scope_evidence.candidate_snapshot )
   in
   check int "preference proof dispatches once" 1 posts;
   check string "domain-valid candidate" "preferred-b" success_id;
-  check (result unit reject) "domain-valid settlement succeeds" (Ok ()) settlement;
   check
     (list string)
     "existing immutable snapshot keeps declared order"
@@ -408,7 +445,11 @@ let test_concurrent_flow_scopes_isolate_attempts_and_future_preferences () =
         match
           EO.settle_flow_domain success (EO.Domain_valid { success_time_unix_s = time })
         with
-        | Ok () -> ()
+        | Ok (EO.Domain_valid_preference_installed _) -> ()
+        | Ok
+            (EO.Domain_rejected_recorded
+            | EO.Domain_valid_preference_superseded _) ->
+          fail "fresh scoped success returned the wrong settlement receipt"
         | Error EO.Domain_already_settled -> fail "fresh scoped success was settled twice"
       in
       Eio.Fiber.both (fun () -> settle success_a 200L) (fun () -> settle success_b 200L);
@@ -479,14 +520,27 @@ let test_domain_rejection_never_updates_preference_and_settlement_is_affine () =
     "structural success alone does not update last-good"
     [ "declared-b"; "rejected-a" ]
     before_settlement;
-  check (result unit reject) "domain rejection settles" (Ok ()) first_settlement;
+  check
+    bool
+    "domain rejection returns a typed receipt"
+    true
+    (match first_settlement with
+     | Ok EO.Domain_rejected_recorded -> true
+     | Ok
+         (EO.Domain_valid_preference_installed _
+         | EO.Domain_valid_preference_superseded _)
+     | Error EO.Domain_already_settled -> false);
   check
     bool
     "duplicate settlement is typed"
     true
     (match duplicate_settlement with
      | Error EO.Domain_already_settled -> true
-     | Ok () -> false);
+     | Ok
+         (EO.Domain_rejected_recorded
+         | EO.Domain_valid_preference_installed _
+         | EO.Domain_valid_preference_superseded _) ->
+       false);
   check
     (list string)
     "domain rejection records no preference"
@@ -514,32 +568,38 @@ let test_concurrent_domain_settlement_has_one_winner () =
       with
       | Error _ -> fail "concurrent-settlement fixture did not succeed"
       | Ok success ->
-        let left_promise, left_resolver = Eio.Promise.create () in
-        let right_promise, right_resolver = Eio.Promise.create () in
-        Eio.Fiber.both
-          (fun () ->
-             Eio.Promise.resolve
-               left_resolver
-               (EO.settle_flow_domain
-                  success
-                  (EO.Domain_valid { success_time_unix_s = 44L })))
-          (fun () ->
-             Eio.Promise.resolve
-               right_resolver
-               (EO.settle_flow_domain
-                  success
-                  (EO.Domain_valid { success_time_unix_s = 45L })));
+        let ready = Atomic.make 0 in
+        let start = Atomic.make false in
+        let contend success_time_unix_s =
+          ignore (Atomic.fetch_and_add ready 1);
+          while not (Atomic.get start) do
+            Domain.cpu_relax ()
+          done;
+          EO.settle_flow_domain success (EO.Domain_valid { success_time_unix_s })
+        in
+        let left_domain = Domain.spawn (fun () -> contend 44L) in
+        let right_domain = Domain.spawn (fun () -> contend 45L) in
+        while Atomic.get ready <> 2 do
+          Domain.cpu_relax ()
+        done;
+        Atomic.set start true;
+        let left = Domain.join left_domain in
+        let right = Domain.join right_domain in
         let future_order =
           frozen_flow ~preferences ~scope snapshot [ "declared-b"; "winner-a" ]
           |> flow_snapshot_ids
         in
-        Eio.Promise.await left_promise, Eio.Promise.await right_promise, future_order
+        left, right, future_order
     in
     let left, right, future_order = result in
     left, right, future_order, posts
   in
   let settled = function
-    | Ok () -> true
+    | Ok (EO.Domain_valid_preference_installed _) -> true
+    | Ok
+        (EO.Domain_rejected_recorded
+        | EO.Domain_valid_preference_superseded _) ->
+      false
     | Error EO.Domain_already_settled -> false
   in
   check bool "exactly one concurrent settlement wins" true (settled left <> settled right);
@@ -552,7 +612,7 @@ let test_concurrent_domain_settlement_has_one_winner () =
 ;;
 
 let test_stale_domain_success_cannot_overwrite_newer_last_good () =
-  let future_order, posts =
+  let (future_order, newer_receipt, stale_receipt), posts =
     with_server ~response:(openai_response {|{"name":"accepted"}|})
     @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
     with_catalog
@@ -573,26 +633,120 @@ let test_stale_domain_success_cannot_overwrite_newer_last_good () =
       | Error _ -> fail "out-of-order settlement fixture did not succeed"
       | Ok success -> success
     in
-    let settle success time =
-      match
-        EO.settle_flow_domain success (EO.Domain_valid { success_time_unix_s = time })
-      with
-      | Ok () -> ()
-      | Error EO.Domain_already_settled -> fail "fresh success was already settled"
-    in
     let newer_success = execute newer_flow in
     let stale_success = execute stale_flow in
-    Eio.Fiber.both
-      (fun () -> settle newer_success 100L)
-      (fun () -> settle stale_success 99L);
-    frozen_flow ~preferences ~scope snapshot [ "stale-a"; "newer-b" ] |> flow_snapshot_ids
+    let newer_receipt =
+      EO.settle_flow_domain
+        newer_success
+        (EO.Domain_valid { success_time_unix_s = 100L })
+    in
+    let stale_receipt =
+      EO.settle_flow_domain stale_success (EO.Domain_valid { success_time_unix_s = 99L })
+    in
+    ( frozen_flow ~preferences ~scope snapshot [ "stale-a"; "newer-b" ]
+      |> flow_snapshot_ids
+    , newer_receipt
+    , stale_receipt )
   in
   check int "out-of-order settlement proof dispatches twice" 2 posts;
   check
     (list string)
     "older success time cannot overwrite newer last-good"
     [ "newer-b"; "stale-a" ]
-    future_order
+    future_order;
+  (match newer_receipt with
+   | Ok
+       (EO.Domain_valid_preference_installed
+          { candidate; success_time_unix_s = 100L }) ->
+     check string "newer preference receipt candidate" "newer-b" candidate.candidate_id
+   | Ok _ | Error _ -> fail "newer success did not install its preference");
+  (match stale_receipt with
+   | Ok
+       (EO.Domain_valid_preference_superseded
+          { current_candidate; current_success_time_unix_s = 100L }) ->
+     check
+       string
+       "stale receipt names retained candidate"
+       "newer-b"
+       current_candidate.candidate_id
+   | Ok _ | Error _ -> fail "stale success was not reported as superseded")
+;;
+
+let test_rebound_preference_is_not_promoted_and_observation_is_typed () =
+  let (rebound_evidence, absent_evidence), posts =
+    with_server ~response:(openai_response {|{"name":"accepted"}|})
+    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
+    with_catalog
+      [ catalog_entry ~id:"binding-a" ~base_url ~native:true ~json:true ()
+      ; catalog_entry ~id:"binding-b" ~base_url ~native:true ~json:true ()
+      ]
+    @@ fun snapshot ->
+    let preferences = EO.create_flow_preference_store () in
+    let scope = flow_scope "/runtime/rebound-preference" in
+    let successful =
+      flow_candidate_as snapshot ~id:"stable-slot" ~target_ref:"binding-a"
+      |> fun candidate -> frozen_candidates ~preferences ~scope [ candidate ]
+      |> start_flow
+      |> execute_ok ~net
+    in
+    let success =
+      match successful with
+      | Ok success -> success
+      | Error _ -> fail "binding fixture did not structurally succeed"
+    in
+    (match
+       EO.settle_flow_domain success (EO.Domain_valid { success_time_unix_s = 77L })
+     with
+     | Ok (EO.Domain_valid_preference_installed _) -> ()
+     | Ok _ | Error _ -> fail "binding fixture did not install its preference");
+    let fallback =
+      flow_candidate_as snapshot ~id:"fallback" ~target_ref:"binding-a"
+    in
+    let rebound =
+      flow_candidate_as snapshot ~id:"stable-slot" ~target_ref:"binding-b"
+    in
+    let rebound_evidence =
+      frozen_candidates ~preferences ~scope [ fallback; rebound ]
+      |> flow_snapshot_evidence
+    in
+    let absent_evidence =
+      frozen_candidates ~preferences ~scope [ fallback ] |> flow_snapshot_evidence
+    in
+    rebound_evidence, absent_evidence
+  in
+  check int "binding observation proof dispatches once" 1 posts;
+  check
+    (list string)
+    "rebound evidence preserves declared order"
+    [ "fallback"; "stable-slot" ]
+    (candidate_ids rebound_evidence.declared_candidate_snapshot);
+  check
+    (list string)
+    "rebound target is not promoted"
+    [ "fallback"; "stable-slot" ]
+    (candidate_ids rebound_evidence.candidate_snapshot);
+  (match rebound_evidence.preference_observation with
+   | EO.Preference_not_applied
+       { candidate
+       ; success_time_unix_s = 77L
+       ; reason = EO.Preference_candidate_binding_changed
+       } ->
+     check string "binding-changed observation slot" "stable-slot" candidate.candidate_id
+   | EO.No_preference_recorded
+   | EO.Preference_applied _
+   | EO.Preference_not_applied _ ->
+     fail "rebound target did not produce binding-changed evidence");
+  (match absent_evidence.preference_observation with
+   | EO.Preference_not_applied
+       { candidate
+       ; success_time_unix_s = 77L
+       ; reason = EO.Preference_candidate_absent
+       } ->
+     check string "absent observation slot" "stable-slot" candidate.candidate_id
+   | EO.No_preference_recorded
+   | EO.Preference_applied _
+   | EO.Preference_not_applied _ ->
+     fail "absent target did not produce typed evidence")
 ;;
 
 let test_blank_flow_scope_is_rejected () =
@@ -1961,6 +2115,10 @@ let () =
             "stale domain success cannot overwrite newer last-good"
             `Quick
             test_stale_domain_success_cannot_overwrite_newer_last_good
+        ; test_case
+            "rebound preference is not promoted and observation is typed"
+            `Quick
+            test_rebound_preference_is_not_promoted_and_observation_is_typed
         ; test_case
             "blank flow scope is rejected"
             `Quick

--- a/test/test_exact_output_flow.ml
+++ b/test/test_exact_output_flow.ml
@@ -170,8 +170,7 @@ let frozen_candidates
 ;;
 
 let frozen_flow ?preferences ?scope snapshot ids =
-  List.map (flow_candidate snapshot) ids
-  |> frozen_candidates ?preferences ?scope
+  List.map (flow_candidate snapshot) ids |> frozen_candidates ?preferences ?scope
 ;;
 
 let start_flow ready =
@@ -282,7 +281,8 @@ let candidate_ids identities =
 let flow_snapshot_evidence ready = EO.flow_attempt_evidence (start_flow ready)
 
 let flow_snapshot_ids ready =
-  flow_snapshot_evidence ready |> fun evidence -> candidate_ids evidence.candidate_snapshot
+  flow_snapshot_evidence ready
+  |> fun evidence -> candidate_ids evidence.candidate_snapshot
 ;;
 
 let test_scope_local_domain_valid_preference_changes_only_future_snapshots () =
@@ -334,9 +334,13 @@ let test_scope_local_domain_valid_preference_changes_only_future_snapshots () =
       in
       (match settlement with
        | Ok
-           (EO.Domain_valid_preference_installed
-              { candidate; success_time_unix_s = 42L }) ->
-         check string "installed preference candidate" "preferred-b" candidate.candidate_id
+           (EO.Domain_valid_preference_installed { candidate; success_time_unix_s = 42L })
+         ->
+         check
+           string
+           "installed preference candidate"
+           "preferred-b"
+           candidate.candidate_id
        | Ok _ | Error _ -> fail "domain-valid preference was not installed exactly");
       let future =
         frozen_flow
@@ -367,8 +371,8 @@ let test_scope_local_domain_valid_preference_changes_only_future_snapshots () =
       (match future_evidence.preference_observation with
        | EO.Preference_applied { candidate; success_time_unix_s = 42L } ->
          check string "applied observation candidate" "preferred-b" candidate.candidate_id
-       | EO.No_preference_recorded | EO.Preference_not_applied _ | EO.Preference_applied _ ->
-         fail "future snapshot did not freeze the applied preference");
+       | EO.No_preference_recorded | EO.Preference_not_applied _ | EO.Preference_applied _
+         -> fail "future snapshot did not freeze the applied preference");
       (match other_scope_evidence.preference_observation with
        | EO.No_preference_recorded -> ()
        | EO.Preference_applied _ | EO.Preference_not_applied _ ->
@@ -446,9 +450,7 @@ let test_concurrent_flow_scopes_isolate_attempts_and_future_preferences () =
           EO.settle_flow_domain success (EO.Domain_valid { success_time_unix_s = time })
         with
         | Ok (EO.Domain_valid_preference_installed _) -> ()
-        | Ok
-            (EO.Domain_rejected_recorded
-            | EO.Domain_valid_preference_superseded _) ->
+        | Ok (EO.Domain_rejected_recorded | EO.Domain_valid_preference_superseded _) ->
           fail "fresh scoped success returned the wrong settlement receipt"
         | Error EO.Domain_already_settled -> fail "fresh scoped success was settled twice"
       in
@@ -527,8 +529,7 @@ let test_domain_rejection_never_updates_preference_and_settlement_is_affine () =
     (match first_settlement with
      | Ok EO.Domain_rejected_recorded -> true
      | Ok
-         (EO.Domain_valid_preference_installed _
-         | EO.Domain_valid_preference_superseded _)
+         (EO.Domain_valid_preference_installed _ | EO.Domain_valid_preference_superseded _)
      | Error EO.Domain_already_settled -> false);
   check
     bool
@@ -537,10 +538,9 @@ let test_domain_rejection_never_updates_preference_and_settlement_is_affine () =
     (match duplicate_settlement with
      | Error EO.Domain_already_settled -> true
      | Ok
-         (EO.Domain_rejected_recorded
+         ( EO.Domain_rejected_recorded
          | EO.Domain_valid_preference_installed _
-         | EO.Domain_valid_preference_superseded _) ->
-       false);
+         | EO.Domain_valid_preference_superseded _ ) -> false);
   check
     (list string)
     "domain rejection records no preference"
@@ -596,10 +596,7 @@ let test_concurrent_domain_settlement_has_one_winner () =
   in
   let settled = function
     | Ok (EO.Domain_valid_preference_installed _) -> true
-    | Ok
-        (EO.Domain_rejected_recorded
-        | EO.Domain_valid_preference_superseded _) ->
-      false
+    | Ok (EO.Domain_rejected_recorded | EO.Domain_valid_preference_superseded _) -> false
     | Error EO.Domain_already_settled -> false
   in
   check bool "exactly one concurrent settlement wins" true (settled left <> settled right);
@@ -636,9 +633,7 @@ let test_stale_domain_success_cannot_overwrite_newer_last_good () =
     let newer_success = execute newer_flow in
     let stale_success = execute stale_flow in
     let newer_receipt =
-      EO.settle_flow_domain
-        newer_success
-        (EO.Domain_valid { success_time_unix_s = 100L })
+      EO.settle_flow_domain newer_success (EO.Domain_valid { success_time_unix_s = 100L })
     in
     let stale_receipt =
       EO.settle_flow_domain stale_success (EO.Domain_valid { success_time_unix_s = 99L })
@@ -655,21 +650,19 @@ let test_stale_domain_success_cannot_overwrite_newer_last_good () =
     [ "newer-b"; "stale-a" ]
     future_order;
   (match newer_receipt with
-   | Ok
-       (EO.Domain_valid_preference_installed
-          { candidate; success_time_unix_s = 100L }) ->
-     check string "newer preference receipt candidate" "newer-b" candidate.candidate_id
+   | Ok (EO.Domain_valid_preference_installed { candidate; success_time_unix_s = 100L })
+     -> check string "newer preference receipt candidate" "newer-b" candidate.candidate_id
    | Ok _ | Error _ -> fail "newer success did not install its preference");
-  (match stale_receipt with
-   | Ok
-       (EO.Domain_valid_preference_superseded
-          { current_candidate; current_success_time_unix_s = 100L }) ->
-     check
-       string
-       "stale receipt names retained candidate"
-       "newer-b"
-       current_candidate.candidate_id
-   | Ok _ | Error _ -> fail "stale success was not reported as superseded")
+  match stale_receipt with
+  | Ok
+      (EO.Domain_valid_preference_superseded
+         { current_candidate; current_success_time_unix_s = 100L }) ->
+    check
+      string
+      "stale receipt names retained candidate"
+      "newer-b"
+      current_candidate.candidate_id
+  | Ok _ | Error _ -> fail "stale success was not reported as superseded"
 ;;
 
 let test_rebound_preference_is_not_promoted_and_observation_is_typed () =
@@ -685,9 +678,8 @@ let test_rebound_preference_is_not_promoted_and_observation_is_typed () =
     let scope = flow_scope "/runtime/rebound-preference" in
     let successful =
       flow_candidate_as snapshot ~id:"stable-slot" ~target_ref:"binding-a"
-      |> fun candidate -> frozen_candidates ~preferences ~scope [ candidate ]
-      |> start_flow
-      |> execute_ok ~net
+      |> fun candidate ->
+      frozen_candidates ~preferences ~scope [ candidate ] |> start_flow |> execute_ok ~net
     in
     let success =
       match successful with
@@ -699,12 +691,8 @@ let test_rebound_preference_is_not_promoted_and_observation_is_typed () =
      with
      | Ok (EO.Domain_valid_preference_installed _) -> ()
      | Ok _ | Error _ -> fail "binding fixture did not install its preference");
-    let fallback =
-      flow_candidate_as snapshot ~id:"fallback" ~target_ref:"binding-a"
-    in
-    let rebound =
-      flow_candidate_as snapshot ~id:"stable-slot" ~target_ref:"binding-b"
-    in
+    let fallback = flow_candidate_as snapshot ~id:"fallback" ~target_ref:"binding-a" in
+    let rebound = flow_candidate_as snapshot ~id:"stable-slot" ~target_ref:"binding-b" in
     let rebound_evidence =
       frozen_candidates ~preferences ~scope [ fallback; rebound ]
       |> flow_snapshot_evidence
@@ -732,21 +720,14 @@ let test_rebound_preference_is_not_promoted_and_observation_is_typed () =
        ; reason = EO.Preference_candidate_binding_changed
        } ->
      check string "binding-changed observation slot" "stable-slot" candidate.candidate_id
-   | EO.No_preference_recorded
-   | EO.Preference_applied _
-   | EO.Preference_not_applied _ ->
+   | EO.No_preference_recorded | EO.Preference_applied _ | EO.Preference_not_applied _ ->
      fail "rebound target did not produce binding-changed evidence");
-  (match absent_evidence.preference_observation with
-   | EO.Preference_not_applied
-       { candidate
-       ; success_time_unix_s = 77L
-       ; reason = EO.Preference_candidate_absent
-       } ->
-     check string "absent observation slot" "stable-slot" candidate.candidate_id
-   | EO.No_preference_recorded
-   | EO.Preference_applied _
-   | EO.Preference_not_applied _ ->
-     fail "absent target did not produce typed evidence")
+  match absent_evidence.preference_observation with
+  | EO.Preference_not_applied
+      { candidate; success_time_unix_s = 77L; reason = EO.Preference_candidate_absent } ->
+    check string "absent observation slot" "stable-slot" candidate.candidate_id
+  | EO.No_preference_recorded | EO.Preference_applied _ | EO.Preference_not_applied _ ->
+    fail "absent target did not produce typed evidence"
 ;;
 
 let test_blank_flow_scope_is_rejected () =

--- a/test/test_exact_output_flow.ml
+++ b/test/test_exact_output_flow.ml
@@ -138,12 +138,25 @@ let credential_getenv = function
   | _ -> Ok None
 ;;
 
-let frozen_flow snapshot ids =
+let flow_scope id =
+  match EO.make_flow_scope ~id with
+  | Ok scope -> scope
+  | Error EO.Blank_flow_scope_id -> fail "fixture flow scope was blank"
+;;
+
+let frozen_flow
+      ?(preferences = EO.create_flow_preference_store ())
+      ?(scope = flow_scope "test-default")
+      snapshot
+      ids
+  =
   match List.map (flow_candidate snapshot) ids with
   | [] -> fail "flow fixture must be nonempty"
   | first :: rest ->
     (match
        EO.snapshot_flow
+         ~preferences
+         ~scope
          ~first
          ~rest
          ~messages:[ msg "return one exact object" ]
@@ -252,6 +265,342 @@ let execute_ok ~net flow =
     flow
 ;;
 
+let flow_snapshot_ids ready =
+  EO.flow_attempt_evidence (start_flow ready)
+  |> fun evidence ->
+  List.map
+    (fun (identity : EO.flow_candidate_identity) -> identity.candidate_id)
+    evidence.candidate_snapshot
+;;
+
+let test_scope_local_domain_valid_preference_changes_only_future_snapshots () =
+  let (success_id, settlement, existing_order, future_order, other_scope_order), posts =
+    with_server ~response:(openai_response {|{"name":"accepted"}|})
+    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
+    with_catalog
+      [ catalog_entry ~id:"preferred-a" ~base_url ~native:true ~json:true ()
+      ; catalog_entry ~id:"preferred-b" ~base_url ~native:true ~json:true ()
+      ]
+    @@ fun snapshot ->
+    let preferences = EO.create_flow_preference_store () in
+    let primary_scope = flow_scope "/runtime/keeper-primary" in
+    let other_scope = flow_scope "/runtime/keeper-other" in
+    let existing =
+      frozen_flow
+        ~preferences
+        ~scope:primary_scope
+        snapshot
+        [ "preferred-a"; "preferred-b" ]
+    in
+    let successful =
+      frozen_flow
+        ~preferences
+        ~scope:primary_scope
+        snapshot
+        [ "preferred-b"; "preferred-a" ]
+      |> start_flow
+      |> execute_ok ~net
+    in
+    match successful with
+    | Error _ -> fail "last-good fixture did not structurally succeed"
+    | Ok success ->
+      let candidate = EO.flow_success_candidate success in
+      let evidence = EO.flow_success_evidence success in
+      check
+        bool
+        "success receipt carries primary scope"
+        true
+        (EO.flow_scope_equal primary_scope candidate.scope);
+      check
+        bool
+        "success evidence carries primary scope"
+        true
+        (EO.flow_scope_equal primary_scope evidence.scope);
+      let success_id = candidate_id candidate in
+      let settlement =
+        EO.settle_flow_domain success (EO.Domain_valid { success_time_unix_s = 42L })
+      in
+      let future =
+        frozen_flow
+          ~preferences
+          ~scope:primary_scope
+          snapshot
+          [ "preferred-a"; "preferred-b" ]
+      in
+      let other_scope =
+        frozen_flow
+          ~preferences
+          ~scope:other_scope
+          snapshot
+          [ "preferred-a"; "preferred-b" ]
+      in
+      ( success_id
+      , settlement
+      , flow_snapshot_ids existing
+      , flow_snapshot_ids future
+      , flow_snapshot_ids other_scope )
+  in
+  check int "preference proof dispatches once" 1 posts;
+  check string "domain-valid candidate" "preferred-b" success_id;
+  check (result unit reject) "domain-valid settlement succeeds" (Ok ()) settlement;
+  check
+    (list string)
+    "existing immutable snapshot keeps declared order"
+    [ "preferred-a"; "preferred-b" ]
+    existing_order;
+  check
+    (list string)
+    "future same-scope snapshot prefers last-good"
+    [ "preferred-b"; "preferred-a" ]
+    future_order;
+  check
+    (list string)
+    "other scope is isolated"
+    [ "preferred-a"; "preferred-b" ]
+    other_scope_order
+;;
+
+let test_concurrent_flow_scopes_isolate_attempts_and_future_preferences () =
+  let call_ids_differ, future_a, future_b, posts =
+    let result, posts =
+      with_server ~response:(openai_response {|{"name":"accepted"}|})
+      @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
+      with_catalog
+        [ catalog_entry ~id:"scope-a" ~base_url ~native:true ~json:true ()
+        ; catalog_entry ~id:"scope-b" ~base_url ~native:true ~json:true ()
+        ]
+      @@ fun snapshot ->
+      let preferences = EO.create_flow_preference_store () in
+      let scope_a = flow_scope "/runtime/concurrent-a" in
+      let scope_b = flow_scope "/runtime/concurrent-b" in
+      let flow_a =
+        frozen_flow ~preferences ~scope:scope_a snapshot [ "scope-a"; "scope-b" ]
+        |> start_flow
+      in
+      let flow_b =
+        frozen_flow ~preferences ~scope:scope_b snapshot [ "scope-b"; "scope-a" ]
+        |> start_flow
+      in
+      let promise_a, resolver_a = Eio.Promise.create () in
+      let promise_b, resolver_b = Eio.Promise.create () in
+      Eio.Fiber.both
+        (fun () -> Eio.Promise.resolve resolver_a (execute_ok ~net flow_a))
+        (fun () -> Eio.Promise.resolve resolver_b (execute_ok ~net flow_b));
+      let require_success label = function
+        | Ok success -> success
+        | Error _ -> failf "%s concurrent scope did not succeed" label
+      in
+      let success_a = Eio.Promise.await promise_a |> require_success "first" in
+      let success_b = Eio.Promise.await promise_b |> require_success "second" in
+      let candidate_a = EO.flow_success_candidate success_a in
+      let candidate_b = EO.flow_success_candidate success_b in
+      check
+        bool
+        "first attempt stays in first scope"
+        true
+        (EO.flow_scope_equal scope_a candidate_a.scope);
+      check
+        bool
+        "second attempt stays in second scope"
+        true
+        (EO.flow_scope_equal scope_b candidate_b.scope);
+      let settle success time =
+        match
+          EO.settle_flow_domain success (EO.Domain_valid { success_time_unix_s = time })
+        with
+        | Ok () -> ()
+        | Error EO.Domain_already_settled -> fail "fresh scoped success was settled twice"
+      in
+      Eio.Fiber.both (fun () -> settle success_a 200L) (fun () -> settle success_b 200L);
+      let call_id candidate =
+        EO.receipt_call_id candidate.EO.receipt |> EO.call_id_to_string
+      in
+      ( not (String.equal (call_id candidate_a) (call_id candidate_b))
+      , frozen_flow ~preferences ~scope:scope_a snapshot [ "scope-b"; "scope-a" ]
+        |> flow_snapshot_ids
+      , frozen_flow ~preferences ~scope:scope_b snapshot [ "scope-a"; "scope-b" ]
+        |> flow_snapshot_ids )
+    in
+    let call_ids_differ, future_a, future_b = result in
+    call_ids_differ, future_a, future_b, posts
+  in
+  check int "two concurrent scopes dispatch independently" 2 posts;
+  check bool "concurrent scopes do not share attempt identity" true call_ids_differ;
+  check
+    (list string)
+    "first scope keeps only its last-good"
+    [ "scope-a"; "scope-b" ]
+    future_a;
+  check
+    (list string)
+    "second scope keeps only its last-good"
+    [ "scope-b"; "scope-a" ]
+    future_b
+;;
+
+let test_domain_rejection_never_updates_preference_and_settlement_is_affine () =
+  let before_settlement, first_settlement, duplicate_settlement, after_settlement, posts =
+    let result, posts =
+      with_server ~response:(openai_response {|{"name":"rejected"}|})
+      @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
+      with_catalog
+        [ catalog_entry ~id:"rejected-a" ~base_url ~native:true ~json:true ()
+        ; catalog_entry ~id:"declared-b" ~base_url ~native:true ~json:true ()
+        ]
+      @@ fun snapshot ->
+      let preferences = EO.create_flow_preference_store () in
+      let scope = flow_scope "/runtime/domain-rejected" in
+      match
+        frozen_flow ~preferences ~scope snapshot [ "rejected-a"; "declared-b" ]
+        |> start_flow
+        |> execute_ok ~net
+      with
+      | Error _ -> fail "domain-rejection fixture did not structurally succeed"
+      | Ok success ->
+        let before_settlement =
+          frozen_flow ~preferences ~scope snapshot [ "declared-b"; "rejected-a" ]
+          |> flow_snapshot_ids
+        in
+        let first_settlement = EO.settle_flow_domain success EO.Domain_rejected in
+        let duplicate_settlement =
+          EO.settle_flow_domain success (EO.Domain_valid { success_time_unix_s = 43L })
+        in
+        let after_settlement =
+          frozen_flow ~preferences ~scope snapshot [ "declared-b"; "rejected-a" ]
+          |> flow_snapshot_ids
+        in
+        before_settlement, first_settlement, duplicate_settlement, after_settlement
+    in
+    let before, first, duplicate, after = result in
+    before, first, duplicate, after, posts
+  in
+  check
+    (list string)
+    "structural success alone does not update last-good"
+    [ "declared-b"; "rejected-a" ]
+    before_settlement;
+  check (result unit reject) "domain rejection settles" (Ok ()) first_settlement;
+  check
+    bool
+    "duplicate settlement is typed"
+    true
+    (match duplicate_settlement with
+     | Error EO.Domain_already_settled -> true
+     | Ok () -> false);
+  check
+    (list string)
+    "domain rejection records no preference"
+    [ "declared-b"; "rejected-a" ]
+    after_settlement;
+  check int "domain-rejection proof dispatches once" 1 posts
+;;
+
+let test_concurrent_domain_settlement_has_one_winner () =
+  let left, right, future_order, posts =
+    let result, posts =
+      with_server ~response:(openai_response {|{"name":"accepted"}|})
+      @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
+      with_catalog
+        [ catalog_entry ~id:"winner-a" ~base_url ~native:true ~json:true ()
+        ; catalog_entry ~id:"declared-b" ~base_url ~native:true ~json:true ()
+        ]
+      @@ fun snapshot ->
+      let preferences = EO.create_flow_preference_store () in
+      let scope = flow_scope "/runtime/concurrent-settlement" in
+      match
+        frozen_flow ~preferences ~scope snapshot [ "winner-a"; "declared-b" ]
+        |> start_flow
+        |> execute_ok ~net
+      with
+      | Error _ -> fail "concurrent-settlement fixture did not succeed"
+      | Ok success ->
+        let left_promise, left_resolver = Eio.Promise.create () in
+        let right_promise, right_resolver = Eio.Promise.create () in
+        Eio.Fiber.both
+          (fun () ->
+             Eio.Promise.resolve
+               left_resolver
+               (EO.settle_flow_domain
+                  success
+                  (EO.Domain_valid { success_time_unix_s = 44L })))
+          (fun () ->
+             Eio.Promise.resolve
+               right_resolver
+               (EO.settle_flow_domain
+                  success
+                  (EO.Domain_valid { success_time_unix_s = 45L })));
+        let future_order =
+          frozen_flow ~preferences ~scope snapshot [ "declared-b"; "winner-a" ]
+          |> flow_snapshot_ids
+        in
+        Eio.Promise.await left_promise, Eio.Promise.await right_promise, future_order
+    in
+    let left, right, future_order = result in
+    left, right, future_order, posts
+  in
+  let settled = function
+    | Ok () -> true
+    | Error EO.Domain_already_settled -> false
+  in
+  check bool "exactly one concurrent settlement wins" true (settled left <> settled right);
+  check
+    (list string)
+    "winning settlement updates future snapshot once"
+    [ "winner-a"; "declared-b" ]
+    future_order;
+  check int "concurrent-settlement proof dispatches once" 1 posts
+;;
+
+let test_stale_domain_success_cannot_overwrite_newer_last_good () =
+  let future_order, posts =
+    with_server ~response:(openai_response {|{"name":"accepted"}|})
+    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
+    with_catalog
+      [ catalog_entry ~id:"stale-a" ~base_url ~native:true ~json:true ()
+      ; catalog_entry ~id:"newer-b" ~base_url ~native:true ~json:true ()
+      ]
+    @@ fun snapshot ->
+    let preferences = EO.create_flow_preference_store () in
+    let scope = flow_scope "/runtime/out-of-order-success" in
+    let newer_flow =
+      frozen_flow ~preferences ~scope snapshot [ "newer-b"; "stale-a" ] |> start_flow
+    in
+    let stale_flow =
+      frozen_flow ~preferences ~scope snapshot [ "stale-a"; "newer-b" ] |> start_flow
+    in
+    let execute flow =
+      match execute_ok ~net flow with
+      | Error _ -> fail "out-of-order settlement fixture did not succeed"
+      | Ok success -> success
+    in
+    let settle success time =
+      match
+        EO.settle_flow_domain success (EO.Domain_valid { success_time_unix_s = time })
+      with
+      | Ok () -> ()
+      | Error EO.Domain_already_settled -> fail "fresh success was already settled"
+    in
+    let newer_success = execute newer_flow in
+    let stale_success = execute stale_flow in
+    Eio.Fiber.both
+      (fun () -> settle newer_success 100L)
+      (fun () -> settle stale_success 99L);
+    frozen_flow ~preferences ~scope snapshot [ "stale-a"; "newer-b" ] |> flow_snapshot_ids
+  in
+  check int "out-of-order settlement proof dispatches twice" 2 posts;
+  check
+    (list string)
+    "older success time cannot overwrite newer last-good"
+    [ "newer-b"; "stale-a" ]
+    future_order
+;;
+
+let test_blank_flow_scope_is_rejected () =
+  match EO.make_flow_scope ~id:" \n\t " with
+  | Error EO.Blank_flow_scope_id -> ()
+  | Ok _ -> fail "blank flow scope was accepted"
+;;
+
 let test_snapshot_defers_admission_and_allocates_nonshared_current_attempts () =
   let (before_a, before_b, result_a, result_b), posts =
     with_server ~response:(openai_response {|{"name":"accepted"}|})
@@ -271,6 +620,8 @@ let test_snapshot_defers_admission_and_allocates_nonshared_current_attempts () =
       | first :: rest ->
         (match
            EO.snapshot_flow
+             ~preferences:(EO.create_flow_preference_store ())
+             ~scope:(flow_scope "nonsharing")
              ~first
              ~rest
              ~messages:[ msg "freeze all" ]
@@ -324,21 +675,22 @@ let test_snapshot_defers_admission_and_allocates_nonshared_current_attempts () =
   | Ok success_a, Ok success_b ->
     List.iter
       (fun success ->
+         let evidence = EO.flow_success_evidence success in
          check
            int
            "only current candidate is admitted"
            1
-           (List.length success.EO.evidence.admissions);
+           (List.length evidence.EO.admissions);
          check
            int
            "only current candidate gets an attempt"
            1
-           (List.length success.evidence.attempts);
+           (List.length evidence.attempts);
          check
            int
            "candidate visit count advances once"
            1
-           (EO.candidate_visit_count_to_int success.evidence.candidate_visit_count))
+           (EO.candidate_visit_count_to_int evidence.candidate_visit_count))
       [ success_a; success_b ];
     check
       bool
@@ -346,20 +698,24 @@ let test_snapshot_defers_admission_and_allocates_nonshared_current_attempts () =
       true
       (not
          (String.equal
-            (EO.receipt_call_id success_a.candidate.receipt |> EO.call_id_to_string)
-            (EO.receipt_call_id success_b.candidate.receipt |> EO.call_id_to_string)));
+            (EO.receipt_call_id (EO.flow_success_candidate success_a).receipt
+             |> EO.call_id_to_string)
+            (EO.receipt_call_id (EO.flow_success_candidate success_b).receipt
+             |> EO.call_id_to_string)));
     List.iter
       (fun success ->
+         let candidate = EO.flow_success_candidate success in
+         let evidence = EO.flow_success_evidence success in
          check
            string
            "attempt visit remains bound to its outer flow"
-           (EO.flow_id_to_string success.EO.evidence.flow_id)
-           (EO.flow_id_to_string success.candidate.visit.flow_id);
+           (EO.flow_id_to_string evidence.flow_id)
+           (EO.flow_id_to_string candidate.visit.flow_id);
          check
            int
            "current candidate visit ordinal is one"
            1
-           (EO.flow_visit_ordinal_to_int success.candidate.visit.ordinal))
+           (EO.flow_visit_ordinal_to_int candidate.visit.ordinal))
       [ success_a; success_b ]
   | Ok _, Error _ | Error _, Ok _ | Error _, Error _ ->
     fail "independent current candidates did not both succeed"
@@ -401,27 +757,27 @@ let test_later_missing_credential_does_not_block_current_success () =
       string
       "current candidate succeeds"
       "current-good"
-      (candidate_id success.candidate);
+      (candidate_id (EO.flow_success_candidate success));
     check
       int
       "full candidate snapshot remains frozen"
       2
-      (List.length success.evidence.candidate_snapshot);
+      (List.length (EO.flow_success_evidence success).candidate_snapshot);
     check
       int
       "only current admission is recorded"
       1
-      (List.length success.evidence.admissions);
+      (List.length (EO.flow_success_evidence success).admissions);
     check
       int
       "only current attempt is allocated"
       1
-      (List.length success.evidence.attempts);
+      (List.length (EO.flow_success_evidence success).attempts);
     check
       int
       "only current candidate is visited"
       1
-      (EO.candidate_visit_count_to_int success.evidence.candidate_visit_count)
+      (EO.candidate_visit_count_to_int (EO.flow_success_evidence success).candidate_visit_count)
   | Error _ -> fail "later missing credential blocked the current candidate"
 ;;
 
@@ -511,36 +867,36 @@ let test_missing_current_credential_advances_after_durable_settlement () =
       string
       "resolved successor succeeds"
       "next-good"
-      (candidate_id success.candidate);
+      (candidate_id (EO.flow_success_candidate success));
     check
       int
       "both candidate outcomes remain ordered"
       2
-      (List.length success.evidence.admissions);
-    check int "only successor gets an attempt" 1 (List.length success.evidence.attempts);
+      (List.length (EO.flow_success_evidence success).admissions);
+    check int "only successor gets an attempt" 1 (List.length (EO.flow_success_evidence success).attempts);
     (match next_visit with
      | Some next ->
        check
          string
          "settled successor visit becomes the successful attempt visit"
          (EO.flow_id_to_string next.flow_id)
-         (EO.flow_id_to_string success.candidate.visit.flow_id);
+         (EO.flow_id_to_string (EO.flow_success_candidate success).visit.flow_id);
        check
          int
          "settled successor ordinal is retained by the attempt"
          (EO.flow_visit_ordinal_to_int next.ordinal)
-         (EO.flow_visit_ordinal_to_int success.candidate.visit.ordinal);
+         (EO.flow_visit_ordinal_to_int (EO.flow_success_candidate success).visit.ordinal);
        check
          string
          "settled successor identity is retained by the attempt"
          next.identity.candidate_id
-         success.candidate.visit.identity.candidate_id
+         (EO.flow_success_candidate success).visit.identity.candidate_id
      | None -> fail "successful successor had no settled visit");
     check
       int
       "both candidates are visited"
       2
-      (EO.candidate_visit_count_to_int success.evidence.candidate_visit_count)
+      (EO.candidate_visit_count_to_int (EO.flow_success_evidence success).candidate_visit_count)
   | Error _ -> fail "durably settled selection rejection did not reach successor"
 ;;
 
@@ -600,7 +956,7 @@ let test_read_failed_current_credential_advances_to_good_successor () =
       string
       "read-failed successor succeeds"
       "read-failed-successor"
-      (candidate_id success.candidate)
+      (candidate_id (EO.flow_success_candidate success))
   | Error _ -> fail "read-failed current candidate blocked its good successor"
 ;;
 
@@ -732,7 +1088,10 @@ let test_unmeasured_constraint_advances_only_after_durable_settlement () =
       ; catalog_entry ~id:"unconstrained-exact" ~base_url ~native:true ~json:true ()
       ]
     @@ fun snapshot ->
-    let ready = frozen_flow snapshot [ "constrained-exact"; "unconstrained-exact" ] in
+    let scope = flow_scope "/runtime/capacity-rejection" in
+    let ready =
+      frozen_flow ~scope snapshot [ "constrained-exact"; "unconstrained-exact" ]
+    in
     let transitions = ref [] in
     let bound = ref [] in
     let result =
@@ -764,6 +1123,11 @@ let test_unmeasured_constraint_advances_only_after_durable_settlement () =
               "settled rejected boundary remains exact"
               (Some 524299)
               rejected_from_tokens;
+            check
+              bool
+              "candidate rejection carries flow scope"
+              true
+              (EO.flow_scope_equal scope (EO.candidate_rejection_scope rejection));
             check
               bool
               "admission receipt is pre-dispatch"
@@ -799,17 +1163,14 @@ let test_unmeasured_constraint_advances_only_after_durable_settlement () =
       string
       "admitted successor succeeds"
       "unconstrained-exact"
-      (candidate_id success.candidate);
-    check
-      int
-      "only reached candidates are admitted"
-      2
-      (List.length success.evidence.admissions);
+      (candidate_id (EO.flow_success_candidate success));
+    let evidence = EO.flow_success_evidence success in
+    check int "only reached candidates are admitted" 2 (List.length evidence.admissions);
     check
       int
       "candidate visit count preserves ordered progress"
       2
-      (EO.candidate_visit_count_to_int success.evidence.candidate_visit_count)
+      (EO.candidate_visit_count_to_int evidence.candidate_visit_count)
   | Error _ -> fail "durably settled admission rejection did not reach its successor"
 ;;
 
@@ -872,7 +1233,7 @@ let test_request_body_capacity_advances_only_after_durable_settlement () =
       string
       "body-cap successor succeeds"
       "body-successor"
-      (candidate_id success.candidate)
+      (candidate_id (EO.flow_success_candidate success))
   | Error _ -> fail "durably settled body-cap rejection did not reach its successor"
 ;;
 
@@ -1145,8 +1506,12 @@ let test_predispatch_transport_failure_advances_after_durable_callback () =
     events;
   match result with
   | Ok success ->
-    check string "successor succeeds" "flow-live" (candidate_id success.candidate);
-    let failed = attempt_for success.evidence "flow-dead" in
+    check
+      string
+      "successor succeeds"
+      "flow-live"
+      (candidate_id (EO.flow_success_candidate success));
+    let failed = attempt_for (EO.flow_success_evidence success) "flow-dead" in
     check
       bool
       "failed receipt remains before dispatch"
@@ -1439,12 +1804,16 @@ let test_success_and_later_domain_rejection_are_terminal () =
   check int "success dispatches exactly once" 1 posts;
   match result with
   | Ok success ->
-    check string "first candidate succeeds" "success-a" (candidate_id success.candidate);
+    check
+      string
+      "first candidate succeeds"
+      "success-a"
+      (candidate_id (EO.flow_success_candidate success));
     check
       int
       "successor remains unavailable to later domain rejection"
       1
-      (List.length success.evidence.attempts)
+      (List.length (EO.flow_success_evidence success).attempts)
   | Error _ -> fail "terminal success fixture failed"
 ;;
 
@@ -1567,6 +1936,30 @@ let () =
     "exact-output-flow"
     [ ( "outer-flow"
       , [ test_case
+            "same-scope last-good changes only future snapshots"
+            `Quick
+            test_scope_local_domain_valid_preference_changes_only_future_snapshots
+        ; test_case
+            "concurrent flow scopes isolate attempts and last-good"
+            `Quick
+            test_concurrent_flow_scopes_isolate_attempts_and_future_preferences
+        ; test_case
+            "domain rejection does not update preference"
+            `Quick
+            test_domain_rejection_never_updates_preference_and_settlement_is_affine
+        ; test_case
+            "concurrent domain settlement has one winner"
+            `Quick
+            test_concurrent_domain_settlement_has_one_winner
+        ; test_case
+            "stale domain success cannot overwrite newer last-good"
+            `Quick
+            test_stale_domain_success_cannot_overwrite_newer_last_good
+        ; test_case
+            "blank flow scope is rejected"
+            `Quick
+            test_blank_flow_scope_is_rejected
+        ; test_case
             "snapshot defers admission and current attempts do not share"
             `Quick
             test_snapshot_defers_admission_and_allocates_nonshared_current_attempts

--- a/test/test_exact_output_flow.ml
+++ b/test/test_exact_output_flow.ml
@@ -843,24 +843,50 @@ let test_preference_store_capacity_is_typed_and_reusable_after_removal () =
   let scope_a = flow_scope "/runtime/capacity-a" in
   let scope_b = flow_scope "/runtime/capacity-b" in
   let candidates = [ flow_candidate snapshot "capacity-candidate" ] in
-  (match snapshot_candidates ~preferences ~scope:scope_a candidates with
-   | Ok _ -> ()
-   | Error _ -> fail "first scope did not reserve the only capacity slot");
-  (match snapshot_candidates ~preferences ~scope:scope_b candidates with
-   | Error (EO.Flow_preference_capacity_exhausted { capacity = 1 }) -> ()
-   | Error (EO.Flow_preference_capacity_exhausted { capacity }) ->
-     failf "capacity exhaustion reported the wrong bound: %d" capacity
-   | Error (EO.Duplicate_flow_candidate_id _) ->
-     fail "capacity exhaustion was reported as a duplicate candidate"
-   | Ok _ -> fail "second scope exceeded the hard preference capacity");
-  (match EO.remove_flow_preference_scope preferences scope_a with
+  let ready = Atomic.make 0 in
+  let start = Atomic.make false in
+  let reserve scope () =
+    ignore (Atomic.fetch_and_add ready 1);
+    while not (Atomic.get start) do
+      Domain.cpu_relax ()
+    done;
+    snapshot_candidates ~preferences ~scope candidates
+  in
+  let left_domain = Domain.spawn (reserve scope_a) in
+  let right_domain = Domain.spawn (reserve scope_b) in
+  while Atomic.get ready <> 2 do
+    Domain.cpu_relax ()
+  done;
+  Atomic.set start true;
+  let left = Domain.join left_domain in
+  let right = Domain.join right_domain in
+  let classify = function
+    | Ok _ -> `Reserved
+    | Error (EO.Flow_preference_capacity_exhausted { capacity = 1 }) -> `Exhausted
+    | Error (EO.Flow_preference_capacity_exhausted { capacity }) ->
+      failf "capacity exhaustion reported the wrong bound: %d" capacity
+    | Error (EO.Duplicate_flow_candidate_id _) ->
+      fail "capacity exhaustion was reported as a duplicate candidate"
+  in
+  let reserved_scope, exhausted_scope =
+    match classify left, classify right with
+    | `Reserved, `Exhausted -> scope_a, scope_b
+    | `Exhausted, `Reserved -> scope_b, scope_a
+    | `Reserved, `Reserved -> fail "concurrent scopes exceeded hard capacity"
+    | `Exhausted, `Exhausted -> fail "concurrent reservation admitted no scope"
+  in
+  (match EO.remove_flow_preference_scope preferences exhausted_scope with
+   | EO.Flow_preference_scope_not_reserved -> ()
+   | EO.Flow_preference_scope_removed ->
+     fail "capacity-exhausted scope was nevertheless reserved");
+  (match EO.remove_flow_preference_scope preferences reserved_scope with
    | EO.Flow_preference_scope_removed -> ()
    | EO.Flow_preference_scope_not_reserved ->
      fail "reserved preference scope was not removable");
-  (match EO.remove_flow_preference_scope preferences scope_a with
+  (match EO.remove_flow_preference_scope preferences reserved_scope with
    | EO.Flow_preference_scope_not_reserved -> ()
    | EO.Flow_preference_scope_removed -> fail "preference scope was removed twice");
-  match snapshot_candidates ~preferences ~scope:scope_b candidates with
+  match snapshot_candidates ~preferences ~scope:exhausted_scope candidates with
   | Ok _ -> ()
   | Error _ -> fail "released capacity was not reusable by a new scope"
 ;;

--- a/test/test_exact_output_flow.ml
+++ b/test/test_exact_output_flow.ml
@@ -625,7 +625,8 @@ let test_concurrent_domain_settlement_has_one_winner () =
    | `Installed, `Already_settled | `Already_settled, `Installed -> ()
    | _ ->
      fail
-       "concurrent settlement did not return exactly one installed receipt and one already-settled error");
+       "concurrent settlement did not return exactly one installed receipt and one \
+        already-settled error");
   check
     (list string)
     "winning settlement updates future snapshot once"


### PR DESCRIPTION
## Summary

- add an explicit caller-owned `flow_preference_store` and opaque `flow_scope`
- require a hard scope capacity, reserve new scopes atomically at snapshot, and
  return typed capacity exhaustion
- add explicit scope removal with a private reservation generation so an old
  success cannot write into a removed-and-recreated textual scope
- bind admission rejections, outer attempt receipts, and aggregate evidence to
  that scope
- make structural `flow_success` opaque and require exactly-once typed domain
  settlement
- allocate an immutable OAS-owned monotonic success ordinal when structural
  success is created; `Domain_valid` carries no caller-provided freshness
- make settlement receipts private while retaining exhaustive observation
- update same-scope last-good only after `Domain_valid`; `Domain_rejected`
  remains terminal
- apply last-good only to future immutable snapshots while preserving the
  declared order of all other candidates
- linearize settlement publication: duplicate settlement cannot return before
  the winning preference commit finishes
- privately extract the exact-flow contract to keep the single public facade
  below the godfile ratchet

## Product boundary

This is the §12.7/§12.9 OAS-owned outer-flow contract:

- MASC supplies domain input, ordered opaque slots, an opaque scope, and the
  explicit process-local store capacity/lifetime policy
- OAS owns immutable candidate snapshots, attempt/receipt truth, effect-safe
  next-candidate execution, reservation generations, structural-success
  ordinals, scope-local future preference, and settlement
- MASC owns domain decode/semantic validation and returns only `Domain_valid`
  or `Domain_rejected`
- structural/domain failure never updates last-good and never resumes the
  terminal flow
- no provider/model/tier/error-string classifier, caller timestamp, implicit
  clock, environment policy, global singleton, probe, TTL/LRU, or background
  daemon is introduced
- no I/O, preparation, or logging occurs while the preference mutex is held

The explicit store is a bounded process-local optimization. It is not
capability evidence, recovery truth, or durable business state.

## Breaking pre-1.0 hard cut

- `create_flow_preference_store` requires `~capacity` and returns a typed result
- `snapshot_flow` requires `~preferences` and `~scope` and can return typed
  preference-capacity exhaustion
- callers explicitly release scope capacity with
  `remove_flow_preference_scope`
- `flow_success` is opaque; use its accessors and `settle_flow_domain`
- `Domain_valid` no longer accepts `success_time_unix_s`
- `domain_settlement_receipt` is private
- `flow_attempt_receipt` and `flow_evidence` carry opaque scope identity
- callers must submit one typed domain disposition after structural success

There is no compatibility wrapper or runtime JSON migration.

## Concurrency and lifetime proof

- duplicate/concurrent settlement of one structural success has exactly one
  winner
- two distinct same-scope structural successes receive increasing frozen
  ordinals; reversed cross-Domain settlement retains only the newer success
- two scopes execute concurrently with non-shared attempt IDs
- each scope updates only its own future candidate snapshots
- pre-existing snapshots remain unchanged
- hard capacity exhaustion is typed and released capacity is reusable
- removing and recreating the same textual scope gives a new private
  reservation; settlement from the old generation fails typed and is consumed
  exactly once
- scope, candidate identity, ordinal, reservation, and one-shot receipt remain
  one immutable outer binding

## Verification

Local, current head `4ecaba2f5`:

- `scripts/dune-local.sh build lib/llm_provider/.llm_provider.objs/byte/llm_provider__Exact_output.cmo`
- exact-output resolver boundary ratchet
- hardening ratchet
- code-smell ratchet (`godfile` held at 11)
- `ocamlformat --check` on every touched OCaml file
- `git diff --check`

The machine's Eio 1.3 switch cannot compile main's Eio 1.4-only
`Eio.Net.Address_lookup_failed`, so fresh CI is the full-suite authority.
[Exact-head CI run 30117370377](https://github.com/jeong-sik/oas/actions/runs/30117370377)
passed OCaml 5.4.1, OCaml 5.5.0, Core Boundary Lint, Lint, OCaml Format,
Version Consistency, Transport Drift, Reasoning Effort SSOT, PR Tree Identity,
Draft Guard, and Code Smell Ratchet.

## Stack and rollout

Restacked on current main including merged jeong-sik/oas#2798 and the Eio 1.4 compatibility
fix jeong-sik/oas#2802.

1. merge/release this scoped domain-settlement layer
2. pin the release in MASC
3. migrate the typed consumer with an explicit capacity and scope-removal
   lifecycle
4. prove fresh-state multi-scope execution before publishing
   serving-constraint rows

Refs jeong-sik/masc#27864.
