### PR TITLE
fix(llm-provider): adopt Eio 1.4 network errors

### DIFF
--- a/agent_sdk.opam
+++ b/agent_sdk.opam
@@ -12,8 +12,8 @@ bug-reports: "https://github.com/jeong-sik/agent-sdk/issues"
 depends: [
   "ocaml" {>= "5.4"}
   "dune" {>= "3.22" & >= "3.22"}
-  "eio"
-  "eio_main" {>= "1.3"}
+  "eio" {>= "1.4"}
+  "eio_main" {>= "1.4"}
   "cohttp-eio" {>= "6.2.0"}
   "tls" {>= "2.0.0"}
   "tls-eio" {>= "2.0.0"}

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -2806,8 +2806,7 @@ let%test "classify_network_exn: typed Eio address lookup failure" =
   match
     classify_network_exn
       (eio_exn
-         (Eio.Net.E
-            (Eio.Net.Address_lookup_failed Eio.Net.Getaddrinfo_error.UNKNOWN)))
+         (Eio.Net.E (Eio.Net.Address_lookup_failed Eio.Net.Getaddrinfo_error.UNKNOWN)))
   with
   | Some (NetworkError { kind = Dns_failure; _ }) -> true
   | Some (HttpError _ | NetworkError _ | TimeoutError _ | AcceptRejected _)

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -836,7 +836,8 @@ let classify_eio_net_error = function
   | Eio.Net.Connection_failure (Eio.Net.Refused backend) ->
     Option.value (classify_eio_backend_error backend) ~default:Connection_refused
   | Eio.Net.Connection_failure Eio.Net.Timeout -> Timeout
-  | Eio.Net.Connection_failure Eio.Net.No_matching_addresses -> Dns_failure
+  | Eio.Net.Address_lookup_failed _ -> Dns_failure
+  | Eio.Net.Invalid_option -> Unknown
 ;;
 
 let rec classify_eio_error = function
@@ -2801,12 +2802,22 @@ let%test "classify_network_exn: typed Eio timeout" =
   | None -> false
 ;;
 
-let%test "classify_network_exn: typed Eio no addresses" =
+let%test "classify_network_exn: typed Eio address lookup failure" =
   match
     classify_network_exn
-      (eio_exn (Eio.Net.E (Eio.Net.Connection_failure Eio.Net.No_matching_addresses)))
+      (eio_exn
+         (Eio.Net.E
+            (Eio.Net.Address_lookup_failed Eio.Net.Getaddrinfo_error.UNKNOWN)))
   with
   | Some (NetworkError { kind = Dns_failure; _ }) -> true
+  | Some (HttpError _ | NetworkError _ | TimeoutError _ | AcceptRejected _)
+  | Some (ProviderTerminal _ | ProviderFailure _)
+  | None -> false
+;;
+
+let%test "classify_network_exn: typed Eio invalid socket option stays unknown" =
+  match classify_network_exn (eio_exn (Eio.Net.E Eio.Net.Invalid_option)) with
+  | Some (NetworkError { kind = Unknown; _ }) -> true
   | Some (HttpError _ | NetworkError _ | TimeoutError _ | AcceptRejected _)
   | Some (ProviderTerminal _ | ProviderFailure _)
   | None -> false


### PR DESCRIPTION
## Problem

Eio 1.4 was published on 2026-07-23 and intentionally changed `Net.getaddrinfo`: lookup failures now raise typed `Address_lookup_failed` instead of producing the removed `No_matching_addresses` connection-failure case. Fresh OAS CI resolves Eio 1.4, so unchanged `http_client.ml` no longer compiles on OCaml 5.4.1 or 5.5.0.

Evidence: https://github.com/ocaml-multicore/eio/releases/tag/v1.4 and OAS run https://github.com/jeong-sik/oas/actions/runs/30108301139.

## Change

- Hard-cut `eio` and `eio_main` to `>= 1.4`; no dual-version compatibility path.
- Map typed `Address_lookup_failed _` to `Dns_failure`.
- Handle the new typed `Invalid_option` case as `Unknown`; no string matching.
- Replace the removed-constructor inline test and cover `Invalid_option`.

## Boundary

This PR does not touch exact-output flow state, provider selection, pricing, MASC, or PR #2799 files.

## Verification

Per current collaboration contract, no local build/test/format was run. GitHub CI is the build authority.