### PR TITLE
fix(exact-output): remove nested settlement lock

### DIFF
--- a/docs/design/exact-output-flow-boundary.md
+++ b/docs/design/exact-output-flow-boundary.md
@@ -128,11 +128,15 @@ timestamp, string, or target-specific tie-break. An older observation leaves
 the installed preference unchanged and returns a typed superseded receipt
 containing the retained candidate identity and ordinal.
 
-The per-success settlement gate remains held until domain-valid preference
-publication completes. A losing duplicate therefore cannot return
-`Domain_already_settled` and immediately observe a pre-publication snapshot.
-The only nested lock order is settlement gate then preference store; no path
-acquires those locks in reverse.
+Each success has a closed atomic settlement state: `Pending`, `Publishing`, or
+`Settled`. Domain-valid acquires the preference-store mutex first, changes
+`Pending` to `Publishing`, publishes under that single lock, and terminalizes
+`Settled` in a protected finalizer before unlocking even if publication raises.
+A losing disposition synchronizes through the same preference-store mutex
+before returning `Domain_already_settled`, so its immediate snapshot cannot
+observe pre-publication state. Domain-rejected may change `Pending` directly to
+`Settled`; after a failed compare-and-set it uses the same publication barrier.
+There is no per-settlement mutex and no nested lock order.
 
 No network or filesystem I/O occurs while the preference mutex is held.
 

--- a/lib/llm_provider/exact_output_flow.ml
+++ b/lib/llm_provider/exact_output_flow.ml
@@ -273,14 +273,14 @@ let%test "domain-valid publication blocks a rejected loser and its immediate sna
           (not returned_before_publication)
           &&
             (match winner_result, loser_result, snapshot with
-             | ( Ok Preference_installed
-               , Error Already_settled
-               , Ok (_, Some (candidate, installed_ordinal)) ) ->
-               String.equal candidate "winner"
-               && Int64.equal
-                    (success_ordinal_to_int64 ordinal)
-                    (success_ordinal_to_int64 installed_ordinal)
-             | _ -> false)))
+            | ( Ok Preference_installed
+              , Error Already_settled
+              , Ok (_, Some (candidate, installed_ordinal)) ) ->
+              String.equal candidate "winner"
+              && Int64.equal
+                   (success_ordinal_to_int64 ordinal)
+                   (success_ordinal_to_int64 installed_ordinal)
+            | _ -> false)))
 ;;
 
 let%test "domain rejection can deterministically win against domain valid" =
@@ -389,8 +389,8 @@ let%test "exception after Publishing terminalizes settlement before store unlock
           raised
           &&
             (match duplicate, snapshot with
-             | Error Already_settled, Ok (_, None) -> true
-             | _ -> false)))
+            | Error Already_settled, Ok (_, None) -> true
+            | _ -> false)))
 ;;
 
 let record_admission progress admission =

--- a/lib/llm_provider/exact_output_flow.ml
+++ b/lib/llm_provider/exact_output_flow.ml
@@ -276,7 +276,7 @@ let%test "domain-valid publication blocks a rejected loser and its immediate sna
             | ( Ok Preference_installed
               , Error Already_settled
               , Ok (_, Some (candidate, installed_ordinal)) ) ->
-              String.equal candidate "winner"
+              candidate = "winner"
               && Int64.equal
                    (success_ordinal_to_int64 ordinal)
                    (success_ordinal_to_int64 installed_ordinal)

--- a/lib/llm_provider/exact_output_flow.ml
+++ b/lib/llm_provider/exact_output_flow.ml
@@ -39,7 +39,6 @@ type settlement_state =
   | Settled
 
 type domain_settlement = settlement_state Atomic.t
-
 type preference_store_error = Invalid_preference_capacity of int
 type preference_reservation_error = Preference_capacity_exhausted of { capacity : int }
 
@@ -193,12 +192,7 @@ let settle_domain_valid_once_with_publication_hook
         (fun () ->
            after_publishing ();
            match
-             record_preference_locked
-               preferences
-               ~scope
-               ~reservation
-               ~candidate
-               ~ordinal
+             record_preference_locked preferences ~scope ~reservation ~candidate ~ordinal
            with
            | Ok installation -> Ok installation
            | Error Preference_scope_not_reserved_for_record ->
@@ -278,15 +272,15 @@ let%test "domain-valid publication blocks a rejected loser and its immediate sna
           let loser_result, snapshot = Domain.join loser in
           (not returned_before_publication)
           &&
-          match winner_result, loser_result, snapshot with
-          | ( Ok Preference_installed
-            , Error Already_settled
-            , Ok (_, Some (candidate, installed_ordinal)) ) ->
-            String.equal candidate "winner"
-            && Int64.equal
-                 (success_ordinal_to_int64 ordinal)
-                 (success_ordinal_to_int64 installed_ordinal)
-          | _ -> false))
+            (match winner_result, loser_result, snapshot with
+             | ( Ok Preference_installed
+               , Error Already_settled
+               , Ok (_, Some (candidate, installed_ordinal)) ) ->
+               String.equal candidate "winner"
+               && Int64.equal
+                    (success_ordinal_to_int64 ordinal)
+                    (success_ordinal_to_int64 installed_ordinal)
+             | _ -> false)))
 ;;
 
 let%test "domain rejection can deterministically win against domain valid" =
@@ -332,9 +326,9 @@ let%test "domain rejection can deterministically win against domain valid" =
           let rejected_result = Domain.join rejected in
           let valid_result = Domain.join valid in
           let snapshot = reserve_preference_scope preferences ~scope in
-          match rejected_result, valid_result, snapshot with
-          | Ok (), Error Already_settled, Ok (_, None) -> true
-          | _ -> false))
+          (match rejected_result, valid_result, snapshot with
+           | Ok (), Error Already_settled, Ok (_, None) -> true
+           | _ -> false)))
 ;;
 
 let%test "two concurrent domain rejections have exactly one winner" =
@@ -394,9 +388,9 @@ let%test "exception after Publishing terminalizes settlement before store unlock
           let snapshot = reserve_preference_scope preferences ~scope in
           raised
           &&
-          match duplicate, snapshot with
-          | Error Already_settled, Ok (_, None) -> true
-          | _ -> false))
+            (match duplicate, snapshot with
+             | Error Already_settled, Ok (_, None) -> true
+             | _ -> false)))
 ;;
 
 let record_admission progress admission =

--- a/lib/llm_provider/exact_output_flow.ml
+++ b/lib/llm_provider/exact_output_flow.ml
@@ -33,10 +33,12 @@ type ('scope, 'candidate) preference_store =
   ; mutable last_success_ordinal : int64
   }
 
-type domain_settlement =
-  { mutex : Mutex.t
-  ; mutable settled : bool
-  }
+type settlement_state =
+  | Pending
+  | Publishing
+  | Settled
+
+type domain_settlement = settlement_state Atomic.t
 
 type preference_store_error = Invalid_preference_capacity of int
 type preference_reservation_error = Preference_capacity_exhausted of { capacity : int }
@@ -95,7 +97,7 @@ let create_preference_store ~capacity =
       }
 ;;
 
-let create_domain_settlement () = { mutex = Mutex.create (); settled = false }
+let create_domain_settlement () = Atomic.make Pending
 
 let with_preference_lock (store : (_, _) preference_store) f =
   Mutex.lock store.mutex;
@@ -140,30 +142,67 @@ let compare_success_ordinal (Success_ordinal left) (Success_ordinal right) =
   Int64.compare left right
 ;;
 
-let record_preference store ~scope ~reservation ~candidate ~ordinal =
-  with_preference_lock store (fun () ->
-    match Hashtbl.find_opt store.entries scope with
-    | None -> Error Preference_scope_not_reserved_for_record
-    | Some entry when entry.reservation != reservation ->
-      Error Preference_scope_not_reserved_for_record
-    | Some { preference = Some (current_candidate, current_ordinal); _ }
-      when compare_success_ordinal ordinal current_ordinal <= 0 ->
-      Ok (Preference_superseded { current_candidate; current_ordinal })
-    | Some entry ->
-      entry.preference <- Some (candidate, ordinal);
-      Ok Preference_installed)
+let record_preference_locked store ~scope ~reservation ~candidate ~ordinal =
+  match Hashtbl.find_opt store.entries scope with
+  | None -> Error Preference_scope_not_reserved_for_record
+  | Some entry when entry.reservation != reservation ->
+    Error Preference_scope_not_reserved_for_record
+  | Some { preference = Some (current_candidate, current_ordinal); _ }
+    when compare_success_ordinal ordinal current_ordinal <= 0 ->
+    Ok (Preference_superseded { current_candidate; current_ordinal })
+  | Some entry ->
+    entry.preference <- Some (candidate, ordinal);
+    Ok Preference_installed
 ;;
 
-let settle_domain_rejected_once settlement =
-  Mutex.lock settlement.mutex;
-  Fun.protect
-    ~finally:(fun () -> Mutex.unlock settlement.mutex)
-    (fun () ->
-       if settlement.settled
-       then Error Already_settled
-       else (
-         settlement.settled <- true;
-         Ok ()))
+let settle_domain_rejected_once_with_publication_hook
+      ~after_failed_cas
+      settlement
+      preferences
+  =
+  if Atomic.compare_and_set settlement Pending Settled
+  then Ok ()
+  else (
+    after_failed_cas ();
+    with_preference_lock preferences (fun () -> ());
+    Error Already_settled)
+;;
+
+let settle_domain_rejected_once settlement preferences =
+  settle_domain_rejected_once_with_publication_hook
+    ~after_failed_cas:ignore
+    settlement
+    preferences
+;;
+
+let settle_domain_valid_once_with_publication_hook
+      ~after_publishing
+      settlement
+      preferences
+      ~scope
+      ~reservation
+      ~candidate
+      ~ordinal
+  =
+  with_preference_lock preferences (fun () ->
+    if not (Atomic.compare_and_set settlement Pending Publishing)
+    then Error Already_settled
+    else
+      Fun.protect
+        ~finally:(fun () -> Atomic.set settlement Settled)
+        (fun () ->
+           after_publishing ();
+           match
+             record_preference_locked
+               preferences
+               ~scope
+               ~reservation
+               ~candidate
+               ~ordinal
+           with
+           | Ok installation -> Ok installation
+           | Error Preference_scope_not_reserved_for_record ->
+             Error Preference_scope_released))
 ;;
 
 let settle_domain_valid_once
@@ -174,21 +213,190 @@ let settle_domain_valid_once
       ~candidate
       ~ordinal
   =
-  Mutex.lock settlement.mutex;
-  Fun.protect
-    ~finally:(fun () -> Mutex.unlock settlement.mutex)
-    (fun () ->
-       if settlement.settled
-       then Error Already_settled
-       else (
-         let installation =
-           record_preference preferences ~scope ~reservation ~candidate ~ordinal
-         in
-         settlement.settled <- true;
-         match installation with
-         | Ok installation -> Ok installation
-         | Error Preference_scope_not_reserved_for_record ->
-           Error Preference_scope_released))
+  settle_domain_valid_once_with_publication_hook
+    ~after_publishing:ignore
+    settlement
+    preferences
+    ~scope
+    ~reservation
+    ~candidate
+    ~ordinal
+;;
+
+let%test "domain-valid publication blocks a rejected loser and its immediate snapshot" =
+  match create_preference_store ~capacity:1 with
+  | Error _ -> false
+  | Ok preferences ->
+    let scope = "valid-wins" in
+    (match reserve_preference_scope preferences ~scope with
+     | Error _ | Ok (_, Some _) -> false
+     | Ok (reservation, None) ->
+       (match allocate_success_ordinal preferences with
+        | Error _ -> false
+        | Ok ordinal ->
+          let settlement = create_domain_settlement () in
+          let publishing = Atomic.make false in
+          let release_publication = Atomic.make false in
+          let rejected_cas_lost = Atomic.make false in
+          let loser_finished = Atomic.make false in
+          let winner =
+            Domain.spawn (fun () ->
+              settle_domain_valid_once_with_publication_hook
+                ~after_publishing:(fun () ->
+                  Atomic.set publishing true;
+                  while not (Atomic.get release_publication) do
+                    Domain.cpu_relax ()
+                  done)
+                settlement
+                preferences
+                ~scope
+                ~reservation
+                ~candidate:"winner"
+                ~ordinal)
+          in
+          while not (Atomic.get publishing) do
+            Domain.cpu_relax ()
+          done;
+          let loser =
+            Domain.spawn (fun () ->
+              let result =
+                settle_domain_rejected_once_with_publication_hook
+                  ~after_failed_cas:(fun () -> Atomic.set rejected_cas_lost true)
+                  settlement
+                  preferences
+              in
+              let snapshot = reserve_preference_scope preferences ~scope in
+              Atomic.set loser_finished true;
+              result, snapshot)
+          in
+          while not (Atomic.get rejected_cas_lost) do
+            Domain.cpu_relax ()
+          done;
+          let returned_before_publication = Atomic.get loser_finished in
+          Atomic.set release_publication true;
+          let winner_result = Domain.join winner in
+          let loser_result, snapshot = Domain.join loser in
+          (not returned_before_publication)
+          &&
+          match winner_result, loser_result, snapshot with
+          | ( Ok Preference_installed
+            , Error Already_settled
+            , Ok (_, Some (candidate, installed_ordinal)) ) ->
+            String.equal candidate "winner"
+            && Int64.equal
+                 (success_ordinal_to_int64 ordinal)
+                 (success_ordinal_to_int64 installed_ordinal)
+          | _ -> false))
+;;
+
+let%test "domain rejection can deterministically win against domain valid" =
+  match create_preference_store ~capacity:1 with
+  | Error _ -> false
+  | Ok preferences ->
+    let scope = "rejected-wins" in
+    (match reserve_preference_scope preferences ~scope with
+     | Error _ | Ok (_, Some _) -> false
+     | Ok (reservation, None) ->
+       (match allocate_success_ordinal preferences with
+        | Error _ -> false
+        | Ok ordinal ->
+          let settlement = create_domain_settlement () in
+          let start = Atomic.make false in
+          let rejection_committed = Atomic.make false in
+          let rejected =
+            Domain.spawn (fun () ->
+              while not (Atomic.get start) do
+                Domain.cpu_relax ()
+              done;
+              let result = settle_domain_rejected_once settlement preferences in
+              Atomic.set rejection_committed true;
+              result)
+          in
+          let valid =
+            Domain.spawn (fun () ->
+              while not (Atomic.get start) do
+                Domain.cpu_relax ()
+              done;
+              while not (Atomic.get rejection_committed) do
+                Domain.cpu_relax ()
+              done;
+              settle_domain_valid_once
+                settlement
+                preferences
+                ~scope
+                ~reservation
+                ~candidate:"loser"
+                ~ordinal)
+          in
+          Atomic.set start true;
+          let rejected_result = Domain.join rejected in
+          let valid_result = Domain.join valid in
+          let snapshot = reserve_preference_scope preferences ~scope in
+          match rejected_result, valid_result, snapshot with
+          | Ok (), Error Already_settled, Ok (_, None) -> true
+          | _ -> false))
+;;
+
+let%test "two concurrent domain rejections have exactly one winner" =
+  match create_preference_store ~capacity:1 with
+  | Error _ -> false
+  | Ok preferences ->
+    let settlement = create_domain_settlement () in
+    let ready = Atomic.make 0 in
+    let start = Atomic.make false in
+    let reject () =
+      ignore (Atomic.fetch_and_add ready 1);
+      while not (Atomic.get start) do
+        Domain.cpu_relax ()
+      done;
+      settle_domain_rejected_once settlement preferences
+    in
+    let left = Domain.spawn reject in
+    let right = Domain.spawn reject in
+    while Atomic.get ready <> 2 do
+      Domain.cpu_relax ()
+    done;
+    Atomic.set start true;
+    (match Domain.join left, Domain.join right with
+     | Ok (), Error Already_settled | Error Already_settled, Ok () -> true
+     | _ -> false)
+;;
+
+let%test "exception after Publishing terminalizes settlement before store unlock" =
+  let exception Injected_after_publishing in
+  match create_preference_store ~capacity:1 with
+  | Error _ -> false
+  | Ok preferences ->
+    let scope = "publishing-exception" in
+    (match reserve_preference_scope preferences ~scope with
+     | Error _ | Ok (_, Some _) -> false
+     | Ok (reservation, None) ->
+       (match allocate_success_ordinal preferences with
+        | Error _ -> false
+        | Ok ordinal ->
+          let settlement = create_domain_settlement () in
+          let raised =
+            try
+              ignore
+                (settle_domain_valid_once_with_publication_hook
+                   ~after_publishing:(fun () -> raise Injected_after_publishing)
+                   settlement
+                   preferences
+                   ~scope
+                   ~reservation
+                   ~candidate:"never-installed"
+                   ~ordinal);
+              false
+            with
+            | Injected_after_publishing -> true
+          in
+          let duplicate = settle_domain_rejected_once settlement preferences in
+          let snapshot = reserve_preference_scope preferences ~scope in
+          raised
+          &&
+          match duplicate, snapshot with
+          | Error Already_settled, Ok (_, None) -> true
+          | _ -> false))
 ;;
 
 let record_admission progress admission =

--- a/lib/llm_provider/exact_output_flow.mli
+++ b/lib/llm_provider/exact_output_flow.mli
@@ -84,14 +84,17 @@ val allocate_success_ordinal
 
 val success_ordinal_to_int64 : success_ordinal -> int64
 
+(** Settlement uses the preference store's single mutex as its publication
+    barrier. Domain-valid acquires that lock before changing [Pending] to
+    [Publishing], terminalizes [Settled] before unlocking even on exception,
+    and publishes the preference while the lock is held. A losing disposition
+    synchronizes through the same lock before returning [Already_settled].
+    There is no per-settlement mutex or nested lock order. *)
 val settle_domain_rejected_once
   :  domain_settlement
+  -> ('scope, 'candidate) preference_store
   -> (unit, domain_settlement_error) result
 
-(** The per-success settlement gate remains held through preference
-    publication. A losing duplicate therefore returns only after the winning
-    domain-valid record is visible. Lock acquisition is strictly settlement
-    gate then preference store; no operation acquires them in reverse order. *)
 val settle_domain_valid_once
   :  domain_settlement
   -> ('scope, 'candidate) preference_store

--- a/lib/llm_provider/exact_output_flow_contract.ml
+++ b/lib/llm_provider/exact_output_flow_contract.ml
@@ -147,7 +147,7 @@ let settle_domain
   let result =
     match disposition with
     | Domain_rejected ->
-      Flow_state.settle_domain_rejected_once settlement
+      Flow_state.settle_domain_rejected_once settlement preferences
       |> Result.map (fun () -> Domain_rejected_recorded)
     | Domain_valid ->
       Flow_state.settle_domain_valid_once

--- a/scripts/check-exact-output-resolver-boundary.sh
+++ b/scripts/check-exact-output-resolver-boundary.sh
@@ -331,6 +331,33 @@ require_code_sequence() {
   fi
 }
 
+require_code_occurrence_count() {
+  local description="$1"
+  local pattern="$2"
+  local expected="$3"
+  local source_file="$4"
+  local actual
+  actual="$(
+    strip_ocaml_noncode < "$source_file" \
+      | awk -v pattern="$pattern" '
+          {
+            remaining = $0
+            while (match(remaining, pattern)) {
+              count++
+              remaining = substr(remaining, RSTART + RLENGTH)
+            }
+          }
+          END { print count + 0 }
+        '
+  )"
+  if [[ "$actual" -ne "$expected" ]]; then
+    echo \
+      "exact-output boundary violation: $description (expected $expected, found $actual)" \
+      >&2
+    return 1
+  fi
+}
+
 scan_code_sequence() {
   local description="$1"
   local pattern="$2"
@@ -1072,6 +1099,20 @@ require_named_function_pattern \
   'with_preference_lock[[:space:]]+preferences.*Atomic[.]compare_and_set[[:space:]]+settlement[[:space:]]+Pending[[:space:]]+Publishing.*Fun[.]protect.*Atomic[.]set[[:space:]]+settlement[[:space:]]+Settled.*record_preference_locked' \
   "$exact_output_flow_source" \
   "settle_domain_valid_once_with_publication_hook"
+require_code_occurrence_count \
+  "locked preference recorder reference set changed" \
+  'record_preference_locked' \
+  2 \
+  "$exact_output_flow_source"
+scan_outside_named_functions \
+  "locked preference recorder escaped its definition or canonical publication path" \
+  'record_preference_locked' \
+  "$exact_output_flow_source" \
+  "record_preference_locked settle_domain_valid_once_with_publication_hook"
+scan_code \
+  "locked preference recorder escaped through the private interface" \
+  'record_preference_locked' \
+  "$module_dir/exact_output_flow.mli"
 require_named_function_pattern \
   "domain-rejected CAS loss stopped synchronizing with preference publication" \
   'Atomic[.]compare_and_set[[:space:]]+settlement[[:space:]]+Pending[[:space:]]+Settled.*after_failed_cas.*with_preference_lock[[:space:]]+preferences.*Error[[:space:]]+Already_settled' \

--- a/scripts/check-exact-output-resolver-boundary.sh
+++ b/scripts/check-exact-output-resolver-boundary.sh
@@ -331,6 +331,18 @@ require_code_sequence() {
   fi
 }
 
+scan_code_sequence() {
+  local description="$1"
+  local pattern="$2"
+  local source_file="$3"
+  local compact
+  compact="$(strip_ocaml_noncode < "$source_file" | awk '{ printf "%s ", $0 } END { print "" }')"
+  if grep -E -- "$pattern" <<< "$compact" >/dev/null; then
+    echo "exact-output boundary violation: $description" >&2
+    return 1
+  fi
+}
+
 require_named_function_pattern() {
   local description="$1"
   local pattern="$2"
@@ -1042,11 +1054,29 @@ require_code_sequence \
   "scope-local preference stopped failing closed on ordinal exhaustion" \
   'let[[:space:]]+allocate_success_ordinal.*Int64[.]max_int.*Int64[.]succ' \
   "$exact_output_flow_source"
-require_named_function_pattern \
-  "domain settlement lost its synchronized commit-before-publication gate" \
-  'Mutex[.]lock[[:space:]]+settlement[.]mutex.*Fun[.]protect.*Mutex[.]unlock[[:space:]]+settlement[.]mutex.*record_preference.*settled[[:space:]]*<-[[:space:]]*true' \
+require_code_sequence \
+  "domain settlement lost its closed atomic publication states" \
+  'type[[:space:]]+settlement_state[[:space:]]*=[[:space:]]*.*Pending.*Publishing.*Settled.*type[[:space:]]+domain_settlement[[:space:]]*=[[:space:]]*settlement_state[[:space:]]+Atomic[.]t' \
+  "$exact_output_flow_source"
+scan_code_sequence \
+  "domain settlement regained a per-settlement mutex" \
+  'type[[:space:]]+domain_settlement[[:space:]]*=[[:space:]]*\{[^}]*Mutex[.]t' \
+  "$exact_output_flow_source"
+scan_named_functions \
+  "domain settlement acquired a second mutex or revived a settlement lock" \
+  'Mutex[.](lock|unlock)|settlement[.][[:alnum:]_]*mutex' \
   "$exact_output_flow_source" \
-  "settle_domain_valid_once"
+  "settle_domain_valid_once_with_publication_hook settle_domain_rejected_once_with_publication_hook"
+require_named_function_pattern \
+  "domain-valid settlement lost store-lock-first atomic publication" \
+  'with_preference_lock[[:space:]]+preferences.*Atomic[.]compare_and_set[[:space:]]+settlement[[:space:]]+Pending[[:space:]]+Publishing.*Fun[.]protect.*Atomic[.]set[[:space:]]+settlement[[:space:]]+Settled.*record_preference_locked' \
+  "$exact_output_flow_source" \
+  "settle_domain_valid_once_with_publication_hook"
+require_named_function_pattern \
+  "domain-rejected CAS loss stopped synchronizing with preference publication" \
+  'Atomic[.]compare_and_set[[:space:]]+settlement[[:space:]]+Pending[[:space:]]+Settled.*after_failed_cas.*with_preference_lock[[:space:]]+preferences.*Error[[:space:]]+Already_settled' \
+  "$exact_output_flow_source" \
+  "settle_domain_rejected_once_with_publication_hook"
 require_named_function_pattern \
   "preference capacity check and reservation add are no longer atomic" \
   'with_preference_lock[[:space:]]+store.*Hashtbl[.]length[[:space:]]+store[.]entries.*Hashtbl[.]add[[:space:]]+store[.]entries' \

--- a/test/check_exact_output_publication_lock.ml
+++ b/test/check_exact_output_publication_lock.ml
@@ -277,11 +277,11 @@ let () =
        exit 2
      | Some expected ->
        (match check_file path with
-         | Error message when String.equal message expected -> ()
+        | Error message when String.equal message expected -> ()
         | Error message ->
           report_error ("negative fixture failed for the wrong reason: " ^ message);
           exit 2
-         | Ok () ->
+        | Ok () ->
           report_error "negative fixture unexpectedly passed";
           exit 2))
   | _ ->

--- a/test/check_exact_output_publication_lock.ml
+++ b/test/check_exact_output_publication_lock.ml
@@ -275,14 +275,14 @@ let () =
      | None ->
        report_error ("unknown negative-fixture mode: " ^ flag);
        exit 2
-      | Some expected ->
-        (match check_file path with
-        | Error message when String.equal message expected -> ()
-         | Error message ->
-           report_error ("negative fixture failed for the wrong reason: " ^ message);
-           exit 2
-        | Ok () ->
-           report_error "negative fixture unexpectedly passed";
+     | Some expected ->
+       (match check_file path with
+         | Error message when String.equal message expected -> ()
+        | Error message ->
+          report_error ("negative fixture failed for the wrong reason: " ^ message);
+          exit 2
+         | Ok () ->
+          report_error "negative fixture unexpectedly passed";
           exit 2))
   | _ ->
     prerr_endline "usage: check_exact_output_publication_lock [--expect-*] SOURCE.ml";

--- a/test/check_exact_output_publication_lock.ml
+++ b/test/check_exact_output_publication_lock.ml
@@ -2,6 +2,7 @@ open Asttypes
 open Parsetree
 
 let outside_callback = "record_preference_locked is outside with_preference_lock callback"
+let namespace_import = "open/include syntax is forbidden in publication lock boundary"
 let fail message = Error message
 
 let parse_implementation path =
@@ -43,6 +44,7 @@ type collected =
   ; mutable recorder_calls : (expression * (arg_label * expression) list) list
   ; mutable recorder_first_class_references : expression list
   ; mutable lock_calls : (expression * (arg_label * expression) list) list
+  ; mutable namespace_import_seen : bool
   }
 
 let observe_binding collected ~top_level name =
@@ -85,6 +87,7 @@ let collect structure =
     ; recorder_calls = []
     ; recorder_first_class_references = []
     ; lock_calls = []
+    ; namespace_import_seen = false
     }
   in
   observe_top_level_bindings collected structure;
@@ -97,8 +100,17 @@ let collect structure =
            | Ppat_alias (_, name) -> observe_binding collected ~top_level:false name.txt
            | _ -> ());
           Ast_iterator.default_iterator.pat self pattern)
+    ; structure_item =
+        (fun self item ->
+          (match item.pstr_desc with
+           | Pstr_open _ | Pstr_include _ -> collected.namespace_import_seen <- true
+           | _ -> ());
+          Ast_iterator.default_iterator.structure_item self item)
     ; expr =
         (fun self expression ->
+          (match expression.pexp_desc with
+           | Pexp_open _ -> collected.namespace_import_seen <- true
+           | _ -> ());
           let is_recorder, recorder_arguments =
             is_named_application "record_preference_locked" expression
           in
@@ -186,7 +198,9 @@ let lock_store_and_callback arguments =
 
 let check structure =
   let collected = collect structure in
-  if
+  if collected.namespace_import_seen
+  then fail namespace_import
+  else if
     collected.recorder_binding_count <> 1
     || collected.recorder_top_level_binding_count <> 1
   then fail "record_preference_locked must have exactly one binding"
@@ -237,6 +251,7 @@ let check_file path =
 
 let expected_error_of_flag = function
   | "--expect-outside-callback" -> Some outside_callback
+  | "--expect-namespace-import" -> Some namespace_import
   | "--expect-shadowed-lock-binding" ->
     Some "with_preference_lock must have exactly one binding"
   | "--expect-noncanonical-recorder" ->
@@ -263,12 +278,12 @@ let () =
      | Some expected ->
        (match check_file path with
         | Error message when String.equal message expected -> ()
-        | Error message ->
-          report_error ("negative fixture failed for the wrong reason: " ^ message);
-          exit 2
-       | Ok () ->
-         report_error "negative fixture unexpectedly passed";
-         exit 2))
+       | Error message ->
+         report_error ("negative fixture failed for the wrong reason: " ^ message);
+         exit 2
+        | Ok () ->
+          report_error "negative fixture unexpectedly passed";
+          exit 2))
   | _ ->
     prerr_endline "usage: check_exact_output_publication_lock [--expect-*] SOURCE.ml";
     exit 2

--- a/test/check_exact_output_publication_lock.ml
+++ b/test/check_exact_output_publication_lock.ml
@@ -100,6 +100,14 @@ let collect structure =
            | Ppat_alias (_, name) -> observe_binding collected ~top_level:false name.txt
            | _ -> ());
           Ast_iterator.default_iterator.pat self pattern)
+    ; open_declaration =
+        (fun self declaration ->
+          collected.namespace_import_seen <- true;
+          Ast_iterator.default_iterator.open_declaration self declaration)
+    ; include_declaration =
+        (fun self declaration ->
+          collected.namespace_import_seen <- true;
+          Ast_iterator.default_iterator.include_declaration self declaration)
     ; structure_item =
         (fun self item ->
           (match item.pstr_desc with
@@ -108,9 +116,6 @@ let collect structure =
           Ast_iterator.default_iterator.structure_item self item)
     ; expr =
         (fun self expression ->
-          (match expression.pexp_desc with
-           | Pexp_open _ -> collected.namespace_import_seen <- true
-           | _ -> ());
           let is_recorder, recorder_arguments =
             is_named_application "record_preference_locked" expression
           in

--- a/test/check_exact_output_publication_lock.ml
+++ b/test/check_exact_output_publication_lock.ml
@@ -20,9 +20,7 @@ let exact_identifier_name expression =
   | _ -> None
 ;;
 
-let simple_identifier expression =
-  exact_identifier_name expression
-;;
+let simple_identifier expression = exact_identifier_name expression
 
 let binding_name pattern =
   match pattern.ppat_desc with
@@ -153,8 +151,7 @@ let expression_binds name root =
       pat =
         (fun self pattern ->
           (match pattern.ppat_desc with
-           | Ppat_var bound | Ppat_alias (_, bound)
-             when String.equal bound.txt name ->
+           | (Ppat_var bound | Ppat_alias (_, bound)) when String.equal bound.txt name ->
              found := true
            | _ -> ());
           Ast_iterator.default_iterator.pat self pattern)
@@ -269,11 +266,10 @@ let () =
         | Error message ->
           report_error ("negative fixture failed for the wrong reason: " ^ message);
           exit 2
-        | Ok () ->
-          report_error "negative fixture unexpectedly passed";
-          exit 2))
+       | Ok () ->
+         report_error "negative fixture unexpectedly passed";
+         exit 2))
   | _ ->
-    prerr_endline
-      "usage: check_exact_output_publication_lock [--expect-*] SOURCE.ml";
+    prerr_endline "usage: check_exact_output_publication_lock [--expect-*] SOURCE.ml";
     exit 2
 ;;

--- a/test/check_exact_output_publication_lock.ml
+++ b/test/check_exact_output_publication_lock.ml
@@ -275,14 +275,14 @@ let () =
      | None ->
        report_error ("unknown negative-fixture mode: " ^ flag);
        exit 2
-     | Some expected ->
-       (match check_file path with
-         | Error message when String.equal message expected -> ()
-        | Error message ->
-          report_error ("negative fixture failed for the wrong reason: " ^ message);
-          exit 2
-         | Ok () ->
-          report_error "negative fixture unexpectedly passed";
+      | Some expected ->
+        (match check_file path with
+        | Error message when String.equal message expected -> ()
+         | Error message ->
+           report_error ("negative fixture failed for the wrong reason: " ^ message);
+           exit 2
+        | Ok () ->
+           report_error "negative fixture unexpectedly passed";
           exit 2))
   | _ ->
     prerr_endline "usage: check_exact_output_publication_lock [--expect-*] SOURCE.ml";

--- a/test/check_exact_output_publication_lock.ml
+++ b/test/check_exact_output_publication_lock.ml
@@ -1,0 +1,227 @@
+open Asttypes
+open Parsetree
+
+let outside_callback =
+  "record_preference_locked is outside with_preference_lock callback"
+;;
+
+let fail message = Error message
+
+let parse_implementation path =
+  let channel = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in channel)
+    (fun () ->
+       let lexbuf = Lexing.from_channel channel in
+       Location.init lexbuf path;
+       Parse.implementation lexbuf)
+;;
+
+let identifier_name expression =
+  match expression.pexp_desc with
+  | Pexp_ident identifier -> Some (Longident.last identifier.txt)
+  | _ -> None
+;;
+
+let simple_identifier expression =
+  match expression.pexp_desc with
+  | Pexp_ident identifier ->
+    (match Longident.flatten identifier.txt with
+     | [ name ] -> Some name
+     | _ -> None)
+  | _ -> None
+;;
+
+let binding_name pattern =
+  match pattern.ppat_desc with
+  | Ppat_var name -> Some name.txt
+  | _ -> None
+;;
+
+let is_named_application name expression =
+  match expression.pexp_desc with
+  | Pexp_apply (callee, arguments) ->
+    Option.equal String.equal (identifier_name callee) (Some name), arguments
+  | _ -> false, []
+;;
+
+type collected =
+  { mutable recorder_binding_count : int
+  ; mutable recorder_calls : (expression * (arg_label * expression) list) list
+  ; mutable recorder_first_class_references : expression list
+  ; mutable lock_calls : (expression * (arg_label * expression) list) list
+  }
+
+let collect structure =
+  let collected =
+    { recorder_binding_count = 0
+    ; recorder_calls = []
+    ; recorder_first_class_references = []
+    ; lock_calls = []
+    }
+  in
+  let iterator =
+    { Ast_iterator.default_iterator with
+      pat =
+        (fun self pattern ->
+           (match binding_name pattern with
+            | Some "record_preference_locked" ->
+              collected.recorder_binding_count <- collected.recorder_binding_count + 1
+            | Some _ | None -> ());
+           Ast_iterator.default_iterator.pat self pattern)
+    ; expr =
+        (fun self expression ->
+           let is_recorder, recorder_arguments =
+             is_named_application "record_preference_locked" expression
+           in
+           let is_lock, lock_arguments =
+             is_named_application "with_preference_lock" expression
+           in
+           if is_recorder
+           then (
+             collected.recorder_calls
+             <- (expression, recorder_arguments) :: collected.recorder_calls;
+             List.iter (fun (_, argument) -> self.expr self argument) recorder_arguments)
+           else (
+             (match expression.pexp_desc with
+              | Pexp_ident identifier
+                when String.equal
+                       (Longident.last identifier.txt)
+                       "record_preference_locked" ->
+                collected.recorder_first_class_references
+                <- expression :: collected.recorder_first_class_references
+              | _ -> ());
+             if is_lock
+             then
+               collected.lock_calls
+               <- (expression, lock_arguments) :: collected.lock_calls;
+             Ast_iterator.default_iterator.expr self expression))
+    }
+  in
+  iterator.structure iterator structure;
+  collected
+;;
+
+let expression_contains target root =
+  let found = ref false in
+  let iterator =
+    { Ast_iterator.default_iterator with
+      expr =
+        (fun self expression ->
+           if expression == target
+           then found := true
+           else Ast_iterator.default_iterator.expr self expression)
+    }
+  in
+  iterator.expr iterator root;
+  !found
+;;
+
+let expression_binds name root =
+  let found = ref false in
+  let iterator =
+    { Ast_iterator.default_iterator with
+      pat =
+        (fun self pattern ->
+           (match binding_name pattern with
+            | Some bound when String.equal bound name -> found := true
+            | Some _ | None -> ());
+           Ast_iterator.default_iterator.pat self pattern)
+    }
+  in
+  iterator.expr iterator root;
+  !found
+;;
+
+let recorder_store_and_labels arguments =
+  match arguments with
+  | [ Nolabel, store
+    ; Labelled "scope", _
+    ; Labelled "reservation", _
+    ; Labelled "candidate", _
+    ; Labelled "ordinal", _
+    ] ->
+    (match simple_identifier store with
+     | Some store_name -> Ok store_name
+     | None -> fail "record_preference_locked store argument is not a simple identifier")
+  | _ -> fail "record_preference_locked is not one saturated direct call"
+;;
+
+let lock_store_and_callback arguments =
+  match arguments with
+  | [ Nolabel, store; Nolabel, callback ] ->
+    (match simple_identifier store with
+     | Some store_name -> Some (store_name, callback)
+     | None -> None)
+  | _ -> None
+;;
+
+let check structure =
+  let collected = collect structure in
+  if collected.recorder_binding_count <> 1
+  then fail "record_preference_locked must have exactly one binding"
+  else if collected.recorder_first_class_references <> []
+  then fail "record_preference_locked escaped as a first-class or partial reference"
+  else
+    match collected.recorder_calls with
+    | [ recorder_call, arguments ] ->
+      (match recorder_store_and_labels arguments with
+       | Error _ as error -> error
+       | Ok recorder_store ->
+         let containing_callbacks =
+           List.filter_map
+             (fun (_, lock_arguments) ->
+                match lock_store_and_callback lock_arguments with
+                | Some (lock_store, callback)
+                  when expression_contains recorder_call callback ->
+                  Some (lock_store, callback)
+                | Some _ | None -> None)
+             collected.lock_calls
+         in
+         (match containing_callbacks with
+          | [] -> fail outside_callback
+          | [ lock_store, callback ] ->
+            if not (String.equal lock_store recorder_store)
+            then fail "preference lock and recorder use different store identifiers"
+            else if expression_binds recorder_store callback
+            then fail "preference store identifier is shadowed inside lock callback"
+            else Ok ()
+          | _ -> fail "record_preference_locked is nested under multiple lock callbacks"))
+    | [] -> fail "record_preference_locked has no saturated direct call"
+    | _ -> fail "record_preference_locked has more than one direct call"
+;;
+
+let report_error message =
+  prerr_endline ("exact-output publication lock violation: " ^ message)
+;;
+
+let check_file path =
+  try check (parse_implementation path) with
+  | Sys_error message -> fail message
+  | Syntaxerr.Error _ -> fail ("syntax error while parsing " ^ path)
+;;
+
+let () =
+  match Array.to_list Sys.argv with
+  | [ _; path ] ->
+    (match check_file path with
+     | Ok () -> ()
+     | Error message ->
+       report_error message;
+       exit 1)
+  | [ _; "--expect-outside-callback"; path ] ->
+    (match check_file path with
+     | Error message when String.equal message outside_callback -> ()
+     | Error message ->
+       report_error
+         ("negative fixture failed for the wrong reason: " ^ message);
+       exit 2
+     | Ok () ->
+       report_error "negative fixture unexpectedly passed";
+       exit 2)
+  | _ ->
+    prerr_endline
+      "usage: check_exact_output_publication_lock \
+       [--expect-outside-callback] SOURCE.ml";
+    exit 2
+;;

--- a/test/check_exact_output_publication_lock.ml
+++ b/test/check_exact_output_publication_lock.ml
@@ -1,10 +1,7 @@
 open Asttypes
 open Parsetree
 
-let outside_callback =
-  "record_preference_locked is outside with_preference_lock callback"
-;;
-
+let outside_callback = "record_preference_locked is outside with_preference_lock callback"
 let fail message = Error message
 
 let parse_implementation path =
@@ -17,19 +14,14 @@ let parse_implementation path =
        Parse.implementation lexbuf)
 ;;
 
-let identifier_name expression =
+let exact_identifier_name expression =
   match expression.pexp_desc with
-  | Pexp_ident identifier -> Some (Longident.last identifier.txt)
+  | Pexp_ident { txt = Longident.Lident name; _ } -> Some name
   | _ -> None
 ;;
 
 let simple_identifier expression =
-  match expression.pexp_desc with
-  | Pexp_ident identifier ->
-    (match Longident.flatten identifier.txt with
-     | [ name ] -> Some name
-     | _ -> None)
-  | _ -> None
+  exact_identifier_name expression
 ;;
 
 let binding_name pattern =
@@ -41,61 +33,98 @@ let binding_name pattern =
 let is_named_application name expression =
   match expression.pexp_desc with
   | Pexp_apply (callee, arguments) ->
-    Option.equal String.equal (identifier_name callee) (Some name), arguments
+    Option.equal String.equal (exact_identifier_name callee) (Some name), arguments
   | _ -> false, []
 ;;
 
 type collected =
   { mutable recorder_binding_count : int
+  ; mutable recorder_top_level_binding_count : int
+  ; mutable lock_binding_count : int
+  ; mutable lock_top_level_binding_count : int
   ; mutable recorder_calls : (expression * (arg_label * expression) list) list
   ; mutable recorder_first_class_references : expression list
   ; mutable lock_calls : (expression * (arg_label * expression) list) list
   }
 
+let observe_binding collected ~top_level name =
+  match name with
+  | "record_preference_locked" ->
+    if top_level
+    then
+      collected.recorder_top_level_binding_count
+      <- collected.recorder_top_level_binding_count + 1
+    else collected.recorder_binding_count <- collected.recorder_binding_count + 1
+  | "with_preference_lock" ->
+    if top_level
+    then
+      collected.lock_top_level_binding_count <- collected.lock_top_level_binding_count + 1
+    else collected.lock_binding_count <- collected.lock_binding_count + 1
+  | _ -> ()
+;;
+
+let observe_top_level_bindings collected structure =
+  List.iter
+    (fun item ->
+       match item.pstr_desc with
+       | Pstr_value (_, bindings) ->
+         List.iter
+           (fun binding ->
+              match binding_name binding.pvb_pat with
+              | Some name -> observe_binding collected ~top_level:true name
+              | None -> ())
+           bindings
+       | _ -> ())
+    structure
+;;
+
 let collect structure =
   let collected =
     { recorder_binding_count = 0
+    ; recorder_top_level_binding_count = 0
+    ; lock_binding_count = 0
+    ; lock_top_level_binding_count = 0
     ; recorder_calls = []
     ; recorder_first_class_references = []
     ; lock_calls = []
     }
   in
+  observe_top_level_bindings collected structure;
   let iterator =
     { Ast_iterator.default_iterator with
       pat =
         (fun self pattern ->
-           (match binding_name pattern with
-            | Some "record_preference_locked" ->
-              collected.recorder_binding_count <- collected.recorder_binding_count + 1
-            | Some _ | None -> ());
-           Ast_iterator.default_iterator.pat self pattern)
+          (match pattern.ppat_desc with
+           | Ppat_var name -> observe_binding collected ~top_level:false name.txt
+           | Ppat_alias (_, name) -> observe_binding collected ~top_level:false name.txt
+           | _ -> ());
+          Ast_iterator.default_iterator.pat self pattern)
     ; expr =
         (fun self expression ->
-           let is_recorder, recorder_arguments =
-             is_named_application "record_preference_locked" expression
-           in
-           let is_lock, lock_arguments =
-             is_named_application "with_preference_lock" expression
-           in
-           if is_recorder
-           then (
-             collected.recorder_calls
-             <- (expression, recorder_arguments) :: collected.recorder_calls;
-             List.iter (fun (_, argument) -> self.expr self argument) recorder_arguments)
-           else (
-             (match expression.pexp_desc with
-              | Pexp_ident identifier
-                when String.equal
-                       (Longident.last identifier.txt)
-                       "record_preference_locked" ->
-                collected.recorder_first_class_references
-                <- expression :: collected.recorder_first_class_references
-              | _ -> ());
-             if is_lock
-             then
-               collected.lock_calls
-               <- (expression, lock_arguments) :: collected.lock_calls;
-             Ast_iterator.default_iterator.expr self expression))
+          let is_recorder, recorder_arguments =
+            is_named_application "record_preference_locked" expression
+          in
+          let is_lock, lock_arguments =
+            is_named_application "with_preference_lock" expression
+          in
+          if is_recorder
+          then (
+            collected.recorder_calls
+            <- (expression, recorder_arguments) :: collected.recorder_calls;
+            List.iter (fun (_, argument) -> self.expr self argument) recorder_arguments)
+          else (
+            (match expression.pexp_desc with
+             | Pexp_ident identifier
+               when String.equal
+                      (Longident.last identifier.txt)
+                      "record_preference_locked" ->
+               collected.recorder_first_class_references
+               <- expression :: collected.recorder_first_class_references
+             | _ -> ());
+            if is_lock
+            then
+              collected.lock_calls <- (expression, lock_arguments) :: collected.lock_calls;
+            Ast_iterator.default_iterator.expr self expression))
     }
   in
   iterator.structure iterator structure;
@@ -108,9 +137,9 @@ let expression_contains target root =
     { Ast_iterator.default_iterator with
       expr =
         (fun self expression ->
-           if expression == target
-           then found := true
-           else Ast_iterator.default_iterator.expr self expression)
+          if expression == target
+          then found := true
+          else Ast_iterator.default_iterator.expr self expression)
     }
   in
   iterator.expr iterator root;
@@ -123,10 +152,12 @@ let expression_binds name root =
     { Ast_iterator.default_iterator with
       pat =
         (fun self pattern ->
-           (match binding_name pattern with
-            | Some bound when String.equal bound name -> found := true
-            | Some _ | None -> ());
-           Ast_iterator.default_iterator.pat self pattern)
+          (match pattern.ppat_desc with
+           | Ppat_var bound | Ppat_alias (_, bound)
+             when String.equal bound.txt name ->
+             found := true
+           | _ -> ());
+          Ast_iterator.default_iterator.pat self pattern)
     }
   in
   iterator.expr iterator root;
@@ -135,11 +166,11 @@ let expression_binds name root =
 
 let recorder_store_and_labels arguments =
   match arguments with
-  | [ Nolabel, store
-    ; Labelled "scope", _
-    ; Labelled "reservation", _
-    ; Labelled "candidate", _
-    ; Labelled "ordinal", _
+  | [ (Nolabel, store)
+    ; (Labelled "scope", _)
+    ; (Labelled "reservation", _)
+    ; (Labelled "candidate", _)
+    ; (Labelled "ordinal", _)
     ] ->
     (match simple_identifier store with
      | Some store_name -> Ok store_name
@@ -149,7 +180,7 @@ let recorder_store_and_labels arguments =
 
 let lock_store_and_callback arguments =
   match arguments with
-  | [ Nolabel, store; Nolabel, callback ] ->
+  | [ (Nolabel, store); (Nolabel, callback) ] ->
     (match simple_identifier store with
      | Some store_name -> Some (store_name, callback)
      | None -> None)
@@ -158,13 +189,19 @@ let lock_store_and_callback arguments =
 
 let check structure =
   let collected = collect structure in
-  if collected.recorder_binding_count <> 1
+  if
+    collected.recorder_binding_count <> 1
+    || collected.recorder_top_level_binding_count <> 1
   then fail "record_preference_locked must have exactly one binding"
+  else if collected.lock_binding_count <> 1 || collected.lock_top_level_binding_count <> 1
+  then fail "with_preference_lock must have exactly one binding"
   else if collected.recorder_first_class_references <> []
-  then fail "record_preference_locked escaped as a first-class or partial reference"
-  else
+  then
+    fail
+      "record_preference_locked escaped as a first-class, partial, or qualified reference"
+  else (
     match collected.recorder_calls with
-    | [ recorder_call, arguments ] ->
+    | [ (recorder_call, arguments) ] ->
       (match recorder_store_and_labels arguments with
        | Error _ as error -> error
        | Ok recorder_store ->
@@ -180,7 +217,7 @@ let check structure =
          in
          (match containing_callbacks with
           | [] -> fail outside_callback
-          | [ lock_store, callback ] ->
+          | [ (lock_store, callback) ] ->
             if not (String.equal lock_store recorder_store)
             then fail "preference lock and recorder use different store identifiers"
             else if expression_binds recorder_store callback
@@ -188,7 +225,7 @@ let check structure =
             else Ok ()
           | _ -> fail "record_preference_locked is nested under multiple lock callbacks"))
     | [] -> fail "record_preference_locked has no saturated direct call"
-    | _ -> fail "record_preference_locked has more than one direct call"
+    | _ -> fail "record_preference_locked has more than one direct call")
 ;;
 
 let report_error message =
@@ -201,6 +238,18 @@ let check_file path =
   | Syntaxerr.Error _ -> fail ("syntax error while parsing " ^ path)
 ;;
 
+let expected_error_of_flag = function
+  | "--expect-outside-callback" -> Some outside_callback
+  | "--expect-shadowed-lock-binding" ->
+    Some "with_preference_lock must have exactly one binding"
+  | "--expect-noncanonical-recorder" ->
+    Some
+      "record_preference_locked escaped as a first-class, partial, or qualified reference"
+  | "--expect-shadowed-store" ->
+    Some "preference store identifier is shadowed inside lock callback"
+  | _ -> None
+;;
+
 let () =
   match Array.to_list Sys.argv with
   | [ _; path ] ->
@@ -209,19 +258,22 @@ let () =
      | Error message ->
        report_error message;
        exit 1)
-  | [ _; "--expect-outside-callback"; path ] ->
-    (match check_file path with
-     | Error message when String.equal message outside_callback -> ()
-     | Error message ->
-       report_error
-         ("negative fixture failed for the wrong reason: " ^ message);
+  | [ _; flag; path ] ->
+    (match expected_error_of_flag flag with
+     | None ->
+       report_error ("unknown negative-fixture mode: " ^ flag);
        exit 2
-     | Ok () ->
-       report_error "negative fixture unexpectedly passed";
-       exit 2)
+     | Some expected ->
+       (match check_file path with
+        | Error message when String.equal message expected -> ()
+        | Error message ->
+          report_error ("negative fixture failed for the wrong reason: " ^ message);
+          exit 2
+        | Ok () ->
+          report_error "negative fixture unexpectedly passed";
+          exit 2))
   | _ ->
     prerr_endline
-      "usage: check_exact_output_publication_lock \
-       [--expect-outside-callback] SOURCE.ml";
+      "usage: check_exact_output_publication_lock [--expect-*] SOURCE.ml";
     exit 2
 ;;

--- a/test/check_exact_output_publication_lock.ml
+++ b/test/check_exact_output_publication_lock.ml
@@ -104,10 +104,18 @@ let collect structure =
         (fun self declaration ->
           collected.namespace_import_seen <- true;
           Ast_iterator.default_iterator.open_declaration self declaration)
+    ; open_description =
+        (fun self description ->
+          collected.namespace_import_seen <- true;
+          Ast_iterator.default_iterator.open_description self description)
     ; include_declaration =
         (fun self declaration ->
           collected.namespace_import_seen <- true;
           Ast_iterator.default_iterator.include_declaration self declaration)
+    ; include_description =
+        (fun self description ->
+          collected.namespace_import_seen <- true;
+          Ast_iterator.default_iterator.include_description self description)
     ; structure_item =
         (fun self item ->
           (match item.pstr_desc with

--- a/test/check_exact_output_publication_lock.ml
+++ b/test/check_exact_output_publication_lock.ml
@@ -277,11 +277,11 @@ let () =
        exit 2
      | Some expected ->
        (match check_file path with
-        | Error message when String.equal message expected -> ()
-       | Error message ->
-         report_error ("negative fixture failed for the wrong reason: " ^ message);
-         exit 2
-        | Ok () ->
+         | Error message when String.equal message expected -> ()
+        | Error message ->
+          report_error ("negative fixture failed for the wrong reason: " ^ message);
+          exit 2
+         | Ok () ->
           report_error "negative fixture unexpectedly passed";
           exit 2))
   | _ ->

--- a/test/dune
+++ b/test/dune
@@ -464,6 +464,7 @@
   ../lib/llm_provider/model_catalog.mli
   ../lib/llm_provider/dune
   fixtures/exact_output_publication_lock/alias_shadowed_store.ml.fixture
+  fixtures/exact_output_publication_lock/class_local_open_import.ml.fixture
   fixtures/exact_output_publication_lock/first_class_recorder.ml.fixture
   fixtures/exact_output_publication_lock/local_open_import.ml.fixture
   fixtures/exact_output_publication_lock/locally_shadowed_lock.ml.fixture
@@ -499,6 +500,10 @@
     %{exe:check_exact_output_publication_lock.exe}
     --expect-namespace-import
     %{dep:fixtures/exact_output_publication_lock/local_open_import.ml.fixture})
+   (run
+    %{exe:check_exact_output_publication_lock.exe}
+    --expect-namespace-import
+    %{dep:fixtures/exact_output_publication_lock/class_local_open_import.ml.fixture})
    (run
     %{exe:check_exact_output_publication_lock.exe}
     --expect-shadowed-lock-binding

--- a/test/dune
+++ b/test/dune
@@ -463,6 +463,10 @@
   ../lib/llm_provider/capabilities.mli
   ../lib/llm_provider/model_catalog.mli
   ../lib/llm_provider/dune
+  fixtures/exact_output_publication_lock/alias_shadowed_store.ml.fixture
+  fixtures/exact_output_publication_lock/first_class_recorder.ml.fixture
+  fixtures/exact_output_publication_lock/locally_shadowed_lock.ml.fixture
+  fixtures/exact_output_publication_lock/module_qualified_recorder.ml.fixture
   fixtures/exact_output_publication_lock/unlocked_after_callback.ml.fixture)
  (action
   (progn
@@ -488,8 +492,24 @@
     %{dep:../lib/llm_provider/exact_output_flow.ml})
    (run
     %{exe:check_exact_output_publication_lock.exe}
-    --expect-outside-callback
-    %{dep:fixtures/exact_output_publication_lock/unlocked_after_callback.ml.fixture}))))
+   --expect-outside-callback
+    %{dep:fixtures/exact_output_publication_lock/unlocked_after_callback.ml.fixture})
+   (run
+    %{exe:check_exact_output_publication_lock.exe}
+    --expect-shadowed-lock-binding
+    %{dep:fixtures/exact_output_publication_lock/locally_shadowed_lock.ml.fixture})
+   (run
+    %{exe:check_exact_output_publication_lock.exe}
+    --expect-noncanonical-recorder
+    %{dep:fixtures/exact_output_publication_lock/module_qualified_recorder.ml.fixture})
+   (run
+    %{exe:check_exact_output_publication_lock.exe}
+    --expect-noncanonical-recorder
+    %{dep:fixtures/exact_output_publication_lock/first_class_recorder.ml.fixture})
+   (run
+    %{exe:check_exact_output_publication_lock.exe}
+    --expect-shadowed-store
+    %{dep:fixtures/exact_output_publication_lock/alias_shadowed_store.ml.fixture}))))
 
 (test
  (name test_complete_http)

--- a/test/dune
+++ b/test/dune
@@ -432,6 +432,11 @@
  (modules test_exact_output_resolver_snapshot)
  (libraries agent_sdk llm_provider alcotest eio_main))
 
+(executable
+ (name check_exact_output_publication_lock)
+ (modules check_exact_output_publication_lock)
+ (libraries compiler-libs.common))
+
 (rule
  (alias runtest)
  (deps
@@ -457,25 +462,34 @@
   ../lib/llm_provider/backend_glm.ml
   ../lib/llm_provider/capabilities.mli
   ../lib/llm_provider/model_catalog.mli
-  ../lib/llm_provider/dune)
+  ../lib/llm_provider/dune
+  fixtures/exact_output_publication_lock/unlocked_after_callback.ml.fixture)
  (action
-  (run
-   bash
-   %{dep:../scripts/check-exact-output-resolver-boundary.sh}
-   %{dep:../lib/llm_provider/exact_output.ml}
-   %{dep:../lib/llm_provider/exact_output_flow.ml}
-   %{dep:../lib/llm_provider/exact_output_flow_contract.ml}
-   %{dep:../lib/llm_provider/exact_output_resolver.ml}
-   %{dep:../lib/llm_provider/exact_output_catalog_binding.ml}
-   %{dep:../lib/llm_provider/exact_output_plan.ml}
-   %{dep:../lib/llm_provider/complete_common.ml}
-   %{dep:../lib/llm_provider/backend_anthropic.ml}
-   %{dep:../lib/llm_provider/backend_ollama.ml}
-   %{dep:../lib/llm_provider/backend_openai.ml}
-   %{dep:../lib/llm_provider/backend_openai_serialize.ml}
-   %{dep:../lib/llm_provider/backend_openai_responses.ml}
-   %{dep:../lib/llm_provider/backend_gemini.ml}
-   %{dep:../lib/llm_provider/backend_glm.ml})))
+  (progn
+   (run
+    bash
+    %{dep:../scripts/check-exact-output-resolver-boundary.sh}
+    %{dep:../lib/llm_provider/exact_output.ml}
+    %{dep:../lib/llm_provider/exact_output_flow.ml}
+    %{dep:../lib/llm_provider/exact_output_flow_contract.ml}
+    %{dep:../lib/llm_provider/exact_output_resolver.ml}
+    %{dep:../lib/llm_provider/exact_output_catalog_binding.ml}
+    %{dep:../lib/llm_provider/exact_output_plan.ml}
+    %{dep:../lib/llm_provider/complete_common.ml}
+    %{dep:../lib/llm_provider/backend_anthropic.ml}
+    %{dep:../lib/llm_provider/backend_ollama.ml}
+    %{dep:../lib/llm_provider/backend_openai.ml}
+    %{dep:../lib/llm_provider/backend_openai_serialize.ml}
+    %{dep:../lib/llm_provider/backend_openai_responses.ml}
+    %{dep:../lib/llm_provider/backend_gemini.ml}
+    %{dep:../lib/llm_provider/backend_glm.ml})
+   (run
+    %{exe:check_exact_output_publication_lock.exe}
+    %{dep:../lib/llm_provider/exact_output_flow.ml})
+   (run
+    %{exe:check_exact_output_publication_lock.exe}
+    --expect-outside-callback
+    %{dep:fixtures/exact_output_publication_lock/unlocked_after_callback.ml.fixture}))))
 
 (test
  (name test_complete_http)

--- a/test/dune
+++ b/test/dune
@@ -492,7 +492,7 @@
     %{dep:../lib/llm_provider/exact_output_flow.ml})
    (run
     %{exe:check_exact_output_publication_lock.exe}
-   --expect-outside-callback
+    --expect-outside-callback
     %{dep:fixtures/exact_output_publication_lock/unlocked_after_callback.ml.fixture})
    (run
     %{exe:check_exact_output_publication_lock.exe}

--- a/test/dune
+++ b/test/dune
@@ -465,6 +465,7 @@
   ../lib/llm_provider/dune
   fixtures/exact_output_publication_lock/alias_shadowed_store.ml.fixture
   fixtures/exact_output_publication_lock/first_class_recorder.ml.fixture
+  fixtures/exact_output_publication_lock/local_open_import.ml.fixture
   fixtures/exact_output_publication_lock/locally_shadowed_lock.ml.fixture
   fixtures/exact_output_publication_lock/module_qualified_recorder.ml.fixture
   fixtures/exact_output_publication_lock/unlocked_after_callback.ml.fixture)
@@ -494,6 +495,10 @@
     %{exe:check_exact_output_publication_lock.exe}
     --expect-outside-callback
     %{dep:fixtures/exact_output_publication_lock/unlocked_after_callback.ml.fixture})
+   (run
+    %{exe:check_exact_output_publication_lock.exe}
+    --expect-namespace-import
+    %{dep:fixtures/exact_output_publication_lock/local_open_import.ml.fixture})
    (run
     %{exe:check_exact_output_publication_lock.exe}
     --expect-shadowed-lock-binding

--- a/test/fixtures/exact_output_publication_lock/alias_shadowed_store.ml.fixture
+++ b/test/fixtures/exact_output_publication_lock/alias_shadowed_store.ml.fixture
@@ -1,0 +1,24 @@
+let record_preference_locked preferences ~scope ~reservation ~candidate ~ordinal =
+  ignore preferences;
+  ignore scope;
+  ignore reservation;
+  ignore candidate;
+  ignore ordinal;
+  Ok ()
+;;
+
+let with_preference_lock preferences callback =
+  ignore preferences;
+  callback ()
+;;
+
+let settle_domain_valid_once_with_publication_hook
+      preferences
+      ~scope
+      ~reservation
+      ~candidate
+      ~ordinal
+  =
+  with_preference_lock preferences (fun (_ as preferences) ->
+    record_preference_locked preferences ~scope ~reservation ~candidate ~ordinal)
+;;

--- a/test/fixtures/exact_output_publication_lock/class_local_open_import.ml.fixture
+++ b/test/fixtures/exact_output_publication_lock/class_local_open_import.ml.fixture
@@ -1,0 +1,24 @@
+let record_preference_locked preferences ~scope ~reservation ~candidate ~ordinal =
+  ignore preferences;
+  ignore scope;
+  ignore reservation;
+  ignore candidate;
+  ignore ordinal;
+  Ok ()
+;;
+
+let with_preference_lock preferences callback =
+  ignore preferences;
+  callback ()
+;;
+
+module M = (val packed_publication_helpers : Publication_helpers)
+
+class publication_lock =
+  let open M in
+  object
+    method publish preferences scope reservation candidate ordinal =
+      with_preference_lock preferences (fun () ->
+        record_preference_locked preferences ~scope ~reservation ~candidate ~ordinal)
+  end
+;;

--- a/test/fixtures/exact_output_publication_lock/first_class_recorder.ml.fixture
+++ b/test/fixtures/exact_output_publication_lock/first_class_recorder.ml.fixture
@@ -1,0 +1,25 @@
+let record_preference_locked preferences ~scope ~reservation ~candidate ~ordinal =
+  ignore preferences;
+  ignore scope;
+  ignore reservation;
+  ignore candidate;
+  ignore ordinal;
+  Ok ()
+;;
+
+let with_preference_lock preferences callback =
+  ignore preferences;
+  callback ()
+;;
+
+let settle_domain_valid_once_with_publication_hook
+      preferences
+      ~scope
+      ~reservation
+      ~candidate
+      ~ordinal
+  =
+  with_preference_lock preferences (fun () ->
+    let escaped = record_preference_locked in
+    escaped preferences ~scope ~reservation ~candidate ~ordinal)
+;;

--- a/test/fixtures/exact_output_publication_lock/local_open_import.ml.fixture
+++ b/test/fixtures/exact_output_publication_lock/local_open_import.ml.fixture
@@ -1,0 +1,26 @@
+let record_preference_locked preferences ~scope ~reservation ~candidate ~ordinal =
+  ignore preferences;
+  ignore scope;
+  ignore reservation;
+  ignore candidate;
+  ignore ordinal;
+  Ok ()
+;;
+
+let with_preference_lock preferences callback =
+  ignore preferences;
+  callback ()
+;;
+
+let settle_domain_valid_once_with_publication_hook
+      preferences
+      ~scope
+      ~reservation
+      ~candidate
+      ~ordinal
+  =
+  let module M = (val packed_publication_helpers : Publication_helpers) in
+  let open M in
+  with_preference_lock preferences (fun () ->
+    record_preference_locked preferences ~scope ~reservation ~candidate ~ordinal)
+;;

--- a/test/fixtures/exact_output_publication_lock/locally_shadowed_lock.ml.fixture
+++ b/test/fixtures/exact_output_publication_lock/locally_shadowed_lock.ml.fixture
@@ -1,0 +1,25 @@
+let record_preference_locked preferences ~scope ~reservation ~candidate ~ordinal =
+  ignore preferences;
+  ignore scope;
+  ignore reservation;
+  ignore candidate;
+  ignore ordinal;
+  Ok ()
+;;
+
+let with_preference_lock preferences callback =
+  ignore preferences;
+  callback ()
+;;
+
+let settle_domain_valid_once_with_publication_hook
+      preferences
+      ~scope
+      ~reservation
+      ~candidate
+      ~ordinal
+  =
+  let with_preference_lock _ callback = callback () in
+  with_preference_lock preferences (fun () ->
+    record_preference_locked preferences ~scope ~reservation ~candidate ~ordinal)
+;;

--- a/test/fixtures/exact_output_publication_lock/module_qualified_recorder.ml.fixture
+++ b/test/fixtures/exact_output_publication_lock/module_qualified_recorder.ml.fixture
@@ -1,0 +1,29 @@
+let record_preference_locked preferences ~scope ~reservation ~candidate ~ordinal =
+  ignore preferences;
+  ignore scope;
+  ignore reservation;
+  ignore candidate;
+  ignore ordinal;
+  Ok ()
+;;
+
+let with_preference_lock preferences callback =
+  ignore preferences;
+  callback ()
+;;
+
+let settle_domain_valid_once_with_publication_hook
+      preferences
+      ~scope
+      ~reservation
+      ~candidate
+      ~ordinal
+  =
+  with_preference_lock preferences (fun () ->
+    Fake.record_preference_locked
+      preferences
+      ~scope
+      ~reservation
+      ~candidate
+      ~ordinal)
+;;

--- a/test/fixtures/exact_output_publication_lock/unlocked_after_callback.ml.fixture
+++ b/test/fixtures/exact_output_publication_lock/unlocked_after_callback.ml.fixture
@@ -7,6 +7,11 @@ let record_preference_locked preferences ~scope ~reservation ~candidate ~ordinal
   Ok ()
 ;;
 
+let with_preference_lock preferences callback =
+  ignore preferences;
+  callback ()
+;;
+
 let settle_domain_valid_once_with_publication_hook
       ~after_publishing
       settlement

--- a/test/fixtures/exact_output_publication_lock/unlocked_after_callback.ml.fixture
+++ b/test/fixtures/exact_output_publication_lock/unlocked_after_callback.ml.fixture
@@ -1,0 +1,34 @@
+let record_preference_locked preferences ~scope ~reservation ~candidate ~ordinal =
+  ignore preferences;
+  ignore scope;
+  ignore reservation;
+  ignore candidate;
+  ignore ordinal;
+  Ok ()
+;;
+
+let settle_domain_valid_once_with_publication_hook
+      ~after_publishing
+      settlement
+      preferences
+      ~scope
+      ~reservation
+      ~candidate
+      ~ordinal
+  =
+  let publication =
+    with_preference_lock preferences (fun () ->
+      if not (Atomic.compare_and_set settlement Pending Publishing)
+      then Error Already_settled
+      else
+        Fun.protect
+          ~finally:(fun () -> Atomic.set settlement Settled)
+          (fun () ->
+             after_publishing ();
+             Ok ()))
+  in
+  match publication with
+  | Error _ as error -> error
+  | Ok () ->
+    record_preference_locked preferences ~scope ~reservation ~candidate ~ordinal
+;;


### PR DESCRIPTION
## Summary

- replace the per-settlement mutex with the closed atomic state `Pending | Publishing | Settled`
- use the existing preference-store mutex as the sole publication barrier for valid and rejected losers
- terminalize `Settled` before store unlock even when publication raises
- add deterministic concurrency proofs and harden the source ratchet against settlement mutexes and nested locking

Follow-up to #2799. OAS retains provider/model/wire and outer exact-flow ownership. No MASC, Pricing, migration, or compatibility behavior is added.

## Validation

- local build/test/format not run by instruction; full PR CI is the authority