### PR TITLE
feat(exact-output): expose outward dispatch fact

### DIFF
--- a/docs/design/exact-output-flow-boundary.md
+++ b/docs/design/exact-output-flow-boundary.md
@@ -178,6 +178,15 @@ is recorded and before that candidate receives its fresh attempt. Such a
 snapshot is point-in-time evidence, not a fabricated attempt or a terminal
 state.
 
+`flow_execution_error_outward_dispatch` projects one closed fact about the
+invocation returning the error: `No_outward_dispatch` or
+`Outward_dispatch_started`. The fact says only whether that invocation began
+its one outward completion dispatch. It does not claim provider acceptance,
+response receipt, billing, physical execution, retryability, failover
+eligibility, or any Pricing decision. OAS derives it from affine flow control
+and private receipt state; callers do not decode phases, counts, HTTP status, or
+provider policy.
+
 ## Explicit exclusions
 
 - `execute_once` never retries and never changes plans.

--- a/lib/llm_provider/exact_output.ml
+++ b/lib/llm_provider/exact_output.ml
@@ -641,8 +641,7 @@ let flow_execution_error_outward_dispatch = function
   | Flow_attempt_start_failed _
   | Flow_before_dispatch_callback_failed _
   | Flow_before_advance_callback_failed _
-  | Flow_candidates_exhausted _ ->
-    No_outward_dispatch
+  | Flow_candidates_exhausted _ -> No_outward_dispatch
   | Flow_success_ordinal_exhausted _ -> Outward_dispatch_started
   | Flow_exact_execution_failed { cause; _ } ->
     outward_dispatch_fact_of_receipt cause.receipt

--- a/lib/llm_provider/exact_output.ml
+++ b/lib/llm_provider/exact_output.ml
@@ -273,6 +273,10 @@ type flow_candidate_failure =
       ; cause : execution_error
       }
 
+type outward_dispatch_fact =
+  | No_outward_dispatch
+  | Outward_dispatch_started
+
 type 'callback_error flow_execution_error =
   | Flow_attempt_already_started of flow_evidence
   | Flow_success_ordinal_exhausted of flow_evidence
@@ -623,6 +627,25 @@ let receipt_dispatch_count receipt =
   match Atomic.get receipt.state with
   | Not_started_state | Before_dispatch_state -> 0
   | Dispatch_started_state | Response_received_state _ | Terminal_state _ -> 1
+;;
+
+let outward_dispatch_fact_of_receipt receipt =
+  match Atomic.get receipt.state with
+  | Not_started_state | Before_dispatch_state -> No_outward_dispatch
+  | Dispatch_started_state | Response_received_state _ | Terminal_state _ ->
+    Outward_dispatch_started
+;;
+
+let flow_execution_error_outward_dispatch = function
+  | Flow_attempt_already_started _
+  | Flow_attempt_start_failed _
+  | Flow_before_dispatch_callback_failed _
+  | Flow_before_advance_callback_failed _
+  | Flow_candidates_exhausted _ ->
+    No_outward_dispatch
+  | Flow_success_ordinal_exhausted _ -> Outward_dispatch_started
+  | Flow_exact_execution_failed { cause; _ } ->
+    outward_dispatch_fact_of_receipt cause.receipt
 ;;
 
 let receipt_http_status receipt =

--- a/lib/llm_provider/exact_output.mli
+++ b/lib/llm_provider/exact_output.mli
@@ -491,6 +491,10 @@ type flow_candidate_failure =
       ; cause : execution_error
       }
 
+type outward_dispatch_fact =
+  | No_outward_dispatch
+  | Outward_dispatch_started
+
 type 'callback_error flow_execution_error =
   | Flow_attempt_already_started of flow_evidence
   | Flow_success_ordinal_exhausted of flow_evidence
@@ -519,6 +523,14 @@ type 'callback_error flow_execution_error =
       ; cause : execution_error
       ; evidence : flow_evidence
       }
+
+(** Closed fact for the invocation returning the error: whether its one outward
+    completion dispatch began. This does not claim provider acceptance, response
+    receipt, billing, retryability, failover eligibility, or any Pricing
+    decision. *)
+val flow_execution_error_outward_dispatch
+  :  'callback_error flow_execution_error
+  -> outward_dispatch_fact
 
 (** Point-in-time aggregate evidence. [scope] is the exact opaque flow scope,
     [declared_candidate_snapshot] is the caller-declared order, and

--- a/test/test_exact_output_flow.ml
+++ b/test/test_exact_output_flow.ml
@@ -1442,7 +1442,7 @@ let test_credential_rejections_are_ordered_zero_dispatch_terminal () =
    | _ -> fail "credential evidence did not retain three typed rejections");
   match result with
   | Error
-      ((EO.Flow_candidates_exhausted { rejection; evidence = terminal_evidence }) as error)
+      (EO.Flow_candidates_exhausted { rejection; evidence = terminal_evidence } as error)
     ->
     check
       bool
@@ -2099,8 +2099,8 @@ let test_callback_failures_are_terminal () =
   check int "failed bind dispatches nothing" 0 before_dispatch_posts;
   (match before_dispatch_result with
    | Error
-       ((EO.Flow_before_dispatch_callback_failed
-           { candidate; cause = "bind-not-durable"; evidence }) as error) ->
+       (EO.Flow_before_dispatch_callback_failed
+          { candidate; cause = "bind-not-durable"; evidence } as error) ->
      check
        bool
        "before-dispatch callback failure starts no outward dispatch"
@@ -2144,8 +2144,8 @@ let test_callback_failures_are_terminal () =
   check int "failed advance dispatches no successor" 0 before_advance_posts;
   match before_advance_result with
   | Error
-      ((EO.Flow_before_advance_callback_failed
-          { failed; next; cause = "release-not-durable"; evidence; _ }) as error) ->
+      (EO.Flow_before_advance_callback_failed
+         { failed; next; cause = "release-not-durable"; evidence; _ } as error) ->
     check
       bool
       "before-advance callback failure starts no outward dispatch"
@@ -2182,7 +2182,7 @@ let test_postdispatch_and_structural_outcomes_never_advance () =
     check int (label ^ " dispatches exactly once") 1 posts;
     check int (label ^ " does not request advance") 0 advances;
     match result with
-    | Error ((EO.Flow_exact_execution_failed { candidate; cause; evidence }) as error) ->
+    | Error (EO.Flow_exact_execution_failed { candidate; cause; evidence } as error) ->
       check
         bool
         (label ^ " records outward dispatch started")
@@ -2279,10 +2279,9 @@ let test_structural_predispatch_failure_does_not_advance () =
   check int "missing clock cannot advance" 0 advances;
   match result with
   | Error
-      ((EO.Flow_exact_execution_failed
-          { cause = { cause = EO.Clock_required_for_timeout; receipt; _ }; evidence; _ }) as
-       error)
-    ->
+      (EO.Flow_exact_execution_failed
+         { cause = { cause = EO.Clock_required_for_timeout; receipt; _ }; evidence; _ } as
+       error) ->
     check
       bool
       "predispatch structural failure starts no outward dispatch"

--- a/test/test_exact_output_flow.ml
+++ b/test/test_exact_output_flow.ml
@@ -1441,7 +1441,14 @@ let test_credential_rejections_are_ordered_zero_dispatch_terminal () =
      check_rejection ~id:"credential-read-failed" ~visit:3 read_failed
    | _ -> fail "credential evidence did not retain three typed rejections");
   match result with
-  | Error (EO.Flow_candidates_exhausted { rejection; evidence = terminal_evidence }) ->
+  | Error
+      ((EO.Flow_candidates_exhausted { rejection; evidence = terminal_evidence }) as error)
+    ->
+    check
+      bool
+      "candidate exhaustion starts no outward dispatch"
+      true
+      (EO.flow_execution_error_outward_dispatch error = EO.No_outward_dispatch);
     check
       string
       "last rejected candidate is terminal"
@@ -2092,15 +2099,32 @@ let test_callback_failures_are_terminal () =
   check int "failed bind dispatches nothing" 0 before_dispatch_posts;
   (match before_dispatch_result with
    | Error
-       (EO.Flow_before_dispatch_callback_failed
-          { candidate; cause = "bind-not-durable"; evidence }) ->
+       ((EO.Flow_before_dispatch_callback_failed
+           { candidate; cause = "bind-not-durable"; evidence }) as error) ->
+     check
+       bool
+       "before-dispatch callback failure starts no outward dispatch"
+       true
+       (EO.flow_execution_error_outward_dispatch error = EO.No_outward_dispatch);
      check string "failed bind candidate" "bind-a" (candidate_id candidate);
      check
        bool
        "failed bind leaves receipt not started"
        true
        (EO.receipt_phase candidate.receipt = EO.Not_started);
-     check int "successor remains unprepared" 1 (List.length evidence.attempts)
+     check int "successor remains unprepared" 1 (List.length evidence.attempts);
+     let start_failed =
+       EO.Flow_attempt_start_failed
+         { candidate = candidate.visit
+         ; cause = EO.Call_id_generation_failed "injected"
+         ; evidence
+         }
+     in
+     check
+       bool
+       "attempt-start failure starts no outward dispatch"
+       true
+       (EO.flow_execution_error_outward_dispatch start_failed = EO.No_outward_dispatch)
    | Ok _ | Error _ -> fail "failed bind did not return typed terminal evidence");
   let before_advance_result, before_advance_posts =
     with_server ~response:(openai_response {|{"name":"unused"}|})
@@ -2120,8 +2144,13 @@ let test_callback_failures_are_terminal () =
   check int "failed advance dispatches no successor" 0 before_advance_posts;
   match before_advance_result with
   | Error
-      (EO.Flow_before_advance_callback_failed
-         { failed; next; cause = "release-not-durable"; evidence; _ }) ->
+      ((EO.Flow_before_advance_callback_failed
+          { failed; next; cause = "release-not-durable"; evidence; _ }) as error) ->
+    check
+      bool
+      "before-advance callback failure starts no outward dispatch"
+      true
+      (EO.flow_execution_error_outward_dispatch error = EO.No_outward_dispatch);
     check string "failed attempt identity" "advance-a" (flow_failure_id failed);
     check string "withheld successor identity" "advance-b" next.identity.candidate_id;
     check int "withheld successor remains unprepared" 1 (List.length evidence.attempts)
@@ -2153,7 +2182,12 @@ let test_postdispatch_and_structural_outcomes_never_advance () =
     check int (label ^ " dispatches exactly once") 1 posts;
     check int (label ^ " does not request advance") 0 advances;
     match result with
-    | Error (EO.Flow_exact_execution_failed { candidate; cause; evidence }) ->
+    | Error ((EO.Flow_exact_execution_failed { candidate; cause; evidence }) as error) ->
+      check
+        bool
+        (label ^ " records outward dispatch started")
+        true
+        (EO.flow_execution_error_outward_dispatch error = EO.Outward_dispatch_started);
       check string (label ^ " terminal candidate") (label ^ "-a") (candidate_id candidate);
       check
         int
@@ -2187,6 +2221,7 @@ let test_success_and_later_domain_rejection_are_terminal () =
   check int "success dispatches exactly once" 1 posts;
   match result with
   | Ok success ->
+    let evidence = EO.flow_success_evidence success in
     check
       string
       "first candidate succeeds"
@@ -2196,7 +2231,20 @@ let test_success_and_later_domain_rejection_are_terminal () =
       int
       "successor remains unavailable to later domain rejection"
       1
-      (List.length (EO.flow_success_evidence success).attempts)
+      (List.length evidence.attempts);
+    check
+      bool
+      "ordinal exhaustion follows a completed outward dispatch"
+      true
+      (EO.flow_execution_error_outward_dispatch
+         (EO.Flow_success_ordinal_exhausted evidence)
+       = EO.Outward_dispatch_started);
+    check
+      bool
+      "replayed invocation starts no new outward dispatch"
+      true
+      (EO.flow_execution_error_outward_dispatch (EO.Flow_attempt_already_started evidence)
+       = EO.No_outward_dispatch)
   | Error _ -> fail "terminal success fixture failed"
 ;;
 
@@ -2231,9 +2279,15 @@ let test_structural_predispatch_failure_does_not_advance () =
   check int "missing clock cannot advance" 0 advances;
   match result with
   | Error
-      (EO.Flow_exact_execution_failed
-         { cause = { cause = EO.Clock_required_for_timeout; receipt; _ }; evidence; _ })
+      ((EO.Flow_exact_execution_failed
+          { cause = { cause = EO.Clock_required_for_timeout; receipt; _ }; evidence; _ }) as
+       error)
     ->
+    check
+      bool
+      "predispatch structural failure starts no outward dispatch"
+      true
+      (EO.flow_execution_error_outward_dispatch error = EO.No_outward_dispatch);
     check
       int
       "structural failure remains zero dispatch"


### PR DESCRIPTION
## Summary
- expose a provider-neutral `outward_dispatch_fact` projection for exact-flow execution errors
- derive exact execution failures from the private monotonic receipt state
- cover every public `flow_execution_error` constructor, including both pre-dispatch and post-dispatch execution failures
- document that the fact does not imply provider acceptance, response receipt, billing, retry/failover policy, or Pricing decisions

## Boundary
This PR adds only the closed fact `No_outward_dispatch | Outward_dispatch_started`. It adds no terminal-stage taxonomy, HTTP/provider policy, retry decision, failover decision, or Pricing logic.

## Validation
Not run locally, per coordination instruction. Draft PR CI is the validation surface; independent review is required before release or merge.
