### PR TITLE
fix(llm-provider): restore Eio 1.3 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,39 @@ jobs:
           opam install odoc --yes
           opam exec -- dune build @doc
 
+  eio-compat:
+    name: Eio ${{ matrix.eio-version }} Compatibility
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        eio-version: ['1.3', '1.4']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup OCaml
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: 5.4.1
+          dune-cache: true
+
+      - name: Install dependencies
+        run: opam exec -- bash scripts/ci-setup-deps.sh
+
+      - name: Select Eio ${{ matrix.eio-version }}
+        run: |
+          opam install \
+            "eio.${{ matrix.eio-version }}" \
+            "eio_main.${{ matrix.eio-version }}" \
+            --yes
+
+      - name: Run typed transport compatibility tests
+        env:
+          OCAMLPARAM: "_,warn-error=+a"
+        run: opam exec -- dune runtest lib/llm_provider
+
   boundary-lint:
     # Runs on every push and PR (including drafts) to give fast feedback
     # without waiting for the full opam-based build matrix.

--- a/agent_sdk.opam
+++ b/agent_sdk.opam
@@ -12,8 +12,8 @@ bug-reports: "https://github.com/jeong-sik/agent-sdk/issues"
 depends: [
   "ocaml" {>= "5.4"}
   "dune" {>= "3.22" & >= "3.22"}
-  "eio" {>= "1.4"}
-  "eio_main" {>= "1.4"}
+  "eio" {>= "1.3"}
+  "eio_main" {>= "1.3"}
   "cohttp-eio" {>= "6.2.0"}
   "tls" {>= "2.0.0"}
   "tls-eio" {>= "2.0.0"}

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -836,8 +836,7 @@ let classify_eio_net_error = function
   | Eio.Net.Connection_failure (Eio.Net.Refused backend) ->
     Option.value (classify_eio_backend_error backend) ~default:Connection_refused
   | Eio.Net.Connection_failure Eio.Net.Timeout -> Timeout
-  | Eio.Net.Address_lookup_failed _ -> Dns_failure
-  | Eio.Net.Invalid_option -> Unknown
+  | _ -> Unknown
 ;;
 
 let rec classify_eio_error = function
@@ -2797,26 +2796,6 @@ let%test "classify_network_exn: typed Eio timeout" =
       (eio_exn (Eio.Net.E (Eio.Net.Connection_failure Eio.Net.Timeout)))
   with
   | Some (NetworkError { kind = Timeout; _ }) -> true
-  | Some (HttpError _ | NetworkError _ | TimeoutError _ | AcceptRejected _)
-  | Some (ProviderTerminal _ | ProviderFailure _)
-  | None -> false
-;;
-
-let%test "classify_network_exn: typed Eio address lookup failure" =
-  match
-    classify_network_exn
-      (eio_exn
-         (Eio.Net.E (Eio.Net.Address_lookup_failed Eio.Net.Getaddrinfo_error.UNKNOWN)))
-  with
-  | Some (NetworkError { kind = Dns_failure; _ }) -> true
-  | Some (HttpError _ | NetworkError _ | TimeoutError _ | AcceptRejected _)
-  | Some (ProviderTerminal _ | ProviderFailure _)
-  | None -> false
-;;
-
-let%test "classify_network_exn: typed Eio invalid socket option stays unknown" =
-  match classify_network_exn (eio_exn (Eio.Net.E Eio.Net.Invalid_option)) with
-  | Some (NetworkError { kind = Unknown; _ }) -> true
   | Some (HttpError _ | NetworkError _ | TimeoutError _ | AcceptRejected _)
   | Some (ProviderTerminal _ | ProviderFailure _)
   | None -> false


### PR DESCRIPTION
## Problem

Merged PR #2802 raised both eio and eio_main to 1.4 and referenced the 1.4-only Address_lookup_failed and Invalid_option constructors.

That makes released OAS impossible to solve together with the current production HTTP stack:

- Piaf 0.2.0 depends on released eio-ssl >= 0.3.0.
- Released eio-ssl 0.3.0 constrains eio >= 0.12 and < 1.4.
- Upstream eio-ssl PR #26 adds Eio 1.4 support but remains open and unreleased.

Official dependency evidence:

- https://github.com/ocaml/opam-repository/blob/master/packages/piaf/piaf.0.2.0/opam
- https://github.com/ocaml/opam-repository/blob/master/packages/eio-ssl/eio-ssl.0.3.0/opam
- https://github.com/anmonteiro/eio-ssl/pull/26

## Change

- Lower only the eio and eio_main minimums from 1.4 to 1.3.
- Keep precise typed classification for constructors shared by Eio 1.3 and 1.4.
- Map every other typed Eio.Net.E case to the existing provider-neutral NetworkError with kind Unknown.
- Remove the two 1.4-only inline fixtures.
- Add a focused Eio 1.3/1.4 CI matrix that runs the llm_provider inline transport tests with warnings as errors.

## Adversarial boundary

This deliberately gives up the Eio 1.4-only Address_lookup_failed to Dns_failure attribution. A single source file cannot name that constructor and still compile against Eio 1.3 without version conditionals, string matching, or unsafe representation inspection.

The fallback is not silent:

- The typed Eio.Io path still returns an explicit NetworkError.
- The original exception message remains attached.
- Unknown remains an explicit transport failure rather than success, None, or provider policy.
- Shared refused, timeout, reset, and Unix backend cases retain their precise typed classifications.

This PR does not pin eio-ssl master, add provider/model policy, use heuristic strings, or add migration/stub logic.

## Verification

Per the active collaboration contract, no local build, test, format, or validation command was run. GitHub CI is the build authority. The new compatibility jobs are required evidence for Eio 1.3 and 1.4.
