### PR TITLE
fix(error-domain): `Invalid_request 가 전달받은 typed reason 을 버리고 있었다

### DIFF
--- a/lib/error_domain.ml
+++ b/lib/error_domain.ml
@@ -12,7 +12,7 @@ type provider_error =
   | `Provider_timeout of Http_client.timeout_phase option * string
   | `Streaming_timeout of Http_client.timeout_phase * string
   | `Overloaded
-  | `Invalid_request of string
+  | `Invalid_request of Llm_provider.Retry.invalid_request_reason * string
   | `Not_found of string
   | `Context_overflow of string * int option
   | `Input_capacity of
@@ -91,7 +91,7 @@ let of_api_error (err : Retry.api_error) : provider_error =
        `Streaming_timeout (phase, r.message)
      | phase -> `Provider_timeout (phase, r.message))
   | Retry.Overloaded _ -> `Overloaded
-  | Retry.InvalidRequest r -> `Invalid_request r.message
+  | Retry.InvalidRequest r -> `Invalid_request (r.reason, r.message)
   | Retry.NotFound r -> `Not_found r.message
   | Retry.ContextOverflow r -> `Context_overflow (r.message, r.limit)
   | Retry.InputCapacity r -> `Input_capacity (r.reason, r.constraint_, r.message)
@@ -112,17 +112,23 @@ let of_provider_error (err : Llm_provider.Error.provider_error) : provider_error
        `Streaming_timeout (phase, r.detail)
      | phase -> `Provider_timeout (phase, r.detail))
   | Llm_provider.Error.CapacityExhausted _ -> `Overloaded
-  | Llm_provider.Error.InvalidRequest r -> `Invalid_request r.reason
+  | Llm_provider.Error.InvalidRequest r ->
+    `Invalid_request (Retry.Unknown_invalid_request, r.reason)
   | Llm_provider.Error.NotFound r -> `Not_found r.detail
   | Llm_provider.Error.MissingApiKey r ->
     `Auth_error (Printf.sprintf "missing API key: %s" r.var_name)
-  | Llm_provider.Error.InvalidConfig r -> `Invalid_request r.detail
-  | Llm_provider.Error.ParseError r -> `Invalid_request r.detail
+  | Llm_provider.Error.InvalidConfig r ->
+    `Invalid_request (Retry.Unknown_invalid_request, r.detail)
+  | Llm_provider.Error.ParseError r ->
+    `Invalid_request (Retry.Unknown_invalid_request, r.detail)
   | Llm_provider.Error.UnknownVariant r ->
-    `Invalid_request (Printf.sprintf "unknown %s variant: %s" r.type_name r.value)
+    `Invalid_request
+      ( Retry.Unknown_invalid_request
+      , Printf.sprintf "unknown %s variant: %s" r.type_name r.value )
   | Llm_provider.Error.ProviderUnavailable r -> `Network_error r.detail
   | Llm_provider.Error.ProviderTerminal r ->
-    `Invalid_request (Printf.sprintf "%s: %s" r.reason r.detail)
+    `Invalid_request
+      (Retry.Unknown_invalid_request, Printf.sprintf "%s: %s" r.reason r.detail)
 ;;
 
 let of_sdk_error (err : Error.sdk_error) : sdk_error_poly =
@@ -169,9 +175,11 @@ let provider_to_sdk : provider_error -> Error.sdk_error = function
       (Llm_provider.Error.Timeout
          { provider = "unknown"; timeout_phase = Some phase; detail = msg })
   | `Overloaded -> Error.Api (Retry.Overloaded { message = "overloaded" })
-  | `Invalid_request msg ->
-    Error.Api
-      (Retry.InvalidRequest { message = msg; reason = Retry.Unknown_invalid_request })
+  (* The reverse direction used to overwrite the reason with
+     Unknown_invalid_request, so a round trip through this module erased a typed
+     capacity refusal even when the forward direction had carried it. *)
+  | `Invalid_request (reason, msg) ->
+    Error.Api (Retry.InvalidRequest { message = msg; reason })
   | `Not_found msg -> Error.Api (Retry.NotFound { message = msg })
   | `Context_overflow (msg, limit) ->
     Error.Api (Retry.ContextOverflow { message = msg; limit })

--- a/lib/error_domain.mli
+++ b/lib/error_domain.mli
@@ -30,7 +30,11 @@ type provider_error =
   | `Provider_timeout of Llm_provider.Http_client.timeout_phase option * string
   | `Streaming_timeout of Llm_provider.Http_client.timeout_phase * string
   | `Overloaded
-  | `Invalid_request of string
+  | `Invalid_request of Llm_provider.Retry.invalid_request_reason * string
+        (** Typed reason first, mirroring [`Input_capacity]. The reason used to be
+            dropped here while [`Input_capacity] kept its own, so a request refused
+            for a declared body-size limit arrived indistinguishable from a JSON
+            parse failure. *)
   | `Not_found of string
   | `Context_overflow of string * int option
   | `Input_capacity of

--- a/lib/error_domain.mli
+++ b/lib/error_domain.mli
@@ -31,7 +31,7 @@ type provider_error =
   | `Streaming_timeout of Llm_provider.Http_client.timeout_phase * string
   | `Overloaded
   | `Invalid_request of Llm_provider.Retry.invalid_request_reason * string
-        (** Typed reason first, mirroring [`Input_capacity]. The reason used to be
+    (** Typed reason first, mirroring [`Input_capacity]. The reason used to be
             dropped here while [`Input_capacity] kept its own, so a request refused
             for a declared body-size limit arrived indistinguishable from a JSON
             parse failure. *)

--- a/test/test_error_domain.ml
+++ b/test/test_error_domain.ml
@@ -136,7 +136,7 @@ let test_to_string_each_variant () =
     ; `Provider_timeout (None, "3s elapsed")
     ; `Streaming_timeout (Http_client.Stream_body, "stream body elapsed")
     ; `Overloaded
-    ; `Invalid_request "bad body"
+    ; `Invalid_request (Llm_provider.Retry.Unknown_invalid_request, "bad body")
     ; `Tool_exec_failed ("search", "crash")
     ; `Tool_timeout ("calc", 30.0)
     ; `Guardrail_violation ("typed-input", "rejected")
@@ -174,7 +174,7 @@ let test_all_variants_convert () =
     ; `Provider_timeout (None, "x")
     ; `Streaming_timeout (Http_client.Stream_idle Http_client.Streaming_thinking, "idle")
     ; `Overloaded
-    ; `Invalid_request "x"
+    ; `Invalid_request (Llm_provider.Retry.Unknown_invalid_request, "x")
     ; `Tool_exec_failed ("t", "d")
     ; `Tool_timeout ("t", 1.0)
     ; `Guardrail_violation ("typed-input", "rejected")
@@ -350,7 +350,7 @@ let test_roundtrip_api_invalid_request () =
   in
   let poly = Error_domain.of_sdk_error orig in
   (match poly with
-   | `Invalid_request "bad" -> ()
+   | `Invalid_request (_, "bad") -> ()
    | _ -> Alcotest.fail "expected Invalid_request");
   let back = Error_domain.to_sdk_error poly in
   match back with
@@ -365,7 +365,8 @@ let test_roundtrip_api_invalid_request_does_not_infer_malformed_json () =
   in
   let poly = Error_domain.of_sdk_error orig in
   (match poly with
-   | `Invalid_request msg -> Alcotest.(check string) "message preserved" message msg
+   | `Invalid_request (_, msg) ->
+     Alcotest.(check string) "message preserved" message msg
    | _ -> Alcotest.fail "expected Invalid_request");
   match Error_domain.to_sdk_error poly with
   | Error.Api (Retry.InvalidRequest { reason = Retry.Unknown_invalid_request; _ } as err)
@@ -638,7 +639,8 @@ let test_retryable_invalid_request () =
   Alcotest.(check bool)
     "invalid_request not retryable"
     false
-    (Error_domain.is_retryable (`Invalid_request "bad"))
+    (Error_domain.is_retryable
+       (`Invalid_request (Llm_provider.Retry.Unknown_invalid_request, "bad")))
 ;;
 
 let test_retryable_tool_exec_failed () =
@@ -768,7 +770,7 @@ let test_provider_roundtrip_all_via_to_sdk () =
     ; `Provider_timeout (None, "x")
     ; `Streaming_timeout (Http_client.Stream_body, "x")
     ; `Overloaded
-    ; `Invalid_request "x"
+    ; `Invalid_request (Llm_provider.Retry.Unknown_invalid_request, "x")
     ]
   in
   List.iter

--- a/test/test_error_domain.ml
+++ b/test/test_error_domain.ml
@@ -365,17 +365,42 @@ let test_roundtrip_api_invalid_request_does_not_infer_malformed_json () =
   in
   let poly = Error_domain.of_sdk_error orig in
   (match poly with
-   | `Invalid_request (_, msg) ->
-     Alcotest.(check string) "message preserved" message msg
+   | `Invalid_request (_, msg) -> Alcotest.(check string) "message preserved" message msg
    | _ -> Alcotest.fail "expected Invalid_request");
+  (* The reason a caller supplied now survives the roundtrip. That is not inference
+     from prose — it is carrying a typed value that was already present. The
+     no-inference property is asserted separately below, starting from
+     Unknown_invalid_request with the same malformed-JSON message. *)
   match Error_domain.to_sdk_error poly with
+  | Error.Api (Retry.InvalidRequest { reason = Retry.Json_parse_error; _ } as err) ->
+    (* retry.ml:118-120 makes a supplied Json_parse_error retryable — malformed
+       model output may come back valid. The roundtrip used to erase the reason and
+       with it that judgement, so this asserted false; preserving the reason
+       restores the retryability the caller's classification implies. *)
+    Alcotest.(check bool)
+      "a preserved Json_parse_error stays retryable"
+      true
+      (Retry.is_retryable err)
+  | _ -> Alcotest.fail "roundtrip mismatch for InvalidRequest"
+;;
+
+(* The original property this file pinned: malformed-JSON prose must not be promoted
+   to Json_parse_error. Before the reason was carried, every roundtrip returned
+   Unknown_invalid_request and satisfied this trivially; now it needs a case that
+   starts there. *)
+let test_roundtrip_api_invalid_request_keeps_unknown_reason_unknown () =
+  let message = "Unexpected token } in JSON at position 12" in
+  let orig =
+    Error.Api (Retry.InvalidRequest { message; reason = Retry.Unknown_invalid_request })
+  in
+  match Error_domain.to_sdk_error (Error_domain.of_sdk_error orig) with
   | Error.Api (Retry.InvalidRequest { reason = Retry.Unknown_invalid_request; _ } as err)
     ->
     Alcotest.(check bool)
       "prose is not inferred after roundtrip"
       false
       (Retry.is_retryable err)
-  | _ -> Alcotest.fail "roundtrip mismatch for InvalidRequest"
+  | _ -> Alcotest.fail "an unknown reason must stay unknown"
 ;;
 
 let test_roundtrip_api_context_overflow () =
@@ -827,6 +852,10 @@ let () =
             "api invalid_request malformed JSON retryability"
             `Quick
             test_roundtrip_api_invalid_request_does_not_infer_malformed_json
+        ; Alcotest.test_case
+            "api invalid_request keeps an unknown reason unknown"
+            `Quick
+            test_roundtrip_api_invalid_request_keeps_unknown_reason_unknown
         ; Alcotest.test_case
             "api context_overflow"
             `Quick

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -1225,7 +1225,7 @@ let test_error_domain_provider_errors () =
     ; `Server_error (500, "internal")
     ; `Overloaded
     ; `Provider_timeout (None, "slow")
-    ; `Invalid_request "bad"
+    ; `Invalid_request (Llm_provider.Retry.Unknown_invalid_request, "bad")
     ]
   in
   List.iter


### PR DESCRIPTION
## 비대칭

`provider_error` 는 `` `Input_capacity `` 에 대해서는 typed reason 을 **보존한다** — 태그가 `Retry.input_capacity_reason` 을 직접 담는다 (`lib/error_domain.mli:36-39`). `` `Invalid_request `` 는 그렇지 않았다:

- 전방 (`lib/error_domain.ml:94`): `| Retry.InvalidRequest r -> \`Invalid_request r.message` — `r.reason` 소멸
- 역방향 (`:178-180`): `Retry.Unknown_invalid_request` 로 재구성 — 도착했던 reason 을 덮어씀

즉 이 모듈을 왕복하면 typed 정체가 사라진다.

## 무엇을 잃는가

`lib/provider_failure_attribution.ml:62-65` 가 과대 요청을
`Retry.InvalidRequest { message; reason = Request_body_too_large { actual_bytes; limit_bytes } }`
로 분류한다 — **두 수치가 다 있고**, 호출자가 `max_request_body_bytes` 를 선언하면 `lib/llm_provider/complete_common.ml:682-687` 이 **dispatch 전에** 판정한다.

그런데 이 모듈을 지나면 JSON 파싱 실패와 구별되지 않는다. 소비자는 "요청이 몇 바이트 초과했다" 와 "요청이 잘못됐다" 를 typed 로 가를 방법이 없다.

## 변경

태그가 reason 을 담는다. 순서는 `` `Input_capacity `` 와 맞춰 **reason 먼저** 다.

```ocaml
| `Invalid_request of Llm_provider.Retry.invalid_request_reason * string
```

Retry 가 아닌 출처에서 `` `Invalid_request `` 를 만드는 5곳 — `Error.InvalidRequest`, `InvalidConfig`, `ParseError`, unknown variant, generic — 은 `Unknown_invalid_request` 를 넘긴다. 그것이 원래 의미하던 값이다.

`invalid_request_reason` 은 생성자가 **3개** (`Json_parse_error` / `Request_body_too_large` / `Unknown_invalid_request`) 이므로, reason 전체를 싣는 비용이 하나만 특수 처리하는 것과 같다. 부분 이전이 남지 않는다.

## 왜 이 변경이 필요한가 (하류)

masc 의 오버플로 복구 경로는 `lib/keeper/keeper_turn_runtime_budget.ml:407` 에서 `Agent_sdk.Error.Api (ContextOverflow { limit; _ })` **만** 매치한다. `ContextOverflow` 는 최상위 api_error 라서 이 모듈의 왕복(`:96` / `:176-177`)을 통과해 도달하는 반면, `Request_body_too_large` 는 생성자 **안의 reason** 이라 버려졌다. **차이는 위치뿐이었다.**

이 PR 이후 masc 는 바이트 차원 초과를 typed 로 받아 압축 트리거로 라우팅할 수 있다 (masc #25720). 그 전에는 상한을 선언해도 턴이 그냥 실패한다 — 라이브 실측으로 `context_compacted` 2,012 시도 / 성공 0 이 누적 중이다.

## 검증

4파일 `ocamlformat` 파싱 통과. `rg --no-ignore` 로 전 저장소 `` `Invalid_request `` 사용 지점 전수 확인 후 갱신 (`lib/error_domain.{ml,mli}`, `test/test_error_domain.ml`, `test/test_pipeline.ml`). **로컬 타입체크 안 함** — 이 트리가 masc 의 agent_sdk 핀 원본이라 로컬 스위치에서 검증할 수 없다. 타입체크 권위는 CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BEwRSse6KzFf9MnVGkjbH
