### PR TITLE
fix(exact-output): admit Gemini anyOf nullable enums

### DIFF
--- a/lib/llm_provider/exact_output_gemini_schema.ml
+++ b/lib/llm_provider/exact_output_gemini_schema.ml
@@ -99,9 +99,7 @@ let rec validate ~path = function
 
 and validate_any_of ~path ~fields branches =
   match
-    List.find_opt
-      (fun (keyword, _) -> not (List.mem keyword any_of_keywords))
-      fields
+    List.find_opt (fun (keyword, _) -> not (List.mem keyword any_of_keywords)) fields
   with
   | Some (keyword, _) -> Error (Unsupported_keyword (path ^ "." ^ keyword))
   | None ->
@@ -122,14 +120,12 @@ and validate_any_of ~path ~fields branches =
        let rec validate_branches index = function
          | [] -> Ok ()
          | schema :: rest ->
-           let* () =
-             validate ~path:(Printf.sprintf "%s.anyOf[%d]" path index) schema
-           in
+           let* () = validate ~path:(Printf.sprintf "%s.anyOf[%d]" path index) schema in
            validate_branches (index + 1) rest
        in
        validate_branches 0 schemas
-     | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _
-     | `List [] -> Error Invalid_schema)
+     | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _ | `List []
+       -> Error Invalid_schema)
 
 and validate_fields ~path ~type_name fields =
   let rec validate_all = function

--- a/lib/llm_provider/exact_output_gemini_schema.ml
+++ b/lib/llm_provider/exact_output_gemini_schema.ml
@@ -20,8 +20,13 @@ let schema_keywords =
   ; "prefixItems"
   ; "minItems"
   ; "maxItems"
+  ; "anyOf"
   ]
 ;;
+
+(* Gemini interprets [oneOf] as [anyOf], so admitting it would erase the
+   caller's exclusivity contract. Keep [oneOf] unsupported. *)
+let any_of_keywords = [ "anyOf"; "title"; "description" ]
 
 let keywords_for_type = function
   | "object" ->
@@ -68,22 +73,63 @@ let schema_base_type = function
 
 let rec validate ~path = function
   | `Assoc fields when assoc_keys_are_unique fields ->
-    (match
-       List.find_opt (fun (keyword, _) -> not (List.mem keyword schema_keywords)) fields
-     with
-     | Some (keyword, _) -> Error (Unsupported_keyword (path ^ "." ^ keyword))
+    (match List.assoc_opt "anyOf" fields with
+     | Some branches -> validate_any_of ~path ~fields branches
      | None ->
-       (match schema_base_type (List.assoc_opt "type" fields) with
-        | Ok type_name ->
-          let supported = keywords_for_type type_name in
-          (match
-             List.find_opt (fun (keyword, _) -> not (List.mem keyword supported)) fields
-           with
-           | Some (keyword, _) -> Error (Unsupported_keyword (path ^ "." ^ keyword))
-           | None -> validate_fields ~path ~type_name fields)
-        | Error _ as error -> error))
+       (match
+          List.find_opt
+            (fun (keyword, _) -> not (List.mem keyword schema_keywords))
+            fields
+        with
+        | Some (keyword, _) -> Error (Unsupported_keyword (path ^ "." ^ keyword))
+        | None ->
+          (match schema_base_type (List.assoc_opt "type" fields) with
+           | Ok type_name ->
+             let supported = keywords_for_type type_name in
+             (match
+                List.find_opt
+                  (fun (keyword, _) -> not (List.mem keyword supported))
+                  fields
+              with
+              | Some (keyword, _) -> Error (Unsupported_keyword (path ^ "." ^ keyword))
+              | None -> validate_fields ~path ~type_name fields)
+           | Error _ as error -> error)))
   | `Assoc _ | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ ->
     Error Invalid_schema
+
+and validate_any_of ~path ~fields branches =
+  match
+    List.find_opt
+      (fun (keyword, _) -> not (List.mem keyword any_of_keywords))
+      fields
+  with
+  | Some (keyword, _) -> Error (Unsupported_keyword (path ^ "." ^ keyword))
+  | None ->
+    let* () =
+      match
+        List.find_opt
+          (function
+            | "anyOf", _ -> false
+            | ("title" | "description"), `String _ -> false
+            | _ -> true)
+          fields
+      with
+      | None -> Ok ()
+      | Some _ -> Error Invalid_schema
+    in
+    (match branches with
+     | `List (_ :: _ as schemas) ->
+       let rec validate_branches index = function
+         | [] -> Ok ()
+         | schema :: rest ->
+           let* () =
+             validate ~path:(Printf.sprintf "%s.anyOf[%d]" path index) schema
+           in
+           validate_branches (index + 1) rest
+       in
+       validate_branches 0 schemas
+     | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _
+     | `List [] -> Error Invalid_schema)
 
 and validate_fields ~path ~type_name fields =
   let rec validate_all = function

--- a/test/test_exact_output_flow.ml
+++ b/test/test_exact_output_flow.ml
@@ -205,6 +205,8 @@ let preference_store ?(capacity = 16) () =
 
 let snapshot_candidates
       ?(messages = [ msg "return one exact object" ])
+      ?(requirement =
+        EO.make_output_requirement ~schema ~minimum_guarantee:EO.Json_syntax)
       ~preferences
       ~scope
       candidates
@@ -218,16 +220,17 @@ let snapshot_candidates
       ~first
       ~rest
       ~messages
-      (EO.make_output_requirement ~schema ~minimum_guarantee:EO.Json_syntax)
+      requirement
 ;;
 
 let frozen_candidates
       ?(preferences = preference_store ())
       ?(scope = flow_scope "test-default")
       ?messages
+      ?requirement
       candidates
   =
-  match snapshot_candidates ?messages ~preferences ~scope candidates with
+  match snapshot_candidates ?messages ?requirement ~preferences ~scope candidates with
   | Ok ready -> ready
   | Error _ -> fail "flow fixture did not admit"
 ;;
@@ -336,16 +339,24 @@ let with_counted_server ?measurement_delay_s ~measurement_reply ~response f =
     let port = fresh_port () in
     let handler _conn request body =
       let request_body = Eio.Buf_read.(of_flow ~max_size:max_int body |> take_all) in
-      match Uri.path (Cohttp.Request.uri request) with
-      | "/v1/messages/count_tokens" ->
+      let path = Uri.path (Cohttp.Request.uri request) in
+      match path with
+      | path
+        when String.equal path "/v1/messages/count_tokens"
+             || String.ends_with ~suffix:":countTokens" path ->
         Atomic.incr measurement_posts;
         atomic_prepend measurement_bodies request_body;
         Option.iter (Eio.Time.sleep clock) measurement_delay_s;
         (match measurement_reply with
          | Measurement_tokens input_tokens ->
+           let body =
+             if String.ends_with ~suffix:":countTokens" path
+             then Printf.sprintf {|{"totalTokens":%d}|} input_tokens
+             else Printf.sprintf {|{"input_tokens":%d}|} input_tokens
+           in
            Cohttp_eio.Server.respond_string
              ~status:`OK
-             ~body:(Printf.sprintf {|{"input_tokens":%d}|} input_tokens)
+             ~body
              ()
          | Measurement_invalid_response ->
            Cohttp_eio.Server.respond_string ~status:`OK ~body:{|{"wrong":true}|} ()
@@ -3483,6 +3494,90 @@ let test_success_and_later_domain_rejection_are_terminal () =
   | Error _ -> fail "terminal success fixture failed"
 ;;
 
+let test_gemini_structural_sibling_rejects_before_outer_dispatch () =
+  let id = "gemini-structural-sibling-flow" in
+  let string_branch =
+    `Assoc [ "type", `String "string"; "enum", `List [ `String "ready" ] ]
+  in
+  let invalid_schema =
+    `Assoc
+      [ ( "anyOf"
+        , `List [ string_branch; `Assoc [ "type", `String "null" ] ] )
+      ; "type", `String "string"
+      ]
+  in
+  let requirement =
+    EO.make_output_requirement
+      ~schema:invalid_schema
+      ~minimum_guarantee:EO.Provider_schema
+  in
+  let (result, evidence), posts =
+    with_counted_server ~measurement_reply:(Measurement_tokens 1) ~response:"unused"
+    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
+    with_catalog
+      [ catalog_entry
+          ~kind:"gemini"
+          ~request_path:""
+          ~id
+          ~base_url:(base_url ^ "/v1beta/models")
+          ~native:true
+          ~json:true
+          ()
+      ]
+    @@ fun snapshot ->
+    let flow =
+      start_flow
+        (frozen_candidates ~requirement [ flow_candidate snapshot id ])
+    in
+    let result =
+      EO.execute_flow_once
+        ~net
+        ~before_measurement_dispatch:(fun _ ->
+          fail "schema rejection reached measurement intent")
+        ~on_measurement_terminal:(fun _ ->
+          fail "schema rejection reached measurement terminal")
+        ~before_dispatch:(fun _ -> fail "schema rejection allocated generation")
+        ~before_advance:(fun ~failed:_ ~next:_ ->
+          fail "single rejected schema requested successor advance")
+        flow
+    in
+    result, EO.flow_attempt_evidence flow
+  in
+  check int "invalid Gemini schema performs no measurement POST" 0 posts.measurement_posts;
+  check int "invalid Gemini schema performs no generation POST" 0 posts.generation_posts;
+  check int "invalid Gemini schema allocates no attempt" 0 (List.length evidence.attempts);
+  match result with
+  | Error
+      (EO.Flow_candidates_exhausted
+         { rejection; evidence = terminal_evidence } as error) ->
+    check
+      bool
+      "invalid Gemini schema starts no generation dispatch"
+      true
+      (EO.flow_execution_error_generation_dispatch error = EO.No_generation_dispatch);
+    (match EO.candidate_rejection_disposition rejection with
+     | EO.Output_requirement_rejected -> ()
+     | _ -> fail "invalid Gemini schema lost its output-requirement disposition");
+    check
+      bool
+      "invalid Gemini schema records no measurement dispatch"
+      true
+      (EO.candidate_rejection_measurement_dispatch_fact rejection
+       = EO.No_measurement_dispatch);
+    check
+      bool
+      "invalid Gemini schema records local invalid measurement outcome"
+      true
+      (EO.candidate_rejection_measurement_outcome rejection
+       = EO.Measurement_local_invalid);
+    check
+      int
+      "terminal invalid Gemini schema retains no attempt"
+      0
+      (List.length terminal_evidence.attempts)
+  | Ok _ | Error _ -> fail "invalid Gemini schema lost typed candidate exhaustion"
+;;
+
 let test_structural_predispatch_failure_does_not_advance () =
   let response =
     {|{"id":"msg-flow","type":"message","role":"assistant","model":"flow","content":[{"type":"text","text":"{\"name\":\"unused\"}"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}|}
@@ -3770,6 +3865,10 @@ let () =
             "success and domain rejection stop"
             `Quick
             test_success_and_later_domain_rejection_are_terminal
+        ; test_case
+            "Gemini structural sibling rejects before outer dispatch"
+            `Quick
+            test_gemini_structural_sibling_rejects_before_outer_dispatch
         ; test_case
             "predispatch structural failure stops"
             `Quick

--- a/test/test_exact_output_flow.ml
+++ b/test/test_exact_output_flow.ml
@@ -214,13 +214,7 @@ let snapshot_candidates
   match candidates with
   | [] -> fail "flow fixture must be nonempty"
   | first :: rest ->
-    EO.snapshot_flow
-      ~preferences
-      ~scope
-      ~first
-      ~rest
-      ~messages
-      requirement
+    EO.snapshot_flow ~preferences ~scope ~first ~rest ~messages requirement
 ;;
 
 let frozen_candidates
@@ -354,10 +348,7 @@ let with_counted_server ?measurement_delay_s ~measurement_reply ~response f =
              then Printf.sprintf {|{"totalTokens":%d}|} input_tokens
              else Printf.sprintf {|{"input_tokens":%d}|} input_tokens
            in
-           Cohttp_eio.Server.respond_string
-             ~status:`OK
-             ~body
-             ()
+           Cohttp_eio.Server.respond_string ~status:`OK ~body ()
          | Measurement_invalid_response ->
            Cohttp_eio.Server.respond_string ~status:`OK ~body:{|{"wrong":true}|} ()
          | Measurement_transport_failure ->
@@ -3501,8 +3492,7 @@ let test_gemini_structural_sibling_rejects_before_outer_dispatch () =
   in
   let invalid_schema =
     `Assoc
-      [ ( "anyOf"
-        , `List [ string_branch; `Assoc [ "type", `String "null" ] ] )
+      [ "anyOf", `List [ string_branch; `Assoc [ "type", `String "null" ] ]
       ; "type", `String "string"
       ]
   in
@@ -3526,8 +3516,7 @@ let test_gemini_structural_sibling_rejects_before_outer_dispatch () =
       ]
     @@ fun snapshot ->
     let flow =
-      start_flow
-        (frozen_candidates ~requirement [ flow_candidate snapshot id ])
+      start_flow (frozen_candidates ~requirement [ flow_candidate snapshot id ])
     in
     let result =
       EO.execute_flow_once
@@ -3548,8 +3537,8 @@ let test_gemini_structural_sibling_rejects_before_outer_dispatch () =
   check int "invalid Gemini schema allocates no attempt" 0 (List.length evidence.attempts);
   match result with
   | Error
-      (EO.Flow_candidates_exhausted
-         { rejection; evidence = terminal_evidence } as error) ->
+      (EO.Flow_candidates_exhausted { rejection; evidence = terminal_evidence } as error)
+    ->
     check
       bool
       "invalid Gemini schema starts no generation dispatch"
@@ -3568,8 +3557,7 @@ let test_gemini_structural_sibling_rejects_before_outer_dispatch () =
       bool
       "invalid Gemini schema records local invalid measurement outcome"
       true
-      (EO.candidate_rejection_measurement_outcome rejection
-       = EO.Measurement_local_invalid);
+      (EO.candidate_rejection_measurement_outcome rejection = EO.Measurement_local_invalid);
     check
       int
       "terminal invalid Gemini schema retains no attempt"

--- a/test/test_exact_output_single_surface.ml
+++ b/test/test_exact_output_single_surface.ml
@@ -1805,25 +1805,19 @@ let test_gemini_any_of_rejections_are_pre_dispatch () =
   in
   let null_branch = `Assoc [ "type", `String "null" ] in
   let rejected_schemas =
-    [ ( "oneOf semantic loss"
-      , `Assoc [ "oneOf", `List [ string_branch; null_branch ] ] )
+    [ "oneOf semantic loss", `Assoc [ "oneOf", `List [ string_branch; null_branch ] ]
     ; "empty anyOf", `Assoc [ "anyOf", `List [] ]
     ; "scalar anyOf", `Assoc [ "anyOf", `String "not-a-schema-list" ]
-    ; ( "malformed nested branch"
-      , `Assoc [ "anyOf", `List [ string_branch; `Bool true ] ] )
+    ; "malformed nested branch", `Assoc [ "anyOf", `List [ string_branch; `Bool true ] ]
     ; ( "structural sibling"
-      , `Assoc
-          [ "anyOf", `List [ string_branch; null_branch ]
-          ; "type", `String "string"
-          ] )
+      , `Assoc [ "anyOf", `List [ string_branch; null_branch ]; "type", `String "string" ]
+      )
     ; ( "mixed-null scalar enum"
       , `Assoc
           [ ( "anyOf"
             , `List
                 [ `Assoc
-                    [ "type", `String "string"
-                    ; "enum", `List [ `String "ready"; `Null ]
-                    ]
+                    [ "type", `String "string"; "enum", `List [ `String "ready"; `Null ] ]
                 ; null_branch
                 ] )
           ] )

--- a/test/test_exact_output_single_surface.ml
+++ b/test/test_exact_output_single_surface.ml
@@ -1733,6 +1733,178 @@ let test_gemini_nullable_schema_admitted () =
   | Error _ -> fail "Gemini generateContent must admit nullable type arrays"
 ;;
 
+let test_gemini_any_of_nullable_enum_admitted_unchanged () =
+  let id = "gemini-any-of-nullable-enum-surface" in
+  let nullable_enum =
+    `Assoc
+      [ ( "anyOf"
+        , `List
+            [ `Assoc
+                [ "type", `String "string"
+                ; ( "enum"
+                  , `List
+                      [ `String "self_observation"
+                      ; `String "external_state"
+                      ; `String "durable_knowledge"
+                      ] )
+                ]
+            ; `Assoc [ "type", `String "null" ]
+            ] )
+      ]
+  in
+  let top_level =
+    `Assoc
+      [ "title", `String "nullable observation kind"
+      ; "description", `String "provider-neutral nullable enum"
+      ; "anyOf", Yojson.Safe.Util.member "anyOf" nullable_enum
+      ]
+  in
+  let nested =
+    `Assoc
+      [ "type", `String "object"
+      ; "properties", `Assoc [ "kind", nullable_enum ]
+      ; "required", `List [ `String "kind" ]
+      ; "additionalProperties", `Bool false
+      ]
+  in
+  with_catalog [ gemini_exact_entry ~id ~request_path:"" ]
+  @@ fun snapshot ->
+  let selected = target snapshot id in
+  List.iter
+    (fun (label, domain_schema) ->
+       match
+         EO.admit
+           ~target:selected
+           ~messages:[ msg label ]
+           (EO.make_output_requirement
+              ~schema:domain_schema
+              ~minimum_guarantee:EO.Provider_schema)
+       with
+       | Error _ -> failf "%s Gemini anyOf schema must admit" label
+       | Ok ready ->
+         let provenance = EO.plan_provenance ready in
+         let source =
+           EO.plan_provenance_source_schema_fingerprint provenance
+           |> EO.schema_fingerprint_to_string
+         in
+         (match EO.plan_provenance_effective_schema_fingerprint provenance with
+          | None -> failf "%s Gemini schema must expose its wire fingerprint" label
+          | Some effective ->
+            check
+              string
+              (label ^ " Gemini preserves the raw schema on wire")
+              source
+              (EO.schema_fingerprint_to_string effective)))
+    [ "top-level nullable enum", top_level; "nested nullable enum", nested ]
+;;
+
+let test_gemini_any_of_rejections_are_pre_dispatch () =
+  let id = "gemini-any-of-rejection-surface" in
+  let string_branch =
+    `Assoc [ "type", `String "string"; "enum", `List [ `String "ready" ] ]
+  in
+  let null_branch = `Assoc [ "type", `String "null" ] in
+  let rejected_schemas =
+    [ ( "oneOf semantic loss"
+      , `Assoc [ "oneOf", `List [ string_branch; null_branch ] ] )
+    ; "empty anyOf", `Assoc [ "anyOf", `List [] ]
+    ; "scalar anyOf", `Assoc [ "anyOf", `String "not-a-schema-list" ]
+    ; ( "malformed nested branch"
+      , `Assoc [ "anyOf", `List [ string_branch; `Bool true ] ] )
+    ; ( "structural sibling"
+      , `Assoc
+          [ "anyOf", `List [ string_branch; null_branch ]
+          ; "type", `String "string"
+          ] )
+    ; ( "mixed-null scalar enum"
+      , `Assoc
+          [ ( "anyOf"
+            , `List
+                [ `Assoc
+                    [ "type", `String "string"
+                    ; "enum", `List [ `String "ready"; `Null ]
+                    ]
+                ; null_branch
+                ] )
+          ] )
+    ; ( "recursive required"
+      , `Assoc
+          [ ( "anyOf"
+            , `List
+                [ `Assoc
+                    [ "type", `String "object"
+                    ; "properties", `Assoc [ "name", string_branch ]
+                    ; "required", `List [ `Int 1 ]
+                    ]
+                ; null_branch
+                ] )
+          ] )
+    ; ( "recursive additionalProperties"
+      , `Assoc
+          [ ( "anyOf"
+            , `List
+                [ `Assoc
+                    [ "type", `String "object"
+                    ; "properties", `Assoc []
+                    ; "additionalProperties", `String "closed"
+                    ]
+                ; null_branch
+                ] )
+          ] )
+    ; ( "recursive bounds"
+      , `Assoc
+          [ ( "anyOf"
+            , `List
+                [ `Assoc
+                    [ "type", `String "array"
+                    ; "items", string_branch
+                    ; "minItems", `Int (-1)
+                    ]
+                ; null_branch
+                ] )
+          ] )
+    ]
+  in
+  let admissions, completion_posts, token_posts, captures =
+    with_server ~response:{|{"unused":true}|}
+    @@ fun ~sw:_ ~net:_ ~clock:_ ~base_url ->
+    let entry =
+      catalog_entry
+        ~id
+        ~kind:Provider_config.Gemini
+        ~base_url
+        ~request_path:""
+        ~capabilities:(capabilities ~native:true ~json:true)
+        ()
+    in
+    with_catalog [ entry ]
+    @@ fun snapshot ->
+    let selected = target snapshot id in
+    List.map
+      (fun (label, domain_schema) ->
+         ( label
+         , EO.admit
+             ~target:selected
+             ~messages:[ msg label ]
+             (EO.make_output_requirement
+                ~schema:domain_schema
+                ~minimum_guarantee:EO.Provider_schema) ))
+      rejected_schemas
+  in
+  List.iter
+    (fun (label, admission) ->
+       match admission with
+       | Error error ->
+         (match EO.admission_error_disposition error with
+          | EO.Output_requirement_rejected -> ()
+          | _ -> failf "%s lost its neutral rejection disposition" label)
+       | Ok _ -> failf "%s must reject before Gemini dispatch" label)
+    admissions;
+  check int "rejected Gemini unions perform no generation POST" 0 completion_posts;
+  check int "rejected Gemini unions perform no measurement POST" 0 token_posts;
+  check int "rejected Gemini unions capture no request" 0 (List.length captures)
+;;
+
 let test_gemini_nested_unsupported_schema_keyword_rejected () =
   let id = "gemini-unsupported-keyword-surface" in
   let unsupported_schema =
@@ -1809,6 +1981,14 @@ let () =
             "Gemini nullable schema admitted"
             `Quick
             test_gemini_nullable_schema_admitted
+        ; test_case
+            "Gemini anyOf nullable enum is preserved"
+            `Quick
+            test_gemini_any_of_nullable_enum_admitted_unchanged
+        ; test_case
+            "Gemini anyOf rejections are pre-dispatch"
+            `Quick
+            test_gemini_any_of_rejections_are_pre_dispatch
         ; test_case
             "Gemini nested unsupported schema keyword rejected"
             `Quick

--- a/test/test_exact_output_single_surface.ml
+++ b/test/test_exact_output_single_surface.ml
@@ -221,6 +221,13 @@ let anthropic_response ?(stop_reason = "end_turn") content =
     stop_reason
 ;;
 
+let gemini_response content =
+  let encoded_content = Yojson.Safe.to_string (`String content) in
+  Printf.sprintf
+    {|{"candidates":[{"content":{"role":"model","parts":[{"text":%s}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2}}|}
+    encoded_content
+;;
+
 let with_server
       ?response_delay_s
       ?(status = `OK)
@@ -1697,11 +1704,15 @@ let test_identity_survives_success_error_and_cancellation () =
   check_receipt_provenance "cancellation" cancel_provenance cancel_receipt
 ;;
 
-let gemini_exact_entry ~id ~request_path =
+let gemini_exact_entry
+      ?(base_url = "https://surface.invalid/v1beta/models")
+      ~id
+      ~request_path
+  =
   catalog_entry
     ~id
     ~kind:Provider_config.Gemini
-    ~base_url:"https://surface.invalid/v1beta/models"
+    ~base_url
     ~request_path
     ~capabilities:(capabilities ~native:true ~json:true)
     ()
@@ -1734,7 +1745,6 @@ let test_gemini_nullable_schema_admitted () =
 ;;
 
 let test_gemini_any_of_nullable_enum_admitted_unchanged () =
-  let id = "gemini-any-of-nullable-enum-surface" in
   let nullable_enum =
     `Assoc
       [ ( "anyOf"
@@ -1767,38 +1777,82 @@ let test_gemini_any_of_nullable_enum_admitted_unchanged () =
       ; "additionalProperties", `Bool false
       ]
   in
-  with_catalog [ gemini_exact_entry ~id ~request_path:"" ]
-  @@ fun snapshot ->
-  let selected = target snapshot id in
-  List.iter
-    (fun (label, domain_schema) ->
-       match
-         EO.admit
-           ~target:selected
-           ~messages:[ msg label ]
-           (EO.make_output_requirement
-              ~schema:domain_schema
-              ~minimum_guarantee:EO.Provider_schema)
-       with
-       | Error _ -> failf "%s Gemini anyOf schema must admit" label
-       | Ok ready ->
-         let provenance = EO.plan_provenance ready in
-         let source =
-           EO.plan_provenance_source_schema_fingerprint provenance
-           |> EO.schema_fingerprint_to_string
-         in
-         (match EO.plan_provenance_effective_schema_fingerprint provenance with
-          | None -> failf "%s Gemini schema must expose its wire fingerprint" label
-          | Some effective ->
-            check
-              string
-              (label ^ " Gemini preserves the raw schema on wire")
-              source
-              (EO.schema_fingerprint_to_string effective)))
-    [ "top-level nullable enum", top_level; "nested nullable enum", nested ]
+  let run ~label ~domain_schema ~content =
+    let id = "gemini-any-of-" ^ label in
+    let (provenance, result), completion_posts, token_posts, captures =
+      with_server ~response:(gemini_response content)
+      @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
+      let entry =
+        gemini_exact_entry
+          ~base_url:(base_url ^ "/v1beta/models")
+          ~id
+          ~request_path:""
+      in
+      with_catalog [ entry ]
+      @@ fun snapshot ->
+      let ready =
+        match
+          EO.admit
+            ~target:(target snapshot id)
+            ~messages:[ msg label ]
+            (EO.make_output_requirement
+               ~schema:domain_schema
+               ~minimum_guarantee:EO.Provider_schema)
+        with
+        | Error _ -> failf "%s Gemini anyOf schema must admit" label
+        | Ok ready -> ready
+      in
+      EO.plan_provenance ready, EO.execute_once ~net (attempt ready)
+    in
+    check int (label ^ " Gemini generation POST") 1 completion_posts;
+    check int (label ^ " Gemini token POST") 0 token_posts;
+    let capture =
+      match captures with
+      | [ capture ] -> capture
+      | _ -> failf "%s Gemini schema must produce one captured request" label
+    in
+    let captured_schema =
+      Yojson.Safe.from_string capture.body
+      |> Yojson.Safe.Util.member "generationConfig"
+      |> Yojson.Safe.Util.member "responseJsonSchema"
+    in
+    check
+      bool
+      (label ^ " Gemini request preserves the raw schema")
+      true
+      (captured_schema = domain_schema);
+    let source =
+      EO.plan_provenance_source_schema_fingerprint provenance
+      |> EO.schema_fingerprint_to_string
+    in
+    (match EO.plan_provenance_effective_schema_fingerprint provenance with
+     | None -> failf "%s Gemini schema must expose its wire fingerprint" label
+     | Some effective ->
+       check
+         string
+         (label ^ " Gemini source and effective fingerprints match")
+         source
+         (EO.schema_fingerprint_to_string effective));
+    match result with
+    | Error _ -> failf "%s Gemini exact execution must succeed" label
+    | Ok success ->
+      check
+        bool
+        (label ^ " Gemini output")
+        true
+        (success.output = Yojson.Safe.from_string content)
+  in
+  run
+    ~label:"top-level-nullable-enum"
+    ~domain_schema:top_level
+    ~content:{|"self_observation"|};
+  run
+    ~label:"nested-nullable-enum"
+    ~domain_schema:nested
+    ~content:{|{"kind":"self_observation"}|}
 ;;
 
-let test_gemini_any_of_rejections_are_pre_dispatch () =
+let test_gemini_any_of_rejections_are_direct_admission () =
   let id = "gemini-any-of-rejection-surface" in
   let string_branch =
     `Assoc [ "type", `String "string"; "enum", `List [ `String "ready" ] ]
@@ -1808,7 +1862,42 @@ let test_gemini_any_of_rejections_are_pre_dispatch () =
     [ "oneOf semantic loss", `Assoc [ "oneOf", `List [ string_branch; null_branch ] ]
     ; "empty anyOf", `Assoc [ "anyOf", `List [] ]
     ; "scalar anyOf", `Assoc [ "anyOf", `String "not-a-schema-list" ]
+    ; ( "non-string title"
+      , `Assoc
+          [ "title", `Int 1; "anyOf", `List [ string_branch; null_branch ] ] )
+    ; ( "non-string description"
+      , `Assoc
+          [ "description", `Bool false
+          ; "anyOf", `List [ string_branch; null_branch ]
+          ] )
+    ; ( "empty enum"
+      , `Assoc
+          [ ( "anyOf"
+            , `List
+                [ `Assoc [ "type", `String "string"; "enum", `List [] ]
+                ; null_branch
+                ] )
+          ] )
+    ; ( "anyOf with oneOf"
+      , `Assoc
+          [ "anyOf", `List [ string_branch; null_branch ]
+          ; "oneOf", `List [ string_branch; null_branch ]
+          ] )
+    ; ( "duplicate anyOf"
+      , `Assoc
+          [ "anyOf", `List [ string_branch; null_branch ]
+          ; "anyOf", `List [ string_branch; null_branch ]
+          ] )
     ; "malformed nested branch", `Assoc [ "anyOf", `List [ string_branch; `Bool true ] ]
+    ; ( "nested unsupported keyword"
+      , `Assoc
+          [ ( "anyOf"
+            , `List
+                [ `Assoc
+                    [ "type", `String "string"; "pattern", `String ".+" ]
+                ; null_branch
+                ] )
+          ] )
     ; ( "structural sibling"
       , `Assoc [ "anyOf", `List [ string_branch; null_branch ]; "type", `String "string" ]
       )
@@ -1859,71 +1948,25 @@ let test_gemini_any_of_rejections_are_pre_dispatch () =
           ] )
     ]
   in
-  let admissions, completion_posts, token_posts, captures =
-    with_server ~response:{|{"unused":true}|}
-    @@ fun ~sw:_ ~net:_ ~clock:_ ~base_url ->
-    let entry =
-      catalog_entry
-        ~id
-        ~kind:Provider_config.Gemini
-        ~base_url
-        ~request_path:""
-        ~capabilities:(capabilities ~native:true ~json:true)
-        ()
-    in
-    with_catalog [ entry ]
-    @@ fun snapshot ->
-    let selected = target snapshot id in
-    List.map
-      (fun (label, domain_schema) ->
-         ( label
-         , EO.admit
-             ~target:selected
-             ~messages:[ msg label ]
-             (EO.make_output_requirement
-                ~schema:domain_schema
-                ~minimum_guarantee:EO.Provider_schema) ))
-      rejected_schemas
-  in
+  with_catalog [ gemini_exact_entry ~id ~request_path:"" ]
+  @@ fun snapshot ->
+  let selected = target snapshot id in
   List.iter
-    (fun (label, admission) ->
-       match admission with
+    (fun (label, domain_schema) ->
+       match
+         EO.admit
+           ~target:selected
+           ~messages:[ msg label ]
+           (EO.make_output_requirement
+              ~schema:domain_schema
+              ~minimum_guarantee:EO.Provider_schema)
+       with
        | Error error ->
          (match EO.admission_error_disposition error with
           | EO.Output_requirement_rejected -> ()
           | _ -> failf "%s lost its neutral rejection disposition" label)
-       | Ok _ -> failf "%s must reject before Gemini dispatch" label)
-    admissions;
-  check int "rejected Gemini unions perform no generation POST" 0 completion_posts;
-  check int "rejected Gemini unions perform no measurement POST" 0 token_posts;
-  check int "rejected Gemini unions capture no request" 0 (List.length captures)
-;;
-
-let test_gemini_nested_unsupported_schema_keyword_rejected () =
-  let id = "gemini-unsupported-keyword-surface" in
-  let unsupported_schema =
-    `Assoc
-      [ "type", `String "object"
-      ; ( "properties"
-        , `Assoc [ "name", `Assoc [ "type", `String "string"; "pattern", `String ".+" ] ]
-        )
-      ]
-  in
-  with_catalog [ gemini_exact_entry ~id ~request_path:"" ]
-  @@ fun snapshot ->
-  match
-    EO.admit
-      ~target:(target snapshot id)
-      ~messages:[ msg "unsupported keyword" ]
-      (EO.make_output_requirement
-         ~schema:unsupported_schema
-         ~minimum_guarantee:EO.Provider_schema)
-  with
-  | Error error ->
-    (match EO.admission_error_disposition error with
-     | EO.Output_requirement_rejected -> ()
-     | _ -> fail "Gemini schema rejection lost its neutral disposition")
-  | Ok _ -> fail "Gemini unsupported schema keyword must reject"
+       | Ok _ -> failf "%s must reject during Gemini admission" label)
+    rejected_schemas
 ;;
 
 let test_gemini_nonempty_request_path_rejected_before_resolution () =
@@ -1980,13 +2023,9 @@ let () =
             `Quick
             test_gemini_any_of_nullable_enum_admitted_unchanged
         ; test_case
-            "Gemini anyOf rejections are pre-dispatch"
+            "Gemini anyOf rejections are direct admission"
             `Quick
-            test_gemini_any_of_rejections_are_pre_dispatch
-        ; test_case
-            "Gemini nested unsupported schema keyword rejected"
-            `Quick
-            test_gemini_nested_unsupported_schema_keyword_rejected
+            test_gemini_any_of_rejections_are_direct_admission
         ; test_case
             "Gemini nonempty request path rejected before resolution"
             `Quick

--- a/test/test_exact_output_single_surface.ml
+++ b/test/test_exact_output_single_surface.ml
@@ -1783,10 +1783,7 @@ let test_gemini_any_of_nullable_enum_admitted_unchanged () =
       with_server ~response:(gemini_response content)
       @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
       let entry =
-        gemini_exact_entry
-          ~base_url:(base_url ^ "/v1beta/models")
-          ~id
-          ~request_path:""
+        gemini_exact_entry ~base_url:(base_url ^ "/v1beta/models") ~id ~request_path:""
       in
       with_catalog [ entry ]
       @@ fun snapshot ->
@@ -1863,20 +1860,15 @@ let test_gemini_any_of_rejections_are_direct_admission () =
     ; "empty anyOf", `Assoc [ "anyOf", `List [] ]
     ; "scalar anyOf", `Assoc [ "anyOf", `String "not-a-schema-list" ]
     ; ( "non-string title"
-      , `Assoc
-          [ "title", `Int 1; "anyOf", `List [ string_branch; null_branch ] ] )
+      , `Assoc [ "title", `Int 1; "anyOf", `List [ string_branch; null_branch ] ] )
     ; ( "non-string description"
       , `Assoc
-          [ "description", `Bool false
-          ; "anyOf", `List [ string_branch; null_branch ]
-          ] )
+          [ "description", `Bool false; "anyOf", `List [ string_branch; null_branch ] ] )
     ; ( "empty enum"
       , `Assoc
           [ ( "anyOf"
-            , `List
-                [ `Assoc [ "type", `String "string"; "enum", `List [] ]
-                ; null_branch
-                ] )
+            , `List [ `Assoc [ "type", `String "string"; "enum", `List [] ]; null_branch ]
+            )
           ] )
     ; ( "anyOf with oneOf"
       , `Assoc
@@ -1893,8 +1885,7 @@ let test_gemini_any_of_rejections_are_direct_admission () =
       , `Assoc
           [ ( "anyOf"
             , `List
-                [ `Assoc
-                    [ "type", `String "string"; "pattern", `String ".+" ]
+                [ `Assoc [ "type", `String "string"; "pattern", `String ".+" ]
                 ; null_branch
                 ] )
           ] )

--- a/test/test_exact_output_single_surface.ml
+++ b/test/test_exact_output_single_surface.ml
@@ -1784,8 +1784,7 @@ let test_gemini_any_of_nullable_enum_admitted_unchanged () =
       with_server ~response:(gemini_response content)
       @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
       let entry =
-        gemini_exact_entry
-          ~base_url:(base_url ^ "/v1beta/models") ~id ~request_path:"" ()
+        gemini_exact_entry ~base_url:(base_url ^ "/v1beta/models") ~id ~request_path:"" ()
       in
       with_catalog [ entry ]
       @@ fun snapshot ->

--- a/test/test_exact_output_single_surface.ml
+++ b/test/test_exact_output_single_surface.ml
@@ -1816,9 +1816,9 @@ let test_gemini_any_of_nullable_enum_admitted_unchanged () =
     in
     check
       bool
-      (label ^ " Gemini request preserves the raw schema")
+      (label ^ " Gemini request preserves schema semantics")
       true
-      (captured_schema = domain_schema);
+      (Yojson.Safe.equal captured_schema domain_schema);
     let source =
       EO.plan_provenance_source_schema_fingerprint provenance
       |> EO.schema_fingerprint_to_string

--- a/test/test_exact_output_single_surface.ml
+++ b/test/test_exact_output_single_surface.ml
@@ -1708,6 +1708,7 @@ let gemini_exact_entry
       ?(base_url = "https://surface.invalid/v1beta/models")
       ~id
       ~request_path
+      ()
   =
   catalog_entry
     ~id
@@ -1730,7 +1731,7 @@ let test_gemini_nullable_schema_admitted () =
       ; "required", `List [ `String "nickname" ]
       ]
   in
-  with_catalog [ gemini_exact_entry ~id ~request_path:"" ]
+  with_catalog [ gemini_exact_entry ~id ~request_path:"" () ]
   @@ fun snapshot ->
   match
     EO.admit
@@ -1783,7 +1784,8 @@ let test_gemini_any_of_nullable_enum_admitted_unchanged () =
       with_server ~response:(gemini_response content)
       @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
       let entry =
-        gemini_exact_entry ~base_url:(base_url ^ "/v1beta/models") ~id ~request_path:""
+        gemini_exact_entry
+          ~base_url:(base_url ^ "/v1beta/models") ~id ~request_path:"" ()
       in
       with_catalog [ entry ]
       @@ fun snapshot ->
@@ -1939,7 +1941,7 @@ let test_gemini_any_of_rejections_are_direct_admission () =
           ] )
     ]
   in
-  with_catalog [ gemini_exact_entry ~id ~request_path:"" ]
+  with_catalog [ gemini_exact_entry ~id ~request_path:"" () ]
   @@ fun snapshot ->
   let selected = target snapshot id in
   List.iter
@@ -1966,7 +1968,7 @@ let test_gemini_nonempty_request_path_rejected_before_resolution () =
   let overlay : EO.catalog_document =
     { source = "Gemini endpoint surface fixture"
     ; contents =
-        catalog_fixture_toml (gemini_exact_entry ~id ~request_path:"/interactions")
+        catalog_fixture_toml (gemini_exact_entry ~id ~request_path:"/interactions" ())
     }
   in
   match EO.load_resolver_snapshot ~io ~catalog:(EO.Embedded_with_overlay overlay) () with


### PR DESCRIPTION
## Summary

- admit nonempty recursive `anyOf` containers with only `title` and `description` metadata
- preserve caller schema semantics modulo JSON object-key order while retaining recursive object, enum, and bound validation
- deliberately reject `oneOf`, structural siblings, malformed branches, and mixed-null scalar enums before any provider dispatch
- execute top-level and nested nullable enums through loopback Gemini and compare captured `generationConfig.responseJsonSchema` with the original schema using JSON semantic equality
- prove a representative structural-sibling rejection through production `execute_flow_once`: callbacks unreachable, `No_measurement_dispatch` + `Measurement_local_invalid`, zero measurement/generation POSTs, and zero generation attempts

## Boundary

MASC continues to provide one provider-neutral content schema. OAS owns Gemini dialect admission and fails closed without provider-specific keyword or value translation. Immutable ready-plan canonicalization may reorder JSON object members, which are unordered by contract; schema keywords, values, and array order remain unchanged. `oneOf` remains unsupported because Gemini documents that it interprets `oneOf` like `anyOf`; accepting it would silently erase exclusivity semantics.

## Changed files

- `lib/llm_provider/exact_output_gemini_schema.ml`
- `test/test_exact_output_single_surface.ml`
- `test/test_exact_output_flow.ml`

## Evidence

- Google Gemini structured output documentation: https://ai.google.dev/gemini-api/docs/structured-output
- Google Gemini GenerateContent schema reference: https://ai.google.dev/api/generate-content
- Checked 2026-07-26 KST, confidence High.

## Validation

No local build, test, formatter, or lint command was run, per coordination instruction; PR CI is the validation authority.

Closes #2811
