### PR TITLE
test(exact-output): observe a format refusal ordering the candidate walk

### DIFF
--- a/test/test_exact_output_flow.ml
+++ b/test/test_exact_output_flow.ml
@@ -1699,6 +1699,69 @@ let test_later_missing_credential_does_not_block_current_success () =
   | Error _ -> fail "later missing credential blocked the current candidate"
 ;;
 
+(* The format axis of the exact-output contract had no behavioural coverage. The
+   chain that carries a format refusal to the next candidate — capability read refuses
+   (exact_output.ml No_structured_output + Json_syntax -> Error Json_syntax_unavailable),
+   the refusal classifies as a candidate rejection (admission_error_disposition ->
+   Output_requirement_rejected), the walk treats a rejection as advanceable
+   (advanceable_flow_failure) — held only by construction. Json_syntax_unavailable
+   appeared nowhere in any test, so nothing observed a format refusal ordering rather
+   than ending the walk. The neighbouring credential cases exercise the same advance
+   step through Runtime_slot_unavailable, which is why the mechanism worked; what was
+   unobserved is that a *format* refusal reaches it and that a capable successor then
+   serves the same request. *)
+let test_format_refusal_orders_the_walk () =
+  let (result, dispositions, advances), posts =
+    with_server ~response:(openai_response {|{"name":"accepted"}|})
+    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
+    with_catalog
+      [ catalog_entry ~id:"no-json" ~base_url ~native:false ~json:false ()
+      ; catalog_entry ~id:"json-capable" ~base_url ~native:true ~json:true ()
+      ]
+    @@ fun snapshot ->
+    let dispositions = ref [] in
+    let advances = ref 0 in
+    let result =
+      EO.execute_flow_once
+        ~net
+        ~on_measurement_terminal:(fun _ -> Ok ())
+        ~before_measurement_dispatch:(fun _ -> Ok ())
+        ~before_dispatch:(fun _ -> Ok ())
+        ~before_advance:(fun ~failed ~next:_ ->
+          incr advances;
+          (match failed with
+           | EO.Flow_candidate_rejected rejection ->
+             dispositions := EO.candidate_rejection_disposition rejection :: !dispositions
+           | _ -> fail "a format refusal did not arrive as a candidate rejection");
+          Ok ())
+        (start_flow (frozen_flow snapshot [ "no-json"; "json-capable" ]))
+    in
+    result, !dispositions, !advances
+  in
+  (* Pre-dispatch: the refused candidate never reaches the wire, so ordering past it
+     is not a duplicate request. *)
+  check int "only the capable candidate posts" 1 posts;
+  check int "the format refusal advanced the walk once" 1 advances;
+  (match dispositions with
+   | [ EO.Output_requirement_rejected ] -> ()
+   | [ _ ] -> fail "a format refusal was classified as some other disposition"
+   | _ -> failf "expected exactly one rejection, saw %d" (List.length dispositions));
+  match result with
+  | Ok success ->
+    check
+      string
+      "the capable successor served the same request"
+      "json-capable"
+      (candidate_id (EO.flow_success_candidate success));
+    check
+      int
+      "both candidates were visited"
+      2
+      (EO.candidate_visit_count_to_int
+         (EO.flow_success_evidence success).candidate_visit_count)
+  | Error _ -> fail "a format refusal ended the walk instead of ordering it"
+;;
+
 let test_missing_current_credential_advances_after_durable_settlement () =
   let (result, transitions, bound, next_visit), posts =
     with_server ~response:(openai_response {|{"name":"accepted"}|})
@@ -4168,6 +4231,10 @@ let () =
             "later missing credential does not block current success"
             `Quick
             test_later_missing_credential_does_not_block_current_success
+        ; test_case
+            "format refusal orders the walk"
+            `Quick
+            test_format_refusal_orders_the_walk
         ; test_case
             "missing current credential advances after durable settlement"
             `Quick


### PR DESCRIPTION
## 왜

exact-output 계약의 **형식 축에 동작 커버리지가 0** 이었다. `Json_syntax_unavailable` 이 이 저장소의 어떤 테스트에도 등장하지 않아, 형식 거부가 워크를 **끝내는 대신 전진시킨다**는 것을 아무것도 관측하지 않았다. 사슬은 구성으로만 성립했다:

```
exact_output.ml       No_structured_output + Json_syntax -> Error Json_syntax_unavailable
exact_output.ml       admission_error_disposition        -> Output_requirement_rejected
exact_output.ml       advanceable_flow_failure: Flow_step_candidate_rejected _ -> Some
exact_output_flow.ml  Some + 남은 후보                    -> execute_candidates rest
```

이웃 credential 케이스들이 그 전진 단계를 이미 실행한다 — 그래서 메커니즘은 동작한다. `advanceable_flow_failure` 가 disposition 을 읽지 않으므로 무엇이 만든 거부든 전진한다. **미관측이던 것은 형식 거부가 거기까지 도달하는지, 그리고 능력 있는 후속이 같은 요청을 실제로 서비스하는지** 다.

## 무엇

후보 2개. 첫 번째는 `supports_response_format_json` 도 `supports_structured_output` 도 선언하지 않고, 요구는 `Json_syntax`.

단정:
- 거부가 **후보 거부로 도달**한다 (다른 실패 경로가 아니라)
- disposition 이 **정확히** `Output_requirement_rejected` — 다른 등급이면 실패
- 워크가 **1회** 전진한다
- 후보 **2개 모두** 방문된다
- 능력 있는 후보가 **성공**한다
- `posts = 1` — 거부된 후보는 wire 에 닿지 않으므로, 그것을 지나 정렬하는 것은 **중복 요청이 아니다**

## 공허하지 않음

첫 후보를 json 가능으로 바꾸면 `"the format refusal advanced the walk once"` 에서 실패한다 (실측).

## 검증

`dune exec test/test_exact_output_flow.exe -- test outer-flow` — 신규 케이스 #14 통과. `dune build @fmt` + promote 적용 후 재실행도 통과.

## 맥락

masc 쪽 하네스(runtime-indifference G-3)가 이 사슬을 정적으로 단정하고 있었다. 정적 단정은 문자열 5개가 동시에 성립함을 보이지만 런타임 정렬을 보이지 않는다 — 이 테스트가 그 간극을 닫는다.

RFC-WAIVED: 테스트 추가만. credential/identity/repo/operator/sandbox/hooks/workflow 범위 밖.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
