### PR TITLE
fix(retry): classify HTTP 413 instead of folding it into Unknown_invalid_request

### DIFF
--- a/lib/llm_provider/retry.ml
+++ b/lib/llm_provider/retry.ml
@@ -6,6 +6,7 @@ type invalid_request_reason =
       { actual_bytes : int
       ; limit_bytes : int
       }
+  | Request_body_refused_by_provider of { status : int }
   | Unknown_invalid_request
 
 type input_capacity_reason =
@@ -62,6 +63,8 @@ let invalid_request_reason_to_string = function
   | Json_parse_error -> "json_parse_error"
   | Request_body_too_large { actual_bytes; limit_bytes } ->
     Printf.sprintf "request_body_too_large(actual=%d,limit=%d)" actual_bytes limit_bytes
+  | Request_body_refused_by_provider { status } ->
+    Printf.sprintf "request_body_refused_by_provider(status=%d)" status
   | Unknown_invalid_request -> "unknown"
 ;;
 
@@ -323,6 +326,17 @@ let classify_error ~retry_after_header ~status ~body : api_error =
        boundary without inspecting provider prose. *)
     AuthorizationError { message }
   | 400 | 422 -> InvalidRequest { message; reason = Unknown_invalid_request }
+  | 413 ->
+    (* HTTP 413 states the refusal cause in the status line: the payload was too
+       large. Leaving it in the catch-all below reported that cause as
+       [Unknown_invalid_request], which a consumer must treat as a defect in what it
+       built rather than a size it can reduce. The limit is not mapped into
+       [Request_body_too_large] because the response does not carry one; a
+       fabricated bound would make that variant's measured pair mean something it
+       does not. This repository already reads 413 as its own case when attributing
+       a failure (provider_failure_attribution.ml, 400 | 413 | 422 -> Attempt_local);
+       classification was the asymmetric half. *)
+    InvalidRequest { message; reason = Request_body_refused_by_provider { status } }
   | 429 ->
     let retry_after = resolve_retry_after ~body ~header:retry_after_header in
     RateLimited { retry_after; message }
@@ -367,7 +381,11 @@ let%test "is_retryable: flat Ollama provider prose is not retryable" =
   match classify_error ~retry_after_header:None ~status:400 ~body with
   | InvalidRequest { reason = Unknown_invalid_request; _ } as err ->
     not (is_retryable err)
-  | InvalidRequest { reason = Json_parse_error | Request_body_too_large _; _ } -> false
+  | InvalidRequest
+      { reason =
+          Json_parse_error | Request_body_too_large _ | Request_body_refused_by_provider _
+      ; _
+      } -> false
   | RateLimited _
   | Overloaded _
   | ServerError _
@@ -387,7 +405,11 @@ let%test "HTTP 400 prose does not synthesize ContextOverflow" =
   in
   match classify_error ~retry_after_header:None ~status:400 ~body with
   | InvalidRequest { reason = Unknown_invalid_request; _ } -> true
-  | InvalidRequest { reason = Json_parse_error | Request_body_too_large _; _ }
+  | InvalidRequest
+      { reason =
+          Json_parse_error | Request_body_too_large _ | Request_body_refused_by_provider _
+      ; _
+      }
   | ContextOverflow _
   | InputCapacity _
   | RateLimited _
@@ -405,7 +427,11 @@ let%test "classify_error returns Unknown InvalidRequest for non-overflow 400" =
   let body = {|{"error":{"message":"bad tool schema"}}|} in
   match classify_error ~retry_after_header:None ~status:400 ~body with
   | InvalidRequest { reason = Unknown_invalid_request; _ } -> true
-  | InvalidRequest { reason = Json_parse_error | Request_body_too_large _; _ } -> false
+  | InvalidRequest
+      { reason =
+          Json_parse_error | Request_body_too_large _ | Request_body_refused_by_provider _
+      ; _
+      } -> false
   | RateLimited _
   | Overloaded _
   | ServerError _

--- a/lib/llm_provider/retry.mli
+++ b/lib/llm_provider/retry.mli
@@ -11,6 +11,20 @@ type invalid_request_reason =
       { actual_bytes : int
       ; limit_bytes : int
       }
+  (** Refused locally, before dispatch, against a declared byte limit. Both
+          integers are measured: the serialized body and the limit it exceeded. *)
+  | Request_body_refused_by_provider of { status : int }
+  (** The provider refused the request for its size. Distinct from
+          {!Request_body_too_large} because the limit is unknown here — the response
+          carries a status, not a bound — and putting an estimate in those fields
+          would make a measured pair mean something it does not.
+
+          Separate from {!Unknown_invalid_request} because the cause is known: a
+          smaller request may succeed, where a malformed one will not. A consumer
+          that shrinks its input on the first and refuses to on the second needs the
+          two apart. [status] rather than a bare marker so a provider that signals
+          this with a status other than 413 leaves that fact in the type instead of
+          in a comment. *)
   | Unknown_invalid_request
 
 type input_capacity_reason =

--- a/test/test_retry.ml
+++ b/test/test_retry.ml
@@ -191,6 +191,39 @@ let test_is_retryable () =
     (Retry.is_retryable (Retry.PaymentRequired { message = "" }))
 ;;
 
+(* 413 states its cause in the status line. Before this it fell through the final
+   catch-all of classify_error and arrived as Unknown_invalid_request, which a consumer
+   must read as a defect in what it built rather than a size it can reduce — the
+   distinction that decides whether shrinking the input is worth trying. *)
+let test_payload_too_large_is_classified_from_the_status () =
+  (match
+     Retry.classify_error
+       ~retry_after_header:None
+       ~status:413
+       ~body:{|{"error":{"message":"request body too large"}}|}
+   with
+   | Retry.InvalidRequest
+       { reason = Retry.Request_body_refused_by_provider { status = 413 }; message } ->
+     check string "the provider message survives" "request body too large" message
+   | Retry.InvalidRequest { reason = Retry.Unknown_invalid_request; _ } ->
+     fail "413 was classified as an unknown invalid request"
+   | _ -> fail "413 was not classified as an invalid request at all");
+  (* The limit is absent on purpose: a 413 response carries a status, not a bound, and
+     Request_body_too_large means a measured pair. *)
+  (match Retry.classify_error ~retry_after_header:None ~status:413 ~body:"" with
+   | Retry.InvalidRequest { reason = Retry.Request_body_too_large _; _ } ->
+     fail "a provider refusal was given fabricated measurements"
+   | _ -> ());
+  (* Neighbouring statuses keep their own classification. *)
+  match
+    ( Retry.classify_error ~retry_after_header:None ~status:400 ~body:""
+    , Retry.classify_error ~retry_after_header:None ~status:422 ~body:"" )
+  with
+  | ( Retry.InvalidRequest { reason = Retry.Unknown_invalid_request; _ }
+    , Retry.InvalidRequest { reason = Retry.Unknown_invalid_request; _ } ) -> ()
+  | _ -> fail "400/422 classification moved with the 413 arm"
+;;
+
 let test_invalid_request_reason_boundary () =
   let expect_unknown body =
     match Retry.classify_error ~retry_after_header:None ~status:400 ~body with
@@ -280,7 +313,11 @@ let () =
             test_classify_error_429_retry_after_finite_guard
         ] )
     ; ( "typed_projection"
-      , [ test_case "retryable predicates" `Quick test_is_retryable
+      , [ test_case
+            "413 is classified from the status"
+            `Quick
+            test_payload_too_large_is_classified_from_the_status
+        ; test_case "retryable predicates" `Quick test_is_retryable
         ; test_case
             "invalid request reason boundary"
             `Quick


### PR DESCRIPTION
Closes #2817.

## 증상

`classify_error`(`lib/llm_provider/retry.ml`)가 열거하는 status 는 401·402·403·400|422·429·404·529·`>=500` 이다. **413 이 없어** 마지막 catch-all 로 떨어진다:

```ocaml
| unhandled_status -> InvalidRequest { message; reason = Unknown_invalid_request }
```

provider 가 **status line 으로 "본문이 너무 큽니다"라고 말해도** 소비자는 알 수 없는 결함을 받는다.

## 왜 중요한가

구분이 장식이 아니다. 소비자는 `Unknown_invalid_request` 를 **만든 것의 결함**으로 다뤄야 한다 — 축소하면 같은 결함을 더 작게 보낼 뿐이다. 반면 크기 거부는 **더 작은 요청이 성공할 수 있다**는 뜻이다.

masc 가 정확히 그렇게 분류한다(`keeper_turn_runtime_budget.ml`, masc#25739). 그래서 413 은 축소 요청을 만들지 못하고 다음 턴이 같은 크기를 다시 보낸다. masc 쪽 추적은 #2817 과 masc#25750.

## 같은 저장소가 이미 413 을 안다

`lib/provider_failure_attribution.ml`: `| 400 | 413 | 422 -> Attempt_local`. 실패 귀속은 413 을 자기 케이스로 읽고, **분류기만 몰랐다**. 비대칭에 명시된 이유가 없었다.

## 왜 기존 변형을 재사용하지 않는가

`Request_body_too_large` 는 `actual_bytes`·`limit_bytes` 를 **둘 다 측정값으로** 든다. 413 응답은 한계가 아니라 status 를 준다. 한계를 조작해 넣으면 그 측정 쌍의 의미가 무너진다 — 바이트 축과 토큰 축을 optional 필드 하나로 합치지 않고 **별 타입으로 둔 것과 같은 이유**다.

```ocaml
| Request_body_refused_by_provider of { status : int }
```

`status` 를 싣는 이유: 413 외의 status 로 이 신호를 주는 provider 가 나오면 그 사실이 **주석이 아니라 타입에** 남는다.

`Unknown_invalid_request` 를 문자열 검사로 보강하는 방향은 금지 패턴(문자열 분류기)이라 택하지 않았다.

## 왕복

`error_domain.ml:181-182` 이 `` `Invalid_request (reason, msg) -> InvalidRequest { message = msg; reason } `` 로 reason 을 덮어쓰지 않고 실어 나른다 — 새 변형도 그대로 왕복한다.

## 검증

| 스위트 | 결과 |
|---|---|
| `test_retry` | **10/10** (신규 1) |
| `test_error_domain` | 65/65 |
| `test_provider_failure_attribution` | 17/17 |
| `test_llm_provider_error` | 34/34 |
| `test_complete_http` | 58/58 |
| `dune build @check` | clean |

신규 케이스가 단정하는 것:
- 413 → 새 변형, provider message 보존
- **조작된 측정값을 받지 않는다** (`Request_body_too_large` 로 오지 않음)
- 400/422 는 자기 분류를 유지한다 (413 arm 이 이웃을 옮기지 않음)

**공허하지 않음**: 413 arm 을 제거하면 이 케이스가 실패한다 (변이 실측).

## 남은 것 (이 PR 범위 밖)

masc 는 `3d4ee19a` 에 핀되어 있어 핀 bump 전까지 영향받지 않는다. bump 후 masc 쪽에서 `capacity_refusal_of_error` 가 이 변형을 바이트 축으로 분류해야 컴팩션이 요청된다 — 그 작업은 masc#25750 에 있다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
