### PR TITLE
docs: fix dead references in CLAUDE.md (bin/, endpoints_from_env)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,6 @@ OCaml 5.x + Eio 기반 에이전트 SDK. 버전 SSOT: `lib/sdk_version.ml` (실�
 
 ```
 lib/        →  agent_sdk       (Layer 1: Agent Runtime)
-bin/        →  oas_cli, oas_runtime
 test/       →  alcotest 기반 단위/통합 테스트
 examples/   →  사용 예제
 ```
@@ -63,8 +62,14 @@ Probes local llama-server instances via OpenAI-compatible API:
 - `GET /slots` — per-slot busy/idle status
 
 ```ocaml
-let statuses = Discovery.discover ~sw ~net
-  ~endpoints:(Discovery.endpoints_from_env ())
+let endpoints =
+  Llm_provider.Discovery.parse_llm_endpoints_env ()
+  |> List.map
+       (Llm_provider.Discovery.endpoint
+          ~protocol:Llm_provider.Discovery.Openai_compatible
+          ~capabilities:Llm_provider.Capabilities.default_capabilities)
+in
+let statuses = Llm_provider.Discovery.discover ~sw ~net ~endpoints
 ```
 
 Configure via `LLM_ENDPOINTS` env var (comma-separated, default `http://127.0.0.1:8085`).


### PR DESCRIPTION
## 목표
CLAUDE.md의 죽은 코드 참조 2건 교정 — 에이전트가 존재하지 않는 디렉터리/함수를 사실로 학습하는 것을 막는다.

## 변경
- Architecture: 삭제된 `bin/ → oas_cli, oas_runtime` 행 제거 (bin/은 #1814, #2074에서 삭제됨)
- LLM Discovery: 존재하지 않는 `Discovery.endpoints_from_env()` 스니펫 → 실제 API (`parse_llm_endpoints_env |> endpoint |> discover`, `examples/observable_agent.ml:201-207`)

## 검증
- `git ls-files 'bin/*'` = 0
- 스니펫 참조 심볼 4개(parse_llm_endpoints_env / endpoint / discover / Openai_compatible / default_capabilities) HEAD 존재 확인
- `:79 llama`는 미변경 — `provider_registry.ml:143` `llama:*` 라우팅 prefix로 실제 해소 (적대 검증에서 refute됨)

RFC-WAIVED: 문서 전용 변경, 코드 무변경.
