### PR TITLE
feat(exact-output): own durable measurement receipts

### DIFF
--- a/lib/llm_provider/dune
+++ b/lib/llm_provider/dune
@@ -11,6 +11,7 @@
   output_token_wire_internal
   request_artifact_internal
   exact_output_count_tokens
+  exact_output_measurement_receipt
   exact_output_measurement_transport
   prepared_completion_request
   http_client_phase_observer

--- a/lib/llm_provider/exact_output.ml
+++ b/lib/llm_provider/exact_output.ml
@@ -21,7 +21,7 @@ type measurement_evidence = Flow_admission.measurement_evidence =
   ; outcome : measurement_outcome
   }
 
-type measurement_operation_id = Flow_admission.measurement_operation_id
+type measurement_operation_id = Measurement_operation_id of string
 
 type measurement_receipt_phase = Flow_admission.measurement_receipt_phase =
   | Measurement_fence_committed
@@ -160,12 +160,39 @@ type flow_measurement_receipt =
 
 type measurement_receipt_snapshot =
   { operation_id : measurement_operation_id
-  ; visit : flow_candidate_visit
+  ; flow_id : flow_id
+  ; visit_ordinal : flow_visit_ordinal
+  ; candidate_id : string
+  ; candidate_binding_sha256 : string
   ; request_body_sha256 : string
   ; phase : measurement_receipt_phase
   ; dispatch : measurement_dispatch_fact
   ; outcome : measurement_outcome option
   }
+
+type measurement_receipt_snapshot_decode_error =
+  | Measurement_receipt_snapshot_malformed_json of string
+  | Measurement_receipt_snapshot_invalid_fields
+  | Measurement_receipt_snapshot_unknown_format of string
+  | Measurement_receipt_snapshot_unsupported_version of int
+  | Measurement_receipt_snapshot_invalid_field of string
+  | Measurement_receipt_snapshot_integrity_mismatch
+
+type measurement_receipt_transition_conflict =
+  | Measurement_operation_mismatch
+  | Measurement_operation_binding_mismatch
+  | Measurement_invalid_commit_phase of measurement_receipt_phase
+  | Measurement_phase_regression of
+      { previous_phase : measurement_receipt_phase
+      ; incoming_phase : measurement_receipt_phase
+      }
+  | Measurement_evidence_conflict
+
+type measurement_receipt_transition =
+  | Measurement_dispatch_intent
+  | Measurement_terminal_advance
+  | Measurement_idempotent_replay
+  | Measurement_transition_conflict of measurement_receipt_transition_conflict
 
 type flow_candidate_step =
   { visit : flow_candidate_visit
@@ -484,17 +511,389 @@ let flow_visit_ordinal_to_int (Flow_visit_ordinal ordinal) = ordinal
 let flow_attempt_id (flow : flow_attempt) = flow.flow_id
 let attempt_receipt (attempt : attempt) = attempt.receipt
 let receipt_call_id = Generation_receipt.call_id
-let measurement_operation_id_to_string = Flow_admission.operation_id_to_string
+let measurement_operation_id_to_string (Measurement_operation_id value) = value
 
 let flow_measurement_receipt_snapshot (measurement : flow_measurement_receipt) =
   let snapshot = Flow_admission.receipt_snapshot measurement.receipt in
-  { operation_id = snapshot.operation_id
-  ; visit = measurement.visit
+  let candidate =
+    Flow_contract.flow_preference_identity_of_candidate measurement.visit.identity
+  in
+  { operation_id =
+      Measurement_operation_id
+        (Flow_admission.operation_id_to_string snapshot.operation_id)
+  ; flow_id = measurement.visit.flow_id
+  ; visit_ordinal = measurement.visit.ordinal
+  ; candidate_id = candidate.candidate_id
+  ; candidate_binding_sha256 = candidate.binding_sha256
   ; request_body_sha256 = snapshot.request_body_sha256
   ; phase = snapshot.phase
   ; dispatch = snapshot.dispatch
   ; outcome = snapshot.outcome
   }
+;;
+
+let measurement_receipt_operation_id (snapshot : measurement_receipt_snapshot) =
+  snapshot.operation_id
+;;
+
+let measurement_receipt_flow_id (snapshot : measurement_receipt_snapshot) =
+  snapshot.flow_id
+;;
+
+let measurement_receipt_visit_ordinal (snapshot : measurement_receipt_snapshot) =
+  snapshot.visit_ordinal
+;;
+
+let measurement_receipt_candidate_id (snapshot : measurement_receipt_snapshot) =
+  snapshot.candidate_id
+;;
+
+let measurement_receipt_candidate_binding_sha256 (snapshot : measurement_receipt_snapshot)
+  =
+  snapshot.candidate_binding_sha256
+;;
+
+let measurement_receipt_request_body_sha256 (snapshot : measurement_receipt_snapshot) =
+  snapshot.request_body_sha256
+;;
+
+let measurement_receipt_phase (snapshot : measurement_receipt_snapshot) = snapshot.phase
+
+let measurement_receipt_dispatch_fact (snapshot : measurement_receipt_snapshot) =
+  snapshot.dispatch
+;;
+
+let measurement_receipt_outcome (snapshot : measurement_receipt_snapshot) =
+  snapshot.outcome
+;;
+
+let measurement_receipt_snapshot_format = "oas.exact-output.measurement-receipt"
+let measurement_receipt_snapshot_version = 1
+let measurement_receipt_sha256 value = Digestif.SHA256.(to_hex (digest_string value))
+
+let measurement_receipt_phase_to_string = function
+  | Measurement_fence_committed -> "fence_committed"
+  | Measurement_wire_started -> "wire_started"
+  | Measurement_terminal -> "terminal"
+;;
+
+let measurement_receipt_phase_of_string = function
+  | "fence_committed" -> Some Measurement_fence_committed
+  | "wire_started" -> Some Measurement_wire_started
+  | "terminal" -> Some Measurement_terminal
+  | _ -> None
+;;
+
+let measurement_dispatch_fact_to_string = function
+  | No_measurement_dispatch -> "no_dispatch"
+  | Measurement_dispatch_unknown -> "dispatch_unknown"
+  | Measurement_dispatch_started -> "dispatch_started"
+;;
+
+let measurement_dispatch_fact_of_string = function
+  | "no_dispatch" -> Some No_measurement_dispatch
+  | "dispatch_unknown" -> Some Measurement_dispatch_unknown
+  | "dispatch_started" -> Some Measurement_dispatch_started
+  | _ -> None
+;;
+
+let measurement_outcome_to_string = function
+  | Measurement_not_required -> "not_required"
+  | Measurement_succeeded -> "succeeded"
+  | Measurement_unsupported -> "unsupported"
+  | Measurement_local_invalid -> "local_invalid"
+  | Measurement_transport_failed -> "transport_failed"
+  | Measurement_invalid_response -> "invalid_response"
+  | Measurement_fence_rejected -> "fence_rejected"
+  | Measurement_cancelled -> "cancelled"
+;;
+
+let measurement_outcome_of_string = function
+  | "not_required" -> Some Measurement_not_required
+  | "succeeded" -> Some Measurement_succeeded
+  | "unsupported" -> Some Measurement_unsupported
+  | "local_invalid" -> Some Measurement_local_invalid
+  | "transport_failed" -> Some Measurement_transport_failed
+  | "invalid_response" -> Some Measurement_invalid_response
+  | "fence_rejected" -> Some Measurement_fence_rejected
+  | "cancelled" -> Some Measurement_cancelled
+  | _ -> None
+;;
+
+let measurement_receipt_payload_json (snapshot : measurement_receipt_snapshot) =
+  `Assoc
+    [ "format", `String measurement_receipt_snapshot_format
+    ; "version", `Int measurement_receipt_snapshot_version
+    ; "operation_id", `String (measurement_operation_id_to_string snapshot.operation_id)
+    ; "flow_id", `String (flow_id_to_string snapshot.flow_id)
+    ; "visit_ordinal", `Int (flow_visit_ordinal_to_int snapshot.visit_ordinal)
+    ; "candidate_id", `String snapshot.candidate_id
+    ; "candidate_binding_sha256", `String snapshot.candidate_binding_sha256
+    ; "request_body_sha256", `String snapshot.request_body_sha256
+    ; "phase", `String (measurement_receipt_phase_to_string snapshot.phase)
+    ; "dispatch", `String (measurement_dispatch_fact_to_string snapshot.dispatch)
+    ; ( "outcome"
+      , match snapshot.outcome with
+        | None -> `Null
+        | Some outcome -> `String (measurement_outcome_to_string outcome) )
+    ]
+;;
+
+let measurement_receipt_snapshot_to_string (snapshot : measurement_receipt_snapshot) =
+  let payload = measurement_receipt_payload_json snapshot in
+  let integrity_sha256 = payload |> Yojson.Safe.to_string |> measurement_receipt_sha256 in
+  match payload with
+  | `Assoc fields ->
+    Yojson.Safe.to_string
+      (`Assoc (fields @ [ "integrity_sha256", `String integrity_sha256 ]))
+  | _ -> assert false
+;;
+
+let measurement_receipt_snapshot_expected_fields =
+  [ "format"
+  ; "version"
+  ; "operation_id"
+  ; "flow_id"
+  ; "visit_ordinal"
+  ; "candidate_id"
+  ; "candidate_binding_sha256"
+  ; "request_body_sha256"
+  ; "phase"
+  ; "dispatch"
+  ; "outcome"
+  ; "integrity_sha256"
+  ]
+;;
+
+let measurement_receipt_is_sha256 value =
+  String.length value = 64
+  && String.for_all
+       (function
+         | '0' .. '9' | 'a' .. 'f' -> true
+         | _ -> false)
+       value
+;;
+
+let measurement_receipt_snapshot_shape_is_valid (snapshot : measurement_receipt_snapshot) =
+  match snapshot.phase, snapshot.dispatch, snapshot.outcome with
+  | Measurement_fence_committed, Measurement_dispatch_unknown, None
+  | Measurement_fence_committed, No_measurement_dispatch, None
+  | Measurement_wire_started, Measurement_dispatch_started, None -> true
+  | Measurement_terminal, _, Some Measurement_not_required -> false
+  | Measurement_terminal, _, Some _ -> true
+  | Measurement_fence_committed, _, _
+  | Measurement_wire_started, _, _
+  | Measurement_terminal, _, None -> false
+;;
+
+let measurement_receipt_snapshot_of_string encoded =
+  let invalid field = Error (Measurement_receipt_snapshot_invalid_field field) in
+  let find fields name =
+    match List.assoc_opt name fields with
+    | Some value -> Ok value
+    | None -> invalid name
+  in
+  let string_field fields name =
+    let* value = find fields name in
+    match value with
+    | `String value -> Ok value
+    | _ -> invalid name
+  in
+  let enum_field fields name decode =
+    let* encoded = string_field fields name in
+    match decode encoded with
+    | Some value -> Ok value
+    | None -> invalid name
+  in
+  try
+    match Yojson.Safe.from_string encoded with
+    | `Assoc fields ->
+      let actual = List.map fst fields |> List.sort String.compare in
+      let expected =
+        List.sort String.compare measurement_receipt_snapshot_expected_fields
+      in
+      if actual <> expected
+      then Error Measurement_receipt_snapshot_invalid_fields
+      else
+        let* format = string_field fields "format" in
+        let* () =
+          if String.equal format measurement_receipt_snapshot_format
+          then Ok ()
+          else Error (Measurement_receipt_snapshot_unknown_format format)
+        in
+        let* version = find fields "version" in
+        let* () =
+          match version with
+          | `Int version when version = measurement_receipt_snapshot_version -> Ok ()
+          | `Int version ->
+            Error (Measurement_receipt_snapshot_unsupported_version version)
+          | _ -> invalid "version"
+        in
+        let* operation_id = string_field fields "operation_id" in
+        let* flow_id = string_field fields "flow_id" in
+        let* visit_ordinal_json = find fields "visit_ordinal" in
+        let* visit_ordinal =
+          match visit_ordinal_json with
+          | `Int ordinal when ordinal > 0 -> Ok ordinal
+          | `Int _ | _ -> invalid "visit_ordinal"
+        in
+        let* candidate_id = string_field fields "candidate_id" in
+        let* candidate_binding_sha256 = string_field fields "candidate_binding_sha256" in
+        let* request_body_sha256 = string_field fields "request_body_sha256" in
+        let* phase = enum_field fields "phase" measurement_receipt_phase_of_string in
+        let* dispatch =
+          enum_field fields "dispatch" measurement_dispatch_fact_of_string
+        in
+        let* outcome_json = find fields "outcome" in
+        let* outcome =
+          match outcome_json with
+          | `Null -> Ok None
+          | `String encoded ->
+            (match measurement_outcome_of_string encoded with
+             | Some outcome -> Ok (Some outcome)
+             | None -> invalid "outcome")
+          | _ -> invalid "outcome"
+        in
+        let* integrity_sha256 = string_field fields "integrity_sha256" in
+        let canonical_nonempty value =
+          (not (String.equal value "")) && String.equal value (String.trim value)
+        in
+        let* () =
+          if canonical_nonempty operation_id then Ok () else invalid "operation_id"
+        in
+        let* () = if canonical_nonempty flow_id then Ok () else invalid "flow_id" in
+        let* () =
+          if canonical_nonempty candidate_id then Ok () else invalid "candidate_id"
+        in
+        let* () =
+          if
+            measurement_receipt_is_sha256 candidate_binding_sha256
+            && measurement_receipt_is_sha256 request_body_sha256
+            && measurement_receipt_is_sha256 integrity_sha256
+          then Ok ()
+          else invalid "sha256"
+        in
+        let snapshot =
+          { operation_id = Measurement_operation_id operation_id
+          ; flow_id = Flow_id flow_id
+          ; visit_ordinal = Flow_visit_ordinal visit_ordinal
+          ; candidate_id
+          ; candidate_binding_sha256
+          ; request_body_sha256
+          ; phase
+          ; dispatch
+          ; outcome
+          }
+        in
+        let* () =
+          if measurement_receipt_snapshot_shape_is_valid snapshot
+          then Ok ()
+          else invalid "receipt_state"
+        in
+        let expected_integrity =
+          measurement_receipt_payload_json snapshot
+          |> Yojson.Safe.to_string
+          |> measurement_receipt_sha256
+        in
+        if String.equal expected_integrity integrity_sha256
+        then Ok snapshot
+        else Error Measurement_receipt_snapshot_integrity_mismatch
+    | _ -> Error Measurement_receipt_snapshot_invalid_fields
+  with
+  | Yojson.Json_error detail -> Error (Measurement_receipt_snapshot_malformed_json detail)
+;;
+
+let measurement_receipt_snapshot_decode_error_to_string = function
+  | Measurement_receipt_snapshot_malformed_json detail ->
+    "measurement receipt malformed JSON: " ^ detail
+  | Measurement_receipt_snapshot_invalid_fields ->
+    "measurement receipt fields do not match the current schema"
+  | Measurement_receipt_snapshot_unknown_format format ->
+    "measurement receipt has unknown format: " ^ format
+  | Measurement_receipt_snapshot_unsupported_version version ->
+    Printf.sprintf "measurement receipt has unsupported version: %d" version
+  | Measurement_receipt_snapshot_invalid_field field ->
+    "measurement receipt has invalid field: " ^ field
+  | Measurement_receipt_snapshot_integrity_mismatch ->
+    "measurement receipt integrity mismatch"
+;;
+
+let measurement_receipt_snapshot_equal
+      (left : measurement_receipt_snapshot)
+      (right : measurement_receipt_snapshot)
+  =
+  String.equal
+    (measurement_operation_id_to_string left.operation_id)
+    (measurement_operation_id_to_string right.operation_id)
+  && String.equal (flow_id_to_string left.flow_id) (flow_id_to_string right.flow_id)
+  && flow_visit_ordinal_to_int left.visit_ordinal
+     = flow_visit_ordinal_to_int right.visit_ordinal
+  && String.equal left.candidate_id right.candidate_id
+  && String.equal left.candidate_binding_sha256 right.candidate_binding_sha256
+  && String.equal left.request_body_sha256 right.request_body_sha256
+  && left.phase = right.phase
+  && left.dispatch = right.dispatch
+  && left.outcome = right.outcome
+;;
+
+let measurement_receipt_operation_binding_equal
+      (left : measurement_receipt_snapshot)
+      (right : measurement_receipt_snapshot)
+  =
+  String.equal (flow_id_to_string left.flow_id) (flow_id_to_string right.flow_id)
+  && flow_visit_ordinal_to_int left.visit_ordinal
+     = flow_visit_ordinal_to_int right.visit_ordinal
+  && String.equal left.candidate_id right.candidate_id
+  && String.equal left.candidate_binding_sha256 right.candidate_binding_sha256
+  && String.equal left.request_body_sha256 right.request_body_sha256
+;;
+
+let measurement_receipt_is_dispatch_intent (snapshot : measurement_receipt_snapshot) =
+  snapshot.phase = Measurement_fence_committed
+  && snapshot.dispatch = Measurement_dispatch_unknown
+  && Option.is_none snapshot.outcome
+;;
+
+let measurement_receipt_phase_rank = function
+  | Measurement_fence_committed -> 0
+  | Measurement_wire_started -> 1
+  | Measurement_terminal -> 2
+;;
+
+let classify_measurement_receipt_transition ~previous ~incoming =
+  match previous with
+  | None ->
+    if measurement_receipt_is_dispatch_intent incoming
+    then Measurement_dispatch_intent
+    else if incoming.phase <> Measurement_fence_committed
+    then Measurement_transition_conflict (Measurement_invalid_commit_phase incoming.phase)
+    else Measurement_transition_conflict Measurement_evidence_conflict
+  | Some previous ->
+    if
+      not
+        (String.equal
+           (measurement_operation_id_to_string previous.operation_id)
+           (measurement_operation_id_to_string incoming.operation_id))
+    then Measurement_transition_conflict Measurement_operation_mismatch
+    else if not (measurement_receipt_operation_binding_equal previous incoming)
+    then Measurement_transition_conflict Measurement_operation_binding_mismatch
+    else if measurement_receipt_snapshot_equal previous incoming
+    then Measurement_idempotent_replay
+    else if
+      measurement_receipt_phase_rank incoming.phase
+      < measurement_receipt_phase_rank previous.phase
+    then
+      Measurement_transition_conflict
+        (Measurement_phase_regression
+           { previous_phase = previous.phase; incoming_phase = incoming.phase })
+    else if
+      previous.phase <> Measurement_terminal
+      && incoming.phase = Measurement_terminal
+      && Option.is_some incoming.outcome
+    then Measurement_terminal_advance
+    else if incoming.phase = Measurement_wire_started
+    then Measurement_transition_conflict (Measurement_invalid_commit_phase incoming.phase)
+    else Measurement_transition_conflict Measurement_evidence_conflict
 ;;
 
 let same_measurement

--- a/lib/llm_provider/exact_output.ml
+++ b/lib/llm_provider/exact_output.ml
@@ -457,6 +457,10 @@ let flow_measurement_receipt_snapshot (measurement : flow_measurement_receipt) =
     ~visit_ordinal:measurement.visit.ordinal
     ~candidate_id:candidate.candidate_id
     ~candidate_binding_sha256:candidate.binding_sha256
+    ~catalog_generation_fingerprint:
+      (catalog_generation_fingerprint measurement.visit.identity.catalog_generation)
+    ~catalog_evidence_sha256:
+      (catalog_evidence_sha256 measurement.visit.identity.catalog_evidence)
     ~request_body_sha256:snapshot.request_body_sha256
     ~phase:snapshot.phase
     ~dispatch:snapshot.dispatch

--- a/lib/llm_provider/exact_output.ml
+++ b/lib/llm_provider/exact_output.ml
@@ -1,33 +1,7 @@
 module Plan = Exact_output_plan
 module Flow_admission = Exact_output_flow_admission
-
-type measurement_dispatch_fact = Flow_admission.measurement_dispatch_fact =
-  | No_measurement_dispatch
-  | Measurement_dispatch_unknown
-  | Measurement_dispatch_started
-
-type measurement_outcome = Flow_admission.measurement_outcome =
-  | Measurement_not_required
-  | Measurement_succeeded
-  | Measurement_unsupported
-  | Measurement_local_invalid
-  | Measurement_transport_failed
-  | Measurement_invalid_response
-  | Measurement_fence_rejected
-  | Measurement_cancelled
-
-type measurement_evidence = Flow_admission.measurement_evidence =
-  { dispatch : measurement_dispatch_fact
-  ; outcome : measurement_outcome
-  }
-
-type measurement_operation_id = Measurement_operation_id of string
-
-type measurement_receipt_phase = Flow_admission.measurement_receipt_phase =
-  | Measurement_fence_committed
-  | Measurement_wire_started
-  | Measurement_terminal
-
+module Measurement_receipt = Exact_output_measurement_receipt
+include Measurement_receipt
 module Exec = Exact_output_execution
 module Flow_state = Exact_output_flow
 module Flow_contract = Exact_output_flow_contract
@@ -143,8 +117,6 @@ type flow_candidate =
   ; admitted_target : admitted_target
   }
 
-type flow_id = Flow_id of string
-type flow_visit_ordinal = Flow_visit_ordinal of int
 type candidate_visit_count = Candidate_visit_count of int
 
 type flow_candidate_visit =
@@ -157,42 +129,6 @@ type flow_measurement_receipt =
   { visit : flow_candidate_visit
   ; receipt : Flow_admission.measurement_receipt
   }
-
-type measurement_receipt_snapshot =
-  { operation_id : measurement_operation_id
-  ; flow_id : flow_id
-  ; visit_ordinal : flow_visit_ordinal
-  ; candidate_id : string
-  ; candidate_binding_sha256 : string
-  ; request_body_sha256 : string
-  ; phase : measurement_receipt_phase
-  ; dispatch : measurement_dispatch_fact
-  ; outcome : measurement_outcome option
-  }
-
-type measurement_receipt_snapshot_decode_error =
-  | Measurement_receipt_snapshot_malformed_json of string
-  | Measurement_receipt_snapshot_invalid_fields
-  | Measurement_receipt_snapshot_unknown_format of string
-  | Measurement_receipt_snapshot_unsupported_version of int
-  | Measurement_receipt_snapshot_invalid_field of string
-  | Measurement_receipt_snapshot_integrity_mismatch
-
-type measurement_receipt_transition_conflict =
-  | Measurement_operation_mismatch
-  | Measurement_operation_binding_mismatch
-  | Measurement_invalid_commit_phase of measurement_receipt_phase
-  | Measurement_phase_regression of
-      { previous_phase : measurement_receipt_phase
-      ; incoming_phase : measurement_receipt_phase
-      }
-  | Measurement_evidence_conflict
-
-type measurement_receipt_transition =
-  | Measurement_dispatch_intent
-  | Measurement_terminal_advance
-  | Measurement_idempotent_replay
-  | Measurement_transition_conflict of measurement_receipt_transition_conflict
 
 type flow_candidate_step =
   { visit : flow_candidate_visit
@@ -506,404 +442,28 @@ let flow_success_output success = success.success
 let flow_success_evidence success = success.evidence
 let flow_success_ordinal success = success.success_ordinal
 let call_id_to_string (Call_id id) = id
-let flow_id_to_string (Flow_id id) = id
-let flow_visit_ordinal_to_int (Flow_visit_ordinal ordinal) = ordinal
 let flow_attempt_id (flow : flow_attempt) = flow.flow_id
 let attempt_receipt (attempt : attempt) = attempt.receipt
 let receipt_call_id = Generation_receipt.call_id
-let measurement_operation_id_to_string (Measurement_operation_id value) = value
 
 let flow_measurement_receipt_snapshot (measurement : flow_measurement_receipt) =
   let snapshot = Flow_admission.receipt_snapshot measurement.receipt in
   let candidate =
     Flow_contract.flow_preference_identity_of_candidate measurement.visit.identity
   in
-  { operation_id =
-      Measurement_operation_id
-        (Flow_admission.operation_id_to_string snapshot.operation_id)
-  ; flow_id = measurement.visit.flow_id
-  ; visit_ordinal = measurement.visit.ordinal
-  ; candidate_id = candidate.candidate_id
-  ; candidate_binding_sha256 = candidate.binding_sha256
-  ; request_body_sha256 = snapshot.request_body_sha256
-  ; phase = snapshot.phase
-  ; dispatch = snapshot.dispatch
-  ; outcome = snapshot.outcome
-  }
+  create_measurement_receipt_snapshot
+    ~operation_id:(Flow_admission.operation_id_to_string snapshot.operation_id)
+    ~flow_id:measurement.visit.flow_id
+    ~visit_ordinal:measurement.visit.ordinal
+    ~candidate_id:candidate.candidate_id
+    ~candidate_binding_sha256:candidate.binding_sha256
+    ~request_body_sha256:snapshot.request_body_sha256
+    ~phase:snapshot.phase
+    ~dispatch:snapshot.dispatch
+    ~outcome:snapshot.outcome
 ;;
 
-let measurement_receipt_operation_id (snapshot : measurement_receipt_snapshot) =
-  snapshot.operation_id
-;;
-
-let measurement_receipt_flow_id (snapshot : measurement_receipt_snapshot) =
-  snapshot.flow_id
-;;
-
-let measurement_receipt_visit_ordinal (snapshot : measurement_receipt_snapshot) =
-  snapshot.visit_ordinal
-;;
-
-let measurement_receipt_candidate_id (snapshot : measurement_receipt_snapshot) =
-  snapshot.candidate_id
-;;
-
-let measurement_receipt_candidate_binding_sha256 (snapshot : measurement_receipt_snapshot)
-  =
-  snapshot.candidate_binding_sha256
-;;
-
-let measurement_receipt_request_body_sha256 (snapshot : measurement_receipt_snapshot) =
-  snapshot.request_body_sha256
-;;
-
-let measurement_receipt_phase (snapshot : measurement_receipt_snapshot) = snapshot.phase
-
-let measurement_receipt_dispatch_fact (snapshot : measurement_receipt_snapshot) =
-  snapshot.dispatch
-;;
-
-let measurement_receipt_outcome (snapshot : measurement_receipt_snapshot) =
-  snapshot.outcome
-;;
-
-let measurement_receipt_snapshot_format = "oas.exact-output.measurement-receipt"
-let measurement_receipt_snapshot_version = 1
-let measurement_receipt_sha256 value = Digestif.SHA256.(to_hex (digest_string value))
-
-let measurement_receipt_phase_to_string = function
-  | Measurement_fence_committed -> "fence_committed"
-  | Measurement_wire_started -> "wire_started"
-  | Measurement_terminal -> "terminal"
-;;
-
-let measurement_receipt_phase_of_string = function
-  | "fence_committed" -> Some Measurement_fence_committed
-  | "wire_started" -> Some Measurement_wire_started
-  | "terminal" -> Some Measurement_terminal
-  | _ -> None
-;;
-
-let measurement_dispatch_fact_to_string = function
-  | No_measurement_dispatch -> "no_dispatch"
-  | Measurement_dispatch_unknown -> "dispatch_unknown"
-  | Measurement_dispatch_started -> "dispatch_started"
-;;
-
-let measurement_dispatch_fact_of_string = function
-  | "no_dispatch" -> Some No_measurement_dispatch
-  | "dispatch_unknown" -> Some Measurement_dispatch_unknown
-  | "dispatch_started" -> Some Measurement_dispatch_started
-  | _ -> None
-;;
-
-let measurement_outcome_to_string = function
-  | Measurement_not_required -> "not_required"
-  | Measurement_succeeded -> "succeeded"
-  | Measurement_unsupported -> "unsupported"
-  | Measurement_local_invalid -> "local_invalid"
-  | Measurement_transport_failed -> "transport_failed"
-  | Measurement_invalid_response -> "invalid_response"
-  | Measurement_fence_rejected -> "fence_rejected"
-  | Measurement_cancelled -> "cancelled"
-;;
-
-let measurement_outcome_of_string = function
-  | "not_required" -> Some Measurement_not_required
-  | "succeeded" -> Some Measurement_succeeded
-  | "unsupported" -> Some Measurement_unsupported
-  | "local_invalid" -> Some Measurement_local_invalid
-  | "transport_failed" -> Some Measurement_transport_failed
-  | "invalid_response" -> Some Measurement_invalid_response
-  | "fence_rejected" -> Some Measurement_fence_rejected
-  | "cancelled" -> Some Measurement_cancelled
-  | _ -> None
-;;
-
-let measurement_receipt_payload_json (snapshot : measurement_receipt_snapshot) =
-  `Assoc
-    [ "format", `String measurement_receipt_snapshot_format
-    ; "version", `Int measurement_receipt_snapshot_version
-    ; "operation_id", `String (measurement_operation_id_to_string snapshot.operation_id)
-    ; "flow_id", `String (flow_id_to_string snapshot.flow_id)
-    ; "visit_ordinal", `Int (flow_visit_ordinal_to_int snapshot.visit_ordinal)
-    ; "candidate_id", `String snapshot.candidate_id
-    ; "candidate_binding_sha256", `String snapshot.candidate_binding_sha256
-    ; "request_body_sha256", `String snapshot.request_body_sha256
-    ; "phase", `String (measurement_receipt_phase_to_string snapshot.phase)
-    ; "dispatch", `String (measurement_dispatch_fact_to_string snapshot.dispatch)
-    ; ( "outcome"
-      , match snapshot.outcome with
-        | None -> `Null
-        | Some outcome -> `String (measurement_outcome_to_string outcome) )
-    ]
-;;
-
-let measurement_receipt_snapshot_to_string (snapshot : measurement_receipt_snapshot) =
-  let payload = measurement_receipt_payload_json snapshot in
-  let integrity_sha256 = payload |> Yojson.Safe.to_string |> measurement_receipt_sha256 in
-  match payload with
-  | `Assoc fields ->
-    Yojson.Safe.to_string
-      (`Assoc (fields @ [ "integrity_sha256", `String integrity_sha256 ]))
-  | _ -> assert false
-;;
-
-let measurement_receipt_snapshot_expected_fields =
-  [ "format"
-  ; "version"
-  ; "operation_id"
-  ; "flow_id"
-  ; "visit_ordinal"
-  ; "candidate_id"
-  ; "candidate_binding_sha256"
-  ; "request_body_sha256"
-  ; "phase"
-  ; "dispatch"
-  ; "outcome"
-  ; "integrity_sha256"
-  ]
-;;
-
-let measurement_receipt_is_sha256 value =
-  String.length value = 64
-  && String.for_all
-       (function
-         | '0' .. '9' | 'a' .. 'f' -> true
-         | _ -> false)
-       value
-;;
-
-let measurement_receipt_snapshot_shape_is_valid (snapshot : measurement_receipt_snapshot) =
-  match snapshot.phase, snapshot.dispatch, snapshot.outcome with
-  | Measurement_fence_committed, Measurement_dispatch_unknown, None
-  | Measurement_fence_committed, No_measurement_dispatch, None
-  | Measurement_wire_started, Measurement_dispatch_started, None -> true
-  | Measurement_terminal, _, Some Measurement_not_required -> false
-  | Measurement_terminal, _, Some _ -> true
-  | Measurement_fence_committed, _, _
-  | Measurement_wire_started, _, _
-  | Measurement_terminal, _, None -> false
-;;
-
-let measurement_receipt_snapshot_of_string encoded =
-  let invalid field = Error (Measurement_receipt_snapshot_invalid_field field) in
-  let find fields name =
-    match List.assoc_opt name fields with
-    | Some value -> Ok value
-    | None -> invalid name
-  in
-  let string_field fields name =
-    let* value = find fields name in
-    match value with
-    | `String value -> Ok value
-    | _ -> invalid name
-  in
-  let enum_field fields name decode =
-    let* encoded = string_field fields name in
-    match decode encoded with
-    | Some value -> Ok value
-    | None -> invalid name
-  in
-  try
-    match Yojson.Safe.from_string encoded with
-    | `Assoc fields ->
-      let actual = List.map fst fields |> List.sort String.compare in
-      let expected =
-        List.sort String.compare measurement_receipt_snapshot_expected_fields
-      in
-      if actual <> expected
-      then Error Measurement_receipt_snapshot_invalid_fields
-      else
-        let* format = string_field fields "format" in
-        let* () =
-          if String.equal format measurement_receipt_snapshot_format
-          then Ok ()
-          else Error (Measurement_receipt_snapshot_unknown_format format)
-        in
-        let* version = find fields "version" in
-        let* () =
-          match version with
-          | `Int version when version = measurement_receipt_snapshot_version -> Ok ()
-          | `Int version ->
-            Error (Measurement_receipt_snapshot_unsupported_version version)
-          | _ -> invalid "version"
-        in
-        let* operation_id = string_field fields "operation_id" in
-        let* flow_id = string_field fields "flow_id" in
-        let* visit_ordinal_json = find fields "visit_ordinal" in
-        let* visit_ordinal =
-          match visit_ordinal_json with
-          | `Int ordinal when ordinal > 0 -> Ok ordinal
-          | `Int _ | _ -> invalid "visit_ordinal"
-        in
-        let* candidate_id = string_field fields "candidate_id" in
-        let* candidate_binding_sha256 = string_field fields "candidate_binding_sha256" in
-        let* request_body_sha256 = string_field fields "request_body_sha256" in
-        let* phase = enum_field fields "phase" measurement_receipt_phase_of_string in
-        let* dispatch =
-          enum_field fields "dispatch" measurement_dispatch_fact_of_string
-        in
-        let* outcome_json = find fields "outcome" in
-        let* outcome =
-          match outcome_json with
-          | `Null -> Ok None
-          | `String encoded ->
-            (match measurement_outcome_of_string encoded with
-             | Some outcome -> Ok (Some outcome)
-             | None -> invalid "outcome")
-          | _ -> invalid "outcome"
-        in
-        let* integrity_sha256 = string_field fields "integrity_sha256" in
-        let canonical_nonempty value =
-          (not (String.equal value "")) && String.equal value (String.trim value)
-        in
-        let* () =
-          if canonical_nonempty operation_id then Ok () else invalid "operation_id"
-        in
-        let* () = if canonical_nonempty flow_id then Ok () else invalid "flow_id" in
-        let* () =
-          if canonical_nonempty candidate_id then Ok () else invalid "candidate_id"
-        in
-        let* () =
-          if
-            measurement_receipt_is_sha256 candidate_binding_sha256
-            && measurement_receipt_is_sha256 request_body_sha256
-            && measurement_receipt_is_sha256 integrity_sha256
-          then Ok ()
-          else invalid "sha256"
-        in
-        let snapshot =
-          { operation_id = Measurement_operation_id operation_id
-          ; flow_id = Flow_id flow_id
-          ; visit_ordinal = Flow_visit_ordinal visit_ordinal
-          ; candidate_id
-          ; candidate_binding_sha256
-          ; request_body_sha256
-          ; phase
-          ; dispatch
-          ; outcome
-          }
-        in
-        let* () =
-          if measurement_receipt_snapshot_shape_is_valid snapshot
-          then Ok ()
-          else invalid "receipt_state"
-        in
-        let expected_integrity =
-          measurement_receipt_payload_json snapshot
-          |> Yojson.Safe.to_string
-          |> measurement_receipt_sha256
-        in
-        if String.equal expected_integrity integrity_sha256
-        then Ok snapshot
-        else Error Measurement_receipt_snapshot_integrity_mismatch
-    | _ -> Error Measurement_receipt_snapshot_invalid_fields
-  with
-  | Yojson.Json_error detail -> Error (Measurement_receipt_snapshot_malformed_json detail)
-;;
-
-let measurement_receipt_snapshot_decode_error_to_string = function
-  | Measurement_receipt_snapshot_malformed_json detail ->
-    "measurement receipt malformed JSON: " ^ detail
-  | Measurement_receipt_snapshot_invalid_fields ->
-    "measurement receipt fields do not match the current schema"
-  | Measurement_receipt_snapshot_unknown_format format ->
-    "measurement receipt has unknown format: " ^ format
-  | Measurement_receipt_snapshot_unsupported_version version ->
-    Printf.sprintf "measurement receipt has unsupported version: %d" version
-  | Measurement_receipt_snapshot_invalid_field field ->
-    "measurement receipt has invalid field: " ^ field
-  | Measurement_receipt_snapshot_integrity_mismatch ->
-    "measurement receipt integrity mismatch"
-;;
-
-let measurement_receipt_snapshot_equal
-      (left : measurement_receipt_snapshot)
-      (right : measurement_receipt_snapshot)
-  =
-  String.equal
-    (measurement_operation_id_to_string left.operation_id)
-    (measurement_operation_id_to_string right.operation_id)
-  && String.equal (flow_id_to_string left.flow_id) (flow_id_to_string right.flow_id)
-  && flow_visit_ordinal_to_int left.visit_ordinal
-     = flow_visit_ordinal_to_int right.visit_ordinal
-  && String.equal left.candidate_id right.candidate_id
-  && String.equal left.candidate_binding_sha256 right.candidate_binding_sha256
-  && String.equal left.request_body_sha256 right.request_body_sha256
-  && left.phase = right.phase
-  && left.dispatch = right.dispatch
-  && left.outcome = right.outcome
-;;
-
-let measurement_receipt_operation_binding_equal
-      (left : measurement_receipt_snapshot)
-      (right : measurement_receipt_snapshot)
-  =
-  String.equal (flow_id_to_string left.flow_id) (flow_id_to_string right.flow_id)
-  && flow_visit_ordinal_to_int left.visit_ordinal
-     = flow_visit_ordinal_to_int right.visit_ordinal
-  && String.equal left.candidate_id right.candidate_id
-  && String.equal left.candidate_binding_sha256 right.candidate_binding_sha256
-  && String.equal left.request_body_sha256 right.request_body_sha256
-;;
-
-let measurement_receipt_is_dispatch_intent (snapshot : measurement_receipt_snapshot) =
-  snapshot.phase = Measurement_fence_committed
-  && snapshot.dispatch = Measurement_dispatch_unknown
-  && Option.is_none snapshot.outcome
-;;
-
-let measurement_receipt_phase_rank = function
-  | Measurement_fence_committed -> 0
-  | Measurement_wire_started -> 1
-  | Measurement_terminal -> 2
-;;
-
-let classify_measurement_receipt_transition ~previous ~incoming =
-  match previous with
-  | None ->
-    if measurement_receipt_is_dispatch_intent incoming
-    then Measurement_dispatch_intent
-    else if incoming.phase <> Measurement_fence_committed
-    then Measurement_transition_conflict (Measurement_invalid_commit_phase incoming.phase)
-    else Measurement_transition_conflict Measurement_evidence_conflict
-  | Some previous ->
-    if
-      not
-        (String.equal
-           (measurement_operation_id_to_string previous.operation_id)
-           (measurement_operation_id_to_string incoming.operation_id))
-    then Measurement_transition_conflict Measurement_operation_mismatch
-    else if not (measurement_receipt_operation_binding_equal previous incoming)
-    then Measurement_transition_conflict Measurement_operation_binding_mismatch
-    else if measurement_receipt_snapshot_equal previous incoming
-    then Measurement_idempotent_replay
-    else if
-      measurement_receipt_phase_rank incoming.phase
-      < measurement_receipt_phase_rank previous.phase
-    then
-      Measurement_transition_conflict
-        (Measurement_phase_regression
-           { previous_phase = previous.phase; incoming_phase = incoming.phase })
-    else if
-      previous.phase <> Measurement_terminal
-      && incoming.phase = Measurement_terminal
-      && Option.is_some incoming.outcome
-    then Measurement_terminal_advance
-    else if incoming.phase = Measurement_wire_started
-    then Measurement_transition_conflict (Measurement_invalid_commit_phase incoming.phase)
-    else Measurement_transition_conflict Measurement_evidence_conflict
-;;
-
-let same_measurement
-      (left : measurement_receipt_snapshot)
-      (right : measurement_receipt_snapshot)
-  =
-  String.equal
-    (measurement_operation_id_to_string left.operation_id)
-    (measurement_operation_id_to_string right.operation_id)
-;;
+let same_measurement = measurement_receipt_same_operation
 
 let publish_measurement (flow : flow_attempt) (measurement : flow_measurement_receipt) =
   Flow_state.publish_measurement

--- a/lib/llm_provider/exact_output.mli
+++ b/lib/llm_provider/exact_output.mli
@@ -278,6 +278,8 @@ type measurement_receipt_snapshot = private
   ; visit_ordinal : flow_visit_ordinal
   ; candidate_id : string
   ; candidate_binding_sha256 : string
+  ; catalog_generation_fingerprint : string
+  ; catalog_evidence_sha256 : string
   ; request_body_sha256 : string
   ; phase : measurement_receipt_phase
   ; dispatch : measurement_dispatch_fact
@@ -296,6 +298,11 @@ type measurement_receipt_transition_conflict =
   | Measurement_operation_mismatch
   | Measurement_operation_binding_mismatch
   | Measurement_invalid_commit_phase of measurement_receipt_phase
+  | Measurement_invalid_previous_boundary of
+      { phase : measurement_receipt_phase
+      ; dispatch : measurement_dispatch_fact
+      ; outcome : measurement_outcome option
+      }
   | Measurement_phase_regression of
       { previous_phase : measurement_receipt_phase
       ; incoming_phase : measurement_receipt_phase
@@ -549,6 +556,12 @@ val measurement_receipt_flow_id : measurement_receipt_snapshot -> flow_id
 val measurement_receipt_visit_ordinal : measurement_receipt_snapshot -> flow_visit_ordinal
 val measurement_receipt_candidate_id : measurement_receipt_snapshot -> string
 val measurement_receipt_candidate_binding_sha256 : measurement_receipt_snapshot -> string
+
+val measurement_receipt_catalog_generation_fingerprint
+  :  measurement_receipt_snapshot
+  -> string
+
+val measurement_receipt_catalog_evidence_sha256 : measurement_receipt_snapshot -> string
 val measurement_receipt_request_body_sha256 : measurement_receipt_snapshot -> string
 val measurement_receipt_phase : measurement_receipt_snapshot -> measurement_receipt_phase
 

--- a/lib/llm_provider/exact_output.mli
+++ b/lib/llm_provider/exact_output.mli
@@ -274,12 +274,39 @@ type flow_measurement_receipt
 
 type measurement_receipt_snapshot = private
   { operation_id : measurement_operation_id
-  ; visit : flow_candidate_visit
+  ; flow_id : flow_id
+  ; visit_ordinal : flow_visit_ordinal
+  ; candidate_id : string
+  ; candidate_binding_sha256 : string
   ; request_body_sha256 : string
   ; phase : measurement_receipt_phase
   ; dispatch : measurement_dispatch_fact
   ; outcome : measurement_outcome option
   }
+
+type measurement_receipt_snapshot_decode_error =
+  | Measurement_receipt_snapshot_malformed_json of string
+  | Measurement_receipt_snapshot_invalid_fields
+  | Measurement_receipt_snapshot_unknown_format of string
+  | Measurement_receipt_snapshot_unsupported_version of int
+  | Measurement_receipt_snapshot_invalid_field of string
+  | Measurement_receipt_snapshot_integrity_mismatch
+
+type measurement_receipt_transition_conflict =
+  | Measurement_operation_mismatch
+  | Measurement_operation_binding_mismatch
+  | Measurement_invalid_commit_phase of measurement_receipt_phase
+  | Measurement_phase_regression of
+      { previous_phase : measurement_receipt_phase
+      ; incoming_phase : measurement_receipt_phase
+      }
+  | Measurement_evidence_conflict
+
+type measurement_receipt_transition =
+  | Measurement_dispatch_intent
+  | Measurement_terminal_advance
+  | Measurement_idempotent_replay
+  | Measurement_transition_conflict of measurement_receipt_transition_conflict
 
 type candidate_rejection_receipt
 
@@ -513,6 +540,48 @@ val measurement_operation_id_to_string : measurement_operation_id -> string
 val flow_measurement_receipt_snapshot
   :  flow_measurement_receipt
   -> measurement_receipt_snapshot
+
+val measurement_receipt_operation_id
+  :  measurement_receipt_snapshot
+  -> measurement_operation_id
+
+val measurement_receipt_flow_id : measurement_receipt_snapshot -> flow_id
+val measurement_receipt_visit_ordinal : measurement_receipt_snapshot -> flow_visit_ordinal
+val measurement_receipt_candidate_id : measurement_receipt_snapshot -> string
+val measurement_receipt_candidate_binding_sha256 : measurement_receipt_snapshot -> string
+val measurement_receipt_request_body_sha256 : measurement_receipt_snapshot -> string
+val measurement_receipt_phase : measurement_receipt_snapshot -> measurement_receipt_phase
+
+val measurement_receipt_dispatch_fact
+  :  measurement_receipt_snapshot
+  -> measurement_dispatch_fact
+
+val measurement_receipt_outcome
+  :  measurement_receipt_snapshot
+  -> measurement_outcome option
+
+(** Encode one immutable receipt using the sole current durable schema. The
+    integrity digest detects corruption; it is not an authenticity signature. *)
+val measurement_receipt_snapshot_to_string : measurement_receipt_snapshot -> string
+
+(** Decode only the current complete schema. Missing, extra, legacy, and
+    internally inconsistent evidence fails closed. *)
+val measurement_receipt_snapshot_of_string
+  :  string
+  -> (measurement_receipt_snapshot, measurement_receipt_snapshot_decode_error) result
+
+val measurement_receipt_snapshot_decode_error_to_string
+  :  measurement_receipt_snapshot_decode_error
+  -> string
+
+(** Classify durable callback evidence for one operation. A first snapshot must
+    be the committed dispatch intent; only a later terminal snapshot advances
+    it. Equal evidence is an idempotent replay. Intermediate live observations
+    are not durable callback boundaries and therefore conflict. *)
+val classify_measurement_receipt_transition
+  :  previous:measurement_receipt_snapshot option
+  -> incoming:measurement_receipt_snapshot
+  -> measurement_receipt_transition
 
 val target_selection_error_disposition
   :  target_selection_error

--- a/lib/llm_provider/exact_output_measurement_receipt.ml
+++ b/lib/llm_provider/exact_output_measurement_receipt.ml
@@ -36,6 +36,8 @@ type measurement_receipt_snapshot =
   ; visit_ordinal : flow_visit_ordinal
   ; candidate_id : string
   ; candidate_binding_sha256 : string
+  ; catalog_generation_fingerprint : string
+  ; catalog_evidence_sha256 : string
   ; request_body_sha256 : string
   ; phase : measurement_receipt_phase
   ; dispatch : measurement_dispatch_fact
@@ -54,6 +56,11 @@ type measurement_receipt_transition_conflict =
   | Measurement_operation_mismatch
   | Measurement_operation_binding_mismatch
   | Measurement_invalid_commit_phase of measurement_receipt_phase
+  | Measurement_invalid_previous_boundary of
+      { phase : measurement_receipt_phase
+      ; dispatch : measurement_dispatch_fact
+      ; outcome : measurement_outcome option
+      }
   | Measurement_phase_regression of
       { previous_phase : measurement_receipt_phase
       ; incoming_phase : measurement_receipt_phase
@@ -77,6 +84,8 @@ let create_measurement_receipt_snapshot
       ~visit_ordinal
       ~candidate_id
       ~candidate_binding_sha256
+      ~catalog_generation_fingerprint
+      ~catalog_evidence_sha256
       ~request_body_sha256
       ~phase
       ~dispatch
@@ -87,6 +96,8 @@ let create_measurement_receipt_snapshot
   ; visit_ordinal
   ; candidate_id
   ; candidate_binding_sha256
+  ; catalog_generation_fingerprint
+  ; catalog_evidence_sha256
   ; request_body_sha256
   ; phase
   ; dispatch
@@ -101,6 +112,14 @@ let measurement_receipt_candidate_id snapshot = snapshot.candidate_id
 
 let measurement_receipt_candidate_binding_sha256 snapshot =
   snapshot.candidate_binding_sha256
+;;
+
+let measurement_receipt_catalog_generation_fingerprint snapshot =
+  snapshot.catalog_generation_fingerprint
+;;
+
+let measurement_receipt_catalog_evidence_sha256 snapshot =
+  snapshot.catalog_evidence_sha256
 ;;
 
 let measurement_receipt_request_body_sha256 snapshot = snapshot.request_body_sha256
@@ -168,6 +187,8 @@ let payload_fields snapshot =
   ; "visit_ordinal", `Int (flow_visit_ordinal_to_int snapshot.visit_ordinal)
   ; "candidate_id", `String snapshot.candidate_id
   ; "candidate_binding_sha256", `String snapshot.candidate_binding_sha256
+  ; "catalog_generation_fingerprint", `String snapshot.catalog_generation_fingerprint
+  ; "catalog_evidence_sha256", `String snapshot.catalog_evidence_sha256
   ; "request_body_sha256", `String snapshot.request_body_sha256
   ; "phase", `String (phase_to_string snapshot.phase)
   ; "dispatch", `String (dispatch_to_string snapshot.dispatch)
@@ -193,6 +214,8 @@ let expected_fields =
   ; "visit_ordinal"
   ; "candidate_id"
   ; "candidate_binding_sha256"
+  ; "catalog_generation_fingerprint"
+  ; "catalog_evidence_sha256"
   ; "request_body_sha256"
   ; "phase"
   ; "dispatch"
@@ -272,6 +295,10 @@ let measurement_receipt_snapshot_of_string encoded =
         in
         let* candidate_id = string_field fields "candidate_id" in
         let* candidate_binding_sha256 = string_field fields "candidate_binding_sha256" in
+        let* catalog_generation_fingerprint =
+          string_field fields "catalog_generation_fingerprint"
+        in
+        let* catalog_evidence_sha256 = string_field fields "catalog_evidence_sha256" in
         let* request_body_sha256 = string_field fields "request_body_sha256" in
         let* phase = enum_field fields "phase" phase_of_string in
         let* dispatch = enum_field fields "dispatch" dispatch_of_string in
@@ -299,6 +326,8 @@ let measurement_receipt_snapshot_of_string encoded =
         let* () =
           if
             is_sha256 candidate_binding_sha256
+            && is_sha256 catalog_generation_fingerprint
+            && is_sha256 catalog_evidence_sha256
             && is_sha256 request_body_sha256
             && is_sha256 integrity_sha256
           then Ok ()
@@ -311,6 +340,8 @@ let measurement_receipt_snapshot_of_string encoded =
             ~visit_ordinal:(Flow_visit_ordinal visit_ordinal)
             ~candidate_id
             ~candidate_binding_sha256
+            ~catalog_generation_fingerprint
+            ~catalog_evidence_sha256
             ~request_body_sha256
             ~phase
             ~dispatch
@@ -352,6 +383,8 @@ let same_snapshot left right =
      = flow_visit_ordinal_to_int right.visit_ordinal
   && String.equal left.candidate_id right.candidate_id
   && String.equal left.candidate_binding_sha256 right.candidate_binding_sha256
+  && String.equal left.catalog_generation_fingerprint right.catalog_generation_fingerprint
+  && String.equal left.catalog_evidence_sha256 right.catalog_evidence_sha256
   && String.equal left.request_body_sha256 right.request_body_sha256
   && left.phase = right.phase
   && left.dispatch = right.dispatch
@@ -370,6 +403,8 @@ let same_binding left right =
      = flow_visit_ordinal_to_int right.visit_ordinal
   && String.equal left.candidate_id right.candidate_id
   && String.equal left.candidate_binding_sha256 right.candidate_binding_sha256
+  && String.equal left.catalog_generation_fingerprint right.catalog_generation_fingerprint
+  && String.equal left.catalog_evidence_sha256 right.catalog_evidence_sha256
   && String.equal left.request_body_sha256 right.request_body_sha256
 ;;
 
@@ -385,6 +420,14 @@ let phase_rank = function
   | Measurement_terminal -> 2
 ;;
 
+let is_terminal_boundary snapshot =
+  snapshot.phase = Measurement_terminal && Option.is_some snapshot.outcome
+;;
+
+let is_durable_boundary snapshot =
+  is_dispatch_intent snapshot || is_terminal_boundary snapshot
+;;
+
 let classify_measurement_receipt_transition ~previous ~incoming =
   match previous with
   | None ->
@@ -394,7 +437,15 @@ let classify_measurement_receipt_transition ~previous ~incoming =
     then Measurement_transition_conflict (Measurement_invalid_commit_phase incoming.phase)
     else Measurement_transition_conflict Measurement_evidence_conflict
   | Some previous ->
-    if not (measurement_receipt_same_operation previous incoming)
+    if not (is_durable_boundary previous)
+    then
+      Measurement_transition_conflict
+        (Measurement_invalid_previous_boundary
+           { phase = previous.phase
+           ; dispatch = previous.dispatch
+           ; outcome = previous.outcome
+           })
+    else if not (measurement_receipt_same_operation previous incoming)
     then Measurement_transition_conflict Measurement_operation_mismatch
     else if not (same_binding previous incoming)
     then Measurement_transition_conflict Measurement_operation_binding_mismatch
@@ -406,7 +457,7 @@ let classify_measurement_receipt_transition ~previous ~incoming =
         (Measurement_phase_regression
            { previous_phase = previous.phase; incoming_phase = incoming.phase })
     else if
-      previous.phase <> Measurement_terminal
+      is_dispatch_intent previous
       && incoming.phase = Measurement_terminal
       && Option.is_some incoming.outcome
     then Measurement_terminal_advance

--- a/lib/llm_provider/exact_output_measurement_receipt.ml
+++ b/lib/llm_provider/exact_output_measurement_receipt.ml
@@ -1,0 +1,416 @@
+module Flow_admission = Exact_output_flow_admission
+
+type measurement_dispatch_fact = Flow_admission.measurement_dispatch_fact =
+  | No_measurement_dispatch
+  | Measurement_dispatch_unknown
+  | Measurement_dispatch_started
+
+type measurement_outcome = Flow_admission.measurement_outcome =
+  | Measurement_not_required
+  | Measurement_succeeded
+  | Measurement_unsupported
+  | Measurement_local_invalid
+  | Measurement_transport_failed
+  | Measurement_invalid_response
+  | Measurement_fence_rejected
+  | Measurement_cancelled
+
+type measurement_evidence = Flow_admission.measurement_evidence =
+  { dispatch : measurement_dispatch_fact
+  ; outcome : measurement_outcome
+  }
+
+type measurement_operation_id = Measurement_operation_id of string
+
+type measurement_receipt_phase = Flow_admission.measurement_receipt_phase =
+  | Measurement_fence_committed
+  | Measurement_wire_started
+  | Measurement_terminal
+
+type flow_id = Flow_id of string
+type flow_visit_ordinal = Flow_visit_ordinal of int
+
+type measurement_receipt_snapshot =
+  { operation_id : measurement_operation_id
+  ; flow_id : flow_id
+  ; visit_ordinal : flow_visit_ordinal
+  ; candidate_id : string
+  ; candidate_binding_sha256 : string
+  ; request_body_sha256 : string
+  ; phase : measurement_receipt_phase
+  ; dispatch : measurement_dispatch_fact
+  ; outcome : measurement_outcome option
+  }
+
+type measurement_receipt_snapshot_decode_error =
+  | Measurement_receipt_snapshot_malformed_json of string
+  | Measurement_receipt_snapshot_invalid_fields
+  | Measurement_receipt_snapshot_unknown_format of string
+  | Measurement_receipt_snapshot_unsupported_version of int
+  | Measurement_receipt_snapshot_invalid_field of string
+  | Measurement_receipt_snapshot_integrity_mismatch
+
+type measurement_receipt_transition_conflict =
+  | Measurement_operation_mismatch
+  | Measurement_operation_binding_mismatch
+  | Measurement_invalid_commit_phase of measurement_receipt_phase
+  | Measurement_phase_regression of
+      { previous_phase : measurement_receipt_phase
+      ; incoming_phase : measurement_receipt_phase
+      }
+  | Measurement_evidence_conflict
+
+type measurement_receipt_transition =
+  | Measurement_dispatch_intent
+  | Measurement_terminal_advance
+  | Measurement_idempotent_replay
+  | Measurement_transition_conflict of measurement_receipt_transition_conflict
+
+let ( let* ) = Result.bind
+let flow_id_to_string (Flow_id value) = value
+let flow_visit_ordinal_to_int (Flow_visit_ordinal value) = value
+let measurement_operation_id_to_string (Measurement_operation_id value) = value
+
+let create_measurement_receipt_snapshot
+      ~operation_id
+      ~flow_id
+      ~visit_ordinal
+      ~candidate_id
+      ~candidate_binding_sha256
+      ~request_body_sha256
+      ~phase
+      ~dispatch
+      ~outcome
+  =
+  { operation_id = Measurement_operation_id operation_id
+  ; flow_id
+  ; visit_ordinal
+  ; candidate_id
+  ; candidate_binding_sha256
+  ; request_body_sha256
+  ; phase
+  ; dispatch
+  ; outcome
+  }
+;;
+
+let measurement_receipt_operation_id snapshot = snapshot.operation_id
+let measurement_receipt_flow_id snapshot = snapshot.flow_id
+let measurement_receipt_visit_ordinal snapshot = snapshot.visit_ordinal
+let measurement_receipt_candidate_id snapshot = snapshot.candidate_id
+
+let measurement_receipt_candidate_binding_sha256 snapshot =
+  snapshot.candidate_binding_sha256
+;;
+
+let measurement_receipt_request_body_sha256 snapshot = snapshot.request_body_sha256
+let measurement_receipt_phase snapshot = snapshot.phase
+let measurement_receipt_dispatch_fact snapshot = snapshot.dispatch
+let measurement_receipt_outcome snapshot = snapshot.outcome
+let snapshot_format = "oas.exact-output.measurement-receipt"
+let snapshot_version = 1
+let sha256 value = Digestif.SHA256.(to_hex (digest_string value))
+
+let phase_to_string = function
+  | Measurement_fence_committed -> "fence_committed"
+  | Measurement_wire_started -> "wire_started"
+  | Measurement_terminal -> "terminal"
+;;
+
+let phase_of_string = function
+  | "fence_committed" -> Some Measurement_fence_committed
+  | "wire_started" -> Some Measurement_wire_started
+  | "terminal" -> Some Measurement_terminal
+  | _ -> None
+;;
+
+let dispatch_to_string = function
+  | No_measurement_dispatch -> "no_dispatch"
+  | Measurement_dispatch_unknown -> "dispatch_unknown"
+  | Measurement_dispatch_started -> "dispatch_started"
+;;
+
+let dispatch_of_string = function
+  | "no_dispatch" -> Some No_measurement_dispatch
+  | "dispatch_unknown" -> Some Measurement_dispatch_unknown
+  | "dispatch_started" -> Some Measurement_dispatch_started
+  | _ -> None
+;;
+
+let outcome_to_string = function
+  | Measurement_not_required -> "not_required"
+  | Measurement_succeeded -> "succeeded"
+  | Measurement_unsupported -> "unsupported"
+  | Measurement_local_invalid -> "local_invalid"
+  | Measurement_transport_failed -> "transport_failed"
+  | Measurement_invalid_response -> "invalid_response"
+  | Measurement_fence_rejected -> "fence_rejected"
+  | Measurement_cancelled -> "cancelled"
+;;
+
+let outcome_of_string = function
+  | "not_required" -> Some Measurement_not_required
+  | "succeeded" -> Some Measurement_succeeded
+  | "unsupported" -> Some Measurement_unsupported
+  | "local_invalid" -> Some Measurement_local_invalid
+  | "transport_failed" -> Some Measurement_transport_failed
+  | "invalid_response" -> Some Measurement_invalid_response
+  | "fence_rejected" -> Some Measurement_fence_rejected
+  | "cancelled" -> Some Measurement_cancelled
+  | _ -> None
+;;
+
+let payload_fields snapshot =
+  [ "format", `String snapshot_format
+  ; "version", `Int snapshot_version
+  ; "operation_id", `String (measurement_operation_id_to_string snapshot.operation_id)
+  ; "flow_id", `String (flow_id_to_string snapshot.flow_id)
+  ; "visit_ordinal", `Int (flow_visit_ordinal_to_int snapshot.visit_ordinal)
+  ; "candidate_id", `String snapshot.candidate_id
+  ; "candidate_binding_sha256", `String snapshot.candidate_binding_sha256
+  ; "request_body_sha256", `String snapshot.request_body_sha256
+  ; "phase", `String (phase_to_string snapshot.phase)
+  ; "dispatch", `String (dispatch_to_string snapshot.dispatch)
+  ; ( "outcome"
+    , match snapshot.outcome with
+      | None -> `Null
+      | Some outcome -> `String (outcome_to_string outcome) )
+  ]
+;;
+
+let measurement_receipt_snapshot_to_string snapshot =
+  let fields = payload_fields snapshot in
+  let integrity_sha256 = `Assoc fields |> Yojson.Safe.to_string |> sha256 in
+  `Assoc (fields @ [ "integrity_sha256", `String integrity_sha256 ])
+  |> Yojson.Safe.to_string
+;;
+
+let expected_fields =
+  [ "format"
+  ; "version"
+  ; "operation_id"
+  ; "flow_id"
+  ; "visit_ordinal"
+  ; "candidate_id"
+  ; "candidate_binding_sha256"
+  ; "request_body_sha256"
+  ; "phase"
+  ; "dispatch"
+  ; "outcome"
+  ; "integrity_sha256"
+  ]
+;;
+
+let is_sha256 value =
+  String.length value = 64
+  && String.for_all
+       (function
+         | '0' .. '9' | 'a' .. 'f' -> true
+         | _ -> false)
+       value
+;;
+
+let shape_is_valid snapshot =
+  match snapshot.phase, snapshot.dispatch, snapshot.outcome with
+  | Measurement_fence_committed, Measurement_dispatch_unknown, None
+  | Measurement_fence_committed, No_measurement_dispatch, None
+  | Measurement_wire_started, Measurement_dispatch_started, None -> true
+  | Measurement_terminal, _, Some Measurement_not_required -> false
+  | Measurement_terminal, _, Some _ -> true
+  | Measurement_fence_committed, _, _
+  | Measurement_wire_started, _, _
+  | Measurement_terminal, _, None -> false
+;;
+
+let measurement_receipt_snapshot_of_string encoded =
+  let invalid field = Error (Measurement_receipt_snapshot_invalid_field field) in
+  let find fields name =
+    match List.assoc_opt name fields with
+    | Some value -> Ok value
+    | None -> invalid name
+  in
+  let string_field fields name =
+    let* value = find fields name in
+    match value with
+    | `String value -> Ok value
+    | _ -> invalid name
+  in
+  let enum_field fields name decode =
+    let* encoded = string_field fields name in
+    match decode encoded with
+    | Some value -> Ok value
+    | None -> invalid name
+  in
+  try
+    match Yojson.Safe.from_string encoded with
+    | `Assoc fields ->
+      let actual = List.map fst fields |> List.sort String.compare in
+      if actual <> List.sort String.compare expected_fields
+      then Error Measurement_receipt_snapshot_invalid_fields
+      else
+        let* format = string_field fields "format" in
+        let* () =
+          if String.equal format snapshot_format
+          then Ok ()
+          else Error (Measurement_receipt_snapshot_unknown_format format)
+        in
+        let* version = find fields "version" in
+        let* () =
+          match version with
+          | `Int version when version = snapshot_version -> Ok ()
+          | `Int version ->
+            Error (Measurement_receipt_snapshot_unsupported_version version)
+          | _ -> invalid "version"
+        in
+        let* operation_id = string_field fields "operation_id" in
+        let* flow_id = string_field fields "flow_id" in
+        let* visit_ordinal_json = find fields "visit_ordinal" in
+        let* visit_ordinal =
+          match visit_ordinal_json with
+          | `Int ordinal when ordinal > 0 -> Ok ordinal
+          | `Int _ | _ -> invalid "visit_ordinal"
+        in
+        let* candidate_id = string_field fields "candidate_id" in
+        let* candidate_binding_sha256 = string_field fields "candidate_binding_sha256" in
+        let* request_body_sha256 = string_field fields "request_body_sha256" in
+        let* phase = enum_field fields "phase" phase_of_string in
+        let* dispatch = enum_field fields "dispatch" dispatch_of_string in
+        let* outcome_json = find fields "outcome" in
+        let* outcome =
+          match outcome_json with
+          | `Null -> Ok None
+          | `String encoded ->
+            (match outcome_of_string encoded with
+             | Some outcome -> Ok (Some outcome)
+             | None -> invalid "outcome")
+          | _ -> invalid "outcome"
+        in
+        let* integrity_sha256 = string_field fields "integrity_sha256" in
+        let canonical_nonempty value =
+          (not (String.equal value "")) && String.equal value (String.trim value)
+        in
+        let* () =
+          if canonical_nonempty operation_id then Ok () else invalid "operation_id"
+        in
+        let* () = if canonical_nonempty flow_id then Ok () else invalid "flow_id" in
+        let* () =
+          if canonical_nonempty candidate_id then Ok () else invalid "candidate_id"
+        in
+        let* () =
+          if
+            is_sha256 candidate_binding_sha256
+            && is_sha256 request_body_sha256
+            && is_sha256 integrity_sha256
+          then Ok ()
+          else invalid "sha256"
+        in
+        let snapshot =
+          create_measurement_receipt_snapshot
+            ~operation_id
+            ~flow_id:(Flow_id flow_id)
+            ~visit_ordinal:(Flow_visit_ordinal visit_ordinal)
+            ~candidate_id
+            ~candidate_binding_sha256
+            ~request_body_sha256
+            ~phase
+            ~dispatch
+            ~outcome
+        in
+        let* () = if shape_is_valid snapshot then Ok () else invalid "receipt_state" in
+        let expected_integrity =
+          `Assoc (payload_fields snapshot) |> Yojson.Safe.to_string |> sha256
+        in
+        if String.equal expected_integrity integrity_sha256
+        then Ok snapshot
+        else Error Measurement_receipt_snapshot_integrity_mismatch
+    | _ -> Error Measurement_receipt_snapshot_invalid_fields
+  with
+  | Yojson.Json_error detail -> Error (Measurement_receipt_snapshot_malformed_json detail)
+;;
+
+let measurement_receipt_snapshot_decode_error_to_string = function
+  | Measurement_receipt_snapshot_malformed_json detail ->
+    "measurement receipt malformed JSON: " ^ detail
+  | Measurement_receipt_snapshot_invalid_fields ->
+    "measurement receipt fields do not match the current schema"
+  | Measurement_receipt_snapshot_unknown_format format ->
+    "measurement receipt has unknown format: " ^ format
+  | Measurement_receipt_snapshot_unsupported_version version ->
+    Printf.sprintf "measurement receipt has unsupported version: %d" version
+  | Measurement_receipt_snapshot_invalid_field field ->
+    "measurement receipt has invalid field: " ^ field
+  | Measurement_receipt_snapshot_integrity_mismatch ->
+    "measurement receipt integrity mismatch"
+;;
+
+let same_snapshot left right =
+  String.equal
+    (measurement_operation_id_to_string left.operation_id)
+    (measurement_operation_id_to_string right.operation_id)
+  && String.equal (flow_id_to_string left.flow_id) (flow_id_to_string right.flow_id)
+  && flow_visit_ordinal_to_int left.visit_ordinal
+     = flow_visit_ordinal_to_int right.visit_ordinal
+  && String.equal left.candidate_id right.candidate_id
+  && String.equal left.candidate_binding_sha256 right.candidate_binding_sha256
+  && String.equal left.request_body_sha256 right.request_body_sha256
+  && left.phase = right.phase
+  && left.dispatch = right.dispatch
+  && left.outcome = right.outcome
+;;
+
+let measurement_receipt_same_operation left right =
+  String.equal
+    (measurement_operation_id_to_string left.operation_id)
+    (measurement_operation_id_to_string right.operation_id)
+;;
+
+let same_binding left right =
+  String.equal (flow_id_to_string left.flow_id) (flow_id_to_string right.flow_id)
+  && flow_visit_ordinal_to_int left.visit_ordinal
+     = flow_visit_ordinal_to_int right.visit_ordinal
+  && String.equal left.candidate_id right.candidate_id
+  && String.equal left.candidate_binding_sha256 right.candidate_binding_sha256
+  && String.equal left.request_body_sha256 right.request_body_sha256
+;;
+
+let is_dispatch_intent snapshot =
+  snapshot.phase = Measurement_fence_committed
+  && snapshot.dispatch = Measurement_dispatch_unknown
+  && Option.is_none snapshot.outcome
+;;
+
+let phase_rank = function
+  | Measurement_fence_committed -> 0
+  | Measurement_wire_started -> 1
+  | Measurement_terminal -> 2
+;;
+
+let classify_measurement_receipt_transition ~previous ~incoming =
+  match previous with
+  | None ->
+    if is_dispatch_intent incoming
+    then Measurement_dispatch_intent
+    else if incoming.phase <> Measurement_fence_committed
+    then Measurement_transition_conflict (Measurement_invalid_commit_phase incoming.phase)
+    else Measurement_transition_conflict Measurement_evidence_conflict
+  | Some previous ->
+    if not (measurement_receipt_same_operation previous incoming)
+    then Measurement_transition_conflict Measurement_operation_mismatch
+    else if not (same_binding previous incoming)
+    then Measurement_transition_conflict Measurement_operation_binding_mismatch
+    else if same_snapshot previous incoming
+    then Measurement_idempotent_replay
+    else if phase_rank incoming.phase < phase_rank previous.phase
+    then
+      Measurement_transition_conflict
+        (Measurement_phase_regression
+           { previous_phase = previous.phase; incoming_phase = incoming.phase })
+    else if
+      previous.phase <> Measurement_terminal
+      && incoming.phase = Measurement_terminal
+      && Option.is_some incoming.outcome
+    then Measurement_terminal_advance
+    else if incoming.phase = Measurement_wire_started
+    then Measurement_transition_conflict (Measurement_invalid_commit_phase incoming.phase)
+    else Measurement_transition_conflict Measurement_evidence_conflict
+;;

--- a/lib/llm_provider/exact_output_measurement_receipt.mli
+++ b/lib/llm_provider/exact_output_measurement_receipt.mli
@@ -38,6 +38,8 @@ type measurement_receipt_snapshot =
   ; visit_ordinal : flow_visit_ordinal
   ; candidate_id : string
   ; candidate_binding_sha256 : string
+  ; catalog_generation_fingerprint : string
+  ; catalog_evidence_sha256 : string
   ; request_body_sha256 : string
   ; phase : measurement_receipt_phase
   ; dispatch : measurement_dispatch_fact
@@ -56,6 +58,11 @@ type measurement_receipt_transition_conflict =
   | Measurement_operation_mismatch
   | Measurement_operation_binding_mismatch
   | Measurement_invalid_commit_phase of measurement_receipt_phase
+  | Measurement_invalid_previous_boundary of
+      { phase : measurement_receipt_phase
+      ; dispatch : measurement_dispatch_fact
+      ; outcome : measurement_outcome option
+      }
   | Measurement_phase_regression of
       { previous_phase : measurement_receipt_phase
       ; incoming_phase : measurement_receipt_phase
@@ -78,6 +85,8 @@ val create_measurement_receipt_snapshot
   -> visit_ordinal:flow_visit_ordinal
   -> candidate_id:string
   -> candidate_binding_sha256:string
+  -> catalog_generation_fingerprint:string
+  -> catalog_evidence_sha256:string
   -> request_body_sha256:string
   -> phase:measurement_receipt_phase
   -> dispatch:measurement_dispatch_fact
@@ -92,6 +101,12 @@ val measurement_receipt_flow_id : measurement_receipt_snapshot -> flow_id
 val measurement_receipt_visit_ordinal : measurement_receipt_snapshot -> flow_visit_ordinal
 val measurement_receipt_candidate_id : measurement_receipt_snapshot -> string
 val measurement_receipt_candidate_binding_sha256 : measurement_receipt_snapshot -> string
+
+val measurement_receipt_catalog_generation_fingerprint
+  :  measurement_receipt_snapshot
+  -> string
+
+val measurement_receipt_catalog_evidence_sha256 : measurement_receipt_snapshot -> string
 val measurement_receipt_request_body_sha256 : measurement_receipt_snapshot -> string
 val measurement_receipt_phase : measurement_receipt_snapshot -> measurement_receipt_phase
 

--- a/lib/llm_provider/exact_output_measurement_receipt.mli
+++ b/lib/llm_provider/exact_output_measurement_receipt.mli
@@ -1,0 +1,124 @@
+(** Private owner of exact-output measurement receipt identity, durable codec,
+    and monotonic callback transitions. The public surface is re-exported only
+    by [Exact_output]. *)
+
+type measurement_dispatch_fact = Exact_output_flow_admission.measurement_dispatch_fact =
+  | No_measurement_dispatch
+  | Measurement_dispatch_unknown
+  | Measurement_dispatch_started
+
+type measurement_outcome = Exact_output_flow_admission.measurement_outcome =
+  | Measurement_not_required
+  | Measurement_succeeded
+  | Measurement_unsupported
+  | Measurement_local_invalid
+  | Measurement_transport_failed
+  | Measurement_invalid_response
+  | Measurement_fence_rejected
+  | Measurement_cancelled
+
+type measurement_evidence = Exact_output_flow_admission.measurement_evidence =
+  { dispatch : measurement_dispatch_fact
+  ; outcome : measurement_outcome
+  }
+
+type measurement_operation_id = Measurement_operation_id of string
+
+type measurement_receipt_phase = Exact_output_flow_admission.measurement_receipt_phase =
+  | Measurement_fence_committed
+  | Measurement_wire_started
+  | Measurement_terminal
+
+type flow_id = Flow_id of string
+type flow_visit_ordinal = Flow_visit_ordinal of int
+
+type measurement_receipt_snapshot =
+  { operation_id : measurement_operation_id
+  ; flow_id : flow_id
+  ; visit_ordinal : flow_visit_ordinal
+  ; candidate_id : string
+  ; candidate_binding_sha256 : string
+  ; request_body_sha256 : string
+  ; phase : measurement_receipt_phase
+  ; dispatch : measurement_dispatch_fact
+  ; outcome : measurement_outcome option
+  }
+
+type measurement_receipt_snapshot_decode_error =
+  | Measurement_receipt_snapshot_malformed_json of string
+  | Measurement_receipt_snapshot_invalid_fields
+  | Measurement_receipt_snapshot_unknown_format of string
+  | Measurement_receipt_snapshot_unsupported_version of int
+  | Measurement_receipt_snapshot_invalid_field of string
+  | Measurement_receipt_snapshot_integrity_mismatch
+
+type measurement_receipt_transition_conflict =
+  | Measurement_operation_mismatch
+  | Measurement_operation_binding_mismatch
+  | Measurement_invalid_commit_phase of measurement_receipt_phase
+  | Measurement_phase_regression of
+      { previous_phase : measurement_receipt_phase
+      ; incoming_phase : measurement_receipt_phase
+      }
+  | Measurement_evidence_conflict
+
+type measurement_receipt_transition =
+  | Measurement_dispatch_intent
+  | Measurement_terminal_advance
+  | Measurement_idempotent_replay
+  | Measurement_transition_conflict of measurement_receipt_transition_conflict
+
+val flow_id_to_string : flow_id -> string
+val flow_visit_ordinal_to_int : flow_visit_ordinal -> int
+val measurement_operation_id_to_string : measurement_operation_id -> string
+
+val create_measurement_receipt_snapshot
+  :  operation_id:string
+  -> flow_id:flow_id
+  -> visit_ordinal:flow_visit_ordinal
+  -> candidate_id:string
+  -> candidate_binding_sha256:string
+  -> request_body_sha256:string
+  -> phase:measurement_receipt_phase
+  -> dispatch:measurement_dispatch_fact
+  -> outcome:measurement_outcome option
+  -> measurement_receipt_snapshot
+
+val measurement_receipt_operation_id
+  :  measurement_receipt_snapshot
+  -> measurement_operation_id
+
+val measurement_receipt_flow_id : measurement_receipt_snapshot -> flow_id
+val measurement_receipt_visit_ordinal : measurement_receipt_snapshot -> flow_visit_ordinal
+val measurement_receipt_candidate_id : measurement_receipt_snapshot -> string
+val measurement_receipt_candidate_binding_sha256 : measurement_receipt_snapshot -> string
+val measurement_receipt_request_body_sha256 : measurement_receipt_snapshot -> string
+val measurement_receipt_phase : measurement_receipt_snapshot -> measurement_receipt_phase
+
+val measurement_receipt_dispatch_fact
+  :  measurement_receipt_snapshot
+  -> measurement_dispatch_fact
+
+val measurement_receipt_outcome
+  :  measurement_receipt_snapshot
+  -> measurement_outcome option
+
+val measurement_receipt_snapshot_to_string : measurement_receipt_snapshot -> string
+
+val measurement_receipt_snapshot_of_string
+  :  string
+  -> (measurement_receipt_snapshot, measurement_receipt_snapshot_decode_error) result
+
+val measurement_receipt_snapshot_decode_error_to_string
+  :  measurement_receipt_snapshot_decode_error
+  -> string
+
+val classify_measurement_receipt_transition
+  :  previous:measurement_receipt_snapshot option
+  -> incoming:measurement_receipt_snapshot
+  -> measurement_receipt_transition
+
+val measurement_receipt_same_operation
+  :  measurement_receipt_snapshot
+  -> measurement_receipt_snapshot
+  -> bool

--- a/test/test_exact_output_flow.ml
+++ b/test/test_exact_output_flow.ml
@@ -3117,6 +3117,233 @@ let test_measured_token_and_body_capacity_are_independent () =
     cases
 ;;
 
+let test_measurement_receipt_codec_and_transition () =
+  let response =
+    {|{"id":"msg-flow","type":"message","role":"assistant","model":"flow","content":[{"type":"text","text":"{\"name\":\"accepted\"}"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}|}
+  in
+  let (intent, terminal), posts =
+    with_counted_server ~measurement_reply:(Measurement_tokens 1) ~response
+    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
+    with_catalog
+      [ catalog_entry
+          ~kind:"anthropic"
+          ~request_path:"/v1/messages"
+          ~serving_constraint:true
+          ~id:"measurement-receipt-codec"
+          ~base_url
+          ~native:true
+          ~json:true
+          ()
+      ]
+    @@ fun snapshot ->
+    let flow = start_flow (frozen_flow snapshot [ "measurement-receipt-codec" ]) in
+    let intent = ref None in
+    let terminal = ref None in
+    let result =
+      EO.execute_flow_once
+        ~net
+        ~before_measurement_dispatch:(fun measurement ->
+          intent := Some (EO.flow_measurement_receipt_snapshot measurement);
+          Ok ())
+        ~on_measurement_terminal:(fun measurement ->
+          terminal := Some (EO.flow_measurement_receipt_snapshot measurement);
+          Ok ())
+        ~before_dispatch:(fun _ -> Ok ())
+        ~before_advance:(fun ~failed:_ ~next:_ -> Ok ())
+        flow
+    in
+    (match result with
+     | Ok _ -> ()
+     | Error _ -> fail "measurement receipt codec fixture did not complete");
+    let require_snapshot label = function
+      | Some snapshot -> snapshot
+      | None -> fail (label ^ " snapshot was not published")
+    in
+    require_snapshot "intent" !intent, require_snapshot "terminal" !terminal
+  in
+  check int "codec fixture measures once" 1 posts.measurement_posts;
+  check int "codec fixture generates once" 1 posts.generation_posts;
+  let decode label encoded =
+    match EO.measurement_receipt_snapshot_of_string encoded with
+    | Ok snapshot -> snapshot
+    | Error error ->
+      failf
+        "%s decode failed: %s"
+        label
+        (EO.measurement_receipt_snapshot_decode_error_to_string error)
+  in
+  let intent_encoded = EO.measurement_receipt_snapshot_to_string intent in
+  let terminal_encoded = EO.measurement_receipt_snapshot_to_string terminal in
+  let decoded_intent = decode "intent" intent_encoded in
+  let decoded_terminal = decode "terminal" terminal_encoded in
+  check
+    string
+    "intent codec is canonical"
+    intent_encoded
+    (EO.measurement_receipt_snapshot_to_string decoded_intent);
+  check
+    string
+    "terminal codec is canonical"
+    terminal_encoded
+    (EO.measurement_receipt_snapshot_to_string decoded_terminal);
+  check
+    string
+    "operation identity survives durable round trip"
+    (EO.measurement_operation_id_to_string (EO.measurement_receipt_operation_id intent))
+    (EO.measurement_operation_id_to_string
+       (EO.measurement_receipt_operation_id decoded_terminal));
+  check
+    bool
+    "first callback is dispatch intent"
+    true
+    (match EO.classify_measurement_receipt_transition ~previous:None ~incoming:intent with
+     | EO.Measurement_dispatch_intent -> true
+     | _ -> false);
+  check
+    bool
+    "same dispatch intent is idempotent"
+    true
+    (match
+       EO.classify_measurement_receipt_transition
+         ~previous:(Some intent)
+         ~incoming:decoded_intent
+     with
+     | EO.Measurement_idempotent_replay -> true
+     | _ -> false);
+  check
+    bool
+    "terminal callback advances the same operation"
+    true
+    (match
+       EO.classify_measurement_receipt_transition
+         ~previous:(Some decoded_intent)
+         ~incoming:decoded_terminal
+     with
+     | EO.Measurement_terminal_advance -> true
+     | _ -> false);
+  check
+    bool
+    "same terminal evidence is idempotent"
+    true
+    (match
+       EO.classify_measurement_receipt_transition
+         ~previous:(Some terminal)
+         ~incoming:decoded_terminal
+     with
+     | EO.Measurement_idempotent_replay -> true
+     | _ -> false);
+  check
+    bool
+    "terminal to intent is a typed monotonicity conflict"
+    true
+    (match
+       EO.classify_measurement_receipt_transition
+         ~previous:(Some terminal)
+         ~incoming:intent
+     with
+     | EO.Measurement_transition_conflict
+         (EO.Measurement_phase_regression
+            { previous_phase = EO.Measurement_terminal
+            ; incoming_phase = EO.Measurement_fence_committed
+            }) -> true
+     | _ -> false);
+  let rewrite_field encoded name replacement =
+    match Yojson.Safe.from_string encoded with
+    | `Assoc fields ->
+      `Assoc
+        (List.map
+           (fun (field, value) ->
+              if String.equal field name then field, replacement else field, value)
+           fields)
+      |> Yojson.Safe.to_string
+    | _ -> fail "encoded measurement receipt was not an object"
+  in
+  let tampered = rewrite_field terminal_encoded "outcome" (`String "cancelled") in
+  (match EO.measurement_receipt_snapshot_of_string tampered with
+   | Error EO.Measurement_receipt_snapshot_integrity_mismatch -> ()
+   | Ok _ | Error _ -> fail "tampered receipt did not fail integrity");
+  let future = rewrite_field terminal_encoded "version" (`Int 2) in
+  (match EO.measurement_receipt_snapshot_of_string future with
+   | Error (EO.Measurement_receipt_snapshot_unsupported_version 2) -> ()
+   | Ok _ | Error _ -> fail "future receipt version did not fail closed");
+  check
+    bool
+    "terminal evidence cannot initialize a dispatch journal"
+    true
+    (match
+       EO.classify_measurement_receipt_transition
+         ~previous:None
+         ~incoming:decoded_terminal
+     with
+     | EO.Measurement_transition_conflict
+         (EO.Measurement_invalid_commit_phase EO.Measurement_terminal) -> true
+     | _ -> false);
+  let rewrite_with_integrity encoded name replacement =
+    match Yojson.Safe.from_string encoded with
+    | `Assoc fields ->
+      let payload =
+        fields
+        |> List.filter (fun (field, _) -> not (String.equal field "integrity_sha256"))
+        |> List.map (fun (field, value) ->
+          if String.equal field name then field, replacement else field, value)
+      in
+      let integrity_sha256 =
+        `Assoc payload
+        |> Yojson.Safe.to_string
+        |> Digestif.SHA256.digest_string
+        |> Digestif.SHA256.to_hex
+      in
+      `Assoc (payload @ [ "integrity_sha256", `String integrity_sha256 ])
+      |> Yojson.Safe.to_string
+    | _ -> fail "encoded measurement receipt was not an object"
+  in
+  let other_operation =
+    rewrite_with_integrity intent_encoded "operation_id" (`String "other-operation")
+    |> decode "other operation"
+  in
+  check
+    bool
+    "operation mismatch is typed"
+    true
+    (match
+       EO.classify_measurement_receipt_transition
+         ~previous:(Some intent)
+         ~incoming:other_operation
+     with
+     | EO.Measurement_transition_conflict EO.Measurement_operation_mismatch -> true
+     | _ -> false);
+  let other_binding =
+    rewrite_with_integrity
+      intent_encoded
+      "candidate_binding_sha256"
+      (`String (String.make 64 'a'))
+    |> decode "other binding"
+  in
+  check
+    bool
+    "operation binding mismatch is typed"
+    true
+    (match
+       EO.classify_measurement_receipt_transition
+         ~previous:(Some intent)
+         ~incoming:other_binding
+     with
+     | EO.Measurement_transition_conflict EO.Measurement_operation_binding_mismatch ->
+       true
+     | _ -> false);
+  let conflicting_intent =
+    rewrite_with_integrity intent_encoded "dispatch" (`String "no_dispatch")
+    |> decode "conflicting intent"
+  in
+  match
+    EO.classify_measurement_receipt_transition
+      ~previous:(Some intent)
+      ~incoming:conflicting_intent
+  with
+  | EO.Measurement_transition_conflict EO.Measurement_evidence_conflict -> ()
+  | _ -> fail "same-phase conflicting evidence was not typed"
+;;
+
 let test_measurement_fence_rejection_is_terminal_without_wire () =
   let response =
     {|{"id":"msg-flow","type":"message","role":"assistant","model":"flow","content":[{"type":"text","text":"{\"name\":\"unused\"}"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}|}
@@ -5055,6 +5282,10 @@ let () =
             "measured token and serialized body capacities are independent"
             `Quick
             test_measured_token_and_body_capacity_are_independent
+        ; test_case
+            "measurement receipt codec and monotonic transition"
+            `Quick
+            test_measurement_receipt_codec_and_transition
         ; test_case
             "measurement fence rejection is terminal without wire"
             `Quick

--- a/test/test_exact_output_flow.ml
+++ b/test/test_exact_output_flow.ml
@@ -3193,6 +3193,16 @@ let test_measurement_receipt_codec_and_transition () =
     (EO.measurement_operation_id_to_string
        (EO.measurement_receipt_operation_id decoded_terminal));
   check
+    string
+    "catalog generation survives durable round trip"
+    (EO.measurement_receipt_catalog_generation_fingerprint intent)
+    (EO.measurement_receipt_catalog_generation_fingerprint decoded_terminal);
+  check
+    string
+    "catalog evidence survives durable round trip"
+    (EO.measurement_receipt_catalog_evidence_sha256 intent)
+    (EO.measurement_receipt_catalog_evidence_sha256 decoded_terminal);
+  check
     bool
     "first callback is dispatch intent"
     true
@@ -3258,6 +3268,33 @@ let test_measurement_receipt_codec_and_transition () =
       |> Yojson.Safe.to_string
     | _ -> fail "encoded measurement receipt was not an object"
   in
+  let remove_field encoded name =
+    match Yojson.Safe.from_string encoded with
+    | `Assoc fields ->
+      `Assoc (List.filter (fun (field, _) -> not (String.equal field name)) fields)
+      |> Yojson.Safe.to_string
+    | _ -> fail "encoded measurement receipt was not an object"
+  in
+  let add_field encoded name value =
+    match Yojson.Safe.from_string encoded with
+    | `Assoc fields -> `Assoc (fields @ [ name, value ]) |> Yojson.Safe.to_string
+    | _ -> fail "encoded measurement receipt was not an object"
+  in
+  (match EO.measurement_receipt_snapshot_of_string "{" with
+   | Error (EO.Measurement_receipt_snapshot_malformed_json _) -> ()
+   | Ok _ | Error _ -> fail "malformed receipt did not fail typed decode");
+  (match
+     remove_field intent_encoded "catalog_evidence_sha256"
+     |> EO.measurement_receipt_snapshot_of_string
+   with
+   | Error EO.Measurement_receipt_snapshot_invalid_fields -> ()
+   | Ok _ | Error _ -> fail "missing receipt field did not fail exact schema");
+  (match
+     add_field intent_encoded "unexpected" (`Bool true)
+     |> EO.measurement_receipt_snapshot_of_string
+   with
+   | Error EO.Measurement_receipt_snapshot_invalid_fields -> ()
+   | Ok _ | Error _ -> fail "extra receipt field did not fail exact schema");
   let tampered = rewrite_field terminal_encoded "outcome" (`String "cancelled") in
   (match EO.measurement_receipt_snapshot_of_string tampered with
    | Error EO.Measurement_receipt_snapshot_integrity_mismatch -> ()
@@ -3297,6 +3334,12 @@ let test_measurement_receipt_codec_and_transition () =
       |> Yojson.Safe.to_string
     | _ -> fail "encoded measurement receipt was not an object"
   in
+  let inconsistent =
+    rewrite_with_integrity terminal_encoded "phase" (`String "fence_committed")
+  in
+  (match EO.measurement_receipt_snapshot_of_string inconsistent with
+   | Error (EO.Measurement_receipt_snapshot_invalid_field "receipt_state") -> ()
+   | Ok _ | Error _ -> fail "internally inconsistent receipt did not fail closed");
   let other_operation =
     rewrite_with_integrity intent_encoded "operation_id" (`String "other-operation")
     |> decode "other operation"
@@ -3330,6 +3373,93 @@ let test_measurement_receipt_codec_and_transition () =
      with
      | EO.Measurement_transition_conflict EO.Measurement_operation_binding_mismatch ->
        true
+     | _ -> false);
+  let check_catalog_binding_conflict label field replacement =
+    let incoming =
+      rewrite_with_integrity intent_encoded field (`String replacement) |> decode label
+    in
+    check
+      bool
+      label
+      true
+      (match
+         EO.classify_measurement_receipt_transition ~previous:(Some intent) ~incoming
+       with
+       | EO.Measurement_transition_conflict EO.Measurement_operation_binding_mismatch ->
+         true
+       | _ -> false)
+  in
+  check_catalog_binding_conflict
+    "catalog generation mismatch is binding conflict"
+    "catalog_generation_fingerprint"
+    (String.make 64 'b');
+  check_catalog_binding_conflict
+    "catalog evidence mismatch is binding conflict"
+    "catalog_evidence_sha256"
+    (String.make 64 'c');
+  let wire_started =
+    intent_encoded
+    |> fun encoded ->
+    rewrite_with_integrity encoded "phase" (`String "wire_started")
+    |> fun encoded ->
+    rewrite_with_integrity encoded "dispatch" (`String "dispatch_started")
+    |> decode "wire started"
+  in
+  let no_dispatch_intent =
+    rewrite_with_integrity intent_encoded "dispatch" (`String "no_dispatch")
+    |> decode "no-dispatch fence"
+  in
+  let check_invalid_previous label previous expected_phase expected_dispatch =
+    check
+      bool
+      label
+      true
+      (match
+         EO.classify_measurement_receipt_transition
+           ~previous:(Some previous)
+           ~incoming:terminal
+       with
+       | EO.Measurement_transition_conflict
+           (EO.Measurement_invalid_previous_boundary { phase; dispatch; outcome = None })
+         -> phase = expected_phase && dispatch = expected_dispatch
+       | _ -> false)
+  in
+  check_invalid_previous
+    "wire-started previous boundary fails closed"
+    wire_started
+    EO.Measurement_wire_started
+    EO.Measurement_dispatch_started;
+  check_invalid_previous
+    "no-dispatch fence previous boundary fails closed"
+    no_dispatch_intent
+    EO.Measurement_fence_committed
+    EO.No_measurement_dispatch;
+  check
+    bool
+    "wire-started incoming snapshot is not a durable commit"
+    true
+    (match
+       EO.classify_measurement_receipt_transition
+         ~previous:(Some intent)
+         ~incoming:wire_started
+     with
+     | EO.Measurement_transition_conflict
+         (EO.Measurement_invalid_commit_phase EO.Measurement_wire_started) -> true
+     | _ -> false);
+  let conflicting_terminal =
+    rewrite_with_integrity terminal_encoded "outcome" (`String "cancelled")
+    |> decode "conflicting terminal"
+  in
+  check
+    bool
+    "terminal evidence conflict fails closed"
+    true
+    (match
+       EO.classify_measurement_receipt_transition
+         ~previous:(Some terminal)
+         ~incoming:conflicting_terminal
+     with
+     | EO.Measurement_transition_conflict EO.Measurement_evidence_conflict -> true
      | _ -> false);
   let conflicting_intent =
     rewrite_with_integrity intent_encoded "dispatch" (`String "no_dispatch")


### PR DESCRIPTION
## Why

MASC must durably journal OAS measurement dispatch intent and terminal evidence without duplicating the OAS receipt schema or reconstructing provider/model metadata.

## Contract

- adds the sole current-schema `Exact_output.measurement_receipt_snapshot` codec with SHA-256 integrity
- adds stable operation and immutable receipt accessors
- classifies dispatch intent, terminal advancement, idempotent replay, operation/binding conflicts, invalid commit phases, phase regression, and evidence conflict
- rejects missing, extra, malformed, future-version, internally inconsistent, and corrupted evidence

## Forward cut

- replaces the snapshot's full resolved `visit` with provider-neutral stable flow/ordinal/candidate-binding identity
- keeps type, codec, and transition ownership in Dune-private `Exact_output_measurement_receipt`; `Agent_sdk.Exact_output` is the sole public surface
- adds no compatibility decoder, default fill, migration, facade, provider/model branch, or Pricing logic

## Validation

- `scripts/dune-local.sh build test/test_exact_output_flow.exe`
- `scripts/dune-local.sh exec test/test_exact_output_flow.exe -- test outer-flow 27`
- `bash scripts/ci-code-smell-ratchet.sh --check`
- `ocamlformat --check lib/llm_provider/exact_output_measurement_receipt.mli lib/llm_provider/exact_output_measurement_receipt.ml lib/llm_provider/exact_output.mli lib/llm_provider/exact_output.ml test/test_exact_output_flow.ml`
- `git diff --check`
