### PR TITLE
feat(exact-output)!: document the 0.227.0 receipt hard cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@ original tag dates. `0.100.4` was never tagged or released.
 `measurement_receipt_catalog_evidence_sha256`.
 
 The durable receipt decoder accepts only the current complete schema.
-Discard pre-0.227.0 persisted measurement receipt snapshots and recreate them
-from fresh flow state; there is no compatibility decoder or migration path.
+Discard retired nested-`visit` snapshots produced before 0.226.1 and recreate
+them from fresh flow state; there is no compatibility decoder or migration
+path. Current-schema 0.226.1 receipts remain valid in 0.227.0.
 
 ## [0.226.1](https://github.com/jeong-sik/oas/compare/v0.226.0...v0.226.1) (2026-07-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,24 @@ original tag dates. `0.100.4` was never tagged or released.
 
 ## Unreleased
 
+### Breaking Changes
+
+`Exact_output.measurement_receipt_snapshot` no longer exposes the nested
+`visit` field. Read receipt identity through
+`measurement_receipt_flow_id`, `measurement_receipt_visit_ordinal`,
+`measurement_receipt_candidate_id`,
+`measurement_receipt_candidate_binding_sha256`,
+`measurement_receipt_catalog_generation_fingerprint`, and
+`measurement_receipt_catalog_evidence_sha256`.
+
+The durable receipt decoder accepts only the current complete schema.
+Discard pre-0.227.0 persisted measurement receipt snapshots and recreate them
+from fresh flow state; there is no compatibility decoder or migration path.
+
 ## [0.226.1](https://github.com/jeong-sik/oas/compare/v0.226.0...v0.226.1) (2026-07-27)
 
+Compatibility notice: this patch release unintentionally included the breaking
+measurement receipt shape above. Consumers should upgrade directly to 0.227.0.
 
 ### Features
 


### PR DESCRIPTION
## Why

`v0.226.1` was published as a patch even though #2820 removed the publicly readable private-record field `measurement_receipt_snapshot.visit`. This forward fix records the breaking boundary and instructs release-please to cut `0.227.0`.

## Migration

- Read receipt identity through the flattened `measurement_receipt_*` accessors.
- Discard only retired nested-`visit` snapshots produced before `0.226.1`; recreate those from fresh flow state.
- Current-schema `0.226.1` receipts remain valid in `0.227.0`.
- No compatibility decoder, migration path, provider/model identity, or Pricing policy is added.

## Canonical merge contract

Squash with an explicit main commit body:

```text
BREAKING CHANGE: measurement_receipt_snapshot no longer exposes the nested visit field. Discard only retired nested-visit snapshots produced before 0.226.1; current-schema 0.226.1 receipts remain valid.

Release-As: 0.227.0
```

## Validation

- `git diff --check`
- Source-only documentation/release intent; release-please and PR CI remain authoritative.