### PR TITLE
feat(exact-output): validate declared Runtime failover

### DIFF
--- a/lib/llm_provider/exact_output.ml
+++ b/lib/llm_provider/exact_output.ml
@@ -5,13 +5,10 @@ include Measurement_receipt
 module Exec = Exact_output_execution
 module Flow_state = Exact_output_flow
 module Flow_contract = Exact_output_flow_contract
-module Domain_settlement = Exact_output_domain_settlement
-module Preference_lifecycle_facade = Exact_output_preference_lifecycle_facade
 module Trace = Exact_output_provider_trace
 module Generation_receipt = Exact_output_generation_receipt
 include Exact_output_resolver
 include Flow_contract
-include Preference_lifecycle_facade
 include Exact_output_ready_admission
 
 let plan_provenance_source_schema_fingerprint (provenance : plan_provenance) =
@@ -145,8 +142,7 @@ type candidate_rejection_cause =
   | Request_admission_rejected of admission_error
 
 type candidate_rejection_receipt =
-  { scope : flow_scope
-  ; visit : flow_candidate_visit
+  { visit : flow_candidate_visit
   ; cause : candidate_rejection_cause
   ; measurement : measurement_evidence
   }
@@ -164,25 +160,18 @@ type candidate_admission =
   | Candidate_rejected of candidate_rejection_receipt
 
 type flow_snapshot =
-  { preferences : flow_preference_store
-  ; scope : flow_scope
-  ; preference_reservation : Flow_contract.flow_preference_reservation
-  ; declared_candidate_snapshot : flow_candidate_identity list
-  ; preference_observation : flow_preference_observation
-  ; candidates : flow_candidate list
+  { candidates : flow_candidate list
   ; messages : Types.message list
   ; requirement : output_requirement
   }
 
 type flow_attempt_receipt =
-  { scope : flow_scope
-  ; visit : flow_candidate_visit
+  { visit : flow_candidate_visit
   ; receipt : receipt
   }
 
 type flow_attempt_snapshot =
-  { scope : flow_scope
-  ; visit : flow_candidate_visit
+  { visit : flow_candidate_visit
   ; receipt : generation_receipt_snapshot
   }
 
@@ -194,12 +183,7 @@ type flow_attempt_publication =
 type flow_attempt =
   { execution : Flow_state.t
   ; flow_id : flow_id
-  ; preferences : flow_preference_store
-  ; scope : flow_scope
-  ; preference_reservation : Flow_contract.flow_preference_reservation
   ; declared_candidate_snapshot : flow_candidate_identity list
-  ; candidate_snapshot : flow_candidate_identity list
-  ; preference_observation : flow_preference_observation
   ; candidates : flow_candidate_step list
   ; messages : Types.message list
   ; requirement : output_requirement
@@ -218,8 +202,6 @@ type flow_snapshot_error =
       ; first_position : int
       ; duplicate_position : int
       }
-  | Flow_preference_capacity_exhausted of { capacity : int }
-  | Flow_preference_reservation_exhausted
 
 type start_attempt_error = Call_id_generation_failed of string
 
@@ -231,10 +213,7 @@ type flow_start_error = Flow_id_generation_failed of string
 
 type flow_evidence =
   { flow_id : flow_id
-  ; scope : flow_scope
   ; declared_candidate_snapshot : flow_candidate_identity list
-  ; candidate_snapshot : flow_candidate_identity list
-  ; preference_observation : flow_preference_observation
   ; candidate_visit_count : candidate_visit_count
   ; measurements : measurement_receipt_snapshot list
   ; admissions : candidate_admission list
@@ -244,28 +223,28 @@ type flow_evidence =
 type flow_success =
   { candidate : flow_attempt_receipt
   ; success : success
-  ; success_ordinal : flow_success_ordinal
   ; evidence : flow_evidence
-  ; domain_settlement : Flow_state.domain_settlement
-  ; preferences : flow_preference_store
-  ; scope : flow_scope
-  ; preference_reservation : Flow_contract.flow_preference_reservation
   }
 
-type domain_settlement_intent = Domain_settlement.intent
+type ('accepted, 'rejection) semantic_verdict =
+  | Accept of 'accepted
+  | Reject_and_advance of 'rejection
 
-type domain_settlement_intent_decode_error = Domain_settlement.decode_error =
-  | Domain_settlement_intent_malformed_json of string
-  | Domain_settlement_intent_invalid_fields
-  | Domain_settlement_intent_unknown_format of string
-  | Domain_settlement_intent_unsupported_version of int
-  | Domain_settlement_intent_invalid_field of string
-  | Domain_settlement_intent_integrity_mismatch
+type 'rejection semantic_rejection_receipt =
+  { transport_success : flow_success
+  ; rejection : 'rejection
+  }
 
-type 'commit_error domain_commit_error = 'commit_error Domain_settlement.commit_error =
-  | Domain_commit_failed of 'commit_error
-  | Domain_settlement_in_progress
-  | Domain_settlement_conflict
+type 'rejection semantic_rejection_trace =
+  { first : 'rejection semantic_rejection_receipt
+  ; rest : 'rejection semantic_rejection_receipt list
+  }
+
+type ('accepted, 'rejection) validated_flow_success =
+  { accepted : 'accepted
+  ; transport_success : flow_success
+  ; prior_rejections : 'rejection semantic_rejection_receipt list
+  }
 
 type flow_candidate_failure =
   | Flow_candidate_rejected of candidate_rejection_receipt
@@ -280,7 +259,6 @@ type generation_dispatch_fact =
 
 type 'callback_error flow_execution_error =
   | Flow_attempt_already_started of flow_evidence
-  | Flow_success_ordinal_exhausted of flow_evidence
   | Flow_attempt_start_failed of
       { candidate : flow_candidate_visit
       ; cause : start_attempt_error
@@ -322,6 +300,16 @@ type 'callback_error flow_execution_error =
       ; evidence : flow_evidence
       }
 
+type ('callback_error, 'rejection) validated_flow_error =
+  | Flow_execution_terminal of
+      { cause : 'callback_error flow_execution_error
+      ; prior_rejections : 'rejection semantic_rejection_receipt list
+      }
+  | Flow_semantic_candidates_exhausted of
+      { rejections : 'rejection semantic_rejection_trace
+      ; evidence : flow_evidence
+      }
+
 type 'callback_error flow_step_failure =
   | Flow_step_candidate_rejected of candidate_rejection_receipt
   | Flow_step_attempt_start_failed of flow_candidate_visit * start_attempt_error
@@ -356,7 +344,7 @@ let make_flow_candidate ~id ~admitted_target =
 
 let flow_candidate_identity (candidate : flow_candidate) = candidate.identity
 
-let snapshot_flow ~preferences ~scope ~first ~rest ~messages requirement =
+let snapshot_flow ~first ~rest ~messages requirement =
   let candidates = first :: rest in
   match
     Flow_state.duplicate_key
@@ -367,30 +355,7 @@ let snapshot_flow ~preferences ~scope ~first ~rest ~messages requirement =
   | Some (candidate_id, first_position, duplicate_position) ->
     Error
       (Duplicate_flow_candidate_id { candidate_id; first_position; duplicate_position })
-  | None ->
-    let declared_candidate_snapshot = List.map flow_candidate_identity candidates in
-    (match
-       Flow_contract.prefer_last_good
-         preferences
-         scope
-         ~candidate_identity:flow_candidate_identity
-         candidates
-     with
-     | Error (Preference_capacity_exhausted { capacity }) ->
-       Error (Flow_preference_capacity_exhausted { capacity })
-     | Error Preference_reservation_space_exhausted ->
-       Error Flow_preference_reservation_exhausted
-     | Ok (candidates, preference_observation, preference_reservation) ->
-       Ok
-         { preferences
-         ; scope
-         ; preference_reservation
-         ; declared_candidate_snapshot
-         ; preference_observation
-         ; candidates
-         ; messages
-         ; requirement
-         })
+  | None -> Ok { candidates; messages; requirement }
 ;;
 
 let start_attempt (ready : ready_plan) =
@@ -429,12 +394,7 @@ let start_flow (ready : flow_snapshot) =
     Ok
       { execution = Flow_state.create ()
       ; flow_id
-      ; preferences = ready.preferences
-      ; scope = ready.scope
-      ; preference_reservation = ready.preference_reservation
-      ; declared_candidate_snapshot = ready.declared_candidate_snapshot
-      ; candidate_snapshot = List.map flow_candidate_identity ready.candidates
-      ; preference_observation = ready.preference_observation
+      ; declared_candidate_snapshot = List.map flow_candidate_identity ready.candidates
       ; candidates
       ; messages = ready.messages
       ; requirement = ready.requirement
@@ -445,7 +405,6 @@ let start_flow (ready : flow_snapshot) =
 let flow_success_candidate success = success.candidate
 let flow_success_output success = success.success
 let flow_success_evidence success = success.evidence
-let flow_success_ordinal success = success.success_ordinal
 let call_id_to_string (Call_id id) = id
 let flow_attempt_id (flow : flow_attempt) = flow.flow_id
 let attempt_receipt (attempt : attempt) = attempt.receipt
@@ -453,15 +412,13 @@ let receipt_call_id = Generation_receipt.call_id
 
 let flow_measurement_receipt_snapshot (measurement : flow_measurement_receipt) =
   let snapshot = Flow_admission.receipt_snapshot measurement.receipt in
-  let candidate =
-    Flow_contract.flow_preference_identity_of_candidate measurement.visit.identity
-  in
   create_measurement_receipt_snapshot
     ~operation_id:(Flow_admission.operation_id_to_string snapshot.operation_id)
     ~flow_id:measurement.visit.flow_id
     ~visit_ordinal:measurement.visit.ordinal
-    ~candidate_id:candidate.candidate_id
-    ~candidate_binding_sha256:candidate.binding_sha256
+    ~candidate_id:measurement.visit.identity.candidate_id
+    ~candidate_binding_sha256:
+      (target_identity_fingerprint measurement.visit.identity.target_identity)
     ~catalog_generation_fingerprint:
       (catalog_generation_fingerprint measurement.visit.identity.catalog_generation)
     ~catalog_evidence_sha256:
@@ -489,10 +446,7 @@ let publish_attempt_snapshot (flow : flow_attempt) (live : flow_attempt_receipt)
   let publication : flow_attempt_publication =
     { call_id = receipt_call_id live.receipt
     ; snapshot =
-        { scope = live.scope
-        ; visit = live.visit
-        ; receipt = Generation_receipt.snapshot live.receipt
-        }
+        { visit = live.visit; receipt = Generation_receipt.snapshot live.receipt }
     }
   in
   Flow_state.publish_attempt flow.progress ~same:same_attempt publication
@@ -516,7 +470,6 @@ let flow_execution_error_generation_dispatch = function
   | Flow_before_dispatch_callback_failed _
   | Flow_before_advance_callback_failed _
   | Flow_candidates_exhausted _ -> No_generation_dispatch
-  | Flow_success_ordinal_exhausted _ -> Generation_dispatch_started
   | Flow_exact_execution_failed { cause; _ } ->
     generation_dispatch_fact_of_receipt cause.receipt
 ;;
@@ -565,29 +518,10 @@ let generation_receipt_snapshot_target_identity =
   Generation_receipt.snapshot_target_identity
 ;;
 
-let domain_settlement_intent_to_string = Domain_settlement.intent_to_string
-let domain_settlement_intent_of_string = Domain_settlement.intent_of_string
-let domain_settlement_intent_id = Domain_settlement.intent_id
-
-let commit_and_settle_flow_domain ~commit success disposition =
-  Domain_settlement.commit_and_settle
-    ~commit
-    ~domain_settlement:success.domain_settlement
-    ~preferences:success.preferences
-    ~scope:success.scope
-    ~reservation:success.preference_reservation
-    ~candidate:success.candidate.visit.identity
-    ~success_ordinal:success.success_ordinal
-    ~flow_id:(flow_id_to_string success.candidate.visit.flow_id)
-    ~execution:(generation_receipt_snapshot success.candidate.receipt)
-    disposition
-;;
-
 let candidate_rejection_identity (receipt : candidate_rejection_receipt) =
   receipt.visit.identity
 ;;
 
-let candidate_rejection_scope (receipt : candidate_rejection_receipt) = receipt.scope
 let candidate_rejection_visit (receipt : candidate_rejection_receipt) = receipt.visit
 
 let candidate_rejection_measurement_dispatch_fact (receipt : candidate_rejection_receipt) =
@@ -643,7 +577,6 @@ let wire_admission_error_disposition = function
 
 let admission_error_disposition = function
   | Provider_schema_unavailable
-  | Json_syntax_unavailable
   | Unsupported_schema_keyword _
   | Unsupported_schema_type _
   | Invalid_schema -> Output_requirement_rejected
@@ -659,10 +592,7 @@ let candidate_rejection_disposition (receipt : candidate_rejection_receipt) =
 let flow_attempt_evidence (flow : flow_attempt) =
   let progress = Flow_state.progress_snapshot flow.progress in
   { flow_id = flow.flow_id
-  ; scope = flow.scope
   ; declared_candidate_snapshot = flow.declared_candidate_snapshot
-  ; candidate_snapshot = flow.candidate_snapshot
-  ; preference_observation = flow.preference_observation
   ; candidate_visit_count = Candidate_visit_count progress.candidate_visit_count
   ; measurements = progress.measurements
   ; admissions = progress.admissions
@@ -769,13 +699,33 @@ let execute_once_with_publication ~publish ~net ?clock (attempt : attempt) =
            ; provenance = ready.provenance
            ; raw_response = raw_response evidence
            }
-       | Exec.Text_output _ ->
-         Error
-           { call_id = receipt_call_id receipt
-           ; receipt
-           ; cause = Internal_non_json_output
-           ; raw_response = Some (raw_response evidence)
-           }))
+       | Exec.Text_output text ->
+         (match ready.provenance.actual_assurance, Plan.response_format ready.plan with
+          | Json_syntax_only, Types.Off ->
+            (try
+               let value = Yojson.Safe.from_string text in
+               Ok
+                 { call_id = receipt_call_id receipt
+                 ; receipt
+                 ; output = value
+                 ; provenance = ready.provenance
+                 ; raw_response = raw_response evidence
+                 }
+             with
+             | Yojson.Json_error _ ->
+               Error
+                 { call_id = receipt_call_id receipt
+                 ; receipt
+                 ; cause = Invalid_json_output
+                 ; raw_response = Some (raw_response evidence)
+                 })
+          | (Json_syntax_only | Provider_schema_requested), _ ->
+            Error
+              { call_id = receipt_call_id receipt
+              ; receipt
+              ; cause = Internal_non_json_output
+              ; raw_response = Some (raw_response evidence)
+              })))
 ;;
 
 let execute_once ~net ?clock attempt =
@@ -790,8 +740,11 @@ let execution_failure_may_advance (error : execution_error) =
        generation. Keep the honest one-dispatch receipt, but allow the frozen
        lane to try its predetermined successor. *)
     receipt_dispatch_count error.receipt = 1
+  | Invalid_json_output, (Response_received | Terminal) ->
+    receipt_dispatch_count error.receipt = 1
   | Completion_failed, (Not_started | Dispatch_started | Response_received | Terminal)
   | Input_capacity_refused _, (Not_started | Before_dispatch | Dispatch_started | Terminal)
+  | Invalid_json_output, (Not_started | Before_dispatch | Dispatch_started)
   | ( ( Attempt_already_started
       | Clock_required_for_timeout
       | Frozen_request_mismatch
@@ -799,7 +752,6 @@ let execution_failure_may_advance (error : execution_error) =
       | Missing_output
       | Ambiguous_output _
       | Unexpected_output_content
-      | Invalid_json_output
       | Internal_non_json_output )
     , _ ) -> false
 ;;
@@ -814,7 +766,7 @@ let admitted_flow_candidate visit (plan : ready_plan) =
 ;;
 
 let record_candidate_rejection (flow : flow_attempt) visit cause measurement =
-  let rejection = { scope = flow.scope; visit; cause; measurement } in
+  let rejection = { visit; cause; measurement } in
   Flow_state.record_admission flow.progress (Candidate_rejected rejection);
   rejection
 ;;
@@ -839,17 +791,20 @@ let execute_flow_candidate
   match resolve_target candidate.admitted_target with
   | Error cause -> reject (Target_selection_rejected cause)
   | Ok target ->
+    let flow_measurement receipt : flow_measurement_receipt =
+      { visit = candidate.visit; receipt }
+    in
     (match
        admit_candidate_request
          ~net
          ?clock
          ~on_measurement_receipt:(fun receipt ->
-           let measurement = { visit = candidate.visit; receipt } in
+           let measurement = flow_measurement receipt in
            publish_measurement flow measurement)
          ~before_measurement_dispatch:(fun receipt ->
-           before_measurement_dispatch { visit = candidate.visit; receipt })
+           before_measurement_dispatch (flow_measurement receipt))
          ~on_measurement_terminal:(fun receipt ->
-           on_measurement_terminal { visit = candidate.visit; receipt })
+           on_measurement_terminal (flow_measurement receipt))
          ~target
          ~messages:flow.messages
          flow.requirement
@@ -867,11 +822,10 @@ let execute_flow_candidate
      | Error (Flow_request_before_measurement_dispatch_failed (receipt, cause)) ->
        Error
          (Flow_step_before_measurement_dispatch_callback_failed
-            ({ visit = candidate.visit; receipt }, cause))
+            (flow_measurement receipt, cause))
      | Error (Flow_request_measurement_terminal_callback_failed (receipt, cause)) ->
        Error
-         (Flow_step_measurement_terminal_callback_failed
-            ({ visit = candidate.visit; receipt }, cause))
+         (Flow_step_measurement_terminal_callback_failed (flow_measurement receipt, cause))
      | Ok plan ->
        let admitted = admitted_flow_candidate candidate.visit plan in
        Flow_state.record_admission flow.progress (Candidate_admitted admitted);
@@ -879,10 +833,7 @@ let execute_flow_candidate
         | Error cause -> Error (Flow_step_attempt_start_failed (candidate.visit, cause))
         | Ok attempt ->
           let candidate_receipt : flow_attempt_receipt =
-            { scope = flow.scope
-            ; visit = candidate.visit
-            ; receipt = attempt_receipt attempt
-            }
+            { visit = candidate.visit; receipt = attempt_receipt attempt }
           in
           publish_attempt_snapshot flow candidate_receipt;
           (match before_dispatch candidate_receipt with
@@ -920,13 +871,14 @@ let advanceable_flow_failure = function
   | Flow_step_before_dispatch_callback_failed _ -> None
 ;;
 
-let execute_flow_once
+let execute_flow_once_validated
       ~net
       ?clock
       ~before_measurement_dispatch
       ~on_measurement_terminal
       ~before_dispatch
       ~before_advance
+      ~validate
       flow
   =
   let outcome =
@@ -941,48 +893,80 @@ let execute_flow_once
            ~on_measurement_terminal
            ~before_dispatch
            flow)
+      ~validate:(fun _candidate (candidate, success) ->
+        let transport_success =
+          { candidate; success; evidence = flow_attempt_evidence flow }
+        in
+        match validate transport_success with
+        | Accept accepted -> Flow_state.Accept (accepted, transport_success)
+        | Reject_and_advance rejection ->
+          Flow_state.Reject_and_advance { transport_success; rejection })
       ~advanceable:advanceable_flow_failure
       ~before_advance:(fun ~failed:_ ~failure ~next ->
         before_advance ~failed:failure ~next:next.visit)
   in
   let evidence = flow_attempt_evidence flow in
+  let terminal prior_rejections cause =
+    Error (Flow_execution_terminal { cause; prior_rejections })
+  in
   match outcome with
-  | Flow_state.Succeeded { success = candidate, success; _ } ->
-    (match Flow_contract.allocate_flow_success_ordinal flow.preferences with
-     | Error Success_ordinal_space_exhausted ->
-       Error (Flow_success_ordinal_exhausted evidence)
-     | Ok success_ordinal ->
-       Ok
-         { candidate
-         ; success
-         ; success_ordinal
-         ; evidence
-         ; domain_settlement = Flow_state.create_domain_settlement ()
-         ; preferences = flow.preferences
-         ; scope = flow.scope
-         ; preference_reservation = flow.preference_reservation
-         })
-  | Flow_state.Attempt_already_started -> Error (Flow_attempt_already_started evidence)
-  | Flow_state.Before_advance_callback_failed { failure; next_candidate; cause; _ } ->
+  | Flow_state.Succeeded { accepted = accepted, transport_success; prior_rejections } ->
+    Ok { accepted; transport_success; prior_rejections }
+  | Flow_state.Semantic_candidates_exhausted { first_rejection; rest_rejections } ->
     Error
+      (Flow_semantic_candidates_exhausted
+         { rejections = { first = first_rejection; rest = rest_rejections }; evidence })
+  | Flow_state.Attempt_already_started ->
+    terminal [] (Flow_attempt_already_started evidence)
+  | Flow_state.Before_advance_callback_failed
+      { failure; next_candidate; cause; prior_rejections; _ } ->
+    terminal
+      prior_rejections
       (Flow_before_advance_callback_failed
          { failed = failure; next = next_candidate.visit; cause; evidence })
-  | Flow_state.Execution_failed { cause; _ } ->
-    (match cause with
-     | Flow_step_candidate_rejected rejection ->
-       Error (Flow_candidates_exhausted { rejection; evidence })
-     | Flow_step_attempt_start_failed (candidate, cause) ->
-       Error (Flow_attempt_start_failed { candidate; cause; evidence })
-     | Flow_step_measurement_start_failed (candidate, cause) ->
-       Error (Flow_measurement_start_failed { candidate; cause; evidence })
-     | Flow_step_before_measurement_dispatch_callback_failed (measurement, cause) ->
-       Error
-         (Flow_before_measurement_dispatch_callback_failed
-            { measurement; cause; evidence })
-     | Flow_step_measurement_terminal_callback_failed (measurement, cause) ->
-       Error (Flow_measurement_terminal_callback_failed { measurement; cause; evidence })
-     | Flow_step_before_dispatch_callback_failed (candidate, cause) ->
-       Error (Flow_before_dispatch_callback_failed { candidate; cause; evidence })
-     | Flow_step_execution_failed { candidate; cause; _ } ->
-       Error (Flow_exact_execution_failed { candidate; cause; evidence }))
+  | Flow_state.Execution_failed { cause; prior_rejections; _ } ->
+    let cause =
+      match cause with
+      | Flow_step_candidate_rejected rejection ->
+        Flow_candidates_exhausted { rejection; evidence }
+      | Flow_step_attempt_start_failed (candidate, cause) ->
+        Flow_attempt_start_failed { candidate; cause; evidence }
+      | Flow_step_measurement_start_failed (candidate, cause) ->
+        Flow_measurement_start_failed { candidate; cause; evidence }
+      | Flow_step_before_measurement_dispatch_callback_failed (measurement, cause) ->
+        Flow_before_measurement_dispatch_callback_failed { measurement; cause; evidence }
+      | Flow_step_measurement_terminal_callback_failed (measurement, cause) ->
+        Flow_measurement_terminal_callback_failed { measurement; cause; evidence }
+      | Flow_step_before_dispatch_callback_failed (candidate, cause) ->
+        Flow_before_dispatch_callback_failed { candidate; cause; evidence }
+      | Flow_step_execution_failed { candidate; cause; _ } ->
+        Flow_exact_execution_failed { candidate; cause; evidence }
+    in
+    terminal prior_rejections cause
+;;
+
+let execute_flow_once
+      ~net
+      ?clock
+      ~before_measurement_dispatch
+      ~on_measurement_terminal
+      ~before_dispatch
+      ~before_advance
+      flow
+  =
+  match
+    execute_flow_once_validated
+      ~net
+      ?clock
+      ~before_measurement_dispatch
+      ~on_measurement_terminal
+      ~before_dispatch
+      ~before_advance
+      ~validate:(fun success -> Accept success)
+      flow
+  with
+  | Ok success -> Ok success.accepted
+  | Error (Flow_execution_terminal { cause; _ }) -> Error cause
+  | Error (Flow_semantic_candidates_exhausted _) ->
+    invalid_arg "Exact_output: accepting validator rejected a flow success"
 ;;

--- a/lib/llm_provider/exact_output.ml
+++ b/lib/llm_provider/exact_output.ml
@@ -871,7 +871,7 @@ let advanceable_flow_failure = function
   | Flow_step_before_dispatch_callback_failed _ -> None
 ;;
 
-let execute_flow_once_validated
+let execute_flow_once
       ~net
       ?clock
       ~before_measurement_dispatch
@@ -943,30 +943,4 @@ let execute_flow_once_validated
         Flow_exact_execution_failed { candidate; cause; evidence }
     in
     terminal prior_rejections cause
-;;
-
-let execute_flow_once
-      ~net
-      ?clock
-      ~before_measurement_dispatch
-      ~on_measurement_terminal
-      ~before_dispatch
-      ~before_advance
-      flow
-  =
-  match
-    execute_flow_once_validated
-      ~net
-      ?clock
-      ~before_measurement_dispatch
-      ~on_measurement_terminal
-      ~before_dispatch
-      ~before_advance
-      ~validate:(fun success -> Accept success)
-      flow
-  with
-  | Ok success -> Ok success.accepted
-  | Error (Flow_execution_terminal { cause; _ }) -> Error cause
-  | Error (Flow_semantic_candidates_exhausted _) ->
-    invalid_arg "Exact_output: accepting validator rejected a flow success"
 ;;

--- a/lib/llm_provider/exact_output.mli
+++ b/lib/llm_provider/exact_output.mli
@@ -482,9 +482,9 @@ val generation_receipt_snapshot_target_identity
   :  generation_receipt_snapshot
   -> target_identity
 
-(** One immutable outer-flow binding. [scope], opaque candidate identity, and
-    the one-shot execution receipt travel together; consumers do not rebuild
-    that join from coordinator or target strings. *)
+(** One immutable outer-flow binding. The opaque candidate identity and one-shot
+    execution receipt travel together; consumers do not rebuild that join from
+    coordinator or target strings. *)
 type flow_attempt_receipt = private
   { visit : flow_candidate_visit
   ; receipt : receipt
@@ -688,7 +688,7 @@ val flow_attempt_evidence : flow_attempt -> flow_evidence
     Every candidate performs at most one generation POST. A final semantic
     rejection returns a typed nonempty exhaustion trace. OAS performs no domain
     commit, settlement, retirement, recovery, or preference update. *)
-val execute_flow_once_validated
+val execute_flow_once
   :  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> ?clock:_ Eio.Time.clock
   -> before_measurement_dispatch:
@@ -704,19 +704,3 @@ val execute_flow_once_validated
   -> ( ('accepted, 'rejection) validated_flow_success
        , ('callback_error, 'rejection) validated_flow_error )
        result
-
-(** Compatibility entrypoint with no preference or settlement semantics. It is
-    exactly [execute_flow_once_validated] with an always-[Accept] validator. *)
-val execute_flow_once
-  :  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
-  -> ?clock:_ Eio.Time.clock
-  -> before_measurement_dispatch:
-       (flow_measurement_receipt -> (unit, 'callback_error) result)
-  -> on_measurement_terminal:(flow_measurement_receipt -> (unit, 'callback_error) result)
-  -> before_dispatch:(flow_attempt_receipt -> (unit, 'callback_error) result)
-  -> before_advance:
-       (failed:flow_candidate_failure
-        -> next:flow_candidate_visit
-        -> (unit, 'callback_error) result)
-  -> flow_attempt
-  -> (flow_success, 'callback_error flow_execution_error) result

--- a/lib/llm_provider/exact_output.mli
+++ b/lib/llm_provider/exact_output.mli
@@ -50,9 +50,6 @@ type receipt
 type call_id
 type schema_fingerprint
 type flow_candidate
-type flow_preference_store
-type flow_scope
-type flow_success_ordinal
 type flow_snapshot
 type flow_attempt
 type flow_success
@@ -244,30 +241,9 @@ type flow_candidate_identity =
   ; target_identity : target_identity
   }
 
-type flow_preference_identity = private
-  { candidate_id : string
-  ; binding_sha256 : string
-  }
-
 type flow_id
 type flow_visit_ordinal
 type candidate_visit_count
-
-type flow_preference_not_applied_reason =
-  | Preference_candidate_absent
-  | Preference_candidate_binding_changed
-
-type flow_preference_observation =
-  | No_preference_recorded
-  | Preference_applied of
-      { candidate : flow_preference_identity
-      ; success_ordinal : flow_success_ordinal
-      }
-  | Preference_not_applied of
-      { candidate : flow_preference_identity
-      ; success_ordinal : flow_success_ordinal
-      ; reason : flow_preference_not_applied_reason
-      }
 
 type flow_candidate_visit = private
   { flow_id : flow_id
@@ -335,7 +311,6 @@ type candidate_admission =
   | Candidate_rejected of candidate_rejection_receipt
 
 type flow_candidate_error = Blank_flow_candidate_id
-type flow_scope_error = Blank_flow_scope_id
 
 type flow_snapshot_error =
   | Duplicate_flow_candidate_id of
@@ -343,16 +318,11 @@ type flow_snapshot_error =
       ; first_position : int
       ; duplicate_position : int
       }
-  | Flow_preference_capacity_exhausted of { capacity : int }
-  | Flow_preference_reservation_exhausted
 
 (** Construct one provider-neutral candidate from a catalog-admitted target.
     Credential selection remains frozen but unresolved until this candidate is
-    reached by {!execute_flow_once}. The trimmed caller identity must be
-    nonempty. It is an opaque caller slot identity: a domain-valid preference
-    may reorder a future snapshot only when both this exact slot identity and
-    the opaque target-identity fingerprint remain unchanged. OAS does not parse
-    provider, model, tier, or coordinator meaning from it. *)
+    reached by the declared-order flow. The trimmed caller identity must be
+    nonempty and is otherwise opaque to OAS. *)
 val make_flow_candidate
   :  id:string
   -> admitted_target:admitted_target
@@ -360,31 +330,13 @@ val make_flow_candidate
 
 val flow_candidate_identity : flow_candidate -> flow_candidate_identity
 
-(** Brand one opaque caller scope. OAS compares the trimmed nonempty identity
-    exactly; it does not parse coordinator, tenant, provider, or model fields. *)
-val make_flow_scope : id:string -> (flow_scope, flow_scope_error) result
-
-val flow_scope_equal : flow_scope -> flow_scope -> bool
-val flow_success_ordinal_to_int64 : flow_success_ordinal -> int64
-
-(** Freeze one nonempty ordered candidate snapshot and its immutable domain
-    input. This validates only flow topology. Credential selection and exact
-    request admission are deferred to the current candidate during
-    {!execute_flow_once}; later candidates are neither selected, prepared, nor
-    assigned attempts speculatively.
-
-    The snapshot atomically reserves [scope] in [preferences]. A new scope fails
-    with [Flow_preference_capacity_exhausted] when the store is full. A
-    domain-valid last-good candidate recorded for the scope is moved to the
-    front only when the same caller slot and opaque target binding are both
-    present. An absent slot or changed target binding is retained as a typed
-    non-applied observation. The remaining candidates retain their declared
-    relative order. This lookup happens exactly once: existing snapshots never
-    change, and preferences from another scope cannot affect this snapshot. *)
+(** Freeze one nonempty caller-declared candidate order and its immutable
+    domain input. This validates only flow topology. Credential selection and
+    exact request admission are deferred until each candidate is reached.
+    No preference store, provider ranking, or future observation may reorder the
+    snapshot. *)
 val snapshot_flow
-  :  preferences:flow_preference_store
-  -> scope:flow_scope
-  -> first:flow_candidate
+  :  first:flow_candidate
   -> rest:flow_candidate list
   -> messages:Types.message list
   -> output_requirement
@@ -534,15 +486,13 @@ val generation_receipt_snapshot_target_identity
     the one-shot execution receipt travel together; consumers do not rebuild
     that join from coordinator or target strings. *)
 type flow_attempt_receipt = private
-  { scope : flow_scope
-  ; visit : flow_candidate_visit
+  { visit : flow_candidate_visit
   ; receipt : receipt
   }
 
 (** Immutable evidence copy of one generation attempt. *)
 type flow_attempt_snapshot = private
-  { scope : flow_scope
-  ; visit : flow_candidate_visit
+  { visit : flow_candidate_visit
   ; receipt : generation_receipt_snapshot
   }
 
@@ -607,7 +557,6 @@ val target_selection_error_disposition
 
 val admission_error_disposition : admission_error -> candidate_rejection_disposition
 val candidate_rejection_identity : candidate_rejection_receipt -> flow_candidate_identity
-val candidate_rejection_scope : candidate_rejection_receipt -> flow_scope
 val candidate_rejection_visit : candidate_rejection_receipt -> flow_candidate_visit
 
 val candidate_rejection_measurement_dispatch_fact
@@ -624,10 +573,7 @@ val candidate_rejection_disposition
 
 type flow_evidence = private
   { flow_id : flow_id
-  ; scope : flow_scope
   ; declared_candidate_snapshot : flow_candidate_identity list
-  ; candidate_snapshot : flow_candidate_identity list
-  ; preference_observation : flow_preference_observation
   ; candidate_visit_count : candidate_visit_count
   ; measurements : measurement_receipt_snapshot list
   ; admissions : candidate_admission list
@@ -637,131 +583,26 @@ type flow_evidence = private
 val flow_success_candidate : flow_success -> flow_attempt_receipt
 val flow_success_output : flow_success -> success
 val flow_success_evidence : flow_success -> flow_evidence
-val flow_success_ordinal : flow_success -> flow_success_ordinal
 
-type domain_disposition =
-  | Domain_valid
-  | Domain_rejected
+type ('accepted, 'rejection) semantic_verdict =
+  | Accept of 'accepted
+  | Reject_and_advance of 'rejection
 
-type domain_settlement_id
-type domain_settlement_intent
-type flow_preference_retirement_id
-type flow_preference_retirement_intent
-
-type domain_settlement_receipt = private
-  { settlement_id : domain_settlement_id
-  ; disposition : domain_disposition
+type 'rejection semantic_rejection_receipt = private
+  { transport_success : flow_success
+  ; rejection : 'rejection
   }
 
-type domain_settlement_intent_decode_error =
-  | Domain_settlement_intent_malformed_json of string
-  | Domain_settlement_intent_invalid_fields
-  | Domain_settlement_intent_unknown_format of string
-  | Domain_settlement_intent_unsupported_version of int
-  | Domain_settlement_intent_invalid_field of string
-  | Domain_settlement_intent_integrity_mismatch
+type 'rejection semantic_rejection_trace = private
+  { first : 'rejection semantic_rejection_receipt
+  ; rest : 'rejection semantic_rejection_receipt list
+  }
 
-type 'commit_error domain_commit_error =
-  | Domain_commit_failed of 'commit_error
-  | Domain_settlement_in_progress
-  | Domain_settlement_conflict
-
-type flow_preference_retirement_receipt
-
-type flow_preference_retirement_intent_decode_error =
-  | Flow_preference_retirement_intent_malformed_json of string
-  | Flow_preference_retirement_intent_invalid_fields
-  | Flow_preference_retirement_intent_unknown_format of string
-  | Flow_preference_retirement_intent_unsupported_version of int
-  | Flow_preference_retirement_intent_invalid_field of string
-  | Flow_preference_retirement_intent_integrity_mismatch
-
-type 'commit_error flow_preference_retirement_commit_error =
-  | Flow_preference_retirement_commit_failed of 'commit_error
-  | Flow_preference_retirement_in_progress
-  | Flow_preference_retirement_conflict
-  | Flow_preference_scope_not_reserved
-
-type flow_preference_recovery_evidence =
-  | Domain_settlement_evidence of domain_settlement_intent
-  | Scope_retirement_evidence of flow_preference_retirement_intent
-
-type flow_preference_recovery_error =
-  | Invalid_concurrent_scope_budget of int
-  | Conflicting_domain_settlement_evidence of domain_settlement_id
-  | Conflicting_scope_retirement_evidence of flow_preference_retirement_id
-
-val domain_settlement_id_to_string : domain_settlement_id -> string
-val domain_settlement_intent_id : domain_settlement_intent -> domain_settlement_id
-val domain_settlement_intent_disposition : domain_settlement_intent -> domain_disposition
-val domain_settlement_intent_to_string : domain_settlement_intent -> string
-
-val domain_settlement_intent_of_string
-  :  string
-  -> (domain_settlement_intent, domain_settlement_intent_decode_error) result
-
-val domain_settlement_receipt_id : domain_settlement_receipt -> domain_settlement_id
-
-val domain_settlement_receipt_disposition
-  :  domain_settlement_receipt
-  -> domain_disposition
-
-(** Fence caller-owned domain validation behind a durable content commit.
-    [commit] receives the only current-schema, provider-neutral replay intent
-    and must store it in authenticated durable state before returning [Ok].
-    No callback runs while the preference mutex is held. A concurrent same-ID,
-    same-disposition publisher receives [Domain_settlement_in_progress] without
-    blocking; a later replay returns the same deterministic receipt. A
-    different disposition is a typed conflict.
-
-    This is logical idempotent replay, not a claim that arbitrary external
-    storage performs a physical effect exactly once. If [commit] raises after
-    its durable effect, restart must decode and resume that committed intent. *)
-val commit_and_settle_flow_domain
-  :  commit:(domain_settlement_intent -> (unit, 'commit_error) result)
-  -> flow_success
-  -> domain_disposition
-  -> (domain_settlement_receipt, 'commit_error domain_commit_error) result
-
-(** Return the stable digest identity of one current-schema retirement. *)
-val flow_preference_retirement_id_to_string : flow_preference_retirement_id -> string
-
-val flow_preference_retirement_intent_id
-  :  flow_preference_retirement_intent
-  -> flow_preference_retirement_id
-
-val flow_preference_retirement_intent_to_string
-  :  flow_preference_retirement_intent
-  -> string
-
-val flow_preference_retirement_intent_of_string
-  :  string
-  -> ( flow_preference_retirement_intent
-       , flow_preference_retirement_intent_decode_error )
-       result
-
-val flow_preference_retirement_receipt_id
-  :  flow_preference_retirement_receipt
-  -> flow_preference_retirement_id
-
-(** Commit the current-schema retirement intent before freeing one reserved
-    opaque scope. Commit failure or cancellation leaves the active store
-    unchanged; same-intent replay is idempotent. *)
-val commit_and_retire_flow_preference_scope
-  :  commit:(flow_preference_retirement_intent -> (unit, 'commit_error) result)
-  -> flow_preference_store
-  -> flow_scope
-  -> ( flow_preference_retirement_receipt
-       , 'commit_error flow_preference_retirement_commit_error )
-       result
-
-(** Validate the complete caller-authenticated evidence set before constructing
-    an active store. Capacity is the larger of [concurrent_scope_budget] and
-    the distinct active valid scopes. No partial store escapes on error. *)
-val recover_flow_preferences
-  :  concurrent_scope_budget:int
-  -> evidence:flow_preference_recovery_evidence list
-  -> (flow_preference_store, flow_preference_recovery_error) result
+type ('accepted, 'rejection) validated_flow_success = private
+  { accepted : 'accepted
+  ; transport_success : flow_success
+  ; prior_rejections : 'rejection semantic_rejection_receipt list
+  }
 
 type flow_candidate_failure =
   | Flow_candidate_rejected of candidate_rejection_receipt
@@ -776,7 +617,6 @@ type generation_dispatch_fact =
 
 type 'callback_error flow_execution_error =
   | Flow_attempt_already_started of flow_evidence
-  | Flow_success_ordinal_exhausted of flow_evidence
   | Flow_attempt_start_failed of
       { candidate : flow_candidate_visit
       ; cause : start_attempt_error
@@ -818,6 +658,16 @@ type 'callback_error flow_execution_error =
       ; evidence : flow_evidence
       }
 
+type ('callback_error, 'rejection) validated_flow_error =
+  | Flow_execution_terminal of
+      { cause : 'callback_error flow_execution_error
+      ; prior_rejections : 'rejection semantic_rejection_receipt list
+      }
+  | Flow_semantic_candidates_exhausted of
+      { rejections : 'rejection semantic_rejection_trace
+      ; evidence : flow_evidence
+      }
+
 (** Closed fact for the invocation returning the error: whether its one outward
     completion dispatch began. This does not claim provider acceptance, response
     receipt, billing, retryability, failover eligibility, or any Pricing
@@ -826,84 +676,37 @@ val flow_execution_error_generation_dispatch
   :  'callback_error flow_execution_error
   -> generation_dispatch_fact
 
-(** Point-in-time aggregate evidence. [scope] is the exact opaque flow scope,
-    [declared_candidate_snapshot] is the caller-declared order, and
-    [candidate_snapshot] is the frozen effective order.
-    [preference_observation] is the single scope lookup frozen when the snapshot
-    was created; it distinguishes no record, an applied binding, an absent
-    recorded slot, and a changed target binding.
-    [candidate_visit_count], [measurements], [admissions], and [attempts]
-    contain only
-    candidates reached so far. Attempts are allocated only after
-    current-candidate target selection and request admission succeed. This
-    remains queryable after cancellation escapes. The affine executor is the
-    sole writer, and every call reads one Atomic immutable progress publication,
-    so measurement receipt snapshots, admissions, and attempt receipt snapshots
-    always describe the same publication epoch. *)
+(** Point-in-time evidence for one affine declared-order flow. The candidate
+    snapshot is frozen exactly as supplied by the caller. Progress contains only
+    candidates reached so far and remains queryable after cancellation. *)
 val flow_attempt_evidence : flow_attempt -> flow_evidence
 
-(** Execute the frozen request once. The attempt is single-use: duplicate or
-    concurrent invocation of the same attempt is rejected before a second dispatch.
-    Obtain {!attempt_receipt} before entering a cancellation scope; its phase is
-    monotonic and remains queryable if cancellation escapes this function. The
-    sole invocation performs at most one outward completion HTTP POST. It calls
-    the direct one-dispatch transport rather than a provider SDK or the generic
-    retry layer; internal model rotation and requested server-side fallback are
-    disabled. This is a generation-dispatch guarantee, not a claim about opaque
-    physical execution inside a provider service. *)
-val execute_once
+(** Execute one affine declared-order flow with caller-owned pure semantic
+    validation. OAS invokes [validate] exactly once after each successful
+    candidate transport. [Reject_and_advance] preserves the opaque evidence and
+    moves directly to the predetermined successor without using [before_advance].
+    Every candidate performs at most one generation POST. A final semantic
+    rejection returns a typed nonempty exhaustion trace. OAS performs no domain
+    commit, settlement, retirement, recovery, or preference update. *)
+val execute_flow_once_validated
   :  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> ?clock:_ Eio.Time.clock
-  -> attempt
-  -> (success, execution_error) result
+  -> before_measurement_dispatch:
+       (flow_measurement_receipt -> (unit, 'callback_error) result)
+  -> on_measurement_terminal:(flow_measurement_receipt -> (unit, 'callback_error) result)
+  -> before_dispatch:(flow_attempt_receipt -> (unit, 'callback_error) result)
+  -> before_advance:
+       (failed:flow_candidate_failure
+        -> next:flow_candidate_visit
+        -> (unit, 'callback_error) result)
+  -> validate:(flow_success -> ('accepted, 'rejection) semantic_verdict)
+  -> flow_attempt
+  -> ( ('accepted, 'rejection) validated_flow_success
+       , ('callback_error, 'rejection) validated_flow_error )
+       result
 
-(** Execute one affine outer flow.
-
-    OAS resolves credentials and prepares the request only for the current
-    frozen candidate. A successful preparation receives one fresh attempt
-    identity, then [before_dispatch] must durably bind that attempt before its
-    sole {!execute_once} call. When provider-native measurement is required,
-    [before_measurement_dispatch] first receives an opaque operation receipt
-    and must durably journal it as a may-dispatch intent. Only after the callback
-    returns [Ok] can the count-token POST start. The receipt is already visible
-    in [flow_attempt_evidence.measurements] while the callback runs.
-
-    The callback receives a committed receipt whose dispatch fact is already
-    [Measurement_dispatch_unknown], never [No_measurement_dispatch]. A committed
-    receipt without a terminal outcome is dispatch-ambiguous and reports
-    [Measurement_dispatch_unknown]. OAS then establishes the connection and a
-    private one-shot capability atomically advances the receipt to
-    [Measurement_dispatch_started] immediately before the sole count-token POST;
-    no user callback runs between that transition and submission. Token
-    measurement is a read-only operation and may be replayed only after the
-    caller reconciles and records the prior unclosed intent. OAS neither retries
-    it automatically nor claims that an unclosed committed receipt did not
-    dispatch.
-
-    [on_measurement_terminal] receives the same opaque receipt after its terminal
-    measurement outcome is installed. OAS allocates no generation attempt,
-    dispatches no generation request, and advances to no successor until this
-    terminal record is durably accepted. Callback rejection returns a typed
-    terminal flow error.
-
-    A typed target-selection or request-admission rejection receives a real
-    [candidate_rejection_receipt] with explicit measurement evidence, but no
-    generation plan, generation call ID, or generation execution receipt.
-
-    [before_advance] receives the settled typed failure and the predetermined
-    next candidate visit. OAS may call it only for a candidate rejection or an
-    execution receipt that is exactly [Before_dispatch] with zero dispatch. The
-    callback can stop but cannot select, replace, skip, or reorder the successor.
-
-    A final candidate rejection returns [Flow_candidates_exhausted]. Callback
-    errors, replay, identity-allocation failure, missing execution prerequisites,
-    frozen-request corruption, cancellation, every post-dispatch outcome, and
-    success are terminal. Cancellation is re-raised after the flow is
-    terminalized; inspect {!flow_attempt_evidence} for monotonic progress.
-    Domain validation occurs after an OAS success through
-    {!commit_and_settle_flow_domain}; either disposition remains terminal and is never
-    failover eligible. Only a domain-valid settlement can affect a future
-    snapshot in the same explicit scope. *)
+(** Compatibility entrypoint with no preference or settlement semantics. It is
+    exactly [execute_flow_once_validated] with an always-[Accept] validator. *)
 val execute_flow_once
   :  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> ?clock:_ Eio.Time.clock

--- a/lib/llm_provider/exact_output_flow.ml
+++ b/lib/llm_provider/exact_output_flow.ml
@@ -112,10 +112,24 @@ type recovery_retirement_error =
   | Preference_retirement_recovery_finished
   | Recovered_retirement_conflict
 
-type ('candidate, 'success, 'execution_error, 'advanceable_error, 'callback_error) outcome =
+type ('accepted, 'rejection) semantic_verdict =
+  | Accept of 'accepted
+  | Reject_and_advance of 'rejection
+
+type ('candidate
+     , 'accepted
+     , 'execution_error
+     , 'advanceable_error
+     , 'semantic_rejection
+     , 'callback_error)
+     outcome =
   | Succeeded of
-      { candidate : 'candidate
-      ; success : 'success
+      { accepted : 'accepted
+      ; prior_rejections : 'semantic_rejection list
+      }
+  | Semantic_candidates_exhausted of
+      { first_rejection : 'semantic_rejection
+      ; rest_rejections : 'semantic_rejection list
       }
   | Attempt_already_started
   | Before_advance_callback_failed of
@@ -123,10 +137,12 @@ type ('candidate, 'success, 'execution_error, 'advanceable_error, 'callback_erro
       ; failure : 'advanceable_error
       ; next_candidate : 'candidate
       ; cause : 'callback_error
+      ; prior_rejections : 'semantic_rejection list
       }
   | Execution_failed of
       { candidate : 'candidate
       ; cause : 'execution_error
+      ; prior_rejections : 'semantic_rejection list
       }
 
 let create () = Atomic.make Not_started
@@ -558,33 +574,53 @@ let promote_candidate ~equal ~key ~preferred candidates =
     selected @ remaining
 ;;
 
-let execute_once state ~candidates ~execute ~advanceable ~before_advance =
+let execute_once state ~candidates ~execute ~validate ~advanceable ~before_advance =
   if not (Atomic.compare_and_set state Not_started Running)
   then Attempt_already_started
   else
     Fun.protect
       ~finally:(fun () -> Atomic.set state Terminal)
       (fun () ->
-         let rec execute_candidates = function
+         let rec execute_candidates prior_rejections_rev = function
            | [] -> invalid_arg "Exact_output_flow: empty candidate snapshot"
            | candidate :: rest ->
              (match execute candidate with
-              | Ok success -> Succeeded { candidate; success }
+              | Ok success ->
+                (match validate candidate success with
+                 | Accept accepted ->
+                   Succeeded
+                     { accepted; prior_rejections = List.rev prior_rejections_rev }
+                 | Reject_and_advance rejection ->
+                   let prior_rejections_rev = rejection :: prior_rejections_rev in
+                   (match rest with
+                    | _ :: _ -> execute_candidates prior_rejections_rev rest
+                    | [] ->
+                      (match List.rev prior_rejections_rev with
+                       | first_rejection :: rest_rejections ->
+                         Semantic_candidates_exhausted
+                           { first_rejection; rest_rejections }
+                       | [] -> assert false)))
               | Error failure ->
                 (match rest, advanceable failure with
                  | next :: _, Some advanceable_failure ->
                    (match
                       before_advance ~failed:candidate ~failure:advanceable_failure ~next
                     with
-                    | Ok () -> execute_candidates rest
+                    | Ok () -> execute_candidates prior_rejections_rev rest
                     | Error cause ->
                       Before_advance_callback_failed
                         { failed_candidate = candidate
                         ; failure = advanceable_failure
                         ; next_candidate = next
                         ; cause
+                        ; prior_rejections = List.rev prior_rejections_rev
                         })
-                 | [], _ | _ :: _, None -> Execution_failed { candidate; cause = failure }))
+                 | [], _ | _ :: _, None ->
+                   Execution_failed
+                     { candidate
+                     ; cause = failure
+                     ; prior_rejections = List.rev prior_rejections_rev
+                     }))
          in
-         execute_candidates candidates)
+         execute_candidates [] candidates)
 ;;

--- a/lib/llm_provider/exact_output_flow.mli
+++ b/lib/llm_provider/exact_output_flow.mli
@@ -66,10 +66,24 @@ type ('admission, 'attempt, 'measurement) progress_snapshot =
   ; measurements : 'measurement list
   }
 
-type ('candidate, 'success, 'execution_error, 'advanceable_error, 'callback_error) outcome =
+type ('accepted, 'rejection) semantic_verdict =
+  | Accept of 'accepted
+  | Reject_and_advance of 'rejection
+
+type ('candidate
+     , 'accepted
+     , 'execution_error
+     , 'advanceable_error
+     , 'semantic_rejection
+     , 'callback_error)
+     outcome =
   | Succeeded of
-      { candidate : 'candidate
-      ; success : 'success
+      { accepted : 'accepted
+      ; prior_rejections : 'semantic_rejection list
+      }
+  | Semantic_candidates_exhausted of
+      { first_rejection : 'semantic_rejection
+      ; rest_rejections : 'semantic_rejection list
       }
   | Attempt_already_started
   | Before_advance_callback_failed of
@@ -77,10 +91,12 @@ type ('candidate, 'success, 'execution_error, 'advanceable_error, 'callback_erro
       ; failure : 'advanceable_error
       ; next_candidate : 'candidate
       ; cause : 'callback_error
+      ; prior_rejections : 'semantic_rejection list
       }
   | Execution_failed of
       { candidate : 'candidate
       ; cause : 'execution_error
+      ; prior_rejections : 'semantic_rejection list
       }
 
 val create : unit -> t
@@ -226,14 +242,13 @@ val promote_candidate
   -> 'candidate list
   -> 'candidate list
 
-(** Execute an immutable, nonempty candidate snapshot once.
+(** Execute one immutable, nonempty candidate snapshot in its declared order.
 
-    [execute] owns preparation, durable pre-dispatch binding, and one-shot
-    execution for the current candidate. [before_advance] receives the
-    already-selected successor and can only confirm or reject its durable
-    transition; it cannot replace or reorder that successor. [advanceable]
-    refines an execution error into the only error type accepted by
-    [before_advance]; terminal errors cannot reach that callback.
+    Each candidate is passed to [execute] at most once. A successful transport
+    result is passed exactly once to the pure [validate] callback. [Accept]
+    terminates the flow; [Reject_and_advance] records opaque evidence and moves
+    directly to the predetermined successor without invoking [before_advance].
+    [before_advance] remains reserved for OAS-classified execution failures.
 
     The outer attempt is affine. A duplicate or concurrent invocation returns
     [Attempt_already_started]. Any exception, including Eio cancellation,
@@ -242,10 +257,18 @@ val execute_once
   :  t
   -> candidates:'candidate list
   -> execute:('candidate -> ('success, 'execution_error) result)
+  -> validate:
+       ('candidate -> 'success -> ('accepted, 'semantic_rejection) semantic_verdict)
   -> advanceable:('execution_error -> 'advanceable_error option)
   -> before_advance:
        (failed:'candidate
         -> failure:'advanceable_error
         -> next:'candidate
         -> (unit, 'callback_error) result)
-  -> ('candidate, 'success, 'execution_error, 'advanceable_error, 'callback_error) outcome
+  -> ( 'candidate
+       , 'accepted
+       , 'execution_error
+       , 'advanceable_error
+       , 'semantic_rejection
+       , 'callback_error )
+       outcome

--- a/lib/llm_provider/exact_output_ready_admission.ml
+++ b/lib/llm_provider/exact_output_ready_admission.ml
@@ -99,7 +99,6 @@ type wire_admission_error =
 
 type admission_error =
   | Provider_schema_unavailable
-  | Json_syntax_unavailable
   | Unsupported_schema_keyword of string
   | Unsupported_schema_type of string
   | Invalid_schema
@@ -183,7 +182,29 @@ let response_format (target : Resolver.selected_target) requirement =
   | Caps.Json_object_only, Json_syntax -> Ok (Types.JsonMode, Json_syntax_only, None)
   | Caps.Json_object_only, Provider_schema -> Error Provider_schema_unavailable
   | Caps.No_structured_output, Provider_schema -> Error Provider_schema_unavailable
-  | Caps.No_structured_output, Json_syntax -> Error Json_syntax_unavailable
+  | Caps.No_structured_output, Json_syntax -> Ok (Types.Off, Json_syntax_only, None)
+;;
+
+let text_json_instruction (Domain_schema schema) : Types.message =
+  let schema = canonical_json schema |> Yojson.Safe.to_string in
+  { role = Types.User
+  ; content =
+      [ Types.Text
+          (Printf.sprintf
+             "Return exactly one JSON value matching this JSON Schema. Do not use \
+              Markdown code fences or include any explanation. JSON Schema: %s"
+             schema)
+      ]
+  ; name = None
+  ; tool_call_id = None
+  ; metadata = []
+  }
+;;
+
+let messages_for_response_format requirement response_format messages =
+  match response_format with
+  | Types.Off -> messages @ [ text_json_instruction requirement.schema ]
+  | Types.JsonMode | Types.JsonSchema _ -> messages
 ;;
 
 let exact_config (target : Resolver.selected_target) response_format =
@@ -315,6 +336,7 @@ let admit ~target ~messages requirement =
   let* response_format, actual_assurance, effective_schema_fingerprint =
     admission_contract ~target requirement
   in
+  let messages = messages_for_response_format requirement response_format messages in
   let* preflight =
     Plan.preflight
       ~config:(exact_config target response_format)
@@ -365,6 +387,7 @@ let admit_candidate_request
           ; outcome = Flow_admission.Measurement_local_invalid
           } ))
   in
+  let messages = messages_for_response_format requirement response_format messages in
   let* preflight =
     Plan.preflight
       ~config:(exact_config target response_format)

--- a/lib/llm_provider/exact_output_ready_admission.mli
+++ b/lib/llm_provider/exact_output_ready_admission.mli
@@ -98,7 +98,6 @@ type wire_admission_error =
 
 type admission_error =
   | Provider_schema_unavailable
-  | Json_syntax_unavailable
   | Unsupported_schema_keyword of string
   | Unsupported_schema_type of string
   | Invalid_schema

--- a/models.toml
+++ b/models.toml
@@ -608,6 +608,26 @@ modality_priority = "visual_first"
 supports_native_streaming = true
 
 [[models]]
+id_prefix = "gemma4:31b-cloud"
+provider_name = "ollama_cloud"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = false
+# Authenticated 2026-07-27 /api/show and /v1/chat/completions probes:
+# thinking is inherent on the OpenAI-compatible wire, not an /api/chat think toggle.
+thinking_control_format = "none"
+supports_response_format_json = true
+supports_structured_output = false
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
+supports_native_streaming = true
+
+[[models]]
 id_prefix = "gemma4:31b"
 provider_name = "ollama_cloud"
 base = "ollama_cloud"
@@ -997,6 +1017,26 @@ supports_reasoning_budget = false
 thinking_control_format = "none"
 supports_multimodal_inputs = false
 supports_image_input = false
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "qwen3.5:cloud"
+provider_name = "ollama_cloud"
+base = "ollama_cloud"
+max_context_tokens = 262144
+supports_tools = true
+supports_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = false
+# Authenticated 2026-07-27 /api/show and /v1/chat/completions probes:
+# json_object returned bare JSON; json_schema returned fenced, unconstrained JSON.
+thinking_control_format = "none"
+supports_response_format_json = true
+supports_structured_output = false
+supports_multimodal_inputs = true
+supports_image_input = true
+modality_priority = "visual_first"
 supports_native_streaming = true
 
 [[models]]

--- a/scripts/check-exact-output-resolver-boundary.sh
+++ b/scripts/check-exact-output-resolver-boundary.sh
@@ -1076,176 +1076,30 @@ require_opaque_type \
   "outer exact flow lost typed candidate-rejection receipts" \
   "$exact_output_interface" \
   candidate_rejection_receipt
-require_code_sequence \
-  "outer exact flow lost explicit scope-local preference ownership" \
-  'type[[:space:]]+flow_preference_store.*type[[:space:]]+flow_scope' \
+scan_code \
+  "retired exact-flow preference or domain lifecycle returned to the public surface" \
+  'flow_preference|flow_scope|flow_success_ordinal|preference_observation|domain_settlement|commit_and_settle|commit_and_retire|recover_flow_preferences' \
   "$exact_output_interface"
 require_code_sequence \
-  "outer exact-flow preference recovery lost evidence-owned admission" \
-  'val[[:space:]]+recover_flow_preferences[[:space:]]*:[[:space:]]*concurrent_scope_budget:int[[:space:]]*->[[:space:]]*evidence:flow_preference_recovery_evidence[[:space:]]+list[[:space:]]*->[[:space:]]*\(flow_preference_store,[[:space:]]*flow_preference_recovery_error\)[[:space:]]*result' \
+  "outer exact flow stopped freezing caller-declared order directly" \
+  'val[[:space:]]+snapshot_flow[[:space:]]*:[[:space:]]*first:flow_candidate[[:space:]]*->[[:space:]]*rest:flow_candidate[[:space:]]+list[[:space:]]*->[[:space:]]*messages:Types[.]message[[:space:]]+list' \
   "$exact_output_interface"
 require_code_sequence \
-  "outer exact-flow snapshot lost typed capacity exhaustion" \
-  'type[[:space:]]+flow_snapshot_error.*Flow_preference_capacity_exhausted[[:space:]]+of[[:space:]]*\{[[:space:]]*capacity[[:space:]]*:[[:space:]]*int' \
+  "outer exact-flow evidence lost its sole declared candidate snapshot" \
+  'type[[:space:]]+flow_evidence[[:space:]]*=[[:space:]]*private.*flow_id[[:space:]]*:.*declared_candidate_snapshot.*candidate_visit_count.*measurements.*admissions.*attempts' \
   "$exact_output_interface"
 require_code_sequence \
-  "outer exact-flow preference lost durable scope retirement" \
-  'type[[:space:]]+flow_preference_retirement_id.*type[[:space:]]+flow_preference_retirement_intent.*val[[:space:]]+commit_and_retire_flow_preference_scope' \
+  "validated exact flow lost its parametric semantic verdict or nonempty trace" \
+  'type[[:space:]]+([^[:space:]]+[[:space:]]*,[[:space:]]*[^[:space:]]+)[[:space:]]+semantic_verdict[[:space:]]*=.*Accept.*Reject_and_advance.*type[[:space:]]+[^[:space:]]+[[:space:]]+semantic_rejection_trace[[:space:]]*=[[:space:]]*private.*first.*rest' \
+  "$exact_output_interface"
+require_code_sequence \
+  "validated exact flow lost its single declared-flow entrypoint" \
+  'val[[:space:]]+execute_flow_once_validated.*validate:[[:space:]]*\(flow_success[[:space:]]*->[[:space:]]*([^[:space:]]+[[:space:]]*,[[:space:]]*[^[:space:]]+)[[:space:]]+semantic_verdict\)' \
   "$exact_output_interface"
 scan_code \
-  "legacy process-local preference recovery or removal returned" \
-  'val[[:space:]]+(begin_flow_preference_recovery|finish_flow_preference_recovery|resume_committed_flow_domain|remove_flow_preference_scope)' \
-  "$exact_output_interface"
-require_code_sequence \
-  "outer exact-flow attempt receipt lost its opaque scope binding" \
-  'type[[:space:]]+flow_attempt_receipt[[:space:]]*=[[:space:]]*private.*scope[[:space:]]*:.*flow_scope.*visit.*receipt' \
-  "$exact_output_interface"
-require_code_sequence \
-  "outer exact-flow evidence lost its opaque scope binding" \
-  'type[[:space:]]+flow_evidence[[:space:]]*=[[:space:]]*private.*flow_id[[:space:]]*:.*scope[[:space:]]*:.*flow_scope.*declared_candidate_snapshot.*candidate_snapshot.*preference_observation' \
-  "$exact_output_interface"
-require_code_sequence \
-  "outer exact flow lost its closed preference observation" \
-  'type[[:space:]]+flow_preference_observation.*No_preference_recorded.*Preference_applied.*Preference_not_applied' \
-  "$exact_output_interface"
-require_named_function_pattern \
-  "scope-local preference stopped requiring opaque target binding equality" \
-  'target_identity_fingerprint' \
-  "$exact_output_flow_contract_source" \
-  "target_binding_equal"
-require_code_sequence \
-  "candidate rejection lost its opaque scope projection" \
-  'val[[:space:]]+candidate_rejection_scope[[:space:]]*:' \
-  "$exact_output_interface"
-require_code_sequence \
-  "outer exact flow lost durable domain settlement" \
-  'type[[:space:]]+domain_disposition.*type[[:space:]]+domain_settlement_id.*type[[:space:]]+domain_settlement_intent.*type[[:space:]]+domain_settlement_receipt[[:space:]]*=[[:space:]]*private.*val[[:space:]]+commit_and_settle_flow_domain.*val[[:space:]]+recover_flow_preferences' \
-  "$exact_output_interface"
-require_code_sequence \
-  "private exact-flow contract exposed forgeable domain settlement receipts" \
-  'type[[:space:]]+domain_settlement_receipt[[:space:]]*=[[:space:]]*private' \
-  "$module_dir/exact_output_flow_contract.mli"
-scan_code \
-  "legacy in-memory domain settlement surface returned" \
-  'val[[:space:]]+settle_flow_domain|Domain_already_settled|Domain_valid_preference_installed|Domain_valid_preference_superseded' \
-  "$exact_output_interface" \
-  "$module_dir/exact_output_flow_contract.mli"
-scan_code \
-  "domain-valid settlement regained caller-forgeable freshness" \
-  'Domain_valid[[:space:]]+of|success_time_unix_s|current_success_time_unix_s' \
-  "$exact_output_source" \
-  "$exact_output_interface" \
-  "$exact_output_flow_source" \
-  "$module_dir/exact_output_flow.mli" \
-  "$exact_output_flow_contract_source" \
-  "$module_dir/exact_output_flow_contract.mli"
-require_code_sequence \
-  "outer exact-flow structural success lost its opaque OAS-owned ordinal" \
-  'type[[:space:]]+flow_success_ordinal.*val[[:space:]]+flow_success_ordinal[[:space:]]*:[[:space:]]*flow_success[[:space:]]*->[[:space:]]*flow_success_ordinal' \
-  "$exact_output_interface"
-require_named_function_pattern \
-  "outer exact-flow structural success stopped allocating its OAS-owned ordinal" \
-  'allocate_flow_success_ordinal[[:space:]]+flow[.]preferences' \
-  "$exact_output_source" \
-  "execute_flow_once"
-scan_code \
-  "outer exact flow exposed forgeable structural success settlement state" \
-  'type[[:space:]]+flow_success[[:space:]]*=' \
-  "$exact_output_interface"
-require_code_sequence \
-  "scope-local preference can be overwritten by an older success ordinal" \
-  'compare_success_ordinal[[:space:]]+ordinal[[:space:]]+current_ordinal[[:space:]]*<=[[:space:]]*0' \
-  "$exact_output_flow_source"
-require_named_function_pattern \
-  "scope-local preference lost snapshot reservation generation validation" \
-  'Hashtbl[.]find_opt[[:space:]]+store[.]entries[[:space:]]+scope.*Some[[:space:]]+entry[[:space:]]+when[[:space:]]+entry[.]reservation[[:space:]]*<>[[:space:]]*reservation[[:space:]]*->[[:space:]]*\(\)' \
-  "$exact_output_flow_source" \
-  "record_preference_locked"
-require_code_sequence \
-  "scope-local preference stopped failing closed on ordinal exhaustion" \
-  'let[[:space:]]+allocate_success_ordinal.*Int64[.]max_int.*Int64[.]succ' \
-  "$exact_output_flow_source"
-require_code_sequence \
-  "domain settlement lost its closed atomic publication states" \
-  'type[[:space:]]+settlement_state[[:space:]]*=[[:space:]]*.*Pending.*Publishing.*Settled.*type[[:space:]]+domain_settlement[[:space:]]*=[[:space:]]*settlement_state[[:space:]]+Atomic[.]t' \
-  "$exact_output_flow_source"
-scan_code_sequence \
-  "domain settlement regained a per-settlement mutex" \
-  'type[[:space:]]+domain_settlement[[:space:]]*=[[:space:]]*\{[^}]*Mutex[.]t' \
-  "$exact_output_flow_source"
-scan_named_functions \
-  "domain settlement acquired a second mutex, blocking wait, or busy wait" \
-  'Mutex[.](lock|unlock)|settlement[.][[:alnum:]_]*mutex|Condition[.]wait|Domain[.]cpu_relax' \
-  "$exact_output_flow_source" \
-  "begin_domain_settlement abort_domain_settlement finish_domain_settlement"
-require_named_function_pattern \
-  "domain settlement lost store-lock-first publishing claim" \
-  'with_preference_lock[[:space:]]+preferences.*Atomic[.]get[[:space:]]+settlement.*Pending[[:space:]]*->.*Atomic[.]set[[:space:]]+settlement[[:space:]]+\(Publishing[[:space:]]+requested\).*Domain_settlement_claimed' \
-  "$exact_output_flow_source" \
-  "begin_domain_settlement"
-require_named_function_pattern \
-  "domain settlement lost replay, nonblocking in-progress, or conflict convergence" \
-  'Settled[[:space:]]+receipt[[:space:]]*->.*same_receipt[[:space:]]+receipt[[:space:]]+requested.*Domain_settlement_replayed[[:space:]]+receipt.*Domain_settlement_conflict.*Publishing[[:space:]]+receipt[[:space:]]*->.*same_receipt[[:space:]]+receipt[[:space:]]+requested.*Domain_settlement_in_progress.*Domain_settlement_conflict' \
-  "$exact_output_flow_source" \
-  "begin_domain_settlement"
-require_named_function_pattern \
-  "aborted domain settlement stopped releasing its publishing claim" \
-  'with_preference_lock[[:space:]]+preferences.*Atomic[.]get[[:space:]]+settlement.*Publishing[[:space:]]+receipt[[:space:]]+when[[:space:]]+same_receipt[[:space:]]+receipt[[:space:]]+requested[[:space:]]*->.*Atomic[.]set[[:space:]]+settlement[[:space:]]+Pending' \
-  "$exact_output_flow_source" \
-  "abort_domain_settlement"
-require_named_function_pattern \
-  "domain settlement lost locked disposition publication" \
-  'with_preference_lock[[:space:]]+preferences.*Atomic[.]get[[:space:]]+settlement.*Publishing[[:space:]]+receipt[[:space:]]+when[[:space:]]+same_receipt[[:space:]]+receipt[[:space:]]+requested.*requested[.]disposition.*Rejected[[:space:]]*->[[:space:]]*\(\).*Valid[[:space:]]*->.*record_preference_locked[[:space:]]+preferences[[:space:]]+~scope[[:space:]]+~reservation[[:space:]]+~candidate[[:space:]]+~ordinal.*Atomic[.]set[[:space:]]+settlement[[:space:]]+\(Settled[[:space:]]+requested\).*Ok[[:space:]]+requested.*Settled[[:space:]]+receipt[[:space:]]+when[[:space:]]+same_receipt[[:space:]]+receipt[[:space:]]+requested[[:space:]]*->[[:space:]]+Ok[[:space:]]+receipt.*Domain_settlement_apply_conflict' \
-  "$exact_output_flow_source" \
-  "finish_domain_settlement"
-require_code_occurrence_count \
-  "locked preference recorder reference set changed" \
-  'record_preference_locked' \
-  2 \
-  "$exact_output_flow_source"
-scan_outside_named_functions \
-  "locked preference recorder escaped its definition or canonical publication path" \
-  'record_preference_locked' \
-  "$exact_output_flow_source" \
-  "record_preference_locked finish_domain_settlement"
-require_code_occurrence_count \
-  "recovered preference installer reference set changed" \
-  'install_recovered_preference_locked' \
-  2 \
-  "$exact_output_flow_source"
-scan_outside_named_functions \
-  "recovered preference installer escaped its definition or locked recovery path" \
-  'install_recovered_preference_locked' \
-  "$exact_output_flow_source" \
-  "install_recovered_preference_locked resume_committed_domain"
-require_named_function_pattern \
-  "recovered preference installation escaped the recovery lock" \
-  'with_preference_lock[[:space:]]+recovery.*install_recovered_preference_locked[[:space:]]+recovery' \
-  "$exact_output_flow_source" \
-  "resume_committed_domain"
-scan_code \
-  "locked preference recorder escaped through the private interface" \
-  'record_preference_locked' \
-  "$module_dir/exact_output_flow.mli"
-scan_named_functions \
-  "durable settlement orchestration acquired a store lock or raw atomic transition" \
-  'with_preference_lock|Mutex[.](lock|unlock)|Atomic[.](get|set|compare_and_set)' \
-  "$exact_output_domain_settlement_source" \
-  "commit_and_settle"
-require_named_function_pattern \
-  "durable settlement lost claim-commit-finish ordering or abort cleanup" \
-  'Flow_contract[.]begin_domain_settlement[[:space:]]+domain_settlement[[:space:]]+preferences[[:space:]]+receipt.*Domain_settlement_replayed.*Domain_settlement_in_progress.*Domain_settlement_conflict.*Domain_settlement_claimed.*Fun[.]protect.*Flow_contract[.]abort_domain_settlement[[:space:]]+domain_settlement[[:space:]]+preferences[[:space:]]+receipt.*match[[:space:]]+commit[[:space:]]+intent[[:space:]]+with.*Domain_commit_failed.*Flow_contract[.]finish_domain_settlement[[:space:]]+domain_settlement[[:space:]]+preferences.*finished[[:space:]]*:=[[:space:]]*true.*Ok[[:space:]]+receipt' \
-  "$exact_output_domain_settlement_source" \
-  "commit_and_settle"
-require_code_sequence \
-  "public durable settlement lost its typed nonblocking publication outcome" \
-  'type[[:space:]]+[^[:space:]]+[[:space:]]+domain_commit_error.*Domain_commit_failed.*Domain_settlement_in_progress.*Domain_settlement_conflict' \
-  "$exact_output_interface"
-require_named_function_pattern \
-  "preference capacity check and reservation add are no longer atomic" \
-  'with_preference_lock[[:space:]]+store.*Hashtbl[.]length[[:space:]]+store[.]entries.*Hashtbl[.]add[[:space:]]+store[.]entries' \
-  "$exact_output_flow_source" \
-  "reserve_preference_scope"
+  "declared exact flow regained preference ordering or domain settlement" \
+  'prefer_last_good|allocate_flow_success_ordinal|commit_and_settle_flow_domain|create_domain_settlement' \
+  "$exact_output_source"
 scan_code \
   "outer exact flow revived a legacy attempt or admission alias" \
   'candidate_attempt_count|admission_rejection|ready_flow|admit_flow' \

--- a/scripts/check-exact-output-resolver-boundary.sh
+++ b/scripts/check-exact-output-resolver-boundary.sh
@@ -824,8 +824,8 @@ require_code_pattern \
   "canonical facade no longer re-exports the private resolver" \
   'include[[:space:]]+Exact_output_resolver' \
   "$exact_output_source"
-require_code_pattern \
-  "canonical facade no longer re-exports the private preference lifecycle facade" \
+scan_code \
+  "canonical facade re-exported the retired preference lifecycle facade" \
   'include[[:space:]]+Preference_lifecycle_facade' \
   "$exact_output_source"
 scan_code \
@@ -1056,7 +1056,7 @@ require_code_sequence \
   "$exact_output_interface"
 require_code_sequence \
   "execution receipt no longer stores the immutable visit" \
-  'type[[:space:]]+flow_attempt_receipt[[:space:]]*=[[:space:]]*private[[:space:]]*\{[^}]*scope[[:space:]]*:[[:space:]]*flow_scope[^}]*visit[[:space:]]*:[[:space:]]*flow_candidate_visit' \
+  'type[[:space:]]+flow_attempt_receipt[[:space:]]*=[[:space:]]*private[[:space:]]*\{[^}]*visit[[:space:]]*:[[:space:]]*flow_candidate_visit[^}]*receipt[[:space:]]*:[[:space:]]*receipt' \
   "$exact_output_interface"
 require_code_sequence \
   "outer exact flow start stopped failing closed on identity allocation" \
@@ -1094,7 +1094,12 @@ require_code_sequence \
   "$exact_output_interface"
 require_code_sequence \
   "validated exact flow lost its single declared-flow entrypoint" \
-  'val[[:space:]]+execute_flow_once_validated.*validate:[[:space:]]*\(flow_success[[:space:]]*->[[:space:]]*([^[:space:]]+[[:space:]]*,[[:space:]]*[^[:space:]]+)[[:space:]]+semantic_verdict\)' \
+  'val[[:space:]]+execute_flow_once.*validate:[[:space:]]*\(flow_success[[:space:]]*->[[:space:]]*([^[:space:]]+[[:space:]]*,[[:space:]]*[^[:space:]]+)[[:space:]]+semantic_verdict\)' \
+  "$exact_output_interface"
+scan_code \
+  "validated exact flow regained a parallel or compatibility entrypoint" \
+  'execute_flow_once_validated|Compatibility entrypoint|always-\[Accept\]' \
+  "$exact_output_source" \
   "$exact_output_interface"
 scan_code \
   "declared exact flow regained preference ordering or domain settlement" \

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -847,6 +847,38 @@ let test_ollama_cloud_current_catalog_resolves () =
     cases
 ;;
 
+let test_ollama_cloud_v1_vendor_models_resolve_exact_capabilities () =
+  List.iter
+    (fun model_id ->
+       match
+         Capabilities.for_provider_model_id
+           ~allow_bare_fallback:false
+           ~provider_label:"ollama_cloud"
+           ~model_id
+       with
+       | None -> failf "ollama_cloud/%s should resolve exactly" model_id
+       | Some c ->
+         check
+           (option int)
+           (model_id ^ " context")
+           (Some 262_144)
+           c.max_context_tokens;
+         check bool (model_id ^ " tools") true c.supports_tools;
+         check bool (model_id ^ " reasoning") true c.supports_reasoning;
+         check bool (model_id ^ " extended thinking") true c.supports_extended_thinking;
+         check bool (model_id ^ " no reasoning budget control") false c.supports_reasoning_budget;
+         check_thinking_control
+           (model_id ^ " inherent thinking has no request control")
+           Capabilities.No_thinking_control
+           c.thinking_control_format;
+         check bool (model_id ^ " json mode") true c.supports_response_format_json;
+         check bool (model_id ^ " no native schema guarantee") false c.supports_structured_output;
+         check bool (model_id ^ " multimodal") true c.supports_multimodal_inputs;
+         check bool (model_id ^ " image input") true c.supports_image_input;
+         check bool (model_id ^ " native streaming") true c.supports_native_streaming)
+    [ "qwen3.5:cloud"; "gemma4:31b-cloud" ]
+;;
+
 let test_ollama_cloud_grouped_rows_have_required_axes () =
   (* Live grouped smokes for these Ollama Cloud rows exercise the same
      production workflow: tool call -> tool_result replay -> final answer while
@@ -2774,6 +2806,10 @@ let () =
             "ollama cloud current catalog"
             `Quick
             test_ollama_cloud_current_catalog_resolves
+        ; test_case
+            "ollama cloud v1 vendor models resolve exact capabilities"
+            `Quick
+            test_ollama_cloud_v1_vendor_models_resolve_exact_capabilities
         ; test_case
             "ollama cloud grouped rows keep required axes"
             `Quick

--- a/test/test_exact_output_flow.ml
+++ b/test/test_exact_output_flow.ml
@@ -402,8 +402,50 @@ let attempt_for evidence id =
   | None -> failf "missing attempt evidence for %s" id
 ;;
 
-let execute_ok ~net flow =
+type no_semantic_rejection = |
+
+let accepting_test_validator success
+  : (EO.flow_success, no_semantic_rejection) EO.semantic_verdict
+  =
+  EO.Accept success
+;;
+
+let transport_test_result
+      (result :
+        ( (EO.flow_success, no_semantic_rejection) EO.validated_flow_success
+          , ('callback_error, no_semantic_rejection) EO.validated_flow_error )
+          result)
+  : (EO.flow_success, 'callback_error EO.flow_execution_error) result
+  =
+  match result with
+  | Ok success -> Ok success.transport_success
+  | Error (EO.Flow_execution_terminal { cause; _ }) -> Error cause
+  | Error (EO.Flow_semantic_candidates_exhausted _) -> .
+;;
+
+let execute_with_accepting_test_validator
+      ~net
+      ?clock
+      ~before_measurement_dispatch
+      ~on_measurement_terminal
+      ~before_dispatch
+      ~before_advance
+      flow
+  =
   EO.execute_flow_once
+    ~net
+    ?clock
+    ~before_measurement_dispatch
+    ~on_measurement_terminal
+    ~before_dispatch
+    ~before_advance
+    ~validate:accepting_test_validator
+    flow
+  |> transport_test_result
+;;
+
+let execute_ok ~net flow =
+  execute_with_accepting_test_validator
     ~net
     ~on_measurement_terminal:(fun _ -> Ok ())
     ~before_measurement_dispatch:(fun _ -> Ok ())
@@ -412,8 +454,8 @@ let execute_ok ~net flow =
     flow
 ;;
 
-let execute_validated ~net ~before_advance ~validate flow =
-  EO.execute_flow_once_validated
+let execute_with_validator ~net ~before_advance ~validate flow =
+  EO.execute_flow_once
     ~net
     ~on_measurement_terminal:(fun _ -> Ok ())
     ~before_measurement_dispatch:(fun _ -> Ok ())
@@ -576,7 +618,7 @@ let test_later_missing_credential_does_not_block_current_success () =
     @@ fun snapshot ->
     let advances = ref 0 in
     let result =
-      EO.execute_flow_once
+      execute_with_accepting_test_validator
         ~net
         ~on_measurement_terminal:(fun _ -> Ok ())
         ~before_measurement_dispatch:(fun _ -> Ok ())
@@ -631,7 +673,7 @@ let test_json_syntax_uses_strict_text_fallback () =
     @@ fun snapshot ->
     let advances = ref 0 in
     let result =
-      EO.execute_flow_once
+      execute_with_accepting_test_validator
         ~net
         ~on_measurement_terminal:(fun _ -> Ok ())
         ~before_measurement_dispatch:(fun _ -> Ok ())
@@ -705,7 +747,7 @@ let test_fenced_text_json_advances_to_frozen_successor () =
     let observed_advance = ref None in
     let advances = ref 0 in
     let result =
-      EO.execute_flow_once
+      execute_with_accepting_test_validator
         ~net
         ~on_measurement_terminal:(fun _ -> Ok ())
         ~before_measurement_dispatch:(fun _ -> Ok ())
@@ -765,7 +807,7 @@ let test_provider_schema_still_requires_native_capability () =
         (frozen_candidates ~requirement [ flow_candidate snapshot "no-native-schema" ])
     in
     let result =
-      EO.execute_flow_once
+      execute_with_accepting_test_validator
         ~net
         ~on_measurement_terminal:(fun _ ->
           fail "provider-schema rejection reached measurement terminal")
@@ -827,7 +869,7 @@ let test_missing_current_credential_advances_after_durable_settlement () =
     let bound = ref [] in
     let next_visit = ref None in
     let result =
-      EO.execute_flow_once
+      execute_with_accepting_test_validator
         ~net
         ~on_measurement_terminal:(fun _ -> Ok ())
         ~before_measurement_dispatch:(fun _ -> Ok ())
@@ -941,7 +983,7 @@ let test_read_failed_current_credential_advances_to_good_successor () =
     @@ fun snapshot ->
     let advances = ref [] in
     let result =
-      EO.execute_flow_once
+      execute_with_accepting_test_validator
         ~net
         ~on_measurement_terminal:(fun _ -> Ok ())
         ~before_measurement_dispatch:(fun _ -> Ok ())
@@ -1017,7 +1059,7 @@ let test_credential_rejections_are_ordered_zero_dispatch_terminal () =
            [ "credential-missing"; "credential-invalid"; "credential-read-failed" ])
     in
     let result =
-      EO.execute_flow_once
+      execute_with_accepting_test_validator
         ~net
         ~on_measurement_terminal:(fun _ -> Ok ())
         ~before_measurement_dispatch:(fun _ -> Ok ())
@@ -1111,7 +1153,7 @@ let test_unmeasured_constraint_advances_only_after_durable_settlement () =
     let transitions = ref [] in
     let bound = ref [] in
     let result =
-      EO.execute_flow_once
+      execute_with_accepting_test_validator
         ~net
         ~on_measurement_terminal:(fun _ -> Ok ())
         ~before_measurement_dispatch:(fun _ -> Ok ())
@@ -1213,7 +1255,7 @@ let test_request_body_capacity_advances_only_after_durable_settlement () =
     @@ fun snapshot ->
     let transition = ref None in
     let result =
-      EO.execute_flow_once
+      execute_with_accepting_test_validator
         ~net
         ~on_measurement_terminal:(fun _ -> Ok ())
         ~before_measurement_dispatch:(fun _ -> Ok ())
@@ -1307,7 +1349,7 @@ let test_measured_token_and_body_capacity_are_independent () =
              (frozen_flow ~messages:[ msg large_input ] snapshot [ "measured-capacity" ])
          in
          let result =
-           EO.execute_flow_once
+           execute_with_accepting_test_validator
              ~net
              ~on_measurement_terminal:(fun _ -> Ok ())
              ~before_measurement_dispatch:(fun _ -> Ok ())
@@ -1405,7 +1447,7 @@ let test_measurement_receipt_codec_and_transition () =
     let intent = ref None in
     let terminal = ref None in
     let result =
-      EO.execute_flow_once
+      execute_with_accepting_test_validator
         ~net
         ~before_measurement_dispatch:(fun measurement ->
           intent := Some (EO.flow_measurement_receipt_snapshot measurement);
@@ -1774,7 +1816,7 @@ let test_measurement_fence_rejection_is_terminal_without_wire () =
     let terminal_callbacks = ref 0 in
     let advances = ref 0 in
     let result =
-      EO.execute_flow_once
+      execute_with_accepting_test_validator
         ~net
         ~on_measurement_terminal:(fun measurement ->
           incr terminal_callbacks;
@@ -1896,7 +1938,7 @@ let test_measurement_fence_nested_http_does_not_mark_outer_dispatch () =
     @@ fun snapshot ->
     let flow = start_flow (frozen_flow snapshot [ "measurement-nested-journal" ]) in
     let result =
-      EO.execute_flow_once
+      execute_with_accepting_test_validator
         ~net
         ~before_measurement_dispatch:(fun measurement ->
           let before = EO.flow_measurement_receipt_snapshot measurement in
@@ -1987,7 +2029,7 @@ let test_measurement_terminal_callback_failure_blocks_generation () =
     let terminal_callbacks = ref 0 in
     let advances = ref 0 in
     let result =
-      EO.execute_flow_once
+      execute_with_accepting_test_validator
         ~net
         ~before_measurement_dispatch:(fun measurement ->
           let snapshot = EO.flow_measurement_receipt_snapshot measurement in
@@ -2073,7 +2115,7 @@ let test_measurement_predispatch_failure_records_zero_dispatch () =
     let intent_callbacks = ref 0 in
     let terminal_callbacks = ref 0 in
     let result =
-      EO.execute_flow_once
+      execute_with_accepting_test_validator
         ~net
         ~before_measurement_dispatch:(fun measurement ->
           incr intent_callbacks;
@@ -2184,7 +2226,7 @@ let test_measurement_cancellation_terminalizes_receipt () =
       try
         ignore
           (Eio.Time.with_timeout_exn clock 0.01 (fun () ->
-             EO.execute_flow_once
+             execute_with_accepting_test_validator
                ~net
                ~on_measurement_terminal:(fun measurement ->
                  incr terminal_callbacks;
@@ -2386,7 +2428,7 @@ let test_predispatch_measurement_failure_advances_without_wire () =
     in
     let advances = ref 0 in
     let result =
-      EO.execute_flow_once
+      execute_with_accepting_test_validator
         ~net
         ~on_measurement_terminal:(fun _ -> Ok ())
         ~before_measurement_dispatch:(fun _ -> Ok ())
@@ -2478,7 +2520,7 @@ let test_postdispatch_measurement_failures_do_not_advance () =
          let advances = ref 0 in
          let terminal_callbacks = ref 0 in
          let result =
-           EO.execute_flow_once
+           execute_with_accepting_test_validator
              ~net
              ~on_measurement_terminal:(fun measurement ->
                incr terminal_callbacks;
@@ -2714,7 +2756,7 @@ let test_all_candidate_rejections_return_typed_zero_dispatch_terminal () =
     let transitions = ref [] in
     let flow = start_flow (frozen_flow snapshot [ "rejected-a"; "rejected-b" ]) in
     let result =
-      EO.execute_flow_once
+      execute_with_accepting_test_validator
         ~net
         ~on_measurement_terminal:(fun _ -> Ok ())
         ~before_measurement_dispatch:(fun _ -> Ok ())
@@ -2826,7 +2868,7 @@ let test_exception_after_durable_rejection_stops_before_successor () =
          let raised =
            try
              ignore
-               (EO.execute_flow_once
+               (execute_with_accepting_test_validator
                   ~net
                   ~on_measurement_terminal:(fun _ -> Ok ())
                   ~before_measurement_dispatch:(fun _ -> Ok ())
@@ -2914,7 +2956,7 @@ let test_predispatch_transport_failure_advances_after_durable_callback () =
     let advanced = ref [] in
     let events = ref [] in
     let result =
-      EO.execute_flow_once
+      execute_with_accepting_test_validator
         ~net
         ~on_measurement_terminal:(fun _ -> Ok ())
         ~before_measurement_dispatch:(fun _ -> Ok ())
@@ -3023,7 +3065,7 @@ let test_exception_after_durable_advance_stops_before_successor () =
          let raised =
            try
              ignore
-               (EO.execute_flow_once
+               (execute_with_accepting_test_validator
                   ~net
                   ~on_measurement_terminal:(fun _ -> Ok ())
                   ~before_measurement_dispatch:(fun _ -> Ok ())
@@ -3162,7 +3204,7 @@ let test_callback_failures_are_terminal () =
       ; catalog_entry ~id:"bind-b" ~base_url ~native:true ~json:true ()
       ]
     @@ fun snapshot ->
-    EO.execute_flow_once
+    execute_with_accepting_test_validator
       ~net
       ~on_measurement_terminal:(fun _ -> Ok ())
       ~before_measurement_dispatch:(fun _ -> Ok ())
@@ -3210,7 +3252,7 @@ let test_callback_failures_are_terminal () =
       ; catalog_entry ~id:"advance-b" ~base_url ~native:true ~json:true ()
       ]
     @@ fun snapshot ->
-    EO.execute_flow_once
+    execute_with_accepting_test_validator
       ~net
       ~on_measurement_terminal:(fun _ -> Ok ())
       ~before_measurement_dispatch:(fun _ -> Ok ())
@@ -3251,7 +3293,7 @@ let assert_typed_capacity_refusal_advances_once ~label ~first_response ~assert_c
     let advances = ref 0 in
     let observed_advance = ref None in
     let result =
-      EO.execute_flow_once
+      execute_with_accepting_test_validator
         ~net
         ~on_measurement_terminal:(fun _ -> Ok ())
         ~before_measurement_dispatch:(fun _ -> Ok ())
@@ -3365,7 +3407,7 @@ let test_generic_400_remains_terminal_without_advance () =
     let flow = start_flow (frozen_flow snapshot [ "generic-400-a"; "generic-400-b" ]) in
     let advances = ref 0 in
     let result =
-      EO.execute_flow_once
+      execute_with_accepting_test_validator
         ~net
         ~on_measurement_terminal:(fun _ -> Ok ())
         ~before_measurement_dispatch:(fun _ -> Ok ())
@@ -3400,7 +3442,7 @@ let test_postdispatch_and_structural_outcomes_never_advance () =
       @@ fun snapshot ->
       let advances = ref 0 in
       let result =
-        EO.execute_flow_once
+        execute_with_accepting_test_validator
           ~net
           ~on_measurement_terminal:(fun _ -> Ok ())
           ~before_measurement_dispatch:(fun _ -> Ok ())
@@ -3476,7 +3518,7 @@ let test_semantic_rejection_advances_to_declared_successor () =
     let validated_ids = ref [] in
     let advances = ref 0 in
     let result =
-      execute_validated
+      execute_with_validator
         ~net
         ~before_advance:(fun ~failed:_ ~next:_ ->
           incr advances;
@@ -3526,7 +3568,7 @@ let test_all_semantic_rejections_return_nonempty_ordered_exhaustion () =
     @@ fun snapshot ->
     let advances = ref 0 in
     let result =
-      execute_validated
+      execute_with_validator
         ~net
         ~before_advance:(fun ~failed:_ ~next:_ ->
           incr advances;
@@ -3581,7 +3623,7 @@ let test_admission_and_semantic_rejections_share_one_declared_walk () =
     let transitions = ref [] in
     let validated_ids = ref [] in
     let result =
-      execute_validated
+      execute_with_validator
         ~net
         ~before_advance:(fun ~failed ~next ->
           transitions
@@ -3635,7 +3677,7 @@ let test_prior_semantic_rejection_survives_later_transport_terminal () =
     @@ fun snapshot ->
     let advances = ref 0 in
     let result =
-      execute_validated
+      execute_with_validator
         ~net
         ~before_advance:(fun ~failed:_ ~next:_ ->
           incr advances;
@@ -3698,7 +3740,7 @@ let test_gemini_structural_sibling_rejects_before_outer_dispatch () =
       start_flow (frozen_candidates ~requirement [ flow_candidate snapshot id ])
     in
     let result =
-      EO.execute_flow_once
+      execute_with_accepting_test_validator
         ~net
         ~before_measurement_dispatch:(fun _ ->
           fail "schema rejection reached measurement intent")
@@ -3771,7 +3813,7 @@ let test_structural_predispatch_failure_does_not_advance () =
     let terminals = ref 0 in
     let advances = ref 0 in
     let result =
-      EO.execute_flow_once
+      execute_with_accepting_test_validator
         ~net
         ~before_measurement_dispatch:(fun _ ->
           incr intents;
@@ -3832,7 +3874,7 @@ let test_concurrent_duplicate_flow_does_not_double_dispatch () =
     @@ fun snapshot ->
     let flow = start_flow (frozen_flow snapshot [ "concurrent-flow" ]) in
     let execute () : (EO.flow_success, string EO.flow_execution_error) result =
-      EO.execute_flow_once
+      execute_with_accepting_test_validator
         ~net
         ~on_measurement_terminal:(fun _ -> Ok ())
         ~before_measurement_dispatch:(fun _ -> Ok ())

--- a/test/test_exact_output_flow.ml
+++ b/test/test_exact_output_flow.ml
@@ -190,83 +190,25 @@ let credential_getenv = function
   | _ -> Ok None
 ;;
 
-let flow_scope id =
-  match EO.make_flow_scope ~id with
-  | Ok scope -> scope
-  | Error EO.Blank_flow_scope_id -> fail "fixture flow scope was blank"
-;;
-
-let preference_store ?(capacity = 16) () =
-  match EO.recover_flow_preferences ~concurrent_scope_budget:capacity ~evidence:[] with
-  | Ok preferences -> preferences
-  | Error (EO.Invalid_concurrent_scope_budget invalid) ->
-    failf "fixture concurrent scope budget was invalid: %d" invalid
-  | Error (EO.Conflicting_domain_settlement_evidence _)
-  | Error (EO.Conflicting_scope_retirement_evidence _) ->
-    fail "empty preference evidence conflicted"
-;;
-
-let settle success disposition =
-  EO.commit_and_settle_flow_domain ~commit:(fun _ -> Ok ()) success disposition
-;;
-
-let settlement_id receipt =
-  EO.domain_settlement_receipt_id receipt |> EO.domain_settlement_id_to_string
-;;
-
-let check_settlement_disposition label expected receipt =
-  check
-    bool
-    label
-    true
-    (match expected, EO.domain_settlement_receipt_disposition receipt with
-     | EO.Domain_valid, EO.Domain_valid | EO.Domain_rejected, EO.Domain_rejected -> true
-     | EO.Domain_valid, EO.Domain_rejected | EO.Domain_rejected, EO.Domain_valid -> false)
-;;
-
-let retire_scope preferences scope =
-  match
-    EO.commit_and_retire_flow_preference_scope ~commit:(fun _ -> Ok ()) preferences scope
-  with
-  | Ok receipt -> receipt
-  | Error (EO.Flow_preference_retirement_commit_failed _) ->
-    fail "infallible retirement commit failed"
-  | Error EO.Flow_preference_retirement_in_progress ->
-    fail "single retirement was in progress"
-  | Error EO.Flow_preference_retirement_conflict -> fail "single retirement conflicted"
-  | Error EO.Flow_preference_scope_not_reserved ->
-    fail "reserved fixture scope was absent"
-;;
-
 let snapshot_candidates
       ?(messages = [ msg "return one exact object" ])
       ?(requirement =
         EO.make_output_requirement ~schema ~minimum_guarantee:EO.Json_syntax)
-      ~preferences
-      ~scope
       candidates
   =
   match candidates with
   | [] -> fail "flow fixture must be nonempty"
-  | first :: rest ->
-    EO.snapshot_flow ~preferences ~scope ~first ~rest ~messages requirement
+  | first :: rest -> EO.snapshot_flow ~first ~rest ~messages requirement
 ;;
 
-let frozen_candidates
-      ?(preferences = preference_store ())
-      ?(scope = flow_scope "test-default")
-      ?messages
-      ?requirement
-      candidates
-  =
-  match snapshot_candidates ?messages ?requirement ~preferences ~scope candidates with
+let frozen_candidates ?messages ?requirement candidates =
+  match snapshot_candidates ?messages ?requirement candidates with
   | Ok ready -> ready
   | Error _ -> fail "flow fixture did not admit"
 ;;
 
-let frozen_flow ?preferences ?scope ?messages snapshot ids =
-  List.map (flow_candidate snapshot) ids
-  |> frozen_candidates ?preferences ?scope ?messages
+let frozen_flow ?messages snapshot ids =
+  List.map (flow_candidate snapshot) ids |> frozen_candidates ?messages
 ;;
 
 let start_flow ready =
@@ -470,6 +412,21 @@ let execute_ok ~net flow =
     flow
 ;;
 
+let execute_validated ~net ~before_advance ~validate flow =
+  EO.execute_flow_once_validated
+    ~net
+    ~on_measurement_terminal:(fun _ -> Ok ())
+    ~before_measurement_dispatch:(fun _ -> Ok ())
+    ~before_dispatch:(fun _ -> Ok ())
+    ~before_advance
+    ~validate
+    flow
+;;
+
+let semantic_rejection_candidate_id (rejection : _ EO.semantic_rejection_receipt) =
+  rejection.EO.transport_success |> EO.flow_success_candidate |> candidate_id
+;;
+
 let candidate_ids identities =
   List.map
     (fun (identity : EO.flow_candidate_identity) -> identity.candidate_id)
@@ -480,1824 +437,7 @@ let flow_snapshot_evidence ready = EO.flow_attempt_evidence (start_flow ready)
 
 let flow_snapshot_ids ready =
   flow_snapshot_evidence ready
-  |> fun evidence -> candidate_ids evidence.candidate_snapshot
-;;
-
-let test_scope_local_domain_valid_preference_changes_only_future_snapshots () =
-  let (success_id, existing_order, future_order, other_scope_order), posts =
-    with_server ~response:(openai_response {|{"name":"accepted"}|})
-    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
-    with_catalog
-      [ catalog_entry ~id:"preferred-a" ~base_url ~native:true ~json:true ()
-      ; catalog_entry ~id:"preferred-b" ~base_url ~native:true ~json:true ()
-      ]
-    @@ fun snapshot ->
-    let preferences = preference_store () in
-    let primary_scope = flow_scope "/runtime/keeper-primary" in
-    let other_scope = flow_scope "/runtime/keeper-other" in
-    let existing =
-      frozen_flow
-        ~preferences
-        ~scope:primary_scope
-        snapshot
-        [ "preferred-a"; "preferred-b" ]
-    in
-    let successful =
-      frozen_flow
-        ~preferences
-        ~scope:primary_scope
-        snapshot
-        [ "preferred-b"; "preferred-a" ]
-      |> start_flow
-      |> execute_ok ~net
-    in
-    match successful with
-    | Error _ -> fail "last-good fixture did not structurally succeed"
-    | Ok success ->
-      let candidate = EO.flow_success_candidate success in
-      let evidence = EO.flow_success_evidence success in
-      let success_ordinal = EO.flow_success_ordinal success in
-      check
-        bool
-        "success receipt carries primary scope"
-        true
-        (EO.flow_scope_equal primary_scope candidate.scope);
-      check
-        bool
-        "success evidence carries primary scope"
-        true
-        (EO.flow_scope_equal primary_scope evidence.scope);
-      let success_id = candidate_id candidate in
-      let settlement = settle success EO.Domain_valid in
-      (match settlement with
-       | Ok receipt ->
-         check_settlement_disposition
-           "domain-valid receipt disposition"
-           EO.Domain_valid
-           receipt;
-         check bool "settlement id is nonempty" true (settlement_id receipt <> "")
-       | Error _ -> fail "domain-valid content commit was not settled");
-      let future =
-        frozen_flow
-          ~preferences
-          ~scope:primary_scope
-          snapshot
-          [ "preferred-a"; "preferred-b" ]
-      in
-      let other_scope =
-        frozen_flow
-          ~preferences
-          ~scope:other_scope
-          snapshot
-          [ "preferred-a"; "preferred-b" ]
-      in
-      let existing_evidence = flow_snapshot_evidence existing in
-      let future_evidence = flow_snapshot_evidence future in
-      let other_scope_evidence = flow_snapshot_evidence other_scope in
-      check
-        (list string)
-        "future evidence preserves declared order"
-        [ "preferred-a"; "preferred-b" ]
-        (candidate_ids future_evidence.declared_candidate_snapshot);
-      (match existing_evidence.preference_observation with
-       | EO.No_preference_recorded -> ()
-       | EO.Preference_applied _ | EO.Preference_not_applied _ ->
-         fail "pre-existing snapshot observed a later preference");
-      (match future_evidence.preference_observation with
-       | EO.Preference_applied { candidate; success_ordinal = observed_ordinal } ->
-         check string "applied observation candidate" "preferred-b" candidate.candidate_id;
-         check
-           bool
-           "applied observation freezes the successful ordinal"
-           true
-           (Int64.equal
-              (EO.flow_success_ordinal_to_int64 success_ordinal)
-              (EO.flow_success_ordinal_to_int64 observed_ordinal))
-       | EO.No_preference_recorded | EO.Preference_not_applied _ ->
-         fail "future snapshot did not freeze the applied preference");
-      (match other_scope_evidence.preference_observation with
-       | EO.No_preference_recorded -> ()
-       | EO.Preference_applied _ | EO.Preference_not_applied _ ->
-         fail "other scope observed the primary preference");
-      ( success_id
-      , candidate_ids existing_evidence.candidate_snapshot
-      , candidate_ids future_evidence.candidate_snapshot
-      , candidate_ids other_scope_evidence.candidate_snapshot )
-  in
-  check int "preference proof dispatches once" 1 posts;
-  check string "domain-valid candidate" "preferred-b" success_id;
-  check
-    (list string)
-    "existing immutable snapshot keeps declared order"
-    [ "preferred-a"; "preferred-b" ]
-    existing_order;
-  check
-    (list string)
-    "future same-scope snapshot prefers last-good"
-    [ "preferred-b"; "preferred-a" ]
-    future_order;
-  check
-    (list string)
-    "other scope is isolated"
-    [ "preferred-a"; "preferred-b" ]
-    other_scope_order
-;;
-
-let test_concurrent_flow_scopes_isolate_attempts_and_future_preferences () =
-  let call_ids_differ, future_a, future_b, posts =
-    let result, posts =
-      with_server ~response:(openai_response {|{"name":"accepted"}|})
-      @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
-      with_catalog
-        [ catalog_entry ~id:"scope-a" ~base_url ~native:true ~json:true ()
-        ; catalog_entry ~id:"scope-b" ~base_url ~native:true ~json:true ()
-        ]
-      @@ fun snapshot ->
-      let preferences = preference_store () in
-      let scope_a = flow_scope "/runtime/concurrent-a" in
-      let scope_b = flow_scope "/runtime/concurrent-b" in
-      let flow_a =
-        frozen_flow ~preferences ~scope:scope_a snapshot [ "scope-a"; "scope-b" ]
-        |> start_flow
-      in
-      let flow_b =
-        frozen_flow ~preferences ~scope:scope_b snapshot [ "scope-b"; "scope-a" ]
-        |> start_flow
-      in
-      let promise_a, resolver_a = Eio.Promise.create () in
-      let promise_b, resolver_b = Eio.Promise.create () in
-      Eio.Fiber.both
-        (fun () -> Eio.Promise.resolve resolver_a (execute_ok ~net flow_a))
-        (fun () -> Eio.Promise.resolve resolver_b (execute_ok ~net flow_b));
-      let require_success label = function
-        | Ok success -> success
-        | Error _ -> failf "%s concurrent scope did not succeed" label
-      in
-      let success_a = Eio.Promise.await promise_a |> require_success "first" in
-      let success_b = Eio.Promise.await promise_b |> require_success "second" in
-      let candidate_a = EO.flow_success_candidate success_a in
-      let candidate_b = EO.flow_success_candidate success_b in
-      check
-        bool
-        "first attempt stays in first scope"
-        true
-        (EO.flow_scope_equal scope_a candidate_a.scope);
-      check
-        bool
-        "second attempt stays in second scope"
-        true
-        (EO.flow_scope_equal scope_b candidate_b.scope);
-      let settle success =
-        match settle success EO.Domain_valid with
-        | Ok receipt ->
-          check_settlement_disposition "fresh scoped settlement" EO.Domain_valid receipt
-        | Error _ -> fail "fresh scoped success could not settle"
-      in
-      Eio.Fiber.both (fun () -> settle success_a) (fun () -> settle success_b);
-      (* Annotated because [flow_attempt_snapshot] now also carries a [receipt]
-         field, and it is defined after [flow_attempt_receipt]
-         (exact_output.mli:517-528). Without a type here OCaml disambiguates the
-         field to the later definition, whose [receipt] is already a
-         [generation_receipt_snapshot], and the snapshot call below then receives
-         the wrong type. The annotation states which join this helper reads instead
-         of depending on declaration order. *)
-      let call_id (candidate : EO.flow_attempt_receipt) =
-        EO.generation_receipt_snapshot candidate.EO.receipt
-        |> EO.generation_receipt_snapshot_call_id
-        |> EO.call_id_to_string
-      in
-      ( not (String.equal (call_id candidate_a) (call_id candidate_b))
-      , frozen_flow ~preferences ~scope:scope_a snapshot [ "scope-b"; "scope-a" ]
-        |> flow_snapshot_ids
-      , frozen_flow ~preferences ~scope:scope_b snapshot [ "scope-a"; "scope-b" ]
-        |> flow_snapshot_ids )
-    in
-    let call_ids_differ, future_a, future_b = result in
-    call_ids_differ, future_a, future_b, posts
-  in
-  check int "two concurrent scopes dispatch independently" 2 posts;
-  check bool "concurrent scopes do not share attempt identity" true call_ids_differ;
-  check
-    (list string)
-    "first scope keeps only its last-good"
-    [ "scope-a"; "scope-b" ]
-    future_a;
-  check
-    (list string)
-    "second scope keeps only its last-good"
-    [ "scope-b"; "scope-a" ]
-    future_b
-;;
-
-let test_domain_rejection_never_updates_preference_and_settlement_is_affine () =
-  let before_settlement, first_settlement, duplicate_settlement, after_settlement, posts =
-    let result, posts =
-      with_server ~response:(openai_response {|{"name":"rejected"}|})
-      @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
-      with_catalog
-        [ catalog_entry ~id:"rejected-a" ~base_url ~native:true ~json:true ()
-        ; catalog_entry ~id:"declared-b" ~base_url ~native:true ~json:true ()
-        ]
-      @@ fun snapshot ->
-      let preferences = preference_store () in
-      let scope = flow_scope "/runtime/domain-rejected" in
-      match
-        frozen_flow ~preferences ~scope snapshot [ "rejected-a"; "declared-b" ]
-        |> start_flow
-        |> execute_ok ~net
-      with
-      | Error _ -> fail "domain-rejection fixture did not structurally succeed"
-      | Ok success ->
-        let before_settlement =
-          frozen_flow ~preferences ~scope snapshot [ "declared-b"; "rejected-a" ]
-          |> flow_snapshot_ids
-        in
-        let first_settlement = settle success EO.Domain_rejected in
-        let duplicate_settlement = settle success EO.Domain_valid in
-        let after_settlement =
-          frozen_flow ~preferences ~scope snapshot [ "declared-b"; "rejected-a" ]
-          |> flow_snapshot_ids
-        in
-        before_settlement, first_settlement, duplicate_settlement, after_settlement
-    in
-    let before, first, duplicate, after = result in
-    before, first, duplicate, after, posts
-  in
-  check
-    (list string)
-    "structural success alone does not update last-good"
-    [ "declared-b"; "rejected-a" ]
-    before_settlement;
-  check
-    bool
-    "domain rejection returns a typed receipt"
-    true
-    (match first_settlement with
-     | Ok receipt -> EO.domain_settlement_receipt_disposition receipt = EO.Domain_rejected
-     | Error _ -> false);
-  check
-    bool
-    "conflicting settlement is typed"
-    true
-    (match duplicate_settlement with
-     | Error EO.Domain_settlement_conflict -> true
-     | Error EO.Domain_settlement_in_progress | Error (EO.Domain_commit_failed _) | Ok _
-       -> false);
-  check
-    (list string)
-    "domain rejection records no preference"
-    [ "declared-b"; "rejected-a" ]
-    after_settlement;
-  check int "domain-rejection proof dispatches once" 1 posts
-;;
-
-let test_concurrent_domain_settlement_has_one_winner () =
-  let first, in_progress, replay, future_order, commits, posts =
-    let result, posts =
-      with_server ~response:(openai_response {|{"name":"accepted"}|})
-      @@ fun ~sw ~net ~clock:_ ~base_url ->
-      with_catalog
-        [ catalog_entry ~id:"winner-a" ~base_url ~native:true ~json:true ()
-        ; catalog_entry ~id:"declared-b" ~base_url ~native:true ~json:true ()
-        ]
-      @@ fun snapshot ->
-      let preferences = preference_store () in
-      let scope = flow_scope "/runtime/concurrent-settlement" in
-      match
-        frozen_flow ~preferences ~scope snapshot [ "winner-a"; "declared-b" ]
-        |> start_flow
-        |> execute_ok ~net
-      with
-      | Error _ -> fail "concurrent-settlement fixture did not succeed"
-      | Ok success ->
-        let commits = Atomic.make 0 in
-        let commit_entered, commit_entered_resolver = Eio.Promise.create () in
-        let release_commit, release_commit_resolver = Eio.Promise.create () in
-        let first_result, first_result_resolver = Eio.Promise.create () in
-        Eio.Fiber.fork ~sw (fun () ->
-          let result =
-            EO.commit_and_settle_flow_domain
-              ~commit:(fun _ ->
-                Atomic.incr commits;
-                Eio.Promise.resolve commit_entered_resolver ();
-                Eio.Promise.await release_commit;
-                Ok ())
-              success
-              EO.Domain_valid
-          in
-          Eio.Promise.resolve first_result_resolver result);
-        Eio.Promise.await commit_entered;
-        let in_progress =
-          EO.commit_and_settle_flow_domain
-            ~commit:(fun _ -> fail "in-progress settlement ran a second commit")
-            success
-            EO.Domain_valid
-        in
-        Eio.Promise.resolve release_commit_resolver ();
-        let first = Eio.Promise.await first_result in
-        let replay =
-          EO.commit_and_settle_flow_domain
-            ~commit:(fun _ -> fail "settled replay ran another commit")
-            success
-            EO.Domain_valid
-        in
-        let future_order =
-          frozen_flow ~preferences ~scope snapshot [ "declared-b"; "winner-a" ]
-          |> flow_snapshot_ids
-        in
-        first, in_progress, replay, future_order, Atomic.get commits
-    in
-    let first, in_progress, replay, future_order, commits = result in
-    first, in_progress, replay, future_order, commits, posts
-  in
-  (match in_progress with
-   | Error EO.Domain_settlement_in_progress -> ()
-   | Error (EO.Domain_commit_failed _) | Error EO.Domain_settlement_conflict | Ok _ ->
-     fail "same-domain concurrent settlement did not return in-progress");
-  let receipt label = function
-    | Ok receipt -> receipt
-    | Error (EO.Domain_commit_failed _)
-    | Error EO.Domain_settlement_in_progress
-    | Error EO.Domain_settlement_conflict ->
-      failf "%s idempotent settlement returned an error" label
-  in
-  let first_receipt = receipt "first" first in
-  let replay_receipt = receipt "replay" replay in
-  check
-    string
-    "later replay returns first receipt"
-    (settlement_id first_receipt)
-    (settlement_id replay_receipt);
-  check int "durable commit callback runs once" 1 commits;
-  check
-    (list string)
-    "winning settlement updates future snapshot once"
-    [ "winner-a"; "declared-b" ]
-    future_order;
-  check int "concurrent-settlement proof dispatches once" 1 posts
-;;
-
-let test_older_success_cannot_overwrite_newer_after_reversed_domain_settlement () =
-  let (future_order, newer_receipt, older_receipt, older_ordinal, newer_ordinal), posts =
-    with_server ~response:(openai_response {|{"name":"accepted"}|})
-    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
-    with_catalog
-      [ catalog_entry ~id:"older-a" ~base_url ~native:true ~json:true ()
-      ; catalog_entry ~id:"newer-b" ~base_url ~native:true ~json:true ()
-      ]
-    @@ fun snapshot ->
-    let preferences = preference_store () in
-    let scope = flow_scope "/runtime/out-of-order-success" in
-    let older_flow =
-      frozen_flow ~preferences ~scope snapshot [ "older-a"; "newer-b" ] |> start_flow
-    in
-    let newer_flow =
-      frozen_flow ~preferences ~scope snapshot [ "newer-b"; "older-a" ] |> start_flow
-    in
-    let execute flow =
-      match execute_ok ~net flow with
-      | Error _ -> fail "out-of-order settlement fixture did not succeed"
-      | Ok success -> success
-    in
-    let older_success = execute older_flow in
-    let newer_success = execute newer_flow in
-    let older_ordinal = EO.flow_success_ordinal older_success in
-    let newer_ordinal = EO.flow_success_ordinal newer_success in
-    let ready = Atomic.make 0 in
-    let start = Atomic.make false in
-    let newer_settled = Atomic.make false in
-    let await_start () =
-      ignore (Atomic.fetch_and_add ready 1);
-      while not (Atomic.get start) do
-        Domain.cpu_relax ()
-      done
-    in
-    let newer_domain =
-      Domain.spawn (fun () ->
-        await_start ();
-        let receipt = settle newer_success EO.Domain_valid in
-        Atomic.set newer_settled true;
-        receipt)
-    in
-    let older_domain =
-      Domain.spawn (fun () ->
-        await_start ();
-        while not (Atomic.get newer_settled) do
-          Domain.cpu_relax ()
-        done;
-        settle older_success EO.Domain_valid)
-    in
-    while Atomic.get ready <> 2 do
-      Domain.cpu_relax ()
-    done;
-    Atomic.set start true;
-    let newer_receipt = Domain.join newer_domain in
-    let older_receipt = Domain.join older_domain in
-    ( frozen_flow ~preferences ~scope snapshot [ "older-a"; "newer-b" ]
-      |> flow_snapshot_ids
-    , newer_receipt
-    , older_receipt
-    , older_ordinal
-    , newer_ordinal )
-  in
-  check int "out-of-order settlement proof dispatches twice" 2 posts;
-  check
-    bool
-    "structural success allocates strictly increasing OAS ordinals"
-    true
-    (Int64.compare
-       (EO.flow_success_ordinal_to_int64 older_ordinal)
-       (EO.flow_success_ordinal_to_int64 newer_ordinal)
-     < 0);
-  check
-    (list string)
-    "later structural success survives reversed cross-domain settlement"
-    [ "newer-b"; "older-a" ]
-    future_order;
-  let require_valid = function
-    | Ok receipt ->
-      check_settlement_disposition
-        "settlement remains domain-valid"
-        EO.Domain_valid
-        receipt;
-      receipt
-    | Error _ -> fail "domain-valid settlement failed"
-  in
-  let newer_receipt = require_valid newer_receipt in
-  let older_receipt = require_valid older_receipt in
-  check
-    bool
-    "distinct successes retain distinct settlement ids"
-    true
-    (not (String.equal (settlement_id newer_receipt) (settlement_id older_receipt)))
-;;
-
-let test_rebound_preference_is_not_promoted_and_observation_is_typed () =
-  let (success_ordinal, rebound_evidence, absent_evidence), posts =
-    with_server ~response:(openai_response {|{"name":"accepted"}|})
-    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
-    with_catalog
-      [ catalog_entry ~id:"binding-a" ~base_url ~native:true ~json:true ()
-      ; catalog_entry ~id:"binding-b" ~base_url ~native:true ~json:true ()
-      ]
-    @@ fun snapshot ->
-    let preferences = preference_store () in
-    let scope = flow_scope "/runtime/rebound-preference" in
-    let successful =
-      flow_candidate_as snapshot ~id:"stable-slot" ~target_ref:"binding-a"
-      |> fun candidate ->
-      frozen_candidates ~preferences ~scope [ candidate ] |> start_flow |> execute_ok ~net
-    in
-    let success =
-      match successful with
-      | Ok success -> success
-      | Error _ -> fail "binding fixture did not structurally succeed"
-    in
-    (match settle success EO.Domain_valid with
-     | Ok _ -> ()
-     | Error _ -> fail "binding fixture did not install its preference");
-    let success_ordinal = EO.flow_success_ordinal success in
-    let fallback = flow_candidate_as snapshot ~id:"fallback" ~target_ref:"binding-a" in
-    let rebound = flow_candidate_as snapshot ~id:"stable-slot" ~target_ref:"binding-b" in
-    let rebound_evidence =
-      frozen_candidates ~preferences ~scope [ fallback; rebound ]
-      |> flow_snapshot_evidence
-    in
-    let absent_evidence =
-      frozen_candidates ~preferences ~scope [ fallback ] |> flow_snapshot_evidence
-    in
-    success_ordinal, rebound_evidence, absent_evidence
-  in
-  check int "binding observation proof dispatches once" 1 posts;
-  check
-    (list string)
-    "rebound evidence preserves declared order"
-    [ "fallback"; "stable-slot" ]
-    (candidate_ids rebound_evidence.declared_candidate_snapshot);
-  check
-    (list string)
-    "rebound target is not promoted"
-    [ "fallback"; "stable-slot" ]
-    (candidate_ids rebound_evidence.candidate_snapshot);
-  (match rebound_evidence.preference_observation with
-   | EO.Preference_not_applied
-       { candidate
-       ; success_ordinal = rebound_ordinal
-       ; reason = EO.Preference_candidate_binding_changed
-       } ->
-     check string "binding-changed observation slot" "stable-slot" candidate.candidate_id;
-     check
-       bool
-       "binding-changed observation keeps successful ordinal"
-       true
-       (Int64.equal
-          (EO.flow_success_ordinal_to_int64 success_ordinal)
-          (EO.flow_success_ordinal_to_int64 rebound_ordinal))
-   | EO.No_preference_recorded | EO.Preference_applied _ | EO.Preference_not_applied _ ->
-     fail "rebound target did not produce binding-changed evidence");
-  match absent_evidence.preference_observation with
-  | EO.Preference_not_applied
-      { candidate
-      ; success_ordinal = absent_ordinal
-      ; reason = EO.Preference_candidate_absent
-      } ->
-    check string "absent observation slot" "stable-slot" candidate.candidate_id;
-    check
-      bool
-      "absent observation keeps successful ordinal"
-      true
-      (Int64.equal
-         (EO.flow_success_ordinal_to_int64 success_ordinal)
-         (EO.flow_success_ordinal_to_int64 absent_ordinal))
-  | EO.No_preference_recorded | EO.Preference_applied _ | EO.Preference_not_applied _ ->
-    fail "absent target did not produce typed evidence"
-;;
-
-let test_blank_flow_scope_is_rejected () =
-  match EO.make_flow_scope ~id:" \n\t " with
-  | Error EO.Blank_flow_scope_id -> ()
-  | Ok _ -> fail "blank flow scope was accepted"
-;;
-
-let test_preference_store_capacity_is_typed_and_reusable_after_removal () =
-  with_catalog
-    [ catalog_entry
-        ~id:"capacity-candidate"
-        ~base_url:"http://127.0.0.1:1"
-        ~native:true
-        ~json:true
-        ()
-    ]
-  @@ fun snapshot ->
-  let zero = preference_store ~capacity:0 () in
-  let zero_scope = flow_scope "/runtime/capacity-zero" in
-  let zero_candidates = [ flow_candidate snapshot "capacity-candidate" ] in
-  (match snapshot_candidates ~preferences:zero ~scope:zero_scope zero_candidates with
-   | Error (EO.Flow_preference_capacity_exhausted { capacity = 0 }) -> ()
-   | Ok _ | Error _ -> fail "zero-capacity store did not reject snapshot admission");
-  let preferences = preference_store ~capacity:1 () in
-  let scope_a = flow_scope "/runtime/capacity-a" in
-  let scope_b = flow_scope "/runtime/capacity-b" in
-  let candidates = [ flow_candidate snapshot "capacity-candidate" ] in
-  let ready = Atomic.make 0 in
-  let start = Atomic.make false in
-  let reserve scope () =
-    ignore (Atomic.fetch_and_add ready 1);
-    while not (Atomic.get start) do
-      Domain.cpu_relax ()
-    done;
-    snapshot_candidates ~preferences ~scope candidates
-  in
-  let left_domain = Domain.spawn (reserve scope_a) in
-  let right_domain = Domain.spawn (reserve scope_b) in
-  while Atomic.get ready <> 2 do
-    Domain.cpu_relax ()
-  done;
-  Atomic.set start true;
-  let left = Domain.join left_domain in
-  let right = Domain.join right_domain in
-  let classify = function
-    | Ok _ -> `Reserved
-    | Error (EO.Flow_preference_capacity_exhausted { capacity = 1 }) -> `Exhausted
-    | Error (EO.Flow_preference_capacity_exhausted { capacity }) ->
-      failf "capacity exhaustion reported the wrong bound: %d" capacity
-    | Error EO.Flow_preference_reservation_exhausted ->
-      fail "capacity exhaustion was reported as reservation exhaustion"
-    | Error (EO.Duplicate_flow_candidate_id _) ->
-      fail "capacity exhaustion was reported as a duplicate candidate"
-  in
-  let reserved_scope, exhausted_scope =
-    match classify left, classify right with
-    | `Reserved, `Exhausted -> scope_a, scope_b
-    | `Exhausted, `Reserved -> scope_b, scope_a
-    | `Reserved, `Reserved -> fail "concurrent scopes exceeded hard capacity"
-    | `Exhausted, `Exhausted -> fail "concurrent reservation admitted no scope"
-  in
-  (match
-     EO.commit_and_retire_flow_preference_scope
-       ~commit:(fun _ -> Ok ())
-       preferences
-       exhausted_scope
-   with
-   | Error EO.Flow_preference_scope_not_reserved -> ()
-   | Ok _ | Error _ -> fail "capacity-exhausted scope was nevertheless reserved");
-  let first_retirement = retire_scope preferences reserved_scope in
-  let replayed_retirement = retire_scope preferences reserved_scope in
-  check
-    string
-    "retirement replay returns the same receipt"
-    (EO.flow_preference_retirement_receipt_id first_retirement
-     |> EO.flow_preference_retirement_id_to_string)
-    (EO.flow_preference_retirement_receipt_id replayed_retirement
-     |> EO.flow_preference_retirement_id_to_string);
-  match snapshot_candidates ~preferences ~scope:exhausted_scope candidates with
-  | Ok _ -> ()
-  | Error _ -> fail "released capacity was not reusable by a new scope"
-;;
-
-let test_removed_scope_consumes_domain_valid_settlement_as_typed_failure () =
-  let settlement, duplicate, replacement_order, posts =
-    let result, posts =
-      with_server ~response:(openai_response {|{"name":"accepted"}|})
-      @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
-      with_catalog
-        [ catalog_entry ~id:"released-a" ~base_url ~native:true ~json:true ()
-        ; catalog_entry ~id:"replacement-b" ~base_url ~native:true ~json:true ()
-        ]
-      @@ fun snapshot ->
-      let preferences = preference_store ~capacity:1 () in
-      let released_scope = flow_scope "/runtime/released" in
-      let success =
-        match
-          frozen_flow
-            ~preferences
-            ~scope:released_scope
-            snapshot
-            [ "released-a"; "replacement-b" ]
-          |> start_flow
-          |> execute_ok ~net
-        with
-        | Ok success -> success
-        | Error _ -> fail "released-scope fixture did not structurally succeed"
-      in
-      ignore (retire_scope preferences released_scope);
-      let _replacement_generation =
-        frozen_flow
-          ~preferences
-          ~scope:released_scope
-          snapshot
-          [ "replacement-b"; "released-a" ]
-      in
-      let settlement = settle success EO.Domain_valid in
-      let duplicate = settle success EO.Domain_valid in
-      let after_stale_settlement =
-        frozen_flow
-          ~preferences
-          ~scope:released_scope
-          snapshot
-          [ "replacement-b"; "released-a" ]
-      in
-      settlement, duplicate, flow_snapshot_ids after_stale_settlement
-    in
-    let settlement, duplicate, replacement_order = result in
-    settlement, duplicate, replacement_order, posts
-  in
-  check int "released-scope proof dispatches once" 1 posts;
-  check
-    bool
-    "domain-valid settlement remains durable after scope release"
-    true
-    (match settlement with
-     | Ok receipt -> EO.domain_settlement_receipt_disposition receipt = EO.Domain_valid
-     | Error _ -> false);
-  check
-    bool
-    "released-scope replay returns the same receipt"
-    true
-    (match settlement, duplicate with
-     | Ok first, Ok second -> String.equal (settlement_id first) (settlement_id second)
-     | Ok _, Error _ | Error _, Ok _ | Error _, Error _ -> false);
-  check
-    (list string)
-    "same scope reuses capacity without accepting stale generation"
-    [ "replacement-b"; "released-a" ]
-    replacement_order
-;;
-
-exception Injected_after_domain_commit
-
-let json_field_string name encoded =
-  match Yojson.Safe.from_string encoded with
-  | `Assoc fields ->
-    (match List.assoc_opt name fields with
-     | Some (`String value) -> value
-     | Some _ | None -> failf "intent field %s was not a string" name)
-  | _ -> fail "intent envelope was not an object"
-;;
-
-let rewrite_json_field name replacement encoded =
-  match Yojson.Safe.from_string encoded with
-  | `Assoc fields ->
-    `Assoc
-      (List.map
-         (fun (field, value) ->
-            if String.equal field name then field, replacement else field, value)
-         fields)
-    |> Yojson.Safe.to_string
-  | _ -> fail "intent envelope was not an object"
-;;
-
-let duplicate_json_field name encoded =
-  match Yojson.Safe.from_string encoded with
-  | `Assoc fields ->
-    (match List.assoc_opt name fields with
-     | Some value -> `Assoc ((name, value) :: fields) |> Yojson.Safe.to_string
-     | None -> failf "intent field %s was absent" name)
-  | _ -> fail "intent envelope was not an object"
-;;
-
-let test_committed_intent_resumes_without_dispatch_and_restores_high_water () =
-  let (first_id, replay_id, future_order, ordinal_advanced, reservation_advanced), posts =
-    with_server ~response:(openai_response {|{"name":"accepted"}|})
-    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
-    with_catalog
-      [ catalog_entry ~id:"durable-a" ~base_url ~native:true ~json:true ()
-      ; catalog_entry ~id:"durable-b" ~base_url ~native:true ~json:true ()
-      ]
-    @@ fun snapshot ->
-    let original_preferences = preference_store () in
-    let scope = flow_scope "/runtime/durable-settlement" in
-    let success =
-      match
-        frozen_flow
-          ~preferences:original_preferences
-          ~scope
-          snapshot
-          [ "durable-a"; "durable-b" ]
-        |> start_flow
-        |> execute_ok ~net
-      with
-      | Ok success -> success
-      | Error _ -> fail "durable settlement fixture did not succeed"
-    in
-    let original_ordinal = EO.flow_success_ordinal success in
-    let encoded = ref None in
-    (try
-       ignore
-         (EO.commit_and_settle_flow_domain
-            ~commit:(fun intent ->
-              encoded := Some (EO.domain_settlement_intent_to_string intent);
-              raise Injected_after_domain_commit)
-            success
-            EO.Domain_valid);
-       fail "injected post-commit crash did not escape"
-     with
-     | Injected_after_domain_commit -> ());
-    let encoded =
-      match !encoded with
-      | Some encoded -> encoded
-      | None -> fail "durable callback did not receive an intent"
-    in
-    let fields =
-      match Yojson.Safe.from_string encoded with
-      | `Assoc fields -> List.map fst fields
-      | _ -> fail "durable intent was not an object"
-    in
-    check
-      (list string)
-      "durable envelope has one provider-neutral current schema"
-      [ "format"
-      ; "version"
-      ; "flow_id"
-      ; "scope"
-      ; "reservation_ordinal"
-      ; "candidate_id"
-      ; "candidate_binding_sha256"
-      ; "success_ordinal"
-      ; "execution_evidence_sha256"
-      ; "settlement_id"
-      ; "disposition"
-      ; "integrity_sha256"
-      ]
-      fields;
-    let encoded_lower = String.lowercase_ascii encoded in
-    let contains_substring text needle =
-      let text_length = String.length text in
-      let needle_length = String.length needle in
-      let rec loop index =
-        index + needle_length <= text_length
-        && (String.equal (String.sub text index needle_length) needle || loop (index + 1))
-      in
-      loop 0
-    in
-    List.iter
-      (fun forbidden ->
-         check
-           bool
-           ("durable envelope excludes " ^ forbidden)
-           false
-           (contains_substring encoded_lower forbidden))
-      [ "provider"; "model"; "catalog"; "credential"; "wire"; "pricing" ];
-    let intent =
-      match EO.domain_settlement_intent_of_string encoded with
-      | Ok intent -> intent
-      | Error _ -> fail "current durable intent did not decode"
-    in
-    let old_version = rewrite_json_field "version" (`Int 0) encoded in
-    (match EO.domain_settlement_intent_of_string old_version with
-     | Error (EO.Domain_settlement_intent_unsupported_version 0) -> ()
-     | Ok _ | Error _ -> fail "old durable intent version did not fail closed");
-    List.iter
-      (fun field ->
-         List.iter
-           (fun raw ->
-              let noncanonical = rewrite_json_field field (`String raw) encoded in
-              match EO.domain_settlement_intent_of_string noncanonical with
-              | Error (EO.Domain_settlement_intent_invalid_field rejected)
-                when String.equal rejected field -> ()
-              | Ok _ | Error _ ->
-                failf
-                  "noncanonical %s=%s survived with original settlement hashes"
-                  field
-                  raw)
-           [ "01"; "+1"; "0x1"; "0_1" ])
-      [ "reservation_ordinal"; "success_ordinal" ];
-    let corrupt =
-      rewrite_json_field "integrity_sha256" (`String (String.make 64 '0')) encoded
-    in
-    (match EO.domain_settlement_intent_of_string corrupt with
-     | Error EO.Domain_settlement_intent_integrity_mismatch -> ()
-     | Ok _ | Error _ -> fail "corrupt durable intent did not fail closed");
-    let recovered_preferences =
-      match
-        EO.recover_flow_preferences
-          ~concurrent_scope_budget:0
-          ~evidence:
-            [ EO.Domain_settlement_evidence intent; EO.Domain_settlement_evidence intent ]
-      with
-      | Ok preferences -> preferences
-      | Error _ -> fail "committed intent did not recover"
-    in
-    let future_order =
-      frozen_flow
-        ~preferences:recovered_preferences
-        ~scope
-        snapshot
-        [ "durable-b"; "durable-a" ]
-      |> flow_snapshot_ids
-    in
-    ignore (retire_scope recovered_preferences scope);
-    let next_success =
-      match
-        frozen_flow
-          ~preferences:recovered_preferences
-          ~scope
-          snapshot
-          [ "durable-b"; "durable-a" ]
-        |> start_flow
-        |> execute_ok ~net
-      with
-      | Ok success -> success
-      | Error _ -> fail "post-recovery success did not execute"
-    in
-    let next_encoded = ref None in
-    (match
-       EO.commit_and_settle_flow_domain
-         ~commit:(fun next ->
-           next_encoded := Some (EO.domain_settlement_intent_to_string next);
-           Error ())
-         next_success
-         EO.Domain_valid
-     with
-     | Error (EO.Domain_commit_failed ()) -> ()
-     | Ok _ | Error EO.Domain_settlement_in_progress | Error EO.Domain_settlement_conflict
-       -> fail "failed durable callback did not remain retryable");
-    let next_encoded =
-      match !next_encoded with
-      | Some encoded -> encoded
-      | None -> fail "next durable intent was not observed"
-    in
-    let original_reservation =
-      json_field_string "reservation_ordinal" encoded |> Int64.of_string
-    in
-    let next_reservation =
-      json_field_string "reservation_ordinal" next_encoded |> Int64.of_string
-    in
-    ( EO.domain_settlement_intent_id intent |> EO.domain_settlement_id_to_string
-    , EO.domain_settlement_intent_id intent |> EO.domain_settlement_id_to_string
-    , future_order
-    , Int64.compare
-        (EO.flow_success_ordinal_to_int64 (EO.flow_success_ordinal next_success))
-        (EO.flow_success_ordinal_to_int64 original_ordinal)
-      > 0
-    , Int64.compare next_reservation original_reservation > 0 )
-  in
-  check int "restart proof dispatches only its two explicit executions" 2 posts;
-  check string "recovery replay returns same receipt" first_id replay_id;
-  check
-    (list string)
-    "recovered last-good affects only future snapshot"
-    [ "durable-a"; "durable-b" ]
-    future_order;
-  check bool "recovery restores success ordinal high-water" true ordinal_advanced;
-  check bool "recovery restores reservation high-water" true reservation_advanced
-;;
-
-let test_retirement_recovery_blocks_stale_and_allows_newer_reservation () =
-  let (retired_blocked, newer_order, retirement_roundtrip), posts =
-    with_server ~response:(openai_response {|{"name":"accepted"}|})
-    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
-    with_catalog
-      [ catalog_entry ~id:"retirement-a" ~base_url ~native:true ~json:true ()
-      ; catalog_entry ~id:"retirement-b" ~base_url ~native:true ~json:true ()
-      ]
-    @@ fun snapshot ->
-    let preferences = preference_store ~capacity:1 () in
-    let scope = flow_scope "/runtime/retirement-order" in
-    let capture_domain candidate =
-      let success =
-        match
-          frozen_flow ~preferences ~scope snapshot [ candidate ]
-          |> start_flow
-          |> execute_ok ~net
-        with
-        | Ok success -> success
-        | Error _ -> fail "retirement recovery fixture did not succeed"
-      in
-      let encoded = ref None in
-      (match
-         EO.commit_and_settle_flow_domain
-           ~commit:(fun intent ->
-             encoded := Some (EO.domain_settlement_intent_to_string intent);
-             Error ())
-           success
-           EO.Domain_valid
-       with
-       | Error (EO.Domain_commit_failed ()) -> ()
-       | Ok _
-       | Error EO.Domain_settlement_in_progress
-       | Error EO.Domain_settlement_conflict ->
-         fail "retirement recovery fixture unexpectedly settled");
-      match !encoded with
-      | None -> fail "retirement recovery fixture emitted no domain intent"
-      | Some encoded ->
-        (match EO.domain_settlement_intent_of_string encoded with
-         | Ok intent -> intent
-         | Error _ -> fail "retirement recovery domain intent did not decode")
-    in
-    let older = capture_domain "retirement-a" in
-    let retirement_encoded = ref None in
-    let retirement_receipt =
-      match
-        EO.commit_and_retire_flow_preference_scope
-          ~commit:(fun intent ->
-            retirement_encoded
-            := Some (EO.flow_preference_retirement_intent_to_string intent);
-            Ok ())
-          preferences
-          scope
-      with
-      | Ok receipt -> receipt
-      | Error _ -> fail "durable retirement did not commit"
-    in
-    let retirement_encoded, retirement =
-      match !retirement_encoded with
-      | None -> fail "durable retirement callback emitted no intent"
-      | Some encoded ->
-        (match EO.flow_preference_retirement_intent_of_string encoded with
-         | Ok intent -> encoded, intent
-         | Error _ -> fail "current retirement intent did not decode")
-    in
-    (match EO.flow_preference_retirement_intent_of_string "{" with
-     | Error (EO.Flow_preference_retirement_intent_malformed_json _) -> ()
-     | Ok _ | Error _ -> fail "malformed retirement intent did not fail closed");
-    (match EO.flow_preference_retirement_intent_of_string "[]" with
-     | Error EO.Flow_preference_retirement_intent_invalid_fields -> ()
-     | Ok _ | Error _ -> fail "non-object retirement intent did not fail closed");
-    (match
-       duplicate_json_field "scope" retirement_encoded
-       |> EO.flow_preference_retirement_intent_of_string
-     with
-     | Error EO.Flow_preference_retirement_intent_invalid_fields -> ()
-     | Ok _ | Error _ -> fail "duplicate retirement field did not fail closed");
-    (match
-       rewrite_json_field "version" (`Int 0) retirement_encoded
-       |> EO.flow_preference_retirement_intent_of_string
-     with
-     | Error (EO.Flow_preference_retirement_intent_unsupported_version 0) -> ()
-     | Ok _ | Error _ -> fail "old retirement intent version did not fail closed");
-    List.iter
-      (fun field ->
-         List.iter
-           (fun raw ->
-              match
-                rewrite_json_field field (`String raw) retirement_encoded
-                |> EO.flow_preference_retirement_intent_of_string
-              with
-              | Error (EO.Flow_preference_retirement_intent_invalid_field rejected)
-                when String.equal rejected field -> ()
-              | Ok _ | Error _ -> failf "noncanonical retirement %s=%s survived" field raw)
-           [ "01"; "+1"; "0x1"; "0_1" ])
-      [ "reservation_ordinal"; "success_high_water" ];
-    List.iter
-      (fun field ->
-         match
-           rewrite_json_field field (`String (String.make 64 '0')) retirement_encoded
-           |> EO.flow_preference_retirement_intent_of_string
-         with
-         | Error EO.Flow_preference_retirement_intent_integrity_mismatch -> ()
-         | Ok _ | Error _ -> failf "retirement %s tampering survived" field)
-      [ "retirement_id"; "integrity_sha256" ];
-    let retirement_roundtrip =
-      String.equal
-        (EO.flow_preference_retirement_receipt_id retirement_receipt
-         |> EO.flow_preference_retirement_id_to_string)
-        (EO.flow_preference_retirement_intent_id retirement
-         |> EO.flow_preference_retirement_id_to_string)
-    in
-    let newer = capture_domain "retirement-b" in
-    let retired_only =
-      match
-        EO.recover_flow_preferences
-          ~concurrent_scope_budget:0
-          ~evidence:
-            [ EO.Domain_settlement_evidence older
-            ; EO.Scope_retirement_evidence retirement
-            ]
-      with
-      | Ok recovered -> recovered
-      | Error _ -> fail "retire-after-valid evidence did not recover"
-    in
-    let retired_blocked =
-      match
-        snapshot_candidates
-          ~preferences:retired_only
-          ~scope
-          [ flow_candidate snapshot "retirement-a" ]
-      with
-      | Error (EO.Flow_preference_capacity_exhausted { capacity = 0 }) -> true
-      | Ok _ | Error _ -> false
-    in
-    let reactivated =
-      match
-        EO.recover_flow_preferences
-          ~concurrent_scope_budget:0
-          ~evidence:
-            [ EO.Domain_settlement_evidence older
-            ; EO.Scope_retirement_evidence retirement
-            ; EO.Domain_settlement_evidence newer
-            ]
-      with
-      | Ok recovered -> recovered
-      | Error _ -> fail "newer valid reservation did not reactivate"
-    in
-    let newer_order =
-      frozen_flow
-        ~preferences:reactivated
-        ~scope
-        snapshot
-        [ "retirement-a"; "retirement-b" ]
-      |> flow_snapshot_ids
-    in
-    retired_blocked, newer_order, retirement_roundtrip
-  in
-  check int "retirement ordering fixture dispatches twice" 2 posts;
-  check bool "retirement prevents stale resurrection" true retired_blocked;
-  check
-    (list string)
-    "genuinely newer reservation reactivates preference"
-    [ "retirement-b"; "retirement-a" ]
-    newer_order;
-  check bool "retirement codec preserves deterministic id" true retirement_roundtrip
-;;
-
-let test_recovery_rejects_superseded_retirement_conflicts_regardless_order () =
-  let (every_order_conflicted, deterministic_conflict_payload), posts =
-    with_server ~response:(openai_response {|{"name":"accepted"}|})
-    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
-    with_catalog
-      [ catalog_entry ~id:"retirement-conflict" ~base_url ~native:true ~json:true () ]
-    @@ fun snapshot ->
-    let scope = flow_scope "/runtime/retirement-conflict-order" in
-    let other_scope = flow_scope "/runtime/retirement-conflict-high-water" in
-    let advance preferences scope =
-      let success =
-        match
-          frozen_flow ~preferences ~scope snapshot [ "retirement-conflict" ]
-          |> start_flow
-          |> execute_ok ~net
-        with
-        | Ok success -> success
-        | Error _ -> fail "retirement conflict fixture did not succeed"
-      in
-      match
-        EO.commit_and_settle_flow_domain
-          ~commit:(fun _ -> Error ())
-          success
-          EO.Domain_valid
-      with
-      | Error (EO.Domain_commit_failed ()) -> ()
-      | Ok _
-      | Error EO.Domain_settlement_in_progress
-      | Error EO.Domain_settlement_conflict ->
-        fail "retirement conflict fixture unexpectedly settled"
-    in
-    let retire preferences =
-      let encoded = ref None in
-      (match
-         EO.commit_and_retire_flow_preference_scope
-           ~commit:(fun intent ->
-             encoded := Some (EO.flow_preference_retirement_intent_to_string intent);
-             Ok ())
-           preferences
-           scope
-       with
-       | Ok _ -> ()
-       | Error _ -> fail "retirement conflict fixture did not retire");
-      match !encoded with
-      | None -> fail "retirement conflict fixture emitted no intent"
-      | Some encoded ->
-        (match EO.flow_preference_retirement_intent_of_string encoded with
-         | Ok intent -> intent
-         | Error _ -> fail "retirement conflict intent did not decode")
-    in
-    let first_preferences = preference_store ~capacity:2 () in
-    advance first_preferences scope;
-    let first = retire first_preferences in
-    let conflicting_preferences = preference_store ~capacity:2 () in
-    advance conflicting_preferences scope;
-    advance conflicting_preferences other_scope;
-    let conflicting = retire conflicting_preferences in
-    let newer_preferences = preference_store ~capacity:2 () in
-    advance newer_preferences scope;
-    let _retired = retire newer_preferences in
-    advance newer_preferences scope;
-    let newer = retire newer_preferences in
-    let retirement_id intent =
-      EO.flow_preference_retirement_intent_id intent
-      |> EO.flow_preference_retirement_id_to_string
-    in
-    let retirement_field field intent =
-      EO.flow_preference_retirement_intent_to_string intent |> json_field_string field
-    in
-    let retirement_reservation intent =
-      retirement_field "reservation_ordinal" intent |> Int64.of_string
-    in
-    let first_id = retirement_id first in
-    let conflicting_id = retirement_id conflicting in
-    let newer_id = retirement_id newer in
-    if String.equal first_id conflicting_id
-    then fail "retirement conflict fixture produced identical older intents";
-    if String.equal conflicting_id newer_id
-    then fail "retirement conflict fixture did not create a distinct newer intent";
-    if String.equal first_id newer_id
-    then fail "retirement conflict fixture reused the first retirement intent";
-    if
-      not
-        (String.equal
-           (retirement_field "scope" first)
-           (retirement_field "scope" conflicting)
-         && String.equal (retirement_field "scope" first) (retirement_field "scope" newer)
-        )
-    then fail "retirement conflict fixture did not preserve one scope";
-    let first_reservation = retirement_reservation first in
-    let conflicting_reservation = retirement_reservation conflicting in
-    let newer_reservation = retirement_reservation newer in
-    if not (Int64.equal first_reservation conflicting_reservation)
-    then fail "retirement conflict fixture did not share the older reservation";
-    if Int64.compare newer_reservation first_reservation <= 0
-    then fail "retirement conflict fixture did not create a newer reservation";
-    let permutations =
-      [ [ first; conflicting; newer ]
-      ; [ first; newer; conflicting ]
-      ; [ conflicting; first; newer ]
-      ; [ conflicting; newer; first ]
-      ; [ newer; first; conflicting ]
-      ; [ newer; conflicting; first ]
-      ]
-    in
-    let permutation_keys =
-      List.map
-        (fun ordered -> List.map retirement_id ordered |> String.concat ":")
-        permutations
-    in
-    if List.length (List.sort_uniq String.compare permutation_keys) <> 6
-    then fail "retirement conflict fixture did not produce six distinct permutations";
-    let conflict_ids =
-      List.map
-        (fun ordered ->
-           match
-             EO.recover_flow_preferences
-               ~concurrent_scope_budget:0
-               ~evidence:
-                 (List.map (fun intent -> EO.Scope_retirement_evidence intent) ordered)
-           with
-           | Error (EO.Conflicting_scope_retirement_evidence id) ->
-             Some (EO.flow_preference_retirement_id_to_string id)
-           | Ok _
-           | Error (EO.Invalid_concurrent_scope_budget _)
-           | Error (EO.Conflicting_domain_settlement_evidence _) -> None)
-        permutations
-    in
-    let every_order_conflicted =
-      List.for_all
-        (function
-          | Some _ -> true
-          | None -> false)
-        conflict_ids
-    in
-    let deterministic_conflict_payload =
-      match conflict_ids with
-      | Some expected :: rest ->
-        (String.equal expected first_id || String.equal expected conflicting_id)
-        && List.for_all
-             (function
-               | Some actual -> String.equal actual expected
-               | None -> false)
-             rest
-      | None :: _ | [] -> false
-    in
-    every_order_conflicted, deterministic_conflict_payload
-  in
-  check int "superseded retirement conflict fixture dispatches five times" 5 posts;
-  check
-    bool
-    "superseded equal-reservation retirements always conflict"
-    true
-    every_order_conflicted;
-  check
-    bool
-    "superseded retirement conflict payload is deterministic"
-    true
-    deterministic_conflict_payload
-;;
-
-let test_rejected_only_recovery_restores_high_water_without_active_scope () =
-  let (zero_active, reservation_advanced, ordinal_advanced), posts =
-    with_server ~response:(openai_response {|{"name":"accepted"}|})
-    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
-    with_catalog
-      [ catalog_entry ~id:"rejected-only" ~base_url ~native:true ~json:true () ]
-    @@ fun snapshot ->
-    let original = preference_store ~capacity:1 () in
-    let original_scope = flow_scope "/runtime/rejected-only/original" in
-    let original_success =
-      match
-        frozen_flow
-          ~preferences:original
-          ~scope:original_scope
-          snapshot
-          [ "rejected-only" ]
-        |> start_flow
-        |> execute_ok ~net
-      with
-      | Ok success -> success
-      | Error _ -> fail "rejected-only fixture did not succeed"
-    in
-    let original_encoded = ref None in
-    (match
-       EO.commit_and_settle_flow_domain
-         ~commit:(fun intent ->
-           original_encoded := Some (EO.domain_settlement_intent_to_string intent);
-           Error ())
-         original_success
-         EO.Domain_rejected
-     with
-     | Error (EO.Domain_commit_failed ()) -> ()
-     | Ok _ | Error EO.Domain_settlement_in_progress | Error EO.Domain_settlement_conflict
-       -> fail "rejected-only fixture unexpectedly settled");
-    let original_encoded, rejected =
-      match !original_encoded with
-      | None -> fail "rejected-only fixture emitted no intent"
-      | Some encoded ->
-        (match EO.domain_settlement_intent_of_string encoded with
-         | Ok intent -> encoded, intent
-         | Error _ -> fail "rejected-only intent did not decode")
-    in
-    let zero =
-      match
-        EO.recover_flow_preferences
-          ~concurrent_scope_budget:0
-          ~evidence:[ EO.Domain_settlement_evidence rejected ]
-      with
-      | Ok recovered -> recovered
-      | Error _ -> fail "rejected-only zero-budget recovery failed"
-    in
-    let zero_active =
-      match
-        snapshot_candidates
-          ~preferences:zero
-          ~scope:original_scope
-          [ flow_candidate snapshot "rejected-only" ]
-      with
-      | Error (EO.Flow_preference_capacity_exhausted { capacity = 0 }) -> true
-      | Ok _ | Error _ -> false
-    in
-    let recovered =
-      match
-        EO.recover_flow_preferences
-          ~concurrent_scope_budget:1
-          ~evidence:[ EO.Domain_settlement_evidence rejected ]
-      with
-      | Ok recovered -> recovered
-      | Error _ -> fail "rejected-only high-water recovery failed"
-    in
-    let next_success =
-      match
-        frozen_flow
-          ~preferences:recovered
-          ~scope:(flow_scope "/runtime/rejected-only/next")
-          snapshot
-          [ "rejected-only" ]
-        |> start_flow
-        |> execute_ok ~net
-      with
-      | Ok success -> success
-      | Error _ -> fail "post rejected-only recovery did not execute"
-    in
-    let next_encoded = ref None in
-    (match
-       EO.commit_and_settle_flow_domain
-         ~commit:(fun intent ->
-           next_encoded := Some (EO.domain_settlement_intent_to_string intent);
-           Error ())
-         next_success
-         EO.Domain_rejected
-     with
-     | Error (EO.Domain_commit_failed ()) -> ()
-     | Ok _ | Error EO.Domain_settlement_in_progress | Error EO.Domain_settlement_conflict
-       -> fail "post rejected-only fixture unexpectedly settled");
-    let next_encoded =
-      match !next_encoded with
-      | Some encoded -> encoded
-      | None -> fail "post rejected-only fixture emitted no intent"
-    in
-    ( zero_active
-    , Int64.compare
-        (json_field_string "reservation_ordinal" next_encoded |> Int64.of_string)
-        (json_field_string "reservation_ordinal" original_encoded |> Int64.of_string)
-      > 0
-    , Int64.compare
-        (json_field_string "success_ordinal" next_encoded |> Int64.of_string)
-        (json_field_string "success_ordinal" original_encoded |> Int64.of_string)
-      > 0 )
-  in
-  check int "rejected-only high-water fixture dispatches twice" 2 posts;
-  check bool "rejected-only evidence consumes no active capacity" true zero_active;
-  check
-    bool
-    "rejected-only recovery restores reservation high-water"
-    true
-    reservation_advanced;
-  check bool "rejected-only recovery restores success high-water" true ordinal_advanced
-;;
-
-let test_retirement_cancellation_replays_stable_intent_after_high_water_drift () =
-  let stable_intent, posts =
-    with_server ~response:(openai_response {|{"name":"accepted"}|})
-    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
-    with_catalog
-      [ catalog_entry ~id:"retirement-stable" ~base_url ~native:true ~json:true () ]
-    @@ fun snapshot ->
-    let preferences = preference_store ~capacity:2 () in
-    let retirement_scope = flow_scope "/runtime/retirement-stable" in
-    (match
-       snapshot_candidates
-         ~preferences
-         ~scope:retirement_scope
-         [ flow_candidate snapshot "retirement-stable" ]
-     with
-     | Ok _ -> ()
-     | Error _ -> fail "retirement cancellation scope was not reserved");
-    let first_encoded = ref None in
-    (try
-       ignore
-         (EO.commit_and_retire_flow_preference_scope
-            ~commit:(fun intent ->
-              first_encoded
-              := Some (EO.flow_preference_retirement_intent_to_string intent);
-              raise
-                (Eio.Cancel.Cancelled (Failure "injected after durable retirement commit")))
-            preferences
-            retirement_scope);
-       fail "injected retirement cancellation did not escape"
-     with
-     | Eio.Cancel.Cancelled _ -> ());
-    let drift_scope = flow_scope "/runtime/retirement-stable-drift" in
-    (match
-       frozen_flow ~preferences ~scope:drift_scope snapshot [ "retirement-stable" ]
-       |> start_flow
-       |> execute_ok ~net
-     with
-     | Ok _ -> ()
-     | Error _ -> fail "success high-water drift fixture did not execute");
-    let failed_replay_encoded = ref None in
-    (match
-       EO.commit_and_retire_flow_preference_scope
-         ~commit:(fun intent ->
-           failed_replay_encoded
-           := Some (EO.flow_preference_retirement_intent_to_string intent);
-           Error ())
-         preferences
-         retirement_scope
-     with
-     | Error (EO.Flow_preference_retirement_commit_failed ()) -> ()
-     | Ok _
-     | Error EO.Flow_preference_retirement_in_progress
-     | Error EO.Flow_preference_retirement_conflict
-     | Error EO.Flow_preference_scope_not_reserved ->
-       fail "failed indeterminate replay did not remain retryable");
-    let replay_encoded = ref None in
-    let replay_receipt =
-      match
-        EO.commit_and_retire_flow_preference_scope
-          ~commit:(fun intent ->
-            replay_encoded := Some (EO.flow_preference_retirement_intent_to_string intent);
-            Ok ())
-          preferences
-          retirement_scope
-      with
-      | Ok receipt -> receipt
-      | Error _ -> fail "indeterminate retirement did not replay"
-    in
-    let first_encoded =
-      match !first_encoded with
-      | Some encoded -> encoded
-      | None -> fail "cancelled retirement exposed no intent"
-    in
-    let replay_encoded =
-      match !replay_encoded with
-      | Some encoded -> encoded
-      | None -> fail "retirement replay exposed no intent"
-    in
-    let failed_replay_encoded =
-      match !failed_replay_encoded with
-      | Some encoded -> encoded
-      | None -> fail "failed retirement replay exposed no intent"
-    in
-    let first_intent =
-      match EO.flow_preference_retirement_intent_of_string first_encoded with
-      | Ok intent -> intent
-      | Error _ -> fail "cancelled retirement intent did not decode"
-    in
-    String.equal first_encoded failed_replay_encoded
-    && String.equal first_encoded replay_encoded
-    && String.equal
-         (EO.flow_preference_retirement_intent_id first_intent
-          |> EO.flow_preference_retirement_id_to_string)
-         (EO.flow_preference_retirement_receipt_id replay_receipt
-          |> EO.flow_preference_retirement_id_to_string)
-  in
-  check int "retirement stability fixture dispatches only high-water drift" 1 posts;
-  check bool "post-commit cancellation replays exact retirement intent" true stable_intent
-;;
-
-let test_retirement_initial_error_preserves_intent_after_high_water_drift () =
-  let (stable_intent, initial_call_count, final_call_count), posts =
-    with_server ~response:(openai_response {|{"name":"accepted"}|})
-    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
-    with_catalog
-      [ catalog_entry ~id:"retirement-error" ~base_url ~native:true ~json:true () ]
-    @@ fun snapshot ->
-    let preferences = preference_store ~capacity:2 () in
-    let retirement_scope = flow_scope "/runtime/retirement-error" in
-    (match
-       snapshot_candidates
-         ~preferences
-         ~scope:retirement_scope
-         [ flow_candidate snapshot "retirement-error" ]
-     with
-     | Ok _ -> ()
-     | Error _ -> fail "retirement error scope was not reserved");
-    let callback_calls = ref 0 in
-    let first_encoded = ref None in
-    (match
-       EO.commit_and_retire_flow_preference_scope
-         ~commit:(fun intent ->
-           incr callback_calls;
-           first_encoded := Some (EO.flow_preference_retirement_intent_to_string intent);
-           Error ())
-         preferences
-         retirement_scope
-     with
-     | Error (EO.Flow_preference_retirement_commit_failed ()) -> ()
-     | Ok _
-     | Error EO.Flow_preference_retirement_in_progress
-     | Error EO.Flow_preference_retirement_conflict
-     | Error EO.Flow_preference_scope_not_reserved ->
-       fail "initial retirement error lost its typed outcome");
-    let initial_call_count = !callback_calls in
-    let drift_scope = flow_scope "/runtime/retirement-error-drift" in
-    (match
-       frozen_flow ~preferences ~scope:drift_scope snapshot [ "retirement-error" ]
-       |> start_flow
-       |> execute_ok ~net
-     with
-     | Ok _ -> ()
-     | Error _ -> fail "retirement error high-water drift did not execute");
-    let retry_encoded = ref None in
-    let retry_receipt =
-      match
-        EO.commit_and_retire_flow_preference_scope
-          ~commit:(fun intent ->
-            incr callback_calls;
-            retry_encoded := Some (EO.flow_preference_retirement_intent_to_string intent);
-            Ok ())
-          preferences
-          retirement_scope
-      with
-      | Ok receipt -> receipt
-      | Error _ -> fail "initial retirement error was not explicitly retryable"
-    in
-    let first_encoded =
-      match !first_encoded with
-      | Some encoded -> encoded
-      | None -> fail "initial retirement error exposed no intent"
-    in
-    let retry_encoded =
-      match !retry_encoded with
-      | Some encoded -> encoded
-      | None -> fail "retirement error retry exposed no intent"
-    in
-    let first_intent =
-      match EO.flow_preference_retirement_intent_of_string first_encoded with
-      | Ok intent -> intent
-      | Error _ -> fail "initial retirement error intent did not decode"
-    in
-    ( String.equal first_encoded retry_encoded
-      && String.equal
-           (EO.flow_preference_retirement_intent_id first_intent
-            |> EO.flow_preference_retirement_id_to_string)
-           (EO.flow_preference_retirement_receipt_id retry_receipt
-            |> EO.flow_preference_retirement_id_to_string)
-    , initial_call_count
-    , !callback_calls )
-  in
-  check int "initial error does not auto-redispatch callback" 1 initial_call_count;
-  check int "explicit retry dispatches callback exactly once" 2 final_call_count;
-  check int "initial error stability fixture dispatches only high-water drift" 1 posts;
-  check bool "initial error retry preserves exact retirement intent" true stable_intent
-;;
-
-let test_recovery_conflicting_disposition_fails_closed () =
-  let conflicted, posts =
-    with_server ~response:(openai_response {|{"name":"accepted"}|})
-    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
-    with_catalog [ catalog_entry ~id:"conflict-a" ~base_url ~native:true ~json:true () ]
-    @@ fun snapshot ->
-    let success =
-      frozen_flow snapshot [ "conflict-a" ] |> start_flow |> execute_ok ~net
-    in
-    let success =
-      match success with
-      | Ok success -> success
-      | Error _ -> fail "conflicting intent fixture did not succeed"
-    in
-    let capture disposition =
-      let encoded = ref None in
-      (match
-         EO.commit_and_settle_flow_domain
-           ~commit:(fun intent ->
-             encoded := Some (EO.domain_settlement_intent_to_string intent);
-             Error ())
-           success
-           disposition
-       with
-       | Error (EO.Domain_commit_failed ()) -> ()
-       | Ok _
-       | Error EO.Domain_settlement_in_progress
-       | Error EO.Domain_settlement_conflict ->
-         fail "failed commit unexpectedly consumed the disposition");
-      match !encoded with
-      | Some encoded ->
-        (match EO.domain_settlement_intent_of_string encoded with
-         | Ok intent -> intent
-         | Error _ -> fail "captured conflict intent did not decode")
-      | None -> fail "commit callback did not receive conflict intent"
-    in
-    let valid = capture EO.Domain_valid in
-    let rejected = capture EO.Domain_rejected in
-    check
-      string
-      "opposite dispositions share structural settlement id"
-      (EO.domain_settlement_intent_id valid |> EO.domain_settlement_id_to_string)
-      (EO.domain_settlement_intent_id rejected |> EO.domain_settlement_id_to_string);
-    match
-      EO.recover_flow_preferences
-        ~concurrent_scope_budget:1
-        ~evidence:
-          [ EO.Domain_settlement_evidence valid; EO.Domain_settlement_evidence rejected ]
-    with
-    | Error (EO.Conflicting_domain_settlement_evidence _) -> true
-    | Ok _
-    | Error (EO.Invalid_concurrent_scope_budget _)
-    | Error (EO.Conflicting_scope_retirement_evidence _) -> false
-  in
-  check int "conflicting recovery performs no extra dispatch" 1 posts;
-  check bool "conflicting disposition fails closed" true conflicted
-;;
-
-let test_recovery_rejects_reused_success_ordinals_regardless_order () =
-  let ( (every_order_conflicted, deterministic_conflict_payload, distinct_ordinals_recover)
-      , posts )
-    =
-    with_server ~response:(openai_response {|{"name":"accepted"}|})
-    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
-    with_catalog
-      [ catalog_entry ~id:"ordinal-a" ~base_url ~native:true ~json:true ()
-      ; catalog_entry ~id:"ordinal-b" ~base_url ~native:true ~json:true ()
-      ]
-    @@ fun snapshot ->
-    let scope = flow_scope "/runtime/success-ordinal-reuse" in
-    let capture preferences candidate =
-      let success =
-        match
-          frozen_flow ~preferences ~scope snapshot [ candidate ]
-          |> start_flow
-          |> execute_ok ~net
-        with
-        | Ok success -> success
-        | Error _ -> fail "success ordinal fixture did not succeed"
-      in
-      let encoded = ref None in
-      (match
-         EO.commit_and_settle_flow_domain
-           ~commit:(fun intent ->
-             encoded := Some (EO.domain_settlement_intent_to_string intent);
-             Error ())
-           success
-           EO.Domain_valid
-       with
-       | Error (EO.Domain_commit_failed ()) -> ()
-       | Ok _
-       | Error EO.Domain_settlement_in_progress
-       | Error EO.Domain_settlement_conflict ->
-         fail "success ordinal fixture unexpectedly settled");
-      match !encoded with
-      | None -> fail "success ordinal fixture emitted no domain intent"
-      | Some encoded ->
-        (match EO.domain_settlement_intent_of_string encoded with
-         | Ok intent -> intent
-         | Error _ -> fail "success ordinal fixture intent did not decode")
-    in
-    let intent_field field intent =
-      EO.domain_settlement_intent_to_string intent |> json_field_string field
-    in
-    let intent_id intent =
-      EO.domain_settlement_intent_id intent |> EO.domain_settlement_id_to_string
-    in
-    let recover_permutation ordered =
-      EO.recover_flow_preferences
-        ~concurrent_scope_budget:1
-        ~evidence:(List.map (fun intent -> EO.Domain_settlement_evidence intent) ordered)
-    in
-    let first_preferences = preference_store ~capacity:1 () in
-    let first = capture first_preferences "ordinal-a" in
-    let second_preferences = preference_store ~capacity:1 () in
-    let second = capture second_preferences "ordinal-b" in
-    if not (String.equal (intent_field "scope" first) (intent_field "scope" second))
-    then fail "success ordinal fixture did not preserve one scope";
-    if
-      not
-        (String.equal
-           (intent_field "reservation_ordinal" first)
-           (intent_field "reservation_ordinal" second))
-    then fail "success ordinal fixture did not share one reservation";
-    if
-      not
-        (String.equal
-           (intent_field "success_ordinal" first)
-           (intent_field "success_ordinal" second))
-    then fail "success ordinal fixture did not reuse the success ordinal";
-    if
-      String.equal
-        (intent_field "candidate_id" first)
-        (intent_field "candidate_id" second)
-    then fail "success ordinal fixture named one candidate twice";
-    if String.equal (intent_id first) (intent_id second)
-    then fail "success ordinal fixture produced one settlement id";
-    let conflict_ids =
-      List.map
-        (fun ordered ->
-           match recover_permutation ordered with
-           | Error (EO.Conflicting_domain_settlement_evidence id) ->
-             Some (EO.domain_settlement_id_to_string id)
-           | Ok _
-           | Error (EO.Invalid_concurrent_scope_budget _)
-           | Error (EO.Conflicting_scope_retirement_evidence _) -> None)
-        [ [ first; second ]; [ second; first ] ]
-    in
-    let every_order_conflicted =
-      List.for_all
-        (function
-          | Some _ -> true
-          | None -> false)
-        conflict_ids
-    in
-    let deterministic_conflict_payload =
-      match conflict_ids with
-      | Some expected :: rest ->
-        (String.equal expected (intent_id first)
-         || String.equal expected (intent_id second))
-        && List.for_all
-             (function
-               | Some actual -> String.equal actual expected
-               | None -> false)
-             rest
-      | None :: _ | [] -> false
-    in
-    let distinct_preferences = preference_store ~capacity:1 () in
-    let distinct_first = capture distinct_preferences "ordinal-a" in
-    let distinct_second = capture distinct_preferences "ordinal-b" in
-    if
-      not
-        (String.equal
-           (intent_field "reservation_ordinal" distinct_first)
-           (intent_field "reservation_ordinal" distinct_second))
-    then fail "distinct-ordinal control did not share one reservation";
-    if
-      String.equal
-        (intent_field "success_ordinal" distinct_first)
-        (intent_field "success_ordinal" distinct_second)
-    then fail "distinct-ordinal control reused a success ordinal";
-    let distinct_ordinals_recover =
-      List.for_all
-        (fun ordered ->
-           match recover_permutation ordered with
-           | Ok _ -> true
-           | Error _ -> false)
-        [ [ distinct_first; distinct_second ]; [ distinct_second; distinct_first ] ]
-    in
-    every_order_conflicted, deterministic_conflict_payload, distinct_ordinals_recover
-  in
-  check int "success ordinal reuse fixture dispatches four times" 4 posts;
-  check bool "reused success ordinals always conflict" true every_order_conflicted;
-  check
-    bool
-    "reused success ordinal conflict payload is deterministic"
-    true
-    deterministic_conflict_payload;
-  check bool "distinct success ordinals still recover" true distinct_ordinals_recover
-;;
-
-let test_recovery_capacity_is_derived_from_distinct_active_scopes () =
-  let (historical_ids_do_not_inflate, high_water_restored), posts =
-    with_server ~response:(openai_response {|{"name":"accepted"}|})
-    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
-    with_catalog [ catalog_entry ~id:"capacity-a" ~base_url ~native:true ~json:true () ]
-    @@ fun snapshot ->
-    let live_preferences = preference_store ~capacity:2 () in
-    let capture preferences scope =
-      let success =
-        frozen_flow ~preferences ~scope snapshot [ "capacity-a" ]
-        |> start_flow
-        |> execute_ok ~net
-      in
-      let success =
-        match success with
-        | Ok success -> success
-        | Error _ -> fail "capacity recovery fixture did not succeed"
-      in
-      let encoded = ref None in
-      (match
-         EO.commit_and_settle_flow_domain
-           ~commit:(fun intent ->
-             encoded := Some (EO.domain_settlement_intent_to_string intent);
-             Error ())
-           success
-           EO.Domain_valid
-       with
-       | Error (EO.Domain_commit_failed ()) -> ()
-       | Ok _
-       | Error EO.Domain_settlement_in_progress
-       | Error EO.Domain_settlement_conflict ->
-         fail "capacity recovery fixture unexpectedly settled");
-      match !encoded with
-      | Some encoded ->
-        (match EO.domain_settlement_intent_of_string encoded with
-         | Ok intent -> intent, encoded
-         | Error _ -> fail "capacity recovery fixture intent did not decode")
-      | None -> fail "capacity recovery fixture did not expose its intent"
-    in
-    let first_scope = flow_scope "/runtime/recovery-capacity/a" in
-    let first, first_encoded = capture live_preferences first_scope in
-    let second, second_encoded = capture live_preferences first_scope in
-    let recovered_preferences =
-      match
-        EO.recover_flow_preferences
-          ~concurrent_scope_budget:0
-          ~evidence:
-            [ EO.Domain_settlement_evidence first; EO.Domain_settlement_evidence second ]
-      with
-      | Ok preferences -> preferences
-      | Error _ -> fail "distinct-scope recovery failed"
-    in
-    let second_scope = flow_scope "/runtime/recovery-capacity/b" in
-    let historical_ids_do_not_inflate =
-      match
-        snapshot_candidates
-          ~preferences:recovered_preferences
-          ~scope:second_scope
-          [ flow_candidate snapshot "capacity-a" ]
-      with
-      | Error (EO.Flow_preference_capacity_exhausted { capacity = 1 }) -> true
-      | Ok _ | Error _ -> false
-    in
-    ignore (retire_scope recovered_preferences first_scope);
-    let _, next_encoded =
-      capture recovered_preferences (flow_scope "/runtime/recovery-capacity/next")
-    in
-    ( historical_ids_do_not_inflate
-    , Int64.compare
-        (json_field_string "reservation_ordinal" next_encoded |> Int64.of_string)
-        (Int64.max
-           (json_field_string "reservation_ordinal" first_encoded |> Int64.of_string)
-           (json_field_string "reservation_ordinal" second_encoded |> Int64.of_string))
-      > 0 )
-  in
-  check int "capacity recovery proof dispatches only live fixtures" 3 posts;
-  check bool "historical ids do not inflate capacity" true historical_ids_do_not_inflate;
-  check bool "recovery restores reservation high-water" true high_water_restored
+  |> fun evidence -> candidate_ids evidence.declared_candidate_snapshot
 ;;
 
 let test_snapshot_defers_admission_and_allocates_nonshared_current_attempts () =
@@ -2319,8 +459,6 @@ let test_snapshot_defers_admission_and_allocates_nonshared_current_attempts () =
       | first :: rest ->
         (match
            EO.snapshot_flow
-             ~preferences:(preference_store ())
-             ~scope:(flow_scope "nonsharing")
              ~first
              ~rest
              ~messages:[ msg "freeze all" ]
@@ -2361,7 +499,7 @@ let test_snapshot_defers_admission_and_allocates_nonshared_current_attempts () =
          int
          "candidate snapshot is complete"
          3
-         (List.length evidence.EO.candidate_snapshot);
+         (List.length evidence.EO.declared_candidate_snapshot);
        check int "no admission is speculative" 0 (List.length evidence.admissions);
        check int "no attempt is speculative" 0 (List.length evidence.attempts);
        check
@@ -2463,7 +601,7 @@ let test_later_missing_credential_does_not_block_current_success () =
       int
       "full candidate snapshot remains frozen"
       2
-      (List.length (EO.flow_success_evidence success).candidate_snapshot);
+      (List.length (EO.flow_success_evidence success).declared_candidate_snapshot);
     check
       int
       "only current admission is recorded"
@@ -2483,27 +621,14 @@ let test_later_missing_credential_does_not_block_current_success () =
   | Error _ -> fail "later missing credential blocked the current candidate"
 ;;
 
-(* The format axis of the exact-output contract had no behavioural coverage. The
-   chain that carries a format refusal to the next candidate — capability read refuses
-   (exact_output.ml No_structured_output + Json_syntax -> Error Json_syntax_unavailable),
-   the refusal classifies as a candidate rejection (admission_error_disposition ->
-   Output_requirement_rejected), the walk treats a rejection as advanceable
-   (advanceable_flow_failure) — held only by construction. Json_syntax_unavailable
-   appeared nowhere in any test, so nothing observed a format refusal ordering rather
-   than ending the walk. The neighbouring credential cases exercise the same advance
-   step through Runtime_slot_unavailable, which is why the mechanism worked; what was
-   unobserved is that a *format* refusal reaches it and that a capable successor then
-   serves the same request. *)
-let test_format_refusal_orders_the_walk () =
-  let (result, dispositions, advances), posts =
-    with_server ~response:(openai_response {|{"name":"accepted"}|})
+let test_json_syntax_uses_strict_text_fallback () =
+  let (result, advances), posts =
+    with_counted_server
+      ~measurement_reply:(Measurement_tokens 1)
+      ~response:(openai_response {|{"name":"accepted"}|})
     @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
-    with_catalog
-      [ catalog_entry ~id:"no-json" ~base_url ~native:false ~json:false ()
-      ; catalog_entry ~id:"json-capable" ~base_url ~native:true ~json:true ()
-      ]
+    with_catalog [ catalog_entry ~id:"text-json" ~base_url ~native:false ~json:false () ]
     @@ fun snapshot ->
-    let dispositions = ref [] in
     let advances = ref 0 in
     let result =
       EO.execute_flow_once
@@ -2511,39 +636,175 @@ let test_format_refusal_orders_the_walk () =
         ~on_measurement_terminal:(fun _ -> Ok ())
         ~before_measurement_dispatch:(fun _ -> Ok ())
         ~before_dispatch:(fun _ -> Ok ())
-        ~before_advance:(fun ~failed ~next:_ ->
+        ~before_advance:(fun ~failed:_ ~next:_ ->
           incr advances;
-          (match failed with
-           | EO.Flow_candidate_rejected rejection ->
-             dispositions := EO.candidate_rejection_disposition rejection :: !dispositions
-           | _ -> fail "a format refusal did not arrive as a candidate rejection");
           Ok ())
-        (start_flow (frozen_flow snapshot [ "no-json"; "json-capable" ]))
+        (start_flow (frozen_flow snapshot [ "text-json" ]))
     in
-    result, !dispositions, !advances
+    result, !advances
   in
-  (* Pre-dispatch: the refused candidate never reaches the wire, so ordering past it
-     is not a duplicate request. *)
-  check int "only the capable candidate posts" 1 posts;
-  check int "the format refusal advanced the walk once" 1 advances;
-  (match dispositions with
-   | [ EO.Output_requirement_rejected ] -> ()
-   | [ _ ] -> fail "a format refusal was classified as some other disposition"
-   | _ -> failf "expected exactly one rejection, saw %d" (List.length dispositions));
+  check int "text fallback skips measurement" 0 posts.measurement_posts;
+  check int "text fallback posts exactly once" 1 posts.generation_posts;
+  check int "successful text fallback does not advance" 0 advances;
+  let request =
+    match posts.generation_bodies with
+    | [ body ] -> Yojson.Safe.from_string body
+    | _ -> fail "text fallback did not retain its single generation body"
+  in
+  (match request with
+   | `Assoc fields ->
+     check
+       bool
+       "text fallback emits no response_format field"
+       false
+       (List.mem_assoc "response_format" fields)
+   | _ -> fail "text fallback request body was not an object");
+  let messages = Yojson.Safe.Util.(request |> member "messages" |> to_list) in
+  check int "strict JSON instruction is appended last" 2 (List.length messages);
+  let instruction =
+    match List.rev messages with
+    | final :: _ -> Yojson.Safe.Util.(final |> member "content" |> to_string)
+    | [] -> fail "text fallback request lost all messages"
+  in
+  check
+    bool
+    "final instruction requires a bare JSON value"
+    true
+    (String.starts_with
+       ~prefix:
+         "Return exactly one JSON value matching this JSON Schema. Do not use Markdown \
+          code fences or include any explanation. JSON Schema:"
+       instruction);
   match result with
   | Ok success ->
     check
       string
-      "the capable successor served the same request"
-      "json-capable"
+      "text fallback candidate serves the request"
+      "text-json"
       (candidate_id (EO.flow_success_candidate success));
     check
-      int
-      "both candidates were visited"
-      2
-      (EO.candidate_visit_count_to_int
-         (EO.flow_success_evidence success).candidate_visit_count)
-  | Error _ -> fail "a format refusal ended the walk instead of ordering it"
+      bool
+      "strict text fallback returns parsed JSON"
+      true
+      ((EO.flow_success_output success).output = `Assoc [ "name", `String "accepted" ])
+  | Error _ -> fail "valid JSON text fallback did not succeed"
+;;
+
+let test_fenced_text_json_advances_to_frozen_successor () =
+  let first_response =
+    `OK, openai_response "```json\n{\"name\":\"must-not-be-cleaned\"}\n```"
+  in
+  let (result, observed_advance, advances), posts =
+    with_server ~first_response ~response:(openai_response {|{"name":"accepted"}|})
+    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
+    with_catalog
+      [ catalog_entry ~id:"fenced-text" ~base_url ~native:false ~json:false ()
+      ; catalog_entry ~id:"bare-text" ~base_url ~native:false ~json:false ()
+      ]
+    @@ fun snapshot ->
+    let observed_advance = ref None in
+    let advances = ref 0 in
+    let result =
+      EO.execute_flow_once
+        ~net
+        ~on_measurement_terminal:(fun _ -> Ok ())
+        ~before_measurement_dispatch:(fun _ -> Ok ())
+        ~before_dispatch:(fun _ -> Ok ())
+        ~before_advance:(fun ~failed ~next ->
+          let candidate, failure = flow_execution_failure failed in
+          observed_advance
+          := Some
+               ( candidate_id candidate
+               , next.identity.candidate_id
+               , failure.EO.cause
+               , EO.receipt_phase failure.receipt
+               , EO.receipt_dispatch_count failure.receipt );
+          incr advances;
+          Ok ())
+        (start_flow (frozen_flow snapshot [ "fenced-text"; "bare-text" ]))
+    in
+    result, !observed_advance, !advances
+  in
+  check int "invalid then valid fallback performs two POSTs" 2 posts;
+  check int "invalid fallback advances once" 1 advances;
+  (match observed_advance with
+   | Some (failed, next, cause, phase, dispatch_count) ->
+     check string "invalid fallback candidate" "fenced-text" failed;
+     check string "frozen fallback successor" "bare-text" next;
+     check bool "fenced text is invalid JSON" true (cause = EO.Invalid_json_output);
+     check bool "invalid fallback receipt is terminal" true (phase = EO.Terminal);
+     check int "invalid fallback preserves one POST" 1 dispatch_count
+   | None -> fail "invalid fallback did not request its frozen successor");
+  match result with
+  | Ok success ->
+    check
+      string
+      "bare JSON successor serves the request"
+      "bare-text"
+      (candidate_id (EO.flow_success_candidate success));
+    check
+      bool
+      "successor output is parsed without cleanup"
+      true
+      ((EO.flow_success_output success).output = `Assoc [ "name", `String "accepted" ])
+  | Error _ -> fail "strict fallback did not advance to its frozen successor"
+;;
+
+let test_provider_schema_still_requires_native_capability () =
+  let requirement =
+    EO.make_output_requirement ~schema ~minimum_guarantee:EO.Provider_schema
+  in
+  let (result, evidence), posts =
+    with_counted_server ~measurement_reply:(Measurement_tokens 1) ~response:"unused"
+    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
+    with_catalog
+      [ catalog_entry ~id:"no-native-schema" ~base_url ~native:false ~json:false () ]
+    @@ fun snapshot ->
+    let flow =
+      start_flow
+        (frozen_candidates ~requirement [ flow_candidate snapshot "no-native-schema" ])
+    in
+    let result =
+      EO.execute_flow_once
+        ~net
+        ~on_measurement_terminal:(fun _ ->
+          fail "provider-schema rejection reached measurement terminal")
+        ~before_measurement_dispatch:(fun _ ->
+          fail "provider-schema rejection reached measurement dispatch")
+        ~before_dispatch:(fun _ ->
+          fail "provider-schema rejection reached generation dispatch")
+        ~before_advance:(fun ~failed:_ ~next:_ ->
+          fail "single provider-schema rejection requested a successor")
+        flow
+    in
+    result, EO.flow_attempt_evidence flow
+  in
+  check
+    int
+    "provider-schema rejection performs no measurement POST"
+    0
+    posts.measurement_posts;
+  check
+    int
+    "provider-schema rejection performs no generation POST"
+    0
+    posts.generation_posts;
+  check
+    int
+    "provider-schema rejection allocates no attempt"
+    0
+    (List.length evidence.attempts);
+  match result with
+  | Error (EO.Flow_candidates_exhausted { rejection; _ } as error) ->
+    check
+      bool
+      "provider-schema rejection starts no outward dispatch"
+      true
+      (EO.flow_execution_error_generation_dispatch error = EO.No_generation_dispatch);
+    (match EO.candidate_rejection_disposition rejection with
+     | EO.Output_requirement_rejected -> ()
+     | _ -> fail "provider-schema rejection lost its typed disposition")
+  | Ok _ | Error _ -> fail "missing native schema support was not rejected pre-dispatch"
 ;;
 
 let test_missing_current_credential_advances_after_durable_settlement () =
@@ -2846,10 +1107,7 @@ let test_unmeasured_constraint_advances_only_after_durable_settlement () =
       ; catalog_entry ~id:"unconstrained-exact" ~base_url ~native:true ~json:true ()
       ]
     @@ fun snapshot ->
-    let scope = flow_scope "/runtime/capacity-rejection" in
-    let ready =
-      frozen_flow ~scope snapshot [ "constrained-exact"; "unconstrained-exact" ]
-    in
+    let ready = frozen_flow snapshot [ "constrained-exact"; "unconstrained-exact" ] in
     let transitions = ref [] in
     let bound = ref [] in
     let result =
@@ -2884,10 +1142,10 @@ let test_unmeasured_constraint_advances_only_after_durable_settlement () =
               (Some 524299)
               rejected_from_tokens;
             check
-              bool
-              "candidate rejection carries flow scope"
-              true
-              (EO.flow_scope_equal scope (EO.candidate_rejection_scope rejection));
+              string
+              "candidate rejection and successor share one flow"
+              (EO.flow_id_to_string (EO.candidate_rejection_visit rejection).flow_id)
+              (EO.flow_id_to_string next.flow_id);
             check
               bool
               "unsupported measurement starts no measurement wire"
@@ -3046,12 +1304,7 @@ let test_measured_token_and_body_capacity_are_independent () =
          @@ fun snapshot ->
          let flow =
            start_flow
-             (frozen_flow
-                ~preferences:(preference_store ())
-                ~scope:(flow_scope ("measured-capacity-" ^ label))
-                ~messages:[ msg large_input ]
-                snapshot
-                [ "measured-capacity" ])
+             (frozen_flow ~messages:[ msg large_input ] snapshot [ "measured-capacity" ])
          in
          let result =
            EO.execute_flow_once
@@ -5184,50 +3437,231 @@ let test_postdispatch_and_structural_outcomes_never_advance () =
   in
   run ~abort_completion:true "partial" "unused";
   run ~status:`Too_many_requests "response" "rate limited";
-  run "structural" (openai_response "not-json");
   run "tool" tool_response
 ;;
 
-let test_success_and_later_domain_rejection_are_terminal () =
-  let result, posts =
+let test_snapshot_preserves_caller_declared_order () =
+  with_catalog
+    [ catalog_entry
+        ~id:"catalog-a"
+        ~base_url:"http://127.0.0.1:1"
+        ~native:true
+        ~json:true
+        ()
+    ; catalog_entry
+        ~id:"catalog-b"
+        ~base_url:"http://127.0.0.1:2"
+        ~native:true
+        ~json:true
+        ()
+    ]
+  @@ fun snapshot ->
+  let ready = frozen_flow snapshot [ "catalog-b"; "catalog-a" ] in
+  check
+    (list string)
+    "snapshot preserves caller order"
+    [ "catalog-b"; "catalog-a" ]
+    (flow_snapshot_ids ready)
+;;
+
+let test_semantic_rejection_advances_to_declared_successor () =
+  let (result, validated_ids, advances), posts =
     with_server ~response:(openai_response {|{"name":"accepted"}|})
     @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
     with_catalog
-      [ catalog_entry ~id:"success-a" ~base_url ~native:true ~json:true ()
-      ; catalog_entry ~id:"success-b" ~base_url ~native:true ~json:true ()
+      [ catalog_entry ~id:"semantic-a" ~base_url ~native:true ~json:true ()
+      ; catalog_entry ~id:"semantic-b" ~base_url ~native:true ~json:true ()
       ]
     @@ fun snapshot ->
-    execute_ok ~net (start_flow (frozen_flow snapshot [ "success-a"; "success-b" ]))
+    let validated_ids = ref [] in
+    let advances = ref 0 in
+    let result =
+      execute_validated
+        ~net
+        ~before_advance:(fun ~failed:_ ~next:_ ->
+          incr advances;
+          Ok ())
+        ~validate:(fun success ->
+          let id = candidate_id (EO.flow_success_candidate success) in
+          validated_ids := id :: !validated_ids;
+          if String.equal id "semantic-a"
+          then EO.Reject_and_advance ("domain-invalid:" ^ id)
+          else EO.Accept id)
+        (start_flow (frozen_flow snapshot [ "semantic-a"; "semantic-b" ]))
+    in
+    result, List.rev !validated_ids, !advances
   in
-  check int "success dispatches exactly once" 1 posts;
+  check int "one POST per visited candidate" 2 posts;
+  check
+    (list string)
+    "validator follows declared order"
+    [ "semantic-a"; "semantic-b" ]
+    validated_ids;
+  check int "semantic rejection bypasses before_advance" 0 advances;
   match result with
   | Ok success ->
-    let evidence = EO.flow_success_evidence success in
+    check string "accepted successor" "semantic-b" success.accepted;
     check
       string
-      "first candidate succeeds"
-      "success-a"
-      (candidate_id (EO.flow_success_candidate success));
+      "transport success belongs to successor"
+      "semantic-b"
+      (candidate_id (EO.flow_success_candidate success.transport_success));
     check
-      int
-      "successor remains unavailable to later domain rejection"
-      1
-      (List.length evidence.attempts);
+      (list string)
+      "prior opaque rejection is preserved"
+      [ "semantic-a" ]
+      (List.map semantic_rejection_candidate_id success.prior_rejections)
+  | Error _ -> fail "declared semantic successor did not succeed"
+;;
+
+let test_all_semantic_rejections_return_nonempty_ordered_exhaustion () =
+  let (result, advances), posts =
+    with_server ~response:(openai_response {|{"name":"rejected"}|})
+    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
+    with_catalog
+      [ catalog_entry ~id:"reject-a" ~base_url ~native:true ~json:true ()
+      ; catalog_entry ~id:"reject-b" ~base_url ~native:true ~json:true ()
+      ; catalog_entry ~id:"reject-c" ~base_url ~native:true ~json:true ()
+      ]
+    @@ fun snapshot ->
+    let advances = ref 0 in
+    let result =
+      execute_validated
+        ~net
+        ~before_advance:(fun ~failed:_ ~next:_ ->
+          incr advances;
+          Ok ())
+        ~validate:(fun success ->
+          let id = candidate_id (EO.flow_success_candidate success) in
+          EO.Reject_and_advance ("rejected:" ^ id))
+        (start_flow (frozen_flow snapshot [ "reject-a"; "reject-b"; "reject-c" ]))
+    in
+    result, !advances
+  in
+  check int "each exhausted candidate posts once" 3 posts;
+  check int "semantic exhaustion bypasses before_advance" 0 advances;
+  match result with
+  | Error (EO.Flow_semantic_candidates_exhausted { rejections; evidence }) ->
+    let ordered = rejections.first :: rejections.rest in
     check
-      bool
-      "ordinal exhaustion follows a completed outward dispatch"
-      true
-      (EO.flow_execution_error_generation_dispatch
-         (EO.Flow_success_ordinal_exhausted evidence)
-       = EO.Generation_dispatch_started);
+      (list string)
+      "nonempty rejection trace preserves declared order"
+      [ "reject-a"; "reject-b"; "reject-c" ]
+      (List.map semantic_rejection_candidate_id ordered);
+    List.iter
+      (fun (rejection : _ EO.semantic_rejection_receipt) ->
+         check
+           int
+           "semantic candidate dispatch count"
+           1
+           (EO.receipt_dispatch_count
+              (EO.flow_success_candidate rejection.transport_success).receipt))
+      ordered;
+    check int "terminal evidence retains every attempt" 3 (List.length evidence.attempts)
+  | Ok _ | Error _ -> fail "semantic exhaustion lost its typed nonempty trace"
+;;
+
+let test_admission_and_semantic_rejections_share_one_declared_walk () =
+  let (result, transitions, validated_ids), posts =
+    with_server ~response:(openai_response {|{"name":"accepted"}|})
+    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
+    with_catalog
+      ~getenv:credential_getenv
+      [ catalog_entry
+          ~api_key_env:"MISSING_FLOW_KEY"
+          ~id:"mixed-missing"
+          ~base_url
+          ~native:true
+          ~json:true
+          ()
+      ; catalog_entry ~id:"mixed-semantic" ~base_url ~native:true ~json:true ()
+      ; catalog_entry ~id:"mixed-accepted" ~base_url ~native:true ~json:true ()
+      ]
+    @@ fun snapshot ->
+    let transitions = ref [] in
+    let validated_ids = ref [] in
+    let result =
+      execute_validated
+        ~net
+        ~before_advance:(fun ~failed ~next ->
+          transitions
+          := (flow_failure_id failed, next.identity.candidate_id) :: !transitions;
+          Ok ())
+        ~validate:(fun success ->
+          let id = candidate_id (EO.flow_success_candidate success) in
+          validated_ids := id :: !validated_ids;
+          if String.equal id "mixed-semantic"
+          then EO.Reject_and_advance id
+          else EO.Accept id)
+        (start_flow
+           (frozen_flow snapshot [ "mixed-missing"; "mixed-semantic"; "mixed-accepted" ]))
+    in
+    result, List.rev !transitions, List.rev !validated_ids
+  in
+  check int "only transport-admitted candidates post" 2 posts;
+  check
+    (list (pair string string))
+    "admission rejection advances only to predetermined successor"
+    [ "mixed-missing", "mixed-semantic" ]
+    transitions;
+  check
+    (list string)
+    "semantic validation retains declared suffix order"
+    [ "mixed-semantic"; "mixed-accepted" ]
+    validated_ids;
+  match result with
+  | Ok success ->
+    check string "mixed walk accepted final candidate" "mixed-accepted" success.accepted;
     check
-      bool
-      "replayed invocation starts no new outward dispatch"
-      true
-      (EO.flow_execution_error_generation_dispatch
-         (EO.Flow_attempt_already_started evidence)
-       = EO.No_generation_dispatch)
-  | Error _ -> fail "terminal success fixture failed"
+      (list string)
+      "mixed walk preserves semantic evidence only"
+      [ "mixed-semantic" ]
+      (List.map semantic_rejection_candidate_id success.prior_rejections)
+  | Error _ -> fail "mixed declared walk did not accept its final candidate"
+;;
+
+let test_prior_semantic_rejection_survives_later_transport_terminal () =
+  let first_response = `OK, openai_response {|{"name":"first"}|} in
+  let (result, advances), posts =
+    with_server
+      ~first_response
+      ~status:`Bad_request
+      ~response:{|{"error":"generic invalid request"}|}
+    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
+    with_catalog
+      [ catalog_entry ~id:"prior-semantic" ~base_url ~native:true ~json:true ()
+      ; catalog_entry ~id:"later-terminal" ~base_url ~native:true ~json:true ()
+      ]
+    @@ fun snapshot ->
+    let advances = ref 0 in
+    let result =
+      execute_validated
+        ~net
+        ~before_advance:(fun ~failed:_ ~next:_ ->
+          incr advances;
+          Ok ())
+        ~validate:(fun success ->
+          EO.Reject_and_advance (candidate_id (EO.flow_success_candidate success)))
+        (start_flow (frozen_flow snapshot [ "prior-semantic"; "later-terminal" ]))
+    in
+    result, !advances
+  in
+  check int "semantic then transport terminal posts once each" 2 posts;
+  check int "neither terminal path requests before_advance" 0 advances;
+  match result with
+  | Error
+      (EO.Flow_execution_terminal
+         { cause = EO.Flow_exact_execution_failed { candidate; evidence; _ }
+         ; prior_rejections
+         }) ->
+    check string "later terminal candidate" "later-terminal" (candidate_id candidate);
+    check
+      (list string)
+      "earlier opaque rejection survives"
+      [ "prior-semantic" ]
+      (List.map semantic_rejection_candidate_id prior_rejections);
+    check int "terminal evidence retains both attempts" 2 (List.length evidence.attempts)
+  | Ok _ | Error _ -> fail "later transport terminal lost prior semantic evidence"
 ;;
 
 let test_gemini_structural_sibling_rejects_before_outer_dispatch () =
@@ -5471,78 +3905,6 @@ let () =
     "exact-output-flow"
     [ ( "outer-flow"
       , [ test_case
-            "same-scope last-good changes only future snapshots"
-            `Quick
-            test_scope_local_domain_valid_preference_changes_only_future_snapshots
-        ; test_case
-            "concurrent flow scopes isolate attempts and last-good"
-            `Quick
-            test_concurrent_flow_scopes_isolate_attempts_and_future_preferences
-        ; test_case
-            "domain rejection does not update preference"
-            `Quick
-            test_domain_rejection_never_updates_preference_and_settlement_is_affine
-        ; test_case
-            "concurrent domain settlement is nonblocking and later replays"
-            `Quick
-            test_concurrent_domain_settlement_has_one_winner
-        ; test_case
-            "older success cannot overwrite newer after reversed domain settlement"
-            `Quick
-            test_older_success_cannot_overwrite_newer_after_reversed_domain_settlement
-        ; test_case
-            "rebound preference is not promoted and observation is typed"
-            `Quick
-            test_rebound_preference_is_not_promoted_and_observation_is_typed
-        ; test_case
-            "blank flow scope is rejected"
-            `Quick
-            test_blank_flow_scope_is_rejected
-        ; test_case
-            "preference capacity is typed and reusable after removal"
-            `Quick
-            test_preference_store_capacity_is_typed_and_reusable_after_removal
-        ; test_case
-            "removed scope keeps durable settlement idempotent"
-            `Quick
-            test_removed_scope_consumes_domain_valid_settlement_as_typed_failure
-        ; test_case
-            "committed intent resumes and restores high-water"
-            `Quick
-            test_committed_intent_resumes_without_dispatch_and_restores_high_water
-        ; test_case
-            "retirement blocks stale and newer reservation reactivates"
-            `Quick
-            test_retirement_recovery_blocks_stale_and_allows_newer_reservation
-        ; test_case
-            "recovery rejects superseded retirement conflicts regardless order"
-            `Quick
-            test_recovery_rejects_superseded_retirement_conflicts_regardless_order
-        ; test_case
-            "rejected-only recovery restores high-water without active scope"
-            `Quick
-            test_rejected_only_recovery_restores_high_water_without_active_scope
-        ; test_case
-            "retirement cancellation replays stable intent after high-water drift"
-            `Quick
-            test_retirement_cancellation_replays_stable_intent_after_high_water_drift
-        ; test_case
-            "retirement initial error preserves intent after high-water drift"
-            `Quick
-            test_retirement_initial_error_preserves_intent_after_high_water_drift
-        ; test_case
-            "recovery rejects conflicting disposition"
-            `Quick
-            test_recovery_conflicting_disposition_fails_closed
-        ; test_case
-            "recovery rejects reused success ordinals regardless order"
-            `Quick
-            test_recovery_rejects_reused_success_ordinals_regardless_order
-        ; test_case
-            "recovery capacity follows distinct active scopes"
-            `Quick
-            test_recovery_capacity_is_derived_from_distinct_active_scopes
-        ; test_case
             "snapshot defers admission and current attempts do not share"
             `Quick
             test_snapshot_defers_admission_and_allocates_nonshared_current_attempts
@@ -5551,9 +3913,17 @@ let () =
             `Quick
             test_later_missing_credential_does_not_block_current_success
         ; test_case
-            "format refusal orders the walk"
+            "JSON syntax uses strict text fallback"
             `Quick
-            test_format_refusal_orders_the_walk
+            test_json_syntax_uses_strict_text_fallback
+        ; test_case
+            "fenced JSON advances to frozen successor"
+            `Quick
+            test_fenced_text_json_advances_to_frozen_successor
+        ; test_case
+            "provider schema still requires native capability"
+            `Quick
+            test_provider_schema_still_requires_native_capability
         ; test_case
             "missing current credential advances after durable settlement"
             `Quick
@@ -5651,9 +4021,25 @@ let () =
             `Quick
             test_postdispatch_and_structural_outcomes_never_advance
         ; test_case
-            "success and domain rejection stop"
+            "snapshot preserves caller declared order"
             `Quick
-            test_success_and_later_domain_rejection_are_terminal
+            test_snapshot_preserves_caller_declared_order
+        ; test_case
+            "semantic rejection advances to declared successor"
+            `Quick
+            test_semantic_rejection_advances_to_declared_successor
+        ; test_case
+            "all semantic rejections return typed nonempty exhaustion"
+            `Quick
+            test_all_semantic_rejections_return_nonempty_ordered_exhaustion
+        ; test_case
+            "admission and semantic rejections share one declared walk"
+            `Quick
+            test_admission_and_semantic_rejections_share_one_declared_walk
+        ; test_case
+            "prior semantic rejection survives later transport terminal"
+            `Quick
+            test_prior_semantic_rejection_survives_later_transport_terminal
         ; test_case
             "Gemini structural sibling rejects before outer dispatch"
             `Quick

--- a/test/test_model_catalog_default.ml
+++ b/test/test_model_catalog_default.ml
@@ -1,5 +1,6 @@
 open Alcotest
 module Capabilities = Llm_provider.Capabilities
+module Capability_vocab = Llm_provider.Capability_vocab
 module Model_catalog = Llm_provider.Model_catalog
 module Serving_constraint = Llm_provider.Serving_constraint
 
@@ -28,6 +29,75 @@ let test_load_default_catalog () =
       (Model_catalog.model_entries expected = Model_catalog.model_entries catalog
        && Model_catalog.provider_entries expected = Model_catalog.provider_entries catalog
       )
+;;
+
+let test_ollama_cloud_v1_vendor_rows_preserve_probe_truth () =
+  let catalog =
+    Model_catalog_test_support.load_repo_model_catalog
+      ~suite:"Ollama Cloud v1 vendor rows"
+  in
+  let entries = Model_catalog.model_entries catalog in
+  List.iter
+    (fun model_id ->
+       let matches =
+         List.filter
+           (fun (entry : Model_catalog.model_entry) ->
+              entry.id_prefix = model_id
+              && entry.provider_name = Some "ollama_cloud")
+           entries
+       in
+       match matches with
+       | [ entry ] ->
+         check
+           (option string)
+           (model_id ^ " capability base")
+           (Some "ollama_cloud")
+           entry.base_label;
+         check
+           (option int)
+           (model_id ^ " context")
+           (Some 262_144)
+           entry.max_context_tokens;
+         check (option bool) (model_id ^ " tools") (Some true) entry.supports_tools;
+         check
+           (option bool)
+           (model_id ^ " reasoning")
+           (Some true)
+           entry.supports_reasoning;
+         check
+           (option bool)
+           (model_id ^ " no reasoning budget control")
+           (Some false)
+           entry.supports_reasoning_budget;
+         check
+           bool
+           (model_id ^ " inherent thinking has no request control")
+           true
+           (entry.thinking_control_format
+            = Some Capability_vocab.No_thinking_control);
+         check
+           (option bool)
+           (model_id ^ " json mode")
+           (Some true)
+           entry.supports_response_format_json;
+         check
+           (option bool)
+           (model_id ^ " no native schema guarantee")
+           (Some false)
+           entry.supports_structured_output;
+         check
+           (option bool)
+           (model_id ^ " image input")
+           (Some true)
+           entry.supports_image_input;
+         check
+           (option bool)
+           (model_id ^ " native streaming")
+           (Some true)
+           entry.supports_native_streaming
+       | [] -> failf "missing ollama_cloud/%s catalog row" model_id
+       | _ -> failf "duplicate ollama_cloud/%s catalog rows" model_id)
+    [ "qwen3.5:cloud"; "gemma4:31b-cloud" ]
 ;;
 
 let test_in_memory_catalog_rejects_invalid_generated_input () =
@@ -184,6 +254,10 @@ let () =
     "model catalog default"
     [ ( "embedded catalog"
       , [ test_case "load_default" `Quick test_load_default_catalog
+        ; test_case
+            "Ollama Cloud v1 vendor rows preserve probe truth"
+            `Quick
+            test_ollama_cloud_v1_vendor_rows_preserve_probe_truth
         ; test_case
             "invalid generated input fails closed"
             `Quick

--- a/test/test_provider_config.ml
+++ b/test/test_provider_config.ml
@@ -1436,6 +1436,44 @@ let test_validate_output_schema_ollama_cloud_catalog_minimax_rejected () =
     | Ok () -> Alcotest.fail "expected Ollama Cloud minimax-m3 capability rejection")
 ;;
 
+let test_ollama_cloud_v1_vendor_models_admit_json_mode_only () =
+  with_repository_model_catalog (fun () ->
+    List.iter
+      (fun model_id ->
+         let make ?output_schema () =
+           Provider_config.make
+             ~kind:OpenAI_compat
+             ~provider_id:"ollama_cloud"
+             ~model_id
+             ~base_url:"https://ollama.com/v1"
+             ~request_path:"/chat/completions"
+             ~response_format_json:true
+             ?output_schema
+             ()
+         in
+         let json_mode = make () in
+         check_bool
+           (model_id ^ " keeps json_object mode")
+           true
+           (json_mode.response_format = Types.JsonMode);
+         check_bool
+           (model_id ^ " admits json_object without a schema")
+           true
+           (Result.is_ok (Provider_config.validate_output_schema_request json_mode));
+         let json_schema = make ~output_schema:(`Assoc [ "type", `String "object" ]) () in
+         match Provider_config.validate_output_schema_request json_schema with
+         | Error msg ->
+           check_string
+             (model_id ^ " rejects native json_schema")
+             (Printf.sprintf
+                "model %s advertises JSON mode (json_object) only; native json_schema \
+                 output is not supported by its declared capability"
+                model_id)
+             msg
+         | Ok () -> Alcotest.failf "%s must reject native json_schema" model_id)
+      [ "qwen3.5:cloud"; "gemma4:31b-cloud" ])
+;;
+
 let test_validate_output_schema_ollama_cloud_catalog_rejects_model_without_so () =
   with_repository_model_catalog (fun () ->
     let cfg =
@@ -2327,6 +2365,10 @@ let () =
             "ollama cloud catalog minimax rejected"
             `Quick
             test_validate_output_schema_ollama_cloud_catalog_minimax_rejected
+        ; Alcotest.test_case
+            "ollama cloud v1 vendor models admit json mode only"
+            `Quick
+            test_ollama_cloud_v1_vendor_models_admit_json_mode_only
         ; Alcotest.test_case
             "ollama cloud catalog rejects model without SO"
             `Quick


### PR DESCRIPTION
## Why

The outer exact-output flow had grown a second lifecycle authority: preference stores reordered caller-declared candidates and domain settlement/recovery APIs duplicated the consumer's SSOT. It also rejected ordinary text runtimes when native JSON mode was absent.

## What

- remove public preference/store/commit/settlement/retirement/recovery flow surfaces
- freeze and execute the caller-declared candidate order
- require one semantic validator on the sole \`execute_flow_once\` API
- advance after typed semantic rejection while preserving the ordered non-empty rejection trace
- admit \`Json_syntax\` on ordinary text runtimes through an OAS-owned strict JSON instruction
- parse exact JSON only; no fence stripping, substring extraction, or prose heuristics
- preserve candidate POST <= 1 and prior receipts across invalid-output failover
- keep \`Provider_schema\` restricted to native provider guarantees
- add provider-scoped Ollama Cloud catalog truth for \`qwen3.5:cloud\` and \`gemma4:31b-cloud\`

## Boundary

OAS owns provider/model resolution, vendor wire encoding, strict parsing, typed transport failure, and frozen-order failover. MASC supplies domain input and the semantic validator, then consumes the accepted value or typed exhaustion. This PR adds no durable store, lease, settlement, or MASC persistence.

## Evidence

- \`dune build --root . test/test_exact_output_flow.exe\`
- \`dune exec --root . test/test_exact_output_flow.exe\` - 38/38
- \`scripts/check-exact-output-resolver-boundary.sh\` - OK
- focused catalog/capability/provider suites - 9/9, 101/101, 119/119
- authenticated 2026-07-27 Ollama probes: Qwen/Gemma JSON mode accepted; native JSON Schema not claimed

## Follow-up

After CI and merge, release a new minor OAS version and forward-migrate MASC call sites to the mandatory-validator surface.