### PR TITLE
feat(provider): admit and observe the exact final request body

### DIFF
--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -612,6 +612,7 @@ let run_handoff_target ~sw ?clock agent (target : Handoff.handoff_target) prompt
       ~tools:target.tools
       ~context_fit_admission:agent.context_fit_admission
       ?model_input_projection:agent.model_input_projection
+      ?pre_dispatch_serialization_observer:agent.pre_dispatch_serialization_observer
       ~options:
         { default_options with
           base_url = agent.options.base_url
@@ -695,6 +696,7 @@ let resume
       ?provider_config
       ?(context_fit_admission = Disabled)
       ?model_input_projection
+      ?pre_dispatch_serialization_observer
       ?checkpoint_sink
       ?config
       ()
@@ -717,6 +719,7 @@ let resume
   ; provider_config
   ; context_fit_admission
   ; model_input_projection
+  ; pre_dispatch_serialization_observer
   ; checkpoint_sink
   }
 ;;

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -39,6 +39,7 @@ type context_fit_admission = Agent_types.context_fit_admission =
   | Enforce_when_supported
 
 type model_input_projection = Agent_types.model_input_projection
+type pre_dispatch_serialization_observer = Agent_types.pre_dispatch_serialization_observer
 
 type options = Agent_types.options =
   { base_url : string
@@ -108,8 +109,9 @@ val sdk_version : string
     replaces [options.provider]; endpoint, credential, request path, headers,
     and capability overrides are not reconstructed from the legacy option.
 
-    [context_fit_admission] and [model_input_projection] are separate from
-    [options] so callers that construct options records remain source-compatible.
+    [context_fit_admission], [model_input_projection], and
+    [pre_dispatch_serialization_observer] are separate from [options] so callers
+    that construct options records remain source-compatible.
     The optional projection is applied once during turn preparation; native
     request measurement and provider dispatch consume the same projected
     messages. A returned [Error detail] or non-reserved callback exception
@@ -123,6 +125,7 @@ val create
   -> ?provider_config:Llm_provider.Provider_config.t
   -> ?context_fit_admission:context_fit_admission
   -> ?model_input_projection:model_input_projection
+  -> ?pre_dispatch_serialization_observer:pre_dispatch_serialization_observer
   -> ?checkpoint_sink:checkpoint_sink
   -> unit
   -> t
@@ -542,6 +545,7 @@ val resume
   -> ?provider_config:Llm_provider.Provider_config.t
   -> ?context_fit_admission:context_fit_admission
   -> ?model_input_projection:model_input_projection
+  -> ?pre_dispatch_serialization_observer:pre_dispatch_serialization_observer
   -> ?checkpoint_sink:checkpoint_sink
   -> ?config:Types.agent_config
   -> unit

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -115,7 +115,11 @@ val sdk_version : string
     The optional projection is applied once during turn preparation; native
     request measurement and provider dispatch consume the same projected
     messages. A returned [Error detail] or non-reserved callback exception
-    fails the turn as {!Error.HookExecutionFailed}. *)
+    fails the turn as {!Error.HookExecutionFailed}.
+
+    [pre_dispatch_serialization_observer] receives metadata-only evidence for
+    the admitted provider body before built-in HTTP dispatch is attempted. It
+    does not prove that transport dispatch started or completed. *)
 val create
   :  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> config:Types.agent_config
@@ -533,9 +537,10 @@ val run_with_handoffs_blocks_detailed
     {!options}; pass it explicitly when resumed turns should continue emitting
     crash-recovery checkpoints. An explicit [provider_config] replaces
     [options.provider] under the same exact-carrier contract as {!create}.
-    [context_fit_admission] and [model_input_projection] must be supplied again
-    when a resumed Agent should retain opt-in provider-fit enforcement and
-    caller-owned provider-message projection. *)
+    [context_fit_admission], [model_input_projection], and
+    [pre_dispatch_serialization_observer] must be supplied again when a resumed
+    Agent should retain opt-in provider-fit enforcement, caller-owned
+    provider-message projection, and pre-dispatch serialization evidence. *)
 val resume
   :  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> checkpoint:Checkpoint.t

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -32,6 +32,7 @@ type context_fit_admission =
   | Enforce_when_supported
 
 type model_input_projection = message list -> (message list, string) result
+type pre_dispatch_serialization_observer = Llm_provider.Request_wire_observer.try_observe
 
 type options =
   { base_url : string
@@ -149,6 +150,7 @@ type t =
   ; provider_config : Llm_provider.Provider_config.t option
   ; context_fit_admission : context_fit_admission
   ; model_input_projection : model_input_projection option
+  ; pre_dispatch_serialization_observer : pre_dispatch_serialization_observer option
   ; checkpoint_sink : checkpoint_sink option
   }
 
@@ -289,6 +291,7 @@ let create
       ?provider_config
       ?(context_fit_admission = Disabled)
       ?model_input_projection
+      ?pre_dispatch_serialization_observer
       ?checkpoint_sink
       ()
   =
@@ -319,6 +322,7 @@ let create
   ; provider_config
   ; context_fit_admission
   ; model_input_projection
+  ; pre_dispatch_serialization_observer
   ; checkpoint_sink
   }
 ;;
@@ -342,6 +346,7 @@ let clone ?(copy_context = false) agent =
   ; provider_config = agent.provider_config
   ; context_fit_admission = agent.context_fit_admission
   ; model_input_projection = agent.model_input_projection
+  ; pre_dispatch_serialization_observer = agent.pre_dispatch_serialization_observer
   ; checkpoint_sink = agent.checkpoint_sink
   }
 ;;

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -38,6 +38,8 @@ type context_fit_admission =
     before request measurement or dispatch. Canonical Agent state is unchanged. *)
 type model_input_projection = Types.message list -> (Types.message list, string) result
 
+type pre_dispatch_serialization_observer = Llm_provider.Request_wire_observer.try_observe
+
 type options =
   { base_url : string
   ; provider : Provider.config option
@@ -170,6 +172,7 @@ type t =
   ; provider_config : Llm_provider.Provider_config.t option
   ; context_fit_admission : context_fit_admission
   ; model_input_projection : model_input_projection option
+  ; pre_dispatch_serialization_observer : pre_dispatch_serialization_observer option
   ; checkpoint_sink : checkpoint_sink option
   }
 
@@ -205,6 +208,7 @@ val create
   -> ?provider_config:Llm_provider.Provider_config.t
   -> ?context_fit_admission:context_fit_admission
   -> ?model_input_projection:model_input_projection
+  -> ?pre_dispatch_serialization_observer:pre_dispatch_serialization_observer
   -> ?checkpoint_sink:checkpoint_sink
   -> unit
   -> t

--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -32,6 +32,7 @@ type t =
   ; provider_config : Llm_provider.Provider_config.t option
   ; context_fit_admission : Agent.context_fit_admission
   ; model_input_projection : Agent.model_input_projection option
+  ; pre_dispatch_serialization_observer : Agent.pre_dispatch_serialization_observer option
   ; stream_idle_timeout_s : float option
   ; first_event_timeout_s : float option
   ; body_timeout_s : float option
@@ -84,6 +85,7 @@ let create ~net ~model =
   ; provider_config = None
   ; context_fit_admission = Agent.Disabled
   ; model_input_projection = None
+  ; pre_dispatch_serialization_observer = None
   ; stream_idle_timeout_s = None
   ; first_event_timeout_s = None
   ; body_timeout_s = None
@@ -189,6 +191,10 @@ let with_context_fit_admission context_fit_admission b = { b with context_fit_ad
 
 let with_model_input_projection model_input_projection b =
   { b with model_input_projection = Some model_input_projection }
+;;
+
+let with_pre_dispatch_serialization_observer observer b =
+  { b with pre_dispatch_serialization_observer = Some observer }
 ;;
 
 let with_base_url url b = { b with base_url = url }
@@ -300,6 +306,7 @@ let build b =
     ?provider_config:b.provider_config
     ~context_fit_admission:b.context_fit_admission
     ?model_input_projection:b.model_input_projection
+    ?pre_dispatch_serialization_observer:b.pre_dispatch_serialization_observer
     ?checkpoint_sink:b.checkpoint_sink
     ()
 ;;

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -134,6 +134,13 @@ val with_context_fit_admission : Agent.context_fit_admission -> t -> t
     [Error detail] fails the turn as a typed hook execution error. *)
 val with_model_input_projection : Agent.model_input_projection -> t -> t
 
+(** Observe metadata-only evidence for the exact provider serialization prepared
+    before dispatch. This hook does not prove that transport dispatch started. *)
+val with_pre_dispatch_serialization_observer
+  :  Agent.pre_dispatch_serialization_observer
+  -> t
+  -> t
+
 val with_base_url : string -> t -> t
 
 (** Inject an {!Llm_provider.Llm_transport.t} for non-HTTP providers.

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -13,6 +13,7 @@ include Complete_sync
 include Complete_stream
 
 type prepared_request = Prepared_completion_request.t
+type serialized_request = Prepared_completion_request.serialized
 type measured_request = Prepared_completion_request.measured
 type admitted_request = Prepared_completion_request.admitted
 
@@ -75,6 +76,7 @@ let complete_prepared_sync
       ?(metrics : Metrics.t option)
       ?body_timeout_s
       ?request_wire_observer
+      ?admitted_body
       ()
   =
   let request = Prepared_completion_request.request prepared in
@@ -171,6 +173,7 @@ let complete_prepared_sync
                ?connection_cache
                ?capture_id:request.capture_id
                ?request_wire_observer:request.request_wire_observer
+               ?admitted_body
                ~config:request_config
                ~messages
                ~tools
@@ -295,12 +298,14 @@ let complete_admitted
       ?request_wire_observer
       ()
   =
+  let admitted_body = Prepared_completion_request.admitted_body admitted in
   complete_prepared_sync
     ~sw
     ~net
     ?clock
     ?transport
     ~prepared:(Prepared_completion_request.admitted_request admitted)
+    ?admitted_body
     ?cache
     ?connection_cache
     ?metrics
@@ -318,6 +323,7 @@ let complete_prepared_stream
       ?(transport : Llm_transport.t option)
       ?wire_observer
       ?request_wire_observer
+      ?admitted_body
       ~(prepared : Prepared_completion_request.t)
       ~(on_event : Types.sse_event -> unit)
       ?metrics
@@ -409,6 +415,7 @@ let complete_prepared_stream
           ?observe_wire_chunk:request.observe_wire_chunk
           ?capture_id:request.capture_id
           ?request_wire_observer:request.request_wire_observer
+          ?admitted_body
           ~latency_counter
           ?on_telemetry
           ~metrics
@@ -504,6 +511,7 @@ let complete_stream_admitted
       ?on_telemetry
       ()
   =
+  let admitted_body = Prepared_completion_request.admitted_body admitted in
   complete_prepared_stream
     ~sw
     ~net
@@ -512,6 +520,7 @@ let complete_stream_admitted
     ?wire_observer
     ?request_wire_observer
     ~prepared:(Prepared_completion_request.admitted_request admitted)
+    ?admitted_body
     ~on_event
     ?metrics
     ?connection_cache

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -89,8 +89,13 @@ let complete_prepared_sync
   let config = request.Llm_transport.config in
   let messages = request.messages in
   let tools = request.tools in
+  let validation =
+    match admitted_body, transport with
+    | Some _, None -> Ok ()
+    | None, _ | Some _, Some _ -> validate_all config
+  in
   let preflight =
-    match validate_all config with
+    match validation with
     | Error err -> Error err
     | Ok () ->
       Http_client.resolve_explicit_deadline
@@ -335,7 +340,12 @@ let complete_prepared_stream
   let config = request.Llm_transport.config in
   let messages = request.messages in
   let tools = request.tools in
-  match validate_all config with
+  let validation =
+    match admitted_body, transport with
+    | Some _, None -> Ok ()
+    | None, _ | Some _, Some _ -> validate_all config
+  in
+  match validation with
   | Error err -> Error err
   | Ok () ->
     let on_event = emit_stream_event on_event in

--- a/lib/llm_provider/complete.ml
+++ b/lib/llm_provider/complete.ml
@@ -36,12 +36,33 @@ type fit_error = Prepared_completion_request.fit_error =
       }
 
 let prepare_request = Prepared_completion_request.prepare
+let admit_request_body = Prepared_completion_request.admit_serialized_body
 let measure_request = Prepared_completion_request.measure
 let resolve_context_limit = Prepared_completion_request.resolve_context_limit
 let requires_token_measurement = Prepared_completion_request.requires_token_measurement
 let serving_constraint = Prepared_completion_request.serving_constraint
 let admit_request = Prepared_completion_request.admit
 let admitted_fit = Prepared_completion_request.admitted_fit
+
+let inspect_serialized_request
+      ~stream
+      ~(config : Provider_config.t)
+      ~(messages : Types.message list)
+      ?(tools = [])
+      ()
+  =
+  Result.bind (validate_all config) (fun () ->
+    Result.map
+      (fun (http_codec, body) ->
+         Request_wire_observer.observation
+           ~capture_id:None
+           ~provider:(Provider_registry.provider_name_of_config config)
+           ~model:config.model_id
+           ~http_codec:(Provider_http_codec.fingerprint_tag http_codec)
+           ~stream
+           ~body)
+      (serialize_final_http_request_unadmitted ~stream ~config ~messages ~tools))
+;;
 
 let complete_prepared_sync
       ~sw
@@ -53,9 +74,16 @@ let complete_prepared_sync
       ?(connection_cache : Http_client.cache option)
       ?(metrics : Metrics.t option)
       ?body_timeout_s
+      ?request_wire_observer
       ()
   =
   let request = Prepared_completion_request.request prepared in
+  let request =
+    match request_wire_observer with
+    | None -> request
+    | Some request_wire_observer ->
+      { request with request_wire_observer = Some request_wire_observer }
+  in
   let config = request.Llm_transport.config in
   let messages = request.messages in
   let tools = request.tools in
@@ -141,6 +169,8 @@ let complete_prepared_sync
                ~on_http_status:m.on_http_status
                ?body_timeout_s
                ?connection_cache
+               ?capture_id:request.capture_id
+               ?request_wire_observer:request.request_wire_observer
                ~config:request_config
                ~messages
                ~tools
@@ -233,9 +263,11 @@ let complete
       ?connection_cache
       ?metrics
       ?body_timeout_s
+      ?capture_id
+      ?request_wire_observer
       ()
   =
-  let prepared = prepare_request ~config ~messages ~tools ~trace_context () in
+  let prepared = prepare_request ~config ~messages ~tools ~trace_context ?capture_id () in
   complete_prepared_sync
     ~sw
     ~net
@@ -246,6 +278,7 @@ let complete
     ?connection_cache
     ?metrics
     ?body_timeout_s
+    ?request_wire_observer
     ()
 ;;
 
@@ -259,6 +292,7 @@ let complete_admitted
       ?connection_cache
       ?metrics
       ?body_timeout_s
+      ?request_wire_observer
       ()
   =
   complete_prepared_sync
@@ -271,6 +305,7 @@ let complete_admitted
     ?connection_cache
     ?metrics
     ?body_timeout_s
+    ?request_wire_observer
     ()
 ;;
 
@@ -282,6 +317,7 @@ let complete_prepared_stream
       ?clock
       ?(transport : Llm_transport.t option)
       ?wire_observer
+      ?request_wire_observer
       ~(prepared : Prepared_completion_request.t)
       ~(on_event : Types.sse_event -> unit)
       ?metrics
@@ -336,6 +372,12 @@ let complete_prepared_stream
           (Wire_observer.show_failure failure)
     in
     let request =
+      let request =
+        match request_wire_observer with
+        | None -> request
+        | Some request_wire_observer ->
+          { request with request_wire_observer = Some request_wire_observer }
+      in
       match wire_observer with
       | None -> request
       | Some try_observe ->
@@ -365,6 +407,8 @@ let complete_prepared_stream
           ?first_event_timeout_s:request.first_event_timeout_s
           ?body_timeout_s:request.body_timeout_s
           ?observe_wire_chunk:request.observe_wire_chunk
+          ?capture_id:request.capture_id
+          ?request_wire_observer:request.request_wire_observer
           ~latency_counter
           ?on_telemetry
           ~metrics
@@ -408,6 +452,7 @@ let complete_stream
       ?transport
       ?capture_id
       ?wire_observer
+      ?request_wire_observer
       ~(config : Provider_config.t)
       ~(messages : Types.message list)
       ?(tools = [])
@@ -436,6 +481,7 @@ let complete_stream
     ?clock
     ?transport
     ?wire_observer
+    ?request_wire_observer
     ~prepared
     ~on_event
     ?metrics
@@ -450,6 +496,7 @@ let complete_stream_admitted
       ?clock
       ?transport
       ?wire_observer
+      ?request_wire_observer
       admitted
       ~on_event
       ?metrics
@@ -463,6 +510,7 @@ let complete_stream_admitted
     ?clock
     ?transport
     ?wire_observer
+    ?request_wire_observer
     ~prepared:(Prepared_completion_request.admitted_request admitted)
     ~on_event
     ?metrics
@@ -492,6 +540,8 @@ let make_http_transport
             ?clock
             ?body_timeout_s
             ?connection_cache
+            ?capture_id:req.capture_id
+            ?request_wire_observer:req.request_wire_observer
             ~config:req.config
             ~messages:req.messages
             ~tools:req.tools
@@ -508,6 +558,8 @@ let make_http_transport
           ?first_event_timeout_s:req.first_event_timeout_s
           ?body_timeout_s:req.body_timeout_s
           ?observe_wire_chunk:req.observe_wire_chunk
+          ?capture_id:req.capture_id
+          ?request_wire_observer:req.request_wire_observer
           ?connection_cache
           ?latency_counter
           ~config:req.config

--- a/lib/llm_provider/complete.mli
+++ b/lib/llm_provider/complete.mli
@@ -16,6 +16,9 @@
 (** One opaque completion request after all caller-owned projection. *)
 type prepared_request
 
+(** The request paired with the exact admitted built-in HTTP serialization. *)
+type serialized_request
+
 (** The same request paired with provider-native measurement evidence. *)
 type measured_request
 
@@ -63,7 +66,7 @@ val prepare_request
 val admit_request_body
   :  stream:bool
   -> prepared_request
-  -> (unit, Http_client.http_error) result
+  -> (serialized_request, Http_client.http_error) result
 
 (** Validate and measure the exact prepared request through the provider-native
     count protocol. Invalid local configuration fails before admission or I/O;
@@ -76,7 +79,7 @@ val measure_request
   -> ?timeout_s:float
   -> sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
-  -> prepared_request
+  -> serialized_request
   -> (measured_request, Count_tokens_sync.completion_request_error) result
 
 (** Resolve the validated positive context-token limit from the explicit

--- a/lib/llm_provider/complete.mli
+++ b/lib/llm_provider/complete.mli
@@ -56,6 +56,15 @@ val prepare_request
   -> unit
   -> prepared_request
 
+(** Serialize and admit the exact final completion body before any optional
+    provider-native token-measurement round-trip. [stream = true] includes every
+    transport-owned stream-field injection. The check is pure and returns the
+    same typed [Request_body_too_large] failure as final HTTP dispatch. *)
+val admit_request_body
+  :  stream:bool
+  -> prepared_request
+  -> (unit, Http_client.http_error) result
+
 (** Validate and measure the exact prepared request through the provider-native
     count protocol. Invalid local configuration fails before admission or I/O;
     the count round-trip uses the same provider admission authority as
@@ -92,6 +101,23 @@ val admit_request
   -> (admitted_request, fit_error) result
 
 val admitted_fit : admitted_request -> context_fit
+
+(** Serialize the exact final body shape that the built-in HTTP transport would
+    send and return metadata only. Streaming inspection includes every
+    transport-owned field injection such as [stream_options.include_usage].
+
+    The function performs no network I/O and does not apply
+    [Provider_config.max_request_body_bytes]; callers may use [body_bytes] to
+    project an input before the authoritative final admission check. All other
+    request validation remains active. The request body, headers, prompts, and
+    tool arguments are not returned. *)
+val inspect_serialized_request
+  :  stream:bool
+  -> config:Provider_config.t
+  -> messages:Types.message list
+  -> ?tools:Yojson.Safe.t list
+  -> unit
+  -> (Request_wire_observer.observation, Http_client.http_error) result
 
 (** {1 Gemini URL Construction} *)
 
@@ -167,6 +193,8 @@ val complete
   -> ?connection_cache:Http_client.cache
   -> ?metrics:Metrics.t
   -> ?body_timeout_s:float
+  -> ?capture_id:string
+  -> ?request_wire_observer:Request_wire_observer.try_observe
   -> unit
   -> (Types.api_response, Http_client.http_error) result
 
@@ -183,6 +211,7 @@ val complete_admitted
   -> ?connection_cache:Http_client.cache
   -> ?metrics:Metrics.t
   -> ?body_timeout_s:float
+  -> ?request_wire_observer:Request_wire_observer.try_observe
   -> unit
   -> (Types.api_response, Http_client.http_error) result
 (** [body_timeout_s] is the exact caller-owned deadline, in seconds, for a
@@ -238,6 +267,13 @@ val complete_admitted
     Redaction is diagnostic sanitization rather than proof that an observation
     is non-sensitive. Callers must retain observations as sensitive data.
 
+    [request_wire_observer], when present, receives one metadata-only
+    observation of the final serialized body after stream-field injection and
+    exact byte admission, immediately before HTTP dispatch. It contains the
+    exact byte length and SHA-256 digest but no body or headers. Rejection and
+    ordinary observer exceptions are diagnostic and do not change the provider
+    result.
+
     Supports both Anthropic native SSE and OpenAI-compatible SSE formats,
     dispatched by {!Provider_config.t.kind}.
 
@@ -291,6 +327,7 @@ val complete_stream
   -> ?transport:Llm_transport.t
   -> ?capture_id:string
   -> ?wire_observer:Wire_observer.try_observe
+  -> ?request_wire_observer:Request_wire_observer.try_observe
   -> config:Provider_config.t
   -> messages:Types.message list
   -> ?tools:Yojson.Safe.t list
@@ -311,6 +348,7 @@ val complete_stream_admitted
   -> ?clock:_ Eio.Time.clock
   -> ?transport:Llm_transport.t
   -> ?wire_observer:Wire_observer.try_observe
+  -> ?request_wire_observer:Request_wire_observer.try_observe
   -> admitted_request
   -> on_event:(Types.sse_event -> unit)
   -> ?metrics:Metrics.t

--- a/lib/llm_provider/complete.mli
+++ b/lib/llm_provider/complete.mli
@@ -61,8 +61,10 @@ val prepare_request
 
 (** Serialize and admit the exact final completion body before any optional
     provider-native token-measurement round-trip. [stream = true] includes every
-    transport-owned stream-field injection. The check is pure and returns the
-    same typed [Request_body_too_large] failure as final HTTP dispatch. *)
+    transport-owned stream-field injection. The returned immutable artifact
+    freezes the codec, body bytes, and digest consumed by a later admitted
+    built-in HTTP dispatch. The check is pure and returns the same typed
+    [Request_body_too_large] failure as final HTTP dispatch. *)
 val admit_request_body
   :  stream:bool
   -> prepared_request
@@ -271,11 +273,11 @@ val complete_admitted
     is non-sensitive. Callers must retain observations as sensitive data.
 
     [request_wire_observer], when present, receives one metadata-only
-    observation of the final serialized body after stream-field injection and
-    exact byte admission, immediately before HTTP dispatch. It contains the
-    exact byte length and SHA-256 digest but no body or headers. Rejection and
-    ordinary observer exceptions are diagnostic and do not change the provider
-    result.
+    pre-dispatch serialization observation after stream-field injection and
+    exact byte admission, before HTTP dispatch is attempted. It contains the
+    exact byte length and SHA-256 digest but no body or headers. It does not
+    prove that transport dispatch started or completed. Rejection and ordinary
+    observer exceptions are diagnostic and do not change the provider result.
 
     Supports both Anthropic native SSE and OpenAI-compatible SSE formats,
     dispatched by {!Provider_config.t.kind}.
@@ -343,8 +345,9 @@ val complete_stream
   -> (Types.api_response, Http_client.http_error) result
 
 (** Streaming counterpart of {!complete_admitted}. Capture identity and idle
-    deadline are fixed when the request is prepared. Wire observation remains
-    an OAS-owned operational sink and cannot alter provider payload fields. *)
+    deadline are fixed when the request is prepared. Pre-dispatch serialization
+    observation remains an OAS-owned operational sink and cannot alter provider
+    payload fields. *)
 val complete_stream_admitted
   :  sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t

--- a/lib/llm_provider/complete_common.ml
+++ b/lib/llm_provider/complete_common.ml
@@ -712,6 +712,84 @@ let serialize_http_request ~stream ~(config : Provider_config.t) ~messages ~tool
     ~tools
 ;;
 
+let finalize_stream_body ~http_codec body =
+  match http_codec with
+  | Provider_http_codec.Gemini_generate_content | Provider_http_codec.Openai_responses ->
+    body
+  | Provider_http_codec.Anthropic_messages | Provider_http_codec.Ollama_chat ->
+    Http_client.inject_stream_param body
+  | Provider_http_codec.Openai_chat | Provider_http_codec.Glm_chat ->
+    (* OpenAI-compatible streaming returns token usage only when the request
+       also sets stream_options.include_usage. Anthropic and Ollama carry usage
+       natively, so they keep stream:true only. *)
+    Http_client.inject_stream_and_options body
+;;
+
+(* Serialize the exact body shape used by the built-in HTTP transport without
+   applying the declared byte ceiling. Callers either inspect the resulting
+   metadata or pass the body through [admit_final_serialized_body] before I/O.
+   Clearing the ceiling cannot change provider wire JSON because the field is
+   local admission configuration, not a serialized provider parameter. *)
+let serialize_final_http_request_unadmitted
+      ~stream
+      ~(config : Provider_config.t)
+      ~messages
+      ~tools
+  =
+  let serialization_config = { config with max_request_body_bytes = None } in
+  Result.map
+    (fun (http_codec, body) ->
+       let body = if stream then finalize_stream_body ~http_codec body else body in
+       http_codec, body)
+    (serialize_http_request ~stream ~config:serialization_config ~messages ~tools)
+;;
+
+(* Streaming serializers may add transport fields after the provider body
+   builder returns (for example [stream_options.include_usage]). Recheck the
+   caller-declared byte boundary against the exact final body instead of
+   assuming the pre-injection measurement is still authoritative. Sync callers
+   use the same helper so there is one final-wire admission contract. *)
+let admit_final_serialized_body ~(config : Provider_config.t) body =
+  let actual_bytes = String.length body in
+  match config.max_request_body_bytes with
+  | Some limit_bytes when actual_bytes > limit_bytes ->
+    Error (Http_client.request_body_too_large_error ~actual_bytes ~limit_bytes)
+  | None | Some _ -> Ok body
+;;
+
+let observe_request_wire
+      ?request_wire_observer
+      ~capture_id
+      ~(config : Provider_config.t)
+      ~http_codec
+      ~stream
+      ~body
+      ()
+  =
+  match request_wire_observer with
+  | None -> ()
+  | Some try_observe ->
+    let observation =
+      Request_wire_observer.observation
+        ~capture_id
+        ~provider:(Provider_registry.provider_name_of_config config)
+        ~model:config.model_id
+        ~http_codec:(Provider_http_codec.fingerprint_tag http_codec)
+        ~stream
+        ~body
+    in
+    (match Request_wire_observer.observe try_observe observation with
+     | Ok () -> ()
+     | Error failure ->
+       (* Request observation is diagnostic. A full caller-owned queue or an
+          ordinary callback bug cannot reinterpret a request that passed typed
+          provider admission as a provider failure. *)
+       Diag.warn
+         "request_wire_observer"
+         "final request observation was not accepted: %s"
+         (Request_wire_observer.show_failure failure))
+;;
+
 (** Strip query string and userinfo from a URL before logging.  Built-in
     providers use clean URLs, but [custom:model@url] accepts arbitrary
     user-supplied URLs; a misconfigured one like

--- a/lib/llm_provider/complete_common.ml
+++ b/lib/llm_provider/complete_common.ml
@@ -757,6 +757,22 @@ let admit_final_serialized_body ~(config : Provider_config.t) body =
   | None | Some _ -> Ok body
 ;;
 
+let observe_pre_dispatch_serialization ?request_wire_observer observation =
+  match request_wire_observer with
+  | None -> ()
+  | Some try_observe ->
+    (match Request_wire_observer.observe try_observe observation with
+     | Ok () -> ()
+     | Error failure ->
+       (* Request observation is diagnostic. A full caller-owned queue or an
+          ordinary callback bug cannot reinterpret a request that passed typed
+          provider admission as a provider failure. *)
+       Diag.warn
+         "request_wire_observer"
+         "pre-dispatch serialization observation was not accepted: %s"
+         (Request_wire_observer.show_failure failure))
+;;
+
 let observe_request_wire
       ?request_wire_observer
       ~capture_id
@@ -766,28 +782,16 @@ let observe_request_wire
       ~body
       ()
   =
-  match request_wire_observer with
-  | None -> ()
-  | Some try_observe ->
-    let observation =
-      Request_wire_observer.observation
-        ~capture_id
-        ~provider:(Provider_registry.provider_name_of_config config)
-        ~model:config.model_id
-        ~http_codec:(Provider_http_codec.fingerprint_tag http_codec)
-        ~stream
-        ~body
-    in
-    (match Request_wire_observer.observe try_observe observation with
-     | Ok () -> ()
-     | Error failure ->
-       (* Request observation is diagnostic. A full caller-owned queue or an
-          ordinary callback bug cannot reinterpret a request that passed typed
-          provider admission as a provider failure. *)
-       Diag.warn
-         "request_wire_observer"
-         "final request observation was not accepted: %s"
-         (Request_wire_observer.show_failure failure))
+  let observation =
+    Request_wire_observer.observation
+      ~capture_id
+      ~provider:(Provider_registry.provider_name_of_config config)
+      ~model:config.model_id
+      ~http_codec:(Provider_http_codec.fingerprint_tag http_codec)
+      ~stream
+      ~body
+  in
+  observe_pre_dispatch_serialization ?request_wire_observer observation
 ;;
 
 (** Strip query string and userinfo from a URL before logging.  Built-in

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -346,6 +346,8 @@ let complete_stream_http
       ?first_event_timeout_s
       ?body_timeout_s
       ?observe_wire_chunk
+      ?capture_id
+      ?request_wire_observer
       ?(on_telemetry : (Telemetry_event.t -> unit) option)
       ?(metrics = Metrics.get_global ())
       ?(connection_cache : Http_client.cache option)
@@ -358,11 +360,17 @@ let complete_stream_http
   let request =
     match validate_all config with
     | Error _ as error -> error
-    | Ok () -> serialize_http_request ~stream:true ~config ~messages ~tools
+    | Ok () ->
+      Result.bind
+        (serialize_final_http_request_unadmitted ~stream:true ~config ~messages ~tools)
+        (fun (http_codec, body_str) ->
+           Result.map
+             (fun final_body -> http_codec, final_body)
+             (admit_final_serialized_body ~config body_str))
   in
   match request with
   | Error err -> Error err
-  | Ok (http_codec, body_str) ->
+  | Ok (http_codec, body_with_stream) ->
     if requires_non_http_transport config.kind
     then
       Error
@@ -380,21 +388,14 @@ let complete_stream_http
         | Anthropic | Kimi | OpenAI_compat | Ollama | Glm | DashScope ->
           config.base_url ^ config.request_path
       in
-      let body_with_stream =
-        match http_codec with
-        | Provider_http_codec.Gemini_generate_content
-        | Provider_http_codec.Openai_responses -> body_str
-        | Provider_http_codec.Anthropic_messages | Provider_http_codec.Ollama_chat ->
-          Http_client.inject_stream_param body_str
-        | Provider_http_codec.Openai_chat | Provider_http_codec.Glm_chat ->
-          (* OpenAI-compatible streaming returns token usage only when the
-             request also sets stream_options.include_usage. Anthropic and
-             Ollama carry usage natively (message_start/message_delta and the
-             NDJSON done-chunk respectively), so they keep stream:true only. *)
-          (* Single parse/serialize pass for both fields (was two passes via the
-             inject_stream_param >> inject_stream_options_include_usage chain). *)
-          Http_client.inject_stream_and_options body_str
-      in
+      observe_request_wire
+        ?request_wire_observer
+        ~capture_id
+        ~config
+        ~http_codec
+        ~stream:true
+        ~body:body_with_stream
+        ();
       let requested_at = Unix.gettimeofday () in
       let latency_counter =
         match latency_counter with

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -348,6 +348,7 @@ let complete_stream_http
       ?observe_wire_chunk
       ?capture_id
       ?request_wire_observer
+      ?admitted_body
       ?(on_telemetry : (Telemetry_event.t -> unit) option)
       ?(metrics = Metrics.get_global ())
       ?(connection_cache : Http_client.cache option)
@@ -362,11 +363,31 @@ let complete_stream_http
     | Error _ as error -> error
     | Ok () ->
       Result.bind
-        (serialize_final_http_request_unadmitted ~stream:true ~config ~messages ~tools)
+        (match admitted_body with
+         | None ->
+           serialize_final_http_request_unadmitted ~stream:true ~config ~messages ~tools
+         | Some admitted_body ->
+           let evidence =
+             Prepared_completion_request.admitted_body_evidence admitted_body
+           in
+           if evidence.stream
+           then
+             Ok
+               ( Prepared_completion_request.admitted_body_http_codec admitted_body
+               , Prepared_completion_request.admitted_body_contents admitted_body )
+           else
+             Error
+               (Http_client.AcceptRejected
+                  { reason =
+                      "sync admitted body cannot be dispatched through the streaming path"
+                  }))
         (fun (http_codec, body_str) ->
-           Result.map
-             (fun final_body -> http_codec, final_body)
-             (admit_final_serialized_body ~config body_str))
+           match admitted_body with
+           | Some _ -> Ok (http_codec, body_str)
+           | None ->
+             Result.map
+               (fun final_body -> http_codec, final_body)
+               (admit_final_serialized_body ~config body_str))
   in
   match request with
   | Error err -> Error err
@@ -388,14 +409,20 @@ let complete_stream_http
         | Anthropic | Kimi | OpenAI_compat | Ollama | Glm | DashScope ->
           config.base_url ^ config.request_path
       in
-      observe_request_wire
-        ?request_wire_observer
-        ~capture_id
-        ~config
-        ~http_codec
-        ~stream:true
-        ~body:body_with_stream
-        ();
+      (match admitted_body with
+       | Some admitted_body ->
+         observe_pre_dispatch_serialization
+           ?request_wire_observer
+           (Prepared_completion_request.admitted_body_evidence admitted_body)
+       | None ->
+         observe_request_wire
+           ?request_wire_observer
+           ~capture_id
+           ~config
+           ~http_codec
+           ~stream:true
+           ~body:body_with_stream
+           ());
       let requested_at = Unix.gettimeofday () in
       let latency_counter =
         match latency_counter with

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -358,8 +358,13 @@ let complete_stream_http
       ~(on_event : Types.sse_event -> unit)
       ()
   =
+  let validation =
+    match admitted_body with
+    | Some _ -> Ok ()
+    | None -> validate_all config
+  in
   let request =
-    match validate_all config with
+    match validation with
     | Error _ as error -> error
     | Ok () ->
       Result.bind

--- a/lib/llm_provider/complete_sync.ml
+++ b/lib/llm_provider/complete_sync.ml
@@ -133,8 +133,13 @@ let complete_http
       ~tools
       ()
   =
+  let validation =
+    match admitted_body with
+    | Some _ -> Ok ()
+    | None -> validate_all config
+  in
   let preflight =
-    match validate_all config with
+    match validation with
     | Error err -> Error err
     | Ok () ->
       (match

--- a/lib/llm_provider/complete_sync.ml
+++ b/lib/llm_provider/complete_sync.ml
@@ -125,6 +125,8 @@ let complete_http
          (provider:string -> model_id:string -> status:int -> unit) option)
       ?body_timeout_s
       ?(connection_cache : Http_client.cache option)
+      ?capture_id
+      ?request_wire_observer
       ~(config : Provider_config.t)
       ~(messages : Types.message list)
       ~tools
@@ -143,9 +145,16 @@ let complete_http
        with
        | Error _ as error -> error
        | Ok body_deadline ->
-         Result.map
-           (fun (http_codec, body_str) -> body_deadline, http_codec, body_str)
-           (serialize_http_request ~stream:false ~config ~messages ~tools))
+         Result.bind
+           (serialize_final_http_request_unadmitted
+              ~stream:false
+              ~config
+              ~messages
+              ~tools)
+           (fun (http_codec, body_str) ->
+              Result.map
+                (fun body_str -> body_deadline, http_codec, body_str)
+                (admit_final_serialized_body ~config body_str)))
   in
   match preflight with
   | Error err -> Error err, None
@@ -210,6 +219,14 @@ let complete_http
         , None ))
       else (
         let provider_label = provider_name in
+        observe_request_wire
+          ?request_wire_observer
+          ~capture_id
+          ~config
+          ~http_codec
+          ~stream:false
+          ~body:body_str
+          ();
         Diag.debug
           "complete"
           "%s %s → %s (%d bytes)"

--- a/lib/llm_provider/complete_sync.ml
+++ b/lib/llm_provider/complete_sync.ml
@@ -127,6 +127,7 @@ let complete_http
       ?(connection_cache : Http_client.cache option)
       ?capture_id
       ?request_wire_observer
+      ?admitted_body
       ~(config : Provider_config.t)
       ~(messages : Types.message list)
       ~tools
@@ -146,15 +147,36 @@ let complete_http
        | Error _ as error -> error
        | Ok body_deadline ->
          Result.bind
-           (serialize_final_http_request_unadmitted
-              ~stream:false
-              ~config
-              ~messages
-              ~tools)
+           (match admitted_body with
+            | None ->
+              serialize_final_http_request_unadmitted
+                ~stream:false
+                ~config
+                ~messages
+                ~tools
+            | Some admitted_body ->
+              let evidence =
+                Prepared_completion_request.admitted_body_evidence admitted_body
+              in
+              if evidence.stream
+              then
+                Error
+                  (Http_client.AcceptRejected
+                     { reason =
+                         "streaming admitted body cannot be dispatched through the sync \
+                          path"
+                     })
+              else
+                Ok
+                  ( Prepared_completion_request.admitted_body_http_codec admitted_body
+                  , Prepared_completion_request.admitted_body_contents admitted_body ))
            (fun (http_codec, body_str) ->
-              Result.map
-                (fun body_str -> body_deadline, http_codec, body_str)
-                (admit_final_serialized_body ~config body_str)))
+              match admitted_body with
+              | Some _ -> Ok (body_deadline, http_codec, body_str)
+              | None ->
+                Result.map
+                  (fun body_str -> body_deadline, http_codec, body_str)
+                  (admit_final_serialized_body ~config body_str)))
   in
   match preflight with
   | Error err -> Error err, None
@@ -219,14 +241,20 @@ let complete_http
         , None ))
       else (
         let provider_label = provider_name in
-        observe_request_wire
-          ?request_wire_observer
-          ~capture_id
-          ~config
-          ~http_codec
-          ~stream:false
-          ~body:body_str
-          ();
+        (match admitted_body with
+         | Some admitted_body ->
+           observe_pre_dispatch_serialization
+             ?request_wire_observer
+             (Prepared_completion_request.admitted_body_evidence admitted_body)
+         | None ->
+           observe_request_wire
+             ?request_wire_observer
+             ~capture_id
+             ~config
+             ~http_codec
+             ~stream:false
+             ~body:body_str
+             ());
         Diag.debug
           "complete"
           "%s %s → %s (%d bytes)"

--- a/lib/llm_provider/llm_transport.ml
+++ b/lib/llm_provider/llm_transport.ml
@@ -8,6 +8,7 @@ type completion_request =
   ; tools : Yojson.Safe.t list
   ; capture_id : string option
   ; observe_wire_chunk : Wire_observer.observe_chunk option
+  ; request_wire_observer : Request_wire_observer.try_observe option
   ; stream_idle_timeout_s : float option
     (** Inter-chunk idle deadline for streaming reads, in seconds. Bounds the
         gap between streamed SSE/NDJSON lines, not total stream duration.

--- a/lib/llm_provider/llm_transport.mli
+++ b/lib/llm_provider/llm_transport.mli
@@ -23,6 +23,11 @@ type completion_request =
         owns redaction, caller delivery, typed failure telemetry, and ordinary
         callback-exception isolation. The original caller callback is never
         exposed through the transport request. *)
+  ; request_wire_observer : Request_wire_observer.try_observe option
+    (** Optional caller-owned observer for the final serialized provider
+        request. HTTP transports invoke it exactly once after final body
+        admission and before dispatch. Custom transports that do their own
+        serialization must provide the same boundary if they participate. *)
   ; stream_idle_timeout_s : float option
     (** Inter-chunk idle deadline for streaming reads, in seconds. Bounds the
         gap between streamed SSE/NDJSON lines, not total stream duration.

--- a/lib/llm_provider/llm_transport.mli
+++ b/lib/llm_provider/llm_transport.mli
@@ -24,10 +24,12 @@ type completion_request =
         callback-exception isolation. The original caller callback is never
         exposed through the transport request. *)
   ; request_wire_observer : Request_wire_observer.try_observe option
-    (** Optional caller-owned observer for the final serialized provider
-        request. HTTP transports invoke it exactly once after final body
-        admission and before dispatch. Custom transports that do their own
-        serialization must provide the same boundary if they participate. *)
+    (** Optional caller-owned observer for pre-dispatch serialization evidence.
+        Built-in HTTP transports invoke it exactly once after final body
+        admission and before attempting dispatch. The observation does not
+        prove that transport dispatch started or completed. Custom transports
+        that do their own serialization must provide the same evidence boundary
+        if they participate. *)
   ; stream_idle_timeout_s : float option
     (** Inter-chunk idle deadline for streaming reads, in seconds. Bounds the
         gap between streamed SSE/NDJSON lines, not total stream duration.

--- a/lib/llm_provider/prepared_completion_request.ml
+++ b/lib/llm_provider/prepared_completion_request.ml
@@ -1,11 +1,23 @@
 type t = { request : Llm_transport.completion_request }
 
+type admitted_body =
+  { http_codec : Provider_http_codec.t
+  ; body : string
+  ; evidence : Request_wire_observer.observation
+  }
+
+type serialized =
+  { prepared : t
+  ; admitted_body : admitted_body
+  }
+
 type measurement =
   | Legacy_measurement of Count_tokens_sync.completion_request_measurement
   | Exact_measurement of Exact_output_count_tokens.completion_request_measurement
 
 type measured =
   { prepared : t
+  ; admitted_body : admitted_body option
   ; measurement : measurement
   }
 
@@ -66,17 +78,27 @@ let admit_serialized_body ~stream prepared =
   let config = request.Llm_transport.config in
   let ( let* ) = Result.bind in
   let* () = Complete_common.validate_all config in
-  let* _http_codec, body =
+  let* http_codec, body =
     Complete_common.serialize_final_http_request_unadmitted
       ~stream
       ~config
       ~messages:request.messages
       ~tools:request.tools
   in
-  Result.map (fun _body -> ()) (Complete_common.admit_final_serialized_body ~config body)
+  let* body = Complete_common.admit_final_serialized_body ~config body in
+  let evidence =
+    Request_wire_observer.observation
+      ~capture_id:request.capture_id
+      ~provider:(Provider_registry.provider_name_of_config config)
+      ~model:config.model_id
+      ~http_codec:(Provider_http_codec.fingerprint_tag http_codec)
+      ~stream
+      ~body
+  in
+  Ok { prepared; admitted_body = { http_codec; body; evidence } }
 ;;
 
-let measure ?connection_cache ?clock ?timeout_s ~sw ~net prepared =
+let measure_prepared ?connection_cache ?clock ?timeout_s ~sw ~net prepared =
   let config = prepared.request.Llm_transport.config in
   let measured () =
     Count_tokens_sync.measure_completion_request
@@ -87,7 +109,7 @@ let measure ?connection_cache ?clock ?timeout_s ~sw ~net prepared =
       ~net
       prepared.request
     |> Result.map (fun measurement ->
-      { prepared; measurement = Legacy_measurement measurement })
+      { prepared; admitted_body = None; measurement = Legacy_measurement measurement })
   in
   match Complete_common.validate_all config with
   | Error (Http_client.AcceptRejected { reason }) ->
@@ -97,8 +119,15 @@ let measure ?connection_cache ?clock ?timeout_s ~sw ~net prepared =
   | Ok () -> Provider_admission.with_admission ~config measured
 ;;
 
+let measure ?connection_cache ?clock ?timeout_s ~sw ~net (serialized : serialized) =
+  let prepared = serialized.prepared in
+  Result.map
+    (fun measured -> { measured with admitted_body = Some serialized.admitted_body })
+    (measure_prepared ?connection_cache ?clock ?timeout_s ~sw ~net prepared)
+;;
+
 let attach_measurement prepared measurement =
-  { prepared; measurement = Exact_measurement measurement }
+  { prepared; admitted_body = None; measurement = Exact_measurement measurement }
 ;;
 
 (* Pure single source for the context-token limit. Uses only the caller-owned
@@ -165,3 +194,8 @@ let admit ~now_unix_s ~max_context_tokens measured =
 
 let admitted_request admitted = admitted.measured.prepared
 let admitted_fit admitted = admitted.fit
+let admitted_body admitted = admitted.measured.admitted_body
+let serialized_request (serialized : serialized) = serialized.prepared
+let admitted_body_http_codec admitted_body = admitted_body.http_codec
+let admitted_body_contents admitted_body = admitted_body.body
+let admitted_body_evidence admitted_body = admitted_body.evidence

--- a/lib/llm_provider/prepared_completion_request.ml
+++ b/lib/llm_provider/prepared_completion_request.ml
@@ -51,6 +51,7 @@ let prepare
       ; tools
       ; capture_id
       ; observe_wire_chunk = None
+      ; request_wire_observer = None
       ; stream_idle_timeout_s
       ; first_event_timeout_s
       ; body_timeout_s
@@ -59,6 +60,21 @@ let prepare
 ;;
 
 let request prepared = prepared.request
+
+let admit_serialized_body ~stream prepared =
+  let request = prepared.request in
+  let config = request.Llm_transport.config in
+  let ( let* ) = Result.bind in
+  let* () = Complete_common.validate_all config in
+  let* _http_codec, body =
+    Complete_common.serialize_final_http_request_unadmitted
+      ~stream
+      ~config
+      ~messages:request.messages
+      ~tools:request.tools
+  in
+  Result.map (fun _body -> ()) (Complete_common.admit_final_serialized_body ~config body)
+;;
 
 let measure ?connection_cache ?clock ?timeout_s ~sw ~net prepared =
   let config = prepared.request.Llm_transport.config in

--- a/lib/llm_provider/prepared_completion_request.mli
+++ b/lib/llm_provider/prepared_completion_request.mli
@@ -41,6 +41,10 @@ val prepare
 
 val request : t -> Llm_transport.completion_request
 
+(** Serialize and admit the exact final completion body without network I/O.
+    Streaming admission includes transport-owned stream-field injection. *)
+val admit_serialized_body : stream:bool -> t -> (unit, Http_client.http_error) result
+
 val measure
   :  ?connection_cache:Http_client.cache
   -> ?clock:_ Eio.Time.clock

--- a/lib/llm_provider/prepared_completion_request.mli
+++ b/lib/llm_provider/prepared_completion_request.mli
@@ -5,8 +5,10 @@
     The public {!Complete} module exposes these states opaquely. *)
 
 type t
+type serialized
 type measured
 type admitted
+type admitted_body
 
 type context_fit =
   { input_tokens : int
@@ -42,8 +44,13 @@ val prepare
 val request : t -> Llm_transport.completion_request
 
 (** Serialize and admit the exact final completion body without network I/O.
-    Streaming admission includes transport-owned stream-field injection. *)
-val admit_serialized_body : stream:bool -> t -> (unit, Http_client.http_error) result
+    Streaming admission includes transport-owned stream-field injection. The
+    returned immutable state owns the exact codec, body, and digest that an
+    admitted built-in HTTP dispatch must consume. *)
+val admit_serialized_body
+  :  stream:bool
+  -> t
+  -> (serialized, Http_client.http_error) result
 
 val measure
   :  ?connection_cache:Http_client.cache
@@ -51,7 +58,7 @@ val measure
   -> ?timeout_s:float
   -> sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
-  -> t
+  -> serialized
   -> (measured, Count_tokens_sync.completion_request_error) result
 
 val attach_measurement
@@ -79,3 +86,8 @@ val admit
 
 val admitted_request : admitted -> t
 val admitted_fit : admitted -> context_fit
+val admitted_body : admitted -> admitted_body option
+val serialized_request : serialized -> t
+val admitted_body_http_codec : admitted_body -> Provider_http_codec.t
+val admitted_body_contents : admitted_body -> string
+val admitted_body_evidence : admitted_body -> Request_wire_observer.observation

--- a/lib/llm_provider/request_wire_observer.ml
+++ b/lib/llm_provider/request_wire_observer.ml
@@ -1,0 +1,121 @@
+(** See [request_wire_observer.mli]. *)
+
+type observation =
+  { capture_id : string option
+  ; provider : string
+  ; model : string
+  ; http_codec : string
+  ; stream : bool
+  ; body_bytes : int
+  ; body_sha256 : string
+  }
+[@@deriving yojson, show]
+
+type rejection = { reason : string } [@@deriving yojson, show]
+type try_observe = observation -> (unit, rejection) result
+
+type failure_cause =
+  | Observer_rejected of rejection
+  | Observer_raised of
+      { message : string
+      ; backtrace : string
+      }
+[@@deriving yojson, show]
+
+type failure =
+  { observation : observation
+  ; cause : failure_cause
+  }
+[@@deriving yojson, show]
+
+let body_sha256 body = Digestif.SHA256.(to_hex (digest_string body))
+
+let observation ~capture_id ~provider ~model ~http_codec ~stream ~body =
+  { capture_id
+  ; provider
+  ; model
+  ; http_codec
+  ; stream
+  ; body_bytes = String.length body
+  ; body_sha256 = body_sha256 body
+  }
+;;
+
+let observe try_observe observation =
+  match try_observe observation with
+  | Ok () -> Ok ()
+  | Error rejection -> Error { observation; cause = Observer_rejected rejection }
+  | exception exn ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    Reserved_exn.reraise_if_reserved exn;
+    Error
+      { observation
+      ; cause =
+          Observer_raised
+            { message = Printexc.to_string exn
+            ; backtrace = Printexc.raw_backtrace_to_string backtrace
+            }
+      }
+;;
+
+let%test "observation measures the exact serialized body" =
+  let body = {|{"model":"m","messages":[]}|} in
+  let actual =
+    observation
+      ~capture_id:(Some "request-1")
+      ~provider:"openai"
+      ~model:"m"
+      ~http_codec:"openai_chat"
+      ~stream:false
+      ~body
+  in
+  actual.body_bytes = String.length body
+  && String.equal actual.body_sha256 (body_sha256 body)
+;;
+
+let%test "observer rejection remains typed" =
+  let observed =
+    observation
+      ~capture_id:None
+      ~provider:"ollama"
+      ~model:"m"
+      ~http_codec:"ollama_chat"
+      ~stream:true
+      ~body:"{}"
+  in
+  match observe (fun _ -> Error { reason = "queue full" }) observed with
+  | Error { observation = actual; cause = Observer_rejected { reason = "queue full" } } ->
+    actual = observed
+  | Ok () | Error _ -> false
+;;
+
+let%test "ordinary observer exception becomes typed evidence" =
+  let observed =
+    observation
+      ~capture_id:None
+      ~provider:"openai"
+      ~model:"m"
+      ~http_codec:"openai_chat"
+      ~stream:false
+      ~body:"{}"
+  in
+  match observe (fun _ -> failwith "observer unavailable") observed with
+  | Error { cause = Observer_raised { message; _ }; _ } ->
+    String.equal message "Failure(\"observer unavailable\")"
+  | Ok () | Error _ -> false
+;;
+
+let%test "reserved observer exception propagates" =
+  let observed =
+    observation
+      ~capture_id:None
+      ~provider:"openai"
+      ~model:"m"
+      ~http_codec:"openai_chat"
+      ~stream:false
+      ~body:"{}"
+  in
+  match observe (fun _ -> raise Sys.Break) observed with
+  | exception Sys.Break -> true
+  | Ok () | Error _ -> false
+;;

--- a/lib/llm_provider/request_wire_observer.ml
+++ b/lib/llm_provider/request_wire_observer.ml
@@ -1,7 +1,10 @@
 (** See [request_wire_observer.mli]. *)
 
+type phase = Pre_dispatch_serialization [@@deriving yojson, show]
+
 type observation =
-  { capture_id : string option
+  { phase : phase
+  ; capture_id : string option
   ; provider : string
   ; model : string
   ; http_codec : string
@@ -31,7 +34,8 @@ type failure =
 let body_sha256 body = Digestif.SHA256.(to_hex (digest_string body))
 
 let observation ~capture_id ~provider ~model ~http_codec ~stream ~body =
-  { capture_id
+  { phase = Pre_dispatch_serialization
+  ; capture_id
   ; provider
   ; model
   ; http_codec

--- a/lib/llm_provider/request_wire_observer.mli
+++ b/lib/llm_provider/request_wire_observer.mli
@@ -1,4 +1,4 @@
-(** Caller-owned observation of one final serialized provider request.
+(** Caller-owned pre-dispatch serialization evidence for one provider request.
 
     OAS invokes the observer after provider-specific serialization and every
     stream-field injection have completed and after the exact serialized-body
@@ -14,7 +14,7 @@
     typed provider configuration (for example [max_request_body_bytes]).
 
     @stability Evolving
-    @since 0.230.0 *)
+    @since 0.229.0 *)
 
 type phase = Pre_dispatch_serialization [@@deriving yojson, show]
 
@@ -33,7 +33,7 @@ type observation =
 type rejection = { reason : string } [@@deriving yojson, show]
 
 (** A synchronous offer into caller-owned observation state. Callers should
-    keep the callback bounded because it runs immediately before dispatch. *)
+    keep the callback bounded because it runs before dispatch is attempted. *)
 type try_observe = observation -> (unit, rejection) result
 
 type failure_cause =

--- a/lib/llm_provider/request_wire_observer.mli
+++ b/lib/llm_provider/request_wire_observer.mli
@@ -1,11 +1,12 @@
 (** Caller-owned observation of one final serialized provider request.
 
     OAS invokes the observer after provider-specific serialization and every
-    stream-field injection have completed, after the exact serialized-body
-    admission check, and immediately before HTTP dispatch. The observation
-    contains only structural identity, byte length, and a SHA-256 digest; the
-    request body, prompts, tool arguments, headers, and credentials are never
-    exposed.
+    stream-field injection have completed and after the exact serialized-body
+    admission check. This is pre-dispatch serialization evidence: it proves
+    which bytes OAS prepared at that boundary, but does not claim that a
+    transport started or completed dispatch. The observation contains only
+    structural identity, byte length, and a SHA-256 digest; the request body,
+    prompts, tool arguments, headers, and credentials are never exposed.
 
     Observation is diagnostic and non-authoritative. Caller rejection or an
     ordinary callback exception is reported as typed failure evidence but does
@@ -15,8 +16,11 @@
     @stability Evolving
     @since 0.230.0 *)
 
+type phase = Pre_dispatch_serialization [@@deriving yojson, show]
+
 type observation =
-  { capture_id : string option
+  { phase : phase
+  ; capture_id : string option
   ; provider : string
   ; model : string
   ; http_codec : string

--- a/lib/llm_provider/request_wire_observer.mli
+++ b/lib/llm_provider/request_wire_observer.mli
@@ -14,7 +14,7 @@
     typed provider configuration (for example [max_request_body_bytes]).
 
     @stability Evolving
-    @since 0.229.0 *)
+    @since 0.230.0 *)
 
 type phase = Pre_dispatch_serialization [@@deriving yojson, show]
 

--- a/lib/llm_provider/request_wire_observer.mli
+++ b/lib/llm_provider/request_wire_observer.mli
@@ -1,0 +1,61 @@
+(** Caller-owned observation of one final serialized provider request.
+
+    OAS invokes the observer after provider-specific serialization and every
+    stream-field injection have completed, after the exact serialized-body
+    admission check, and immediately before HTTP dispatch. The observation
+    contains only structural identity, byte length, and a SHA-256 digest; the
+    request body, prompts, tool arguments, headers, and credentials are never
+    exposed.
+
+    Observation is diagnostic and non-authoritative. Caller rejection or an
+    ordinary callback exception is reported as typed failure evidence but does
+    not rewrite the provider result. Request admission remains owned by the
+    typed provider configuration (for example [max_request_body_bytes]).
+
+    @stability Evolving
+    @since 0.230.0 *)
+
+type observation =
+  { capture_id : string option
+  ; provider : string
+  ; model : string
+  ; http_codec : string
+  ; stream : bool
+  ; body_bytes : int
+  ; body_sha256 : string
+  }
+[@@deriving yojson, show]
+
+type rejection = { reason : string } [@@deriving yojson, show]
+
+(** A synchronous offer into caller-owned observation state. Callers should
+    keep the callback bounded because it runs immediately before dispatch. *)
+type try_observe = observation -> (unit, rejection) result
+
+type failure_cause =
+  | Observer_rejected of rejection
+  | Observer_raised of
+      { message : string
+      ; backtrace : string
+      }
+[@@deriving yojson, show]
+
+type failure =
+  { observation : observation
+  ; cause : failure_cause
+  }
+[@@deriving yojson, show]
+
+(** Construct metadata for the exact [body]. *)
+val observation
+  :  capture_id:string option
+  -> provider:string
+  -> model:string
+  -> http_codec:string
+  -> stream:bool
+  -> body:string
+  -> observation
+
+(** Offer one observation exactly once. Reserved exceptions propagate;
+    rejection and ordinary exceptions become typed failure evidence. *)
+val observe : try_observe -> observation -> (unit, failure) result

--- a/lib/pipeline/pipeline_stage_route.ml
+++ b/lib/pipeline/pipeline_stage_route.ml
@@ -233,46 +233,54 @@ let dispatch_sync
           ~trace_context
           ()
       in
-      (* Reject stale or future-dated evidence, then resolve the context limit.
-         Both are network-free and therefore precede token measurement. *)
-      match preflight_serving_constraint ~binding ~now_unix_s prepared with
+      (* Reject an oversized exact completion body, stale/future-dated
+         evidence, and an unknown context limit before token measurement.
+         All three checks are network-free. *)
+      match
+        Llm_provider.Complete.admit_request_body ~stream:false prepared
+        |> Result.map_error (Provider_failure_attribution.of_http_error ~binding)
+      with
       | Error error -> Error error
       | Ok () ->
-        (match Llm_provider.Complete.resolve_context_limit prepared with
-         | Error error -> Error (fit_error ~binding error)
-         | Ok max_context_tokens ->
-           (match
-              Llm_provider.Complete.measure_request
-                ~sw
-                ~net:agent.net
-                ?clock
-                ?timeout_s:agent.options.body_timeout_s
-                prepared
-            with
-            | Error error ->
-              Error
-                (measurement_error
-                   ~binding
-                   ~constraint_:(Llm_provider.Complete.serving_constraint prepared)
-                   error)
-            | Ok measured ->
+        (match preflight_serving_constraint ~binding ~now_unix_s prepared with
+         | Error error -> Error error
+         | Ok () ->
+           (match Llm_provider.Complete.resolve_context_limit prepared with
+            | Error error -> Error (fit_error ~binding error)
+            | Ok max_context_tokens ->
               (match
-                 Llm_provider.Complete.admit_request
-                   ~now_unix_s
-                   ~max_context_tokens
-                   measured
-               with
-               | Error error -> Error (fit_error ~binding error)
-               | Ok admitted ->
-                 Llm_provider.Complete.complete_admitted
+                 Llm_provider.Complete.measure_request
                    ~sw
                    ~net:agent.net
                    ?clock
-                   ?transport:agent.options.transport
-                   admitted
-                   ?body_timeout_s:agent.options.body_timeout_s
-                   ()
-                 |> Result.map_error (Provider_failure_attribution.of_http_error ~binding))))
+                   ?timeout_s:agent.options.body_timeout_s
+                   prepared
+               with
+               | Error error ->
+                 Error
+                   (measurement_error
+                      ~binding
+                      ~constraint_:(Llm_provider.Complete.serving_constraint prepared)
+                      error)
+               | Ok measured ->
+                 (match
+                    Llm_provider.Complete.admit_request
+                      ~now_unix_s
+                      ~max_context_tokens
+                      measured
+                  with
+                  | Error error -> Error (fit_error ~binding error)
+                  | Ok admitted ->
+                    Llm_provider.Complete.complete_admitted
+                      ~sw
+                      ~net:agent.net
+                      ?clock
+                      ?transport:agent.options.transport
+                      admitted
+                      ?body_timeout_s:agent.options.body_timeout_s
+                      ()
+                    |> Result.map_error
+                         (Provider_failure_attribution.of_http_error ~binding)))))
     in
     if enforce_context_fit agent pc
     then finish_call ?on_provider_failure (admitted_call ())
@@ -339,47 +347,54 @@ let dispatch_stream
           ?body_timeout_s:agent.options.body_timeout_s
           ()
       in
-      (* Reject stale or future-dated evidence, then resolve the context limit.
-         Both are network-free and therefore precede token measurement. *)
-      match preflight_serving_constraint ~binding ~now_unix_s prepared with
+      (* Keep the streaming final-body admission ahead of every measurement
+         round-trip just like the synchronous path. *)
+      match
+        Llm_provider.Complete.admit_request_body ~stream:true prepared
+        |> Result.map_error (Provider_failure_attribution.of_http_error ~binding)
+      with
       | Error error -> Error error
       | Ok () ->
-        (match Llm_provider.Complete.resolve_context_limit prepared with
-         | Error error -> Error (fit_error ~binding error)
-         | Ok max_context_tokens ->
-           (match
-              Llm_provider.Complete.measure_request
-                ~sw
-                ~net:agent.net
-                ?clock
-                ?timeout_s:agent.options.body_timeout_s
-                prepared
-            with
-            | Error error ->
-              Error
-                (measurement_error
-                   ~binding
-                   ~constraint_:(Llm_provider.Complete.serving_constraint prepared)
-                   error)
-            | Ok measured ->
+        (match preflight_serving_constraint ~binding ~now_unix_s prepared with
+         | Error error -> Error error
+         | Ok () ->
+           (match Llm_provider.Complete.resolve_context_limit prepared with
+            | Error error -> Error (fit_error ~binding error)
+            | Ok max_context_tokens ->
               (match
-                 Llm_provider.Complete.admit_request
-                   ~now_unix_s
-                   ~max_context_tokens
-                   measured
-               with
-               | Error error -> Error (fit_error ~binding error)
-               | Ok admitted ->
-                 Llm_provider.Complete.complete_stream_admitted
+                 Llm_provider.Complete.measure_request
                    ~sw
                    ~net:agent.net
                    ?clock
-                   ?transport:agent.options.transport
-                   admitted
-                   ~on_event
-                   ?on_telemetry
-                   ()
-                 |> Result.map_error (Provider_failure_attribution.of_http_error ~binding))))
+                   ?timeout_s:agent.options.body_timeout_s
+                   prepared
+               with
+               | Error error ->
+                 Error
+                   (measurement_error
+                      ~binding
+                      ~constraint_:(Llm_provider.Complete.serving_constraint prepared)
+                      error)
+               | Ok measured ->
+                 (match
+                    Llm_provider.Complete.admit_request
+                      ~now_unix_s
+                      ~max_context_tokens
+                      measured
+                  with
+                  | Error error -> Error (fit_error ~binding error)
+                  | Ok admitted ->
+                    Llm_provider.Complete.complete_stream_admitted
+                      ~sw
+                      ~net:agent.net
+                      ?clock
+                      ?transport:agent.options.transport
+                      admitted
+                      ~on_event
+                      ?on_telemetry
+                      ()
+                    |> Result.map_error
+                         (Provider_failure_attribution.of_http_error ~binding)))))
     in
     if enforce_context_fit agent pc
     then finish_call ?on_provider_failure (admitted_call ())

--- a/lib/pipeline/pipeline_stage_route.ml
+++ b/lib/pipeline/pipeline_stage_route.ml
@@ -220,6 +220,7 @@ let dispatch_sync
         ~tools
         ~trace_context
         ?body_timeout_s:agent.options.body_timeout_s
+        ?request_wire_observer:agent.pre_dispatch_serialization_observer
         ()
       |> Result.map_error (Provider_failure_attribution.of_http_error ~binding)
     in
@@ -241,7 +242,7 @@ let dispatch_sync
         |> Result.map_error (Provider_failure_attribution.of_http_error ~binding)
       with
       | Error error -> Error error
-      | Ok () ->
+      | Ok serialized ->
         (match preflight_serving_constraint ~binding ~now_unix_s prepared with
          | Error error -> Error error
          | Ok () ->
@@ -254,7 +255,7 @@ let dispatch_sync
                    ~net:agent.net
                    ?clock
                    ?timeout_s:agent.options.body_timeout_s
-                   prepared
+                   serialized
                with
                | Error error ->
                  Error
@@ -278,6 +279,7 @@ let dispatch_sync
                       ?transport:agent.options.transport
                       admitted
                       ?body_timeout_s:agent.options.body_timeout_s
+                      ?request_wire_observer:agent.pre_dispatch_serialization_observer
                       ()
                     |> Result.map_error
                          (Provider_failure_attribution.of_http_error ~binding)))))
@@ -330,6 +332,7 @@ let dispatch_stream
         ?stream_idle_timeout_s:agent.options.stream_idle_timeout_s
         ?first_event_timeout_s:agent.options.first_event_timeout_s
         ?body_timeout_s:agent.options.body_timeout_s
+        ?request_wire_observer:agent.pre_dispatch_serialization_observer
         ()
       |> Result.map_error (Provider_failure_attribution.of_http_error ~binding)
     in
@@ -354,7 +357,7 @@ let dispatch_stream
         |> Result.map_error (Provider_failure_attribution.of_http_error ~binding)
       with
       | Error error -> Error error
-      | Ok () ->
+      | Ok serialized ->
         (match preflight_serving_constraint ~binding ~now_unix_s prepared with
          | Error error -> Error error
          | Ok () ->
@@ -367,7 +370,7 @@ let dispatch_stream
                    ~net:agent.net
                    ?clock
                    ?timeout_s:agent.options.body_timeout_s
-                   prepared
+                   serialized
                with
                | Error error ->
                  Error
@@ -392,6 +395,7 @@ let dispatch_stream
                       admitted
                       ~on_event
                       ?on_telemetry
+                      ?request_wire_observer:agent.pre_dispatch_serialization_observer
                       ()
                     |> Result.map_error
                          (Provider_failure_attribution.of_http_error ~binding)))))

--- a/test/test_agent_pipeline.ml
+++ b/test/test_agent_pipeline.ml
@@ -51,10 +51,11 @@ let openai_tool_use_response tool_name input_json =
 ;;
 
 (** Multi-response mock: returns responses in order, cycling. *)
-let start_multi_mock ~sw ~net ~port (responses : string list) =
+let start_multi_mock ?(on_body = fun _ -> ()) ~sw ~net ~port (responses : string list) =
   let idx = Atomic.make 0 in
   let handler _conn _req body =
-    let _ = Eio.Buf_read.(of_flow ~max_size:max_int body |> take_all) in
+    let body = Eio.Buf_read.(of_flow ~max_size:max_int body |> take_all) in
+    on_body body;
     let n = List.length responses in
     let i = Atomic.fetch_and_add idx 1 in
     let resp = List.nth responses (i mod n) in
@@ -74,7 +75,15 @@ let start_multi_mock ~sw ~net ~port (responses : string list) =
   Printf.sprintf "http://127.0.0.1:%d" port
 ;;
 
-let make_agent ~net ?(tools = []) ?hooks ?tool_choice ?(model_id = "mock-model") base_url =
+let make_agent
+      ~net
+      ?(tools = [])
+      ?hooks
+      ?tool_choice
+      ?pre_dispatch_serialization_observer
+      ?(model_id = "mock-model")
+      base_url
+  =
   let config =
     { (Types.default_config ~model:"test-model") with name = "test-agent"; tool_choice }
   in
@@ -91,7 +100,7 @@ let make_agent ~net ?(tools = []) ?hooks ?tool_choice ?(model_id = "mock-model")
          | None -> Hooks.empty)
     }
   in
-  Agent.create ~net ~config ~tools ~options ()
+  Agent.create ~net ~config ~tools ~options ?pre_dispatch_serialization_observer ()
 ;;
 
 let extract_text (resp : Types.api_response) =
@@ -257,9 +266,10 @@ let openai_sse text =
     text
 ;;
 
-let start_sse_mock ~sw ~net ~port sse_body =
+let start_sse_mock ?(on_body = fun _ -> ()) ~sw ~net ~port sse_body =
   let handler _conn _req body =
-    let _ = Eio.Buf_read.(of_flow ~max_size:max_int body |> take_all) in
+    let body = Eio.Buf_read.(of_flow ~max_size:max_int body |> take_all) in
+    on_body body;
     let headers = Cohttp.Header.of_list [ "content-type", "text/event-stream" ] in
     Cohttp_eio.Server.respond_string ~status:`OK ~headers ~body:sse_body ()
   in
@@ -296,6 +306,104 @@ let test_agent_run_stream () =
       check bool "events" true (List.length !events > 0);
       Eio.Switch.fail sw Exit
     | Error e -> fail (Error.to_string e)
+  with
+  | Exit -> ()
+;;
+
+let check_pre_dispatch_serialization ~label ~body observations =
+  match List.rev observations with
+  | [ observation ] ->
+    check
+      bool
+      (label ^ " phase")
+      true
+      (observation.Llm_provider.Request_wire_observer.phase
+       = Llm_provider.Request_wire_observer.Pre_dispatch_serialization);
+    check int (label ^ " body bytes") (String.length body) observation.body_bytes;
+    check
+      string
+      (label ^ " body digest")
+      Digestif.SHA256.(to_hex (digest_string body))
+      observation.body_sha256
+  | observations -> failf "%s observer called %d times" label (List.length observations)
+;;
+
+let test_agent_run_observes_pre_dispatch_serialization () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let bodies = ref [] in
+    let observations = ref [] in
+    let url =
+      start_multi_mock
+        ~on_body:(fun body -> bodies := body :: !bodies)
+        ~sw
+        ~net:env#net
+        ~port:20033
+        [ openai_text_response "observed sync" ]
+    in
+    let agent =
+      make_agent
+        ~net:env#net
+        ~pre_dispatch_serialization_observer:(fun observation ->
+          observations := observation :: !observations;
+          Ok ())
+        url
+    in
+    (match Agent.run ~sw agent "observe sync serialization" with
+     | Ok _ -> ()
+     | Error error -> fail (Error.to_string error));
+    (match List.rev !bodies with
+     | [ body ] ->
+       check_pre_dispatch_serialization
+         ~label:"Agent.run compatibility"
+         ~body
+         !observations
+     | bodies -> failf "sync server received %d bodies" (List.length bodies));
+    Eio.Switch.fail sw Exit
+  with
+  | Exit -> ()
+;;
+
+let test_agent_run_stream_observes_pre_dispatch_serialization () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let bodies = ref [] in
+    let observations = ref [] in
+    let url =
+      start_sse_mock
+        ~on_body:(fun body -> bodies := body :: !bodies)
+        ~sw
+        ~net:env#net
+        ~port:20034
+        (openai_sse "observed stream")
+    in
+    let agent =
+      make_agent
+        ~net:env#net
+        ~pre_dispatch_serialization_observer:(fun observation ->
+          observations := observation :: !observations;
+          Ok ())
+        url
+    in
+    (match
+       Agent.run_stream ~sw ~on_event:(fun _ -> ()) agent "observe stream serialization"
+     with
+     | Ok _ -> ()
+     | Error error -> fail (Error.to_string error));
+    (match List.rev !bodies with
+     | [ body ] ->
+       check_pre_dispatch_serialization
+         ~label:"Agent.run_stream compatibility"
+         ~body
+         !observations
+     | bodies -> failf "stream server received %d bodies" (List.length bodies));
+    Eio.Switch.fail sw Exit
   with
   | Exit -> ()
 ;;
@@ -530,7 +638,19 @@ let () =
         ; test_case "tool error" `Quick test_agent_run_tool_error
         ; test_case "pre_tool hook" `Quick test_agent_run_pre_tool_hook
         ] )
-    ; "streaming", [ test_case "run_stream" `Quick test_agent_run_stream ]
+    ; ( "streaming"
+      , [ test_case "run_stream" `Quick test_agent_run_stream
+        ; test_case
+            "run_stream pre-dispatch serialization observer"
+            `Quick
+            test_agent_run_stream_observes_pre_dispatch_serialization
+        ] )
     ; "hooks", [ test_case "hooks" `Quick test_agent_run_with_hooks ]
+    ; ( "observation"
+      , [ test_case
+            "run pre-dispatch serialization observer"
+            `Quick
+            test_agent_run_observes_pre_dispatch_serialization
+        ] )
     ]
 ;;

--- a/test/test_anthropic_input_token_count.ml
+++ b/test/test_anthropic_input_token_count.ml
@@ -354,6 +354,100 @@ let check_pre_dispatch_serialization ~label ~body observations =
   | observations -> failf "%s observer called %d times" label (List.length observations)
 ;;
 
+let thinking_catalog anthropic_thinking_control =
+  let contents =
+    Printf.sprintf
+      {|
+[[models]]
+id_prefix = "frozen-catalog-model"
+base = "anthropic"
+anthropic_thinking_control = "%s"
+max_context_tokens = 512
+max_output_tokens = 64
+|}
+      anthropic_thinking_control
+  in
+  match Model_catalog.of_toml_string ~source:"frozen admitted body test" contents with
+  | Ok catalog -> catalog
+  | Error detail -> fail detail
+;;
+
+let test_admitted_body_is_frozen_across_catalog_mutation () =
+  let previous_catalog = Model_catalog.global () in
+  Fun.protect
+    ~finally:(fun () ->
+      match previous_catalog with
+      | Some catalog -> Model_catalog.set_global catalog
+      | None -> Model_catalog.clear_global ())
+    (fun () ->
+       Model_catalog.set_global (thinking_catalog "manual_budget");
+       let observations = ref [] in
+       let (result, admitted_evidence, fresh_serialization), completion_body =
+         with_admitted_http_mock ~stream:false
+         @@ fun ~sw ~net ~base_url ->
+         let cfg =
+           { (config ~max_context:512 base_url) with
+             model_id = "frozen-catalog-model"
+           ; enable_thinking = Some true
+           ; thinking_budget = Some 1024
+           ; response_format = Off
+           ; output_schema = None
+           }
+         in
+         let prepared = Complete.prepare_request ~config:cfg ~messages () in
+         let admitted_evidence =
+           Complete.inspect_serialized_request ~stream:false ~config:cfg ~messages ()
+           |> Result.get_ok
+         in
+         let serialized =
+           Complete.admit_request_body ~stream:false prepared |> Result.get_ok
+         in
+         let measured = Complete.measure_request ~sw ~net serialized |> Result.get_ok in
+         let admitted =
+           Complete.admit_request ~now_unix_s:0 ~max_context_tokens:512 measured
+           |> Result.get_ok
+         in
+         Model_catalog.set_global (thinking_catalog "always_adaptive");
+         let fresh_serialization =
+           Complete.inspect_serialized_request ~stream:false ~config:cfg ~messages ()
+         in
+         let result =
+           Complete.complete_admitted
+             ~sw
+             ~net
+             ~request_wire_observer:(fun observation ->
+               observations := observation :: !observations;
+               Ok ())
+             admitted
+             ()
+         in
+         result, admitted_evidence, fresh_serialization
+       in
+       (match fresh_serialization with
+        | Error _ -> ()
+        | Ok _ -> fail "catalog mutation did not invalidate fresh serialization");
+       (match result with
+        | Ok _ -> ()
+        | Error _ -> fail "frozen admitted body was reserialized before dispatch");
+       match completion_body with
+       | None -> fail "frozen admitted body did not reach completion dispatch"
+       | Some body ->
+         check
+           int
+           "frozen admission bytes"
+           admitted_evidence.Request_wire_observer.body_bytes
+           (String.length body);
+         check
+           string
+           "frozen admission digest"
+           admitted_evidence.body_sha256
+           Digestif.SHA256.(to_hex (digest_string body));
+         check_pre_dispatch_serialization
+           ~label:"frozen admitted body"
+           ~body
+           !observations)
+;;
+
 let test_transport_success () =
   let result, (path, headers, body) =
     with_mock ~status:`OK ~response:{|{"input_tokens":321}|}
@@ -1391,6 +1485,10 @@ let () =
             "Agent admitted stream observes dispatched serialization"
             `Quick
             test_agent_admitted_stream_observer_sees_dispatched_body
+        ; test_case
+            "admitted body is frozen across catalog mutation"
+            `Quick
+            test_admitted_body_is_frozen_across_catalog_mutation
         ; test_case
             "Agent projection is shared by measurement and dispatch"
             `Quick

--- a/test/test_anthropic_input_token_count.ml
+++ b/test/test_anthropic_input_token_count.ml
@@ -55,6 +55,7 @@ let config
       ?(request_path = "/proxy/messages")
       ?max_context
       ?max_concurrent_requests
+      ?max_request_body_bytes
       ?model_capabilities_override
       base_url
   =
@@ -77,6 +78,7 @@ let config
     ~supports_tool_choice_override:true
     ~output_schema:(`Assoc [ "type", `String "object" ])
     ?max_concurrent_requests
+    ?max_request_body_bytes
     ?model_capabilities_override
     ()
 ;;
@@ -136,6 +138,7 @@ let completion_request config : Llm_transport.completion_request =
   ; tools = [ tool ]
   ; capture_id = Some "request-count-fixture"
   ; observe_wire_chunk = None
+  ; request_wire_observer = None
   ; stream_idle_timeout_s = None
   ; first_event_timeout_s = None
   ; body_timeout_s = None
@@ -718,6 +721,56 @@ let test_resolve_before_measure_skips_count_roundtrip_stream () =
   check int "no /count_tokens round-trip for an unknown limit (stream)" 0 posts
 ;;
 
+let expect_request_body_rejection label = function
+  | Error
+      (Agent_sdk.Error.Api
+         (Retry.InvalidRequest
+            { reason = Retry.Request_body_too_large { actual_bytes; limit_bytes }; _ }))
+    ->
+    check int (label ^ " declared byte limit") 1 limit_bytes;
+    check bool (label ^ " exact body exceeds limit") true (actual_bytes > limit_bytes)
+  | Error error -> fail (label ^ ": " ^ Agent_sdk.Error.to_string error)
+  | Ok _ -> fail (label ^ ": oversized completion body was admitted")
+;;
+
+let run_body_admission_before_measurement ~stream =
+  let dispatched = ref false in
+  let result, posts =
+    with_post_counter
+    @@ fun ~sw ~net ~base_url ->
+    let agent =
+      build_admission_agent
+        ~net
+        ~provider_config:(config ~max_context:1048576 ~max_request_body_bytes:1 base_url)
+        ~transport:(dispatch_tripwire dispatched)
+        ()
+    in
+    if stream
+    then
+      Agent_sdk.Agent.run_stream
+        ~sw
+        ~on_event:(fun _ -> ())
+        agent
+        "admit exact streaming body before measurement"
+    else Agent_sdk.Agent.run ~sw agent "admit exact sync body before measurement"
+  in
+  result, posts, !dispatched
+;;
+
+let test_sync_body_admission_precedes_measurement () =
+  let result, posts, dispatched = run_body_admission_before_measurement ~stream:false in
+  expect_request_body_rejection "sync" result;
+  check int "sync body rejection makes no count request" 0 posts;
+  check bool "sync body rejection makes no completion request" false dispatched
+;;
+
+let test_stream_body_admission_precedes_measurement () =
+  let result, posts, dispatched = run_body_admission_before_measurement ~stream:true in
+  expect_request_body_rejection "stream" result;
+  check int "stream body rejection makes no count request" 0 posts;
+  check bool "stream body rejection makes no completion request" false dispatched
+;;
+
 let test_measurement_validates_before_io () =
   Eio_main.run
   @@ fun env ->
@@ -1206,6 +1259,14 @@ let () =
             "Kimi Agent overflow blocks dispatch"
             `Quick
             test_kimi_agent_overflow_blocks_dispatch
+        ; test_case
+            "sync body admission precedes token measurement"
+            `Quick
+            test_sync_body_admission_precedes_measurement
+        ; test_case
+            "stream body admission precedes token measurement"
+            `Quick
+            test_stream_body_admission_precedes_measurement
         ; test_case
             "invalid count response is provider parse failure"
             `Quick

--- a/test/test_anthropic_input_token_count.ml
+++ b/test/test_anthropic_input_token_count.ml
@@ -83,6 +83,12 @@ let config
     ()
 ;;
 
+let serialize_sync prepared =
+  match Complete.admit_request_body ~stream:false prepared with
+  | Ok serialized -> serialized
+  | Error _ -> fail "request serialization admission failed"
+;;
+
 let kimi_config ?max_context base_url =
   { (config ~kind:Provider_config.Kimi ?max_context base_url) with
     response_format = Off
@@ -103,17 +109,22 @@ let response =
 let build_admission_agent
       ?model_input_projection
       ?body_timeout_s
+      ?pre_dispatch_serialization_observer
       ~net
       ~provider_config
-      ~transport
+      ?transport
       ()
   =
   let builder =
     Agent_sdk.Builder.create ~net ~model:provider_config.Provider_config.model_id
     |> Agent_sdk.Builder.with_provider_config provider_config
     |> Agent_sdk.Builder.with_context_fit_admission Agent_sdk.Agent.Enforce_when_supported
-    |> Agent_sdk.Builder.with_transport transport
     |> Agent_sdk.Builder.without_event_bus
+  in
+  let builder =
+    match transport with
+    | None -> builder
+    | Some transport -> Agent_sdk.Builder.with_transport transport builder
   in
   let builder =
     match model_input_projection with
@@ -124,6 +135,12 @@ let build_admission_agent
     match body_timeout_s with
     | None -> builder
     | Some timeout_s -> Agent_sdk.Builder.with_body_timeout timeout_s builder
+  in
+  let builder =
+    match pre_dispatch_serialization_observer with
+    | None -> builder
+    | Some observer ->
+      Agent_sdk.Builder.with_pre_dispatch_serialization_observer observer builder
   in
   builder
   |> Agent_sdk.Builder.build_safe
@@ -253,6 +270,90 @@ let with_mock ~status ~response f =
     f ~sw ~net ~base_url)
 ;;
 
+let admitted_anthropic_stream_response =
+  "event: message_start\n\
+   data: \
+   {\"type\":\"message_start\",\"message\":{\"id\":\"msg-1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"input-count-fixture\",\"content\":[],\"stop_reason\":null,\"usage\":{\"input_tokens\":10,\"output_tokens\":0}}}\n\n\
+   event: content_block_start\n\
+   data: \
+   {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n\
+   event: content_block_delta\n\
+   data: \
+   {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"accepted\"}}\n\n\
+   event: content_block_stop\n\
+   data: {\"type\":\"content_block_stop\",\"index\":0}\n\n\
+   event: message_delta\n\
+   data: \
+   {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":1}}\n\n\
+   event: message_stop\n\
+   data: {\"type\":\"message_stop\"}\n\n"
+;;
+
+let admitted_anthropic_sync_response =
+  {|{"id":"msg-1","type":"message","role":"assistant","model":"input-count-fixture","content":[{"type":"text","text":"accepted"}],"stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":1}}|}
+;;
+
+let with_admitted_http_mock ~stream f =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let net = Eio.Stdenv.net env in
+  let port = fresh_port () in
+  let completion_body = ref None in
+  let handler _conn request body =
+    let body = Eio.Buf_read.(of_flow ~max_size:max_int body |> take_all) in
+    let path = Cohttp.Request.uri request |> Uri.path in
+    if String.ends_with ~suffix:"/count_tokens" path
+    then Cohttp_eio.Server.respond_string ~status:`OK ~body:{|{"input_tokens":10}|} ()
+    else (
+      completion_body := Some body;
+      let headers =
+        if stream
+        then Cohttp.Header.of_list [ "content-type", "text/event-stream" ]
+        else Cohttp.Header.init ()
+      in
+      let response =
+        if stream
+        then admitted_anthropic_stream_response
+        else admitted_anthropic_sync_response
+      in
+      Cohttp_eio.Server.respond_string ~status:`OK ~headers ~body:response ())
+  in
+  let socket =
+    Eio.Net.listen
+      net
+      ~sw
+      ~backlog:4
+      ~reuse_addr:true
+      (`Tcp (Eio.Net.Ipaddr.V4.loopback, port))
+  in
+  let server = Cohttp_eio.Server.make ~callback:handler () in
+  Eio.Fiber.fork_daemon ~sw (fun () ->
+    Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()));
+  let base_url = Printf.sprintf "http://127.0.0.1:%d" port in
+  let result = f ~sw ~net ~base_url in
+  result, !completion_body
+;;
+
+let check_pre_dispatch_serialization ~label ~body observations =
+  match List.rev observations with
+  | [ observation ] ->
+    check
+      bool
+      (label ^ " phase")
+      true
+      (observation.Request_wire_observer.phase
+       = Request_wire_observer.Pre_dispatch_serialization);
+    check int (label ^ " body bytes") (String.length body) observation.body_bytes;
+    check
+      string
+      (label ^ " body digest")
+      Digestif.SHA256.(to_hex (digest_string body))
+      observation.body_sha256
+  | observations -> failf "%s observer called %d times" label (List.length observations)
+;;
+
 let test_transport_success () =
   let result, (path, headers, body) =
     with_mock ~status:`OK ~response:{|{"input_tokens":321}|}
@@ -342,7 +443,7 @@ let test_prepared_measure_admit_dispatch () =
         ()
     in
     let measured =
-      match Complete.measure_request ~sw ~net prepared with
+      match Complete.measure_request ~sw ~net (serialize_sync prepared) with
       | Ok measured -> measured
       | Error _ -> fail "expected prepared request measurement"
     in
@@ -401,7 +502,7 @@ let test_prepared_context_overflow_is_typed () =
         ~tools:[ tool ]
         ()
     in
-    match Complete.measure_request ~sw ~net prepared with
+    match Complete.measure_request ~sw ~net (serialize_sync prepared) with
     | Error _ -> fail "expected prepared request measurement"
     | Ok measured ->
       (match Complete.resolve_context_limit prepared with
@@ -428,7 +529,9 @@ let test_prepared_admission_resolves_catalog_context_limit () =
       |> Option.get
     in
     let prepared = Complete.prepare_request ~config:cfg ~messages ~tools:[ tool ] () in
-    let measured = Complete.measure_request ~sw ~net prepared |> Result.get_ok in
+    let measured =
+      Complete.measure_request ~sw ~net (serialize_sync prepared) |> Result.get_ok
+    in
     let max_context_tokens = Complete.resolve_context_limit prepared |> Result.get_ok in
     Complete.admit_request ~now_unix_s:0 ~max_context_tokens measured, expected
   in
@@ -771,7 +874,7 @@ let test_stream_body_admission_precedes_measurement () =
   check bool "stream body rejection makes no completion request" false dispatched
 ;;
 
-let test_measurement_validates_before_io () =
+let test_serialization_admission_validates_before_io () =
   Eio_main.run
   @@ fun env ->
   Eio.Switch.run
@@ -780,8 +883,8 @@ let test_measurement_validates_before_io () =
     config ~request_path:"/v1/responses" ~max_concurrent_requests:0 "http://127.0.0.1:1"
   in
   let prepared = Complete.prepare_request ~config:cfg ~messages ~tools:[ tool ] () in
-  match Complete.measure_request ~sw ~net:(Eio.Stdenv.net env) prepared with
-  | Error (Count_tokens_sync.Invalid_completion_request detail) ->
+  match Complete.admit_request_body ~stream:false prepared with
+  | Error (Http_client.AcceptRejected { reason = detail }) ->
     check bool "validation identifies local config" true (String.length detail > 0);
     check
       bool
@@ -797,7 +900,7 @@ let test_measurement_uses_provider_admission () =
     @@ fun ~sw ~net ~base_url ->
     let cfg = config ~max_context:512 ~max_concurrent_requests:1 base_url in
     let prepared = Complete.prepare_request ~config:cfg ~messages ~tools:[ tool ] () in
-    let result = Complete.measure_request ~sw ~net prepared in
+    let result = Complete.measure_request ~sw ~net (serialize_sync prepared) in
     result, Provider_admission.snapshot_for ~config:cfg
   in
   match result with
@@ -865,6 +968,51 @@ let test_agent_stream_route_uses_prepared_admission () =
     check string "stream response" "accepted" (Types.visible_text_of_response actual);
     check string "stream dispatch model" "input-count-fixture" request.config.model_id;
     check int "stream dispatch messages" 1 (List.length request.messages)
+;;
+
+let run_admitted_agent_observer ~stream =
+  let observations = ref [] in
+  let (result, observations), completion_body =
+    with_admitted_http_mock ~stream
+    @@ fun ~sw ~net ~base_url ->
+    let provider_config = config ~max_context:512 base_url in
+    let agent =
+      build_admission_agent
+        ~net
+        ~provider_config
+        ~pre_dispatch_serialization_observer:(fun observation ->
+          observations := observation :: !observations;
+          Ok ())
+        ()
+    in
+    let result =
+      if stream
+      then
+        Agent_sdk.Agent.run_stream
+          ~sw
+          ~on_event:(fun _ -> ())
+          agent
+          "observe admitted stream serialization"
+      else Agent_sdk.Agent.run ~sw agent "observe admitted sync serialization"
+    in
+    result, !observations
+  in
+  (match result with
+   | Ok _ -> ()
+   | Error error -> fail (Agent_sdk.Error.to_string error));
+  match completion_body with
+  | None -> fail "admitted Agent path did not reach completion dispatch"
+  | Some body -> body, observations
+;;
+
+let test_agent_admitted_sync_observer_sees_dispatched_body () =
+  let body, observations = run_admitted_agent_observer ~stream:false in
+  check_pre_dispatch_serialization ~label:"Agent.run admitted" ~body observations
+;;
+
+let test_agent_admitted_stream_observer_sees_dispatched_body () =
+  let body, observations = run_admitted_agent_observer ~stream:true in
+  check_pre_dispatch_serialization ~label:"Agent.run_stream admitted" ~body observations
 ;;
 
 let test_agent_projection_is_shared_by_measurement_and_dispatch () =
@@ -1220,9 +1368,9 @@ let () =
             `Quick
             test_unmeasurable_constraint_fails_typed_without_dispatch
         ; test_case
-            "measurement validates before I/O"
+            "serialization admission validates before I/O"
             `Quick
-            test_measurement_validates_before_io
+            test_serialization_admission_validates_before_io
         ; test_case
             "measurement uses provider admission"
             `Quick
@@ -1235,6 +1383,14 @@ let () =
             "Agent stream route uses prepared admission"
             `Quick
             test_agent_stream_route_uses_prepared_admission
+        ; test_case
+            "Agent admitted sync observes dispatched serialization"
+            `Quick
+            test_agent_admitted_sync_observer_sees_dispatched_body
+        ; test_case
+            "Agent admitted stream observes dispatched serialization"
+            `Quick
+            test_agent_admitted_stream_observer_sees_dispatched_body
         ; test_case
             "Agent projection is shared by measurement and dispatch"
             `Quick

--- a/test/test_anthropic_input_token_count.ml
+++ b/test/test_anthropic_input_token_count.ml
@@ -390,17 +390,25 @@ let test_admitted_body_is_frozen_across_catalog_mutation () =
              model_id = "frozen-catalog-model"
            ; enable_thinking = Some true
            ; thinking_budget = Some 1024
+           ; tool_choice = Some Auto
            ; response_format = Off
            ; output_schema = None
            }
          in
          let prepared = Complete.prepare_request ~config:cfg ~messages () in
          let admitted_evidence =
-           Complete.inspect_serialized_request ~stream:false ~config:cfg ~messages ()
-           |> Result.get_ok
+           match
+             Complete.inspect_serialized_request ~stream:false ~config:cfg ~messages ()
+           with
+           | Ok evidence -> evidence
+           | Error (Http_client.AcceptRejected { reason }) -> fail reason
+           | Error _ -> fail "initial frozen-body serialization failed"
          in
          let serialized =
-           Complete.admit_request_body ~stream:false prepared |> Result.get_ok
+           match Complete.admit_request_body ~stream:false prepared with
+           | Ok serialized -> serialized
+           | Error (Http_client.AcceptRejected { reason }) -> fail reason
+           | Error _ -> fail "initial frozen-body admission failed"
          in
          let measured = Complete.measure_request ~sw ~net serialized |> Result.get_ok in
          let admitted =

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -337,6 +337,7 @@ let test_complete_request_body_limit_rejects_before_io () =
     Eio.Switch.run
     @@ fun sw ->
     let request_count = ref 0 in
+    let observed_request_count = ref 0 in
     let base_url =
       start_mock_server
         ~sw
@@ -353,19 +354,156 @@ let test_complete_request_body_limit_rejects_before_io () =
         ~max_request_body_bytes:1
         ()
     in
+    let request_wire_observer _observation =
+      incr observed_request_count;
+      Ok ()
+    in
     check_request_body_too_large
       ~label:"sync request-body admission"
-      (Complete.complete ~sw ~net:env#net ~config ~messages ());
+      (Complete.complete ~sw ~net:env#net ~request_wire_observer ~config ~messages ());
     check_request_body_too_large
       ~label:"stream request-body admission"
       (Complete.complete_stream
          ~sw
          ~net:env#net
+         ~request_wire_observer
          ~config
          ~messages
          ~on_event:(fun _ -> ())
          ());
     check int "request-body admission performs no HTTP request" 0 !request_count;
+    check int "rejected body is not reported as dispatched" 0 !observed_request_count;
+    Eio.Switch.fail sw Exit
+  with
+  | Exit -> ()
+;;
+
+let test_complete_request_wire_observer_sees_exact_sync_body () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let captured_body = ref None in
+    let observed = ref [] in
+    let base_url =
+      start_mock_server
+        ~sw
+        ~net:env#net
+        ~capture_body:captured_body
+        (openai_response "observed")
+    in
+    let request_wire_observer observation =
+      observed := observation :: !observed;
+      Ok ()
+    in
+    (match
+       Complete.complete
+         ~sw
+         ~net:env#net
+         ~capture_id:"sync-request-1"
+         ~request_wire_observer
+         ~config:(make_openai_config base_url)
+         ~messages
+         ()
+     with
+     | Error _ -> fail "request observation changed the provider result"
+     | Ok _ -> ());
+    (match !captured_body, !observed with
+     | Some body, [ observation ] ->
+       check
+         (option string)
+         "capture id"
+         (Some "sync-request-1")
+         observation.Request_wire_observer.capture_id;
+       check string "provider" "openai_compat" observation.provider;
+       check string "model" "gpt-4" observation.model;
+       check string "codec" "openai-chat" observation.http_codec;
+       check bool "sync" false observation.stream;
+       check int "exact bytes" (String.length body) observation.body_bytes;
+       check
+         string
+         "exact digest"
+         Digestif.SHA256.(to_hex (digest_string body))
+         observation.body_sha256
+     | None, _ -> fail "mock server did not capture the request body"
+     | Some _, _ -> fail "request observer was not invoked exactly once");
+    Eio.Switch.fail sw Exit
+  with
+  | Exit -> ()
+;;
+
+let test_complete_stream_rechecks_limit_after_final_wire_injection () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let request_count = ref 0 in
+    let base_url =
+      start_mock_server
+        ~sw
+        ~net:env#net
+        ~on_request:(fun () -> incr request_count)
+        "must not arrive"
+    in
+    let unlimited = make_openai_config base_url in
+    let pre_injection_bytes =
+      match
+        Complete_common.serialize_http_request
+          ~stream:true
+          ~config:unlimited
+          ~messages
+          ~tools:[]
+      with
+      | Error _ -> fail "fixture serialization failed"
+      | Ok (_, body) -> String.length body
+    in
+    let final_bytes =
+      match
+        Complete.inspect_serialized_request ~stream:true ~config:unlimited ~messages ()
+      with
+      | Error _ -> fail "final request inspection failed"
+      | Ok observation -> observation.Request_wire_observer.body_bytes
+    in
+    check
+      bool
+      "stream injection grows the final body"
+      true
+      (final_bytes > pre_injection_bytes);
+    let config =
+      Provider_config.make
+        ~kind:Provider_config.OpenAI_compat
+        ~model_id:"gpt-4"
+        ~base_url
+        ~request_path:"/v1/chat/completions"
+        ~temperature:0.0
+        ~max_tokens:100
+        ~max_request_body_bytes:(final_bytes - 1)
+        ()
+    in
+    (match Complete.inspect_serialized_request ~stream:true ~config ~messages () with
+     | Error _ -> fail "inspection incorrectly applied the dispatch byte ceiling"
+     | Ok observation ->
+       check int "inspection exact final bytes" final_bytes observation.body_bytes);
+    (match
+       Complete.complete_stream
+         ~sw
+         ~net:env#net
+         ~config
+         ~messages
+         ~on_event:(fun _ -> ())
+         ()
+     with
+     | Error
+         (Http_client.ProviderFailure
+            { kind = Http_client.Request_body_too_large { actual_bytes; limit_bytes }; _ })
+       ->
+       check int "declared final limit" (final_bytes - 1) limit_bytes;
+       check int "admission exact final bytes" final_bytes actual_bytes
+     | Ok _ -> fail "final stream body bypassed the serialized byte limit"
+     | Error _ -> fail "final stream body returned the wrong typed rejection");
+    check int "no HTTP dispatch" 0 !request_count;
     Eio.Switch.fail sw Exit
   with
   | Exit -> ()
@@ -1500,6 +1638,62 @@ let test_complete_kimi_anthropic_stream_codec () =
       ~stream:true
       ~captured_body:!captured_body
       ~captured_path:!captured_path;
+    Eio.Switch.fail sw Exit
+  with
+  | Exit -> ()
+;;
+
+let test_complete_request_wire_observer_sees_exact_stream_body () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let captured_body = ref None in
+    let observed = ref [] in
+    let url =
+      start_sse_server
+        ~sw
+        ~net:env#net
+        ~capture_body:captured_body
+        (anthropic_sse_response "observed stream")
+    in
+    let request_wire_observer observation =
+      observed := observation :: !observed;
+      Ok ()
+    in
+    (match
+       Complete.complete_stream
+         ~sw
+         ~net:env#net
+         ~capture_id:"stream-request-1"
+         ~request_wire_observer
+         ~config:(make_kimi_config url)
+         ~messages
+         ~on_event:(fun _ -> ())
+         ()
+     with
+     | Ok resp -> check string "stream response" "observed stream" (text_of_response resp)
+     | Error _ -> fail "request observation changed the streaming provider result");
+    (match !captured_body, !observed with
+     | Some body, [ observation ] ->
+       check
+         (option string)
+         "capture id"
+         (Some "stream-request-1")
+         observation.Request_wire_observer.capture_id;
+       check string "provider" "kimi" observation.provider;
+       check string "model" "kimi-for-coding" observation.model;
+       check string "codec" "anthropic-messages" observation.http_codec;
+       check bool "stream" true observation.stream;
+       check int "exact bytes" (String.length body) observation.body_bytes;
+       check
+         string
+         "exact digest"
+         Digestif.SHA256.(to_hex (digest_string body))
+         observation.body_sha256
+     | None, _ -> fail "SSE server did not capture the request body"
+     | Some _, _ -> fail "stream request observer was not invoked exactly once");
     Eio.Switch.fail sw Exit
   with
   | Exit -> ()
@@ -2873,6 +3067,14 @@ let () =
             `Quick
             test_complete_request_body_limit_rejects_before_io
         ; test_case
+            "wire observer sees exact sync body"
+            `Quick
+            test_complete_request_wire_observer_sees_exact_sync_body
+        ; test_case
+            "stream body limit includes final wire injection"
+            `Quick
+            test_complete_stream_rechecks_limit_after_final_wire_injection
+        ; test_case
             "empty http error body has context"
             `Quick
             test_complete_http_empty_error_body_has_context
@@ -2987,6 +3189,10 @@ let () =
             "Kimi Anthropic Messages SSE codec"
             `Quick
             test_complete_kimi_anthropic_stream_codec
+        ; test_case
+            "wire observer sees exact stream body"
+            `Quick
+            test_complete_request_wire_observer_sees_exact_stream_body
         ; test_case
             "HTTP stream rejects typed empty completion"
             `Quick

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -372,7 +372,7 @@ let test_complete_request_body_limit_rejects_before_io () =
          ~on_event:(fun _ -> ())
          ());
     check int "request-body admission performs no HTTP request" 0 !request_count;
-    check int "rejected body is not reported as dispatched" 0 !observed_request_count;
+    check int "rejected body produces no serialization evidence" 0 !observed_request_count;
     Eio.Switch.fail sw Exit
   with
   | Exit -> ()


### PR DESCRIPTION
## What changed

- serialize the exact final provider request body, including streaming field injection, through one shared boundary
- reject `max_request_body_bytes` overflow before provider-native token measurement and before completion HTTP I/O
- expose metadata-only final-wire observation (`capture_id`, provider/model/codec, stream flag, exact bytes, SHA-256) immediately before built-in HTTP dispatch
- thread the observer through prepared, admitted, direct, and built-in transport paths
- keep observer rejection and ordinary callback failures diagnostic instead of rewriting provider results

## Why

The previous request-size check could observe a pre-stream body while transport-owned fields were added later. On the Agent context-fit path, provider-native token counting could also make HTTP I/O before the exact completion body was admitted. MASC therefore could neither prove what final body was dispatched nor fail closed early for oversized Keeper requests.

## Impact

Callers can now preflight the same serialized body shape used by built-in HTTP transport and receive typed `Request_body_too_large` failures before optional count-token I/O. MASC can record final-wire size/digest evidence without receiving prompts, headers, credentials, or request bodies.

## Validation

- `scripts/dune-local.sh build test/test_complete_http.exe`
- `_build/default/test/test_complete_http.exe` — 61 tests passed
- `scripts/dune-local.sh build test/test_anthropic_input_token_count.exe`
- `_build/default/test/test_anthropic_input_token_count.exe` — 30 tests passed
- `git diff --check origin/main`
- OCaml format and parse checks for all touched files

Repository-wide `scripts/dune-local.sh build @check` currently stops in unchanged baseline test `test/test_exact_output_single_surface.ml:638` because `EO.execute_once` is unbound. Tracked separately in #2837.