### PR TITLE
docs(provider): align observer since tag with release

### DIFF
--- a/lib/llm_provider/request_wire_observer.mli
+++ b/lib/llm_provider/request_wire_observer.mli
@@ -14,7 +14,7 @@
     typed provider configuration (for example [max_request_body_bytes]).
 
     @stability Evolving
-    @since 0.230.0 *)
+    @since 0.229.1 *)
 
 type phase = Pre_dispatch_serialization [@@deriving yojson, show]
 


### PR DESCRIPTION
## Summary
- align `Request_wire_observer` public `@since` metadata with the release-please version selected for the merged feature
- keep the public contract truthful for the actual `0.229.1` release

## Validation
- `ocamlformat --check lib/llm_provider/request_wire_observer.mli`
- `scripts/dune-local.sh build @fmt`
- `git diff --check`

## Evidence
- release PR #2843 selects `0.229.1` under the repository pre-1.0 patch-bump policy
- merged feature PR #2838 currently documents `0.230.0`, so this change closes that mismatch