### PR TITLE
fix(hooks)!: require typed pre-tool approval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ original tag dates. `0.100.4` was never tagged or released.
 
 ## Unreleased
 
+### Breaking Changes
+
+`Hooks.PreToolUse` no longer accepts generic `ElicitInput` as tool execution
+authority. Existing callers must keep `ElicitInput`/`with_elicitation` at
+`BeforeTurn`, and migrate exact tool approval to
+`ElicitToolApproval { question }` plus `Builder.with_tool_approval`. The
+approval callback is synchronous and caller-owned; only `Approved` executes the
+exact invocation, while `Denied`, `Timed_out`, a missing callback, and callback
+failure open no effect. OAS does not install a timer, persist a pending approval,
+or issue a resume token at this boundary.
+
+Exhaustive consumers must also handle `ElicitToolApproval`,
+`K_ElicitToolApproval`, and `ToolApprovalCompleted`, and direct `Agent.options`
+record construction must provide the new `tool_approval` field.
+
 ## [0.229.1](https://github.com/jeong-sik/oas/compare/v0.229.0...v0.229.1) (2026-07-28)
 
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Anything outside this repository — multi-process coordination, repo-wide task 
 | `Agent` | Multi-turn agent loop with automatic tool_use handling (abstract `Agent.t`) |
 | `Tool` / `Tool_set` | Tool definition, JSON Schema generation, O(1) lookup |
 | `Builder` | Fluent API for agent construction with `build_safe` validation |
-| `Hooks` | Generic lifecycle callbacks; `PreToolUse` accepts exact caller-owned `Continue`, `Block`, or `ElicitInput` decisions |
+| `Hooks` | Generic lifecycle callbacks; `PreToolUse` accepts exact caller-owned `Continue`, `Block`, or `ElicitToolApproval` decisions |
 | `Context` | Cross-turn shared state (scoped key-value store, `Yojson.Safe.t` values) |
 | `Error` / `Error_domain` | 2-level structured errors: 8 domain variants + Internal, poly-variant mapping |
 | `Log` | Structured logging with level filtering and composable sinks |

--- a/README.md
+++ b/README.md
@@ -201,7 +201,8 @@ the agent. A caller that has already settled an external-effect decision may
 return `Hooks.Block reason` from `PreToolUse`, or `Hooks.ElicitToolApproval`
 and configure `Builder.with_tool_approval` when the exact call needs caller
 input. `Hooks.ElicitInput` is generic user input and cannot authorize a tool;
-OAS does not own approval,
+the approval callback must settle synchronously. OAS does not install a timer
+or durable pause at that boundary and does not own approval,
 judging, risk levels, or HITL orchestration.
 
 ## Build and test

--- a/README.md
+++ b/README.md
@@ -198,8 +198,10 @@ let my_hooks = { Hooks.empty with
 OAS sends the caller-supplied `Tool_set` to the provider unchanged. A product
 that needs tool exposure policy applies its own typed gate before constructing
 the agent. A caller that has already settled an external-effect decision may
-return `Hooks.Block reason` from `PreToolUse`, or `Hooks.ElicitInput request`
-when the exact call needs caller input; OAS does not own approval,
+return `Hooks.Block reason` from `PreToolUse`, or `Hooks.ElicitToolApproval`
+and configure `Builder.with_tool_approval` when the exact call needs caller
+input. `Hooks.ElicitInput` is generic user input and cannot authorize a tool;
+OAS does not own approval,
 judging, risk levels, or HITL orchestration.
 
 ## Build and test

--- a/docs/EVENT-CATALOG.md
+++ b/docs/EVENT-CATALOG.md
@@ -83,6 +83,7 @@ Pattern-matchable OCaml sum type. **Stable across every provider.**
 | `HandoffRequested` | `agent/agent.ml` | Agent delegates control to another agent |
 | `HandoffCompleted` | `agent/agent.ml` | Handoff target finished |
 | `ElicitationCompleted` | `pipeline/pipeline_stage_prepare.ml` | User elicitation round completed |
+| `ToolApprovalCompleted` | `agent/agent_tool_pre_execution_gate.ml` | Caller-owned exact tool approval settled before invocation |
 | `InferenceTelemetry` | `pipeline/pipeline.ml` | Per-turn provider timing/token telemetry when reported by the backend |
 | `Custom (name, json)` | anywhere | Extension point — see §2.3 |
 

--- a/docs/rfc/RFC-OAS-039-suspend-tool-call-for-input.md
+++ b/docs/rfc/RFC-OAS-039-suspend-tool-call-for-input.md
@@ -11,12 +11,12 @@
 ## 0. Summary
 
 `Pre_tool_use` is the first hook stage that knows the exact tool occurrence and
-input. This RFC admits `ElicitInput` at that stage and settles it through the
-existing caller-configured `options.elicitation` callback before the tool
-invocation is opened.
+input. This RFC admits `ElicitToolApproval` at that stage and settles it
+through the separate caller-configured `options.tool_approval` callback before
+the tool invocation is opened.
 
-- `Answer _` authorizes the exact call.
-- `Declined` and `Timeout` produce a typed non-retryable `ToolResult` without
+- Only the closed `Approved` result authorizes the exact call.
+- `Denied` and `Timed_out` produce a typed non-retryable `ToolResult` without
   executing the tool.
 - A missing callback fails closed as `Hook_execution_failed`; no invocation or
   effect is started.
@@ -40,23 +40,29 @@ The legal decisions are:
 
 ```ocaml
 | Before_turn  -> [ K_Continue; K_ElicitInput; K_Nudge ]
-| Pre_tool_use -> [ K_Continue; K_Block; K_ElicitInput ]
+| Pre_tool_use -> [ K_Continue; K_Block; K_ElicitToolApproval ]
 ```
 
-When a `Pre_tool_use` hook returns `ElicitInput request`,
-`Agent_tools.execute_tools` consults the configured callback:
+When a `Pre_tool_use` hook returns `ElicitToolApproval prompt`,
+`Agent_tools.execute_tools` creates an immutable request containing that prompt,
+the exact invocation, tool name, and input, then consults the configured typed
+callback:
 
 ```ocaml
-match options.elicitation request with
-| Answer _ -> execute_the_exact_call ()
-| Declined -> blocked_tool_result "Tool execution was declined by the caller"
-| Timeout -> blocked_tool_result "Tool execution approval timed out"
+match options.tool_approval exact_request with
+| Approved -> execute_the_exact_call ()
+| Denied -> blocked_tool_result "Tool execution was denied by the caller"
+| Timed_out -> blocked_tool_result "Tool execution approval timed out"
 ```
 
-The callback result is a typed gate response. It is not appended as a `User`
-message. A refusal is represented as the same model-visible, deterministic
-failure shape used by `Hooks.Block`, and no tool lifecycle event is emitted for
-an effect that never started.
+Generic `Answer of Yojson.Safe.t` and a JSON Schema are deliberately absent from
+this boundary. They express user input, not execution authority; accepting a
+schema-shaped JSON value would reintroduce an untyped approval protocol. A
+generic `ElicitInput` returned at `Pre_tool_use` is stage-illegal and fails
+closed before its callback or any effect runs. The approval result is not
+appended as a `User` message. A refusal is represented as the same
+model-visible, deterministic failure shape used by `Hooks.Block`, and no tool
+lifecycle event is emitted for an effect that never started.
 
 ## 3. Fail-closed boundary
 
@@ -80,23 +86,23 @@ exist, a missing callback fails before `open_invocation`.
 ## 4. Public contract
 
 The hook decision matrix in `Hooks`, the README, and the event catalog all list
-`ElicitInput` as legal at `Pre_tool_use`.
+`ElicitToolApproval` as legal at `Pre_tool_use`.
 
 The configured callback is honored consistently at both legal elicitation
 stages, with stage-specific transcript behavior:
 
 - `Before_turn`: an `Answer` may add a user message before provider dispatch.
-- `Pre_tool_use`: an `Answer` authorizes the exact call and adds no user
-  message.
+- `Pre_tool_use`: an `Approved` result authorizes the exact call and adds no
+  user message.
 
 ## 5. Verification
 
 Focused tests must prove:
 
-1. `ElicitInput` is legal at `Pre_tool_use` and remains illegal at every other
-   unsupported stage.
-2. `Answer` executes the exact call once.
-3. `Declined` and `Timeout` execute it zero times and return a typed
+1. `ElicitToolApproval` is legal at `Pre_tool_use` and remains illegal at every
+   other unsupported stage; generic `ElicitInput` is rejected there.
+2. `Approved` executes the exact call once.
+3. `Denied` and `Timed_out` execute it zero times and return a typed
    non-retryable failure.
 4. Missing callback support fails closed before invocation/effect execution.
 5. The public hook matrix and user-facing documentation agree with runtime

--- a/docs/rfc/RFC-OAS-039-suspend-tool-call-for-input.md
+++ b/docs/rfc/RFC-OAS-039-suspend-tool-call-for-input.md
@@ -1,4 +1,4 @@
-# RFC-OAS-039: Settle pre-tool input before execution
+# RFC-OAS-039: Synchronous exact-tool approval before execution
 
 | | |
 |---|---|
@@ -20,6 +20,13 @@ the tool invocation is opened.
   executing the tool.
 - A missing callback fails closed as `Hook_execution_failed`; no invocation or
   effect is started.
+
+This is deliberately a synchronous authorization gate, not an SDK-owned
+durable suspension. OAS installs no timer, stores no pending approval request,
+and exposes no resume token here. The callback must settle any remote prompt,
+deadline, or restart policy before it returns; `Timed_out` reports a deadline
+already enforced by the caller. A callback that does not return blocks its
+dispatch fiber by contract.
 
 The before-turn `Agent.provide_input` API is intentionally not reused. It
 appends a `User` message and has different transcript semantics.
@@ -63,6 +70,10 @@ closed before its callback or any effect runs. The approval result is not
 appended as a `User` message. A refusal is represented as the same
 model-visible, deterministic failure shape used by `Hooks.Block`, and no tool
 lifecycle event is emitted for an effect that never started.
+
+A non-reserved callback exception is a typed `Hook_execution_failed` result
+before invocation. Runtime cancellation and other reserved exceptions continue
+to propagate through the surrounding structured-concurrency scope.
 
 ## 3. Fail-closed boundary
 

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -59,6 +59,7 @@ type options = Agent_types.options =
     (** Discovery/metadata path only.  Surfaced via {!Agent.card} for
           A2A negotiation.  Does not affect runtime prompt composition. *)
   ; elicitation : Hooks.elicitation_callback option
+  ; tool_approval : Hooks.tool_approval_callback option
   ; description : string option
   ; periodic_callbacks : periodic_callback list
   ; slot_id : int option

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -60,6 +60,7 @@ type options = Agent_types.options =
           A2A negotiation.  Does not affect runtime prompt composition. *)
   ; elicitation : Hooks.elicitation_callback option
   ; tool_approval : Hooks.tool_approval_callback option
+    (** Closed exact-tool approval callback. *)
   ; description : string option
   ; periodic_callbacks : periodic_callback list
   ; slot_id : int option

--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -60,7 +60,7 @@ type options = Agent_types.options =
           A2A negotiation.  Does not affect runtime prompt composition. *)
   ; elicitation : Hooks.elicitation_callback option
   ; tool_approval : Hooks.tool_approval_callback option
-    (** Closed exact-tool approval callback. *)
+    (** Closed synchronous exact-tool approval callback. *)
   ; description : string option
   ; periodic_callbacks : periodic_callback list
   ; slot_id : int option

--- a/lib/agent/agent_elicitation.ml
+++ b/lib/agent/agent_elicitation.ml
@@ -15,7 +15,12 @@ let sanitize_request_id_component value =
   if trimmed = "" then "agent" else trimmed
 ;;
 
-let input_required_of_request ~agent_name ~turn ?created_at req =
+let input_required_of_request
+      ~agent_name
+      ~turn
+      ?created_at
+      (req : Hooks.elicitation_request)
+  =
   let created_at = Option.value created_at ~default:(Unix.gettimeofday ()) in
   let participant = sanitize_request_id_component agent_name in
   let created_ms = int_of_float (created_at *. 1000.0) in

--- a/lib/agent/agent_lifecycle.ml
+++ b/lib/agent/agent_lifecycle.ml
@@ -88,6 +88,7 @@ let hook_decision_to_string = function
   | Hooks.Continue -> "continue"
   | Hooks.AdjustParams _ -> "adjust_params"
   | Hooks.ElicitInput _ -> "elicit_input"
+  | Hooks.ElicitToolApproval _ -> "elicit_tool_approval"
   | Hooks.Nudge _ -> "nudge"
   | Hooks.HookFailed _ -> "hook_failed"
   | Hooks.Block _ -> "block"

--- a/lib/agent/agent_tool_execution_types.ml
+++ b/lib/agent/agent_tool_execution_types.ml
@@ -60,6 +60,13 @@ type tool_dispatch =
   ; deferred_failure : deferred_failure option
   }
 
+type scheduled_tool_outcome =
+  { index : int
+  ; completed_result : tool_execution_result option
+  ; completion : batch_completion
+  ; failure : execution_failure_cause option
+  }
+
 type pending_tool_dispatch =
   { result : tool_execution_result
   ; finish_observers : unit -> tool_dispatch

--- a/lib/agent/agent_tool_pre_execution_gate.ml
+++ b/lib/agent/agent_tool_pre_execution_gate.ml
@@ -10,6 +10,19 @@ type scheduled_settlement =
   | Run_admitted
   | Return_outcome of Agent_tool_execution_types.scheduled_tool_outcome
 
+let blocked_tool_result ~invocation ~tool_name ~input ~content =
+  { Agent_tool_execution_types.invocation
+  ; tool_name
+  ; input
+  ; content
+  ; outcome =
+      Types.Tool_failed
+        { failure_kind = Types.Non_retryable_tool_error
+        ; error_class = Some Types.Deterministic
+        }
+  }
+;;
+
 let publish_approval
       ?correlation_id
       ?run_id
@@ -83,37 +96,31 @@ let settle
       }
 ;;
 
-let settle_existing_rejection
+let settle_existing_block
       durable
       (result : Agent_tool_execution_types.tool_execution_result)
   =
-  Execution_agent_scope.execute_phased
+  Execution_agent_scope.settle_unattempted_invocation
     durable
-    ~invoke:(fun ~start_child:_ ~tool_name:_ ~input:_ ->
-      (result.content, result.outcome), (fun () -> ()))
-  |> Result.map (function
-    | Execution_agent_scope.Executed (settled, _, _)
-    | Execution_agent_scope.Replayed settled ->
-      { Agent_tool_execution_types.invocation = settled.invocation
-      ; tool_name = settled.tool_name
-      ; input = settled.input
-      ; content = settled.content
-      ; outcome = settled.outcome
-      })
+    ~content:result.content
+    ~outcome:result.outcome
+  |> Result.map (fun () -> result)
 ;;
 
 let scheduled_settlement
-      ?settle_rejected
+      ?settle_blocked
       ~index
       ~invocation
       ~tool_name
-      ~blocked_result
+      ~input
   = function
   | Admit -> Run_admitted
   | Block reason ->
-    let result = blocked_result reason in
     let result =
-      match settle_rejected with
+      blocked_tool_result ~invocation ~tool_name ~input ~content:reason
+    in
+    let result =
+      match settle_blocked with
       | None -> result
       | Some settle -> settle result
     in
@@ -124,12 +131,6 @@ let scheduled_settlement
       ; failure = None
       }
   | Reject { stage; detail } ->
-    let result = blocked_result detail in
-    (match settle_rejected with
-     | None -> ()
-     | Some settle ->
-       let _ = settle result in
-       ());
     Return_outcome
       { index
       ; completed_result = None
@@ -138,10 +139,6 @@ let scheduled_settlement
           Some
             (Agent_tool_execution_types.Hook_failure
                (Agent_tool_execution_types.Hook_execution_failed
-                  { hook_name = "pre_tool_use"
-                  ; stage
-                  ; tool_name
-                  ; invocation
-                  ; detail
-                  }))
+                  { hook_name = "pre_tool_use"; stage; tool_name; invocation; detail }))
       }
+;;

--- a/lib/agent/agent_tool_pre_execution_gate.ml
+++ b/lib/agent/agent_tool_pre_execution_gate.ml
@@ -96,7 +96,7 @@ let settle
       }
 ;;
 
-let settle_existing_rejection
+let settle_existing_block
       durable
       (result : Agent_tool_execution_types.tool_execution_result)
   =
@@ -107,12 +107,12 @@ let settle_existing_rejection
   |> Result.map (fun () -> result)
 ;;
 
-let scheduled_settlement ?settle_rejected ~index ~invocation ~tool_name ~input = function
+let scheduled_settlement ?settle_blocked ~index ~invocation ~tool_name ~input = function
   | Admit -> Run_admitted
   | Block reason ->
     let result = blocked_tool_result ~invocation ~tool_name ~input ~content:reason in
     let result =
-      match settle_rejected with
+      match settle_blocked with
       | None -> result
       | Some settle -> settle result
     in
@@ -123,14 +123,6 @@ let scheduled_settlement ?settle_rejected ~index ~invocation ~tool_name ~input =
       ; failure = None
       }
   | Reject { stage; detail } ->
-    let rejected = blocked_tool_result ~invocation ~tool_name ~input ~content:detail in
-    (match settle_rejected with
-     | None -> ()
-     | Some settle ->
-       let (_settled : Agent_tool_execution_types.tool_execution_result) =
-         settle rejected
-       in
-       ());
     Return_outcome
       { index
       ; completed_result = None

--- a/lib/agent/agent_tool_pre_execution_gate.ml
+++ b/lib/agent/agent_tool_pre_execution_gate.ml
@@ -54,12 +54,21 @@ let settle
          }
      | Some callback ->
        let request = { Hooks.prompt; invocation; tool_name; input } in
-       let approval = callback request in
-       publish_approval ?correlation_id ?run_id ~event_bus ~agent_name request approval;
-       (match approval with
-        | Hooks.Approved -> Admit
-        | Hooks.Denied -> Block "Tool execution was denied by the caller"
-        | Hooks.Timed_out -> Block "Tool execution approval timed out"))
+       (match callback request with
+        | exception exception_ ->
+          Llm_provider.Reserved_exn.reraise_if_reserved exception_;
+          Reject
+            { stage = Hooks.Pre_tool_use
+            ; detail =
+                "tool_approval callback raised before tool execution: "
+                ^ Printexc.to_string exception_
+            }
+        | approval ->
+          publish_approval ?correlation_id ?run_id ~event_bus ~agent_name request approval;
+          (match approval with
+           | Hooks.Approved -> Admit
+           | Hooks.Denied -> Block "Tool execution was denied by the caller"
+           | Hooks.Timed_out -> Block "Tool execution approval timed out")))
   | (Hooks.AdjustParams _ | Hooks.ElicitInput _ | Hooks.Nudge _) as decision ->
     Reject
       { stage = Hooks.Pre_tool_use

--- a/lib/agent/agent_tool_pre_execution_gate.ml
+++ b/lib/agent/agent_tool_pre_execution_gate.ml
@@ -6,7 +6,14 @@ type settlement =
       ; detail : string
       }
 
-let publish_response ?correlation_id ?run_id ~event_bus ~agent_name request response =
+let publish_approval
+      ?correlation_id
+      ?run_id
+      ~event_bus
+      ~agent_name
+      (request : Hooks.tool_approval_request)
+      approval
+  =
   match event_bus with
   | Some bus ->
     Event_bus.publish
@@ -14,32 +21,46 @@ let publish_response ?correlation_id ?run_id ~event_bus ~agent_name request resp
       (Event_bus.mk_event
          ?correlation_id
          ?run_id
-         (Event_bus.ElicitationCompleted
-            { agent_name; question = request.Hooks.question; response }))
+         (Event_bus.ToolApprovalCompleted
+            { agent_name
+            ; invocation = request.invocation
+            ; tool_name = request.tool_name
+            ; approval
+            }))
   | None -> ()
 ;;
 
-let settle ?elicitation ?correlation_id ?run_id ~event_bus ~agent_name = function
+let settle
+      ?tool_approval
+      ?correlation_id
+      ?run_id
+      ~event_bus
+      ~agent_name
+      ~invocation
+      ~tool_name
+      ~input
+  = function
   | Hooks.Continue -> Admit
   | Hooks.Block reason -> Block reason
   | Hooks.HookFailed { stage; detail } -> Reject { stage; detail }
-  | Hooks.ElicitInput request ->
-    (match elicitation with
+  | Hooks.ElicitToolApproval prompt ->
+    (match tool_approval with
      | None ->
        Reject
          { stage = Hooks.Pre_tool_use
          ; detail =
-             "ElicitInput at pre_tool_use requires the configured elicitation callback; \
+             "ElicitToolApproval at pre_tool_use requires the configured tool_approval callback; \
               no tool invocation was opened"
          }
      | Some callback ->
-       let response = callback request in
-       publish_response ?correlation_id ?run_id ~event_bus ~agent_name request response;
-       (match response with
-        | Hooks.Answer _ -> Admit
-        | Hooks.Declined -> Block "Tool execution was declined by the caller"
-        | Hooks.Timeout -> Block "Tool execution approval timed out"))
-  | (Hooks.AdjustParams _ | Hooks.Nudge _) as decision ->
+       let request = { Hooks.prompt = prompt; invocation; tool_name; input } in
+       let approval = callback request in
+       publish_approval ?correlation_id ?run_id ~event_bus ~agent_name request approval;
+       (match approval with
+        | Hooks.Approved -> Admit
+        | Hooks.Denied -> Block "Tool execution was denied by the caller"
+        | Hooks.Timed_out -> Block "Tool execution approval timed out"))
+  | (Hooks.AdjustParams _ | Hooks.ElicitInput _ | Hooks.Nudge _) as decision ->
     Reject
       { stage = Hooks.Pre_tool_use
       ; detail =

--- a/lib/agent/agent_tool_pre_execution_gate.ml
+++ b/lib/agent/agent_tool_pre_execution_gate.ml
@@ -6,6 +6,10 @@ type settlement =
       ; detail : string
       }
 
+type scheduled_settlement =
+  | Run_admitted
+  | Return_outcome of Agent_tool_execution_types.scheduled_tool_outcome
+
 let publish_approval
       ?correlation_id
       ?run_id
@@ -78,3 +82,66 @@ let settle
             (Hooks.decision_kind_to_string (Hooks.classify_decision decision))
       }
 ;;
+
+let settle_existing_rejection
+      durable
+      (result : Agent_tool_execution_types.tool_execution_result)
+  =
+  Execution_agent_scope.execute_phased
+    durable
+    ~invoke:(fun ~start_child:_ ~tool_name:_ ~input:_ ->
+      (result.content, result.outcome), (fun () -> ()))
+  |> Result.map (function
+    | Execution_agent_scope.Executed (settled, _, _)
+    | Execution_agent_scope.Replayed settled ->
+      { Agent_tool_execution_types.invocation = settled.invocation
+      ; tool_name = settled.tool_name
+      ; input = settled.input
+      ; content = settled.content
+      ; outcome = settled.outcome
+      })
+;;
+
+let scheduled_settlement
+      ?settle_rejected
+      ~index
+      ~invocation
+      ~tool_name
+      ~blocked_result
+  = function
+  | Admit -> Run_admitted
+  | Block reason ->
+    let result = blocked_result reason in
+    let result =
+      match settle_rejected with
+      | None -> result
+      | Some settle -> settle result
+    in
+    Return_outcome
+      { index
+      ; completed_result = Some result
+      ; completion = Agent_tool_execution_types.Continue_after_batch
+      ; failure = None
+      }
+  | Reject { stage; detail } ->
+    let result = blocked_result detail in
+    (match settle_rejected with
+     | None -> ()
+     | Some settle ->
+       let _ = settle result in
+       ());
+    Return_outcome
+      { index
+      ; completed_result = None
+      ; completion = Agent_tool_execution_types.Continue_after_batch
+      ; failure =
+          Some
+            (Agent_tool_execution_types.Hook_failure
+               (Agent_tool_execution_types.Hook_execution_failed
+                  { hook_name = "pre_tool_use"
+                  ; stage
+                  ; tool_name
+                  ; invocation
+                  ; detail
+                  }))
+      }

--- a/lib/agent/agent_tool_pre_execution_gate.ml
+++ b/lib/agent/agent_tool_pre_execution_gate.ml
@@ -49,11 +49,11 @@ let settle
        Reject
          { stage = Hooks.Pre_tool_use
          ; detail =
-             "ElicitToolApproval at pre_tool_use requires the configured tool_approval callback; \
-              no tool invocation was opened"
+             "ElicitToolApproval at pre_tool_use requires the configured tool_approval \
+              callback; no tool invocation was opened"
          }
      | Some callback ->
-       let request = { Hooks.prompt = prompt; invocation; tool_name; input } in
+       let request = { Hooks.prompt; invocation; tool_name; input } in
        let approval = callback request in
        publish_approval ?correlation_id ?run_id ~event_bus ~agent_name request approval;
        (match approval with

--- a/lib/agent/agent_tool_pre_execution_gate.ml
+++ b/lib/agent/agent_tool_pre_execution_gate.ml
@@ -96,7 +96,7 @@ let settle
       }
 ;;
 
-let settle_existing_block
+let settle_existing_rejection
       durable
       (result : Agent_tool_execution_types.tool_execution_result)
   =
@@ -107,12 +107,12 @@ let settle_existing_block
   |> Result.map (fun () -> result)
 ;;
 
-let scheduled_settlement ?settle_blocked ~index ~invocation ~tool_name ~input = function
+let scheduled_settlement ?settle_rejected ~index ~invocation ~tool_name ~input = function
   | Admit -> Run_admitted
   | Block reason ->
     let result = blocked_tool_result ~invocation ~tool_name ~input ~content:reason in
     let result =
-      match settle_blocked with
+      match settle_rejected with
       | None -> result
       | Some settle -> settle result
     in
@@ -123,6 +123,14 @@ let scheduled_settlement ?settle_blocked ~index ~invocation ~tool_name ~input = 
       ; failure = None
       }
   | Reject { stage; detail } ->
+    let rejected = blocked_tool_result ~invocation ~tool_name ~input ~content:detail in
+    (match settle_rejected with
+     | None -> ()
+     | Some settle ->
+       let (_settled : Agent_tool_execution_types.tool_execution_result) =
+         settle rejected
+       in
+       ());
     Return_outcome
       { index
       ; completed_result = None

--- a/lib/agent/agent_tool_pre_execution_gate.ml
+++ b/lib/agent/agent_tool_pre_execution_gate.ml
@@ -107,18 +107,10 @@ let settle_existing_block
   |> Result.map (fun () -> result)
 ;;
 
-let scheduled_settlement
-      ?settle_blocked
-      ~index
-      ~invocation
-      ~tool_name
-      ~input
-  = function
+let scheduled_settlement ?settle_blocked ~index ~invocation ~tool_name ~input = function
   | Admit -> Run_admitted
   | Block reason ->
-    let result =
-      blocked_tool_result ~invocation ~tool_name ~input ~content:reason
-    in
+    let result = blocked_tool_result ~invocation ~tool_name ~input ~content:reason in
     let result =
       match settle_blocked with
       | None -> result

--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -889,16 +889,16 @@ let execute_tools
       ?on_tool_execution_finished
       ?on_hook_invoked
   in
-  let collect_batch outcomes =
+  let collect_batch (outcomes : scheduled_tool_outcome list) =
     let completed =
       List.filter_map
-        (fun outcome ->
+        (fun (outcome : scheduled_tool_outcome) ->
            Option.map (fun result -> outcome.index, result) outcome.completed_result)
         outcomes
     in
     let failure =
       List.fold_left
-        (fun selected outcome ->
+        (fun selected (outcome : scheduled_tool_outcome) ->
            match outcome.failure with
            | None -> selected
            | Some candidate -> prefer_failure selected candidate)
@@ -907,7 +907,7 @@ let execute_tools
     in
     let completion =
       List.fold_left
-        (fun selected outcome ->
+        (fun selected (outcome : scheduled_tool_outcome) ->
            match selected, outcome.completion with
            | (Terminal_completed _ | Terminal_failed _), _ -> selected
            | Continue_after_batch, candidate -> candidate)

--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -702,12 +702,12 @@ let execute_scheduled_tool
          { invocation; detail = Execution_agent_scope.error_to_string error });
     raise Abort_tool_dispatch
   in
-  let settle_existing_block durable result =
-    match Agent_tool_pre_execution_gate.settle_existing_block durable result with
+  let settle_existing_rejection durable result =
+    match Agent_tool_pre_execution_gate.settle_existing_rejection durable result with
     | Ok result -> result
     | Error error -> durability_failure error
   in
-  let settle_gate ?settle_blocked execute_admitted =
+  let settle_gate ?settle_rejected execute_admitted =
     let decision =
       invoke_hook
         ?on_hook_invoked
@@ -737,7 +737,7 @@ let execute_scheduled_tool
     in
     match
       Agent_tool_pre_execution_gate.scheduled_settlement
-        ?settle_blocked
+        ?settle_rejected
         ~index
         ~invocation
         ~tool_name:name
@@ -765,7 +765,7 @@ let execute_scheduled_tool
       (match Execution_agent_scope.invocation_progress durable with
        | Error error -> durability_failure error
        | Ok Execution_agent_scope.Invocation_unattempted ->
-         settle_gate ~settle_blocked:(settle_existing_block durable) execute_existing
+         settle_gate ~settle_rejected:(settle_existing_rejection durable) execute_existing
        | Ok Execution_agent_scope.Invocation_attempted_or_settled -> execute_existing ())
     | Ok None ->
       let execute_admitted () =

--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -724,7 +724,24 @@ let execute_scheduled_tool
          { invocation; detail = Execution_agent_scope.error_to_string error });
     raise Abort_tool_dispatch
   in
-  let settle_gate execute_admitted =
+  let settle_existing_rejection durable result =
+    match
+      Execution_agent_scope.execute_phased
+        durable
+        ~invoke:(fun ~start_child:_ ~tool_name:_ ~input:_ ->
+          (result.content, result.outcome), (fun () -> ()))
+    with
+    | Error error -> durability_failure error
+    | Ok (Execution_agent_scope.Executed (settled, _, _))
+    | Ok (Execution_agent_scope.Replayed settled) ->
+      { invocation = settled.invocation
+      ; tool_name = settled.tool_name
+      ; input = settled.input
+      ; content = settled.content
+      ; outcome = settled.outcome
+      }
+  in
+  let settle_gate ?settle_rejected execute_admitted =
     let decision =
       invoke_hook
         ?on_hook_invoked
@@ -753,13 +770,24 @@ let execute_scheduled_tool
         decision
     with
     | Agent_tool_pre_execution_gate.Block reason ->
+      let result = blocked_tool_result ~invocation ~name ~input ~content:reason in
+      let result =
+        match settle_rejected with
+        | None -> result
+        | Some settle -> settle result
+      in
       { index
-      ; completed_result =
-          Some (blocked_tool_result ~invocation ~name ~input ~content:reason)
+      ; completed_result = Some result
       ; completion = Continue_after_batch
       ; failure = None
       }
     | Agent_tool_pre_execution_gate.Reject { stage; detail } ->
+      (match settle_rejected with
+       | None -> ()
+       | Some settle ->
+         ignore
+           (settle
+              (blocked_tool_result ~invocation ~name ~input ~content:detail)));
       { index
       ; completed_result = None
       ; completion = Continue_after_batch
@@ -792,7 +820,10 @@ let execute_scheduled_tool
       in
       (match Execution_agent_scope.invocation_progress durable with
        | Error error -> durability_failure error
-       | Ok Execution_agent_scope.Invocation_unattempted -> settle_gate execute_existing
+       | Ok Execution_agent_scope.Invocation_unattempted ->
+         settle_gate
+           ~settle_rejected:(settle_existing_rejection durable)
+           execute_existing
        | Ok Execution_agent_scope.Invocation_attempted_or_settled -> execute_existing ())
     | Ok None ->
       let execute_admitted () =

--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -724,6 +724,60 @@ let execute_scheduled_tool
          { invocation; detail = Execution_agent_scope.error_to_string error });
     raise Abort_tool_dispatch
   in
+  let settle_gate execute_admitted =
+    let decision =
+      invoke_hook
+        ?on_hook_invoked
+        ~tracer
+        ~agent_name
+        ~turn_count
+        ~hook_name:"pre_tool_use"
+        hooks.pre_tool_use
+        (Hooks.PreToolUse
+           { invocation
+           ; tool_name = name
+           ; input
+           ; accumulated_cost_usd = usage.Types.estimated_cost_usd
+           })
+    in
+    match
+      Agent_tool_pre_execution_gate.settle
+        ?tool_approval
+        ?correlation_id
+        ?run_id
+        ~event_bus
+        ~agent_name
+        ~invocation
+        ~tool_name:name
+        ~input
+        decision
+    with
+    | Agent_tool_pre_execution_gate.Block reason ->
+      (* Intentional caller rejection is a model-visible tool result, but it is
+         not a tool execution. No Tool_called/Tool_completed lifecycle evidence
+         is emitted for a call that never crossed the caller's gate. *)
+      { index
+      ; completed_result =
+          Some (blocked_tool_result ~invocation ~name ~input ~content:reason)
+      ; completion = Continue_after_batch
+      ; failure = None
+      }
+    | Agent_tool_pre_execution_gate.Reject { stage; detail } ->
+      { index
+      ; completed_result = None
+      ; completion = Continue_after_batch
+      ; failure =
+          Some
+            (Hook_failure
+               (hook_execution_error
+                  ~hook_name:"pre_tool_use"
+                  ~stage
+                  ~tool_name:name
+                  ~invocation
+                  ~detail))
+      }
+    | Agent_tool_pre_execution_gate.Admit -> execute_admitted ()
+  in
   try
     let execution_provider = Execution_context.provider_attempt () in
     let existing =
@@ -735,14 +789,24 @@ let execute_scheduled_tool
     match existing with
     | Error error -> durability_failure error
     | Ok (Some durable_invocation) ->
-      (* An existing durable occurrence proves the pre-tool gate already
-         admitted this exact call. Replaying it must not invoke the gate or any
-         lifecycle observer again. If no attempt was committed, [execute_phased]
-         starts the effect once; an in-flight attempt fails closed. *)
-      let (_ : tool_dispatch) =
-        with_tool_span (fun () -> execute_durable durable_invocation)
-      in
-      outcome ()
+      (match Execution_agent_scope.invocation_progress durable_invocation with
+       | Error error -> durability_failure error
+       | Ok Execution_agent_scope.Invocation_unattempted ->
+         (* A durable occurrence created by an older protocol may predate typed
+            approval. With no committed effect attempt, re-run the current gate
+            before allowing execution. *)
+         settle_gate (fun () ->
+           let (_ : tool_dispatch) =
+             with_tool_span (fun () -> execute_durable durable_invocation)
+           in
+           outcome ())
+       | Ok Execution_agent_scope.Invocation_attempted_or_settled ->
+         (* Once an attempt exists, replay/unknown-effect handling is owned by
+            the durable settlement layer and must not invoke the gate again. *)
+         let (_ : tool_dispatch) =
+           with_tool_span (fun () -> execute_durable durable_invocation)
+         in
+         outcome ())
     | Ok None ->
       let execute_admitted () =
         let idem_key = Durable_event.make_idempotency_key ~tool_name:name ~input in
@@ -807,58 +871,7 @@ let execute_scheduled_tool
           record_caught_exception exception_ backtrace;
           outcome ()
       in
-      let decision =
-        invoke_hook
-          ?on_hook_invoked
-          ~tracer
-          ~agent_name
-          ~turn_count
-          ~hook_name:"pre_tool_use"
-          hooks.pre_tool_use
-          (Hooks.PreToolUse
-             { invocation
-             ; tool_name = name
-             ; input
-             ; accumulated_cost_usd = usage.Types.estimated_cost_usd
-             })
-      in
-      (match
-         Agent_tool_pre_execution_gate.settle
-           ?tool_approval
-           ?correlation_id
-           ?run_id
-           ~event_bus
-           ~agent_name
-           ~invocation
-           ~tool_name:name
-           ~input
-           decision
-       with
-       | Agent_tool_pre_execution_gate.Block reason ->
-         (* Intentional caller rejection is a model-visible tool result, but it is
-         not a tool execution. No Tool_called/Tool_completed lifecycle evidence
-         is emitted for a call that never crossed the caller's gate. *)
-         { index
-         ; completed_result =
-             Some (blocked_tool_result ~invocation ~name ~input ~content:reason)
-         ; completion = Continue_after_batch
-         ; failure = None
-         }
-       | Agent_tool_pre_execution_gate.Reject { stage; detail } ->
-         { index
-         ; completed_result = None
-         ; completion = Continue_after_batch
-         ; failure =
-             Some
-               (Hook_failure
-                  (hook_execution_error
-                     ~hook_name:"pre_tool_use"
-                     ~stage
-                     ~tool_name:name
-                     ~invocation
-                     ~detail))
-         }
-       | Agent_tool_pre_execution_gate.Admit -> execute_admitted ())
+      settle_gate execute_admitted
   with
   | Hook_observer_raised (exception_, backtrace) ->
     record_caught_exception exception_ backtrace;

--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -534,13 +534,6 @@ let find_and_execute_tool
   | Hook_observer_raised (exn, backtrace) -> reraise_hook_observer exn backtrace
 ;;
 
-type scheduled_tool_outcome =
-  { index : int
-  ; completed_result : tool_execution_result option
-  ; completion : batch_completion
-  ; failure : execution_failure_cause option
-  }
-
 exception Abort_tool_dispatch
 
 let execute_scheduled_tool
@@ -725,21 +718,9 @@ let execute_scheduled_tool
     raise Abort_tool_dispatch
   in
   let settle_existing_rejection durable result =
-    match
-      Execution_agent_scope.execute_phased
-        durable
-        ~invoke:(fun ~start_child:_ ~tool_name:_ ~input:_ ->
-          (result.content, result.outcome), (fun () -> ()))
-    with
+    match Agent_tool_pre_execution_gate.settle_existing_rejection durable result with
+    | Ok result -> result
     | Error error -> durability_failure error
-    | Ok (Execution_agent_scope.Executed (settled, _, _))
-    | Ok (Execution_agent_scope.Replayed settled) ->
-      { invocation = settled.invocation
-      ; tool_name = settled.tool_name
-      ; input = settled.input
-      ; content = settled.content
-      ; outcome = settled.outcome
-      }
   in
   let settle_gate ?settle_rejected execute_admitted =
     let decision =
@@ -757,7 +738,7 @@ let execute_scheduled_tool
            ; accumulated_cost_usd = usage.Types.estimated_cost_usd
            })
     in
-    match
+    let settlement =
       Agent_tool_pre_execution_gate.settle
         ?tool_approval
         ?correlation_id
@@ -768,40 +749,19 @@ let execute_scheduled_tool
         ~tool_name:name
         ~input
         decision
+    in
+    match
+      Agent_tool_pre_execution_gate.scheduled_settlement
+        ?settle_rejected
+        ~index
+        ~invocation
+        ~tool_name:name
+        ~blocked_result:(fun content ->
+          blocked_tool_result ~invocation ~name ~input ~content)
+        settlement
     with
-    | Agent_tool_pre_execution_gate.Block reason ->
-      let result = blocked_tool_result ~invocation ~name ~input ~content:reason in
-      let result =
-        match settle_rejected with
-        | None -> result
-        | Some settle -> settle result
-      in
-      { index
-      ; completed_result = Some result
-      ; completion = Continue_after_batch
-      ; failure = None
-      }
-    | Agent_tool_pre_execution_gate.Reject { stage; detail } ->
-      (match settle_rejected with
-       | None -> ()
-       | Some settle ->
-         ignore
-           (settle
-              (blocked_tool_result ~invocation ~name ~input ~content:detail)));
-      { index
-      ; completed_result = None
-      ; completion = Continue_after_batch
-      ; failure =
-          Some
-            (Hook_failure
-               (hook_execution_error
-                  ~hook_name:"pre_tool_use"
-                  ~stage
-                  ~tool_name:name
-                  ~invocation
-                  ~detail))
-      }
-    | Agent_tool_pre_execution_gate.Admit -> execute_admitted ()
+    | Agent_tool_pre_execution_gate.Run_admitted -> execute_admitted ()
+    | Agent_tool_pre_execution_gate.Return_outcome outcome -> outcome
   in
   try
     let execution_provider = Execution_context.provider_attempt () in

--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -753,9 +753,6 @@ let execute_scheduled_tool
         decision
     with
     | Agent_tool_pre_execution_gate.Block reason ->
-      (* Intentional caller rejection is a model-visible tool result, but it is
-         not a tool execution. No Tool_called/Tool_completed lifecycle evidence
-         is emitted for a call that never crossed the caller's gate. *)
       { index
       ; completed_result =
           Some (blocked_tool_result ~invocation ~name ~input ~content:reason)
@@ -788,25 +785,15 @@ let execute_scheduled_tool
     in
     match existing with
     | Error error -> durability_failure error
-    | Ok (Some durable_invocation) ->
-      (match Execution_agent_scope.invocation_progress durable_invocation with
+    | Ok (Some durable) ->
+      let execute_existing () =
+        let (_ : tool_dispatch) = with_tool_span (fun () -> execute_durable durable) in
+        outcome ()
+      in
+      (match Execution_agent_scope.invocation_progress durable with
        | Error error -> durability_failure error
-       | Ok Execution_agent_scope.Invocation_unattempted ->
-         (* A durable occurrence created by an older protocol may predate typed
-            approval. With no committed effect attempt, re-run the current gate
-            before allowing execution. *)
-         settle_gate (fun () ->
-           let (_ : tool_dispatch) =
-             with_tool_span (fun () -> execute_durable durable_invocation)
-           in
-           outcome ())
-       | Ok Execution_agent_scope.Invocation_attempted_or_settled ->
-         (* Once an attempt exists, replay/unknown-effect handling is owned by
-            the durable settlement layer and must not invoke the gate again. *)
-         let (_ : tool_dispatch) =
-           with_tool_span (fun () -> execute_durable durable_invocation)
-         in
-         outcome ())
+       | Ok Execution_agent_scope.Invocation_unattempted -> settle_gate execute_existing
+       | Ok Execution_agent_scope.Invocation_attempted_or_settled -> execute_existing ())
     | Ok None ->
       let execute_admitted () =
         let idem_key = Durable_event.make_idempotency_key ~tool_name:name ~input in

--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -702,12 +702,12 @@ let execute_scheduled_tool
          { invocation; detail = Execution_agent_scope.error_to_string error });
     raise Abort_tool_dispatch
   in
-  let settle_existing_rejection durable result =
-    match Agent_tool_pre_execution_gate.settle_existing_rejection durable result with
+  let settle_existing_block durable result =
+    match Agent_tool_pre_execution_gate.settle_existing_block durable result with
     | Ok result -> result
     | Error error -> durability_failure error
   in
-  let settle_gate ?settle_rejected execute_admitted =
+  let settle_gate ?settle_blocked execute_admitted =
     let decision =
       invoke_hook
         ?on_hook_invoked
@@ -737,7 +737,7 @@ let execute_scheduled_tool
     in
     match
       Agent_tool_pre_execution_gate.scheduled_settlement
-        ?settle_rejected
+        ?settle_blocked
         ~index
         ~invocation
         ~tool_name:name
@@ -765,7 +765,7 @@ let execute_scheduled_tool
       (match Execution_agent_scope.invocation_progress durable with
        | Error error -> durability_failure error
        | Ok Execution_agent_scope.Invocation_unattempted ->
-         settle_gate ~settle_rejected:(settle_existing_rejection durable) execute_existing
+         settle_gate ~settle_blocked:(settle_existing_block durable) execute_existing
        | Ok Execution_agent_scope.Invocation_attempted_or_settled -> execute_existing ())
     | Ok None ->
       let execute_admitted () =

--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -549,7 +549,7 @@ let execute_scheduled_tool
       ~tool_index
       ~(hooks : Hooks.hooks)
       ~event_bus
-      ?elicitation
+      ?tool_approval
       ?journal
       ~tracer
       ~agent_name
@@ -824,11 +824,14 @@ let execute_scheduled_tool
       in
       (match
          Agent_tool_pre_execution_gate.settle
-           ?elicitation
+           ?tool_approval
            ?correlation_id
            ?run_id
            ~event_bus
            ~agent_name
+           ~invocation
+           ~tool_name:name
+           ~input
            decision
        with
        | Agent_tool_pre_execution_gate.Block reason ->
@@ -870,7 +873,7 @@ let execute_tools
       ~context
       ~tools
       ~(hooks : Hooks.hooks)
-      ?elicitation
+      ?tool_approval
       ~event_bus
       ?journal
       ~tracer
@@ -901,7 +904,7 @@ let execute_tools
       ~tool_index
       ~hooks
       ~event_bus
-      ?elicitation
+      ?tool_approval
       ?journal
       ~tracer
       ~agent_name

--- a/lib/agent/agent_tools.ml
+++ b/lib/agent/agent_tools.ml
@@ -78,21 +78,6 @@ let unknown_tool_failure ~requested ~available =
 
 let resolve_tool_call tool_index name input = name, input, find_in_index tool_index name
 
-let tool_failure_result ~invocation ~name ~input ~content ~error_class =
-  { invocation
-  ; tool_name = name
-  ; input
-  ; content
-  ; outcome =
-      Tool_failed
-        { failure_kind = Non_retryable_tool_error; error_class = Some error_class }
-  }
-;;
-
-let blocked_tool_result ~invocation ~name ~input ~content =
-  tool_failure_result ~invocation ~name ~input ~content ~error_class:Types.Deterministic
-;;
-
 let schedule_tool_use ~tool_index index (id, name, input) =
   let execution_mode, completion =
     match find_in_index tool_index name with
@@ -717,12 +702,12 @@ let execute_scheduled_tool
          { invocation; detail = Execution_agent_scope.error_to_string error });
     raise Abort_tool_dispatch
   in
-  let settle_existing_rejection durable result =
-    match Agent_tool_pre_execution_gate.settle_existing_rejection durable result with
+  let settle_existing_block durable result =
+    match Agent_tool_pre_execution_gate.settle_existing_block durable result with
     | Ok result -> result
     | Error error -> durability_failure error
   in
-  let settle_gate ?settle_rejected execute_admitted =
+  let settle_gate ?settle_blocked execute_admitted =
     let decision =
       invoke_hook
         ?on_hook_invoked
@@ -752,12 +737,11 @@ let execute_scheduled_tool
     in
     match
       Agent_tool_pre_execution_gate.scheduled_settlement
-        ?settle_rejected
+        ?settle_blocked
         ~index
         ~invocation
         ~tool_name:name
-        ~blocked_result:(fun content ->
-          blocked_tool_result ~invocation ~name ~input ~content)
+        ~input
         settlement
     with
     | Agent_tool_pre_execution_gate.Run_admitted -> execute_admitted ()
@@ -781,9 +765,7 @@ let execute_scheduled_tool
       (match Execution_agent_scope.invocation_progress durable with
        | Error error -> durability_failure error
        | Ok Execution_agent_scope.Invocation_unattempted ->
-         settle_gate
-           ~settle_rejected:(settle_existing_rejection durable)
-           execute_existing
+         settle_gate ~settle_blocked:(settle_existing_block durable) execute_existing
        | Ok Execution_agent_scope.Invocation_attempted_or_settled -> execute_existing ())
     | Ok None ->
       let execute_admitted () =

--- a/lib/agent/agent_tools.mli
+++ b/lib/agent/agent_tools.mli
@@ -158,7 +158,10 @@ val find_and_execute_tool
     [Hooks.Approved] admits the exact call; [Denied] and [Timed_out] return
     deterministic blocked tool results. Generic [ElicitInput]/[Answer] never
     grants execution authority. A missing approval callback fails closed as
-    [Hook_failure].
+    [Hook_failure]. OAS installs no timer and persists no pending request at
+    this boundary; [Timed_out] means the caller enforced and reported its own
+    deadline. A non-reserved callback exception becomes [Hook_failure] before
+    execution, while cancellation and other reserved exceptions propagate.
 
     An ordinary tool-handler exception is localized to that call as a
     non-retryable tool result. A terminal tool-handler exception propagates

--- a/lib/agent/agent_tools.mli
+++ b/lib/agent/agent_tools.mli
@@ -153,10 +153,12 @@ val find_and_execute_tool
     - Tools without a declared descriptor default to [Tool_contract.Serial].
 
     For each [ToolUse] block, applies the [PreToolUse] hook before execution.
-    [ElicitInput] is settled synchronously through the caller-owned
-    [elicitation] callback before any invocation is opened. [Answer _] admits
-    the exact call; [Declined] and [Timeout] return deterministic blocked tool
-    results. A missing callback fails closed as [Hook_failure].
+    [ElicitToolApproval] is settled synchronously through the caller-owned
+    [tool_approval] callback before any invocation is opened. Only
+    [Hooks.Approved] admits the exact call; [Denied] and [Timed_out] return
+    deterministic blocked tool results. Generic [ElicitInput]/[Answer] never
+    grants execution authority. A missing approval callback fails closed as
+    [Hook_failure].
 
     An ordinary tool-handler exception is localized to that call as a
     non-retryable tool result. A terminal tool-handler exception propagates
@@ -192,7 +194,7 @@ val execute_tools
   :  context:Context.t
   -> tools:Tool.t list
   -> hooks:Hooks.hooks
-  -> ?elicitation:Hooks.elicitation_callback
+  -> ?tool_approval:Hooks.tool_approval_callback
   -> event_bus:Event_bus.t option
   -> ?journal:Durable_event.journal
   -> tracer:Tracing.t

--- a/lib/agent/agent_trace.ml
+++ b/lib/agent/agent_trace.ml
@@ -92,7 +92,7 @@ let execute_tools_with_trace agent active_run ~turn ?before_tool_execution tool_
     ~context:agent.context
     ~tools
     ~hooks:agent.options.hooks
-    ?elicitation:agent.options.elicitation
+    ?tool_approval:agent.options.tool_approval
     ~event_bus:agent.options.event_bus
     ?journal:agent.options.journal
     ~tracer:agent.options.tracer

--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -192,7 +192,7 @@ let resolve_turn_params ~hooks ~messages ~turn ~invoke_hook =
      | Hooks.AdjustParams params -> Ok params
      | Hooks.Continue -> Ok Hooks.default_turn_params
      | Hooks.HookFailed { stage; detail } -> Error (Hook_failed { stage; detail })
-     | Hooks.ElicitInput _ | Hooks.Nudge _ | Hooks.Block _ ->
+     | Hooks.ElicitInput _ | Hooks.ElicitToolApproval _ | Hooks.Nudge _ | Hooks.Block _ ->
        Error (Illegal_decision decision))
 ;;
 

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -59,6 +59,7 @@ type options =
   ; event_bus : Event_bus.t option
   ; skill_registry : Skill_registry.t option
   ; elicitation : Hooks.elicitation_callback option
+  ; tool_approval : Hooks.tool_approval_callback option
   ; description : string option
   ; periodic_callbacks : periodic_callback list
   ; slot_id : int option
@@ -130,6 +131,7 @@ let default_options =
   ; event_bus = None
   ; skill_registry = None
   ; elicitation = None
+  ; tool_approval = None
   ; description = None
   ; periodic_callbacks = []
   ; slot_id = None
@@ -215,7 +217,8 @@ let card t =
         List.map (fun (tool : Tool.t) -> tool.schema) (Tool_set.to_list t.tools)
     ; supported_providers
     ; mcp_clients_count = List.length t.options.mcp_clients
-    ; has_elicitation = Option.is_some t.options.elicitation
+    ; has_elicitation =
+        Option.is_some t.options.elicitation || Option.is_some t.options.tool_approval
     ; skills
     }
 ;;

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -96,6 +96,7 @@ type options =
     (** Discovery/metadata path only.  Surfaced via {!Agent.card} for
           A2A negotiation.  Does not affect runtime prompt composition. *)
   ; elicitation : Hooks.elicitation_callback option
+  ; tool_approval : Hooks.tool_approval_callback option
   ; description : string option
   ; periodic_callbacks : periodic_callback list
   ; slot_id : int option

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -97,7 +97,7 @@ type options =
           A2A negotiation.  Does not affect runtime prompt composition. *)
   ; elicitation : Hooks.elicitation_callback option
   ; tool_approval : Hooks.tool_approval_callback option
-    (** Closed exact-tool approval callback. *)
+    (** Closed synchronous exact-tool approval callback. *)
   ; description : string option
   ; periodic_callbacks : periodic_callback list
   ; slot_id : int option

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -97,6 +97,7 @@ type options =
           A2A negotiation.  Does not affect runtime prompt composition. *)
   ; elicitation : Hooks.elicitation_callback option
   ; tool_approval : Hooks.tool_approval_callback option
+    (** Closed exact-tool approval callback. *)
   ; description : string option
   ; periodic_callbacks : periodic_callback list
   ; slot_id : int option

--- a/lib/agent/builder.ml
+++ b/lib/agent/builder.ml
@@ -46,6 +46,7 @@ type t =
   ; event_bus : Event_bus.t option
   ; skill_registry : Skill_registry.t option
   ; elicitation : Hooks.elicitation_callback option
+  ; tool_approval : Hooks.tool_approval_callback option
   ; description : string option
   ; periodic_callbacks : Agent.periodic_callback list
   ; contract : Contract.t
@@ -107,6 +108,7 @@ let create ~net ~model =
     event_bus = Some (Event_bus.create ())
   ; skill_registry = None
   ; elicitation = None
+  ; tool_approval = None
   ; description = None
   ; periodic_callbacks = []
   ; contract = Contract.empty
@@ -227,6 +229,7 @@ let with_body_timeout s b = { b with body_timeout_s = Some s }
 let with_context_injector injector b = { b with context_injector = Some injector }
 let with_skill_registry reg b = { b with skill_registry = Some reg }
 let with_elicitation cb b = { b with elicitation = Some cb }
+let with_tool_approval cb b = { b with tool_approval = Some cb }
 let with_description desc b = { b with description = Some desc }
 
 let with_periodic_callback cb b =
@@ -289,6 +292,7 @@ let build b =
     ; event_bus = b.event_bus
     ; skill_registry = b.skill_registry
     ; elicitation = b.elicitation
+    ; tool_approval = b.tool_approval
     ; description = b.description
     ; periodic_callbacks = b.periodic_callbacks
     ; slot_id = b.slot_id

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -110,7 +110,8 @@ val with_body_timeout : float -> t -> t
 val with_elicitation : Hooks.elicitation_callback -> t -> t
 
 (** Configure the closed typed approval boundary used only by
-    [Hooks.ElicitToolApproval] at [PreToolUse]. *)
+    [Hooks.ElicitToolApproval] at [PreToolUse]. The callback settles
+    synchronously; OAS does not install a timeout or durable pause. *)
 val with_tool_approval : Hooks.tool_approval_callback -> t -> t
 
 val with_description : string -> t -> t

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -112,6 +112,7 @@ val with_elicitation : Hooks.elicitation_callback -> t -> t
 (** Configure the closed typed approval boundary used only by
     [Hooks.ElicitToolApproval] at [PreToolUse]. *)
 val with_tool_approval : Hooks.tool_approval_callback -> t -> t
+
 val with_description : string -> t -> t
 val with_periodic_callback : Agent.periodic_callback -> t -> t
 val with_periodic_callbacks : Agent.periodic_callback list -> t -> t

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -108,6 +108,10 @@ val with_first_event_timeout : float -> t -> t
 val with_body_timeout : float -> t -> t
 
 val with_elicitation : Hooks.elicitation_callback -> t -> t
+
+(** Configure the closed typed approval boundary used only by
+    [Hooks.ElicitToolApproval] at [PreToolUse]. *)
+val with_tool_approval : Hooks.tool_approval_callback -> t -> t
 val with_description : string -> t -> t
 val with_periodic_callback : Agent.periodic_callback -> t -> t
 val with_periodic_callbacks : Agent.periodic_callback list -> t -> t

--- a/lib/base/hooks.ml
+++ b/lib/base/hooks.ml
@@ -466,7 +466,13 @@ let%test "invoke_validated: Sys.Break remains reserved" =
   match invoke_validated (Some (fun _ -> raise Sys.Break)) event with
   | exception Sys.Break -> true
   | (exception _)
-  | Continue | AdjustParams _ | ElicitInput _ | Nudge _ | HookFailed _ | Block _ -> false
+  | Continue
+  | AdjustParams _
+  | ElicitInput _
+  | ElicitToolApproval _
+  | Nudge _
+  | HookFailed _
+  | Block _ -> false
 ;;
 
 (* ── Block variant (RFC-0321) regression tests ─────────────── *)

--- a/lib/base/hooks.ml
+++ b/lib/base/hooks.ml
@@ -153,10 +153,7 @@ type elicitation_callback = elicitation_request -> elicitation_response
     that value is user input, not execution authority. Keep the prompt and the
     exact runtime request distinct so malformed data is unrepresentable at the
     authorization boundary. *)
-type tool_approval_prompt =
-  { question : string
-  ; timeout_s : float option
-  }
+type tool_approval_prompt = { question : string }
 
 type tool_approval_request =
   { prompt : tool_approval_prompt

--- a/lib/base/hooks.ml
+++ b/lib/base/hooks.ml
@@ -149,6 +149,29 @@ type elicitation_response =
     Returns the user's response or Declined/Timeout. *)
 type elicitation_callback = elicitation_request -> elicitation_response
 
+(** A pre-tool authorization cannot be represented by [Answer of Yojson.Safe.t]:
+    that value is user input, not execution authority. Keep the prompt and the
+    exact runtime request distinct so malformed data is unrepresentable at the
+    authorization boundary. *)
+type tool_approval_prompt =
+  { question : string
+  ; timeout_s : float option
+  }
+
+type tool_approval_request =
+  { prompt : tool_approval_prompt
+  ; invocation : Tool_contract.Invocation.t
+  ; tool_name : string
+  ; input : Yojson.Safe.t
+  }
+
+type tool_approval =
+  | Approved
+  | Denied
+  | Timed_out
+
+type tool_approval_callback = tool_approval_request -> tool_approval
+
 (** Typed lifecycle stage used by the hook decision matrix. *)
 type hook_stage =
   | Before_turn
@@ -167,6 +190,8 @@ type hook_decision =
   | AdjustParams of turn_params
   (** BeforeTurnParams only: override params for this turn *)
   | ElicitInput of elicitation_request (** Request user input before proceeding *)
+  | ElicitToolApproval of tool_approval_prompt
+  (** PreToolUse only: request a caller-owned exact-tool authorization. *)
   | Nudge of string (** BeforeTurn: inject a user-role message before tool preparation. *)
   | HookFailed of
       { stage : hook_stage
@@ -228,11 +253,12 @@ type context_injector =
 
 (** Classification of hook_decision variants for the decision matrix.
     Using a separate type avoids comparing functional values
-    (AdjustParams, ElicitInput carry payloads). *)
+   (AdjustParams and elicitation decisions carry payloads). *)
 type hook_decision_kind =
   | K_Continue
   | K_AdjustParams
   | K_ElicitInput
+  | K_ElicitToolApproval
   | K_Nudge
   | K_HookFailed
   | K_Block
@@ -241,6 +267,7 @@ let classify_decision = function
   | Continue -> K_Continue
   | AdjustParams _ -> K_AdjustParams
   | ElicitInput _ -> K_ElicitInput
+  | ElicitToolApproval _ -> K_ElicitToolApproval
   | Nudge _ -> K_Nudge
   | HookFailed _ -> K_HookFailed
   | Block _ -> K_Block
@@ -250,6 +277,7 @@ let decision_kind_to_string = function
   | K_Continue -> "Continue"
   | K_AdjustParams -> "AdjustParams"
   | K_ElicitInput -> "ElicitInput"
+  | K_ElicitToolApproval -> "ElicitToolApproval"
   | K_Nudge -> "Nudge"
   | K_HookFailed -> "HookFailed"
   | K_Block -> "Block"
@@ -283,12 +311,12 @@ let hook_stage_to_string = function
 (** Legal decision matrix.
 
     {v
-    Stage                | Continue | AdjustParams | ElicitInput | Nudge | Block
-    ---------------------+----------+--------------+-------------+-------+------
-    before_turn          |    Y     |              |      Y      |   Y   |
+    Stage                | Continue | AdjustParams | ElicitInput | ElicitToolApproval | Nudge | Block
+    ---------------------+----------+--------------+-------------+-------------------+-------+------
+    before_turn          |    Y     |              |      Y      |                   |   Y   |
     before_turn_params   |    Y     |      Y       |             |       |
     after_turn           |    Y     |              |             |       |
-    pre_tool_use         |    Y     |              |      Y      |       |   Y
+    pre_tool_use         |    Y     |              |             |         Y         |       |   Y
     post_tool_use        |    Y     |              |             |       |
     post_tool_use_failure|    Y     |              |             |       |
     on_stop              |    Y     |              |             |       |
@@ -299,11 +327,12 @@ let hook_stage_to_string = function
     Fail-closed: any decision not explicitly listed is rejected. [Block] is
     legal only at [pre_tool_use].
 
-    [ElicitInput] is legal at two stages. At [before_turn] it asks before the
-    model runs. At [pre_tool_use] the configured elicitation callback settles
-    the exact call before its invocation is opened (RFC-OAS-039): a caller gate
-    that authorizes a specific command with a specific input can only decide
-    once both exist, which is after the model has chosen them. Without this,
+    [ElicitInput] is legal only at [before_turn], where it asks before the model
+    runs. [ElicitToolApproval] is legal only at [pre_tool_use] and its separate
+    typed callback settles the exact call before its invocation is opened. A
+    caller gate that authorizes a specific command with a specific input can
+    only decide once both exist, which is after the model has chosen them.
+    Without this,
     such a gate has to answer the call without caller input, and
     {!Llm_provider.Types.tool_result_outcome} offers only [Tool_succeeded] or
     [Tool_failed] — so a deferral would have to report a success that did not
@@ -313,7 +342,7 @@ let legal_decisions_for_stage stage =
   | Before_turn -> [ K_Continue; K_ElicitInput; K_Nudge ]
   | Before_turn_params -> [ K_Continue; K_AdjustParams ]
   | After_turn -> [ K_Continue ]
-  | Pre_tool_use -> [ K_Continue; K_Block; K_ElicitInput ]
+  | Pre_tool_use -> [ K_Continue; K_Block; K_ElicitToolApproval ]
   | Post_tool_use | Post_tool_use_failure | On_stop | On_error | On_tool_error ->
     [ K_Continue ]
 ;;

--- a/lib/base/hooks.mli
+++ b/lib/base/hooks.mli
@@ -108,11 +108,9 @@ type elicitation_callback = elicitation_request -> elicitation_response
 
 (** Prompt supplied by a [PreToolUse] hook when caller approval is required.
     It deliberately has no generic JSON schema: authorization is a closed
-    protocol, not an arbitrary elicitation answer. *)
-type tool_approval_prompt =
-  { question : string
-  ; timeout_s : float option
-  }
+    protocol, not an arbitrary elicitation answer. OAS does not install a timer
+    or persist a pending approval request at this synchronous boundary. *)
+type tool_approval_prompt = { question : string }
 
 (** Exact immutable tool occurrence presented to the caller-owned approval
     boundary. [input] is the invocation input selected by the provider. *)
@@ -129,7 +127,10 @@ type tool_approval =
   | Denied
   | Timed_out
 
-(** Caller-owned settlement callback for an exact tool occurrence. *)
+(** Caller-owned synchronous settlement callback for an exact tool occurrence.
+    It must return a closed decision. If the caller needs a timeout, remote
+    prompt, or restart recovery, it must settle those concerns before returning;
+    [Timed_out] reports a timeout already enforced by the caller. *)
 type tool_approval_callback = tool_approval_request -> tool_approval
 
 (** Closed set of lifecycle stages accepted by the hook decision matrix. *)

--- a/lib/base/hooks.mli
+++ b/lib/base/hooks.mli
@@ -106,6 +106,31 @@ type elicitation_response =
 
 type elicitation_callback = elicitation_request -> elicitation_response
 
+(** Prompt supplied by a [PreToolUse] hook when caller approval is required.
+    It deliberately has no generic JSON schema: authorization is a closed
+    protocol, not an arbitrary elicitation answer. *)
+type tool_approval_prompt =
+  { question : string
+  ; timeout_s : float option
+  }
+
+(** Exact immutable tool occurrence presented to the caller-owned approval
+    boundary. [input] is the invocation input selected by the provider. *)
+type tool_approval_request =
+  { prompt : tool_approval_prompt
+  ; invocation : Tool_contract.Invocation.t
+  ; tool_name : string
+  ; input : Yojson.Safe.t
+  }
+
+(** Closed authorization result for an exact tool occurrence. *)
+type tool_approval =
+  | Approved
+  | Denied
+  | Timed_out
+
+type tool_approval_callback = tool_approval_request -> tool_approval
+
 (** Closed set of lifecycle stages accepted by the hook decision matrix. *)
 type hook_stage =
   | Before_turn
@@ -123,6 +148,10 @@ type hook_decision =
   | Continue
   | AdjustParams of turn_params
   | ElicitInput of elicitation_request
+  | ElicitToolApproval of tool_approval_prompt
+  (** PreToolUse only: ask the caller to settle the exact invocation through
+      {!tool_approval_callback}. Generic [ElicitInput] answers cannot grant
+      execution authority. *)
   | Nudge of string (** BeforeTurn: inject a user-role message before tool preparation. *)
   | HookFailed of
       { stage : hook_stage
@@ -171,12 +200,12 @@ val empty : hooks
     Returning an unlisted decision is a programming error.
 
     {v
-    Stage                | Continue | AdjustParams | ElicitInput | Nudge | Block
-    ---------------------+----------+--------------+-------------+-------+------
-    before_turn          |    Y     |              |      Y      |   Y   |
+    Stage                | Continue | AdjustParams | ElicitInput | ElicitToolApproval | Nudge | Block
+    ---------------------+----------+--------------+-------------+-------------------+-------+------
+    before_turn          |    Y     |              |      Y      |                   |   Y   |
     before_turn_params   |    Y     |      Y       |             |       |
     after_turn           |    Y     |              |             |       |
-    pre_tool_use         |    Y     |              |      Y      |       |   Y
+    pre_tool_use         |    Y     |              |             |         Y         |       |   Y
     post_tool_use        |    Y     |              |             |       |
     post_tool_use_failure|    Y     |              |             |       |
     on_stop              |    Y     |              |             |       |
@@ -191,6 +220,7 @@ type hook_decision_kind =
   | K_Continue
   | K_AdjustParams
   | K_ElicitInput
+  | K_ElicitToolApproval
   | K_Nudge
   | K_HookFailed
   | K_Block

--- a/lib/base/hooks.mli
+++ b/lib/base/hooks.mli
@@ -129,6 +129,7 @@ type tool_approval =
   | Denied
   | Timed_out
 
+(** Caller-owned settlement callback for an exact tool occurrence. *)
 type tool_approval_callback = tool_approval_request -> tool_approval
 
 (** Closed set of lifecycle stages accepted by the hook decision matrix. *)

--- a/lib/event_bus.ml
+++ b/lib/event_bus.ml
@@ -81,6 +81,12 @@ type payload =
       ; question : string
       ; response : Hooks.elicitation_response
       }
+  | ToolApprovalCompleted of
+      { agent_name : string
+      ; invocation : Tool_contract.Invocation.t
+      ; tool_name : string
+      ; approval : Hooks.tool_approval
+      }
   | InferenceTelemetry of
       { agent_name : string
       ; turn : int
@@ -121,6 +127,7 @@ let payload_kind = function
   | HandoffRequested _ -> "handoff_requested"
   | HandoffCompleted _ -> "handoff_completed"
   | ElicitationCompleted _ -> "elicitation_completed"
+  | ToolApprovalCompleted _ -> "tool_approval_completed"
   | InferenceTelemetry _ -> "inference_telemetry"
   | Custom (name, _) -> Printf.sprintf "custom:%s" name
 ;;
@@ -252,6 +259,7 @@ let rec matches filter event =
      | HandoffRequested r -> r.from_agent = name || r.to_agent = name
      | HandoffCompleted r -> r.from_agent = name || r.to_agent = name
      | ElicitationCompleted r -> r.agent_name = name
+     | ToolApprovalCompleted r -> r.agent_name = name
      | InferenceTelemetry r -> r.agent_name = name
      | Custom _ -> true)
   | Tools_only ->
@@ -266,6 +274,7 @@ let rec matches filter event =
      | HandoffRequested _
      | HandoffCompleted _
      | ElicitationCompleted _
+     | ToolApprovalCompleted _
      | InferenceTelemetry _
      | Custom _ -> false)
   | Topic topic ->
@@ -282,6 +291,7 @@ let rec matches filter event =
      | HandoffRequested _
      | HandoffCompleted _
      | ElicitationCompleted _
+     | ToolApprovalCompleted _
      | InferenceTelemetry _ -> false)
   | Correlation id -> String.equal event.meta.correlation_id id
   | Run id -> String.equal event.meta.run_id id

--- a/lib/event_bus.mli
+++ b/lib/event_bus.mli
@@ -120,6 +120,15 @@ type payload =
       ; question : string
       ; response : Hooks.elicitation_response
       }
+  | ToolApprovalCompleted of
+      { agent_name : string
+      ; invocation : Tool_contract.Invocation.t
+      ; tool_name : string
+      ; approval : Hooks.tool_approval
+      }
+  (** Caller-owned approval for an exact tool occurrence was settled before
+      the invocation was opened. The tool input is intentionally not copied
+      into the event. *)
   | InferenceTelemetry of
       { agent_name : string
       ; turn : int

--- a/lib/execution_agent_scope.ml
+++ b/lib/execution_agent_scope.ml
@@ -525,6 +525,23 @@ let invocation_progress invocation =
        , _ ) -> Error (Resume_topology_mismatch "invocation changed node kind"))
 ;;
 
+let settle_unattempted_invocation invocation ~content ~outcome =
+  let durable = invocation.durable in
+  let result =
+    Llm_provider.Types.ToolResult
+      { tool_use_id = Tool_contract.Invocation.tool_use_id durable.invocation
+      ; content
+      ; outcome
+      ; json = None
+      ; content_blocks = None
+      }
+  in
+  transact
+    invocation.scope.writer
+    (Tx.settle_unattempted_tool_invocation ~invocation:invocation.locator.node ~result ())
+  |> Result.map (fun _events -> ())
+;;
+
 let provider_invocations provider =
   let scope = provider.turn.scope in
   match Writer.find_node scope.writer provider.node with

--- a/lib/execution_agent_scope.ml
+++ b/lib/execution_agent_scope.ml
@@ -57,6 +57,10 @@ type execution =
   | Executed of tool_result * Journal.cursor * int
   | Replayed of tool_result
 
+type invocation_progress =
+  | Invocation_unattempted
+  | Invocation_attempted_or_settled
+
 type abort_reason =
   | Failed of Event.failure
   | Cancelled of
@@ -500,6 +504,25 @@ let find_invocation provider ~invocation ~tool_name ~input =
             (Resume_topology_mismatch
                "tool occurrence identity differs from the restored Agent checkpoint"))
      | _ :: _ :: _ -> Error (Resume_topology_mismatch "duplicate tool occurrence"))
+;;
+
+let invocation_progress invocation =
+  let scope = invocation.scope in
+  match Writer.find_node scope.writer invocation.locator.node with
+  | Error error -> Error (Scope_unavailable error)
+  | Ok None -> Error (Resume_topology_mismatch "tool invocation disappeared")
+  | Ok (Some view) ->
+    (match view.materialized, view.children, view.status with
+     | Journal.Tool_invocation_state { result = None; _ }, [], Journal.Open ->
+       Ok Invocation_unattempted
+     | Journal.Tool_invocation_state _, _, _ -> Ok Invocation_attempted_or_settled
+     | ( Journal.Agent_run_state
+       | Journal.Agent_turn_state
+       | Journal.Provider_attempt_state _
+       | Journal.Output_block_state _
+       | Journal.Tool_attempt_state )
+       , _
+       , _ -> Error (Resume_topology_mismatch "invocation changed node kind"))
 ;;
 
 let provider_invocations provider =

--- a/lib/execution_agent_scope.ml
+++ b/lib/execution_agent_scope.ml
@@ -516,13 +516,13 @@ let invocation_progress invocation =
      | Journal.Tool_invocation_state { result = None; _ }, [], Journal.Open ->
        Ok Invocation_unattempted
      | Journal.Tool_invocation_state _, _, _ -> Ok Invocation_attempted_or_settled
-     | ( Journal.Agent_run_state
-       | Journal.Agent_turn_state
-       | Journal.Provider_attempt_state _
-       | Journal.Output_block_state _
-       | Journal.Tool_attempt_state )
+     | ( ( Journal.Agent_run_state
+         | Journal.Agent_turn_state
+         | Journal.Provider_attempt_state _
+         | Journal.Output_block_state _
+         | Journal.Tool_attempt_state )
        , _
-       , _ -> Error (Resume_topology_mismatch "invocation changed node kind"))
+       , _ ) -> Error (Resume_topology_mismatch "invocation changed node kind"))
 ;;
 
 let provider_invocations provider =

--- a/lib/execution_agent_scope.mli
+++ b/lib/execution_agent_scope.mli
@@ -160,6 +160,14 @@ val find_invocation
     current gate again before execution. *)
 val invocation_progress : invocation -> (invocation_progress, error) result
 
+(** Persist a model-visible blocked result without opening an effect attempt.
+    Only an open invocation classified as [Invocation_unattempted] is accepted. *)
+val settle_unattempted_invocation
+  :  invocation
+  -> content:string
+  -> outcome:Llm_provider.Types.tool_result_outcome
+  -> (unit, error) result
+
 val provider_invocations_settled : provider_attempt -> (bool, error) result
 
 (** Exact immutable invocation authority reconstructed only from persisted

--- a/lib/execution_agent_scope.mli
+++ b/lib/execution_agent_scope.mli
@@ -32,6 +32,10 @@ type execution =
   | Executed of tool_result * Execution_journal.cursor * int
   | Replayed of tool_result
 
+type invocation_progress =
+  | Invocation_unattempted
+  | Invocation_attempted_or_settled
+
 type abort_reason =
   | Failed of Execution_event.failure
   | Cancelled of
@@ -149,6 +153,12 @@ val find_invocation
   -> tool_name:string
   -> input:Yojson.Safe.t
   -> (invocation option, error) result
+
+(** Classify whether a durable invocation has crossed the effect-attempt
+    boundary. An unattempted invocation carries no approval authority by
+    itself: callers upgrading from an older admission protocol must run the
+    current gate again before execution. *)
+val invocation_progress : invocation -> (invocation_progress, error) result
 
 val provider_invocations_settled : provider_attempt -> (bool, error) result
 

--- a/lib/execution_journal.ml
+++ b/lib/execution_journal.ml
@@ -1746,6 +1746,42 @@ let stage_settle_tool_attempt journal state ~attempt ~invocation ~result =
   }
 ;;
 
+let stage_settle_unattempted_tool_invocation journal state ~invocation ~result =
+  let* invocation_record = node_record_or_error state invocation in
+  let* () =
+    match
+      ( Event.node_kind invocation_record.node
+      , invocation_record.tool_result
+      , invocation_record.children_rev
+      , invocation_record.status )
+    with
+    | Event.Tool_invocation _, None, [], Open -> Ok ()
+    | Event.Tool_invocation _, (None | Some _), (_ :: _ | []), (Open | Closed _) ->
+      Error
+        (Invalid_argument
+           "blocked settlement requires an open, unattempted tool invocation")
+    | ( ( Event.Agent_run _
+        | Event.Agent_turn _
+        | Event.Provider_attempt _
+        | Event.Output_block _
+        | Event.Tool_attempt )
+      , (None | Some _)
+      , (_ :: _ | [])
+      , (Open | Closed _) ) ->
+      Error (Invalid_argument "blocked settlement requires a Tool_invocation node")
+  in
+  let* result_committed =
+    stage_update_node journal state ~node:invocation (Event.Tool_result result)
+  in
+  let+ invocation_closed =
+    stage_close_node journal result_committed.next_state ~node:invocation Event.Succeeded
+  in
+  { next_state = invocation_closed.next_state
+  ; events = [ result_committed.value; invocation_closed.value ]
+  ; value = [ result_committed.value; invocation_closed.value ]
+  }
+;;
+
 let stage_finish_run ?causes journal state ~run terminal =
   let* event_id = identity_result (Event.Event_id.fresh ()) in
   let* terminal = payload_result (Event.validate_terminal terminal) in
@@ -1924,6 +1960,11 @@ module Transaction = struct
         ; result : Llm_provider.Types.content_block
         }
         -> Event.t list t
+    | Settle_unattempted_tool_invocation :
+        { invocation : Event.Node_id.t
+        ; result : Llm_provider.Types.content_block
+        }
+        -> Event.t list t
     | Finish_run :
         { causes : Event.cause list
         ; run : run
@@ -1955,6 +1996,10 @@ module Transaction = struct
 
   let settle_tool_attempt ~attempt ~invocation ~result () =
     Settle_tool_attempt { attempt; invocation; result }
+  ;;
+
+  let settle_unattempted_tool_invocation ~invocation ~result () =
+    Settle_unattempted_tool_invocation { invocation; result }
   ;;
 
   let finish_run ?(causes = []) ~run terminal = Finish_run { causes; run; terminal }
@@ -2006,6 +2051,13 @@ let stage : type value. batch -> value Transaction.t -> (batch * value, error) r
          batch.journal
          batch.staged_state
          ~attempt
+         ~invocation
+         ~result)
+  | Transaction.Settle_unattempted_tool_invocation { invocation; result } ->
+    stage_mutation
+      (stage_settle_unattempted_tool_invocation
+         batch.journal
+         batch.staged_state
          ~invocation
          ~result)
   | Transaction.Finish_run { causes; run; terminal } ->

--- a/lib/execution_journal.mli
+++ b/lib/execution_journal.mli
@@ -426,6 +426,15 @@ module Transaction : sig
     -> unit
     -> Execution_event.t list t
 
+  (** Atomically materialize a blocked ToolResult and close an invocation that
+      has no effect attempt. This cannot settle an attempted or closed
+      invocation. *)
+  val settle_unattempted_tool_invocation
+    :  invocation:Execution_event.Node_id.t
+    -> result:Llm_provider.Types.content_block
+    -> unit
+    -> Execution_event.t list t
+
   val finish_run
     :  ?causes:Execution_event.cause list
     -> run:run

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -481,7 +481,11 @@ let stage_output ?raw_trace_run ?before_tool_execution ~turn agent response =
                  ~tool_name:None
                  ~tool_use_id:None
                  ~detail)
-          | (Hooks.AdjustParams _ | Hooks.ElicitInput _ | Hooks.Nudge _ | Hooks.Block _)
+          | ( Hooks.AdjustParams _
+            | Hooks.ElicitInput _
+            | Hooks.ElicitToolApproval _
+            | Hooks.Nudge _
+            | Hooks.Block _ )
             as decision ->
             Error
               (Pipeline_common.illegal_hook_decision_sdk_error

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -485,8 +485,7 @@ let stage_output ?raw_trace_run ?before_tool_execution ~turn agent response =
             | Hooks.ElicitInput _
             | Hooks.ElicitToolApproval _
             | Hooks.Nudge _
-            | Hooks.Block _ )
-            as decision ->
+            | Hooks.Block _ ) as decision ->
             Error
               (Pipeline_common.illegal_hook_decision_sdk_error
                  ~hook_name:"on_stop"

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -87,7 +87,7 @@ let stage_input ?raw_trace_run ?clock ~turn agent =
          ~tool_name:None
          ~tool_use_id:None
          ~detail)
-  | Hooks.AdjustParams _ | Hooks.Block _ ->
+  | Hooks.AdjustParams _ | Hooks.ElicitToolApproval _ | Hooks.Block _ ->
     (* Reject illegal hook decisions with a typed error instead of crashing.
        [Hooks.invoke_validated] normally filters these out; this branch guards
        against a validation bypass or future hook matrix drift. [Block] is

--- a/lib/protocol/agent_card.mli
+++ b/lib/protocol/agent_card.mli
@@ -16,6 +16,10 @@ type capability =
   | Checkpoint
   | MCP
   | Elicitation
+  (** The agent has at least one caller-owned elicitation boundary: generic
+      before-turn input, exact pre-tool approval, or both. This capability does
+      not promise remote prompting, suspension, timeout enforcement, or
+      restart-resumable pending state. *)
   | Custom_cap of string
 [@@deriving yojson, show]
 
@@ -78,6 +82,7 @@ type agent_info =
   ; supported_providers : string list
   ; mcp_clients_count : int
   ; has_elicitation : bool
+    (** [true] for generic elicitation, exact tool approval, or both. *)
   ; skills : skill_meta list
   }
 

--- a/test/test_elicitation.ml
+++ b/test/test_elicitation.ml
@@ -72,20 +72,17 @@ let test_hook_decision_to_string () =
 ;;
 
 let test_hook_decision_tool_approval () =
-  let prompt : Hooks.tool_approval_prompt =
-    { question = "Approve exact tool call?"; timeout_s = Some 10.0 }
-  in
+  let prompt : Hooks.tool_approval_prompt = { question = "Approve exact tool call?" } in
   let decision = Hooks.ElicitToolApproval prompt in
   match decision with
   | Hooks.ElicitToolApproval returned ->
-    Alcotest.(check string) "question" "Approve exact tool call?" returned.question;
-    Alcotest.(check bool) "timeout preserved" true (returned.timeout_s = Some 10.0)
+    Alcotest.(check string) "question" "Approve exact tool call?" returned.question
   | _ -> Alcotest.fail "expected ElicitToolApproval"
 ;;
 
 let test_hook_decision_tool_approval_to_string () =
   let decision =
-    Hooks.ElicitToolApproval { question = "Approve exact tool call?"; timeout_s = None }
+    Hooks.ElicitToolApproval { question = "Approve exact tool call?" }
   in
   Alcotest.(check string)
     "string"

--- a/test/test_elicitation.ml
+++ b/test/test_elicitation.ml
@@ -81,9 +81,7 @@ let test_hook_decision_tool_approval () =
 ;;
 
 let test_hook_decision_tool_approval_to_string () =
-  let decision =
-    Hooks.ElicitToolApproval { question = "Approve exact tool call?" }
-  in
+  let decision = Hooks.ElicitToolApproval { question = "Approve exact tool call?" } in
   Alcotest.(check string)
     "string"
     "elicit_tool_approval"

--- a/test/test_elicitation.ml
+++ b/test/test_elicitation.ml
@@ -174,7 +174,10 @@ let test_event_bus_filter_agent () =
 let test_agent_options_elicitation_default () =
   let opts = Agent.default_options in
   Alcotest.(check bool) "generic default none" true (Option.is_none opts.elicitation);
-  Alcotest.(check bool) "tool approval default none" true (Option.is_none opts.tool_approval)
+  Alcotest.(check bool)
+    "tool approval default none"
+    true
+    (Option.is_none opts.tool_approval)
 ;;
 
 let test_agent_elicit_input_without_callback_pauses () =

--- a/test/test_elicitation.ml
+++ b/test/test_elicitation.ml
@@ -71,6 +71,28 @@ let test_hook_decision_to_string () =
   Alcotest.(check string) "string" "elicit_input" s
 ;;
 
+let test_hook_decision_tool_approval () =
+  let prompt : Hooks.tool_approval_prompt =
+    { question = "Approve exact tool call?"; timeout_s = Some 10.0 }
+  in
+  let decision = Hooks.ElicitToolApproval prompt in
+  match decision with
+  | Hooks.ElicitToolApproval returned ->
+    Alcotest.(check string) "question" "Approve exact tool call?" returned.question;
+    Alcotest.(check bool) "timeout preserved" true (returned.timeout_s = Some 10.0)
+  | _ -> Alcotest.fail "expected ElicitToolApproval"
+;;
+
+let test_hook_decision_tool_approval_to_string () =
+  let decision =
+    Hooks.ElicitToolApproval { question = "Approve exact tool call?"; timeout_s = None }
+  in
+  Alcotest.(check string)
+    "string"
+    "elicit_tool_approval"
+    (Agent_lifecycle.hook_decision_to_string decision)
+;;
+
 (* ── Elicitation callback ──────────────────────────────── *)
 
 let test_elicitation_callback_answer () =
@@ -151,7 +173,8 @@ let test_event_bus_filter_agent () =
 
 let test_agent_options_elicitation_default () =
   let opts = Agent.default_options in
-  Alcotest.(check bool) "default none" true (Option.is_none opts.elicitation)
+  Alcotest.(check bool) "generic default none" true (Option.is_none opts.elicitation);
+  Alcotest.(check bool) "tool approval default none" true (Option.is_none opts.tool_approval)
 ;;
 
 let test_agent_elicit_input_without_callback_pauses () =
@@ -222,6 +245,11 @@ let () =
     ; ( "hook_decision"
       , [ test_case "ElicitInput variant" `Quick test_hook_decision_elicit_input
         ; test_case "to_string" `Quick test_hook_decision_to_string
+        ; test_case "ElicitToolApproval variant" `Quick test_hook_decision_tool_approval
+        ; test_case
+            "tool approval to_string"
+            `Quick
+            test_hook_decision_tool_approval_to_string
         ] )
     ; ( "callback"
       , [ test_case "answer" `Quick test_elicitation_callback_answer

--- a/test/test_hooks.ml
+++ b/test/test_hooks.ml
@@ -229,19 +229,22 @@ let test_validate_legal_before_turn_params () =
   check bool "AdjustParams at before_turn_params" true (Result.is_ok ok2)
 ;;
 
-let gate_request =
+let input_request =
   { Hooks.question = "authorize this command?"; schema = None; timeout_s = None }
 ;;
 
+let tool_approval_prompt =
+  { Hooks.question = "authorize this command?"; timeout_s = None }
+;;
+
 let test_validate_legal_pre_tool_use () =
-  (* RFC-OAS-039: [ElicitInput] is legal here so a caller gate that authorizes
-     a specific command with a specific input — which it can only judge after
-     the model has chosen both — can consult the configured callback first.
-     [Types.tool_result_outcome] offers only [Tool_succeeded] or [Tool_failed],
-     so without this the gate would have to report a success that did not
-     happen. *)
+  (* RFC-OAS-039: only the typed approval decision is legal after the model
+     chose the exact tool occurrence. Generic user input is never authority. *)
   let decisions =
-    [ Hooks.Continue; Hooks.Block "blocked"; Hooks.ElicitInput gate_request ]
+    [ Hooks.Continue
+    ; Hooks.Block "blocked"
+    ; Hooks.ElicitToolApproval tool_approval_prompt
+    ]
   in
   List.iter
     (fun d ->
@@ -257,9 +260,12 @@ let test_validate_legal_pre_tool_use () =
 ;;
 
 let test_validate_illegal_pre_tool_use_stays_closed () =
-  (* Negative control for the widening above: admitting [ElicitInput] must not
-     open the stage to the other payload-carrying decisions. *)
-  let decisions = [ Hooks.AdjustParams Hooks.default_turn_params; Hooks.Nudge "hint" ] in
+  let decisions =
+    [ Hooks.AdjustParams Hooks.default_turn_params
+    ; Hooks.ElicitInput input_request
+    ; Hooks.Nudge "hint"
+    ]
+  in
   List.iter
     (fun d ->
        let result = Hooks.validate_decision ~stage:Hooks.Pre_tool_use d in
@@ -274,10 +280,33 @@ let test_validate_illegal_pre_tool_use_stays_closed () =
 ;;
 
 let test_elicit_input_illegal_where_it_cannot_settle_input () =
-  (* [ElicitInput] is legal only before a turn or exact tool call. The
-     observe-only stages run after the action whose input would be settled. *)
+  (* Generic input is legal only before a turn. *)
   let stages =
     [ Hooks.Before_turn_params
+    ; Hooks.After_turn
+    ; Hooks.Pre_tool_use
+    ; Hooks.Post_tool_use
+    ; Hooks.Post_tool_use_failure
+    ; Hooks.On_stop
+    ; Hooks.On_error
+    ; Hooks.On_tool_error
+    ]
+  in
+  List.iter
+    (fun stage ->
+       let result = Hooks.validate_decision ~stage (Hooks.ElicitInput input_request) in
+       check
+         bool
+         (Printf.sprintf "ElicitInput rejected at %s" (Hooks.hook_stage_to_string stage))
+         true
+         (Result.is_error result))
+    stages
+;;
+
+let test_elicit_tool_approval_illegal_outside_pre_tool_use () =
+  let stages =
+    [ Hooks.Before_turn
+    ; Hooks.Before_turn_params
     ; Hooks.After_turn
     ; Hooks.Post_tool_use
     ; Hooks.Post_tool_use_failure
@@ -288,10 +317,14 @@ let test_elicit_input_illegal_where_it_cannot_settle_input () =
   in
   List.iter
     (fun stage ->
-       let result = Hooks.validate_decision ~stage (Hooks.ElicitInput gate_request) in
+       let result =
+         Hooks.validate_decision ~stage (Hooks.ElicitToolApproval tool_approval_prompt)
+       in
        check
          bool
-         (Printf.sprintf "ElicitInput rejected at %s" (Hooks.hook_stage_to_string stage))
+         (Printf.sprintf
+            "ElicitToolApproval rejected at %s"
+            (Hooks.hook_stage_to_string stage))
          true
          (Result.is_error result))
     stages
@@ -370,6 +403,8 @@ let test_classify_and_to_string () =
     ; Hooks.Block "blocked", "Block"
     ; Hooks.AdjustParams Hooks.default_turn_params, "AdjustParams"
     ; Hooks.ElicitInput { question = "q"; schema = None; timeout_s = None }, "ElicitInput"
+    ; Hooks.ElicitToolApproval { question = "q"; timeout_s = None }
+      , "ElicitToolApproval"
     ; Hooks.Nudge "n", "Nudge"
     ; Hooks.HookFailed { stage = Hooks.Before_turn; detail = "boom" }, "HookFailed"
     ]
@@ -463,6 +498,7 @@ let test_invoke_validated_illegal_block_returns_hook_failed_with_warning () =
       | Hooks.Continue
       | Hooks.AdjustParams _
       | Hooks.ElicitInput _
+      | Hooks.ElicitToolApproval _
       | Hooks.Nudge _
       | Hooks.Block _ -> false)
   in
@@ -489,16 +525,16 @@ let test_invoke_validated_illegal_returns_hook_failed () =
 ;;
 
 (** Pin the fail-closed result for every decision that is illegal at
-    pre_tool_use (AdjustParams / Nudge): the decision returns
+    pre_tool_use (AdjustParams / ElicitInput / Nudge): the decision returns
     HookFailed and [on_illegal] receives the stage, the
     rejected decision and a message naming the decision kind. *)
 let test_invoke_validated_pre_tool_use_fail_closed_pinned () =
-  (* [ElicitInput] left this list in RFC-OAS-039: it is now legal here and
-     consults the configured callback instead of failing it. The stage stays fail-closed for
-     everything else, which is what this pin exists to hold. Its legality is
-     covered by [test_validate_legal_pre_tool_use], and the stages where it
-     remains illegal by [test_elicit_input_illegal_where_it_cannot_settle_input]. *)
-  let illegal = [ Hooks.AdjustParams Hooks.default_turn_params; Hooks.Nudge "nudge" ] in
+  let illegal =
+    [ Hooks.AdjustParams Hooks.default_turn_params
+    ; Hooks.ElicitInput input_request
+    ; Hooks.Nudge "nudge"
+    ]
+  in
   List.iter
     (fun decision ->
        let kind_name = Hooks.decision_kind_to_string (Hooks.classify_decision decision) in
@@ -616,6 +652,10 @@ let () =
             "illegal: ElicitInput where input cannot be settled"
             `Quick
             test_elicit_input_illegal_where_it_cannot_settle_input
+        ; test_case
+            "illegal: ElicitToolApproval outside pre_tool_use"
+            `Quick
+            test_elicit_tool_approval_illegal_outside_pre_tool_use
         ; test_case
             "legal: observe-only stages"
             `Quick

--- a/test/test_hooks.ml
+++ b/test/test_hooks.ml
@@ -430,34 +430,6 @@ let contains_substring ~needle haystack =
   n = 0 || loop 0
 ;;
 
-let settle_tool_approval callback =
-  Agent_tool_pre_execution_gate.settle
-    ~tool_approval:callback
-    ~event_bus:None
-    ~agent_name:"test-agent"
-    ~invocation:(invocation ())
-    ~tool_name:"gated"
-    ~input:(`Assoc [])
-    (Hooks.ElicitToolApproval { question = "Approve?" })
-;;
-
-let test_tool_approval_callback_failure_is_typed () =
-  match settle_tool_approval (fun _ -> failwith "approval unavailable") with
-  | Agent_tool_pre_execution_gate.Reject { stage = Hooks.Pre_tool_use; detail } ->
-    check
-      bool
-      "callback failure retained"
-      true
-      (contains_substring ~needle:"approval unavailable" detail)
-  | _ -> fail "expected typed pre-tool rejection"
-;;
-
-let test_tool_approval_reserved_exception_propagates () =
-  match settle_tool_approval (fun _ -> raise Sys.Break) with
-  | exception Sys.Break -> ()
-  | _ -> fail "reserved callback exception was flattened"
-;;
-
 let capture_traceln f =
   Eio_main.run
   @@ fun env ->
@@ -728,14 +700,6 @@ let () =
             "fail-closed without hook_name returns HookFailed"
             `Quick
             test_invoke_validated_fail_closed_without_hook_name
-        ; test_case
-            "tool approval callback failure is typed"
-            `Quick
-            test_tool_approval_callback_failure_is_typed
-        ; test_case
-            "tool approval reserved exception propagates"
-            `Quick
-            test_tool_approval_reserved_exception_propagates
         ] )
     ]
 ;;

--- a/test/test_hooks.ml
+++ b/test/test_hooks.ml
@@ -403,8 +403,7 @@ let test_classify_and_to_string () =
     ; Hooks.Block "blocked", "Block"
     ; Hooks.AdjustParams Hooks.default_turn_params, "AdjustParams"
     ; Hooks.ElicitInput { question = "q"; schema = None; timeout_s = None }, "ElicitInput"
-    ; Hooks.ElicitToolApproval { question = "q"; timeout_s = None }
-      , "ElicitToolApproval"
+    ; Hooks.ElicitToolApproval { question = "q"; timeout_s = None }, "ElicitToolApproval"
     ; Hooks.Nudge "n", "Nudge"
     ; Hooks.HookFailed { stage = Hooks.Before_turn; detail = "boom" }, "HookFailed"
     ]

--- a/test/test_hooks.ml
+++ b/test/test_hooks.ml
@@ -233,9 +233,7 @@ let input_request =
   { Hooks.question = "authorize this command?"; schema = None; timeout_s = None }
 ;;
 
-let tool_approval_prompt =
-  { Hooks.question = "authorize this command?"; timeout_s = None }
-;;
+let tool_approval_prompt = { Hooks.question = "authorize this command?" }
 
 let test_validate_legal_pre_tool_use () =
   (* RFC-OAS-039: only the typed approval decision is legal after the model
@@ -403,7 +401,7 @@ let test_classify_and_to_string () =
     ; Hooks.Block "blocked", "Block"
     ; Hooks.AdjustParams Hooks.default_turn_params, "AdjustParams"
     ; Hooks.ElicitInput { question = "q"; schema = None; timeout_s = None }, "ElicitInput"
-    ; Hooks.ElicitToolApproval { question = "q"; timeout_s = None }, "ElicitToolApproval"
+    ; Hooks.ElicitToolApproval { question = "q" }, "ElicitToolApproval"
     ; Hooks.Nudge "n", "Nudge"
     ; Hooks.HookFailed { stage = Hooks.Before_turn; detail = "boom" }, "HookFailed"
     ]
@@ -430,6 +428,34 @@ let contains_substring ~needle haystack =
   let h = String.length haystack in
   let rec loop i = i + n <= h && (String.sub haystack i n = needle || loop (i + 1)) in
   n = 0 || loop 0
+;;
+
+let settle_tool_approval callback =
+  Agent_tool_pre_execution_gate.settle
+    ~tool_approval:callback
+    ~event_bus:None
+    ~agent_name:"test-agent"
+    ~invocation:(invocation ())
+    ~tool_name:"gated"
+    ~input:(`Assoc [])
+    (Hooks.ElicitToolApproval { question = "Approve?" })
+;;
+
+let test_tool_approval_callback_failure_is_typed () =
+  match settle_tool_approval (fun _ -> failwith "approval unavailable") with
+  | Agent_tool_pre_execution_gate.Reject { stage = Hooks.Pre_tool_use; detail } ->
+    check
+      bool
+      "callback failure retained"
+      true
+      (contains_substring ~needle:"approval unavailable" detail)
+  | _ -> fail "expected typed pre-tool rejection"
+;;
+
+let test_tool_approval_reserved_exception_propagates () =
+  match settle_tool_approval (fun _ -> raise Sys.Break) with
+  | exception Sys.Break -> ()
+  | _ -> fail "reserved callback exception was flattened"
 ;;
 
 let capture_traceln f =
@@ -702,6 +728,14 @@ let () =
             "fail-closed without hook_name returns HookFailed"
             `Quick
             test_invoke_validated_fail_closed_without_hook_name
+        ; test_case
+            "tool approval callback failure is typed"
+            `Quick
+            test_tool_approval_callback_failure_is_typed
+        ; test_case
+            "tool approval reserved exception propagates"
+            `Quick
+            test_tool_approval_reserved_exception_propagates
         ] )
     ]
 ;;

--- a/test/test_multivendor_events.ml
+++ b/test/test_multivendor_events.ml
@@ -87,6 +87,12 @@ let test_envelope_preserved_across_variants () =
     ; HandoffCompleted { from_agent = "alpha"; to_agent = "beta"; elapsed = 0.5 }
     ; ElicitationCompleted
         { agent_name = "alpha"; question = "?"; response = Hooks.Declined }
+    ; ToolApprovalCompleted
+        { agent_name = "alpha"
+        ; invocation = invocation ()
+        ; tool_name = "echo"
+        ; approval = Hooks.Denied
+        }
     ; AgentCompleted
         { agent_name = "alpha"
         ; task_id = "t1"
@@ -145,6 +151,13 @@ let test_payload_kind_mapping () =
     ; ( ElicitationCompleted
           { agent_name = "a"; question = "?"; response = Hooks.Declined }
       , "elicitation_completed" )
+    ; ( ToolApprovalCompleted
+          { agent_name = "a"
+          ; invocation = invocation ()
+          ; tool_name = "t"
+          ; approval = Hooks.Denied
+          }
+      , "tool_approval_completed" )
     ; Custom ("runtime.session_started", `Null), "custom:runtime.session_started"
     ; Custom ("durable.tool_called", `Null), "custom:durable.tool_called"
     ; ( Custom ("provider.anthropic.cache_hit", `Null)

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -13,6 +13,8 @@ module Internal_writer = Internal.Execution_lane_writer
 module Internal_scope = Internal.Execution_agent_scope
 module Internal_binding = Binding_identity
 module Internal_settlement = Internal.Execution_tool_settlement
+module Internal_pre_tool_gate = Internal.Agent_tool_pre_execution_gate
+module Internal_tool_types = Internal.Agent_tool_execution_types
 
 let invocation tool_use_id =
   let schedule : Tool_contract.schedule =
@@ -1951,6 +1953,34 @@ let test_agent_run_reports_unknown_effect_for_operator_repair () =
   test_agent_run_resumes_tool_without_duplicate_effects ~settled:false ()
 ;;
 
+let test_legacy_hook_rejection_runs_durable_settlement () =
+  let settled = ref false in
+  let outcome =
+    match
+      Internal_pre_tool_gate.scheduled_settlement
+        ~settle_rejected:(fun result ->
+          settled := true;
+          result)
+        ~index:0
+        ~invocation:(invocation "legacy-rejected-tool-use")
+        ~tool_name:"durable_tool"
+        ~input:(`Assoc [])
+        (Internal_pre_tool_gate.Reject
+           { stage = Hooks.Pre_tool_use; detail = "typed gate rejected" })
+    with
+    | Internal_pre_tool_gate.Run_admitted ->
+      Alcotest.fail "rejected legacy invocation was admitted"
+    | Internal_pre_tool_gate.Return_outcome outcome -> outcome
+  in
+  Alcotest.(check bool) "durable settlement ran" true !settled;
+  match outcome with
+  | { Internal_tool_types.completed_result = None
+    ; failure = Some (Internal_tool_types.Hook_failure _)
+    ; _
+    } -> ()
+  | _ -> Alcotest.fail "rejected legacy invocation returned the wrong typed failure"
+;;
+
 (* A legacy journal could contain an invocation opened after an untyped
    [Answer (`Bool false)] and crash before committing the effect attempt. The
    invocation node alone is not current typed approval authority: resume must
@@ -3692,6 +3722,10 @@ let () =
             "unattempted legacy invocation requires typed readmission"
             `Quick
             test_unattempted_legacy_invocation_requires_typed_readmission
+        ; Alcotest.test_case
+            "legacy hook rejection runs durable settlement"
+            `Quick
+            test_legacy_hook_rejection_runs_durable_settlement
         ; Alcotest.test_case
             "Agent.run resume matches original prompt not injected User message"
             `Quick

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -1951,6 +1951,139 @@ let test_agent_run_reports_unknown_effect_for_operator_repair () =
   test_agent_run_resumes_tool_without_duplicate_effects ~settled:false ()
 ;;
 
+(* A legacy journal could contain an invocation opened after an untyped
+   [Answer (`Bool false)] and crash before committing the effect attempt. The
+   invocation node alone is not current typed approval authority: resume must
+   run the current gate again, and a denial must keep the effect closed. *)
+let test_unattempted_legacy_invocation_requires_typed_readmission () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun runtime_sw ->
+  let domain_mgr = Eio.Stdenv.domain_mgr env in
+  let runtime =
+    match Internal_runtime.create ~sw:runtime_sw ~domain_mgr ~domain_count:1 with
+    | Ok runtime -> runtime
+    | Error error -> Alcotest.fail (Internal_runtime.create_error_to_string error)
+  in
+  let codec = Internal_codec.of_runtime runtime in
+  let native_path = Filename.temp_file "oas-legacy-tool-approval-" ".dir" in
+  Sys.remove native_path;
+  let dir = Eio.Path.(Eio.Stdenv.fs env / native_path) in
+  Fun.protect
+    ~finally:(fun () -> Eio.Path.rmtree ~missing_ok:true dir)
+    (fun () ->
+       Eio.Path.mkdirs ~exists_ok:false ~perm:0o700 dir;
+       match
+         Internal_writer.run ~codec ~dir (fun ~sw:_ writer ->
+           let scope =
+             match Internal_scope.start ~writer ~agent_name:"legacy-approval-test" with
+             | Ok scope -> scope
+             | Error error -> Alcotest.fail (Internal_scope.error_to_string error)
+           in
+           let turn =
+             match Internal_scope.open_turn scope ~ordinal:0 with
+             | Ok turn -> turn
+             | Error error -> Alcotest.fail (Internal_scope.error_to_string error)
+           in
+           let binding =
+             match
+               Internal_binding.of_provider_config
+                 ~transport:Internal_binding.Injected
+                 (Provider_mock.to_provider_config ())
+             with
+             | Ok binding -> binding
+             | Error detail -> Alcotest.fail detail
+           in
+           let provider =
+             match Internal_scope.open_provider_attempt turn ~ordinal:0 binding with
+             | Ok provider -> provider
+             | Error error -> Alcotest.fail (Internal_scope.error_to_string error)
+           in
+           let tool_input = `Assoc [ "value", `Int 7 ] in
+           let tool_use_id = "legacy-unattempted-tool-use" in
+           record_durable_provider_response
+             provider
+             (durable_tool_response [ tool_use_id, "durable_tool", tool_input ]);
+           let durable_invocation = invocation tool_use_id in
+           (match
+              Internal_scope.open_invocation
+                provider
+                ~invocation:durable_invocation
+                ~tool_name:"durable_tool"
+                ~input:tool_input
+            with
+            | Ok _ -> ()
+            | Error error -> Alcotest.fail (Internal_scope.error_to_string error));
+           let effect_count = ref 0 in
+           let approval_count = ref 0 in
+           let tool =
+             Tool.create
+               ~name:"durable_tool"
+               ~description:"must remain closed after typed denial"
+               ~parameters:[]
+               (fun _ ->
+                  incr effect_count;
+                  Ok { Types.content = "unexpected-effect"; _meta = None })
+           in
+           let hooks =
+             { Hooks.empty with
+               pre_tool_use =
+                 Some
+                   (fun _ ->
+                     Hooks.ElicitToolApproval
+                       { Hooks.question = "Approve legacy durable call?" })
+             }
+           in
+           let agent =
+             Agent.create
+               ~net:(Eio.Stdenv.net env)
+               ~config:(Types.default_config ~model:"test-model")
+               ~tools:[ tool ]
+               ~options:
+                 { Agent.default_options with
+                   hooks
+                 ; tool_approval =
+                     Some
+                       (fun _ ->
+                         incr approval_count;
+                         Hooks.Denied)
+                 }
+               ()
+           in
+           let options = Agent.options agent in
+           let report =
+             Internal.Execution_context.with_provider_attempt provider (fun () ->
+               Agent_tools.execute_tools
+                 ~context:(Agent.context agent)
+                 ~tools:(Tool_set.to_list (Agent.tools agent))
+                 ~hooks:options.hooks
+                 ?tool_approval:options.tool_approval
+                 ~event_bus:options.event_bus
+                 ~tracer:options.tracer
+                 ~agent_name:(Agent.state agent).config.name
+                 ~turn_count:0
+                 ~usage:Types.empty_usage
+                 [ Types.ToolUse
+                     { id = tool_use_id; name = "durable_tool"; input = tool_input }
+                 ])
+           in
+           Alcotest.(check int) "typed approval runs once" 1 !approval_count;
+           Alcotest.(check int) "denied legacy effect stays closed" 0 !effect_count;
+           match report with
+           | Ok
+               { Agent_tools.completed_results =
+                   [ { outcome = Types.Tool_failed _; _ } ]
+               ; _
+               } -> ()
+           | Ok _ -> Alcotest.fail "typed denial did not produce a blocked ToolResult"
+           | Error _ -> Alcotest.fail "typed denial returned an execution error")
+       with
+       | Ok () -> ()
+       | Error failure ->
+         Alcotest.fail (Internal_writer.scope_failure_to_string failure))
+;;
+
 (* A context injector appends User-role messages during a turn (see
    [Agent_turn.apply_context_injection]); after such a turn the latest User
    message in the restored checkpoint is the injected one, not the run's
@@ -3503,6 +3636,10 @@ let () =
             "Agent.run resumes settled tool without duplicate effects"
             `Quick
             test_agent_run_resumes_settled_tool_without_duplicate_effects
+        ; Alcotest.test_case
+            "unattempted legacy invocation requires typed readmission"
+            `Quick
+            test_unattempted_legacy_invocation_requires_typed_readmission
         ; Alcotest.test_case
             "Agent.run resume matches original prompt not injected User message"
             `Quick

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -13,8 +13,6 @@ module Internal_writer = Internal.Execution_lane_writer
 module Internal_scope = Internal.Execution_agent_scope
 module Internal_binding = Binding_identity
 module Internal_settlement = Internal.Execution_tool_settlement
-module Internal_pre_tool_gate = Internal.Agent_tool_pre_execution_gate
-module Internal_tool_types = Internal.Agent_tool_execution_types
 
 let invocation tool_use_id =
   let schedule : Tool_contract.schedule =
@@ -1953,34 +1951,6 @@ let test_agent_run_reports_unknown_effect_for_operator_repair () =
   test_agent_run_resumes_tool_without_duplicate_effects ~settled:false ()
 ;;
 
-let test_legacy_hook_rejection_runs_durable_settlement () =
-  let settled = ref false in
-  let outcome =
-    match
-      Internal_pre_tool_gate.scheduled_settlement
-        ~settle_rejected:(fun result ->
-          settled := true;
-          result)
-        ~index:0
-        ~invocation:(invocation "legacy-rejected-tool-use")
-        ~tool_name:"durable_tool"
-        ~input:(`Assoc [])
-        (Internal_pre_tool_gate.Reject
-           { stage = Hooks.Pre_tool_use; detail = "typed gate rejected" })
-    with
-    | Internal_pre_tool_gate.Run_admitted ->
-      Alcotest.fail "rejected legacy invocation was admitted"
-    | Internal_pre_tool_gate.Return_outcome outcome -> outcome
-  in
-  Alcotest.(check bool) "durable settlement ran" true !settled;
-  match outcome with
-  | { Internal_tool_types.completed_result = None
-    ; failure = Some (Internal_tool_types.Hook_failure _)
-    ; _
-    } -> ()
-  | _ -> Alcotest.fail "rejected legacy invocation returned the wrong typed failure"
-;;
-
 (* A legacy journal could contain an invocation opened after an untyped
    [Answer (`Bool false)] and crash before committing the effect attempt. The
    invocation node alone is not current typed approval authority: resume must
@@ -3722,10 +3692,6 @@ let () =
             "unattempted legacy invocation requires typed readmission"
             `Quick
             test_unattempted_legacy_invocation_requires_typed_readmission
-        ; Alcotest.test_case
-            "legacy hook rejection runs durable settlement"
-            `Quick
-            test_legacy_hook_rejection_runs_durable_settlement
         ; Alcotest.test_case
             "Agent.run resume matches original prompt not injected User message"
             `Quick

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -1987,10 +1987,19 @@ let test_unattempted_legacy_invocation_requires_typed_readmission () =
              | Error error -> Alcotest.fail (Internal_scope.error_to_string error)
            in
            let binding =
+             let provider_config =
+               Llm_provider.Provider_config.make
+                 ~kind:Llm_provider.Provider_config.OpenAI_compat
+                 ~model_id:"test-model"
+                 ~base_url:"http://legacy-approval.invalid"
+                 ~api_key:""
+                 ~request_path:"/v1/chat/completions"
+                 ()
+             in
              match
                Internal_binding.of_provider_config
                  ~transport:Internal_binding.Injected
-                 (Provider_mock.to_provider_config ())
+                 provider_config
              with
              | Ok binding -> binding
              | Error detail -> Alcotest.fail detail
@@ -2072,16 +2081,14 @@ let test_unattempted_legacy_invocation_requires_typed_readmission () =
            Alcotest.(check int) "denied legacy effect stays closed" 0 !effect_count;
            match report with
            | Ok
-               { Agent_tools.completed_results =
-                   [ { outcome = Types.Tool_failed _; _ } ]
+               { Agent_tools.completed_results = [ { outcome = Types.Tool_failed _; _ } ]
                ; _
                } -> ()
            | Ok _ -> Alcotest.fail "typed denial did not produce a blocked ToolResult"
            | Error _ -> Alcotest.fail "typed denial returned an execution error")
        with
        | Ok () -> ()
-       | Error failure ->
-         Alcotest.fail (Internal_writer.scope_failure_to_string failure))
+       | Error failure -> Alcotest.fail (Internal_writer.scope_failure_to_string failure))
 ;;
 
 (* A context injector appends User-role messages during a turn (see

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -2079,13 +2079,23 @@ let test_unattempted_legacy_invocation_requires_typed_readmission () =
            in
            Alcotest.(check int) "typed approval runs once" 1 !approval_count;
            Alcotest.(check int) "denied legacy effect stays closed" 0 !effect_count;
-           match report with
-           | Ok
-               { Agent_tools.completed_results = [ { outcome = Types.Tool_failed _; _ } ]
-               ; _
-               } -> ()
-           | Ok _ -> Alcotest.fail "typed denial did not produce a blocked ToolResult"
-           | Error _ -> Alcotest.fail "typed denial returned an execution error")
+           (match report with
+            | Ok
+                { Agent_tools.completed_results = [ { outcome = Types.Tool_failed _; _ } ]
+                ; _
+                } -> ()
+            | Ok _ -> Alcotest.fail "typed denial did not produce a blocked ToolResult"
+            | Error _ -> Alcotest.fail "typed denial returned an execution error");
+           (match
+              Internal_scope.close_provider_attempt
+                provider
+                Internal.Execution_event.Succeeded
+            with
+            | Ok () -> ()
+            | Error error ->
+              Alcotest.fail
+                ("typed denial left the durable invocation open: "
+                 ^ Internal_scope.error_to_string error)))
        with
        | Ok () -> ()
        | Error failure -> Alcotest.fail (Internal_writer.scope_failure_to_string failure))

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -446,6 +446,7 @@ let test_provider_turn_identity_is_shared_across_multiturn_tool_loop () =
             | HandoffRequested _
             | HandoffCompleted _
             | ElicitationCompleted _
+            | ToolApprovalCompleted _
             | InferenceTelemetry _
             | Custom _ -> started, ready, completed, tools)
          ([], [], [], [])
@@ -1651,6 +1652,7 @@ let test_agent_run_uses_durable_tool_authority () =
            | HandoffRequested _
            | HandoffCompleted _
            | ElicitationCompleted _
+           | ToolApprovalCompleted _
            | InferenceTelemetry _
            | Custom _ -> false)
        in

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -2024,6 +2024,11 @@ let test_unattempted_legacy_invocation_requires_typed_readmission () =
             with
             | Ok _ -> ()
             | Error error -> Alcotest.fail (Internal_scope.error_to_string error));
+           let before_denial =
+             match Internal_writer.current_cursor writer with
+             | Ok cursor -> cursor
+             | Error error -> Alcotest.fail (Internal_writer.read_error_to_string error)
+           in
            let effect_count = ref 0 in
            let approval_count = ref 0 in
            let tool =
@@ -2086,16 +2091,46 @@ let test_unattempted_legacy_invocation_requires_typed_readmission () =
                 } -> ()
             | Ok _ -> Alcotest.fail "typed denial did not produce a blocked ToolResult"
             | Error _ -> Alcotest.fail "typed denial returned an execution error");
-           (match
-              Internal_scope.close_provider_attempt
-                provider
-                Internal.Execution_event.Succeeded
-            with
-            | Ok () -> ()
-            | Error error ->
-              Alcotest.fail
-                ("typed denial left the durable invocation open: "
-                 ^ Internal_scope.error_to_string error)))
+           (match Internal_scope.provider_invocations_settled provider with
+            | Ok true -> ()
+            | Ok false -> Alcotest.fail "denied legacy invocation stayed open"
+            | Error error -> Alcotest.fail (Internal_scope.error_to_string error));
+           let denial_events =
+             match Internal_writer.read_page writer ~after:before_denial ~limit:8 () with
+             | Ok page -> page.events
+             | Error error -> Alcotest.fail (Internal_writer.read_error_to_string error)
+           in
+           Alcotest.(check int)
+             "typed denial opens no durable effect attempt"
+             0
+             (List.fold_left
+                (fun count event ->
+                   match Internal.Execution_event.payload event with
+                   | Internal.Execution_event.Node_opened node ->
+                     (match Internal.Execution_event.node_kind node with
+                      | Internal.Execution_event.Tool_attempt -> count + 1
+                      | Internal.Execution_event.Agent_run _
+                      | Internal.Execution_event.Agent_turn _
+                      | Internal.Execution_event.Provider_attempt _
+                      | Internal.Execution_event.Output_block _
+                      | Internal.Execution_event.Tool_invocation _ -> count)
+                   | Internal.Execution_event.Node_updated _
+                   | Internal.Execution_event.Node_closed _ -> count)
+                0
+                denial_events);
+           List.iter
+             (fun close ->
+                match close () with
+                | Ok () -> ()
+                | Error error -> Alcotest.fail (Internal_scope.error_to_string error))
+             [ (fun () ->
+                 Internal_scope.close_provider_attempt
+                   provider
+                   Internal.Execution_event.Succeeded)
+             ; (fun () ->
+                 Internal_scope.close_turn turn Internal.Execution_event.Succeeded)
+             ; (fun () -> Internal_scope.finish scope Internal.Execution_event.Succeeded)
+             ])
        with
        | Ok () -> ()
        | Error failure -> Alcotest.fail (Internal_writer.scope_failure_to_string failure))

--- a/test/test_tool_execution.ml
+++ b/test/test_tool_execution.ml
@@ -247,6 +247,60 @@ let test_pre_tool_approval_callback_settles_gate () =
     ]
 ;;
 
+let approval_failure_fixture env callback =
+  let executed = ref 0 in
+  let tool =
+    Tool.create ~name:"gated" ~description:"gated tool" ~parameters:[] (fun _ ->
+      incr executed;
+      Ok { Types.content = "must-not-run"; _meta = None })
+  in
+  let hooks =
+    { Hooks.empty with
+      pre_tool_use = Some (fun _ -> Hooks.ElicitToolApproval { question = "Approve?" })
+    }
+  in
+  let result =
+    execute_result_with_tools_in_env
+      env
+      ~tools:[ tool ]
+      ~hooks
+      ~tool_approval:callback
+      [ ToolUse { id = "gated-callback"; name = "gated"; input = `Assoc [] } ]
+  in
+  !executed, result
+;;
+
+let test_pre_tool_approval_callback_failure_is_typed () =
+  Eio_main.run
+  @@ fun env ->
+  let executed, result =
+    approval_failure_fixture env (fun _ -> failwith "approval unavailable")
+  in
+  check int "callback failure opens no effect" 0 executed;
+  match result with
+  | Error
+      { Agent_tools.cause =
+          Agent_tools.Hook_failure
+            (Agent_tools.Hook_execution_failed { stage = Hooks.Pre_tool_use; detail; _ })
+      ; _
+      } ->
+    check
+      bool
+      "callback failure detail is retained"
+      true
+      (contains_substring ~needle:"approval unavailable" detail)
+  | Error _ -> fail "callback failure returned the wrong typed error"
+  | Ok _ -> fail "callback failure did not fail closed"
+;;
+
+let test_pre_tool_approval_reserved_exception_propagates () =
+  Eio_main.run
+  @@ fun env ->
+  match approval_failure_fixture env (fun _ -> raise Sys.Break) with
+  | exception Sys.Break -> ()
+  | _ -> fail "reserved callback exception was flattened"
+;;
+
 let execute_with_tools_in_env
       env
       ~tools
@@ -1398,6 +1452,14 @@ let () =
             "typed approval callback settles pre-tool gate"
             `Quick
             test_pre_tool_approval_callback_settles_gate
+        ; test_case
+            "approval callback failure is typed"
+            `Quick
+            test_pre_tool_approval_callback_failure_is_typed
+        ; test_case
+            "approval reserved exception propagates"
+            `Quick
+            test_pre_tool_approval_reserved_exception_propagates
         ] )
     ; ( "routing"
       , [ test_case

--- a/test/test_tool_execution.ml
+++ b/test/test_tool_execution.ml
@@ -141,12 +141,18 @@ let test_pre_tool_approval_callback_settles_gate () =
      check bool "approval sees the exact tool input" true (`Assoc [] = request.input)
    | None -> fail "approval callback was not invoked");
   (match approved_events with
-   | { Event_bus.payload =
-         Event_bus.ToolApprovalCompleted
-           { tool_name = "gated"; approval = Hooks.Approved; _ }
-     ; _
-     }
-     :: _ -> ()
+   | { Event_bus.payload = Event_bus.ToolApprovalCompleted observed; _ } :: _ ->
+     check string "approval event keeps the exact tool name" "gated" observed.tool_name;
+     check
+       string
+       "approval event keeps the exact tool occurrence"
+       "gated-1"
+       (Tool_contract.Invocation.tool_use_id observed.invocation);
+     check
+       bool
+       "approval event keeps the exact decision"
+       true
+       (observed.approval = Hooks.Approved)
    | _ -> fail "approved gate did not publish its typed approval result");
   (match approved with
    | Ok { Agent_tools.completed_results = [ result ]; completion = Continue_after_batch }
@@ -299,6 +305,14 @@ let test_pre_tool_approval_reserved_exception_propagates () =
   match approval_failure_fixture env (fun _ -> raise Sys.Break) with
   | exception Sys.Break -> ()
   | _ -> fail "reserved callback exception was flattened"
+;;
+
+let test_pre_tool_approval_eio_cancellation_propagates () =
+  Eio_main.run
+  @@ fun env ->
+  match approval_failure_fixture env (fun _ -> raise (Eio.Cancel.Cancelled Exit)) with
+  | exception Eio.Cancel.Cancelled Exit -> ()
+  | _ -> fail "caller cancellation was flattened"
 ;;
 
 let execute_with_tools_in_env
@@ -1460,6 +1474,10 @@ let () =
             "approval reserved exception propagates"
             `Quick
             test_pre_tool_approval_reserved_exception_propagates
+        ; test_case
+            "approval caller cancellation propagates"
+            `Quick
+            test_pre_tool_approval_eio_cancellation_propagates
         ] )
     ; ( "routing"
       , [ test_case

--- a/test/test_tool_execution.ml
+++ b/test/test_tool_execution.ml
@@ -97,13 +97,9 @@ let execute_result_with_tools_in_env
 let test_pre_tool_approval_callback_settles_gate () =
   Eio_main.run
   @@ fun env ->
-  let prompt =
-    { Hooks.question = "Approve exact tool call?"; timeout_s = None }
-  in
+  let prompt = { Hooks.question = "Approve exact tool call?"; timeout_s = None } in
   let hooks =
-    { Hooks.empty with
-      pre_tool_use = Some (fun _ -> Hooks.ElicitToolApproval prompt)
-    }
+    { Hooks.empty with pre_tool_use = Some (fun _ -> Hooks.ElicitToolApproval prompt) }
   in
   let run approval =
     let executed = ref 0 in
@@ -136,7 +132,8 @@ let test_pre_tool_approval_callback_settles_gate () =
   check int "approved call executes once" 1 approved_count;
   (match approved_request with
    | Some request ->
-     check string
+     check
+       string
        "approval sees the exact tool occurrence"
        "gated-1"
        (Tool_contract.Invocation.tool_use_id request.invocation);
@@ -146,10 +143,7 @@ let test_pre_tool_approval_callback_settles_gate () =
   (match approved_events with
    | { Event_bus.payload =
          Event_bus.ToolApprovalCompleted
-           { tool_name = "gated"
-           ; approval = Hooks.Approved
-           ; _
-           }
+           { tool_name = "gated"; approval = Hooks.Approved; _ }
      ; _
      }
      :: _ -> ()
@@ -211,15 +205,15 @@ let test_pre_tool_approval_callback_settles_gate () =
       pre_tool_use =
         Some
           (fun _ ->
-             Hooks.ElicitInput
-               { question = "Approve exact tool call?"
-               ; schema = Some (`Assoc [ "type", `String "boolean" ])
-               ; timeout_s = None
-               })
+            Hooks.ElicitInput
+              { question = "Approve exact tool call?"
+              ; schema = Some (`Assoc [ "type", `String "boolean" ])
+              ; timeout_s = None
+              })
     }
   in
   List.iter
-    (fun answer ->
+    (fun (case, answer) ->
        let generic_callback_count = ref 0 in
        let generic_effect_count = ref 0 in
        let generic_input_tool =
@@ -245,9 +239,12 @@ let test_pre_tool_approval_callback_settles_gate () =
             } -> ()
         | Error _ -> fail "generic JSON elicitation returned the wrong typed failure"
         | Ok _ -> fail "generic JSON elicitation became a tool approval");
-       check int "generic callback is not consulted" 0 !generic_callback_count;
-       check int "generic false/schema reply opens no effect" 0 !generic_effect_count)
-    [ `Bool false; `Assoc [ "approved", `Bool true ] ]
+       check int (case ^ ": generic callback is not consulted") 0 !generic_callback_count;
+       check int (case ^ ": generic reply opens no effect") 0 !generic_effect_count)
+    [ "false", `Bool false
+    ; "schema mismatch", `Assoc [ "approved", `Bool true ]
+    ; "malformed approval-shaped string", `String "{approved:true}"
+    ]
 ;;
 
 let execute_with_tools_in_env

--- a/test/test_tool_execution.ml
+++ b/test/test_tool_execution.ml
@@ -51,6 +51,7 @@ let execute_result_with_tools_in_env
       ~tools
       ~hooks
       ?elicitation
+      ?tool_approval
       ?event_bus
       ?journal
       ?before_tool_execution
@@ -60,7 +61,7 @@ let execute_result_with_tools_in_env
       tool_uses
   =
   let net = Eio.Stdenv.net env in
-  let options = { Agent.default_options with hooks; elicitation } in
+  let options = { Agent.default_options with hooks; elicitation; tool_approval } in
   let agent =
     Agent.create
       ~config:(Types.default_config ~model:"test-model")
@@ -79,7 +80,7 @@ let execute_result_with_tools_in_env
     ~context:(Agent.context agent)
     ~tools:(Tool_set.to_list (Agent.tools agent))
     ~hooks:opts.hooks
-    ?elicitation:opts.elicitation
+    ?tool_approval:opts.tool_approval
     ~event_bus
     ?journal
     ~tracer:opts.tracer
@@ -93,17 +94,20 @@ let execute_result_with_tools_in_env
     tool_uses
 ;;
 
-let test_pre_tool_elicitation_callback_settles_gate () =
+let test_pre_tool_approval_callback_settles_gate () =
   Eio_main.run
   @@ fun env ->
-  let request =
-    { Hooks.question = "Approve exact tool call?"; schema = None; timeout_s = None }
+  let prompt =
+    { Hooks.question = "Approve exact tool call?"; timeout_s = None }
   in
   let hooks =
-    { Hooks.empty with pre_tool_use = Some (fun _ -> Hooks.ElicitInput request) }
+    { Hooks.empty with
+      pre_tool_use = Some (fun _ -> Hooks.ElicitToolApproval prompt)
+    }
   in
-  let run response =
+  let run approval =
     let executed = ref 0 in
+    let observed_request = ref None in
     let event_bus = Event_bus.create () in
     let event_config =
       Event_bus.subscription_config ~capacity:4 ~overflow:Event_bus.Drop_newest
@@ -120,25 +124,36 @@ let test_pre_tool_elicitation_callback_settles_gate () =
         env
         ~tools:[ tool ]
         ~hooks
-        ~elicitation:(fun _ -> response)
+        ~tool_approval:(fun request ->
+          observed_request := Some request;
+          approval)
         ~event_bus
         [ ToolUse { id = "gated-1"; name = "gated"; input = `Assoc [] } ]
     in
-    !executed, result, Event_bus.drain subscription
+    !executed, result, Event_bus.drain subscription, !observed_request
   in
-  let approved_count, approved, approved_events = run (Hooks.Answer (`Bool true)) in
+  let approved_count, approved, approved_events, approved_request = run Hooks.Approved in
   check int "approved call executes once" 1 approved_count;
+  (match approved_request with
+   | Some request ->
+     check string
+       "approval sees the exact tool occurrence"
+       "gated-1"
+       (Tool_contract.Invocation.tool_use_id request.invocation);
+     check string "approval sees the exact tool name" "gated" request.tool_name;
+     check bool "approval sees the exact tool input" true (`Assoc [] = request.input)
+   | None -> fail "approval callback was not invoked");
   (match approved_events with
    | { Event_bus.payload =
-         Event_bus.ElicitationCompleted
-           { question = "Approve exact tool call?"
-           ; response = Hooks.Answer (`Bool true)
+         Event_bus.ToolApprovalCompleted
+           { tool_name = "gated"
+           ; approval = Hooks.Approved
            ; _
            }
      ; _
      }
      :: _ -> ()
-   | _ -> fail "approved gate did not publish its typed elicitation response");
+   | _ -> fail "approved gate did not publish its typed approval result");
   (match approved with
    | Ok { Agent_tools.completed_results = [ result ]; completion = Continue_after_batch }
      ->
@@ -150,13 +165,13 @@ let test_pre_tool_elicitation_callback_settles_gate () =
    | Ok _ -> fail "approved gate returned an unexpected report"
    | Error _ -> fail "approved gate failed");
   List.iter
-    (fun response ->
-       let count, rejected, events = run response in
+    (fun approval ->
+       let count, rejected, events, _ = run approval in
        check int "rejected call does not execute" 0 count;
        (match events with
-        | { Event_bus.payload = Event_bus.ElicitationCompleted observed; _ } :: _ ->
-          check bool "rejected response is preserved" true (observed.response = response)
-        | _ -> fail "rejected gate did not publish its typed elicitation response");
+        | { Event_bus.payload = Event_bus.ToolApprovalCompleted observed; _ } :: _ ->
+          check bool "rejected approval is preserved" true (observed.approval = approval)
+        | _ -> fail "rejected gate did not publish its typed approval result");
        match rejected with
        | Ok
            { Agent_tools.completed_results =
@@ -168,7 +183,7 @@ let test_pre_tool_elicitation_callback_settles_gate () =
            } -> ()
        | Ok _ -> fail "rejected gate did not return a typed tool failure"
        | Error _ -> fail "rejected gate failed")
-    [ Hooks.Declined; Hooks.Timeout ];
+    [ Hooks.Denied; Hooks.Timed_out ];
   let missing_callback_count = ref 0 in
   let missing_callback_tool =
     Tool.create ~name:"gated" ~description:"gated tool" ~parameters:[] (fun _ ->
@@ -190,7 +205,49 @@ let test_pre_tool_elicitation_callback_settles_gate () =
        } -> ()
    | Error _ -> fail "missing callback returned the wrong typed failure"
    | Ok _ -> fail "missing callback did not fail closed");
-  check int "missing callback opens no effect" 0 !missing_callback_count
+  check int "missing callback opens no effect" 0 !missing_callback_count;
+  let generic_input_hook =
+    { Hooks.empty with
+      pre_tool_use =
+        Some
+          (fun _ ->
+             Hooks.ElicitInput
+               { question = "Approve exact tool call?"
+               ; schema = Some (`Assoc [ "type", `String "boolean" ])
+               ; timeout_s = None
+               })
+    }
+  in
+  List.iter
+    (fun answer ->
+       let generic_callback_count = ref 0 in
+       let generic_effect_count = ref 0 in
+       let generic_input_tool =
+         Tool.create ~name:"gated" ~description:"gated tool" ~parameters:[] (fun _ ->
+           incr generic_effect_count;
+           Ok { Types.content = "must-not-run"; _meta = None })
+       in
+       (match
+          execute_result_with_tools_in_env
+            env
+            ~tools:[ generic_input_tool ]
+            ~hooks:generic_input_hook
+            ~elicitation:(fun _ ->
+              incr generic_callback_count;
+              Hooks.Answer answer)
+            [ ToolUse { id = "gated-generic"; name = "gated"; input = `Assoc [] } ]
+        with
+        | Error
+            { Agent_tools.cause =
+                Agent_tools.Hook_failure
+                  (Agent_tools.Hook_execution_failed { stage = Hooks.Pre_tool_use; _ })
+            ; _
+            } -> ()
+        | Error _ -> fail "generic JSON elicitation returned the wrong typed failure"
+        | Ok _ -> fail "generic JSON elicitation became a tool approval");
+       check int "generic callback is not consulted" 0 !generic_callback_count;
+       check int "generic false/schema reply opens no effect" 0 !generic_effect_count)
+    [ `Bool false; `Assoc [ "approved", `Bool true ] ]
 ;;
 
 let execute_with_tools_in_env
@@ -1341,9 +1398,9 @@ let () =
             `Quick
             test_block_is_deterministic_failure
         ; test_case
-            "elicitation callback settles pre-tool gate"
+            "typed approval callback settles pre-tool gate"
             `Quick
-            test_pre_tool_elicitation_callback_settles_gate
+            test_pre_tool_approval_callback_settles_gate
         ] )
     ; ( "routing"
       , [ test_case

--- a/test/test_tool_execution.ml
+++ b/test/test_tool_execution.ml
@@ -97,7 +97,7 @@ let execute_result_with_tools_in_env
 let test_pre_tool_approval_callback_settles_gate () =
   Eio_main.run
   @@ fun env ->
-  let prompt = { Hooks.question = "Approve exact tool call?"; timeout_s = None } in
+  let prompt = { Hooks.question = "Approve exact tool call?" } in
   let hooks =
     { Hooks.empty with pre_tool_use = Some (fun _ -> Hooks.ElicitToolApproval prompt) }
   in


### PR DESCRIPTION
Fixes jeong-sik/oas#2848.
Addresses jeong-sik/masc#27859 by choosing the synchronous caller-owned contract.

## 변경

- generic `ElicitInput`/`Answer`와 도구 실행 승인을 분리했어용.
- `ElicitToolApproval`은 exact invocation·tool·input을 typed callback에 전달하고 `Approved`만 실행해용.
- `false`, 임의 JSON, schema가 붙은 generic request는 pre-tool 단계에서 fail-closed라 invocation 0회예용.
- 승인 결과는 exact invocation ID/name/decision을 보존한 `ToolApprovalCompleted` 이벤트로 남겨용.
- 가짜 SDK timeout 약속은 타입에서 제거했어용. 이 callback은 동기 caller-owned 경계이며, deadline·원격 prompt·restart 정책은 caller가 정산한 뒤 `Timed_out` 등 closed decision으로 반환해용.
- callback의 일반 예외는 실행 전 typed `Hook_failure`, 실제 `Eio.Cancel.Cancelled`를 포함한 reserved 예외는 그대로 전파해용.
- legacy durable invocation은 typed gate를 다시 통과하며, `Denied`/`Timed_out`/`Block`만 effect attempt 없이 invocation을 원자적으로 닫아용. `Reject`/`Hook_failure`는 ToolResult 성공처럼 정규화하지 않고 caller failure/abort 경계를 유지해용.
- `Agent_card.Elicitation`이 generic input과 exact tool approval을 포함하되 원격 prompting/suspension/timeout/restart durability는 약속하지 않음을 명시했어용.
- breaking migration을 CHANGELOG에 명시했어용.

## 판정 (head `74292e97bdd714c2a879920693ef22fce9b8009b`)

- P0: 없음. jeong-sik/oas#2848 임의 JSON 승인 우회 해소했어용.
- P1: 없음. #2849의 동기 계약 한정안을 타입·문서·예외 경계까지 구현했고, legacy `Reject`를 failed ToolResult로 바꾸던 잘못된 시도는 같은 branch에서 즉시 revert했어용.
- P2: 없음. 본문·CI·리뷰 근거를 현재 HEAD로 갱신했어용.
- P3: actual Eio cancellation, exact event identity, public capability 의미까지 회귀·문서로 닫았어용.

`35a334531`/`74292e97b`는 서로 상쇄되며 `git diff --quiet b90d82a27 74292e97b`가 성공해 현재 tree는 마지막 로컬 focused 검증 tree와 동일해용.

## 검증

- focused public execution flow: 157/157
- current-head CI run `30392962884`: OCaml 5.4.1/5.5.0, Eio 1.3/1.4, lint, format, ratchet, transport/core/version/reasoning gates 전부 성공
- current-head review threads: 0
- PR tree identity / Draft Auto-Merge Guard: 성공

## 0.230.0 release plan

- 이 변경은 Stable Hooks API의 source/behavior breaking migration이므로 `0.229.2` patch로 내보내지 않아용.
- 기존 release-please PR #2847은 이 변경 전 shape로 병합하지 않아용.
- 이 PR을 squash merge할 때 `fix(hooks)!:`와 아래 `BREAKING CHANGE:` footer를 보존해용.
- merge 뒤 release-please가 같은 release branch/PR을 `0.230.0`으로 재계산했는지 확인하고, public symbols의 `@since 0.230.0`, changelog, version files, current-head CI를 재검토한 뒤에만 release PR을 병합해용.
- MASC는 실제 `v0.230.0` tag/release를 확인한 뒤에만 pin을 올려용.

[근거] `gh pr view 2850 --json headRefOid,mergeable,mergeStateStatus,statusCheckRollup`, `gh run view 30392962884 --json status,conclusion,headSha,jobs`, GraphQL `reviewThreads`, `git diff --quiet b90d82a27 74292e97b` · 확인 2026-07-29 05:06 KST · 신뢰도 High
