### PR TITLE
refactor(eval): require explicit metric policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ original tag dates. `0.100.4` was never tagged or released.
 * **provider tools:** reject historical OpenAI `parameters` lists; current
   callers must supply `input_schema` or an already-provider-shaped JSON Schema
   object.
+`Eval.compare` and its implicit lower-is-better policy have been removed.
+`Eval.compare_with_specs` now compares only metrics selected by an explicit
+`metric_spec`.
 
 ## [0.230.0](https://github.com/jeong-sik/oas/compare/v0.229.1...v0.230.0) (2026-07-28)
 

--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -309,34 +309,25 @@ let compute_delta_for_goal
        if baseline_val = candidate_val then Unchanged, None else Regression, None)
 ;;
 
-let compare_with specs ~(baseline : run_metrics) ~(candidate : run_metrics) =
+let compare_with_specs ~specs ~(baseline : run_metrics) ~(candidate : run_metrics) =
   let deltas =
     List.filter_map
       (fun (bm : metric) ->
          match
-           List.find_opt (fun (cm : metric) -> cm.name = bm.name) candidate.metrics
+           ( List.find_opt (fun (spec : metric_spec) -> spec.name = bm.name) specs
+           , List.find_opt (fun (cm : metric) -> cm.name = bm.name) candidate.metrics )
          with
-         | None -> None
-         | Some cm ->
+         | Some spec, Some cm ->
+           let threshold_pct =
+             Option.value spec.tolerance_pct ~default:default_delta_threshold_pct
+           in
            let direction, delta_pct =
-             match specs with
-             | None -> compute_delta ~baseline_val:bm.value ~candidate_val:cm.value ()
-             | Some specs ->
-               let threshold_pct, goal =
-                 match
-                   List.find_opt (fun (spec : metric_spec) -> spec.name = bm.name) specs
-                 with
-                 | None -> default_delta_threshold_pct, Lower
-                 | Some spec ->
-                   ( Option.value spec.tolerance_pct ~default:default_delta_threshold_pct
-                   , spec.goal )
-               in
-               compute_delta_for_goal
-                 ~threshold_pct
-                 ~goal
-                 ~baseline_val:bm.value
-                 ~candidate_val:cm.value
-                 ()
+             compute_delta_for_goal
+               ~threshold_pct
+               ~goal:spec.goal
+               ~baseline_val:bm.value
+               ~candidate_val:cm.value
+               ()
            in
            Some
              { metric_name = bm.name
@@ -344,21 +335,14 @@ let compare_with specs ~(baseline : run_metrics) ~(candidate : run_metrics) =
              ; candidate_value = cm.value
              ; direction
              ; delta_pct
-             })
+             }
+         | None, _ | _, None -> None)
       baseline.metrics
   in
   let regressions = List.filter (fun d -> d.direction = Regression) deltas in
   let improvements = List.filter (fun d -> d.direction = Improvement) deltas in
   let unchanged = List.filter (fun d -> d.direction = Unchanged) deltas in
   { baseline; candidate; regressions; improvements; unchanged }
-;;
-
-let compare ~(baseline : run_metrics) ~(candidate : run_metrics) =
-  compare_with None ~baseline ~candidate
-;;
-
-let compare_with_specs ~specs ~(baseline : run_metrics) ~(candidate : run_metrics) =
-  compare_with (Some specs) ~baseline ~candidate
 ;;
 
 (* ── Threshold checking ───────────────────────────────────────── *)

--- a/lib/eval.mli
+++ b/lib/eval.mli
@@ -118,12 +118,9 @@ val compute_delta
   -> unit
   -> change_direction * float option
 
-(** Compare two runs, classifying each metric as regression/improvement/unchanged. *)
-val compare : baseline:run_metrics -> candidate:run_metrics -> comparison
-
-(** Compare two runs using per-metric goals instead of the legacy
-    "lower is better" default. Metrics without a matching spec fall back
-    to the legacy behavior. *)
+(** Compare the metrics selected by [specs]. A metric is compared only when it
+    exists in both runs and has a matching spec; [goal] and [tolerance_pct] are
+    therefore the single comparison policy for every returned delta. *)
 val compare_with_specs
   :  specs:metric_spec list
   -> baseline:run_metrics

--- a/test/test_eval.ml
+++ b/test/test_eval.ml
@@ -92,7 +92,8 @@ let test_collector_verdict () =
 let test_compare_regression () =
   let baseline = mk_run_metrics [ mk_metric "latency" (Float_val 100.0) ] in
   let candidate = mk_run_metrics ~run_id:"r2" [ mk_metric "latency" (Float_val 120.0) ] in
-  let cmp = Eval.compare ~baseline ~candidate in
+  let specs = [ { Eval.name = "latency"; goal = Lower; tolerance_pct = None } ] in
+  let cmp = Eval.compare_with_specs ~specs ~baseline ~candidate in
   Alcotest.(check int) "regressions" 1 (List.length cmp.regressions);
   Alcotest.(check int) "improvements" 0 (List.length cmp.improvements)
 ;;
@@ -100,7 +101,8 @@ let test_compare_regression () =
 let test_compare_improvement () =
   let baseline = mk_run_metrics [ mk_metric "latency" (Float_val 100.0) ] in
   let candidate = mk_run_metrics ~run_id:"r2" [ mk_metric "latency" (Float_val 80.0) ] in
-  let cmp = Eval.compare ~baseline ~candidate in
+  let specs = [ { Eval.name = "latency"; goal = Lower; tolerance_pct = None } ] in
+  let cmp = Eval.compare_with_specs ~specs ~baseline ~candidate in
   Alcotest.(check int) "regressions" 0 (List.length cmp.regressions);
   Alcotest.(check int) "improvements" 1 (List.length cmp.improvements)
 ;;
@@ -108,7 +110,8 @@ let test_compare_improvement () =
 let test_compare_unchanged () =
   let baseline = mk_run_metrics [ mk_metric "score" (Float_val 0.95) ] in
   let candidate = mk_run_metrics ~run_id:"r2" [ mk_metric "score" (Float_val 0.96) ] in
-  let cmp = Eval.compare ~baseline ~candidate in
+  let specs = [ { Eval.name = "score"; goal = Higher; tolerance_pct = None } ] in
+  let cmp = Eval.compare_with_specs ~specs ~baseline ~candidate in
   Alcotest.(check int) "unchanged" 1 (List.length cmp.unchanged)
 ;;
 
@@ -121,6 +124,24 @@ let test_compare_with_specs_higher_is_better () =
   let cmp = Eval.compare_with_specs ~specs ~baseline ~candidate in
   Alcotest.(check int) "improvements" 1 (List.length cmp.improvements);
   Alcotest.(check int) "regressions" 0 (List.length cmp.regressions)
+;;
+
+let test_compare_with_specs_excludes_unspecified_metrics () =
+  let baseline =
+    mk_run_metrics
+      [ mk_metric "accuracy" (Float_val 0.90); mk_metric "latency" (Float_val 100.0) ]
+  in
+  let candidate =
+    mk_run_metrics
+      ~run_id:"r2"
+      [ mk_metric "accuracy" (Float_val 0.95); mk_metric "latency" (Float_val 200.0) ]
+  in
+  let specs =
+    [ { Eval.name = "accuracy"; goal = Eval.Higher; tolerance_pct = Some 1.0 } ]
+  in
+  let cmp = Eval.compare_with_specs ~specs ~baseline ~candidate in
+  Alcotest.(check int) "selected improvement" 1 (List.length cmp.improvements);
+  Alcotest.(check int) "unspecified regression excluded" 0 (List.length cmp.regressions)
 ;;
 
 (* ── threshold tests ──────────────────────────────────────────── *)
@@ -206,6 +227,10 @@ let () =
             "spec higher better"
             `Quick
             test_compare_with_specs_higher_is_better
+        ; Alcotest.test_case
+            "unspecified metrics excluded"
+            `Quick
+            test_compare_with_specs_excludes_unspecified_metrics
         ] )
     ; ( "threshold"
       , [ Alcotest.test_case "pass" `Quick test_threshold_pass

--- a/test/test_eval_coverage.ml
+++ b/test/test_eval_coverage.ml
@@ -279,7 +279,12 @@ let test_compare_missing_candidate_metric () =
     mk_run [ mk_metric "a" (Float_val 1.0); mk_metric "b" (Float_val 2.0) ]
   in
   let candidate = mk_run ~run_id:"r2" [ mk_metric "a" (Float_val 1.0) ] in
-  let cmp = Eval.compare ~baseline ~candidate in
+  let specs =
+    [ { Eval.name = "a"; goal = Lower; tolerance_pct = None }
+    ; { Eval.name = "b"; goal = Lower; tolerance_pct = None }
+    ]
+  in
+  let cmp = Eval.compare_with_specs ~specs ~baseline ~candidate in
   (* "b" is in baseline but not candidate -- it is simply absent from deltas
      because compare only iterates baseline metrics and filters by candidate *)
   Alcotest.(check int) "unchanged" 1 (List.length cmp.unchanged)
@@ -290,7 +295,8 @@ let test_compare_missing_candidate_metric () =
 let test_compare_string_metric () =
   let baseline = mk_run [ mk_metric "name" (String_val "test") ] in
   let candidate = mk_run ~run_id:"r2" [ mk_metric "name" (String_val "test") ] in
-  let cmp = Eval.compare ~baseline ~candidate in
+  let specs = [ { Eval.name = "name"; goal = Exact; tolerance_pct = None } ] in
+  let cmp = Eval.compare_with_specs ~specs ~baseline ~candidate in
   Alcotest.(check int) "unchanged" 1 (List.length cmp.unchanged)
 ;;
 


### PR DESCRIPTION
## Summary

- remove the compatibility `Eval.compare` API and its implicit lower-is-better policy
- make `metric_spec` the sole comparison-policy SSOT
- compare only metrics selected by an explicit spec and present in both runs

## Feature trace

`Eval.compare_with_specs` remains the current quantitative comparison entry point. It preserves the baseline/candidate receipts and regression/improvement/unchanged output shape. Each returned delta now has exactly one policy origin: the matching spec's goal and optional tolerance.

An unspecified metric is outside this comparison selection. No legacy fallback, migration path, exception Gate, or secondary policy representation is introduced.

## Blast radius

Repository search found no production caller of `Eval.compare`; only focused Eval tests used the compatibility surface. Tests now declare Lower/Higher/Exact policies explicitly, and pin that an unspecified common metric is excluded.

## Verification

- `scripts/dune-local.sh build test/test_eval.exe test/test_eval_coverage.exe @fmt`
- `test_eval.exe` — 15/15
- `test_eval_coverage.exe` — 33/33
- repository scan for `Eval.compare` and legacy lower fallback — clean
- `git diff --check`
