### PR TITLE
test(pipeline): pin injected transport stop invariant

### DIFF
--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -302,10 +302,12 @@ let stage_collect ?raw_trace_run ?clock ~turn agent response =
 (** Handle tool execution and context injection. *)
 let stage_execute ?raw_trace_run ?before_tool_execution ~turn ~response agent tools =
   (* The caller (stage_output) proves the tool-call set is non-empty: a
-     StopToolUse turn that carried no tool block is rejected before this stage
-     (Stop_reason_wire.reconcile downgrades it to Unknown at parse time).
-     Threading [Nonempty.t] makes the empty case a compile error instead of a
-     silent [ToolsExecuted] that re-issues the same Thinking turn forever. *)
+     StopToolUse turn that carried no tool block is rejected before this stage.
+     Provider wire parsers classify that shape as UnmatchedToolCalls, while the
+     driver independently covers injected transports that produce api_response
+     values directly. Threading [Nonempty.t] makes the empty case a compile
+     error instead of a silent [ToolsExecuted] that re-issues the same Thinking
+     turn forever. *)
   let tool_uses = Nonempty.to_list tools in
   Tracing.with_span
     agent.options.tracer
@@ -427,12 +429,12 @@ let stage_output ?raw_trace_run ?before_tool_execution ~turn agent response =
          in
          (match Nonempty.of_list tool_uses with
           | None ->
-            (* Defends the StopToolUse => has-tool-block invariant at the driver.
-               F1 (Stop_reason_wire.reconcile) guarantees the parsers never emit
-               StopToolUse without a tool block, so this is unreachable in
-               practice; if a future parser regresses it fails closed with a
-               typed error instead of silently returning [ToolsExecuted] and
-               re-issuing the identical Thinking turn forever. *)
+            (* Provider-owned wire parsers enforce this invariant through
+               Stop_reason_wire.reconcile. The driver check is still required:
+               Builder.with_transport is a public current Feature, and an
+               injected transport returns api_response directly without
+               crossing a provider parser. Rejecting the malformed response
+               here prevents an empty [ToolsExecuted] loop. *)
             Error
               (Error.Agent
                  (UnrecognizedStopReason
@@ -506,8 +508,9 @@ let tag_error stage result =
       _log
       "pipeline stage failed"
       [ Log.S ("stage", stage); Log.S ("error", Error_domain.ctx_to_string ctx) ];
-    (* Stage context is logged for diagnostics;
-       we still propagate sdk_error for backward compat *)
+    (* Stage context is an observation-only projection. [Error.sdk_error] is
+       the canonical public Agent/Pipeline error contract and is returned
+       unchanged so its typed fields and provider attribution are preserved. *)
     Error e
 ;;
 

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -301,13 +301,9 @@ let stage_collect ?raw_trace_run ?clock ~turn agent response =
 
 (** Handle tool execution and context injection. *)
 let stage_execute ?raw_trace_run ?before_tool_execution ~turn ~response agent tools =
-  (* The caller (stage_output) proves the tool-call set is non-empty: a
-     StopToolUse turn that carried no tool block is rejected before this stage.
-     Provider wire parsers classify that shape as UnmatchedToolCalls, while the
-     driver independently covers injected transports that produce api_response
-     values directly. Threading [Nonempty.t] makes the empty case a compile
-     error instead of a silent [ToolsExecuted] that re-issues the same Thinking
-     turn forever. *)
+  (* [stage_output] rejects empty StopToolUse from provider and injected
+     transports. [Nonempty.t] then prevents a silent empty [ToolsExecuted]
+     loop at compile time. *)
   let tool_uses = Nonempty.to_list tools in
   Tracing.with_span
     agent.options.tracer
@@ -429,12 +425,9 @@ let stage_output ?raw_trace_run ?before_tool_execution ~turn agent response =
          in
          (match Nonempty.of_list tool_uses with
           | None ->
-            (* Provider-owned wire parsers enforce this invariant through
-               Stop_reason_wire.reconcile. The driver check is still required:
-               Builder.with_transport is a public current Feature, and an
-               injected transport returns api_response directly without
-               crossing a provider parser. Rejecting the malformed response
-               here prevents an empty [ToolsExecuted] loop. *)
+            (* Provider parsers reconcile this shape, but public injected
+               transports return [api_response] directly. This driver Gate
+               prevents their empty [ToolsExecuted] loop. *)
             Error
               (Error.Agent
                  (UnrecognizedStopReason
@@ -508,9 +501,8 @@ let tag_error stage result =
       _log
       "pipeline stage failed"
       [ Log.S ("stage", stage); Log.S ("error", Error_domain.ctx_to_string ctx) ];
-    (* Stage context is an observation-only projection. [Error.sdk_error] is
-       the canonical public Agent/Pipeline error contract and is returned
-       unchanged so its typed fields and provider attribution are preserved. *)
+    (* Stage context is observation-only. Return canonical [Error.sdk_error]
+       unchanged, including typed fields and provider attribution. *)
     Error e
 ;;
 

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -642,37 +642,22 @@ let test_pipeline_output_completes_repetition_truncation () =
   | Error err -> Alcotest.failf "unexpected run error: %s" (Error.to_string err)
 ;;
 
-let test_pipeline_output_rejects_unmatched_tool_stop () =
+let test_pipeline_output_rejects_tool_stop_without_block () =
   Eio_main.run
   @@ fun env ->
   Eio.Switch.run
   @@ fun sw ->
   let net = Eio.Stdenv.net env in
-  let agent =
-    make_pipeline_test_agent ~net ~response:(pipeline_response UnmatchedToolCalls)
+  let reject stop_reason expected =
+    let agent = make_pipeline_test_agent ~net ~response:(pipeline_response stop_reason) in
+    match Internal_pipeline.run_turn ~sw ~api_strategy:Internal_pipeline.Sync agent with
+    | Error (Error.Agent (UnrecognizedStopReason { reason })) ->
+      Alcotest.(check string) "tool stop rejection" expected reason
+    | Error err -> Alcotest.failf "unexpected run error: %s" (Error.to_string err)
+    | Ok _ -> Alcotest.fail "expected malformed tool-stop rejection"
   in
-  match Internal_pipeline.run_turn ~sw ~api_strategy:Internal_pipeline.Sync agent with
-  | Error (Error.Agent (UnrecognizedStopReason { reason })) ->
-    Alcotest.(check string) "unmatched tool stop reason" "unmatched_tool_calls" reason
-  | Error err -> Alcotest.failf "unexpected run error: %s" (Error.to_string err)
-  | Ok _ -> Alcotest.fail "expected malformed tool-stop rejection"
-;;
-
-let test_pipeline_output_rejects_injected_stop_tool_use_without_block () =
-  Eio_main.run
-  @@ fun env ->
-  Eio.Switch.run
-  @@ fun sw ->
-  let net = Eio.Stdenv.net env in
-  let agent = make_pipeline_test_agent ~net ~response:(pipeline_response StopToolUse) in
-  match Internal_pipeline.run_turn ~sw ~api_strategy:Internal_pipeline.Sync agent with
-  | Error (Error.Agent (UnrecognizedStopReason { reason })) ->
-    Alcotest.(check string)
-      "injected transport cannot bypass tool-block invariant"
-      "StopToolUse turn carried no tool block"
-      reason
-  | Error err -> Alcotest.failf "unexpected run error: %s" (Error.to_string err)
-  | Ok _ -> Alcotest.fail "expected malformed injected tool-stop rejection"
+  reject UnmatchedToolCalls "unmatched_tool_calls";
+  reject StopToolUse "StopToolUse turn carried no tool block"
 ;;
 
 let test_pipeline_text_tool_intent_remains_text () =
@@ -3657,13 +3642,9 @@ let () =
             `Quick
             test_pipeline_output_completes_repetition_truncation
         ; Alcotest.test_case
-            "output rejects unmatched tool stop"
+            "output rejects tool stop without block"
             `Quick
-            test_pipeline_output_rejects_unmatched_tool_stop
-        ; Alcotest.test_case
-            "output rejects injected tool stop without block"
-            `Quick
-            test_pipeline_output_rejects_injected_stop_tool_use_without_block
+            test_pipeline_output_rejects_tool_stop_without_block
         ; Alcotest.test_case
             "text tool intent remains text"
             `Quick

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -658,6 +658,23 @@ let test_pipeline_output_rejects_unmatched_tool_stop () =
   | Ok _ -> Alcotest.fail "expected malformed tool-stop rejection"
 ;;
 
+let test_pipeline_output_rejects_injected_stop_tool_use_without_block () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let net = Eio.Stdenv.net env in
+  let agent = make_pipeline_test_agent ~net ~response:(pipeline_response StopToolUse) in
+  match Internal_pipeline.run_turn ~sw ~api_strategy:Internal_pipeline.Sync agent with
+  | Error (Error.Agent (UnrecognizedStopReason { reason })) ->
+    Alcotest.(check string)
+      "injected transport cannot bypass tool-block invariant"
+      "StopToolUse turn carried no tool block"
+      reason
+  | Error err -> Alcotest.failf "unexpected run error: %s" (Error.to_string err)
+  | Ok _ -> Alcotest.fail "expected malformed injected tool-stop rejection"
+;;
+
 let test_pipeline_text_tool_intent_remains_text () =
   Eio_main.run
   @@ fun env ->
@@ -3643,6 +3660,10 @@ let () =
             "output rejects unmatched tool stop"
             `Quick
             test_pipeline_output_rejects_unmatched_tool_stop
+        ; Alcotest.test_case
+            "output rejects injected tool stop without block"
+            `Quick
+            test_pipeline_output_rejects_injected_stop_tool_use_without_block
         ; Alcotest.test_case
             "text tool intent remains text"
             `Quick


### PR DESCRIPTION
## Summary

- document `Error.sdk_error` as the current canonical Agent/Pipeline error contract, not a compatibility payload
- document why the driver-level `StopToolUse => non-empty ToolUse` check is non-replaceable
- add a regression test that reaches the Gate through a public injected transport, bypassing provider wire reconciliation

## Reverse trace

Provider-owned HTTP/stream parsers use `Stop_reason_wire.reconcile`, but that is not the only response entry point. `Builder.with_transport` is a public current Feature used by CLI/custom transports, and `Llm_transport.t` returns `api_response` directly. Such a transport can produce `StopToolUse` without a tool block, so removing the driver Gate would admit an empty `ToolsExecuted` loop.

The stage error path is also current-only: `Pipeline.run_turn` and every public Agent runner return `Error.sdk_error`. `Error_domain.with_stage` is an observation-only log projection; the original typed error is returned unchanged to preserve its fields and provider attribution.

No new Gate, compatibility layer, migration path, or facade is added.

## Verification

- `scripts/dune-local.sh build test/test_pipeline.exe @fmt`
- `test_pipeline.exe` — 59/59
- `git diff --check`
