### PR TITLE
refactor(provider): remove dead identity compatibility bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ original tag dates. `0.100.4` was never tagged or released.
   callers must supply `input_schema` or an already-provider-shaped JSON Schema
   object.
 
+The unused `Binding_identity.of_resolved_provider` compatibility bridge has
+been removed. Binding identities are constructed only from canonical
+`Llm_provider.Provider_config.t` values.
+
 ## [0.230.0](https://github.com/jeong-sik/oas/compare/v0.229.1...v0.230.0) (2026-07-28)
 
 

--- a/lib/agent/agent.ml
+++ b/lib/agent/agent.ml
@@ -129,11 +129,6 @@ let run_turn_core ~sw ?clock ~api_strategy ?raw_trace_run agent =
 (* Original run_turn_core implementation removed — now in Pipeline.run_turn.
    See git history for the previous 240-line monolithic version. *)
 
-(* Backward-compatible wrappers *)
-let run_turn_with_trace ~sw ?clock ?raw_trace_run agent =
-  run_turn_core ~sw ?clock ~api_strategy:Sync ?raw_trace_run agent
-;;
-
 let provide_input agent request response =
   if Agent_elicitation.apply_response ~metadata:[] agent request response then ()
 ;;

--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -1,7 +1,6 @@
 (** Shared turn logic for sync and streaming paths.
 
-    Contains helper functions that both [Agent.run_turn_with_trace] and
-    [Agent.run_turn_stream_with_trace] call, eliminating ~60% code duplication.
+    Contains helper functions shared by the sync and streaming Agent drivers.
 
     These functions take explicit parameters (not Agent.t) to avoid
     circular module dependency: Agent -> Agent_turn is fine,

--- a/lib/agent/agent_turn.mli
+++ b/lib/agent/agent_turn.mli
@@ -1,7 +1,6 @@
 (** Shared turn logic for sync and streaming paths.
 
-    Contains helper functions that both [Agent.run_turn_with_trace] and
-    [Agent.run_turn_stream_with_trace] call, eliminating code duplication.
+    Contains helper functions shared by the sync and streaming Agent drivers.
 
     These functions take explicit parameters (not [Agent.t]) to avoid
     circular module dependency: [Agent -> Agent_turn] is fine,

--- a/lib/binding_identity.ml
+++ b/lib/binding_identity.ml
@@ -69,49 +69,6 @@ let of_provider_config ~transport config =
   }
 ;;
 
-let of_resolved_provider
-      ~transport
-      ~(provider : Provider.config)
-      ~base_url
-      ~request_path
-      ~api_key
-  =
-  let open Result_syntax in
-  let api_key_secret = Secret.of_string api_key in
-  let non_custom_identity kind =
-    let config =
-      PC.make ~kind ~model_id:provider.model_id ~base_url ~api_key ~request_path ()
-    in
-    let provider_identity, binding = provider_and_binding config in
-    let auth_scheme, credential_scope =
-      match binding with
-      | Some binding -> auth_scheme_of_binding binding, binding.credential_scope
-      | None -> (if Secret.is_empty api_key_secret then No_auth else Api_key), None
-    in
-    provider_identity, auth_scheme, credential_scope
-  in
-  let provider_identity, auth_scheme, credential_scope =
-    match provider.provider with
-    | Provider.Custom_registered { name } ->
-      (match Provider_runtime_binding.find name with
-       | Some binding ->
-         Registered binding.id, auth_scheme_of_binding binding, binding.credential_scope
-       | None -> Registered name, Provider_defined, None)
-    | Provider.Anthropic -> non_custom_identity PC.Anthropic
-    | Provider.Local _ | Provider.OpenAICompat _ -> non_custom_identity PC.OpenAI_compat
-  in
-  let+ model_id = Llm_provider.Model_id.of_string provider.model_id in
-  { provider = provider_identity
-  ; model_id
-  ; transport
-  ; endpoint = canonical_uri base_url
-  ; request_path = canonical_uri request_path
-  ; auth_scheme
-  ; credential_scope
-  ; credential_identity = Secret.identity api_key_secret
-  }
-;;
-
 let equal_provider left right =
   match left, right with
   | Registered left, Registered right -> String.equal left right

--- a/lib/binding_identity.mli
+++ b/lib/binding_identity.mli
@@ -22,18 +22,6 @@ val of_provider_config
   -> Llm_provider.Provider_config.t
   -> (t, string) result
 
-(** Construct from a successfully resolved legacy {!Provider.config} call.
-    [base_url], [request_path], and [api_key] are the exact values selected by
-    the OAS adapter for that call.  This is the OAS-owned compatibility bridge;
-    no embedding runtime reconstructs provider identity from display strings. *)
-val of_resolved_provider
-  :  transport:transport
-  -> provider:Provider.config
-  -> base_url:string
-  -> request_path:string
-  -> api_key:string
-  -> (t, string) result
-
 val equal : t -> t -> bool
 val hash : t -> int
 

--- a/test/test_provider_failure_attribution.ml
+++ b/test/test_provider_failure_attribution.ml
@@ -153,38 +153,6 @@ let test_redacted_snapshot_rejects_noncanonical_input () =
   reject "short fingerprint" (replace "credential_fingerprint" (`String "abcdef0"))
 ;;
 
-let test_custom_provider_keeps_registered_identity () =
-  let provider : Provider.config =
-    { provider = Provider.Custom_registered { name = "dynamic-provider" }
-    ; model_id = "model-a"
-    ; api_key_env = ""
-    }
-  in
-  let identity =
-    Binding_identity.of_resolved_provider
-      ~transport:Binding_identity.Http
-      ~provider
-      ~base_url:"https://dynamic.example.test"
-      ~request_path:"/v1/dynamic"
-      ~api_key:"credential-a"
-    |> require_identity
-  in
-  let json = Binding_identity.to_redacted_yojson identity in
-  let provider_json = Yojson.Safe.Util.member "provider" json in
-  check_string
-    "custom provider remains registered"
-    "registered"
-    (Yojson.Safe.Util.member "registration" provider_json |> Yojson.Safe.Util.to_string);
-  check_string
-    "registered identity is the provider registry key"
-    "dynamic-provider"
-    (Yojson.Safe.Util.member "id" provider_json |> Yojson.Safe.Util.to_string);
-  check_string
-    "unknown custom auth stays typed instead of guessed"
-    "provider_defined"
-    (Yojson.Safe.Util.member "auth_scheme" json |> Yojson.Safe.Util.to_string)
-;;
-
 let test_binding_identity_rejects_invalid_model_identity () =
   let invalid = { (config ()) with model_id = "  " } in
   match Binding_identity.of_provider_config ~transport:Binding_identity.Http invalid with
@@ -744,10 +712,6 @@ let () =
             "redacted snapshot strict boundary"
             `Quick
             test_redacted_snapshot_rejects_noncanonical_input
-        ; Alcotest.test_case
-            "custom registry identity"
-            `Quick
-            test_custom_provider_keeps_registered_identity
         ; Alcotest.test_case
             "invalid model identity"
             `Quick


### PR DESCRIPTION
## Summary

- remove the unused `Binding_identity.of_resolved_provider` compatibility bridge
- remove the unexported, uncalled `Agent.run_turn_with_trace` compatibility wrapper
- update internal turn documentation to name the actual sync/stream drivers

## Feature trace

Current provider routing constructs one canonical `Llm_provider.Provider_config.t` before dispatch. `Pipeline_stage_route.binding_identity_for_call` then calls `Binding_identity.of_provider_config`; execution scope, provider failure attribution, credential ownership, hashing, and redacted snapshots consume that identity.

The removed bridge had no production caller and reinterpreted the older `Provider.config` surface into a second identity shape. Its only caller was a bridge-specific test. No migration, fallback, new Gate, or facade is introduced.

## Verification

- `scripts/dune-local.sh build test/test_provider_failure_attribution.exe test/test_agent_sdk.exe @fmt`
- `test_provider_failure_attribution.exe` — 16/16
- `test_agent_sdk.exe` — 16/16
- repository scan for removed symbols — clean outside changelog
- `git diff --check`
