### PR TITLE
refactor(structured): remove forced-tool compatibility schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ original tag dates. `0.100.4` was never tagged or released.
 
 ### Breaking Changes
 
+`Structured.schema` now contains only the provider-native JSON Schema
+parameters and typed parser. The unused forced-tool `name` and `description`
+fields, `schema_to_tool_json`, and `extract_tool_input` are removed rather than
+retained as compatibility state. Current callers use
+`schema_to_json_schema`, `extract`, `extract_stream`, or `schema_extractor`.
+
 `Provider_config` now carries provider-native JSON Schema requests only as
 `response_format = JsonSchema schema`. The duplicate `output_schema` record
 field, constructor argument, derivation helper, and the Exact Output

--- a/docs/schema-surfaces/runtime-output-surfaces.v1.json
+++ b/docs/schema-surfaces/runtime-output-surfaces.v1.json
@@ -142,13 +142,13 @@
       "owner": "OAS",
       "producer": "Structured output helpers",
       "consumer": ["agent callers", "provider-native structured output routes"],
-      "wire_or_artifact": "Structured.schema to JSON schema/tool input schema",
+      "wire_or_artifact": "Structured.schema to provider-native JSON Schema",
       "schema_source": ["lib/structured.mli", "lib/base/types.mli"],
       "validator": "schema.parse and provider response_format validation",
       "tests": ["test/test_structured.ml", "test/test_structured_deep.ml"],
       "stability": "evolving",
       "version_field": null,
-      "notes": "JsonSchema response_format is the provider-native path; caller-side parse remains authoritative."
+      "notes": "JsonSchema response_format is the only schema request path; caller-side parse remains authoritative."
     }
   ]
 }

--- a/lib/structured.ml
+++ b/lib/structured.ml
@@ -1,29 +1,16 @@
 (** Structured output helpers.
 
-    This module keeps exact tool-use helpers ([schema_to_tool_json],
-    [extract_tool_input]) for callers using forced tool calls,
-    but the direct extraction APIs now prefer provider-native JSON schema
-    output via {!Llm_provider.Complete}. Unsupported providers fail fast
-    instead of silently falling back to prompt-only JSON mode. *)
+    Direct extraction uses provider-native JSON schema output via
+    {!Llm_provider.Complete}. Unsupported providers fail fast instead of
+    silently falling back to prompt-only JSON mode. *)
 
 open Result_syntax
 open Types
 
 type 'a schema =
-  { name : string
-  ; description : string
-  ; params : tool_param list
+  { params : tool_param list
   ; parse : Yojson.Safe.t -> ('a, string) result
   }
-
-(** Build the tool_schema JSON for an extraction schema *)
-let schema_to_tool_json (s : _ schema) : Yojson.Safe.t =
-  `Assoc
-    [ "name", `String s.name
-    ; "description", `String s.description
-    ; "input_schema", Types.params_to_input_schema s.params
-    ]
-;;
 
 let schema_to_json_schema (s : _ schema) : Yojson.Safe.t =
   Types.params_to_input_schema s.params
@@ -39,35 +26,6 @@ let text_block = function
   | Audio _
   | ToolUse _
   | ToolResult _ -> None
-;;
-
-(** Extract a tool_use input JSON from an API response's content blocks.
-    Returns the first ToolUse matching the schema name, or an error. *)
-let extract_tool_input ~(schema : _ schema) (content : content_block list) =
-  let found =
-    List.find_map
-      (function
-        | ToolUse { name; input; _ } when name = schema.name -> Some input
-        | Text _
-        | Thinking _
-        | ReasoningDetails _
-        | RedactedThinking _
-        | Image _
-        | Document _
-        | Audio _
-        | ToolUse _
-        | ToolResult _ -> None)
-      content
-  in
-  let* json =
-    found
-    |> Option.to_result
-         ~none:
-           (Error.Internal
-              (Printf.sprintf "No tool_use block for '%s' in response" schema.name))
-  in
-  schema.parse json
-  |> Result.map_error (fun e -> Error.Serialization (JsonParseError { detail = e }))
 ;;
 
 let parse_json_string text =
@@ -268,93 +226,6 @@ let extract_stream
 [@@@coverage off]
 (* === Inline tests === *)
 
-let test_schema : string schema =
-  { name = "test_extract"
-  ; description = "A test schema"
-  ; params =
-      [ { name = "value"
-        ; description = "The value"
-        ; param_type = String
-        ; required = true
-        }
-      ; { name = "count"
-        ; description = "A count"
-        ; param_type = Integer
-        ; required = false
-        }
-      ]
-  ; parse =
-      (fun json ->
-        let open Yojson.Safe.Util in
-        match json |> member "value" |> to_string_option with
-        | Some s -> Ok s
-        | None -> Error "missing value field")
-  }
-;;
-
-let%test "schema_to_tool_json produces valid structure" =
-  let json = schema_to_tool_json test_schema in
-  let open Yojson.Safe.Util in
-  json |> member "name" |> to_string = "test_extract"
-  && json |> member "description" |> to_string = "A test schema"
-  &&
-  let input_schema = json |> member "input_schema" in
-  input_schema |> member "type" |> to_string = "object"
-;;
-
-let%test "schema_to_tool_json required field lists required params" =
-  let json = schema_to_tool_json test_schema in
-  let open Yojson.Safe.Util in
-  let required = json |> member "input_schema" |> member "required" |> to_list in
-  List.length required = 1 && List.exists (fun j -> to_string j = "value") required
-;;
-
-let%test "schema_to_tool_json properties have correct types" =
-  let json = schema_to_tool_json test_schema in
-  let open Yojson.Safe.Util in
-  let props = json |> member "input_schema" |> member "properties" in
-  let value_type = props |> member "value" |> member "type" |> to_string in
-  let count_type = props |> member "count" |> member "type" |> to_string in
-  value_type = "string" && count_type = "integer"
-;;
-
-let%test "extract_tool_input finds matching tool_use block" =
-  let content =
-    [ Text "some text"
-    ; ToolUse
-        { id = "tu1"; name = "test_extract"; input = `Assoc [ "value", `String "hello" ] }
-    ]
-  in
-  match extract_tool_input ~schema:test_schema content with
-  | Ok "hello" -> true
-  | _ -> false
-;;
-
-let%test "extract_tool_input returns error when no matching block" =
-  let content = [ Text "only text" ] in
-  match extract_tool_input ~schema:test_schema content with
-  | Error (Error.Internal _) -> true
-  | _ -> false
-;;
-
-let%test "extract_tool_input skips non-matching tool names" =
-  let content = [ ToolUse { id = "tu1"; name = "other_tool"; input = `Assoc [] } ] in
-  match extract_tool_input ~schema:test_schema content with
-  | Error (Error.Internal _) -> true
-  | _ -> false
-;;
-
-let%test "extract_tool_input parse error propagates" =
-  let content =
-    [ ToolUse
-        { id = "tu1"; name = "test_extract"; input = `Assoc [ "wrong", `String "x" ] }
-    ]
-  in
-  match extract_tool_input ~schema:test_schema content with
-  | Error (Error.Serialization _) -> true
-  | _ -> false
-;;
-
 let%test "json_extractor parses json from text block" =
   let extractor =
     json_extractor (fun j -> Yojson.Safe.Util.(j |> member "key" |> to_string))
@@ -438,51 +309,6 @@ let%test "text_extractor returns error when parse returns None" =
 ;;
 
 (* --- Additional coverage tests --- *)
-
-let%test "schema_to_tool_json empty params" =
-  let s : string schema =
-    { name = "empty"; description = "d"; params = []; parse = (fun _ -> Ok "x") }
-  in
-  let json = schema_to_tool_json s in
-  let open Yojson.Safe.Util in
-  let props = json |> member "input_schema" |> member "properties" in
-  let required = json |> member "input_schema" |> member "required" |> to_list in
-  props = `Assoc [] && required = []
-;;
-
-let%test "schema_to_tool_json boolean param type" =
-  let s : bool schema =
-    { name = "booltest"
-    ; description = "d"
-    ; params =
-        [ { name = "flag"; description = "f"; param_type = Boolean; required = true } ]
-    ; parse = (fun _ -> Ok true)
-    }
-  in
-  let json = schema_to_tool_json s in
-  let open Yojson.Safe.Util in
-  let flag_type =
-    json
-    |> member "input_schema"
-    |> member "properties"
-    |> member "flag"
-    |> member "type"
-    |> to_string
-  in
-  flag_type = "boolean"
-;;
-
-let%test "extract_tool_input multiple tool_use picks matching name" =
-  let content =
-    [ ToolUse { id = "t1"; name = "other"; input = `Assoc [ "x", `Int 1 ] }
-    ; ToolUse
-        { id = "t2"; name = "test_extract"; input = `Assoc [ "value", `String "found" ] }
-    ]
-  in
-  match extract_tool_input ~schema:test_schema content with
-  | Ok "found" -> true
-  | _ -> false
-;;
 
 let%test "json_extractor type error produces descriptive message" =
   let extractor =

--- a/lib/structured.mli
+++ b/lib/structured.mli
@@ -1,8 +1,7 @@
 (** Structured output helpers.
 
     Direct extraction prefers provider-native JSON schema output via
-    {!Llm_provider.Complete}. The legacy tool-use helpers remain available
-    for callers that still want forced tool calls.
+    {!Llm_provider.Complete}.
 
     @stability Evolving
     @since 0.93.1 *)
@@ -12,24 +11,12 @@ open Types
 (** {1 Schema} *)
 
 type 'a schema =
-  { name : string
-  ; description : string
-  ; params : tool_param list
+  { params : tool_param list
   ; parse : Yojson.Safe.t -> ('a, string) result
   }
 
-val schema_to_tool_json : _ schema -> Yojson.Safe.t
-
-(** Return the object JSON schema used for provider-native structured output.
-
-    This is the same schema shape embedded under [input_schema] by
-    {!schema_to_tool_json}, but without the tool wrapper fields. *)
+(** Return the object JSON schema used for provider-native structured output. *)
 val schema_to_json_schema : _ schema -> Yojson.Safe.t
-
-val extract_tool_input
-  :  schema:'a schema
-  -> content_block list
-  -> ('a, Error.sdk_error) result
 
 (** {1 Direct extraction} *)
 

--- a/test/test_full_pipeline_cov.ml
+++ b/test/test_full_pipeline_cov.ml
@@ -547,9 +547,7 @@ let test_structured_extract () =
     in
     Llm_provider.Provider_catalog.set_global provider_catalog;
     let schema : (string * int) Structured.schema =
-      { name = "get_info"
-      ; description = "Get info"
-      ; params =
+      { params =
           [ { name = "name"
             ; param_type = Types.String
             ; description = "name"
@@ -595,41 +593,26 @@ let test_structured_extract () =
   | Exit -> ()
 ;;
 
-(* ── 17. Structured schema_to_tool_json ───────────────────────── *)
+(* ── 17. Structured schema_to_json_schema ───────────────────────── *)
 
 let test_schema_to_json () =
   let schema : unit Structured.schema =
-    { name = "test_tool"
-    ; description = "A test"
-    ; params =
+    { params =
         [ { name = "x"; param_type = Types.Integer; description = "num"; required = true }
         ; { name = "y"; param_type = Types.String; description = "str"; required = false }
         ]
     ; parse = (fun _ -> Ok ())
     }
   in
-  let json = Structured.schema_to_tool_json schema in
-  let name = Yojson.Safe.Util.(json |> member "name" |> to_string) in
-  check string "schema name" "test_tool" name
+  let json = Structured.schema_to_json_schema schema in
+  let open Yojson.Safe.Util in
+  check string "schema type" "object" (json |> member "type" |> to_string);
+  check
+    string
+    "x type"
+    "integer"
+    (json |> member "properties" |> member "x" |> member "type" |> to_string)
 ;;
-
-(* ── 18. Structured extract_tool_input error ──────────────────── *)
-
-let test_extract_tool_input_missing () =
-  let schema : unit Structured.schema =
-    { name = "missing_tool"
-    ; description = "Missing"
-    ; params = []
-    ; parse = (fun _ -> Ok ())
-    }
-  in
-  let content = [ Types.Text "no tool here" ] in
-  match Structured.extract_tool_input ~schema content with
-  | Ok _ -> fail "expected error"
-  | Error _ -> ()
-;;
-
-(* ── 19. Agent card generation ────────────────────────────────── *)
 
 let test_agent_card () =
   Eio_main.run
@@ -699,7 +682,6 @@ let () =
     ; ( "structured"
       , [ test_case "extract" `Quick test_structured_extract
         ; test_case "schema json" `Quick test_schema_to_json
-        ; test_case "missing tool" `Quick test_extract_tool_input_missing
         ] )
     ; ( "errors"
       , [ test_case "http 500" `Quick test_http_500

--- a/test/test_structured.ml
+++ b/test/test_structured.ml
@@ -6,9 +6,7 @@ open Types
 (* --- Test schema --- *)
 
 let person_schema : (string * int) Structured.schema =
-  { name = "extract_person"
-  ; description = "Extract person info"
-  ; params =
+  { params =
       [ { name = "name"
         ; description = "Person name"
         ; param_type = String
@@ -32,22 +30,13 @@ let person_schema : (string * int) Structured.schema =
   }
 ;;
 
-(* --- schema_to_tool_json --- *)
+(* --- schema_to_json_schema --- *)
 
 let test_schema_to_json_structure () =
-  let json = Structured.schema_to_tool_json person_schema in
+  let json = Structured.schema_to_json_schema person_schema in
   let open Yojson.Safe.Util in
-  Alcotest.(check string) "name" "extract_person" (json |> member "name" |> to_string);
-  Alcotest.(check string)
-    "description"
-    "Extract person info"
-    (json |> member "description" |> to_string);
-  let input_schema = json |> member "input_schema" in
-  Alcotest.(check string)
-    "type is object"
-    "object"
-    (input_schema |> member "type" |> to_string);
-  let props = input_schema |> member "properties" in
+  Alcotest.(check string) "type is object" "object" (json |> member "type" |> to_string);
+  let props = json |> member "properties" in
   Alcotest.(check string)
     "name prop type"
     "string"
@@ -56,7 +45,7 @@ let test_schema_to_json_structure () =
     "age prop type"
     "integer"
     (props |> member "age" |> member "type" |> to_string);
-  let required = input_schema |> member "required" |> to_list |> List.map to_string in
+  let required = json |> member "required" |> to_list |> List.map to_string in
   Alcotest.(check bool) "name required" true (List.mem "name" required);
   Alcotest.(check bool) "age required" true (List.mem "age" required)
 ;;
@@ -78,81 +67,9 @@ let test_schema_to_json_schema_structure () =
     (props |> member "name" |> member "type" |> to_string)
 ;;
 
-(* --- extract_tool_input --- *)
-
-let test_extract_tool_input_success () =
-  let input_json = `Assoc [ "name", `String "Alice"; "age", `Int 30 ] in
-  let content =
-    [ Text "some text"
-    ; ToolUse { id = "tu_1"; name = "extract_person"; input = input_json }
-    ]
-  in
-  match Structured.extract_tool_input ~schema:person_schema content with
-  | Ok (name, age) ->
-    Alcotest.(check string) "name" "Alice" name;
-    Alcotest.(check int) "age" 30 age
-  | Error e -> Alcotest.fail ("unexpected error: " ^ Error.to_string e)
-;;
-
-let test_extract_tool_input_wrong_name () =
-  let input_json = `Assoc [ "x", `Int 1 ] in
-  let content = [ ToolUse { id = "tu_2"; name = "other_tool"; input = input_json } ] in
-  match Structured.extract_tool_input ~schema:person_schema content with
-  | Error msg ->
-    Alcotest.(check bool)
-      "mentions schema name"
-      true
-      (let target = "extract_person" in
-       let tlen = String.length target in
-       let s = Error.to_string msg in
-       let mlen = String.length s in
-       let rec has i =
-         i + tlen <= mlen && (String.sub s i tlen = target || has (i + 1))
-       in
-       has 0)
-  | Ok _ -> Alcotest.fail "expected error for wrong tool name"
-;;
-
-let test_extract_tool_input_no_tool_use () =
-  let content = [ Text "just text" ] in
-  match Structured.extract_tool_input ~schema:person_schema content with
-  | Error _ -> ()
-  | Ok _ -> Alcotest.fail "expected error for empty content"
-;;
-
-let test_extract_tool_input_parse_failure () =
-  (* Valid ToolUse name but invalid input JSON for the parser *)
-  let input_json = `Assoc [ "name", `Int 999 ] in
-  let content =
-    [ ToolUse { id = "tu_3"; name = "extract_person"; input = input_json } ]
-  in
-  match Structured.extract_tool_input ~schema:person_schema content with
-  | Error _ -> ()
-  | Ok _ -> Alcotest.fail "expected parse error"
-;;
-
-let test_extract_picks_first_match () =
-  let input1 = `Assoc [ "name", `String "First"; "age", `Int 1 ] in
-  let input2 = `Assoc [ "name", `String "Second"; "age", `Int 2 ] in
-  let content =
-    [ ToolUse { id = "tu_4"; name = "extract_person"; input = input1 }
-    ; ToolUse { id = "tu_5"; name = "extract_person"; input = input2 }
-    ]
-  in
-  match Structured.extract_tool_input ~schema:person_schema content with
-  | Ok (name, age) ->
-    Alcotest.(check string) "first match" "First" name;
-    Alcotest.(check int) "first age" 1 age
-  | Error e -> Alcotest.fail ("unexpected error: " ^ Error.to_string e)
-;;
-
-(* --- schema edge cases --- *)
-
 let test_schema_optional_params () =
   let schema : unit Structured.schema =
-    { name = "test_opt"
-    ; description = "Test optional params"
-    ; params =
+    { params =
         [ { name = "required_f"; description = "R"; param_type = String; required = true }
         ; { name = "optional_f"
           ; description = "O"
@@ -163,75 +80,26 @@ let test_schema_optional_params () =
     ; parse = (fun _ -> Ok ())
     }
   in
-  let json = Structured.schema_to_tool_json schema in
+  let json = Structured.schema_to_json_schema schema in
   let open Yojson.Safe.Util in
-  let required =
-    json |> member "input_schema" |> member "required" |> to_list |> List.map to_string
-  in
+  let required = json |> member "required" |> to_list |> List.map to_string in
   Alcotest.(check bool) "required_f in list" true (List.mem "required_f" required);
   Alcotest.(check bool) "optional_f not in list" false (List.mem "optional_f" required)
 ;;
 
-let test_extract_with_thinking_blocks () =
-  let input_json = `Assoc [ "name", `String "Bob"; "age", `Int 25 ] in
-  let content =
-    [ Types.Thinking { signature = Some "sig"; content = "some thinking..." }
-    ; Text "preamble"
-    ; ToolUse { id = "tu_t"; name = "extract_person"; input = input_json }
-    ]
-  in
-  match Structured.extract_tool_input ~schema:person_schema content with
-  | Ok (name, age) ->
-    Alcotest.(check string) "name" "Bob" name;
-    Alcotest.(check int) "age" 25 age
-  | Error e -> Alcotest.fail ("unexpected error: " ^ Error.to_string e)
-;;
-
-let test_schema_tool_choice_name () =
-  let json = Structured.schema_to_tool_json person_schema in
-  let open Yojson.Safe.Util in
-  (* The name field is what tool_choice=Tool(name) would reference *)
-  Alcotest.(check string)
-    "name for tool_choice"
-    "extract_person"
-    (json |> member "name" |> to_string);
-  let props = json |> member "input_schema" |> member "properties" |> to_assoc in
-  Alcotest.(check int) "property count" 2 (List.length props)
-;;
-
-let test_extract_from_empty_content () =
-  match Structured.extract_tool_input ~schema:person_schema [] with
-  | Error msg ->
-    Alcotest.(check bool)
-      "mentions schema name"
-      true
-      (String.length (Error.to_string msg) > 0)
-  | Ok _ -> Alcotest.fail "expected error for empty content"
-;;
-
-(* --- Additional schema_to_tool_json coverage --- *)
-
 let test_schema_empty_params () =
-  let schema : unit Structured.schema =
-    { name = "no_params"
-    ; description = "No params tool"
-    ; params = []
-    ; parse = (fun _ -> Ok ())
-    }
-  in
-  let json = Structured.schema_to_tool_json schema in
+  let schema : unit Structured.schema = { params = []; parse = (fun _ -> Ok ()) } in
+  let json = Structured.schema_to_json_schema schema in
   let open Yojson.Safe.Util in
-  let props = json |> member "input_schema" |> member "properties" |> to_assoc in
+  let props = json |> member "properties" |> to_assoc in
   Alcotest.(check int) "no properties" 0 (List.length props);
-  let required = json |> member "input_schema" |> member "required" |> to_list in
+  let required = json |> member "required" |> to_list in
   Alcotest.(check int) "no required" 0 (List.length required)
 ;;
 
 let test_schema_all_param_types () =
   let schema : unit Structured.schema =
-    { name = "all_types"
-    ; description = "All param types"
-    ; params =
+    { params =
         [ { name = "s"; description = "string"; param_type = String; required = true }
         ; { name = "i"; description = "integer"; param_type = Integer; required = true }
         ; { name = "n"; description = "number"; param_type = Number; required = false }
@@ -240,9 +108,9 @@ let test_schema_all_param_types () =
     ; parse = (fun _ -> Ok ())
     }
   in
-  let json = Structured.schema_to_tool_json schema in
+  let json = Structured.schema_to_json_schema schema in
   let open Yojson.Safe.Util in
-  let props = json |> member "input_schema" |> member "properties" in
+  let props = json |> member "properties" in
   Alcotest.(check string)
     "string type"
     "string"
@@ -259,9 +127,7 @@ let test_schema_all_param_types () =
     "boolean type"
     "boolean"
     (props |> member "b" |> member "type" |> to_string);
-  let required =
-    json |> member "input_schema" |> member "required" |> to_list |> List.map to_string
-  in
+  let required = json |> member "required" |> to_list |> List.map to_string in
   Alcotest.(check int) "2 required" 2 (List.length required);
   Alcotest.(check bool) "s required" true (List.mem "s" required);
   Alcotest.(check bool) "i required" true (List.mem "i" required);
@@ -269,11 +135,9 @@ let test_schema_all_param_types () =
   Alcotest.(check bool) "b not required" false (List.mem "b" required)
 ;;
 
-let test_schema_description_preserved () =
+let test_param_description_preserved () =
   let schema : unit Structured.schema =
-    { name = "desc_test"
-    ; description = "My detailed description"
-    ; params =
+    { params =
         [ { name = "x"
           ; description = "field X description"
           ; param_type = String
@@ -283,81 +147,17 @@ let test_schema_description_preserved () =
     ; parse = (fun _ -> Ok ())
     }
   in
-  let json = Structured.schema_to_tool_json schema in
+  let json = Structured.schema_to_json_schema schema in
   let open Yojson.Safe.Util in
-  Alcotest.(check string)
-    "schema desc"
-    "My detailed description"
-    (json |> member "description" |> to_string);
   let x_desc =
-    json
-    |> member "input_schema"
-    |> member "properties"
-    |> member "x"
-    |> member "description"
-    |> to_string
+    json |> member "properties" |> member "x" |> member "description" |> to_string
   in
   Alcotest.(check string) "param desc" "field X description" x_desc
 ;;
 
-(* --- extract_tool_input error types --- *)
-
-let test_extract_parse_error_is_serialization () =
-  let input_json = `Assoc [ "name", `Int 999 ] in
-  let content =
-    [ ToolUse { id = "tu_x"; name = "extract_person"; input = input_json } ]
-  in
-  match Structured.extract_tool_input ~schema:person_schema content with
-  | Error (Error.Serialization _) -> ()
-  | Error e -> Alcotest.failf "expected Serialization, got: %s" (Error.to_string e)
-  | Ok _ -> Alcotest.fail "expected parse error"
-;;
-
-let test_extract_missing_tool_is_internal () =
-  let content = [ Text "no tools here" ] in
-  match Structured.extract_tool_input ~schema:person_schema content with
-  | Error (Error.Internal s) ->
-    Alcotest.(check bool)
-      "mentions schema name"
-      true
-      (let tgt = "extract_person" in
-       let tlen = String.length tgt in
-       let slen = String.length s in
-       let rec has i = i + tlen <= slen && (String.sub s i tlen = tgt || has (i + 1)) in
-       has 0)
-  | Error e -> Alcotest.failf "expected Internal, got: %s" (Error.to_string e)
-  | Ok _ -> Alcotest.fail "expected error"
-;;
-
-(* --- extract_tool_input: ToolResult blocks ignored --- *)
-
-let test_extract_ignores_tool_result () =
-  let input_json = `Assoc [ "name", `String "Carol"; "age", `Int 40 ] in
-  let content =
-    [ ToolResult
-        { tool_use_id = "old"
-        ; content = "previous result"
-        ; outcome = Tool_succeeded
-        ; json = None
-        ; content_blocks = None
-        }
-    ; ToolUse { id = "tu_r"; name = "extract_person"; input = input_json }
-    ]
-  in
-  match Structured.extract_tool_input ~schema:person_schema content with
-  | Ok (name, age) ->
-    Alcotest.(check string) "name" "Carol" name;
-    Alcotest.(check int) "age" 40 age
-  | Error e -> Alcotest.fail ("unexpected: " ^ Error.to_string e)
-;;
-
-(* --- schema with many required/optional mix --- *)
-
 let test_schema_mixed_required () =
   let schema : unit Structured.schema =
-    { name = "mixed"
-    ; description = "Mixed"
-    ; params =
+    { params =
         [ { name = "a"; description = "A"; param_type = String; required = true }
         ; { name = "b"; description = "B"; param_type = String; required = false }
         ; { name = "c"; description = "C"; param_type = Integer; required = true }
@@ -367,11 +167,9 @@ let test_schema_mixed_required () =
     ; parse = (fun _ -> Ok ())
     }
   in
-  let json = Structured.schema_to_tool_json schema in
+  let json = Structured.schema_to_json_schema schema in
   let open Yojson.Safe.Util in
-  let required =
-    json |> member "input_schema" |> member "required" |> to_list |> List.map to_string
-  in
+  let required = json |> member "required" |> to_list |> List.map to_string in
   Alcotest.(check int) "3 required" 3 (List.length required);
   Alcotest.(check bool) "a required" true (List.mem "a" required);
   Alcotest.(check bool) "c required" true (List.mem "c" required);
@@ -491,9 +289,7 @@ let test_schema_extractor_parse_failure () =
 
 let test_schema_extractor_parser_json_error () =
   let schema : unit Structured.schema =
-    { name = "nested_json"
-    ; description = "Parse nested JSON"
-    ; params = []
+    { params = []
     ; parse =
         (fun json ->
           let open Yojson.Safe.Util in
@@ -514,10 +310,9 @@ let test_schema_extractor_parser_json_error () =
 let () =
   Alcotest.run
     "structured"
-    [ ( "schema_to_tool_json"
+    [ ( "schema_to_json_schema"
       , [ Alcotest.test_case "structure" `Quick test_schema_to_json_structure
         ; Alcotest.test_case "optional params" `Quick test_schema_optional_params
-        ; Alcotest.test_case "tool choice name" `Quick test_schema_tool_choice_name
         ; Alcotest.test_case
             "json schema structure"
             `Quick
@@ -525,31 +320,10 @@ let () =
         ; Alcotest.test_case "empty params" `Quick test_schema_empty_params
         ; Alcotest.test_case "all param types" `Quick test_schema_all_param_types
         ; Alcotest.test_case
-            "description preserved"
+            "parameter description preserved"
             `Quick
-            test_schema_description_preserved
+            test_param_description_preserved
         ; Alcotest.test_case "mixed required" `Quick test_schema_mixed_required
-        ] )
-    ; ( "extract_tool_input"
-      , [ Alcotest.test_case "success" `Quick test_extract_tool_input_success
-        ; Alcotest.test_case "wrong name" `Quick test_extract_tool_input_wrong_name
-        ; Alcotest.test_case "no tool_use" `Quick test_extract_tool_input_no_tool_use
-        ; Alcotest.test_case "parse failure" `Quick test_extract_tool_input_parse_failure
-        ; Alcotest.test_case "picks first match" `Quick test_extract_picks_first_match
-        ; Alcotest.test_case
-            "with thinking blocks"
-            `Quick
-            test_extract_with_thinking_blocks
-        ; Alcotest.test_case "empty content" `Quick test_extract_from_empty_content
-        ; Alcotest.test_case
-            "parse error type"
-            `Quick
-            test_extract_parse_error_is_serialization
-        ; Alcotest.test_case
-            "missing tool type"
-            `Quick
-            test_extract_missing_tool_is_internal
-        ; Alcotest.test_case "ignores tool_result" `Quick test_extract_ignores_tool_result
         ] )
     ; ( "extractors"
       , [ Alcotest.test_case "json_extractor success" `Quick test_json_extractor_success

--- a/test/test_structured_coverage.ml
+++ b/test/test_structured_coverage.ml
@@ -1,8 +1,7 @@
 (** Additional coverage tests for Structured module.
 
-    Targets uncovered branches in json_extractor (Type_error, Failure),
-    text_extractor edge cases, and extract_tool_input variants
-    not covered by test_structured.ml. *)
+    Targets uncovered branches in json_extractor (Type_error, Failure) and
+    text_extractor edge cases not covered by test_structured.ml. *)
 
 open Agent_sdk
 open Types
@@ -19,33 +18,6 @@ let make_response content : Types.api_response =
   ; content
   ; usage = None
   ; telemetry = None
-  }
-;;
-
-let person_schema : (string * int) Structured.schema =
-  { name = "extract_person"
-  ; description = "Extract person info"
-  ; params =
-      [ { name = "name"
-        ; description = "Person name"
-        ; param_type = String
-        ; required = true
-        }
-      ; { name = "age"
-        ; description = "Person age"
-        ; param_type = Integer
-        ; required = true
-        }
-      ]
-  ; parse =
-      (fun json ->
-        let open Yojson.Safe.Util in
-        try
-          let name = json |> member "name" |> to_string in
-          let age = json |> member "age" |> to_int in
-          Ok (name, age)
-        with
-        | exn -> Error (Printexc.to_string exn))
   }
 ;;
 
@@ -166,79 +138,9 @@ let test_text_extractor_parse_returns_none () =
   | Ok _ -> Alcotest.fail "expected error"
 ;;
 
-(* ── extract_tool_input: Image block ignored ────────────────────── *)
-
-let test_extract_ignores_image () =
-  let input_json = `Assoc [ "name", `String "Alice"; "age", `Int 30 ] in
-  let content =
-    [ Image { media_type = "image/png"; data = "abc"; source_type = Types.Base64 }
-    ; ToolUse { id = "tu_img"; name = "extract_person"; input = input_json }
-    ]
-  in
-  match Structured.extract_tool_input ~schema:person_schema content with
-  | Ok (name, age) ->
-    check_string "name" "Alice" name;
-    Alcotest.(check int) "age" 30 age
-  | Error e -> Alcotest.fail ("unexpected error: " ^ Error.to_string e)
-;;
-
-(* ── extract_tool_input: Document block ignored ─────────────────── *)
-
-let test_extract_ignores_document () =
-  let input_json = `Assoc [ "name", `String "Bob"; "age", `Int 25 ] in
-  let content =
-    [ Document { media_type = "application/pdf"; data = "x"; source_type = Types.Base64 }
-    ; ToolUse { id = "tu_doc"; name = "extract_person"; input = input_json }
-    ]
-  in
-  match Structured.extract_tool_input ~schema:person_schema content with
-  | Ok (name, _) -> check_string "name" "Bob" name
-  | Error e -> Alcotest.fail ("unexpected error: " ^ Error.to_string e)
-;;
-
-(* ── extract_tool_input: RedactedThinking ignored ───────────────── *)
-
-let test_extract_ignores_redacted_thinking () =
-  let input_json = `Assoc [ "name", `String "Carol"; "age", `Int 40 ] in
-  let content =
-    [ RedactedThinking "redacted"
-    ; ToolUse { id = "tu_rt"; name = "extract_person"; input = input_json }
-    ]
-  in
-  match Structured.extract_tool_input ~schema:person_schema content with
-  | Ok (name, _) -> check_string "name" "Carol" name
-  | Error e -> Alcotest.fail ("unexpected error: " ^ Error.to_string e)
-;;
-
-(* ── extract_tool_input: only wrong-name tools ──────────────────── *)
-
-let test_extract_only_wrong_name_tools () =
-  let content =
-    [ ToolUse { id = "tu_a"; name = "wrong_tool_a"; input = `Null }
-    ; ToolUse { id = "tu_b"; name = "wrong_tool_b"; input = `Null }
-    ]
-  in
-  match Structured.extract_tool_input ~schema:person_schema content with
-  | Error (Error.Internal msg) ->
-    check_bool
-      "mentions schema name"
-      true
-      (let tgt = "extract_person" in
-       let tlen = String.length tgt in
-       let slen = String.length msg in
-       let rec has i = i + tlen <= slen && (String.sub msg i tlen = tgt || has (i + 1)) in
-       has 0)
-  | Error _ -> Alcotest.fail "expected Internal error"
-  | Ok _ -> Alcotest.fail "expected error"
-;;
-
-(* ── schema_to_tool_json: Array and Object param types ──────────── *)
-
 let test_schema_array_object_param_types () =
   let schema : unit Structured.schema =
-    { name = "complex_types"
-    ; description = "Test array/object types"
-    ; params =
+    { params =
         [ { name = "items"
           ; description = "An array"
           ; param_type = Array
@@ -253,9 +155,9 @@ let test_schema_array_object_param_types () =
     ; parse = (fun _ -> Ok ())
     }
   in
-  let json = Structured.schema_to_tool_json schema in
+  let json = Structured.schema_to_json_schema schema in
   let open Yojson.Safe.Util in
-  let props = json |> member "input_schema" |> member "properties" in
+  let props = json |> member "properties" in
   check_string "array type" "array" (props |> member "items" |> member "type" |> to_string);
   check_string
     "object type"
@@ -263,13 +165,11 @@ let test_schema_array_object_param_types () =
     (props |> member "config" |> member "type" |> to_string)
 ;;
 
-(* ── schema_to_tool_json: single required param ─────────────────── *)
+(* ── schema_to_json_schema: single required param ─────────────────── *)
 
 let test_schema_single_required () =
   let schema : string Structured.schema =
-    { name = "single"
-    ; description = "Single param"
-    ; params =
+    { params =
         [ { name = "value"
           ; description = "The value"
           ; param_type = String
@@ -283,49 +183,29 @@ let test_schema_single_required () =
           | exn -> Error (Printexc.to_string exn))
     }
   in
-  let json = Structured.schema_to_tool_json schema in
+  let json = Structured.schema_to_json_schema schema in
   let open Yojson.Safe.Util in
-  let required =
-    json |> member "input_schema" |> member "required" |> to_list |> List.map to_string
-  in
+  let required = json |> member "required" |> to_list |> List.map to_string in
   Alcotest.(check int) "1 required" 1 (List.length required);
   check_string "required name" "value" (List.hd required)
 ;;
 
-(* ── schema_to_tool_json: all optional params ───────────────────── *)
+(* ── schema_to_json_schema: all optional params ───────────────────── *)
 
 let test_schema_all_optional () =
   let schema : unit Structured.schema =
-    { name = "all_optional"
-    ; description = "All optional"
-    ; params =
+    { params =
         [ { name = "a"; description = "A"; param_type = String; required = false }
         ; { name = "b"; description = "B"; param_type = Integer; required = false }
         ]
     ; parse = (fun _ -> Ok ())
     }
   in
-  let json = Structured.schema_to_tool_json schema in
+  let json = Structured.schema_to_json_schema schema in
   let open Yojson.Safe.Util in
-  let required = json |> member "input_schema" |> member "required" |> to_list in
+  let required = json |> member "required" |> to_list in
   Alcotest.(check int) "0 required" 0 (List.length required)
 ;;
-
-(* ── extract_tool_input: Audio block ignored ────────────────────── *)
-
-let test_extract_ignores_audio () =
-  let input_json = `Assoc [ "name", `String "Dan"; "age", `Int 35 ] in
-  let content =
-    [ Audio { media_type = "audio/mp3"; data = "bin"; source_type = Types.Base64 }
-    ; ToolUse { id = "tu_aud"; name = "extract_person"; input = input_json }
-    ]
-  in
-  match Structured.extract_tool_input ~schema:person_schema content with
-  | Ok (name, _) -> check_string "name" "Dan" name
-  | Error e -> Alcotest.fail ("unexpected error: " ^ Error.to_string e)
-;;
-
-(* ── json_extractor: valid JSON but wrong structure ─────────────── *)
 
 let test_json_extractor_wrong_structure () =
   let extract =
@@ -338,34 +218,6 @@ let test_json_extractor_wrong_structure () =
   | Error _ -> ()
   | Ok _ -> Alcotest.fail "expected error for missing field"
 ;;
-
-(* ── extract_tool_input: mixed block types with schema match ────── *)
-
-let test_extract_mixed_blocks () =
-  let input_json = `Assoc [ "name", `String "Eve"; "age", `Int 50 ] in
-  let content =
-    [ Text "preamble"
-    ; Thinking { signature = Some "s"; content = "reasoning" }
-    ; ToolResult
-        { tool_use_id = "old"
-        ; content = "old result"
-        ; outcome = Tool_succeeded
-        ; json = None
-        ; content_blocks = None
-        }
-    ; Image { media_type = "image/png"; data = "img"; source_type = Types.Base64 }
-    ; ToolUse { id = "tu_mix"; name = "wrong_tool"; input = `Null }
-    ; ToolUse { id = "tu_right"; name = "extract_person"; input = input_json }
-    ]
-  in
-  match Structured.extract_tool_input ~schema:person_schema content with
-  | Ok (name, age) ->
-    check_string "name" "Eve" name;
-    Alcotest.(check int) "age" 50 age
-  | Error e -> Alcotest.fail ("unexpected: " ^ Error.to_string e)
-;;
-
-(* ── Suite ──────────────────────────────────────────────────────── *)
 
 let () =
   Alcotest.run
@@ -389,21 +241,7 @@ let () =
             `Quick
             test_text_extractor_parse_returns_none
         ] )
-    ; ( "extract_tool_input_blocks"
-      , [ Alcotest.test_case "ignores Image" `Quick test_extract_ignores_image
-        ; Alcotest.test_case "ignores Document" `Quick test_extract_ignores_document
-        ; Alcotest.test_case
-            "ignores RedactedThinking"
-            `Quick
-            test_extract_ignores_redacted_thinking
-        ; Alcotest.test_case "ignores Audio" `Quick test_extract_ignores_audio
-        ; Alcotest.test_case
-            "only wrong-name tools"
-            `Quick
-            test_extract_only_wrong_name_tools
-        ; Alcotest.test_case "mixed blocks" `Quick test_extract_mixed_blocks
-        ] )
-    ; ( "schema_to_tool_json"
+    ; ( "schema_to_json_schema"
       , [ Alcotest.test_case
             "array/object types"
             `Quick

--- a/test/test_structured_deep.ml
+++ b/test/test_structured_deep.ml
@@ -1,8 +1,8 @@
 (** Deep coverage tests for Structured module.
 
-    Targets uncovered branches in structured.ml (51 uncovered points).
-    Focuses on schema property ordering, complex parse functions, error path
-    classification, and exact extract_tool_input edge cases. *)
+    Targets uncovered branches in structured.ml.
+    Focuses on schema property ordering, complex parse functions, and error
+    path classification. *)
 
 open Agent_sdk
 open Types
@@ -15,13 +15,11 @@ let make_response ?(usage = None) content : Types.api_response =
 
 (* ── Schema property ordering: fold_left + List.rev ─────────── *)
 
-(** schema_to_tool_json uses fold_left then List.rev to preserve
+(** schema_to_json_schema uses fold_left then List.rev to preserve
     parameter declaration order in properties. Verify ordering. *)
 let test_property_ordering_preserved () =
   let schema : unit Structured.schema =
-    { name = "ordered"
-    ; description = "Test ordering"
-    ; params =
+    { params =
         [ { name = "first"; description = "1st"; param_type = String; required = true }
         ; { name = "second"; description = "2nd"; param_type = Integer; required = true }
         ; { name = "third"; description = "3rd"; param_type = Boolean; required = false }
@@ -29,11 +27,9 @@ let test_property_ordering_preserved () =
     ; parse = (fun _ -> Ok ())
     }
   in
-  let json = Structured.schema_to_tool_json schema in
+  let json = Structured.schema_to_json_schema schema in
   let open Yojson.Safe.Util in
-  let prop_names =
-    json |> member "input_schema" |> member "properties" |> to_assoc |> List.map fst
-  in
+  let prop_names = json |> member "properties" |> to_assoc |> List.map fst in
   Alcotest.(check (list string))
     "property order matches declaration"
     [ "first"; "second"; "third" ]
@@ -43,9 +39,7 @@ let test_property_ordering_preserved () =
 (** Required list preserves filter_map order (declaration order). *)
 let test_required_ordering () =
   let schema : unit Structured.schema =
-    { name = "req_order"
-    ; description = "Required ordering"
-    ; params =
+    { params =
         [ { name = "z_last"; description = "Z"; param_type = String; required = true }
         ; { name = "a_first"; description = "A"; param_type = Integer; required = true }
         ; { name = "m_mid"; description = "M"; param_type = Number; required = false }
@@ -53,11 +47,9 @@ let test_required_ordering () =
     ; parse = (fun _ -> Ok ())
     }
   in
-  let json = Structured.schema_to_tool_json schema in
+  let json = Structured.schema_to_json_schema schema in
   let open Yojson.Safe.Util in
-  let required =
-    json |> member "input_schema" |> member "required" |> to_list |> List.map to_string
-  in
+  let required = json |> member "required" |> to_list |> List.map to_string in
   (* filter_map preserves order: z_last first, a_first second *)
   Alcotest.(check (list string))
     "required in declaration order"
@@ -68,129 +60,6 @@ let test_required_ordering () =
 (* ── Complex parse functions ────────────────────────────────── *)
 
 (** Schema with a parse that returns a nested record type. *)
-let test_complex_parse_success () =
-  let schema : (string * float * bool) Structured.schema =
-    { name = "complex_parse"
-    ; description = "Parse complex structure"
-    ; params =
-        [ { name = "label"; description = "Label"; param_type = String; required = true }
-        ; { name = "score"; description = "Score"; param_type = Number; required = true }
-        ; { name = "active"
-          ; description = "Active"
-          ; param_type = Boolean
-          ; required = true
-          }
-        ]
-    ; parse =
-        (fun json ->
-          let open Yojson.Safe.Util in
-          try
-            let label = json |> member "label" |> to_string in
-            let score = json |> member "score" |> to_float in
-            let active = json |> member "active" |> to_bool in
-            Ok (label, score, active)
-          with
-          | exn -> Error (Printexc.to_string exn))
-    }
-  in
-  let input_json =
-    `Assoc [ "label", `String "test"; "score", `Float 0.95; "active", `Bool true ]
-  in
-  let content =
-    [ ToolUse { id = "tu_cx"; name = "complex_parse"; input = input_json } ]
-  in
-  match Structured.extract_tool_input ~schema content with
-  | Ok (label, score, active) ->
-    Alcotest.(check string) "label" "test" label;
-    Alcotest.(check (float 0.001)) "score" 0.95 score;
-    Alcotest.(check bool) "active" true active
-  | Error e -> Alcotest.fail ("unexpected: " ^ Error.to_string e)
-;;
-
-(** Parse function that returns Error with a detailed message. *)
-let test_complex_parse_detailed_error () =
-  let schema : int Structured.schema =
-    { name = "detail_error"
-    ; description = "Detailed error"
-    ; params = []
-    ; parse =
-        (fun json ->
-          let open Yojson.Safe.Util in
-          match json |> member "value" with
-          | `Null -> Error "value field is null"
-          | `Int n when n < 0 -> Error "value must be non-negative"
-          | `Int n -> Ok n
-          | _ -> Error "value must be an integer")
-    }
-  in
-  (* Test null value path *)
-  let content_null =
-    [ ToolUse { id = "tu_n"; name = "detail_error"; input = `Assoc [ "value", `Null ] } ]
-  in
-  (match Structured.extract_tool_input ~schema content_null with
-   | Error (Error.Serialization (JsonParseError { detail })) ->
-     Alcotest.(check string) "null error detail" "value field is null" detail
-   | Error e -> Alcotest.failf "expected Serialization, got: %s" (Error.to_string e)
-   | Ok _ -> Alcotest.fail "expected error");
-  (* Test negative value path *)
-  let content_neg =
-    [ ToolUse
-        { id = "tu_neg"; name = "detail_error"; input = `Assoc [ "value", `Int (-5) ] }
-    ]
-  in
-  (match Structured.extract_tool_input ~schema content_neg with
-   | Error (Error.Serialization (JsonParseError { detail })) ->
-     Alcotest.(check string) "neg error detail" "value must be non-negative" detail
-   | Error e -> Alcotest.failf "expected Serialization, got: %s" (Error.to_string e)
-   | Ok _ -> Alcotest.fail "expected error");
-  (* Test non-integer path *)
-  let content_str =
-    [ ToolUse
-        { id = "tu_s"
-        ; name = "detail_error"
-        ; input = `Assoc [ "value", `String "not a number" ]
-        }
-    ]
-  in
-  match Structured.extract_tool_input ~schema content_str with
-  | Error (Error.Serialization (JsonParseError { detail })) ->
-    Alcotest.(check string) "string error detail" "value must be an integer" detail
-  | Error e -> Alcotest.failf "expected Serialization, got: %s" (Error.to_string e)
-  | Ok _ -> Alcotest.fail "expected error"
-;;
-
-(* ── extract_tool_input: multiple ToolUse with different names ── *)
-
-(** When content has ToolUse blocks for different schemas, only the
-    matching one is extracted. *)
-let test_extract_skips_unrelated_tools () =
-  let schema : string Structured.schema =
-    { name = "target_tool"
-    ; description = "Target"
-    ; params = []
-    ; parse =
-        (fun json ->
-          let open Yojson.Safe.Util in
-          Ok (json |> member "data" |> to_string))
-    }
-  in
-  let content =
-    [ ToolUse { id = "tu_a"; name = "other_tool_1"; input = `Assoc [ "x", `Int 1 ] }
-    ; ToolUse { id = "tu_b"; name = "other_tool_2"; input = `Assoc [ "y", `Int 2 ] }
-    ; ToolUse
-        { id = "tu_c"; name = "target_tool"; input = `Assoc [ "data", `String "found" ] }
-    ; ToolUse
-        { id = "tu_d"; name = "target_tool"; input = `Assoc [ "data", `String "second" ] }
-    ]
-  in
-  match Structured.extract_tool_input ~schema content with
-  | Ok v -> Alcotest.(check string) "first matching tool" "found" v
-  | Error e -> Alcotest.fail ("unexpected: " ^ Error.to_string e)
-;;
-
-(* ── json_extractor with different JSON structures ──────────── *)
-
-(** json_extractor parsing a JSON array from text block. *)
 let test_json_extractor_array () =
   let extract =
     Structured.json_extractor (fun json ->
@@ -262,9 +131,7 @@ let test_text_extractor_empty_string () =
 
 let test_schema_all_six_param_types () =
   let schema : unit Structured.schema =
-    { name = "all_six"
-    ; description = "All 6 types"
-    ; params =
+    { params =
         [ { name = "s"; description = "string"; param_type = String; required = true }
         ; { name = "i"; description = "integer"; param_type = Integer; required = true }
         ; { name = "n"; description = "number"; param_type = Number; required = true }
@@ -275,9 +142,9 @@ let test_schema_all_six_param_types () =
     ; parse = (fun _ -> Ok ())
     }
   in
-  let json = Structured.schema_to_tool_json schema in
+  let json = Structured.schema_to_json_schema schema in
   let open Yojson.Safe.Util in
-  let props = json |> member "input_schema" |> member "properties" in
+  let props = json |> member "properties" in
   Alcotest.(check string)
     "string"
     "string"
@@ -302,20 +169,16 @@ let test_schema_all_six_param_types () =
     "object"
     "object"
     (props |> member "o" |> member "type" |> to_string);
-  let required =
-    json |> member "input_schema" |> member "required" |> to_list |> List.map to_string
-  in
+  let required = json |> member "required" |> to_list |> List.map to_string in
   Alcotest.(check int) "6 required" 6 (List.length required)
 ;;
 
 (* ── Schema JSON structure validation ───────────────────────── *)
 
-(** Verify the full JSON structure matches Anthropic tool definition format. *)
+(** Verify the full provider-native JSON Schema structure. *)
 let test_schema_json_full_structure () =
   let schema : string Structured.schema =
-    { name = "get_weather"
-    ; description = "Get weather for a city"
-    ; params =
+    { params =
         [ { name = "city"
           ; description = "City name"
           ; param_type = String
@@ -333,58 +196,20 @@ let test_schema_json_full_structure () =
           Ok (json |> member "city" |> to_string))
     }
   in
-  let json = Structured.schema_to_tool_json schema in
+  let json = Structured.schema_to_json_schema schema in
   let open Yojson.Safe.Util in
   (* Top-level keys *)
   let keys = json |> to_assoc |> List.map fst in
   Alcotest.(check (list string))
     "top-level keys"
-    [ "name"; "description"; "input_schema" ]
-    keys;
-  (* input_schema keys *)
-  let is_keys = json |> member "input_schema" |> to_assoc |> List.map fst in
-  Alcotest.(check (list string))
-    "input_schema keys"
     [ "type"; "properties"; "required" ]
-    is_keys;
+    keys;
   (* Property descriptions preserved *)
   let city_desc =
-    json
-    |> member "input_schema"
-    |> member "properties"
-    |> member "city"
-    |> member "description"
-    |> to_string
+    json |> member "properties" |> member "city" |> member "description" |> to_string
   in
   Alcotest.(check string) "city description" "City name" city_desc
 ;;
-
-(* ── extract_tool_input with ToolUse containing complex input ── *)
-
-(** Extract from ToolUse where input is a deeply nested JSON. *)
-let test_extract_deeply_nested_input () =
-  let schema : string Structured.schema =
-    { name = "nested_tool"
-    ; description = "Nested"
-    ; params = []
-    ; parse =
-        (fun json ->
-          let open Yojson.Safe.Util in
-          Ok (json |> member "level1" |> member "level2" |> member "value" |> to_string))
-    }
-  in
-  let nested_input =
-    `Assoc [ "level1", `Assoc [ "level2", `Assoc [ "value", `String "deep_value" ] ] ]
-  in
-  let content =
-    [ ToolUse { id = "tu_deep"; name = "nested_tool"; input = nested_input } ]
-  in
-  match Structured.extract_tool_input ~schema content with
-  | Ok v -> Alcotest.(check string) "deep value" "deep_value" v
-  | Error e -> Alcotest.fail ("unexpected: " ^ Error.to_string e)
-;;
-
-(* ── Suite ──────────────────────────────────────────────────── *)
 
 let () =
   Alcotest.run
@@ -395,20 +220,6 @@ let () =
             `Quick
             test_property_ordering_preserved
         ; Alcotest.test_case "required ordering" `Quick test_required_ordering
-        ] )
-    ; ( "complex_parse"
-      , [ Alcotest.test_case "nested record parse" `Quick test_complex_parse_success
-        ; Alcotest.test_case
-            "detailed error paths"
-            `Quick
-            test_complex_parse_detailed_error
-        ] )
-    ; ( "extract_tool_input_deep"
-      , [ Alcotest.test_case
-            "skips unrelated tools"
-            `Quick
-            test_extract_skips_unrelated_tools
-        ; Alcotest.test_case "deeply nested input" `Quick test_extract_deeply_nested_input
         ] )
     ; ( "json_extractor_deep"
       , [ Alcotest.test_case "parse array" `Quick test_json_extractor_array

--- a/test/test_structured_ext.ml
+++ b/test/test_structured_ext.ml
@@ -1,16 +1,14 @@
 (** Extended coverage tests for Structured module pure functions.
-    Targets: json_extractor, text_extractor, schema_to_tool_json. *)
+    Targets: json_extractor, text_extractor, schema_to_json_schema. *)
 
 open Alcotest
 open Agent_sdk
 
-(* ── schema_to_tool_json ─────────────────────────────── *)
+(* ── schema_to_json_schema ─────────────────────────────── *)
 
 let test_schema_basic () =
   let schema : int Structured.schema =
-    { name = "get_count"
-    ; description = "Returns a count"
-    ; params =
+    { params =
         [ { name = "value"
           ; param_type = Types.Integer
           ; description = "the count"
@@ -23,21 +21,22 @@ let test_schema_basic () =
           Ok (json |> member "value" |> to_int))
     }
   in
-  let json = Structured.schema_to_tool_json schema in
+  let json = Structured.schema_to_json_schema schema in
   let open Yojson.Safe.Util in
-  check string "name" "get_count" (json |> member "name" |> to_string);
-  check string "description" "Returns a count" (json |> member "description" |> to_string);
-  let input_schema = json |> member "input_schema" in
-  check string "type" "object" (input_schema |> member "type" |> to_string);
-  let required = input_schema |> member "required" |> to_list in
+  check string "type" "object" (json |> member "type" |> to_string);
+  let properties = json |> member "properties" in
+  check
+    string
+    "value type"
+    "integer"
+    (properties |> member "value" |> member "type" |> to_string);
+  let required = json |> member "required" |> to_list in
   check int "1 required" 1 (List.length required)
 ;;
 
 let test_schema_no_required () =
   let schema : string Structured.schema =
-    { name = "optional_tool"
-    ; description = "All optional"
-    ; params =
+    { params =
         [ { name = "hint"
           ; param_type = Types.String
           ; description = "optional hint"
@@ -47,23 +46,17 @@ let test_schema_no_required () =
     ; parse = (fun _ -> Ok "ok")
     }
   in
-  let json = Structured.schema_to_tool_json schema in
+  let json = Structured.schema_to_json_schema schema in
   let open Yojson.Safe.Util in
-  let required = json |> member "input_schema" |> member "required" |> to_list in
+  let required = json |> member "required" |> to_list in
   check int "0 required" 0 (List.length required)
 ;;
 
 let test_schema_empty_params () =
-  let schema : unit Structured.schema =
-    { name = "no_params"
-    ; description = "No parameters"
-    ; params = []
-    ; parse = (fun _ -> Ok ())
-    }
-  in
-  let json = Structured.schema_to_tool_json schema in
+  let schema : unit Structured.schema = { params = []; parse = (fun _ -> Ok ()) } in
+  let json = Structured.schema_to_json_schema schema in
   let open Yojson.Safe.Util in
-  let props = json |> member "input_schema" |> member "properties" in
+  let props = json |> member "properties" in
   check
     bool
     "empty properties"
@@ -72,65 +65,6 @@ let test_schema_empty_params () =
      | `Assoc [] -> true
      | _ -> false)
 ;;
-
-(* ── extract_tool_input ──────────────────────────────── *)
-
-let int_schema : int Structured.schema =
-  { name = "get_number"
-  ; description = "Returns a number"
-  ; params = []
-  ; parse =
-      (fun json ->
-        let open Yojson.Safe.Util in
-        Ok (json |> member "value" |> to_int))
-  }
-;;
-
-let test_extract_found () =
-  let content =
-    [ Types.Text "thinking..."
-    ; Types.ToolUse
-        { id = "t1"; name = "get_number"; input = `Assoc [ "value", `Int 42 ] }
-    ]
-  in
-  match Structured.extract_tool_input ~schema:int_schema content with
-  | Ok v -> check int "value" 42 v
-  | Error _ -> fail "expected Ok"
-;;
-
-let test_extract_not_found () =
-  let content = [ Types.Text "no tools here" ] in
-  match Structured.extract_tool_input ~schema:int_schema content with
-  | Ok _ -> fail "expected Error"
-  | Error _ -> ()
-;;
-
-let test_extract_wrong_name () =
-  let content =
-    [ Types.ToolUse
-        { id = "t1"; name = "wrong_tool"; input = `Assoc [ "value", `Int 42 ] }
-    ]
-  in
-  match Structured.extract_tool_input ~schema:int_schema content with
-  | Ok _ -> fail "expected Error for wrong name"
-  | Error _ -> ()
-;;
-
-let test_extract_parse_error () =
-  let bad_schema : int Structured.schema =
-    { name = "get_number"
-    ; description = ""
-    ; params = []
-    ; parse = (fun _ -> Error "parse failed")
-    }
-  in
-  let content = [ Types.ToolUse { id = "t1"; name = "get_number"; input = `Assoc [] } ] in
-  match Structured.extract_tool_input ~schema:bad_schema content with
-  | Ok _ -> fail "expected Error"
-  | Error _ -> ()
-;;
-
-(* ── json_extractor ──────────────────────────────────── *)
 
 let test_json_extractor_valid () =
   let extract =
@@ -260,16 +194,10 @@ let test_text_extractor_empty () =
 let () =
   run
     "structured_ext"
-    [ ( "schema_to_tool_json"
+    [ ( "schema_to_json_schema"
       , [ test_case "basic" `Quick test_schema_basic
         ; test_case "no required" `Quick test_schema_no_required
         ; test_case "empty params" `Quick test_schema_empty_params
-        ] )
-    ; ( "extract_tool_input"
-      , [ test_case "found" `Quick test_extract_found
-        ; test_case "not found" `Quick test_extract_not_found
-        ; test_case "wrong name" `Quick test_extract_wrong_name
-        ; test_case "parse error" `Quick test_extract_parse_error
         ] )
     ; ( "json_extractor"
       , [ test_case "valid" `Quick test_json_extractor_valid

--- a/test/test_structured_stream.ml
+++ b/test/test_structured_stream.ml
@@ -1,58 +1,10 @@
 (** Tests for Structured output + SSE streaming integration.
 
-    Verifies that emit_synthetic_events, parse_sse_event, and
-    extract_tool_input compose correctly for the structured output
-    streaming pattern (extract_stream). *)
+    Verifies that emit_synthetic_events and parse_sse_event compose correctly
+    for the structured output streaming pattern (extract_stream). *)
 
 open Agent_sdk
 open Types
-
-(* ── Schemas ─────────────────────────────────────────────────────── *)
-
-let person_schema : (string * int) Structured.schema =
-  { name = "extract_person"
-  ; description = "Extract person info"
-  ; params =
-      [ { name = "name"
-        ; description = "Person name"
-        ; param_type = String
-        ; required = true
-        }
-      ; { name = "age"
-        ; description = "Person age"
-        ; param_type = Integer
-        ; required = true
-        }
-      ]
-  ; parse =
-      (fun json ->
-        let open Yojson.Safe.Util in
-        try
-          let name = json |> member "name" |> to_string in
-          let age = json |> member "age" |> to_int in
-          Ok (name, age)
-        with
-        | exn -> Error (Printexc.to_string exn))
-  }
-;;
-
-let color_schema : string Structured.schema =
-  { name = "extract_color"
-  ; description = "Extract color"
-  ; params =
-      [ { name = "color"
-        ; description = "Color name"
-        ; param_type = String
-        ; required = true
-        }
-      ]
-  ; parse =
-      (fun json ->
-        let open Yojson.Safe.Util in
-        try Ok (json |> member "color" |> to_string) with
-        | exn -> Error (Printexc.to_string exn))
-  }
-;;
 
 (* ── Helpers ─────────────────────────────────────────────────────── *)
 
@@ -202,42 +154,6 @@ let test_tool_use_json_parseable () =
 
 (* ── 4. multiple_schemas ─────────────────────────────────────────── *)
 
-let test_multiple_schemas () =
-  let person_json = Structured.schema_to_tool_json person_schema in
-  let color_json = Structured.schema_to_tool_json color_schema in
-  let open Yojson.Safe.Util in
-  Alcotest.(check string)
-    "person"
-    "extract_person"
-    (person_json |> member "name" |> to_string);
-  Alcotest.(check string)
-    "color"
-    "extract_color"
-    (color_json |> member "name" |> to_string);
-  (* extract_tool_input picks the matching schema *)
-  let content =
-    [ ToolUse
-        { id = "tu_p"
-        ; name = "extract_person"
-        ; input = `Assoc [ "name", `String "X"; "age", `Int 1 ]
-        }
-    ; ToolUse
-        { id = "tu_c"
-        ; name = "extract_color"
-        ; input = `Assoc [ "color", `String "blue" ]
-        }
-    ]
-  in
-  (match Structured.extract_tool_input ~schema:color_schema content with
-   | Ok color -> Alcotest.(check string) "color matched" "blue" color
-   | Error e -> Alcotest.fail ("color error: " ^ Error.to_string e));
-  match Structured.extract_tool_input ~schema:person_schema content with
-  | Ok (name, _) -> Alcotest.(check string) "person matched" "X" name
-  | Error e -> Alcotest.fail ("person error: " ^ Error.to_string e)
-;;
-
-(* ── 5. accumulate_json_deltas ───────────────────────────────────── *)
-
 let test_accumulate_json_deltas () =
   let parts = [ {|{"name"|}; {|: "Alice"|}; {|, "age": 30}|} ] in
   let buf = Buffer.create 64 in
@@ -287,99 +203,6 @@ let test_accumulate_partial_then_complete () =
 
 (* ── 8. extract_after_accumulation ───────────────────────────────── *)
 
-let test_extract_after_accumulation () =
-  (* Full roundtrip: schema → synthetic events → accumulate → parse *)
-  let input_json = `Assoc [ "name", `String "Zoe"; "age", `Int 28 ] in
-  let response =
-    make_tool_response ~tool_id:"tu_rt" ~tool_name:"extract_person" ~input_json
-  in
-  (* Step 1: emit synthetic events and accumulate InputJsonDelta *)
-  let blocks : (int, Buffer.t) Hashtbl.t = Hashtbl.create 4 in
-  let block_types : (int, string) Hashtbl.t = Hashtbl.create 4 in
-  let block_tool_ids : (int, string) Hashtbl.t = Hashtbl.create 4 in
-  let block_tool_names : (int, string) Hashtbl.t = Hashtbl.create 4 in
-  Llm_provider.Streaming.emit_synthetic_events response (fun evt ->
-    match evt with
-    | ContentBlockStart { index; content_type; tool_id; tool_name } ->
-      Hashtbl.replace block_types index content_type;
-      Hashtbl.replace blocks index (Buffer.create 64);
-      (match tool_id with
-       | Some id -> Hashtbl.replace block_tool_ids index id
-       | None -> ());
-      (match tool_name with
-       | Some n -> Hashtbl.replace block_tool_names index n
-       | None -> ())
-    | ContentBlockDelta { index; delta } ->
-      let buf =
-        match Hashtbl.find_opt blocks index with
-        | Some b -> b
-        | None ->
-          let b = Buffer.create 64 in
-          Hashtbl.replace blocks index b;
-          b
-      in
-      (match delta with
-       | InputJsonDelta s -> Buffer.add_string buf s
-       | InputJsonSnapshot s ->
-         Buffer.clear buf;
-         Buffer.add_string buf s
-       | TextDelta s -> Buffer.add_string buf s
-       | ThinkingDelta s -> Buffer.add_string buf s
-       | ReasoningDetailsDelta { reasoning_content = Some s; _ } ->
-         Buffer.add_string buf s
-       | ReasoningDetailsDelta { reasoning_content = None; _ } -> ()
-       | MediaDelta { data; _ } -> Buffer.add_string buf data
-       | ThinkingSignatureDelta _ -> ())
-    | _ -> ());
-  (* Step 2: reconstruct content blocks (same as streaming.ml) *)
-  let content =
-    Hashtbl.fold
-      (fun index ctype acc ->
-         let text =
-           match Hashtbl.find_opt blocks index with
-           | Some buf -> Buffer.contents buf
-           | None -> ""
-         in
-         let block =
-           match ctype with
-           | "tool_use" ->
-             let tid =
-               match Hashtbl.find_opt block_tool_ids index with
-               | Some id -> id
-               | None -> ""
-             in
-             let tname =
-               match Hashtbl.find_opt block_tool_names index with
-               | Some n -> n
-               | None -> ""
-             in
-             (try
-                Some
-                  (ToolUse
-                     { id = tid; name = tname; input = Yojson.Safe.from_string text })
-              with
-              | Yojson.Json_error _ -> None)
-           | "text" -> Some (Text text)
-           | _ -> None
-         in
-         match block with
-         | Some b -> (index, b) :: acc
-         | None -> acc)
-      block_types
-      []
-    |> List.sort (fun (a, _) (b, _) -> compare a b)
-    |> List.map snd
-  in
-  (* Step 3: extract using schema *)
-  match Structured.extract_tool_input ~schema:person_schema content with
-  | Ok (name, age) ->
-    Alcotest.(check string) "roundtrip name" "Zoe" name;
-    Alcotest.(check int) "roundtrip age" 28 age
-  | Error e -> Alcotest.fail ("roundtrip error: " ^ Error.to_string e)
-;;
-
-(* ── Suite ────────────────────────────────────────────────────────── *)
-
 let () =
   Alcotest.run
     "structured_stream"
@@ -388,8 +211,6 @@ let () =
         ; Alcotest.test_case "callback fires" `Quick test_on_event_callback_fires
         ; Alcotest.test_case "json parseable" `Quick test_tool_use_json_parseable
         ] )
-    ; ( "schema_selection"
-      , [ Alcotest.test_case "multiple schemas" `Quick test_multiple_schemas ] )
     ; ( "delta_accumulation"
       , [ Alcotest.test_case "multi-fragment" `Quick test_accumulate_json_deltas
         ; Alcotest.test_case "empty delta" `Quick test_accumulate_empty_delta
@@ -397,12 +218,6 @@ let () =
             "partial then complete"
             `Quick
             test_accumulate_partial_then_complete
-        ] )
-    ; ( "roundtrip"
-      , [ Alcotest.test_case
-            "extract after accumulation"
-            `Quick
-            test_extract_after_accumulation
         ] )
     ]
 ;;


### PR DESCRIPTION
## Scope

Hard-cut the unused forced-tool Structured contract. This is intentionally stacked on #2858 because both changes touch the structured-output boundary.

- remove `Structured.schema_to_tool_json` and `Structured.extract_tool_input`
- remove the now-unread `Structured.schema.name` and `description` fields
- retain only provider-native JSON Schema generation and typed response parsing
- remove compatibility-only tests; keep current direct, Agent-level, and streaming Feature coverage
- update the runtime output surface inventory and changelog

## Feature / Gate audit

Production callers of the removed helpers: **0**. The removed name/description fields were consumed only by the removed tool wrapper. Current Feature entry points remain `schema_to_json_schema`, `extract`, `extract_stream`, and `schema_extractor`. No adapter, migration, fallback, or replacement Gate is added.

Blast radius: public Structured schema constructors must stop supplying the two unused fields. Internal/current callers and tests are updated atomically.

## Verification

- `scripts/dune-local.sh build test/test_structured.exe test/test_structured_ext.exe test/test_structured_deep.exe test/test_structured_coverage.exe test/test_structured_stream.exe test/test_full_pipeline_cov.exe @fmt`
- Structured focused suites: 19 + 10 + 9 + 12 + 6 tests passed
- `test_full_pipeline_cov.exe`: 16/16 passed (loopback run outside sandbox)
- `bash scripts/ci-code-smell-ratchet.sh --check`
- `bash scripts/hardening-ratchet.sh --check`
- `jq empty docs/schema-surfaces/runtime-output-surfaces.v1.json`

RATCHET-WAIVED: no