### PR TITLE
fix(eval)!: reject incomplete metric comparisons

### DIFF
--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -111,8 +111,19 @@ type metric_goal =
 type metric_spec =
   { name : string
   ; goal : metric_goal
-  ; tolerance_pct : float option
+  ; tolerance_pct : float
   }
+
+type comparison_error =
+  | Duplicate_metric_spec of string
+  | Duplicate_baseline_metric of string
+  | Duplicate_candidate_metric of string
+  | Missing_baseline_metric of string
+  | Missing_candidate_metric of string
+  | Invalid_tolerance_pct of
+      { metric_name : string
+      ; tolerance_pct : float
+      }
 
 (* ── Run metrics ──────────────────────────────────────────────── *)
 
@@ -310,39 +321,62 @@ let compute_delta_for_goal
 ;;
 
 let compare_with_specs ~specs ~(baseline : run_metrics) ~(candidate : run_metrics) =
-  let deltas =
-    List.filter_map
-      (fun (bm : metric) ->
-         match
-           ( List.find_opt (fun (spec : metric_spec) -> spec.name = bm.name) specs
-           , List.find_opt (fun (cm : metric) -> cm.name = bm.name) candidate.metrics )
-         with
-         | Some spec, Some cm ->
-           let threshold_pct =
-             Option.value spec.tolerance_pct ~default:default_delta_threshold_pct
-           in
-           let direction, delta_pct =
-             compute_delta_for_goal
-               ~threshold_pct
-               ~goal:spec.goal
-               ~baseline_val:bm.value
-               ~candidate_val:cm.value
-               ()
-           in
-           Some
-             { metric_name = bm.name
-             ; baseline_value = bm.value
-             ; candidate_value = cm.value
-             ; direction
-             ; delta_pct
-             }
-         | None, _ | _, None -> None)
-      baseline.metrics
+  let find_unique_metric ~duplicate_error ~missing_error name metrics =
+    match List.filter (fun (metric : metric) -> String.equal metric.name name) metrics with
+    | [] -> Error (missing_error name)
+    | [ metric ] -> Ok metric
+    | _ -> Error (duplicate_error name)
   in
+  let rec collect seen deltas = function
+    | [] -> Ok (List.rev deltas)
+    | (spec : metric_spec) :: rest ->
+      if List.exists (String.equal spec.name) seen
+      then Error (Duplicate_metric_spec spec.name)
+      else if spec.tolerance_pct < 0.0 || not (Float.is_finite spec.tolerance_pct)
+      then
+        Error
+          (Invalid_tolerance_pct
+             { metric_name = spec.name; tolerance_pct = spec.tolerance_pct })
+      else (
+        let ( let* ) = Result.bind in
+        let* baseline_metric =
+          find_unique_metric
+            ~duplicate_error:(fun name -> Duplicate_baseline_metric name)
+            ~missing_error:(fun name -> Missing_baseline_metric name)
+            spec.name
+            baseline.metrics
+        in
+        let* candidate_metric =
+          find_unique_metric
+            ~duplicate_error:(fun name -> Duplicate_candidate_metric name)
+            ~missing_error:(fun name -> Missing_candidate_metric name)
+            spec.name
+            candidate.metrics
+        in
+        let direction, delta_pct =
+          compute_delta_for_goal
+            ~threshold_pct:spec.tolerance_pct
+            ~goal:spec.goal
+            ~baseline_val:baseline_metric.value
+            ~candidate_val:candidate_metric.value
+            ()
+        in
+        let delta =
+          { metric_name = spec.name
+          ; baseline_value = baseline_metric.value
+          ; candidate_value = candidate_metric.value
+          ; direction
+          ; delta_pct
+          }
+        in
+        collect (spec.name :: seen) (delta :: deltas) rest)
+  in
+  let ( let* ) = Result.bind in
+  let* deltas = collect [] [] specs in
   let regressions = List.filter (fun d -> d.direction = Regression) deltas in
   let improvements = List.filter (fun d -> d.direction = Improvement) deltas in
   let unchanged = List.filter (fun d -> d.direction = Unchanged) deltas in
-  { baseline; candidate; regressions; improvements; unchanged }
+  Ok { baseline; candidate; regressions; improvements; unchanged }
 ;;
 
 (* ── Threshold checking ───────────────────────────────────────── *)

--- a/lib/eval.mli
+++ b/lib/eval.mli
@@ -48,8 +48,19 @@ type metric_goal =
 type metric_spec =
   { name : string
   ; goal : metric_goal
-  ; tolerance_pct : float option
+  ; tolerance_pct : float
   }
+
+type comparison_error =
+  | Duplicate_metric_spec of string
+  | Duplicate_baseline_metric of string
+  | Duplicate_candidate_metric of string
+  | Missing_baseline_metric of string
+  | Missing_candidate_metric of string
+  | Invalid_tolerance_pct of
+      { metric_name : string
+      ; tolerance_pct : float
+      }
 
 (** {1 Run metrics} *)
 
@@ -118,14 +129,14 @@ val compute_delta
   -> unit
   -> change_direction * float option
 
-(** Compare the metrics selected by [specs]. A metric is compared only when it
-    exists in both runs and has a matching spec; [goal] and [tolerance_pct] are
-    therefore the single comparison policy for every returned delta. *)
+(** Compare exactly the metrics selected by [specs]. Every selected metric must
+    occur exactly once in each run, every spec name must be unique, and every
+    tolerance must be finite and non-negative. *)
 val compare_with_specs
   :  specs:metric_spec list
   -> baseline:run_metrics
   -> candidate:run_metrics
-  -> comparison
+  -> (comparison, comparison_error) result
 
 (** {1 Threshold checking} *)
 

--- a/test/test_eval.ml
+++ b/test/test_eval.ml
@@ -89,11 +89,22 @@ let test_collector_verdict () =
 
 (* ── comparison tests ─────────────────────────────────────────── *)
 
+let comparison_or_fail = function
+  | Ok comparison -> comparison
+  | Error _ -> Alcotest.fail "expected comparison"
+;;
+
 let test_compare_regression () =
   let baseline = mk_run_metrics [ mk_metric "latency" (Float_val 100.0) ] in
   let candidate = mk_run_metrics ~run_id:"r2" [ mk_metric "latency" (Float_val 120.0) ] in
-  let specs = [ { Eval.name = "latency"; goal = Lower; tolerance_pct = None } ] in
-  let cmp = Eval.compare_with_specs ~specs ~baseline ~candidate in
+  let specs =
+    [ { Eval.name = "latency"
+      ; goal = Lower
+      ; tolerance_pct = Eval.default_delta_threshold_pct
+      }
+    ]
+  in
+  let cmp = Eval.compare_with_specs ~specs ~baseline ~candidate |> comparison_or_fail in
   Alcotest.(check int) "regressions" 1 (List.length cmp.regressions);
   Alcotest.(check int) "improvements" 0 (List.length cmp.improvements)
 ;;
@@ -101,8 +112,14 @@ let test_compare_regression () =
 let test_compare_improvement () =
   let baseline = mk_run_metrics [ mk_metric "latency" (Float_val 100.0) ] in
   let candidate = mk_run_metrics ~run_id:"r2" [ mk_metric "latency" (Float_val 80.0) ] in
-  let specs = [ { Eval.name = "latency"; goal = Lower; tolerance_pct = None } ] in
-  let cmp = Eval.compare_with_specs ~specs ~baseline ~candidate in
+  let specs =
+    [ { Eval.name = "latency"
+      ; goal = Lower
+      ; tolerance_pct = Eval.default_delta_threshold_pct
+      }
+    ]
+  in
+  let cmp = Eval.compare_with_specs ~specs ~baseline ~candidate |> comparison_or_fail in
   Alcotest.(check int) "regressions" 0 (List.length cmp.regressions);
   Alcotest.(check int) "improvements" 1 (List.length cmp.improvements)
 ;;
@@ -110,8 +127,14 @@ let test_compare_improvement () =
 let test_compare_unchanged () =
   let baseline = mk_run_metrics [ mk_metric "score" (Float_val 0.95) ] in
   let candidate = mk_run_metrics ~run_id:"r2" [ mk_metric "score" (Float_val 0.96) ] in
-  let specs = [ { Eval.name = "score"; goal = Higher; tolerance_pct = None } ] in
-  let cmp = Eval.compare_with_specs ~specs ~baseline ~candidate in
+  let specs =
+    [ { Eval.name = "score"
+      ; goal = Higher
+      ; tolerance_pct = Eval.default_delta_threshold_pct
+      }
+    ]
+  in
+  let cmp = Eval.compare_with_specs ~specs ~baseline ~candidate |> comparison_or_fail in
   Alcotest.(check int) "unchanged" 1 (List.length cmp.unchanged)
 ;;
 
@@ -119,9 +142,9 @@ let test_compare_with_specs_higher_is_better () =
   let baseline = mk_run_metrics [ mk_metric "accuracy" (Float_val 0.90) ] in
   let candidate = mk_run_metrics ~run_id:"r2" [ mk_metric "accuracy" (Float_val 0.95) ] in
   let specs =
-    [ { Eval.name = "accuracy"; goal = Eval.Higher; tolerance_pct = Some 1.0 } ]
+    [ { Eval.name = "accuracy"; goal = Eval.Higher; tolerance_pct = 1.0 } ]
   in
-  let cmp = Eval.compare_with_specs ~specs ~baseline ~candidate in
+  let cmp = Eval.compare_with_specs ~specs ~baseline ~candidate |> comparison_or_fail in
   Alcotest.(check int) "improvements" 1 (List.length cmp.improvements);
   Alcotest.(check int) "regressions" 0 (List.length cmp.regressions)
 ;;
@@ -137,11 +160,21 @@ let test_compare_with_specs_excludes_unspecified_metrics () =
       [ mk_metric "accuracy" (Float_val 0.95); mk_metric "latency" (Float_val 200.0) ]
   in
   let specs =
-    [ { Eval.name = "accuracy"; goal = Eval.Higher; tolerance_pct = Some 1.0 } ]
+    [ { Eval.name = "accuracy"; goal = Eval.Higher; tolerance_pct = 1.0 } ]
   in
-  let cmp = Eval.compare_with_specs ~specs ~baseline ~candidate in
+  let cmp = Eval.compare_with_specs ~specs ~baseline ~candidate |> comparison_or_fail in
   Alcotest.(check int) "selected improvement" 1 (List.length cmp.improvements);
   Alcotest.(check int) "unspecified regression excluded" 0 (List.length cmp.regressions)
+;;
+
+let test_compare_rejects_invalid_tolerance () =
+  let baseline = mk_run_metrics [ mk_metric "latency" (Float_val 100.0) ] in
+  let candidate = mk_run_metrics ~run_id:"r2" [ mk_metric "latency" (Float_val 101.0) ] in
+  let specs = [ { Eval.name = "latency"; goal = Lower; tolerance_pct = Float.nan } ] in
+  match Eval.compare_with_specs ~specs ~baseline ~candidate with
+  | Error (Eval.Invalid_tolerance_pct { metric_name; _ }) ->
+    Alcotest.(check string) "metric name" "latency" metric_name
+  | Ok _ | Error _ -> Alcotest.fail "expected Invalid_tolerance_pct"
 ;;
 
 (* ── threshold tests ──────────────────────────────────────────── *)
@@ -231,6 +264,10 @@ let () =
             "unspecified metrics excluded"
             `Quick
             test_compare_with_specs_excludes_unspecified_metrics
+        ; Alcotest.test_case
+            "invalid tolerance rejected"
+            `Quick
+            test_compare_rejects_invalid_tolerance
         ] )
     ; ( "threshold"
       , [ Alcotest.test_case "pass" `Quick test_threshold_pass

--- a/test/test_eval_coverage.ml
+++ b/test/test_eval_coverage.ml
@@ -280,14 +280,20 @@ let test_compare_missing_candidate_metric () =
   in
   let candidate = mk_run ~run_id:"r2" [ mk_metric "a" (Float_val 1.0) ] in
   let specs =
-    [ { Eval.name = "a"; goal = Lower; tolerance_pct = None }
-    ; { Eval.name = "b"; goal = Lower; tolerance_pct = None }
+    [ { Eval.name = "a"
+      ; goal = Lower
+      ; tolerance_pct = Eval.default_delta_threshold_pct
+      }
+    ; { Eval.name = "b"
+      ; goal = Lower
+      ; tolerance_pct = Eval.default_delta_threshold_pct
+      }
     ]
   in
-  let cmp = Eval.compare_with_specs ~specs ~baseline ~candidate in
-  (* "b" is in baseline but not candidate -- it is simply absent from deltas
-     because compare only iterates baseline metrics and filters by candidate *)
-  Alcotest.(check int) "unchanged" 1 (List.length cmp.unchanged)
+  match Eval.compare_with_specs ~specs ~baseline ~candidate with
+  | Error (Eval.Missing_candidate_metric name) ->
+    Alcotest.(check string) "missing metric" "b" name
+  | Ok _ | Error _ -> Alcotest.fail "expected Missing_candidate_metric"
 ;;
 
 (* ── compare: string metric unchanged ─────────────────── *)
@@ -295,9 +301,10 @@ let test_compare_missing_candidate_metric () =
 let test_compare_string_metric () =
   let baseline = mk_run [ mk_metric "name" (String_val "test") ] in
   let candidate = mk_run ~run_id:"r2" [ mk_metric "name" (String_val "test") ] in
-  let specs = [ { Eval.name = "name"; goal = Exact; tolerance_pct = None } ] in
-  let cmp = Eval.compare_with_specs ~specs ~baseline ~candidate in
-  Alcotest.(check int) "unchanged" 1 (List.length cmp.unchanged)
+  let specs = [ { Eval.name = "name"; goal = Exact; tolerance_pct = 0.0 } ] in
+  match Eval.compare_with_specs ~specs ~baseline ~candidate with
+  | Ok cmp -> Alcotest.(check int) "unchanged" 1 (List.length cmp.unchanged)
+  | Error _ -> Alcotest.fail "expected comparison"
 ;;
 
 (* ── threshold: no matching metric ────────────────────── *)


### PR DESCRIPTION
## 문제

병합된 #2854의 `compare_with_specs`가 선택된 metric이 baseline/candidate에 없거나 중복돼도 성공 결과에서 조용히 제외했어용. `tolerance_pct = None`도 내부 5% default로 바뀌어 호출자가 선택하지 않은 정책이 적용됐어용.

## 수정

- tolerance를 필수 finite/non-negative 값으로 만들었어용.
- 선택 metric의 누락·중복과 spec 중복을 typed `comparison_error`로 반환해용.
- 비교는 baseline 전체가 아니라 명시된 spec 목록만 순회해용.
- 누락을 성공으로 고정하던 테스트를 typed error 검증으로 교체했어용.

## 검증

- `ocamlformat --check` — PASS
- `ocamlc -stop-after parsing` — PASS
- `git diff --check` — PASS
- 로컬 Dune은 실행하지 않았고 exact-head CI를 기준으로 확인해용.

[근거] #2854 merge head `940a32afaa8f47e0e6870f331a5a9221ac816a1e` + OCaml 5.4 Float 공식 문서 https://ocaml.org/manual/5.4/api/Float.html, 2026-07-29 확인, 신뢰도 High.