### PR TITLE
fix(checkpoint)!: hard-cut current schema to v9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,9 @@ constructors return canonical `Tool.t` values directly, and the secondary
 typed runtime representation, erasure bridge, and unused agent-tool raw input
 field have been removed.
 
-* **checkpoint persistence:** accept only the exact current v8 checkpoint
-  schema. Released v5/v6 artifacts must be reset rather than migrated at
-  runtime.
+* **checkpoint persistence:** accept only the exact current v9 checkpoint
+  schema. All earlier artifacts, including released v8, must be reset rather
+  than migrated at runtime.
 * **provider tools:** reject historical OpenAI `parameters` lists; current
   callers must supply `input_schema` or an already-provider-shaped JSON Schema
   object.

--- a/lib/checkpoint.mli
+++ b/lib/checkpoint.mli
@@ -98,10 +98,10 @@ type delta =
 (** {1 Serialization} *)
 
 (** Serialize an exact current checkpoint to JSON. Raises [Invalid_argument]
-    when a manually constructed value violates the v8 contract. *)
+    when a manually constructed value violates the v9 contract. *)
 val to_json : t -> Yojson.Safe.t
 
-(** Deserialize only the exact current v8 checkpoint schema. Every other
+(** Deserialize only the exact current v9 checkpoint schema. Every other
     version is rejected. *)
 val of_json : Yojson.Safe.t -> (t, Error.sdk_error) result
 
@@ -122,7 +122,7 @@ val delta_of_json : Yojson.Safe.t -> (delta, Error.sdk_error) result
 val compute_delta : t -> t -> delta
 
 (** Apply a delta to a base checkpoint. Both the base and resulting checkpoint
-    must satisfy the exact current v8 contract. *)
+    must satisfy the exact current v9 contract. *)
 val apply_delta : t -> delta -> (t, Error.sdk_error) result
 
 (** {1 Queries} *)

--- a/lib/checkpoint_codec.ml
+++ b/lib/checkpoint_codec.ml
@@ -495,12 +495,12 @@ let checkpoint_to_json cp =
 ;;
 
 let validate_checkpoint cp =
-  Checkpoint_v8_contract.validate_v8_json (checkpoint_to_json cp)
+  Checkpoint_v9_contract.validate_v9_json (checkpoint_to_json cp)
 ;;
 
 let validated_checkpoint_json_exn ~scope cp =
   let json = checkpoint_to_json cp in
-  match Checkpoint_v8_contract.validate_v8_json json with
+  match Checkpoint_v9_contract.validate_v9_json json with
   | Ok () -> json
   | Error error -> invalid_arg (scope ^ ": " ^ Error.to_string error)
 ;;
@@ -765,7 +765,7 @@ let to_json cp = validated_checkpoint_json_exn ~scope:"Checkpoint.to_json" cp
 let decode_current_json json =
   try
     let open Yojson.Safe.Util in
-    let* () = Checkpoint_v8_contract.validate_v8_json json in
+    let* () = Checkpoint_v9_contract.validate_v9_json json in
     let* tool_choice =
       match json |> member "tool_choice" with
       | `Null -> Ok None

--- a/lib/checkpoint_types.ml
+++ b/lib/checkpoint_types.ml
@@ -1,6 +1,6 @@
 open Types
 
-let checkpoint_version = 8
+let checkpoint_version = 9
 
 type t =
   { version : int

--- a/lib/checkpoint_v9_contract.ml
+++ b/lib/checkpoint_v9_contract.ml
@@ -1,9 +1,9 @@
-(** Exact validator for the current checkpoint-v8 persistence schema. *)
+(** Exact validator for the current checkpoint-v9 persistence schema. *)
 
 open Result_syntax
 
-let target_version = 8
-let checkpoint_scope = "Checkpoint v8"
+let target_version = Checkpoint_types.checkpoint_version
+let checkpoint_scope = "Checkpoint v9"
 
 let json_errorf format =
   Printf.ksprintf
@@ -310,7 +310,7 @@ let validate_pricing_gap ~scope = function
 ;;
 
 let validate_current_usage json =
-  let scope = "Checkpoint v8 usage" in
+  let scope = "Checkpoint v9 usage" in
   let* fields =
     validate_object_shape ~scope ~required:current_usage_fields ~optional:[] json
   in
@@ -676,7 +676,7 @@ let validate_common_checkpoint_fields ~scope fields =
   validate_unique_object ~scope:(scope ^ ".context") context
 ;;
 
-let validate_v8_json json =
+let validate_v9_json json =
   let scope = checkpoint_scope in
   let* fields =
     validate_object_shape ~scope ~required:current_checkpoint_fields ~optional:[] json

--- a/test/test_checkpoint.ml
+++ b/test/test_checkpoint.ml
@@ -180,13 +180,13 @@ let () =
   run
     "Checkpoint"
     [ ( "version"
-      , [ test_case "checkpoint_version is 8" `Quick (fun () ->
-            check int "version" 8 Checkpoint.checkpoint_version)
+      , [ test_case "checkpoint_version is 9" `Quick (fun () ->
+            check int "version" 9 Checkpoint.checkpoint_version)
         ; test_case "version field in to_json" `Quick (fun () ->
             let cp = make_checkpoint () in
             let json = Checkpoint.to_json cp in
             let v = Yojson.Safe.Util.(json |> member "version" |> to_int) in
-            check int "version" 8 v)
+            check int "version" 9 v)
         ; test_case "wrong version returns Error" `Quick (fun () ->
             let cp = make_checkpoint () in
             let json = Checkpoint.to_json cp in
@@ -232,6 +232,17 @@ let () =
             | Error (Error.Serialization (Error.VersionMismatch { got = 7; _ })) -> ()
             | Error error -> fail ("unexpected error: " ^ Error.to_string error)
             | Ok _ -> fail "checkpoint v7 must be rejected")
+        ; test_case "released v8 is rejected" `Quick (fun () ->
+            let json =
+              match Checkpoint.to_json (make_checkpoint ()) with
+              | `Assoc fields ->
+                `Assoc (("version", `Int 8) :: List.remove_assoc "version" fields)
+              | _ -> fail "current checkpoint serializer must return an object"
+            in
+            match Checkpoint.of_json json with
+            | Error (Error.Serialization (Error.VersionMismatch { got = 8; _ })) -> ()
+            | Error error -> fail ("unexpected error: " ^ Error.to_string error)
+            | Ok _ -> fail "checkpoint v8 must be rejected")
         ; test_case "missing version is rejected explicitly" `Quick (fun () ->
             match Checkpoint.of_json (`Assoc []) with
             | Error (Error.Serialization (Error.JsonParseError { detail })) ->
@@ -1333,7 +1344,7 @@ let () =
               | other -> other
             in
             check bool "error" true (Result.is_error (Checkpoint.of_json bad)))
-        ; test_case "current v8 rejects unknown nested message field" `Quick (fun () ->
+        ; test_case "current v9 rejects unknown nested message field" `Quick (fun () ->
             let message : Types.message =
               { role = Types.User
               ; content = [ Types.Text "hello" ]
@@ -1354,7 +1365,7 @@ let () =
               "unknown message field"
               true
               (Result.is_error (Checkpoint.of_json bad)))
-        ; test_case "current v8 rejects normalized empty metadata" `Quick (fun () ->
+        ; test_case "current v9 rejects normalized empty metadata" `Quick (fun () ->
             let message : Types.message =
               { role = Types.User
               ; content = [ Types.Text "hello" ]
@@ -1371,7 +1382,7 @@ let () =
                    (update_first_json (append_json_field "metadata" (`Assoc [])))
             in
             check bool "empty metadata" true (Result.is_error (Checkpoint.of_json bad)))
-        ; test_case "current v8 preserves blank reasoning content" `Quick (fun () ->
+        ; test_case "current v9 preserves blank reasoning content" `Quick (fun () ->
             let message : Types.message =
               { role = Types.Assistant
               ; content =
@@ -1418,7 +1429,7 @@ let () =
                |> index 0
                |> member "reasoning_content"
                |> to_string))
-        ; test_case "current v8 rejects duplicate nested content field" `Quick (fun () ->
+        ; test_case "current v9 rejects duplicate nested content field" `Quick (fun () ->
             let message : Types.message =
               { role = Types.User
               ; content = [ Types.Text "hello" ]
@@ -1444,7 +1455,7 @@ let () =
               "duplicate content field"
               true
               (Result.is_error (Checkpoint.of_json bad)))
-        ; test_case "current v8 rejects unknown nested tool field" `Quick (fun () ->
+        ; test_case "current v9 rejects unknown nested tool field" `Quick (fun () ->
             let bad =
               make_checkpoint ~tools:[ sample_tool_schema ] ()
               |> Checkpoint.to_json
@@ -1457,7 +1468,7 @@ let () =
               "unknown tool field"
               true
               (Result.is_error (Checkpoint.of_json bad)))
-        ; test_case "current v8 rejects noncanonical response format" `Quick (fun () ->
+        ; test_case "current v9 rejects noncanonical response format" `Quick (fun () ->
             let bad =
               make_checkpoint ()
               |> Checkpoint.to_json
@@ -1468,7 +1479,7 @@ let () =
               "legacy response format"
               true
               (Result.is_error (Checkpoint.of_json bad)))
-        ; test_case "current v8 rejects malformed nested MCP headers" `Quick (fun () ->
+        ; test_case "current v9 rejects malformed nested MCP headers" `Quick (fun () ->
             let session : Mcp_session.info =
               { server_name = "http-tools"
               ; command = "http"
@@ -1488,7 +1499,7 @@ let () =
                    (update_first_json (replace_json_field "http_headers" (`Assoc [])))
             in
             check bool "malformed headers" true (Result.is_error (Checkpoint.of_json bad)))
-        ; test_case "current v8 rejects duplicate context keys" `Quick (fun () ->
+        ; test_case "current v9 rejects duplicate context keys" `Quick (fun () ->
             let bad =
               make_checkpoint ()
               |> Checkpoint.to_json
@@ -1497,7 +1508,7 @@ let () =
                    (`Assoc [ "channel", `String "one"; "channel", `String "two" ])
             in
             check bool "duplicate context" true (Result.is_error (Checkpoint.of_json bad)))
-        ; test_case "current v8 rejects normalized reasoning effort" `Quick (fun () ->
+        ; test_case "current v9 rejects normalized reasoning effort" `Quick (fun () ->
             let bad =
               make_checkpoint ()
               |> Checkpoint.to_json


### PR DESCRIPTION
## 문제

#2851이 released v8의 허용 도메인을 줄였지만 `checkpoint_version = 8`을 유지했어용. 같은 버전인데 이전 artifact가 새 decoder에서 거부돼 consumer가 문맥을 초기화할 수 있었어용.

## 수정

- current checkpoint contract를 v9로 올렸어용.
- v8을 포함한 모든 이전 버전을 명시적으로 거부해용.
- validator/module/docs/tests를 v9로 맞췄어용.
- version 숫자는 `Checkpoint_types.checkpoint_version` 한 곳만 SSOT예용.
- migration·fallback·compatibility reader는 추가하지 않았어용.

## 검증

- `ocamlformat --check` — PASS
- `ocamlc -stop-after parsing` — PASS
- `git diff --check` — PASS
- 로컬 Dune은 실행하지 않았고 exact-head CI를 기준으로 확인해용.

[근거] OAS main #2851 + MASC `worker_container` decode 실패 경로, 2026-07-29 확인, 신뢰도 High.