### PR TITLE
fix(checkpoint): derive v9 diagnostic scope

### DIFF
--- a/lib/checkpoint_v9_contract.ml
+++ b/lib/checkpoint_v9_contract.ml
@@ -3,7 +3,7 @@
 open Result_syntax
 
 let target_version = Checkpoint_types.checkpoint_version
-let checkpoint_scope = "Checkpoint v9"
+let checkpoint_scope = Printf.sprintf "Checkpoint v%d" target_version
 
 let json_errorf format =
   Printf.ksprintf
@@ -310,7 +310,7 @@ let validate_pricing_gap ~scope = function
 ;;
 
 let validate_current_usage json =
-  let scope = "Checkpoint v9 usage" in
+  let scope = checkpoint_scope ^ " usage" in
   let* fields =
     validate_object_shape ~scope ~required:current_usage_fields ~optional:[] json
   in


### PR DESCRIPTION
## 문제

병합된 #2867이 version SSOT는 `Checkpoint_types`로 올렸지만 진단 scope에 `v9` 문자열을 두 번 하드코딩했어용.

## 수정

- `checkpoint_scope`를 `checkpoint_version`에서 파생했어용.
- usage scope도 `checkpoint_scope`에서 파생했어용.

## 검증

- format/parse-only/diff check — PASS
- 로컬 Dune은 실행하지 않았고 CI를 확인해용.

[근거] #2867 merge head `a0bea77cfdabdd5a38cbfdc050ace52e38d2a111`, 2026-07-29 확인, 신뢰도 High.