### PR TITLE
docs(release): correct 0.231.0 hard-cut contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,9 @@ been removed. Binding identities are constructed only from canonical
 ### ⚠ BREAKING CHANGES
 
 * **checkpoint:** hard-cut current schema to v9 ([#2867](https://github.com/jeong-sik/oas/issues/2867))
-* **persistence:** agent_sdk accepts only v8 checkpoints and canonical Tool-role result batches. Older checkpoint formats, non-Tool ToolResult histories, and Agent_tool.create_typed_untyped are unsupported; reset persisted state and use Typed_tool.to_untyped at the direct dispatch boundary.
+* **persistence:** agent_sdk accepts only current v9 checkpoints and canonical Tool-role result batches. Older checkpoint and tool-history formats are unsupported; reset persisted state instead of adding runtime migration code.
+* **provider:** provider-native JSON Schema requests use `response_format` only. The duplicate `output_schema` state and its contradictory-state gates are removed ([#2858](https://github.com/jeong-sik/oas/issues/2858)).
+* **tool:** `Typed_tool` constructors return canonical `Tool.t` values directly. The secondary typed runtime, `Agent_tool.create_typed_untyped`, and `Typed_tool.to_untyped` bridges are removed ([#2853](https://github.com/jeong-sik/oas/issues/2853)).
 
 ### Bug Fixes
 


### PR DESCRIPTION
## 문제

병합·배포된 0.231.0 release note가 현재 v9 hard-cut과 모순되게 v8을 안내하고, 이미 제거된 Typed_tool.to_untyped 사용을 지시해용.

## 수정

- current v9 checkpoint만 허용하며 과거 상태는 runtime migration 없이 reset한다고 명시했어용.
- provider JSON Schema SSOT는 response_format 하나라고 명시했어용.
- Typed_tool constructor가 canonical Tool.t를 직접 반환하며 제거된 bridge를 사용하지 않는다고 명시했어용.

코드나 migration 구현은 추가하지 않았고 CHANGELOG만 바로잡았어용.

## 검증

- git diff --check — PASS
- 문서 전용 변경이라 빌드 대상 없음

[근거] v0.231.0 published release 및 origin/main 2cb7d9226, 2026-07-29 확인, 신뢰도 High.