### PR TITLE
fix(exact-output): keep JSON syntax prompt-only

### DIFF
--- a/lib/llm_provider/exact_output.mli
+++ b/lib/llm_provider/exact_output.mli
@@ -122,7 +122,11 @@ type resolver_snapshot_error =
 
 type minimum_guarantee =
   | Json_syntax
+      (** Prompt-only JSON contract.  OAS appends the schema instruction and
+          validates the response locally; it does not send a provider-native
+          response-format request. *)
   | Provider_schema
+      (** Explicit opt-in to a provider-native schema request. *)
 
 type actual_assurance =
   | Json_syntax_only

--- a/lib/llm_provider/exact_output_ready_admission.ml
+++ b/lib/llm_provider/exact_output_ready_admission.ml
@@ -163,10 +163,14 @@ let schema_for_wire (target : Resolver.selected_target) (Domain_schema domain_sc
 ;;
 
 let response_format (target : Resolver.selected_target) requirement =
-  match
-    Caps.structured_output_support target.capabilities, requirement.minimum_guarantee
-  with
-  | Caps.Native_json_schema, (Json_syntax | Provider_schema) ->
+  match requirement.minimum_guarantee with
+  (* Json_syntax is fulfilled by the prompt plus local parser/validator.  Do
+     not turn a caller's syntax requirement into a provider-native schema
+     request based on incidental target capabilities. *)
+  | Json_syntax -> Ok (Types.Off, Json_syntax_only, None)
+  | Provider_schema ->
+    (match Caps.structured_output_support target.capabilities with
+     | Caps.Native_json_schema ->
     let* () =
       match target.config.kind, requirement.schema with
       | PC.Gemini, Domain_schema schema -> validate_gemini_schema ~path:"$" schema
@@ -178,10 +182,7 @@ let response_format (target : Resolver.selected_target) requirement =
       ( Types.JsonSchema wire_schema
       , Provider_schema_requested
       , Some (fingerprint_schema wire_schema) )
-  | Caps.Json_object_only, Json_syntax -> Ok (Types.JsonMode, Json_syntax_only, None)
-  | Caps.Json_object_only, Provider_schema -> Error Provider_schema_unavailable
-  | Caps.No_structured_output, Provider_schema -> Error Provider_schema_unavailable
-  | Caps.No_structured_output, Json_syntax -> Ok (Types.Off, Json_syntax_only, None)
+     | Caps.Json_object_only | Caps.No_structured_output -> Error Provider_schema_unavailable)
 ;;
 
 let text_json_instruction (Domain_schema schema) : Types.message =

--- a/lib/llm_provider/exact_output_ready_admission.mli
+++ b/lib/llm_provider/exact_output_ready_admission.mli
@@ -9,7 +9,11 @@ type domain_schema
 
 type minimum_guarantee =
   | Json_syntax
+      (** Prompt-only JSON contract.  OAS appends the schema instruction and
+          validates the response locally; it does not send a provider-native
+          response-format request. *)
   | Provider_schema
+      (** Explicit opt-in to a provider-native schema request. *)
 
 type actual_assurance =
   | Json_syntax_only

--- a/test/test_exact_output_flow.ml
+++ b/test/test_exact_output_flow.ml
@@ -663,13 +663,13 @@ let test_later_missing_credential_does_not_block_current_success () =
   | Error _ -> fail "later missing credential blocked the current candidate"
 ;;
 
-let test_json_syntax_uses_strict_text_fallback () =
+let test_json_syntax_is_prompt_only_even_for_native_target () =
   let (result, advances), posts =
     with_counted_server
       ~measurement_reply:(Measurement_tokens 1)
       ~response:(openai_response {|{"name":"accepted"}|})
     @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
-    with_catalog [ catalog_entry ~id:"text-json" ~base_url ~native:false ~json:false () ]
+    with_catalog [ catalog_entry ~id:"text-json" ~base_url ~native:true ~json:true () ]
     @@ fun snapshot ->
     let advances = ref 0 in
     let result =
@@ -685,22 +685,22 @@ let test_json_syntax_uses_strict_text_fallback () =
     in
     result, !advances
   in
-  check int "text fallback skips measurement" 0 posts.measurement_posts;
-  check int "text fallback posts exactly once" 1 posts.generation_posts;
-  check int "successful text fallback does not advance" 0 advances;
+  check int "prompt-only syntax skips measurement" 0 posts.measurement_posts;
+  check int "prompt-only syntax posts exactly once" 1 posts.generation_posts;
+  check int "successful prompt-only syntax does not advance" 0 advances;
   let request =
     match posts.generation_bodies with
     | [ body ] -> Yojson.Safe.from_string body
-    | _ -> fail "text fallback did not retain its single generation body"
+    | _ -> fail "prompt-only syntax did not retain its single generation body"
   in
   (match request with
    | `Assoc fields ->
      check
        bool
-       "text fallback emits no response_format field"
+       "prompt-only syntax emits no response_format field for a native target"
        false
        (List.mem_assoc "response_format" fields)
-   | _ -> fail "text fallback request body was not an object");
+   | _ -> fail "prompt-only syntax request body was not an object");
   let messages = Yojson.Safe.Util.(request |> member "messages" |> to_list) in
   check int "strict JSON instruction is appended last" 2 (List.length messages);
   let instruction =
@@ -721,7 +721,7 @@ let test_json_syntax_uses_strict_text_fallback () =
   | Ok success ->
     check
       string
-      "text fallback candidate serves the request"
+      "prompt-only syntax candidate serves the request"
       "text-json"
       (candidate_id (EO.flow_success_candidate success));
     check
@@ -3955,9 +3955,9 @@ let () =
             `Quick
             test_later_missing_credential_does_not_block_current_success
         ; test_case
-            "JSON syntax uses strict text fallback"
+            "JSON syntax is prompt-only even for a native target"
             `Quick
-            test_json_syntax_uses_strict_text_fallback
+            test_json_syntax_is_prompt_only_even_for_native_target
         ; test_case
             "fenced JSON advances to frozen successor"
             `Quick

--- a/test/test_exact_output_single_surface.ml
+++ b/test/test_exact_output_single_surface.ml
@@ -425,9 +425,14 @@ let test_tier_table_and_provider_schema_rejection () =
   let text_only = plan snapshot "none" EO.Json_syntax |> EO.plan_provenance in
   check
     bool
-    "native preferred for syntax minimum"
+    "syntax minimum does not request a provider schema"
     true
-    (EO.plan_provenance_actual_assurance native_json = EO.Provider_schema_requested);
+    (EO.plan_provenance_actual_assurance native_json = EO.Json_syntax_only);
+  check
+    bool
+    "syntax minimum has no effective schema"
+    true
+    (Option.is_none (EO.plan_provenance_effective_schema_fingerprint native_json));
   check
     bool
     "native satisfies provider schema"
@@ -741,9 +746,9 @@ let test_no_measure_one_post_and_wire_authority () =
       in
       with_catalog [ entry ]
       @@ fun snapshot ->
-      let ready = plan_for_schema snapshot id domain_schema EO.Json_syntax in
+      let ready = plan_for_schema snapshot id domain_schema EO.Provider_schema in
       let execution =
-        flow_for_schema snapshot id domain_schema EO.Json_syntax |> attempt
+        flow_for_schema snapshot id domain_schema EO.Provider_schema |> attempt
       in
       EO.plan_provenance ready, EO.plan_fingerprint ready, execute_once ~net execution
     in


### PR DESCRIPTION
## 변경

`Json_syntax`는 대상 runtime capability와 무관하게 `response_format=Off`로 유지하고, 기존의 prompt JSON instruction + local parser/validator 계약을 사용합니다.

provider-native schema는 별도 명시 계약인 `Provider_schema`에서만 요청합니다. 새 facade·호환 레이어·파생 상태는 추가하지 않았습니다.

## 검증

- `scripts/dune-local.sh build test/test_exact_output_single_surface.exe test/test_exact_output_flow.exe`
- `test_exact_output_single_surface.exe` (24 passed)
- `test_exact_output_flow.exe` (38 passed)

native-capable OpenAI fixture에서도 `Json_syntax` HTTP body에 `response_format`이 없고 JSON instruction이 마지막 message로 붙는 것을 검증합니다.