### PR TITLE
style: repair main ocamlformat drift

### DIFF
--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -322,7 +322,9 @@ let compute_delta_for_goal
 
 let compare_with_specs ~specs ~(baseline : run_metrics) ~(candidate : run_metrics) =
   let find_unique_metric ~duplicate_error ~missing_error name metrics =
-    match List.filter (fun (metric : metric) -> String.equal metric.name name) metrics with
+    match
+      List.filter (fun (metric : metric) -> String.equal metric.name name) metrics
+    with
     | [] -> Error (missing_error name)
     | [ metric ] -> Ok metric
     | _ -> Error (duplicate_error name)

--- a/lib/llm_provider/exact_output.mli
+++ b/lib/llm_provider/exact_output.mli
@@ -122,11 +122,10 @@ type resolver_snapshot_error =
 
 type minimum_guarantee =
   | Json_syntax
-      (** Prompt-only JSON contract.  OAS appends the schema instruction and
+  (** Prompt-only JSON contract.  OAS appends the schema instruction and
           validates the response locally; it does not send a provider-native
           response-format request. *)
-  | Provider_schema
-      (** Explicit opt-in to a provider-native schema request. *)
+  | Provider_schema (** Explicit opt-in to a provider-native schema request. *)
 
 type actual_assurance =
   | Json_syntax_only

--- a/lib/llm_provider/exact_output_ready_admission.ml
+++ b/lib/llm_provider/exact_output_ready_admission.ml
@@ -171,18 +171,24 @@ let response_format (target : Resolver.selected_target) requirement =
   | Provider_schema ->
     (match Caps.structured_output_support target.capabilities with
      | Caps.Native_json_schema ->
-    let* () =
-      match target.config.kind, requirement.schema with
-      | PC.Gemini, Domain_schema schema -> validate_gemini_schema ~path:"$" schema
-      | ( (PC.Anthropic | PC.Kimi | PC.OpenAI_compat | PC.Ollama | PC.Glm | PC.DashScope)
-        , Domain_schema _ ) -> Ok ()
-    in
-    let wire_schema = schema_for_wire target requirement.schema in
-    Ok
-      ( Types.JsonSchema wire_schema
-      , Provider_schema_requested
-      , Some (fingerprint_schema wire_schema) )
-     | Caps.Json_object_only | Caps.No_structured_output -> Error Provider_schema_unavailable)
+       let* () =
+         match target.config.kind, requirement.schema with
+         | PC.Gemini, Domain_schema schema -> validate_gemini_schema ~path:"$" schema
+         | ( ( PC.Anthropic
+             | PC.Kimi
+             | PC.OpenAI_compat
+             | PC.Ollama
+             | PC.Glm
+             | PC.DashScope )
+           , Domain_schema _ ) -> Ok ()
+       in
+       let wire_schema = schema_for_wire target requirement.schema in
+       Ok
+         ( Types.JsonSchema wire_schema
+         , Provider_schema_requested
+         , Some (fingerprint_schema wire_schema) )
+     | Caps.Json_object_only | Caps.No_structured_output ->
+       Error Provider_schema_unavailable)
 ;;
 
 let text_json_instruction (Domain_schema schema) : Types.message =

--- a/lib/llm_provider/exact_output_ready_admission.mli
+++ b/lib/llm_provider/exact_output_ready_admission.mli
@@ -9,11 +9,10 @@ type domain_schema
 
 type minimum_guarantee =
   | Json_syntax
-      (** Prompt-only JSON contract.  OAS appends the schema instruction and
+  (** Prompt-only JSON contract.  OAS appends the schema instruction and
           validates the response locally; it does not send a provider-native
           response-format request. *)
-  | Provider_schema
-      (** Explicit opt-in to a provider-native schema request. *)
+  | Provider_schema (** Explicit opt-in to a provider-native schema request. *)
 
 type actual_assurance =
   | Json_syntax_only

--- a/test/test_eval.ml
+++ b/test/test_eval.ml
@@ -141,9 +141,7 @@ let test_compare_unchanged () =
 let test_compare_with_specs_higher_is_better () =
   let baseline = mk_run_metrics [ mk_metric "accuracy" (Float_val 0.90) ] in
   let candidate = mk_run_metrics ~run_id:"r2" [ mk_metric "accuracy" (Float_val 0.95) ] in
-  let specs =
-    [ { Eval.name = "accuracy"; goal = Eval.Higher; tolerance_pct = 1.0 } ]
-  in
+  let specs = [ { Eval.name = "accuracy"; goal = Eval.Higher; tolerance_pct = 1.0 } ] in
   let cmp = Eval.compare_with_specs ~specs ~baseline ~candidate |> comparison_or_fail in
   Alcotest.(check int) "improvements" 1 (List.length cmp.improvements);
   Alcotest.(check int) "regressions" 0 (List.length cmp.regressions)
@@ -159,9 +157,7 @@ let test_compare_with_specs_excludes_unspecified_metrics () =
       ~run_id:"r2"
       [ mk_metric "accuracy" (Float_val 0.95); mk_metric "latency" (Float_val 200.0) ]
   in
-  let specs =
-    [ { Eval.name = "accuracy"; goal = Eval.Higher; tolerance_pct = 1.0 } ]
-  in
+  let specs = [ { Eval.name = "accuracy"; goal = Eval.Higher; tolerance_pct = 1.0 } ] in
   let cmp = Eval.compare_with_specs ~specs ~baseline ~candidate |> comparison_or_fail in
   Alcotest.(check int) "selected improvement" 1 (List.length cmp.improvements);
   Alcotest.(check int) "unspecified regression excluded" 0 (List.length cmp.regressions)

--- a/test/test_eval_coverage.ml
+++ b/test/test_eval_coverage.ml
@@ -280,14 +280,8 @@ let test_compare_missing_candidate_metric () =
   in
   let candidate = mk_run ~run_id:"r2" [ mk_metric "a" (Float_val 1.0) ] in
   let specs =
-    [ { Eval.name = "a"
-      ; goal = Lower
-      ; tolerance_pct = Eval.default_delta_threshold_pct
-      }
-    ; { Eval.name = "b"
-      ; goal = Lower
-      ; tolerance_pct = Eval.default_delta_threshold_pct
-      }
+    [ { Eval.name = "a"; goal = Lower; tolerance_pct = Eval.default_delta_threshold_pct }
+    ; { Eval.name = "b"; goal = Lower; tolerance_pct = Eval.default_delta_threshold_pct }
     ]
   in
   match Eval.compare_with_specs ~specs ~baseline ~candidate with


### PR DESCRIPTION
## 문제

main `40ac4c42e` CI에서 build/test는 통과했지만 `OCaml Format`이 6개 파일 drift로 실패했어용.

## 수정

CI가 제시한 6개 파일에 repo ocamlformat을 그대로 적용했어용. 기능 계약은 바꾸지 않았어용.

## 검증

- 대상 SHA: `da6b52169`
- `ocamlformat --check` — PASS
- `ocamlc -stop-after parsing` — PASS
- `git diff --check` — PASS
- 로컬 Dune은 실행하지 않았고 PR CI로 확인해용.

[근거] OAS CI run 30432272370의 OCaml Format 실패 로그, 2026-07-29 확인, 신뢰도 High.