### PR TITLE
fix(eval): enforce typed metric comparison policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,19 @@ field have been removed.
   object.
 `Eval.compare` and its implicit lower-is-better policy have been removed.
 `Eval.compare_with_specs` now compares only metrics selected by an explicit
-`metric_spec`.
+`metric_spec`. Its policy now distinguishes relative, absolute, numeric-exact,
+and value-exact comparison. It rejects non-finite or incompatible values,
+unit/tag identity mismatches, and undefined relative changes from zero instead
+of silently classifying them. The conflicting tuple-returning `compute_delta`
+comparison authority is removed. Absolute tolerances are kinded as integer or
+float so integer boundaries stay exact. `check_thresholds` now returns typed
+errors for missing, duplicate, incompatible, non-finite, empty, or invalid
+threshold contracts instead of reporting them as passed. Comparison and
+threshold errors retain the canonical name/unit/tags identity, and threshold
+evidence renders that full identity. Metric JSON decoding rejects duplicate
+or unknown object fields and duplicate tag names.
+The name-only `Eval.find_metric` and `Eval.find_metric_value` helpers are
+removed because metric identity is the exact name/unit/tag tuple.
 
 The unused `Binding_identity.of_resolved_provider` compatibility bridge has
 been removed. Binding identities are constructed only from canonical

--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -7,7 +7,8 @@
     - [metric_value] is a closed variant for type-safe comparisons.
     - [collector] is mutable during a run, finalized into immutable [run_metrics].
     - [compare] detects regressions and improvements between two runs.
-    - [check_thresholds] produces a {!Harness.verdict} for CI integration. *)
+    - [check_thresholds] produces a typed result containing a
+      {!Harness.verdict} for CI integration. *)
 
 (* ── Metric value ─────────────────────────────────────────────── *)
 
@@ -41,22 +42,60 @@ let show_metric_value = function
 
 let pp_metric_value fmt v = Format.fprintf fmt "%s" (show_metric_value v)
 
-let metric_value_to_float = function
-  | Int_val i -> Some (float_of_int i)
-  | Float_val f -> Some f
-  | Bool_val b -> Some (if b then 1.0 else 0.0)
-  | String_val _ -> None
+let duplicate_assoc_key fields =
+  let names = List.map fst fields |> List.sort String.compare in
+  let rec find = function
+    | name :: next_name :: _ when String.equal name next_name -> Some name
+    | _ :: rest -> find rest
+    | [] -> None
+  in
+  find names
+;;
+
+let unknown_metric_field fields =
+  List.find_map
+    (fun (name, _) ->
+       match name with
+       | "name" | "value" | "unit" | "tags" -> None
+       | _ -> Some name)
+    fields
+;;
+
+let canonical_metric_tags tags =
+  let sorted =
+    List.sort
+      (fun (left_name, left_value) (right_name, right_value) ->
+         let name_order = String.compare left_name right_name in
+         if name_order <> 0 then name_order else String.compare left_value right_value)
+      tags
+  in
+  let rec validate = function
+    | (name, _) :: (next_name, _) :: _ when String.equal name next_name -> Error name
+    | _ :: rest -> validate rest
+    | [] -> Ok sorted
+  in
+  validate sorted
 ;;
 
 let tags_of_json = function
-  | `Assoc kvs -> List.map (fun (k, v) -> k, Yojson.Safe.Util.to_string v) kvs
-  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> []
-;;
-
-let numeric_threshold_violated ~compare value threshold =
-  match metric_value_to_float value, metric_value_to_float threshold with
-  | Some v, Some limit -> compare v limit
-  | None, _ | _, None -> false
+  | `Assoc kvs ->
+    let ( let* ) = Result.bind in
+    let* tags =
+      List.fold_right
+        (fun (name, value) result ->
+           let* tags = result in
+           match value with
+           | `String value -> Ok ((name, value) :: tags)
+           | `Assoc _ | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null ->
+             Error "metric tags must contain string values")
+        kvs
+        (Ok [])
+    in
+    (match canonical_metric_tags tags with
+     | Ok tags -> Ok tags
+     | Error name -> Error (Printf.sprintf "duplicate metric tag %S" name))
+  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ ->
+    Error "metric tags must be an object"
 ;;
 
 (* ── Metric ───────────────────────────────────────────────────── *)
@@ -68,7 +107,58 @@ type metric =
   ; tags : (string * string) list
   }
 
-let metric_to_yojson m =
+type metric_identity =
+  { name : string
+  ; unit_ : string option
+  ; tags : (string * string) list
+  }
+
+let canonical_metric_identity (identity : metric_identity) =
+  match canonical_metric_tags identity.tags with
+  | Ok tags -> Ok { identity with tags }
+  | Error tag_name -> Error tag_name
+;;
+
+let metric_identity_equal (left : metric_identity) (right : metric_identity) =
+  String.equal left.name right.name && left.unit_ = right.unit_ && left.tags = right.tags
+;;
+
+let metric_identity_of_metric (metric : metric) : metric_identity =
+  { name = metric.name; unit_ = metric.unit_; tags = metric.tags }
+;;
+
+type metric_lookup_error =
+  | Duplicate_lookup_metric of metric_identity
+  | Missing_lookup_metric of metric_identity
+  | Duplicate_lookup_tag of
+      { identity : metric_identity
+      ; tag_name : string
+      }
+
+let find_metric_for_identity ~(expected : metric_identity) metrics =
+  let ( let* ) = Result.bind in
+  let same_name =
+    List.filter (fun (metric : metric) -> String.equal metric.name expected.name) metrics
+  in
+  let rec canonicalize acc = function
+    | [] -> Ok (List.rev acc)
+    | (metric : metric) :: rest ->
+      let identity = metric_identity_of_metric metric in
+      (match canonical_metric_identity identity with
+       | Error tag_name -> Error (Duplicate_lookup_tag { identity; tag_name })
+       | Ok identity -> canonicalize ((identity, metric) :: acc) rest)
+  in
+  let* candidates = canonicalize [] same_name in
+  let exact =
+    List.filter (fun (identity, _) -> metric_identity_equal expected identity) candidates
+  in
+  match exact with
+  | [ (identity, metric) ] -> Ok (identity, metric)
+  | _ :: _ :: _ -> Error (Duplicate_lookup_metric expected)
+  | [] -> Error (Missing_lookup_metric expected)
+;;
+
+let metric_to_yojson (m : metric) =
   let base = [ "name", `String m.name; "value", metric_value_to_yojson m.value ] in
   let unit_part =
     match m.unit_ with
@@ -85,44 +175,96 @@ let metric_to_yojson m =
 
 let metric_of_yojson json =
   let open Yojson.Safe.Util in
-  try
-    let name = json |> member "name" |> to_string in
-    let value_json = json |> member "value" in
-    match metric_value_of_yojson value_json with
-    | Error e -> Error e
-    | Ok value ->
-      let unit_ = json |> member "unit" |> to_string_option in
-      let tags = json |> member "tags" |> tags_of_json in
-      Ok { name; value; unit_; tags }
-  with
-  | Type_error (msg, _) -> Error msg
+  let decode () =
+    try
+      let name = json |> member "name" |> to_string in
+      let value_json = json |> member "value" in
+      match metric_value_of_yojson value_json with
+      | Error e -> Error e
+      | Ok value ->
+        let unit_ = json |> member "unit" |> to_string_option in
+        let tags_json =
+          match json with
+          | `Assoc fields -> List.assoc_opt "tags" fields
+          | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> None
+        in
+        (match
+           match tags_json with
+           | None -> Ok []
+           | Some tags -> tags_of_json tags
+         with
+         | Error e -> Error e
+         | Ok tags -> Ok { name; value; unit_; tags })
+    with
+    | Type_error (msg, _) -> Error msg
+  in
+  match json with
+  | `Assoc fields ->
+    (match duplicate_assoc_key fields with
+     | Some name -> Error (Printf.sprintf "duplicate metric field %S" name)
+     | None ->
+       (match unknown_metric_field fields with
+        | Some name -> Error (Printf.sprintf "unknown metric field %S" name)
+        | None -> decode ()))
+  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> decode ()
 ;;
 
-let show_metric m = Printf.sprintf "%s=%s" m.name (show_metric_value m.value)
+let show_metric (m : metric) = Printf.sprintf "%s=%s" m.name (show_metric_value m.value)
 let pp_metric fmt m = Format.fprintf fmt "%s" (show_metric m)
 
 (* ── Metric comparison policy ─────────────────────────────────── *)
 
-type metric_goal =
-  | Higher
-  | Lower
-  | Exact
+type numeric_tolerance =
+  | Relative_pct of float
+  | Absolute_int of int64
+  | Absolute_float of float
+
+type metric_policy =
+  | Higher_is_better of numeric_tolerance
+  | Lower_is_better of numeric_tolerance
+  | Exact_numeric of numeric_tolerance
+  | Exact_value
 
 type metric_spec =
-  { name : string
-  ; goal : metric_goal
-  ; tolerance_pct : float
+  { identity : metric_identity
+  ; policy : metric_policy
   }
 
+type metric_side =
+  | Expected
+  | Baseline
+  | Candidate
+
 type comparison_error =
-  | Duplicate_metric_spec of string
-  | Duplicate_baseline_metric of string
-  | Duplicate_candidate_metric of string
-  | Missing_baseline_metric of string
-  | Missing_candidate_metric of string
-  | Invalid_tolerance_pct of
-      { metric_name : string
-      ; tolerance_pct : float
+  | Duplicate_metric_spec of metric_identity
+  | Duplicate_baseline_metric of metric_identity
+  | Duplicate_candidate_metric of metric_identity
+  | Missing_baseline_metric of metric_identity
+  | Missing_candidate_metric of metric_identity
+  | Duplicate_metric_tag of
+      { identity : metric_identity
+      ; side : metric_side
+      ; tag_name : string
+      }
+  | Invalid_numeric_tolerance of
+      { identity : metric_identity
+      ; tolerance : numeric_tolerance
+      }
+  | Incompatible_metric_values of
+      { identity : metric_identity
+      ; policy : metric_policy
+      ; baseline_value : metric_value
+      ; candidate_value : metric_value
+      }
+  | Non_finite_metric_value of
+      { identity : metric_identity
+      ; side : metric_side
+      ; value : float
+      }
+  | Non_finite_numeric_result of metric_identity
+  | Relative_tolerance_zero_baseline of
+      { identity : metric_identity
+      ; candidate_value : metric_value
       }
 
 (* ── Run metrics ──────────────────────────────────────────────── *)
@@ -236,10 +378,8 @@ type change_direction =
   | Improvement
   | Unchanged
 
-let no_numeric_delta _baseline _candidate = Unchanged, None
-
 type metric_delta =
-  { metric_name : string
+  { identity : metric_identity
   ; baseline_value : metric_value
   ; candidate_value : metric_value
   ; direction : change_direction
@@ -254,124 +394,172 @@ type comparison =
   ; unchanged : metric_delta list
   }
 
-(** Threshold percentage for classifying a delta as regression/improvement.
-    Default 5.0%: changes within +/-5% are classified as Unchanged. *)
-let default_delta_threshold_pct = 5.0
-
-let compute_delta
-      ?(threshold_pct = default_delta_threshold_pct)
-      ~baseline_val
-      ~candidate_val
-      ()
-  =
-  match metric_value_to_float baseline_val, metric_value_to_float candidate_val with
-  | Some bv, Some cv when bv <> 0.0 ->
-    let pct = (cv -. bv) /. Float.abs bv *. 100.0 in
-    let direction =
-      if pct > threshold_pct
-      then Regression
-      else if pct < -.threshold_pct
-      then Improvement
-      else Unchanged
-    in
-    direction, Some pct
-  | Some bv, Some cv ->
-    let direction =
-      if cv > bv then Regression else if cv < bv then Improvement else Unchanged
-    in
-    direction, None
-  | None, _ | _, None -> no_numeric_delta baseline_val candidate_val
-;;
-
-let compute_delta_for_goal
-      ?(threshold_pct = default_delta_threshold_pct)
-      ~goal
-      ~baseline_val
-      ~candidate_val
-      ()
-  =
-  match goal with
-  | Lower -> compute_delta ~threshold_pct ~baseline_val ~candidate_val ()
-  | Higher ->
-    let direction, pct =
-      compute_delta
-        ~threshold_pct
-        ~baseline_val:candidate_val
-        ~candidate_val:baseline_val
-        ()
-    in
-    let pct = Option.map ( ~-. ) pct in
-    direction, pct
-  | Exact ->
-    (match metric_value_to_float baseline_val, metric_value_to_float candidate_val with
-     | Some bv, Some cv ->
-       let diff = Float.abs (cv -. bv) in
-       let pct =
-         if Float.abs bv < 1e-10 then None else Some (diff /. Float.abs bv *. 100.0)
-       in
-       let direction =
-         match pct with
-         | Some v when v > threshold_pct -> Regression
-         | None when diff > 0.0 -> Regression
-         | Some _ | None -> Unchanged
-       in
-       direction, pct
-     | None, _ | _, None ->
-       if baseline_val = candidate_val then Unchanged, None else Regression, None)
-;;
-
 let compare_with_specs ~specs ~(baseline : run_metrics) ~(candidate : run_metrics) =
-  let find_unique_metric ~duplicate_error ~missing_error name metrics =
-    match
-      List.filter (fun (metric : metric) -> String.equal metric.name name) metrics
-    with
-    | [] -> Error (missing_error name)
-    | [ metric ] -> Ok metric
-    | _ -> Error (duplicate_error name)
+  let lookup ~side ~duplicate_error ~missing_error expected metrics =
+    match find_metric_for_identity ~expected metrics with
+    | Ok found -> Ok found
+    | Error (Duplicate_lookup_metric identity) -> Error (duplicate_error identity)
+    | Error (Missing_lookup_metric identity) -> Error (missing_error identity)
+    | Error (Duplicate_lookup_tag { identity; tag_name }) ->
+      Error (Duplicate_metric_tag { identity; side; tag_name })
+  in
+  let validate_finite ~identity ~side = function
+    | Float_val value when not (Float.is_finite value) ->
+      Error (Non_finite_metric_value { identity; side; value })
+    | Int_val _ | Float_val _ | Bool_val _ | String_val _ -> Ok ()
+  in
+  let validate_tolerance identity tolerance =
+    match tolerance with
+    | Relative_pct value | Absolute_float value ->
+      if value < 0.0 || not (Float.is_finite value)
+      then Error (Invalid_numeric_tolerance { identity; tolerance })
+      else Ok ()
+    | Absolute_int value ->
+      if Int64.compare value 0L < 0
+      then Error (Invalid_numeric_tolerance { identity; tolerance })
+      else Ok ()
+  in
+  let numeric_delta ~identity ~policy ~tolerance ~baseline_value ~candidate_value =
+    let ( let* ) = Result.bind in
+    let* () = validate_tolerance identity tolerance in
+    let* () = validate_finite ~identity ~side:Baseline baseline_value in
+    let* () = validate_finite ~identity ~side:Candidate candidate_value in
+    let finite_result value =
+      if Float.is_finite value
+      then Ok value
+      else Error (Non_finite_numeric_result identity)
+    in
+    let classify difference_sign exceeds_tolerance =
+      if not exceeds_tolerance
+      then Ok Unchanged
+      else (
+        match policy with
+        | Lower_is_better _ ->
+          Ok (if difference_sign > 0 then Regression else Improvement)
+        | Higher_is_better _ ->
+          Ok (if difference_sign > 0 then Improvement else Regression)
+        | Exact_numeric _ -> Ok Regression
+        | Exact_value ->
+          Error
+            (Incompatible_metric_values
+               { identity; policy; baseline_value; candidate_value }))
+    in
+    match baseline_value, candidate_value, tolerance with
+    | Int_val baseline, Int_val candidate, Absolute_int limit ->
+      let difference = Int64.sub (Int64.of_int candidate) (Int64.of_int baseline) in
+      let* direction =
+        classify
+          (Int64.compare difference 0L)
+          (Int64.compare (Int64.abs difference) limit > 0)
+      in
+      Ok (direction, None)
+    | Float_val baseline, Float_val candidate, Absolute_float limit ->
+      let* difference = candidate -. baseline |> finite_result in
+      let* direction =
+        classify (Float.compare difference 0.0) (Float.abs difference > limit)
+      in
+      Ok (direction, None)
+    | Int_val baseline, Int_val candidate, Relative_pct limit ->
+      if Int.equal baseline 0
+      then
+        if Int.equal candidate 0
+        then Ok (Unchanged, Some 0.0)
+        else Error (Relative_tolerance_zero_baseline { identity; candidate_value })
+      else (
+        let difference = Int64.sub (Int64.of_int candidate) (Int64.of_int baseline) in
+        let* delta_pct =
+          Int64.to_float difference /. Float.abs (float_of_int baseline) *. 100.0
+          |> finite_result
+        in
+        let* direction =
+          classify (Int64.compare difference 0L) (Float.abs delta_pct > limit)
+        in
+        Ok (direction, Some delta_pct))
+    | Float_val baseline, Float_val candidate, Relative_pct limit ->
+      if Float.equal baseline 0.0
+      then
+        if Float.equal candidate 0.0
+        then Ok (Unchanged, Some 0.0)
+        else Error (Relative_tolerance_zero_baseline { identity; candidate_value })
+      else
+        let* difference = candidate -. baseline |> finite_result in
+        let* delta_pct = difference /. Float.abs baseline *. 100.0 |> finite_result in
+        let* direction =
+          classify (Float.compare difference 0.0) (Float.abs delta_pct > limit)
+        in
+        Ok (direction, Some delta_pct)
+    | (Int_val _ | Float_val _ | Bool_val _ | String_val _), _, _ ->
+      Error
+        (Incompatible_metric_values { identity; policy; baseline_value; candidate_value })
+  in
+  let compute_policy_delta ~identity ~policy ~baseline_value ~candidate_value =
+    match policy with
+    | Higher_is_better tolerance | Lower_is_better tolerance | Exact_numeric tolerance ->
+      numeric_delta ~identity ~policy ~tolerance ~baseline_value ~candidate_value
+    | Exact_value ->
+      let ( let* ) = Result.bind in
+      let* () = validate_finite ~identity ~side:Baseline baseline_value in
+      let* () = validate_finite ~identity ~side:Candidate candidate_value in
+      (match baseline_value, candidate_value with
+       | Int_val baseline, Int_val candidate ->
+         Ok ((if Int.equal baseline candidate then Unchanged else Regression), None)
+       | Float_val baseline, Float_val candidate ->
+         Ok ((if Float.equal baseline candidate then Unchanged else Regression), None)
+       | Bool_val baseline, Bool_val candidate ->
+         Ok ((if Bool.equal baseline candidate then Unchanged else Regression), None)
+       | String_val baseline, String_val candidate ->
+         Ok ((if String.equal baseline candidate then Unchanged else Regression), None)
+       | (Int_val _ | Float_val _ | Bool_val _ | String_val _), _ ->
+         Error
+           (Incompatible_metric_values
+              { identity; policy; baseline_value; candidate_value }))
   in
   let rec collect seen deltas = function
     | [] -> Ok (List.rev deltas)
     | (spec : metric_spec) :: rest ->
-      if List.exists (String.equal spec.name) seen
-      then Error (Duplicate_metric_spec spec.name)
-      else if spec.tolerance_pct < 0.0 || not (Float.is_finite spec.tolerance_pct)
-      then
-        Error
-          (Invalid_tolerance_pct
-             { metric_name = spec.name; tolerance_pct = spec.tolerance_pct })
-      else (
-        let ( let* ) = Result.bind in
-        let* baseline_metric =
-          find_unique_metric
-            ~duplicate_error:(fun name -> Duplicate_baseline_metric name)
-            ~missing_error:(fun name -> Missing_baseline_metric name)
-            spec.name
+      let ( let* ) = Result.bind in
+      let* expected_identity =
+        match canonical_metric_identity spec.identity with
+        | Ok identity -> Ok identity
+        | Error tag_name ->
+          Error
+            (Duplicate_metric_tag { identity = spec.identity; side = Expected; tag_name })
+      in
+      if List.exists (metric_identity_equal expected_identity) seen
+      then Error (Duplicate_metric_spec expected_identity)
+      else
+        let* _, baseline_metric =
+          lookup
+            ~side:Baseline
+            ~duplicate_error:(fun identity -> Duplicate_baseline_metric identity)
+            ~missing_error:(fun identity -> Missing_baseline_metric identity)
+            expected_identity
             baseline.metrics
         in
-        let* candidate_metric =
-          find_unique_metric
-            ~duplicate_error:(fun name -> Duplicate_candidate_metric name)
-            ~missing_error:(fun name -> Missing_candidate_metric name)
-            spec.name
+        let* _, candidate_metric =
+          lookup
+            ~side:Candidate
+            ~duplicate_error:(fun identity -> Duplicate_candidate_metric identity)
+            ~missing_error:(fun identity -> Missing_candidate_metric identity)
+            expected_identity
             candidate.metrics
         in
-        let direction, delta_pct =
-          compute_delta_for_goal
-            ~threshold_pct:spec.tolerance_pct
-            ~goal:spec.goal
-            ~baseline_val:baseline_metric.value
-            ~candidate_val:candidate_metric.value
-            ()
+        let* direction, delta_pct =
+          compute_policy_delta
+            ~identity:expected_identity
+            ~policy:spec.policy
+            ~baseline_value:baseline_metric.value
+            ~candidate_value:candidate_metric.value
         in
         let delta =
-          { metric_name = spec.name
+          { identity = expected_identity
           ; baseline_value = baseline_metric.value
           ; candidate_value = candidate_metric.value
           ; direction
           ; delta_pct
           }
         in
-        collect (spec.name :: seen) (delta :: deltas) rest)
+        collect (expected_identity :: seen) (delta :: deltas) rest
   in
   let ( let* ) = Result.bind in
   let* deltas = collect [] [] specs in
@@ -384,68 +572,143 @@ let compare_with_specs ~specs ~(baseline : run_metrics) ~(candidate : run_metric
 (* ── Threshold checking ───────────────────────────────────────── *)
 
 type threshold =
-  { metric_name : string
+  { identity : metric_identity
   ; max_value : metric_value option
   ; min_value : metric_value option
   }
 
-let check_thresholds (rm : run_metrics) (thresholds : threshold list) : Harness.verdict =
-  let violations =
-    List.filter_map
-      (fun th ->
-         match List.find_opt (fun (m : metric) -> m.name = th.metric_name) rm.metrics with
-         | None -> None
-         | Some m ->
-           (* Build each violation message where the threshold value is in
-              scope (parse, don't validate): the [Some v when violated]
-              guard carries [v] directly, eliminating the [Option.get] that
-              previously re-extracted it from [th.max_value]/[th.min_value]
-              under the invariant that the bool guard implied [Some]. Max
-              takes priority over min, as before. *)
-           let max_violation =
-             match th.max_value with
-             | Some max_v when numeric_threshold_violated ~compare:( > ) m.value max_v ->
-               Some
-                 (Printf.sprintf
-                    "%s=%s exceeds max %s"
-                    th.metric_name
-                    (show_metric_value m.value)
-                    (show_metric_value max_v))
-             | _ -> None
-           in
-           let min_violation =
-             match th.min_value with
-             | Some min_v when numeric_threshold_violated ~compare:( < ) m.value min_v ->
-               Some
-                 (Printf.sprintf
-                    "%s=%s below min %s"
-                    th.metric_name
-                    (show_metric_value m.value)
-                    (show_metric_value min_v))
-             | _ -> None
-           in
-           (match max_violation with
-            | Some _ -> max_violation
-            | None -> min_violation))
-      thresholds
+type threshold_error =
+  | Duplicate_threshold of metric_identity
+  | Duplicate_threshold_metric of metric_identity
+  | Missing_threshold_metric of metric_identity
+  | Empty_threshold of metric_identity
+  | Incompatible_threshold_value of
+      { identity : metric_identity
+      ; metric_value : metric_value
+      ; threshold_value : metric_value
+      }
+  | Non_finite_threshold_value of
+      { identity : metric_identity
+      ; value : float
+      }
+  | Invalid_threshold_range of metric_identity
+  | Duplicate_threshold_identity_tag of
+      { identity : metric_identity
+      ; tag_name : string
+      }
+
+let show_canonical_metric_identity (identity : metric_identity) =
+  let unit_json =
+    match identity.unit_ with
+    | Some unit_ -> `String unit_
+    | None -> `Null
   in
+  `Assoc
+    [ "name", `String identity.name
+    ; "unit", unit_json
+    ; "tags", Util.json_of_string_pairs identity.tags
+    ]
+  |> Yojson.Safe.to_string
+;;
+
+let check_thresholds (rm : run_metrics) (thresholds : threshold list) =
+  let compare_values identity metric_value threshold_value =
+    match metric_value, threshold_value with
+    | Int_val metric, Int_val threshold -> Ok (Int.compare metric threshold)
+    | Float_val metric, Float_val threshold ->
+      if not (Float.is_finite metric)
+      then Error (Non_finite_threshold_value { identity; value = metric })
+      else if not (Float.is_finite threshold)
+      then Error (Non_finite_threshold_value { identity; value = threshold })
+      else Ok (Float.compare metric threshold)
+    | (Int_val _ | Float_val _ | Bool_val _ | String_val _), _ ->
+      Error (Incompatible_threshold_value { identity; metric_value; threshold_value })
+  in
+  let lookup expected =
+    match find_metric_for_identity ~expected rm.metrics with
+    | Ok found -> Ok found
+    | Error (Duplicate_lookup_metric identity) ->
+      Error (Duplicate_threshold_metric identity)
+    | Error (Missing_lookup_metric identity) -> Error (Missing_threshold_metric identity)
+    | Error (Duplicate_lookup_tag { identity; tag_name }) ->
+      Error (Duplicate_threshold_identity_tag { identity; tag_name })
+  in
+  let validate_range identity (threshold : threshold) =
+    match threshold.min_value, threshold.max_value with
+    | None, None -> Error (Empty_threshold identity)
+    | Some min_value, Some max_value ->
+      let ( let* ) = Result.bind in
+      let* order = compare_values identity min_value max_value in
+      if order > 0 then Error (Invalid_threshold_range identity) else Ok ()
+    | Some _, None | None, Some _ -> Ok ()
+  in
+  let rec collect seen violations = function
+    | [] -> Ok (List.rev violations)
+    | (threshold : threshold) :: rest ->
+      let ( let* ) = Result.bind in
+      let* expected_identity =
+        match canonical_metric_identity threshold.identity with
+        | Ok identity -> Ok identity
+        | Error tag_name ->
+          Error
+            (Duplicate_threshold_identity_tag { identity = threshold.identity; tag_name })
+      in
+      if List.exists (metric_identity_equal expected_identity) seen
+      then Error (Duplicate_threshold expected_identity)
+      else
+        let* () = validate_range expected_identity threshold in
+        let* _, metric = lookup expected_identity in
+        let* max_violation =
+          match threshold.max_value with
+          | None -> Ok None
+          | Some max_value ->
+            let* order = compare_values expected_identity metric.value max_value in
+            if order > 0
+            then
+              Ok
+                (Some
+                   (Printf.sprintf
+                      "%s=%s exceeds max %s"
+                      (show_canonical_metric_identity expected_identity)
+                      (show_metric_value metric.value)
+                      (show_metric_value max_value)))
+            else Ok None
+        in
+        let* min_violation =
+          match threshold.min_value with
+          | None -> Ok None
+          | Some min_value ->
+            let* order = compare_values expected_identity metric.value min_value in
+            if order < 0
+            then
+              Ok
+                (Some
+                   (Printf.sprintf
+                      "%s=%s below min %s"
+                      (show_canonical_metric_identity expected_identity)
+                      (show_metric_value metric.value)
+                      (show_metric_value min_value)))
+            else Ok None
+        in
+        let violations =
+          match max_violation, min_violation with
+          | None, None -> violations
+          | Some violation, None | None, Some violation -> violation :: violations
+          | Some max_violation, Some min_violation ->
+            min_violation :: max_violation :: violations
+        in
+        collect (expected_identity :: seen) violations rest
+  in
+  let ( let* ) = Result.bind in
+  let* violations = collect [] [] thresholds in
   let passed = violations = [] in
-  { passed
-  ; score = Some (if passed then 1.0 else 0.0)
-  ; evidence = violations
-  ; detail =
-      (if passed
-       then Some "all thresholds met"
-       else Some (Printf.sprintf "%d threshold violation(s)" (List.length violations)))
-  }
-;;
-
-(* ── Metric lookup ────────────────────────────────────────────── *)
-
-let find_metric (rm : run_metrics) name =
-  List.find_opt (fun (m : metric) -> m.name = name) rm.metrics
-;;
-
-let find_metric_value rm name =
-  Option.map (fun (m : metric) -> m.value) (find_metric rm name)
+  Ok
+    { Harness.passed
+    ; score = Some (if passed then 1.0 else 0.0)
+    ; evidence = violations
+    ; detail =
+        (if passed
+         then Some "all thresholds met"
+         else Some (Printf.sprintf "%d threshold violation(s)" (List.length violations)))
+    }
 ;;

--- a/lib/eval.mli
+++ b/lib/eval.mli
@@ -20,9 +20,6 @@ val metric_value_of_yojson : Yojson.Safe.t -> (metric_value, string) result
 val show_metric_value : metric_value -> string
 val pp_metric_value : Format.formatter -> metric_value -> unit
 
-(** Convert to float if possible. String_val returns None. *)
-val metric_value_to_float : metric_value -> float option
-
 (** {1 Metric} *)
 
 (** A named metric with optional unit and tags. *)
@@ -33,33 +30,75 @@ type metric =
   ; tags : (string * string) list
   }
 
+type metric_identity =
+  { name : string
+  ; unit_ : string option
+  ; tags : (string * string) list
+  }
+
 val metric_to_yojson : metric -> Yojson.Safe.t
+
+(** Decode a metric, rejecting duplicate object fields, duplicate tag names,
+    non-object tags, and non-string tag values. Decoded tags are canonicalized
+    by name and value. *)
 val metric_of_yojson : Yojson.Safe.t -> (metric, string) result
+
 val show_metric : metric -> string
 val pp_metric : Format.formatter -> metric -> unit
 
 (** {1 Metric comparison policy} *)
 
-type metric_goal =
-  | Higher
-  | Lower
-  | Exact
+type numeric_tolerance =
+  | Relative_pct of float
+  | Absolute_int of int64
+  | Absolute_float of float
+
+type metric_policy =
+  | Higher_is_better of numeric_tolerance
+  | Lower_is_better of numeric_tolerance
+  | Exact_numeric of numeric_tolerance
+  | Exact_value
 
 type metric_spec =
-  { name : string
-  ; goal : metric_goal
-  ; tolerance_pct : float
+  { identity : metric_identity
+  ; policy : metric_policy
   }
 
+type metric_side =
+  | Expected
+  | Baseline
+  | Candidate
+
 type comparison_error =
-  | Duplicate_metric_spec of string
-  | Duplicate_baseline_metric of string
-  | Duplicate_candidate_metric of string
-  | Missing_baseline_metric of string
-  | Missing_candidate_metric of string
-  | Invalid_tolerance_pct of
-      { metric_name : string
-      ; tolerance_pct : float
+  | Duplicate_metric_spec of metric_identity
+  | Duplicate_baseline_metric of metric_identity
+  | Duplicate_candidate_metric of metric_identity
+  | Missing_baseline_metric of metric_identity
+  | Missing_candidate_metric of metric_identity
+  | Duplicate_metric_tag of
+      { identity : metric_identity
+      ; side : metric_side
+      ; tag_name : string
+      }
+  | Invalid_numeric_tolerance of
+      { identity : metric_identity
+      ; tolerance : numeric_tolerance
+      }
+  | Incompatible_metric_values of
+      { identity : metric_identity
+      ; policy : metric_policy
+      ; baseline_value : metric_value
+      ; candidate_value : metric_value
+      }
+  | Non_finite_metric_value of
+      { identity : metric_identity
+      ; side : metric_side
+      ; value : float
+      }
+  | Non_finite_numeric_result of metric_identity
+  | Relative_tolerance_zero_baseline of
+      { identity : metric_identity
+      ; candidate_value : metric_value
       }
 
 (** {1 Run metrics} *)
@@ -103,7 +142,7 @@ type change_direction =
   | Unchanged
 
 type metric_delta =
-  { metric_name : string
+  { identity : metric_identity
   ; baseline_value : metric_value
   ; candidate_value : metric_value
   ; direction : change_direction
@@ -118,20 +157,11 @@ type comparison =
   ; unchanged : metric_delta list
   }
 
-(** Default threshold percentage (5.0%) for classifying deltas. *)
-val default_delta_threshold_pct : float
-
-(** Compute direction and delta percentage between two values. *)
-val compute_delta
-  :  ?threshold_pct:float
-  -> baseline_val:metric_value
-  -> candidate_val:metric_value
-  -> unit
-  -> change_direction * float option
-
-(** Compare exactly the metrics selected by [specs]. Every selected metric must
-    occur exactly once in each run, every spec name must be unique, and every
-    tolerance must be finite and non-negative. *)
+(** Compare exactly the metrics selected by [specs]. Metric identity includes
+    unit and tags, numeric policies require same-kind finite values, and every
+    tolerance must be finite and non-negative. Relative tolerance is undefined
+    for a non-zero change from a zero baseline; use [Absolute_int] or
+    [Absolute_float] explicitly. *)
 val compare_with_specs
   :  specs:metric_spec list
   -> baseline:run_metrics
@@ -141,18 +171,34 @@ val compare_with_specs
 (** {1 Threshold checking} *)
 
 type threshold =
-  { metric_name : string
+  { identity : metric_identity
   ; max_value : metric_value option
   ; min_value : metric_value option
   }
 
-(** Check run metrics against thresholds, producing a harness verdict. *)
-val check_thresholds : run_metrics -> threshold list -> Harness.verdict
+type threshold_error =
+  | Duplicate_threshold of metric_identity
+  | Duplicate_threshold_metric of metric_identity
+  | Missing_threshold_metric of metric_identity
+  | Empty_threshold of metric_identity
+  | Incompatible_threshold_value of
+      { identity : metric_identity
+      ; metric_value : metric_value
+      ; threshold_value : metric_value
+      }
+  | Non_finite_threshold_value of
+      { identity : metric_identity
+      ; value : float
+      }
+  | Invalid_threshold_range of metric_identity
+  | Duplicate_threshold_identity_tag of
+      { identity : metric_identity
+      ; tag_name : string
+      }
 
-(** {1 Metric lookup} *)
-
-(** Find a metric by name. *)
-val find_metric : run_metrics -> string -> metric option
-
-(** Find a metric value by name. *)
-val find_metric_value : run_metrics -> string -> metric_value option
+(** Check run metrics against unique, present, same-kind finite thresholds.
+    Violation evidence identifies the canonical name/unit/tags tuple. *)
+val check_thresholds
+  :  run_metrics
+  -> threshold list
+  -> (Harness.verdict, threshold_error) result

--- a/test/test_eval.ml
+++ b/test/test_eval.ml
@@ -4,7 +4,19 @@ open Agent_sdk
 
 (* ── Helpers ──────────────────────────────────────────────────── *)
 
-let mk_metric name value = { Eval.name; value; unit_ = None; tags = [] }
+let mk_metric ?unit_ ?(tags = []) name value = { Eval.name; value; unit_; tags }
+
+let metric_identity ?unit_ ?(tags = []) name : Eval.metric_identity =
+  { name; unit_; tags }
+;;
+
+let metric_spec ?unit_ ?tags name policy : Eval.metric_spec =
+  { identity = metric_identity ?unit_ ?tags name; policy }
+;;
+
+let threshold ?unit_ ?tags ?max_value ?min_value name : Eval.threshold =
+  { identity = metric_identity ?unit_ ?tags name; max_value; min_value }
+;;
 
 let mk_run_metrics ?(run_id = "r1") ?(agent_name = "test") metrics =
   { Eval.run_id; agent_name; timestamp = 0.0; metrics; harness_verdicts = [] }
@@ -27,25 +39,6 @@ let test_metric_value_yojson_roundtrip () =
     values
 ;;
 
-let test_metric_value_to_float () =
-  Alcotest.(check (option (float 0.001)))
-    "int"
-    (Some 42.0)
-    (Eval.metric_value_to_float (Int_val 42));
-  Alcotest.(check (option (float 0.001)))
-    "float"
-    (Some 3.14)
-    (Eval.metric_value_to_float (Float_val 3.14));
-  Alcotest.(check (option (float 0.001)))
-    "bool true"
-    (Some 1.0)
-    (Eval.metric_value_to_float (Bool_val true));
-  Alcotest.(check (option (float 0.001)))
-    "string"
-    None
-    (Eval.metric_value_to_float (String_val "x"))
-;;
-
 (* ── metric tests ─────────────────────────────────────────────── *)
 
 let test_metric_yojson_roundtrip () =
@@ -65,6 +58,45 @@ let test_metric_yojson_roundtrip () =
       (Eval.show_metric_value m.value)
       (Eval.show_metric_value m2.value)
   | Error e -> Alcotest.fail e
+;;
+
+let test_metric_yojson_rejects_malformed_tags () =
+  List.iter
+    (fun tags ->
+       let json =
+         `Assoc [ "name", `String "latency"; "value", `Float 1.0; "tags", tags ]
+       in
+       match Eval.metric_of_yojson json with
+       | Error _ -> ()
+       | Ok _ -> Alcotest.fail "explicit malformed tags must be rejected")
+    [ `List [ `String "not-an-object" ]; `Null ]
+;;
+
+let test_metric_yojson_rejects_duplicate_fields_and_tags () =
+  let valid_tags = `Assoc [ "env", `String "prod" ] in
+  let duplicate_tag_key =
+    `Assoc
+      [ "name", `String "latency"
+      ; "value", `Float 1.0
+      ; "tags", `Assoc [ "env", `String "prod"; "env", `String "stage" ]
+      ]
+  in
+  let duplicate_top_level first second =
+    `Assoc
+      [ "name", `String "latency"; "value", `Float 1.0; "tags", first; "tags", second ]
+  in
+  List.iter
+    (fun json ->
+       match Eval.metric_of_yojson json with
+       | Error _ -> ()
+       | Ok _ -> Alcotest.fail "duplicate JSON identity fields must be rejected")
+    [ duplicate_tag_key
+    ; duplicate_top_level valid_tags `Null
+    ; duplicate_top_level `Null valid_tags
+    ; `Assoc [ "name", `String "latency"; "name", `String "other"; "value", `Float 1.0 ]
+    ; `Assoc
+        [ "name", `String "latency"; "value", `Float 1.0; "fallback", `String "invented" ]
+    ]
 ;;
 
 (* ── collector tests ──────────────────────────────────────────── *)
@@ -97,13 +129,7 @@ let comparison_or_fail = function
 let test_compare_regression () =
   let baseline = mk_run_metrics [ mk_metric "latency" (Float_val 100.0) ] in
   let candidate = mk_run_metrics ~run_id:"r2" [ mk_metric "latency" (Float_val 120.0) ] in
-  let specs =
-    [ { Eval.name = "latency"
-      ; goal = Lower
-      ; tolerance_pct = Eval.default_delta_threshold_pct
-      }
-    ]
-  in
+  let specs = [ metric_spec "latency" (Lower_is_better (Relative_pct 5.0)) ] in
   let cmp = Eval.compare_with_specs ~specs ~baseline ~candidate |> comparison_or_fail in
   Alcotest.(check int) "regressions" 1 (List.length cmp.regressions);
   Alcotest.(check int) "improvements" 0 (List.length cmp.improvements)
@@ -112,13 +138,7 @@ let test_compare_regression () =
 let test_compare_improvement () =
   let baseline = mk_run_metrics [ mk_metric "latency" (Float_val 100.0) ] in
   let candidate = mk_run_metrics ~run_id:"r2" [ mk_metric "latency" (Float_val 80.0) ] in
-  let specs =
-    [ { Eval.name = "latency"
-      ; goal = Lower
-      ; tolerance_pct = Eval.default_delta_threshold_pct
-      }
-    ]
-  in
+  let specs = [ metric_spec "latency" (Lower_is_better (Relative_pct 5.0)) ] in
   let cmp = Eval.compare_with_specs ~specs ~baseline ~candidate |> comparison_or_fail in
   Alcotest.(check int) "regressions" 0 (List.length cmp.regressions);
   Alcotest.(check int) "improvements" 1 (List.length cmp.improvements)
@@ -127,13 +147,7 @@ let test_compare_improvement () =
 let test_compare_unchanged () =
   let baseline = mk_run_metrics [ mk_metric "score" (Float_val 0.95) ] in
   let candidate = mk_run_metrics ~run_id:"r2" [ mk_metric "score" (Float_val 0.96) ] in
-  let specs =
-    [ { Eval.name = "score"
-      ; goal = Higher
-      ; tolerance_pct = Eval.default_delta_threshold_pct
-      }
-    ]
-  in
+  let specs = [ metric_spec "score" (Higher_is_better (Relative_pct 5.0)) ] in
   let cmp = Eval.compare_with_specs ~specs ~baseline ~candidate |> comparison_or_fail in
   Alcotest.(check int) "unchanged" 1 (List.length cmp.unchanged)
 ;;
@@ -141,7 +155,7 @@ let test_compare_unchanged () =
 let test_compare_with_specs_higher_is_better () =
   let baseline = mk_run_metrics [ mk_metric "accuracy" (Float_val 0.90) ] in
   let candidate = mk_run_metrics ~run_id:"r2" [ mk_metric "accuracy" (Float_val 0.95) ] in
-  let specs = [ { Eval.name = "accuracy"; goal = Eval.Higher; tolerance_pct = 1.0 } ] in
+  let specs = [ metric_spec "accuracy" (Higher_is_better (Relative_pct 1.0)) ] in
   let cmp = Eval.compare_with_specs ~specs ~baseline ~candidate |> comparison_or_fail in
   Alcotest.(check int) "improvements" 1 (List.length cmp.improvements);
   Alcotest.(check int) "regressions" 0 (List.length cmp.regressions)
@@ -157,7 +171,7 @@ let test_compare_with_specs_excludes_unspecified_metrics () =
       ~run_id:"r2"
       [ mk_metric "accuracy" (Float_val 0.95); mk_metric "latency" (Float_val 200.0) ]
   in
-  let specs = [ { Eval.name = "accuracy"; goal = Eval.Higher; tolerance_pct = 1.0 } ] in
+  let specs = [ metric_spec "accuracy" (Higher_is_better (Relative_pct 1.0)) ] in
   let cmp = Eval.compare_with_specs ~specs ~baseline ~candidate |> comparison_or_fail in
   Alcotest.(check int) "selected improvement" 1 (List.length cmp.improvements);
   Alcotest.(check int) "unspecified regression excluded" 0 (List.length cmp.regressions)
@@ -166,59 +180,335 @@ let test_compare_with_specs_excludes_unspecified_metrics () =
 let test_compare_rejects_invalid_tolerance () =
   let baseline = mk_run_metrics [ mk_metric "latency" (Float_val 100.0) ] in
   let candidate = mk_run_metrics ~run_id:"r2" [ mk_metric "latency" (Float_val 101.0) ] in
-  let specs = [ { Eval.name = "latency"; goal = Lower; tolerance_pct = Float.nan } ] in
+  let specs = [ metric_spec "latency" (Lower_is_better (Relative_pct Float.nan)) ] in
   match Eval.compare_with_specs ~specs ~baseline ~candidate with
-  | Error (Eval.Invalid_tolerance_pct { metric_name; _ }) ->
-    Alcotest.(check string) "metric name" "latency" metric_name
-  | Ok _ | Error _ -> Alcotest.fail "expected Invalid_tolerance_pct"
+  | Error (Eval.Invalid_numeric_tolerance { identity; _ }) ->
+    Alcotest.(check string) "metric name" "latency" identity.name
+  | Ok _ | Error _ -> Alcotest.fail "expected Invalid_numeric_tolerance"
+;;
+
+let test_compare_rejects_invalid_absolute_tolerances () =
+  let baseline = mk_run_metrics [ mk_metric "count" (Int_val 10) ] in
+  let candidate = mk_run_metrics ~run_id:"r2" [ mk_metric "count" (Int_val 11) ] in
+  List.iter
+    (fun policy ->
+       match
+         Eval.compare_with_specs
+           ~specs:[ metric_spec "count" policy ]
+           ~baseline
+           ~candidate
+       with
+       | Error (Eval.Invalid_numeric_tolerance { identity; _ }) ->
+         Alcotest.(check string) "metric name" "count" identity.name
+       | Ok _ | Error _ -> Alcotest.fail "expected Invalid_numeric_tolerance")
+    [ Exact_numeric (Absolute_int (-1L)); Exact_numeric (Absolute_float Float.infinity) ]
+;;
+
+let test_compare_requires_exact_metric_identity () =
+  let baseline = mk_run_metrics [ mk_metric ~unit_:"ms" "latency" (Float_val 100.0) ] in
+  let candidate =
+    mk_run_metrics ~run_id:"r2" [ mk_metric ~unit_:"s" "latency" (Float_val 0.1) ]
+  in
+  let specs =
+    [ metric_spec ~unit_:"ms" "latency" (Lower_is_better (Relative_pct 5.0)) ]
+  in
+  match Eval.compare_with_specs ~specs ~baseline ~candidate with
+  | Error (Eval.Missing_candidate_metric identity) ->
+    Alcotest.(check string) "metric name" "latency" identity.name;
+    Alcotest.(check (option string)) "exact unit" (Some "ms") identity.unit_
+  | Ok _ | Error _ -> Alcotest.fail "expected Missing_candidate_metric"
+;;
+
+let test_compare_rejects_incompatible_metric_values () =
+  let baseline = mk_run_metrics [ mk_metric "quality" (String_val "high") ] in
+  let candidate =
+    mk_run_metrics ~run_id:"r2" [ mk_metric "quality" (String_val "low") ]
+  in
+  let specs = [ metric_spec "quality" (Higher_is_better (Relative_pct 5.0)) ] in
+  match Eval.compare_with_specs ~specs ~baseline ~candidate with
+  | Error (Eval.Incompatible_metric_values { identity; _ }) ->
+    Alcotest.(check string) "metric name" "quality" identity.name
+  | Ok _ | Error _ -> Alcotest.fail "expected Incompatible_metric_values"
+;;
+
+let test_compare_rejects_non_finite_metric_value () =
+  let baseline = mk_run_metrics [ mk_metric "latency" (Float_val Float.nan) ] in
+  let candidate = mk_run_metrics ~run_id:"r2" [ mk_metric "latency" (Float_val 1.0) ] in
+  let specs = [ metric_spec "latency" (Lower_is_better (Absolute_float 0.1)) ] in
+  match Eval.compare_with_specs ~specs ~baseline ~candidate with
+  | Error (Eval.Non_finite_metric_value { identity; side = Baseline; _ }) ->
+    Alcotest.(check string) "metric name" "latency" identity.name
+  | Ok _ | Error _ -> Alcotest.fail "expected Non_finite_metric_value"
+;;
+
+let test_compare_zero_baseline_requires_absolute_tolerance () =
+  let baseline = mk_run_metrics [ mk_metric "latency" (Float_val 0.0) ] in
+  let candidate = mk_run_metrics ~run_id:"r2" [ mk_metric "latency" (Float_val 0.1) ] in
+  let relative_specs = [ metric_spec "latency" (Lower_is_better (Relative_pct 5.0)) ] in
+  (match Eval.compare_with_specs ~specs:relative_specs ~baseline ~candidate with
+   | Error (Eval.Relative_tolerance_zero_baseline { identity; _ }) ->
+     Alcotest.(check string) "metric name" "latency" identity.name
+   | Ok _ | Error _ -> Alcotest.fail "expected Relative_tolerance_zero_baseline");
+  let absolute_specs = [ metric_spec "latency" (Lower_is_better (Absolute_float 0.2)) ] in
+  let comparison =
+    Eval.compare_with_specs ~specs:absolute_specs ~baseline ~candidate
+    |> comparison_or_fail
+  in
+  Alcotest.(check int) "within absolute tolerance" 1 (List.length comparison.unchanged)
+;;
+
+let test_compare_preserves_exact_int_difference () =
+  let baseline = mk_run_metrics [ mk_metric "count" (Int_val (max_int - 1)) ] in
+  let candidate = mk_run_metrics ~run_id:"r2" [ mk_metric "count" (Int_val max_int) ] in
+  let specs = [ metric_spec "count" (Lower_is_better (Absolute_int 0L)) ] in
+  let comparison =
+    Eval.compare_with_specs ~specs ~baseline ~candidate |> comparison_or_fail
+  in
+  Alcotest.(check int) "exact integer boundary" 1 (List.length comparison.regressions)
+;;
+
+let test_compare_absolute_float_does_not_compute_relative_delta () =
+  let baseline = mk_run_metrics [ mk_metric "range" (Float_val 1e-308) ] in
+  let candidate = mk_run_metrics ~run_id:"r2" [ mk_metric "range" (Float_val 1.0) ] in
+  let specs = [ metric_spec "range" (Exact_numeric (Absolute_float 2.0)) ] in
+  let comparison =
+    Eval.compare_with_specs ~specs ~baseline ~candidate |> comparison_or_fail
+  in
+  match comparison.unchanged with
+  | [ delta ] ->
+    Alcotest.(check bool) "no unused percentage" true (Option.is_none delta.delta_pct)
+  | _ -> Alcotest.fail "expected unchanged absolute comparison"
+;;
+
+let test_compare_rejects_derived_numeric_overflow () =
+  let baseline = mk_run_metrics [ mk_metric "range" (Float_val (-.Float.max_float)) ] in
+  let candidate =
+    mk_run_metrics ~run_id:"r2" [ mk_metric "range" (Float_val Float.max_float) ]
+  in
+  let specs = [ metric_spec "range" (Exact_numeric (Absolute_float 0.0)) ] in
+  match Eval.compare_with_specs ~specs ~baseline ~candidate with
+  | Error (Eval.Non_finite_numeric_result identity) ->
+    Alcotest.(check string) "metric name" "range" identity.name
+  | Ok _ | Error _ -> Alcotest.fail "expected Non_finite_numeric_result"
+;;
+
+let test_compare_tag_identity_is_order_insensitive () =
+  let baseline =
+    mk_run_metrics
+      [ mk_metric ~tags:[ "env", "prod"; "region", "kr" ] "latency" (Float_val 1.0) ]
+  in
+  let candidate =
+    mk_run_metrics
+      ~run_id:"r2"
+      [ mk_metric ~tags:[ "region", "kr"; "env", "prod" ] "latency" (Float_val 1.0) ]
+  in
+  let specs =
+    [ metric_spec ~tags:[ "env", "prod"; "region", "kr" ] "latency" Exact_value ]
+  in
+  let comparison =
+    Eval.compare_with_specs ~specs ~baseline ~candidate |> comparison_or_fail
+  in
+  Alcotest.(check int) "same identity" 1 (List.length comparison.unchanged)
+;;
+
+let test_compare_selects_composite_metric_identities () =
+  let metrics first second third =
+    [ mk_metric ~unit_:"ms" ~tags:[ "env", "prod" ] "latency" (Float_val first)
+    ; mk_metric ~unit_:"ms" ~tags:[ "env", "stage" ] "latency" (Float_val second)
+    ; mk_metric ~unit_:"s" ~tags:[ "env", "prod" ] "latency" (Float_val third)
+    ]
+  in
+  let baseline = mk_run_metrics (metrics 100.0 200.0 1.0) in
+  let candidate = mk_run_metrics ~run_id:"r2" (metrics 90.0 220.0 1.0) in
+  let specs =
+    [ metric_spec
+        ~unit_:"ms"
+        ~tags:[ "env", "prod" ]
+        "latency"
+        (Lower_is_better (Absolute_float 0.0))
+    ; metric_spec
+        ~unit_:"ms"
+        ~tags:[ "env", "stage" ]
+        "latency"
+        (Lower_is_better (Absolute_float 0.0))
+    ; metric_spec
+        ~unit_:"s"
+        ~tags:[ "env", "prod" ]
+        "latency"
+        (Lower_is_better (Absolute_float 0.0))
+    ]
+  in
+  let comparison =
+    Eval.compare_with_specs ~specs ~baseline ~candidate |> comparison_or_fail
+  in
+  Alcotest.(check int) "one exact improvement" 1 (List.length comparison.improvements);
+  Alcotest.(check int) "one exact regression" 1 (List.length comparison.regressions);
+  Alcotest.(check int) "different unit selected" 1 (List.length comparison.unchanged)
+;;
+
+let test_compare_rejects_duplicate_exact_identity () =
+  let duplicate = mk_metric ~tags:[ "env", "prod" ] "latency" (Float_val 1.0) in
+  let baseline = mk_run_metrics [ duplicate; duplicate ] in
+  let candidate = mk_run_metrics ~run_id:"r2" [ duplicate ] in
+  let specs = [ metric_spec ~tags:[ "env", "prod" ] "latency" Exact_value ] in
+  match Eval.compare_with_specs ~specs ~baseline ~candidate with
+  | Error (Eval.Duplicate_baseline_metric identity) ->
+    Alcotest.(check string) "metric name" "latency" identity.name
+  | Ok _ | Error _ -> Alcotest.fail "expected Duplicate_baseline_metric"
+;;
+
+let test_compare_rejects_duplicate_spec_and_tag () =
+  let metric = mk_metric "latency" (Float_val 1.0) in
+  let baseline = mk_run_metrics [ metric ] in
+  let candidate = mk_run_metrics ~run_id:"r2" [ metric ] in
+  let spec = metric_spec "latency" Exact_value in
+  (match Eval.compare_with_specs ~specs:[ spec; spec ] ~baseline ~candidate with
+   | Error (Eval.Duplicate_metric_spec identity) ->
+     Alcotest.(check string) "duplicate spec" "latency" identity.name
+   | Ok _ | Error _ -> Alcotest.fail "expected Duplicate_metric_spec");
+  let baseline =
+    mk_run_metrics
+      [ mk_metric ~tags:[ "env", "prod"; "env", "stage" ] "latency" (Float_val 1.0) ]
+  in
+  match Eval.compare_with_specs ~specs:[ spec ] ~baseline ~candidate with
+  | Error (Eval.Duplicate_metric_tag { identity; side = Baseline; _ }) ->
+    Alcotest.(check string) "duplicate tag" "latency" identity.name
+  | Ok _ | Error _ -> Alcotest.fail "expected Duplicate_metric_tag"
+;;
+
+let test_compare_rejects_non_finite_candidate () =
+  let baseline = mk_run_metrics [ mk_metric "latency" (Float_val 1.0) ] in
+  let candidate =
+    mk_run_metrics ~run_id:"r2" [ mk_metric "latency" (Float_val Float.infinity) ]
+  in
+  let specs = [ metric_spec "latency" (Lower_is_better (Absolute_float 0.0)) ] in
+  match Eval.compare_with_specs ~specs ~baseline ~candidate with
+  | Error (Eval.Non_finite_metric_value { identity; side = Candidate; _ }) ->
+    Alcotest.(check string) "metric name" "latency" identity.name
+  | Ok _ | Error _ -> Alcotest.fail "expected candidate Non_finite_metric_value"
 ;;
 
 (* ── threshold tests ──────────────────────────────────────────── *)
 
+let threshold_or_fail = function
+  | Ok verdict -> verdict
+  | Error _ -> Alcotest.fail "expected threshold verdict"
+;;
+
 let test_threshold_pass () =
   let rm = mk_run_metrics [ mk_metric "latency" (Float_val 50.0) ] in
-  let ths =
-    [ { Eval.metric_name = "latency"
-      ; max_value = Some (Float_val 100.0)
-      ; min_value = None
-      }
-    ]
-  in
-  let v = Eval.check_thresholds rm ths in
+  let ths = [ threshold ~max_value:(Float_val 100.0) "latency" ] in
+  let v = Eval.check_thresholds rm ths |> threshold_or_fail in
   Alcotest.(check bool) "passed" true v.passed
 ;;
 
 let test_threshold_fail_max () =
   let rm = mk_run_metrics [ mk_metric "latency" (Float_val 150.0) ] in
-  let ths =
-    [ { Eval.metric_name = "latency"
-      ; max_value = Some (Float_val 100.0)
-      ; min_value = None
-      }
-    ]
-  in
-  let v = Eval.check_thresholds rm ths in
+  let ths = [ threshold ~max_value:(Float_val 100.0) "latency" ] in
+  let v = Eval.check_thresholds rm ths |> threshold_or_fail in
   Alcotest.(check bool) "failed" false v.passed;
   Alcotest.(check int) "evidence" 1 (List.length v.evidence)
 ;;
 
 let test_threshold_fail_min () =
   let rm = mk_run_metrics [ mk_metric "score" (Float_val 0.3) ] in
-  let ths =
-    [ { Eval.metric_name = "score"; max_value = None; min_value = Some (Float_val 0.5) } ]
-  in
-  let v = Eval.check_thresholds rm ths in
+  let ths = [ threshold ~min_value:(Float_val 0.5) "score" ] in
+  let v = Eval.check_thresholds rm ths |> threshold_or_fail in
   Alcotest.(check bool) "failed" false v.passed
 ;;
 
-(* ── lookup tests ─────────────────────────────────────────────── *)
+let test_threshold_requires_exact_metric_identity () =
+  let rm = mk_run_metrics [ mk_metric ~unit_:"ms" "latency" (Float_val 50.0) ] in
+  let thresholds = [ threshold ~unit_:"s" ~max_value:(Float_val 100.0) "latency" ] in
+  match Eval.check_thresholds rm thresholds with
+  | Error (Eval.Missing_threshold_metric identity) ->
+    Alcotest.(check string) "metric name" "latency" identity.name;
+    Alcotest.(check (option string)) "exact unit" (Some "s") identity.unit_
+  | Ok _ | Error _ -> Alcotest.fail "expected Missing_threshold_metric"
+;;
 
-let test_find_metric () =
-  let rm = mk_run_metrics [ mk_metric "a" (Int_val 1); mk_metric "b" (Int_val 2) ] in
-  (match Eval.find_metric rm "a" with
-   | Some m -> Alcotest.(check string) "found" "a" m.name
-   | None -> Alcotest.fail "not found");
-  Alcotest.(check bool) "missing" true (Option.is_none (Eval.find_metric rm "c"))
+let test_thresholds_select_composite_metric_identities () =
+  let rm =
+    mk_run_metrics
+      [ mk_metric ~unit_:"ms" ~tags:[ "env", "prod" ] "latency" (Int_val 10)
+      ; mk_metric ~unit_:"ms" ~tags:[ "env", "stage" ] "latency" (Int_val 20)
+      ; mk_metric ~unit_:"s" ~tags:[ "env", "prod" ] "latency" (Int_val 1)
+      ]
+  in
+  let thresholds =
+    [ threshold ~unit_:"ms" ~tags:[ "env", "prod" ] ~max_value:(Int_val 10) "latency"
+    ; threshold ~unit_:"ms" ~tags:[ "env", "stage" ] ~max_value:(Int_val 20) "latency"
+    ; threshold ~unit_:"s" ~tags:[ "env", "prod" ] ~max_value:(Int_val 1) "latency"
+    ]
+  in
+  let verdict = Eval.check_thresholds rm thresholds |> threshold_or_fail in
+  Alcotest.(check bool) "both exact identities pass" true verdict.passed
+;;
+
+let test_threshold_evidence_preserves_canonical_identity () =
+  let rm =
+    mk_run_metrics
+      [ mk_metric
+          ~unit_:"ms"
+          ~tags:[ "region", "kr"; "env", "prod" ]
+          "latency"
+          (Int_val 20)
+      ]
+  in
+  let thresholds =
+    [ threshold
+        ~unit_:"ms"
+        ~tags:[ "env", "prod"; "region", "kr" ]
+        ~max_value:(Int_val 10)
+        "latency"
+    ]
+  in
+  let verdict = Eval.check_thresholds rm thresholds |> threshold_or_fail in
+  match verdict.evidence with
+  | [ evidence ] ->
+    Alcotest.(check string)
+      "canonical identity"
+      {|{"name":"latency","unit":"ms","tags":{"env":"prod","region":"kr"}}=20 exceeds max 10|}
+      evidence
+  | _ -> Alcotest.fail "expected one threshold violation"
+;;
+
+let test_threshold_rejects_duplicate_empty_and_invalid_range () =
+  let rm = mk_run_metrics [ mk_metric "latency" (Int_val 10) ] in
+  let exact = threshold ~max_value:(Int_val 10) "latency" in
+  (match Eval.check_thresholds rm [ exact; exact ] with
+   | Error (Eval.Duplicate_threshold identity) ->
+     Alcotest.(check string) "duplicate" "latency" identity.name
+   | Ok _ | Error _ -> Alcotest.fail "expected Duplicate_threshold");
+  (match Eval.check_thresholds rm [ threshold "latency" ] with
+   | Error (Eval.Empty_threshold identity) ->
+     Alcotest.(check string) "empty" "latency" identity.name
+   | Ok _ | Error _ -> Alcotest.fail "expected Empty_threshold");
+  match
+    Eval.check_thresholds
+      rm
+      [ threshold ~min_value:(Int_val 11) ~max_value:(Int_val 10) "latency" ]
+  with
+  | Error (Eval.Invalid_threshold_range identity) ->
+    Alcotest.(check string) "range" "latency" identity.name
+  | Ok _ | Error _ -> Alcotest.fail "expected Invalid_threshold_range"
+;;
+
+let test_threshold_rejects_duplicate_metric_and_non_finite_value () =
+  let metric = mk_metric "latency" (Float_val 10.0) in
+  let limit = threshold ~max_value:(Float_val 10.0) "latency" in
+  (match Eval.check_thresholds (mk_run_metrics [ metric; metric ]) [ limit ] with
+   | Error (Eval.Duplicate_threshold_metric identity) ->
+     Alcotest.(check string) "duplicate metric" "latency" identity.name
+   | Ok _ | Error _ -> Alcotest.fail "expected Duplicate_threshold_metric");
+  match
+    Eval.check_thresholds
+      (mk_run_metrics [ metric ])
+      [ threshold ~max_value:(Float_val Float.nan) "latency" ]
+  with
+  | Error (Eval.Non_finite_threshold_value { identity; _ }) ->
+    Alcotest.(check string) "non-finite threshold" "latency" identity.name
+  | Ok _ | Error _ -> Alcotest.fail "expected Non_finite_threshold_value"
 ;;
 
 (* ── run_metrics serialization ────────────────────────────────── *)
@@ -240,10 +530,18 @@ let () =
     "Eval"
     [ ( "metric_value"
       , [ Alcotest.test_case "yojson roundtrip" `Quick test_metric_value_yojson_roundtrip
-        ; Alcotest.test_case "to_float" `Quick test_metric_value_to_float
         ] )
     ; ( "metric"
-      , [ Alcotest.test_case "yojson roundtrip" `Quick test_metric_yojson_roundtrip ] )
+      , [ Alcotest.test_case "yojson roundtrip" `Quick test_metric_yojson_roundtrip
+        ; Alcotest.test_case
+            "malformed tags rejected"
+            `Quick
+            test_metric_yojson_rejects_malformed_tags
+        ; Alcotest.test_case
+            "duplicate fields and tags rejected"
+            `Quick
+            test_metric_yojson_rejects_duplicate_fields_and_tags
+        ] )
     ; ( "collector"
       , [ Alcotest.test_case "basic" `Quick test_collector_basic
         ; Alcotest.test_case "verdict" `Quick test_collector_verdict
@@ -264,13 +562,84 @@ let () =
             "invalid tolerance rejected"
             `Quick
             test_compare_rejects_invalid_tolerance
+        ; Alcotest.test_case
+            "invalid absolute tolerances rejected"
+            `Quick
+            test_compare_rejects_invalid_absolute_tolerances
+        ; Alcotest.test_case
+            "exact metric identity required"
+            `Quick
+            test_compare_requires_exact_metric_identity
+        ; Alcotest.test_case
+            "incompatible metric values rejected"
+            `Quick
+            test_compare_rejects_incompatible_metric_values
+        ; Alcotest.test_case
+            "non-finite metric rejected"
+            `Quick
+            test_compare_rejects_non_finite_metric_value
+        ; Alcotest.test_case
+            "zero baseline requires absolute tolerance"
+            `Quick
+            test_compare_zero_baseline_requires_absolute_tolerance
+        ; Alcotest.test_case
+            "exact int difference preserved"
+            `Quick
+            test_compare_preserves_exact_int_difference
+        ; Alcotest.test_case
+            "absolute float skips relative delta"
+            `Quick
+            test_compare_absolute_float_does_not_compute_relative_delta
+        ; Alcotest.test_case
+            "derived numeric overflow rejected"
+            `Quick
+            test_compare_rejects_derived_numeric_overflow
+        ; Alcotest.test_case
+            "tag order is not identity"
+            `Quick
+            test_compare_tag_identity_is_order_insensitive
+        ; Alcotest.test_case
+            "composite identities are selected exactly"
+            `Quick
+            test_compare_selects_composite_metric_identities
+        ; Alcotest.test_case
+            "duplicate exact identity rejected"
+            `Quick
+            test_compare_rejects_duplicate_exact_identity
+        ; Alcotest.test_case
+            "duplicate spec and tag rejected"
+            `Quick
+            test_compare_rejects_duplicate_spec_and_tag
+        ; Alcotest.test_case
+            "non-finite candidate rejected"
+            `Quick
+            test_compare_rejects_non_finite_candidate
         ] )
     ; ( "threshold"
       , [ Alcotest.test_case "pass" `Quick test_threshold_pass
         ; Alcotest.test_case "fail max" `Quick test_threshold_fail_max
         ; Alcotest.test_case "fail min" `Quick test_threshold_fail_min
+        ; Alcotest.test_case
+            "exact metric identity required"
+            `Quick
+            test_threshold_requires_exact_metric_identity
+        ; Alcotest.test_case
+            "composite identities are selected exactly"
+            `Quick
+            test_thresholds_select_composite_metric_identities
+        ; Alcotest.test_case
+            "violation evidence preserves identity"
+            `Quick
+            test_threshold_evidence_preserves_canonical_identity
+        ; Alcotest.test_case
+            "duplicate empty and invalid range rejected"
+            `Quick
+            test_threshold_rejects_duplicate_empty_and_invalid_range
+        ; Alcotest.test_case
+            "duplicate metric and non-finite threshold rejected"
+            `Quick
+            test_threshold_rejects_duplicate_metric_and_non_finite_value
         ] )
-    ; "lookup", [ Alcotest.test_case "find_metric" `Quick test_find_metric ]
     ; ( "serialization"
       , [ Alcotest.test_case "run_metrics yojson" `Quick test_run_metrics_yojson ] )
     ]

--- a/test/test_eval_coverage.ml
+++ b/test/test_eval_coverage.ml
@@ -1,19 +1,18 @@
 (** Extended coverage tests for the Eval module.
 
     Existing tests cover:
-    - metric_value yojson roundtrip, to_float
+    - metric_value yojson roundtrip
     - metric yojson roundtrip
     - collector basic, verdict
     - comparison regression/improvement/unchanged
     - threshold pass/fail max/min
-    - find_metric
     - run_metrics yojson
 
     This file targets uncovered paths in:
-    - Eval.ml: metric_value_of_yojson error path, compute_delta edge cases
+    - Eval.ml: metric_value_of_yojson error path, comparison edge cases
       (baseline zero, non-numeric, custom threshold), pp_* formatters,
       show_run_metrics, metric_of_yojson error path, run_metrics_of_yojson
-      error path, find_metric_value *)
+      error path *)
 
 open Agent_sdk
 
@@ -21,6 +20,18 @@ open Agent_sdk
 
 let mk_metric ?(unit_ = None) ?(tags = []) name value : Eval.metric =
   { name; value; unit_; tags }
+;;
+
+let metric_identity ?unit_ ?(tags = []) name : Eval.metric_identity =
+  { name; unit_; tags }
+;;
+
+let metric_spec ?unit_ ?tags name policy : Eval.metric_spec =
+  { identity = metric_identity ?unit_ ?tags name; policy }
+;;
+
+let threshold ?unit_ ?tags ?max_value ?min_value name : Eval.threshold =
+  { identity = metric_identity ?unit_ ?tags name; max_value; min_value }
 ;;
 
 let mk_run ?(run_id = "r1") ?(agent_name = "test") ?(verdicts = []) metrics
@@ -208,85 +219,33 @@ let test_run_metrics_to_yojson_score_none () =
   Alcotest.(check bool) "score null" true (v0 |> member "score" = `Null)
 ;;
 
-(* ── find_metric_value ────────────────────────────────── *)
-
-let test_find_metric_value_found () =
-  let rm = mk_run [ mk_metric "score" (Float_val 0.95) ] in
-  match Eval.find_metric_value rm "score" with
-  | Some (Float_val f) -> Alcotest.(check (float 0.01)) "value" 0.95 f
-  | _ -> Alcotest.fail "expected Float_val"
-;;
-
-let test_find_metric_value_missing () =
-  let rm = mk_run [] in
-  Alcotest.(check bool) "None" true (Eval.find_metric_value rm "nonexistent" = None)
-;;
-
-(* ── compute_delta edge cases ─────────────────────────── *)
-
-let test_compute_delta_baseline_zero () =
-  let dir, pct =
-    Eval.compute_delta ~baseline_val:(Float_val 0.0) ~candidate_val:(Float_val 5.0) ()
-  in
-  Alcotest.(check bool) "regression for zero baseline" true (dir = Eval.Regression);
-  Alcotest.(check bool) "no pct" true (pct = None)
-;;
-
-let test_compute_delta_both_zero () =
-  let dir, _ =
-    Eval.compute_delta ~baseline_val:(Float_val 0.0) ~candidate_val:(Float_val 0.0) ()
-  in
-  Alcotest.(check bool) "unchanged" true (dir = Eval.Unchanged)
-;;
-
-let test_compute_delta_zero_baseline_negative () =
-  let dir, _ =
-    Eval.compute_delta ~baseline_val:(Float_val 0.0) ~candidate_val:(Float_val (-1.0)) ()
-  in
-  Alcotest.(check bool) "improvement" true (dir = Eval.Improvement)
-;;
-
-let test_compute_delta_non_numeric () =
-  let dir, pct =
-    Eval.compute_delta ~baseline_val:(String_val "a") ~candidate_val:(String_val "b") ()
-  in
-  Alcotest.(check bool) "unchanged for strings" true (dir = Eval.Unchanged);
-  Alcotest.(check bool) "no pct" true (pct = None)
-;;
-
-let test_compute_delta_custom_threshold () =
-  let dir, _ =
-    Eval.compute_delta
-      ~threshold_pct:1.0
-      ~baseline_val:(Float_val 100.0)
-      ~candidate_val:(Float_val 102.0)
-      ()
-  in
-  Alcotest.(check bool) "regression with 1% threshold" true (dir = Eval.Regression)
-;;
-
-let test_compute_delta_bool_values () =
-  let dir, _ =
-    Eval.compute_delta ~baseline_val:(Bool_val false) ~candidate_val:(Bool_val true) ()
-  in
-  Alcotest.(check bool) "regression false->true" true (dir = Eval.Regression)
-;;
-
 (* ── compare: missing metric in candidate ─────────────── *)
 
 let test_compare_missing_candidate_metric () =
   let baseline =
-    mk_run [ mk_metric "a" (Float_val 1.0); mk_metric "b" (Float_val 2.0) ]
+    mk_run
+      [ mk_metric "a" (Float_val 1.0)
+      ; mk_metric ~unit_:(Some "ms") ~tags:[ "env", "prod" ] "b" (Float_val 2.0)
+      ]
   in
   let candidate = mk_run ~run_id:"r2" [ mk_metric "a" (Float_val 1.0) ] in
   let specs =
-    [ { Eval.name = "a"; goal = Lower; tolerance_pct = Eval.default_delta_threshold_pct }
-    ; { Eval.name = "b"; goal = Lower; tolerance_pct = Eval.default_delta_threshold_pct }
+    [ metric_spec "a" (Lower_is_better (Relative_pct 5.0))
+    ; metric_spec
+        ~unit_:"ms"
+        ~tags:[ "env", "prod" ]
+        "b"
+        (Lower_is_better (Relative_pct 5.0))
     ]
   in
   match Eval.compare_with_specs ~specs ~baseline ~candidate with
-  | Error (Eval.Missing_candidate_metric name) ->
-    Alcotest.(check string) "missing metric" "b" name
+  | Error (Eval.Missing_candidate_metric identity) ->
+    Alcotest.(check string) "missing metric" "b" identity.name;
+    Alcotest.(check (option string)) "missing unit" (Some "ms") identity.unit_;
+    Alcotest.(check (list (pair string string)))
+      "missing tags"
+      [ "env", "prod" ]
+      identity.tags
   | Ok _ | Error _ -> Alcotest.fail "expected Missing_candidate_metric"
 ;;
 
@@ -295,7 +254,7 @@ let test_compare_missing_candidate_metric () =
 let test_compare_string_metric () =
   let baseline = mk_run [ mk_metric "name" (String_val "test") ] in
   let candidate = mk_run ~run_id:"r2" [ mk_metric "name" (String_val "test") ] in
-  let specs = [ { Eval.name = "name"; goal = Exact; tolerance_pct = 0.0 } ] in
+  let specs = [ metric_spec "name" Exact_value ] in
   match Eval.compare_with_specs ~specs ~baseline ~candidate with
   | Ok cmp -> Alcotest.(check int) "unchanged" 1 (List.length cmp.unchanged)
   | Error _ -> Alcotest.fail "expected comparison"
@@ -305,49 +264,45 @@ let test_compare_string_metric () =
 
 let test_threshold_no_matching_metric () =
   let rm = mk_run [ mk_metric "x" (Int_val 1) ] in
-  let ths =
-    [ { Eval.metric_name = "missing"; max_value = Some (Int_val 10); min_value = None } ]
-  in
-  let v = Eval.check_thresholds rm ths in
-  Alcotest.(check bool) "pass when metric absent" true v.passed
+  let ths = [ threshold ~max_value:(Int_val 10) "missing" ] in
+  match Eval.check_thresholds rm ths with
+  | Error (Eval.Missing_threshold_metric identity) ->
+    Alcotest.(check string) "missing metric" "missing" identity.name
+  | Ok _ | Error _ -> Alcotest.fail "expected Missing_threshold_metric"
 ;;
 
 (* ── threshold: non-numeric values ────────────────────── *)
 
 let test_threshold_non_numeric () =
   let rm = mk_run [ mk_metric "name" (String_val "test") ] in
-  let ths =
-    [ { Eval.metric_name = "name"; max_value = Some (String_val "z"); min_value = None } ]
-  in
-  let v = Eval.check_thresholds rm ths in
-  Alcotest.(check bool) "pass for non-numeric" true v.passed
+  let ths = [ threshold ~max_value:(String_val "z") "name" ] in
+  match Eval.check_thresholds rm ths with
+  | Error (Eval.Incompatible_threshold_value { identity; _ }) ->
+    Alcotest.(check string) "metric name" "name" identity.name
+  | Ok _ | Error _ -> Alcotest.fail "expected Incompatible_threshold_value"
 ;;
 
 (* ── threshold: both max and min ──────────────────────── *)
 
 let test_threshold_both_pass () =
   let rm = mk_run [ mk_metric "x" (Float_val 50.0) ] in
-  let ths =
-    [ { Eval.metric_name = "x"
-      ; max_value = Some (Float_val 100.0)
-      ; min_value = Some (Float_val 10.0)
-      }
-    ]
+  let ths = [ threshold ~max_value:(Float_val 100.0) ~min_value:(Float_val 10.0) "x" ] in
+  let v =
+    match Eval.check_thresholds rm ths with
+    | Ok verdict -> verdict
+    | Error _ -> Alcotest.fail "expected threshold verdict"
   in
-  let v = Eval.check_thresholds rm ths in
   Alcotest.(check bool) "both pass" true v.passed
 ;;
 
 let test_threshold_both_fail_min () =
   let rm = mk_run [ mk_metric "x" (Float_val 5.0) ] in
-  let ths =
-    [ { Eval.metric_name = "x"
-      ; max_value = Some (Float_val 100.0)
-      ; min_value = Some (Float_val 10.0)
-      }
-    ]
+  let ths = [ threshold ~max_value:(Float_val 100.0) ~min_value:(Float_val 10.0) "x" ] in
+  let v =
+    match Eval.check_thresholds rm ths with
+    | Ok verdict -> verdict
+    | Error _ -> Alcotest.fail "expected threshold verdict"
   in
-  let v = Eval.check_thresholds rm ths in
   Alcotest.(check bool) "fail min" false v.passed
 ;;
 
@@ -391,21 +346,6 @@ let () =
             `Quick
             test_run_metrics_to_yojson_with_verdicts
         ; Alcotest.test_case "score None" `Quick test_run_metrics_to_yojson_score_none
-        ] )
-    ; ( "find_metric_value"
-      , [ Alcotest.test_case "found" `Quick test_find_metric_value_found
-        ; Alcotest.test_case "missing" `Quick test_find_metric_value_missing
-        ] )
-    ; ( "compute_delta"
-      , [ Alcotest.test_case "baseline zero" `Quick test_compute_delta_baseline_zero
-        ; Alcotest.test_case "both zero" `Quick test_compute_delta_both_zero
-        ; Alcotest.test_case
-            "zero negative"
-            `Quick
-            test_compute_delta_zero_baseline_negative
-        ; Alcotest.test_case "non-numeric" `Quick test_compute_delta_non_numeric
-        ; Alcotest.test_case "custom threshold" `Quick test_compute_delta_custom_threshold
-        ; Alcotest.test_case "bool values" `Quick test_compute_delta_bool_values
         ] )
     ; ( "compare_extra"
       , [ Alcotest.test_case


### PR DESCRIPTION
대상 커밋: `88716ecb725b178f4412d5521e174c650247cc8b`

- 비교·threshold 정책과 허용 오차를 typed contract로 만들었어용.
- metric identity는 canonical `(name, unit, tags)` 하나로 조회·중복 판정·오류·evidence에 사용해용.
- JSON의 unknown/duplicate field, `tags:null`, duplicate tag를 decode 경계에서 거부해용.
- name-only lookup과 암묵 mismatch 선택 휴리스틱은 제거했어용.

로컬 검증은 ocamlformat, 파싱, `git diff --check`만 통과했어용. Dune 빌드와 테스트는 CI에서 확인해용.