### PR TITLE
refactor(agent-card): require current interface contract

### DIFF
--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -137,7 +137,13 @@ val clone : ?copy_context:bool -> t -> t
 
 (** {1 Agent Card} *)
 
-val card : t -> Agent_card.agent_card
+(** Build a discovery card with the exact caller-owned interface authority.
+    The authority is mandatory and non-empty; OAS never invents an endpoint,
+    protocol binding, or protocol version. *)
+val card
+  :  supported_interfaces:Agent_card.supported_interfaces
+  -> t
+  -> Agent_card.agent_card
 
 (** {1 Execution} *)
 

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -182,7 +182,7 @@ let typed_provider_name (cfg : Llm_provider.Provider_config.t) =
   Provider_runtime_binding.provider_id_of_provider_config cfg
 ;;
 
-let card t =
+let card ~supported_interfaces t =
   let supported_providers =
     match t.options.provider_config with
     | Some config -> [ typed_provider_name config ]
@@ -208,6 +208,7 @@ let card t =
     ; has_elicitation =
         Option.is_some t.options.elicitation || Option.is_some t.options.tool_approval
     ; skills
+    ; supported_interfaces
     }
 ;;
 

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -216,7 +216,10 @@ val clone : ?copy_context:bool -> t -> t
 
 (** {1 Agent card} *)
 
-val card : t -> Agent_card.agent_card
+val card
+  :  supported_interfaces:Agent_card.supported_interfaces
+  -> t
+  -> Agent_card.agent_card
 
 (** {1 Lifecycle management} *)
 

--- a/lib/async_agent.ml
+++ b/lib/async_agent.ml
@@ -52,10 +52,7 @@ let invoke_cancel_fn future =
 
 (* ── Agent name extraction ────────────────────────────────────── *)
 
-let agent_name agent =
-  let card = Agent.card agent in
-  card.Agent_card.name
-;;
+let agent_name agent = (Agent.state agent).config.name
 
 let run_agent_result ~sw ?clock agent prompt =
   try Agent.run ~sw ?clock agent prompt with

--- a/lib/consumer.ml
+++ b/lib/consumer.ml
@@ -9,7 +9,7 @@ type run_result =
   ; elapsed : float
   }
 
-let agent_name agent = (Agent.card agent).Agent_card.name
+let agent_name agent = (Agent.state agent).config.name
 
 let run_agent ~sw ?clock ?harness agent prompt =
   let t0 = Unix.gettimeofday () in

--- a/lib/protocol/agent_card.ml
+++ b/lib/protocol/agent_card.ml
@@ -41,6 +41,9 @@ type supported_interface =
   ; tenant : string option
   }
 
+type supported_interfaces =
+  | Supported_interfaces of supported_interface * supported_interface list
+
 type skill_meta =
   { name : string
   ; description : string option
@@ -50,17 +53,92 @@ type skill_meta =
 type agent_card =
   { name : string
   ; description : string option
-  ; protocol_version : string (** A2A protocol version, e.g. "1.0" *)
   ; version : string (** Agent implementation version *)
-  ; url : string option
   ; authentication : authentication option
-  ; supported_interfaces : supported_interface list
+  ; supported_interfaces : supported_interfaces
   ; capabilities : capability list
   ; tools : Types.tool_schema list
   ; skills : skill_meta list
   ; supported_providers : string list
   ; metadata : (string * Yojson.Safe.t) list
   }
+
+let invalid_config ~field ~detail =
+  Error (Error.Config (Error.InvalidConfig { field; detail }))
+;;
+
+let validate_non_empty ~field value =
+  if String.equal value ""
+  then invalid_config ~field ~detail:"must not be empty"
+  else if not (String.equal value (String.trim value))
+  then invalid_config ~field ~detail:"must not contain surrounding whitespace"
+  else Ok value
+;;
+
+let validate_object_fields ~path ~known fields =
+  let rec loop seen = function
+    | [] -> Ok ()
+    | (name, _) :: rest ->
+      let field = path ^ "." ^ name in
+      if List.mem name seen
+      then invalid_config ~field ~detail:"must not be duplicated"
+      else if not (List.mem name known)
+      then invalid_config ~field ~detail:"is not supported"
+      else loop (name :: seen) rest
+  in
+  loop [] fields
+;;
+
+let create_supported_interface_at ~path ~url ~protocol_binding ~protocol_version ~tenant =
+  let ( let* ) = Result.bind in
+  let* url = validate_non_empty ~field:(path ^ ".url") url in
+  let uri = Uri.of_string url in
+  let* () =
+    match Uri.Absolute_http.of_uri uri with
+    | Ok absolute_uri
+      when Uri.Absolute_http.scheme absolute_uri = `Https
+           && not (String.equal (Uri.Absolute_http.host absolute_uri) "") -> Ok ()
+    | _ ->
+      invalid_config
+        ~field:(path ^ ".url")
+        ~detail:"must be an absolute HTTPS URL with a non-empty host"
+  in
+  let* protocol_binding =
+    validate_non_empty ~field:(path ^ ".protocolBinding") protocol_binding
+  in
+  let* protocol_version =
+    validate_non_empty ~field:(path ^ ".protocolVersion") protocol_version
+  in
+  let* tenant =
+    match tenant with
+    | None -> Ok None
+    | Some value ->
+      let* value = validate_non_empty ~field:(path ^ ".tenant") value in
+      Ok (Some value)
+  in
+  Ok { url; protocol_binding; protocol_version; tenant }
+;;
+
+let create_supported_interface ~url ~protocol_binding ~protocol_version ?tenant () =
+  create_supported_interface_at
+    ~path:"supported_interface"
+    ~url
+    ~protocol_binding
+    ~protocol_version
+    ~tenant
+;;
+
+let supported_interfaces first rest = Supported_interfaces (first, rest)
+let supported_interfaces_to_list (Supported_interfaces (first, rest)) = first :: rest
+
+let supported_interfaces_of_list_at ~field = function
+  | [] -> invalid_config ~field ~detail:"must contain at least one interface"
+  | first :: rest -> Ok (supported_interfaces first rest)
+;;
+
+let supported_interfaces_of_list interfaces =
+  supported_interfaces_of_list_at ~field:"supported_interfaces" interfaces
+;;
 
 (* ── Manual JSON serialization ─────────────────────────── *)
 
@@ -86,18 +164,6 @@ let capability_of_string = function
   | "mcp" -> MCP
   | "elicitation" -> Elicitation
   | s -> Custom_cap s
-;;
-
-let default_supported_interfaces (card : agent_card) =
-  match card.supported_interfaces, card.url with
-  | [], Some url ->
-    [ { url
-      ; protocol_binding = "JSONRPC"
-      ; protocol_version = card.protocol_version
-      ; tenant = None
-      }
-    ]
-  | interfaces, _ -> interfaces
 ;;
 
 let to_json (card : agent_card) : Yojson.Safe.t =
@@ -138,13 +204,11 @@ let to_json (card : agent_card) : Yojson.Safe.t =
                  match si.tenant with
                  | Some tenant -> [ "tenant", `String tenant ]
                  | None -> []))
-           (default_supported_interfaces card)) )
+           (supported_interfaces_to_list card.supported_interfaces)) )
   in
   `Assoc
     ([ "name", `String card.name ]
      @ opt "description" card.description
-     @ [ "protocolVersion", `String card.protocol_version ]
-     @ opt "url" card.url
      @ opt_auth
      @ [ interfaces_json ]
      @ [ "version", `String card.version
@@ -171,148 +235,251 @@ let to_json (card : agent_card) : Yojson.Safe.t =
      | m -> [ "metadata", `Assoc m ])
 ;;
 
+let required_field fields ?key field =
+  let key = Option.value key ~default:field in
+  match List.assoc_opt key fields with
+  | Some value -> Ok value
+  | None -> invalid_config ~field ~detail:"is required"
+;;
+
+let required_string fields ?key field =
+  let ( let* ) = Result.bind in
+  let* value = required_field fields ?key field in
+  match value with
+  | `String value -> validate_non_empty ~field value
+  | _ -> invalid_config ~field ~detail:"must be a string"
+;;
+
+let optional_string fields ?key field =
+  let key = Option.value key ~default:field in
+  match List.assoc_opt key fields with
+  | None | Some `Null -> Ok None
+  | Some (`String value) -> Ok (Some value)
+  | Some _ -> invalid_config ~field ~detail:"must be a string or null"
+;;
+
+let required_list fields ?key field =
+  let ( let* ) = Result.bind in
+  let* value = required_field fields ?key field in
+  match value with
+  | `List values -> Ok values
+  | _ -> invalid_config ~field ~detail:"must be an array"
+;;
+
+let rec map_indexed_result index f = function
+  | [] -> Ok []
+  | value :: rest ->
+    let ( let* ) = Result.bind in
+    let* value = f index value in
+    let* rest = map_indexed_result (index + 1) f rest in
+    Ok (value :: rest)
+;;
+
+let strings_of_json ~field values =
+  map_indexed_result
+    0
+    (fun index -> function
+       | `String value ->
+         validate_non_empty ~field:(Printf.sprintf "%s[%d]" field index) value
+       | _ ->
+         invalid_config
+           ~field:(Printf.sprintf "%s[%d]" field index)
+           ~detail:"must be a string")
+    values
+;;
+
+let supported_interface_of_json index = function
+  | `Assoc fields ->
+    let ( let* ) = Result.bind in
+    let path = Printf.sprintf "supportedInterfaces[%d]" index in
+    let* () =
+      validate_object_fields
+        ~path
+        ~known:[ "url"; "protocolBinding"; "protocolVersion"; "tenant" ]
+        fields
+    in
+    let* url = required_string fields ~key:"url" (path ^ ".url") in
+    let* protocol_binding =
+      required_string fields ~key:"protocolBinding" (path ^ ".protocolBinding")
+    in
+    let* protocol_version =
+      required_string fields ~key:"protocolVersion" (path ^ ".protocolVersion")
+    in
+    let* tenant = optional_string fields ~key:"tenant" (path ^ ".tenant") in
+    create_supported_interface_at ~path ~url ~protocol_binding ~protocol_version ~tenant
+  | _ ->
+    invalid_config
+      ~field:(Printf.sprintf "supportedInterfaces[%d]" index)
+      ~detail:"must be an object"
+;;
+
+let credential_ref_of_json = function
+  | `Assoc fields ->
+    let ( let* ) = Result.bind in
+    let* () =
+      validate_object_fields
+        ~path:"authentication.credential_ref"
+        ~known:[ "type"; "name"; "path" ]
+        fields
+    in
+    let* kind = required_string fields ~key:"type" "authentication.credential_ref.type" in
+    (match kind with
+     | "env" ->
+       let* () =
+         validate_object_fields
+           ~path:"authentication.credential_ref"
+           ~known:[ "type"; "name" ]
+           fields
+       in
+       let* name =
+         required_string fields ~key:"name" "authentication.credential_ref.name"
+       in
+       Ok (Env name)
+     | "file" ->
+       let* () =
+         validate_object_fields
+           ~path:"authentication.credential_ref"
+           ~known:[ "type"; "path" ]
+           fields
+       in
+       let* path =
+         required_string fields ~key:"path" "authentication.credential_ref.path"
+       in
+       Ok (File path)
+     | value ->
+       invalid_config
+         ~field:"authentication.credential_ref.type"
+         ~detail:(Printf.sprintf "unsupported value %S" value))
+  | _ -> invalid_config ~field:"authentication.credential_ref" ~detail:"must be an object"
+;;
+
+let authentication_of_json fields =
+  match List.assoc_opt "authentication" fields with
+  | None | Some `Null -> Ok None
+  | Some (`Assoc auth_fields) ->
+    let ( let* ) = Result.bind in
+    let* () =
+      validate_object_fields
+        ~path:"authentication"
+        ~known:[ "schemes"; "credential_ref"; "credentials" ]
+        auth_fields
+    in
+    let* () =
+      match List.assoc_opt "credentials" auth_fields with
+      | None -> Ok ()
+      | Some _ ->
+        invalid_config
+          ~field:"authentication.credentials"
+          ~detail:"literal credentials are forbidden; use credential_ref"
+    in
+    let* schemes_json =
+      required_list auth_fields ~key:"schemes" "authentication.schemes"
+    in
+    let* schemes = strings_of_json ~field:"authentication.schemes" schemes_json in
+    let* () =
+      match schemes with
+      | [] ->
+        invalid_config
+          ~field:"authentication.schemes"
+          ~detail:"must contain at least one scheme"
+      | _ -> Ok ()
+    in
+    let* credential_ref =
+      match List.assoc_opt "credential_ref" auth_fields with
+      | None | Some `Null -> Ok No_credential
+      | Some value -> credential_ref_of_json value
+    in
+    Ok (Some { schemes; credential_ref })
+  | Some _ -> invalid_config ~field:"authentication" ~detail:"must be an object or null"
+;;
+
+let skill_of_json index = function
+  | `Assoc fields ->
+    let ( let* ) = Result.bind in
+    let path = Printf.sprintf "skills[%d]" index in
+    let* () = validate_object_fields ~path ~known:[ "name"; "description" ] fields in
+    let* name = required_string fields ~key:"name" (path ^ ".name") in
+    let* description =
+      optional_string fields ~key:"description" (path ^ ".description")
+    in
+    Ok { name; description }
+  | _ ->
+    invalid_config ~field:(Printf.sprintf "skills[%d]" index) ~detail:"must be an object"
+;;
+
+let tool_schema_of_json index json =
+  match Types.tool_schema_of_yojson json with
+  | Ok tool -> Ok tool
+  | Error detail -> invalid_config ~field:(Printf.sprintf "tools[%d]" index) ~detail
+;;
+
 let of_json (json : Yojson.Safe.t) : (agent_card, Error.sdk_error) result =
-  let open Yojson.Safe.Util in
-  try
-    let name = json |> member "name" |> to_string in
-    let description =
-      match json |> member "description" with
-      | `Null -> None
-      | v -> Some (to_string v)
+  match json with
+  | `Assoc fields ->
+    let ( let* ) = Result.bind in
+    let* () =
+      validate_object_fields
+        ~path:"agent_card"
+        ~known:
+          [ "name"
+          ; "description"
+          ; "version"
+          ; "authentication"
+          ; "supportedInterfaces"
+          ; "capabilities"
+          ; "tools"
+          ; "skills"
+          ; "supported_providers"
+          ; "metadata"
+          ]
+        fields
     in
-    let version = json |> member "version" |> to_string in
-    let top_level_protocol_version =
-      json |> member "protocolVersion" |> to_string_option
+    let* name = required_string fields "name" in
+    let* description = optional_string fields "description" in
+    let* version = required_string fields "version" in
+    let* interface_values = required_list fields "supportedInterfaces" in
+    let* interfaces = map_indexed_result 0 supported_interface_of_json interface_values in
+    let* supported_interfaces =
+      supported_interfaces_of_list_at ~field:"supportedInterfaces" interfaces
     in
-    let url =
-      match json |> member "url" with
-      | `Null -> None
-      | v -> Some (to_string v)
+    let* capability_values = required_list fields "capabilities" in
+    let* capability_names = strings_of_json ~field:"capabilities" capability_values in
+    let capabilities = List.map capability_of_string capability_names in
+    let* tool_values = required_list fields "tools" in
+    let* tools = map_indexed_result 0 tool_schema_of_json tool_values in
+    let* skill_values = required_list fields "skills" in
+    let* skills = map_indexed_result 0 skill_of_json skill_values in
+    let* provider_values = required_list fields "supported_providers" in
+    let* supported_providers =
+      strings_of_json ~field:"supported_providers" provider_values
     in
-    let raw_supported_interfaces =
-      match json |> member "supportedInterfaces" with
-      | `List items ->
-        List.filter_map
-          (fun item ->
-             match item |> member "url" |> to_string_option with
-             | Some iface_url ->
-               let protocol_binding =
-                 match item |> member "protocolBinding" |> to_string_option with
-                 | Some binding -> Some binding
-                 | None -> item |> member "type" |> to_string_option
-               in
-               (match protocol_binding with
-                | Some binding ->
-                  let protocol_version =
-                    match item |> member "protocolVersion" |> to_string_option with
-                    | Some v -> v
-                    | None ->
-                      (match top_level_protocol_version with
-                       | Some v -> v
-                       | None -> "0.1")
-                  in
-                  let tenant = item |> member "tenant" |> to_string_option in
-                  Some
-                    { url = iface_url
-                    ; protocol_binding = binding
-                    ; protocol_version
-                    ; tenant
-                    }
-                | None -> None)
-             | None -> None)
-          items
-      | _ -> []
-    in
-    let protocol_version =
-      match top_level_protocol_version with
-      | Some v -> v
-      | None ->
-        (match raw_supported_interfaces with
-         | first :: _ -> first.protocol_version
-         | [] -> "0.1")
-    in
-    let supported_interfaces =
-      match raw_supported_interfaces, url with
-      | [], Some card_url ->
-        [ { url = card_url
-          ; protocol_binding = "JSONRPC"
-          ; protocol_version
-          ; tenant = None
-          }
-        ]
-      | interfaces, _ -> interfaces
-    in
-    let capabilities =
-      json
-      |> member "capabilities"
-      |> to_list
-      |> List.map (fun j -> capability_of_string (to_string j))
-    in
-    let supported_providers =
-      json |> member "supported_providers" |> to_list |> Util.string_list_of_json
-    in
-    let metadata =
-      match json |> member "metadata" with
-      | `Assoc pairs -> pairs
-      | _ -> []
-    in
-    (* tools and skills contain runtime objects (functions) that cannot
-       be fully restored from JSON.  Callers must re-attach them after
-       deserializing the card skeleton. *)
-    let authentication_result =
-      match json |> member "authentication" with
-      | `Assoc _ as auth_json ->
-        let schemes =
-          auth_json |> member "schemes" |> to_list |> Util.string_list_of_json
+    let* metadata =
+      match List.assoc_opt "metadata" fields with
+      | None | Some `Null -> Ok []
+      | Some (`Assoc pairs) ->
+        let* () =
+          validate_object_fields
+            ~path:"metadata"
+            ~known:(List.map fst pairs |> List.sort_uniq String.compare)
+            pairs
         in
-        (match auth_json |> member "credentials" with
-         | `String _ ->
-           Error
-             (Error.Config
-                (SensitiveValueInConfig
-                   { detail =
-                       "Agent_card authentication contains a literal credential; use \
-                        credential_ref (env/file) instead"
-                   }))
-         | _ ->
-           let credential_ref =
-             match auth_json |> member "credential_ref" with
-             | `Assoc fields ->
-               (match List.assoc_opt "type" fields with
-                | Some (`String "env") ->
-                  (match List.assoc_opt "name" fields with
-                   | Some (`String name) -> Env name
-                   | _ -> No_credential)
-                | Some (`String "file") ->
-                  (match List.assoc_opt "path" fields with
-                   | Some (`String path) -> File path
-                   | _ -> No_credential)
-                | _ -> No_credential)
-             | _ -> No_credential
-           in
-           Ok (Some { schemes; credential_ref }))
-      | _ -> Ok None
+        Ok pairs
+      | Some _ -> invalid_config ~field:"metadata" ~detail:"must be an object or null"
     in
-    match authentication_result with
-    | Error e -> Error e
-    | Ok authentication ->
-      Ok
-        { name
-        ; description
-        ; protocol_version
-        ; version
-        ; url
-        ; authentication
-        ; supported_interfaces
-        ; capabilities
-        ; tools = []
-        ; skills = []
-        ; supported_providers
-        ; metadata
-        }
-  with
-  | Type_error (msg, _) ->
-    Error (Error.Internal (Printf.sprintf "Agent_card.of_json: %s" msg))
+    let* authentication = authentication_of_json fields in
+    Ok
+      { name
+      ; description
+      ; version
+      ; authentication
+      ; supported_interfaces
+      ; capabilities
+      ; tools
+      ; skills
+      ; supported_providers
+      ; metadata
+      }
+  | _ -> invalid_config ~field:"agent_card" ~detail:"must be an object"
 ;;
 
 (* ── Construct from agent_info (decoupled from Agent.t) ── *)
@@ -327,27 +494,29 @@ type agent_info =
   ; mcp_clients_count : int
   ; has_elicitation : bool
   ; skills : skill_meta list
+  ; supported_interfaces : supported_interfaces
   }
 
 let of_info (info : agent_info) : agent_card =
-  let caps = ref [] in
-  let add cap = caps := cap :: !caps in
-  if info.tool_schemas <> [] then add Tools;
-  add Streaming;
-  (match info.config.enable_thinking with
-   | Some true -> add Thinking
-   | _ -> ());
-  if info.mcp_clients_count > 0 then add MCP;
-  if info.has_elicitation then add Elicitation;
+  let optional_capability condition capability =
+    if condition then [ capability ] else []
+  in
+  let capabilities =
+    optional_capability (info.tool_schemas <> []) Tools
+    @ [ Streaming ]
+    @ (match info.config.enable_thinking with
+       | Some true -> [ Thinking ]
+       | Some false | None -> [])
+    @ optional_capability (info.mcp_clients_count > 0) MCP
+    @ optional_capability info.has_elicitation Elicitation
+  in
   let all_providers = List.sort_uniq String.compare info.supported_providers in
   { name = info.agent_name
   ; description = info.agent_description
-  ; protocol_version = "1.0"
   ; version = info.version
-  ; url = None
-  ; authentication = Some { schemes = []; credential_ref = No_credential }
-  ; supported_interfaces = []
-  ; capabilities = List.rev !caps
+  ; authentication = None
+  ; supported_interfaces = info.supported_interfaces
+  ; capabilities
   ; tools = info.tool_schemas
   ; skills = info.skills
   ; supported_providers = all_providers

--- a/lib/protocol/agent_card.mli
+++ b/lib/protocol/agent_card.mli
@@ -38,12 +38,34 @@ type authentication =
   ; credential_ref : credential_ref
   }
 
-type supported_interface =
+type supported_interface = private
   { url : string
   ; protocol_binding : string
   ; protocol_version : string
   ; tenant : string option
   }
+
+(** A caller-owned, non-empty collection of validated interfaces. *)
+type supported_interfaces
+
+val create_supported_interface
+  :  url:string
+  -> protocol_binding:string
+  -> protocol_version:string
+  -> ?tenant:string
+  -> unit
+  -> (supported_interface, Error.sdk_error) result
+
+val supported_interfaces
+  :  supported_interface
+  -> supported_interface list
+  -> supported_interfaces
+
+val supported_interfaces_of_list
+  :  supported_interface list
+  -> (supported_interfaces, Error.sdk_error) result
+
+val supported_interfaces_to_list : supported_interfaces -> supported_interface list
 
 type skill_meta =
   { name : string
@@ -58,7 +80,7 @@ type agent_card =
   ; version : string
   ; url : string option
   ; authentication : authentication option
-  ; supported_interfaces : supported_interface list
+  ; supported_interfaces : supported_interfaces
   ; capabilities : capability list
   ; tools : Types.tool_schema list
   ; skills : skill_meta list
@@ -86,6 +108,9 @@ type agent_info =
   ; has_elicitation : bool
     (** [true] for generic elicitation, exact tool approval, or both. *)
   ; skills : skill_meta list
+  ; supported_interfaces : supported_interfaces
+    (** Exact caller-owned interface authority. Construction cannot synthesize
+        a default URL, binding, or protocol version. *)
   }
 
 val of_info : agent_info -> agent_card

--- a/lib/protocol/agent_card.mli
+++ b/lib/protocol/agent_card.mli
@@ -76,9 +76,7 @@ type skill_meta =
 type agent_card =
   { name : string
   ; description : string option
-  ; protocol_version : string
   ; version : string
-  ; url : string option
   ; authentication : authentication option
   ; supported_interfaces : supported_interfaces
   ; capabilities : capability list

--- a/test/test_agent_card.ml
+++ b/test/test_agent_card.ml
@@ -1,8 +1,29 @@
 open Agent_sdk
 
-let jsonrpc_interface url : Agent_card.supported_interface =
-  { url; protocol_binding = "JSONRPC"; protocol_version = "1.0"; tenant = None }
+let expect_ok = function
+  | Ok value -> value
+  | Error error -> Alcotest.fail (Error.to_string error)
 ;;
+
+let expect_invalid_config ~field = function
+  | Error (Error.Config (Error.InvalidConfig { field = actual; _ })) ->
+    Alcotest.(check string) "invalid field path" field actual
+  | Error error ->
+    Alcotest.fail
+      (Printf.sprintf "expected InvalidConfig(%s), got %s" field (Error.to_string error))
+  | Ok _ -> Alcotest.fail (Printf.sprintf "expected InvalidConfig(%s)" field)
+;;
+
+let jsonrpc_interface url =
+  Agent_card.create_supported_interface
+    ~url
+    ~protocol_binding:"JSONRPC"
+    ~protocol_version:"1.0"
+    ()
+  |> expect_ok
+;;
+
+let jsonrpc_interfaces url = Agent_card.supported_interfaces (jsonrpc_interface url) []
 
 let base_info : Agent_card.agent_info =
   { agent_name = "test-agent"
@@ -30,6 +51,7 @@ let base_info : Agent_card.agent_info =
   ; mcp_clients_count = 0
   ; has_elicitation = false
   ; skills = []
+  ; supported_interfaces = jsonrpc_interfaces "https://agent.example/a2a"
   }
 ;;
 
@@ -37,7 +59,6 @@ let test_of_info_basic () =
   let card = Agent_card.of_info base_info in
   Alcotest.(check string) "name" "test-agent" card.name;
   Alcotest.(check (option string)) "description" (Some "A test agent") card.description;
-  Alcotest.(check string) "protocol version" "1.0" card.protocol_version;
   Alcotest.(check string) "version" Agent_sdk.Sdk_version.version card.version
 ;;
 
@@ -145,15 +166,20 @@ let test_json_roundtrip () =
   match Agent_card.of_json json with
   | Ok card2 ->
     Alcotest.(check string) "name preserved" card.name card2.name;
-    Alcotest.(check string)
-      "protocol preserved"
-      card.protocol_version
-      card2.protocol_version;
     Alcotest.(check string) "version preserved" card.version card2.version;
     Alcotest.(check int)
       "caps count"
       (List.length card.capabilities)
-      (List.length card2.capabilities)
+      (List.length card2.capabilities);
+    Alcotest.(check int) "tools preserved" 1 (List.length card2.tools);
+    (match Agent_card.supported_interfaces_to_list card2.supported_interfaces with
+     | [ interface ] ->
+       Alcotest.(check string)
+         "interface URL preserved"
+         "https://agent.example/a2a"
+         interface.url
+     | interfaces ->
+       Alcotest.failf "expected one interface, got %d" (List.length interfaces))
   | Error e -> Alcotest.fail (Error.to_string e)
 ;;
 
@@ -162,26 +188,27 @@ let test_to_json_structure () =
   let json = Agent_card.to_json card in
   let open Yojson.Safe.Util in
   let name = json |> member "name" |> to_string in
-  let protocol_version = json |> member "protocolVersion" |> to_string in
   let caps = json |> member "capabilities" |> to_list in
   let tools = json |> member "tools" |> to_list in
   let interfaces = json |> member "supportedInterfaces" |> to_list in
   Alcotest.(check string) "json name" "test-agent" name;
-  Alcotest.(check string) "json protocol version" "1.0" protocol_version;
+  Alcotest.(check bool) "no top-level url" true (json |> member "url" = `Null);
+  Alcotest.(check bool)
+    "no top-level protocol version"
+    true
+    (json |> member "protocolVersion" = `Null);
   Alcotest.(check bool) "has caps" true (List.length caps > 0);
   Alcotest.(check int) "1 tool" 1 (List.length tools);
-  Alcotest.(check int) "no interfaces by default" 0 (List.length interfaces)
+  Alcotest.(check int) "one declared interface" 1 (List.length interfaces)
 ;;
 
-let test_to_json_synthesizes_supported_interface () =
+let test_to_json_uses_declared_supported_interface () =
   let card : Agent_card.agent_card =
-    { name = "synth-agent"
+    { name = "explicit-interface-agent"
     ; description = None
-    ; protocol_version = "1.0"
     ; version = "1.0"
-    ; url = Some "http://agent.local/a2a"
     ; authentication = None
-    ; supported_interfaces = []
+    ; supported_interfaces = jsonrpc_interfaces "https://agent.example/a2a"
     ; capabilities = []
     ; tools = []
     ; skills = []
@@ -192,11 +219,11 @@ let test_to_json_synthesizes_supported_interface () =
   let json = Agent_card.to_json card in
   let open Yojson.Safe.Util in
   let interfaces = json |> member "supportedInterfaces" |> to_list in
-  Alcotest.(check int) "synthesized interface count" 1 (List.length interfaces);
+  Alcotest.(check int) "declared interface count" 1 (List.length interfaces);
   let iface = List.hd interfaces in
   Alcotest.(check string)
     "url"
-    "http://agent.local/a2a"
+    "https://agent.example/a2a"
     (iface |> member "url" |> to_string);
   Alcotest.(check string)
     "binding"
@@ -209,9 +236,7 @@ let test_to_json_synthesizes_supported_interface () =
 ;;
 
 let test_of_json_invalid () =
-  match Agent_card.of_json (`String "bad") with
-  | Error _ -> ()
-  | Ok _ -> Alcotest.fail "should fail on invalid json"
+  Agent_card.of_json (`String "bad") |> expect_invalid_config ~field:"agent_card"
 ;;
 
 (* ── capability_to/of_string roundtrip ──────────────────── *)
@@ -243,13 +268,11 @@ let test_json_with_authentication () =
   let card : Agent_card.agent_card =
     { name = "auth-agent"
     ; description = Some "with auth"
-    ; protocol_version = "1.0"
     ; version = "1.0"
-    ; url = Some "http://agent.local:8080"
     ; authentication =
         Some
           { schemes = [ "bearer"; "api-key" ]; credential_ref = Env "AGENT_CARD_API_KEY" }
-    ; supported_interfaces = [ jsonrpc_interface "http://agent.local:8080" ]
+    ; supported_interfaces = jsonrpc_interfaces "https://agent.example:8080"
     ; capabilities = [ Tools; Streaming ]
     ; tools = []
     ; skills = []
@@ -261,8 +284,6 @@ let test_json_with_authentication () =
   match Agent_card.of_json json with
   | Ok card2 ->
     Alcotest.(check string) "name" "auth-agent" card2.name;
-    Alcotest.(check string) "protocol version" "1.0" card2.protocol_version;
-    Alcotest.(check (option string)) "url" (Some "http://agent.local:8080") card2.url;
     (match card2.authentication with
      | Some auth ->
        Alcotest.(check (list string)) "schemes" [ "bearer"; "api-key" ] auth.schemes;
@@ -271,7 +292,10 @@ let test_json_with_authentication () =
          true
          (auth.credential_ref = Agent_card.Env "AGENT_CARD_API_KEY")
      | None -> Alcotest.fail "expected auth");
-    Alcotest.(check int) "interface count" 1 (List.length card2.supported_interfaces);
+    Alcotest.(check int)
+      "interface count"
+      1
+      (List.length (Agent_card.supported_interfaces_to_list card2.supported_interfaces));
     Alcotest.(check int) "metadata" 1 (List.length card2.metadata)
   | Error e -> Alcotest.fail (Error.to_string e)
 ;;
@@ -280,11 +304,9 @@ let test_json_no_auth_no_metadata () =
   let card : Agent_card.agent_card =
     { name = "simple"
     ; description = None
-    ; protocol_version = "1.0"
     ; version = "0.1"
-    ; url = None
     ; authentication = None
-    ; supported_interfaces = []
+    ; supported_interfaces = jsonrpc_interfaces "https://simple.example/a2a"
     ; capabilities = []
     ; tools = []
     ; skills = []
@@ -296,7 +318,6 @@ let test_json_no_auth_no_metadata () =
   match Agent_card.of_json json with
   | Ok card2 ->
     Alcotest.(check (option string)) "no desc" None card2.description;
-    Alcotest.(check (option string)) "no url" None card2.url;
     Alcotest.(check bool) "no auth" true (Option.is_none card2.authentication);
     Alcotest.(check (list string)) "no metadata" [] (List.map fst card2.metadata)
   | Error e -> Alcotest.fail (Error.to_string e)
@@ -306,8 +327,15 @@ let test_json_rejects_literal_credentials () =
   let json =
     `Assoc
       [ "name", `String "bad-agent"
-      ; "protocolVersion", `String "1.0"
       ; "version", `String "1.0"
+      ; ( "supportedInterfaces"
+        , `List
+            [ `Assoc
+                [ "url", `String "https://bad-agent.example/a2a"
+                ; "protocolBinding", `String "JSONRPC"
+                ; "protocolVersion", `String "1.0"
+                ]
+            ] )
       ; "capabilities", `List []
       ; "tools", `List []
       ; "skills", `List []
@@ -321,22 +349,23 @@ let test_json_rejects_literal_credentials () =
   in
   match Agent_card.of_json json with
   | Ok _ -> Alcotest.fail "expected error for literal credentials"
-  | Error (Error.Config (SensitiveValueInConfig _)) ->
+  | Error (Error.Config (InvalidConfig { field; _ }))
+    when String.equal field "authentication.credentials" ->
     Alcotest.(check bool) "rejects literal credentials" true true
   | Error e ->
     Alcotest.fail
-      (Printf.sprintf "expected SensitiveValueInConfig, got %s" (Error.to_string e))
+      (Printf.sprintf
+         "expected InvalidConfig(authentication.credentials), got %s"
+         (Error.to_string e))
 ;;
 
 let test_json_auth_no_credentials () =
   let card : Agent_card.agent_card =
     { name = "auth-noc"
     ; description = None
-    ; protocol_version = "1.0"
     ; version = "1.0"
-    ; url = None
     ; authentication = Some { schemes = [ "oauth" ]; credential_ref = No_credential }
-    ; supported_interfaces = []
+    ; supported_interfaces = jsonrpc_interfaces "https://auth.example/a2a"
     ; capabilities = []
     ; tools = []
     ; skills = []
@@ -375,11 +404,9 @@ let test_to_json_with_skills () =
   let card : Agent_card.agent_card =
     { name = "skill-agent"
     ; description = None
-    ; protocol_version = "1.0"
     ; version = "1.0"
-    ; url = None
     ; authentication = None
-    ; supported_interfaces = []
+    ; supported_interfaces = jsonrpc_interfaces "https://skill.example/a2a"
     ; capabilities = []
     ; tools = []
     ; skills =
@@ -398,7 +425,7 @@ let test_to_json_with_skills () =
   Alcotest.(check string) "skill name" "greet" (first |> member "name" |> to_string)
 ;;
 
-let test_legacy_json_backfills_interfaces () =
+let test_legacy_only_json_is_rejected () =
   let legacy_json =
     `Assoc
       [ "name", `String "legacy-agent"
@@ -411,23 +438,18 @@ let test_legacy_json_backfills_interfaces () =
       ; "supported_providers", `List []
       ]
   in
-  match Agent_card.of_json legacy_json with
-  | Ok card ->
-    Alcotest.(check string) "default protocol version" "0.1" card.protocol_version;
-    Alcotest.(check int) "synthesized interface" 1 (List.length card.supported_interfaces)
-  | Error e -> Alcotest.fail (Error.to_string e)
+  Agent_card.of_json legacy_json |> expect_invalid_config ~field:"supportedInterfaces"
 ;;
 
-let test_interface_protocol_version_inherits_card_version () =
+let test_interface_requires_protocol_version () =
   let json =
     `Assoc
       [ "name", `String "v1-agent"
       ; "version", `String "1.2.3"
-      ; "protocolVersion", `String "1.0"
       ; ( "supportedInterfaces"
         , `List
             [ `Assoc
-                [ "url", `String "http://agent.local/a2a"
+                [ "url", `String "https://agent.example/a2a"
                 ; "protocolBinding", `String "JSONRPC"
                 ]
             ] )
@@ -437,12 +459,161 @@ let test_interface_protocol_version_inherits_card_version () =
       ; "supported_providers", `List []
       ]
   in
-  match Agent_card.of_json json with
-  | Ok card ->
-    Alcotest.(check string) "card protocol version" "1.0" card.protocol_version;
-    let iface = List.hd card.supported_interfaces in
-    Alcotest.(check string) "interface protocol version" "1.0" iface.protocol_version
-  | Error e -> Alcotest.fail (Error.to_string e)
+  Agent_card.of_json json
+  |> expect_invalid_config ~field:"supportedInterfaces[0].protocolVersion"
+;;
+
+let test_interface_rejects_type_alias () =
+  let json =
+    `Assoc
+      [ "name", `String "v1-agent"
+      ; "version", `String "1.2.3"
+      ; ( "supportedInterfaces"
+        , `List
+            [ `Assoc
+                [ "url", `String "https://agent.example/a2a"
+                ; "type", `String "JSONRPC"
+                ; "protocolVersion", `String "1.0"
+                ]
+            ] )
+      ; "capabilities", `List []
+      ; "tools", `List []
+      ; "skills", `List []
+      ; "supported_providers", `List []
+      ]
+  in
+  Agent_card.of_json json
+  |> expect_invalid_config ~field:"supportedInterfaces[0].protocolBinding"
+;;
+
+let test_supported_interfaces_rejects_empty () =
+  Agent_card.supported_interfaces_of_list []
+  |> expect_invalid_config ~field:"supported_interfaces"
+;;
+
+let test_interface_rejects_non_https_url () =
+  Agent_card.create_supported_interface
+    ~url:"http://agent.example/a2a"
+    ~protocol_binding:"JSONRPC"
+    ~protocol_version:"1.0"
+    ()
+  |> expect_invalid_config ~field:"supported_interface.url"
+;;
+
+let test_interface_rejects_relative_url () =
+  Agent_card.create_supported_interface
+    ~url:"/a2a"
+    ~protocol_binding:"JSONRPC"
+    ~protocol_version:"1.0"
+    ()
+  |> expect_invalid_config ~field:"supported_interface.url"
+;;
+
+let test_interface_rejects_empty_binding () =
+  Agent_card.create_supported_interface
+    ~url:"https://agent.example/a2a"
+    ~protocol_binding:""
+    ~protocol_version:"1.0"
+    ()
+  |> expect_invalid_config ~field:"supported_interface.protocolBinding"
+;;
+
+let test_interface_rejects_empty_version () =
+  Agent_card.create_supported_interface
+    ~url:"https://agent.example/a2a"
+    ~protocol_binding:"JSONRPC"
+    ~protocol_version:""
+    ()
+  |> expect_invalid_config ~field:"supported_interface.protocolVersion"
+;;
+
+let replace_json_field key value = function
+  | `Assoc fields -> `Assoc ((key, value) :: List.remove_assoc key fields)
+  | _ -> Alcotest.fail "test fixture must be an object"
+;;
+
+let valid_json () = Agent_card.of_info base_info |> Agent_card.to_json
+
+let test_json_rejects_empty_interfaces () =
+  valid_json ()
+  |> replace_json_field "supportedInterfaces" (`List [])
+  |> Agent_card.of_json
+  |> expect_invalid_config ~field:"supportedInterfaces"
+;;
+
+let test_json_rejects_malformed_metadata () =
+  valid_json ()
+  |> replace_json_field "metadata" (`List [])
+  |> Agent_card.of_json
+  |> expect_invalid_config ~field:"metadata"
+;;
+
+let test_json_rejects_malformed_authentication () =
+  valid_json ()
+  |> replace_json_field "authentication" (`String "bearer")
+  |> Agent_card.of_json
+  |> expect_invalid_config ~field:"authentication"
+;;
+
+let test_json_rejects_incomplete_credential_ref () =
+  let authentication =
+    `Assoc
+      [ "schemes", `List [ `String "bearer" ]
+      ; "credential_ref", `Assoc [ "type", `String "env" ]
+      ]
+  in
+  valid_json ()
+  |> replace_json_field "authentication" authentication
+  |> Agent_card.of_json
+  |> expect_invalid_config ~field:"authentication.credential_ref.name"
+;;
+
+let test_json_rejects_unknown_top_level_field () =
+  match valid_json () with
+  | `Assoc fields ->
+    Agent_card.of_json (`Assoc (("url", `String "https://legacy.example") :: fields))
+    |> expect_invalid_config ~field:"agent_card.url"
+  | _ -> Alcotest.fail "valid card must encode as an object"
+;;
+
+let test_json_rejects_duplicate_top_level_field () =
+  match valid_json () with
+  | `Assoc fields ->
+    Agent_card.of_json (`Assoc (("name", `String "duplicate") :: fields))
+    |> expect_invalid_config ~field:"agent_card.name"
+  | _ -> Alcotest.fail "valid card must encode as an object"
+;;
+
+let test_json_rejects_unknown_interface_field () =
+  let interface =
+    `Assoc
+      [ "url", `String "https://agent.example/a2a"
+      ; "protocolBinding", `String "JSONRPC"
+      ; "protocolVersion", `String "1.0"
+      ; "type", `String "legacy"
+      ]
+  in
+  valid_json ()
+  |> replace_json_field "supportedInterfaces" (`List [ interface ])
+  |> Agent_card.of_json
+  |> expect_invalid_config ~field:"supportedInterfaces[0].type"
+;;
+
+let test_interface_rejects_empty_tenant () =
+  Agent_card.create_supported_interface
+    ~url:"https://agent.example/a2a"
+    ~protocol_binding:"JSONRPC"
+    ~protocol_version:"1.0"
+    ~tenant:""
+    ()
+  |> expect_invalid_config ~field:"supported_interface.tenant"
+;;
+
+let test_json_rejects_duplicate_metadata_field () =
+  valid_json ()
+  |> replace_json_field "metadata" (`Assoc [ "env", `String "a"; "env", `String "b" ])
+  |> Agent_card.of_json
+  |> expect_invalid_config ~field:"metadata.env"
 ;;
 
 let () =
@@ -473,9 +644,9 @@ let () =
       , [ test_case "roundtrip" `Quick test_json_roundtrip
         ; test_case "to_json structure" `Quick test_to_json_structure
         ; test_case
-            "to_json synthesizes supported interface"
+            "to_json uses declared supported interface"
             `Quick
-            test_to_json_synthesizes_supported_interface
+            test_to_json_uses_declared_supported_interface
         ; test_case "of_json invalid" `Quick test_of_json_invalid
         ; test_case "with auth" `Quick test_json_with_authentication
         ; test_case "no auth no meta" `Quick test_json_no_auth_no_metadata
@@ -486,13 +657,73 @@ let () =
             test_json_rejects_literal_credentials
         ; test_case "with skills" `Quick test_to_json_with_skills
         ; test_case
-            "legacy json backfills interfaces"
+            "legacy-only json is rejected"
             `Quick
-            test_legacy_json_backfills_interfaces
+            test_legacy_only_json_is_rejected
         ; test_case
-            "interface protocol version inherits card version"
+            "interface requires protocol version"
             `Quick
-            test_interface_protocol_version_inherits_card_version
+            test_interface_requires_protocol_version
+        ; test_case
+            "interface rejects type alias"
+            `Quick
+            test_interface_rejects_type_alias
+        ; test_case
+            "supported interfaces reject empty"
+            `Quick
+            test_supported_interfaces_rejects_empty
+        ; test_case
+            "interface rejects non-HTTPS URL"
+            `Quick
+            test_interface_rejects_non_https_url
+        ; test_case
+            "interface rejects relative URL"
+            `Quick
+            test_interface_rejects_relative_url
+        ; test_case
+            "interface rejects empty binding"
+            `Quick
+            test_interface_rejects_empty_binding
+        ; test_case
+            "interface rejects empty version"
+            `Quick
+            test_interface_rejects_empty_version
+        ; test_case
+            "JSON rejects empty interfaces"
+            `Quick
+            test_json_rejects_empty_interfaces
+        ; test_case
+            "JSON rejects malformed metadata"
+            `Quick
+            test_json_rejects_malformed_metadata
+        ; test_case
+            "JSON rejects malformed authentication"
+            `Quick
+            test_json_rejects_malformed_authentication
+        ; test_case
+            "JSON rejects incomplete credential ref"
+            `Quick
+            test_json_rejects_incomplete_credential_ref
+        ; test_case
+            "JSON rejects unknown top-level field"
+            `Quick
+            test_json_rejects_unknown_top_level_field
+        ; test_case
+            "JSON rejects duplicate top-level field"
+            `Quick
+            test_json_rejects_duplicate_top_level_field
+        ; test_case
+            "JSON rejects unknown interface field"
+            `Quick
+            test_json_rejects_unknown_interface_field
+        ; test_case
+            "interface rejects empty tenant"
+            `Quick
+            test_interface_rejects_empty_tenant
+        ; test_case
+            "JSON rejects duplicate metadata field"
+            `Quick
+            test_json_rejects_duplicate_metadata_field
         ] )
     ]
 ;;

--- a/test/test_agent_card.ml
+++ b/test/test_agent_card.ml
@@ -438,7 +438,7 @@ let test_legacy_only_json_is_rejected () =
       ; "supported_providers", `List []
       ]
   in
-  Agent_card.of_json legacy_json |> expect_invalid_config ~field:"supportedInterfaces"
+  Agent_card.of_json legacy_json |> expect_invalid_config ~field:"agent_card.url"
 ;;
 
 let test_interface_requires_protocol_version () =
@@ -482,8 +482,7 @@ let test_interface_rejects_type_alias () =
       ; "supported_providers", `List []
       ]
   in
-  Agent_card.of_json json
-  |> expect_invalid_config ~field:"supportedInterfaces[0].protocolBinding"
+  Agent_card.of_json json |> expect_invalid_config ~field:"supportedInterfaces[0].type"
 ;;
 
 let test_supported_interfaces_rejects_empty () =

--- a/test/test_builder.ml
+++ b/test/test_builder.ml
@@ -2,6 +2,16 @@
 
 open Agent_sdk
 
+let card_interfaces =
+  Agent_card.create_supported_interface
+    ~url:"https://test-agent.example/a2a"
+    ~protocol_binding:"JSONRPC"
+    ~protocol_version:"1.0"
+    ()
+  |> Result.get_ok
+  |> fun interface -> Agent_card.supported_interfaces interface []
+;;
+
 (** Run a function inside Eio with network access. *)
 let with_net f =
   Eio_main.run
@@ -348,7 +358,7 @@ let test_with_provider_config_reaches_dispatch_losslessly () =
   Alcotest.(check (list string))
     "agent card observes canonical provider identity"
     [ "ollama" ]
-    (Agent.card agent).supported_providers;
+    (Agent.card ~supported_interfaces:card_interfaces agent).supported_providers;
   let result = Eio.Switch.run (fun sw -> Agent.run ~sw agent "hello") in
   (match result with
    | Ok _ -> ()

--- a/test/test_builder_coverage.ml
+++ b/test/test_builder_coverage.ml
@@ -10,6 +10,16 @@
 
 open Agent_sdk
 
+let card_interfaces =
+  Agent_card.create_supported_interface
+    ~url:"https://test-agent.example/a2a"
+    ~protocol_binding:"JSONRPC"
+    ~protocol_version:"1.0"
+    ()
+  |> Result.get_ok
+  |> fun interface -> Agent_card.supported_interfaces interface []
+;;
+
 (* ── Builder chain methods ────────────────────────────────── *)
 
 let test_builder_chain () =
@@ -242,7 +252,7 @@ let test_agent_card () =
   in
   match Builder.build_safe b with
   | Ok agent ->
-    let card = Agent.card agent in
+    let card = Agent.card ~supported_interfaces:card_interfaces agent in
     Alcotest.(check string) "card name" "card-test" card.name
   | Error e -> Alcotest.fail (Error.to_string e)
 ;;

--- a/test/test_full_pipeline_cov.ml
+++ b/test/test_full_pipeline_cov.ml
@@ -8,6 +8,16 @@
 open Agent_sdk
 open Alcotest
 
+let card_interfaces =
+  Agent_card.create_supported_interface
+    ~url:"https://test-agent.example/a2a"
+    ~protocol_binding:"JSONRPC"
+    ~protocol_version:"1.0"
+    ()
+  |> Result.get_ok
+  |> fun interface -> Agent_card.supported_interfaces interface []
+;;
+
 (* ── Mock server helpers ──────────────────────────────────────── *)
 
 let escape_json_string s =
@@ -614,7 +624,7 @@ let test_agent_card () =
   @@ fun _sw ->
   let url = "http://127.0.0.1:21019" in
   let agent = make_agent ~net:env#net url in
-  let card = Agent.card agent in
+  let card = Agent.card ~supported_interfaces:card_interfaces agent in
   check string "card name" "cov-agent" card.name
 ;;
 

--- a/test/test_pipeline_common_coverage.ml
+++ b/test/test_pipeline_common_coverage.ml
@@ -15,6 +15,16 @@ let openai_config =
     ()
 ;;
 
+let card_interfaces =
+  Agent_card.create_supported_interface
+    ~url:"https://coverage-agent.example/a2a"
+    ~protocol_binding:"JSONRPC"
+    ~protocol_version:"1.0"
+    ()
+  |> Result.get_ok
+  |> fun interface -> Agent_card.supported_interfaces interface []
+;;
+
 let echo_tool =
   Tool.create
     ~name:"echo"
@@ -123,7 +133,7 @@ let test_agent_type_accessors_card_and_state_mutators () =
     "provider config option"
     true
     (Option.is_some (Internal_agent.options agent).provider_config);
-  let card = Internal_agent.card agent in
+  let card = Internal_agent.card ~supported_interfaces:card_interfaces agent in
   check_string "card name" "coverage-agent" card.name;
   check_opt_string "card description" (Some "Coverage agent") card.description;
   check_int "card tools" 1 (List.length card.tools);

--- a/test/test_skill_discovery.ml
+++ b/test/test_skill_discovery.ml
@@ -7,6 +7,16 @@
 
 open Agent_sdk
 
+let card_interfaces =
+  Agent_card.create_supported_interface
+    ~url:"https://test-agent.example/a2a"
+    ~protocol_binding:"JSONRPC"
+    ~protocol_version:"1.0"
+    ()
+  |> Result.get_ok
+  |> fun interface -> Agent_card.supported_interfaces interface []
+;;
+
 let with_net f = Eio_main.run @@ fun env -> f (Eio.Stdenv.net env)
 
 let contains ~needle haystack =
@@ -62,7 +72,7 @@ let test_registry_does_not_inject_prompt () =
     false
     (contains ~needle:"[Skill: discovery-only]" prompt);
   (* But the skill is in the agent card *)
-  let card = Agent.card agent in
+  let card = Agent.card ~supported_interfaces:card_interfaces agent in
   Alcotest.(check bool)
     "card has discovery-only skill"
     true
@@ -166,7 +176,7 @@ let test_both_paths_coexist () =
     false
     (contains ~needle:"[Skill: catalog]" prompt);
   (* Agent card has the registry skill *)
-  let card = Agent.card agent in
+  let card = Agent.card ~supported_interfaces:card_interfaces agent in
   Alcotest.(check bool) "card has catalog" true (Agent_card.has_skill card "catalog")
 ;;
 

--- a/test/test_usability_v030.ml
+++ b/test/test_usability_v030.ml
@@ -4,6 +4,16 @@
 
 open Agent_sdk
 
+let card_interfaces =
+  Agent_card.create_supported_interface
+    ~url:"https://test-agent.example/a2a"
+    ~protocol_binding:"JSONRPC"
+    ~protocol_version:"1.0"
+    ()
+  |> Result.get_ok
+  |> fun interface -> Agent_card.supported_interfaces interface []
+;;
+
 let build_exn b =
   match Builder.build_safe b with
   | Ok agent -> agent
@@ -53,7 +63,7 @@ let test_builder_with_skill_registry () =
     |> Builder.with_skill_registry reg
     |> build_exn
   in
-  let card = Agent.card agent in
+  let card = Agent.card ~supported_interfaces:card_interfaces agent in
   Alcotest.(check string) "card name" "polyglot" (card_name card);
   Alcotest.(check (option string))
     "card desc"
@@ -90,7 +100,7 @@ let test_card_json_export () =
     |> Builder.with_thinking_budget 2000
     |> build_exn
   in
-  let card = Agent.card agent in
+  let card = Agent.card ~supported_interfaces:card_interfaces agent in
   let json = Agent_card.to_json card in
   let open Yojson.Safe.Util in
   let name = json |> member "name" |> to_string in
@@ -128,7 +138,7 @@ let test_builder_with_elicitation () =
     |> Builder.with_elicitation cb
     |> build_exn
   in
-  let card = Agent.card agent in
+  let card = Agent.card ~supported_interfaces:card_interfaces agent in
   Alcotest.(check bool)
     "elicitation cap"
     true


### PR DESCRIPTION
대상 head: `f82d09d80171d27c01e5ecd8807442c684b58ec6`

Agent Card를 현재 caller-owned interface 계약으로 hard cut 했어용.

- `supported_interfaces`를 검증된 non-empty 불변 타입으로 만들었어용.
- caller가 절대 HTTPS URL·binding·protocol version을 반드시 제공해용.
- top-level URL 합성, `JSONRPC`/`0.1` 추정, legacy alias를 제거했어용.
- 외부 JSON 오류는 `InvalidConfig`와 정확한 field path로 반환해용.
- unknown·duplicate field, malformed metadata/auth/credential ref를 fail-closed 처리했어용.
- tools/skills를 역직렬화에서 버리던 silent failure를 제거했어용.
- capability 조립은 mutable ref 없이 불변으로 구성해용.

최신 `main`(`a5485c74b8571b90e95fd258a549d54222da9eae`) 위에서 충돌을 해소했어용. 로컬 Dune은 실행하지 않았고 13개 수정 파일의 포맷·파싱·diff 검증만 통과했어용. 전체 검증은 CI에서 확인해용.