### PR TITLE
refactor(runtime): require current persistence fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ instead of being inferred as `STOP` from tool-block presence.
 
 ### Breaking Changes
 
+Runtime session and participant event JSON now require all current optional
+fields to be present: `pending_input` on sessions, `raw_trace_run_id` on
+participant/output-delta payloads, and `stop_reason` /
+`completion_anomaly` on successful completion payloads. Their values remain
+optional and may be `null`, but historical payloads that omit the fields are
+no longer backfilled during decoding.
+
 `Structured.schema` now contains only the provider-native JSON Schema
 parameters and typed parser. The unused forced-tool `name` and `description`
 fields, `schema_to_tool_json`, and `extract_tool_input` are removed rather than

--- a/lib/runtime.ml
+++ b/lib/runtime.ml
@@ -87,7 +87,7 @@ type session =
   ; planned_participants : string list
   ; participants : participant list
   ; artifacts : artifact list
-  ; pending_input : input_request option [@default None]
+  ; pending_input : input_request option
   ; turn_count : int
   ; last_seq : int
   ; outcome : string option
@@ -245,7 +245,7 @@ type participant_event_common =
   ; summary : string option
   ; provider : string option
   ; model : string option
-  ; raw_trace_run_id : string option [@default None]
+  ; raw_trace_run_id : string option
   }
 [@@deriving yojson, show]
 
@@ -254,8 +254,8 @@ type participant_live_event = { participant : participant_event_common }
 
 type participant_completed_event =
   { participant : participant_event_common
-  ; stop_reason : string option [@default None]
-  ; completion_anomaly : completion_anomaly option [@default None]
+  ; stop_reason : string option
+  ; completion_anomaly : completion_anomaly option
   }
 [@@deriving yojson, show]
 
@@ -268,7 +268,7 @@ type participant_failed_event =
 type output_delta_event =
   { participant_name : string
   ; delta : string
-  ; raw_trace_run_id : string option [@default None]
+  ; raw_trace_run_id : string option
   }
 [@@deriving yojson, show]
 

--- a/lib/runtime.mli
+++ b/lib/runtime.mli
@@ -99,7 +99,7 @@ type session =
   ; planned_participants : string list
   ; participants : participant list
   ; artifacts : artifact list
-  ; pending_input : input_request option [@default None]
+  ; pending_input : input_request option
   ; turn_count : int
   ; last_seq : int
   ; outcome : string option
@@ -251,7 +251,7 @@ type participant_event_common =
   ; summary : string option
   ; provider : string option
   ; model : string option
-  ; raw_trace_run_id : string option [@default None]
+  ; raw_trace_run_id : string option
   }
 [@@deriving yojson, show]
 
@@ -262,8 +262,8 @@ type participant_live_event = { participant : participant_event_common }
     payload. *)
 type participant_completed_event =
   { participant : participant_event_common
-  ; stop_reason : string option [@default None]
-  ; completion_anomaly : completion_anomaly option [@default None]
+  ; stop_reason : string option
+  ; completion_anomaly : completion_anomaly option
   }
 [@@deriving yojson, show]
 
@@ -277,7 +277,7 @@ type participant_failed_event =
 type output_delta_event =
   { participant_name : string
   ; delta : string
-  ; raw_trace_run_id : string option [@default None]
+  ; raw_trace_run_id : string option
   }
 [@@deriving yojson, show]
 

--- a/test/test_runtime_types.ml
+++ b/test/test_runtime_types.ml
@@ -152,7 +152,16 @@ let test_session () =
     ~of_yojson:Runtime.session_of_yojson
     ~show:Runtime.show_session
     ~name:"session"
-    v
+    v;
+  let without_pending_input =
+    match Runtime.session_to_yojson v with
+    | `Assoc fields -> `Assoc (List.remove_assoc "pending_input" fields)
+    | _ -> Alcotest.fail "session must encode as an object"
+  in
+  Alcotest.(check bool)
+    "missing pending_input rejected"
+    true
+    (Result.is_error (Runtime.session_of_yojson without_pending_input))
 ;;
 
 let test_init_request () =
@@ -407,12 +416,23 @@ let test_event_kind () =
     events
 ;;
 
-let test_output_delta_legacy_json_defaults_raw_trace_run_id () =
-  let json = `Assoc [ "participant_name", `String "sub"; "delta", `String "legacy" ] in
-  match Runtime.output_delta_event_of_yojson json with
-  | Ok detail ->
-    Alcotest.(check (option string)) "raw trace default" None detail.raw_trace_run_id
-  | Error msg -> Alcotest.failf "output_delta_event parse failed: %s" msg
+let test_output_delta_requires_current_raw_trace_field () =
+  let current : Runtime.output_delta_event =
+    { participant_name = "sub"; delta = "current"; raw_trace_run_id = None }
+  in
+  roundtrip
+    ~to_yojson:Runtime.output_delta_event_to_yojson
+    ~of_yojson:Runtime.output_delta_event_of_yojson
+    ~show:Runtime.show_output_delta_event
+    ~name:"output_delta_event"
+    current;
+  let missing_field_json =
+    `Assoc [ "participant_name", `String "sub"; "delta", `String "historical" ]
+  in
+  Alcotest.(check bool)
+    "missing raw_trace_run_id rejected"
+    true
+    (Result.is_error (Runtime.output_delta_event_of_yojson missing_field_json))
 ;;
 
 let completion_anomaly count =
@@ -507,6 +527,28 @@ let test_participant_lifecycle_payloads_exclude_contradictions () =
   let completed_json = Runtime.participant_completed_event_to_yojson completed in
   let failed_json = Runtime.participant_failed_event_to_yojson failed in
   let live_json = Runtime.participant_live_event_to_yojson live in
+  let participant_json = Runtime.participant_event_common_to_yojson participant in
+  Alcotest.(check bool)
+    "participant requires raw trace field"
+    true
+    (participant_json
+     |> remove_field "raw_trace_run_id"
+     |> Runtime.participant_event_common_of_yojson
+     |> Result.is_error);
+  Alcotest.(check bool)
+    "completed requires stop reason field"
+    true
+    (completed_json
+     |> remove_field "stop_reason"
+     |> Runtime.participant_completed_event_of_yojson
+     |> Result.is_error);
+  Alcotest.(check bool)
+    "completed requires anomaly field"
+    true
+    (completed_json
+     |> remove_field "completion_anomaly"
+     |> Runtime.participant_completed_event_of_yojson
+     |> Result.is_error);
   Alcotest.(check bool)
     "completed rejects failure cause"
     true
@@ -538,10 +580,7 @@ let test_participant_lifecycle_payloads_exclude_contradictions () =
   Alcotest.(check bool)
     "legacy flat completed payload rejected"
     true
-    (participant
-     |> Runtime.participant_event_common_to_yojson
-     |> Runtime.participant_completed_event_of_yojson
-     |> Result.is_error)
+    (participant_json |> Runtime.participant_completed_event_of_yojson |> Result.is_error)
 ;;
 
 let test_event () =
@@ -596,9 +635,9 @@ let () =
             `Quick
             test_participant_lifecycle_payloads_exclude_contradictions
         ; Alcotest.test_case
-            "output delta legacy json"
+            "output delta requires current raw trace field"
             `Quick
-            test_output_delta_legacy_json_defaults_raw_trace_run_id
+            test_output_delta_requires_current_raw_trace_field
         ; Alcotest.test_case "event" `Quick test_event
         ] )
     ]


### PR DESCRIPTION
## Scope

- require `pending_input` to be present in current session JSON
- require `raw_trace_run_id` to be present in current participant and output-delta JSON
- require `stop_reason` and `completion_anomaly` to be present in current successful-completion JSON
- retain all five values as options, so explicit JSON `null` remains valid
- reject historical payloads that omit these fields instead of backfilling `None`

No migration, repair decoder, synthetic trace identity, or additional Gate was added.

## Feature / Gate audit

- Session producer/consumer type: `Runtime.session`; current constructors already
  carry `pending_input`, and input-request transitions update the same field.
- Producer/consumer types: `Runtime.Agent_became_live`, `Agent_completed`,
  `Agent_failed`, and `Agent_output_delta`.
- Current typed construction already supplies each field explicitly at every call site.
- The derived Yojson decoder is the single wire boundary. Removing `[@default None]` makes that existing boundary enforce the current shape; no downstream duplicate check exists.
- Current events with explicit `None` values round-trip, proving the Feature still supports absent optional evidence without confusing absence of a value with absence of the current field.

## Blast radius

- Only persisted/exchanged session or participant event JSON that omits a current field is rejected.
- The OCaml record shapes and all current constructors are unchanged.
- MASC current source has no direct dependency on these OAS Runtime event records.

## Verification

- changed OCaml files: `ocamlformat` + parse check — pass
- current explicit-`None` round-trips and missing-field rejection coverage added
- `git diff --check` — pass
- `bash scripts/ci-code-smell-ratchet.sh --check` — pass
- `bash scripts/hardening-ratchet.sh --check` — pass
- focused Dune build (`test_runtime_types`, `@fmt`) — pass
- focused Runtime types tests — 20/20 pass
