### PR TITLE
fix(provider): finish exact carrier hard cut

### DIFF
--- a/docs/rfc/RFC-OAS-034-endpoint-capability-boundary.md
+++ b/docs/rfc/RFC-OAS-034-endpoint-capability-boundary.md
@@ -88,7 +88,7 @@ capability(MTP, tool_choice, reasoning dialect, structured output)를 결정하�
 |---|------|------|----------|
 | B3 | `provider_registry.ml:533-534` `provider_name_of_config` (`OpenAI_compat + is_local → "nous"`) | 임의 로컬 OpenAI-compat 엔드포인트(bare llama.cpp/vLLM)가 loopback host만으로 특정 벤더 "nous"(Nous Research)로 라벨링. (a) `complete.ml`의 `~provider:` 텔레메트리가 모든 로컬 요청을 nous로 **무조건 오귀속**(+ free-pricing); (b) `registry_capabilities_for_provider_config` fallback이 `nous → openai_compat_chat_extended_capabilities`를 주어 uncatalogued 로컬 모델에 `supports_reasoning`/`extended_thinking`/`reasoning_budget` **권한 인플레이션**. 자기 `.mli` 계약(§69-78 "stable kind-derived label")과 `capabilities.ml:388-409` declaration-over-probing 철학에 모순. | medium |
 
-**조치**: `is_local → "nous"` 특례 삭제. 로컬은 중립 `"openai_compat"`(또는 locality-무관 `"local"`)로. 확장 caps는 catalog/manifest row나 명시 override에서만. `is_local`은 auth-less/zero-pricing 같은 전송·비용 관심사에만 — 그건 `provider.ml:670`(`is_local → Provider.Local`, 동일 wire dialect, capability 누수 0)에서 이미 올바르게 분리돼 있다(legit 대조군).
+**조치**: `is_local → "nous"` 특례 삭제. 현재 typed 계약에는 locality로 선택되는 legacy carrier가 없다. 호출자가 `Provider_config.make`의 `kind`, `provider_id`, `base_url`, `request_path`, credential을 명시하고, `Provider_config.is_local`은 loopback 여부만 투영해야 한다. provider identity·capability·pricing·auth는 locality에서 추론하지 않는다.
 
 ### P3 — Borderline (경화 / 일관성, 낮은 우선순위)
 
@@ -104,7 +104,7 @@ capability(MTP, tool_choice, reasoning dialect, structured output)를 결정하�
 - `ollama.com → ollama_cloud`(`provider_config.ml:211`) — vendor-canonical host==provider (case a).
 - `zai_catalog.ml` `is_zai/is_coding_base_url` — 정확 `Uri.host` 등가 + path prefix + env override, look-alike 거부 테스트 핀 (a+c).
 - `http_client.ml:242` `cdn_per_header_limit_bytes = 8192` — RunPod/Cloudflare edge per-header-line 한계를 host-gate 없는 generic 전송 상수로, 진단에만 (b). **B1/B2가 어떻게 달랐어야 하는지의 정답.**
-- `provider.ml:670` `is_local → Provider.Local` — 동일 wire dialect·path, auth 없음·zero-pricing만 차이, capability 누수 0 (b). **B3의 `is_local`이 어디까지만 써야 했는지.**
+- `Provider_config.make` + `Provider_config.is_local` — caller가 typed provider identity·wire·credential을 명시하고 locality는 loopback 투영으로만 유지한다. capability·pricing·auth 정책은 locality에서 파생하지 않는다 (b).
 - `request_path_targets_responses_api`(832) + `validate_request_path`(842) — path가 실제 API envelope 결정, 정확 문자열 등가 + exhaustive match fail-closed (c).
 
 ## 4. Migration

--- a/examples/observable_agent.ml
+++ b/examples/observable_agent.ml
@@ -1,14 +1,13 @@
 (** Observable agent: see every pipeline step in the terminal.
 
     Demonstrates:
-    - Provider discovery (auto-detect running llama-server)
+    - Explicit provider configuration
     - Event_bus with real-time event printing
     - Hooks for pipeline step visibility
-    - Automatic fallback to mock server if no LLM is available
+    - Explicit mock mode
 
-    Default: discovers LLM via LLM_ENDPOINTS (or localhost:8085).
-    Fallback: built-in mock HTTP server if no LLM is reachable.
-    Force mock: OAS_MOCK=1
+    Live mode: set LLM_BASE_URL and LLM_MODEL.
+    Mock mode: set OAS_MOCK=1 and OAS_MOCK_PORT. OAS_MOCK=0 selects live mode.
 
     Usage:
       dune exec examples/observable_agent.exe *)
@@ -137,7 +136,7 @@ let get_time_tool =
          })
 ;;
 
-(* ── Mock HTTP server (fallback) ─────────────────────── *)
+(* ── Mock HTTP server ────────────────────────────────── *)
 
 let text_body text =
   Printf.sprintf
@@ -166,8 +165,7 @@ let mock_handler call_count _conn _req body =
   Cohttp_eio.Server.respond_string ~status:`OK ~body:response_body ()
 ;;
 
-let start_mock_server ~env ~sw =
-  let port = 18301 in
+let start_mock_server ~env ~sw ~port =
   let call_count = ref 0 in
   let socket =
     Eio.Net.listen
@@ -179,11 +177,58 @@ let start_mock_server ~env ~sw =
   in
   let server = Cohttp_eio.Server.make ~callback:(mock_handler call_count) () in
   Eio.Fiber.fork ~sw (fun () ->
-    Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()));
+    Cohttp_eio.Server.run socket server ~on_error:(fun exn -> Eio.Switch.fail sw exn));
   Printf.sprintf "http://127.0.0.1:%d" port
 ;;
 
-(* ── Provider resolution ─────────────────────────────── *)
+(* ── Explicit provider selection ─────────────────────── *)
+
+type provider_request =
+  | Live_config of
+      { url : string
+      ; model : string
+      }
+  | Mock_requested of { port : int }
+
+type provider_config_error =
+  | Missing_env of string
+  | Invalid_mock_mode of string
+  | Invalid_mock_port of string
+
+let provider_config_error_to_string = function
+  | Missing_env name -> Printf.sprintf "%s must be set for the selected mode" name
+  | Invalid_mock_mode value ->
+    Printf.sprintf "OAS_MOCK must be exactly 0 or 1, got %S" value
+  | Invalid_mock_port value ->
+    Printf.sprintf
+      "OAS_MOCK_PORT must be a canonical decimal integer from 1 to 65535, got %S"
+      value
+;;
+
+let live_provider_request () =
+  match
+    ( Llm_provider.Cli_common_env.get "LLM_BASE_URL"
+    , Llm_provider.Cli_common_env.get "LLM_MODEL" )
+  with
+  | Some url, Some model -> Ok (Live_config { url; model })
+  | None, _ -> Error (Missing_env "LLM_BASE_URL")
+  | Some _, None -> Error (Missing_env "LLM_MODEL")
+;;
+
+let provider_request_from_env () =
+  match Llm_provider.Cli_common_env.get "OAS_MOCK" with
+  | None | Some "0" -> live_provider_request ()
+  | Some "1" ->
+    (match Llm_provider.Cli_common_env.get "OAS_MOCK_PORT" with
+     | None -> Error (Missing_env "OAS_MOCK_PORT")
+     | Some raw ->
+       (match int_of_string_opt raw with
+        | Some port
+          when port >= 1 && port <= 65535 && String.equal raw (string_of_int port) ->
+          Ok (Mock_requested { port })
+        | None | Some _ -> Error (Invalid_mock_port raw)))
+  | Some value -> Error (Invalid_mock_mode value)
+;;
 
 type provider_source =
   | Live of
@@ -192,48 +237,26 @@ type provider_source =
       }
   | Mock of { url : string }
 
-let resolve_provider ~sw ~net =
-  let force_mock = Sys.getenv_opt "OAS_MOCK" <> None in
-  if force_mock
-  then None
-  else (
-    let endpoints =
-      Llm_provider.Discovery.parse_llm_endpoints_env ()
-      |> List.map
-           (Llm_provider.Discovery.endpoint
-              ~protocol:Llm_provider.Discovery.Openai_compatible
-              ~capabilities:Llm_provider.Capabilities.default_capabilities)
-    in
-    let statuses = Llm_provider.Discovery.discover ~sw ~net ~endpoints in
-    List.find_map
-      (fun (s : Llm_provider.Discovery.endpoint_status) ->
-         if s.healthy
-         then (
-           let model =
-             match s.models with
-             | m :: _ -> m.id
-             | [] -> "unknown"
-           in
-           Some (s.url, model))
-         else None)
-      statuses)
-;;
-
 (* ── Main ────────────────────────────────────────────── *)
 
 let () =
-  (* Do not inject mock credentials. Set ANTHROPIC_API_KEY explicitly or use
-     OAS_MOCK=1 for the built-in mock fallback. *)
+  let provider_request =
+    match provider_request_from_env () with
+    | Ok request -> request
+    | Error error ->
+      Printf.eprintf "Configuration error: %s\n" (provider_config_error_to_string error);
+      exit 2
+  in
   Eio_main.run
   @@ fun env ->
   try
     Eio.Switch.run
     @@ fun sw ->
-    (* 1. Discover provider *)
+    (* 1. Materialize the explicitly selected provider. *)
     let source =
-      match resolve_provider ~sw ~net:env#net with
-      | Some (url, model) -> Live { url; model }
-      | None -> Mock { url = start_mock_server ~env ~sw }
+      match provider_request with
+      | Live_config { url; model } -> Live { url; model }
+      | Mock_requested { port } -> Mock { url = start_mock_server ~env ~sw ~port }
     in
     let base_url, model_label =
       match source with

--- a/lib/agent_sdk.ml
+++ b/lib/agent_sdk.ml
@@ -2,7 +2,8 @@
 
     A type-safe, Eio-based single-provider agent runtime.
 
-    Example usage:
+    Example usage (the same provider wiring is compiled by
+    [examples/basic_agent.ml]):
     {[
       open Agent_sdk
 
@@ -23,7 +24,7 @@
         Eio.Switch.run @@ fun sw ->
         let provider_config =
           Llm_provider.Provider_config.make
-            ~kind:OpenAI_compat
+            ~kind:Llm_provider.Provider_config.OpenAI_compat
             ~model_id:"qwen3.5"
             ~base_url:"http://127.0.0.1:8085"
             ()
@@ -41,7 +42,7 @@
         | Ok response ->
             List.iter (function
               | Types.Text t -> print_endline t | _ -> ()) response.content
-        | Error e -> prerr_endline ("Error: " ^ e)
+        | Error e -> prerr_endline ("Error: " ^ Error.to_string e)
     ]}
 *)
 

--- a/lib/provider.ml
+++ b/lib/provider.ml
@@ -25,22 +25,6 @@ type cost_estimate = Llm_provider.Pricing.cost_estimate =
 let pricing_for_model_opt = Llm_provider.Pricing.pricing_for_model_opt
 let estimate_cost = Llm_provider.Pricing.estimate_cost
 
-(** Return only the auth-specific headers for a given provider kind.
-    This keeps [Provider_config.t.headers] free of sensitive tokens until
-    request time. *)
-let auth_headers_only_for_kind
-      ~(kind : Llm_provider.Provider_config.provider_kind)
-      ~api_key
-  =
-  match String.trim api_key with
-  | "" -> []
-  | key ->
-    (match kind with
-     | Anthropic | Kimi -> [ "x-api-key", key ]
-     | Gemini -> [ "x-goog-api-key", key ]
-     | OpenAI_compat | Ollama | Glm | DashScope -> [ "Authorization", "Bearer " ^ key ])
-;;
-
 let provider_config_with_agent_config
       ~(config : Types.agent_config)
       (provider_config : Llm_provider.Provider_config.t)

--- a/lib/provider.mli
+++ b/lib/provider.mli
@@ -137,14 +137,6 @@ type capabilities = Llm_provider.Capabilities.capabilities =
 
 val default_capabilities : capabilities
 
-(** Return only the auth-specific headers for a given provider kind.
-    This keeps [Provider_config.t.headers] free of sensitive tokens until
-    request time. *)
-val auth_headers_only_for_kind
-  :  kind:Llm_provider.Provider_config.provider_kind
-  -> api_key:string
-  -> (string * string) list
-
 (** {2 Pricing: per-model cost estimation} *)
 
 (* Re-exported from [Llm_provider.Pricing] so [Provider.pricing] is the same type

--- a/test/test_provider.ml
+++ b/test/test_provider.ml
@@ -15,31 +15,6 @@ let require_estimated_cost = function
   | Provider.Incomplete _ -> Alcotest.fail "expected an exact cost estimate"
 ;;
 
-let test_auth_headers_only_for_kind () =
-  let check label expected kind api_key =
-    Alcotest.(check (list (pair string string)))
-      label
-      expected
-      (Provider.auth_headers_only_for_kind ~kind ~api_key)
-  in
-  check "empty key" [] Llm_provider.Provider_config.Anthropic "";
-  check
-    "anthropic"
-    [ "x-api-key", "sk-ant-test" ]
-    Llm_provider.Provider_config.Anthropic
-    "sk-ant-test";
-  check
-    "gemini"
-    [ "x-goog-api-key", "gemini-test" ]
-    Llm_provider.Provider_config.Gemini
-    "gemini-test";
-  check
-    "openai-compatible"
-    [ "Authorization", "Bearer compat-test" ]
-    Llm_provider.Provider_config.OpenAI_compat
-    "compat-test"
-;;
-
 let test_pricing_sonnet () =
   let p = declared_pricing "claude-sonnet-4-6-20250514" in
   Alcotest.(check (float 0.001)) "input/M" 3.0 p.input_per_million;
@@ -140,10 +115,7 @@ let () =
   install_embedded_model_catalog ();
   Alcotest.run
     "Provider"
-    [ ( "auth"
-      , [ Alcotest.test_case "auth headers only" `Quick test_auth_headers_only_for_kind ]
-      )
-    ; ( "pricing"
+    [ ( "pricing"
       , [ Alcotest.test_case "sonnet pricing" `Quick test_pricing_sonnet
         ; Alcotest.test_case "gpt-5.5 pricing" `Quick test_pricing_gpt55
         ; Alcotest.test_case


### PR DESCRIPTION
대상 커밋: `8607b120fc9eb1e84a37fed6202aa5942b4e9ff8`

병합된 #2873의 남은 P2를 정리했어용.

- Provider_config와 중복인 auth header 공개 API를 제거했어용.
- Agent SDK 문서 예제를 실제 타입에 맞췄어용.
- 낡은 RFC carrier 설명을 현재 typed 계약으로 교체했어용.
- observable 예제의 discovery·first-healthy·unknown model·자동 mock fallback을 제거했어용. live/mock 설정은 정확한 환경값이 없거나 잘못되면 실패해용.

로컬 검증은 ocamlformat, 파싱, `git diff --check`만 통과했어용. Dune 빌드와 테스트는 CI에서 확인해용.