### PR TITLE
fix(models): GLM-5-Turbo reasoning_streaming_format 추가 (스트리밍 회복)

### DIFF
--- a/models.toml
+++ b/models.toml
@@ -1526,6 +1526,7 @@ supports_reasoning = true
 supports_extended_thinking = true
 supports_response_format_json = true
 supports_native_streaming = true
+reasoning_streaming_format = "delta:reasoning_content"
 input_per_million = 1.2
 output_per_million = 4.0
 cache_write_multiplier = 1.0


### PR DESCRIPTION
## 배경
GLM-5-Turbo keeper turn이 ~60초씩 걸리는 원인.

라이브 로그: `decode_tok_s=-`, `"streaming":["No_streaming_reasoning"]`, `reasoning_replay_dropped`.

## 원인
`models.toml` GLM-5-Turbo 항목이 `supports_native_streaming=true`, `supports_reasoning=true`인데 **`reasoning_streaming_format`이 빠져 있었다**. OAS가 streaming reasoning을 "지원 불가"로 판정(`No_streaming_reasoning`) → keeper가 batch(non-streaming)로 폴백(`keeper_turn.mli:17`: streaming 실패 시 batch) → 전체 응답을 한 번에 대기 → ~60초/turn.

다른 GLM 항목(glm-5.2 등)은 `reasoning_streaming_format = "delta:reasoning_content"`를 가진다. GLM-5-Turbo만 누락. `backend_glm.ml`은 이미 `parse_stream_chunk`로 `delta.reasoning_content`를 파싱하므로 코드는 지원한다.

## 수정
GLM-5-Turbo 항목에 `reasoning_streaming_format = "delta:reasoning_content"` 한 줄 추가. GLM wire 필드(`reasoning_content`)와 일치.

## 효과
streaming reasoning 활성 → batch 폴백 해소 → 첫 토큰이 즉시, turn latency가 수 초~10초대로 줄 예상.

## 검증
배포 후 keeper 라이브 로그에서 `decode_tok_s` 양수화 + `No_streaming_reasoning` 소멸 확인. capability 로드 시 reasoning_streaming_format 누락 경고가 없어야 한다.

연관: kimi/GLM capability 키 비호환(oas#2452, #26263)과 같은 부류 — provider는 지원하지만 카탈로그 한 줄이 빠져서 못 쓰는 패턴.
