### PR TITLE
fix(glm): consume the resolved stream dialect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ derived index.
 
 ### Bug Fixes
 
+GLM streaming now parses reasoning deltas through the resolved typed
+model/provider dialect. The backend no longer hardcodes
+`delta.reasoning_content` independently of the catalog.
+
 Gemini streaming and non-streaming responses now share one finish-reason
 mapping. A function-call block truncated by `MAX_TOKENS` remains terminal and
 is not promoted to executable tool use. Documented policy filters map to

--- a/lib/llm_provider/backend_glm.ml
+++ b/lib/llm_provider/backend_glm.ml
@@ -295,13 +295,10 @@ let parse_response body =
 
 (* ── Streaming ───────────────────────────────────── *)
 
-(** Parse Glm SSE chunk.  Glm uses Openai SSE format but adds
-    [delta.reasoning_content] for thinking. We parse this as
-    [delta_reasoning] in the openai_chunk type. *)
-let parse_stream_chunk data =
-  Streaming.parse_openai_sse_chunk
-    ~streaming_reasoning:(Reasoning_dialect.Delta_field "reasoning_content")
-    data
+(** Parse a GLM SSE chunk using the resolved model/provider dialect.
+    The catalog is the sole authority for reasoning-field interpretation. *)
+let parse_stream_chunk ~streaming_reasoning data =
+  Streaming.parse_openai_sse_chunk ~streaming_reasoning data
 ;;
 
 (* ── Inline tests ────────────────────────────────── *)
@@ -648,7 +645,11 @@ let%test "extract_reasoning_content skips empty reasoning" =
 
 let%test "parse_stream_chunk delegates to openai" =
   let data = {|{"id":"x","choices":[{"delta":{"content":"hi"},"index":0}]}|} in
-  match parse_stream_chunk data with
+  match
+    parse_stream_chunk
+      ~streaming_reasoning:(Reasoning_dialect.Delta_field "reasoning_content")
+      data
+  with
   | Streaming.Openai_chunk chunk -> chunk.delta_content = Some "hi"
   | Streaming.Openai_done
   | Streaming.Openai_empty

--- a/lib/llm_provider/backend_glm.mli
+++ b/lib/llm_provider/backend_glm.mli
@@ -98,6 +98,9 @@ val parse_response : string -> api_response
     as a {!Types.Thinking} content block to the parsed response. *)
 val extract_reasoning_content : api_response -> string -> api_response
 
-(** Parse a Glm SSE streaming chunk.
-    Delegates to {!Streaming.parse_openai_sse_chunk}. *)
-val parse_stream_chunk : string -> Streaming.openai_sse_parse_result
+(** Parse a GLM SSE streaming chunk using the resolved typed reasoning
+    dialect. Delegates to {!Streaming.parse_openai_sse_chunk}. *)
+val parse_stream_chunk
+  :  streaming_reasoning:Reasoning_dialect.streaming_reasoning
+  -> string
+  -> Streaming.openai_sse_parse_result

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -774,7 +774,7 @@ let complete_stream_http
                                     ]
                                   , None ))
                              | Provider_http_codec.Glm_chat ->
-                               Backend_glm.parse_stream_chunk data
+                               Backend_glm.parse_stream_chunk ~streaming_reasoning data
                                |> Streaming.openai_sse_parse_result_to_events
                                     (get_state ())
                              | Provider_http_codec.Ollama_chat ->

--- a/test/test_backend_glm_coverage.ml
+++ b/test/test_backend_glm_coverage.ml
@@ -1,6 +1,7 @@
 open Alcotest
 module K = Llm_provider.Backend_glm
 module PC = Llm_provider.Provider_config
+module RD = Llm_provider.Reasoning_dialect
 module S = Llm_provider.Streaming
 module T = Llm_provider.Types
 
@@ -212,14 +213,28 @@ let test_extract_reasoning_handles_empty_and_malformed_bodies () =
   unchanged "malformed json" {|not json|}
 ;;
 
-let test_parse_stream_chunk_delegates_reasoning_delta () =
+let test_parse_stream_chunk_uses_resolved_reasoning_dialect () =
   let data =
     {|{"id":"chunk-1","model":"glm-5.1","choices":[{"delta":{"reasoning_content":"thinking","content":"token"},"index":0}]}|}
   in
-  match K.parse_stream_chunk data with
+  match
+    K.parse_stream_chunk ~streaming_reasoning:(RD.Delta_field "reasoning_content") data
+  with
   | S.Openai_chunk chunk ->
     check (option string) "content" (Some "token") chunk.delta_content;
     check (option string) "reasoning" (Some "thinking") chunk.delta_reasoning
+  | S.Openai_done | S.Openai_empty | S.Openai_provider_error _ | S.Openai_parse_failed _
+    -> fail "expected stream chunk"
+;;
+
+let test_parse_stream_chunk_does_not_invent_missing_dialect () =
+  let data =
+    {|{"id":"chunk-1","model":"glm-5.1","choices":[{"delta":{"reasoning_content":"thinking","content":"token"},"index":0}]}|}
+  in
+  match K.parse_stream_chunk ~streaming_reasoning:RD.No_streaming_reasoning data with
+  | S.Openai_chunk chunk ->
+    check (option string) "content" (Some "token") chunk.delta_content;
+    check (option string) "reasoning stays absent" None chunk.delta_reasoning
   | S.Openai_done | S.Openai_empty | S.Openai_provider_error _ | S.Openai_parse_failed _
     -> fail "expected stream chunk"
 ;;
@@ -252,9 +267,13 @@ let () =
             `Quick
             test_extract_reasoning_handles_empty_and_malformed_bodies
         ; test_case
-            "stream reasoning delta"
+            "stream uses resolved reasoning dialect"
             `Quick
-            test_parse_stream_chunk_delegates_reasoning_delta
+            test_parse_stream_chunk_uses_resolved_reasoning_dialect
+        ; test_case
+            "stream does not invent a missing dialect"
+            `Quick
+            test_parse_stream_chunk_does_not_invent_missing_dialect
         ] )
     ]
 ;;


### PR DESCRIPTION
jeong-sik/oas#2880 병합 후 남은 parser SSOT P1을 고쳤어용.

- `Glm_chat` parser가 resolved typed `streaming_reasoning`을 소비해용.
- `reasoning_content` 하드코딩을 제거했어용.
- dialect가 없을 때 reasoning delta를 임의 해석하지 않는 회귀 테스트를 추가했어용.

검토 SHA: `32bbe0907`
추적: jeong-sik/masc#27855
공식 근거: https://docs.z.ai/guides/llm/glm-5-turbo

로컬 Dune은 실행하지 않았고 포맷·파싱·diff만 확인했어용. OCaml 5.4 Build는 CI가 권위예용.