### PR TITLE
feat(exact-output): project exact request body size

### DIFF
--- a/lib/llm_provider/exact_output.ml
+++ b/lib/llm_provider/exact_output.ml
@@ -11,6 +11,13 @@ include Exact_output_resolver
 include Flow_contract
 include Exact_output_ready_admission
 
+let project_request_body ~target ~messages requirement =
+  Exact_output_ready_admission.project_request_body
+    ~target:(Exact_output_resolver.projection_target target)
+    ~messages
+    requirement
+;;
+
 let plan_provenance_source_schema_fingerprint (provenance : plan_provenance) =
   provenance.source_schema_fingerprint
 ;;

--- a/lib/llm_provider/exact_output.mli
+++ b/lib/llm_provider/exact_output.mli
@@ -140,6 +140,12 @@ type target_catalog_admission_error =
 type wire_admission_error
 type admission_error
 
+type request_body_projection = private
+  { actual_bytes : int
+  ; limit_bytes : int option
+  ; within_limit : bool
+  }
+
 type token_capacity_rejection =
   | Capacity_evidence_not_yet_valid of
       { now_unix_s : int
@@ -393,6 +399,20 @@ val make_output_requirement
   :  schema:Yojson.Safe.t
   -> minimum_guarantee:minimum_guarantee
   -> output_requirement
+
+(** Project the exact serialized generation-body size for one catalog-admitted
+    target without resolving credentials, allocating an attempt, measuring
+    tokens, or dispatching. The same provider serializer and output requirement
+    transformation used by admission produce [actual_bytes].
+
+    [within_limit] compares only the target's declared request-body ceiling.
+    This function is not a token/context-fit oracle; callers must not convert
+    bytes to tokens or infer an undeclared context boundary from it. *)
+val project_request_body
+  :  target:admitted_target
+  -> messages:Types.message list
+  -> output_requirement
+  -> (request_body_projection, admission_error) result
 
 (** Pure admission. It performs no token-count request, estimation, provider
     completion, or global admission. The returned immutable plan freezes one

--- a/lib/llm_provider/exact_output_plan.ml
+++ b/lib/llm_provider/exact_output_plan.ml
@@ -468,6 +468,10 @@ let preflight_connect_timeout_s (preflight : preflight) = preflight.wire.connect
 let preflight_body_timeout_s (preflight : preflight) = preflight.wire.body_timeout_s
 let preflight_request_body_sha256 (preflight : preflight) = preflight.wire.body_sha256
 
+let preflight_request_body_bytes (preflight : preflight) =
+  String.length preflight.wire.body
+;;
+
 let resolve_context_limit (preflight : preflight) =
   Prepared_completion_request.resolve_context_limit preflight.prepared
 ;;

--- a/lib/llm_provider/exact_output_plan.mli
+++ b/lib/llm_provider/exact_output_plan.mli
@@ -76,6 +76,7 @@ val serving_constraint : preflight -> Serving_constraint.t option
 val preflight_connect_timeout_s : preflight -> float option
 val preflight_body_timeout_s : preflight -> float option
 val preflight_request_body_sha256 : preflight -> string
+val preflight_request_body_bytes : preflight -> int
 
 val resolve_context_limit
   :  preflight

--- a/lib/llm_provider/exact_output_ready_admission.ml
+++ b/lib/llm_provider/exact_output_ready_admission.ml
@@ -103,6 +103,20 @@ type admission_error =
   | Invalid_schema
   | Wire_admission_rejected of wire_admission_error
 
+type request_body_projection =
+  { actual_bytes : int
+  ; limit_bytes : int option
+  ; within_limit : bool
+  }
+
+type request_target =
+  { config : PC.t
+  ; capabilities : Caps.capabilities
+  ; anthropic_thinking_control : Caps.anthropic_thinking_control option
+  ; body_timeout_s : float option
+  ; model_admitted : bool
+  }
+
 type 'callback_error flow_request_error =
   | Flow_request_admission_failed of admission_error * Flow_admission.measurement_evidence
   | Flow_request_measurement_start_failed of string
@@ -141,6 +155,24 @@ let make_output_requirement ~schema ~minimum_guarantee =
   }
 ;;
 
+let request_target_of_selected (target : Resolver.selected_target) =
+  { config = target.config
+  ; capabilities = target.capabilities
+  ; anthropic_thinking_control = target.anthropic_thinking_control
+  ; body_timeout_s = target.body_timeout_s
+  ; model_admitted = Resolver.selected_target_model_admitted target
+  }
+;;
+
+let request_target_of_projection (target : Resolver.projection_target) =
+  { config = target.config
+  ; capabilities = target.capabilities
+  ; anthropic_thinking_control = target.anthropic_thinking_control
+  ; body_timeout_s = target.body_timeout_s
+  ; model_admitted = target.model_admitted
+  }
+;;
+
 let validate_gemini_schema ~path schema =
   match Gemini_schema.validate ~path schema with
   | Ok () -> Ok ()
@@ -151,7 +183,7 @@ let validate_gemini_schema ~path schema =
   | Error Gemini_schema.Invalid_schema -> Error Invalid_schema
 ;;
 
-let schema_for_wire (target : Resolver.selected_target) (Domain_schema domain_schema) =
+let schema_for_wire (target : request_target) (Domain_schema domain_schema) =
   match Provider_http_codec.(json_schema_wire (of_config target.config)) with
   | Raw_schema -> domain_schema
   | Openai_named_schema ->
@@ -162,7 +194,7 @@ let schema_for_wire (target : Resolver.selected_target) (Domain_schema domain_sc
       ]
 ;;
 
-let response_format (target : Resolver.selected_target) requirement =
+let response_format (target : request_target) requirement =
   match requirement.minimum_guarantee with
   (* Json_syntax is fulfilled by the prompt plus local parser/validator.  Do
      not turn a caller's syntax requirement into a provider-native schema
@@ -213,7 +245,7 @@ let messages_for_response_format requirement response_format messages =
   | Types.JsonMode | Types.JsonSchema _ -> messages
 ;;
 
-let exact_config (target : Resolver.selected_target) response_format =
+let exact_config (target : request_target) response_format =
   { target.config with
     temperature = None
   ; top_p = None
@@ -282,9 +314,9 @@ let token_capacity_rejection = function
       }
 ;;
 
-let admission_contract ~(target : Resolver.selected_target) requirement =
+let admission_contract ~(target : request_target) requirement =
   let* () =
-    if Resolver.selected_target_model_admitted target
+    if target.model_admitted
     then Ok ()
     else
       Error
@@ -335,17 +367,41 @@ let ready_plan
   }
 ;;
 
+let project_request_body ~target ~messages requirement =
+  let target = request_target_of_projection target in
+  let* response_format, _, _ = admission_contract ~target requirement in
+  let messages = messages_for_response_format requirement response_format messages in
+  let config = exact_config target response_format in
+  match
+    Plan.preflight
+      ~config
+      ~messages
+      ~body_timeout_s:target.body_timeout_s
+      ~anthropic_thinking_control:target.anthropic_thinking_control
+  with
+  | Ok preflight ->
+    Ok
+      { actual_bytes = Plan.preflight_request_body_bytes preflight
+      ; limit_bytes = config.max_request_body_bytes
+      ; within_limit = true
+      }
+  | Error (Plan.Request_body_too_large { actual_bytes; limit_bytes }) ->
+    Ok { actual_bytes; limit_bytes = Some limit_bytes; within_limit = false }
+  | Error error -> Error (Wire_admission_rejected (wire_admission_error error))
+;;
+
 let admit ~target ~messages requirement =
+  let request_target = request_target_of_selected target in
   let* response_format, actual_assurance, effective_schema_fingerprint =
-    admission_contract ~target requirement
+    admission_contract ~target:request_target requirement
   in
   let messages = messages_for_response_format requirement response_format messages in
   let* preflight =
     Plan.preflight
-      ~config:(exact_config target response_format)
+      ~config:(exact_config request_target response_format)
       ~messages
-      ~body_timeout_s:target.body_timeout_s
-      ~anthropic_thinking_control:target.anthropic_thinking_control
+      ~body_timeout_s:request_target.body_timeout_s
+      ~anthropic_thinking_control:request_target.anthropic_thinking_control
     |> Result.map_error (fun error ->
       Wire_admission_rejected (wire_admission_error error))
   in
@@ -381,8 +437,9 @@ let admit_candidate_request
       ~messages
       requirement
   =
+  let request_target = request_target_of_selected target in
   let* response_format, actual_assurance, effective_schema_fingerprint =
-    admission_contract ~target requirement
+    admission_contract ~target:request_target requirement
     |> Result.map_error (fun error ->
       Flow_request_admission_failed
         ( error
@@ -393,10 +450,10 @@ let admit_candidate_request
   let messages = messages_for_response_format requirement response_format messages in
   let* preflight =
     Plan.preflight
-      ~config:(exact_config target response_format)
+      ~config:(exact_config request_target response_format)
       ~messages
-      ~body_timeout_s:target.body_timeout_s
-      ~anthropic_thinking_control:target.anthropic_thinking_control
+      ~body_timeout_s:request_target.body_timeout_s
+      ~anthropic_thinking_control:request_target.anthropic_thinking_control
     |> Result.map_error (fun error ->
       Flow_request_admission_failed
         ( Wire_admission_rejected (wire_admission_error error)

--- a/lib/llm_provider/exact_output_ready_admission.mli
+++ b/lib/llm_provider/exact_output_ready_admission.mli
@@ -105,6 +105,12 @@ type admission_error =
   | Invalid_schema
   | Wire_admission_rejected of wire_admission_error
 
+type request_body_projection = private
+  { actual_bytes : int
+  ; limit_bytes : int option
+  ; within_limit : bool
+  }
+
 type 'callback_error flow_request_error =
   | Flow_request_admission_failed of
       admission_error * Exact_output_flow_admission.measurement_evidence
@@ -121,6 +127,16 @@ val make_output_requirement
   :  schema:Yojson.Safe.t
   -> minimum_guarantee:minimum_guarantee
   -> output_requirement
+
+(** Purely serialize the exact provider request body for one credential-free
+    admitted-target projection. The returned count is produced by the same
+    provider serializer used by admission. Token/context fit is deliberately
+    outside this body-only contract. *)
+val project_request_body
+  :  target:Exact_output_resolver.projection_target
+  -> messages:Types.message list
+  -> output_requirement
+  -> (request_body_projection, admission_error) result
 
 val admit
   :  target:Exact_output_resolver.selected_target

--- a/lib/llm_provider/exact_output_resolver.ml
+++ b/lib/llm_provider/exact_output_resolver.ml
@@ -122,6 +122,14 @@ type admitted_target =
   ; evidence : catalog_evidence
   }
 
+type projection_target =
+  { config : PC.t
+  ; capabilities : Caps.capabilities
+  ; anthropic_thinking_control : Caps.anthropic_thinking_control option
+  ; body_timeout_s : float option
+  ; model_admitted : bool
+  }
+
 type selected_target =
   { config : PC.t
   ; capabilities : Caps.capabilities
@@ -905,6 +913,17 @@ let admit_target_ref snapshot value =
 let admitted_target_identity (admitted : admitted_target) = admitted.target.identity
 let admitted_target_catalog_generation (admitted : admitted_target) = admitted.generation
 let admitted_target_catalog_evidence (admitted : admitted_target) = admitted.evidence
+
+let projection_target (admitted : admitted_target) =
+  let target = admitted.target in
+  { config = target.config
+  ; capabilities = target.capabilities
+  ; anthropic_thinking_control = target.anthropic_thinking_control
+  ; body_timeout_s = target.body_timeout_s
+  ; model_admitted =
+      Binding.target_model_admitted target.capabilities ~model_id:target.config.model_id
+  }
+;;
 
 let resolve_target (admitted : admitted_target) =
   let target = admitted.target in

--- a/lib/llm_provider/exact_output_resolver.mli
+++ b/lib/llm_provider/exact_output_resolver.mli
@@ -3,6 +3,15 @@ type catalog_evidence
 type target_identity
 type resolver_snapshot
 type admitted_target
+
+type projection_target = private
+  { config : Provider_config.t
+  ; capabilities : Capabilities.capabilities
+  ; anthropic_thinking_control : Capabilities.anthropic_thinking_control option
+  ; body_timeout_s : float option
+  ; model_admitted : bool
+  }
+
 type resolver_io = { getenv : string -> (string option, unit) result }
 
 type catalog_document =
@@ -123,5 +132,10 @@ val admit_target_ref
   :  resolver_snapshot
   -> string
   -> (admitted_target, target_catalog_admission_error) result
+
+(** Return the credential-free immutable request projection captured by
+    [admit_target_ref]. This value may be used only for pure wire-size
+    projection; it cannot be dispatched or converted into a selected target. *)
+val projection_target : admitted_target -> projection_target
 
 val resolve_target : admitted_target -> (selected_target, target_selection_error) result

--- a/test/test_exact_output_flow.ml
+++ b/test/test_exact_output_flow.ml
@@ -1311,6 +1311,68 @@ let test_request_body_capacity_advances_only_after_durable_settlement () =
   | Error _ -> fail "durably settled body-cap rejection did not reach its successor"
 ;;
 
+let test_request_body_projection_is_exact_and_credential_free () =
+  let id = "body-projection" in
+  let base_url = "https://projection.invalid" in
+  let api_key_env = "MISSING_FLOW_KEY" in
+  let requirement =
+    EO.make_output_requirement ~schema ~minimum_guarantee:EO.Provider_schema
+  in
+  let messages = [ msg "measure the exact provider request body" ] in
+  let project ?max_request_body_bytes () =
+    with_catalog
+      ~getenv:credential_getenv
+      [ catalog_entry
+          ?max_request_body_bytes
+          ~api_key_env
+          ~id
+          ~base_url
+          ~native:true
+          ~json:true
+          ()
+      ]
+    @@ fun snapshot ->
+    let target = admitted_target snapshot id in
+    let projection =
+      match EO.project_request_body ~target ~messages requirement with
+      | Ok projection -> projection
+      | Error _ -> fail "credential-free body projection was rejected"
+    in
+    (match EO.resolve_target target with
+     | Error _ -> ()
+     | Ok _ -> fail "fixture did not retain its missing credential");
+    projection
+  in
+  let uncapped = project () in
+  check bool "uncapped body projection is finite" true (uncapped.actual_bytes > 0);
+  check (option int) "uncapped target preserves no limit" None uncapped.limit_bytes;
+  check bool "uncapped projection fits" true uncapped.within_limit;
+  let exact = project ~max_request_body_bytes:uncapped.actual_bytes () in
+  check
+    int
+    "declared cap does not change body bytes"
+    uncapped.actual_bytes
+    exact.actual_bytes;
+  check
+    (option int)
+    "exact cap is preserved"
+    (Some uncapped.actual_bytes)
+    exact.limit_bytes;
+  check bool "exact boundary fits" true exact.within_limit;
+  let rejected = project ~max_request_body_bytes:(uncapped.actual_bytes - 1) () in
+  check
+    int
+    "over-limit projection returns the same exact body bytes"
+    uncapped.actual_bytes
+    rejected.actual_bytes;
+  check
+    (option int)
+    "over-limit projection preserves the exact cap"
+    (Some (uncapped.actual_bytes - 1))
+    rejected.limit_bytes;
+  check bool "limit minus one is rejected" false rejected.within_limit
+;;
+
 let test_measured_token_and_body_capacity_are_independent () =
   let large_input = String.make 65536 'x' in
   let response =
@@ -3986,6 +4048,10 @@ let () =
             "request body cap advances after durable settlement"
             `Quick
             test_request_body_capacity_advances_only_after_durable_settlement
+        ; test_case
+            "request body projection is exact and credential-free"
+            `Quick
+            test_request_body_projection_is_exact_and_credential_free
         ; test_case
             "measured token and serialized body capacities are independent"
             `Quick


### PR DESCRIPTION
## What changed

- expose a pure exact-output request-body projection for one catalog-admitted target
- reuse the same provider serializer and output-requirement transformation as admission
- return exact serialized bytes, the target-declared byte cap, and whether the body fits
- keep credential lookup, attempt allocation, token measurement, and network dispatch outside this projection

## Why

MASC compaction must select a bounded atomic planning window before dispatch. Rebuilding provider JSON or estimating bytes in MASC would duplicate OAS wire authority. This API lets the caller ask OAS for the exact prepared body size without resolving credentials or starting an exact-output attempt.

The contract is deliberately body-only. It does not claim token/context fit, and callers must not derive tokens from bytes. Native exact token preflight for unsupported providers remains tracked by jeong-sik/masc#27885.

## Validation

- `ocamlformat --check test/test_exact_output_flow.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_exact_output_flow.exe @test/runtest-test_exact_output_flow`
- exact-output outer-flow suite: 39/39 passed