### PR TITLE
feat(agent): preserve typed provider message origins

### DIFF
--- a/lib/agent/agent.mli
+++ b/lib/agent/agent.mli
@@ -38,6 +38,27 @@ type context_fit_admission = Agent_types.context_fit_admission =
   | Disabled
   | Enforce_when_supported
 
+type prepared_message_origin = Agent_types.prepared_message_origin =
+  | Canonical_history
+  | Current_user
+  | Extra_system_context
+  | Caller_projection of { source : string }
+
+type prepared_message = Agent_types.prepared_message
+
+val prepared_message_value : prepared_message -> Types.message
+val prepared_message_origin : prepared_message -> prepared_message_origin
+
+val map_prepared_message
+  :  (Types.message -> Types.message)
+  -> prepared_message
+  -> prepared_message
+
+val caller_projected_message
+  :  source:string
+  -> Types.message
+  -> (prepared_message, string) result
+
 type model_input_projection = Agent_types.model_input_projection
 type pre_dispatch_serialization_observer = Agent_types.pre_dispatch_serialization_observer
 
@@ -114,8 +135,10 @@ val sdk_version : string
     that construct options records remain source-compatible.
     The optional projection is applied once during turn preparation; native
     request measurement and provider dispatch consume the same projected
-    messages. A returned [Error detail] or non-reserved callback exception
-    fails the turn as {!Error.HookExecutionFailed}.
+    messages. Existing messages can only be transformed while preserving their
+    typed origin; caller-added messages require an explicit projection source.
+    A returned [Error detail] or non-reserved callback exception fails the turn
+    as {!Error.HookExecutionFailed}.
 
     [pre_dispatch_serialization_observer] receives metadata-only evidence for
     the admitted provider body before built-in HTTP dispatch is attempted. It

--- a/lib/agent/agent_input.ml
+++ b/lib/agent/agent_input.ml
@@ -62,42 +62,42 @@ let validate_user_input_blocks blocks =
 
 let append_user_input agent user_blocks =
   let user_msg =
-    { role = User
-    ; content = sanitize_user_input_blocks user_blocks
-    ; name = None
-    ; tool_call_id = None
-    ; metadata = []
-    }
+    mark_current_user_message
+      { role = User
+      ; content = sanitize_user_input_blocks user_blocks
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = []
+      }
   in
+  let historical_messages = List.map clear_current_user_marker (base_messages agent) in
   update_state agent (fun state ->
-    { state with messages = Util.snoc (base_messages agent) user_msg });
+    { state with messages = Util.snoc historical_messages user_msg });
   user_msg.content
 ;;
 
 let resume_user_input agent user_blocks =
   let exact_input = sanitize_user_input_blocks user_blocks in
-  (* Match the resume prompt against the run's ORIGINAL prompt, not the latest
-     User message. [append_user_input] snocs the original prompt immediately
-     after the seed messages ([config.initial_messages]), so it lives at index
-     [List.length config.initial_messages] in [state.messages]. Context
-     injection (Agent_turn.apply_context_injection) appends further User-role
-     messages during a turn, so a reverse scan for the last User message can
-     pick an injected message instead of the original prompt and falsely reject
-     a valid resume.
-
-     The positional anchor is [config.initial_messages], NOT [base_messages
-     agent]: [base_messages] returns the whole [state.messages] once it is
-     non-empty, which at resume is the full restored conversation — its length
-     is not the prompt's index. [config.initial_messages] is the seed/history
-     prefix the prompt was appended after, so its length is the prompt's index.
-
-     No recorded prompt identity exists to match against (neither
-     Checkpoint_types.t nor the durable execution journal stores the original
-     input), so positional matching is the bounded, deterministic option. *)
-  let base_len = List.length agent.state.config.initial_messages in
-  match List.nth_opt agent.state.messages base_len with
-  | Some { role = User; content; _ } when content = exact_input -> Ok exact_input
-  | Some { role = User; _ } ->
+  let rec find_current found = function
+    | [] -> Ok found
+    | message :: rest ->
+      (match prepared_message_of_canonical message with
+       | Error detail -> Error detail
+       | Ok prepared ->
+         (match prepared_message_origin prepared with
+          | Current_user ->
+            (match found with
+             | None -> find_current (Some message) rest
+             | Some _ -> Error "checkpoint contains multiple current-user origins")
+          | Canonical_history | Extra_system_context | Caller_projection _ ->
+            find_current found rest))
+  in
+  match find_current None agent.state.messages with
+  | Error detail ->
+    Error
+      (Error.Config (Error.InvalidConfig { field = "execution_store.resume"; detail }))
+  | Ok (Some { role = User; content; _ }) when content = exact_input -> Ok exact_input
+  | Ok (Some { role = User; _ }) ->
     Error
       (Error.Config
          (Error.InvalidConfig
@@ -106,7 +106,7 @@ let resume_user_input agent user_blocks =
                 "resume input differs from the original User prompt in the restored \
                  Agent checkpoint"
             }))
-  | Some _ | None ->
+  | Ok (Some _) | Ok None ->
     Error
       (Error.Config
          (Error.InvalidConfig

--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -27,30 +27,41 @@ let prepare_tools ~(tools : Tool_set.t) () =
 ;;
 
 let prepare_messages ~messages ~turn_params () =
-  match turn_params.Hooks.extra_system_context with
-  | None -> messages
-  | Some ctx ->
-    (* Append (not prepend) so that the conversation prefix remains
-       byte-identical across turns — critical for local LLM KV-cache
-       reuse.  The dynamic context (timestamps, tool counts) changes
-       every turn; placing it at the tail keeps the stable history
-       prefix cacheable.  Anthropic API handles caching server-side
-       regardless of position, but Ollama/llama.cpp prefix-match. *)
-    let system_msg =
-      { role = User
-      ; content = [ Text ("[system context] " ^ ctx) ]
-      ; name = None
-      ; tool_call_id = None
-      ; metadata = []
-      }
-    in
-    messages @ [ system_msg ]
+  let rec annotate acc = function
+    | [] -> Ok (List.rev acc)
+    | message :: rest ->
+      (match Agent_types.prepared_message_of_canonical message with
+       | Error _ as error -> error
+       | Ok prepared -> annotate (prepared :: acc) rest)
+  in
+  Result.map
+    (fun prepared ->
+       match turn_params.Hooks.extra_system_context with
+       | None -> prepared
+       | Some ctx ->
+         (* Append (not prepend) so that the conversation prefix remains
+            byte-identical across turns — critical for local LLM KV-cache
+            reuse.  The dynamic context (timestamps, tool counts) changes
+            every turn; placing it at the tail keeps the stable history
+            prefix cacheable.  Anthropic API handles caching server-side
+            regardless of position, but Ollama/llama.cpp prefix-match. *)
+         let system_msg =
+           { role = User
+           ; content = [ Text ("[system context] " ^ ctx) ]
+           ; name = None
+           ; tool_call_id = None
+           ; metadata = []
+           }
+         in
+         prepared @ [ Agent_types.prepared_extra_system_context system_msg ])
+    (annotate [] messages)
 ;;
 
 let prepare_turn ~tools ~messages ~turn_params ?model_input_projection () =
   let tools_json, visible_tool_names = prepare_tools ~tools () in
-  let prepared = prepare_messages ~messages ~turn_params () in
-  let effective_messages =
+  let ( let* ) = Result.bind in
+  let* prepared = prepare_messages ~messages ~turn_params () in
+  let* prepared_messages =
     match model_input_projection with
     | None -> Ok prepared
     | Some project ->
@@ -59,9 +70,10 @@ let prepare_turn ~tools ~messages ~turn_params ?model_input_projection () =
          Llm_provider.Reserved_exn.reraise_if_reserved exn;
          Error (Printexc.to_string exn))
   in
-  Result.map
-    (fun effective_messages -> { tools_json; effective_messages; visible_tool_names })
-    effective_messages
+  let effective_messages =
+    List.map Agent_types.prepared_message_value prepared_messages
+  in
+  Ok { tools_json; effective_messages; visible_tool_names }
 ;;
 
 let provider_config_with_agent_config

--- a/lib/agent/agent_turn.mli
+++ b/lib/agent/agent_turn.mli
@@ -40,7 +40,7 @@ val prepare_messages
   :  messages:Types.message list
   -> turn_params:Hooks.turn_params
   -> unit
-  -> Types.message list
+  -> (Agent_types.prepared_message list, string) result
 
 (** Full turn preparation: exact caller-supplied tools plus messages. A failed
     caller projection is returned before provider measurement or dispatch.

--- a/lib/agent/agent_types.ml
+++ b/lib/agent/agent_types.ml
@@ -31,7 +31,78 @@ type context_fit_admission =
   | Disabled
   | Enforce_when_supported
 
-type model_input_projection = message list -> (message list, string) result
+type prepared_message_origin =
+  | Canonical_history
+  | Current_user
+  | Extra_system_context
+  | Caller_projection of { source : string }
+
+type prepared_message =
+  { message : message
+  ; origin : prepared_message_origin
+  }
+
+let current_user_marker_key = "oas.prepared_input.current_user.v1"
+
+let clear_current_user_marker message =
+  { message with
+    metadata =
+      List.filter
+        (fun (key, _) -> not (String.equal key current_user_marker_key))
+        message.metadata
+  }
+;;
+
+let mark_current_user_message message =
+  let message = clear_current_user_marker message in
+  { message with metadata = (current_user_marker_key, `Bool true) :: message.metadata }
+;;
+
+let current_user_marker_values message =
+  List.filter_map
+    (fun (key, value) ->
+       if String.equal key current_user_marker_key then Some value else None)
+    message.metadata
+;;
+
+let prepared_message_of_canonical message =
+  let origin =
+    match current_user_marker_values message with
+    | [] -> Ok Canonical_history
+    | [ `Bool true ] -> Ok Current_user
+    | [ _ ] -> Error "current-user origin marker is malformed"
+    | _ -> Error "current-user origin marker is duplicated"
+  in
+  Result.map
+    (fun origin -> { message = clear_current_user_marker message; origin })
+    origin
+;;
+
+let prepared_extra_system_context message =
+  { message = clear_current_user_marker message; origin = Extra_system_context }
+;;
+
+let prepared_message_value prepared = prepared.message
+let prepared_message_origin prepared = prepared.origin
+
+let map_prepared_message project prepared =
+  { prepared with message = clear_current_user_marker (project prepared.message) }
+;;
+
+let caller_projected_message ~source message =
+  let source = String.trim source in
+  if source = ""
+  then Error "caller projection source must be non-empty"
+  else
+    Ok
+      { message = clear_current_user_marker message
+      ; origin = Caller_projection { source }
+      }
+;;
+
+type model_input_projection =
+  prepared_message list -> (prepared_message list, string) result
+
 type pre_dispatch_serialization_observer = Llm_provider.Request_wire_observer.try_observe
 
 type options =

--- a/lib/agent/agent_types.mli
+++ b/lib/agent/agent_types.mli
@@ -34,9 +34,41 @@ type context_fit_admission =
   | Disabled
   | Enforce_when_supported
 
-(** Caller-owned provider-message projection. [Error detail] aborts the turn
-    before request measurement or dispatch. Canonical Agent state is unchanged. *)
-type model_input_projection = Types.message list -> (Types.message list, string) result
+(** Typed origin of one final provider-bound message before provider-specific
+    serialization. *)
+type prepared_message_origin =
+  | Canonical_history
+  | Current_user
+  | Extra_system_context
+  | Caller_projection of { source : string }
+
+(** An origin-bearing provider-bound message. The representation is abstract so
+    a caller projection can preserve an existing origin or create a new message
+    only through the explicit [Caller_projection] constructor below. *)
+type prepared_message
+
+val prepared_message_value : prepared_message -> Types.message
+val prepared_message_origin : prepared_message -> prepared_message_origin
+
+(** Transform one prepared message while preserving its origin. OAS-owned
+    internal metadata is removed from the returned provider carrier. *)
+val map_prepared_message
+  :  (Types.message -> Types.message)
+  -> prepared_message
+  -> prepared_message
+
+(** Construct a caller-added provider message with an explicit, non-empty
+    producer identity. *)
+val caller_projected_message
+  :  source:string
+  -> Types.message
+  -> (prepared_message, string) result
+
+(** Caller-owned provider-message projection. Every final message retains a
+    typed origin. [Error detail] aborts the turn before request measurement or
+    dispatch. Canonical Agent state is unchanged. *)
+type model_input_projection =
+  prepared_message list -> (prepared_message list, string) result
 
 type pre_dispatch_serialization_observer = Llm_provider.Request_wire_observer.try_observe
 
@@ -192,6 +224,14 @@ val net : t -> [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
 val set_state : t -> Types.agent_state -> unit
 val update_state : t -> (Types.agent_state -> Types.agent_state) -> unit
 val description : t -> string option
+
+(** Internal run-boundary helpers. The current-user marker is checkpoint-only
+    and is removed before provider dispatch. *)
+val mark_current_user_message : Types.message -> Types.message
+
+val clear_current_user_marker : Types.message -> Types.message
+val prepared_message_of_canonical : Types.message -> (prepared_message, string) result
+val prepared_extra_system_context : Types.message -> prepared_message
 
 (** {1 SDK version} *)
 

--- a/lib/agent/builder.mli
+++ b/lib/agent/builder.mli
@@ -127,10 +127,14 @@ val with_provider_config : Llm_provider.Provider_config.t -> t -> t
     [Complete] compatibility behavior. *)
 val with_context_fit_admission : Agent.context_fit_admission -> t -> t
 
-(** Apply a caller-owned projection once to the complete provider-bound message
-    list. Native request measurement and actual dispatch consume that same
-    projected request; canonical Agent state and checkpoints remain unchanged.
-    [Error detail] fails the turn as a typed hook execution error. *)
+(** Apply a caller-owned projection once to the complete provider-bound
+    message list. Each input is an abstract {!Agent.prepared_message}: transform
+    it with {!Agent.map_prepared_message} to preserve its typed origin, and add
+    a new provider-only message with {!Agent.caller_projected_message} and an
+    explicit producer identity. Native request measurement and actual dispatch
+    consume that same projected request; canonical Agent state and checkpoints
+    remain unchanged. [Error detail] fails the turn as a typed hook execution
+    error. *)
 val with_model_input_projection : Agent.model_input_projection -> t -> t
 
 (** Observe metadata-only evidence for the exact provider serialization prepared

--- a/test/test_agent_turn.ml
+++ b/test/test_agent_turn.ml
@@ -27,6 +27,13 @@ let prepared_turn = function
   | Error detail -> Alcotest.fail detail
 ;;
 
+let prepared_messages = function
+  | Ok messages -> messages
+  | Error detail -> Alcotest.fail detail
+;;
+
+let prepared_value = Agent.prepared_message_value
+
 (* ── prepare_turn tests ────────────────────────────────────── *)
 
 let test_prepare_turn_empty_tools () =
@@ -152,6 +159,7 @@ let test_prepare_messages_no_reducer () =
   in
   let result =
     Agent_turn.prepare_messages ~messages:msgs ~turn_params:Hooks.default_turn_params ()
+    |> prepared_messages
   in
   Alcotest.(check int) "same count" 1 (List.length result)
 ;;
@@ -169,9 +177,11 @@ let test_prepare_messages_extra_context () =
   let turn_params =
     { Hooks.default_turn_params with extra_system_context = Some "You are in test mode." }
   in
-  let result = Agent_turn.prepare_messages ~messages:msgs ~turn_params () in
+  let result =
+    Agent_turn.prepare_messages ~messages:msgs ~turn_params () |> prepared_messages
+  in
   Alcotest.(check int) "prepended system msg" 2 (List.length result);
-  let first = List.hd result in
+  let first = List.hd result |> prepared_value in
   Alcotest.(check bool) "is User role" true (first.role = Types.User);
   match first.content with
   | [ Types.Text _ ] -> ()
@@ -195,7 +205,9 @@ let test_prepare_messages_system_prompt_override_noop () =
       system_prompt_override = Some "Custom system prompt"
     }
   in
-  let result = Agent_turn.prepare_messages ~messages:msgs ~turn_params () in
+  let result =
+    Agent_turn.prepare_messages ~messages:msgs ~turn_params () |> prepared_messages
+  in
   (* system_prompt_override is handled in pipeline stage_parse, not
      in prepare_messages. Message count should remain unchanged. *)
   Alcotest.(check int) "no extra message from override" 1 (List.length result)
@@ -217,16 +229,75 @@ let test_prepare_messages_both_override_and_extra_context () =
     ; system_prompt_override = Some "You are a reviewer."
     }
   in
-  let result = Agent_turn.prepare_messages ~messages:msgs ~turn_params () in
+  let result =
+    Agent_turn.prepare_messages ~messages:msgs ~turn_params () |> prepared_messages
+  in
   (* extra_system_context injects a User message; system_prompt_override
      is applied separately in pipeline. So only extra_system_context
      adds a message here. *)
   Alcotest.(check int) "extra context adds 1 message" 2 (List.length result);
-  let first = List.hd result in
+  let first = List.hd result |> prepared_value in
   Alcotest.(check bool) "injected msg is User" true (first.role = Types.User);
   match first.content with
   | [ Types.Text _ ] -> ()
   | _ -> Alcotest.fail "expected single Text block"
+;;
+
+let test_prepare_messages_retains_typed_origins () =
+  let history =
+    { Types.role = Types.Assistant
+    ; content = [ Types.Text "prior" ]
+    ; name = None
+    ; tool_call_id = None
+    ; metadata = []
+    }
+  in
+  let current =
+    Agent_types.mark_current_user_message
+      { Types.role = Types.User
+      ; content = [ Types.Text "now" ]
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = []
+      }
+  in
+  let turn_params =
+    { Hooks.default_turn_params with extra_system_context = Some "runtime" }
+  in
+  let prepared =
+    Agent_turn.prepare_messages ~messages:[ history; current ] ~turn_params ()
+    |> prepared_messages
+  in
+  let origins = List.map Agent.prepared_message_origin prepared in
+  Alcotest.(check int) "three prepared messages" 3 (List.length origins);
+  (match origins with
+   | [ Agent.Canonical_history; Agent.Current_user; Agent.Extra_system_context ] -> ()
+   | _ -> Alcotest.fail "prepared message origins changed");
+  let current_wire = List.nth prepared 1 |> prepared_value in
+  Alcotest.(check int)
+    "current-user marker stripped before projection"
+    0
+    (List.length current_wire.metadata)
+;;
+
+let test_projection_addition_requires_source () =
+  let message =
+    { Types.role = Types.User
+    ; content = [ Types.Text "projection" ]
+    ; name = None
+    ; tool_call_id = None
+    ; metadata = []
+    }
+  in
+  (match Agent.caller_projected_message ~source:"" message with
+   | Error _ -> ()
+   | Ok _ -> Alcotest.fail "empty caller projection source was accepted");
+  match Agent.caller_projected_message ~source:"keeper_gate_replay" message with
+  | Error detail -> Alcotest.fail detail
+  | Ok prepared ->
+    (match Agent.prepared_message_origin prepared with
+     | Agent.Caller_projection { source = "keeper_gate_replay" } -> ()
+     | _ -> Alcotest.fail "caller projection source was not retained")
 ;;
 
 let starts_with ~prefix s =
@@ -774,6 +845,14 @@ let () =
             "both override and extra_context"
             `Quick
             test_prepare_messages_both_override_and_extra_context
+        ; Alcotest.test_case
+            "typed origins"
+            `Quick
+            test_prepare_messages_retains_typed_origins
+        ; Alcotest.test_case
+            "projection source required"
+            `Quick
+            test_projection_addition_requires_source
         ] )
     ; ( "accumulate_usage"
       , [ Alcotest.test_case "with response" `Quick test_accumulate_usage_with_response

--- a/test/test_anthropic_input_token_count.ml
+++ b/test/test_anthropic_input_token_count.ml
@@ -1114,6 +1114,7 @@ let test_agent_admitted_stream_observer_sees_dispatched_body () =
 
 let test_agent_projection_is_shared_by_measurement_and_dispatch () =
   let projection_calls = ref 0 in
+  let projected_origins = ref [] in
   let (result, dispatched), (_, _, measured_body) =
     with_mock ~status:`OK ~response:{|{"input_tokens":321}|}
     @@ fun ~sw ~net ~base_url ->
@@ -1136,7 +1137,17 @@ let test_agent_projection_is_shared_by_measurement_and_dispatch () =
         ~transport
         ~model_input_projection:(fun provider_messages ->
           incr projection_calls;
-          Ok (provider_messages @ [ hydrated ]))
+          match
+            Agent_sdk.Agent.caller_projected_message
+              ~source:"test_hydrated_artifact"
+              hydrated
+          with
+          | Error detail -> Error detail
+          | Ok hydrated ->
+            let projected = provider_messages @ [ hydrated ] in
+            projected_origins
+            := List.map Agent_sdk.Agent.prepared_message_origin projected;
+            Ok projected)
         ()
     in
     let result = Agent_sdk.Agent.run ~sw agent "canonical input" in
@@ -1147,7 +1158,19 @@ let test_agent_projection_is_shared_by_measurement_and_dispatch () =
   | Ok _, None -> fail "projected request was not dispatched"
   | Ok _, Some request ->
     check int "projection is applied exactly once" 1 !projection_calls;
+    (match !projected_origins with
+     | [ Agent_sdk.Agent.Current_user
+       ; Agent_sdk.Agent.Caller_projection { source = "test_hydrated_artifact" }
+       ] -> ()
+     | _ -> fail "actual Agent projection lost typed message origins");
     check int "dispatch receives projected messages" 2 (List.length request.messages);
+    check
+      bool
+      "checkpoint-only origin marker is absent from provider messages"
+      true
+      (List.for_all
+         (fun (message : Types.message) -> message.metadata = [])
+         request.messages);
     check
       string
       "measurement and dispatch share exact request"

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -14,6 +14,8 @@ module Internal_scope = Internal.Execution_agent_scope
 module Internal_binding = Binding_identity
 module Internal_settlement = Internal.Execution_tool_settlement
 
+let current_user_msg text = Agent_types.mark_current_user_message (Types.user_msg text)
+
 let invocation tool_use_id =
   let schedule : Tool_contract.schedule =
     { planned_index = 0
@@ -1944,12 +1946,13 @@ let test_agent_run_resumes_tool_without_duplicate_effects
          agent
          { config
          ; messages =
-             [ { Types.role = User
-               ; content = [ Text "run the tool" ]
-               ; name = None
-               ; tool_call_id = None
-               ; metadata = []
-               }
+             [ Agent_types.mark_current_user_message
+                 { Types.role = User
+                 ; content = [ Text "run the tool" ]
+                 ; name = None
+                 ; tool_call_id = None
+                 ; metadata = []
+                 }
              ; { Types.role = Assistant
                ; content =
                    [ ToolUse
@@ -2217,10 +2220,8 @@ let test_unattempted_legacy_invocation_requires_typed_readmission () =
 (* A context injector appends User-role messages during a turn (see
    [Agent_turn.apply_context_injection]); after such a turn the latest User
    message in the restored checkpoint is the injected one, not the run's
-   original prompt. Resume must match the original prompt (at the base-messages
-   boundary), so it succeeds even though a later injected User message differs.
-   Reverting [resume_user_input] to a latest-User-message scan makes this fail:
-   the injected message no longer equals the resume prompt. *)
+   original prompt. Resume follows the typed current-user origin, so it succeeds
+   even though a later injected User message differs. *)
 let test_agent_run_resume_ignores_injected_user_context_message () =
   test_agent_run_resumes_tool_without_duplicate_effects
     ~settled:true
@@ -2482,12 +2483,7 @@ let test_agent_run_resumes_settled_closed_turn
          agent
          { config
          ; messages =
-             [ { Types.role = User
-               ; content = [ Text "run the tool" ]
-               ; name = None
-               ; tool_call_id = None
-               ; metadata = []
-               }
+             [ current_user_msg "run the tool"
              ; { Types.role = Assistant
                ; content =
                    [ ToolUse
@@ -3206,7 +3202,7 @@ let test_agent_run_replays_precheckpoint_terminal_settlement () =
          Internal_agent.set_state
            initial_agent
            { (Internal_agent.state initial_agent) with
-             messages = [ Types.user_msg "run the durable tool" ]
+             messages = [ current_user_msg "run the durable tool" ]
            };
          let locator_json = ref None in
          (match
@@ -3430,12 +3426,7 @@ let test_agent_run_resumes_all_blocked_settled_turn () =
          agent
          { config
          ; messages =
-             [ { Types.role = User
-               ; content = [ Text "run the tool" ]
-               ; name = None
-               ; tool_call_id = None
-               ; metadata = []
-               }
+             [ current_user_msg "run the tool"
              ; { Types.role = Assistant
                ; content =
                    [ ToolUse
@@ -3626,12 +3617,7 @@ let test_agent_run_resume_fires_on_yield () =
          agent
          { config
          ; messages =
-             [ { Types.role = User
-               ; content = [ Text "run the tool" ]
-               ; name = None
-               ; tool_call_id = None
-               ; metadata = []
-               }
+             [ current_user_msg "run the tool"
              ; { Types.role = Assistant
                ; content =
                    [ ToolUse


### PR DESCRIPTION
## Summary
- hard-cut model input projections to abstract origin-bearing prepared messages
- mark the current user explicitly in checkpoint state and remove the marker before provider serialization
- require caller-added provider messages to declare a non-empty projection source
- remove positional prompt matching from durable resume

## Why
MASC must attribute the final provider-bound context without reconstructing message origins from list indexes or byte subtraction. This makes origin part of the OAS preparation contract while keeping exact wire byte/hash evidence in the existing request observer.

## Validation
- scripts/dune-local.sh build @test/runtest-test_agent_turn @test/runtest-test_pipeline @test/runtest-test_anthropic_input_token_count
- scripts/dune-local.sh build @test/runtest-test_agent_advanced @test/runtest-test_checkpoint @test/runtest-test_checkpoint_store @test/runtest-test_checkpoint_delta @test/runtest-test_session_resume
- ocamlformat --check on changed OCaml files
- git diff --check