### PR TITLE
fix(exact-output): preserve typed advance evidence

### DIFF
--- a/docs/design/exact-output-flow-boundary.md
+++ b/docs/design/exact-output-flow-boundary.md
@@ -65,9 +65,16 @@ dispatch. For each predetermined candidate:
 3. For an admitted candidate, the caller's `before_dispatch` callback must
    confirm its durable binding before OAS invokes the unchanged single-plan
    `execute_once`.
-4. OAS may select the next frozen candidate only after either that candidate
-   rejection receipt or a first-use transport failure whose exact execution
-   receipt is `Before_dispatch` with `dispatch_count = 0`.
+4. OAS may select the next frozen candidate only after one of these typed
+   outcomes:
+   - that candidate rejection receipt;
+   - a first-use transport failure whose exact execution receipt is
+     `Before_dispatch` with `dispatch_count = 0`;
+   - an HTTP 413 request-body refusal recorded at `Response_received` with
+     `dispatch_count = 1`;
+   - locally detected invalid JSON after one structurally complete response,
+     recorded at `Response_received` or `Terminal` with
+     `dispatch_count = 1`.
 5. The caller's `before_advance` callback receives the typed failure and
    the predetermined successor visit, and must durably confirm release before
    OAS prepares that successor.
@@ -89,8 +96,8 @@ The following outcomes are terminal:
 - duplicate/replayed execution;
 - cancellation;
 - a missing execution prerequisite or frozen-request invariant failure;
-- any receipt with `dispatch_count > 0`;
-- response, partial, tool, structural-output, or normalization exposure;
+- any dispatched response outside the two typed advance cases above;
+- partial, tool, ambiguous structural-output, or non-JSON-contract exposure;
 - a final typed candidate rejection, reported as `Flow_candidates_exhausted`;
 - structural success.
 
@@ -99,6 +106,12 @@ callback exactly once. `Accept` returns the accepted value and prior rejection
 evidence. `Reject_and_advance` preserves the transport success and domain
 rejection as immutable evidence, then advances directly to the predetermined
 successor. A final semantic rejection returns a typed nonempty trace.
+
+The two post-response advance cases may add one completion dispatch for each
+subsequent declared candidate. This is explicit failover blast radius, not a
+retry of the same candidate: every attempt remains affine and every successful
+advance is retained with its exact failed and successor visits. Provider error
+prose is diagnostic only and cannot authorize an advance.
 
 OAS performs no domain commit, replay, ranking update, or lifecycle transition
 after validation. Those effects remain behind the caller's existing domain
@@ -114,14 +127,15 @@ Every flow evidence projection carries:
 - ordered admission outcomes only for candidates reached so far;
 - every non-shared execution receipt allocated for an admitted current
   candidate;
+- every successfully confirmed transport-failure advance, bound to the failed
+  visit and its predetermined adjacent successor;
 
 Terminal variants additionally carry the candidate's exact
 rejection, success, or execution failure. The `admitted_flow_candidate` and
 `flow_attempt_receipt` wrappers embed the same precomputed visit; a rejection
 embeds that visit without fabricating a plan, call ID, or execution receipt. A
 new `start_flow` always allocates a new flow identity; restart resume is
-unsupported here and belongs to the caller's authenticated lease or operation
-journal.
+unsupported here and belongs to the caller's authenticated operation journal.
 
 Every admission rejection and allocated outer attempt receipt carries the same
 precomputed visit as the flow evidence. The flow identity, candidate identity,

--- a/lib/llm_provider/exact_output.ml
+++ b/lib/llm_provider/exact_output.ml
@@ -87,16 +87,12 @@ type raw_response = Trace.raw_response =
   ; body_sha256 : string
   }
 
-type input_capacity_refusal =
-  | Context_window_refused of { limit_tokens : int option }
-  | Serialized_request_refused of { http_status : int }
-
 type execution_error_cause =
   | Attempt_already_started
   | Clock_required_for_timeout
   | Frozen_request_mismatch
   | Completion_failed
-  | Input_capacity_refused of input_capacity_refusal
+  | Serialized_request_refused of { http_status : int }
   | Incomplete_output
   | Missing_output
   | Ambiguous_output of int
@@ -187,6 +183,19 @@ type flow_attempt_snapshot =
   ; receipt : generation_receipt_snapshot
   }
 
+type flow_advance_failure_snapshot =
+  | Flow_advance_candidate_rejected of candidate_rejection_receipt
+  | Flow_advance_execution_failed of
+      { candidate : flow_attempt_snapshot
+      ; cause : execution_error_cause
+      ; raw_response_sha256 : string option
+      }
+
+type flow_advance_receipt =
+  { failed : flow_advance_failure_snapshot
+  ; next : flow_candidate_visit
+  }
+
 type flow_attempt_publication =
   { call_id : call_id
   ; snapshot : flow_attempt_snapshot
@@ -202,7 +211,8 @@ type flow_attempt =
   ; progress :
       ( candidate_admission
         , flow_attempt_publication
-        , measurement_receipt_snapshot )
+        , measurement_receipt_snapshot
+        , flow_advance_receipt )
         Flow_state.progress
   }
 
@@ -230,6 +240,7 @@ type flow_evidence =
   ; measurements : measurement_receipt_snapshot list
   ; admissions : candidate_admission list
   ; attempts : flow_attempt_snapshot list
+  ; advances : flow_advance_receipt list
   }
 
 type flow_success =
@@ -608,7 +619,22 @@ let flow_attempt_evidence (flow : flow_attempt) =
   ; measurements = progress.measurements
   ; admissions = progress.admissions
   ; attempts = List.map (fun publication -> publication.snapshot) progress.attempts
+  ; advances = progress.advances
   }
+;;
+
+let flow_advance_failure_snapshot = function
+  | Flow_candidate_rejected receipt -> Flow_advance_candidate_rejected receipt
+  | Flow_candidate_execution_failed { candidate; cause } ->
+    Flow_advance_execution_failed
+      { candidate =
+          { visit = candidate.visit
+          ; receipt = Generation_receipt.snapshot candidate.receipt
+          }
+      ; cause = cause.cause
+      ; raw_response_sha256 =
+          Option.map (fun response -> response.body_sha256) cause.raw_response
+      }
 ;;
 
 let observe_phase = Generation_receipt.observe_phase
@@ -616,12 +642,10 @@ let synchronize_receipt = Generation_receipt.synchronize
 let raw_response = Trace.raw_response
 let record_provider_trace = Generation_receipt.record_provider_trace
 
-let input_capacity_refusal_of_http_error ~code ~body ~retry_after_header =
+let serialized_request_refusal_of_http_error ~code ~body ~retry_after_header =
   match Retry.classify_error ~retry_after_header ~status:code ~body with
-  | Retry.ContextOverflow { limit; _ } ->
-    Some (Context_window_refused { limit_tokens = limit })
   | Retry.InvalidRequest { reason = Retry.Request_body_refused_by_provider { status }; _ }
-    -> Some (Serialized_request_refused { http_status = status })
+    -> Some status
   | Retry.RateLimited _
   | Retry.Overloaded _
   | Retry.ServerError _
@@ -630,6 +654,7 @@ let input_capacity_refusal_of_http_error ~code ~body ~retry_after_header =
   | Retry.PaymentRequired _
   | Retry.InvalidRequest _
   | Retry.NotFound _
+  | Retry.ContextOverflow _
   | Retry.InputCapacity _
   | Retry.NetworkError _
   | Retry.Timeout _ -> None
@@ -639,8 +664,8 @@ let execution_error_cause = function
   | Exec.Clock_required_for_timeout -> Clock_required_for_timeout
   | Exec.Frozen_request_mismatch -> Frozen_request_mismatch
   | Exec.Provider_error (Http_client.HttpError { code; body; retry_after_header }) ->
-    (match input_capacity_refusal_of_http_error ~code ~body ~retry_after_header with
-     | Some refusal -> Input_capacity_refused refusal
+    (match serialized_request_refusal_of_http_error ~code ~body ~retry_after_header with
+     | Some http_status -> Serialized_request_refused { http_status }
      | None -> Completion_failed)
   | Exec.Provider_error _ -> Completion_failed
   | Exec.Output_normalization_failed (Exec.Incomplete_structured_response _) ->
@@ -746,7 +771,7 @@ let execute_once ~net ?clock attempt =
 let execution_failure_may_advance (error : execution_error) =
   match error.cause, receipt_phase error.receipt with
   | Completion_failed, Before_dispatch -> receipt_dispatch_count error.receipt = 0
-  | Input_capacity_refused _, Response_received ->
+  | Serialized_request_refused _, Response_received ->
     (* The response contract proves that the provider rejected this input before
        generation. Keep the honest one-dispatch receipt, but allow the frozen
        lane to try its predetermined successor. *)
@@ -754,7 +779,8 @@ let execution_failure_may_advance (error : execution_error) =
   | Invalid_json_output, (Response_received | Terminal) ->
     receipt_dispatch_count error.receipt = 1
   | Completion_failed, (Not_started | Dispatch_started | Response_received | Terminal)
-  | Input_capacity_refused _, (Not_started | Before_dispatch | Dispatch_started | Terminal)
+  | ( Serialized_request_refused _
+    , (Not_started | Before_dispatch | Dispatch_started | Terminal) )
   | Invalid_json_output, (Not_started | Before_dispatch | Dispatch_started)
   | ( ( Attempt_already_started
       | Clock_required_for_timeout
@@ -914,7 +940,13 @@ let execute_flow_once
           Flow_state.Reject_and_advance { transport_success; rejection })
       ~advanceable:advanceable_flow_failure
       ~before_advance:(fun ~failed:_ ~failure ~next ->
-        before_advance ~failed:failure ~next:next.visit)
+        match before_advance ~failed:failure ~next:next.visit with
+        | Error _ as error -> error
+        | Ok () ->
+          Flow_state.record_advance
+            flow.progress
+            { failed = flow_advance_failure_snapshot failure; next = next.visit };
+          Ok ())
   in
   let evidence = flow_attempt_evidence flow in
   let terminal prior_rejections cause =

--- a/lib/llm_provider/exact_output.mli
+++ b/lib/llm_provider/exact_output.mli
@@ -208,16 +208,12 @@ type raw_response =
   ; body_sha256 : string
   }
 
-type input_capacity_refusal =
-  | Context_window_refused of { limit_tokens : int option }
-  | Serialized_request_refused of { http_status : int }
-
 type execution_error_cause =
   | Attempt_already_started
   | Clock_required_for_timeout
   | Frozen_request_mismatch
   | Completion_failed
-  | Input_capacity_refused of input_capacity_refusal
+  | Serialized_request_refused of { http_status : int }
   | Incomplete_output
   | Missing_output
   | Ambiguous_output of int
@@ -519,6 +515,19 @@ type flow_attempt_snapshot = private
   ; receipt : generation_receipt_snapshot
   }
 
+type flow_advance_failure_snapshot =
+  | Flow_advance_candidate_rejected of candidate_rejection_receipt
+  | Flow_advance_execution_failed of
+      { candidate : flow_attempt_snapshot
+      ; cause : execution_error_cause
+      ; raw_response_sha256 : string option
+      }
+
+type flow_advance_receipt = private
+  { failed : flow_advance_failure_snapshot
+  ; next : flow_candidate_visit
+  }
+
 val candidate_visit_count_to_int : candidate_visit_count -> int
 val measurement_operation_id_to_string : measurement_operation_id -> string
 
@@ -601,6 +610,7 @@ type flow_evidence = private
   ; measurements : measurement_receipt_snapshot list
   ; admissions : candidate_admission list
   ; attempts : flow_attempt_snapshot list
+  ; advances : flow_advance_receipt list
   }
 
 val flow_success_candidate : flow_success -> flow_attempt_receipt
@@ -710,7 +720,7 @@ val flow_attempt_evidence : flow_attempt -> flow_evidence
     moves directly to the predetermined successor without using [before_advance].
     Every candidate performs at most one generation POST. A final semantic
     rejection returns a typed nonempty exhaustion trace. OAS performs no domain
-    commit, settlement, retirement, recovery, or preference update. *)
+    durable commit, recovery, retirement, or preference update. *)
 val execute_flow_once
   :  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> ?clock:_ Eio.Time.clock

--- a/lib/llm_provider/exact_output_flow.ml
+++ b/lib/llm_provider/exact_output_flow.ml
@@ -5,22 +5,24 @@ type state =
 
 type t = state Atomic.t
 
-type ('admission, 'attempt, 'measurement) progress_snapshot =
+type ('admission, 'attempt, 'measurement, 'advance) progress_snapshot =
   { candidate_visit_count : int
   ; admissions : 'admission list
   ; attempts : 'attempt list
   ; measurements : 'measurement list
+  ; advances : 'advance list
   }
 
-type ('admission, 'attempt, 'measurement) progress_state =
+type ('admission, 'attempt, 'measurement, 'advance) progress_state =
   { candidate_visit_count : int
   ; admissions_rev : 'admission list
   ; attempts_rev : 'attempt list
   ; measurements_rev : 'measurement list
+  ; advances_rev : 'advance list
   }
 
-type ('admission, 'attempt, 'measurement) progress =
-  ('admission, 'attempt, 'measurement) progress_state Atomic.t
+type ('admission, 'attempt, 'measurement, 'advance) progress =
+  ('admission, 'attempt, 'measurement, 'advance) progress_state Atomic.t
 
 type ('accepted, 'rejection) semantic_verdict =
   | Accept of 'accepted
@@ -63,6 +65,7 @@ let create_progress () =
     ; admissions_rev = []
     ; attempts_rev = []
     ; measurements_rev = []
+    ; advances_rev = []
     }
 ;;
 
@@ -104,12 +107,18 @@ let publish_measurement progress ~same measurement =
     }
 ;;
 
+let record_advance progress advance =
+  let current = Atomic.get progress in
+  Atomic.set progress { current with advances_rev = advance :: current.advances_rev }
+;;
+
 let progress_snapshot progress =
   let current = Atomic.get progress in
   { candidate_visit_count = current.candidate_visit_count
   ; admissions = List.rev current.admissions_rev
   ; attempts = List.rev current.attempts_rev
   ; measurements = List.rev current.measurements_rev
+  ; advances = List.rev current.advances_rev
   }
 ;;
 

--- a/lib/llm_provider/exact_output_flow.mli
+++ b/lib/llm_provider/exact_output_flow.mli
@@ -5,13 +5,14 @@
     types that wrap the private exact plan and execution modules. *)
 
 type t
-type ('admission, 'attempt, 'measurement) progress
+type ('admission, 'attempt, 'measurement, 'advance) progress
 
-type ('admission, 'attempt, 'measurement) progress_snapshot =
+type ('admission, 'attempt, 'measurement, 'advance) progress_snapshot =
   { candidate_visit_count : int
   ; admissions : 'admission list
   ; attempts : 'attempt list
   ; measurements : 'measurement list
+  ; advances : 'advance list
   }
 
 type ('accepted, 'rejection) semantic_verdict =
@@ -52,26 +53,38 @@ val create : unit -> t
 (** Progress has exactly one writer: the invocation that wins [execute_once]'s
     affine gate. Concurrent readers may observe the honest point between a
     recorded admission and its subsequently allocated attempt. *)
-val create_progress : unit -> ('admission, 'attempt, 'measurement) progress
+val create_progress : unit -> ('admission, 'attempt, 'measurement, 'advance) progress
 
-val record_admission : ('admission, 'attempt, 'measurement) progress -> 'admission -> unit
-val record_attempt : ('admission, 'attempt, 'measurement) progress -> 'attempt -> unit
+val record_admission
+  :  ('admission, 'attempt, 'measurement, 'advance) progress
+  -> 'admission
+  -> unit
+
+val record_attempt
+  :  ('admission, 'attempt, 'measurement, 'advance) progress
+  -> 'attempt
+  -> unit
 
 val publish_attempt
-  :  ('admission, 'attempt, 'measurement) progress
+  :  ('admission, 'attempt, 'measurement, 'advance) progress
   -> same:('attempt -> 'attempt -> bool)
   -> 'attempt
   -> unit
 
 val publish_measurement
-  :  ('admission, 'attempt, 'measurement) progress
+  :  ('admission, 'attempt, 'measurement, 'advance) progress
   -> same:('measurement -> 'measurement -> bool)
   -> 'measurement
   -> unit
 
+val record_advance
+  :  ('admission, 'attempt, 'measurement, 'advance) progress
+  -> 'advance
+  -> unit
+
 val progress_snapshot
-  :  ('admission, 'attempt, 'measurement) progress
-  -> ('admission, 'attempt, 'measurement) progress_snapshot
+  :  ('admission, 'attempt, 'measurement, 'advance) progress
+  -> ('admission, 'attempt, 'measurement, 'advance) progress_snapshot
 
 val duplicate_key
   :  equal:('key -> 'key -> bool)

--- a/lib/llm_provider/retry.ml
+++ b/lib/llm_provider/retry.ml
@@ -277,114 +277,6 @@ let extract_error_message (body : string) : string =
     body
 ;;
 
-(** Ollama Cloud reports context overflow as a top-level [error] string with no
-    machine-readable [code] or [type]. Preserve only the exact causal grammars
-    observed on that wire, including its canonical UUID reference. Generic
-    context-related prose remains unknown. This classification belongs at the
-    provider response boundary; consumers must not repeat it. *)
-let is_ascii_digit = function
-  | '0' .. '9' -> true
-  | _ -> false
-;;
-
-let is_ascii_hex = function
-  | '0' .. '9' | 'a' .. 'f' | 'A' .. 'F' -> true
-  | _ -> false
-;;
-
-let is_uuid_reference reference =
-  String.length reference = 36
-  &&
-  let rec loop index =
-    if index = 36
-    then true
-    else if index = 8 || index = 13 || index = 18 || index = 23
-    then Char.equal reference.[index] '-' && loop (index + 1)
-    else is_ascii_hex reference.[index] && loop (index + 1)
-  in
-  loop 0
-;;
-
-let consume_ascii_digits text start =
-  let text_length = String.length text in
-  let rec consume index =
-    if index < text_length && is_ascii_digit text.[index]
-    then consume (index + 1)
-    else index
-  in
-  let finish = consume start in
-  if finish = start then None else Some finish
-;;
-
-let has_uuid_reference_tail ~prefix tail =
-  let prefix_length = String.length prefix in
-  String.starts_with ~prefix tail
-  && String.ends_with ~suffix:")" tail
-  && String.length tail > prefix_length + 1
-  &&
-  let reference =
-    String.sub tail prefix_length (String.length tail - prefix_length - 1)
-  in
-  is_uuid_reference reference
-;;
-
-let reports_excess_context_tokens message =
-  let prefix = "prompt too long; exceeded max context length by " in
-  if not (String.starts_with ~prefix message)
-  then false
-  else (
-    match consume_ascii_digits message (String.length prefix) with
-    | None -> false
-    | Some digits_end ->
-      let tail = String.sub message digits_end (String.length message - digits_end) in
-      has_uuid_reference_tail ~prefix:" tokens (ref: " tail)
-;;
-
-let reported_context_limit message =
-  let prefix = "The prompt is too long: " in
-  let limit_prefix = ", model maximum context length: " in
-  if not (String.starts_with ~prefix message)
-  then None
-  else (
-    match consume_ascii_digits message (String.length prefix) with
-    | None -> None
-    | Some prompt_digits_end ->
-      let after_prompt =
-        String.sub message prompt_digits_end (String.length message - prompt_digits_end)
-      in
-      if not (String.starts_with ~prefix:limit_prefix after_prompt)
-      then None
-      else (
-        let limit_start = prompt_digits_end + String.length limit_prefix in
-        match consume_ascii_digits message limit_start with
-        | None -> None
-        | Some limit_digits_end ->
-          let tail =
-            String.sub message limit_digits_end (String.length message - limit_digits_end)
-          in
-          if has_uuid_reference_tail ~prefix:" (ref: " tail
-          then
-            String.sub message limit_start (limit_digits_end - limit_start)
-            |> int_of_string_opt
-          else None))
-;;
-
-let observed_context_overflow body =
-  try
-    let json = Yojson.Safe.from_string body in
-    let open Yojson.Safe.Util in
-    match json |> member "error" with
-    | `String message ->
-      (match reported_context_limit message with
-       | Some limit -> Some (message, Some limit)
-       | None when reports_excess_context_tokens message -> Some (message, None)
-       | None -> None)
-    | `Assoc _ | `List _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> None
-  with
-  | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ | Yojson.Safe.Util.Undefined _ ->
-    None
-;;
-
 (** A retry_after delay is usable only when it is finite and non-negative:
     those are the values that can feed a sleep/backoff computation without
     producing a nonsensical or unbounded wait. Yojson parses JSON number
@@ -433,10 +325,7 @@ let classify_error ~retry_after_header ~status ~body : api_error =
        replaying the same request is not a transport retry. Preserve that exact
        boundary without inspecting provider prose. *)
     AuthorizationError { message }
-  | 400 ->
-    (match observed_context_overflow body with
-     | Some (message, limit) -> ContextOverflow { message; limit }
-     | None -> InvalidRequest { message; reason = Unknown_invalid_request })
+  | 400 -> InvalidRequest { message; reason = Unknown_invalid_request }
   | 422 -> InvalidRequest { message; reason = Unknown_invalid_request }
   | 413 ->
     (* HTTP 413 states the refusal cause in the status line: the payload was too
@@ -555,17 +444,12 @@ let%test "HTTP 400 prompt-too-long report without ref stays Unknown InvalidReque
   | Timeout _ -> false
 ;;
 
-let%test "HTTP 400 prompt-too-long report with UUID ref preserves ContextOverflow" =
+let%test "HTTP 400 prompt-too-long report with UUID ref stays unknown" =
   let body =
     {|{"error":"prompt too long; exceeded max context length by 62887 tokens (ref: 1630a4a4-998f-400a-9d54-2d87537e0c03)"}|}
   in
   match classify_error ~retry_after_header:None ~status:400 ~body with
-  | ContextOverflow
-      { message =
-          "prompt too long; exceeded max context length by 62887 tokens (ref: \
-           1630a4a4-998f-400a-9d54-2d87537e0c03)"
-      ; limit = None
-      } -> true
+  | InvalidRequest { reason = Unknown_invalid_request; _ } -> true
   | RateLimited _
   | Overloaded _
   | ServerError _
@@ -580,17 +464,12 @@ let%test "HTTP 400 prompt-too-long report with UUID ref preserves ContextOverflo
   | Timeout _ -> false
 ;;
 
-let%test "measured Ollama HTTP 400 preserves the declared context limit" =
+let%test "measured Ollama HTTP 400 prose stays unknown" =
   let body =
     {|{"error":"The prompt is too long: 1400014, model maximum context length: 1048576 (ref: 8519ccf3-5d45-4686-9ac1-64d159f75ec1)"}|}
   in
   match classify_error ~retry_after_header:None ~status:400 ~body with
-  | ContextOverflow
-      { message =
-          "The prompt is too long: 1400014, model maximum context length: 1048576 (ref: \
-           8519ccf3-5d45-4686-9ac1-64d159f75ec1)"
-      ; limit = Some 1048576
-      } -> true
+  | InvalidRequest { reason = Unknown_invalid_request; _ } -> true
   | RateLimited _
   | Overloaded _
   | ServerError _

--- a/test/test_exact_output_flow.ml
+++ b/test/test_exact_output_flow.ml
@@ -385,6 +385,13 @@ let flow_failure_id = function
   | EO.Flow_candidate_execution_failed { candidate; _ } -> candidate_id candidate
 ;;
 
+let flow_advance_failure_id = function
+  | EO.Flow_advance_candidate_rejected rejection ->
+    (EO.candidate_rejection_identity rejection).candidate_id
+  | EO.Flow_advance_execution_failed { candidate; _ } ->
+    candidate.visit.identity.candidate_id
+;;
+
 let flow_execution_failure = function
   | EO.Flow_candidate_execution_failed { candidate; cause; _ } -> candidate, cause
   | EO.Flow_candidate_rejected _ ->
@@ -784,6 +791,19 @@ let test_fenced_text_json_advances_to_frozen_successor () =
       "bare JSON successor serves the request"
       "bare-text"
       (candidate_id (EO.flow_success_candidate success));
+    (match (EO.flow_success_evidence success).advances with
+     | [ advance ] ->
+       check
+         string
+         "durable advance binds failed candidate"
+         "fenced-text"
+         (flow_advance_failure_id advance.failed);
+       check
+         string
+         "durable advance binds declared successor"
+         "bare-text"
+         advance.next.identity.candidate_id
+     | _ -> fail "successful fallback did not retain exactly one advance receipt");
     check
       bool
       "successor output is parsed without cleanup"
@@ -3334,7 +3354,12 @@ let test_callback_failures_are_terminal () =
       (EO.flow_execution_error_generation_dispatch error = EO.No_generation_dispatch);
     check string "failed attempt identity" "advance-a" (flow_failure_id failed);
     check string "withheld successor identity" "advance-b" next.identity.candidate_id;
-    check int "withheld successor remains unprepared" 1 (List.length evidence.attempts)
+    check int "withheld successor remains unprepared" 1 (List.length evidence.attempts);
+    check
+      int
+      "failed callback publishes no advance receipt"
+      0
+      (List.length evidence.advances)
   | Ok _ | Error _ -> fail "failed advance did not return typed terminal evidence"
 ;;
 
@@ -3404,6 +3429,11 @@ let assert_typed_capacity_refusal_advances_once ~label ~first_response ~assert_c
   check int (label ^ " typed capacity requests one successor advance") 1 advances;
   check
     int
+    (label ^ " typed capacity retains one advance receipt")
+    1
+    (List.length evidence.advances);
+  check
+    int
     (label ^ " typed capacity retains two attempts")
     2
     (List.length evidence.attempts);
@@ -3433,17 +3463,44 @@ let assert_typed_capacity_refusal_advances_once ~label ~first_response ~assert_c
   | Error _ -> fail (label ^ " typed capacity refusal did not advance")
 ;;
 
-let test_context_window_400_refusal_advances_once_to_successor () =
-  assert_typed_capacity_refusal_advances_once
-    ~label:"context-window"
-    ~first_response:
-      ( `Bad_request
-      , {|{"error":"The prompt is too long: 1400014, model maximum context length: 1048576 (ref: 8519ccf3-5d45-4686-9ac1-64d159f75ec1)"}|}
-      )
-    ~assert_cause:(function
-    | EO.Input_capacity_refused
-        (EO.Context_window_refused { limit_tokens = Some 1048576 }) -> ()
-    | _ -> fail "context-window 400 lost its typed capacity cause")
+let test_context_window_400_prose_remains_terminal () =
+  let response =
+    {|{"error":"The prompt is too long: 1400014, model maximum context length: 1048576 (ref: 8519ccf3-5d45-4686-9ac1-64d159f75ec1)"}|}
+  in
+  let (result, advances), posts =
+    with_server ~status:`Bad_request ~response
+    @@ fun ~sw:_ ~net ~clock:_ ~base_url ->
+    with_catalog
+      [ catalog_entry ~id:"context-prose-a" ~base_url ~native:true ~json:true ()
+      ; catalog_entry ~id:"context-prose-b" ~base_url ~native:true ~json:true ()
+      ]
+    @@ fun snapshot ->
+    let advances = ref 0 in
+    let result =
+      execute_with_accepting_test_validator
+        ~net
+        ~on_measurement_terminal:(fun _ -> Ok ())
+        ~before_measurement_dispatch:(fun _ -> Ok ())
+        ~before_dispatch:(fun _ -> Ok ())
+        ~before_advance:(fun ~failed:_ ~next:_ ->
+          incr advances;
+          Ok ())
+        (start_flow (frozen_flow snapshot [ "context-prose-a"; "context-prose-b" ]))
+    in
+    result, !advances
+  in
+  check int "HTTP 400 prose dispatches once" 1 posts;
+  check int "HTTP 400 prose requests no advance" 0 advances;
+  match result with
+  | Error
+      (EO.Flow_execution_terminal { cause = EO.Flow_exact_execution_failed failure; _ })
+    ->
+    check
+      bool
+      "HTTP 400 prose remains unattributed completion failure"
+      true
+      (failure.cause.cause = EO.Completion_failed)
+  | Ok _ | Error _ -> fail "HTTP 400 prose did not remain terminal"
 ;;
 
 let test_serialized_request_413_refusal_advances_once_to_successor () =
@@ -3452,8 +3509,7 @@ let test_serialized_request_413_refusal_advances_once_to_successor () =
     ~first_response:
       (Cohttp.Code.status_of_code 413, {|{"error":"request body too large"}|})
     ~assert_cause:(function
-      | EO.Input_capacity_refused (EO.Serialized_request_refused { http_status = 413 }) ->
-        ()
+      | EO.Serialized_request_refused { http_status = 413 } -> ()
       | _ -> fail "HTTP 413 lost its typed serialized-request cause")
 ;;
 
@@ -3610,6 +3666,11 @@ let test_semantic_rejection_advances_to_declared_successor () =
       "transport success belongs to successor"
       "semantic-b"
       (candidate_id (EO.flow_success_candidate success.transport_success));
+    check
+      int
+      "semantic rejection emits no transport advance receipt"
+      0
+      (List.length (EO.flow_success_evidence success.transport_success).advances);
     check
       (list string)
       "prior opaque rejection is preserved"
@@ -4113,9 +4174,9 @@ let () =
             `Quick
             test_callback_failures_are_terminal
         ; test_case
-            "context-window 400 advances with one dispatch per candidate"
+            "context-window 400 prose remains terminal"
             `Quick
-            test_context_window_400_refusal_advances_once_to_successor
+            test_context_window_400_prose_remains_terminal
         ; test_case
             "HTTP 413 serialized request advances with one dispatch per candidate"
             `Quick

--- a/test/test_exact_output_flow.ml
+++ b/test/test_exact_output_flow.ml
@@ -3492,9 +3492,7 @@ let test_context_window_400_prose_remains_terminal () =
   check int "HTTP 400 prose dispatches once" 1 posts;
   check int "HTTP 400 prose requests no advance" 0 advances;
   match result with
-  | Error
-      (EO.Flow_execution_terminal { cause = EO.Flow_exact_execution_failed failure; _ })
-    ->
+  | Error (EO.Flow_exact_execution_failed failure) ->
     check
       bool
       "HTTP 400 prose remains unattributed completion failure"


### PR DESCRIPTION
## Summary

- retain every successful transport-failure advance in the same atomic flow progress snapshot as admissions, attempts, and measurements
- remove HTTP 400 provider-prose parsing that promoted diagnostic strings into typed context-overflow facts
- hard-cut the now-dead context-window refusal variant; only typed HTTP 413 request-body refusal and local invalid-JSON evidence may advance after dispatch
- align the exact-output boundary document with the actual failover blast radius and evidence contract

## Adversarial rationale

A durable validated-flow codec would otherwise omit successful before_advance transitions and could launder a prose heuristic as exact typed evidence. This PR is the prerequisite boundary repair; the codec remains a separate follow-up.

## Verification

- ocamlformat on every touched OCaml file
- ocamlc -stop-after parsing on every touched OCaml implementation/interface
- git diff --check
- full Dune build/test intentionally delegated to PR CI

[Evidence] OCaml 5.5 manual: https://ocaml.org/manual/5.5/index.html (checked 2026-07-30, High confidence)

Status: do not merge until exact-head CI and adversarial review are complete.