### PR TITLE
feat(agent): type extra context carrier provenance

### DIFF
--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -41,7 +41,7 @@ let prepare_messages ~messages ~turn_params () =
       ; content = [ Text ("[system context] " ^ ctx) ]
       ; name = None
       ; tool_call_id = None
-      ; metadata = []
+      ; metadata = Extra_system_context_provenance.metadata
       }
     in
     messages @ [ system_msg ]

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -389,6 +389,32 @@ module Conversation_metadata = struct
   ;;
 end
 
+module Extra_system_context_provenance = struct
+  type classification =
+    | Absent
+    | Present
+    | Invalid
+    | Duplicate
+
+  let key = "oas.extra_system_context.v1"
+  let entry = key, `Bool true
+  let metadata = [ entry ]
+
+  let classify metadata =
+    let values =
+      List.filter_map
+        (fun (field_key, value) ->
+           if String.equal field_key key then Some value else None)
+        metadata
+    in
+    match values with
+    | [] -> Absent
+    | [ `Bool true ] -> Present
+    | [ _ ] -> Invalid
+    | _ -> Duplicate
+  ;;
+end
+
 (** Exact producer binding for stored reasoning artifacts. *)
 module Reasoning_source = struct
   type provider_instance = Provider_instance_id of string [@@deriving show]

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -233,6 +233,20 @@ module Conversation_metadata : sig
   val is_mergeable_followup : metadata -> bool
 end
 
+(** Exact provenance for the synthetic User message created from
+    [Hooks.extra_system_context]. Consumers can remove or attribute that carrier
+    by typed identity instead of assuming a list position or matching text. *)
+module Extra_system_context_provenance : sig
+  type classification =
+    | Absent
+    | Present
+    | Invalid
+    | Duplicate
+
+  val metadata : metadata
+  val classify : metadata -> classification
+end
+
 (** Producer binding stamped on stored reasoning artifacts: provider kind,
     concrete endpoint instance, canonical request model, and typed replay
     contract. Whether a difference in any of those dimensions still admits

--- a/test/test_agent_turn.ml
+++ b/test/test_agent_turn.ml
@@ -170,11 +170,38 @@ let test_prepare_messages_extra_context () =
     { Hooks.default_turn_params with extra_system_context = Some "You are in test mode." }
   in
   let result = Agent_turn.prepare_messages ~messages:msgs ~turn_params () in
-  Alcotest.(check int) "prepended system msg" 2 (List.length result);
-  let first = List.hd result in
-  Alcotest.(check bool) "is User role" true (first.role = Types.User);
-  match first.content with
-  | [ Types.Text _ ] -> ()
+  Alcotest.(check int) "appended system context" 2 (List.length result);
+  let carrier = List.nth result 1 in
+  Alcotest.(check bool) "is User role" true (carrier.role = Types.User);
+  Alcotest.(check bool)
+    "typed provenance is present"
+    true
+    (Types.Extra_system_context_provenance.classify carrier.metadata
+     = Types.Extra_system_context_provenance.Present);
+  let provenance_key =
+    match Types.Extra_system_context_provenance.metadata with
+    | [ key, `Bool true ] -> key
+    | _ -> Alcotest.fail "provenance metadata shape drifted"
+  in
+  Alcotest.(check bool)
+    "missing provenance is explicit"
+    true
+    (Types.Extra_system_context_provenance.classify []
+     = Types.Extra_system_context_provenance.Absent);
+  Alcotest.(check bool)
+    "malformed provenance is explicit"
+    true
+    (Types.Extra_system_context_provenance.classify
+       [ provenance_key, `Bool false ]
+     = Types.Extra_system_context_provenance.Invalid);
+  Alcotest.(check bool)
+    "duplicate provenance is explicit"
+    true
+    (Types.Extra_system_context_provenance.classify
+       (carrier.metadata @ carrier.metadata)
+     = Types.Extra_system_context_provenance.Duplicate);
+  match carrier.content with
+  | [ Types.Text "[system context] You are in test mode." ] -> ()
   | _ -> Alcotest.fail "expected single Text block"
 ;;
 
@@ -222,9 +249,14 @@ let test_prepare_messages_both_override_and_extra_context () =
      is applied separately in pipeline. So only extra_system_context
      adds a message here. *)
   Alcotest.(check int) "extra context adds 1 message" 2 (List.length result);
-  let first = List.hd result in
-  Alcotest.(check bool) "injected msg is User" true (first.role = Types.User);
-  match first.content with
+  let carrier = List.nth result 1 in
+  Alcotest.(check bool) "injected msg is User" true (carrier.role = Types.User);
+  Alcotest.(check bool)
+    "typed provenance is present"
+    true
+    (Types.Extra_system_context_provenance.classify carrier.metadata
+     = Types.Extra_system_context_provenance.Present);
+  match carrier.content with
   | [ Types.Text _ ] -> ()
   | _ -> Alcotest.fail "expected single Text block"
 ;;


### PR DESCRIPTION
## Summary
- stamp the OAS-generated extra-system-context User message with closed typed provenance
- expose exact absent/present/invalid/duplicate classification
- verify the appended carrier and malformed/duplicate metadata cases

## Why
MASC must attribute final provider input without guessing that a prompt carrier is the last message or dropping all message composition when prompt context exists.

## Verification
- ocamlformat --check: pass
- git diff --check: pass
- local Dune intentionally not run; exact-head CI is build authority