### PR TITLE
feat(exact-output): persist validated flow evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ original tag dates. `0.100.4` was never tagged or released.
 
 ### Changed
 
+Validated exact-output flows can now be frozen through the direct
+`Exact_output.snapshot_validated_flow_evidence` API. The current-only canonical
+snapshot preserves declared-order admission, measurement, attempt, transport
+advance, semantic rejection, and final acceptance evidence without
+reconstructing a live flow during decode.
+
 Execution projection no longer re-checks committed event sequence uniqueness.
 The read-only event store supplies only private validated snapshots, and the
 journal reducer enforces the exact next sequence before projection mutates its
@@ -28,6 +34,11 @@ refusal, while a missing or unknown terminal reason remains non-executable
 instead of being inferred as `STOP` from tool-block presence.
 
 ### Breaking Changes
+
+`Exact_output.execution_error_cause` no longer exposes the removed
+`Input_capacity_refused` wrapper. Current callers match the typed
+`Serialized_request_refused { http_status }` cause directly; no compatibility
+constructor or migration decoder is provided.
 
 `Structured.schema` now contains only the provider-native JSON Schema
 parameters and typed parser. The unused forced-tool `name` and `description`

--- a/docs/design/exact-output-flow-boundary.md
+++ b/docs/design/exact-output-flow-boundary.md
@@ -127,8 +127,16 @@ Every flow evidence projection carries:
 - ordered admission outcomes only for candidates reached so far;
 - every non-shared execution receipt allocated for an admitted current
   candidate;
-- every successfully confirmed transport-failure advance, bound to the failed
-  visit and its predetermined adjacent successor;
+- every successfully confirmed candidate-admission rejection or typed
+  transport-failure advance, bound to the failed visit and its predetermined
+  adjacent successor;
+
+After semantic validation succeeds, callers can project their accepted and
+rejected domain values exactly once into a current-only durable transcript.
+OAS preserves the declared candidate order, admissions, measurement receipts,
+generation attempts, advances, semantic rejections, and final acceptance in
+one integrity-bound snapshot. Decoding reconstructs evidence only; it never
+reconstructs a live affine flow or performs a domain commit.
 
 Terminal variants additionally carry the candidate's exact
 rejection, success, or execution failure. The `admitted_flow_candidate` and

--- a/lib/llm_provider/dune
+++ b/lib/llm_provider/dune
@@ -25,6 +25,7 @@
   exact_output_generation_receipt
   exact_output_provider_trace
   exact_output_ready_admission
+  exact_output_validated_flow_evidence
   exact_output_plan)
  (libraries
   yojson

--- a/lib/llm_provider/exact_output.ml
+++ b/lib/llm_provider/exact_output.ml
@@ -6,6 +6,7 @@ module Exec = Exact_output_execution
 module Flow_state = Exact_output_flow
 module Trace = Exact_output_provider_trace
 module Generation_receipt = Exact_output_generation_receipt
+module Validated_flow_evidence = Exact_output_validated_flow_evidence
 include Exact_output_resolver
 include Exact_output_ready_admission
 
@@ -267,6 +268,56 @@ type ('accepted, 'rejection) validated_flow_success =
   { accepted : 'accepted
   ; transport_success : flow_success
   ; prior_rejections : 'rejection semantic_rejection_receipt list
+  }
+
+type validated_flow_evidence_snapshot = Validated_flow_evidence.t
+
+type validated_flow_evidence_source_error =
+  | Evidence_ordinal_out_of_bounds of
+      { collection : string
+      ; ordinal : int
+      ; visited_candidates : int
+      }
+  | Evidence_duplicate_ordinal of
+      { collection : string
+      ; ordinal : int
+      }
+  | Evidence_missing_entry of
+      { collection : string
+      ; ordinal : int
+      }
+  | Evidence_unexpected_entry of
+      { collection : string
+      ; ordinal : int
+      }
+  | Evidence_flow_identity_mismatch of
+      { collection : string
+      ; ordinal : int
+      }
+  | Evidence_unsupported_state of
+      { collection : string
+      ; ordinal : int
+      ; detail : string
+      }
+
+type validated_flow_evidence_invariant_error = Validated_flow_evidence.invariant_error
+type validated_flow_evidence_decode_error = Validated_flow_evidence.decode_error
+
+type ('accepted_error, 'rejection_error) validated_flow_evidence_projection_error =
+  | Accepted_evidence_projection_failed of 'accepted_error
+  | Rejection_evidence_projection_failed of
+      { ordinal : int
+      ; cause : 'rejection_error
+      }
+  | Validated_flow_source_evidence_invalid of validated_flow_evidence_source_error
+  | Validated_flow_evidence_invariant_failed of validated_flow_evidence_invariant_error
+
+type validated_flow_projected_success =
+  { ordinal : int
+  ; projector : Yojson.Safe.t
+  ; output_sha256 : string
+  ; raw_response_sha256 : string
+  ; call_id : string
   }
 
 type flow_candidate_failure =
@@ -609,6 +660,850 @@ let candidate_rejection_disposition (receipt : candidate_rejection_receipt) =
   match receipt.cause with
   | Target_selection_rejected cause -> target_selection_error_disposition cause
   | Request_admission_rejected cause -> admission_error_disposition cause
+;;
+
+let validated_flow_evidence_source_error_to_string = function
+  | Evidence_ordinal_out_of_bounds { collection; ordinal; visited_candidates } ->
+    Printf.sprintf
+      "%s evidence ordinal %d is outside visited range 1..%d"
+      collection
+      ordinal
+      visited_candidates
+  | Evidence_duplicate_ordinal { collection; ordinal } ->
+    Printf.sprintf "%s evidence repeats ordinal %d" collection ordinal
+  | Evidence_missing_entry { collection; ordinal } ->
+    Printf.sprintf "%s evidence is missing ordinal %d" collection ordinal
+  | Evidence_unexpected_entry { collection; ordinal } ->
+    Printf.sprintf "%s evidence is unexpected at ordinal %d" collection ordinal
+  | Evidence_flow_identity_mismatch { collection; ordinal } ->
+    Printf.sprintf
+      "%s evidence has a different flow identity at ordinal %d"
+      collection
+      ordinal
+  | Evidence_unsupported_state { collection; ordinal; detail } ->
+    Printf.sprintf
+      "%s evidence at ordinal %d has unsupported state: %s"
+      collection
+      ordinal
+      detail
+;;
+
+let validated_flow_evidence_invariant_error_to_string =
+  Validated_flow_evidence.invariant_error_to_string
+;;
+
+let validated_flow_evidence_decode_error_to_string =
+  Validated_flow_evidence.decode_error_to_string
+;;
+
+let validated_flow_evidence_to_string = Validated_flow_evidence.to_string
+let validated_flow_evidence_of_string = Validated_flow_evidence.of_string
+let validated_flow_evidence_sha256 = Validated_flow_evidence.sha256
+
+let validated_flow_evidence_accepted_domain_sha256 =
+  Validated_flow_evidence.accepted_domain_sha256
+;;
+
+let evidence_sha256 value = Digestif.SHA256.(to_hex (digest_string value))
+
+let rec canonical_evidence_json = function
+  | `Assoc fields ->
+    `Assoc
+      (fields
+       |> List.map (fun (name, value) -> name, canonical_evidence_json value)
+       |> List.sort (fun (left, _) (right, _) -> String.compare left right))
+  | `List values -> `List (List.map canonical_evidence_json values)
+  | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Tuple _ | `Variant _)
+    as value -> value
+;;
+
+let output_evidence_sha256 value =
+  value |> canonical_evidence_json |> Yojson.Safe.to_string |> evidence_sha256
+;;
+
+let evidence_candidate (identity : flow_candidate_identity)
+  : Validated_flow_evidence.candidate
+  =
+  { candidate_id = identity.candidate_id
+  ; candidate_binding_sha256 = target_identity_fingerprint identity.target_identity
+  ; catalog_generation_sha256 = catalog_generation_fingerprint identity.catalog_generation
+  ; catalog_evidence_sha256 = catalog_evidence_sha256 identity.catalog_evidence
+  }
+;;
+
+let evidence_assurance = function
+  | Json_syntax_only -> Validated_flow_evidence.Json_syntax_only
+  | Provider_schema_requested -> Validated_flow_evidence.Provider_schema_requested
+;;
+
+let evidence_provenance (provenance : plan_provenance)
+  : Validated_flow_evidence.provenance
+  =
+  { source_schema_sha256 =
+      schema_fingerprint_to_string provenance.source_schema_fingerprint
+  ; effective_schema_sha256 =
+      Option.map schema_fingerprint_to_string provenance.effective_schema_fingerprint
+  ; assurance = evidence_assurance provenance.actual_assurance
+  ; candidate_binding_sha256 = target_identity_fingerprint provenance.target_identity
+  ; catalog_generation_sha256 =
+      catalog_generation_fingerprint provenance.catalog_generation
+  ; catalog_evidence_sha256 = catalog_evidence_sha256 provenance.catalog_evidence
+  }
+;;
+
+let evidence_measurement_dispatch = function
+  | No_measurement_dispatch -> Ok Validated_flow_evidence.No_measurement_dispatch
+  | Measurement_dispatch_started ->
+    Ok Validated_flow_evidence.Measurement_dispatch_started
+  | Measurement_dispatch_unknown -> Error "terminal measurement dispatch remains unknown"
+;;
+
+let evidence_measurement_outcome = function
+  | Measurement_not_required -> Validated_flow_evidence.Measurement_not_required
+  | Measurement_succeeded -> Validated_flow_evidence.Measurement_succeeded
+  | Measurement_unsupported -> Validated_flow_evidence.Measurement_unsupported
+  | Measurement_local_invalid -> Validated_flow_evidence.Measurement_local_invalid
+  | Measurement_transport_failed -> Validated_flow_evidence.Measurement_transport_failed
+  | Measurement_invalid_response -> Validated_flow_evidence.Measurement_invalid_response
+  | Measurement_fence_rejected -> Validated_flow_evidence.Measurement_fence_rejected
+  | Measurement_cancelled -> Validated_flow_evidence.Measurement_cancelled
+;;
+
+let evidence_measurement_state ~collection ~ordinal (measurement : measurement_evidence) =
+  match evidence_measurement_dispatch measurement.dispatch with
+  | Error detail -> Error (Evidence_unsupported_state { collection; ordinal; detail })
+  | Ok dispatch ->
+    Ok
+      Validated_flow_evidence.
+        { dispatch; outcome = evidence_measurement_outcome measurement.outcome }
+;;
+
+let input_capacity_evidence_json = function
+  | Token_measurement_required { accepted_through_tokens; rejected_from_tokens } ->
+    `Assoc
+      [ "kind", `String "token_measurement_required"
+      ; "accepted_through_tokens", `Int accepted_through_tokens
+      ; ( "rejected_from_tokens"
+        , Option.fold ~none:`Null ~some:(fun value -> `Int value) rejected_from_tokens )
+      ]
+  | Context_window_exceeded { input_tokens; reserved_output_tokens; max_context_tokens }
+    ->
+    `Assoc
+      [ "kind", `String "context_window_exceeded"
+      ; "input_tokens", `Int input_tokens
+      ; "reserved_output_tokens", `Int reserved_output_tokens
+      ; "max_context_tokens", `Int max_context_tokens
+      ]
+  | Token_capacity_rejected
+      (Capacity_evidence_not_yet_valid { now_unix_s; checked_at_unix_s }) ->
+    `Assoc
+      [ "kind", `String "capacity_evidence_not_yet_valid"
+      ; "now_unix_s", `Int now_unix_s
+      ; "checked_at_unix_s", `Int checked_at_unix_s
+      ]
+  | Token_capacity_rejected (Capacity_evidence_expired { now_unix_s; expires_at_unix_s })
+    ->
+    `Assoc
+      [ "kind", `String "capacity_evidence_expired"
+      ; "now_unix_s", `Int now_unix_s
+      ; "expires_at_unix_s", `Int expires_at_unix_s
+      ]
+  | Token_capacity_rejected
+      (Capacity_boundary_unknown
+         { input_tokens; accepted_through_tokens; rejected_from_tokens }) ->
+    `Assoc
+      [ "kind", `String "capacity_boundary_unknown"
+      ; "input_tokens", `Int input_tokens
+      ; "accepted_through_tokens", `Int accepted_through_tokens
+      ; ( "rejected_from_tokens"
+        , Option.fold ~none:`Null ~some:(fun value -> `Int value) rejected_from_tokens )
+      ]
+  | Token_capacity_rejected
+      (Capacity_input_rejected
+         { input_tokens; accepted_through_tokens; rejected_from_tokens }) ->
+    `Assoc
+      [ "kind", `String "capacity_input_rejected"
+      ; "input_tokens", `Int input_tokens
+      ; "accepted_through_tokens", `Int accepted_through_tokens
+      ; "rejected_from_tokens", `Int rejected_from_tokens
+      ]
+  | Serialized_request_body_too_large { actual_bytes; limit_bytes } ->
+    `Assoc
+      [ "kind", `String "serialized_request_body_too_large"
+      ; "actual_bytes", `Int actual_bytes
+      ; "limit_bytes", `Int limit_bytes
+      ]
+;;
+
+let wire_admission_error_evidence_json = function
+  | Capability_snapshot_missing ->
+    `Assoc [ "kind", `String "capability_snapshot_missing" ]
+  | Output_contract_unavailable ->
+    `Assoc [ "kind", `String "output_contract_unavailable" ]
+  | Cross_feature_not_allowed -> `Assoc [ "kind", `String "cross_feature_not_allowed" ]
+  | Global_admission_not_allowed ->
+    `Assoc [ "kind", `String "global_admission_not_allowed" ]
+  | Invalid_connect_timeout -> `Assoc [ "kind", `String "invalid_connect_timeout" ]
+  | Invalid_body_timeout -> `Assoc [ "kind", `String "invalid_body_timeout" ]
+  | Caller_supplied_header_not_allowed ->
+    `Assoc [ "kind", `String "caller_supplied_header_not_allowed" ]
+  | Unsupported_image_input -> `Assoc [ "kind", `String "unsupported_image_input" ]
+  | Unsupported_document_input -> `Assoc [ "kind", `String "unsupported_document_input" ]
+  | Unsupported_audio_input -> `Assoc [ "kind", `String "unsupported_audio_input" ]
+  | Unsupported_system_prompt -> `Assoc [ "kind", `String "unsupported_system_prompt" ]
+  | Token_measurement_required observation ->
+    `Assoc
+      [ "kind", `String "token_measurement_required"
+      ; "accepted_through_tokens", `Int observation.accepted_through_tokens
+      ; ( "rejected_from_tokens"
+        , Option.fold
+            ~none:`Null
+            ~some:(fun value -> `Int value)
+            observation.rejected_from_tokens )
+      ]
+  | Context_limit_unavailable -> `Assoc [ "kind", `String "context_limit_unavailable" ]
+  | Invalid_context_limit -> `Assoc [ "kind", `String "invalid_context_limit" ]
+  | Output_reservation_unavailable ->
+    `Assoc [ "kind", `String "output_reservation_unavailable" ]
+  | Measured_context_window_exceeded fit ->
+    `Assoc
+      [ "kind", `String "measured_context_window_exceeded"
+      ; "input_tokens", `Int fit.input_tokens
+      ; "reserved_output_tokens", `Int fit.reserved_output_tokens
+      ; "max_context_tokens", `Int fit.max_context_tokens
+      ]
+  | Measured_serving_constraint_rejected reason ->
+    `Assoc
+      [ "kind", `String "measured_serving_constraint_rejected"
+      ; "evidence", input_capacity_evidence_json (Token_capacity_rejected reason)
+      ]
+  | Token_measurement_failed -> `Assoc [ "kind", `String "token_measurement_failed" ]
+  | Unsupported_target_model { model_id } ->
+    `Assoc [ "kind", `String "unsupported_target_model"; "model_id", `String model_id ]
+  | Target_request_rejected -> `Assoc [ "kind", `String "target_request_rejected" ]
+  | Request_body_too_large { actual_bytes; limit_bytes } ->
+    `Assoc
+      [ "kind", `String "request_body_too_large"
+      ; "actual_bytes", `Int actual_bytes
+      ; "limit_bytes", `Int limit_bytes
+      ]
+  | Request_serialization_rejected ->
+    `Assoc [ "kind", `String "request_serialization_rejected" ]
+;;
+
+let admission_error_evidence_json = function
+  | Provider_schema_unavailable ->
+    `Assoc [ "kind", `String "provider_schema_unavailable" ]
+  | Unsupported_schema_keyword keyword ->
+    `Assoc [ "kind", `String "unsupported_schema_keyword"; "keyword", `String keyword ]
+  | Unsupported_schema_type schema_type ->
+    `Assoc
+      [ "kind", `String "unsupported_schema_type"; "schema_type", `String schema_type ]
+  | Invalid_schema -> `Assoc [ "kind", `String "invalid_schema" ]
+  | Wire_admission_rejected cause ->
+    `Assoc
+      [ "kind", `String "wire_admission_rejected"
+      ; "cause", wire_admission_error_evidence_json cause
+      ]
+;;
+
+let target_selection_error_evidence_json = function
+  | Missing_target_credential { target_ref; environment_variable } ->
+    `Assoc
+      [ "kind", `String "missing_target_credential"
+      ; "target_ref", `String target_ref
+      ; "environment_variable", `String environment_variable
+      ]
+  | Target_credential_invalid { target_ref; environment_variable } ->
+    `Assoc
+      [ "kind", `String "target_credential_invalid"
+      ; "target_ref", `String target_ref
+      ; "environment_variable", `String environment_variable
+      ]
+  | Target_credential_read_failed { target_ref; environment_variable } ->
+    `Assoc
+      [ "kind", `String "target_credential_read_failed"
+      ; "target_ref", `String target_ref
+      ; "environment_variable", `String environment_variable
+      ]
+;;
+
+let candidate_rejection_evidence_json (receipt : candidate_rejection_receipt) =
+  match receipt.cause with
+  | Target_selection_rejected cause ->
+    `Assoc
+      [ "kind", `String "target_selection_rejected"
+      ; "cause", target_selection_error_evidence_json cause
+      ]
+  | Request_admission_rejected cause ->
+    `Assoc
+      [ "kind", `String "request_admission_rejected"
+      ; "cause", admission_error_evidence_json cause
+      ]
+;;
+
+let index_evidence_by_ordinal ~collection ~visited_candidates ~ordinal values =
+  let slots = Array.make (visited_candidates + 1) None in
+  let rec fill = function
+    | [] -> Ok slots
+    | value :: rest ->
+      let position = ordinal value in
+      if position < 1 || position > visited_candidates
+      then
+        Error
+          (Evidence_ordinal_out_of_bounds
+             { collection; ordinal = position; visited_candidates })
+      else (
+        match slots.(position) with
+        | Some _ -> Error (Evidence_duplicate_ordinal { collection; ordinal = position })
+        | None ->
+          slots.(position) <- Some value;
+          fill rest)
+  in
+  fill values
+;;
+
+let same_flow_id expected actual =
+  String.equal (flow_id_to_string expected) (flow_id_to_string actual)
+;;
+
+let same_candidate_identity
+      (left : flow_candidate_identity)
+      (right : flow_candidate_identity)
+  =
+  String.equal left.candidate_id right.candidate_id
+  && String.equal
+       (target_identity_fingerprint left.target_identity)
+       (target_identity_fingerprint right.target_identity)
+  && String.equal
+       (catalog_generation_fingerprint left.catalog_generation)
+       (catalog_generation_fingerprint right.catalog_generation)
+  && String.equal
+       (catalog_evidence_sha256 left.catalog_evidence)
+       (catalog_evidence_sha256 right.catalog_evidence)
+;;
+
+let evidence_measurement ~flow_id ~ordinal (snapshot : measurement_receipt_snapshot) =
+  if not (same_flow_id flow_id snapshot.flow_id)
+  then Error (Evidence_flow_identity_mismatch { collection = "measurement"; ordinal })
+  else (
+    match snapshot.phase, snapshot.outcome with
+    | Measurement_terminal, Some outcome ->
+      (match evidence_measurement_dispatch snapshot.dispatch with
+       | Error detail ->
+         Error
+           (Evidence_unsupported_state { collection = "measurement"; ordinal; detail })
+       | Ok dispatch ->
+         Ok
+           Validated_flow_evidence.
+             { operation_id = measurement_operation_id_to_string snapshot.operation_id
+             ; request_body_sha256 = snapshot.request_body_sha256
+             ; candidate_binding_sha256 = snapshot.candidate_binding_sha256
+             ; catalog_generation_sha256 = snapshot.catalog_generation_fingerprint
+             ; catalog_evidence_sha256 = snapshot.catalog_evidence_sha256
+             ; dispatch
+             ; outcome = evidence_measurement_outcome outcome
+             })
+    | (Measurement_fence_committed | Measurement_wire_started | Measurement_terminal), _
+      ->
+      Error
+        (Evidence_unsupported_state
+           { collection = "measurement"
+           ; ordinal
+           ; detail = "snapshot is not terminal with an outcome"
+           }))
+;;
+
+let evidence_attempt_phase ~ordinal = function
+  | Before_dispatch -> Ok Validated_flow_evidence.Before_dispatch
+  | Response_received -> Ok Validated_flow_evidence.Response_received
+  | Terminal -> Ok Validated_flow_evidence.Terminal
+  | Not_started | Dispatch_started ->
+    Error
+      (Evidence_unsupported_state
+         { collection = "attempt"
+         ; ordinal
+         ; detail = "snapshot is not at a durable transcript boundary"
+         })
+;;
+
+let evidence_attempt
+      ~flow_id
+      ~ordinal
+      ~raw_response_sha256
+      (snapshot : flow_attempt_snapshot)
+  =
+  if not (same_flow_id flow_id snapshot.visit.flow_id)
+  then Error (Evidence_flow_identity_mismatch { collection = "attempt"; ordinal })
+  else (
+    let receipt = snapshot.receipt in
+    match evidence_attempt_phase ~ordinal (generation_receipt_snapshot_phase receipt) with
+    | Error _ as error -> error
+    | Ok phase ->
+      Ok
+        Validated_flow_evidence.
+          { call_id = call_id_to_string (generation_receipt_snapshot_call_id receipt)
+          ; plan_sha256 = generation_receipt_snapshot_plan_fingerprint receipt
+          ; request_body_sha256 = generation_receipt_snapshot_request_body_sha256 receipt
+          ; candidate_binding_sha256 =
+              generation_receipt_snapshot_target_identity receipt
+              |> target_identity_fingerprint
+          ; catalog_generation_sha256 =
+              generation_receipt_snapshot_catalog_generation receipt
+              |> catalog_generation_fingerprint
+          ; catalog_evidence_sha256 =
+              generation_receipt_snapshot_catalog_evidence receipt
+              |> catalog_evidence_sha256
+          ; phase
+          ; dispatch_count = generation_receipt_snapshot_dispatch_count receipt
+          ; http_status = generation_receipt_snapshot_http_status receipt
+          ; provider_trace_sha256 =
+              generation_receipt_snapshot_provider_trace receipt
+              |> Option.map provider_trace_fingerprint
+          ; raw_response_sha256
+          })
+;;
+
+let evidence_transport_failure ~ordinal = function
+  | Flow_advance_candidate_rejected _ ->
+    Ok (Validated_flow_evidence.Candidate_rejected, None)
+  | Flow_advance_execution_failed { cause = Completion_failed; raw_response_sha256; _ } ->
+    Ok (Validated_flow_evidence.Completion_failed_before_dispatch, raw_response_sha256)
+  | Flow_advance_execution_failed
+      { cause = Serialized_request_refused { http_status }; raw_response_sha256; _ } ->
+    Ok
+      ( Validated_flow_evidence.Serialized_request_refused { http_status }
+      , raw_response_sha256 )
+  | Flow_advance_execution_failed { cause = Invalid_json_output; raw_response_sha256; _ }
+    -> Ok (Validated_flow_evidence.Invalid_json_output, raw_response_sha256)
+  | Flow_advance_execution_failed { cause; _ } ->
+    let detail =
+      match cause with
+      | Attempt_already_started -> "attempt_already_started"
+      | Clock_required_for_timeout -> "clock_required_for_timeout"
+      | Frozen_request_mismatch -> "frozen_request_mismatch"
+      | Completion_failed -> "completion_failed"
+      | Serialized_request_refused _ -> "serialized_request_refused"
+      | Incomplete_output -> "incomplete_output"
+      | Missing_output -> "missing_output"
+      | Ambiguous_output _ -> "ambiguous_output"
+      | Unexpected_output_content -> "unexpected_output_content"
+      | Invalid_json_output -> "invalid_json_output"
+      | Internal_non_json_output -> "internal_non_json_output"
+    in
+    Error (Evidence_unsupported_state { collection = "advance"; ordinal; detail })
+;;
+
+let evidence_admission ~flow_id ~ordinal ~expected_identity = function
+  | Candidate_rejected receipt ->
+    if not (same_flow_id flow_id receipt.visit.flow_id)
+    then Error (Evidence_flow_identity_mismatch { collection = "admission"; ordinal })
+    else if not (same_candidate_identity expected_identity receipt.visit.identity)
+    then
+      Error
+        (Evidence_unsupported_state
+           { collection = "admission"
+           ; ordinal
+           ; detail = "candidate identity differs from declared snapshot"
+           })
+    else (
+      match
+        evidence_measurement_state ~collection:"admission" ~ordinal receipt.measurement
+      with
+      | Error _ as error -> error
+      | Ok measurement ->
+        Ok
+          (Validated_flow_evidence.Rejected
+             { rejection = candidate_rejection_evidence_json receipt; measurement }))
+  | Candidate_admitted admitted ->
+    if not (same_flow_id flow_id admitted.visit.flow_id)
+    then Error (Evidence_flow_identity_mismatch { collection = "admission"; ordinal })
+    else if not (same_candidate_identity expected_identity admitted.visit.identity)
+    then
+      Error
+        (Evidence_unsupported_state
+           { collection = "admission"
+           ; ordinal
+           ; detail = "candidate identity differs from declared snapshot"
+           })
+    else (
+      match
+        evidence_measurement_state ~collection:"admission" ~ordinal admitted.measurement
+      with
+      | Error _ as error -> error
+      | Ok measurement ->
+        Ok
+          (Validated_flow_evidence.Admitted
+             { plan_sha256 = admitted.plan_fingerprint
+             ; request_body_sha256 = admitted.request_body_sha256
+             ; provenance = evidence_provenance admitted.provenance
+             ; measurement
+             }))
+;;
+
+let visit_ordinal visit = flow_visit_ordinal_to_int visit.ordinal
+
+let advance_failed_visit = function
+  | Flow_advance_candidate_rejected receipt -> receipt.visit
+  | Flow_advance_execution_failed { candidate; _ } -> candidate.visit
+;;
+
+let attempt_snapshot_call_id snapshot =
+  generation_receipt_snapshot_call_id snapshot.receipt |> call_id_to_string
+;;
+
+let projected_flow_success ~ordinal ~projector (transport : flow_success) =
+  let success = transport.success in
+  { ordinal
+  ; projector
+  ; output_sha256 = output_evidence_sha256 success.output
+  ; raw_response_sha256 = success.raw_response.body_sha256
+  ; call_id = call_id_to_string success.call_id
+  }
+;;
+
+let snapshot_validated_flow_evidence
+      ~project_accepted
+      ~project_rejection
+      (validated : ('accepted, 'rejection) validated_flow_success)
+  =
+  let source_result = function
+    | Ok value -> Ok value
+    | Error error -> Error (Validated_flow_source_evidence_invalid error)
+  in
+  let final_transport = validated.transport_success in
+  let evidence = final_transport.evidence in
+  let visited_candidates = candidate_visit_count_to_int evidence.candidate_visit_count in
+  let admissions_count = List.length evidence.admissions in
+  let declared_count = List.length evidence.declared_candidate_snapshot in
+  let* () =
+    if visited_candidates < 1 || visited_candidates > declared_count
+    then
+      Error
+        (Validated_flow_source_evidence_invalid
+           (Evidence_unsupported_state
+              { collection = "flow"
+              ; ordinal = visited_candidates
+              ; detail =
+                  Printf.sprintf
+                    "visited candidate count is outside declared count %d"
+                    declared_count
+              }))
+    else if visited_candidates = admissions_count
+    then Ok ()
+    else
+      Error
+        (Validated_flow_source_evidence_invalid
+           (Evidence_unsupported_state
+              { collection = "admission"
+              ; ordinal = admissions_count
+              ; detail =
+                  Printf.sprintf
+                    "candidate visit count is %d but admission count is %d"
+                    visited_candidates
+                    admissions_count
+              }))
+  in
+  let declared_source = Array.of_list evidence.declared_candidate_snapshot in
+  let admission_ordinal = function
+    | Candidate_admitted admitted -> visit_ordinal admitted.visit
+    | Candidate_rejected receipt -> visit_ordinal receipt.visit
+  in
+  let* admissions =
+    index_evidence_by_ordinal
+      ~collection:"admission"
+      ~visited_candidates
+      ~ordinal:admission_ordinal
+      evidence.admissions
+    |> source_result
+  in
+  let* attempts =
+    index_evidence_by_ordinal
+      ~collection:"attempt"
+      ~visited_candidates
+      ~ordinal:(fun snapshot -> visit_ordinal snapshot.visit)
+      evidence.attempts
+    |> source_result
+  in
+  let* measurements =
+    index_evidence_by_ordinal
+      ~collection:"measurement"
+      ~visited_candidates
+      ~ordinal:(fun snapshot -> flow_visit_ordinal_to_int snapshot.visit_ordinal)
+      evidence.measurements
+    |> source_result
+  in
+  let* advances =
+    index_evidence_by_ordinal
+      ~collection:"advance"
+      ~visited_candidates
+      ~ordinal:(fun receipt -> visit_ordinal (advance_failed_visit receipt.failed))
+      evidence.advances
+    |> source_result
+  in
+  let rec project_rejections projected_rev = function
+    | [] -> Ok (List.rev projected_rev)
+    | receipt :: rest ->
+      let ordinal = visit_ordinal receipt.transport_success.candidate.visit in
+      if ordinal < 1 || ordinal > visited_candidates
+      then
+        Error
+          (Validated_flow_source_evidence_invalid
+             (Evidence_ordinal_out_of_bounds
+                { collection = "semantic_rejection"; ordinal; visited_candidates }))
+      else if
+        not (same_flow_id evidence.flow_id receipt.transport_success.evidence.flow_id)
+      then
+        Error
+          (Validated_flow_source_evidence_invalid
+             (Evidence_flow_identity_mismatch
+                { collection = "semantic_rejection"; ordinal }))
+      else if
+        not
+          (same_candidate_identity
+             declared_source.(ordinal - 1)
+             receipt.transport_success.candidate.visit.identity)
+      then
+        Error
+          (Validated_flow_source_evidence_invalid
+             (Evidence_unsupported_state
+                { collection = "semantic_rejection"
+                ; ordinal
+                ; detail = "candidate identity differs from declared snapshot"
+                }))
+      else (
+        match project_rejection receipt.rejection with
+        | Error cause -> Error (Rejection_evidence_projection_failed { ordinal; cause })
+        | Ok projector ->
+          project_rejections
+            (projected_flow_success ~ordinal ~projector receipt.transport_success
+             :: projected_rev)
+            rest)
+  in
+  let* projected_rejections = project_rejections [] validated.prior_rejections in
+  let* semantic_rejections =
+    index_evidence_by_ordinal
+      ~collection:"semantic_rejection"
+      ~visited_candidates
+      ~ordinal:(fun projected -> projected.ordinal)
+      projected_rejections
+    |> source_result
+  in
+  let accepted_ordinal = visit_ordinal final_transport.candidate.visit in
+  let* () =
+    if accepted_ordinal < 1 || accepted_ordinal > visited_candidates
+    then
+      Error
+        (Validated_flow_source_evidence_invalid
+           (Evidence_ordinal_out_of_bounds
+              { collection = "accepted"; ordinal = accepted_ordinal; visited_candidates }))
+    else if not (same_flow_id evidence.flow_id final_transport.candidate.visit.flow_id)
+    then
+      Error
+        (Validated_flow_source_evidence_invalid
+           (Evidence_flow_identity_mismatch
+              { collection = "accepted"; ordinal = accepted_ordinal }))
+    else if
+      not
+        (same_candidate_identity
+           declared_source.(accepted_ordinal - 1)
+           final_transport.candidate.visit.identity)
+    then
+      Error
+        (Validated_flow_source_evidence_invalid
+           (Evidence_unsupported_state
+              { collection = "accepted"
+              ; ordinal = accepted_ordinal
+              ; detail = "candidate identity differs from declared snapshot"
+              }))
+    else Ok ()
+  in
+  let* accepted_projector =
+    match project_accepted validated.accepted with
+    | Ok value -> Ok value
+    | Error cause -> Error (Accepted_evidence_projection_failed cause)
+  in
+  let accepted =
+    projected_flow_success
+      ~ordinal:accepted_ordinal
+      ~projector:accepted_projector
+      final_transport
+  in
+  let declared_candidates =
+    Array.to_list declared_source |> List.map evidence_candidate
+  in
+  let rec build_steps ordinal steps_rev =
+    if ordinal > visited_candidates
+    then Ok (List.rev steps_rev)
+    else (
+      match admissions.(ordinal) with
+      | None ->
+        Error
+          (Validated_flow_source_evidence_invalid
+             (Evidence_missing_entry { collection = "admission"; ordinal }))
+      | Some source_admission ->
+        let expected_identity = declared_source.(ordinal - 1) in
+        let* admission =
+          evidence_admission
+            ~flow_id:evidence.flow_id
+            ~ordinal
+            ~expected_identity
+            source_admission
+          |> source_result
+        in
+        let* measurement =
+          match measurements.(ordinal) with
+          | None -> Ok None
+          | Some snapshot ->
+            let* value =
+              evidence_measurement ~flow_id:evidence.flow_id ~ordinal snapshot
+              |> source_result
+            in
+            Ok (Some value)
+        in
+        let advance = advances.(ordinal) in
+        let semantic = semantic_rejections.(ordinal) in
+        let is_accepted = ordinal = accepted.ordinal in
+        let outcome_count =
+          (if Option.is_some advance then 1 else 0)
+          + (if Option.is_some semantic then 1 else 0)
+          + if is_accepted then 1 else 0
+        in
+        if outcome_count <> 1
+        then
+          Error
+            (Validated_flow_source_evidence_invalid
+               ((if outcome_count = 0
+                 then Evidence_missing_entry
+                 else Evidence_unexpected_entry)
+                  { collection = "outcome"; ordinal }))
+        else
+          let* outcome, raw_response_sha256, expected_call_id =
+            match advance, semantic, is_accepted with
+            | Some receipt, None, false ->
+              let failed_visit = advance_failed_visit receipt.failed in
+              let next_ordinal = visit_ordinal receipt.next in
+              if not (same_flow_id evidence.flow_id failed_visit.flow_id)
+              then
+                Error
+                  (Validated_flow_source_evidence_invalid
+                     (Evidence_flow_identity_mismatch
+                        { collection = "advance.failed"; ordinal }))
+              else if
+                not (same_candidate_identity expected_identity failed_visit.identity)
+              then
+                Error
+                  (Validated_flow_source_evidence_invalid
+                     (Evidence_unsupported_state
+                        { collection = "advance.failed"
+                        ; ordinal
+                        ; detail = "candidate identity differs from declared snapshot"
+                        }))
+              else if not (same_flow_id evidence.flow_id receipt.next.flow_id)
+              then
+                Error
+                  (Validated_flow_source_evidence_invalid
+                     (Evidence_flow_identity_mismatch { collection = "advance"; ordinal }))
+              else if
+                next_ordinal < 1
+                || next_ordinal > Array.length declared_source
+                || not
+                     (same_candidate_identity
+                        declared_source.(next_ordinal - 1)
+                        receipt.next.identity)
+              then
+                Error
+                  (Validated_flow_source_evidence_invalid
+                     (Evidence_unsupported_state
+                        { collection = "advance.next"
+                        ; ordinal
+                        ; detail = "candidate identity differs from declared snapshot"
+                        }))
+              else
+                let* failure, raw_response_sha256 =
+                  evidence_transport_failure ~ordinal receipt.failed |> source_result
+                in
+                let expected_call_id =
+                  match receipt.failed with
+                  | Flow_advance_candidate_rejected _ -> None
+                  | Flow_advance_execution_failed { candidate; _ } ->
+                    Some (attempt_snapshot_call_id candidate)
+                in
+                Ok
+                  ( Validated_flow_evidence.Advance { next_ordinal; failure }
+                  , raw_response_sha256
+                  , expected_call_id )
+            | None, Some projected, false ->
+              Ok
+                ( Validated_flow_evidence.Semantic_rejected
+                    { projector = projected.projector
+                    ; output_sha256 = projected.output_sha256
+                    }
+                , Some projected.raw_response_sha256
+                , Some projected.call_id )
+            | None, None, true ->
+              Ok
+                ( Validated_flow_evidence.Accepted
+                    { projector = accepted.projector
+                    ; output_sha256 = accepted.output_sha256
+                    }
+                , Some accepted.raw_response_sha256
+                , Some accepted.call_id )
+            | Some _, Some _, _
+            | Some _, None, true
+            | None, Some _, true
+            | None, None, false ->
+              Error
+                (Validated_flow_source_evidence_invalid
+                   (Evidence_unexpected_entry { collection = "outcome"; ordinal }))
+          in
+          let* attempt =
+            match attempts.(ordinal), expected_call_id with
+            | None, None -> Ok None
+            | None, Some _ ->
+              Error
+                (Validated_flow_source_evidence_invalid
+                   (Evidence_missing_entry { collection = "attempt"; ordinal }))
+            | Some _, None ->
+              Error
+                (Validated_flow_source_evidence_invalid
+                   (Evidence_unexpected_entry { collection = "attempt"; ordinal }))
+            | Some snapshot, Some expected_call_id ->
+              let actual_call_id = attempt_snapshot_call_id snapshot in
+              if not (String.equal expected_call_id actual_call_id)
+              then
+                Error
+                  (Validated_flow_source_evidence_invalid
+                     (Evidence_unsupported_state
+                        { collection = "attempt"
+                        ; ordinal
+                        ; detail = "call identity differs from outcome evidence"
+                        }))
+              else
+                let* value =
+                  evidence_attempt
+                    ~flow_id:evidence.flow_id
+                    ~ordinal
+                    ~raw_response_sha256
+                    snapshot
+                  |> source_result
+                in
+                Ok (Some value)
+          in
+          build_steps
+            (ordinal + 1)
+            (Validated_flow_evidence.{ ordinal; admission; measurement; attempt; outcome }
+             :: steps_rev))
+  in
+  let* steps = build_steps 1 [] in
+  match
+    Validated_flow_evidence.create
+      ~flow_id:(flow_id_to_string evidence.flow_id)
+      ~declared_candidates
+      ~steps
+  with
+  | Ok snapshot -> Ok snapshot
+  | Error error -> Error (Validated_flow_evidence_invariant_failed error)
 ;;
 
 let flow_attempt_evidence (flow : flow_attempt) =

--- a/lib/llm_provider/exact_output.mli
+++ b/lib/llm_provider/exact_output.mli
@@ -637,6 +637,59 @@ type ('accepted, 'rejection) validated_flow_success = private
   ; prior_rejections : 'rejection semantic_rejection_receipt list
   }
 
+(** Immutable, current-only evidence for one successfully validated flow.
+    Decoding reconstructs only this durable snapshot, never a live flow or its
+    domain values. *)
+type validated_flow_evidence_snapshot
+
+type validated_flow_evidence_source_error
+type validated_flow_evidence_invariant_error
+type validated_flow_evidence_decode_error
+
+type ('accepted_error, 'rejection_error) validated_flow_evidence_projection_error =
+  | Accepted_evidence_projection_failed of 'accepted_error
+  | Rejection_evidence_projection_failed of
+      { ordinal : int
+      ; cause : 'rejection_error
+      }
+  | Validated_flow_source_evidence_invalid of validated_flow_evidence_source_error
+  | Validated_flow_evidence_invariant_failed of validated_flow_evidence_invariant_error
+
+(** Project domain values exactly once in declared visit order and freeze the
+    complete successful transcript. Transport/output digests are taken from
+    the same typed [flow_success] that produced each semantic verdict. *)
+val snapshot_validated_flow_evidence
+  :  project_accepted:('accepted -> (Yojson.Safe.t, 'accepted_error) result)
+  -> project_rejection:('rejection -> (Yojson.Safe.t, 'rejection_error) result)
+  -> ('accepted, 'rejection) validated_flow_success
+  -> ( validated_flow_evidence_snapshot
+       , ('accepted_error, 'rejection_error) validated_flow_evidence_projection_error )
+       result
+
+val validated_flow_evidence_to_string : validated_flow_evidence_snapshot -> string
+
+val validated_flow_evidence_of_string
+  :  string
+  -> (validated_flow_evidence_snapshot, validated_flow_evidence_decode_error) result
+
+val validated_flow_evidence_sha256 : validated_flow_evidence_snapshot -> string
+
+val validated_flow_evidence_accepted_domain_sha256
+  :  validated_flow_evidence_snapshot
+  -> string
+
+val validated_flow_evidence_source_error_to_string
+  :  validated_flow_evidence_source_error
+  -> string
+
+val validated_flow_evidence_invariant_error_to_string
+  :  validated_flow_evidence_invariant_error
+  -> string
+
+val validated_flow_evidence_decode_error_to_string
+  :  validated_flow_evidence_decode_error
+  -> string
+
 type flow_candidate_failure =
   | Flow_candidate_rejected of candidate_rejection_receipt
   | Flow_candidate_execution_failed of

--- a/lib/llm_provider/exact_output_validated_flow_evidence.ml
+++ b/lib/llm_provider/exact_output_validated_flow_evidence.ml
@@ -379,6 +379,11 @@ let measurement_state_is_valid measurement =
   && measurement.outcome = Measurement_succeeded
 ;;
 
+let rejected_measurement_receipt_state_is_valid measurement =
+  measurement.dispatch = No_measurement_dispatch
+  && measurement.outcome <> Measurement_not_required
+;;
+
 let attempt_success_state_is_valid attempt =
   match attempt.phase with
   | Terminal ->
@@ -426,6 +431,7 @@ let check_measurement
       ~candidate
       ~request_body_sha256
       ~measurement_ids
+      ~state_is_valid
       measurement
   =
   let* () =
@@ -469,7 +475,7 @@ let check_measurement
            })
   in
   if
-    (not (measurement_state_is_valid measurement))
+    (not (state_is_valid measurement))
     || not
          (Option.fold
             ~none:true
@@ -485,7 +491,7 @@ let check_measurement
                measurement.catalog_evidence_sha256
                candidate.catalog_evidence_sha256)
   then
-    if measurement_state_is_valid measurement
+    if state_is_valid measurement
     then Error (Measurement_binding_mismatch { ordinal })
     else Error (Invalid_measurement_state { ordinal })
   else Ok ()
@@ -830,16 +836,19 @@ let create ~flow_id ~declared_candidates ~steps =
           Error (Final_step_not_accepted { ordinal })
         | Normalized_semantic_rejected _ -> Ok ()
       in
-      let admission_measurement, request_body_sha256, receipt_required =
+      let ( admission_measurement
+          , request_body_sha256
+          , receipt_required
+          , receipt_state_is_valid )
+        =
         match normalized_admission with
         | Normalized_admitted admitted ->
           ( admitted.measurement
           , Some admitted.request_body_sha256
-          , admitted.measurement.outcome <> Measurement_not_required )
+          , admitted.measurement.outcome <> Measurement_not_required
+          , measurement_state_is_valid )
         | Normalized_rejected rejected ->
-          ( rejected.measurement
-          , None
-          , rejected.measurement.dispatch <> No_measurement_dispatch )
+          rejected.measurement, None, false, rejected_measurement_receipt_state_is_valid
       in
       let* () =
         match admission_measurement.outcome, step.measurement with
@@ -861,6 +870,7 @@ let create ~flow_id ~declared_candidates ~steps =
               ~candidate
               ~request_body_sha256
               ~measurement_ids
+              ~state_is_valid:receipt_state_is_valid
               measurement
       in
       let* () =

--- a/lib/llm_provider/exact_output_validated_flow_evidence.ml
+++ b/lib/llm_provider/exact_output_validated_flow_evidence.ml
@@ -25,6 +25,12 @@ type measurement_dispatch =
 type measurement_outcome =
   | Measurement_not_required
   | Measurement_succeeded
+  | Measurement_unsupported
+  | Measurement_local_invalid
+  | Measurement_transport_failed
+  | Measurement_invalid_response
+  | Measurement_fence_rejected
+  | Measurement_cancelled
 
 type measurement_evidence =
   { dispatch : measurement_dispatch
@@ -351,7 +357,6 @@ let check_provenance ~ordinal candidate provenance =
 
 let rejected_measurement_state_is_valid evidence =
   evidence.dispatch = No_measurement_dispatch
-  && evidence.outcome = Measurement_not_required
 ;;
 
 let admitted_measurement_state_is_valid evidence =
@@ -359,7 +364,14 @@ let admitted_measurement_state_is_valid evidence =
   | No_measurement_dispatch, Measurement_not_required
   | Measurement_dispatch_started, Measurement_succeeded -> true
   | No_measurement_dispatch, Measurement_succeeded
-  | Measurement_dispatch_started, Measurement_not_required -> false
+  | Measurement_dispatch_started, Measurement_not_required
+  | ( (No_measurement_dispatch | Measurement_dispatch_started)
+    , ( Measurement_unsupported
+      | Measurement_local_invalid
+      | Measurement_transport_failed
+      | Measurement_invalid_response
+      | Measurement_fence_rejected
+      | Measurement_cancelled ) ) -> false
 ;;
 
 let measurement_state_is_valid measurement =
@@ -566,6 +578,12 @@ let measurement_dispatch_to_string = function
 let measurement_outcome_to_string = function
   | Measurement_not_required -> "not_required"
   | Measurement_succeeded -> "succeeded"
+  | Measurement_unsupported -> "unsupported"
+  | Measurement_local_invalid -> "local_invalid"
+  | Measurement_transport_failed -> "transport_failed"
+  | Measurement_invalid_response -> "invalid_response"
+  | Measurement_fence_rejected -> "fence_rejected"
+  | Measurement_cancelled -> "cancelled"
 ;;
 
 let attempt_phase_to_string = function
@@ -1039,6 +1057,12 @@ let measurement_dispatch_of_string ~path = function
 let measurement_outcome_of_string ~path = function
   | "not_required" -> Ok Measurement_not_required
   | "succeeded" -> Ok Measurement_succeeded
+  | "unsupported" -> Ok Measurement_unsupported
+  | "local_invalid" -> Ok Measurement_local_invalid
+  | "transport_failed" -> Ok Measurement_transport_failed
+  | "invalid_response" -> Ok Measurement_invalid_response
+  | "fence_rejected" -> Ok Measurement_fence_rejected
+  | "cancelled" -> Ok Measurement_cancelled
   | _ -> invalid_fields path "unknown measurement outcome"
 ;;
 

--- a/lib/llm_provider/exact_output_validated_flow_evidence.ml
+++ b/lib/llm_provider/exact_output_validated_flow_evidence.ml
@@ -1,0 +1,1388 @@
+type candidate =
+  { candidate_id : string
+  ; candidate_binding_sha256 : string
+  ; catalog_generation_sha256 : string
+  ; catalog_evidence_sha256 : string
+  }
+
+type assurance =
+  | Json_syntax_only
+  | Provider_schema_requested
+
+type provenance =
+  { source_schema_sha256 : string
+  ; effective_schema_sha256 : string option
+  ; assurance : assurance
+  ; candidate_binding_sha256 : string
+  ; catalog_generation_sha256 : string
+  ; catalog_evidence_sha256 : string
+  }
+
+type measurement_dispatch =
+  | No_measurement_dispatch
+  | Measurement_dispatch_started
+
+type measurement_outcome =
+  | Measurement_not_required
+  | Measurement_succeeded
+
+type measurement_evidence =
+  { dispatch : measurement_dispatch
+  ; outcome : measurement_outcome
+  }
+
+type admitted =
+  { plan_sha256 : string
+  ; request_body_sha256 : string
+  ; provenance : provenance
+  ; measurement : measurement_evidence
+  }
+
+type rejected =
+  { rejection : Yojson.Safe.t
+  ; measurement : measurement_evidence
+  }
+
+type admission =
+  | Rejected of rejected
+  | Admitted of admitted
+
+type measurement =
+  { operation_id : string
+  ; request_body_sha256 : string
+  ; candidate_binding_sha256 : string
+  ; catalog_generation_sha256 : string
+  ; catalog_evidence_sha256 : string
+  ; dispatch : measurement_dispatch
+  ; outcome : measurement_outcome
+  }
+
+type attempt_phase =
+  | Before_dispatch
+  | Response_received
+  | Terminal
+
+type attempt =
+  { call_id : string
+  ; plan_sha256 : string
+  ; request_body_sha256 : string
+  ; candidate_binding_sha256 : string
+  ; catalog_generation_sha256 : string
+  ; catalog_evidence_sha256 : string
+  ; phase : attempt_phase
+  ; dispatch_count : int
+  ; http_status : int option
+  ; provider_trace_sha256 : string option
+  ; raw_response_sha256 : string option
+  }
+
+type transport_failure =
+  | Candidate_rejected
+  | Completion_failed_before_dispatch
+  | Serialized_request_refused of { http_status : int }
+  | Invalid_json_output
+
+type advance =
+  { next_ordinal : int
+  ; failure : transport_failure
+  }
+
+type outcome =
+  | Advance of advance
+  | Semantic_rejected of
+      { projector : Yojson.Safe.t
+      ; output_sha256 : string
+      }
+  | Accepted of
+      { projector : Yojson.Safe.t
+      ; output_sha256 : string
+      }
+
+type step =
+  { ordinal : int
+  ; admission : admission
+  ; measurement : measurement option
+  ; attempt : attempt option
+  ; outcome : outcome
+  }
+
+type invariant_error =
+  | Empty_flow_id
+  | Empty_declared_candidates
+  | Empty_steps
+  | Non_canonical_identifier of
+      { field : string
+      ; ordinal : int option
+      }
+  | Invalid_sha256 of
+      { field : string
+      ; ordinal : int option
+      }
+  | Invalid_http_status of
+      { field : string
+      ; ordinal : int
+      }
+  | Duplicate_candidate_id of
+      { candidate_id : string
+      ; first_position : int
+      ; duplicate_position : int
+      }
+  | Duplicate_call_id of
+      { call_id : string
+      ; first_ordinal : int
+      ; duplicate_ordinal : int
+      }
+  | Duplicate_measurement_operation_id of
+      { operation_id : string
+      ; first_ordinal : int
+      ; duplicate_ordinal : int
+      }
+  | More_steps_than_declared_candidates
+  | Non_contiguous_step_ordinal of
+      { expected : int
+      ; actual : int
+      }
+  | Invalid_measurement_state of { ordinal : int }
+  | Measurement_binding_mismatch of { ordinal : int }
+  | Rejected_admission_has_attempt of { ordinal : int }
+  | Rejected_admission_did_not_advance of { ordinal : int }
+  | Admitted_candidate_missing_attempt of { ordinal : int }
+  | Attempt_binding_mismatch of { ordinal : int }
+  | Invalid_attempt_state of { ordinal : int }
+  | Non_adjacent_advance of
+      { ordinal : int
+      ; next_ordinal : int
+      }
+  | Advance_failure_mismatch of { ordinal : int }
+  | Nonfinal_step_accepted of { ordinal : int }
+  | Final_step_not_accepted of { ordinal : int }
+  | Invalid_projector_json of
+      { ordinal : int
+      ; location : string
+      }
+
+type decode_error =
+  | Malformed_json of string
+  | Invalid_fields of
+      { path : string
+      ; detail : string
+      }
+  | Invalid_transcript of invariant_error
+  | Integrity_mismatch
+  | Non_canonical_encoding
+
+type projector =
+  { json : Yojson.Safe.t
+  ; digest : string
+  }
+
+type normalized_admission =
+  | Normalized_rejected of
+      { rejection : projector
+      ; measurement : measurement_evidence
+      }
+  | Normalized_admitted of admitted
+
+type normalized_outcome =
+  | Normalized_advance of advance
+  | Normalized_semantic_rejected of
+      { projector : projector
+      ; output_sha256 : string
+      }
+  | Normalized_accepted of
+      { projector : projector
+      ; output_sha256 : string
+      }
+
+type normalized_step =
+  { ordinal : int
+  ; admission : normalized_admission
+  ; measurement : measurement option
+  ; attempt : attempt option
+  ; outcome : normalized_outcome
+  }
+
+type t =
+  { flow_id : string
+  ; declared_candidates : candidate array
+  ; steps : normalized_step array
+  ; integrity_sha256 : string
+  ; accepted_sha256 : string
+  }
+
+let ( let* ) = Result.bind
+let digest value = Digestif.SHA256.(to_hex (digest_string value))
+
+let is_sha256 value =
+  String.length value = 64
+  && String.for_all
+       (function
+         | '0' .. '9' | 'a' .. 'f' -> true
+         | _ -> false)
+       value
+;;
+
+let is_canonical_identifier value =
+  (not (String.equal value "")) && String.equal value (String.trim value)
+;;
+
+let duplicate_key fields =
+  let seen = Hashtbl.create (List.length fields) in
+  List.find_map
+    (fun (key, _) ->
+       if Hashtbl.mem seen key
+       then Some key
+       else (
+         Hashtbl.add seen key ();
+         None))
+    fields
+;;
+
+let rec canonicalize_projector_json json =
+  match json with
+  | `Assoc fields ->
+    (match duplicate_key fields with
+     | Some _ -> Error ()
+     | None ->
+       let rec loop acc = function
+         | [] ->
+           Ok
+             (`Assoc
+                 (List.sort (fun (left, _) (right, _) -> String.compare left right) acc))
+         | (key, value) :: rest ->
+           let* value = canonicalize_projector_json value in
+           loop ((key, value) :: acc) rest
+       in
+       loop [] fields)
+  | `List values ->
+    let rec loop acc = function
+      | [] -> Ok (`List (List.rev acc))
+      | value :: rest ->
+        let* value = canonicalize_projector_json value in
+        loop (value :: acc) rest
+    in
+    loop [] values
+  | (`Null | `Bool _ | `Int _ | `Intlit _ | `Floatlit _ | `String _) as scalar ->
+    Ok scalar
+  | `Float value when Float.is_finite value -> Ok (`Float value)
+  | `Float _ -> Error ()
+  | `Tuple _ | `Variant _ -> Error ()
+;;
+
+let projector ~ordinal ~location json =
+  try
+    match canonicalize_projector_json json with
+    | Error () -> Error (Invalid_projector_json { ordinal; location })
+    | Ok json ->
+      let canonical = Yojson.Safe.to_string json in
+      (match Yojson.Safe.from_string canonical with
+       | reparsed when String.equal canonical (Yojson.Safe.to_string reparsed) ->
+         Ok { json; digest = digest canonical }
+       | _ -> Error (Invalid_projector_json { ordinal; location })
+       | exception Yojson.Json_error _ ->
+         Error (Invalid_projector_json { ordinal; location }))
+  with
+  | Stack_overflow -> Error (Invalid_projector_json { ordinal; location })
+;;
+
+let check_identifier ?ordinal field value =
+  if is_canonical_identifier value
+  then Ok ()
+  else Error (Non_canonical_identifier { field; ordinal })
+;;
+
+let check_sha256 ?ordinal field value =
+  if is_sha256 value then Ok () else Error (Invalid_sha256 { field; ordinal })
+;;
+
+let check_optional_sha256 ~ordinal field = function
+  | None -> Ok ()
+  | Some value -> check_sha256 ~ordinal field value
+;;
+
+let check_candidate ?ordinal candidate =
+  let* () = check_identifier ?ordinal "candidate_id" candidate.candidate_id in
+  let* () =
+    check_sha256 ?ordinal "candidate_binding_sha256" candidate.candidate_binding_sha256
+  in
+  let* () =
+    check_sha256 ?ordinal "catalog_generation_sha256" candidate.catalog_generation_sha256
+  in
+  check_sha256 ?ordinal "catalog_evidence_sha256" candidate.catalog_evidence_sha256
+;;
+
+let check_provenance ~ordinal candidate provenance =
+  let* () =
+    check_sha256 ~ordinal "source_schema_sha256" provenance.source_schema_sha256
+  in
+  let* () =
+    check_optional_sha256
+      ~ordinal
+      "effective_schema_sha256"
+      provenance.effective_schema_sha256
+  in
+  let* () =
+    check_sha256
+      ~ordinal
+      "provenance.candidate_binding_sha256"
+      provenance.candidate_binding_sha256
+  in
+  let* () =
+    check_sha256
+      ~ordinal
+      "provenance.catalog_generation_sha256"
+      provenance.catalog_generation_sha256
+  in
+  let* () =
+    check_sha256
+      ~ordinal
+      "provenance.catalog_evidence_sha256"
+      provenance.catalog_evidence_sha256
+  in
+  if
+    String.equal candidate.candidate_binding_sha256 provenance.candidate_binding_sha256
+    && String.equal
+         candidate.catalog_generation_sha256
+         provenance.catalog_generation_sha256
+    && String.equal candidate.catalog_evidence_sha256 provenance.catalog_evidence_sha256
+  then Ok ()
+  else Error (Attempt_binding_mismatch { ordinal })
+;;
+
+let rejected_measurement_state_is_valid evidence =
+  evidence.dispatch = No_measurement_dispatch
+  && evidence.outcome = Measurement_not_required
+;;
+
+let admitted_measurement_state_is_valid evidence =
+  match evidence.dispatch, evidence.outcome with
+  | No_measurement_dispatch, Measurement_not_required
+  | Measurement_dispatch_started, Measurement_succeeded -> true
+  | No_measurement_dispatch, Measurement_succeeded
+  | Measurement_dispatch_started, Measurement_not_required -> false
+;;
+
+let measurement_state_is_valid measurement =
+  measurement.dispatch = Measurement_dispatch_started
+  && measurement.outcome = Measurement_succeeded
+;;
+
+let attempt_success_state_is_valid attempt =
+  match attempt.phase with
+  | Terminal ->
+    attempt.dispatch_count = 1
+    && Option.exists (fun status -> status >= 200 && status <= 299) attempt.http_status
+    && Option.is_some attempt.provider_trace_sha256
+    && Option.is_some attempt.raw_response_sha256
+  | Before_dispatch | Response_received -> false
+;;
+
+let attempt_advance_state_is_valid attempt failure =
+  match failure, attempt.phase with
+  | Completion_failed_before_dispatch, Before_dispatch ->
+    attempt.dispatch_count = 0
+    && Option.is_none attempt.http_status
+    && Option.is_none attempt.provider_trace_sha256
+    && Option.is_none attempt.raw_response_sha256
+  | Serialized_request_refused { http_status }, Response_received ->
+    http_status = 413
+    && attempt.dispatch_count = 1
+    && attempt.http_status = Some http_status
+    && Option.is_some attempt.provider_trace_sha256
+    && Option.is_some attempt.raw_response_sha256
+  | Invalid_json_output, (Response_received | Terminal) ->
+    attempt.dispatch_count = 1
+    && Option.exists (fun status -> status >= 200 && status <= 299) attempt.http_status
+    && Option.is_some attempt.provider_trace_sha256
+    && Option.is_some attempt.raw_response_sha256
+  | Candidate_rejected, _
+  | Completion_failed_before_dispatch, (Response_received | Terminal)
+  | Serialized_request_refused _, (Before_dispatch | Terminal)
+  | Invalid_json_output, Before_dispatch -> false
+;;
+
+let check_http_status ~ordinal field = function
+  | None -> Ok ()
+  | Some status ->
+    if status >= 100 && status <= 599
+    then Ok ()
+    else Error (Invalid_http_status { field; ordinal })
+;;
+
+let check_measurement
+      ~ordinal
+      ~candidate
+      ~request_body_sha256
+      ~measurement_ids
+      measurement
+  =
+  let* () =
+    check_identifier ~ordinal "measurement.operation_id" measurement.operation_id
+  in
+  let* () =
+    check_sha256
+      ~ordinal
+      "measurement.request_body_sha256"
+      measurement.request_body_sha256
+  in
+  let* () =
+    check_sha256
+      ~ordinal
+      "measurement.candidate_binding_sha256"
+      measurement.candidate_binding_sha256
+  in
+  let* () =
+    check_sha256
+      ~ordinal
+      "measurement.catalog_generation_sha256"
+      measurement.catalog_generation_sha256
+  in
+  let* () =
+    check_sha256
+      ~ordinal
+      "measurement.catalog_evidence_sha256"
+      measurement.catalog_evidence_sha256
+  in
+  let* () =
+    match Hashtbl.find_opt measurement_ids measurement.operation_id with
+    | None ->
+      Hashtbl.add measurement_ids measurement.operation_id ordinal;
+      Ok ()
+    | Some first_ordinal ->
+      Error
+        (Duplicate_measurement_operation_id
+           { operation_id = measurement.operation_id
+           ; first_ordinal
+           ; duplicate_ordinal = ordinal
+           })
+  in
+  if
+    (not (measurement_state_is_valid measurement))
+    || not
+         (Option.fold
+            ~none:true
+            ~some:(String.equal measurement.request_body_sha256)
+            request_body_sha256
+          && String.equal
+               measurement.candidate_binding_sha256
+               candidate.candidate_binding_sha256
+          && String.equal
+               measurement.catalog_generation_sha256
+               candidate.catalog_generation_sha256
+          && String.equal
+               measurement.catalog_evidence_sha256
+               candidate.catalog_evidence_sha256)
+  then
+    if measurement_state_is_valid measurement
+    then Error (Measurement_binding_mismatch { ordinal })
+    else Error (Invalid_measurement_state { ordinal })
+  else Ok ()
+;;
+
+let check_attempt ~ordinal ~candidate ~admitted ~call_ids ~outcome attempt =
+  let* () = check_identifier ~ordinal "attempt.call_id" attempt.call_id in
+  let* () = check_sha256 ~ordinal "attempt.plan_sha256" attempt.plan_sha256 in
+  let* () =
+    check_sha256 ~ordinal "attempt.request_body_sha256" attempt.request_body_sha256
+  in
+  let* () =
+    check_sha256
+      ~ordinal
+      "attempt.candidate_binding_sha256"
+      attempt.candidate_binding_sha256
+  in
+  let* () =
+    check_sha256
+      ~ordinal
+      "attempt.catalog_generation_sha256"
+      attempt.catalog_generation_sha256
+  in
+  let* () =
+    check_sha256
+      ~ordinal
+      "attempt.catalog_evidence_sha256"
+      attempt.catalog_evidence_sha256
+  in
+  let* () =
+    check_optional_sha256
+      ~ordinal
+      "attempt.provider_trace_sha256"
+      attempt.provider_trace_sha256
+  in
+  let* () =
+    check_optional_sha256
+      ~ordinal
+      "attempt.raw_response_sha256"
+      attempt.raw_response_sha256
+  in
+  let* () = check_http_status ~ordinal "attempt.http_status" attempt.http_status in
+  let* () =
+    match Hashtbl.find_opt call_ids attempt.call_id with
+    | None ->
+      Hashtbl.add call_ids attempt.call_id ordinal;
+      Ok ()
+    | Some first_ordinal ->
+      Error
+        (Duplicate_call_id
+           { call_id = attempt.call_id; first_ordinal; duplicate_ordinal = ordinal })
+  in
+  let provenance = admitted.provenance in
+  let binding_matches =
+    String.equal attempt.plan_sha256 admitted.plan_sha256
+    && String.equal attempt.request_body_sha256 admitted.request_body_sha256
+    && String.equal attempt.candidate_binding_sha256 candidate.candidate_binding_sha256
+    && String.equal attempt.catalog_generation_sha256 candidate.catalog_generation_sha256
+    && String.equal attempt.catalog_evidence_sha256 candidate.catalog_evidence_sha256
+    && String.equal provenance.candidate_binding_sha256 candidate.candidate_binding_sha256
+    && String.equal
+         provenance.catalog_generation_sha256
+         candidate.catalog_generation_sha256
+    && String.equal provenance.catalog_evidence_sha256 candidate.catalog_evidence_sha256
+  in
+  if not binding_matches
+  then Error (Attempt_binding_mismatch { ordinal })
+  else (
+    match outcome with
+    | Normalized_accepted _ | Normalized_semantic_rejected _ ->
+      if attempt_success_state_is_valid attempt
+      then Ok ()
+      else Error (Invalid_attempt_state { ordinal })
+    | Normalized_advance { failure; _ } ->
+      if attempt_advance_state_is_valid attempt failure
+      then Ok ()
+      else Error (Invalid_attempt_state { ordinal }))
+;;
+
+let assurance_to_string = function
+  | Json_syntax_only -> "json_syntax_only"
+  | Provider_schema_requested -> "provider_schema_requested"
+;;
+
+let measurement_dispatch_to_string = function
+  | No_measurement_dispatch -> "no_dispatch"
+  | Measurement_dispatch_started -> "dispatch_started"
+;;
+
+let measurement_outcome_to_string = function
+  | Measurement_not_required -> "not_required"
+  | Measurement_succeeded -> "succeeded"
+;;
+
+let attempt_phase_to_string = function
+  | Before_dispatch -> "before_dispatch"
+  | Response_received -> "response_received"
+  | Terminal -> "terminal"
+;;
+
+let candidate_json candidate =
+  `Assoc
+    [ "candidate_id", `String candidate.candidate_id
+    ; "candidate_binding_sha256", `String candidate.candidate_binding_sha256
+    ; "catalog_generation_sha256", `String candidate.catalog_generation_sha256
+    ; "catalog_evidence_sha256", `String candidate.catalog_evidence_sha256
+    ]
+;;
+
+let provenance_json provenance =
+  `Assoc
+    [ "source_schema_sha256", `String provenance.source_schema_sha256
+    ; ( "effective_schema_sha256"
+      , Option.fold
+          ~none:`Null
+          ~some:(fun value -> `String value)
+          provenance.effective_schema_sha256 )
+    ; "assurance", `String (assurance_to_string provenance.assurance)
+    ; "candidate_binding_sha256", `String provenance.candidate_binding_sha256
+    ; "catalog_generation_sha256", `String provenance.catalog_generation_sha256
+    ; "catalog_evidence_sha256", `String provenance.catalog_evidence_sha256
+    ]
+;;
+
+let measurement_evidence_json measurement =
+  `Assoc
+    [ "dispatch", `String (measurement_dispatch_to_string measurement.dispatch)
+    ; "outcome", `String (measurement_outcome_to_string measurement.outcome)
+    ]
+;;
+
+let admission_json = function
+  | Normalized_rejected rejected ->
+    `Assoc
+      [ "kind", `String "rejected"
+      ; "rejection", rejected.rejection.json
+      ; "measurement", measurement_evidence_json rejected.measurement
+      ]
+  | Normalized_admitted admitted ->
+    `Assoc
+      [ "kind", `String "admitted"
+      ; "plan_sha256", `String admitted.plan_sha256
+      ; "request_body_sha256", `String admitted.request_body_sha256
+      ; "provenance", provenance_json admitted.provenance
+      ; "measurement", measurement_evidence_json admitted.measurement
+      ]
+;;
+
+let measurement_json measurement =
+  `Assoc
+    [ "operation_id", `String measurement.operation_id
+    ; "request_body_sha256", `String measurement.request_body_sha256
+    ; "candidate_binding_sha256", `String measurement.candidate_binding_sha256
+    ; "catalog_generation_sha256", `String measurement.catalog_generation_sha256
+    ; "catalog_evidence_sha256", `String measurement.catalog_evidence_sha256
+    ; "dispatch", `String (measurement_dispatch_to_string measurement.dispatch)
+    ; "outcome", `String (measurement_outcome_to_string measurement.outcome)
+    ]
+;;
+
+let attempt_json attempt =
+  let optional_string = Option.fold ~none:`Null ~some:(fun value -> `String value) in
+  `Assoc
+    [ "call_id", `String attempt.call_id
+    ; "plan_sha256", `String attempt.plan_sha256
+    ; "request_body_sha256", `String attempt.request_body_sha256
+    ; "candidate_binding_sha256", `String attempt.candidate_binding_sha256
+    ; "catalog_generation_sha256", `String attempt.catalog_generation_sha256
+    ; "catalog_evidence_sha256", `String attempt.catalog_evidence_sha256
+    ; "phase", `String (attempt_phase_to_string attempt.phase)
+    ; "dispatch_count", `Int attempt.dispatch_count
+    ; ( "http_status"
+      , Option.fold ~none:`Null ~some:(fun status -> `Int status) attempt.http_status )
+    ; "provider_trace_sha256", optional_string attempt.provider_trace_sha256
+    ; "raw_response_sha256", optional_string attempt.raw_response_sha256
+    ]
+;;
+
+let failure_json = function
+  | Candidate_rejected -> `Assoc [ "kind", `String "candidate_rejected" ]
+  | Completion_failed_before_dispatch ->
+    `Assoc [ "kind", `String "completion_failed_before_dispatch" ]
+  | Serialized_request_refused { http_status } ->
+    `Assoc
+      [ "kind", `String "serialized_request_refused"; "http_status", `Int http_status ]
+  | Invalid_json_output -> `Assoc [ "kind", `String "invalid_json_output" ]
+;;
+
+let outcome_json = function
+  | Normalized_advance advance ->
+    `Assoc
+      [ "kind", `String "advance"
+      ; "next_ordinal", `Int advance.next_ordinal
+      ; "failure", failure_json advance.failure
+      ]
+  | Normalized_semantic_rejected { projector; output_sha256 } ->
+    `Assoc
+      [ "kind", `String "semantic_rejected"
+      ; "projector", projector.json
+      ; "output_sha256", `String output_sha256
+      ]
+  | Normalized_accepted { projector; output_sha256 } ->
+    `Assoc
+      [ "kind", `String "accepted"
+      ; "projector", projector.json
+      ; "output_sha256", `String output_sha256
+      ]
+;;
+
+let step_json step =
+  `Assoc
+    [ "ordinal", `Int step.ordinal
+    ; "admission", admission_json step.admission
+    ; "measurement", Option.fold ~none:`Null ~some:measurement_json step.measurement
+    ; "attempt", Option.fold ~none:`Null ~some:attempt_json step.attempt
+    ; "outcome", outcome_json step.outcome
+    ]
+;;
+
+let payload_json ~flow_id ~declared_candidates ~steps =
+  `Assoc
+    [ "flow_id", `String flow_id
+    ; ( "declared_candidates"
+      , `List (Array.to_list declared_candidates |> List.map candidate_json) )
+    ; "steps", `List (Array.to_list steps |> List.map step_json)
+    ]
+;;
+
+let payload_string ~flow_id ~declared_candidates ~steps =
+  payload_json ~flow_id ~declared_candidates ~steps |> Yojson.Safe.to_string
+;;
+
+let create ~flow_id ~declared_candidates ~steps =
+  let* () = if is_canonical_identifier flow_id then Ok () else Error Empty_flow_id in
+  let declared_candidates = Array.of_list declared_candidates in
+  let steps = Array.of_list steps in
+  let declared_count = Array.length declared_candidates in
+  let step_count = Array.length steps in
+  let* () = if declared_count = 0 then Error Empty_declared_candidates else Ok () in
+  let* () = if step_count = 0 then Error Empty_steps else Ok () in
+  let* () =
+    if step_count > declared_count
+    then Error More_steps_than_declared_candidates
+    else Ok ()
+  in
+  let candidate_ids = Hashtbl.create declared_count in
+  let rec validate_declared position =
+    if position = declared_count
+    then Ok ()
+    else (
+      let candidate = declared_candidates.(position) in
+      let* () = check_candidate candidate in
+      match Hashtbl.find_opt candidate_ids candidate.candidate_id with
+      | Some first_position ->
+        Error
+          (Duplicate_candidate_id
+             { candidate_id = candidate.candidate_id
+             ; first_position
+             ; duplicate_position = position + 1
+             })
+      | None ->
+        Hashtbl.add candidate_ids candidate.candidate_id (position + 1);
+        validate_declared (position + 1))
+  in
+  let* () = validate_declared 0 in
+  let call_ids = Hashtbl.create step_count in
+  let measurement_ids = Hashtbl.create step_count in
+  let rec validate_steps index normalized_rev =
+    if index = step_count
+    then Ok (List.rev normalized_rev)
+    else (
+      let step = steps.(index) in
+      let ordinal = index + 1 in
+      let is_final = index = step_count - 1 in
+      let* () =
+        if step.ordinal = ordinal
+        then Ok ()
+        else
+          Error
+            (Non_contiguous_step_ordinal { expected = ordinal; actual = step.ordinal })
+      in
+      let candidate = declared_candidates.(index) in
+      let* normalized_admission =
+        match step.admission with
+        | Rejected rejected ->
+          let* rejection =
+            projector ~ordinal ~location:"admission.rejection" rejected.rejection
+          in
+          let* () =
+            if rejected_measurement_state_is_valid rejected.measurement
+            then Ok ()
+            else Error (Invalid_measurement_state { ordinal })
+          in
+          Ok (Normalized_rejected { rejection; measurement = rejected.measurement })
+        | Admitted admitted ->
+          let* () = check_sha256 ~ordinal "admission.plan_sha256" admitted.plan_sha256 in
+          let* () =
+            check_sha256
+              ~ordinal
+              "admission.request_body_sha256"
+              admitted.request_body_sha256
+          in
+          let* () = check_provenance ~ordinal candidate admitted.provenance in
+          let* () =
+            if admitted_measurement_state_is_valid admitted.measurement
+            then Ok ()
+            else Error (Invalid_measurement_state { ordinal })
+          in
+          Ok (Normalized_admitted admitted)
+      in
+      let* normalized_outcome =
+        match step.outcome with
+        | Advance advance -> Ok (Normalized_advance advance)
+        | Semantic_rejected { projector = value; output_sha256 } ->
+          let* projector =
+            projector ~ordinal ~location:"outcome.semantic_rejected" value
+          in
+          let* () = check_sha256 ~ordinal "outcome.output_sha256" output_sha256 in
+          Ok (Normalized_semantic_rejected { projector; output_sha256 })
+        | Accepted { projector = value; output_sha256 } ->
+          let* projector = projector ~ordinal ~location:"outcome.accepted" value in
+          let* () = check_sha256 ~ordinal "outcome.output_sha256" output_sha256 in
+          Ok (Normalized_accepted { projector; output_sha256 })
+      in
+      let* () =
+        match normalized_outcome with
+        | Normalized_advance advance ->
+          if advance.next_ordinal = ordinal + 1 && not is_final
+          then Ok ()
+          else
+            Error (Non_adjacent_advance { ordinal; next_ordinal = advance.next_ordinal })
+        | Normalized_accepted _ when not is_final ->
+          Error (Nonfinal_step_accepted { ordinal })
+        | Normalized_accepted _ -> Ok ()
+        | Normalized_semantic_rejected _ when is_final ->
+          Error (Final_step_not_accepted { ordinal })
+        | Normalized_semantic_rejected _ -> Ok ()
+      in
+      let admission_measurement, request_body_sha256, receipt_required =
+        match normalized_admission with
+        | Normalized_admitted admitted ->
+          ( admitted.measurement
+          , Some admitted.request_body_sha256
+          , admitted.measurement.outcome <> Measurement_not_required )
+        | Normalized_rejected rejected ->
+          ( rejected.measurement
+          , None
+          , rejected.measurement.dispatch <> No_measurement_dispatch )
+      in
+      let* () =
+        match admission_measurement.outcome, step.measurement with
+        | Measurement_not_required, None -> Ok ()
+        | Measurement_not_required, Some _ ->
+          Error (Invalid_measurement_state { ordinal })
+        | _, None ->
+          if not receipt_required
+          then Ok ()
+          else Error (Measurement_binding_mismatch { ordinal })
+        | _, Some measurement ->
+          if
+            admission_measurement.dispatch <> measurement.dispatch
+            || admission_measurement.outcome <> measurement.outcome
+          then Error (Measurement_binding_mismatch { ordinal })
+          else
+            check_measurement
+              ~ordinal
+              ~candidate
+              ~request_body_sha256
+              ~measurement_ids
+              measurement
+      in
+      let* () =
+        match normalized_admission, step.attempt, normalized_outcome with
+        | Normalized_rejected _, Some _, _ ->
+          Error (Rejected_admission_has_attempt { ordinal })
+        | ( Normalized_rejected _
+          , None
+          , Normalized_advance { failure = Candidate_rejected; _ } ) -> Ok ()
+        | Normalized_rejected _, None, _ ->
+          Error (Rejected_admission_did_not_advance { ordinal })
+        | Normalized_admitted _, None, _ ->
+          Error (Admitted_candidate_missing_attempt { ordinal })
+        | ( Normalized_admitted admitted
+          , Some attempt
+          , Normalized_advance { failure = Candidate_rejected; _ } ) ->
+          let _ = admitted, attempt in
+          Error (Advance_failure_mismatch { ordinal })
+        | Normalized_admitted admitted, Some attempt, outcome ->
+          check_attempt ~ordinal ~candidate ~admitted ~call_ids ~outcome attempt
+      in
+      let normalized =
+        { ordinal
+        ; admission = normalized_admission
+        ; measurement = step.measurement
+        ; attempt = step.attempt
+        ; outcome = normalized_outcome
+        }
+      in
+      validate_steps (index + 1) (normalized :: normalized_rev))
+  in
+  let* normalized_steps = validate_steps 0 [] in
+  let normalized_steps = Array.of_list normalized_steps in
+  let* accepted_sha256 =
+    match normalized_steps.(step_count - 1).outcome with
+    | Normalized_accepted { projector; _ } -> Ok projector.digest
+    | Normalized_advance _ | Normalized_semantic_rejected _ ->
+      Error (Final_step_not_accepted { ordinal = step_count })
+  in
+  let integrity_sha256 =
+    payload_string ~flow_id ~declared_candidates ~steps:normalized_steps |> digest
+  in
+  Ok
+    { flow_id
+    ; declared_candidates
+    ; steps = normalized_steps
+    ; integrity_sha256
+    ; accepted_sha256
+    }
+;;
+
+let to_string transcript =
+  `Assoc
+    [ "flow_id", `String transcript.flow_id
+    ; ( "declared_candidates"
+      , `List (Array.to_list transcript.declared_candidates |> List.map candidate_json) )
+    ; "steps", `List (Array.to_list transcript.steps |> List.map step_json)
+    ; "integrity_sha256", `String transcript.integrity_sha256
+    ]
+  |> Yojson.Safe.to_string
+;;
+
+let sha256 transcript = transcript.integrity_sha256
+let accepted_domain_sha256 transcript = transcript.accepted_sha256
+let invalid_fields path detail = Error (Invalid_fields { path; detail })
+
+let exact_assoc ~path expected = function
+  | `Assoc fields ->
+    (match duplicate_key fields with
+     | Some key -> invalid_fields path ("duplicate field: " ^ key)
+     | None ->
+       let actual = List.map fst fields |> List.sort String.compare in
+       let expected = List.sort String.compare expected in
+       if actual = expected
+       then Ok fields
+       else invalid_fields path "fields do not match current schema")
+  | _ -> invalid_fields path "expected object"
+;;
+
+let field ~path fields name =
+  match List.assoc_opt name fields with
+  | Some value -> Ok value
+  | None -> invalid_fields (path ^ "." ^ name) "missing field"
+;;
+
+let string_field ~path fields name =
+  let* value = field ~path fields name in
+  match value with
+  | `String value -> Ok value
+  | _ -> invalid_fields (path ^ "." ^ name) "expected string"
+;;
+
+let int_field ~path fields name =
+  let* value = field ~path fields name in
+  match value with
+  | `Int value -> Ok value
+  | _ -> invalid_fields (path ^ "." ^ name) "expected integer"
+;;
+
+let optional_string_field ~path fields name =
+  let* value = field ~path fields name in
+  match value with
+  | `Null -> Ok None
+  | `String value -> Ok (Some value)
+  | _ -> invalid_fields (path ^ "." ^ name) "expected string or null"
+;;
+
+let optional_int_field ~path fields name =
+  let* value = field ~path fields name in
+  match value with
+  | `Null -> Ok None
+  | `Int value -> Ok (Some value)
+  | _ -> invalid_fields (path ^ "." ^ name) "expected integer or null"
+;;
+
+let list_field ~path fields name =
+  let* value = field ~path fields name in
+  match value with
+  | `List values -> Ok values
+  | _ -> invalid_fields (path ^ "." ^ name) "expected array"
+;;
+
+let parse_candidate ~path json =
+  let* fields =
+    exact_assoc
+      ~path
+      [ "candidate_id"
+      ; "candidate_binding_sha256"
+      ; "catalog_generation_sha256"
+      ; "catalog_evidence_sha256"
+      ]
+      json
+  in
+  let* candidate_id = string_field ~path fields "candidate_id" in
+  let* candidate_binding_sha256 = string_field ~path fields "candidate_binding_sha256" in
+  let* catalog_generation_sha256 =
+    string_field ~path fields "catalog_generation_sha256"
+  in
+  let* catalog_evidence_sha256 = string_field ~path fields "catalog_evidence_sha256" in
+  Ok
+    { candidate_id
+    ; candidate_binding_sha256
+    ; catalog_generation_sha256
+    ; catalog_evidence_sha256
+    }
+;;
+
+let assurance_of_string ~path = function
+  | "json_syntax_only" -> Ok Json_syntax_only
+  | "provider_schema_requested" -> Ok Provider_schema_requested
+  | _ -> invalid_fields path "unknown assurance"
+;;
+
+let parse_provenance ~path json =
+  let* fields =
+    exact_assoc
+      ~path
+      [ "source_schema_sha256"
+      ; "effective_schema_sha256"
+      ; "assurance"
+      ; "candidate_binding_sha256"
+      ; "catalog_generation_sha256"
+      ; "catalog_evidence_sha256"
+      ]
+      json
+  in
+  let* source_schema_sha256 = string_field ~path fields "source_schema_sha256" in
+  let* effective_schema_sha256 =
+    optional_string_field ~path fields "effective_schema_sha256"
+  in
+  let* assurance_value = string_field ~path fields "assurance" in
+  let* assurance = assurance_of_string ~path:(path ^ ".assurance") assurance_value in
+  let* candidate_binding_sha256 = string_field ~path fields "candidate_binding_sha256" in
+  let* catalog_generation_sha256 =
+    string_field ~path fields "catalog_generation_sha256"
+  in
+  let* catalog_evidence_sha256 = string_field ~path fields "catalog_evidence_sha256" in
+  Ok
+    { source_schema_sha256
+    ; effective_schema_sha256
+    ; assurance
+    ; candidate_binding_sha256
+    ; catalog_generation_sha256
+    ; catalog_evidence_sha256
+    }
+;;
+
+let measurement_dispatch_of_string ~path = function
+  | "no_dispatch" -> Ok No_measurement_dispatch
+  | "dispatch_started" -> Ok Measurement_dispatch_started
+  | _ -> invalid_fields path "unknown measurement dispatch"
+;;
+
+let measurement_outcome_of_string ~path = function
+  | "not_required" -> Ok Measurement_not_required
+  | "succeeded" -> Ok Measurement_succeeded
+  | _ -> invalid_fields path "unknown measurement outcome"
+;;
+
+let parse_measurement_evidence ~path json =
+  let* fields = exact_assoc ~path [ "dispatch"; "outcome" ] json in
+  let* dispatch_value = string_field ~path fields "dispatch" in
+  let* dispatch =
+    measurement_dispatch_of_string ~path:(path ^ ".dispatch") dispatch_value
+  in
+  let* outcome_value = string_field ~path fields "outcome" in
+  let* outcome = measurement_outcome_of_string ~path:(path ^ ".outcome") outcome_value in
+  Ok { dispatch; outcome }
+;;
+
+let parse_admission ~path json =
+  match json with
+  | `Assoc raw_fields ->
+    (match List.assoc_opt "kind" raw_fields with
+     | Some (`String "rejected") ->
+       let* fields = exact_assoc ~path [ "kind"; "rejection"; "measurement" ] json in
+       let* rejection = field ~path fields "rejection" in
+       let* measurement_json = field ~path fields "measurement" in
+       let* measurement =
+         parse_measurement_evidence ~path:(path ^ ".measurement") measurement_json
+       in
+       Ok (Rejected { rejection; measurement })
+     | Some (`String "admitted") ->
+       let* fields =
+         exact_assoc
+           ~path
+           [ "kind"; "plan_sha256"; "request_body_sha256"; "provenance"; "measurement" ]
+           json
+       in
+       let* plan_sha256 = string_field ~path fields "plan_sha256" in
+       let* request_body_sha256 = string_field ~path fields "request_body_sha256" in
+       let* provenance_json = field ~path fields "provenance" in
+       let* provenance = parse_provenance ~path:(path ^ ".provenance") provenance_json in
+       let* measurement_json = field ~path fields "measurement" in
+       let* measurement =
+         parse_measurement_evidence ~path:(path ^ ".measurement") measurement_json
+       in
+       Ok (Admitted { plan_sha256; request_body_sha256; provenance; measurement })
+     | Some (`String _) -> invalid_fields (path ^ ".kind") "unknown admission kind"
+     | Some _ -> invalid_fields (path ^ ".kind") "expected string"
+     | None -> invalid_fields (path ^ ".kind") "missing field")
+  | _ -> invalid_fields path "expected object"
+;;
+
+let parse_measurement ~path json =
+  match json with
+  | `Null -> Ok None
+  | _ ->
+    let* fields =
+      exact_assoc
+        ~path
+        [ "operation_id"
+        ; "request_body_sha256"
+        ; "candidate_binding_sha256"
+        ; "catalog_generation_sha256"
+        ; "catalog_evidence_sha256"
+        ; "dispatch"
+        ; "outcome"
+        ]
+        json
+    in
+    let* operation_id = string_field ~path fields "operation_id" in
+    let* request_body_sha256 = string_field ~path fields "request_body_sha256" in
+    let* candidate_binding_sha256 =
+      string_field ~path fields "candidate_binding_sha256"
+    in
+    let* catalog_generation_sha256 =
+      string_field ~path fields "catalog_generation_sha256"
+    in
+    let* catalog_evidence_sha256 = string_field ~path fields "catalog_evidence_sha256" in
+    let* dispatch_value = string_field ~path fields "dispatch" in
+    let* dispatch =
+      measurement_dispatch_of_string ~path:(path ^ ".dispatch") dispatch_value
+    in
+    let* outcome_value = string_field ~path fields "outcome" in
+    let* outcome =
+      measurement_outcome_of_string ~path:(path ^ ".outcome") outcome_value
+    in
+    Ok
+      (Some
+         { operation_id
+         ; request_body_sha256
+         ; candidate_binding_sha256
+         ; catalog_generation_sha256
+         ; catalog_evidence_sha256
+         ; dispatch
+         ; outcome
+         })
+;;
+
+let attempt_phase_of_string ~path = function
+  | "before_dispatch" -> Ok Before_dispatch
+  | "response_received" -> Ok Response_received
+  | "terminal" -> Ok Terminal
+  | _ -> invalid_fields path "unknown attempt phase"
+;;
+
+let parse_attempt ~path json =
+  match json with
+  | `Null -> Ok None
+  | _ ->
+    let* fields =
+      exact_assoc
+        ~path
+        [ "call_id"
+        ; "plan_sha256"
+        ; "request_body_sha256"
+        ; "candidate_binding_sha256"
+        ; "catalog_generation_sha256"
+        ; "catalog_evidence_sha256"
+        ; "phase"
+        ; "dispatch_count"
+        ; "http_status"
+        ; "provider_trace_sha256"
+        ; "raw_response_sha256"
+        ]
+        json
+    in
+    let* call_id = string_field ~path fields "call_id" in
+    let* plan_sha256 = string_field ~path fields "plan_sha256" in
+    let* request_body_sha256 = string_field ~path fields "request_body_sha256" in
+    let* candidate_binding_sha256 =
+      string_field ~path fields "candidate_binding_sha256"
+    in
+    let* catalog_generation_sha256 =
+      string_field ~path fields "catalog_generation_sha256"
+    in
+    let* catalog_evidence_sha256 = string_field ~path fields "catalog_evidence_sha256" in
+    let* phase_value = string_field ~path fields "phase" in
+    let* phase = attempt_phase_of_string ~path:(path ^ ".phase") phase_value in
+    let* dispatch_count = int_field ~path fields "dispatch_count" in
+    let* http_status = optional_int_field ~path fields "http_status" in
+    let* provider_trace_sha256 =
+      optional_string_field ~path fields "provider_trace_sha256"
+    in
+    let* raw_response_sha256 = optional_string_field ~path fields "raw_response_sha256" in
+    Ok
+      (Some
+         { call_id
+         ; plan_sha256
+         ; request_body_sha256
+         ; candidate_binding_sha256
+         ; catalog_generation_sha256
+         ; catalog_evidence_sha256
+         ; phase
+         ; dispatch_count
+         ; http_status
+         ; provider_trace_sha256
+         ; raw_response_sha256
+         })
+;;
+
+let parse_failure ~path json =
+  match json with
+  | `Assoc fields ->
+    (match List.assoc_opt "kind" fields with
+     | Some (`String "candidate_rejected") ->
+       let* _ = exact_assoc ~path [ "kind" ] json in
+       Ok Candidate_rejected
+     | Some (`String "completion_failed_before_dispatch") ->
+       let* _ = exact_assoc ~path [ "kind" ] json in
+       Ok Completion_failed_before_dispatch
+     | Some (`String "serialized_request_refused") ->
+       let* fields = exact_assoc ~path [ "kind"; "http_status" ] json in
+       let* http_status = int_field ~path fields "http_status" in
+       Ok (Serialized_request_refused { http_status })
+     | Some (`String "invalid_json_output") ->
+       let* _ = exact_assoc ~path [ "kind" ] json in
+       Ok Invalid_json_output
+     | Some (`String _) -> invalid_fields (path ^ ".kind") "unknown failure kind"
+     | Some _ -> invalid_fields (path ^ ".kind") "expected string"
+     | None -> invalid_fields (path ^ ".kind") "missing field")
+  | _ -> invalid_fields path "expected object"
+;;
+
+let parse_outcome ~path json =
+  match json with
+  | `Assoc raw_fields ->
+    (match List.assoc_opt "kind" raw_fields with
+     | Some (`String "advance") ->
+       let* fields = exact_assoc ~path [ "kind"; "next_ordinal"; "failure" ] json in
+       let* next_ordinal = int_field ~path fields "next_ordinal" in
+       let* failure_json = field ~path fields "failure" in
+       let* failure = parse_failure ~path:(path ^ ".failure") failure_json in
+       Ok (Advance { next_ordinal; failure })
+     | Some (`String "semantic_rejected") ->
+       let* fields = exact_assoc ~path [ "kind"; "projector"; "output_sha256" ] json in
+       let* projector = field ~path fields "projector" in
+       let* output_sha256 = string_field ~path fields "output_sha256" in
+       Ok (Semantic_rejected { projector; output_sha256 })
+     | Some (`String "accepted") ->
+       let* fields = exact_assoc ~path [ "kind"; "projector"; "output_sha256" ] json in
+       let* projector = field ~path fields "projector" in
+       let* output_sha256 = string_field ~path fields "output_sha256" in
+       Ok (Accepted { projector; output_sha256 })
+     | Some (`String _) -> invalid_fields (path ^ ".kind") "unknown outcome kind"
+     | Some _ -> invalid_fields (path ^ ".kind") "expected string"
+     | None -> invalid_fields (path ^ ".kind") "missing field")
+  | _ -> invalid_fields path "expected object"
+;;
+
+let parse_step ~index json =
+  let path = Printf.sprintf "$.steps[%d]" index in
+  let* fields =
+    exact_assoc ~path [ "ordinal"; "admission"; "measurement"; "attempt"; "outcome" ] json
+  in
+  let* ordinal = int_field ~path fields "ordinal" in
+  let* admission_json = field ~path fields "admission" in
+  let* admission = parse_admission ~path:(path ^ ".admission") admission_json in
+  let* measurement_json = field ~path fields "measurement" in
+  let* measurement = parse_measurement ~path:(path ^ ".measurement") measurement_json in
+  let* attempt_json = field ~path fields "attempt" in
+  let* attempt = parse_attempt ~path:(path ^ ".attempt") attempt_json in
+  let* outcome_json = field ~path fields "outcome" in
+  let* outcome = parse_outcome ~path:(path ^ ".outcome") outcome_json in
+  Ok { ordinal; admission; measurement; attempt; outcome }
+;;
+
+let rec parse_list_indexed parse index acc = function
+  | [] -> Ok (List.rev acc)
+  | value :: rest ->
+    let* value = parse ~index value in
+    parse_list_indexed parse (index + 1) (value :: acc) rest
+;;
+
+let of_string encoded =
+  try
+    let json = Yojson.Safe.from_string encoded in
+    let* fields =
+      exact_assoc
+        ~path:"$"
+        [ "flow_id"; "declared_candidates"; "steps"; "integrity_sha256" ]
+        json
+    in
+    let* flow_id = string_field ~path:"$" fields "flow_id" in
+    let* declared_json = list_field ~path:"$" fields "declared_candidates" in
+    let* declared_candidates =
+      parse_list_indexed
+        (fun ~index value ->
+           parse_candidate ~path:(Printf.sprintf "$.declared_candidates[%d]" index) value)
+        0
+        []
+        declared_json
+    in
+    let* steps_json = list_field ~path:"$" fields "steps" in
+    let* steps = parse_list_indexed parse_step 0 [] steps_json in
+    let* encoded_integrity = string_field ~path:"$" fields "integrity_sha256" in
+    if not (is_sha256 encoded_integrity)
+    then invalid_fields "$.integrity_sha256" "expected lowercase SHA-256"
+    else (
+      match create ~flow_id ~declared_candidates ~steps with
+      | Error error -> Error (Invalid_transcript error)
+      | Ok transcript ->
+        if not (String.equal encoded_integrity transcript.integrity_sha256)
+        then Error Integrity_mismatch
+        else if not (String.equal encoded (to_string transcript))
+        then Error Non_canonical_encoding
+        else Ok transcript)
+  with
+  | Yojson.Json_error detail -> Error (Malformed_json detail)
+  | Stack_overflow -> Error (Malformed_json "JSON nesting exhausted the parser stack")
+;;
+
+let invariant_error_to_string = function
+  | Empty_flow_id -> "flow_id must be nonempty and canonical"
+  | Empty_declared_candidates -> "declared candidate snapshot must be nonempty"
+  | Empty_steps -> "successful transcript must contain at least one step"
+  | Non_canonical_identifier { field; ordinal } ->
+    Printf.sprintf
+      "%s%s must be nonempty and canonical"
+      (Option.fold
+         ~none:""
+         ~some:(fun ordinal -> Printf.sprintf "step %d " ordinal)
+         ordinal)
+      field
+  | Invalid_sha256 { field; ordinal } ->
+    Printf.sprintf
+      "%s%s must be a lowercase SHA-256"
+      (Option.fold
+         ~none:""
+         ~some:(fun ordinal -> Printf.sprintf "step %d " ordinal)
+         ordinal)
+      field
+  | Invalid_http_status { field; ordinal } ->
+    Printf.sprintf "step %d %s must be a valid HTTP status" ordinal field
+  | Duplicate_candidate_id { candidate_id; first_position; duplicate_position } ->
+    Printf.sprintf
+      "candidate_id %s is duplicated at positions %d and %d"
+      candidate_id
+      first_position
+      duplicate_position
+  | Duplicate_call_id { call_id; first_ordinal; duplicate_ordinal } ->
+    Printf.sprintf
+      "call_id %s is duplicated at steps %d and %d"
+      call_id
+      first_ordinal
+      duplicate_ordinal
+  | Duplicate_measurement_operation_id { operation_id; first_ordinal; duplicate_ordinal }
+    ->
+    Printf.sprintf
+      "measurement operation_id %s is duplicated at steps %d and %d"
+      operation_id
+      first_ordinal
+      duplicate_ordinal
+  | More_steps_than_declared_candidates ->
+    "visited steps exceed the declared candidate snapshot"
+  | Non_contiguous_step_ordinal { expected; actual } ->
+    Printf.sprintf "step ordinal is not contiguous: expected %d, got %d" expected actual
+  | Invalid_measurement_state { ordinal } ->
+    Printf.sprintf "step %d measurement dispatch/outcome state is invalid" ordinal
+  | Measurement_binding_mismatch { ordinal } ->
+    Printf.sprintf "step %d measurement binding does not match its candidate" ordinal
+  | Rejected_admission_has_attempt { ordinal } ->
+    Printf.sprintf "step %d rejected admission has a generation attempt" ordinal
+  | Rejected_admission_did_not_advance { ordinal } ->
+    Printf.sprintf "step %d rejected admission did not advance as rejected" ordinal
+  | Admitted_candidate_missing_attempt { ordinal } ->
+    Printf.sprintf "step %d admitted candidate has no generation attempt" ordinal
+  | Attempt_binding_mismatch { ordinal } ->
+    Printf.sprintf "step %d attempt/provenance binding is inconsistent" ordinal
+  | Invalid_attempt_state { ordinal } ->
+    Printf.sprintf "step %d attempt phase/dispatch/status state is invalid" ordinal
+  | Non_adjacent_advance { ordinal; next_ordinal } ->
+    Printf.sprintf "step %d advances to nonadjacent ordinal %d" ordinal next_ordinal
+  | Advance_failure_mismatch { ordinal } ->
+    Printf.sprintf "step %d advance failure contradicts its admission" ordinal
+  | Nonfinal_step_accepted { ordinal } ->
+    Printf.sprintf "nonfinal step %d is accepted" ordinal
+  | Final_step_not_accepted { ordinal } ->
+    Printf.sprintf "final step %d is not accepted" ordinal
+  | Invalid_projector_json { ordinal; location } ->
+    Printf.sprintf "step %d %s is not canonicalizable JSON" ordinal location
+;;
+
+let decode_error_to_string = function
+  | Malformed_json detail -> "validated flow evidence malformed JSON: " ^ detail
+  | Invalid_fields { path; detail } ->
+    Printf.sprintf "validated flow evidence invalid at %s: %s" path detail
+  | Invalid_transcript error ->
+    "validated flow evidence violates an invariant: " ^ invariant_error_to_string error
+  | Integrity_mismatch -> "validated flow evidence integrity mismatch"
+  | Non_canonical_encoding -> "validated flow evidence is not canonical current JSON"
+;;

--- a/lib/llm_provider/exact_output_validated_flow_evidence.mli
+++ b/lib/llm_provider/exact_output_validated_flow_evidence.mli
@@ -1,0 +1,208 @@
+(** Private, normalized durable evidence for one successfully validated exact
+    flow.
+
+    This leaf owns no live execution value and does not depend on the
+    [Exact_output] facade.  Its sole durable representation is the current
+    canonical JSON emitted by [to_string]. *)
+
+type t
+
+type candidate =
+  { candidate_id : string
+  ; candidate_binding_sha256 : string
+  ; catalog_generation_sha256 : string
+  ; catalog_evidence_sha256 : string
+  }
+
+type assurance =
+  | Json_syntax_only
+  | Provider_schema_requested
+
+type provenance =
+  { source_schema_sha256 : string
+  ; effective_schema_sha256 : string option
+  ; assurance : assurance
+  ; candidate_binding_sha256 : string
+  ; catalog_generation_sha256 : string
+  ; catalog_evidence_sha256 : string
+  }
+
+type measurement_dispatch =
+  | No_measurement_dispatch
+  | Measurement_dispatch_started
+
+type measurement_outcome =
+  | Measurement_not_required
+  | Measurement_succeeded
+
+type measurement_evidence =
+  { dispatch : measurement_dispatch
+  ; outcome : measurement_outcome
+  }
+
+type admitted =
+  { plan_sha256 : string
+  ; request_body_sha256 : string
+  ; provenance : provenance
+  ; measurement : measurement_evidence
+  }
+
+type rejected =
+  { rejection : Yojson.Safe.t
+  ; measurement : measurement_evidence
+  }
+
+type admission =
+  | Rejected of rejected
+  | Admitted of admitted
+
+type measurement =
+  { operation_id : string
+  ; request_body_sha256 : string
+  ; candidate_binding_sha256 : string
+  ; catalog_generation_sha256 : string
+  ; catalog_evidence_sha256 : string
+  ; dispatch : measurement_dispatch
+  ; outcome : measurement_outcome
+  }
+
+type attempt_phase =
+  | Before_dispatch
+  | Response_received
+  | Terminal
+
+type attempt =
+  { call_id : string
+  ; plan_sha256 : string
+  ; request_body_sha256 : string
+  ; candidate_binding_sha256 : string
+  ; catalog_generation_sha256 : string
+  ; catalog_evidence_sha256 : string
+  ; phase : attempt_phase
+  ; dispatch_count : int
+  ; http_status : int option
+  ; provider_trace_sha256 : string option
+  ; raw_response_sha256 : string option
+  }
+
+type transport_failure =
+  | Candidate_rejected
+  | Completion_failed_before_dispatch
+  | Serialized_request_refused of { http_status : int }
+  | Invalid_json_output
+
+type advance =
+  { next_ordinal : int
+  ; failure : transport_failure
+  }
+
+type outcome =
+  | Advance of advance
+  | Semantic_rejected of
+      { projector : Yojson.Safe.t
+      ; output_sha256 : string
+      }
+  | Accepted of
+      { projector : Yojson.Safe.t
+      ; output_sha256 : string
+      }
+
+type step =
+  { ordinal : int
+  ; admission : admission
+  ; measurement : measurement option
+  ; attempt : attempt option
+  ; outcome : outcome
+  }
+
+type invariant_error =
+  | Empty_flow_id
+  | Empty_declared_candidates
+  | Empty_steps
+  | Non_canonical_identifier of
+      { field : string
+      ; ordinal : int option
+      }
+  | Invalid_sha256 of
+      { field : string
+      ; ordinal : int option
+      }
+  | Invalid_http_status of
+      { field : string
+      ; ordinal : int
+      }
+  | Duplicate_candidate_id of
+      { candidate_id : string
+      ; first_position : int
+      ; duplicate_position : int
+      }
+  | Duplicate_call_id of
+      { call_id : string
+      ; first_ordinal : int
+      ; duplicate_ordinal : int
+      }
+  | Duplicate_measurement_operation_id of
+      { operation_id : string
+      ; first_ordinal : int
+      ; duplicate_ordinal : int
+      }
+  | More_steps_than_declared_candidates
+  | Non_contiguous_step_ordinal of
+      { expected : int
+      ; actual : int
+      }
+  | Invalid_measurement_state of { ordinal : int }
+  | Measurement_binding_mismatch of { ordinal : int }
+  | Rejected_admission_has_attempt of { ordinal : int }
+  | Rejected_admission_did_not_advance of { ordinal : int }
+  | Admitted_candidate_missing_attempt of { ordinal : int }
+  | Attempt_binding_mismatch of { ordinal : int }
+  | Invalid_attempt_state of { ordinal : int }
+  | Non_adjacent_advance of
+      { ordinal : int
+      ; next_ordinal : int
+      }
+  | Advance_failure_mismatch of { ordinal : int }
+  | Nonfinal_step_accepted of { ordinal : int }
+  | Final_step_not_accepted of { ordinal : int }
+  | Invalid_projector_json of
+      { ordinal : int
+      ; location : string
+      }
+
+type decode_error =
+  | Malformed_json of string
+  | Invalid_fields of
+      { path : string
+      ; detail : string
+      }
+  | Invalid_transcript of invariant_error
+  | Integrity_mismatch
+  | Non_canonical_encoding
+
+(** [create] validates transcript topology in one forward pass. Projector JSON
+    is recursively canonicalized and rejected when any object contains a
+    duplicate key. *)
+val create
+  :  flow_id:string
+  -> declared_candidates:candidate list
+  -> steps:step list
+  -> (t, invariant_error) result
+
+(** Canonical current-only JSON. It contains no format, version, migration, or
+    legacy discriminator. *)
+val to_string : t -> string
+
+(** Decode only an exact canonical value emitted by [to_string]. Missing,
+    unknown, duplicate, noncanonical, and internally inconsistent data fails
+    closed. No live execution type is reconstructed. *)
+val of_string : string -> (t, decode_error) result
+
+(** Integrity digest of the normalized transcript payload. *)
+val sha256 : t -> string
+
+(** Digest of the final accepted projector JSON. *)
+val accepted_domain_sha256 : t -> string
+
+val invariant_error_to_string : invariant_error -> string
+val decode_error_to_string : decode_error -> string

--- a/lib/llm_provider/exact_output_validated_flow_evidence.mli
+++ b/lib/llm_provider/exact_output_validated_flow_evidence.mli
@@ -34,6 +34,12 @@ type measurement_dispatch =
 type measurement_outcome =
   | Measurement_not_required
   | Measurement_succeeded
+  | Measurement_unsupported
+  | Measurement_local_invalid
+  | Measurement_transport_failed
+  | Measurement_invalid_response
+  | Measurement_fence_rejected
+  | Measurement_cancelled
 
 type measurement_evidence =
   { dispatch : measurement_dispatch

--- a/scripts/check-exact-output-resolver-boundary.sh
+++ b/scripts/check-exact-output-resolver-boundary.sh
@@ -1049,7 +1049,15 @@ require_code_sequence \
   "$exact_output_interface"
 require_code_sequence \
   "outer exact-flow evidence lost its sole declared candidate snapshot" \
-  'type[[:space:]]+flow_evidence[[:space:]]*=[[:space:]]*private.*flow_id[[:space:]]*:.*declared_candidate_snapshot.*candidate_visit_count.*measurements.*admissions.*attempts' \
+  'type[[:space:]]+flow_evidence[[:space:]]*=[[:space:]]*private.*flow_id[[:space:]]*:.*declared_candidate_snapshot.*candidate_visit_count.*measurements.*admissions.*attempts.*advances' \
+  "$exact_output_interface"
+require_opaque_type \
+  "validated exact flow lost its current durable evidence snapshot" \
+  "$exact_output_interface" \
+  validated_flow_evidence_snapshot
+require_code_sequence \
+  "validated exact flow lost its direct durable evidence adapter" \
+  'val[[:space:]]+snapshot_validated_flow_evidence.*project_accepted:.*project_rejection:.*validated_flow_success.*validated_flow_evidence_snapshot' \
   "$exact_output_interface"
 require_code_sequence \
   "validated exact flow lost its parametric semantic verdict or nonempty trace" \

--- a/test/dune
+++ b/test/dune
@@ -424,6 +424,11 @@
  (libraries agent_sdk llm_provider alcotest eio_main))
 
 (test
+ (name test_exact_output_validated_flow_evidence)
+ (modules test_exact_output_validated_flow_evidence)
+ (libraries agent_sdk llm_provider alcotest digestif eio_main))
+
+(test
  (name test_exact_output_resolver_snapshot)
  (modules test_exact_output_resolver_snapshot)
  (libraries agent_sdk llm_provider alcotest eio_main))

--- a/test/test_exact_output_validated_flow_evidence.ml
+++ b/test/test_exact_output_validated_flow_evidence.ml
@@ -1,0 +1,344 @@
+open Alcotest
+open Llm_provider
+module EO = Agent_sdk.Exact_output
+
+let msg text : Types.message =
+  { role = Types.User
+  ; content = [ Types.Text text ]
+  ; name = None
+  ; tool_call_id = None
+  ; metadata = []
+  }
+;;
+
+let schema =
+  `Assoc
+    [ "type", `String "object"
+    ; "properties", `Assoc [ "name", `Assoc [ "type", `String "string" ] ]
+    ; "required", `List [ `String "name" ]
+    ; "additionalProperties", `Bool false
+    ]
+;;
+
+let catalog_entry ~id ~base_url ~api_key_env =
+  Printf.sprintf
+    "[[providers]]\n\
+     id = %S\n\
+     kind = \"openai_compat\"\n\
+     base_url = %S\n\
+     request_path = \"/v1/chat/completions\"\n\
+     api_key_env = %S\n\n\
+     [[models]]\n\
+     id_prefix = %S\n\
+     provider_name = %S\n\
+     max_context_tokens = 8192\n\
+     max_output_tokens = 1024\n\
+     supports_response_format_json = true\n\
+     supports_structured_output = true\n\n\
+     [[targets]]\n\
+     id = %S\n\
+     provider_ref = %S\n\
+     model_id = %S\n"
+    id
+    base_url
+    api_key_env
+    (id ^ "-model")
+    id
+    id
+    id
+    (id ^ "-model")
+;;
+
+let with_catalog ~base_url f =
+  let ids = [ "evidence-a"; "evidence-b"; "evidence-c"; "evidence-d" ] in
+  let contents =
+    ids
+    |> List.map (fun id ->
+      catalog_entry
+        ~id
+        ~base_url
+        ~api_key_env:(if String.equal id "evidence-a" then "MISSING_EVIDENCE_KEY" else ""))
+    |> String.concat "\n"
+  in
+  let document : EO.catalog_document =
+    { source = "validated-flow-evidence-test"; contents }
+  in
+  let io : EO.resolver_io = { getenv = (fun _ -> Ok None) } in
+  match EO.load_resolver_snapshot ~io ~catalog:(EO.Embedded_with_overlay document) () with
+  | Ok snapshot -> f snapshot
+  | Error _ -> fail "evidence catalog did not load"
+;;
+
+let admitted_target snapshot id =
+  match EO.admit_target_ref snapshot id with
+  | Ok target -> target
+  | Error _ -> failf "target %s was not admitted" id
+;;
+
+let candidate snapshot id =
+  match EO.make_flow_candidate ~id ~admitted_target:(admitted_target snapshot id) with
+  | Ok candidate -> candidate
+  | Error EO.Blank_flow_candidate_id -> fail "fixture candidate id was blank"
+;;
+
+let start_flow snapshot =
+  let candidates =
+    List.map
+      (candidate snapshot)
+      [ "evidence-a"; "evidence-b"; "evidence-c"; "evidence-d" ]
+  in
+  let frozen =
+    match candidates with
+    | first :: rest ->
+      EO.snapshot_flow
+        ~first
+        ~rest
+        ~messages:[ msg "return one exact object" ]
+        (EO.make_output_requirement ~schema ~minimum_guarantee:EO.Json_syntax)
+    | [] -> fail "candidate fixture is empty"
+  in
+  match frozen with
+  | Error _ -> fail "flow snapshot was rejected"
+  | Ok frozen ->
+    (match EO.start_flow frozen with
+     | Ok flow -> flow
+     | Error (EO.Flow_id_generation_failed detail) ->
+       failf "flow identity allocation failed: %s" detail)
+;;
+
+let fresh_port () =
+  let socket = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+  Unix.setsockopt socket Unix.SO_REUSEADDR true;
+  Unix.bind socket (Unix.ADDR_INET (Unix.inet_addr_loopback, 0));
+  let port =
+    match Unix.getsockname socket with
+    | Unix.ADDR_INET (_, port) -> port
+    | _ -> fail "loopback socket did not expose a TCP port"
+  in
+  Unix.close socket;
+  port
+;;
+
+let openai_response content =
+  let encoded_content = Yojson.Safe.to_string (`String content) in
+  Printf.sprintf
+    {|{"id":"evidence-response","model":"evidence","choices":[{"index":0,"message":{"role":"assistant","content":%s},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}|}
+    encoded_content
+;;
+
+let sha256 value = Digestif.SHA256.(to_hex (digest_string value))
+
+let recompute_integrity = function
+  | `Assoc fields ->
+    let payload_fields =
+      List.filter (fun (name, _) -> not (String.equal name "integrity_sha256")) fields
+    in
+    let integrity_sha256 = `Assoc payload_fields |> Yojson.Safe.to_string |> sha256 in
+    `Assoc (payload_fields @ [ "integrity_sha256", `String integrity_sha256 ])
+  | _ -> fail "durable evidence was not an object"
+;;
+
+let break_first_step_ordinal = function
+  | `Assoc fields ->
+    let replace_steps = function
+      | `List (`Assoc first_fields :: rest) ->
+        let first_fields =
+          List.map
+            (fun (name, value) ->
+               if String.equal name "ordinal" then name, `Int 2 else name, value)
+            first_fields
+        in
+        `List (`Assoc first_fields :: rest)
+      | _ -> fail "durable evidence steps were empty or malformed"
+    in
+    `Assoc
+      (List.map
+         (fun (name, value) ->
+            if String.equal name "steps" then name, replace_steps value else name, value)
+         fields)
+  | _ -> fail "durable evidence was not an object"
+;;
+
+let with_server f =
+  let posts = Atomic.make 0 in
+  let result =
+    Eio_main.run
+    @@ fun env ->
+    Eio.Switch.run
+    @@ fun sw ->
+    let net = Eio.Stdenv.net env in
+    let port = fresh_port () in
+    let handler _conn _request body =
+      ignore (Eio.Buf_read.(of_flow ~max_size:max_int body |> take_all) : string);
+      let index = Atomic.fetch_and_add posts 1 in
+      let response =
+        if index = 0
+        then openai_response "not-json"
+        else openai_response {|{"name":"accepted"}|}
+      in
+      Cohttp_eio.Server.respond_string ~status:`OK ~body:response ()
+    in
+    let socket =
+      Eio.Net.listen
+        net
+        ~sw
+        ~backlog:8
+        ~reuse_addr:true
+        (`Tcp (Eio.Net.Ipaddr.V4.loopback, port))
+    in
+    let server = Cohttp_eio.Server.make ~callback:handler () in
+    Eio.Fiber.fork_daemon ~sw (fun () ->
+      Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()));
+    f ~net ~base_url:(Printf.sprintf "http://127.0.0.1:%d" port)
+  in
+  result, Atomic.get posts
+;;
+
+let candidate_id (success : EO.flow_success) =
+  (EO.flow_success_candidate success).visit.identity.candidate_id
+;;
+
+let run_mixed_flow () =
+  with_server
+  @@ fun ~net ~base_url ->
+  with_catalog ~base_url
+  @@ fun snapshot ->
+  EO.execute_flow_once
+    ~net
+    ~before_measurement_dispatch:(fun _ -> Ok ())
+    ~on_measurement_terminal:(fun _ -> Ok ())
+    ~before_dispatch:(fun _ -> Ok ())
+    ~before_advance:(fun ~failed:_ ~next:_ -> Ok ())
+    ~validate:(fun success ->
+      let id = candidate_id success in
+      if String.equal id "evidence-c"
+      then EO.Reject_and_advance ("rejected:" ^ id)
+      else EO.Accept id)
+    (start_flow snapshot)
+;;
+
+let snapshot success ~accepted_calls ~rejection_calls =
+  EO.snapshot_validated_flow_evidence
+    ~project_accepted:(fun value ->
+      incr accepted_calls;
+      Ok (`Assoc [ "accepted", `String value ]))
+    ~project_rejection:(fun value ->
+      incr rejection_calls;
+      Ok (`Assoc [ "rejected", `String value ]))
+    success
+;;
+
+let test_mixed_transcript_round_trip_and_projector_cardinality () =
+  let result, posts = run_mixed_flow () in
+  check int "only admitted candidates dispatch" 3 posts;
+  match result with
+  | Error _ -> fail "mixed flow did not reach its declared accepted candidate"
+  | Ok success ->
+    check string "accepted candidate" "evidence-d" success.accepted;
+    let evidence = EO.flow_success_evidence success.transport_success in
+    check int "four admissions retained" 4 (List.length evidence.admissions);
+    check int "three attempts retained" 3 (List.length evidence.attempts);
+    check int "two transport advances retained" 2 (List.length evidence.advances);
+    check int "one semantic rejection retained" 1 (List.length success.prior_rejections);
+    let accepted_calls = ref 0 in
+    let rejection_calls = ref 0 in
+    let durable =
+      match snapshot success ~accepted_calls ~rejection_calls with
+      | Ok durable -> durable
+      | Error _ -> fail "valid typed flow did not produce durable evidence"
+    in
+    check int "accepted projector invoked once" 1 !accepted_calls;
+    check int "rejection projector invoked once" 1 !rejection_calls;
+    let encoded = EO.validated_flow_evidence_to_string durable in
+    let decoded =
+      match EO.validated_flow_evidence_of_string encoded with
+      | Ok decoded -> decoded
+      | Error error ->
+        failf
+          "durable evidence did not decode: %s"
+          (EO.validated_flow_evidence_decode_error_to_string error)
+    in
+    check
+      string
+      "canonical encoding survives round trip"
+      encoded
+      (EO.validated_flow_evidence_to_string decoded);
+    check
+      string
+      "transcript digest survives round trip"
+      (EO.validated_flow_evidence_sha256 durable)
+      (EO.validated_flow_evidence_sha256 decoded);
+    check
+      string
+      "accepted domain digest survives round trip"
+      (EO.validated_flow_evidence_accepted_domain_sha256 durable)
+      (EO.validated_flow_evidence_accepted_domain_sha256 decoded);
+    let tampered =
+      match Yojson.Safe.from_string encoded with
+      | `Assoc fields ->
+        `Assoc
+          (List.map
+             (fun (name, value) ->
+                if String.equal name "flow_id"
+                then name, `String "different-flow"
+                else name, value)
+             fields)
+        |> Yojson.Safe.to_string
+      | _ -> fail "durable evidence was not an object"
+    in
+    (match EO.validated_flow_evidence_of_string tampered with
+     | Error _ -> ()
+     | Ok _ -> fail "tampered durable evidence decoded");
+    let structurally_invalid =
+      encoded
+      |> Yojson.Safe.from_string
+      |> break_first_step_ordinal
+      |> recompute_integrity
+      |> Yojson.Safe.to_string
+    in
+    (match EO.validated_flow_evidence_of_string structurally_invalid with
+     | Error _ -> ()
+     | Ok _ -> fail "re-hashed structurally invalid evidence decoded")
+;;
+
+let test_projection_failure_is_typed_and_short_circuits_acceptance () =
+  let result, _posts = run_mixed_flow () in
+  match result with
+  | Error _ -> fail "mixed flow did not reach projection test"
+  | Ok success ->
+    let accepted_calls = ref 0 in
+    let rejection_calls = ref 0 in
+    let projected =
+      EO.snapshot_validated_flow_evidence
+        ~project_accepted:(fun _ ->
+          incr accepted_calls;
+          Ok (`Assoc []))
+        ~project_rejection:(fun _ ->
+          incr rejection_calls;
+          Error "rejection projector failed")
+        success
+    in
+    check int "failing rejection projector invoked once" 1 !rejection_calls;
+    check int "accepted projector not invoked after rejection failure" 0 !accepted_calls;
+    (match projected with
+     | Error
+         (EO.Rejection_evidence_projection_failed
+            { ordinal = 3; cause = "rejection projector failed" }) -> ()
+     | Ok _ | Error _ -> fail "projection failure lost its typed ordinal and cause")
+;;
+
+let () =
+  run
+    "exact-output validated flow evidence"
+    [ ( "durable transcript"
+      , [ test_case
+            "mixed order round trip and projector cardinality"
+            `Quick
+            test_mixed_transcript_round_trip_and_projector_cardinality
+        ; test_case
+            "typed projection failure"
+            `Quick
+            test_projection_failure_is_typed_and_short_circuits_acceptance
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
- add a current-only canonical codec for successful validated-flow evidence
- expose one direct `Agent_sdk.Exact_output` smart constructor that projects domain values exactly once
- preserve declared candidates, admissions, optional measurement receipts, attempts, transport advances, semantic rejections, and final acceptance with integrity and strict decode
- hard-cut dead schema/version/legacy state; no compatibility decoder or MASC dependency

## Adversarial evidence
- actual flow entrypoints proved no-dispatch rejection outcomes and optional terminal measurement receipts are live typed evidence, so both are preserved
- live adapter cross-checks declared candidate, failed/next visit, flow, call, raw response, and parsed output identity before serialization
- mixed test: admission rejection -> invalid JSON transport advance -> semantic rejection -> accepted candidate
- tamper tests cover both stale integrity and structurally invalid evidence with recomputed integrity

## Verification
- `ocamlformat` on all touched OCaml files
- `ocamlc -stop-after parsing` on all touched OCaml files
- existing `check-exact-output-resolver-boundary.sh` passes with the new contract
- `git diff --check`
- no local Dune build/test; CI is the build authority

## Known review risk
- the strict codec is about 1,420 lines and the direct adapter adds about 895 lines to `exact_output.ml`; this PR remains draft/do-not-merge until CI and adversarial split review establish whether private leaf extraction can reduce that surface without creating a facade-from-facade cycle.