### PR TITLE
fix(exact-output): constrain canonical JSON to Safe.t

### DIFF
--- a/lib/llm_provider/exact_output.ml
+++ b/lib/llm_provider/exact_output.ml
@@ -706,18 +706,18 @@ let validated_flow_evidence_accepted_domain_sha256 =
 
 let evidence_sha256 value = Digestif.SHA256.(to_hex (digest_string value))
 
-let rec canonical_evidence_json = function
+let rec canonical_evidence_json (json : Yojson.Safe.t) : Yojson.Safe.t =
+  match json with
   | `Assoc fields ->
     `Assoc
       (fields
        |> List.map (fun (name, value) -> name, canonical_evidence_json value)
        |> List.sort (fun (left, _) (right, _) -> String.compare left right))
   | `List values -> `List (List.map canonical_evidence_json values)
-  | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Tuple _ | `Variant _)
-    as value -> value
+  | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _) as value -> value
 ;;
 
-let output_evidence_sha256 value =
+let output_evidence_sha256 (value : Yojson.Safe.t) =
   value |> canonical_evidence_json |> Yojson.Safe.to_string |> evidence_sha256
 ;;
 

--- a/lib/llm_provider/exact_output_validated_flow_evidence.ml
+++ b/lib/llm_provider/exact_output_validated_flow_evidence.ml
@@ -244,7 +244,9 @@ let duplicate_key fields =
     fields
 ;;
 
-let rec canonicalize_projector_json json =
+let rec canonicalize_projector_json (json : Yojson.Safe.t)
+  : (Yojson.Safe.t, unit) result
+  =
   match json with
   | `Assoc fields ->
     (match duplicate_key fields with
@@ -268,11 +270,9 @@ let rec canonicalize_projector_json json =
         loop (value :: acc) rest
     in
     loop [] values
-  | (`Null | `Bool _ | `Int _ | `Intlit _ | `Floatlit _ | `String _) as scalar ->
-    Ok scalar
+  | (`Null | `Bool _ | `Int _ | `Intlit _ | `String _) as scalar -> Ok scalar
   | `Float value when Float.is_finite value -> Ok (`Float value)
   | `Float _ -> Error ()
-  | `Tuple _ | `Variant _ -> Error ()
 ;;
 
 let projector ~ordinal ~location json =


### PR DESCRIPTION
## What

- type both exact-output canonicalizers as `Yojson.Safe.t`
- remove `Floatlit`, `Tuple`, and `Variant` branches that are impossible in Safe JSON

## Why

OAS `0.231.7` cannot be installed with the declared Yojson 3.x dependency. OCaml 5.5 rejects the widened polymorphic variants before `Yojson.Safe.to_string`; the merged #2896 CI reports the same failure.

## Validation

- `ocamlc -stop-after parsing` on both changed modules
- `ocamlformat --check` on both changed modules
- `git diff --check`
- full type/build verification: PR CI