### PR TITLE
fix(exact-output): disambiguate evidence records

### DIFF
--- a/lib/llm_provider/exact_output.ml
+++ b/lib/llm_provider/exact_output.ml
@@ -1141,7 +1141,7 @@ let evidence_admission ~flow_id ~ordinal ~expected_identity = function
              }))
 ;;
 
-let visit_ordinal visit = flow_visit_ordinal_to_int visit.ordinal
+let visit_ordinal (visit : flow_candidate_visit) = flow_visit_ordinal_to_int visit.ordinal
 
 let advance_failed_visit = function
   | Flow_advance_candidate_rejected receipt -> receipt.visit

--- a/lib/llm_provider/exact_output_validated_flow_evidence_canonical_json.ml
+++ b/lib/llm_provider/exact_output_validated_flow_evidence_canonical_json.ml
@@ -100,7 +100,7 @@ let attempt_phase_to_string = function
   | Terminal -> "terminal"
 ;;
 
-let candidate_json candidate =
+let candidate_json (candidate : candidate) =
   `Assoc
     [ "candidate_id", `String candidate.candidate_id
     ; "candidate_binding_sha256", `String candidate.candidate_binding_sha256
@@ -109,7 +109,7 @@ let candidate_json candidate =
     ]
 ;;
 
-let provenance_json provenance =
+let provenance_json (provenance : provenance) =
   `Assoc
     [ "source_schema_sha256", `String provenance.source_schema_sha256
     ; ( "effective_schema_sha256"
@@ -124,14 +124,15 @@ let provenance_json provenance =
     ]
 ;;
 
-let measurement_evidence_json measurement =
+let measurement_evidence_json (measurement : measurement_evidence) =
   `Assoc
     [ "dispatch", `String (measurement_dispatch_to_string measurement.dispatch)
     ; "outcome", `String (measurement_outcome_to_string measurement.outcome)
     ]
 ;;
 
-let admission_json = function
+let admission_json (admission : normalized_admission) =
+  match admission with
   | Normalized_rejected rejected ->
     `Assoc
       [ "kind", `String "rejected"
@@ -148,7 +149,7 @@ let admission_json = function
       ]
 ;;
 
-let measurement_json measurement =
+let measurement_json (measurement : measurement) =
   `Assoc
     [ "operation_id", `String measurement.operation_id
     ; "request_body_sha256", `String measurement.request_body_sha256
@@ -160,7 +161,7 @@ let measurement_json measurement =
     ]
 ;;
 
-let attempt_json attempt =
+let attempt_json (attempt : attempt) =
   let optional_string = Option.fold ~none:`Null ~some:(fun value -> `String value) in
   `Assoc
     [ "call_id", `String attempt.call_id
@@ -209,7 +210,7 @@ let outcome_json = function
       ]
 ;;
 
-let step_json step =
+let step_json (step : normalized_step) =
   `Assoc
     [ "ordinal", `Int step.ordinal
     ; "admission", admission_json step.admission


### PR DESCRIPTION
## What

- bind canonical evidence JSON helpers to their exact private record types
- bind visit ordinal projection to `flow_candidate_visit`

## Why

Merged #2903 still fails OCaml 5.5 compilation because shared record labels infer `measurement` instead of `measurement_evidence`, and `int` instead of `flow_visit_ordinal`. This is a type-only repair; the current-only wire representation and public `Exact_output` facade are unchanged.

## Validation

- OCaml parser checks
- `ocamlformat --check`
- code-smell and hardening ratchets
- exact-output resolver boundary
- `git diff --check`
- full build/test: PR CI