### PR TITLE
fix(exact-output): pin evidence record types

### DIFF
--- a/lib/llm_provider/exact_output.ml
+++ b/lib/llm_provider/exact_output.ml
@@ -1243,7 +1243,7 @@ let snapshot_validated_flow_evidence
   in
   let rec project_rejections projected_rev = function
     | [] -> Ok (List.rev projected_rev)
-    | receipt :: rest ->
+    | (receipt : _ semantic_rejection_receipt) :: rest ->
       let ordinal = visit_ordinal receipt.transport_success.candidate.visit in
       if ordinal < 1 || ordinal > visited_candidates
       then

--- a/lib/llm_provider/exact_output_validated_flow_evidence_codec.ml
+++ b/lib/llm_provider/exact_output_validated_flow_evidence_codec.ml
@@ -352,7 +352,7 @@ let parse_outcome ~path json =
   | _ -> invalid_fields path "expected object"
 ;;
 
-let parse_step ~index json =
+let parse_step ~index json : (step, decode_error) result =
   let path = Printf.sprintf "$.steps[%d]" index in
   let* fields =
     exact_assoc ~path [ "ordinal"; "admission"; "measurement"; "attempt"; "outcome" ] json

--- a/lib/llm_provider/exact_output_validated_flow_evidence_validation.ml
+++ b/lib/llm_provider/exact_output_validated_flow_evidence_validation.ml
@@ -4,7 +4,7 @@ module Check = Exact_output_validated_flow_evidence_validation_primitives
 
 let ( let* ) = Result.bind
 
-let normalize ~declared_candidates ~steps =
+let normalize ~(declared_candidates : candidate list) ~(steps : step list) =
   let declared_candidates = Array.of_list declared_candidates in
   let steps = Array.of_list steps in
   let declared_count = Array.length declared_candidates in


### PR DESCRIPTION
## Summary

- Pin record types at evidence projection and codec boundaries.
- Restore OCaml 5.5 type inference after the durable evidence codec split.
- Fix the three follow-on compile failures left after #2904 fixed the first two.

## Scope

This is a compile-only hotfix. It does not change the evidence schema, runtime behavior, or public API.

## Validation

- ocamlformat check on all changed files
- OCaml parser check on all changed files
- git diff check
- The focused llm_provider build was attempted but could not start because the shared Dune lock is held by an unrelated MASC full build. GitHub CI is the build authority.

## Reproduced failures

- receipt inferred as validated_flow_success instead of semantic_rejection_receipt
- parse_step result inferred with normalized_admission
- normalize steps inferred as normalized steps

#2904 covers the initial rejected.measurement and visit.ordinal ambiguities.
