### PR TITLE
fix(exact-output): complete evidence type disambiguation

### DIFF
--- a/lib/llm_provider/exact_output.ml
+++ b/lib/llm_provider/exact_output.ml
@@ -1373,10 +1373,9 @@ let snapshot_validated_flow_evidence
         then
           Error
             (Validated_flow_source_evidence_invalid
-               ((if outcome_count = 0
-                 then Evidence_missing_entry
-                 else Evidence_unexpected_entry)
-                  { collection = "outcome"; ordinal }))
+               (if outcome_count = 0
+                then Evidence_missing_entry { collection = "outcome"; ordinal }
+                else Evidence_unexpected_entry { collection = "outcome"; ordinal }))
         else
           let* outcome, raw_response_sha256, expected_call_id =
             match advance, semantic, is_accepted with

--- a/lib/llm_provider/exact_output_validated_flow_evidence_codec.ml
+++ b/lib/llm_provider/exact_output_validated_flow_evidence_codec.ml
@@ -366,7 +366,7 @@ let parse_step ~index json : (step, decode_error) result =
   let* attempt = parse_attempt ~path:(path ^ ".attempt") attempt_json in
   let* outcome_json = field ~path fields "outcome" in
   let* outcome = parse_outcome ~path:(path ^ ".outcome") outcome_json in
-  Ok { ordinal; admission; measurement; attempt; outcome }
+  Ok ({ ordinal; admission; measurement; attempt; outcome } : step)
 ;;
 
 let rec parse_list_indexed parse index acc = function

--- a/lib/llm_provider/exact_output_validated_flow_evidence_validation_primitives.ml
+++ b/lib/llm_provider/exact_output_validated_flow_evidence_validation_primitives.ml
@@ -67,11 +67,11 @@ let check_provenance ~ordinal candidate provenance =
   else Error (Attempt_binding_mismatch { ordinal })
 ;;
 
-let rejected_measurement_state_is_valid evidence =
+let rejected_measurement_state_is_valid (evidence : measurement_evidence) =
   evidence.dispatch = No_measurement_dispatch
 ;;
 
-let admitted_measurement_state_is_valid evidence =
+let admitted_measurement_state_is_valid (evidence : measurement_evidence) =
   match evidence.dispatch, evidence.outcome with
   | No_measurement_dispatch, Measurement_not_required
   | Measurement_dispatch_started, Measurement_succeeded -> true
@@ -86,12 +86,12 @@ let admitted_measurement_state_is_valid evidence =
       | Measurement_cancelled ) ) -> false
 ;;
 
-let measurement_state_is_valid measurement =
+let measurement_state_is_valid (measurement : measurement) =
   measurement.dispatch = Measurement_dispatch_started
   && measurement.outcome = Measurement_succeeded
 ;;
 
-let rejected_measurement_receipt_state_is_valid measurement =
+let rejected_measurement_receipt_state_is_valid (measurement : measurement) =
   measurement.dispatch = No_measurement_dispatch
   && measurement.outcome <> Measurement_not_required
 ;;

--- a/lib/llm_provider/exact_output_validated_flow_evidence_validation_primitives.ml
+++ b/lib/llm_provider/exact_output_validated_flow_evidence_validation_primitives.ml
@@ -96,11 +96,16 @@ let rejected_measurement_receipt_state_is_valid (measurement : measurement) =
   && measurement.outcome <> Measurement_not_required
 ;;
 
+let successful_http_status = function
+  | Some status -> status >= 200 && status <= 299
+  | None -> false
+;;
+
 let attempt_success_state_is_valid attempt =
   match attempt.phase with
   | Terminal ->
     attempt.dispatch_count = 1
-    && Option.exists (fun status -> status >= 200 && status <= 299) attempt.http_status
+    && successful_http_status attempt.http_status
     && Option.is_some attempt.provider_trace_sha256
     && Option.is_some attempt.raw_response_sha256
   | Before_dispatch | Response_received -> false
@@ -121,7 +126,7 @@ let attempt_advance_state_is_valid attempt failure =
     && Option.is_some attempt.raw_response_sha256
   | Invalid_json_output, (Response_received | Terminal) ->
     attempt.dispatch_count = 1
-    && Option.exists (fun status -> status >= 200 && status <= 299) attempt.http_status
+    && successful_http_status attempt.http_status
     && Option.is_some attempt.provider_trace_sha256
     && Option.is_some attempt.raw_response_sha256
   | Candidate_rejected, _


### PR DESCRIPTION
## Summary

- Complete record-type disambiguation after #2906.
- Type measurement validation helpers at their actual evidence or receipt boundary.
- Type the decoded record expression itself as a step.
- Construct source-evidence error variants explicitly instead of treating payload constructors as first-class functions.
- Preserve the same 2xx validation on both OCaml 5.4 and 5.5 without relying on the 5.5-only `Option.exists`.

## Scope

Compile-only follow-up. No schema, runtime behavior, or public API change.

## Validation

- `ocamlformat --check` on all changed files
- `ocamlc -stop-after parsing` on all changed files
- code-smell ratchet: pass
- hardening ratchet: pass
- `git diff --check`
- full build/test: PR CI
- local Dune intentionally not run; GitHub CI is the build authority

## Reproduced failures

- rejected measurement evidence inferred as a measurement receipt
- decoded admission inferred as normalized admission
- `Evidence_missing_entry` used without its required payload
- OCaml 5.4 build rejects `Option.exists`, which the OCaml manual marks as available since 5.5

[근거] OCaml 5.5 `Option` API: https://ocaml.org/manual/5.5/api/Option.html, checked 2026-07-30 KST, confidence High.
