### PR TITLE
Derive streaming connection reuse from observed EOF

### DIFF
--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -460,9 +460,6 @@ let complete_stream_http
           ?clock
           ?connect_timeout_s:config.connect_timeout_s
           ~on_response_status
-          ~reuse_connection:(function
-            | Ok _ -> true
-            | Error _ -> false)
           ~net
           ~url
           ~headers:(config.headers @ Provider_config.auth_headers_for_config config)

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -2129,12 +2129,31 @@ let post_stream ?cache ?clock ?connect_timeout_s ~sw ~net ~url ~headers ~body ()
       Error (HttpError { code; body = body_str; retry_after_header }))
 ;;
 
+let track_source_eof source =
+  let eof_seen = ref false in
+  let module Source = struct
+    type t = unit
+
+    let read_methods = []
+
+    let single_read () buffer =
+      match Eio.Flow.single_read source buffer with
+      | count -> count
+      | exception End_of_file ->
+        eof_seen := true;
+        raise End_of_file
+    ;;
+  end
+  in
+  let operations = Eio.Flow.Pi.source (module Source) in
+  Eio.Resource.T ((), operations), eof_seen
+;;
+
 let with_post_stream
       ?cache
       ?clock
       ?connect_timeout_s
       ?on_response_status
-      ?(reuse_connection = fun _ -> true)
       ~net
       ~url
       ~headers
@@ -2207,10 +2226,12 @@ let with_post_stream
           on_response_status;
         match status with
         | `OK ->
+          let tracked_body, body_eof_seen = track_source_eof resp_body in
           Ok
             ( uri
             , conn
-            , Eio.Buf_read.of_flow ~max_size:Api_common.max_response_body resp_body )
+            , body_eof_seen
+            , Eio.Buf_read.of_flow ~max_size:Api_common.max_response_body tracked_body )
         | status ->
           let code = Cohttp.Code.code_of_status status in
           let resp_headers = Cohttp.Response.headers resp in
@@ -2241,7 +2262,7 @@ let with_post_stream
 
      The connection is parked back into the cache only after [f] returns
      successfully, ensuring the reader is no longer using the flow. *)
-  let* uri, conn, reader = post_result in
+  let* uri, conn, body_eof_seen, reader = post_result in
   let body_result =
     try Ok (f reader) with
     | Eio.Time.Timeout ->
@@ -2267,7 +2288,7 @@ let with_post_stream
          raise exn)
   in
   (match body_result, cache with
-   | Ok result, Some cache when reuse_connection result ->
+   | Ok _, Some cache when !body_eof_seen ->
      cache_return cache uri { connection = conn; last_used_at = 0.0 }
    | Ok _, Some _ | Ok _, None -> Eio.Resource.close conn
    | Error _, _ -> Eio.Resource.close conn);

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -1119,7 +1119,7 @@ let valid_single_content_length = function
   | [] | _ :: _ :: _ -> false
 ;;
 
-let sync_response_connection_is_reusable ~request_headers response =
+let response_connection_is_reusable ~request_headers response =
   let response_headers = Cohttp.Response.headers response in
   let status = Cohttp.Response.status response |> Cohttp.Code.code_of_status in
   let response_allows_persistence =
@@ -1982,7 +1982,7 @@ let post_sync_once_after_validation
      | Ok response_body ->
        let release_result =
          match
-           cache, sync_response_connection_is_reusable ~request_headers:header response
+           cache, response_connection_is_reusable ~request_headers:header response
          with
          | Some cache, true ->
            (try
@@ -2227,9 +2227,16 @@ let with_post_stream
         match status with
         | `OK ->
           let tracked_body, body_eof_seen = track_source_eof resp_body in
+          (* EOF proves the body was drained; it does not prove the connection
+             may be reused. A response with neither content-length nor chunked
+             framing is delimited BY the close, so its EOF arrives precisely
+             because the peer went away. The same predicate the synchronous
+             path uses answers the second question. *)
+          let reusable = response_connection_is_reusable ~request_headers:hdr resp in
           Ok
             ( uri
             , conn
+            , reusable
             , body_eof_seen
             , Eio.Buf_read.of_flow ~max_size:Api_common.max_response_body tracked_body )
         | status ->
@@ -2262,7 +2269,7 @@ let with_post_stream
 
      The connection is parked back into the cache only after [f] returns
      successfully, ensuring the reader is no longer using the flow. *)
-  let* uri, conn, body_eof_seen, reader = post_result in
+  let* uri, conn, response_is_reusable, body_eof_seen, reader = post_result in
   let body_result =
     try Ok (f reader) with
     | Eio.Time.Timeout ->
@@ -2288,7 +2295,7 @@ let with_post_stream
          raise exn)
   in
   (match body_result, cache with
-   | Ok _, Some cache when !body_eof_seen ->
+   | Ok _, Some cache when response_is_reusable && !body_eof_seen ->
      cache_return cache uri { connection = conn; last_used_at = 0.0 }
    | Ok _, Some _ | Ok _, None -> Eio.Resource.close conn
    | Error _, _ -> Eio.Resource.close conn);

--- a/lib/llm_provider/http_client.mli
+++ b/lib/llm_provider/http_client.mli
@@ -531,9 +531,13 @@ val post_stream
     [Stream_idle]); callers that let it propagate get
     [TimeoutError { phase = Unknown_timeout; _ }] as a safe default.
 
-    A cached connection is parked only when the response body source itself
-    reports end-of-file while [f] is consuming it. If [f] returns before that,
-    the connection is closed regardless of [f]'s return value. *)
+    A cached connection is parked only when BOTH hold: the response body
+    source itself reported end-of-file while [f] was consuming it, and the
+    response says the connection may persist (HTTP version, [Connection],
+    upgrade, and self-delimiting framing). EOF alone is not enough — a
+    response with neither content-length nor chunked framing is delimited by
+    the close itself, so its EOF means the peer went away. If [f] returns
+    before EOF, the connection is closed regardless of [f]'s return value. *)
 val with_post_stream
   :  ?cache:cache
   -> ?clock:_ Eio.Time.clock

--- a/lib/llm_provider/http_client.mli
+++ b/lib/llm_provider/http_client.mli
@@ -531,15 +531,14 @@ val post_stream
     [Stream_idle]); callers that let it propagate get
     [TimeoutError { phase = Unknown_timeout; _ }] as a safe default.
 
-    [reuse_connection] is evaluated on [f]'s successful return value before a
-    cached connection is parked. Callers that stop before consuming the full
-    body must return [false], which closes the connection instead. *)
+    A cached connection is parked only when the response body source itself
+    reports end-of-file while [f] is consuming it. If [f] returns before that,
+    the connection is closed regardless of [f]'s return value. *)
 val with_post_stream
   :  ?cache:cache
   -> ?clock:_ Eio.Time.clock
   -> ?connect_timeout_s:float
   -> ?on_response_status:(int -> unit)
-  -> ?reuse_connection:('a -> bool)
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> url:string
   -> headers:(string * string) list

--- a/test/dune
+++ b/test/dune
@@ -547,13 +547,6 @@
     --allow-callback-in
     http_client.mli
     "with_post_stream|?on_response_status|arrow(_,constr(int),constr(unit))"
-    ; Same shape as ~f above: the predicate is applied to ~f's own return, so
-    ; its 'a is the one the signature already binds. Only the caller knows
-    ; whether it drained the body, and that is what decides whether the
-    ; connection may be parked.
-    --allow-callback-in
-    http_client.mli
-    "with_post_stream|?reuse_connection|arrow(_,var(a),constr(bool))"
     --allow-callback-in
     http_client.mli
     "read_sse|~on_data|arrow(~event_type,constr(option,constr(string)),arrow(_,constr(string),constr(unit)))"

--- a/test/test_http_client_cache.ml
+++ b/test/test_http_client_cache.ml
@@ -518,6 +518,67 @@ let test_stream_typed_error_closes_unconsumed_connection () =
   | Exit -> ()
 ;;
 
+(* A close-delimited stream reaches EOF precisely BECAUSE the peer went away.
+   Draining it proves the body was fully read; it proves nothing about whether
+   the socket may serve another request. Parking it would hand the next caller
+   a dead connection. *)
+let test_stream_connection_close_does_not_park () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let port = fresh_port () in
+    let body = "data: one\n\ndata: two\n\n" in
+    let handler flow _addr =
+      let reader = Eio.Buf_read.of_flow flow ~max_size:8192 in
+      drain_request_headers reader;
+      try
+        Eio.Flow.copy_string
+          ("HTTP/1.1 200 OK\r\n\
+            Content-Type: text/event-stream\r\n\
+            Connection: close\r\n\
+            \r\n"
+           ^ body)
+          flow
+      with
+      | End_of_file | Eio.Io _ | Unix.Unix_error _ -> ()
+    in
+    let socket =
+      Eio.Net.listen
+        env#net
+        ~sw
+        ~backlog:8
+        ~reuse_addr:true
+        (`Tcp (Eio.Net.Ipaddr.V4.loopback, port))
+    in
+    Eio.Fiber.fork ~sw (fun () ->
+      Eio.Net.run_server socket handler ~on_error:(fun _ -> ()) ~max_connections:4);
+    let url = Printf.sprintf "http://127.0.0.1:%d" port in
+    let cache = Http_client.create_cache ~sw () in
+    let seen = ref 0 in
+    (match
+       Http_client.with_post_stream
+         ~cache
+         ~net:env#net
+         ~url
+         ~headers:[]
+         ~body:""
+         ~f:(fun reader ->
+           Http_client.read_sse ~reader ~on_data:(fun ~event_type:_ _ -> incr seen) ();
+           Ok ())
+         ()
+     with
+     | Ok (Ok ()) -> ()
+     | Ok (Error _) | Error _ -> Alcotest.fail "close-delimited stream should drain");
+    Alcotest.(check int) "stream fully drained" 2 !seen;
+    let stats = Http_client.cache_stats cache in
+    Alcotest.(check int) "connection-close stream is not parked" 0 stats.total_idle;
+    Eio.Switch.fail sw Exit
+  with
+  | Exit -> ()
+;;
+
 let with_raw_one_dispatch_server
       ?(http_version = "HTTP/1.1")
       ?(status = "200 OK")
@@ -927,6 +988,10 @@ let () =
             "typed error closes unconsumed connection"
             `Quick
             test_stream_typed_error_closes_unconsumed_connection
+        ; Alcotest.test_case
+            "connection-close stream is not parked"
+            `Quick
+            test_stream_connection_close_does_not_park
         ] )
     ; ( "validation"
       , [ Alcotest.test_case

--- a/test/test_http_client_cache.ml
+++ b/test/test_http_client_cache.ml
@@ -504,9 +504,6 @@ let test_stream_typed_error_closes_unconsumed_connection () =
          ~url
          ~headers:[]
          ~body:""
-         ~reuse_connection:(function
-           | Ok _ -> true
-           | Error _ -> false)
          ~f:(fun _reader -> Error `Stop)
          ()
      with


### PR DESCRIPTION
Follow-up to jeong-sik/oas#2910.

## What changed
- track EOF inside the HTTP response source
- cache a streaming connection only after the source reports EOF
- remove the caller-owned `reuse_connection` predicate and its public callback allowance

## Verification
- `scripts/dune-local.sh build @fmt test/test_http_client_cache.exe test/test_complete_http.exe test/test_sse_budget_anchor.exe test/check_public_mli_callbacks.exe`
- `test_http_client_cache.exe`: 17/17
- `test_complete_http.exe`: 67/67
- `test_sse_budget_anchor.exe`: 5/5
- public callback checker: PASS
- `scripts/hardening-ratchet.sh --check`: PASS