### PR TITLE
fix(sse): keep first-event deadline until data arrives

### DIFF
--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -2602,14 +2602,15 @@ let read_sse
       | None, _ -> inner ()
     in
     (* P3a (RFC-OAS-037 review): the transition to the inter-token idle budget
-       must fire on GENUINE first output — a data/event field — NOT on a bare
-       blank dispatch delimiter. A provider that emits a leading blank line
-       before real prefill would otherwise switch to the short idle budget
-       prematurely and re-introduce the very bug this RFC fixes for it.
+       must fire on GENUINE first output — a data field — NOT on a bare event
+       type, blank dispatch delimiter, or other metadata. An [event] field
+       selects the dispatch type but carries no payload; counting it as the
+       first event would replace the caller's first-event bound with the
+       shorter inter-token bound before any provider data arrived.
        [Sse_comment] is already filtered inside [inner]; the only non-field
        line [inner] can return is [Sse_blank]. *)
     (match parsed with
-     | (Sse_event_type _ | Sse_data _) when not !first_event_seen ->
+     | Sse_data _ when not !first_event_seen ->
        first_event_seen := true;
        budget_anchor := None
      | Sse_data _ -> budget_anchor := None

--- a/lib/llm_provider/http_client.mli
+++ b/lib/llm_provider/http_client.mli
@@ -584,8 +584,12 @@ val with_post_stream
     only AFTER the first meaningful line for inter-token idle. A silent
     prefill on a large context is slow-but-alive, not a hang, so it must not
     be cut by the short [idle_timeout] value. A "meaningful line" here is a
-    genuine data/event field: a bare blank dispatch delimiter does NOT end the
-    first-event wait (it would switch to the short idle budget prematurely).
+    genuine [data] field, and only that. An [event] field selects the dispatch
+    type but carries no payload, and a bare blank line is only a dispatch
+    delimiter: neither ends the first-event wait. Ending it on either would
+    replace the caller's first-event bound with the shorter inter-token one
+    before any provider data arrived — and when only [first_event_timeout] is
+    wired, it would leave the read unarmed entirely.
     The effective bound is resolved from caller-supplied values only, in the
     order [first_event_timeout] > [body_timeout] (the caller's total body
     budget) > [idle_timeout] (the pre-RFC bound, kept so callers that wired

--- a/test/test_sse_budget_anchor.ml
+++ b/test/test_sse_budget_anchor.ml
@@ -98,6 +98,15 @@ let test_blank_delimiters_do_not_renew_first_event_budget () =
   |> check_timed_out "bare dispatch delimiters"
 ;;
 
+let test_event_fields_do_not_end_first_event_budget () =
+  (* An [event] field only selects the dispatch type. Until a [data] field
+     arrives, the EventSource parser has no payload-bearing event to deliver. *)
+  read_sse_over
+    ~budget_kind:`First_event
+    [ "event: message\n"; "\n"; "event: future\n"; "\n" ]
+  |> check_timed_out "event fields without data"
+;;
+
 let test_ignored_fields_do_not_renew_idle_budget () =
   (* Same hole after the stream has produced: the inter-token budget must
      measure from the last payload, not from the last ignorable line. *)
@@ -141,6 +150,10 @@ let () =
             "bare delimiters do not renew"
             `Quick
             test_blank_delimiters_do_not_renew_first_event_budget
+        ; test_case
+            "event fields without data do not end first-event budget"
+            `Quick
+            test_event_fields_do_not_end_first_event_budget
         ] )
     ; ( "idle"
       , [ test_case


### PR DESCRIPTION
## Summary

An SSE `event:` field selects the dispatch type but is metadata, not a payload-bearing event. The reader previously marked first output as seen on that line, switching from the caller-provided first-event/TTFT deadline to the shorter inter-token idle deadline before any `data:` field arrived.

This PR transitions to the inter-token idle budget only after a `data:` field and adds a deterministic mock-clock regression test.

## Boundary

- OAS-only change.
- No provider/model heuristic or error-string classification.
- No MASC dependency or lifecycle decision.
- Existing typed malformed SSE / NDJSON errors remain unchanged.

## Protocol reference

The [WHATWG Server-sent events specification](https://html.spec.whatwg.org/multipage/server-sent-events.html) treats `event:` as event-type metadata; dispatch requires accumulated data. The reader now keeps the first-event deadline until payload data arrives.

## Validation

- `test_sse_budget_anchor.exe`: 6/6
- `test_http_client.exe`: 34/34
- `test_complete_http.exe`: 67/67
- `git diff --check`: clean

Draft for CI and adversarial review.