### PR TITLE
fix: preserve Ollama NDJSON outcome kinds

### DIFF
--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -194,7 +194,8 @@ let%test
   | Error _ -> false
 ;;
 
-(* A provider error remains [SSEError], never [MessageStop] or an empty result. *)
+(* A provider error remains a typed provider-error event, never [MessageStop]
+   or an empty result. The concrete constructor preserves the wire format. *)
 let%test "OpenAI-compatible provider error result finalizes Error" =
   let acc = Complete_stream_acc.create_stream_acc () in
   let st = Streaming.create_openai_stream_state ~provider:"openai" ~model:"m" () in
@@ -385,6 +386,7 @@ let complete_stream_http
            it. Classifying it as a wire error made the summary contradict the
            [Provider_reported_error] this stream actually returns. *)
         | Types.SSEError _ -> `Provider_reported_error
+        | Types.NDJSONError _ -> `Provider_reported_error
         (* [SSEParseFailed] is emitted by format-agnostic producers — the
            Ollama (NDJSON) tool-routing path raises it via
            [Streaming.reject_tool_block ~protocol:"ollama"] — so the format
@@ -626,7 +628,7 @@ let complete_stream_http
                            | Streaming.Ollama_provider_error { message; error_type; raw }
                              ->
                              dispatch
-                               ([ Types.SSEError { message; error_type; raw } ], None)
+                               ([ Types.NDJSONError { message; error_type; raw } ], None)
                            | Streaming.Ollama_chunk chunk ->
                              (match chunk.oll_timings with
                               | Some _ as t -> ollama_timings := t

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -131,8 +131,9 @@ let%test "clean stream finalizes Ok: Ollama done:true" =
      Streaming.parse_ollama_ndjson_chunk
        {|{"model":"m","done":true,"done_reason":"stop","message":{"role":"assistant","content":""}}|}
    with
-   | Some chunk -> accumulate_events acc (fst (Streaming.ollama_chunk_to_events st chunk))
-   | None -> ());
+   | Streaming.Ollama_chunk chunk ->
+     accumulate_events acc (fst (Streaming.ollama_chunk_to_events st chunk))
+   | Streaming.Ollama_provider_error _ | Streaming.Ollama_parse_failed _ -> ());
   match Complete_stream_acc.finalize_stream_acc acc with
   | Ok _ -> true
   | Error _ -> false
@@ -620,15 +621,13 @@ let complete_stream_http
                          if not (Complete_stream_acc.stream_failed acc)
                          then (
                            match Streaming.parse_ollama_ndjson_chunk line with
-                           | None ->
+                           | Streaming.Ollama_parse_failed { raw; reason } ->
+                             dispatch ([ Types.NDJSONParseFailed { raw; reason } ], None)
+                           | Streaming.Ollama_provider_error { message; error_type; raw }
+                             ->
                              dispatch
-                               ( [ Types.NDJSONParseFailed
-                                     { raw = line
-                                     ; reason = "ollama_ndjson_chunk_parse_failure"
-                                     }
-                                 ]
-                               , None )
-                           | Some chunk ->
+                               ([ Types.SSEError { message; error_type; raw } ], None)
+                           | Streaming.Ollama_chunk chunk ->
                              (match chunk.oll_timings with
                               | Some _ as t -> ollama_timings := t
                               | None -> ());

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -169,6 +169,8 @@ let accumulate_event (acc : stream_acc) = function
      | None -> ())
   | Types.SSEError { message; error_type; raw } ->
     acc.sse_error := Some (Types.Stream_provider_error { message; error_type; raw })
+  | Types.NDJSONError { message; error_type; raw } ->
+    acc.sse_error := Some (Types.Stream_provider_error { message; error_type; raw })
   | Types.SSEParseFailed { raw; reason } ->
     acc.sse_error := Some (Types.Stream_parse_failed { reason; raw })
   | Types.NDJSONParseFailed { raw; reason } ->

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -2123,128 +2123,182 @@ type ollama_chunk =
   ; oll_timings : inference_timings option
   }
 
-let parse_ollama_ndjson_chunk data_str : ollama_chunk option =
+type ollama_ndjson_parse_result =
+  | Ollama_chunk of ollama_chunk
+  | Ollama_provider_error of
+      { message : string
+      ; error_type : string option
+      ; raw : string
+      }
+  | Ollama_parse_failed of
+      { reason : string
+      ; raw : string
+      }
+
+let ollama_required_fields json =
+  let open Yojson.Safe.Util in
+  match
+    json |> member "model" |> to_string_option, json |> member "done" |> to_bool_option
+  with
+  | Some model, Some is_done when not (Api_common.string_is_blank model) ->
+    Some (model, is_done)
+  | Some _, Some _ | None, _ | _, None -> None
+;;
+
+type ollama_line_shape =
+  | Ollama_data_fields of string * bool
+  | Ollama_provider_error_fields of
+      { message : string
+      ; error_type : string option
+      }
+  | Ollama_malformed_fields of string
+
+let ollama_line_shape ~raw json =
+  let open Yojson.Safe.Util in
+  match json |> member "error" with
+  | `String message -> Ollama_provider_error_fields { message; error_type = None }
+  | `Assoc error_fields ->
+    let error = `Assoc error_fields in
+    let message =
+      error |> member "message" |> to_string_option |> Option.value ~default:raw
+    in
+    let error_type = error |> member "type" |> to_string_option in
+    Ollama_provider_error_fields { message; error_type }
+  | `Null ->
+    (match ollama_required_fields json with
+     | Some (model, is_done) -> Ollama_data_fields (model, is_done)
+     | None -> Ollama_malformed_fields "ollama_ndjson_missing_required_field")
+  | `Bool _ | `Int _ | `Intlit _ | `Float _ | `List _ ->
+    Ollama_malformed_fields "ollama_ndjson_error_field_type"
+;;
+
+let parse_ollama_ndjson_chunk data_str : ollama_ndjson_parse_result =
   let open Yojson.Safe.Util in
   try
     let json = Yojson.Safe.from_string data_str in
-    let oll_model = Cli_common_json.member_str "model" json in
-    let oll_is_done = Cli_common_json.member_bool "done" json in
-    let oll_done_reason = json |> member "done_reason" |> to_string_option in
-    let message = json |> member "message" in
-    let oll_delta_content =
-      match message with
-      | `Assoc _ ->
-        let s = message |> member "content" |> to_string_option in
-        (match s with
-         | Some "" -> None
-         | other -> other)
-      | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ -> None
-    in
-    let oll_delta_thinking =
-      match message with
-      | `Assoc _ ->
-        let s = message |> member "thinking" |> to_string_option in
-        (match s with
-         | Some "" -> None
-         | other -> other)
-      | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ -> None
-    in
-    let oll_tool_calls =
-      match message with
-      | `Assoc _ ->
-        (match message |> member "tool_calls" with
-         | `List items ->
-           List.mapi
-             (fun idx tc ->
-                let func = tc |> member "function" in
-                let oll_tc_name = func |> member "name" |> to_string_option in
-                let oll_tc_id = tc |> member "id" |> to_string_option in
-                let oll_tc_arguments =
-                  match func |> member "arguments" with
-                  | `Null -> None
-                  | (`Assoc _ | `List _) as v ->
-                    Some (Args_complete (Yojson.Safe.to_string v))
-                  | `String s -> Some (Args_fragment s)
-                  | other -> Some (Args_complete (Yojson.Safe.to_string other))
-                in
-                { oll_tc_index = idx; oll_tc_id; oll_tc_name; oll_tc_arguments })
-             items
-         | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _ -> [])
-      | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ -> []
-    in
-    (* Token-count usage. Ollama only emits these on the done chunk.
-       When both counts are zero we return None, matching the
-       non-streaming path in [Backend_ollama.parse_ollama_response]
-       so that a downstream consumer's usage-trust classification sees
-       [Usage_missing] instead of [zero_token_usage_reported]. *)
-    let oll_usage =
-      let input = json |> member "prompt_eval_count" |> to_int_option in
-      let output = json |> member "eval_count" |> to_int_option in
-      match input, output with
-      | None, None -> None
-      | Some _, None | None, Some _ | Some _, Some _ ->
-        let input_tokens = Option.value ~default:0 input in
-        let output_tokens = Option.value ~default:0 output in
-        if input_tokens = 0 && output_tokens = 0
-        then None
-        else
-          Some
-            { input_tokens
-            ; output_tokens
-            ; cache_creation_input_tokens = 0
-            ; cache_read_input_tokens = 0
-            ; cost_usd = None
-            }
-    in
-    (* inference_timings: same wire-format the non-streaming
-       Backend_ollama.parse_ollama_response builds, so downstream
-       (record_llm_tok_s_metrics) is byte-identical between the two
-       paths. Durations are nanoseconds on the wire; convert to ms
-       and tok/s here. *)
-    let oll_timings =
-      let prompt_n = json |> member "prompt_eval_count" |> to_int_option in
-      let prompt_ns = json |> member "prompt_eval_duration" |> to_int_option in
-      let predicted_n = json |> member "eval_count" |> to_int_option in
-      let predicted_ns = json |> member "eval_duration" |> to_int_option in
-      let any_set =
-        Option.is_some prompt_n
-        || Option.is_some prompt_ns
-        || Option.is_some predicted_n
-        || Option.is_some predicted_ns
+    match ollama_line_shape ~raw:data_str json with
+    | Ollama_provider_error_fields { message; error_type } ->
+      Ollama_provider_error { message; error_type; raw = data_str }
+    | Ollama_malformed_fields reason -> Ollama_parse_failed { reason; raw = data_str }
+    | Ollama_data_fields (oll_model, oll_is_done) ->
+      let oll_done_reason = json |> member "done_reason" |> to_string_option in
+      let message = json |> member "message" in
+      let oll_delta_content =
+        match message with
+        | `Assoc _ ->
+          let s = message |> member "content" |> to_string_option in
+          (match s with
+           | Some "" -> None
+           | other -> other)
+        | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ -> None
       in
-      if not any_set
-      then None
-      else (
-        let ms_of_ns ns_opt = Option.map (fun ns -> float_of_int ns /. 1e6) ns_opt in
-        let per_second n_opt ns_opt =
-          match n_opt, ns_opt with
-          | Some n, Some ns when ns > 0 ->
-            Some (float_of_int n /. (float_of_int ns /. 1e9))
-          | Some _, Some _ | Some _, None | None, Some _ | None, None -> None
+      let oll_delta_thinking =
+        match message with
+        | `Assoc _ ->
+          let s = message |> member "thinking" |> to_string_option in
+          (match s with
+           | Some "" -> None
+           | other -> other)
+        | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ -> None
+      in
+      let oll_tool_calls =
+        match message with
+        | `Assoc _ ->
+          (match message |> member "tool_calls" with
+           | `List items ->
+             List.mapi
+               (fun idx tc ->
+                  let func = tc |> member "function" in
+                  let oll_tc_name = func |> member "name" |> to_string_option in
+                  let oll_tc_id = tc |> member "id" |> to_string_option in
+                  let oll_tc_arguments =
+                    match func |> member "arguments" with
+                    | `Null -> None
+                    | (`Assoc _ | `List _) as v ->
+                      Some (Args_complete (Yojson.Safe.to_string v))
+                    | `String s -> Some (Args_fragment s)
+                    | other -> Some (Args_complete (Yojson.Safe.to_string other))
+                  in
+                  { oll_tc_index = idx; oll_tc_id; oll_tc_name; oll_tc_arguments })
+               items
+           | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _ -> [])
+        | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ -> []
+      in
+      (* Token-count usage. Ollama only emits these on the done chunk.
+         When both counts are zero we return None, matching the
+         non-streaming path in [Backend_ollama.parse_ollama_response]
+         so that a downstream consumer's usage-trust classification sees
+         [Usage_missing] instead of [zero_token_usage_reported]. *)
+      let oll_usage =
+        let input = json |> member "prompt_eval_count" |> to_int_option in
+        let output = json |> member "eval_count" |> to_int_option in
+        match input, output with
+        | None, None -> None
+        | Some _, None | None, Some _ | Some _, Some _ ->
+          let input_tokens = Option.value ~default:0 input in
+          let output_tokens = Option.value ~default:0 output in
+          if input_tokens = 0 && output_tokens = 0
+          then None
+          else
+            Some
+              { input_tokens
+              ; output_tokens
+              ; cache_creation_input_tokens = 0
+              ; cache_read_input_tokens = 0
+              ; cost_usd = None
+              }
+      in
+      (* inference_timings: same wire-format the non-streaming
+         Backend_ollama.parse_ollama_response builds, so downstream
+         (record_llm_tok_s_metrics) is byte-identical between the two
+         paths. Durations are nanoseconds on the wire; convert to ms
+         and tok/s here. *)
+      let oll_timings =
+        let prompt_n = json |> member "prompt_eval_count" |> to_int_option in
+        let prompt_ns = json |> member "prompt_eval_duration" |> to_int_option in
+        let predicted_n = json |> member "eval_count" |> to_int_option in
+        let predicted_ns = json |> member "eval_duration" |> to_int_option in
+        let any_set =
+          Option.is_some prompt_n
+          || Option.is_some prompt_ns
+          || Option.is_some predicted_n
+          || Option.is_some predicted_ns
         in
-        Some
-          { prompt_n
-          ; prompt_ms = ms_of_ns prompt_ns
-          ; prompt_per_second = per_second prompt_n prompt_ns
-          ; predicted_n
-          ; predicted_ms = ms_of_ns predicted_ns
-          ; predicted_per_second = per_second predicted_n predicted_ns
-          ; cache_n = None
-          })
-    in
-    Some
-      { oll_model
-      ; oll_delta_content
-      ; oll_delta_thinking
-      ; oll_tool_calls
-      ; oll_done_reason
-      ; oll_is_done
-      ; oll_usage
-      ; oll_timings
-      }
+        if not any_set
+        then None
+        else (
+          let ms_of_ns ns_opt = Option.map (fun ns -> float_of_int ns /. 1e6) ns_opt in
+          let per_second n_opt ns_opt =
+            match n_opt, ns_opt with
+            | Some n, Some ns when ns > 0 ->
+              Some (float_of_int n /. (float_of_int ns /. 1e9))
+            | Some _, Some _ | Some _, None | None, Some _ | None, None -> None
+          in
+          Some
+            { prompt_n
+            ; prompt_ms = ms_of_ns prompt_ns
+            ; prompt_per_second = per_second prompt_n prompt_ns
+            ; predicted_n
+            ; predicted_ms = ms_of_ns predicted_ns
+            ; predicted_per_second = per_second predicted_n predicted_ns
+            ; cache_n = None
+            })
+      in
+      Ollama_chunk
+        { oll_model
+        ; oll_delta_content
+        ; oll_delta_thinking
+        ; oll_tool_calls
+        ; oll_done_reason
+        ; oll_is_done
+        ; oll_usage
+        ; oll_timings
+        }
   with
-  | Yojson.Json_error _ -> None
-  | Type_error (_, _) -> None
+  | Yojson.Json_error message ->
+    Ollama_parse_failed { reason = "json_error: " ^ message; raw = data_str }
+  | Type_error (message, _) ->
+    Ollama_parse_failed { reason = "type_error: " ^ message; raw = data_str }
 ;;
 
 (** Convert a parsed {!ollama_chunk} into {!sse_event} list.
@@ -2379,8 +2433,8 @@ let%test "parse_ollama_ndjson_chunk: content delta line" =
     {|{"model":"dashscope-3:8b","message":{"role":"assistant","content":"hi"},"done":false}|}
   in
   match parse_ollama_ndjson_chunk line with
-  | None -> false
-  | Some c ->
+  | Ollama_parse_failed _ | Ollama_provider_error _ -> false
+  | Ollama_chunk c ->
     c.oll_model = "dashscope-3:8b"
     && c.oll_delta_content = Some "hi"
     && c.oll_delta_thinking = None
@@ -2398,8 +2452,8 @@ let%test "parse_ollama_ndjson_chunk: done line carries timings + usage" =
        "eval_count":50,"eval_duration":1000000000}|}
   in
   match parse_ollama_ndjson_chunk line with
-  | None -> false
-  | Some c ->
+  | Ollama_parse_failed _ | Ollama_provider_error _ -> false
+  | Ollama_chunk c ->
     c.oll_is_done
     && c.oll_done_reason = Some "stop"
     && (match c.oll_usage with
@@ -2426,11 +2480,11 @@ let%test "parse_ollama_ndjson_chunk: zero eval_duration → per_second None" =
        "done":true,"eval_count":10,"eval_duration":0}|}
   in
   match parse_ollama_ndjson_chunk line with
-  | Some c ->
+  | Ollama_chunk c ->
     (match c.oll_timings with
      | Some t -> t.predicted_n = Some 10 && t.predicted_per_second = None
      | None -> false)
-  | None -> false
+  | Ollama_parse_failed _ | Ollama_provider_error _ -> false
 ;;
 
 let%test "parse_ollama_ndjson_chunk: tool_calls fully formed in done line" =
@@ -2440,8 +2494,8 @@ let%test "parse_ollama_ndjson_chunk: tool_calls fully formed in done line" =
        "done":true,"done_reason":"tool_calls"}|}
   in
   match parse_ollama_ndjson_chunk line with
-  | None -> false
-  | Some c ->
+  | Ollama_parse_failed _ | Ollama_provider_error _ -> false
+  | Ollama_chunk c ->
     (match c.oll_tool_calls with
      | [ tc ] ->
        tc.oll_tc_name = Some "foo"
@@ -2456,19 +2510,29 @@ let%test "parse_ollama_ndjson_chunk: tool_calls fully formed in done line" =
        false)
 ;;
 
-let%test "parse_ollama_ndjson_chunk: malformed json → None" =
-  parse_ollama_ndjson_chunk "{not valid" = None
+let%test "parse_ollama_ndjson_chunk: malformed json is explicit" =
+  match parse_ollama_ndjson_chunk "{not valid" with
+  | Ollama_parse_failed _ -> true
+  | Ollama_chunk _ | Ollama_provider_error _ -> false
 ;;
 
-let%test "parse_ollama_ndjson_chunk: done with zero token counts → None" =
+let%test "parse_ollama_ndjson_chunk: provider error is explicit" =
+  match parse_ollama_ndjson_chunk {|{"error":"model failed"}|} with
+  | Ollama_provider_error { message; error_type = None; raw } ->
+    message = "model failed" && raw = {|{"error":"model failed"}|}
+  | Ollama_chunk _ | Ollama_parse_failed _ -> false
+  | Ollama_provider_error { error_type = Some _; _ } -> false
+;;
+
+let%test "parse_ollama_ndjson_chunk: done with zero token counts keeps chunk" =
   let line =
     {|{"model":"dashscope-3:8b","message":{"role":"assistant","content":""},
        "done_reason":"stop","done":true,
        "prompt_eval_count":0,"eval_count":0}|}
   in
   match parse_ollama_ndjson_chunk line with
-  | None -> false
-  | Some c -> c.oll_is_done && c.oll_usage = None
+  | Ollama_chunk c -> c.oll_is_done && c.oll_usage = None
+  | Ollama_parse_failed _ | Ollama_provider_error _ -> false
 ;;
 
 (* ── ollama_chunk_to_events tests ─────────────────────────── *)

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -2153,14 +2153,14 @@ type ollama_line_shape =
       }
   | Ollama_malformed_fields of string
 
-let ollama_line_shape ~raw json =
+let ollama_line_shape json =
   let open Yojson.Safe.Util in
   match json |> member "error" with
   | `String message -> Ollama_provider_error_fields { message; error_type = None }
   | `Assoc error_fields ->
     let error = `Assoc error_fields in
     let message =
-      error |> member "message" |> to_string_option |> Option.value ~default:raw
+      error |> member "message" |> to_string_option |> Option.value ~default:""
     in
     let error_type = error |> member "type" |> to_string_option in
     Ollama_provider_error_fields { message; error_type }
@@ -2176,7 +2176,7 @@ let parse_ollama_ndjson_chunk data_str : ollama_ndjson_parse_result =
   let open Yojson.Safe.Util in
   try
     let json = Yojson.Safe.from_string data_str in
-    match ollama_line_shape ~raw:data_str json with
+    match ollama_line_shape json with
     | Ollama_provider_error_fields { message; error_type } ->
       Ollama_provider_error { message; error_type; raw = data_str }
     | Ollama_malformed_fields reason -> Ollama_parse_failed { reason; raw = data_str }
@@ -2521,6 +2521,16 @@ let%test "parse_ollama_ndjson_chunk: provider error is explicit" =
   | Ollama_provider_error { message; error_type = None; raw } ->
     message = "model failed" && raw = {|{"error":"model failed"}|}
   | Ollama_chunk _ | Ollama_parse_failed _ -> false
+  | Ollama_provider_error { error_type = Some _; _ } -> false
+;;
+
+let%test "parse_ollama_ndjson_chunk: missing provider message does not copy raw" =
+  let raw = {|{"error":{"type":"server_error","detail":"opaque"}}|} in
+  match parse_ollama_ndjson_chunk raw with
+  | Ollama_provider_error { message; error_type = Some "server_error"; raw = r } ->
+    message = "" && r = raw
+  | Ollama_chunk _ | Ollama_parse_failed _ -> false
+  | Ollama_provider_error { error_type = None; _ } -> false
   | Ollama_provider_error { error_type = Some _; _ } -> false
 ;;
 

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -173,6 +173,7 @@ let sse_event_is_first_token_signal (e : sse_event) : bool =
   | MessageStop
   | Ping
   | SSEError _
+  | NDJSONError _
   | SSEParseFailed _
   | NDJSONParseFailed _
   | SSEUnknownEventType _
@@ -198,6 +199,7 @@ let sse_event_is_deliverable_progress_signal (e : sse_event) : bool =
   | MessageStop
   | Ping
   | SSEError _
+  | NDJSONError _
   | SSEParseFailed _
   | NDJSONParseFailed _
   | SSEUnknownEventType _
@@ -1259,6 +1261,7 @@ let test_tool_use_start_with_name = function
   | MessageStop
   | Ping
   | SSEError _
+  | NDJSONError _
   | SSEParseFailed _
   | NDJSONParseFailed _
   | SSEUnknownEventType _
@@ -1277,6 +1280,7 @@ let test_tool_use_start = function
   | MessageStop
   | Ping
   | SSEError _
+  | NDJSONError _
   | SSEParseFailed _
   | NDJSONParseFailed _
   | SSEUnknownEventType _
@@ -1295,6 +1299,7 @@ let test_input_json_delta = function
   | MessageStop
   | Ping
   | SSEError _
+  | NDJSONError _
   | SSEParseFailed _
   | NDJSONParseFailed _
   | SSEUnknownEventType _

--- a/lib/llm_provider/streaming.mli
+++ b/lib/llm_provider/streaming.mli
@@ -201,10 +201,22 @@ type ollama_chunk =
   ; oll_timings : inference_timings option
   }
 
-(** Parse one NDJSON line into an {!ollama_chunk}. Returns [None]
-    when the line is not valid JSON or is missing the expected
-    [message]/[done] keys. *)
-val parse_ollama_ndjson_chunk : string -> ollama_chunk option
+type ollama_ndjson_parse_result =
+  | Ollama_chunk of ollama_chunk
+  | Ollama_provider_error of
+      { message : string
+      ; error_type : string option
+      ; raw : string
+      }
+  | Ollama_parse_failed of
+      { reason : string
+      ; raw : string
+      }
+
+(** Parse one NDJSON line without collapsing provider errors or malformed
+    records into an absent chunk. The Ollama error envelope is a provider
+    fact; missing or incorrectly typed data fields are wire failures. *)
+val parse_ollama_ndjson_chunk : string -> ollama_ndjson_parse_result
 
 (** Convert a parsed {!ollama_chunk} into {!sse_event} list.
     Synthesises [ContentBlockStart] events on first occurrence of

--- a/lib/llm_provider/streaming.mli
+++ b/lib/llm_provider/streaming.mli
@@ -215,7 +215,9 @@ type ollama_ndjson_parse_result =
 
 (** Parse one NDJSON line without collapsing provider errors or malformed
     records into an absent chunk. The Ollama error envelope is a provider
-    fact; missing or incorrectly typed data fields are wire failures. *)
+    fact; missing or incorrectly typed data fields are wire failures. When a
+    provider error object omits [message], [message] stays empty and the
+    original payload remains available only through [raw]. *)
 val parse_ollama_ndjson_chunk : string -> ollama_ndjson_parse_result
 
 (** Convert a parsed {!ollama_chunk} into {!sse_event} list.

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -917,6 +917,11 @@ type sse_event =
                 can feed it to [Retry.classify_error] (retry_after, hard-quota
                 detection) exactly as the non-streaming path does. *)
       }
+  | NDJSONError of
+      { message : string
+      ; error_type : string option
+      ; raw : string
+      }
   | SSEParseFailed of
       { raw : string
       ; reason : string

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -562,6 +562,14 @@ type sse_event =
             ["rate_limit_exceeded"]) and [raw] the original error JSON, so the
             consumer can converge onto the same classification path as an
             initial HTTP error instead of collapsing to [NetworkError {Unknown}]. *)
+  | NDJSONError of
+      { message : string
+      ; error_type : string option
+      ; raw : string
+      }
+  (** A provider-reported error envelope delivered in an NDJSON stream.
+      This is deliberately distinct from [SSEError]: the wire format is a
+      transport fact and must not be relabelled at the event boundary. *)
   | SSEParseFailed of
       { raw : string
       ; reason : string

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -2046,6 +2046,93 @@ let test_complete_ollama_malformed_ndjson_is_wire_error () =
   | Exit -> ()
 ;;
 
+let test_complete_ollama_provider_error_is_not_wire_error () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let url =
+      start_sse_server
+        ~sw
+        ~net:env#net
+        ~content_type:"application/x-ndjson"
+        {|{"error":"model failed"}
+|}
+    in
+    let telemetry = ref [] in
+    (match
+       Complete.complete_stream
+         ~sw
+         ~net:env#net
+         ~config:(make_config ~kind:Provider_config.Ollama ~request_path:"/api/chat" url)
+         ~messages
+         ~on_event:(fun _ -> ())
+         ~on_telemetry:(fun event -> telemetry := event :: !telemetry)
+         ()
+     with
+     | Error
+         (Http_client.ProviderFailure
+            { kind = Http_client.Provider_reported_error { error_type = None }; _ }) -> ()
+     | Error _ -> fail "expected a typed provider-reported error"
+     | Ok _ -> fail "a provider error envelope must not complete successfully");
+    let terminal =
+      List.find_map
+        (function
+          | Telemetry_event.Streaming_summary { terminal; _ } -> Some terminal
+          | _ -> None)
+        !telemetry
+    in
+    check
+      (option (testable Telemetry_event.pp_streaming_terminal ( = )))
+      "provider error telemetry is not a wire failure"
+      (Some (Telemetry_event.Terminal_error "provider_stream_error"))
+      terminal;
+    Eio.Switch.fail sw Exit
+  with
+  | Exit -> ()
+;;
+
+let test_complete_ollama_missing_required_ndjson_field_is_wire_error () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let url =
+      start_sse_server
+        ~sw
+        ~net:env#net
+        ~content_type:"application/x-ndjson"
+        {|{"model":"test-model","message":{"role":"assistant","content":"before"},"done":false}
+{}
+{"model":"test-model","message":{"role":"assistant","content":"after"},"done":true,"done_reason":"stop"}
+|}
+    in
+    (match
+       Complete.complete_stream
+         ~sw
+         ~net:env#net
+         ~config:(make_config ~kind:Provider_config.Ollama ~request_path:"/api/chat" url)
+         ~messages
+         ~on_event:(fun _ -> ())
+         ~on_telemetry:(fun _ -> ())
+         ()
+     with
+     | Error
+         (Http_client.ProviderFailure
+            { kind =
+                Http_client.Provider_wire_error
+                  { format = Http_client.Ndjson; kind = Http_client.Malformed_payload }
+            ; _
+            }) -> ()
+     | Error _ -> fail "expected typed malformed NDJSON payload"
+     | Ok _ -> fail "missing required NDJSON field must not complete successfully");
+    Eio.Switch.fail sw Exit
+  with
+  | Exit -> ()
+;;
+
 let test_complete_ollama_incomplete_ndjson_preserves_wire_format () =
   Eio_main.run
   @@ fun env ->
@@ -3491,6 +3578,14 @@ let () =
             "malformed Ollama NDJSON preserves its wire format"
             `Quick
             test_complete_ollama_malformed_ndjson_is_wire_error
+        ; test_case
+            "Ollama provider errors are not wire failures"
+            `Quick
+            test_complete_ollama_provider_error_is_not_wire_error
+        ; test_case
+            "missing Ollama NDJSON fields are wire errors"
+            `Quick
+            test_complete_ollama_missing_required_ndjson_field_is_wire_error
         ; test_case
             "incomplete Ollama NDJSON preserves its wire format"
             `Quick

--- a/test/test_complete_http.ml
+++ b/test/test_complete_http.ml
@@ -2061,13 +2061,14 @@ let test_complete_ollama_provider_error_is_not_wire_error () =
 |}
     in
     let telemetry = ref [] in
+    let events = ref [] in
     (match
        Complete.complete_stream
          ~sw
          ~net:env#net
          ~config:(make_config ~kind:Provider_config.Ollama ~request_path:"/api/chat" url)
          ~messages
-         ~on_event:(fun _ -> ())
+         ~on_event:(fun event -> events := event :: !events)
          ~on_telemetry:(fun event -> telemetry := event :: !telemetry)
          ()
      with
@@ -2076,6 +2077,29 @@ let test_complete_ollama_provider_error_is_not_wire_error () =
             { kind = Http_client.Provider_reported_error { error_type = None }; _ }) -> ()
      | Error _ -> fail "expected a typed provider-reported error"
      | Ok _ -> fail "a provider error envelope must not complete successfully");
+    let ndjson_errors =
+      List.filter_map
+        (function
+          | Types.NDJSONError { message; error_type = None; raw } -> Some (message, raw)
+          | Types.NDJSONError { error_type = Some _; _ } -> None
+          | _ -> None)
+        !events
+    in
+    check
+      bool
+      "Ollama provider error is not relabelled as SSE"
+      true
+      (not
+         (List.exists
+            (function
+              | Types.SSEError _ -> true
+              | _ -> false)
+            !events));
+    (match ndjson_errors with
+     | [ (message, raw) ] ->
+       check string "NDJSON provider error message" "model failed" message;
+       check string "NDJSON provider error raw" {|{"error":"model failed"}|} raw
+     | _ -> fail "Ollama provider error must remain exactly one NDJSON event");
     let terminal =
       List.find_map
         (function

--- a/test/test_streaming_edge_cases.ml
+++ b/test/test_streaming_edge_cases.ml
@@ -145,6 +145,7 @@ let test_first_token_classifier_edges () =
     ; MessageDelta { stop_reason = None; usage = None }
     ; MessageStop
     ; SSEError { message = "boom"; error_type = None; raw = "boom" }
+    ; NDJSONError { message = "boom"; error_type = None; raw = "boom" }
     ; SSEParseFailed { raw = "x"; reason = "bad" }
     ; SSEUnknownEventType { event_type = "future"; raw = "{}" }
     ]

--- a/test/test_streaming_edge_cases.ml
+++ b/test/test_streaming_edge_cases.ml
@@ -72,6 +72,13 @@ let require_openai_chunk label = function
     fail (Printf.sprintf "%s: unexpected parse failure: %s" label reason)
 ;;
 
+let require_ollama_chunk label = function
+  | S.Ollama_chunk chunk -> chunk
+  | S.Ollama_provider_error _ -> fail (label ^ ": unexpected provider error")
+  | S.Ollama_parse_failed { reason; _ } ->
+    fail (Printf.sprintf "%s: unexpected parse failure: %s" label reason)
+;;
+
 let test_anthropic_sse_parser_edges () =
   (match
      S.parse_sse_event
@@ -623,14 +630,14 @@ let test_gemini_event_edge_branches () =
 
 let test_ollama_parse_edge_shapes () =
   let non_object_message =
-    require_some
+    require_ollama_chunk
       "non-object message"
       (S.parse_ollama_ndjson_chunk {|{"model":"m","message":"text","done":false}|})
   in
   check (option string) "no content" None non_object_message.oll_delta_content;
   check int "no tool calls" 0 (List.length non_object_message.oll_tool_calls);
   let args_variants =
-    require_some
+    require_ollama_chunk
       "tool argument variants"
       (S.parse_ollama_ndjson_chunk
          {|{"model":"m","message":{"content":"","thinking":"","tool_calls":[{"id":"a","function":{"name":"null_args","arguments":null}},{"function":{"name":"string_args","arguments":"{\"x\":1}"}},{"function":{"name":"bool_args","arguments":true}}]},"done":true,"prompt_eval_duration":1000000,"eval_duration":0}|})
@@ -659,9 +666,21 @@ let test_ollama_parse_edge_shapes () =
      check (option (float 0.001)) "prompt ms" (Some 1.0) t.prompt_ms;
      check (option (float 0.001)) "zero eval rate" None t.predicted_per_second
    | None -> fail "expected timings");
+  (match S.parse_ollama_ndjson_chunk {|{"done":false}|} with
+   | S.Ollama_parse_failed _ -> ()
+   | S.Ollama_chunk _ | S.Ollama_provider_error _ -> fail "missing model must fail");
+  (match S.parse_ollama_ndjson_chunk {|{"model":"m"}|} with
+   | S.Ollama_parse_failed _ -> ()
+   | S.Ollama_chunk _ | S.Ollama_provider_error _ -> fail "missing done must fail");
+  (match S.parse_ollama_ndjson_chunk {|{"model":"   ","done":false}|} with
+   | S.Ollama_parse_failed _ -> ()
+   | S.Ollama_chunk _ | S.Ollama_provider_error _ -> fail "blank model must fail");
+  (match S.parse_ollama_ndjson_chunk {|{"error":42,"model":"m","done":false}|} with
+   | S.Ollama_parse_failed _ -> ()
+   | S.Ollama_chunk _ | S.Ollama_provider_error _ -> fail "invalid error field must fail");
   match S.parse_ollama_ndjson_chunk {|{"model":1,"done":false}|} with
-  | None -> ()
-  | Some _ -> fail "type error should return None"
+  | S.Ollama_parse_failed _ -> ()
+  | S.Ollama_chunk _ | S.Ollama_provider_error _ -> fail "type error should fail"
 ;;
 
 let test_ollama_event_edge_branches () =

--- a/test/test_streaming_openai.ml
+++ b/test/test_streaming_openai.ml
@@ -1462,8 +1462,9 @@ let test_stream_tool_args_valid_parsed () =
 
 let parse_ollama_line_exn data =
   match S.parse_ollama_ndjson_chunk data with
-  | Some chunk -> chunk
-  | None -> Alcotest.fail "expected Ollama NDJSON stream chunk"
+  | S.Ollama_chunk chunk -> chunk
+  | S.Ollama_provider_error _ -> Alcotest.fail "expected Ollama NDJSON stream chunk"
+  | S.Ollama_parse_failed _ -> Alcotest.fail "expected Ollama NDJSON stream chunk"
 ;;
 
 let test_ollama_native_interleaved_thinking_tool_text_finalizes () =

--- a/test/test_streaming_openai.ml
+++ b/test/test_streaming_openai.ml
@@ -1463,8 +1463,15 @@ let test_stream_tool_args_valid_parsed () =
 let parse_ollama_line_exn data =
   match S.parse_ollama_ndjson_chunk data with
   | S.Ollama_chunk chunk -> chunk
-  | S.Ollama_provider_error _ -> Alcotest.fail "expected Ollama NDJSON stream chunk"
-  | S.Ollama_parse_failed _ -> Alcotest.fail "expected Ollama NDJSON stream chunk"
+  | S.Ollama_provider_error { message; error_type; _ } ->
+    Alcotest.failf
+      "expected Ollama NDJSON stream chunk, got provider error message=%S type=%s"
+      message
+      (Option.value ~default:"<none>" error_type)
+  | S.Ollama_parse_failed { reason; _ } ->
+    Alcotest.failf
+      "expected Ollama NDJSON stream chunk, got parse failure reason=%S"
+      reason
 ;;
 
 let test_ollama_native_interleaved_thinking_tool_text_finalizes () =

--- a/test/test_structured_stream.ml
+++ b/test/test_structured_stream.ml
@@ -115,6 +115,7 @@ let test_on_event_callback_fires () =
       | MessageStop -> "message_stop"
       | Ping -> "ping"
       | SSEError _ -> "error"
+      | NDJSONError _ -> "error"
       | SSEParseFailed _ -> "parse_failed"
       | NDJSONParseFailed _ -> "ndjson_parse_failed"
       | SSEUnknownEventType _ -> "unknown_event_type"


### PR DESCRIPTION
## Summary

- Make the Ollama NDJSON parser return a closed outcome: chunk, provider error, or parse failure.
- Require a non-blank `model` string and a boolean `done` field before accepting a data chunk.
- Preserve the official Ollama error envelope as a provider-reported outcome instead of treating it as malformed wire data.
- Preserve the Ollama provider error as `Types.NDJSONError` at the stream-event boundary; it must not be relabelled as `Types.SSEError`.
- Route missing fields, wrong field types, and invalid JSON to typed NDJSON `Malformed_payload` without allowing a later `done` line to complete the stream.
- Keep an omitted provider error message empty; the original payload remains in the bounded/redacted `raw` diagnostic channel.

## Boundary

- OAS only.
- No provider retry or rate-limit inference.
- No MASC dependency.
- Provider error diagnostics keep the provider-owned error type and raw payload.
- This is deliberately fail-closed for the Ollama wire contract; a non-conforming compatibility server now produces a typed malformed-wire outcome.

## Protocol evidence

The official [Ollama streaming documentation](https://docs.ollama.com/api/streaming) and [chat API documentation](https://docs.ollama.com/api/chat) describe streamed NDJSON response objects with `model` and `done` fields. The [Ollama error documentation](https://docs.ollama.com/api/errors) documents an NDJSON error envelope with an `error` property, which is why provider errors are recognized before data-field validation.

## Validation

- `dune fmt`
- `test/test_streaming_edge_cases.exe`: 14/14
- `test/test_complete_http.exe`: 69/69
- `test/test_streaming_openai.exe`: 50/50
- `test/test_structured_stream.exe`: 6/6

Ready for CI and adversarial review.