### PR TITLE
provider: add finite capacity projection

### DIFF
--- a/lib/llm_provider/capacity_projection.ml
+++ b/lib/llm_provider/capacity_projection.ml
@@ -1,0 +1,114 @@
+type capacity_pressure =
+  | Request_body of
+      { actual_bytes : int
+      ; limit_bytes : int
+      }
+  | Context_window of
+      { input_tokens : int
+      ; reserved_output_tokens : int
+      ; max_context_tokens : int
+      }
+
+type measurement =
+  { serialized_body_bytes : int option
+  ; input_tokens : int option
+  }
+
+type 'error projection_error =
+  | Measurement_failed of 'error
+  | Invalid_pressure of capacity_pressure
+  | Missing_measurement of capacity_pressure
+  | Invalid_measurement of measurement
+  | Pressure_mismatch of
+      { expected : capacity_pressure
+      ; measured : measurement
+      }
+  | Candidate_not_smaller of
+      { previous : int
+      ; candidate : int
+      }
+
+type 'value projection =
+  | Candidate of
+      { value : 'value
+      ; measurement : measurement
+      }
+  | Exhausted of capacity_pressure
+
+let pressure_metric = function
+  | Request_body { actual_bytes; _ } -> actual_bytes
+  | Context_window { input_tokens; _ } -> input_tokens
+;;
+
+let valid_pressure = function
+  | Request_body { actual_bytes; limit_bytes } -> actual_bytes >= 0 && limit_bytes >= 0
+  | Context_window { input_tokens; reserved_output_tokens; max_context_tokens } ->
+    input_tokens >= 0 && reserved_output_tokens >= 0 && max_context_tokens >= 0
+;;
+
+let valid_measurement { serialized_body_bytes; input_tokens } =
+  Option.for_all (fun value -> value >= 0) serialized_body_bytes
+  && Option.for_all (fun value -> value >= 0) input_tokens
+;;
+
+let measured_metric pressure measurement =
+  match pressure with
+  | Request_body _ -> measurement.serialized_body_bytes
+  | Context_window _ -> measurement.input_tokens
+;;
+
+let fits pressure measurement =
+  match pressure with
+  | Request_body { limit_bytes; _ } ->
+    Option.exists
+      (fun actual_bytes -> actual_bytes <= limit_bytes)
+      measurement.serialized_body_bytes
+  | Context_window { reserved_output_tokens; max_context_tokens; _ } ->
+    Option.exists
+      (fun input_tokens -> input_tokens + reserved_output_tokens <= max_context_tokens)
+      measurement.input_tokens
+;;
+
+let pressure_matches pressure measurement =
+  match pressure with
+  | Request_body { actual_bytes; _ } ->
+    measurement.serialized_body_bytes = Some actual_bytes
+  | Context_window { input_tokens; _ } -> measurement.input_tokens = Some input_tokens
+;;
+
+let project ~pressure ~current ~candidates ~measure =
+  if not (valid_pressure pressure)
+  then Error (Invalid_pressure pressure)
+  else (
+    match measure current with
+    | Error error -> Error (Measurement_failed error)
+    | Ok current_measurement ->
+      if not (valid_measurement current_measurement)
+      then Error (Invalid_measurement current_measurement)
+      else if not (pressure_matches pressure current_measurement)
+      then
+        Error (Pressure_mismatch { expected = pressure; measured = current_measurement })
+      else (
+        let initial_metric = pressure_metric pressure in
+        let rec loop previous_metric = function
+          | [] -> Ok (Exhausted pressure)
+          | value :: rest ->
+            (match measure value with
+             | Error error -> Error (Measurement_failed error)
+             | Ok measurement ->
+               if not (valid_measurement measurement)
+               then Error (Invalid_measurement measurement)
+               else (
+                 match measured_metric pressure measurement with
+                 | None -> Error (Missing_measurement pressure)
+                 | Some candidate_metric when candidate_metric >= previous_metric ->
+                   Error
+                     (Candidate_not_smaller
+                        { previous = previous_metric; candidate = candidate_metric })
+                 | Some candidate_metric ->
+                   if fits pressure measurement
+                   then Ok (Candidate { value; measurement })
+                   else loop candidate_metric rest))
+        in
+        loop initial_metric candidates))
+;;

--- a/lib/llm_provider/capacity_projection.ml
+++ b/lib/llm_provider/capacity_projection.ml
@@ -65,13 +65,13 @@ let measured_metric pressure measurement =
 let fits pressure measurement =
   match pressure with
   | Request_body { limit_bytes; _ } ->
-    Option.exists
-      (fun actual_bytes -> actual_bytes <= limit_bytes)
-      measurement.serialized_body_bytes
+    (match measurement.serialized_body_bytes with
+     | Some actual_bytes -> actual_bytes <= limit_bytes
+     | None -> false)
   | Context_window { reserved_output_tokens; max_context_tokens; _ } ->
-    Option.exists
-      (fun input_tokens -> input_tokens + reserved_output_tokens <= max_context_tokens)
-      measurement.input_tokens
+    (match measurement.input_tokens with
+     | Some input_tokens -> input_tokens + reserved_output_tokens <= max_context_tokens
+     | None -> false)
 ;;
 
 let pressure_matches pressure measurement =

--- a/lib/llm_provider/capacity_projection.ml
+++ b/lib/llm_provider/capacity_projection.ml
@@ -47,8 +47,13 @@ let valid_pressure = function
 ;;
 
 let valid_measurement { serialized_body_bytes; input_tokens } =
-  Option.for_all (fun value -> value >= 0) serialized_body_bytes
-  && Option.for_all (fun value -> value >= 0) input_tokens
+  (match serialized_body_bytes with
+   | None -> true
+   | Some value -> value >= 0)
+  &&
+  match input_tokens with
+  | None -> true
+  | Some value -> value >= 0
 ;;
 
 let measured_metric pressure measurement =
@@ -85,30 +90,33 @@ let project ~pressure ~current ~candidates ~measure =
     | Ok current_measurement ->
       if not (valid_measurement current_measurement)
       then Error (Invalid_measurement current_measurement)
-      else if not (pressure_matches pressure current_measurement)
-      then
-        Error (Pressure_mismatch { expected = pressure; measured = current_measurement })
       else (
-        let initial_metric = pressure_metric pressure in
-        let rec loop previous_metric = function
-          | [] -> Ok (Exhausted pressure)
-          | value :: rest ->
-            (match measure value with
-             | Error error -> Error (Measurement_failed error)
-             | Ok measurement ->
-               if not (valid_measurement measurement)
-               then Error (Invalid_measurement measurement)
-               else (
-                 match measured_metric pressure measurement with
-                 | None -> Error (Missing_measurement pressure)
-                 | Some candidate_metric when candidate_metric >= previous_metric ->
-                   Error
-                     (Candidate_not_smaller
-                        { previous = previous_metric; candidate = candidate_metric })
-                 | Some candidate_metric ->
-                   if fits pressure measurement
-                   then Ok (Candidate { value; measurement })
-                   else loop candidate_metric rest))
-        in
-        loop initial_metric candidates))
+        match measured_metric pressure current_measurement with
+        | None -> Error (Missing_measurement pressure)
+        | Some _ when not (pressure_matches pressure current_measurement) ->
+          Error
+            (Pressure_mismatch { expected = pressure; measured = current_measurement })
+        | Some _ ->
+          let initial_metric = pressure_metric pressure in
+          let rec loop previous_metric = function
+            | [] -> Ok (Exhausted pressure)
+            | value :: rest ->
+              (match measure value with
+               | Error error -> Error (Measurement_failed error)
+               | Ok measurement ->
+                 if not (valid_measurement measurement)
+                 then Error (Invalid_measurement measurement)
+                 else (
+                   match measured_metric pressure measurement with
+                   | None -> Error (Missing_measurement pressure)
+                   | Some candidate_metric when candidate_metric >= previous_metric ->
+                     Error
+                       (Candidate_not_smaller
+                          { previous = previous_metric; candidate = candidate_metric })
+                   | Some candidate_metric ->
+                     if fits pressure measurement
+                     then Ok (Candidate { value; measurement })
+                     else loop candidate_metric rest))
+          in
+          loop initial_metric candidates))
 ;;

--- a/lib/llm_provider/capacity_projection.mli
+++ b/lib/llm_provider/capacity_projection.mli
@@ -1,0 +1,49 @@
+(** Provider-neutral projection over a caller-owned, finite candidate sequence.
+
+    The caller supplies the exact serializer or native token measurement via
+    [measure]. This module only applies the typed capacity rule and never
+    invents a retry count or a provider-specific reduction. *)
+
+type capacity_pressure =
+  | Request_body of
+      { actual_bytes : int
+      ; limit_bytes : int
+      }
+  | Context_window of
+      { input_tokens : int
+      ; reserved_output_tokens : int
+      ; max_context_tokens : int
+      }
+
+type measurement =
+  { serialized_body_bytes : int option
+  ; input_tokens : int option
+  }
+
+type 'error projection_error =
+  | Measurement_failed of 'error
+  | Invalid_pressure of capacity_pressure
+  | Missing_measurement of capacity_pressure
+  | Invalid_measurement of measurement
+  | Pressure_mismatch of
+      { expected : capacity_pressure
+      ; measured : measurement
+      }
+  | Candidate_not_smaller of
+      { previous : int
+      ; candidate : int
+      }
+
+type 'value projection =
+  | Candidate of
+      { value : 'value
+      ; measurement : measurement
+      }
+  | Exhausted of capacity_pressure
+
+val project
+  :  pressure:capacity_pressure
+  -> current:'value
+  -> candidates:'value list
+  -> measure:('value -> (measurement, 'error) result)
+  -> ('value projection, 'error projection_error) result

--- a/test/dune
+++ b/test/dune
@@ -404,6 +404,11 @@
  (libraries llm_provider alcotest))
 
 (test
+ (name test_capacity_projection)
+ (modules test_capacity_projection)
+ (libraries llm_provider alcotest))
+
+(test
  (name test_input_token_count)
  (modules test_input_token_count)
  (libraries llm_provider alcotest))

--- a/test/test_capacity_projection.ml
+++ b/test/test_capacity_projection.ml
@@ -43,12 +43,64 @@ let test_context_exhaustion_is_typed () =
   | Error _ -> Alcotest.fail "exhaustion must not be a retry error"
 ;;
 
+let test_missing_current_measurement_is_typed () =
+  let measure _ =
+    Ok
+      { Llm_provider.Capacity_projection.serialized_body_bytes = None
+      ; input_tokens = None
+      }
+  in
+  match
+    Llm_provider.Capacity_projection.project
+      ~pressure:
+        (Llm_provider.Capacity_projection.Request_body
+           { actual_bytes = 9; limit_bytes = 4 })
+      ~current:"current"
+      ~candidates:[]
+      ~measure
+  with
+  | Error (Llm_provider.Capacity_projection.Missing_measurement _) -> ()
+  | Error _ -> Alcotest.fail "expected Missing_measurement for the current value"
+  | Ok _ -> Alcotest.fail "missing current measurement unexpectedly projected"
+;;
+
+let test_candidate_must_strictly_decrease () =
+  let measure value =
+    Ok
+      { Llm_provider.Capacity_projection.serialized_body_bytes = Some value
+      ; input_tokens = None
+      }
+  in
+  match
+    Llm_provider.Capacity_projection.project
+      ~pressure:
+        (Llm_provider.Capacity_projection.Request_body
+           { actual_bytes = 9; limit_bytes = 4 })
+      ~current:9
+      ~candidates:[ 9 ]
+      ~measure
+  with
+  | Error
+      (Llm_provider.Capacity_projection.Candidate_not_smaller
+         { previous = 9; candidate = 9 }) -> ()
+  | Error _ -> Alcotest.fail "expected Candidate_not_smaller"
+  | Ok _ -> Alcotest.fail "non-decreasing candidate unexpectedly projected"
+;;
+
 let () =
   Alcotest.run
     "capacity projection"
     [ ( "finite projection"
       , [ Alcotest.test_case "request body" `Quick test_request_body_projection
         ; Alcotest.test_case "context exhaustion" `Quick test_context_exhaustion_is_typed
+        ; Alcotest.test_case
+            "missing current measurement"
+            `Quick
+            test_missing_current_measurement_is_typed
+        ; Alcotest.test_case
+            "candidate decrease"
+            `Quick
+            test_candidate_must_strictly_decrease
         ] )
     ]
 ;;

--- a/test/test_capacity_projection.ml
+++ b/test/test_capacity_projection.ml
@@ -1,0 +1,54 @@
+let test_request_body_projection () =
+  let measure value =
+    Ok
+      { Llm_provider.Capacity_projection.serialized_body_bytes =
+          Some (String.length value)
+      ; input_tokens = None
+      }
+  in
+  match
+    Llm_provider.Capacity_projection.project
+      ~pressure:
+        (Llm_provider.Capacity_projection.Request_body
+           { actual_bytes = 9; limit_bytes = 4 })
+      ~current:"123456789"
+      ~candidates:[ "12345"; "1234" ]
+      ~measure
+  with
+  | Ok (Llm_provider.Capacity_projection.Candidate { value = "1234"; _ }) -> ()
+  | Ok _ -> Alcotest.fail "expected the first fitting candidate"
+  | Error _ -> Alcotest.fail "projection unexpectedly failed"
+;;
+
+let test_context_exhaustion_is_typed () =
+  let measure value =
+    Ok
+      { Llm_provider.Capacity_projection.serialized_body_bytes = None
+      ; input_tokens = Some value
+      }
+  in
+  match
+    Llm_provider.Capacity_projection.project
+      ~pressure:
+        (Llm_provider.Capacity_projection.Context_window
+           { input_tokens = 10; reserved_output_tokens = 3; max_context_tokens = 8 })
+      ~current:10
+      ~candidates:[ 9; 8 ]
+      ~measure
+  with
+  | Ok
+      (Llm_provider.Capacity_projection.Exhausted
+         (Llm_provider.Capacity_projection.Context_window _)) -> ()
+  | Ok _ -> Alcotest.fail "expected typed exhaustion"
+  | Error _ -> Alcotest.fail "exhaustion must not be a retry error"
+;;
+
+let () =
+  Alcotest.run
+    "capacity projection"
+    [ ( "finite projection"
+      , [ Alcotest.test_case "request body" `Quick test_request_body_projection
+        ; Alcotest.test_case "context exhaustion" `Quick test_context_exhaustion_is_typed
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

- add provider-neutral `capacity_pressure` and finite `capacity_projection` types
- require caller-owned exact serialization or native token measurement for every candidate
- reject non-decreasing candidates with typed errors and return typed `Exhausted` when candidates end

## Validation

- `scripts/dune-local.sh build test/test_capacity_projection.exe__
- `scripts/dune-local.sh exec test/test_capacity_projection.exe__
- `ocamlformat --check__
