### PR TITLE
fix(llm): preserve terminal stop semantics

### DIFF
--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -771,17 +771,6 @@ let%test "parse_ollama_response trusts complete tool blocks over stop label" =
   | Error _ -> false
 ;;
 
-let%test "parse_ollama_response keeps unknown reason non-executable" =
-  let json =
-    {|{"model":"dashscope-3:8b","done":true,"done_reason":"provider_terminal",
-       "message":{"role":"assistant","content":"",
-         "tool_calls":[{"function":{"name":"get_weather","arguments":"{\"city\":\"Seoul\"}"}}]}}|}
-  in
-  match parse_ollama_response json with
-  | Ok response -> response.stop_reason = Types.Unknown "provider_terminal"
-  | Error _ -> false
-;;
-
 let%test "parse_ollama_response maps overflow done_reason to ContextWindowExceeded" =
   match
     parse_ollama_response

--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -771,6 +771,17 @@ let%test "parse_ollama_response trusts complete tool blocks over stop label" =
   | Error _ -> false
 ;;
 
+let%test "parse_ollama_response keeps unknown reason non-executable" =
+  let json =
+    {|{"model":"dashscope-3:8b","done":true,"done_reason":"provider_terminal",
+       "message":{"role":"assistant","content":"",
+         "tool_calls":[{"function":{"name":"get_weather","arguments":"{\"city\":\"Seoul\"}"}}]}}|}
+  in
+  match parse_ollama_response json with
+  | Ok response -> response.stop_reason = Types.Unknown "provider_terminal"
+  | Error _ -> false
+;;
+
 let%test "parse_ollama_response maps overflow done_reason to ContextWindowExceeded" =
   match
     parse_ollama_response

--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -341,12 +341,9 @@ let parse_ollama_response json_str =
       json |> member "done_reason" |> to_string_option |> Option.value ~default:"stop"
     in
     let stop_reason =
-      match String.lowercase_ascii done_reason with
-      | "tool_calls" when tool_blocks <> [] -> StopToolUse
-      | "length" -> MaxTokens
-      | "stop" -> EndTurn
-      | _other when tool_blocks <> [] -> StopToolUse
-      | other -> Unknown other
+      Stop_reason_wire.of_finish
+        (Stop_reason_wire.wire_finish_of_string done_reason)
+        ~has_tool_blocks:(tool_blocks <> [])
     in
     let input_tokens = Cli_common_json.member_int "prompt_eval_count" json in
     let output_tokens = Cli_common_json.member_int "eval_count" json in
@@ -752,6 +749,15 @@ let%test "parse_ollama_response maps done_reason=tool_calls to StopToolUse" =
       (match resp.content with
       | [ Types.ToolUse { name = "get_weather"; _ } ] -> true
       | _ -> false)
+;;
+
+let%test "parse_ollama_response maps overflow done_reason to ContextWindowExceeded" =
+  match
+    parse_ollama_response
+      {|{"model":"dashscope-3:8b","done":true,"done_reason":"model_context_window_exceeded","message":{"role":"assistant","content":""}}|}
+  with
+  | Ok response -> response.stop_reason = Types.ContextWindowExceeded
+  | Error _ -> false
 ;;
 
 let%test "parse_ollama_response returns Error on error field" =

--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -751,6 +751,37 @@ let%test "parse_ollama_response maps done_reason=tool_calls to StopToolUse" =
       | _ -> false)
 ;;
 
+let%test "parse_ollama_response rejects tool_calls without tool blocks" =
+  match
+    parse_ollama_response
+      {|{"model":"dashscope-3:8b","done":true,"done_reason":"tool_calls","message":{"role":"assistant","content":""}}|}
+  with
+  | Ok response -> response.stop_reason = Types.UnmatchedToolCalls
+  | Error _ -> false
+;;
+
+let%test "parse_ollama_response trusts complete tool blocks over stop label" =
+  let json =
+    {|{"model":"dashscope-3:8b","done":true,"done_reason":"stop",
+       "message":{"role":"assistant","content":"",
+         "tool_calls":[{"function":{"name":"get_weather","arguments":"{\"city\":\"Seoul\"}"}}]}}|}
+  in
+  match parse_ollama_response json with
+  | Ok response -> response.stop_reason = Types.StopToolUse
+  | Error _ -> false
+;;
+
+let%test "parse_ollama_response keeps unknown reason non-executable" =
+  let json =
+    {|{"model":"dashscope-3:8b","done":true,"done_reason":"provider_terminal",
+       "message":{"role":"assistant","content":"",
+         "tool_calls":[{"function":{"name":"get_weather","arguments":"{\"city\":\"Seoul\"}"}}]}}|}
+  in
+  match parse_ollama_response json with
+  | Ok response -> response.stop_reason = Types.Unknown "provider_terminal"
+  | Error _ -> false
+;;
+
 let%test "parse_ollama_response maps overflow done_reason to ContextWindowExceeded" =
   match
     parse_ollama_response

--- a/lib/llm_provider/backend_ollama.ml
+++ b/lib/llm_provider/backend_ollama.ml
@@ -337,8 +337,10 @@ let parse_ollama_response json_str =
       | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ ->
         Error "malformed_ollama_response:message_not_object"
     in
-    let done_reason =
-      json |> member "done_reason" |> to_string_option |> Option.value ~default:"stop"
+    let* done_reason =
+      match json |> member "done_reason" |> to_string_option with
+      | Some done_reason -> Ok done_reason
+      | None -> Error "malformed_ollama_response:missing_done_reason"
     in
     let stop_reason =
       Stop_reason_wire.of_finish
@@ -801,6 +803,15 @@ let%test "parse_ollama_response returns Error on error field" =
 let%test "parse_ollama_response rejects a missing message" =
   match parse_ollama_response {|{"model":"dashscope-3:8b","done":true}|} with
   | Error "malformed_ollama_response:missing_message" -> true
+  | Error _ | Ok _ -> false
+;;
+
+let%test "parse_ollama_response rejects a missing done reason" =
+  match
+    parse_ollama_response
+      {|{"model":"dashscope-3:8b","done":true,"message":{"role":"assistant","content":"ok"}}|}
+  with
+  | Error "malformed_ollama_response:missing_done_reason" -> true
   | Error _ | Ok _ -> false
 ;;
 

--- a/lib/llm_provider/backend_openai_parse.ml
+++ b/lib/llm_provider/backend_openai_parse.ml
@@ -337,8 +337,10 @@ let parse_openai_response_result_json_raw (raw_json : Yojson.Safe.t) =
   | `Null ->
     let choice = json |> member "choices" |> index 0 in
     let msg = choice |> member "message" in
-    let finish_reason =
-      choice |> member "finish_reason" |> to_string_option |> Option.value ~default:"stop"
+    let* finish_reason =
+      match choice |> member "finish_reason" |> to_string_option with
+      | Some finish_reason -> Ok finish_reason
+      | None -> Error "malformed_openai_response:missing_finish_reason"
     in
     let text_content = text_content_of_openai_content (msg |> member "content") in
     let* tool_blocks = parse_tool_calls_field (msg |> member "tool_calls") in
@@ -406,6 +408,15 @@ let parse_openai_response_result_json raw_json =
     {!parse_openai_response_result_json} directly to avoid re-parsing. *)
 let parse_openai_response_result json_str =
   parse_openai_response_result_json (Yojson.Safe.from_string json_str)
+;;
+
+let%test "missing finish reason is not synthesized as stop" =
+  match
+    parse_openai_response_result
+      {|{"id":"chat-1","model":"m","choices":[{"message":{"content":"ok"}}]}|}
+  with
+  | Error (Provider_error "malformed_openai_response:missing_finish_reason") -> true
+  | Error _ | Ok _ -> false
 ;;
 
 let%test "usage_of_openai_json supports mlx_vlm input/output token fields" =

--- a/lib/llm_provider/backend_openai_responses.ml
+++ b/lib/llm_provider/backend_openai_responses.ml
@@ -646,11 +646,15 @@ let response_failed_message json =
 ;;
 
 let stop_reason_of_response_json ~has_tool_calls json =
-  Responses_stop_reason.of_status
-    ~status:(response_status json)
-    ~incomplete_reason:(response_incomplete_reason json)
-    ~failed_message:(response_failed_message json)
-    ~has_tool_calls
+  match
+    Responses_stop_reason.of_status
+      ~status:(response_status json)
+      ~incomplete_reason:(response_incomplete_reason json)
+      ~failed_message:(response_failed_message json)
+      ~has_tool_calls
+  with
+  | Some stop_reason -> Ok stop_reason
+  | None -> Error "malformed_openai_responses:missing_status"
 ;;
 
 let parse_response_result json_str =
@@ -700,6 +704,7 @@ let parse_response_result json_str =
             | Audio _ -> false)
           content
       in
+      let* stop_reason = stop_reason_of_response_json ~has_tool_calls json in
       Ok
         { id =
             opt_bind (json_assoc_opt "id" json) json_string_opt
@@ -707,7 +712,7 @@ let parse_response_result json_str =
         ; model =
             opt_bind (json_assoc_opt "model" json) json_string_opt
             |> Option.value ~default:""
-        ; stop_reason = stop_reason_of_response_json ~has_tool_calls json
+        ; stop_reason
         ; content
         ; usage = usage_of_response_json json
         ; telemetry = telemetry_of_response_json json

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -139,6 +139,38 @@ let%test "clean stream finalizes Ok: Ollama done:true" =
   | Error _ -> false
 ;;
 
+let%test "Ollama done without reason finalizes typed incomplete" =
+  let acc = Complete_stream_acc.create_stream_acc () in
+  let st = Streaming.create_openai_stream_state ~provider:"ollama" ~model:"m" () in
+  (match
+     Streaming.parse_ollama_ndjson_chunk
+       {|{"model":"m","done":true,"message":{"role":"assistant","content":"partial"}}|}
+   with
+   | Streaming.Ollama_chunk chunk ->
+     accumulate_events acc (fst (Streaming.ollama_chunk_to_events st chunk))
+   | Streaming.Ollama_provider_error _ | Streaming.Ollama_parse_failed _ -> ());
+  match Complete_stream_acc.finalize_stream_acc acc with
+  | Error (Types.Stream_incomplete { reason = "stream_terminated_without_stop_reason" }) ->
+    true
+  | Error _ | Ok _ -> false
+;;
+
+let%test "Responses terminal event without status finalizes typed incomplete" =
+  let acc = Complete_stream_acc.create_stream_acc () in
+  let st = Streaming.create_openai_stream_state ~provider:"openai" ~model:"m" () in
+  let events, _ =
+    Streaming.responses_sse_to_events
+      st
+      (Some "response.completed")
+      {|{"response":{"id":"resp-1","model":"m","output":[]}}|}
+  in
+  accumulate_events acc events;
+  match Complete_stream_acc.finalize_stream_acc acc with
+  | Error (Types.Stream_incomplete { reason = "stream_terminal_without_stop_reason" }) ->
+    true
+  | Error _ | Ok _ -> false
+;;
+
 let%test "truncated stream (no terminal stop_reason) finalizes Error, not phantom Ok" =
   let acc = Complete_stream_acc.create_stream_acc () in
   Complete_stream_acc.accumulate_event

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -155,9 +155,7 @@ let%test "truncated stream (no terminal stop_reason) finalizes Error, not phanto
 
 (* A [data: [DONE]] sentinel proves transport closure, but cannot invent the
    missing model stop reason. The completion stays fail-closed. *)
-let%test
-    "OpenAI-compat [DONE] without finish_reason fails closed"
-  =
+let%test "OpenAI-compat [DONE] without finish_reason fails closed" =
   let acc = Complete_stream_acc.create_stream_acc () in
   let st = Streaming.create_openai_stream_state ~provider:"openai" ~model:"m" () in
   accumulate_openai_payload
@@ -166,9 +164,8 @@ let%test
     {|{"choices":[{"delta":{"content":"hi"},"finish_reason":null}]}|};
   accumulate_openai_payload acc st "[DONE]";
   match Complete_stream_acc.finalize_stream_acc acc with
-  | Error
-      (Types.Stream_incomplete
-        { reason = "stream_terminal_without_stop_reason" }) -> true
+  | Error (Types.Stream_incomplete { reason = "stream_terminal_without_stop_reason" }) ->
+    true
   | Error _ | Ok _ -> false
 ;;
 

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -153,13 +153,10 @@ let%test "truncated stream (no terminal stop_reason) finalizes Error, not phanto
   | Ok _ -> false
 ;;
 
-(* GAP 1: an OpenAI-compatible stream whose only completion signal is the
-   [data: [DONE]] sentinel (every content chunk carries [finish_reason: null]).
-   The closed parser and event projection preserve that terminal fact as
-   [MessageStop], so finalization can use the default [EndTurn]. *)
+(* A [data: [DONE]] sentinel proves transport closure, but cannot invent the
+   missing model stop reason. The completion stays fail-closed. *)
 let%test
-    "clean stream finalizes Ok: OpenAI-compat [DONE] without finish_reason defaults \
-     EndTurn (covers GLM/Kimi/DashScope)"
+    "OpenAI-compat [DONE] without finish_reason fails closed"
   =
   let acc = Complete_stream_acc.create_stream_acc () in
   let st = Streaming.create_openai_stream_state ~provider:"openai" ~model:"m" () in
@@ -169,8 +166,10 @@ let%test
     {|{"choices":[{"delta":{"content":"hi"},"finish_reason":null}]}|};
   accumulate_openai_payload acc st "[DONE]";
   match Complete_stream_acc.finalize_stream_acc acc with
-  | Ok resp -> resp.stop_reason = Types.EndTurn
-  | Error _ -> false
+  | Error
+      (Types.Stream_incomplete
+        { reason = "stream_terminal_without_stop_reason" }) -> true
+  | Error _ | Ok _ -> false
 ;;
 
 (* The [DONE] sentinel must not overwrite a real stop_reason that already

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -150,8 +150,8 @@ let%test "Ollama done without reason finalizes typed incomplete" =
      accumulate_events acc (fst (Streaming.ollama_chunk_to_events st chunk))
    | Streaming.Ollama_provider_error _ | Streaming.Ollama_parse_failed _ -> ());
   match Complete_stream_acc.finalize_stream_acc acc with
-  | Error (Types.Stream_incomplete { reason = "stream_terminated_without_stop_reason" }) ->
-    true
+  | Error (Types.Stream_incomplete { reason = "stream_terminated_without_stop_reason" })
+    -> true
   | Error _ | Ok _ -> false
 ;;
 

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -181,9 +181,8 @@ let accumulate_event (acc : stream_acc) = function
   | Types.MessageStop ->
     (* Explicit terminal sentinel from the provider ([data: [DONE]] for
        OpenAI-compatible streams, [message_stop] for Anthropic). It carries no
-       stop_reason, but its presence proves the stream closed cleanly rather than
-       being truncated, so the finalizer may default a missing stop_reason to
-       EndTurn instead of failing closed. *)
+       stop_reason. Its presence distinguishes a provider contract violation
+       from a truncated transport, but cannot synthesize completion semantics. *)
     acc.done_sentinel_seen := true
   | Types.Ping | Types.Connected | Types.Timeout _ -> ()
 ;;
@@ -224,24 +223,17 @@ let block_kind_of_string = function
 let finalize_stream_acc (acc : stream_acc) =
   match !(acc.sse_error) with
   | Some serr -> Error serr
-  | None when (not !(acc.stop_reason_received)) && not !(acc.done_sentinel_seen) ->
-    (* Stream ended without a terminal stop_reason AND without an explicit
-       terminal sentinel. This is a truncated stream: the connection dropped
-       mid-stream (End_of_file in sse_parser) before any [data: [DONE]] /
-       message_stop arrived. Without this check the default EndTurn would make a
-       truncated stream look like a successful completion (phantom completion).
-
-       When a sentinel WAS seen ([done_sentinel_seen] is true) the stream closed
-       cleanly, so we fall through to the success arm below even if no
-       stop_reason was reported -- some OpenAI-compatible providers send
-       [data: [DONE]] with every prior chunk carrying [finish_reason: null], and
-       [acc.stop_reason] already defaults to EndTurn. This mirrors the
-       Ollama-native ([done: true]) and Responses-API terminal defaults; only a
-       sentinel-less close is rejected. *)
+  | None when not !(acc.stop_reason_received) ->
+    (* A terminal sentinel proves transport closure, not why the model stopped.
+       Missing provider semantics stay typed as incomplete instead of being
+       silently promoted to [EndTurn]. *)
     Error
-      (* Preserve the established diagnostic reason while giving callers a
-         typed incomplete-stream fact instead of calling it malformed JSON. *)
-      (Types.Stream_incomplete { reason = "stream_terminated_without_stop_reason" })
+      (Types.Stream_incomplete
+         { reason =
+             (if !(acc.done_sentinel_seen)
+              then "stream_terminal_without_stop_reason"
+              else "stream_terminated_without_stop_reason")
+         })
   | None ->
     let indices =
       Hashtbl.fold (fun k _ acc -> k :: acc) acc.block_types [] |> List.sort compare

--- a/lib/llm_provider/responses_stop_reason.ml
+++ b/lib/llm_provider/responses_stop_reason.ml
@@ -104,10 +104,6 @@ let%test "unknown status with tools remains non-executable" =
 ;;
 
 let%test "missing status with tools remains non-executable" =
-  of_status
-    ~status:None
-    ~incomplete_reason:None
-    ~failed_message:None
-    ~has_tool_calls:true
+  of_status ~status:None ~incomplete_reason:None ~failed_message:None ~has_tool_calls:true
   = Types.Unknown "missing_status"
 ;;

--- a/lib/llm_provider/responses_stop_reason.ml
+++ b/lib/llm_provider/responses_stop_reason.ml
@@ -1,9 +1,5 @@
 (** OpenAI Responses terminal status -> stop_reason SSOT. *)
 
-let normalized_status status =
-  status |> Option.value ~default:"" |> String.lowercase_ascii
-;;
-
 let incomplete_stop_reason incomplete_reason =
   match incomplete_reason with
   | Some "max_output_tokens" -> Types.MaxTokens
@@ -22,12 +18,15 @@ let failed_stop_reason failed_message =
 ;;
 
 let of_status ~status ~incomplete_reason ~failed_message ~has_tool_calls =
-  match normalized_status status with
-  | "incomplete" -> incomplete_stop_reason incomplete_reason
-  | "failed" -> failed_stop_reason failed_message
-  | _ when has_tool_calls -> Types.StopToolUse
-  | "completed" | "" -> Types.EndTurn
-  | other -> Types.Unknown other
+  match status with
+  | None -> Types.Unknown "missing_status"
+  | Some status ->
+    (match String.lowercase_ascii status with
+     | "incomplete" -> incomplete_stop_reason incomplete_reason
+     | "failed" -> failed_stop_reason failed_message
+     | "completed" when has_tool_calls -> Types.StopToolUse
+     | "completed" -> Types.EndTurn
+     | other -> Types.Unknown other)
 ;;
 
 [@@@coverage off]
@@ -93,4 +92,22 @@ let%test "unknown status without tools is preserved" =
     ~failed_message:None
     ~has_tool_calls:false
   = Types.Unknown "queued"
+;;
+
+let%test "unknown status with tools remains non-executable" =
+  of_status
+    ~status:(Some "queued")
+    ~incomplete_reason:None
+    ~failed_message:None
+    ~has_tool_calls:true
+  = Types.Unknown "queued"
+;;
+
+let%test "missing status with tools remains non-executable" =
+  of_status
+    ~status:None
+    ~incomplete_reason:None
+    ~failed_message:None
+    ~has_tool_calls:true
+  = Types.Unknown "missing_status"
 ;;

--- a/lib/llm_provider/responses_stop_reason.ml
+++ b/lib/llm_provider/responses_stop_reason.ml
@@ -8,7 +8,10 @@ let incomplete_stop_reason incomplete_reason =
   match incomplete_reason with
   | Some "max_output_tokens" -> Types.MaxTokens
   | Some "content_filter" -> Types.ContentFilter
-  | Some reason -> Types.Unknown reason
+  | Some reason ->
+    (match Types.stop_reason_of_string (String.lowercase_ascii reason) with
+     | Types.ContextWindowExceeded -> Types.ContextWindowExceeded
+     | _ -> Types.Unknown reason)
   | None -> Types.Unknown "incomplete"
 ;;
 
@@ -45,6 +48,15 @@ let%test "incomplete content filter is typed" =
     ~failed_message:None
     ~has_tool_calls:true
   = Types.ContentFilter
+;;
+
+let%test "incomplete context overflow is typed" =
+  of_status
+    ~status:(Some "incomplete")
+    ~incomplete_reason:(Some "model_context_window_exceeded")
+    ~failed_message:None
+    ~has_tool_calls:false
+  = Types.ContextWindowExceeded
 ;;
 
 let%test "unknown incomplete reason remains unknown" =

--- a/lib/llm_provider/responses_stop_reason.ml
+++ b/lib/llm_provider/responses_stop_reason.ml
@@ -19,14 +19,15 @@ let failed_stop_reason failed_message =
 
 let of_status ~status ~incomplete_reason ~failed_message ~has_tool_calls =
   match status with
-  | None -> Types.Unknown "missing_status"
+  | None -> None
   | Some status ->
-    (match String.lowercase_ascii status with
-     | "incomplete" -> incomplete_stop_reason incomplete_reason
-     | "failed" -> failed_stop_reason failed_message
-     | "completed" when has_tool_calls -> Types.StopToolUse
-     | "completed" -> Types.EndTurn
-     | other -> Types.Unknown other)
+    Some
+      (match String.lowercase_ascii status with
+       | "incomplete" -> incomplete_stop_reason incomplete_reason
+       | "failed" -> failed_stop_reason failed_message
+       | "completed" when has_tool_calls -> Types.StopToolUse
+       | "completed" -> Types.EndTurn
+       | other -> Types.Unknown other)
 ;;
 
 [@@@coverage off]
@@ -37,7 +38,7 @@ let%test "incomplete max output tokens wins over tool calls" =
     ~incomplete_reason:(Some "max_output_tokens")
     ~failed_message:None
     ~has_tool_calls:true
-  = Types.MaxTokens
+  = Some Types.MaxTokens
 ;;
 
 let%test "incomplete content filter is typed" =
@@ -46,7 +47,7 @@ let%test "incomplete content filter is typed" =
     ~incomplete_reason:(Some "content_filter")
     ~failed_message:None
     ~has_tool_calls:true
-  = Types.ContentFilter
+  = Some Types.ContentFilter
 ;;
 
 let%test "incomplete context overflow is typed" =
@@ -55,7 +56,7 @@ let%test "incomplete context overflow is typed" =
     ~incomplete_reason:(Some "model_context_window_exceeded")
     ~failed_message:None
     ~has_tool_calls:false
-  = Types.ContextWindowExceeded
+  = Some Types.ContextWindowExceeded
 ;;
 
 let%test "unknown incomplete reason remains unknown" =
@@ -64,7 +65,7 @@ let%test "unknown incomplete reason remains unknown" =
     ~incomplete_reason:(Some "tool_use")
     ~failed_message:None
     ~has_tool_calls:true
-  = Types.Unknown "tool_use"
+  = Some (Types.Unknown "tool_use")
 ;;
 
 let%test "failed message wins over tool calls" =
@@ -73,7 +74,7 @@ let%test "failed message wins over tool calls" =
     ~incomplete_reason:None
     ~failed_message:(Some "quota exhausted")
     ~has_tool_calls:true
-  = Types.Unknown "quota exhausted"
+  = Some (Types.Unknown "quota exhausted")
 ;;
 
 let%test "completed with tool calls is tool use" =
@@ -82,7 +83,7 @@ let%test "completed with tool calls is tool use" =
     ~incomplete_reason:None
     ~failed_message:None
     ~has_tool_calls:true
-  = Types.StopToolUse
+  = Some Types.StopToolUse
 ;;
 
 let%test "unknown status without tools is preserved" =
@@ -91,7 +92,7 @@ let%test "unknown status without tools is preserved" =
     ~incomplete_reason:None
     ~failed_message:None
     ~has_tool_calls:false
-  = Types.Unknown "queued"
+  = Some (Types.Unknown "queued")
 ;;
 
 let%test "unknown status with tools remains non-executable" =
@@ -100,10 +101,10 @@ let%test "unknown status with tools remains non-executable" =
     ~incomplete_reason:None
     ~failed_message:None
     ~has_tool_calls:true
-  = Types.Unknown "queued"
+  = Some (Types.Unknown "queued")
 ;;
 
-let%test "missing status with tools remains non-executable" =
+let%test "missing status remains absent" =
   of_status ~status:None ~incomplete_reason:None ~failed_message:None ~has_tool_calls:true
-  = Types.Unknown "missing_status"
+  = None
 ;;

--- a/lib/llm_provider/responses_stop_reason.mli
+++ b/lib/llm_provider/responses_stop_reason.mli
@@ -4,11 +4,14 @@
     Responses exposes terminal state through [status] plus optional
     [incomplete_details.reason] / [error.message]. Both the non-streaming
     Responses parser and the Responses SSE terminal event handler must use this
-    module so cut-off or failed responses win over partial tool-call items. *)
+    module so cut-off or failed responses win over partial tool-call items.
+    A missing [status] stays [None]; callers either reject before returning a
+    non-streaming response or let the stream accumulator report an incomplete
+    terminal contract. *)
 
 val of_status
   :  status:string option
   -> incomplete_reason:string option
   -> failed_message:string option
   -> has_tool_calls:bool
-  -> Types.stop_reason
+  -> Types.stop_reason option

--- a/lib/llm_provider/stop_reason_wire.ml
+++ b/lib/llm_provider/stop_reason_wire.ml
@@ -48,16 +48,7 @@ let of_finish (w : wire_finish) ~has_tool_blocks : Types.stop_reason =
   | Content_filter -> Types.ContentFilter
   | Repetition_truncation -> Types.RepetitionTruncation
   | Context_window_exceeded -> Types.ContextWindowExceeded
-  | Other other ->
-    (* [Other] means the token is not representable in the provider finish
-       vocabulary, not that the canonical stop-reason decoder failed. Keep a
-       typed canonical value when one exists. Ollama historically treats any
-       terminal reason accompanied by complete tool blocks as a tool request;
-       preserve that provider contract while retaining [Unknown] for a truly
-       unknown reason without tools. *)
-    if has_tool_blocks
-    then Types.StopToolUse
-    else Types.stop_reason_of_string other
+  | Other other -> Types.Unknown other
 ;;
 
 let provisional_of_string s : Types.stop_reason =
@@ -161,10 +152,6 @@ let%test "reconcile preserves EndTurn without tools" =
 let%test "reconcile preserves Unknown with tools as non-executable" =
   reconcile (Types.Unknown "provider_terminal") ~has_tool_blocks:true
   = Types.Unknown "provider_terminal"
-;;
-
-let%test "of_finish restores canonical reason outside wire vocabulary" =
-  of_finish (Other "stop_sequence") ~has_tool_blocks:false = Types.StopSequence
 ;;
 
 (* Truncation safety: MaxTokens + tool blocks is NOT upgraded, because a

--- a/lib/llm_provider/stop_reason_wire.ml
+++ b/lib/llm_provider/stop_reason_wire.ml
@@ -48,7 +48,16 @@ let of_finish (w : wire_finish) ~has_tool_blocks : Types.stop_reason =
   | Content_filter -> Types.ContentFilter
   | Repetition_truncation -> Types.RepetitionTruncation
   | Context_window_exceeded -> Types.ContextWindowExceeded
-  | Other other -> Types.Unknown other
+  | Other other ->
+    (* [Other] means the token is not representable in the provider finish
+       vocabulary, not that the canonical stop-reason decoder failed. Keep a
+       typed canonical value when one exists. Ollama historically treats any
+       terminal reason accompanied by complete tool blocks as a tool request;
+       preserve that provider contract while retaining [Unknown] for a truly
+       unknown reason without tools. *)
+    if has_tool_blocks
+    then Types.StopToolUse
+    else Types.stop_reason_of_string other
 ;;
 
 let provisional_of_string s : Types.stop_reason =
@@ -152,6 +161,10 @@ let%test "reconcile preserves EndTurn without tools" =
 let%test "reconcile preserves Unknown with tools as non-executable" =
   reconcile (Types.Unknown "provider_terminal") ~has_tool_blocks:true
   = Types.Unknown "provider_terminal"
+;;
+
+let%test "of_finish restores canonical reason outside wire vocabulary" =
+  of_finish (Other "stop_sequence") ~has_tool_blocks:false = Types.StopSequence
 ;;
 
 (* Truncation safety: MaxTokens + tool blocks is NOT upgraded, because a

--- a/lib/llm_provider/stop_reason_wire.ml
+++ b/lib/llm_provider/stop_reason_wire.ml
@@ -9,23 +9,27 @@ type wire_finish =
   | Other of string
 
 let wire_finish_of_string s =
-  match String.lowercase_ascii s with
+  let normalized = String.lowercase_ascii s in
+  match normalized with
   | "tool_calls" -> Tool_calls
-  | "length" | "max_tokens" | "length_limit" -> Length
-  | "stop" | "end_turn" -> Stop
-  | "refusal" -> Refusal
-  | "content_filter" -> Content_filter
-  | "repetition_truncation" -> Repetition_truncation
-  (* SSOT parity with [Types.stop_reason_of_string]: the OpenAI/GLM finish-reason
-     decoder must recognize canonical and provider-dialect overflow tokens so an
-     empty completion that reports it reaches [Retry.overflow_of_empty_completion]
-     as [ContextWindowExceeded] instead of the [Unknown _] dead arm. *)
-  | "model_context_window_exceeded"
-  | "context_window_exceeded"
-  | "context_length_exceeded"
-  | "max_context_length"
-  | "context_limit_exceeded" -> Context_window_exceeded
-  | other -> Other other
+  | "stop" -> Stop
+  | other ->
+    (* [Types.stop_reason_of_string] owns the canonical and provider-dialect
+       tokens.  This boundary only translates that typed result into the
+       smaller finish-reason vocabulary needed for tool-block reconciliation. *)
+    (match Types.stop_reason_of_string other with
+     | Types.StopToolUse -> Tool_calls
+     | Types.EndTurn -> Stop
+     | Types.MaxTokens -> Length
+     | Types.Refusal -> Refusal
+     | Types.ContentFilter -> Content_filter
+     | Types.RepetitionTruncation -> Repetition_truncation
+     | Types.ContextWindowExceeded -> Context_window_exceeded
+     | Types.StopSequence
+     | Types.PauseTurn
+     | Types.Compaction
+     | Types.UnmatchedToolCalls
+     | Types.Unknown _ -> Other other)
 ;;
 
 let of_finish (w : wire_finish) ~has_tool_blocks : Types.stop_reason =

--- a/lib/llm_provider/stop_reason_wire.ml
+++ b/lib/llm_provider/stop_reason_wire.ml
@@ -48,7 +48,7 @@ let of_finish (w : wire_finish) ~has_tool_blocks : Types.stop_reason =
   | Content_filter -> Types.ContentFilter
   | Repetition_truncation -> Types.RepetitionTruncation
   | Context_window_exceeded -> Types.ContextWindowExceeded
-  | Other other -> Types.Unknown other
+  | Other other -> Types.stop_reason_of_string other
 ;;
 
 let provisional_of_string s : Types.stop_reason =
@@ -60,7 +60,7 @@ let provisional_of_string s : Types.stop_reason =
   | Content_filter -> Types.ContentFilter
   | Repetition_truncation -> Types.RepetitionTruncation
   | Context_window_exceeded -> Types.ContextWindowExceeded
-  | Other other -> Types.Unknown other
+  | Other other -> Types.stop_reason_of_string other
 ;;
 
 let reconcile (sr : Types.stop_reason) ~has_tool_blocks : Types.stop_reason =
@@ -152,6 +152,14 @@ let%test "reconcile preserves EndTurn without tools" =
 let%test "reconcile preserves Unknown with tools as non-executable" =
   reconcile (Types.Unknown "provider_terminal") ~has_tool_blocks:true
   = Types.Unknown "provider_terminal"
+;;
+
+let%test "of_finish restores canonical reason outside wire vocabulary" =
+  of_finish (Other "stop_sequence") ~has_tool_blocks:true = Types.StopSequence
+;;
+
+let%test "provisional restores canonical reason outside wire vocabulary" =
+  provisional_of_string "pause_turn" = Types.PauseTurn
 ;;
 
 (* Truncation safety: MaxTokens + tool blocks is NOT upgraded, because a

--- a/lib/llm_provider/stop_reason_wire.mli
+++ b/lib/llm_provider/stop_reason_wire.mli
@@ -26,13 +26,11 @@ type wire_finish =
   | Context_window_exceeded
   | Other of string
 
-(** Case-insensitive OpenAI-compatible vocabulary. ["end_turn"] maps to [Stop].
-    ["model_context_window_exceeded"] maps to [Context_window_exceeded] so the
-    OpenAI/GLM finish-reason decoder recognizes the same overflow token as the
-    canonical {!Types.stop_reason_of_string} decoder (previously only the
-    Anthropic/cache path decoded it; the OpenAI/GLM path surfaced it as
-    [Other _ -> Types.Unknown], which the empty-completion overflow classifier
-    routed to provider-unavailability instead of context overflow). *)
+(** Case-insensitive OpenAI-compatible vocabulary. OpenAI-specific
+    ["tool_calls"] and ["stop"] are handled here; canonical and provider-dialect
+    tokens are owned by {!Types.stop_reason_of_string} and translated from its
+    typed result. Thus an overflow token reaches [Context_window_exceeded]
+    without duplicating its wire spellings in this module. *)
 val wire_finish_of_string : string -> wire_finish
 
 (** Canonical parse-time mapping for backends that know the assembled tool-block

--- a/lib/llm_provider/stop_reason_wire.mli
+++ b/lib/llm_provider/stop_reason_wire.mli
@@ -27,16 +27,19 @@ type wire_finish =
   | Other of string
 
 (** Case-insensitive OpenAI-compatible vocabulary. OpenAI-specific
-    ["tool_calls"] and ["stop"] are handled here; canonical and provider-dialect
-    tokens are owned by {!Types.stop_reason_of_string} and translated from its
-    typed result. Thus an overflow token reaches [Context_window_exceeded]
-    without duplicating its wire spellings in this module. *)
+    ["tool_calls"] and ["stop"] are handled here because the canonical
+    {!Types.stop_reason_of_string} spellings are ["tool_use"] and ["end_turn"].
+    All other canonical and provider-dialect tokens are owned by that decoder
+    and translated from its typed result. Thus an overflow token reaches
+    [Context_window_exceeded] without duplicating its wire spellings here. *)
 val wire_finish_of_string : string -> wire_finish
 
 (** Canonical parse-time mapping for backends that know the assembled tool-block
     set at parse time (the non-streaming OpenAI parser). [Tool_calls] without a
-    tool block fails closed to [UnmatchedToolCalls]. [Other] preserves the raw
-    terminal label as non-executable [Unknown], regardless of content. [Stop]
+    tool block fails closed to [UnmatchedToolCalls]. [Other] re-decodes through
+    {!Types.stop_reason_of_string}: canonical tokens outside this module's
+    vocabulary keep their typed value and unrecognized tokens stay [Unknown].
+    No token reaching [Other] maps to executable [StopToolUse]. [Stop]
     (finish_reason=stop/end_turn) with a tool block present upgrades to
     [StopToolUse] — a provider that emits complete tool_calls but labels the
     turn as normal completion is mislabeling a tool-request turn, and the

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -2437,12 +2437,10 @@ let ollama_chunk_to_events (state : openai_stream_state) (chunk : ollama_chunk)
       match chunk.oll_done_reason with
       | None -> Some EndTurn
       | Some reason ->
-        (match String.lowercase_ascii reason with
-         | "tool_calls" when chunk.oll_tool_calls <> [] -> Some StopToolUse
-         | "length" -> Some MaxTokens
-         | "stop" -> Some EndTurn
-         | _other when chunk.oll_tool_calls <> [] -> Some StopToolUse
-         | other -> Some (Unknown other))
+        Some
+          (Stop_reason_wire.of_finish
+             (Stop_reason_wire.wire_finish_of_string reason)
+             ~has_tool_blocks:(chunk.oll_tool_calls <> []))
     in
     emit (MessageDelta { stop_reason; usage = chunk.oll_usage }));
   List.rev !events, !telemetry_event
@@ -2643,6 +2641,22 @@ let%test "ollama_chunk_to_events: done with stop_reason emits MessageDelta" =
   | unexpected_events ->
     let (_ : sse_event list) = unexpected_events in
     false
+;;
+
+let%test "ollama_chunk_to_events: overflow reason stays typed" =
+  let state = create_openai_stream_state () in
+  let chunk =
+    { oll_content = ""
+    ; oll_thinking = None
+    ; oll_tool_calls = []
+    ; oll_is_done = true
+    ; oll_done_reason = Some "model_context_window_exceeded"
+    ; oll_usage = None
+    }
+  in
+  match fst (ollama_chunk_to_events state chunk) with
+  | [ MessageDelta { stop_reason = Some ContextWindowExceeded; usage = None } ] -> true
+  | _ -> false
 ;;
 
 let%test "ollama_chunk_to_events: done with zero usage → usage=None" =

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -1341,7 +1341,7 @@ let%test
     }
   in
   let state = create_openai_stream_state () in
-  let chunk =
+  let chunk : ollama_chunk =
     { chunk_id = "c"
     ; chunk_model = "minimax-m3"
     ; delta_content = None

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -2646,12 +2646,14 @@ let%test "ollama_chunk_to_events: done with stop_reason emits MessageDelta" =
 let%test "ollama_chunk_to_events: overflow reason stays typed" =
   let state = create_openai_stream_state () in
   let chunk : ollama_chunk =
-    { oll_content = ""
-    ; oll_thinking = None
+    { oll_model = "dashscope-3:8b"
+    ; oll_delta_content = None
+    ; oll_delta_thinking = None
     ; oll_tool_calls = []
-    ; oll_is_done = true
     ; oll_done_reason = Some "model_context_window_exceeded"
+    ; oll_is_done = true
     ; oll_usage = None
+    ; oll_timings = None
     }
   in
   match fst (ollama_chunk_to_events state chunk) with

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -1711,7 +1711,7 @@ let responses_sse_to_events (state : openai_stream_state) event_type data_str
       let emit_terminal response =
         emit
           (MessageDelta
-             { stop_reason = Some (responses_stop_reason_of_response response)
+             { stop_reason = responses_stop_reason_of_response response
              ; usage = responses_usage_of_response response
              });
         emit MessageStop
@@ -2435,7 +2435,10 @@ let ollama_chunk_to_events (state : openai_stream_state) (chunk : ollama_chunk)
   then (
     let stop_reason =
       match chunk.oll_done_reason with
-      | None -> Some (Unknown "missing_done_reason")
+      (* Non-streaming parsing can reject before returning content. Streaming
+         may already have delivered deltas, so absence stays [None] and the
+         accumulator returns typed [Stream_incomplete] at finalization. *)
+      | None -> None
       | Some reason ->
         Some
           (Stop_reason_wire.of_finish

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -1341,7 +1341,7 @@ let%test
     }
   in
   let state = create_openai_stream_state () in
-  let chunk : ollama_chunk =
+  let chunk =
     { chunk_id = "c"
     ; chunk_model = "minimax-m3"
     ; delta_content = None
@@ -2645,7 +2645,7 @@ let%test "ollama_chunk_to_events: done with stop_reason emits MessageDelta" =
 
 let%test "ollama_chunk_to_events: overflow reason stays typed" =
   let state = create_openai_stream_state () in
-  let chunk =
+  let chunk : ollama_chunk =
     { oll_content = ""
     ; oll_thinking = None
     ; oll_tool_calls = []

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -2435,7 +2435,7 @@ let ollama_chunk_to_events (state : openai_stream_state) (chunk : ollama_chunk)
   then (
     let stop_reason =
       match chunk.oll_done_reason with
-      | None -> Some EndTurn
+      | None -> Some (Unknown "missing_done_reason")
       | Some reason ->
         Some
           (Stop_reason_wire.of_finish

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -1614,28 +1614,43 @@ let test_responses_stop_reason_ssot_status_table () =
     true
     (Responses_stop_reason.of_status
        ~status:(Some "failed")
-       ~incomplete_reason:None
-       ~failed_message:(Some "quota exhausted")
-       ~has_tool_calls:true
-     = Unknown "quota exhausted");
+     ~incomplete_reason:None
+     ~failed_message:(Some "quota exhausted")
+     ~has_tool_calls:true
+     = Some (Unknown "quota exhausted"));
   check_bool
     "completed with tool calls is tool use"
     true
     (Responses_stop_reason.of_status
        ~status:(Some "completed")
-       ~incomplete_reason:None
-       ~failed_message:None
-       ~has_tool_calls:true
-     = StopToolUse);
+     ~incomplete_reason:None
+     ~failed_message:None
+     ~has_tool_calls:true
+     = Some StopToolUse);
   check_bool
     "unknown status without tools is preserved"
     true
     (Responses_stop_reason.of_status
        ~status:(Some "queued")
+     ~incomplete_reason:None
+     ~failed_message:None
+     ~has_tool_calls:false
+     = Some (Unknown "queued"));
+  check_bool
+    "missing status stays absent"
+    true
+    (Responses_stop_reason.of_status
+       ~status:None
        ~incomplete_reason:None
        ~failed_message:None
-       ~has_tool_calls:false
-     = Unknown "queued")
+       ~has_tool_calls:true
+     = None);
+  match Backend_openai_responses.parse_response_result
+          {|{"id":"resp-missing-status","model":"m","output":[]}|}
+  with
+  | Error "malformed_openai_responses:missing_status" -> ()
+  | Error message -> Alcotest.fail ("unexpected missing-status error: " ^ message)
+  | Ok _ -> Alcotest.fail "missing Responses status must fail closed"
 ;;
 
 let test_responses_preserves_encrypted_reasoning_item_for_replay () =

--- a/test/test_backend_openai_codec.ml
+++ b/test/test_backend_openai_codec.ml
@@ -1614,27 +1614,27 @@ let test_responses_stop_reason_ssot_status_table () =
     true
     (Responses_stop_reason.of_status
        ~status:(Some "failed")
-     ~incomplete_reason:None
-     ~failed_message:(Some "quota exhausted")
-     ~has_tool_calls:true
+       ~incomplete_reason:None
+       ~failed_message:(Some "quota exhausted")
+       ~has_tool_calls:true
      = Some (Unknown "quota exhausted"));
   check_bool
     "completed with tool calls is tool use"
     true
     (Responses_stop_reason.of_status
        ~status:(Some "completed")
-     ~incomplete_reason:None
-     ~failed_message:None
-     ~has_tool_calls:true
+       ~incomplete_reason:None
+       ~failed_message:None
+       ~has_tool_calls:true
      = Some StopToolUse);
   check_bool
     "unknown status without tools is preserved"
     true
     (Responses_stop_reason.of_status
        ~status:(Some "queued")
-     ~incomplete_reason:None
-     ~failed_message:None
-     ~has_tool_calls:false
+       ~incomplete_reason:None
+       ~failed_message:None
+       ~has_tool_calls:false
      = Some (Unknown "queued"));
   check_bool
     "missing status stays absent"
@@ -1645,8 +1645,9 @@ let test_responses_stop_reason_ssot_status_table () =
        ~failed_message:None
        ~has_tool_calls:true
      = None);
-  match Backend_openai_responses.parse_response_result
-          {|{"id":"resp-missing-status","model":"m","output":[]}|}
+  match
+    Backend_openai_responses.parse_response_result
+      {|{"id":"resp-missing-status","model":"m","output":[]}|}
   with
   | Error "malformed_openai_responses:missing_status" -> ()
   | Error message -> Alcotest.fail ("unexpected missing-status error: " ^ message)

--- a/test/test_streaming_coverage.ml
+++ b/test/test_streaming_coverage.ml
@@ -228,11 +228,10 @@ let test_acc_message_delta_stop_reason () =
 let test_acc_message_delta_none_stop_reason () =
   let acc = Streaming.create_stream_acc () in
   Streaming.accumulate_event acc (MessageDelta { stop_reason = None; usage = None });
-  let resp = finalize_ok acc in
-  (* Default is EndTurn *)
-  match resp.stop_reason with
-  | EndTurn -> ()
-  | _ -> Alcotest.fail "expected default EndTurn"
+  match Streaming.finalize_stream_acc acc with
+  | Error (Stream_incomplete { reason = "stream_terminated_without_stop_reason" }) -> ()
+  | Error _ -> Alcotest.fail "expected typed missing stop reason"
+  | Ok _ -> Alcotest.fail "missing stop reason must not become EndTurn"
 ;;
 
 let test_acc_message_delta_with_usage () =

--- a/test/test_streaming_edge_cases.ml
+++ b/test/test_streaming_edge_cases.ml
@@ -738,7 +738,7 @@ let test_ollama_event_edge_branches () =
       (S.create_openai_stream_state ())
       (ollama_chunk ~is_done:true ())
   in
-   (match done_none_events with
+  (match done_none_events with
    | [ MessageDelta { stop_reason = None; _ } ] -> ()
    | _ -> fail "done without reason should remain absent");
   let done_length_events, _ =

--- a/test/test_streaming_edge_cases.ml
+++ b/test/test_streaming_edge_cases.ml
@@ -738,9 +738,9 @@ let test_ollama_event_edge_branches () =
       (S.create_openai_stream_state ())
       (ollama_chunk ~is_done:true ())
   in
-  (match done_none_events with
-   | [ MessageDelta { stop_reason = Some (Unknown "missing_done_reason"); _ } ] -> ()
-   | _ -> fail "done without reason should remain non-executable");
+   (match done_none_events with
+   | [ MessageDelta { stop_reason = None; _ } ] -> ()
+   | _ -> fail "done without reason should remain absent");
   let done_length_events, _ =
     S.ollama_chunk_to_events
       (S.create_openai_stream_state ())

--- a/test/test_streaming_edge_cases.ml
+++ b/test/test_streaming_edge_cases.ml
@@ -739,8 +739,8 @@ let test_ollama_event_edge_branches () =
       (ollama_chunk ~is_done:true ())
   in
   (match done_none_events with
-   | [ MessageDelta { stop_reason = Some EndTurn; _ } ] -> ()
-   | _ -> fail "done without reason should be EndTurn");
+   | [ MessageDelta { stop_reason = Some (Unknown "missing_done_reason"); _ } ] -> ()
+   | _ -> fail "done without reason should remain non-executable");
   let done_length_events, _ =
     S.ollama_chunk_to_events
       (S.create_openai_stream_state ())

--- a/test/test_streaming_edge_cases.ml
+++ b/test/test_streaming_edge_cases.ml
@@ -764,8 +764,8 @@ let test_ollama_event_edge_branches () =
       (ollama_chunk ~is_done:true ~done_reason:"content_filter" ())
   in
   match done_unknown_events with
-  | [ MessageDelta { stop_reason = Some (Unknown "content_filter"); _ } ] -> ()
-  | _ -> fail "unknown done reason should be preserved"
+  | [ MessageDelta { stop_reason = Some ContentFilter; _ } ] -> ()
+  | _ -> fail "canonical content_filter reason should stay typed"
 ;;
 
 let () =

--- a/test/test_streaming_edge_cases.ml
+++ b/test/test_streaming_edge_cases.ml
@@ -755,8 +755,9 @@ let test_ollama_event_edge_branches () =
       (ollama_chunk ~is_done:true ~done_reason:"future" ~tool_calls:[ tc_none ] ())
   in
   (match done_unknown_tool_events with
-   | [ ContentBlockStart _; MessageDelta { stop_reason = Some StopToolUse; _ } ] -> ()
-   | _ -> fail "unknown done reason with tools should stop for tool use");
+   | [ ContentBlockStart _; MessageDelta { stop_reason = Some (Unknown "future"); _ } ] ->
+     ()
+   | _ -> fail "unknown done reason with tools should remain non-executable");
   let done_unknown_events, _ =
     S.ollama_chunk_to_events
       (S.create_openai_stream_state ())


### PR DESCRIPTION
## Summary
- decode Ollama non-streaming `done_reason` through the shared typed stop-reason boundary
- decode Ollama NDJSON terminal reasons through the same boundary
- preserve typed context overflow for OpenAI Responses incomplete outcomes

## Why
MASC is removing its downstream semantic-string fallback for `Unknown "model_context_window_exceeded"`. OAS must therefore preserve the typed `ContextWindowExceeded` contract at every producer boundary instead of requiring a consumer workaround.

## Validation
- `ocamlformat --check` on all changed files
- `ocamlc -stop-after parsing` on all changed files
- `git diff --check`
- no local Dune; CI is build authority

## Linked radius
- unblocks the current-only hard cut in MASC #26667
- no migration, legacy compatibility, consumer string matching, or facade chain added