### PR TITLE
fix(session): reuse OS entropy ID generator

### DIFF
--- a/lib/session.ml
+++ b/lib/session.ml
@@ -19,7 +19,10 @@ let generate_id () =
 
 let create ?id ?resumed_from ?cwd ?(metadata = Context.create_sync ()) () =
   let now = Unix.gettimeofday () in
-  { id = Option.value id ~default:(generate_id ())
+  { id =
+      (match id with
+       | Some id -> id
+       | None -> generate_id ())
   ; started_at = now
   ; last_active_at = now
   ; turn_count = 0

--- a/lib/session.ml
+++ b/lib/session.ml
@@ -11,10 +11,12 @@ type t =
   ; metadata : Context.t
   }
 
+exception Entropy_unavailable of string
+
 let generate_id () =
   match Random_id.create () with
   | Ok value -> "session-" ^ value
-  | Error message -> failwith ("Session.generate_id: " ^ message)
+  | Error message -> raise (Entropy_unavailable message)
 ;;
 
 let create ?id ?resumed_from ?cwd ?(metadata = Context.create_sync ()) () =

--- a/lib/session.ml
+++ b/lib/session.ml
@@ -12,10 +12,9 @@ type t =
   }
 
 let generate_id () =
-  let t = Unix.gettimeofday () in
-  let hi = Float.to_int (Float.rem t 1_000_000.) in
-  let lo = Random.int 0xFFFF in
-  Printf.sprintf "session-%06x%04x" hi lo
+  match Random_id.create () with
+  | Ok value -> "session-" ^ value
+  | Error message -> failwith ("Session.generate_id: " ^ message)
 ;;
 
 let create ?id ?resumed_from ?cwd ?(metadata = Context.create_sync ()) () =

--- a/lib/session.mli
+++ b/lib/session.mli
@@ -21,11 +21,16 @@ type t =
 
 (** {1 Lifecycle} *)
 
-(** Generate a session ID from operating-system entropy. Raises if the OS
-    entropy source is unavailable. *)
+(** Raised when the operating-system entropy source cannot mint a session ID. *)
+exception Entropy_unavailable of string
+
+(** Generate a session ID from operating-system entropy.
+    @raise Entropy_unavailable if the entropy source is unavailable. *)
 val generate_id : unit -> string
 
-(** Create a new session. *)
+(** Create a new session.
+    @raise Entropy_unavailable when [id] is omitted and the entropy source is
+    unavailable. *)
 val create
   :  ?id:string
   -> ?resumed_from:string
@@ -43,7 +48,8 @@ val touch : t -> t
 (** Elapsed seconds since session start. *)
 val elapsed : t -> float
 
-(** Resume a session from a checkpoint. *)
+(** Resume a session from a checkpoint.
+    @raise Entropy_unavailable if the entropy source is unavailable. *)
 val resume_from : Checkpoint.t -> t
 
 (** {1 Serialization} *)

--- a/lib/session.mli
+++ b/lib/session.mli
@@ -21,7 +21,8 @@ type t =
 
 (** {1 Lifecycle} *)
 
-(** Generate a unique session ID. *)
+(** Generate a session ID from operating-system entropy. Raises if the OS
+    entropy source is unavailable. *)
 val generate_id : unit -> string
 
 (** Create a new session. *)

--- a/test/test_session.ml
+++ b/test/test_session.ml
@@ -11,7 +11,11 @@ let () =
               bool
               "starts with session-"
               true
-              (String.length s.id > 8 && String.sub s.id 0 8 = "session-"))
+              (String.length s.id = 40
+               && String.sub s.id 0 8 = "session-"
+               && String.for_all
+                    (fun ch -> (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f'))
+                    (String.sub s.id 8 32)))
         ; test_case "custom id" `Quick (fun () ->
             let s = Session.create ~id:"my-session" () in
             check string "id" "my-session" s.id)


### PR DESCRIPTION
## 문제

Session.generate_id만 같은 library의 Random_id를 재사용하지 않고 wall-clock 조각과 16-bit Random.int를 조합했습니다. 프로세스 시드와 같은 시간대의 생성량에 충돌 특성이 묶이고, 이미 존재하는 OS entropy 경계를 우회합니다.

## 변경

- 기존 Random_id.create의 128-bit OS entropy 값을 session- prefix와 함께 사용합니다.
- OS entropy가 없으면 기존 API 형태를 유지하면서 명시적으로 예외를 냅니다. 약한 ID로 조용히 fallback하지 않습니다.
- 기본 ID 테스트가 정확한 32자리 lowercase hex payload를 고정합니다.

## 검증

- ocamlformat 0.29.0
- touched-file parser
- git diff --check
- 로컬 Dune은 실행하지 않았고 전체 build/test는 PR CI를 권위로 둡니다.