### PR TITLE
fix(streaming): fail closed on malformed Gemini SSE parts

### DIFF
--- a/lib/llm_provider/capabilities.ml
+++ b/lib/llm_provider/capabilities.ml
@@ -642,7 +642,9 @@ let gemini_capabilities =
   ; supports_caching = true
   ; supports_prompt_caching = false
   ; prompt_cache_alignment = None
-  ; supports_code_execution = true
+  ; (* The Generate Content adapter does not serialize the [codeExecution]
+       tool or project executableCode/codeExecutionResult response Parts. *)
+    supports_code_execution = false
   ; (* Google Gemini's generateContent API documents [topK] as part of
      generationConfig (ai.google.dev/api/generate-content). The
      [backend_gemini.build_request] serializer already emits it at

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -122,6 +122,7 @@ let%test "clean stream finalizes Ok: Gemini finishReason" =
       | Ok (events, _telemetry) -> accumulate_events acc events
       | Error _ -> ())
    | Streaming.Gemini_unsupported_part _ -> ()
+   | Streaming.Gemini_unsupported_response _ -> ()
    | Streaming.Gemini_parse_failed _ -> ());
   match Complete_stream_acc.finalize_stream_acc acc with
   | Ok _ -> true
@@ -427,6 +428,7 @@ let complete_stream_http
         (* Event types exist only in SSE; NDJSON has no event field. *)
         | Types.SSEUnknownEventType _ -> `Wire_error Http_client.Sse
         | Types.SSEUnsupportedPart _ -> `Capability_mismatch
+        | Types.SSEUnsupportedResponse _ -> `Capability_mismatch
         | Types.NDJSONParseFailed _ -> `Wire_error Http_client.Ndjson
         | Types.Connected -> `Skip
         | Types.Timeout _ -> `Wire_error active_wire_format
@@ -730,6 +732,16 @@ let complete_stream_http
                                         ; raw
                                         }
                                     ]
+                                  , None )
+                                | Streaming.Gemini_unsupported_response { response; raw } ->
+                                  ( [ Types.SSEUnsupportedResponse
+                                        { provider_kind = Provider_kind.Gemini
+                                        ; response =
+                                            Streaming.gemini_unsupported_response_wire_name
+                                              response
+                                        ; raw
+                                        }
+                                    ]
                                   , None ))
                              | Provider_http_codec.Glm_chat ->
                                Backend_glm.parse_stream_chunk ~streaming_reasoning data
@@ -833,7 +845,8 @@ let complete_stream_http
                              | Types.Stream_incomplete _ ->
                                Complete_stream_error.wire_error_terminal_label
                                  active_wire_format
-                             | Types.Stream_unsupported_part _ ->
+                             | Types.Stream_unsupported_part _
+                             | Types.Stream_unsupported_response _ ->
                                Complete_stream_error.capability_mismatch_terminal_label)
                      | Telemetry_event.Terminal_error _
                      | Telemetry_event.Terminal_cancelled -> ());

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -121,6 +121,7 @@ let%test "clean stream finalizes Ok: Gemini finishReason" =
      (match Streaming.gemini_chunk_to_events st chunk with
       | Ok (events, _telemetry) -> accumulate_events acc events
       | Error _ -> ())
+   | Streaming.Gemini_unsupported_part _ -> ()
    | Streaming.Gemini_parse_failed _ -> ());
   match Complete_stream_acc.finalize_stream_acc acc with
   | Ok _ -> true
@@ -713,7 +714,17 @@ let complete_stream_http
                                    | Error { reason } ->
                                      [ Types.SSEParseFailed { raw = data; reason } ], None)
                                 | Streaming.Gemini_parse_failed { reason; raw } ->
-                                  [ Types.SSEParseFailed { raw; reason } ], None)
+                                  [ Types.SSEParseFailed { raw; reason } ], None
+                                | Streaming.Gemini_unsupported_part { part; raw } ->
+                                  ( [ Types.SSEUnknownEventType
+                                        { event_type =
+                                            "gemini.part."
+                                            ^ Streaming.gemini_unsupported_part_wire_name
+                                                part
+                                        ; raw
+                                        }
+                                    ]
+                                  , None ))
                              | Provider_http_codec.Glm_chat ->
                                Backend_glm.parse_stream_chunk ~streaming_reasoning data
                                |> Streaming.openai_sse_parse_result_to_events

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -733,11 +733,13 @@ let complete_stream_http
                                         }
                                     ]
                                   , None )
-                                | Streaming.Gemini_unsupported_response { response; raw } ->
+                                | Streaming.Gemini_unsupported_response { response; raw }
+                                  ->
                                   ( [ Types.SSEUnsupportedResponse
                                         { provider_kind = Provider_kind.Gemini
                                         ; response =
-                                            Streaming.gemini_unsupported_response_wire_name
+                                            Streaming
+                                            .gemini_unsupported_response_wire_name
                                               response
                                         ; raw
                                         }

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -426,6 +426,7 @@ let complete_stream_http
         | Types.SSEParseFailed _ -> `Wire_error active_wire_format
         (* Event types exist only in SSE; NDJSON has no event field. *)
         | Types.SSEUnknownEventType _ -> `Wire_error Http_client.Sse
+        | Types.SSEUnsupportedPart _ -> `Capability_mismatch
         | Types.NDJSONParseFailed _ -> `Wire_error Http_client.Ndjson
         | Types.Connected -> `Skip
         | Types.Timeout _ -> `Wire_error active_wire_format
@@ -589,7 +590,12 @@ let complete_stream_http
                        stream_idle_state := Http_client.Streaming_unknown;
                        terminal_state
                        := Telemetry_event.Terminal_error
-                            Complete_stream_error.provider_reported_terminal_label)
+                            Complete_stream_error.provider_reported_terminal_label
+                     | `Capability_mismatch ->
+                       stream_idle_state := Http_client.Streaming_unknown;
+                       terminal_state
+                       := Telemetry_event.Terminal_error
+                            Complete_stream_error.capability_mismatch_terminal_label)
                   events;
                 (* No thinking-only wall-clock cutoff: active reasoning
                      deltas ARE stream liveness. [stream_idle_timeout_s]
@@ -716,11 +722,11 @@ let complete_stream_http
                                 | Streaming.Gemini_parse_failed { reason; raw } ->
                                   [ Types.SSEParseFailed { raw; reason } ], None
                                 | Streaming.Gemini_unsupported_part { part; raw } ->
-                                  ( [ Types.SSEUnknownEventType
-                                        { event_type =
-                                            "gemini.part."
-                                            ^ Streaming.gemini_unsupported_part_wire_name
-                                                part
+                                  ( [ Types.SSEUnsupportedPart
+                                        { provider_kind = Provider_kind.Gemini
+                                        ; part =
+                                            Streaming.gemini_unsupported_part_wire_name
+                                              part
                                         ; raw
                                         }
                                     ]
@@ -826,7 +832,9 @@ let complete_stream_http
                              | Types.Stream_unknown_event _
                              | Types.Stream_incomplete _ ->
                                Complete_stream_error.wire_error_terminal_label
-                                 active_wire_format)
+                                 active_wire_format
+                             | Types.Stream_unsupported_part _ ->
+                               Complete_stream_error.capability_mismatch_terminal_label)
                      | Telemetry_event.Terminal_error _
                      | Telemetry_event.Terminal_cancelled -> ());
                     Error

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -117,8 +117,11 @@ let%test "clean stream finalizes Ok: Gemini finishReason" =
      Streaming.parse_gemini_sse_chunk
        {|{"candidates":[{"content":{"parts":[{"text":"hi"}]},"finishReason":"STOP"}]}|}
    with
-   | Some chunk -> accumulate_events acc (fst (Streaming.gemini_chunk_to_events st chunk))
-   | None -> ());
+   | Streaming.Gemini_chunk chunk ->
+     (match Streaming.gemini_chunk_to_events st chunk with
+      | Ok (events, _telemetry) -> accumulate_events acc events
+      | Error _ -> ())
+   | Streaming.Gemini_parse_failed _ -> ());
   match Complete_stream_acc.finalize_stream_acc acc with
   | Ok _ -> true
   | Error _ -> false
@@ -702,15 +705,15 @@ let complete_stream_http
                                     (get_state ())
                              | Provider_http_codec.Gemini_generate_content ->
                                (match Streaming.parse_gemini_sse_chunk data with
-                                | Some chunk ->
-                                  Streaming.gemini_chunk_to_events (get_state ()) chunk
-                                | None ->
-                                  ( [ Types.SSEParseFailed
-                                        { raw = data
-                                        ; reason = "gemini_sse_chunk_parse_failure"
-                                        }
-                                    ]
-                                  , None ))
+                                | Streaming.Gemini_chunk chunk ->
+                                  (match
+                                     Streaming.gemini_chunk_to_events (get_state ()) chunk
+                                   with
+                                   | Ok events -> events
+                                   | Error { reason } ->
+                                     [ Types.SSEParseFailed { raw = data; reason } ], None)
+                                | Streaming.Gemini_parse_failed { reason; raw } ->
+                                  [ Types.SSEParseFailed { raw; reason } ], None)
                              | Provider_http_codec.Glm_chat ->
                                Backend_glm.parse_stream_chunk ~streaming_reasoning data
                                |> Streaming.openai_sse_parse_result_to_events

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -177,6 +177,8 @@ let accumulate_event (acc : stream_acc) = function
     acc.sse_error := Some (Types.Stream_ndjson_parse_failed { reason; raw })
   | Types.SSEUnknownEventType { event_type; raw } ->
     acc.sse_error := Some (Types.Stream_unknown_event { event_type; raw })
+  | Types.SSEUnsupportedPart { provider_kind; part; raw } ->
+    acc.sse_error := Some (Types.Stream_unsupported_part { provider_kind; part; raw })
   | Types.StreamIncomplete _ -> acc.terminal_incomplete := true
   | Types.MessageStop ->
     (* Explicit terminal sentinel from the provider ([data: [DONE]] for
@@ -930,7 +932,8 @@ let%test "finalize_stream_acc fails closed on InputJsonDelta multi-object args (
       ( Types.Stream_provider_error _
       | Types.Stream_unknown_event _
       | Types.Stream_incomplete _
-      | Types.Stream_ndjson_parse_failed _ )
+      | Types.Stream_ndjson_parse_failed _
+      | Types.Stream_unsupported_part _ )
   | Ok _ -> false
 ;;
 
@@ -974,7 +977,8 @@ let%test "finalize_stream_acc fails closed on live multi-object tool args" =
       ( Types.Stream_provider_error _
       | Types.Stream_unknown_event _
       | Types.Stream_incomplete _
-      | Types.Stream_ndjson_parse_failed _ )
+      | Types.Stream_ndjson_parse_failed _
+      | Types.Stream_unsupported_part _ )
   | Ok _ -> false
 ;;
 
@@ -1017,7 +1021,8 @@ let%test "accumulate_event SSEError records typed provider error" =
       ( Types.Stream_parse_failed _
       | Types.Stream_unknown_event _
       | Types.Stream_incomplete _
-      | Types.Stream_ndjson_parse_failed _ )
+      | Types.Stream_ndjson_parse_failed _
+      | Types.Stream_unsupported_part _ )
   | None -> false
 ;;
 
@@ -1039,7 +1044,8 @@ let%test "accumulate_event SSEParseFailed marks typed parse failure with reason"
       ( Types.Stream_provider_error _
       | Types.Stream_unknown_event _
       | Types.Stream_incomplete _
-      | Types.Stream_ndjson_parse_failed _ )
+      | Types.Stream_ndjson_parse_failed _
+      | Types.Stream_unsupported_part _ )
   | None -> false
 ;;
 
@@ -1055,8 +1061,24 @@ let%test "accumulate_event SSEUnknownEventType marks typed unknown event with ty
       ( Types.Stream_provider_error _
       | Types.Stream_parse_failed _
       | Types.Stream_incomplete _
-      | Types.Stream_ndjson_parse_failed _ )
+      | Types.Stream_ndjson_parse_failed _
+      | Types.Stream_unsupported_part _ )
   | None -> false
+;;
+
+let%test "accumulate_event SSEUnsupportedPart preserves capability fact" =
+  let raw = {|{"candidates":[{"content":{"parts":[{"executableCode":{}}]}}]}|} in
+  let acc = create_stream_acc () in
+  accumulate_event
+    acc
+    (Types.SSEUnsupportedPart
+       { provider_kind = Provider_kind.Gemini; part = "executableCode"; raw });
+  match !(acc.sse_error) with
+  | Some
+      (Types.Stream_unsupported_part
+         { provider_kind = Provider_kind.Gemini; part; raw = observed_raw }) ->
+    part = "executableCode" && observed_raw = raw
+  | Some _ | None -> false
 ;;
 
 let%test "accumulate_event NDJSONParseFailed preserves wire-specific error" =
@@ -1071,7 +1093,8 @@ let%test "accumulate_event NDJSONParseFailed preserves wire-specific error" =
       ( Types.Stream_provider_error _
       | Types.Stream_parse_failed _
       | Types.Stream_unknown_event _
-      | Types.Stream_incomplete _ )
+      | Types.Stream_incomplete _
+      | Types.Stream_unsupported_part _ )
   | None -> false
 ;;
 
@@ -1089,7 +1112,8 @@ let%test
       ( Types.Stream_provider_error _
       | Types.Stream_unknown_event _
       | Types.Stream_incomplete _
-      | Types.Stream_ndjson_parse_failed _ )
+      | Types.Stream_ndjson_parse_failed _
+      | Types.Stream_unsupported_part _ )
   | None -> false
 ;;
 
@@ -1127,7 +1151,8 @@ let%test "finalize_stream_acc fails closed for unknown block kind with text" =
       ( Types.Stream_provider_error _
       | Types.Stream_unknown_event _
       | Types.Stream_incomplete _
-      | Types.Stream_ndjson_parse_failed _ )
+      | Types.Stream_ndjson_parse_failed _
+      | Types.Stream_unsupported_part _ )
   | Ok _ -> false
 ;;
 
@@ -1149,7 +1174,8 @@ let%test "finalize_stream_acc fails closed for empty unknown block kind" =
       ( Types.Stream_provider_error _
       | Types.Stream_unknown_event _
       | Types.Stream_incomplete _
-      | Types.Stream_ndjson_parse_failed _ )
+      | Types.Stream_ndjson_parse_failed _
+      | Types.Stream_unsupported_part _ )
   | Ok _ -> false
 ;;
 
@@ -1245,7 +1271,8 @@ let%test "finalize_stream_acc fails closed for media payload without metadata" =
       ( Types.Stream_provider_error _
       | Types.Stream_unknown_event _
       | Types.Stream_incomplete _
-      | Types.Stream_ndjson_parse_failed _ )
+      | Types.Stream_ndjson_parse_failed _
+      | Types.Stream_unsupported_part _ )
   | Ok _ -> false
 ;;
 
@@ -1275,7 +1302,8 @@ let%test "finalize_stream_acc fails closed on malformed tool_use arguments" =
       ( Types.Stream_provider_error _
       | Types.Stream_unknown_event _
       | Types.Stream_incomplete _
-      | Types.Stream_ndjson_parse_failed _ )
+      | Types.Stream_ndjson_parse_failed _
+      | Types.Stream_unsupported_part _ )
   | Ok _ -> false
 ;;
 
@@ -1399,7 +1427,8 @@ let%test "finalize_stream_acc tool_use missing id fails closed" =
       ( Types.Stream_provider_error _
       | Types.Stream_unknown_event _
       | Types.Stream_incomplete _
-      | Types.Stream_ndjson_parse_failed _ )
+      | Types.Stream_ndjson_parse_failed _
+      | Types.Stream_unsupported_part _ )
   | Ok _ -> false
 ;;
 
@@ -1421,7 +1450,8 @@ let%test "finalize_stream_acc tool_use blank id fails closed" =
       ( Types.Stream_provider_error _
       | Types.Stream_unknown_event _
       | Types.Stream_incomplete _
-      | Types.Stream_ndjson_parse_failed _ )
+      | Types.Stream_ndjson_parse_failed _
+      | Types.Stream_unsupported_part _ )
   | Ok _ -> false
 ;;
 
@@ -1465,7 +1495,8 @@ let%test "finalize_stream_acc tool_result missing id fails closed" =
       ( Types.Stream_provider_error _
       | Types.Stream_unknown_event _
       | Types.Stream_incomplete _
-      | Types.Stream_ndjson_parse_failed _ )
+      | Types.Stream_ndjson_parse_failed _
+      | Types.Stream_unsupported_part _ )
   | Ok _ -> false
 ;;
 
@@ -1550,7 +1581,8 @@ let%test "finalize_stream_acc fails closed for media payload without metadata" =
       ( Types.Stream_provider_error _
       | Types.Stream_unknown_event _
       | Types.Stream_incomplete _
-      | Types.Stream_ndjson_parse_failed _ )
+      | Types.Stream_ndjson_parse_failed _
+      | Types.Stream_unsupported_part _ )
   | Ok _ -> false
 ;;
 
@@ -1606,7 +1638,8 @@ let%test "finalize_stream_acc returns Error when sse_error is set" =
       ( Types.Stream_parse_failed _
       | Types.Stream_unknown_event _
       | Types.Stream_incomplete _
-      | Types.Stream_ndjson_parse_failed _ )
+      | Types.Stream_ndjson_parse_failed _
+      | Types.Stream_unsupported_part _ )
   | Ok _ -> false
 ;;
 

--- a/lib/llm_provider/complete_stream_acc.ml
+++ b/lib/llm_provider/complete_stream_acc.ml
@@ -179,6 +179,9 @@ let accumulate_event (acc : stream_acc) = function
     acc.sse_error := Some (Types.Stream_unknown_event { event_type; raw })
   | Types.SSEUnsupportedPart { provider_kind; part; raw } ->
     acc.sse_error := Some (Types.Stream_unsupported_part { provider_kind; part; raw })
+  | Types.SSEUnsupportedResponse { provider_kind; response; raw } ->
+    acc.sse_error
+    := Some (Types.Stream_unsupported_response { provider_kind; response; raw })
   | Types.StreamIncomplete _ -> acc.terminal_incomplete := true
   | Types.MessageStop ->
     (* Explicit terminal sentinel from the provider ([data: [DONE]] for
@@ -933,7 +936,8 @@ let%test "finalize_stream_acc fails closed on InputJsonDelta multi-object args (
       | Types.Stream_unknown_event _
       | Types.Stream_incomplete _
       | Types.Stream_ndjson_parse_failed _
-      | Types.Stream_unsupported_part _ )
+      | Types.Stream_unsupported_part _
+      | Types.Stream_unsupported_response _ )
   | Ok _ -> false
 ;;
 
@@ -978,7 +982,8 @@ let%test "finalize_stream_acc fails closed on live multi-object tool args" =
       | Types.Stream_unknown_event _
       | Types.Stream_incomplete _
       | Types.Stream_ndjson_parse_failed _
-      | Types.Stream_unsupported_part _ )
+      | Types.Stream_unsupported_part _
+      | Types.Stream_unsupported_response _ )
   | Ok _ -> false
 ;;
 
@@ -1022,7 +1027,8 @@ let%test "accumulate_event SSEError records typed provider error" =
       | Types.Stream_unknown_event _
       | Types.Stream_incomplete _
       | Types.Stream_ndjson_parse_failed _
-      | Types.Stream_unsupported_part _ )
+      | Types.Stream_unsupported_part _
+      | Types.Stream_unsupported_response _ )
   | None -> false
 ;;
 
@@ -1045,7 +1051,8 @@ let%test "accumulate_event SSEParseFailed marks typed parse failure with reason"
       | Types.Stream_unknown_event _
       | Types.Stream_incomplete _
       | Types.Stream_ndjson_parse_failed _
-      | Types.Stream_unsupported_part _ )
+      | Types.Stream_unsupported_part _
+      | Types.Stream_unsupported_response _ )
   | None -> false
 ;;
 
@@ -1062,7 +1069,8 @@ let%test "accumulate_event SSEUnknownEventType marks typed unknown event with ty
       | Types.Stream_parse_failed _
       | Types.Stream_incomplete _
       | Types.Stream_ndjson_parse_failed _
-      | Types.Stream_unsupported_part _ )
+      | Types.Stream_unsupported_part _
+      | Types.Stream_unsupported_response _ )
   | None -> false
 ;;
 
@@ -1081,6 +1089,21 @@ let%test "accumulate_event SSEUnsupportedPart preserves capability fact" =
   | Some _ | None -> false
 ;;
 
+let%test "accumulate_event SSEUnsupportedResponse preserves capability fact" =
+  let raw = {|{"candidates":[{},{}]}|} in
+  let acc = create_stream_acc () in
+  accumulate_event
+    acc
+    (Types.SSEUnsupportedResponse
+       { provider_kind = Provider_kind.Gemini; response = "candidates"; raw });
+  match !(acc.sse_error) with
+  | Some
+      (Types.Stream_unsupported_response
+         { provider_kind = Provider_kind.Gemini; response; raw = observed_raw }) ->
+    response = "candidates" && observed_raw = raw
+  | Some _ | None -> false
+;;
+
 let%test "accumulate_event NDJSONParseFailed preserves wire-specific error" =
   let acc = create_stream_acc () in
   accumulate_event
@@ -1094,7 +1117,8 @@ let%test "accumulate_event NDJSONParseFailed preserves wire-specific error" =
       | Types.Stream_parse_failed _
       | Types.Stream_unknown_event _
       | Types.Stream_incomplete _
-      | Types.Stream_unsupported_part _ )
+      | Types.Stream_unsupported_part _
+      | Types.Stream_unsupported_response _ )
   | None -> false
 ;;
 
@@ -1113,7 +1137,8 @@ let%test
       | Types.Stream_unknown_event _
       | Types.Stream_incomplete _
       | Types.Stream_ndjson_parse_failed _
-      | Types.Stream_unsupported_part _ )
+      | Types.Stream_unsupported_part _
+      | Types.Stream_unsupported_response _ )
   | None -> false
 ;;
 
@@ -1152,7 +1177,8 @@ let%test "finalize_stream_acc fails closed for unknown block kind with text" =
       | Types.Stream_unknown_event _
       | Types.Stream_incomplete _
       | Types.Stream_ndjson_parse_failed _
-      | Types.Stream_unsupported_part _ )
+      | Types.Stream_unsupported_part _
+      | Types.Stream_unsupported_response _ )
   | Ok _ -> false
 ;;
 
@@ -1175,7 +1201,8 @@ let%test "finalize_stream_acc fails closed for empty unknown block kind" =
       | Types.Stream_unknown_event _
       | Types.Stream_incomplete _
       | Types.Stream_ndjson_parse_failed _
-      | Types.Stream_unsupported_part _ )
+      | Types.Stream_unsupported_part _
+      | Types.Stream_unsupported_response _ )
   | Ok _ -> false
 ;;
 
@@ -1272,7 +1299,8 @@ let%test "finalize_stream_acc fails closed for media payload without metadata" =
       | Types.Stream_unknown_event _
       | Types.Stream_incomplete _
       | Types.Stream_ndjson_parse_failed _
-      | Types.Stream_unsupported_part _ )
+      | Types.Stream_unsupported_part _
+      | Types.Stream_unsupported_response _ )
   | Ok _ -> false
 ;;
 
@@ -1303,7 +1331,8 @@ let%test "finalize_stream_acc fails closed on malformed tool_use arguments" =
       | Types.Stream_unknown_event _
       | Types.Stream_incomplete _
       | Types.Stream_ndjson_parse_failed _
-      | Types.Stream_unsupported_part _ )
+      | Types.Stream_unsupported_part _
+      | Types.Stream_unsupported_response _ )
   | Ok _ -> false
 ;;
 
@@ -1428,7 +1457,8 @@ let%test "finalize_stream_acc tool_use missing id fails closed" =
       | Types.Stream_unknown_event _
       | Types.Stream_incomplete _
       | Types.Stream_ndjson_parse_failed _
-      | Types.Stream_unsupported_part _ )
+      | Types.Stream_unsupported_part _
+      | Types.Stream_unsupported_response _ )
   | Ok _ -> false
 ;;
 
@@ -1451,7 +1481,8 @@ let%test "finalize_stream_acc tool_use blank id fails closed" =
       | Types.Stream_unknown_event _
       | Types.Stream_incomplete _
       | Types.Stream_ndjson_parse_failed _
-      | Types.Stream_unsupported_part _ )
+      | Types.Stream_unsupported_part _
+      | Types.Stream_unsupported_response _ )
   | Ok _ -> false
 ;;
 
@@ -1496,7 +1527,8 @@ let%test "finalize_stream_acc tool_result missing id fails closed" =
       | Types.Stream_unknown_event _
       | Types.Stream_incomplete _
       | Types.Stream_ndjson_parse_failed _
-      | Types.Stream_unsupported_part _ )
+      | Types.Stream_unsupported_part _
+      | Types.Stream_unsupported_response _ )
   | Ok _ -> false
 ;;
 
@@ -1582,7 +1614,8 @@ let%test "finalize_stream_acc fails closed for media payload without metadata" =
       | Types.Stream_unknown_event _
       | Types.Stream_incomplete _
       | Types.Stream_ndjson_parse_failed _
-      | Types.Stream_unsupported_part _ )
+      | Types.Stream_unsupported_part _
+      | Types.Stream_unsupported_response _ )
   | Ok _ -> false
 ;;
 
@@ -1639,7 +1672,8 @@ let%test "finalize_stream_acc returns Error when sse_error is set" =
       | Types.Stream_unknown_event _
       | Types.Stream_incomplete _
       | Types.Stream_ndjson_parse_failed _
-      | Types.Stream_unsupported_part _ )
+      | Types.Stream_unsupported_part _
+      | Types.Stream_unsupported_response _ )
   | Ok _ -> false
 ;;
 

--- a/lib/llm_provider/complete_stream_error.ml
+++ b/lib/llm_provider/complete_stream_error.ml
@@ -165,6 +165,21 @@ let http_error_of_stream_error
     in
     Http_client.ProviderFailure
       { kind = Http_client.Capability_mismatch { capability = Some capability }; message }
+  | Types.Stream_unsupported_response { provider_kind; response; raw } ->
+    let capability =
+      Printf.sprintf "%s.response.%s" (Provider_kind.to_string provider_kind) response
+    in
+    let message =
+      match raw with
+      | "" -> Printf.sprintf "provider emitted an unsupported response: %s" capability
+      | raw ->
+        Printf.sprintf
+          "provider emitted an unsupported response: %s raw=%S"
+          capability
+          (parse_error_raw_excerpt raw)
+    in
+    Http_client.ProviderFailure
+      { kind = Http_client.Capability_mismatch { capability = Some capability }; message }
 ;;
 
 let%test "generic stream provider type stays diagnostic" =
@@ -294,5 +309,20 @@ let%test "unsupported content part is a capability mismatch" =
     && message
        = "provider emitted an unsupported content part: gemini.part.executableCode \
           raw=\"{}\""
+  | _ -> false
+;;
+
+let%test "unsupported response is a capability mismatch" =
+  match
+    http_error_of_stream_error
+      (Types.Stream_unsupported_response
+         { provider_kind = Provider_kind.Gemini; response = "candidates"; raw = "{}" })
+  with
+  | Http_client.ProviderFailure
+      { kind = Http_client.Capability_mismatch { capability = Some capability }; message }
+    ->
+    capability = "gemini.response.candidates"
+    && message
+       = "provider emitted an unsupported response: gemini.response.candidates raw=\"{}\""
   | _ -> false
 ;;

--- a/lib/llm_provider/complete_stream_error.ml
+++ b/lib/llm_provider/complete_stream_error.ml
@@ -18,6 +18,7 @@ let parse_error_raw_excerpt raw =
    projection above so a published [Streaming_summary] can never disagree with
    the error it accompanies: both are derived from the same two functions. *)
 let provider_reported_terminal_label = "provider_stream_error"
+let capability_mismatch_terminal_label = "capability_mismatch"
 
 let wire_error_terminal_label wire_format =
   Http_client.provider_wire_format_to_string wire_format ^ "_wire_error"
@@ -149,6 +150,21 @@ let http_error_of_stream_error
             { format = Http_client.Sse; kind = Http_client.Unknown_event }
       ; message = Printf.sprintf "SSE unknown event type: %s" event_type
       }
+  | Types.Stream_unsupported_part { provider_kind; part; raw } ->
+    let capability =
+      Printf.sprintf "%s.part.%s" (Provider_kind.to_string provider_kind) part
+    in
+    let message =
+      match raw with
+      | "" -> Printf.sprintf "provider emitted an unsupported content part: %s" capability
+      | raw ->
+        Printf.sprintf
+          "provider emitted an unsupported content part: %s raw=%S"
+          capability
+          (parse_error_raw_excerpt raw)
+    in
+    Http_client.ProviderFailure
+      { kind = Http_client.Capability_mismatch { capability = Some capability }; message }
 ;;
 
 let%test "generic stream provider type stays diagnostic" =
@@ -263,4 +279,20 @@ let%test "stream unknown event is wire evidence" =
   maps_to_sse_wire_failure
     ~expected_kind:Http_client.Unknown_event
     (Types.Stream_unknown_event { event_type = "surprise"; raw = "event: surprise" })
+;;
+
+let%test "unsupported content part is a capability mismatch" =
+  match
+    http_error_of_stream_error
+      (Types.Stream_unsupported_part
+         { provider_kind = Provider_kind.Gemini; part = "executableCode"; raw = "{}" })
+  with
+  | Http_client.ProviderFailure
+      { kind = Http_client.Capability_mismatch { capability = Some capability }; message }
+    ->
+    capability = "gemini.part.executableCode"
+    && message
+       = "provider emitted an unsupported content part: gemini.part.executableCode \
+          raw=\"{}\""
+  | _ -> false
 ;;

--- a/lib/llm_provider/complete_stream_error.mli
+++ b/lib/llm_provider/complete_stream_error.mli
@@ -2,6 +2,10 @@
     from a wire failure: the response was structurally valid. *)
 val provider_reported_terminal_label : string
 
+(** Terminal telemetry label for a provider capability that OAS does not
+    project. This is distinct from a malformed or unknown wire payload. *)
+val capability_mismatch_terminal_label : string
+
 (** Terminal telemetry label for a wire-contract failure in the given format.
     Derived from the same format value as the returned typed error, so the
     published summary cannot name a different wire format than the failure. *)

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -2095,6 +2095,7 @@ let validate_gemini_part ~position part =
          "%s.inlineData:not_object(got %s)"
          path
          (Json_util.json_type_name value))
+  | [ (key, _) ] -> Error (Printf.sprintf "%s.%s:unsupported_payload" path key)
   | _ :: _ :: _ -> Error (path ^ ":multiple_payloads")
 ;;
 

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -2095,7 +2095,7 @@ let validate_gemini_part ~position part =
          "%s.inlineData:not_object(got %s)"
          path
          (Json_util.json_type_name value))
-  | _ -> Error (path ^ ":multiple_payloads")
+  | _ :: _ :: _ -> Error (path ^ ":multiple_payloads")
 ;;
 
 type gemini_payload_failure =

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -1846,10 +1846,14 @@ let responses_sse_to_events (state : openai_stream_state) event_type data_str
     JSON payloads: [{candidates: [{content: {parts: [...]}}]}].
     Each chunk may contain text, thought, or functionCall parts. *)
 
+type gemini_terminal_reason =
+  | Gemini_candidate_finish_reason of string
+  | Gemini_prompt_block_reason of string
+
 type gemini_chunk =
-  { gem_model : string
+  { gem_model : string option
   ; gem_parts : Yojson.Safe.t list
-  ; gem_finish_reason : string option
+  ; gem_finish_reason : gemini_terminal_reason option
   ; gem_usage : api_usage option
   }
 
@@ -1863,8 +1867,7 @@ type gemini_unsupported_part =
   | Gemini_audio_transcription
   | Gemini_streaming_function_call_arguments
 
-type gemini_unsupported_response =
-  | Gemini_multiple_candidates of { count : int }
+type gemini_unsupported_response = Gemini_multiple_candidates of { count : int }
 
 type gemini_sse_parse_result =
   | Gemini_chunk of gemini_chunk
@@ -1954,7 +1957,9 @@ let gemini_optional_int_default_zero ~path key json =
          (Json_util.json_type_name value))
 ;;
 
-let gemini_part_metadata_object_fields = [ "partMetadata"; "mediaResolution"; "videoMetadata" ]
+let gemini_part_metadata_object_fields =
+  [ "partMetadata"; "mediaResolution"; "videoMetadata" ]
+;;
 
 let gemini_part_metadata_fields =
   [ "thought"; "thoughtSignature" ] @ gemini_part_metadata_object_fields
@@ -2042,7 +2047,7 @@ let validate_gemini_part ~position part =
   | [ ("functionCall", (`Assoc function_call_fields as function_call)) ] ->
     let unsupported_field =
       List.find_opt
-        (fun (key, _) -> not (List.mem key [ "id"; "name"; "args" ]))
+        (fun (key, _) -> not (List.mem key [ "id"; "name"; "args"; "willContinue" ]))
         function_call_fields
     in
     let* () =
@@ -2060,6 +2065,17 @@ let validate_gemini_part ~position part =
         Error
           (Printf.sprintf
              "%s.functionCall.args:not_object(got %s)"
+             path
+             (Json_util.json_type_name value))
+    in
+    let* () =
+      match gemini_assoc_field "willContinue" function_call with
+      | None | Some `Null | Some (`Bool false) -> Ok ()
+      | Some (`Bool true) -> Error (path ^ ".functionCall:streaming_arguments_unsupported")
+      | Some value ->
+        Error
+          (Printf.sprintf
+             "%s.functionCall.willContinue:not_boolean(got %s)"
              path
              (Json_util.json_type_name value))
     in
@@ -2180,7 +2196,7 @@ let gemini_unsupported_part_of_json ~position part =
       match List.assoc_opt "functionCall" fields with
       | Some (`Assoc function_call_fields) ->
         List.mem_assoc "partialArgs" function_call_fields
-        || List.mem_assoc "willContinue" function_call_fields
+        || List.assoc_opt "willContinue" function_call_fields = Some (`Bool true)
       | Some _ | None -> false
     in
     if streaming_function_call
@@ -2336,9 +2352,9 @@ let gemini_unsupported_part_of_json ~position part =
              gemini_optional_object ~path:tool_response_path "response" tool_response
            in
            Ok Gemini_tool_response)
-      | [ ( ((Gemini_function_response_payload | Gemini_file_data_payload
-             | Gemini_audio_transcription_payload) as
-             kind)
+      | [ ( (( Gemini_function_response_payload
+             | Gemini_file_data_payload
+             | Gemini_audio_transcription_payload ) as kind)
           , value )
         ] ->
         let ( let* ) = Result.bind in
@@ -2387,9 +2403,17 @@ let parse_gemini_json json : (gemini_chunk, gemini_payload_failure) result =
   let* model_version = gemini_optional_string ~path:"gemini" "modelVersion" json in
   let* candidates_value = gemini_field ~path:"gemini" "candidates" json in
   let* candidates = gemini_list ~path:"gemini.candidates" candidates_value in
-  let* candidate =
+  let* candidate, gem_finish_reason =
     match candidates with
-    | [ candidate ] -> Ok candidate
+    | [ candidate ] ->
+      let* candidate = gemini_object ~path:"gemini.candidates[0]" candidate in
+      let* finish_reason =
+        gemini_optional_string ~path:"gemini.candidates[0]" "finishReason" candidate
+      in
+      Ok
+        ( candidate
+        , Option.map (fun reason -> Gemini_candidate_finish_reason reason) finish_reason
+        )
     | _ :: _ ->
       Error
         (Gemini_payload_unsupported_response
@@ -2399,16 +2423,10 @@ let parse_gemini_json json : (gemini_chunk, gemini_payload_failure) result =
       let* prompt_feedback =
         gemini_object ~path:"gemini.promptFeedback" prompt_feedback
       in
-      let* _block_reason =
+      let* block_reason =
         gemini_required_string ~path:"gemini.promptFeedback" "blockReason" prompt_feedback
       in
-      Ok
-        (`Assoc
-            [ "finishReason", `String "SAFETY"; "content", `Assoc [ "parts", `List [] ] ])
-  in
-  let* candidate = gemini_object ~path:"gemini.candidates[0]" candidate in
-  let* gem_finish_reason =
-    gemini_optional_string ~path:"gemini.candidates[0]" "finishReason" candidate
+      Ok (`Assoc [], Some (Gemini_prompt_block_reason block_reason))
   in
   let terminal_without_content = Option.is_some gem_finish_reason in
   let* parts =
@@ -2484,12 +2502,7 @@ let parse_gemini_json json : (gemini_chunk, gemini_payload_failure) result =
               "gemini.usageMetadata:not_object(got %s)"
               (Json_util.json_type_name value)))
   in
-  Ok
-    { gem_model = Option.value ~default:"" model_version
-    ; gem_parts = parts
-    ; gem_finish_reason
-    ; gem_usage
-    }
+  Ok { gem_model = model_version; gem_parts = parts; gem_finish_reason; gem_usage }
 ;;
 
 let parse_gemini_sse_chunk data_str : gemini_sse_parse_result =
@@ -2738,13 +2751,15 @@ let gemini_chunk_to_events_impl (state : openai_stream_state) (chunk : gemini_ch
     chunk.gem_parts;
   (* Finish reason *)
   (match chunk.gem_finish_reason with
-   | Some reason ->
+   | Some (Gemini_candidate_finish_reason reason) ->
      let stop_reason =
        Backend_gemini.stop_reason_of_finish_reason
          ~has_tool_use:(Hashtbl.length state.tool_block_indices > 0)
          reason
      in
      emit (MessageDelta { stop_reason = Some stop_reason; usage = chunk.gem_usage })
+   | Some (Gemini_prompt_block_reason _) ->
+     emit (MessageDelta { stop_reason = Some Refusal; usage = chunk.gem_usage })
    | None -> ());
   List.rev !events, !telemetry_event
 ;;

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -754,7 +754,7 @@ type openai_stream_state =
         the sole identity authority for an open tool block. *)
   ; mutable next_block_index : int
   ; mutable thinking_state : thinking_state
-  ; mutable gemini_message_model : string option
+  ; mutable gemini_message_model : Model_id.t option
   ; provider : string
   ; model : string
   }
@@ -2217,171 +2217,181 @@ let gemini_unsupported_part_of_json ~position part =
     in
     (match streaming_function_call with
      | Some unsupported_part ->
-      Some
-        (let ( let* ) = Result.bind in
-         let* () =
-           gemini_validate_allowed_fields
-             ~path
-             ~allowed:(gemini_supported_part_payloads @ gemini_part_metadata_fields)
-             fields
-         in
-         let* () = validate_gemini_part_metadata ~path (`Assoc fields) in
-         let function_call_path = path ^ ".functionCall" in
-         let* function_call_fields =
-           match List.assoc_opt "functionCall" fields with
-           | Some value -> gemini_object_fields ~path:function_call_path value
-           | None -> Error (function_call_path ^ ":missing")
-         in
-         let* () =
-           gemini_validate_allowed_fields
-             ~path:function_call_path
-             ~allowed:[ "id"; "name"; "args"; "partialArgs"; "willContinue" ]
-             function_call_fields
-         in
-         let function_call = `Assoc function_call_fields in
-         let* _id = gemini_optional_string ~path:function_call_path "id" function_call in
-         let* _name =
-           gemini_optional_string ~path:function_call_path "name" function_call
-         in
-         let* () = gemini_optional_object ~path:function_call_path "args" function_call in
-         let* () =
-           match gemini_assoc_field "partialArgs" function_call with
-           | None | Some `Null | Some (`List _) -> Ok ()
-           | Some value ->
-             Error
-               (Printf.sprintf
-                  "%s.partialArgs:not_array(got %s)"
-                  function_call_path
-                  (Json_util.json_type_name value))
-         in
-         let* () =
-           match gemini_assoc_field "willContinue" function_call with
-           | None | Some `Null | Some (`Bool _) -> Ok ()
-           | Some value ->
-             Error
-               (Printf.sprintf
-                  "%s.willContinue:not_boolean(got %s)"
-                  function_call_path
-                  (Json_util.json_type_name value))
-         in
-         Ok unsupported_part)
+       Some
+         (let ( let* ) = Result.bind in
+          let* () =
+            gemini_validate_allowed_fields
+              ~path
+              ~allowed:(gemini_supported_part_payloads @ gemini_part_metadata_fields)
+              fields
+          in
+          let* () = validate_gemini_part_metadata ~path (`Assoc fields) in
+          let function_call_path = path ^ ".functionCall" in
+          let* function_call_fields =
+            match List.assoc_opt "functionCall" fields with
+            | Some value -> gemini_object_fields ~path:function_call_path value
+            | None -> Error (function_call_path ^ ":missing")
+          in
+          let* () =
+            gemini_validate_allowed_fields
+              ~path:function_call_path
+              ~allowed:[ "id"; "name"; "args"; "partialArgs"; "willContinue" ]
+              function_call_fields
+          in
+          let function_call = `Assoc function_call_fields in
+          let* _id = gemini_optional_string ~path:function_call_path "id" function_call in
+          let* _name =
+            gemini_optional_string ~path:function_call_path "name" function_call
+          in
+          let* () =
+            gemini_optional_object ~path:function_call_path "args" function_call
+          in
+          let* () =
+            match gemini_assoc_field "partialArgs" function_call with
+            | None | Some `Null | Some (`List _) -> Ok ()
+            | Some value ->
+              Error
+                (Printf.sprintf
+                   "%s.partialArgs:not_array(got %s)"
+                   function_call_path
+                   (Json_util.json_type_name value))
+          in
+          let* () =
+            match gemini_assoc_field "willContinue" function_call with
+            | None | Some `Null | Some (`Bool _) -> Ok ()
+            | Some value ->
+              Error
+                (Printf.sprintf
+                   "%s.willContinue:not_boolean(got %s)"
+                   function_call_path
+                   (Json_util.json_type_name value))
+          in
+          Ok unsupported_part)
      | None ->
-      let payloads =
-        List.filter_map
-          (fun kind ->
-             let key = gemini_unsupported_payload_kind_wire_name kind in
-             match List.assoc_opt key fields with
-             | Some value -> Some (kind, value)
-             | None -> None)
-          gemini_unsupported_payload_kinds
-      in
-      match payloads with
-      | [] -> None
-      | _ :: _ :: _ -> Some (Error (path ^ ":multiple_payloads"))
-      | [ (Gemini_executable_code_payload, value) ] ->
-        let ( let* ) = Result.bind in
-        Some
-          (let* () = validate_gemini_unsupported_part_envelope ~path fields in
-           let* code_fields =
-             gemini_object_fields ~path:(path ^ ".executableCode") value
-           in
-           let* () =
-             gemini_validate_allowed_fields
-               ~path:(path ^ ".executableCode")
-               ~allowed:[ "id"; "language"; "code" ]
-               code_fields
-           in
-           let code = `Assoc code_fields in
-           let* _id = gemini_optional_string ~path:(path ^ ".executableCode") "id" code in
-           let* _language =
-             gemini_required_string ~path:(path ^ ".executableCode") "language" code
-           in
-           let* _code =
-             gemini_required_string ~path:(path ^ ".executableCode") "code" code
-           in
-           Ok Gemini_executable_code)
-      | [ (Gemini_code_execution_result_payload, value) ] ->
-        let ( let* ) = Result.bind in
-        Some
-          (let* () = validate_gemini_unsupported_part_envelope ~path fields in
-           let* result_fields =
-             gemini_object_fields ~path:(path ^ ".codeExecutionResult") value
-           in
-           let* () =
-             gemini_validate_allowed_fields
-               ~path:(path ^ ".codeExecutionResult")
-               ~allowed:[ "id"; "outcome"; "output" ]
-               result_fields
-           in
-           let result = `Assoc result_fields in
-           let* _id =
-             gemini_optional_string ~path:(path ^ ".codeExecutionResult") "id" result
-           in
-           let* _outcome =
-             gemini_required_string ~path:(path ^ ".codeExecutionResult") "outcome" result
-           in
-           let* _output =
-             gemini_optional_string ~path:(path ^ ".codeExecutionResult") "output" result
-           in
-           Ok Gemini_code_execution_result)
-      | [ (Gemini_tool_call_payload, value) ] ->
-        let ( let* ) = Result.bind in
-        Some
-          (let* () = validate_gemini_unsupported_part_envelope ~path fields in
-           let tool_call_path = path ^ ".toolCall" in
-           let* tool_call_fields = gemini_object_fields ~path:tool_call_path value in
-           let* () =
-             gemini_validate_allowed_fields
-               ~path:tool_call_path
-               ~allowed:[ "id"; "toolType"; "args" ]
-               tool_call_fields
-           in
-           let tool_call = `Assoc tool_call_fields in
-           let* _id = gemini_required_string ~path:tool_call_path "id" tool_call in
-           let* _tool_type =
-             gemini_required_string ~path:tool_call_path "toolType" tool_call
-           in
-           let* () = gemini_optional_object ~path:tool_call_path "args" tool_call in
-           Ok Gemini_tool_call)
-      | [ (Gemini_tool_response_payload, value) ] ->
-        let ( let* ) = Result.bind in
-        Some
-          (let* () = validate_gemini_unsupported_part_envelope ~path fields in
-           let tool_response_path = path ^ ".toolResponse" in
-           let* tool_response_fields =
-             gemini_object_fields ~path:tool_response_path value
-           in
-           let* () =
-             gemini_validate_allowed_fields
-               ~path:tool_response_path
-               ~allowed:[ "id"; "toolType"; "response" ]
-               tool_response_fields
-           in
-           let tool_response = `Assoc tool_response_fields in
-           let* _id =
-             gemini_required_string ~path:tool_response_path "id" tool_response
-           in
-           let* _tool_type =
-             gemini_required_string ~path:tool_response_path "toolType" tool_response
-           in
-           let* () =
-             gemini_optional_object ~path:tool_response_path "response" tool_response
-           in
-           Ok Gemini_tool_response)
-      | [ ( (( Gemini_function_response_payload
-             | Gemini_file_data_payload
-             | Gemini_audio_transcription_payload ) as kind)
-          , value )
-        ] ->
-        let ( let* ) = Result.bind in
-        Some
-          (let* () = validate_gemini_unsupported_part_envelope ~path fields in
-           let* _ =
-             gemini_object_fields
-               ~path:(path ^ "." ^ gemini_unsupported_payload_kind_wire_name kind)
-               value
-           in
-           Ok (gemini_unsupported_part_of_payload_kind kind)))
+       let payloads =
+         List.filter_map
+           (fun kind ->
+              let key = gemini_unsupported_payload_kind_wire_name kind in
+              match List.assoc_opt key fields with
+              | Some value -> Some (kind, value)
+              | None -> None)
+           gemini_unsupported_payload_kinds
+       in
+       (match payloads with
+        | [] -> None
+        | _ :: _ :: _ -> Some (Error (path ^ ":multiple_payloads"))
+        | [ (Gemini_executable_code_payload, value) ] ->
+          let ( let* ) = Result.bind in
+          Some
+            (let* () = validate_gemini_unsupported_part_envelope ~path fields in
+             let* code_fields =
+               gemini_object_fields ~path:(path ^ ".executableCode") value
+             in
+             let* () =
+               gemini_validate_allowed_fields
+                 ~path:(path ^ ".executableCode")
+                 ~allowed:[ "id"; "language"; "code" ]
+                 code_fields
+             in
+             let code = `Assoc code_fields in
+             let* _id =
+               gemini_optional_string ~path:(path ^ ".executableCode") "id" code
+             in
+             let* _language =
+               gemini_required_string ~path:(path ^ ".executableCode") "language" code
+             in
+             let* _code =
+               gemini_required_string ~path:(path ^ ".executableCode") "code" code
+             in
+             Ok Gemini_executable_code)
+        | [ (Gemini_code_execution_result_payload, value) ] ->
+          let ( let* ) = Result.bind in
+          Some
+            (let* () = validate_gemini_unsupported_part_envelope ~path fields in
+             let* result_fields =
+               gemini_object_fields ~path:(path ^ ".codeExecutionResult") value
+             in
+             let* () =
+               gemini_validate_allowed_fields
+                 ~path:(path ^ ".codeExecutionResult")
+                 ~allowed:[ "id"; "outcome"; "output" ]
+                 result_fields
+             in
+             let result = `Assoc result_fields in
+             let* _id =
+               gemini_optional_string ~path:(path ^ ".codeExecutionResult") "id" result
+             in
+             let* _outcome =
+               gemini_required_string
+                 ~path:(path ^ ".codeExecutionResult")
+                 "outcome"
+                 result
+             in
+             let* _output =
+               gemini_optional_string
+                 ~path:(path ^ ".codeExecutionResult")
+                 "output"
+                 result
+             in
+             Ok Gemini_code_execution_result)
+        | [ (Gemini_tool_call_payload, value) ] ->
+          let ( let* ) = Result.bind in
+          Some
+            (let* () = validate_gemini_unsupported_part_envelope ~path fields in
+             let tool_call_path = path ^ ".toolCall" in
+             let* tool_call_fields = gemini_object_fields ~path:tool_call_path value in
+             let* () =
+               gemini_validate_allowed_fields
+                 ~path:tool_call_path
+                 ~allowed:[ "id"; "toolType"; "args" ]
+                 tool_call_fields
+             in
+             let tool_call = `Assoc tool_call_fields in
+             let* _id = gemini_required_string ~path:tool_call_path "id" tool_call in
+             let* _tool_type =
+               gemini_required_string ~path:tool_call_path "toolType" tool_call
+             in
+             let* () = gemini_optional_object ~path:tool_call_path "args" tool_call in
+             Ok Gemini_tool_call)
+        | [ (Gemini_tool_response_payload, value) ] ->
+          let ( let* ) = Result.bind in
+          Some
+            (let* () = validate_gemini_unsupported_part_envelope ~path fields in
+             let tool_response_path = path ^ ".toolResponse" in
+             let* tool_response_fields =
+               gemini_object_fields ~path:tool_response_path value
+             in
+             let* () =
+               gemini_validate_allowed_fields
+                 ~path:tool_response_path
+                 ~allowed:[ "id"; "toolType"; "response" ]
+                 tool_response_fields
+             in
+             let tool_response = `Assoc tool_response_fields in
+             let* _id =
+               gemini_required_string ~path:tool_response_path "id" tool_response
+             in
+             let* _tool_type =
+               gemini_required_string ~path:tool_response_path "toolType" tool_response
+             in
+             let* () =
+               gemini_optional_object ~path:tool_response_path "response" tool_response
+             in
+             Ok Gemini_tool_response)
+        | [ ( (( Gemini_function_response_payload
+               | Gemini_file_data_payload
+               | Gemini_audio_transcription_payload ) as kind)
+            , value )
+          ] ->
+          let ( let* ) = Result.bind in
+          Some
+            (let* () = validate_gemini_unsupported_part_envelope ~path fields in
+             let* _ =
+               gemini_object_fields
+                 ~path:(path ^ "." ^ gemini_unsupported_payload_kind_wire_name kind)
+                 value
+             in
+             Ok (gemini_unsupported_part_of_payload_kind kind))))
   | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> None
 ;;
 
@@ -2542,6 +2552,24 @@ let parse_gemini_sse_chunk data_str : gemini_sse_parse_result =
        Gemini_unsupported_response { raw = data_str; response })
 ;;
 
+let gemini_message_start_for_model (state : openai_stream_state) raw_model =
+  match Model_id.of_string raw_model with
+  | Error reason ->
+    raise
+      (Backend_gemini.Gemini_api_error
+         (Printf.sprintf "gemini.modelVersion invalid: %s" reason))
+  | Ok model_id ->
+    (match state.gemini_message_model with
+     | None ->
+       state.gemini_message_model <- Some model_id;
+       Some (MessageStart { id = ""; model = Model_id.to_string model_id; usage = None })
+     | Some observed when Model_id.equal observed model_id -> None
+     | Some _ ->
+       raise
+         (Backend_gemini.Gemini_api_error
+            "gemini.modelVersion changed within one streamed response"))
+;;
+
 let gemini_chunk_to_events_impl (state : openai_stream_state) (chunk : gemini_chunk)
   : sse_event list * Telemetry_event.t option
   =
@@ -2550,13 +2578,8 @@ let gemini_chunk_to_events_impl (state : openai_stream_state) (chunk : gemini_ch
   let emit evt = events := evt :: !events in
   let telemetry_event = ref None in
   (match chunk.gem_model with
-   | Some model
-     when (match state.gemini_message_model with
-           | Some observed -> not (String.equal observed model)
-           | None -> true) ->
-     state.gemini_message_model <- Some model;
-     emit (MessageStart { id = ""; model; usage = None })
-   | Some _ | None -> ());
+   | Some model -> Option.iter emit (gemini_message_start_for_model state model)
+   | None -> ());
   let has_thought_part =
     List.exists
       (fun part ->

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -196,6 +196,7 @@ let sse_event_is_first_token_signal (e : sse_event) : bool =
   | NDJSONParseFailed _
   | SSEUnknownEventType _
   | SSEUnsupportedPart _
+  | SSEUnsupportedResponse _
   | Connected
   | Timeout _
   | StreamIncomplete _ -> false
@@ -223,6 +224,7 @@ let sse_event_is_deliverable_progress_signal (e : sse_event) : bool =
   | NDJSONParseFailed _
   | SSEUnknownEventType _
   | SSEUnsupportedPart _
+  | SSEUnsupportedResponse _
   | Connected
   | Timeout _
   | StreamIncomplete _ -> false
@@ -1286,6 +1288,7 @@ let test_tool_use_start_with_name = function
   | NDJSONParseFailed _
   | SSEUnknownEventType _
   | SSEUnsupportedPart _
+  | SSEUnsupportedResponse _
   | Connected
   | Timeout _
   | StreamIncomplete _ -> None
@@ -1306,6 +1309,7 @@ let test_tool_use_start = function
   | NDJSONParseFailed _
   | SSEUnknownEventType _
   | SSEUnsupportedPart _
+  | SSEUnsupportedResponse _
   | Connected
   | Timeout _
   | StreamIncomplete _ -> None
@@ -1326,6 +1330,7 @@ let test_input_json_delta = function
   | NDJSONParseFailed _
   | SSEUnknownEventType _
   | SSEUnsupportedPart _
+  | SSEUnsupportedResponse _
   | Connected
   | Timeout _
   | StreamIncomplete _ -> None
@@ -1858,10 +1863,17 @@ type gemini_unsupported_part =
   | Gemini_audio_transcription
   | Gemini_streaming_function_call_arguments
 
+type gemini_unsupported_response =
+  | Gemini_multiple_candidates of { count : int }
+
 type gemini_sse_parse_result =
   | Gemini_chunk of gemini_chunk
   | Gemini_unsupported_part of
       { part : gemini_unsupported_part
+      ; raw : string
+      }
+  | Gemini_unsupported_response of
+      { response : gemini_unsupported_response
       ; raw : string
       }
   | Gemini_parse_failed of
@@ -1942,6 +1954,12 @@ let gemini_optional_int_default_zero ~path key json =
          (Json_util.json_type_name value))
 ;;
 
+let gemini_part_metadata_object_fields = [ "partMetadata"; "mediaResolution"; "videoMetadata" ]
+
+let gemini_part_metadata_fields =
+  [ "thought"; "thoughtSignature" ] @ gemini_part_metadata_object_fields
+;;
+
 let validate_gemini_part_metadata ~path part =
   let ( let* ) = Result.bind in
   let* () =
@@ -1979,11 +1997,7 @@ let validate_gemini_part_metadata ~path part =
               key
               (Json_util.json_type_name value)))
   in
-  validate_objects [ "partMetadata"; "mediaResolution"; "videoMetadata" ]
-;;
-
-let gemini_part_metadata_fields =
-  [ "thought"; "thoughtSignature"; "partMetadata"; "mediaResolution"; "videoMetadata" ]
+  validate_objects gemini_part_metadata_object_fields
 ;;
 
 let gemini_supported_part_payloads = [ "text"; "functionCall"; "inlineData" ]
@@ -2026,17 +2040,9 @@ let validate_gemini_part ~position part =
     Error
       (Printf.sprintf "%s.text:not_string(got %s)" path (Json_util.json_type_name value))
   | [ ("functionCall", (`Assoc function_call_fields as function_call)) ] ->
-    let* () =
-      if
-        List.mem_assoc "partialArgs" function_call_fields
-        || List.mem_assoc "willContinue" function_call_fields
-      then Error (path ^ ".functionCall:streaming_arguments_unsupported")
-      else Ok ()
-    in
     let unsupported_field =
       List.find_opt
-        (fun (key, _) ->
-           not (List.mem key [ "id"; "name"; "args"; "partialArgs"; "willContinue" ]))
+        (fun (key, _) -> not (List.mem key [ "id"; "name"; "args" ]))
         function_call_fields
     in
     let* () =
@@ -2077,31 +2083,60 @@ let validate_gemini_part ~position part =
 type gemini_payload_failure =
   | Gemini_payload_malformed of string
   | Gemini_payload_unsupported_part of gemini_unsupported_part
+  | Gemini_payload_unsupported_response of gemini_unsupported_response
+
+type gemini_unsupported_payload_kind =
+  | Gemini_executable_code_payload
+  | Gemini_code_execution_result_payload
+  | Gemini_tool_call_payload
+  | Gemini_tool_response_payload
+  | Gemini_function_response_payload
+  | Gemini_file_data_payload
+  | Gemini_audio_transcription_payload
+
+let gemini_unsupported_payload_kind_wire_name = function
+  | Gemini_executable_code_payload -> "executableCode"
+  | Gemini_code_execution_result_payload -> "codeExecutionResult"
+  | Gemini_tool_call_payload -> "toolCall"
+  | Gemini_tool_response_payload -> "toolResponse"
+  | Gemini_function_response_payload -> "functionResponse"
+  | Gemini_file_data_payload -> "fileData"
+  | Gemini_audio_transcription_payload -> "audioTranscription"
+;;
 
 let gemini_unsupported_part_wire_name = function
-  | Gemini_executable_code -> "executableCode"
-  | Gemini_code_execution_result -> "codeExecutionResult"
-  | Gemini_tool_call -> "toolCall"
-  | Gemini_tool_response -> "toolResponse"
-  | Gemini_function_response -> "functionResponse"
-  | Gemini_file_data -> "fileData"
-  | Gemini_audio_transcription -> "audioTranscription"
+  | Gemini_executable_code ->
+    gemini_unsupported_payload_kind_wire_name Gemini_executable_code_payload
+  | Gemini_code_execution_result ->
+    gemini_unsupported_payload_kind_wire_name Gemini_code_execution_result_payload
+  | Gemini_tool_call -> gemini_unsupported_payload_kind_wire_name Gemini_tool_call_payload
+  | Gemini_tool_response ->
+    gemini_unsupported_payload_kind_wire_name Gemini_tool_response_payload
+  | Gemini_function_response ->
+    gemini_unsupported_payload_kind_wire_name Gemini_function_response_payload
+  | Gemini_file_data -> gemini_unsupported_payload_kind_wire_name Gemini_file_data_payload
+  | Gemini_audio_transcription ->
+    gemini_unsupported_payload_kind_wire_name Gemini_audio_transcription_payload
   | Gemini_streaming_function_call_arguments -> "functionCall.partialArgs"
 ;;
 
-let gemini_unsupported_part_kinds =
-  [ Gemini_executable_code
-  ; Gemini_code_execution_result
-  ; Gemini_tool_call
-  ; Gemini_tool_response
-  ; Gemini_function_response
-  ; Gemini_file_data
-  ; Gemini_audio_transcription
+let gemini_unsupported_response_wire_name = function
+  | Gemini_multiple_candidates _ -> "candidates"
+;;
+
+let gemini_unsupported_payload_kinds =
+  [ Gemini_executable_code_payload
+  ; Gemini_code_execution_result_payload
+  ; Gemini_tool_call_payload
+  ; Gemini_tool_response_payload
+  ; Gemini_function_response_payload
+  ; Gemini_file_data_payload
+  ; Gemini_audio_transcription_payload
   ]
 ;;
 
 let gemini_unsupported_part_fields =
-  List.map gemini_unsupported_part_wire_name gemini_unsupported_part_kinds
+  List.map gemini_unsupported_payload_kind_wire_name gemini_unsupported_payload_kinds
   @ gemini_part_metadata_fields
 ;;
 
@@ -2202,16 +2237,16 @@ let gemini_unsupported_part_of_json ~position part =
       let payloads =
         List.filter_map
           (fun kind ->
-             let key = gemini_unsupported_part_wire_name kind in
+             let key = gemini_unsupported_payload_kind_wire_name kind in
              match List.assoc_opt key fields with
              | Some value -> Some (kind, value)
              | None -> None)
-          gemini_unsupported_part_kinds
+          gemini_unsupported_payload_kinds
       in
       match payloads with
       | [] -> None
       | _ :: _ :: _ -> Some (Error (path ^ ":multiple_payloads"))
-      | [ (Gemini_executable_code, value) ] ->
+      | [ (Gemini_executable_code_payload, value) ] ->
         let ( let* ) = Result.bind in
         Some
           (let* () = validate_gemini_unsupported_part_envelope ~path fields in
@@ -2233,7 +2268,7 @@ let gemini_unsupported_part_of_json ~position part =
              gemini_required_string ~path:(path ^ ".executableCode") "code" code
            in
            Ok Gemini_executable_code)
-      | [ (Gemini_code_execution_result, value) ] ->
+      | [ (Gemini_code_execution_result_payload, value) ] ->
         let ( let* ) = Result.bind in
         Some
           (let* () = validate_gemini_unsupported_part_envelope ~path fields in
@@ -2257,7 +2292,7 @@ let gemini_unsupported_part_of_json ~position part =
              gemini_optional_string ~path:(path ^ ".codeExecutionResult") "output" result
            in
            Ok Gemini_code_execution_result)
-      | [ (Gemini_tool_call, value) ] ->
+      | [ (Gemini_tool_call_payload, value) ] ->
         let ( let* ) = Result.bind in
         Some
           (let* () = validate_gemini_unsupported_part_envelope ~path fields in
@@ -2276,7 +2311,7 @@ let gemini_unsupported_part_of_json ~position part =
            in
            let* () = gemini_optional_object ~path:tool_call_path "args" tool_call in
            Ok Gemini_tool_call)
-      | [ (Gemini_tool_response, value) ] ->
+      | [ (Gemini_tool_response_payload, value) ] ->
         let ( let* ) = Result.bind in
         Some
           (let* () = validate_gemini_unsupported_part_envelope ~path fields in
@@ -2301,7 +2336,8 @@ let gemini_unsupported_part_of_json ~position part =
              gemini_optional_object ~path:tool_response_path "response" tool_response
            in
            Ok Gemini_tool_response)
-      | [ ( ((Gemini_function_response | Gemini_file_data | Gemini_audio_transcription) as
+      | [ ( ((Gemini_function_response_payload | Gemini_file_data_payload
+             | Gemini_audio_transcription_payload) as
              kind)
           , value )
         ] ->
@@ -2310,11 +2346,14 @@ let gemini_unsupported_part_of_json ~position part =
           (let* () = validate_gemini_unsupported_part_envelope ~path fields in
            let* _ =
              gemini_object_fields
-               ~path:(path ^ "." ^ gemini_unsupported_part_wire_name kind)
+               ~path:(path ^ "." ^ gemini_unsupported_payload_kind_wire_name kind)
                value
            in
-           Ok kind)
-      | [ (Gemini_streaming_function_call_arguments, _) ] -> assert false)
+           Ok
+             (match kind with
+              | Gemini_function_response_payload -> Gemini_function_response
+              | Gemini_file_data_payload -> Gemini_file_data
+              | Gemini_audio_transcription_payload -> Gemini_audio_transcription)))
   | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> None
 ;;
 
@@ -2352,7 +2391,9 @@ let parse_gemini_json json : (gemini_chunk, gemini_payload_failure) result =
     match candidates with
     | [ candidate ] -> Ok candidate
     | _ :: _ ->
-      Error (Gemini_payload_malformed "gemini.candidates:multiple_candidates_unsupported")
+      Error
+        (Gemini_payload_unsupported_response
+           (Gemini_multiple_candidates { count = List.length candidates }))
     | [] ->
       let* prompt_feedback = gemini_field ~path:"gemini" "promptFeedback" json in
       let* prompt_feedback =
@@ -2463,7 +2504,9 @@ let parse_gemini_sse_chunk data_str : gemini_sse_parse_result =
      | Error (Gemini_payload_malformed reason) ->
        Gemini_parse_failed { raw = data_str; reason }
      | Error (Gemini_payload_unsupported_part part) ->
-       Gemini_unsupported_part { raw = data_str; part })
+       Gemini_unsupported_part { raw = data_str; part }
+     | Error (Gemini_payload_unsupported_response response) ->
+       Gemini_unsupported_response { raw = data_str; response })
 ;;
 
 let gemini_chunk_to_events_impl (state : openai_stream_state) (chunk : gemini_chunk)

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -1843,8 +1843,20 @@ type gemini_chunk =
   ; gem_usage : api_usage option
   }
 
+type gemini_unsupported_part =
+  | Gemini_executable_code
+  | Gemini_code_execution_result
+  | Gemini_tool_call
+  | Gemini_tool_response
+  | Gemini_function_response
+  | Gemini_file_data
+
 type gemini_sse_parse_result =
   | Gemini_chunk of gemini_chunk
+  | Gemini_unsupported_part of
+      { part : gemini_unsupported_part
+      ; raw : string
+      }
   | Gemini_parse_failed of
       { reason : string
       ; raw : string
@@ -2014,16 +2026,56 @@ let validate_gemini_part ~position part =
   | _ -> Error (path ^ ":multiple_payloads")
 ;;
 
-let parse_gemini_json json : (gemini_chunk, string) result =
+type gemini_payload_failure =
+  | Gemini_payload_malformed of string
+  | Gemini_payload_unsupported_part of gemini_unsupported_part
+
+let gemini_unsupported_part_wire_name = function
+  | Gemini_executable_code -> "executableCode"
+  | Gemini_code_execution_result -> "codeExecutionResult"
+  | Gemini_tool_call -> "toolCall"
+  | Gemini_tool_response -> "toolResponse"
+  | Gemini_function_response -> "functionResponse"
+  | Gemini_file_data -> "fileData"
+;;
+
+let gemini_unsupported_part_of_json = function
+  | `Assoc fields ->
+    [ Gemini_executable_code
+    ; Gemini_code_execution_result
+    ; Gemini_tool_call
+    ; Gemini_tool_response
+    ; Gemini_function_response
+    ; Gemini_file_data
+    ]
+    |> List.find_opt (fun part ->
+      List.mem_assoc (gemini_unsupported_part_wire_name part) fields)
+  | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> None
+;;
+
+let parse_gemini_json json : (gemini_chunk, gemini_payload_failure) result =
+  let malformed result =
+    Result.map_error (fun reason -> Gemini_payload_malformed reason) result
+  in
+  let gemini_optional_string ~path key json =
+    malformed (gemini_optional_string ~path key json)
+  in
+  let gemini_field ~path key json = malformed (gemini_field ~path key json) in
+  let gemini_list ~path json = malformed (gemini_list ~path json) in
+  let gemini_object ~path json = malformed (gemini_object ~path json) in
+  let gemini_optional_int_default_zero ~path key json =
+    malformed (gemini_optional_int_default_zero ~path key json)
+  in
   let ( let* ) = Result.bind in
   let* () =
     match json with
     | `Assoc _ -> Ok ()
     | value ->
       Error
-        (Printf.sprintf
-           "gemini_sse_payload:not_object(got %s)"
-           (Json_util.json_type_name value))
+        (Gemini_payload_malformed
+           (Printf.sprintf
+              "gemini_sse_payload:not_object(got %s)"
+              (Json_util.json_type_name value)))
   in
   let* model_version = gemini_optional_string ~path:"gemini" "modelVersion" json in
   let* candidates_value = gemini_field ~path:"gemini" "candidates" json in
@@ -2031,8 +2083,9 @@ let parse_gemini_json json : (gemini_chunk, string) result =
   let* candidate =
     match candidates with
     | [ candidate ] -> Ok candidate
-    | _ :: _ -> Error "gemini.candidates:multiple_candidates_unsupported"
-    | [] -> Error "gemini.candidates:empty"
+    | _ :: _ ->
+      Error (Gemini_payload_malformed "gemini.candidates:multiple_candidates_unsupported")
+    | [] -> Error (Gemini_payload_malformed "gemini.candidates:empty")
   in
   let* candidate = gemini_object ~path:"gemini.candidates[0]" candidate in
   let* content = gemini_field ~path:"gemini.candidates[0]" "content" candidate in
@@ -2042,8 +2095,12 @@ let parse_gemini_json json : (gemini_chunk, string) result =
   let rec validate_parts position = function
     | [] -> Ok ()
     | part :: rest ->
-      let* () = validate_gemini_part ~position part in
-      validate_parts (position + 1) rest
+      (match gemini_unsupported_part_of_json part with
+       | Some part -> Error (Gemini_payload_unsupported_part part)
+       | None ->
+         (match validate_gemini_part ~position part with
+          | Error reason -> Error (Gemini_payload_malformed reason)
+          | Ok () -> validate_parts (position + 1) rest))
   in
   let* () = validate_parts 0 parts in
   let* gem_finish_reason =
@@ -2081,9 +2138,10 @@ let parse_gemini_json json : (gemini_chunk, string) result =
            })
     | Some value ->
       Error
-        (Printf.sprintf
-           "gemini.usageMetadata:not_object(got %s)"
-           (Json_util.json_type_name value))
+        (Gemini_payload_malformed
+           (Printf.sprintf
+              "gemini.usageMetadata:not_object(got %s)"
+              (Json_util.json_type_name value)))
   in
   Ok
     { gem_model = Option.value ~default:"" model_version
@@ -2102,7 +2160,10 @@ let parse_gemini_sse_chunk data_str : gemini_sse_parse_result =
   | json ->
     (match parse_gemini_json json with
      | Ok chunk -> Gemini_chunk chunk
-     | Error reason -> Gemini_parse_failed { raw = data_str; reason })
+     | Error (Gemini_payload_malformed reason) ->
+       Gemini_parse_failed { raw = data_str; reason }
+     | Error (Gemini_payload_unsupported_part part) ->
+       Gemini_unsupported_part { raw = data_str; part })
 ;;
 
 let gemini_chunk_to_events_impl (state : openai_stream_state) (chunk : gemini_chunk)

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -1843,47 +1843,269 @@ type gemini_chunk =
   ; gem_usage : api_usage option
   }
 
-let parse_gemini_sse_chunk data_str : gemini_chunk option =
-  let open Yojson.Safe.Util in
-  try
-    let json = Yojson.Safe.from_string data_str in
-    let gem_model = Cli_common_json.member_str "modelVersion" json in
-    let candidate =
-      match json |> member "candidates" with
-      | `List (c :: _) -> c
-      | `List [] -> `Assoc []
-      | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _ ->
-        `Assoc []
-    in
-    let gem_parts =
-      match candidate |> member "content" |> member "parts" with
-      | `List ps -> ps
-      | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _ -> []
-    in
-    let gem_finish_reason = candidate |> member "finishReason" |> to_string_option in
-    let gem_usage =
-      let um = json |> member "usageMetadata" in
-      if um = `Null
-      then None
-      else
-        Some
-          { input_tokens = Cli_common_json.member_int "promptTokenCount" um
-          ; output_tokens = Cli_common_json.member_int "candidatesTokenCount" um
-          ; cache_creation_input_tokens = 0
-          ; cache_read_input_tokens =
-              Cli_common_json.member_int "cachedContentTokenCount" um
-          ; cost_usd = None
-          }
-    in
-    Some { gem_model; gem_parts; gem_finish_reason; gem_usage }
-  with
-  | Yojson.Safe.Util.Type_error _
-  | Yojson.Safe.Util.Undefined _
-  | Yojson.Json_error _
-  | Invalid_argument _ -> None
+type gemini_sse_parse_result =
+  | Gemini_chunk of gemini_chunk
+  | Gemini_parse_failed of
+      { reason : string
+      ; raw : string
+      }
+
+type gemini_chunk_to_events_error = { reason : string }
+
+let gemini_assoc_field key = function
+  | `Assoc fields -> List.assoc_opt key fields
+  | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> None
 ;;
 
-let gemini_chunk_to_events (state : openai_stream_state) (chunk : gemini_chunk)
+let gemini_field ~path key json =
+  match json with
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some value -> Ok value
+     | None -> Error (Printf.sprintf "%s.%s:missing" path key))
+  | value ->
+    Error (Printf.sprintf "%s:not_object(got %s)" path (Json_util.json_type_name value))
+;;
+
+let gemini_object ~path = function
+  | `Assoc _ as value -> Ok value
+  | value ->
+    Error (Printf.sprintf "%s:not_object(got %s)" path (Json_util.json_type_name value))
+;;
+
+let gemini_list ~path = function
+  | `List values -> Ok values
+  | value ->
+    Error (Printf.sprintf "%s:not_array(got %s)" path (Json_util.json_type_name value))
+;;
+
+let gemini_optional_string ~path key json =
+  match gemini_assoc_field key json with
+  | None | Some `Null -> Ok None
+  | Some (`String value) -> Ok (Some value)
+  | Some value ->
+    Error
+      (Printf.sprintf
+         "%s.%s:not_string(got %s)"
+         path
+         key
+         (Json_util.json_type_name value))
+;;
+
+let gemini_required_string ~path key json =
+  match gemini_field ~path key json with
+  | Ok (`String value) when not (Api_common.string_is_blank value) -> Ok value
+  | Ok (`String _) -> Error (Printf.sprintf "%s.%s:blank" path key)
+  | Ok value ->
+    Error
+      (Printf.sprintf
+         "%s.%s:not_string(got %s)"
+         path
+         key
+         (Json_util.json_type_name value))
+  | Error _ as error -> error
+;;
+
+let gemini_optional_int_default_zero ~path key json =
+  match gemini_assoc_field key json with
+  | None | Some `Null -> Ok 0
+  | Some (`Int value) -> Ok value
+  | Some (`Intlit raw) ->
+    (match int_of_string_opt raw with
+     | Some value -> Ok value
+     | None -> Error (Printf.sprintf "%s.%s:not_integer" path key))
+  | Some value ->
+    Error
+      (Printf.sprintf
+         "%s.%s:not_integer(got %s)"
+         path
+         key
+         (Json_util.json_type_name value))
+;;
+
+let validate_gemini_part ~position part =
+  let ( let* ) = Result.bind in
+  let path = Printf.sprintf "gemini.candidates[0].content.parts[%d]" position in
+  let* fields =
+    match part with
+    | `Assoc fields -> Ok fields
+    | value ->
+      Error (Printf.sprintf "%s:not_object(got %s)" path (Json_util.json_type_name value))
+  in
+  let part = `Assoc fields in
+  let* () =
+    let supported_payloads = [ "text"; "functionCall"; "inlineData" ] in
+    let metadata_fields = [ "thought"; "thoughtSignature" ] in
+    let unsupported_field =
+      List.find_opt
+        (fun (key, _) -> not (List.mem key (supported_payloads @ metadata_fields)))
+        fields
+    in
+    match unsupported_field with
+    | Some (key, _) -> Error (Printf.sprintf "%s.%s:unsupported_field" path key)
+    | None -> Ok ()
+  in
+  let* () =
+    match gemini_assoc_field "thought" part with
+    | None | Some `Null | Some (`Bool _) -> Ok ()
+    | Some value ->
+      Error
+        (Printf.sprintf
+           "%s.thought:not_boolean(got %s)"
+           path
+           (Json_util.json_type_name value))
+  in
+  let* () =
+    match gemini_assoc_field "thoughtSignature" part with
+    | None | Some `Null -> Ok ()
+    | Some (`String value) when not (Api_common.string_is_blank value) -> Ok ()
+    | Some (`String _) -> Error (Printf.sprintf "%s.thoughtSignature:blank" path)
+    | Some value ->
+      Error
+        (Printf.sprintf
+           "%s.thoughtSignature:not_string(got %s)"
+           path
+           (Json_util.json_type_name value))
+  in
+  let payloads =
+    List.filter_map
+      (fun key ->
+         match gemini_assoc_field key part with
+         | None -> None
+         | Some value -> Some (key, value))
+      [ "text"; "functionCall"; "inlineData" ]
+  in
+  match payloads with
+  | [] -> Error (path ^ ":missing_supported_payload")
+  | [ ("text", `String _) ] -> Ok ()
+  | [ ("text", value) ] ->
+    Error
+      (Printf.sprintf "%s.text:not_string(got %s)" path (Json_util.json_type_name value))
+  | [ ("functionCall", (`Assoc function_call_fields as function_call)) ] ->
+    let unsupported_field =
+      List.find_opt
+        (fun (key, _) -> not (List.mem key [ "id"; "name"; "args" ]))
+        function_call_fields
+    in
+    let* () =
+      match unsupported_field with
+      | Some (key, _) ->
+        Error (Printf.sprintf "%s.functionCall.%s:unsupported_field" path key)
+      | None -> Ok ()
+    in
+    let* _id = gemini_optional_string ~path:(path ^ ".functionCall") "id" function_call in
+    let* _ = gemini_required_string ~path:(path ^ ".functionCall") "name" function_call in
+    let* args = gemini_field ~path:(path ^ ".functionCall") "args" function_call in
+    let* _args = gemini_object ~path:(path ^ ".functionCall.args") args in
+    Ok ()
+  | [ ("functionCall", value) ] ->
+    Error
+      (Printf.sprintf
+         "%s.functionCall:not_object(got %s)"
+         path
+         (Json_util.json_type_name value))
+  | [ ("inlineData", `Assoc _) ] -> Ok ()
+  | [ ("inlineData", value) ] ->
+    Error
+      (Printf.sprintf
+         "%s.inlineData:not_object(got %s)"
+         path
+         (Json_util.json_type_name value))
+  | _ -> Error (path ^ ":multiple_payloads")
+;;
+
+let parse_gemini_json json : (gemini_chunk, string) result =
+  let ( let* ) = Result.bind in
+  let* () =
+    match json with
+    | `Assoc _ -> Ok ()
+    | value ->
+      Error
+        (Printf.sprintf
+           "gemini_sse_payload:not_object(got %s)"
+           (Json_util.json_type_name value))
+  in
+  let* model_version = gemini_optional_string ~path:"gemini" "modelVersion" json in
+  let* candidates_value = gemini_field ~path:"gemini" "candidates" json in
+  let* candidates = gemini_list ~path:"gemini.candidates" candidates_value in
+  let* candidate =
+    match candidates with
+    | [ candidate ] -> Ok candidate
+    | _ :: _ -> Error "gemini.candidates:multiple_candidates_unsupported"
+    | [] -> Error "gemini.candidates:empty"
+  in
+  let* candidate = gemini_object ~path:"gemini.candidates[0]" candidate in
+  let* content = gemini_field ~path:"gemini.candidates[0]" "content" candidate in
+  let* content = gemini_object ~path:"gemini.candidates[0].content" content in
+  let* parts_value = gemini_field ~path:"gemini.candidates[0].content" "parts" content in
+  let* parts = gemini_list ~path:"gemini.candidates[0].content.parts" parts_value in
+  let rec validate_parts position = function
+    | [] -> Ok ()
+    | part :: rest ->
+      let* () = validate_gemini_part ~position part in
+      validate_parts (position + 1) rest
+  in
+  let* () = validate_parts 0 parts in
+  let* gem_finish_reason =
+    gemini_optional_string ~path:"gemini.candidates[0]" "finishReason" candidate
+  in
+  let* gem_usage =
+    match gemini_assoc_field "usageMetadata" json with
+    | None | Some `Null -> Ok None
+    | Some (`Assoc _ as usage) ->
+      let* input_tokens =
+        gemini_optional_int_default_zero
+          ~path:"gemini.usageMetadata"
+          "promptTokenCount"
+          usage
+      in
+      let* output_tokens =
+        gemini_optional_int_default_zero
+          ~path:"gemini.usageMetadata"
+          "candidatesTokenCount"
+          usage
+      in
+      let* cache_read_input_tokens =
+        gemini_optional_int_default_zero
+          ~path:"gemini.usageMetadata"
+          "cachedContentTokenCount"
+          usage
+      in
+      Ok
+        (Some
+           { input_tokens
+           ; output_tokens
+           ; cache_creation_input_tokens = 0
+           ; cache_read_input_tokens
+           ; cost_usd = None
+           })
+    | Some value ->
+      Error
+        (Printf.sprintf
+           "gemini.usageMetadata:not_object(got %s)"
+           (Json_util.json_type_name value))
+  in
+  Ok
+    { gem_model = Option.value ~default:"" model_version
+    ; gem_parts = parts
+    ; gem_finish_reason
+    ; gem_usage
+    }
+;;
+
+let parse_gemini_sse_chunk data_str : gemini_sse_parse_result =
+  match Yojson.Safe.from_string data_str with
+  | exception Yojson.Json_error message ->
+    Gemini_parse_failed { raw = data_str; reason = "json_error: " ^ message }
+  | exception Invalid_argument message ->
+    Gemini_parse_failed { raw = data_str; reason = "json_invalid_argument: " ^ message }
+  | json ->
+    (match parse_gemini_json json with
+     | Ok chunk -> Gemini_chunk chunk
+     | Error reason -> Gemini_parse_failed { raw = data_str; reason })
+;;
+
+let gemini_chunk_to_events_impl (state : openai_stream_state) (chunk : gemini_chunk)
   : sse_event list * Telemetry_event.t option
   =
   let open Yojson.Safe.Util in
@@ -2117,6 +2339,29 @@ let gemini_chunk_to_events (state : openai_stream_state) (chunk : gemini_chunk)
      emit (MessageDelta { stop_reason = Some stop_reason; usage = chunk.gem_usage })
    | None -> ());
   List.rev !events, !telemetry_event
+;;
+
+let rec validate_gemini_parts position = function
+  | [] -> Ok ()
+  | part :: rest ->
+    (match validate_gemini_part ~position part with
+     | Error _ as error -> error
+     | Ok () -> validate_gemini_parts (position + 1) rest)
+;;
+
+let gemini_chunk_to_events state chunk =
+  match validate_gemini_parts 0 chunk.gem_parts with
+  | Error reason -> Error { reason = "gemini_sse_chunk_shape_failure: " ^ reason }
+  | Ok () ->
+    (try Ok (gemini_chunk_to_events_impl state chunk) with
+     | Backend_gemini.Gemini_api_error reason ->
+       Error { reason = "gemini_sse_chunk_decode_failure: " ^ reason }
+     | Yojson.Safe.Util.Type_error (reason, _) ->
+       Error { reason = "gemini_sse_chunk_decode_type_error: " ^ reason }
+     | Yojson.Safe.Util.Undefined (reason, _) ->
+       Error { reason = "gemini_sse_chunk_decode_undefined: " ^ reason }
+     | Invalid_argument reason ->
+       Error { reason = "gemini_sse_chunk_decode_invalid_argument: " ^ reason })
 ;;
 
 (** {1 Ollama NDJSON Streaming}

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -1853,6 +1853,10 @@ type gemini_unsupported_part =
   | Gemini_code_execution_result
   | Gemini_tool_call
   | Gemini_tool_response
+  | Gemini_function_response
+  | Gemini_file_data
+  | Gemini_audio_transcription
+  | Gemini_streaming_function_call_arguments
 
 type gemini_sse_parse_result =
   | Gemini_chunk of gemini_chunk
@@ -1950,19 +1954,38 @@ let validate_gemini_part_metadata ~path part =
            path
            (Json_util.json_type_name value))
   in
-  match gemini_assoc_field "thoughtSignature" part with
-  | None | Some `Null -> Ok ()
-  | Some (`String value) when not (Api_common.string_is_blank value) -> Ok ()
-  | Some (`String _) -> Error (Printf.sprintf "%s.thoughtSignature:blank" path)
-  | Some value ->
-    Error
-      (Printf.sprintf
-         "%s.thoughtSignature:not_string(got %s)"
-         path
-         (Json_util.json_type_name value))
+  let* () =
+    match gemini_assoc_field "thoughtSignature" part with
+    | None | Some `Null -> Ok ()
+    | Some (`String value) when not (Api_common.string_is_blank value) -> Ok ()
+    | Some (`String _) -> Error (Printf.sprintf "%s.thoughtSignature:blank" path)
+    | Some value ->
+      Error
+        (Printf.sprintf
+           "%s.thoughtSignature:not_string(got %s)"
+           path
+           (Json_util.json_type_name value))
+  in
+  let rec validate_objects = function
+    | [] -> Ok ()
+    | key :: rest ->
+      (match gemini_assoc_field key part with
+       | None | Some `Null | Some (`Assoc _) -> validate_objects rest
+       | Some value ->
+         Error
+           (Printf.sprintf
+              "%s.%s:not_object(got %s)"
+              path
+              key
+              (Json_util.json_type_name value)))
+  in
+  validate_objects [ "partMetadata"; "mediaResolution"; "videoMetadata" ]
 ;;
 
-let gemini_part_metadata_fields = [ "thought"; "thoughtSignature" ]
+let gemini_part_metadata_fields =
+  [ "thought"; "thoughtSignature"; "partMetadata"; "mediaResolution"; "videoMetadata" ]
+;;
+
 let gemini_supported_part_payloads = [ "text"; "functionCall"; "inlineData" ]
 
 let validate_gemini_part ~position part =
@@ -2003,9 +2026,17 @@ let validate_gemini_part ~position part =
     Error
       (Printf.sprintf "%s.text:not_string(got %s)" path (Json_util.json_type_name value))
   | [ ("functionCall", (`Assoc function_call_fields as function_call)) ] ->
+    let* () =
+      if
+        List.mem_assoc "partialArgs" function_call_fields
+        || List.mem_assoc "willContinue" function_call_fields
+      then Error (path ^ ".functionCall:streaming_arguments_unsupported")
+      else Ok ()
+    in
     let unsupported_field =
       List.find_opt
-        (fun (key, _) -> not (List.mem key [ "id"; "name"; "args" ]))
+        (fun (key, _) ->
+           not (List.mem key [ "id"; "name"; "args"; "partialArgs"; "willContinue" ]))
         function_call_fields
     in
     let* () =
@@ -2016,8 +2047,16 @@ let validate_gemini_part ~position part =
     in
     let* _id = gemini_optional_string ~path:(path ^ ".functionCall") "id" function_call in
     let* _ = gemini_required_string ~path:(path ^ ".functionCall") "name" function_call in
-    let* args = gemini_field ~path:(path ^ ".functionCall") "args" function_call in
-    let* _args = gemini_object ~path:(path ^ ".functionCall.args") args in
+    let* () =
+      match gemini_assoc_field "args" function_call with
+      | None | Some `Null | Some (`Assoc _) -> Ok ()
+      | Some value ->
+        Error
+          (Printf.sprintf
+             "%s.functionCall.args:not_object(got %s)"
+             path
+             (Json_util.json_type_name value))
+    in
     Ok ()
   | [ ("functionCall", value) ] ->
     Error
@@ -2044,6 +2083,10 @@ let gemini_unsupported_part_wire_name = function
   | Gemini_code_execution_result -> "codeExecutionResult"
   | Gemini_tool_call -> "toolCall"
   | Gemini_tool_response -> "toolResponse"
+  | Gemini_function_response -> "functionResponse"
+  | Gemini_file_data -> "fileData"
+  | Gemini_audio_transcription -> "audioTranscription"
+  | Gemini_streaming_function_call_arguments -> "functionCall.partialArgs"
 ;;
 
 let gemini_unsupported_part_kinds =
@@ -2051,6 +2094,9 @@ let gemini_unsupported_part_kinds =
   ; Gemini_code_execution_result
   ; Gemini_tool_call
   ; Gemini_tool_response
+  ; Gemini_function_response
+  ; Gemini_file_data
+  ; Gemini_audio_transcription
   ]
 ;;
 
@@ -2095,106 +2141,180 @@ let gemini_unsupported_part_of_json ~position part =
   let path = Printf.sprintf "gemini.candidates[0].content.parts[%d]" position in
   match part with
   | `Assoc fields ->
-    let payloads =
-      List.filter_map
-        (fun kind ->
-           let key = gemini_unsupported_part_wire_name kind in
-           match List.assoc_opt key fields with
-           | Some value -> Some (kind, value)
-           | None -> None)
-        gemini_unsupported_part_kinds
+    let streaming_function_call =
+      match List.assoc_opt "functionCall" fields with
+      | Some (`Assoc function_call_fields) ->
+        List.mem_assoc "partialArgs" function_call_fields
+        || List.mem_assoc "willContinue" function_call_fields
+      | Some _ | None -> false
     in
-    (match payloads with
-     | [] -> None
-     | _ :: _ :: _ -> Some (Error (path ^ ":multiple_payloads"))
-     | [ (Gemini_executable_code, value) ] ->
-       let ( let* ) = Result.bind in
-       Some
-         (let* () = validate_gemini_unsupported_part_envelope ~path fields in
-          let* code_fields =
-            gemini_object_fields ~path:(path ^ ".executableCode") value
-          in
-          let* () =
-            gemini_validate_allowed_fields
-              ~path:(path ^ ".executableCode")
-              ~allowed:[ "id"; "language"; "code" ]
-              code_fields
-          in
-          let code = `Assoc code_fields in
-          let* _id = gemini_optional_string ~path:(path ^ ".executableCode") "id" code in
-          let* _language =
-            gemini_required_string ~path:(path ^ ".executableCode") "language" code
-          in
-          let* _code =
-            gemini_required_string ~path:(path ^ ".executableCode") "code" code
-          in
-          Ok Gemini_executable_code)
-     | [ (Gemini_code_execution_result, value) ] ->
-       let ( let* ) = Result.bind in
-       Some
-         (let* () = validate_gemini_unsupported_part_envelope ~path fields in
-          let* result_fields =
-            gemini_object_fields ~path:(path ^ ".codeExecutionResult") value
-          in
-          let* () =
-            gemini_validate_allowed_fields
-              ~path:(path ^ ".codeExecutionResult")
-              ~allowed:[ "id"; "outcome"; "output" ]
-              result_fields
-          in
-          let result = `Assoc result_fields in
-          let* _id =
-            gemini_optional_string ~path:(path ^ ".codeExecutionResult") "id" result
-          in
-          let* _outcome =
-            gemini_required_string ~path:(path ^ ".codeExecutionResult") "outcome" result
-          in
-          let* _output =
-            gemini_optional_string ~path:(path ^ ".codeExecutionResult") "output" result
-          in
-          Ok Gemini_code_execution_result)
-     | [ (Gemini_tool_call, value) ] ->
-       let ( let* ) = Result.bind in
-       Some
-         (let* () = validate_gemini_unsupported_part_envelope ~path fields in
-          let tool_call_path = path ^ ".toolCall" in
-          let* tool_call_fields = gemini_object_fields ~path:tool_call_path value in
-          let* () =
-            gemini_validate_allowed_fields
-              ~path:tool_call_path
-              ~allowed:[ "id"; "toolType"; "args" ]
-              tool_call_fields
-          in
-          let tool_call = `Assoc tool_call_fields in
-          let* _id = gemini_required_string ~path:tool_call_path "id" tool_call in
-          let* _tool_type =
-            gemini_required_string ~path:tool_call_path "toolType" tool_call
-          in
-          let* () = gemini_optional_object ~path:tool_call_path "args" tool_call in
-          Ok Gemini_tool_call)
-     | [ (Gemini_tool_response, value) ] ->
-       let ( let* ) = Result.bind in
-       Some
-         (let* () = validate_gemini_unsupported_part_envelope ~path fields in
-          let tool_response_path = path ^ ".toolResponse" in
-          let* tool_response_fields =
-            gemini_object_fields ~path:tool_response_path value
-          in
-          let* () =
-            gemini_validate_allowed_fields
-              ~path:tool_response_path
-              ~allowed:[ "id"; "toolType"; "response" ]
-              tool_response_fields
-          in
-          let tool_response = `Assoc tool_response_fields in
-          let* _id = gemini_required_string ~path:tool_response_path "id" tool_response in
-          let* _tool_type =
-            gemini_required_string ~path:tool_response_path "toolType" tool_response
-          in
-          let* () =
-            gemini_optional_object ~path:tool_response_path "response" tool_response
-          in
-          Ok Gemini_tool_response))
+    if streaming_function_call
+    then
+      Some
+        (let ( let* ) = Result.bind in
+         let* () =
+           gemini_validate_allowed_fields
+             ~path
+             ~allowed:(gemini_supported_part_payloads @ gemini_part_metadata_fields)
+             fields
+         in
+         let* () = validate_gemini_part_metadata ~path (`Assoc fields) in
+         let function_call_path = path ^ ".functionCall" in
+         let* function_call_fields =
+           match List.assoc_opt "functionCall" fields with
+           | Some value -> gemini_object_fields ~path:function_call_path value
+           | None -> Error (function_call_path ^ ":missing")
+         in
+         let* () =
+           gemini_validate_allowed_fields
+             ~path:function_call_path
+             ~allowed:[ "id"; "name"; "args"; "partialArgs"; "willContinue" ]
+             function_call_fields
+         in
+         let function_call = `Assoc function_call_fields in
+         let* _id = gemini_optional_string ~path:function_call_path "id" function_call in
+         let* _name =
+           gemini_optional_string ~path:function_call_path "name" function_call
+         in
+         let* () = gemini_optional_object ~path:function_call_path "args" function_call in
+         let* () =
+           match gemini_assoc_field "partialArgs" function_call with
+           | None | Some `Null | Some (`List _) -> Ok ()
+           | Some value ->
+             Error
+               (Printf.sprintf
+                  "%s.partialArgs:not_array(got %s)"
+                  function_call_path
+                  (Json_util.json_type_name value))
+         in
+         let* () =
+           match gemini_assoc_field "willContinue" function_call with
+           | None | Some `Null | Some (`Bool _) -> Ok ()
+           | Some value ->
+             Error
+               (Printf.sprintf
+                  "%s.willContinue:not_boolean(got %s)"
+                  function_call_path
+                  (Json_util.json_type_name value))
+         in
+         Ok Gemini_streaming_function_call_arguments)
+    else (
+      let payloads =
+        List.filter_map
+          (fun kind ->
+             let key = gemini_unsupported_part_wire_name kind in
+             match List.assoc_opt key fields with
+             | Some value -> Some (kind, value)
+             | None -> None)
+          gemini_unsupported_part_kinds
+      in
+      match payloads with
+      | [] -> None
+      | _ :: _ :: _ -> Some (Error (path ^ ":multiple_payloads"))
+      | [ (Gemini_executable_code, value) ] ->
+        let ( let* ) = Result.bind in
+        Some
+          (let* () = validate_gemini_unsupported_part_envelope ~path fields in
+           let* code_fields =
+             gemini_object_fields ~path:(path ^ ".executableCode") value
+           in
+           let* () =
+             gemini_validate_allowed_fields
+               ~path:(path ^ ".executableCode")
+               ~allowed:[ "id"; "language"; "code" ]
+               code_fields
+           in
+           let code = `Assoc code_fields in
+           let* _id = gemini_optional_string ~path:(path ^ ".executableCode") "id" code in
+           let* _language =
+             gemini_required_string ~path:(path ^ ".executableCode") "language" code
+           in
+           let* _code =
+             gemini_required_string ~path:(path ^ ".executableCode") "code" code
+           in
+           Ok Gemini_executable_code)
+      | [ (Gemini_code_execution_result, value) ] ->
+        let ( let* ) = Result.bind in
+        Some
+          (let* () = validate_gemini_unsupported_part_envelope ~path fields in
+           let* result_fields =
+             gemini_object_fields ~path:(path ^ ".codeExecutionResult") value
+           in
+           let* () =
+             gemini_validate_allowed_fields
+               ~path:(path ^ ".codeExecutionResult")
+               ~allowed:[ "id"; "outcome"; "output" ]
+               result_fields
+           in
+           let result = `Assoc result_fields in
+           let* _id =
+             gemini_optional_string ~path:(path ^ ".codeExecutionResult") "id" result
+           in
+           let* _outcome =
+             gemini_required_string ~path:(path ^ ".codeExecutionResult") "outcome" result
+           in
+           let* _output =
+             gemini_optional_string ~path:(path ^ ".codeExecutionResult") "output" result
+           in
+           Ok Gemini_code_execution_result)
+      | [ (Gemini_tool_call, value) ] ->
+        let ( let* ) = Result.bind in
+        Some
+          (let* () = validate_gemini_unsupported_part_envelope ~path fields in
+           let tool_call_path = path ^ ".toolCall" in
+           let* tool_call_fields = gemini_object_fields ~path:tool_call_path value in
+           let* () =
+             gemini_validate_allowed_fields
+               ~path:tool_call_path
+               ~allowed:[ "id"; "toolType"; "args" ]
+               tool_call_fields
+           in
+           let tool_call = `Assoc tool_call_fields in
+           let* _id = gemini_required_string ~path:tool_call_path "id" tool_call in
+           let* _tool_type =
+             gemini_required_string ~path:tool_call_path "toolType" tool_call
+           in
+           let* () = gemini_optional_object ~path:tool_call_path "args" tool_call in
+           Ok Gemini_tool_call)
+      | [ (Gemini_tool_response, value) ] ->
+        let ( let* ) = Result.bind in
+        Some
+          (let* () = validate_gemini_unsupported_part_envelope ~path fields in
+           let tool_response_path = path ^ ".toolResponse" in
+           let* tool_response_fields =
+             gemini_object_fields ~path:tool_response_path value
+           in
+           let* () =
+             gemini_validate_allowed_fields
+               ~path:tool_response_path
+               ~allowed:[ "id"; "toolType"; "response" ]
+               tool_response_fields
+           in
+           let tool_response = `Assoc tool_response_fields in
+           let* _id =
+             gemini_required_string ~path:tool_response_path "id" tool_response
+           in
+           let* _tool_type =
+             gemini_required_string ~path:tool_response_path "toolType" tool_response
+           in
+           let* () =
+             gemini_optional_object ~path:tool_response_path "response" tool_response
+           in
+           Ok Gemini_tool_response)
+      | [ ( ((Gemini_function_response | Gemini_file_data | Gemini_audio_transcription) as
+             kind)
+          , value )
+        ] ->
+        let ( let* ) = Result.bind in
+        Some
+          (let* () = validate_gemini_unsupported_part_envelope ~path fields in
+           let* _ =
+             gemini_object_fields
+               ~path:(path ^ "." ^ gemini_unsupported_part_wire_name kind)
+               value
+           in
+           Ok kind)
+      | [ (Gemini_streaming_function_call_arguments, _) ] -> assert false)
   | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> None
 ;;
 
@@ -2204,6 +2324,9 @@ let parse_gemini_json json : (gemini_chunk, gemini_payload_failure) result =
   in
   let gemini_optional_string ~path key json =
     malformed (gemini_optional_string ~path key json)
+  in
+  let gemini_required_string ~path key json =
+    malformed (gemini_required_string ~path key json)
   in
   let gemini_field ~path key json = malformed (gemini_field ~path key json) in
   let gemini_list ~path json = malformed (gemini_list ~path json) in
@@ -2230,13 +2353,36 @@ let parse_gemini_json json : (gemini_chunk, gemini_payload_failure) result =
     | [ candidate ] -> Ok candidate
     | _ :: _ ->
       Error (Gemini_payload_malformed "gemini.candidates:multiple_candidates_unsupported")
-    | [] -> Error (Gemini_payload_malformed "gemini.candidates:empty")
+    | [] ->
+      let* prompt_feedback = gemini_field ~path:"gemini" "promptFeedback" json in
+      let* prompt_feedback =
+        gemini_object ~path:"gemini.promptFeedback" prompt_feedback
+      in
+      let* _block_reason =
+        gemini_required_string ~path:"gemini.promptFeedback" "blockReason" prompt_feedback
+      in
+      Ok
+        (`Assoc
+            [ "finishReason", `String "SAFETY"; "content", `Assoc [ "parts", `List [] ] ])
   in
   let* candidate = gemini_object ~path:"gemini.candidates[0]" candidate in
-  let* content = gemini_field ~path:"gemini.candidates[0]" "content" candidate in
-  let* content = gemini_object ~path:"gemini.candidates[0].content" content in
-  let* parts_value = gemini_field ~path:"gemini.candidates[0].content" "parts" content in
-  let* parts = gemini_list ~path:"gemini.candidates[0].content.parts" parts_value in
+  let* gem_finish_reason =
+    gemini_optional_string ~path:"gemini.candidates[0]" "finishReason" candidate
+  in
+  let terminal_without_content = Option.is_some gem_finish_reason in
+  let* parts =
+    match gemini_assoc_field "content" candidate with
+    | (None | Some `Null) when terminal_without_content -> Ok []
+    | None -> Error (Gemini_payload_malformed "gemini.candidates[0].content:missing")
+    | Some content ->
+      let* content = gemini_object ~path:"gemini.candidates[0].content" content in
+      (match gemini_assoc_field "parts" content with
+       | (None | Some `Null) when terminal_without_content -> Ok []
+       | None ->
+         Error (Gemini_payload_malformed "gemini.candidates[0].content.parts:missing")
+       | Some parts_value ->
+         gemini_list ~path:"gemini.candidates[0].content.parts" parts_value)
+  in
   let rec validate_parts position unsupported_part = function
     | [] -> Ok unsupported_part
     | part :: rest ->
@@ -2259,9 +2405,6 @@ let parse_gemini_json json : (gemini_chunk, gemini_payload_failure) result =
     match unsupported_part with
     | None -> Ok ()
     | Some part -> Error (Gemini_payload_unsupported_part part)
-  in
-  let* gem_finish_reason =
-    gemini_optional_string ~path:"gemini.candidates[0]" "finishReason" candidate
   in
   let* gem_usage =
     match gemini_assoc_field "usageMetadata" json with
@@ -2387,7 +2530,11 @@ let gemini_chunk_to_events_impl (state : openai_stream_state) (chunk : gemini_ch
          match part |> member "functionCall" with
          | `Assoc _ as fc ->
            let name = Cli_common_json.member_str "name" fc in
-           let args = fc |> member "args" in
+           let args =
+             match fc |> member "args" with
+             | `Null -> `Assoc []
+             | args -> args
+           in
            let provider_tool_id = fc |> member "id" |> to_string_option in
            let thought_signature = part_thought_signature in
            let resolution, start =

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -195,6 +195,7 @@ let sse_event_is_first_token_signal (e : sse_event) : bool =
   | SSEParseFailed _
   | NDJSONParseFailed _
   | SSEUnknownEventType _
+  | SSEUnsupportedPart _
   | Connected
   | Timeout _
   | StreamIncomplete _ -> false
@@ -221,6 +222,7 @@ let sse_event_is_deliverable_progress_signal (e : sse_event) : bool =
   | SSEParseFailed _
   | NDJSONParseFailed _
   | SSEUnknownEventType _
+  | SSEUnsupportedPart _
   | Connected
   | Timeout _
   | StreamIncomplete _ -> false
@@ -1283,6 +1285,7 @@ let test_tool_use_start_with_name = function
   | SSEParseFailed _
   | NDJSONParseFailed _
   | SSEUnknownEventType _
+  | SSEUnsupportedPart _
   | Connected
   | Timeout _
   | StreamIncomplete _ -> None
@@ -1302,6 +1305,7 @@ let test_tool_use_start = function
   | SSEParseFailed _
   | NDJSONParseFailed _
   | SSEUnknownEventType _
+  | SSEUnsupportedPart _
   | Connected
   | Timeout _
   | StreamIncomplete _ -> None
@@ -1321,6 +1325,7 @@ let test_input_json_delta = function
   | SSEParseFailed _
   | NDJSONParseFailed _
   | SSEUnknownEventType _
+  | SSEUnsupportedPart _
   | Connected
   | Timeout _
   | StreamIncomplete _ -> None
@@ -1848,8 +1853,6 @@ type gemini_unsupported_part =
   | Gemini_code_execution_result
   | Gemini_tool_call
   | Gemini_tool_response
-  | Gemini_function_response
-  | Gemini_file_data
 
 type gemini_sse_parse_result =
   | Gemini_chunk of gemini_chunk
@@ -1935,6 +1938,33 @@ let gemini_optional_int_default_zero ~path key json =
          (Json_util.json_type_name value))
 ;;
 
+let validate_gemini_part_metadata ~path part =
+  let ( let* ) = Result.bind in
+  let* () =
+    match gemini_assoc_field "thought" part with
+    | None | Some `Null | Some (`Bool _) -> Ok ()
+    | Some value ->
+      Error
+        (Printf.sprintf
+           "%s.thought:not_boolean(got %s)"
+           path
+           (Json_util.json_type_name value))
+  in
+  match gemini_assoc_field "thoughtSignature" part with
+  | None | Some `Null -> Ok ()
+  | Some (`String value) when not (Api_common.string_is_blank value) -> Ok ()
+  | Some (`String _) -> Error (Printf.sprintf "%s.thoughtSignature:blank" path)
+  | Some value ->
+    Error
+      (Printf.sprintf
+         "%s.thoughtSignature:not_string(got %s)"
+         path
+         (Json_util.json_type_name value))
+;;
+
+let gemini_part_metadata_fields = [ "thought"; "thoughtSignature" ]
+let gemini_supported_part_payloads = [ "text"; "functionCall"; "inlineData" ]
+
 let validate_gemini_part ~position part =
   let ( let* ) = Result.bind in
   let path = Printf.sprintf "gemini.candidates[0].content.parts[%d]" position in
@@ -1946,46 +1976,25 @@ let validate_gemini_part ~position part =
   in
   let part = `Assoc fields in
   let* () =
-    let supported_payloads = [ "text"; "functionCall"; "inlineData" ] in
-    let metadata_fields = [ "thought"; "thoughtSignature" ] in
     let unsupported_field =
       List.find_opt
-        (fun (key, _) -> not (List.mem key (supported_payloads @ metadata_fields)))
+        (fun (key, _) ->
+           not
+             (List.mem key (gemini_supported_part_payloads @ gemini_part_metadata_fields)))
         fields
     in
     match unsupported_field with
     | Some (key, _) -> Error (Printf.sprintf "%s.%s:unsupported_field" path key)
     | None -> Ok ()
   in
-  let* () =
-    match gemini_assoc_field "thought" part with
-    | None | Some `Null | Some (`Bool _) -> Ok ()
-    | Some value ->
-      Error
-        (Printf.sprintf
-           "%s.thought:not_boolean(got %s)"
-           path
-           (Json_util.json_type_name value))
-  in
-  let* () =
-    match gemini_assoc_field "thoughtSignature" part with
-    | None | Some `Null -> Ok ()
-    | Some (`String value) when not (Api_common.string_is_blank value) -> Ok ()
-    | Some (`String _) -> Error (Printf.sprintf "%s.thoughtSignature:blank" path)
-    | Some value ->
-      Error
-        (Printf.sprintf
-           "%s.thoughtSignature:not_string(got %s)"
-           path
-           (Json_util.json_type_name value))
-  in
+  let* () = validate_gemini_part_metadata ~path part in
   let payloads =
     List.filter_map
       (fun key ->
          match gemini_assoc_field key part with
          | None -> None
          | Some value -> Some (key, value))
-      [ "text"; "functionCall"; "inlineData" ]
+      gemini_supported_part_payloads
   in
   match payloads with
   | [] -> Error (path ^ ":missing_supported_payload")
@@ -2035,21 +2044,157 @@ let gemini_unsupported_part_wire_name = function
   | Gemini_code_execution_result -> "codeExecutionResult"
   | Gemini_tool_call -> "toolCall"
   | Gemini_tool_response -> "toolResponse"
-  | Gemini_function_response -> "functionResponse"
-  | Gemini_file_data -> "fileData"
 ;;
 
-let gemini_unsupported_part_of_json = function
+let gemini_unsupported_part_kinds =
+  [ Gemini_executable_code
+  ; Gemini_code_execution_result
+  ; Gemini_tool_call
+  ; Gemini_tool_response
+  ]
+;;
+
+let gemini_unsupported_part_fields =
+  List.map gemini_unsupported_part_wire_name gemini_unsupported_part_kinds
+  @ gemini_part_metadata_fields
+;;
+
+let gemini_validate_allowed_fields ~path ~allowed fields =
+  match List.find_opt (fun (key, _) -> not (List.mem key allowed)) fields with
+  | Some (key, _) -> Error (Printf.sprintf "%s.%s:unsupported_field" path key)
+  | None -> Ok ()
+;;
+
+let gemini_object_fields ~path = function
+  | `Assoc fields -> Ok fields
+  | value ->
+    Error (Printf.sprintf "%s:not_object(got %s)" path (Json_util.json_type_name value))
+;;
+
+let gemini_optional_object ~path key json =
+  match gemini_assoc_field key json with
+  | None | Some `Null | Some (`Assoc _) -> Ok ()
+  | Some value ->
+    Error
+      (Printf.sprintf
+         "%s.%s:not_object(got %s)"
+         path
+         key
+         (Json_util.json_type_name value))
+;;
+
+let validate_gemini_unsupported_part_envelope ~path fields =
+  let ( let* ) = Result.bind in
+  let* () =
+    gemini_validate_allowed_fields ~path ~allowed:gemini_unsupported_part_fields fields
+  in
+  validate_gemini_part_metadata ~path (`Assoc fields)
+;;
+
+let gemini_unsupported_part_of_json ~position part =
+  let path = Printf.sprintf "gemini.candidates[0].content.parts[%d]" position in
+  match part with
   | `Assoc fields ->
-    [ Gemini_executable_code
-    ; Gemini_code_execution_result
-    ; Gemini_tool_call
-    ; Gemini_tool_response
-    ; Gemini_function_response
-    ; Gemini_file_data
-    ]
-    |> List.find_opt (fun part ->
-      List.mem_assoc (gemini_unsupported_part_wire_name part) fields)
+    let payloads =
+      List.filter_map
+        (fun kind ->
+           let key = gemini_unsupported_part_wire_name kind in
+           match List.assoc_opt key fields with
+           | Some value -> Some (kind, value)
+           | None -> None)
+        gemini_unsupported_part_kinds
+    in
+    (match payloads with
+     | [] -> None
+     | _ :: _ :: _ -> Some (Error (path ^ ":multiple_payloads"))
+     | [ (Gemini_executable_code, value) ] ->
+       let ( let* ) = Result.bind in
+       Some
+         (let* () = validate_gemini_unsupported_part_envelope ~path fields in
+          let* code_fields =
+            gemini_object_fields ~path:(path ^ ".executableCode") value
+          in
+          let* () =
+            gemini_validate_allowed_fields
+              ~path:(path ^ ".executableCode")
+              ~allowed:[ "id"; "language"; "code" ]
+              code_fields
+          in
+          let code = `Assoc code_fields in
+          let* _id = gemini_optional_string ~path:(path ^ ".executableCode") "id" code in
+          let* _language =
+            gemini_required_string ~path:(path ^ ".executableCode") "language" code
+          in
+          let* _code =
+            gemini_required_string ~path:(path ^ ".executableCode") "code" code
+          in
+          Ok Gemini_executable_code)
+     | [ (Gemini_code_execution_result, value) ] ->
+       let ( let* ) = Result.bind in
+       Some
+         (let* () = validate_gemini_unsupported_part_envelope ~path fields in
+          let* result_fields =
+            gemini_object_fields ~path:(path ^ ".codeExecutionResult") value
+          in
+          let* () =
+            gemini_validate_allowed_fields
+              ~path:(path ^ ".codeExecutionResult")
+              ~allowed:[ "id"; "outcome"; "output" ]
+              result_fields
+          in
+          let result = `Assoc result_fields in
+          let* _id =
+            gemini_optional_string ~path:(path ^ ".codeExecutionResult") "id" result
+          in
+          let* _outcome =
+            gemini_required_string ~path:(path ^ ".codeExecutionResult") "outcome" result
+          in
+          let* _output =
+            gemini_optional_string ~path:(path ^ ".codeExecutionResult") "output" result
+          in
+          Ok Gemini_code_execution_result)
+     | [ (Gemini_tool_call, value) ] ->
+       let ( let* ) = Result.bind in
+       Some
+         (let* () = validate_gemini_unsupported_part_envelope ~path fields in
+          let tool_call_path = path ^ ".toolCall" in
+          let* tool_call_fields = gemini_object_fields ~path:tool_call_path value in
+          let* () =
+            gemini_validate_allowed_fields
+              ~path:tool_call_path
+              ~allowed:[ "id"; "toolType"; "args" ]
+              tool_call_fields
+          in
+          let tool_call = `Assoc tool_call_fields in
+          let* _id = gemini_required_string ~path:tool_call_path "id" tool_call in
+          let* _tool_type =
+            gemini_required_string ~path:tool_call_path "toolType" tool_call
+          in
+          let* () = gemini_optional_object ~path:tool_call_path "args" tool_call in
+          Ok Gemini_tool_call)
+     | [ (Gemini_tool_response, value) ] ->
+       let ( let* ) = Result.bind in
+       Some
+         (let* () = validate_gemini_unsupported_part_envelope ~path fields in
+          let tool_response_path = path ^ ".toolResponse" in
+          let* tool_response_fields =
+            gemini_object_fields ~path:tool_response_path value
+          in
+          let* () =
+            gemini_validate_allowed_fields
+              ~path:tool_response_path
+              ~allowed:[ "id"; "toolType"; "response" ]
+              tool_response_fields
+          in
+          let tool_response = `Assoc tool_response_fields in
+          let* _id = gemini_required_string ~path:tool_response_path "id" tool_response in
+          let* _tool_type =
+            gemini_required_string ~path:tool_response_path "toolType" tool_response
+          in
+          let* () =
+            gemini_optional_object ~path:tool_response_path "response" tool_response
+          in
+          Ok Gemini_tool_response))
   | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> None
 ;;
 
@@ -2092,17 +2237,29 @@ let parse_gemini_json json : (gemini_chunk, gemini_payload_failure) result =
   let* content = gemini_object ~path:"gemini.candidates[0].content" content in
   let* parts_value = gemini_field ~path:"gemini.candidates[0].content" "parts" content in
   let* parts = gemini_list ~path:"gemini.candidates[0].content.parts" parts_value in
-  let rec validate_parts position = function
-    | [] -> Ok ()
+  let rec validate_parts position unsupported_part = function
+    | [] -> Ok unsupported_part
     | part :: rest ->
-      (match gemini_unsupported_part_of_json part with
-       | Some part -> Error (Gemini_payload_unsupported_part part)
+      (match gemini_unsupported_part_of_json ~position part with
+       | Some (Ok part) ->
+         let unsupported_part =
+           match unsupported_part with
+           | Some _ -> unsupported_part
+           | None -> Some part
+         in
+         validate_parts (position + 1) unsupported_part rest
+       | Some (Error reason) -> Error (Gemini_payload_malformed reason)
        | None ->
          (match validate_gemini_part ~position part with
           | Error reason -> Error (Gemini_payload_malformed reason)
-          | Ok () -> validate_parts (position + 1) rest))
+          | Ok () -> validate_parts (position + 1) unsupported_part rest))
   in
-  let* () = validate_parts 0 parts in
+  let* unsupported_part = validate_parts 0 None parts in
+  let* () =
+    match unsupported_part with
+    | None -> Ok ()
+    | Some part -> Error (Gemini_payload_unsupported_part part)
+  in
   let* gem_finish_reason =
     gemini_optional_string ~path:"gemini.candidates[0]" "finishReason" candidate
   in

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -2119,6 +2119,16 @@ let gemini_unsupported_payload_kind_wire_name = function
   | Gemini_audio_transcription_payload -> "audioTranscription"
 ;;
 
+let gemini_unsupported_part_of_payload_kind = function
+  | Gemini_executable_code_payload -> Gemini_executable_code
+  | Gemini_code_execution_result_payload -> Gemini_code_execution_result
+  | Gemini_tool_call_payload -> Gemini_tool_call
+  | Gemini_tool_response_payload -> Gemini_tool_response
+  | Gemini_function_response_payload -> Gemini_function_response
+  | Gemini_file_data_payload -> Gemini_file_data
+  | Gemini_audio_transcription_payload -> Gemini_audio_transcription
+;;
+
 let gemini_unsupported_part_wire_name = function
   | Gemini_executable_code ->
     gemini_unsupported_payload_kind_wire_name Gemini_executable_code_payload
@@ -2364,11 +2374,7 @@ let gemini_unsupported_part_of_json ~position part =
                ~path:(path ^ "." ^ gemini_unsupported_payload_kind_wire_name kind)
                value
            in
-           Ok
-             (match kind with
-              | Gemini_function_response_payload -> Gemini_function_response
-              | Gemini_file_data_payload -> Gemini_file_data
-              | Gemini_audio_transcription_payload -> Gemini_audio_transcription)))
+           Ok (gemini_unsupported_part_of_payload_kind kind)))
   | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> None
 ;;
 

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -754,6 +754,7 @@ type openai_stream_state =
         the sole identity authority for an open tool block. *)
   ; mutable next_block_index : int
   ; mutable thinking_state : thinking_state
+  ; mutable gemini_message_model : string option
   ; provider : string
   ; model : string
   }
@@ -768,6 +769,7 @@ let create_openai_stream_state ?(provider = "") ?(model = "") () =
   ; tool_block_identities = Hashtbl.create 4
   ; next_block_index = 0
   ; thinking_state = Not_thinking
+  ; gemini_message_model = None
   ; provider
   ; model
   }
@@ -1866,6 +1868,7 @@ type gemini_unsupported_part =
   | Gemini_file_data
   | Gemini_audio_transcription
   | Gemini_streaming_function_call_arguments
+  | Gemini_streaming_function_call_continuation
 
 type gemini_unsupported_response = Gemini_multiple_candidates of { count : int }
 
@@ -2143,6 +2146,7 @@ let gemini_unsupported_part_wire_name = function
   | Gemini_audio_transcription ->
     gemini_unsupported_payload_kind_wire_name Gemini_audio_transcription_payload
   | Gemini_streaming_function_call_arguments -> "functionCall.partialArgs"
+  | Gemini_streaming_function_call_continuation -> "functionCall.willContinue"
 ;;
 
 let gemini_unsupported_response_wire_name = function
@@ -2204,12 +2208,15 @@ let gemini_unsupported_part_of_json ~position part =
     let streaming_function_call =
       match List.assoc_opt "functionCall" fields with
       | Some (`Assoc function_call_fields) ->
-        List.mem_assoc "partialArgs" function_call_fields
-        || List.assoc_opt "willContinue" function_call_fields = Some (`Bool true)
-      | Some _ | None -> false
+        if List.mem_assoc "partialArgs" function_call_fields
+        then Some Gemini_streaming_function_call_arguments
+        else if List.assoc_opt "willContinue" function_call_fields = Some (`Bool true)
+        then Some Gemini_streaming_function_call_continuation
+        else None
+      | Some _ | None -> None
     in
-    if streaming_function_call
-    then
+    (match streaming_function_call with
+     | Some unsupported_part ->
       Some
         (let ( let* ) = Result.bind in
          let* () =
@@ -2257,8 +2264,8 @@ let gemini_unsupported_part_of_json ~position part =
                   function_call_path
                   (Json_util.json_type_name value))
          in
-         Ok Gemini_streaming_function_call_arguments)
-    else (
+         Ok unsupported_part)
+     | None ->
       let payloads =
         List.filter_map
           (fun kind ->
@@ -2542,6 +2549,14 @@ let gemini_chunk_to_events_impl (state : openai_stream_state) (chunk : gemini_ch
   let events = ref [] in
   let emit evt = events := evt :: !events in
   let telemetry_event = ref None in
+  (match chunk.gem_model with
+   | Some model
+     when (match state.gemini_message_model with
+           | Some observed -> not (String.equal observed model)
+           | None -> true) ->
+     state.gemini_message_model <- Some model;
+     emit (MessageStart { id = ""; model; usage = None })
+   | Some _ | None -> ());
   let has_thought_part =
     List.exists
       (fun part ->

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -2400,8 +2400,11 @@ let parse_gemini_json json : (gemini_chunk, gemini_payload_failure) result =
               (Json_util.json_type_name value)))
   in
   let* model_version = gemini_optional_string ~path:"gemini" "modelVersion" json in
-  let* candidates_value = gemini_field ~path:"gemini" "candidates" json in
-  let* candidates = gemini_list ~path:"gemini.candidates" candidates_value in
+  let* candidates =
+    match gemini_assoc_field "candidates" json with
+    | None | Some `Null -> Ok []
+    | Some candidates -> gemini_list ~path:"gemini.candidates" candidates
+  in
   let* candidate, gem_finish_reason =
     match candidates with
     | [ candidate ] ->

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -2385,6 +2385,11 @@ let parse_gemini_json json : (gemini_chunk, gemini_payload_failure) result =
   let gemini_optional_string ~path key json =
     malformed (gemini_optional_string ~path key json)
   in
+  let gemini_optional_finish_reason ~path json =
+    match gemini_optional_string ~path "finishReason" json with
+    | Ok (Some "") -> Ok None
+    | result -> result
+  in
   let gemini_required_string ~path key json =
     malformed (gemini_required_string ~path key json)
   in
@@ -2416,7 +2421,7 @@ let parse_gemini_json json : (gemini_chunk, gemini_payload_failure) result =
     | [ candidate ] ->
       let* candidate = gemini_object ~path:"gemini.candidates[0]" candidate in
       let* finish_reason =
-        gemini_optional_string ~path:"gemini.candidates[0]" "finishReason" candidate
+        gemini_optional_finish_reason ~path:"gemini.candidates[0]" candidate
       in
       Ok
         ( candidate

--- a/lib/llm_provider/streaming.ml
+++ b/lib/llm_provider/streaming.ml
@@ -2070,8 +2070,7 @@ let validate_gemini_part ~position part =
     in
     let* () =
       match gemini_assoc_field "willContinue" function_call with
-      | None | Some `Null | Some (`Bool false) -> Ok ()
-      | Some (`Bool true) -> Error (path ^ ".functionCall:streaming_arguments_unsupported")
+      | None | Some `Null | Some (`Bool _) -> Ok ()
       | Some value ->
         Error
           (Printf.sprintf

--- a/lib/llm_provider/streaming.mli
+++ b/lib/llm_provider/streaming.mli
@@ -164,6 +164,10 @@ type gemini_unsupported_part =
   | Gemini_code_execution_result
   | Gemini_tool_call
   | Gemini_tool_response
+  | Gemini_function_response
+  | Gemini_file_data
+  | Gemini_audio_transcription
+  | Gemini_streaming_function_call_arguments
 
 type gemini_sse_parse_result =
   | Gemini_chunk of gemini_chunk

--- a/lib/llm_provider/streaming.mli
+++ b/lib/llm_provider/streaming.mli
@@ -172,6 +172,7 @@ type gemini_unsupported_part =
   | Gemini_file_data
   | Gemini_audio_transcription
   | Gemini_streaming_function_call_arguments
+  | Gemini_streaming_function_call_continuation
 
 type gemini_unsupported_response = Gemini_multiple_candidates of { count : int }
 

--- a/lib/llm_provider/streaming.mli
+++ b/lib/llm_provider/streaming.mli
@@ -159,12 +159,25 @@ type gemini_chunk =
   ; gem_usage : api_usage option
   }
 
-val parse_gemini_sse_chunk : string -> gemini_chunk option
+type gemini_sse_parse_result =
+  | Gemini_chunk of gemini_chunk
+  | Gemini_parse_failed of
+      { reason : string
+      ; raw : string
+      }
+
+(** Parse one Gemini SSE data payload without collapsing malformed JSON or
+    malformed candidate/part shapes into an absent chunk. A caller that
+    receives [Gemini_parse_failed] must surface the raw payload as a wire
+    failure. *)
+val parse_gemini_sse_chunk : string -> gemini_sse_parse_result
+
+type gemini_chunk_to_events_error = { reason : string }
 
 val gemini_chunk_to_events
   :  openai_stream_state
   -> gemini_chunk
-  -> sse_event list * Telemetry_event.t option
+  -> (sse_event list * Telemetry_event.t option, gemini_chunk_to_events_error) result
 
 (** {1 Ollama NDJSON Streaming}
 

--- a/lib/llm_provider/streaming.mli
+++ b/lib/llm_provider/streaming.mli
@@ -152,10 +152,14 @@ val responses_sse_to_events
     We reuse {!openai_stream_state} for block tracking since the
     state management pattern is identical. *)
 
+type gemini_terminal_reason =
+  | Gemini_candidate_finish_reason of string
+  | Gemini_prompt_block_reason of string
+
 type gemini_chunk =
-  { gem_model : string
+  { gem_model : string option
   ; gem_parts : Yojson.Safe.t list
-  ; gem_finish_reason : string option
+  ; gem_finish_reason : gemini_terminal_reason option
   ; gem_usage : api_usage option
   }
 
@@ -169,8 +173,7 @@ type gemini_unsupported_part =
   | Gemini_audio_transcription
   | Gemini_streaming_function_call_arguments
 
-type gemini_unsupported_response =
-  | Gemini_multiple_candidates of { count : int }
+type gemini_unsupported_response = Gemini_multiple_candidates of { count : int }
 
 type gemini_sse_parse_result =
   | Gemini_chunk of gemini_chunk
@@ -196,7 +199,6 @@ type gemini_sse_parse_result =
 val parse_gemini_sse_chunk : string -> gemini_sse_parse_result
 
 val gemini_unsupported_part_wire_name : gemini_unsupported_part -> string
-
 val gemini_unsupported_response_wire_name : gemini_unsupported_response -> string
 
 type gemini_chunk_to_events_error = { reason : string }

--- a/lib/llm_provider/streaming.mli
+++ b/lib/llm_provider/streaming.mli
@@ -169,10 +169,17 @@ type gemini_unsupported_part =
   | Gemini_audio_transcription
   | Gemini_streaming_function_call_arguments
 
+type gemini_unsupported_response =
+  | Gemini_multiple_candidates of { count : int }
+
 type gemini_sse_parse_result =
   | Gemini_chunk of gemini_chunk
   | Gemini_unsupported_part of
       { part : gemini_unsupported_part
+      ; raw : string
+      }
+  | Gemini_unsupported_response of
+      { response : gemini_unsupported_response
       ; raw : string
       }
   | Gemini_parse_failed of
@@ -183,11 +190,14 @@ type gemini_sse_parse_result =
 (** Parse one Gemini SSE data payload without collapsing malformed JSON or
     malformed candidate/part shapes into an absent chunk. Official Part kinds
     that OAS does not project are returned as [Gemini_unsupported_part], not
-    relabelled as malformed bytes. Callers must surface either failure with the
-    raw payload. *)
+    relabelled as malformed bytes. Official response shapes that OAS does not
+    project are returned as [Gemini_unsupported_response]. Callers must surface
+    either capability fact with the raw payload. *)
 val parse_gemini_sse_chunk : string -> gemini_sse_parse_result
 
 val gemini_unsupported_part_wire_name : gemini_unsupported_part -> string
+
+val gemini_unsupported_response_wire_name : gemini_unsupported_response -> string
 
 type gemini_chunk_to_events_error = { reason : string }
 

--- a/lib/llm_provider/streaming.mli
+++ b/lib/llm_provider/streaming.mli
@@ -164,8 +164,6 @@ type gemini_unsupported_part =
   | Gemini_code_execution_result
   | Gemini_tool_call
   | Gemini_tool_response
-  | Gemini_function_response
-  | Gemini_file_data
 
 type gemini_sse_parse_result =
   | Gemini_chunk of gemini_chunk

--- a/lib/llm_provider/streaming.mli
+++ b/lib/llm_provider/streaming.mli
@@ -159,18 +159,33 @@ type gemini_chunk =
   ; gem_usage : api_usage option
   }
 
+type gemini_unsupported_part =
+  | Gemini_executable_code
+  | Gemini_code_execution_result
+  | Gemini_tool_call
+  | Gemini_tool_response
+  | Gemini_function_response
+  | Gemini_file_data
+
 type gemini_sse_parse_result =
   | Gemini_chunk of gemini_chunk
+  | Gemini_unsupported_part of
+      { part : gemini_unsupported_part
+      ; raw : string
+      }
   | Gemini_parse_failed of
       { reason : string
       ; raw : string
       }
 
 (** Parse one Gemini SSE data payload without collapsing malformed JSON or
-    malformed candidate/part shapes into an absent chunk. A caller that
-    receives [Gemini_parse_failed] must surface the raw payload as a wire
-    failure. *)
+    malformed candidate/part shapes into an absent chunk. Official Part kinds
+    that OAS does not project are returned as [Gemini_unsupported_part], not
+    relabelled as malformed bytes. Callers must surface either failure with the
+    raw payload. *)
 val parse_gemini_sse_chunk : string -> gemini_sse_parse_result
+
+val gemini_unsupported_part_wire_name : gemini_unsupported_part -> string
 
 type gemini_chunk_to_events_error = { reason : string }
 

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -934,6 +934,11 @@ type sse_event =
       { event_type : string
       ; raw : string
       }
+  | SSEUnsupportedPart of
+      { provider_kind : Provider_kind.t
+      ; part : string
+      ; raw : string
+      }
   | Connected
   | Timeout of string
   | StreamIncomplete of { reason : string }
@@ -962,6 +967,11 @@ type stream_error =
   | Stream_incomplete of { reason : string }
   | Stream_unknown_event of
       { event_type : string
+      ; raw : string
+      }
+  | Stream_unsupported_part of
+      { provider_kind : Provider_kind.t
+      ; part : string
       ; raw : string
       }
 

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -939,6 +939,11 @@ type sse_event =
       ; part : string
       ; raw : string
       }
+  | SSEUnsupportedResponse of
+      { provider_kind : Provider_kind.t
+      ; response : string
+      ; raw : string
+      }
   | Connected
   | Timeout of string
   | StreamIncomplete of { reason : string }
@@ -972,6 +977,11 @@ type stream_error =
   | Stream_unsupported_part of
       { provider_kind : Provider_kind.t
       ; part : string
+      ; raw : string
+      }
+  | Stream_unsupported_response of
+      { provider_kind : Provider_kind.t
+      ; response : string
       ; raw : string
       }
 

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -606,6 +606,15 @@ type sse_event =
       projected by this adapter. This is distinct from malformed payloads and
       unknown SSE event types: callers must surface it as a capability
       mismatch rather than treating it as transport corruption. *)
+  | SSEUnsupportedResponse of
+      { provider_kind : Provider_kind.t
+      ; response : string
+      ; raw : string
+      }
+  (** The provider emitted a valid response-level shape whose capability is not
+      projected by this adapter. This is distinct from an unsupported content
+      part and from malformed payloads; callers must preserve the response
+      boundary when classifying the capability mismatch. *)
   | Connected
   | Timeout of string
   | StreamIncomplete of { reason : string }
@@ -647,6 +656,11 @@ type stream_error =
   | Stream_unsupported_part of
       { provider_kind : Provider_kind.t
       ; part : string
+      ; raw : string
+      }
+  | Stream_unsupported_response of
+      { provider_kind : Provider_kind.t
+      ; response : string
       ; raw : string
       }
 

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -597,6 +597,15 @@ type sse_event =
             type the OAS adapter has not yet learned. Emit explicitly so
             the consumer can decide (log + skip vs fail-fast) instead of
             silent data loss. *)
+  | SSEUnsupportedPart of
+      { provider_kind : Provider_kind.t
+      ; part : string
+      ; raw : string
+      }
+  (** The provider emitted a valid content part whose capability is not
+      projected by this adapter. This is distinct from malformed payloads and
+      unknown SSE event types: callers must surface it as a capability
+      mismatch rather than treating it as transport corruption. *)
   | Connected
   | Timeout of string
   | StreamIncomplete of { reason : string }
@@ -633,6 +642,11 @@ type stream_error =
       malformed payload and must remain distinct at the transport boundary. *)
   | Stream_unknown_event of
       { event_type : string
+      ; raw : string
+      }
+  | Stream_unsupported_part of
+      { provider_kind : Provider_kind.t
+      ; part : string
       ; raw : string
       }
 

--- a/test/test_backend_gemini.ml
+++ b/test/test_backend_gemini.ml
@@ -37,6 +37,18 @@ let to_int json = Yojson.Safe.Util.to_int json
 let to_list json = Yojson.Safe.Util.to_list json
 let to_bool json = Yojson.Safe.Util.to_bool json
 
+let parse_gemini_chunk data =
+  match Streaming.parse_gemini_sse_chunk data with
+  | Streaming.Gemini_chunk chunk -> Some chunk
+  | Streaming.Gemini_parse_failed _ -> None
+;;
+
+let gemini_events state chunk =
+  match Streaming.gemini_chunk_to_events state chunk with
+  | Ok events -> events
+  | Error { reason } -> fail ("unexpected Gemini stream decode failure: " ^ reason)
+;;
+
 let content_has_reasoning =
   List.exists (function
     | Types.Thinking _ | ReasoningDetails _ | RedactedThinking _ -> true
@@ -1092,11 +1104,11 @@ let test_gemini_stream_text () =
     }]
   }|}
   in
-  match Streaming.parse_gemini_sse_chunk data with
+  match parse_gemini_chunk data with
   | Some chunk ->
     check int "one part" 1 (List.length chunk.gem_parts);
     let state = Streaming.create_openai_stream_state () in
-    let events, _tel = Streaming.gemini_chunk_to_events state chunk in
+    let events, _tel = gemini_events state chunk in
     check bool "has events" true (List.length events > 0)
   | None -> fail "expected Some chunk"
 ;;
@@ -1112,10 +1124,10 @@ let test_gemini_stream_thinking () =
     }]
   }|}
   in
-  match Streaming.parse_gemini_sse_chunk data with
+  match parse_gemini_chunk data with
   | Some chunk ->
     let state = Streaming.create_openai_stream_state () in
-    let events, _tel = Streaming.gemini_chunk_to_events state chunk in
+    let events, _tel = gemini_events state chunk in
     let has_thinking =
       List.exists
         (function
@@ -1140,10 +1152,10 @@ let test_gemini_stream_function_call () =
     }]
   }|}
   in
-  match Streaming.parse_gemini_sse_chunk data with
+  match parse_gemini_chunk data with
   | Some chunk ->
     let state = Streaming.create_openai_stream_state () in
-    let events, _tel = Streaming.gemini_chunk_to_events state chunk in
+    let events, _tel = gemini_events state chunk in
     (match events with
      | [ Types.ContentBlockStart { content_type = "tool_use"; tool_id = Some id; _ }
        ; Types.ContentBlockDelta _
@@ -1155,7 +1167,7 @@ let test_gemini_stream_function_call () =
 let test_gemini_stream_repeated_idless_calls_stay_distinct () =
   let chunk =
     match
-      Streaming.parse_gemini_sse_chunk
+      parse_gemini_chunk
         {|{"candidates":[{"content":{"parts":[{"functionCall":{"name":"lookup","args":{"q":"same"}}}]}}]}|}
     with
     | Some chunk -> chunk
@@ -1163,7 +1175,7 @@ let test_gemini_stream_repeated_idless_calls_stay_distinct () =
   in
   let state = Streaming.create_openai_stream_state () in
   let start_id () =
-    match fst (Streaming.gemini_chunk_to_events state chunk) with
+    match fst (gemini_events state chunk) with
     | ContentBlockStart { content_type = "tool_use"; tool_id = Some id; _ } :: _ -> id
     | _ -> fail "expected identified Gemini tool start"
   in
@@ -1182,10 +1194,10 @@ let test_gemini_stream_finish () =
     "usageMetadata": {"promptTokenCount": 10, "candidatesTokenCount": 3}
   }|}
   in
-  match Streaming.parse_gemini_sse_chunk data with
+  match parse_gemini_chunk data with
   | Some chunk ->
     let state = Streaming.create_openai_stream_state () in
-    let events, _tel = Streaming.gemini_chunk_to_events state chunk in
+    let events, _tel = gemini_events state chunk in
     let has_delta =
       List.exists
         (function
@@ -1298,9 +1310,9 @@ let test_gemini_stream_thinking_delta_index () =
   }|}
   in
   let state = Streaming.create_openai_stream_state () in
-  (match Streaming.parse_gemini_sse_chunk data1 with
+  (match parse_gemini_chunk data1 with
    | Some chunk ->
-     let events, _tel = Streaming.gemini_chunk_to_events state chunk in
+     let events, _tel = gemini_events state chunk in
      (* ContentBlockStart at index 0, ContentBlockDelta at index 0 *)
      (match events with
       | [ ContentBlockStart { index = start_idx; content_type = "thinking"; _ }
@@ -1321,9 +1333,9 @@ let test_gemini_stream_thinking_delta_index () =
     }]
   }|}
   in
-  (match Streaming.parse_gemini_sse_chunk data2 with
+  (match parse_gemini_chunk data2 with
    | Some chunk ->
-     let events, _tel = Streaming.gemini_chunk_to_events state chunk in
+     let events, _tel = gemini_events state chunk in
      (match events with
       | [ ContentBlockDelta { index; delta = ThinkingDelta _; _ } ] ->
         check int "subsequent thinking index" 0 index
@@ -1340,9 +1352,9 @@ let test_gemini_stream_thinking_delta_index () =
     }]
   }|}
   in
-  match Streaming.parse_gemini_sse_chunk data3 with
+  match parse_gemini_chunk data3 with
   | Some chunk ->
-    let events, _tel = Streaming.gemini_chunk_to_events state chunk in
+    let events, _tel = gemini_events state chunk in
     (match events with
      | [ ContentBlockStart { index = start_idx; content_type = "text"; _ }
        ; ContentBlockDelta { index = delta_idx; delta = TextDelta "answer"; _ }
@@ -1368,9 +1380,9 @@ let test_gemini_stream_tool_first_then_text () =
     }]
   }|}
   in
-  (match Streaming.parse_gemini_sse_chunk data1 with
+  (match parse_gemini_chunk data1 with
    | Some chunk ->
-     let events, _tel = Streaming.gemini_chunk_to_events state chunk in
+     let events, _tel = gemini_events state chunk in
      (match events with
       | [ ContentBlockStart { index; content_type = "tool_use"; _ }
         ; ContentBlockDelta { index = d_idx; delta = InputJsonSnapshot _; _ }
@@ -1390,9 +1402,9 @@ let test_gemini_stream_tool_first_then_text () =
     }]
   }|}
   in
-  (match Streaming.parse_gemini_sse_chunk data2 with
+  (match parse_gemini_chunk data2 with
    | Some chunk ->
-     let events, _tel = Streaming.gemini_chunk_to_events state chunk in
+     let events, _tel = gemini_events state chunk in
      (match events with
       | [ ContentBlockStart { index = s_idx; content_type = "text"; _ }
         ; ContentBlockDelta { index = d_idx; delta = TextDelta "here are the results"; _ }
@@ -1412,9 +1424,9 @@ let test_gemini_stream_tool_first_then_text () =
     }]
   }|}
   in
-  match Streaming.parse_gemini_sse_chunk data3 with
+  match parse_gemini_chunk data3 with
   | Some chunk ->
-    let events, _tel = Streaming.gemini_chunk_to_events state chunk in
+    let events, _tel = gemini_events state chunk in
     (match events with
      | [ ContentBlockDelta { index; delta = TextDelta " for your query"; _ } ] ->
        check int "subsequent text index" 1 index
@@ -1438,10 +1450,10 @@ let test_gemini_stream_function_call_preserves_thought_signature () =
     }]
   }|}
   in
-  match Streaming.parse_gemini_sse_chunk data with
+  match parse_gemini_chunk data with
   | None -> fail "expected Some chunk"
   | Some chunk ->
-    let events, _tel = Streaming.gemini_chunk_to_events state chunk in
+    let events, _tel = gemini_events state chunk in
     (match events with
      | [ ContentBlockStart
            { index = redacted_idx
@@ -1513,10 +1525,10 @@ let test_gemini_stream_textual_parts_preserve_thought_signatures () =
     }]
   }|}
   in
-  match Streaming.parse_gemini_sse_chunk data with
+  match parse_gemini_chunk data with
   | None -> fail "expected Some chunk"
   | Some chunk ->
-    let events, _tel = Streaming.gemini_chunk_to_events state chunk in
+    let events, _tel = gemini_events state chunk in
     (match events with
      | [ ContentBlockStart
            { index = 0
@@ -1572,10 +1584,10 @@ let test_gemini_stream_signed_inline_image () =
   let data =
     {|{"candidates":[{"content":{"role":"model","parts":[{"inlineData":{"mimeType":"image/png","data":"iVBORw0KGgo="},"thoughtSignature":"sig-stream-image"}]},"finishReason":"STOP"}]}|}
   in
-  match Streaming.parse_gemini_sse_chunk data with
+  match parse_gemini_chunk data with
   | None -> fail "expected signed image chunk"
   | Some chunk ->
-    let events, _ = Streaming.gemini_chunk_to_events state chunk in
+    let events, _ = gemini_events state chunk in
     (match events with
      | [ ContentBlockStart
            { index = 0; content_type = "redacted_thinking"; tool_id = Some carrier; _ }
@@ -1606,7 +1618,7 @@ let test_gemini_stream_signed_inline_image () =
 ;;
 
 let parse_gemini_chunk_exn data =
-  match Streaming.parse_gemini_sse_chunk data with
+  match parse_gemini_chunk data with
   | Some chunk -> chunk
   | None -> fail "expected Gemini SSE chunk"
 ;;
@@ -1621,7 +1633,7 @@ let test_gemini_stream_interleaved_thinking_tool_text_finalizes () =
   let acc = Complete_stream_acc.create_stream_acc () in
   let feed data =
     let chunk = parse_gemini_chunk_exn data in
-    let events, _tel = Streaming.gemini_chunk_to_events state chunk in
+    let events, _tel = gemini_events state chunk in
     List.iter (Complete_stream_acc.accumulate_event acc) events
   in
   feed

--- a/test/test_backend_gemini.ml
+++ b/test/test_backend_gemini.ml
@@ -41,6 +41,7 @@ let parse_gemini_chunk data =
   match Streaming.parse_gemini_sse_chunk data with
   | Streaming.Gemini_chunk chunk -> Some chunk
   | Streaming.Gemini_unsupported_part _ -> None
+  | Streaming.Gemini_unsupported_response _ -> None
   | Streaming.Gemini_parse_failed _ -> None
 ;;
 

--- a/test/test_backend_gemini.ml
+++ b/test/test_backend_gemini.ml
@@ -40,6 +40,7 @@ let to_bool json = Yojson.Safe.Util.to_bool json
 let parse_gemini_chunk data =
   match Streaming.parse_gemini_sse_chunk data with
   | Streaming.Gemini_chunk chunk -> Some chunk
+  | Streaming.Gemini_unsupported_part _ -> None
   | Streaming.Gemini_parse_failed _ -> None
 ;;
 
@@ -1215,7 +1216,7 @@ let test_gemini_capabilities_named () =
   check bool "thinking" true caps.supports_extended_thinking;
   check bool "audio" true caps.supports_audio_input;
   check bool "video" true caps.supports_video_input;
-  check bool "code_execution" true caps.supports_code_execution;
+  check bool "code_execution" false caps.supports_code_execution;
   check bool "caching" true caps.supports_caching;
   match caps.max_context_tokens with
   | Some n -> check int "1M context" 1_000_000 n

--- a/test/test_capabilities.ml
+++ b/test/test_capabilities.ml
@@ -239,7 +239,7 @@ let test_lookup_gemini () =
   | Some c ->
     check bool "audio" true c.supports_audio_input;
     check bool "video" true c.supports_video_input;
-    check bool "code execution" true c.supports_code_execution;
+    check bool "code execution" false c.supports_code_execution;
     check bool "structured output" true c.supports_structured_output
   | None -> fail "should match gemini"
 ;;

--- a/test/test_gemini_edge_cases.ml
+++ b/test/test_gemini_edge_cases.ml
@@ -116,7 +116,7 @@ let test_sse_function_call () =
     check "has parts" (List.length chunk.gem_parts > 0);
     check
       "finish reason STOP"
-      (chunk.gem_finish_reason = Some (S.Gemini_candidate_finish_reason "STOP"));
+      (chunk.gem_finish_reason = Some (Streaming.Gemini_candidate_finish_reason "STOP"));
     let state = Streaming.create_openai_stream_state () in
     let events, _tel = gemini_events state chunk in
     let has_tool_start =

--- a/test/test_gemini_edge_cases.ml
+++ b/test/test_gemini_edge_cases.ml
@@ -114,7 +114,9 @@ let test_sse_function_call () =
   | Some chunk ->
     check "parsed chunk" true;
     check "has parts" (List.length chunk.gem_parts > 0);
-    check "finish reason STOP" (chunk.gem_finish_reason = Some "STOP");
+    check
+      "finish reason STOP"
+      (chunk.gem_finish_reason = Some (S.Gemini_candidate_finish_reason "STOP"));
     let state = Streaming.create_openai_stream_state () in
     let events, _tel = gemini_events state chunk in
     let has_tool_start =

--- a/test/test_gemini_edge_cases.ml
+++ b/test/test_gemini_edge_cases.ml
@@ -14,6 +14,7 @@ let parse_gemini_chunk data =
   match Streaming.parse_gemini_sse_chunk data with
   | Streaming.Gemini_chunk chunk -> Some chunk
   | Streaming.Gemini_unsupported_part _ -> None
+  | Streaming.Gemini_unsupported_response _ -> None
   | Streaming.Gemini_parse_failed _ -> None
 ;;
 

--- a/test/test_gemini_edge_cases.ml
+++ b/test/test_gemini_edge_cases.ml
@@ -10,6 +10,18 @@ let check label cond =
     exit 1)
 ;;
 
+let parse_gemini_chunk data =
+  match Streaming.parse_gemini_sse_chunk data with
+  | Streaming.Gemini_chunk chunk -> Some chunk
+  | Streaming.Gemini_parse_failed _ -> None
+;;
+
+let gemini_events state chunk =
+  match Streaming.gemini_chunk_to_events state chunk with
+  | Ok events -> events
+  | Error { reason } -> failwith ("unexpected Gemini stream decode failure: " ^ reason)
+;;
+
 let string_has haystack needle =
   let nlen = String.length needle in
   let hlen = String.length haystack in
@@ -96,13 +108,13 @@ let test_sse_function_call () =
   let chunk_data =
     {|{"candidates":[{"content":{"parts":[{"functionCall":{"name":"get_weather","args":{"city":"Seoul"}},"thoughtSignature":"abc123"}],"role":"model"},"finishReason":"STOP","index":0}],"usageMetadata":{"promptTokenCount":44,"candidatesTokenCount":15},"modelVersion":"gemini-2.5-flash"}|}
   in
-  match Streaming.parse_gemini_sse_chunk chunk_data with
+  match parse_gemini_chunk chunk_data with
   | Some chunk ->
     check "parsed chunk" true;
     check "has parts" (List.length chunk.gem_parts > 0);
     check "finish reason STOP" (chunk.gem_finish_reason = Some "STOP");
     let state = Streaming.create_openai_stream_state () in
-    let events, _tel = Streaming.gemini_chunk_to_events state chunk in
+    let events, _tel = gemini_events state chunk in
     let has_tool_start =
       List.exists
         (function

--- a/test/test_gemini_edge_cases.ml
+++ b/test/test_gemini_edge_cases.ml
@@ -13,6 +13,7 @@ let check label cond =
 let parse_gemini_chunk data =
   match Streaming.parse_gemini_sse_chunk data with
   | Streaming.Gemini_chunk chunk -> Some chunk
+  | Streaming.Gemini_unsupported_part _ -> None
   | Streaming.Gemini_parse_failed _ -> None
 ;;
 

--- a/test/test_llm_provider_cov.ml
+++ b/test/test_llm_provider_cov.ml
@@ -1218,7 +1218,7 @@ let test_gemini_capabilities () =
   let c = Capabilities.gemini_capabilities in
   Alcotest.(check bool) "audio" true c.supports_audio_input;
   Alcotest.(check bool) "video" true c.supports_video_input;
-  Alcotest.(check bool) "code_execution" true c.supports_code_execution;
+  Alcotest.(check bool) "code_execution" false c.supports_code_execution;
   (* Gemini generationConfig accepts topK — pin so capability-gated
      consumers do not silently drop it for Gemini configs. *)
   Alcotest.(check bool) "top_k" true c.supports_top_k;
@@ -1292,7 +1292,7 @@ let test_for_model_id_gpt4o () =
 
 let test_for_model_id_gemini25 () =
   match Capabilities.for_model_id gemini25_flash_model with
-  | Some c -> Alcotest.(check bool) "code_execution" true c.supports_code_execution
+  | Some c -> Alcotest.(check bool) "code_execution" false c.supports_code_execution
   | None -> Alcotest.fail "expected Some for legacy gemini"
 ;;
 

--- a/test/test_stream_accumulator.ml
+++ b/test/test_stream_accumulator.ml
@@ -33,6 +33,7 @@ let stream_error_to_string = function
   | Stream_ndjson_parse_failed { reason; _ } -> reason
   | Stream_incomplete { reason } -> reason
   | Stream_unknown_event { event_type; _ } -> "unknown_event:" ^ event_type
+  | Stream_unsupported_part { part; _ } -> "unsupported_part:" ^ part
 ;;
 
 let fail_unexpected_stream_error err =

--- a/test/test_stream_accumulator.ml
+++ b/test/test_stream_accumulator.ml
@@ -34,6 +34,7 @@ let stream_error_to_string = function
   | Stream_incomplete { reason } -> reason
   | Stream_unknown_event { event_type; _ } -> "unknown_event:" ^ event_type
   | Stream_unsupported_part { part; _ } -> "unsupported_part:" ^ part
+  | Stream_unsupported_response { response; _ } -> "unsupported_response:" ^ response
 ;;
 
 let fail_unexpected_stream_error err =

--- a/test/test_streaming_cov.ml
+++ b/test/test_streaming_cov.ml
@@ -23,6 +23,7 @@ let stream_error_to_string = function
   | Types.Stream_ndjson_parse_failed { reason; _ } -> reason
   | Types.Stream_incomplete { reason } -> reason
   | Types.Stream_unknown_event { event_type; _ } -> "unknown_event:" ^ event_type
+  | Types.Stream_unsupported_part { part; _ } -> "unsupported_part:" ^ part
 ;;
 
 let fail_unexpected_stream_error err =

--- a/test/test_streaming_cov.ml
+++ b/test/test_streaming_cov.ml
@@ -24,6 +24,8 @@ let stream_error_to_string = function
   | Types.Stream_incomplete { reason } -> reason
   | Types.Stream_unknown_event { event_type; _ } -> "unknown_event:" ^ event_type
   | Types.Stream_unsupported_part { part; _ } -> "unsupported_part:" ^ part
+  | Types.Stream_unsupported_response { response; _ } ->
+    "unsupported_response:" ^ response
 ;;
 
 let fail_unexpected_stream_error err =

--- a/test/test_streaming_coverage.ml
+++ b/test/test_streaming_coverage.ml
@@ -30,6 +30,7 @@ let stream_error_to_string = function
   | Stream_ndjson_parse_failed { reason; _ } -> reason
   | Stream_incomplete { reason } -> reason
   | Stream_unknown_event { event_type; _ } -> "unknown_event:" ^ event_type
+  | Stream_unsupported_part { part; _ } -> "unsupported_part:" ^ part
 ;;
 
 let fail_unexpected_stream_error err =

--- a/test/test_streaming_coverage.ml
+++ b/test/test_streaming_coverage.ml
@@ -31,6 +31,7 @@ let stream_error_to_string = function
   | Stream_incomplete { reason } -> reason
   | Stream_unknown_event { event_type; _ } -> "unknown_event:" ^ event_type
   | Stream_unsupported_part { part; _ } -> "unsupported_part:" ^ part
+  | Stream_unsupported_response { response; _ } -> "unsupported_response:" ^ response
 ;;
 
 let fail_unexpected_stream_error err =

--- a/test/test_streaming_edge_cases.ml
+++ b/test/test_streaming_edge_cases.ml
@@ -79,6 +79,18 @@ let require_ollama_chunk label = function
     fail (Printf.sprintf "%s: unexpected parse failure: %s" label reason)
 ;;
 
+let parse_gemini_chunk data =
+  match S.parse_gemini_sse_chunk data with
+  | S.Gemini_chunk chunk -> Some chunk
+  | S.Gemini_parse_failed _ -> None
+;;
+
+let require_gemini_events label state chunk =
+  match S.gemini_chunk_to_events state chunk with
+  | Ok events -> events
+  | Error { reason } -> fail (Printf.sprintf "%s: %s" label reason)
+;;
+
 let test_anthropic_sse_parser_edges () =
   (match
      S.parse_sse_event
@@ -542,27 +554,58 @@ let test_openai_event_edge_branches () =
 
 let test_gemini_parse_edge_shapes () =
   (match
-     S.parse_gemini_sse_chunk
-       {|{"modelVersion":"gem","candidates":[],"usageMetadata":null}|}
+     parse_gemini_chunk {|{"modelVersion":"gem","candidates":[],"usageMetadata":null}|}
    with
    | None -> ()
    | Some _ -> fail "empty candidates should be rejected by missing content");
   (match
-     S.parse_gemini_sse_chunk
+     parse_gemini_chunk
        {|{"modelVersion":"gem","candidates":{"unexpected":true},"usageMetadata":null}|}
    with
    | None -> ()
    | Some _ -> fail "non-list candidates should be rejected by missing content");
-  let non_list_parts =
-    require_some
-      "non-list parts"
-      (S.parse_gemini_sse_chunk
-         {|{"modelVersion":"gem","candidates":[{"content":{"parts":{"bad":true}}}],"usageMetadata":null}|})
-  in
-  check int "non-list parts ignored" 0 (List.length non_list_parts.gem_parts);
+  (match
+     S.parse_gemini_sse_chunk
+       {|{"candidates":[{"content":{"parts":[{"text":"a"}]}},{"content":{"parts":[{"text":"b"}]}}]}|}
+   with
+   | S.Gemini_parse_failed { reason; _ } ->
+     check
+       string
+       "multiple candidates reason"
+       "gemini.candidates:multiple_candidates_unsupported"
+       reason
+   | S.Gemini_chunk _ -> fail "multiple Gemini candidates must not be dropped");
+  (match
+     S.parse_gemini_sse_chunk
+       {|{"modelVersion":"gem","candidates":[{"content":{"parts":{"bad":true}}}],"usageMetadata":null}|}
+   with
+   | S.Gemini_parse_failed { reason; _ } ->
+     check
+       string
+       "non-list parts reason"
+       "gemini.candidates[0].content.parts:not_array(got object)"
+       reason
+   | S.Gemini_chunk _ -> fail "non-list parts must be rejected");
   match S.parse_gemini_sse_chunk "{not-json" with
-  | None -> ()
-  | Some _ -> fail "invalid gemini json should return None"
+  | S.Gemini_parse_failed { raw; reason } ->
+    check string "invalid gemini raw" "{not-json" raw;
+    check bool "invalid gemini reason" true (String.length reason > 0)
+  | S.Gemini_chunk _ -> fail "invalid gemini json should be rejected"
+;;
+
+let test_gemini_part_shape_failure_is_explicit () =
+  match
+    S.parse_gemini_sse_chunk
+      {|{"candidates":[{"content":{"parts":[{"unknownPart":{}}]}}]}|}
+  with
+  | S.Gemini_parse_failed { raw; reason } ->
+    check bool "unknown part raw preserved" true (String.length raw > 0);
+    check
+      string
+      "unknown part reason"
+      "gemini.candidates[0].content.parts[0].unknownPart:unsupported_field"
+      reason
+  | S.Gemini_chunk _ -> fail "unknown Gemini part must not be accepted"
 ;;
 
 let gemini_chunk ?(parts = []) ?finish_reason ?usage () : S.gemini_chunk =
@@ -576,9 +619,16 @@ let gemini_chunk ?(parts = []) ?finish_reason ?usage () : S.gemini_chunk =
 let test_gemini_event_edge_branches () =
   let state = S.create_openai_stream_state ~provider:"gemini" ~model:"gem" () in
   let thought_part = `Assoc [ "thought", `Bool true; "text", `String "plan" ] in
-  ignore (S.gemini_chunk_to_events state (gemini_chunk ~parts:[ thought_part ] ()));
+  ignore
+    (require_gemini_events
+       "thought chunk"
+       state
+       (gemini_chunk ~parts:[ thought_part ] ()));
   let no_thought_events, telemetry =
-    S.gemini_chunk_to_events state (gemini_chunk ~parts:[ `Assoc [] ] ())
+    require_gemini_events
+      "empty text chunk"
+      state
+      (gemini_chunk ~parts:[ `Assoc [ "text", `String "" ] ] ())
   in
   check_event_count "no-thought chunk emits no events" 0 no_thought_events;
   (match telemetry with
@@ -586,33 +636,37 @@ let test_gemini_event_edge_branches () =
      check string "provider" "gemini" r.provider
    | _ -> fail "expected gemini thinking completion telemetry");
   let restarted_events, _ =
-    S.gemini_chunk_to_events state (gemini_chunk ~parts:[ thought_part ] ())
+    require_gemini_events
+      "restarted thought chunk"
+      state
+      (gemini_chunk ~parts:[ thought_part ] ())
   in
   check_event_count "thinking after done restarts and emits delta" 1 restarted_events;
-  let empty_text_with_call =
+  let function_call_part =
     `Assoc
-      [ "text", `String ""
-      ; ( "functionCall"
+      [ ( "functionCall"
         , `Assoc [ "name", `String "lookup"; "args", `Assoc [ "q", `String "seoul" ] ] )
       ]
   in
   let tool_events, _ =
-    S.gemini_chunk_to_events
+    require_gemini_events
+      "function call"
       (S.create_openai_stream_state ())
-      (gemini_chunk ~parts:[ empty_text_with_call ] ())
+      (gemini_chunk ~parts:[ function_call_part ] ())
   in
-  check_event_count "empty text can still carry function call" 2 tool_events;
-  let empty_text_without_call =
-    `Assoc [ "text", `String ""; "functionCall", `String "not-an-object" ]
-  in
-  let ignored_events, _ =
-    S.gemini_chunk_to_events
-      (S.create_openai_stream_state ())
-      (gemini_chunk ~parts:[ empty_text_without_call ] ())
-  in
-  check_event_count "non-object functionCall ignored" 0 ignored_events;
+  check_event_count "function call emits start and arguments" 2 tool_events;
+  let empty_text_without_call = `Assoc [ "functionCall", `String "not-an-object" ] in
+  (match
+     S.gemini_chunk_to_events
+       (S.create_openai_stream_state ())
+       (gemini_chunk ~parts:[ empty_text_without_call ] ())
+   with
+   | Error { reason } ->
+     check bool "non-object functionCall rejected" true (String.length reason > 0)
+   | Ok _ -> fail "non-object functionCall must not be ignored");
   let max_tokens_events, _ =
-    S.gemini_chunk_to_events
+    require_gemini_events
+      "max tokens chunk"
       (S.create_openai_stream_state ())
       (gemini_chunk ~finish_reason:"MAX_TOKENS" ~usage:(usage ()) ())
   in
@@ -620,7 +674,8 @@ let test_gemini_event_edge_branches () =
    | [ MessageDelta { stop_reason = Some MaxTokens; usage = Some _ } ] -> ()
    | _ -> fail "expected gemini max-tokens finish");
   let unknown_events, _ =
-    S.gemini_chunk_to_events
+    require_gemini_events
+      "safety finish chunk"
       (S.create_openai_stream_state ())
       (gemini_chunk ~finish_reason:"SAFETY" ())
   in
@@ -802,6 +857,7 @@ let () =
         ] )
     ; ( "gemini_sse"
       , [ test_case "parse edge shapes" `Quick test_gemini_parse_edge_shapes
+        ; test_case "part shape failure" `Quick test_gemini_part_shape_failure_is_explicit
         ; test_case "event edge branches" `Quick test_gemini_event_edge_branches
         ] )
     ; ( "ollama_ndjson"

--- a/test/test_streaming_edge_cases.ml
+++ b/test/test_streaming_edge_cases.ml
@@ -556,6 +556,26 @@ let test_openai_event_edge_branches () =
 
 let test_gemini_parse_edge_shapes () =
   (match
+     S.parse_gemini_sse_chunk
+       {|{"candidates":[{"content":{"parts":[{"text":"no model"}]}}]}|}
+   with
+   | S.Gemini_chunk chunk ->
+     check (option string) "absent modelVersion" None chunk.gem_model
+   | S.Gemini_parse_failed { reason; _ } ->
+     failf "absent optional modelVersion was rejected: %s" reason
+   | S.Gemini_unsupported_part _ -> fail "absent modelVersion is not a Part kind"
+   | S.Gemini_unsupported_response _ -> fail "absent modelVersion is not a response kind");
+  (match
+     S.parse_gemini_sse_chunk
+       {|{"modelVersion":"","candidates":[{"content":{"parts":[{"text":"empty model"}]}}]}|}
+   with
+   | S.Gemini_chunk chunk ->
+     check (option string) "empty modelVersion remains distinct" (Some "") chunk.gem_model
+   | S.Gemini_parse_failed { reason; _ } ->
+     failf "empty modelVersion was rejected instead of preserved: %s" reason
+   | S.Gemini_unsupported_part _ -> fail "empty modelVersion is not a Part kind"
+   | S.Gemini_unsupported_response _ -> fail "empty modelVersion is not a response kind");
+  (match
      parse_gemini_chunk {|{"modelVersion":"gem","candidates":[],"usageMetadata":null}|}
    with
    | None -> ()
@@ -606,9 +626,14 @@ let test_gemini_parse_edge_shapes () =
   | S.Gemini_unsupported_response _ -> fail "invalid JSON is not a response kind"
 ;;
 
-let check_gemini_refusal label payload =
+let check_gemini_refusal label expected_reason payload =
   match S.parse_gemini_sse_chunk payload with
   | S.Gemini_chunk chunk ->
+    check
+      bool
+      (label ^ ": terminal reason preserved")
+      true
+      (chunk.gem_finish_reason = expected_reason);
     let events, _ = require_gemini_events label (S.create_openai_stream_state ()) chunk in
     (match events with
      | [ MessageDelta { stop_reason = Some Refusal; _ } ] -> ()
@@ -624,9 +649,15 @@ let check_gemini_refusal label payload =
 let test_gemini_policy_blocks_are_not_wire_failures () =
   check_gemini_refusal
     "prompt policy block"
+    (Some (S.Gemini_prompt_block_reason "OTHER"))
+    {|{"modelVersion":"gem","promptFeedback":{"blockReason":"OTHER"},"candidates":[]}|};
+  check_gemini_refusal
+    "safety prompt policy block"
+    (Some (S.Gemini_prompt_block_reason "SAFETY"))
     {|{"modelVersion":"gem","promptFeedback":{"blockReason":"SAFETY"},"candidates":[]}|};
   check_gemini_refusal
     "candidate policy block"
+    (Some (S.Gemini_candidate_finish_reason "PROHIBITED_CONTENT"))
     {|{"modelVersion":"gem","candidates":[{"finishReason":"PROHIBITED_CONTENT"}]}|}
 ;;
 
@@ -663,7 +694,19 @@ let test_gemini_supported_metadata_and_function_call_shapes () =
    | S.Gemini_parse_failed { reason; _ } ->
      failf "optional functionCall.args was rejected: %s" reason
    | S.Gemini_unsupported_part _ -> fail "argument-free function call is supported"
-   | S.Gemini_unsupported_response _ -> fail "argument-free function call is not a response");
+   | S.Gemini_unsupported_response _ ->
+     fail "argument-free function call is not a response");
+  (match
+     S.parse_gemini_sse_chunk
+       {|{"candidates":[{"content":{"parts":[{"functionCall":{"name":"lookup","args":{},"willContinue":false}}]}}]}|}
+   with
+   | S.Gemini_chunk _ -> ()
+   | S.Gemini_parse_failed { reason; _ } ->
+     failf "terminal willContinue=false was rejected: %s" reason
+   | S.Gemini_unsupported_part _ ->
+     fail "terminal willContinue=false is not incremental arguments"
+   | S.Gemini_unsupported_response _ ->
+     fail "terminal willContinue=false is not a response kind");
   match
     S.parse_gemini_sse_chunk
       {|{"candidates":[{"content":{"parts":[{"functionCall":{"name":"lookup","partialArgs":[],"willContinue":true}}]}}]}|}
@@ -756,7 +799,8 @@ let test_gemini_unsupported_part_shape_is_explicit () =
       reason
   | S.Gemini_unsupported_part _ -> fail "malformed executableCode must remain malformed"
   | S.Gemini_chunk _ -> fail "malformed executableCode must not be accepted"
-  | S.Gemini_unsupported_response _ -> fail "malformed executableCode is not a response kind"
+  | S.Gemini_unsupported_response _ ->
+    fail "malformed executableCode is not a response kind"
 ;;
 
 let test_gemini_builtin_tool_parts_are_typed () =
@@ -817,9 +861,10 @@ let test_gemini_malformed_part_precedes_unsupported_part () =
 ;;
 
 let gemini_chunk ?(parts = []) ?finish_reason ?usage () : S.gemini_chunk =
-  { gem_model = "gemini-test"
+  { gem_model = Some "gemini-test"
   ; gem_parts = parts
-  ; gem_finish_reason = finish_reason
+  ; gem_finish_reason =
+      Option.map (fun reason -> S.Gemini_candidate_finish_reason reason) finish_reason
   ; gem_usage = usage
   }
 ;;

--- a/test/test_streaming_edge_cases.ml
+++ b/test/test_streaming_edge_cases.ml
@@ -597,6 +597,75 @@ let test_gemini_parse_edge_shapes () =
   | S.Gemini_unsupported_part _ -> fail "invalid JSON is not a Part kind"
 ;;
 
+let check_gemini_refusal label payload =
+  match S.parse_gemini_sse_chunk payload with
+  | S.Gemini_chunk chunk ->
+    let events, _ = require_gemini_events label (S.create_openai_stream_state ()) chunk in
+    (match events with
+     | [ MessageDelta { stop_reason = Some Refusal; _ } ] -> ()
+     | _ -> failf "%s: expected a typed refusal" label)
+  | S.Gemini_parse_failed { reason; _ } ->
+    failf "%s: valid policy block was rejected: %s" label reason
+  | S.Gemini_unsupported_part _ ->
+    failf "%s: policy block is not an unsupported Part" label
+;;
+
+let test_gemini_policy_blocks_are_not_wire_failures () =
+  check_gemini_refusal
+    "prompt policy block"
+    {|{"modelVersion":"gem","promptFeedback":{"blockReason":"SAFETY"},"candidates":[]}|};
+  check_gemini_refusal
+    "candidate policy block"
+    {|{"modelVersion":"gem","candidates":[{"finishReason":"PROHIBITED_CONTENT"}]}|}
+;;
+
+let test_gemini_supported_metadata_and_function_call_shapes () =
+  (match
+     S.parse_gemini_sse_chunk
+       {|{"candidates":[{"content":{"parts":[{"text":"ok","partMetadata":{},"mediaResolution":{},"videoMetadata":{}}]}}]}|}
+   with
+   | S.Gemini_chunk _ -> ()
+   | S.Gemini_parse_failed { reason; _ } ->
+     failf "official Part metadata was rejected: %s" reason
+   | S.Gemini_unsupported_part _ -> fail "Part metadata is not a payload kind");
+  (match
+     S.parse_gemini_sse_chunk
+       {|{"candidates":[{"content":{"parts":[{"functionCall":{"name":"lookup"}}]}}]}|}
+   with
+   | S.Gemini_chunk chunk ->
+     let events, _ =
+       require_gemini_events
+         "argument-free function call"
+         (S.create_openai_stream_state ())
+         chunk
+     in
+     check
+       bool
+       "missing args becomes the empty object"
+       true
+       (List.exists
+          (function
+            | ContentBlockDelta { delta = InputJsonSnapshot "{}"; _ } -> true
+            | _ -> false)
+          events)
+   | S.Gemini_parse_failed { reason; _ } ->
+     failf "optional functionCall.args was rejected: %s" reason
+   | S.Gemini_unsupported_part _ -> fail "argument-free function call is supported");
+  match
+    S.parse_gemini_sse_chunk
+      {|{"candidates":[{"content":{"parts":[{"functionCall":{"name":"lookup","partialArgs":[],"willContinue":true}}]}}]}|}
+  with
+  | S.Gemini_unsupported_part { part; _ } ->
+    check
+      string
+      "streaming function args remain explicit"
+      "functionCall.partialArgs"
+      (S.gemini_unsupported_part_wire_name part)
+  | S.Gemini_chunk _ -> fail "streaming function args must not be dropped"
+  | S.Gemini_parse_failed { reason; _ } ->
+    failf "official streaming function args were called malformed: %s" reason
+;;
+
 let test_gemini_part_shape_failure_is_explicit () =
   match
     S.parse_gemini_sse_chunk
@@ -618,16 +687,28 @@ let test_gemini_official_unsupported_part_is_not_malformed () =
   let raw =
     {|{"candidates":[{"content":{"parts":[{"executableCode":{"language":"PYTHON","code":"print(1)"}}]}}]}|}
   in
-  match S.parse_gemini_sse_chunk raw with
-  | S.Gemini_unsupported_part { part; raw = observed_raw } ->
+  (match S.parse_gemini_sse_chunk raw with
+   | S.Gemini_unsupported_part { part; raw = observed_raw } ->
+     check
+       string
+       "typed unsupported Part"
+       "executableCode"
+       (S.gemini_unsupported_part_wire_name part);
+     check string "unsupported Part raw preserved" raw observed_raw
+   | S.Gemini_parse_failed _ -> fail "official unsupported Part must not be malformed"
+   | S.Gemini_chunk _ -> fail "unsupported Part must not be silently accepted");
+  match
+    S.parse_gemini_sse_chunk
+      {|{"candidates":[{"content":{"parts":[{"functionResponse":{"name":"lookup","response":{}}}]}}]}|}
+  with
+  | S.Gemini_unsupported_part { part; _ } ->
     check
       string
-      "typed unsupported Part"
-      "executableCode"
-      (S.gemini_unsupported_part_wire_name part);
-    check string "unsupported Part raw preserved" raw observed_raw
-  | S.Gemini_parse_failed _ -> fail "official unsupported Part must not be malformed"
-  | S.Gemini_chunk _ -> fail "unsupported Part must not be silently accepted"
+      "typed function response Part"
+      "functionResponse"
+      (S.gemini_unsupported_part_wire_name part)
+  | S.Gemini_parse_failed _ -> fail "official functionResponse must not be malformed"
+  | S.Gemini_chunk _ -> fail "unsupported functionResponse must not be dropped"
 ;;
 
 let test_gemini_unsupported_part_shape_is_explicit () =
@@ -960,6 +1041,14 @@ let () =
         ] )
     ; ( "gemini_sse"
       , [ test_case "parse edge shapes" `Quick test_gemini_parse_edge_shapes
+        ; test_case
+            "policy blocks are typed refusals"
+            `Quick
+            test_gemini_policy_blocks_are_not_wire_failures
+        ; test_case
+            "supported metadata and function calls"
+            `Quick
+            test_gemini_supported_metadata_and_function_call_shapes
         ; test_case "part shape failure" `Quick test_gemini_part_shape_failure_is_explicit
         ; test_case
             "official unsupported Part is typed"

--- a/test/test_streaming_edge_cases.ml
+++ b/test/test_streaming_edge_cases.ml
@@ -573,8 +573,30 @@ let test_gemini_parse_edge_shapes () =
      check (option string) "empty modelVersion remains distinct" (Some "") chunk.gem_model
    | S.Gemini_parse_failed { reason; _ } ->
      failf "empty modelVersion was rejected instead of preserved: %s" reason
-   | S.Gemini_unsupported_part _ -> fail "empty modelVersion is not a Part kind"
-   | S.Gemini_unsupported_response _ -> fail "empty modelVersion is not a response kind");
+  | S.Gemini_unsupported_part _ -> fail "empty modelVersion is not a Part kind"
+  | S.Gemini_unsupported_response _ -> fail "empty modelVersion is not a response kind");
+  (match
+     S.parse_gemini_sse_chunk
+       {|{"modelVersion":"gemini-wire-model","candidates":[{"content":{"parts":[{"text":"done"}]},"finishReason":"STOP"}]}|}
+   with
+   | S.Gemini_chunk chunk ->
+     let events, _ =
+       require_gemini_events
+         "response model propagation"
+         (S.create_openai_stream_state ~model:"requested-model" ())
+         chunk
+     in
+     let acc = Llm_provider.Complete_stream_acc.create_stream_acc () in
+     List.iter (Llm_provider.Complete_stream_acc.accumulate_event acc) events;
+     (match Llm_provider.Complete_stream_acc.finalize_stream_acc acc with
+      | Ok response ->
+        check string "wire model reaches final response" "gemini-wire-model" response.model
+      | Error _ -> fail "terminal Gemini chunk did not finalize")
+   | S.Gemini_parse_failed { reason; _ } ->
+     failf "model propagation fixture was rejected: %s" reason
+   | S.Gemini_unsupported_part _ -> fail "model propagation has no unsupported Part"
+   | S.Gemini_unsupported_response _ ->
+     fail "model propagation has no unsupported response");
   (match
      S.parse_gemini_sse_chunk
        {|{"candidates":[{"content":{"parts":[{"text":"partial"}]},"finishReason":""}]}|}
@@ -648,7 +670,9 @@ let check_gemini_refusal label expected_reason payload =
       (chunk.gem_finish_reason = expected_reason);
     let events, _ = require_gemini_events label (S.create_openai_stream_state ()) chunk in
     (match events with
-     | [ MessageDelta { stop_reason = Some Refusal; _ } ] -> ()
+     | [ MessageStart { model = "gem"; _ }
+       ; MessageDelta { stop_reason = Some Refusal; _ }
+       ] -> ()
      | _ -> failf "%s: expected a typed refusal" label)
   | S.Gemini_parse_failed { reason; _ } ->
     failf "%s: valid policy block was rejected: %s" label reason
@@ -723,6 +747,21 @@ let test_gemini_supported_metadata_and_function_call_shapes () =
      fail "terminal willContinue=false is not incremental arguments"
    | S.Gemini_unsupported_response _ ->
      fail "terminal willContinue=false is not a response kind");
+  (match
+     S.parse_gemini_sse_chunk
+       {|{"candidates":[{"content":{"parts":[{"functionCall":{"name":"lookup","willContinue":true}}]}}]}|}
+   with
+   | S.Gemini_unsupported_part { part; _ } ->
+     check
+       string
+       "streaming continuation remains explicit"
+       "functionCall.willContinue"
+       (S.gemini_unsupported_part_wire_name part)
+   | S.Gemini_chunk _ -> fail "streaming continuation must not be dropped"
+   | S.Gemini_parse_failed { reason; _ } ->
+     failf "official streaming continuation was called malformed: %s" reason
+   | S.Gemini_unsupported_response _ ->
+     fail "streaming continuation is not a response kind");
   match
     S.parse_gemini_sse_chunk
       {|{"candidates":[{"content":{"parts":[{"functionCall":{"name":"lookup","partialArgs":[],"willContinue":true}}]}}]}|}
@@ -923,7 +962,7 @@ let test_gemini_event_edge_branches () =
       (S.create_openai_stream_state ())
       (gemini_chunk ~parts:[ function_call_part ] ())
   in
-  check_event_count "function call emits start and arguments" 2 tool_events;
+  check_event_count "function call emits message, tool start, and arguments" 3 tool_events;
   let empty_text_without_call = `Assoc [ "functionCall", `String "not-an-object" ] in
   (match
      S.gemini_chunk_to_events
@@ -940,7 +979,9 @@ let test_gemini_event_edge_branches () =
       (gemini_chunk ~finish_reason:"MAX_TOKENS" ~usage:(usage ()) ())
   in
   (match max_tokens_events with
-   | [ MessageDelta { stop_reason = Some MaxTokens; usage = Some _ } ] -> ()
+   | [ MessageStart { model = "gemini-test"; _ }
+     ; MessageDelta { stop_reason = Some MaxTokens; usage = Some _ }
+     ] -> ()
    | _ -> fail "expected gemini max-tokens finish");
   let unknown_events, _ =
     require_gemini_events
@@ -949,7 +990,9 @@ let test_gemini_event_edge_branches () =
       (gemini_chunk ~finish_reason:"SAFETY" ())
   in
   match unknown_events with
-  | [ MessageDelta { stop_reason = Some Refusal; _ } ] -> ()
+  | [ MessageStart { model = "gemini-test"; _ }
+    ; MessageDelta { stop_reason = Some Refusal; _ }
+    ] -> ()
   | _ -> fail "expected gemini unknown finish"
 ;;
 

--- a/test/test_streaming_edge_cases.ml
+++ b/test/test_streaming_edge_cases.ml
@@ -573,8 +573,8 @@ let test_gemini_parse_edge_shapes () =
      check (option string) "empty modelVersion remains distinct" (Some "") chunk.gem_model
    | S.Gemini_parse_failed { reason; _ } ->
      failf "empty modelVersion was rejected instead of preserved: %s" reason
-  | S.Gemini_unsupported_part _ -> fail "empty modelVersion is not a Part kind"
-  | S.Gemini_unsupported_response _ -> fail "empty modelVersion is not a response kind");
+   | S.Gemini_unsupported_part _ -> fail "empty modelVersion is not a Part kind"
+   | S.Gemini_unsupported_response _ -> fail "empty modelVersion is not a response kind");
   (match
      S.parse_gemini_sse_chunk
        {|{"modelVersion":"gemini-wire-model","candidates":[{"content":{"parts":[{"text":"done"}]},"finishReason":"STOP"}]}|}
@@ -590,7 +590,11 @@ let test_gemini_parse_edge_shapes () =
      List.iter (Llm_provider.Complete_stream_acc.accumulate_event acc) events;
      (match Llm_provider.Complete_stream_acc.finalize_stream_acc acc with
       | Ok response ->
-        check string "wire model reaches final response" "gemini-wire-model" response.model
+        check
+          string
+          "wire model reaches final response"
+          "gemini-wire-model"
+          response.model
       | Error _ -> fail "terminal Gemini chunk did not finalize")
    | S.Gemini_parse_failed { reason; _ } ->
      failf "model propagation fixture was rejected: %s" reason
@@ -924,6 +928,55 @@ let gemini_chunk ?(parts = []) ?finish_reason ?usage () : S.gemini_chunk =
   }
 ;;
 
+let test_gemini_model_identity_is_single_and_fail_closed () =
+  let state = S.create_openai_stream_state ~provider:"gemini" ~model:"gem" () in
+  let text_part text = `Assoc [ "text", `String text ] in
+  let first_events, _ =
+    require_gemini_events
+      "first model observation"
+      state
+      (gemini_chunk ~parts:[ text_part "first" ] ())
+  in
+  check
+    bool
+    "first model observation emits MessageStart"
+    true
+    (List.exists
+       (function
+         | MessageStart _ -> true
+         | _ -> false)
+       first_events);
+  let repeated_events, _ =
+    require_gemini_events
+      "repeated model observation"
+      state
+      (gemini_chunk ~parts:[ text_part "second" ] ())
+  in
+  check
+    bool
+    "repeated identical model does not emit MessageStart"
+    false
+    (List.exists
+       (function
+         | MessageStart _ -> true
+         | _ -> false)
+       repeated_events);
+  let changed_chunk =
+    { (gemini_chunk ~parts:[ text_part "changed" ] ()) with
+      gem_model = Some "different-gemini-model"
+    }
+  in
+  match S.gemini_chunk_to_events state changed_chunk with
+  | Error { reason } ->
+    check
+      string
+      "changed model is an explicit stream failure"
+      "gemini_sse_chunk_decode_failure: gemini.modelVersion changed within one streamed \
+       response"
+      reason
+  | Ok _ -> fail "changed modelVersion must not be silently accepted"
+;;
+
 let test_gemini_event_edge_branches () =
   let state = S.create_openai_stream_state ~provider:"gemini" ~model:"gem" () in
   let thought_part = `Assoc [ "thought", `Bool true; "text", `String "plan" ] in
@@ -1194,6 +1247,10 @@ let () =
             "malformed sibling is not hidden"
             `Quick
             test_gemini_malformed_part_precedes_unsupported_part
+        ; test_case
+            "model identity is single and fail-closed"
+            `Quick
+            test_gemini_model_identity_is_single_and_fail_closed
         ; test_case "event edge branches" `Quick test_gemini_event_edge_branches
         ] )
     ; ( "ollama_ndjson"

--- a/test/test_streaming_edge_cases.ml
+++ b/test/test_streaming_edge_cases.ml
@@ -656,6 +656,10 @@ let test_gemini_policy_blocks_are_not_wire_failures () =
     (Some (S.Gemini_prompt_block_reason "SAFETY"))
     {|{"modelVersion":"gem","promptFeedback":{"blockReason":"SAFETY"},"candidates":[]}|};
   check_gemini_refusal
+    "omitted empty candidates policy block"
+    (Some (S.Gemini_prompt_block_reason "SAFETY"))
+    {|{"modelVersion":"gem","promptFeedback":{"blockReason":"SAFETY"}}|};
+  check_gemini_refusal
     "candidate policy block"
     (Some (S.Gemini_candidate_finish_reason "PROHIBITED_CONTENT"))
     {|{"modelVersion":"gem","candidates":[{"finishReason":"PROHIBITED_CONTENT"}]}|}

--- a/test/test_streaming_edge_cases.ml
+++ b/test/test_streaming_edge_cases.ml
@@ -576,6 +576,18 @@ let test_gemini_parse_edge_shapes () =
    | S.Gemini_unsupported_part _ -> fail "empty modelVersion is not a Part kind"
    | S.Gemini_unsupported_response _ -> fail "empty modelVersion is not a response kind");
   (match
+     S.parse_gemini_sse_chunk
+       {|{"candidates":[{"content":{"parts":[{"text":"partial"}]},"finishReason":""}]}|}
+   with
+   | S.Gemini_chunk chunk ->
+     (match chunk.gem_finish_reason with
+      | None -> ()
+      | Some _ -> fail "empty finishReason became a terminal reason")
+   | S.Gemini_parse_failed { reason; _ } ->
+     failf "empty finishReason was rejected: %s" reason
+   | S.Gemini_unsupported_part _ -> fail "empty finishReason is not a Part kind"
+   | S.Gemini_unsupported_response _ -> fail "empty finishReason is not a response kind");
+  (match
      parse_gemini_chunk {|{"modelVersion":"gem","candidates":[],"usageMetadata":null}|}
    with
    | None -> ()

--- a/test/test_streaming_edge_cases.ml
+++ b/test/test_streaming_edge_cases.ml
@@ -630,6 +630,87 @@ let test_gemini_official_unsupported_part_is_not_malformed () =
   | S.Gemini_chunk _ -> fail "unsupported Part must not be silently accepted"
 ;;
 
+let test_gemini_unsupported_part_shape_is_explicit () =
+  let result_raw =
+    {|{"candidates":[{"content":{"parts":[{"codeExecutionResult":{"outcome":"OUTCOME_OK","output":"1"}}]}}]}|}
+  in
+  (match S.parse_gemini_sse_chunk result_raw with
+   | S.Gemini_unsupported_part { part; raw } ->
+     check
+       string
+       "typed code execution result Part"
+       "codeExecutionResult"
+       (S.gemini_unsupported_part_wire_name part);
+     check string "code execution result raw preserved" result_raw raw
+   | S.Gemini_parse_failed _ -> fail "official code execution result must be typed"
+   | S.Gemini_chunk _ -> fail "unsupported Part must not be silently accepted");
+  match
+    S.parse_gemini_sse_chunk
+      {|{"candidates":[{"content":{"parts":[{"executableCode":{"language":"PYTHON"}}]}}]}|}
+  with
+  | S.Gemini_parse_failed { reason; _ } ->
+    check
+      string
+      "malformed executable code reason"
+      "gemini.candidates[0].content.parts[0].executableCode.code:missing"
+      reason
+  | S.Gemini_unsupported_part _ -> fail "malformed executableCode must remain malformed"
+  | S.Gemini_chunk _ -> fail "malformed executableCode must not be accepted"
+;;
+
+let test_gemini_builtin_tool_parts_are_typed () =
+  let tool_call_raw =
+    {|{"candidates":[{"content":{"parts":[{"thoughtSignature":"sig","toolCall":{"toolType":"GOOGLE_SEARCH_WEB","args":{"queries":["seoul"]},"id":"call-1"}}]}}]}|}
+  in
+  (match S.parse_gemini_sse_chunk tool_call_raw with
+   | S.Gemini_unsupported_part { part; raw } ->
+     check string "typed toolCall" "toolCall" (S.gemini_unsupported_part_wire_name part);
+     check string "toolCall raw preserved" tool_call_raw raw
+   | S.Gemini_parse_failed _ -> fail "official toolCall must be typed"
+   | S.Gemini_chunk _ -> fail "unsupported toolCall must not be silently accepted");
+  let tool_response_raw =
+    {|{"candidates":[{"content":{"parts":[{"thoughtSignature":"sig","toolResponse":{"toolType":"GOOGLE_SEARCH_WEB","response":{"search_suggestions":"x"},"id":"call-1"}}]}}]}|}
+  in
+  (match S.parse_gemini_sse_chunk tool_response_raw with
+   | S.Gemini_unsupported_part { part; raw } ->
+     check
+       string
+       "typed toolResponse"
+       "toolResponse"
+       (S.gemini_unsupported_part_wire_name part);
+     check string "toolResponse raw preserved" tool_response_raw raw
+   | S.Gemini_parse_failed _ -> fail "official toolResponse must be typed"
+   | S.Gemini_chunk _ -> fail "unsupported toolResponse must not be silently accepted");
+  match
+    S.parse_gemini_sse_chunk
+      {|{"candidates":[{"content":{"parts":[{"toolCall":{"toolType":"GOOGLE_SEARCH_WEB"}}]}}]}|}
+  with
+  | S.Gemini_parse_failed { reason; _ } ->
+    check
+      string
+      "malformed toolCall reason"
+      "gemini.candidates[0].content.parts[0].toolCall.id:missing"
+      reason
+  | S.Gemini_unsupported_part _ -> fail "malformed toolCall must remain malformed"
+  | S.Gemini_chunk _ -> fail "malformed toolCall must not be accepted"
+;;
+
+let test_gemini_malformed_part_precedes_unsupported_part () =
+  match
+    S.parse_gemini_sse_chunk
+      {|{"candidates":[{"content":{"parts":[{"executableCode":{"language":"PYTHON","code":"print(1)"}},{"unknownPart":{}}]}}]}|}
+  with
+  | S.Gemini_parse_failed { reason; _ } ->
+    check
+      string
+      "malformed sibling reason"
+      "gemini.candidates[0].content.parts[1].unknownPart:unsupported_field"
+      reason
+  | S.Gemini_unsupported_part _ ->
+    fail "malformed sibling must not be hidden by unsupported Part"
+  | S.Gemini_chunk _ -> fail "malformed sibling must not be accepted"
+;;
+
 let gemini_chunk ?(parts = []) ?finish_reason ?usage () : S.gemini_chunk =
   { gem_model = "gemini-test"
   ; gem_parts = parts
@@ -884,6 +965,18 @@ let () =
             "official unsupported Part is typed"
             `Quick
             test_gemini_official_unsupported_part_is_not_malformed
+        ; test_case
+            "unsupported Part shape is explicit"
+            `Quick
+            test_gemini_unsupported_part_shape_is_explicit
+        ; test_case
+            "built-in tool Parts are typed"
+            `Quick
+            test_gemini_builtin_tool_parts_are_typed
+        ; test_case
+            "malformed sibling is not hidden"
+            `Quick
+            test_gemini_malformed_part_precedes_unsupported_part
         ; test_case "event edge branches" `Quick test_gemini_event_edge_branches
         ] )
     ; ( "ollama_ndjson"

--- a/test/test_streaming_edge_cases.ml
+++ b/test/test_streaming_edge_cases.ml
@@ -83,6 +83,7 @@ let parse_gemini_chunk data =
   match S.parse_gemini_sse_chunk data with
   | S.Gemini_chunk chunk -> Some chunk
   | S.Gemini_unsupported_part _ -> None
+  | S.Gemini_unsupported_response _ -> None
   | S.Gemini_parse_failed _ -> None
 ;;
 
@@ -569,14 +570,20 @@ let test_gemini_parse_edge_shapes () =
      S.parse_gemini_sse_chunk
        {|{"candidates":[{"content":{"parts":[{"text":"a"}]}},{"content":{"parts":[{"text":"b"}]}}]}|}
    with
-   | S.Gemini_parse_failed { reason; _ } ->
-     check
-       string
-       "multiple candidates reason"
-       "gemini.candidates:multiple_candidates_unsupported"
-       reason
+   | S.Gemini_unsupported_response { response; raw } ->
+     (match response with
+      | S.Gemini_multiple_candidates { count } ->
+        check int "multiple candidates count" 2 count;
+        check
+          string
+          "multiple candidates wire field"
+          "candidates"
+          (S.gemini_unsupported_response_wire_name response);
+        check bool "multiple candidates raw preserved" true (String.length raw > 0))
    | S.Gemini_chunk _ -> fail "multiple Gemini candidates must not be dropped"
-   | S.Gemini_unsupported_part _ -> fail "multiple candidates are not a Part kind");
+   | S.Gemini_unsupported_part _ -> fail "multiple candidates are not a Part kind"
+   | S.Gemini_parse_failed { reason; _ } ->
+     failf "multiple candidates were collapsed into malformed: %s" reason);
   (match
      S.parse_gemini_sse_chunk
        {|{"modelVersion":"gem","candidates":[{"content":{"parts":{"bad":true}}}],"usageMetadata":null}|}
@@ -588,13 +595,15 @@ let test_gemini_parse_edge_shapes () =
        "gemini.candidates[0].content.parts:not_array(got object)"
        reason
    | S.Gemini_chunk _ -> fail "non-list parts must be rejected"
-   | S.Gemini_unsupported_part _ -> fail "non-list parts are not a Part kind");
+   | S.Gemini_unsupported_part _ -> fail "non-list parts are not a Part kind"
+   | S.Gemini_unsupported_response _ -> fail "non-list parts are not a response kind");
   match S.parse_gemini_sse_chunk "{not-json" with
   | S.Gemini_parse_failed { raw; reason } ->
     check string "invalid gemini raw" "{not-json" raw;
     check bool "invalid gemini reason" true (String.length reason > 0)
   | S.Gemini_chunk _ -> fail "invalid gemini json should be rejected"
   | S.Gemini_unsupported_part _ -> fail "invalid JSON is not a Part kind"
+  | S.Gemini_unsupported_response _ -> fail "invalid JSON is not a response kind"
 ;;
 
 let check_gemini_refusal label payload =
@@ -608,6 +617,8 @@ let check_gemini_refusal label payload =
     failf "%s: valid policy block was rejected: %s" label reason
   | S.Gemini_unsupported_part _ ->
     failf "%s: policy block is not an unsupported Part" label
+  | S.Gemini_unsupported_response _ ->
+    failf "%s: policy block is not an unsupported response" label
 ;;
 
 let test_gemini_policy_blocks_are_not_wire_failures () =
@@ -627,7 +638,8 @@ let test_gemini_supported_metadata_and_function_call_shapes () =
    | S.Gemini_chunk _ -> ()
    | S.Gemini_parse_failed { reason; _ } ->
      failf "official Part metadata was rejected: %s" reason
-   | S.Gemini_unsupported_part _ -> fail "Part metadata is not a payload kind");
+   | S.Gemini_unsupported_part _ -> fail "Part metadata is not a payload kind"
+   | S.Gemini_unsupported_response _ -> fail "Part metadata is not a response kind");
   (match
      S.parse_gemini_sse_chunk
        {|{"candidates":[{"content":{"parts":[{"functionCall":{"name":"lookup"}}]}}]}|}
@@ -650,7 +662,8 @@ let test_gemini_supported_metadata_and_function_call_shapes () =
           events)
    | S.Gemini_parse_failed { reason; _ } ->
      failf "optional functionCall.args was rejected: %s" reason
-   | S.Gemini_unsupported_part _ -> fail "argument-free function call is supported");
+   | S.Gemini_unsupported_part _ -> fail "argument-free function call is supported"
+   | S.Gemini_unsupported_response _ -> fail "argument-free function call is not a response");
   match
     S.parse_gemini_sse_chunk
       {|{"candidates":[{"content":{"parts":[{"functionCall":{"name":"lookup","partialArgs":[],"willContinue":true}}]}}]}|}
@@ -664,6 +677,8 @@ let test_gemini_supported_metadata_and_function_call_shapes () =
   | S.Gemini_chunk _ -> fail "streaming function args must not be dropped"
   | S.Gemini_parse_failed { reason; _ } ->
     failf "official streaming function args were called malformed: %s" reason
+  | S.Gemini_unsupported_response _ ->
+    fail "streaming function args are not a response kind"
 ;;
 
 let test_gemini_part_shape_failure_is_explicit () =
@@ -681,6 +696,7 @@ let test_gemini_part_shape_failure_is_explicit () =
   | S.Gemini_chunk _ -> fail "unknown Gemini part must not be accepted"
   | S.Gemini_unsupported_part _ ->
     fail "unknown fields must remain malformed, not official unsupported Parts"
+  | S.Gemini_unsupported_response _ -> fail "unknown fields are not a response kind"
 ;;
 
 let test_gemini_official_unsupported_part_is_not_malformed () =
@@ -696,7 +712,8 @@ let test_gemini_official_unsupported_part_is_not_malformed () =
        (S.gemini_unsupported_part_wire_name part);
      check string "unsupported Part raw preserved" raw observed_raw
    | S.Gemini_parse_failed _ -> fail "official unsupported Part must not be malformed"
-   | S.Gemini_chunk _ -> fail "unsupported Part must not be silently accepted");
+   | S.Gemini_chunk _ -> fail "unsupported Part must not be silently accepted"
+   | S.Gemini_unsupported_response _ -> fail "unsupported Part is not a response kind");
   match
     S.parse_gemini_sse_chunk
       {|{"candidates":[{"content":{"parts":[{"functionResponse":{"name":"lookup","response":{}}}]}}]}|}
@@ -709,6 +726,7 @@ let test_gemini_official_unsupported_part_is_not_malformed () =
       (S.gemini_unsupported_part_wire_name part)
   | S.Gemini_parse_failed _ -> fail "official functionResponse must not be malformed"
   | S.Gemini_chunk _ -> fail "unsupported functionResponse must not be dropped"
+  | S.Gemini_unsupported_response _ -> fail "functionResponse is not a response kind"
 ;;
 
 let test_gemini_unsupported_part_shape_is_explicit () =
@@ -724,7 +742,8 @@ let test_gemini_unsupported_part_shape_is_explicit () =
        (S.gemini_unsupported_part_wire_name part);
      check string "code execution result raw preserved" result_raw raw
    | S.Gemini_parse_failed _ -> fail "official code execution result must be typed"
-   | S.Gemini_chunk _ -> fail "unsupported Part must not be silently accepted");
+   | S.Gemini_chunk _ -> fail "unsupported Part must not be silently accepted"
+   | S.Gemini_unsupported_response _ -> fail "unsupported Part is not a response kind");
   match
     S.parse_gemini_sse_chunk
       {|{"candidates":[{"content":{"parts":[{"executableCode":{"language":"PYTHON"}}]}}]}|}
@@ -737,6 +756,7 @@ let test_gemini_unsupported_part_shape_is_explicit () =
       reason
   | S.Gemini_unsupported_part _ -> fail "malformed executableCode must remain malformed"
   | S.Gemini_chunk _ -> fail "malformed executableCode must not be accepted"
+  | S.Gemini_unsupported_response _ -> fail "malformed executableCode is not a response kind"
 ;;
 
 let test_gemini_builtin_tool_parts_are_typed () =
@@ -748,7 +768,8 @@ let test_gemini_builtin_tool_parts_are_typed () =
      check string "typed toolCall" "toolCall" (S.gemini_unsupported_part_wire_name part);
      check string "toolCall raw preserved" tool_call_raw raw
    | S.Gemini_parse_failed _ -> fail "official toolCall must be typed"
-   | S.Gemini_chunk _ -> fail "unsupported toolCall must not be silently accepted");
+   | S.Gemini_chunk _ -> fail "unsupported toolCall must not be silently accepted"
+   | S.Gemini_unsupported_response _ -> fail "toolCall is not a response kind");
   let tool_response_raw =
     {|{"candidates":[{"content":{"parts":[{"thoughtSignature":"sig","toolResponse":{"toolType":"GOOGLE_SEARCH_WEB","response":{"search_suggestions":"x"},"id":"call-1"}}]}}]}|}
   in
@@ -761,7 +782,8 @@ let test_gemini_builtin_tool_parts_are_typed () =
        (S.gemini_unsupported_part_wire_name part);
      check string "toolResponse raw preserved" tool_response_raw raw
    | S.Gemini_parse_failed _ -> fail "official toolResponse must be typed"
-   | S.Gemini_chunk _ -> fail "unsupported toolResponse must not be silently accepted");
+   | S.Gemini_chunk _ -> fail "unsupported toolResponse must not be silently accepted"
+   | S.Gemini_unsupported_response _ -> fail "toolResponse is not a response kind");
   match
     S.parse_gemini_sse_chunk
       {|{"candidates":[{"content":{"parts":[{"toolCall":{"toolType":"GOOGLE_SEARCH_WEB"}}]}}]}|}
@@ -774,6 +796,7 @@ let test_gemini_builtin_tool_parts_are_typed () =
       reason
   | S.Gemini_unsupported_part _ -> fail "malformed toolCall must remain malformed"
   | S.Gemini_chunk _ -> fail "malformed toolCall must not be accepted"
+  | S.Gemini_unsupported_response _ -> fail "malformed toolCall is not a response kind"
 ;;
 
 let test_gemini_malformed_part_precedes_unsupported_part () =
@@ -790,6 +813,7 @@ let test_gemini_malformed_part_precedes_unsupported_part () =
   | S.Gemini_unsupported_part _ ->
     fail "malformed sibling must not be hidden by unsupported Part"
   | S.Gemini_chunk _ -> fail "malformed sibling must not be accepted"
+  | S.Gemini_unsupported_response _ -> fail "malformed sibling is not a response kind"
 ;;
 
 let gemini_chunk ?(parts = []) ?finish_reason ?usage () : S.gemini_chunk =

--- a/test/test_streaming_edge_cases.ml
+++ b/test/test_streaming_edge_cases.ml
@@ -82,6 +82,7 @@ let require_ollama_chunk label = function
 let parse_gemini_chunk data =
   match S.parse_gemini_sse_chunk data with
   | S.Gemini_chunk chunk -> Some chunk
+  | S.Gemini_unsupported_part _ -> None
   | S.Gemini_parse_failed _ -> None
 ;;
 
@@ -574,7 +575,8 @@ let test_gemini_parse_edge_shapes () =
        "multiple candidates reason"
        "gemini.candidates:multiple_candidates_unsupported"
        reason
-   | S.Gemini_chunk _ -> fail "multiple Gemini candidates must not be dropped");
+   | S.Gemini_chunk _ -> fail "multiple Gemini candidates must not be dropped"
+   | S.Gemini_unsupported_part _ -> fail "multiple candidates are not a Part kind");
   (match
      S.parse_gemini_sse_chunk
        {|{"modelVersion":"gem","candidates":[{"content":{"parts":{"bad":true}}}],"usageMetadata":null}|}
@@ -585,12 +587,14 @@ let test_gemini_parse_edge_shapes () =
        "non-list parts reason"
        "gemini.candidates[0].content.parts:not_array(got object)"
        reason
-   | S.Gemini_chunk _ -> fail "non-list parts must be rejected");
+   | S.Gemini_chunk _ -> fail "non-list parts must be rejected"
+   | S.Gemini_unsupported_part _ -> fail "non-list parts are not a Part kind");
   match S.parse_gemini_sse_chunk "{not-json" with
   | S.Gemini_parse_failed { raw; reason } ->
     check string "invalid gemini raw" "{not-json" raw;
     check bool "invalid gemini reason" true (String.length reason > 0)
   | S.Gemini_chunk _ -> fail "invalid gemini json should be rejected"
+  | S.Gemini_unsupported_part _ -> fail "invalid JSON is not a Part kind"
 ;;
 
 let test_gemini_part_shape_failure_is_explicit () =
@@ -606,6 +610,24 @@ let test_gemini_part_shape_failure_is_explicit () =
       "gemini.candidates[0].content.parts[0].unknownPart:unsupported_field"
       reason
   | S.Gemini_chunk _ -> fail "unknown Gemini part must not be accepted"
+  | S.Gemini_unsupported_part _ ->
+    fail "unknown fields must remain malformed, not official unsupported Parts"
+;;
+
+let test_gemini_official_unsupported_part_is_not_malformed () =
+  let raw =
+    {|{"candidates":[{"content":{"parts":[{"executableCode":{"language":"PYTHON","code":"print(1)"}}]}}]}|}
+  in
+  match S.parse_gemini_sse_chunk raw with
+  | S.Gemini_unsupported_part { part; raw = observed_raw } ->
+    check
+      string
+      "typed unsupported Part"
+      "executableCode"
+      (S.gemini_unsupported_part_wire_name part);
+    check string "unsupported Part raw preserved" raw observed_raw
+  | S.Gemini_parse_failed _ -> fail "official unsupported Part must not be malformed"
+  | S.Gemini_chunk _ -> fail "unsupported Part must not be silently accepted"
 ;;
 
 let gemini_chunk ?(parts = []) ?finish_reason ?usage () : S.gemini_chunk =
@@ -858,6 +880,10 @@ let () =
     ; ( "gemini_sse"
       , [ test_case "parse edge shapes" `Quick test_gemini_parse_edge_shapes
         ; test_case "part shape failure" `Quick test_gemini_part_shape_failure_is_explicit
+        ; test_case
+            "official unsupported Part is typed"
+            `Quick
+            test_gemini_official_unsupported_part_is_not_malformed
         ; test_case "event edge branches" `Quick test_gemini_event_edge_branches
         ] )
     ; ( "ollama_ndjson"

--- a/test/test_structured_stream.ml
+++ b/test/test_structured_stream.ml
@@ -119,6 +119,7 @@ let test_on_event_callback_fires () =
       | SSEParseFailed _ -> "parse_failed"
       | NDJSONParseFailed _ -> "ndjson_parse_failed"
       | SSEUnknownEventType _ -> "unknown_event_type"
+      | SSEUnsupportedPart _ -> "unsupported_part"
       | Connected -> "connected"
       | Timeout _ -> "timeout"
       | StreamIncomplete _ -> "stream_incomplete"

--- a/test/test_structured_stream.ml
+++ b/test/test_structured_stream.ml
@@ -120,6 +120,7 @@ let test_on_event_callback_fires () =
       | NDJSONParseFailed _ -> "ndjson_parse_failed"
       | SSEUnknownEventType _ -> "unknown_event_type"
       | SSEUnsupportedPart _ -> "unsupported_part"
+      | SSEUnsupportedResponse _ -> "unsupported_response"
       | Connected -> "connected"
       | Timeout _ -> "timeout"
       | StreamIncomplete _ -> "stream_incomplete"


### PR DESCRIPTION
## Summary

- Make Gemini SSE parsing a closed result: malformed JSON and malformed candidate/Part shapes become explicit wire parse failures with the raw payload preserved.
- Validate the supported Gemini Part boundary before event conversion so unsupported or malformed function calls, media, and payload combinations cannot disappear silently.
- Convert both parser failures and event-decoder failures to OAS SSEParseFailed events in complete_stream.
- Update streaming callers and regression coverage; remove the old synthetic test expectation that treated a Gemini oneof violation as valid.

## Verification

- ocamlc -stop-after parsing: all six touched OCaml files
- ocamlformat --check: all six touched OCaml files
- git diff --check
- focused Dune build: lib/llm_provider/llm_provider.cma
- focused test executables:
  - test/test_streaming_edge_cases.exe: 15 passed
  - test/test_backend_gemini.exe: 55 passed
  - test/test_gemini_edge_cases.exe: 5 edge cases passed

## Contract evidence

Gemini GenerateContent responses expose candidate content and finish reasons, and function calls are structured Parts. Unsupported wire shapes must remain observable as a transport parse failure:
- https://ai.google.dev/api/generate-content
- https://ai.google.dev/gemini-api/docs/generate-content/function-calling

This PR is OAS-only and does not introduce any MASC dependency.