### PR TITLE
feat: enforce per-turn tool surfaces

### DIFF
--- a/lib/agent/agent_trace.ml
+++ b/lib/agent/agent_trace.ml
@@ -39,10 +39,17 @@ let invoke_hook_with_trace agent ?raw_trace_run ~turn ~hook_name hook_opt event 
        decision)
 ;;
 
-let execute_tools_with_trace agent active_run ~turn ?before_tool_execution tool_uses =
+let execute_tools_with_trace
+      agent
+      active_run
+      ~turn
+      ~tools
+      ?before_tool_execution
+      tool_uses
+  =
   let correlation_id = Option.bind agent.options.raw_trace Raw_trace.session_id in
   let run_id = Option.map Raw_trace.active_run_id active_run in
-  let tools = Tool_set.to_list agent.tools in
+  let tools = Tool_set.to_list tools in
   let on_tool_execution_started =
     match active_run with
     | None -> None

--- a/lib/agent/agent_trace.mli
+++ b/lib/agent/agent_trace.mli
@@ -40,6 +40,7 @@ val execute_tools_with_trace
   :  t
   -> Raw_trace.active_run option
   -> turn:int
+  -> tools:Tool_set.t
   -> ?before_tool_execution:(unit -> unit)
   -> Types.content_block list
   -> (Agent_tools.execution_report, Agent_tools.execution_failure) result

--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -25,6 +25,8 @@ type preparation_error =
   | Model_input_projection_failed of string
 
 let preparation_error_to_string = function
+  | Tool_selection_failed Tool_set.Blank_selection ->
+    "selected tool name must not be blank"
   | Tool_selection_failed (Tool_set.Duplicate_selection name) ->
     Printf.sprintf "duplicate selected tool name %S" name
   | Tool_selection_failed (Tool_set.Unknown_selection name) ->

--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -22,6 +22,7 @@ type turn_preparation =
 type preparation_error =
   | Tool_selection_failed of Tool_set.selection_error
   | Tool_choice_not_visible of string
+  | Required_tool_choice_without_tools
   | Model_input_projection_failed of string
 
 let preparation_error_to_string = function
@@ -33,6 +34,8 @@ let preparation_error_to_string = function
     Printf.sprintf "selected tool name %S is not registered" name
   | Tool_choice_not_visible name ->
     Printf.sprintf "named tool %S is outside the selected tool surface" name
+  | Required_tool_choice_without_tools ->
+    "required tool choice cannot be used with an empty selected tool surface"
   | Model_input_projection_failed detail -> detail
 ;;
 
@@ -80,6 +83,8 @@ let prepare_turn ~tools ~messages ~turn_params ?model_input_projection () =
     match turn_params.tool_choice with
     | Some (Tool name) when not (Tool_set.mem name visible_tools) ->
       Error (Tool_choice_not_visible name)
+    | Some Any when Tool_set.size visible_tools = 0 ->
+      Error Required_tool_choice_without_tools
     | Some (Tool _ | Auto | Any | None_) | None -> Ok ()
   in
   let tools_json, visible_tool_names = prepare_tools ~tools:visible_tools () in

--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -66,15 +66,16 @@ let prepare_messages ~messages ~turn_params () =
 ;;
 
 let prepare_turn ~tools ~messages ~turn_params ?model_input_projection () =
-  let selected_tools =
+  let selected_names =
     match turn_params.Hooks.tool_surface with
-    | Hooks.All_tools -> Ok tools
-    | Hooks.Selected_tools names ->
-      Tool_set.select_exact ~names tools
-      |> Result.map_error (fun error -> Tool_selection_failed error)
+    | Hooks.All_tools -> Tool_set.names tools
+    | Hooks.Selected_tools names -> names
   in
   let ( let* ) = Result.bind in
-  let* visible_tools = selected_tools in
+  let* visible_tools =
+    Tool_set.select_exact ~names:selected_names tools
+    |> Result.map_error (fun error -> Tool_selection_failed error)
+  in
   let* () =
     match turn_params.tool_choice with
     | Some (Tool name) when not (Tool_set.mem name visible_tools) ->

--- a/lib/agent/agent_turn.ml
+++ b/lib/agent/agent_turn.ml
@@ -15,8 +15,24 @@ let _log = Log.create ~module_name:"agent_turn" ()
 type turn_preparation =
   { tools_json : Yojson.Safe.t list option
   ; effective_messages : message list
+  ; visible_tools : Tool_set.t
   ; visible_tool_names : string list
   }
+
+type preparation_error =
+  | Tool_selection_failed of Tool_set.selection_error
+  | Tool_choice_not_visible of string
+  | Model_input_projection_failed of string
+
+let preparation_error_to_string = function
+  | Tool_selection_failed (Tool_set.Duplicate_selection name) ->
+    Printf.sprintf "duplicate selected tool name %S" name
+  | Tool_selection_failed (Tool_set.Unknown_selection name) ->
+    Printf.sprintf "selected tool name %S is not registered" name
+  | Tool_choice_not_visible name ->
+    Printf.sprintf "named tool %S is outside the selected tool surface" name
+  | Model_input_projection_failed detail -> detail
+;;
 
 let prepare_tools ~(tools : Tool_set.t) () =
   let selected = Tool_set.to_list tools in
@@ -48,19 +64,39 @@ let prepare_messages ~messages ~turn_params () =
 ;;
 
 let prepare_turn ~tools ~messages ~turn_params ?model_input_projection () =
-  let tools_json, visible_tool_names = prepare_tools ~tools () in
+  let selected_tools =
+    match turn_params.Hooks.tool_surface with
+    | Hooks.All_tools -> Ok tools
+    | Hooks.Selected_tools names ->
+      Tool_set.select_exact ~names tools
+      |> Result.map_error (fun error -> Tool_selection_failed error)
+  in
+  let ( let* ) = Result.bind in
+  let* visible_tools = selected_tools in
+  let* () =
+    match turn_params.tool_choice with
+    | Some (Tool name) when not (Tool_set.mem name visible_tools) ->
+      Error (Tool_choice_not_visible name)
+    | Some (Tool _ | Auto | Any | None_) | None -> Ok ()
+  in
+  let tools_json, visible_tool_names = prepare_tools ~tools:visible_tools () in
   let prepared = prepare_messages ~messages ~turn_params () in
   let effective_messages =
     match model_input_projection with
     | None -> Ok prepared
     | Some project ->
-      (try project prepared with
+      (try
+         Result.map_error
+           (fun detail -> Model_input_projection_failed detail)
+           (project prepared)
+       with
        | exn ->
          Llm_provider.Reserved_exn.reraise_if_reserved exn;
-         Error (Printexc.to_string exn))
+         Error (Model_input_projection_failed (Printexc.to_string exn)))
   in
   Result.map
-    (fun effective_messages -> { tools_json; effective_messages; visible_tool_names })
+    (fun effective_messages ->
+       { tools_json; effective_messages; visible_tools; visible_tool_names })
     effective_messages
 ;;
 

--- a/lib/agent/agent_turn.mli
+++ b/lib/agent/agent_turn.mli
@@ -15,6 +15,7 @@
 type turn_preparation =
   { tools_json : Yojson.Safe.t list option
   ; effective_messages : Types.message list
+  ; visible_tools : Tool_set.t
   ; visible_tool_names : string list
     (** Names of the caller-supplied tools. This is exactly the list the LLM
         sees this turn. Useful for [Event_bus.TurnReady] subscribers and
@@ -25,6 +26,13 @@ type turn_preparation =
 
         @since 0.162.0 *)
   }
+
+type preparation_error =
+  | Tool_selection_failed of Tool_set.selection_error
+  | Tool_choice_not_visible of string
+  | Model_input_projection_failed of string
+
+val preparation_error_to_string : preparation_error -> string
 
 (** Serialize every caller-supplied tool with its complete input schema. *)
 val prepare_tools : tools:Tool_set.t -> unit -> Yojson.Safe.t list option * string list
@@ -53,7 +61,7 @@ val prepare_turn
   -> turn_params:Hooks.turn_params
   -> ?model_input_projection:Agent_types.model_input_projection
   -> unit
-  -> (turn_preparation, string) result
+  -> (turn_preparation, preparation_error) result
 
 (** Project caller-owned turn controls onto the exact provider carrier.
     Provider identity and transport fields remain unchanged; model-specific

--- a/lib/agent/agent_turn.mli
+++ b/lib/agent/agent_turn.mli
@@ -31,6 +31,7 @@ type turn_preparation =
 type preparation_error =
   | Tool_selection_failed of Tool_set.selection_error
   | Tool_choice_not_visible of string
+  | Required_tool_choice_without_tools
   | Model_input_projection_failed of string
 
 val preparation_error_to_string : preparation_error -> string

--- a/lib/agent/agent_turn.mli
+++ b/lib/agent/agent_turn.mli
@@ -17,8 +17,9 @@ type turn_preparation =
   ; effective_messages : Types.message list
   ; visible_tools : Tool_set.t
   ; visible_tool_names : string list
-    (** Names of the caller-supplied tools. This is exactly the list the LLM
-        sees this turn. Useful for [Event_bus.TurnReady] subscribers and
+    (** Names selected from the caller-owned tool set for this turn. This is
+        exactly the list the LLM sees and the executor accepts. Useful for
+        [Event_bus.TurnReady] subscribers and
         deterministic substrate observability. Empty list when no
         tools are presented to the LLM.
 
@@ -50,8 +51,9 @@ val prepare_messages
   -> unit
   -> Types.message list
 
-(** Full turn preparation: exact caller-supplied tools plus messages. A failed
-    caller projection is returned before provider measurement or dispatch.
+(** Full turn preparation: exact selected tools plus messages. Selection,
+    named tool choice, and caller projection failures are returned before
+    provider measurement or dispatch.
 
     @since 0.185.0 added optional [config] parameter for provider-facing
       thinking preservation. *)

--- a/lib/base/hooks.ml
+++ b/lib/base/hooks.ml
@@ -6,6 +6,12 @@
 
 open Types
 
+(** Exact provider and execution surface for one turn. [Selected_tools] names
+    are validated against the caller-owned tool set before provider dispatch. *)
+type tool_surface =
+  | All_tools
+  | Selected_tools of string list
+
 (** Per-turn adjustable parameters.
     Hooks can return [AdjustParams] from [BeforeTurnParams] to override
     these for a single turn. Values revert to the agent's base config
@@ -17,6 +23,7 @@ type turn_params =
   ; enable_thinking : bool option
   ; preserve_thinking : bool option
   ; tool_choice : tool_choice option
+  ; tool_surface : tool_surface
   ; extra_system_context : string option
   ; system_prompt_override : string option
   }
@@ -28,6 +35,7 @@ let default_turn_params =
   ; enable_thinking = None
   ; preserve_thinking = None
   ; tool_choice = None
+  ; tool_surface = All_tools
   ; extra_system_context = None
   ; system_prompt_override = None
   }

--- a/lib/base/hooks.mli
+++ b/lib/base/hooks.mli
@@ -5,6 +5,10 @@
 
 (** Per-turn adjustable parameters.
     Returned via [AdjustParams] from [BeforeTurnParams] hook. *)
+type tool_surface =
+  | All_tools
+  | Selected_tools of string list
+
 type turn_params =
   { temperature : float option
   ; thinking_budget : int option
@@ -12,6 +16,7 @@ type turn_params =
   ; enable_thinking : bool option
   ; preserve_thinking : bool option
   ; tool_choice : Types.tool_choice option
+  ; tool_surface : tool_surface
   ; extra_system_context : string option
   ; system_prompt_override : string option
   }

--- a/lib/dune
+++ b/lib/dune
@@ -9,6 +9,7 @@
   execution_cause
   execution_json
   execution_provider_response_snapshot
+  execution_provider_attempt_surface
   execution_tool_schedule
   execution_event
   execution_runtime
@@ -30,8 +31,11 @@
   pipeline_checkpoint
   pipeline_execution_scope
   pipeline_execution_resume
+  pipeline_stage_execute
+  pipeline_tool_surface
   pipeline_terminal_tool
   pipeline_terminal_resume
+  tool_surface_names
   agent_execution_event_writer)
  (libraries
   llm_provider

--- a/lib/execution_agent_scope.ml
+++ b/lib/execution_agent_scope.ml
@@ -96,6 +96,7 @@ type error =
       }
   | Invocation_locator_mismatch
   | Resume_topology_mismatch of string
+  | Tool_not_in_provider_surface of string
   | Invalid_tool_result
   | Settlement_failed of Settlement.error
 
@@ -127,6 +128,8 @@ let error_to_string = function
   | Invocation_locator_mismatch ->
     "execution invocation locator does not match durable topology"
   | Resume_topology_mismatch detail -> "execution resume topology mismatch: " ^ detail
+  | Tool_not_in_provider_surface name ->
+    Printf.sprintf "tool %S is outside the durable provider surface" name
   | Invalid_tool_result -> "execution settlement returned an invalid ToolResult"
   | Settlement_failed error -> settlement_error_to_string error
 ;;
@@ -368,14 +371,29 @@ let resume_current_turn scope =
                 Error (Resume_topology_mismatch "requested turn is already closed")))))
 ;;
 
-let open_provider_attempt turn ~ordinal binding =
-  match Event.provider_attempt ~ordinal binding with
+let open_provider_attempt turn ~ordinal ~tool_names binding =
+  match Event.provider_attempt ~ordinal ~tool_names binding with
   | Error detail -> Error (Invalid_provider_attempt detail)
   | Ok kind ->
     transact
       turn.scope.writer
       (Tx.open_node ~run:turn.scope.run ~parent:turn.node ~kind ())
     |> Result.map (fun (node, _event) -> { turn; node })
+;;
+
+let provider_tool_names (provider : provider_attempt) =
+  match Writer.find_node provider.turn.scope.writer provider.node with
+  | Error error -> Error (Scope_unavailable error)
+  | Ok None -> Error (Resume_topology_mismatch "provider attempt node disappeared")
+  | Ok (Some view) ->
+    (match Event.node_kind view.node with
+     | Event.Provider_attempt { tool_names; _ } -> Ok tool_names
+     | Event.Agent_run _
+     | Event.Agent_turn _
+     | Event.Output_block _
+     | Event.Tool_invocation _
+     | Event.Tool_attempt ->
+       Error (Resume_topology_mismatch "provider authority points to a non-provider node"))
 ;;
 
 let resume_provider_attempt (turn : turn) =
@@ -422,24 +440,29 @@ let resume_provider_attempt (turn : turn) =
 ;;
 
 let open_invocation provider ~invocation ~tool_name ~input =
-  let scope = provider.turn.scope in
-  match
-    transact
-      scope.writer
-      (Tx.open_tool_invocation
-         ~run:scope.run
-         ~provider_attempt:provider.node
-         ~invocation
-         ~tool_name
-         ~input
-         ())
-  with
+  match provider_tool_names provider with
   | Error _ as error -> error
-  | Ok (node, _events) ->
-    let locator = { run_id = Journal.run_id scope.run; node } in
-    Settlement.rebind ~writer:scope.writer ~invocation_node:node
-    |> Result.map (fun durable -> { durable; locator; scope })
-    |> Result.map_error (fun error -> Settlement_failed error)
+  | Ok tool_names when not (List.mem tool_name tool_names) ->
+    Error (Tool_not_in_provider_surface tool_name)
+  | Ok _ ->
+    let scope = provider.turn.scope in
+    (match
+       transact
+         scope.writer
+         (Tx.open_tool_invocation
+            ~run:scope.run
+            ~provider_attempt:provider.node
+            ~invocation
+            ~tool_name
+            ~input
+            ())
+     with
+     | Error _ as error -> error
+     | Ok (node, _events) ->
+       let locator = { run_id = Journal.run_id scope.run; node } in
+       Settlement.rebind ~writer:scope.writer ~invocation_node:node
+       |> Result.map (fun durable -> { durable; locator; scope })
+       |> Result.map_error (fun error -> Settlement_failed error))
 ;;
 
 let invocation_locator invocation = invocation.locator

--- a/lib/execution_agent_scope.mli
+++ b/lib/execution_agent_scope.mli
@@ -61,6 +61,7 @@ type error =
       }
   | Invocation_locator_mismatch
   | Resume_topology_mismatch of string
+  | Tool_not_in_provider_surface of string
   | Invalid_tool_result
   | Settlement_failed of Execution_tool_settlement.error
 
@@ -123,10 +124,14 @@ val turn_ordinal : turn -> int
 val open_provider_attempt
   :  turn
   -> ordinal:int
+  -> tool_names:string list
   -> Binding_identity.t
   -> (provider_attempt, error) result
 
 val resume_provider_attempt : turn -> (provider_resume, error) result
+
+(** Exact tool surface serialized for this provider attempt. *)
+val provider_tool_names : provider_attempt -> (string list, error) result
 
 (** Materialize the exact provider response once on its owning attempt. *)
 val record_provider_response

--- a/lib/execution_event.ml
+++ b/lib/execution_event.ml
@@ -133,21 +133,7 @@ let validate_node_kind = function
   | Agent_turn { ordinal } ->
     if ordinal < 0 then Error "agent turn ordinal must be non-negative" else Ok ()
   | Provider_attempt { ordinal; tool_names; _ } ->
-    if ordinal < 0
-    then Error "provider attempt ordinal must be non-negative"
-    else (
-      let seen = Hashtbl.create (List.length tool_names) in
-      let rec validate = function
-        | [] -> Ok ()
-        | name :: rest ->
-          let* () = validate_non_blank "tool_name" name in
-          if Hashtbl.mem seen name
-          then Error (Printf.sprintf "provider attempt tool name %S is duplicated" name)
-          else (
-            Hashtbl.add seen name ();
-            validate rest)
-      in
-      validate tool_names)
+    Execution_provider_attempt_surface.validate ~ordinal ~tool_names
   | Output_block { ordinal; _ } ->
     if ordinal < 0 then Error "output block ordinal must be non-negative" else Ok ()
   | Tool_invocation { provider_tool_use_id = _; tool_name; schedule; completion } ->
@@ -164,7 +150,6 @@ let provider_attempt ~ordinal ~tool_names binding =
   let+ () = validate_node_kind kind in
   kind
 ;;
-
 let make_node ~node_id ~run_id ~parent_node_id ~kind =
   let* () = validate_node_kind kind in
   Ok { node_id; run_id; parent_node_id; kind }
@@ -560,12 +545,7 @@ let node_kind_to_yojson_unchecked = function
   | Agent_turn { ordinal } ->
     `Assoc [ "type", `String "agent_turn"; "ordinal", `Int ordinal ]
   | Provider_attempt { ordinal; target; tool_names } ->
-    `Assoc
-      [ "type", `String "provider_attempt"
-      ; "ordinal", `Int ordinal
-      ; "target", Binding_identity.Redacted_snapshot.to_yojson target
-      ; "tool_names", `List (List.map (fun name -> `String name) tool_names)
-      ]
+    Execution_provider_attempt_surface.to_yojson ~ordinal ~target ~tool_names
   | Output_block { ordinal; block_kind } ->
     `Assoc
       [ "type", `String "output_block"
@@ -588,7 +568,6 @@ let node_kind_to_yojson kind =
   let+ () = validate_node_kind kind in
   node_kind_to_yojson_unchecked kind
 ;;
-
 let node_kind_of_yojson json =
   let* header =
     object_fields
@@ -635,15 +614,8 @@ let node_kind_of_yojson json =
         let* target = Binding_identity.Redacted_snapshot.of_yojson target_json in
         let* tool_names_json = field "tool_names" fields in
         let* tool_names =
-          match tool_names_json with
-          | `List names ->
-            let rec decode_names decoded_rev = function
-              | [] -> Ok (List.rev decoded_rev)
-              | `String name :: rest -> decode_names (name :: decoded_rev) rest
-              | _ :: _ -> Error "provider attempt tool_names must contain only strings"
-            in
-            decode_names [] names
-          | _ -> Error "provider attempt tool_names must be an array"
+          Tool_surface_names.of_yojson tool_names_json
+          |> Result.map_error (fun detail -> "provider attempt " ^ detail)
         in
         Ok (Provider_attempt { ordinal; target; tool_names }))
     | "output_block" ->

--- a/lib/execution_event.ml
+++ b/lib/execution_event.ml
@@ -920,7 +920,7 @@ let payload_of_yojson json =
   | value -> Error ("unknown execution payload: " ^ value)
 ;;
 
-let schema_version_current = 3
+let schema_version_current = 4
 
 let to_yojson event =
   `Assoc

--- a/lib/execution_event.ml
+++ b/lib/execution_event.ml
@@ -54,6 +54,7 @@ type node_kind =
   | Provider_attempt of
       { ordinal : int
       ; target : Binding_identity.Redacted_snapshot.t
+      ; tool_names : string list
       }
   | Output_block of
       { ordinal : int
@@ -71,13 +72,14 @@ let pp_node_kind formatter = function
   | Agent_run { agent_name } ->
     Format.fprintf formatter "Agent_run {agent_name=%S}" agent_name
   | Agent_turn { ordinal } -> Format.fprintf formatter "Agent_turn {ordinal=%d}" ordinal
-  | Provider_attempt { ordinal; target } ->
+  | Provider_attempt { ordinal; target; tool_names } ->
     Format.fprintf
       formatter
-      "Provider_attempt {ordinal=%d; target=%a}"
+      "Provider_attempt {ordinal=%d; target=%a; tool_names=[%s]}"
       ordinal
       Binding_identity.Redacted_snapshot.pp
       target
+      (String.concat "," tool_names)
   | Output_block { ordinal; block_kind } ->
     Format.fprintf
       formatter
@@ -130,8 +132,22 @@ let validate_node_kind = function
   | Agent_run { agent_name } -> validate_non_blank "agent_name" agent_name
   | Agent_turn { ordinal } ->
     if ordinal < 0 then Error "agent turn ordinal must be non-negative" else Ok ()
-  | Provider_attempt { ordinal; _ } ->
-    if ordinal < 0 then Error "provider attempt ordinal must be non-negative" else Ok ()
+  | Provider_attempt { ordinal; tool_names; _ } ->
+    if ordinal < 0
+    then Error "provider attempt ordinal must be non-negative"
+    else (
+      let seen = Hashtbl.create (List.length tool_names) in
+      let rec validate = function
+        | [] -> Ok ()
+        | name :: rest ->
+          let* () = validate_non_blank "tool_name" name in
+          if Hashtbl.mem seen name
+          then Error (Printf.sprintf "provider attempt tool name %S is duplicated" name)
+          else (
+            Hashtbl.add seen name ();
+            validate rest)
+      in
+      validate tool_names)
   | Output_block { ordinal; _ } ->
     if ordinal < 0 then Error "output block ordinal must be non-negative" else Ok ()
   | Tool_invocation { provider_tool_use_id = _; tool_name; schedule; completion } ->
@@ -140,9 +156,10 @@ let validate_node_kind = function
   | Tool_attempt -> Ok ()
 ;;
 
-let provider_attempt ~ordinal binding =
+let provider_attempt ~ordinal ~tool_names binding =
   let kind =
-    Provider_attempt { ordinal; target = Binding_identity.redacted_snapshot binding }
+    Provider_attempt
+      { ordinal; target = Binding_identity.redacted_snapshot binding; tool_names }
   in
   let+ () = validate_node_kind kind in
   kind
@@ -160,6 +177,7 @@ let equal_node_kind left right =
   | Provider_attempt left, Provider_attempt right ->
     left.ordinal = right.ordinal
     && Binding_identity.Redacted_snapshot.equal left.target right.target
+    && List.equal String.equal left.tool_names right.tool_names
   | Output_block left, Output_block right ->
     left.ordinal = right.ordinal
     && equal_output_block_kind left.block_kind right.block_kind
@@ -541,11 +559,12 @@ let node_kind_to_yojson_unchecked = function
     `Assoc [ "type", `String "agent_run"; "agent_name", `String agent_name ]
   | Agent_turn { ordinal } ->
     `Assoc [ "type", `String "agent_turn"; "ordinal", `Int ordinal ]
-  | Provider_attempt { ordinal; target } ->
+  | Provider_attempt { ordinal; target; tool_names } ->
     `Assoc
       [ "type", `String "provider_attempt"
       ; "ordinal", `Int ordinal
       ; "target", Binding_identity.Redacted_snapshot.to_yojson target
+      ; "tool_names", `List (List.map (fun name -> `String name) tool_names)
       ]
   | Output_block { ordinal; block_kind } ->
     `Assoc
@@ -579,6 +598,7 @@ let node_kind_of_yojson json =
         [ "agent_name"
         ; "ordinal"
         ; "target"
+        ; "tool_names"
         ; "block_kind"
         ; "provider_tool_use_id"
         ; "tool_name"
@@ -609,11 +629,23 @@ let node_kind_of_yojson json =
         let+ ordinal = int_field "ordinal" fields in
         Agent_turn { ordinal })
     | "provider_attempt" ->
-      decode ~required:[ "ordinal"; "target" ] ~optional:[] (fun fields ->
+      decode ~required:[ "ordinal"; "target"; "tool_names" ] ~optional:[] (fun fields ->
         let* ordinal = int_field "ordinal" fields in
         let* target_json = field "target" fields in
-        let+ target = Binding_identity.Redacted_snapshot.of_yojson target_json in
-        Provider_attempt { ordinal; target })
+        let* target = Binding_identity.Redacted_snapshot.of_yojson target_json in
+        let* tool_names_json = field "tool_names" fields in
+        let* tool_names =
+          match tool_names_json with
+          | `List names ->
+            let rec decode_names decoded_rev = function
+              | [] -> Ok (List.rev decoded_rev)
+              | `String name :: rest -> decode_names (name :: decoded_rev) rest
+              | _ :: _ -> Error "provider attempt tool_names must contain only strings"
+            in
+            decode_names [] names
+          | _ -> Error "provider attempt tool_names must be an array"
+        in
+        Ok (Provider_attempt { ordinal; target; tool_names }))
     | "output_block" ->
       decode ~required:[ "ordinal"; "block_kind" ] ~optional:[] (fun fields ->
         let* ordinal = int_field "ordinal" fields in

--- a/lib/execution_event.ml
+++ b/lib/execution_event.ml
@@ -73,13 +73,7 @@ let pp_node_kind formatter = function
     Format.fprintf formatter "Agent_run {agent_name=%S}" agent_name
   | Agent_turn { ordinal } -> Format.fprintf formatter "Agent_turn {ordinal=%d}" ordinal
   | Provider_attempt { ordinal; target; tool_names } ->
-    Format.fprintf
-      formatter
-      "Provider_attempt {ordinal=%d; target=%a; tool_names=[%s]}"
-      ordinal
-      Binding_identity.Redacted_snapshot.pp
-      target
-      (String.concat "," tool_names)
+    Execution_provider_attempt_surface.pp formatter ~ordinal ~target ~tool_names
   | Output_block { ordinal; block_kind } ->
     Format.fprintf
       formatter
@@ -150,6 +144,7 @@ let provider_attempt ~ordinal ~tool_names binding =
   let+ () = validate_node_kind kind in
   kind
 ;;
+
 let make_node ~node_id ~run_id ~parent_node_id ~kind =
   let* () = validate_node_kind kind in
   Ok { node_id; run_id; parent_node_id; kind }
@@ -568,6 +563,7 @@ let node_kind_to_yojson kind =
   let+ () = validate_node_kind kind in
   node_kind_to_yojson_unchecked kind
 ;;
+
 let node_kind_of_yojson json =
   let* header =
     object_fields

--- a/lib/execution_event.mli
+++ b/lib/execution_event.mli
@@ -64,6 +64,7 @@ type node_kind =
   | Provider_attempt of
       { ordinal : int
       ; target : Binding_identity.Redacted_snapshot.t
+      ; tool_names : string list
       }
   | Output_block of
       { ordinal : int
@@ -81,7 +82,11 @@ type node_kind =
     identity already selected for dispatch. The stored target is its durable
     redacted observation, never a second config resolution or dispatch key. The
     journal allocates the attempt's occurrence identity when the node opens. *)
-val provider_attempt : ordinal:int -> Binding_identity.t -> (node_kind, string) result
+val provider_attempt
+  :  ordinal:int
+  -> tool_names:string list
+  -> Binding_identity.t
+  -> (node_kind, string) result
 
 val pp_node_kind : Format.formatter -> node_kind -> unit
 val show_node_kind : node_kind -> string

--- a/lib/execution_event_store.ml
+++ b/lib/execution_event_store.ml
@@ -240,8 +240,9 @@ let lock_name = ".writer.lock"
 let frame_magic = "OASE"
 let frame_version = 1
 
-(* Version 2 hard-cuts recursive work to exact tool attempts; WAL framing is unchanged. *)
-let store_format_version = 2
+(* Version 3 hard-cuts provider-attempt surfaces to the event schema; format 2
+   is intentionally not reopened. WAL framing is unchanged. *)
+let store_format_version = 3
 let frame_header_size = 48
 
 module Active_path_map = Map.Make (String)

--- a/lib/execution_provider_attempt_surface.ml
+++ b/lib/execution_provider_attempt_surface.ml
@@ -1,13 +1,23 @@
 let validate ~ordinal ~tool_names =
   if ordinal < 0
   then Error "provider attempt ordinal must be non-negative"
-  else
+  else (
     match Tool_surface_names.validate tool_names with
     | Ok () -> Ok ()
     | Error Tool_surface_names.Blank_name ->
       Error "provider attempt tool name must not be blank"
     | Error (Tool_surface_names.Duplicate_name name) ->
-      Error (Printf.sprintf "provider attempt tool name %S is duplicated" name)
+      Error (Printf.sprintf "provider attempt tool name %S is duplicated" name))
+;;
+
+let pp formatter ~ordinal ~target ~tool_names =
+  Format.fprintf
+    formatter
+    "Provider_attempt {ordinal=%d; target=%a; tool_names=[%s]}"
+    ordinal
+    Binding_identity.Redacted_snapshot.pp
+    target
+    (String.concat "," tool_names)
 ;;
 
 let to_yojson ~ordinal ~target ~tool_names =

--- a/lib/execution_provider_attempt_surface.ml
+++ b/lib/execution_provider_attempt_surface.ml
@@ -1,0 +1,20 @@
+let validate ~ordinal ~tool_names =
+  if ordinal < 0
+  then Error "provider attempt ordinal must be non-negative"
+  else
+    match Tool_surface_names.validate tool_names with
+    | Ok () -> Ok ()
+    | Error Tool_surface_names.Blank_name ->
+      Error "provider attempt tool name must not be blank"
+    | Error (Tool_surface_names.Duplicate_name name) ->
+      Error (Printf.sprintf "provider attempt tool name %S is duplicated" name)
+;;
+
+let to_yojson ~ordinal ~target ~tool_names =
+  `Assoc
+    [ "type", `String "provider_attempt"
+    ; "ordinal", `Int ordinal
+    ; "target", Binding_identity.Redacted_snapshot.to_yojson target
+    ; "tool_names", Tool_surface_names.to_yojson tool_names
+    ]
+;;

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -304,172 +304,6 @@ let stage_collect ?raw_trace_run ?clock ~turn ~provider_config agent response =
 
 (* ── Stage 5: Execute ────────────────────────────────────── *)
 
-(** Reject provider ToolUse blocks outside the exact surface serialized for
-    this turn. The check runs before the response becomes durable authority. *)
-let validate_response_tool_surface ~visible_tools (response : Types.api_response) =
-  let rec validate = function
-    | [] -> Ok ()
-    | ToolUse { name; _ } :: rest ->
-      if Tool_set.mem name visible_tools
-      then validate rest
-      else
-        Error
-          (Error.Config
-             (InvalidConfig
-                { field = "tool_surface"
-                ; detail =
-                    Printf.sprintf
-                      "provider called tool %S outside the selected turn surface"
-                      name
-                }))
-    | ( Text _
-      | Thinking _
-      | ReasoningDetails _
-      | RedactedThinking _
-      | ToolResult _
-      | Image _
-      | Document _
-      | Audio _ )
-      :: rest -> validate rest
-  in
-  validate response.content
-;;
-
-let select_durable_tool_surface ~tool_names tools =
-  match Tool_set.select_exact ~names:tool_names tools with
-  | Ok selected -> Ok selected
-  | Error selection_error ->
-    let detail =
-      match selection_error with
-      | Tool_set.Duplicate_selection name ->
-        Printf.sprintf "durable provider tool name %S is duplicated" name
-      | Tool_set.Unknown_selection name ->
-        Printf.sprintf "durable provider tool name %S is not registered" name
-    in
-    Error (Error.Config (InvalidConfig { field = "tool_surface"; detail }))
-;;
-
-let%test "selected turn surface rejects a hidden provider ToolUse" =
-  let visible_tool =
-    Tool.create ~name:"search" ~description:"search" ~parameters:[] (fun _ ->
-      Ok { Types.content = ""; _meta = None })
-  in
-  let response : Types.api_response =
-    { id = "response"
-    ; model = "model"
-    ; stop_reason = StopToolUse
-    ; content = [ ToolUse { id = "call"; name = "write"; input = `Assoc [] } ]
-    ; usage = None
-    ; telemetry = None
-    }
-  in
-  match
-    validate_response_tool_surface
-      ~visible_tools:(Tool_set.singleton visible_tool)
-      response
-  with
-  | Error (Error.Config (InvalidConfig { field = "tool_surface"; _ })) -> true
-  | Error _ | Ok () -> false
-;;
-
-(** Handle tool execution and context injection. *)
-let stage_execute
-      ?raw_trace_run
-      ?before_tool_execution
-      ~turn
-      ~response
-      ~available_tools
-      agent
-      tools
-  =
-  (* [stage_output] rejects empty StopToolUse from provider and injected
-     transports. [Nonempty.t] then prevents a silent empty [ToolsExecuted]
-     loop at compile time. *)
-  let tool_uses = Nonempty.to_list tools in
-  Tracing.with_span
-    agent.options.tracer
-    { kind = Tool_exec
-    ; name = "turn:execute"
-    ; agent_name = agent.state.config.name
-    ; turn
-    ; extra = []
-    ; links = []
-    }
-    (fun _tracer ->
-       let results, completion, failure =
-         execute_tools_with_trace
-           agent
-           raw_trace_run
-           ~turn
-           ~tools:available_tools
-           ?before_tool_execution
-           tool_uses
-         |> Pipeline_terminal_tool.unpack_execution_result
-       in
-       let tool_results = Agent_turn.make_tool_results results in
-       let* () =
-         match tool_results with
-         | [] -> Ok ()
-         | _ ->
-           (* Commit completed effects before surfacing a terminal hook or
-              observer failure.  Updating memory first prevents same-process
-              replay even when the caller-owned checkpoint sink itself fails;
-              the checkpoint then makes the same invariant durable. *)
-           update_state agent (fun state ->
-             { state with
-               messages = Util.snoc state.messages (make_message ~role:Tool tool_results)
-             });
-           let base_state = agent.state in
-           persist_turn_checkpoint_for_state agent After_tool_results_appended base_state
-       in
-       match failure with
-       | Some
-           (Agent_tools.Hook_failure
-              (Agent_tools.Hook_execution_failed
-                 { hook_name; stage; tool_name; invocation; detail })) ->
-         Error
-           (Pipeline_common.hook_failed_sdk_error
-              ~hook_name
-              ~stage
-              ~tool_name:(Some tool_name)
-              ~tool_use_id:(Some (Tool_contract.Invocation.tool_use_id invocation))
-              ~detail)
-       | Some (Agent_tools.Observer_failure { exception_; backtrace; _ }) ->
-         Printexc.raise_with_backtrace exception_ backtrace
-       | Some (Agent_tools.Durability_failure { invocation; detail }) ->
-         Pipeline_terminal_tool.durability_failure ~invocation ~detail
-       | None ->
-         let finish = Pipeline_terminal_tool.outcome ~response completion in
-         (match agent.options.context_injector with
-          | None -> finish After_tool_results_appended
-          | Some injector ->
-            let* messages =
-              Agent_turn.apply_context_injection
-                ~context:agent.context
-                ~messages:agent.state.messages
-                ~injector
-                ~tool_uses
-                ~results
-              |> Result.map_error (fun error ->
-                Error.Internal
-                  (Printf.sprintf
-                     "context injector failed%s: %s"
-                     (match error.Agent_turn.tool_name with
-                      | Some name -> " for tool " ^ name
-                      | None -> "")
-                     error.detail))
-            in
-            let injected_state = { agent.state with messages } in
-            set_state agent injected_state;
-            let* () =
-              persist_turn_checkpoint_for_state
-                agent
-                After_context_injection
-                injected_state
-            in
-            finish After_context_injection))
-;;
-
 let replay_settled_before_checkpoint agent =
   Pipeline_terminal_resume.replay
     ~persist_checkpoint:(persist_turn_checkpoint_for_state agent)
@@ -522,7 +356,7 @@ let stage_output
                  (UnrecognizedStopReason
                     { reason = "StopToolUse turn carried no tool block" }))
           | Some tool_uses_nonempty ->
-            stage_execute
+            Pipeline_stage_execute.run
               ?raw_trace_run
               ?before_tool_execution
               ~turn
@@ -736,7 +570,9 @@ let run_new_turn
            Error (Error.Agent (GuardrailViolation { validator = validator_name; reason }))
          | Guardrails_async.Pass ->
            let* () =
-             validate_response_tool_surface ~visible_tools:prep.visible_tools response
+             Pipeline_tool_surface.validate_response
+               ~visible_tools:prep.visible_tools
+               response
            in
            let* () =
              Pipeline_execution_scope.record_provider_response execution response
@@ -794,8 +630,10 @@ let run_turn
          ([turn_ordinal]), not [agent.state.turn_count], so the resumed turn is
          traced under the exact ordinal the crashed run used (#2709). *)
     ~execute:(fun ~turn ~response ~tool_names tool_uses ->
-      let* available_tools = select_durable_tool_surface ~tool_names agent.tools in
-      stage_execute
+      let* available_tools =
+        Pipeline_tool_surface.select_durable ~tool_names agent.tools
+      in
+      Pipeline_stage_execute.run
         ?raw_trace_run
         ?before_tool_execution
         ~turn

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -304,8 +304,84 @@ let stage_collect ?raw_trace_run ?clock ~turn ~provider_config agent response =
 
 (* ── Stage 5: Execute ────────────────────────────────────── *)
 
+(** Reject provider ToolUse blocks outside the exact surface serialized for
+    this turn. The check runs before the response becomes durable authority. *)
+let validate_response_tool_surface ~visible_tools (response : Types.api_response) =
+  let rec validate = function
+    | [] -> Ok ()
+    | ToolUse { name; _ } :: rest ->
+      if Tool_set.mem name visible_tools
+      then validate rest
+      else
+        Error
+          (Error.Config
+             (InvalidConfig
+                { field = "tool_surface"
+                ; detail =
+                    Printf.sprintf
+                      "provider called tool %S outside the selected turn surface"
+                      name
+                }))
+    | ( Text _
+      | Thinking _
+      | ReasoningDetails _
+      | RedactedThinking _
+      | ToolResult _
+      | Image _
+      | Document _
+      | Audio _ )
+      :: rest -> validate rest
+  in
+  validate response.content
+;;
+
+let select_durable_tool_surface ~tool_names tools =
+  match Tool_set.select_exact ~names:tool_names tools with
+  | Ok selected -> Ok selected
+  | Error selection_error ->
+    let detail =
+      match selection_error with
+      | Tool_set.Duplicate_selection name ->
+        Printf.sprintf "durable provider tool name %S is duplicated" name
+      | Tool_set.Unknown_selection name ->
+        Printf.sprintf "durable provider tool name %S is not registered" name
+    in
+    Error (Error.Config (InvalidConfig { field = "tool_surface"; detail }))
+;;
+
+let%test "selected turn surface rejects a hidden provider ToolUse" =
+  let visible_tool =
+    Tool.create ~name:"search" ~description:"search" ~parameters:[] (fun _ ->
+      Ok { Types.content = ""; _meta = None })
+  in
+  let response : Types.api_response =
+    { id = "response"
+    ; model = "model"
+    ; stop_reason = StopToolUse
+    ; content = [ ToolUse { id = "call"; name = "write"; input = `Assoc [] } ]
+    ; usage = None
+    ; telemetry = None
+    }
+  in
+  match
+    validate_response_tool_surface
+      ~visible_tools:(Tool_set.singleton visible_tool)
+      response
+  with
+  | Error (Error.Config (InvalidConfig { field = "tool_surface"; _ })) -> true
+  | Error _ | Ok () -> false
+;;
+
 (** Handle tool execution and context injection. *)
-let stage_execute ?raw_trace_run ?before_tool_execution ~turn ~response agent tools =
+let stage_execute
+      ?raw_trace_run
+      ?before_tool_execution
+      ~turn
+      ~response
+      ~available_tools
+      agent
+      tools
+  =
   (* [stage_output] rejects empty StopToolUse from provider and injected
      transports. [Nonempty.t] then prevents a silent empty [ToolsExecuted]
      loop at compile time. *)
@@ -325,6 +401,7 @@ let stage_execute ?raw_trace_run ?before_tool_execution ~turn ~response agent to
            agent
            raw_trace_run
            ~turn
+           ~tools:available_tools
            ?before_tool_execution
            tool_uses
          |> Pipeline_terminal_tool.unpack_execution_result
@@ -400,7 +477,14 @@ let replay_settled_before_checkpoint agent =
 ;;
 
 (** Map stop_reason to turn_outcome. *)
-let stage_output ?raw_trace_run ?before_tool_execution ~turn agent response =
+let stage_output
+      ?raw_trace_run
+      ?before_tool_execution
+      ~turn
+      ~available_tools
+      agent
+      response
+  =
   Tracing.with_span
     agent.options.tracer
     { kind = Hook_invoke
@@ -443,6 +527,7 @@ let stage_output ?raw_trace_run ?before_tool_execution ~turn agent response =
               ?before_tool_execution
               ~turn
               ~response
+              ~available_tools
               agent
               tool_uses_nonempty)
        | UnmatchedToolCalls ->
@@ -598,7 +683,9 @@ let run_new_turn
         ?raw_trace_run
         ?on_provider_failure
         ~before_provider_attempt:
-          (Pipeline_execution_scope.before_provider_attempt execution)
+          (Pipeline_execution_scope.before_provider_attempt
+             execution
+             ~tool_names:prep.visible_tool_names)
         ~turn_config
         agent
         prep
@@ -649,6 +736,9 @@ let run_new_turn
            Error (Error.Agent (GuardrailViolation { validator = validator_name; reason }))
          | Guardrails_async.Pass ->
            let* () =
+             validate_response_tool_surface ~visible_tools:prep.visible_tools response
+           in
+           let* () =
              Pipeline_execution_scope.record_provider_response execution response
              |> tag_error "response"
            in
@@ -658,10 +748,22 @@ let run_new_turn
            in
            (match Pipeline_execution_scope.provider execution with
             | None ->
-              stage_output ?raw_trace_run ?before_tool_execution ~turn agent response
+              stage_output
+                ?raw_trace_run
+                ?before_tool_execution
+                ~turn
+                ~available_tools:prep.visible_tools
+                agent
+                response
             | Some provider ->
               Execution_context.with_provider_attempt provider (fun () ->
-                stage_output ?raw_trace_run ?before_tool_execution ~turn agent response))
+                stage_output
+                  ?raw_trace_run
+                  ?before_tool_execution
+                  ~turn
+                  ~available_tools:prep.visible_tools
+                  agent
+                  response))
            |> tag_error "output")
     in
     (match outcome with
@@ -691,8 +793,16 @@ let run_turn
          identity is the durable turn ordinal supplied by [dispatch]
          ([turn_ordinal]), not [agent.state.turn_count], so the resumed turn is
          traced under the exact ordinal the crashed run used (#2709). *)
-    ~execute:(fun ~turn ~response tool_uses ->
-      stage_execute ?raw_trace_run ?before_tool_execution ~turn ~response agent tool_uses)
+    ~execute:(fun ~turn ~response ~tool_names tool_uses ->
+      let* available_tools = select_durable_tool_surface ~tool_names agent.tools in
+      stage_execute
+        ?raw_trace_run
+        ?before_tool_execution
+        ~turn
+        ~response
+        ~available_tools
+        agent
+        tool_uses)
     ~all_pre_tool_use_blocked:(ToolsExecuted After_tool_results_appended)
     ~tools_settled_before_checkpoint:(replay_settled_before_checkpoint agent)
     ~tools_settled:Pipeline_terminal_tool.recovered_outcome

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -565,16 +565,17 @@ let run_new_turn
           to coerce a tool call (the former
           [handle_missing_required_tool_use]/[validate_completion_contract]
           pass). *)
-        (* Stage 3.5: Async output validation *)
+        let* () =
+          Pipeline_tool_surface.validate_response
+            ~visible_tools:prep.visible_tools
+            response
+        in
+        (* Stage 3.5: Async output validation. Tool-surface authority is checked
+           first so caller validators never observe an unauthorized ToolUse. *)
         (match Guardrails_async.run_output async_guard.output_validators response with
          | Guardrails_async.Fail { validator_name; reason } ->
            Error (Error.Agent (GuardrailViolation { validator = validator_name; reason }))
          | Guardrails_async.Pass ->
-           let* () =
-             Pipeline_tool_surface.validate_response
-               ~visible_tools:prep.visible_tools
-               response
-           in
            let* () =
              Pipeline_execution_scope.record_provider_response execution response
              |> tag_error "response"

--- a/lib/pipeline/pipeline.ml
+++ b/lib/pipeline/pipeline.ml
@@ -1,9 +1,10 @@
 (** Six-stage Agent turn pipeline: Input, Parse, Route, Collect, Execute, Output.
 
-    [Output] ([stage_output]) dispatches [Execute] ([stage_execute]) internally
-    on StopToolUse, so Execute is a sub-step of Output, not a stage that runs
-    between Collect and Output. This matches the dataflow diagram in
-    pipeline.mli: [Input] -> [Parse] -> [Route] -> [Collect] -> [Output]. *)
+    [Output] ([stage_output]) dispatches [Execute]
+    ([Pipeline_stage_execute.run]) internally on StopToolUse, so Execute is a
+    sub-step of Output, not a stage that runs between Collect and Output. This
+    matches the dataflow diagram in pipeline.mli:
+    [Input] -> [Parse] -> [Route] -> [Collect] -> [Output]. *)
 
 open Types
 open Agent_types

--- a/lib/pipeline/pipeline_execution_resume.ml
+++ b/lib/pipeline/pipeline_execution_resume.ml
@@ -241,9 +241,12 @@ let run
                  (Error.Internal "durable execution resume lost its provider authority")
              | Some provider ->
                Execution_context.with_provider_attempt provider (fun () ->
+                 let* tool_names =
+                   Pipeline_execution_scope.provider_tool_names execution
+                 in
                  let* settled = Pipeline_execution_scope.invocations_settled execution in
                  if not settled
-                 then execute ~response tool_blocks
+                 then execute ~response ~tool_names tool_blocks
                  else
                    let* persisted =
                      Pipeline_execution_scope.settled_invocations_with_results execution
@@ -254,7 +257,7 @@ let run
                          without opening an invocation. With no persisted result
                          authority, safely re-run admission rather than inventing
                          a result. *)
-                     execute ~response tool_blocks
+                     execute ~response ~tool_names tool_blocks
                    | persisted ->
                      let invocations =
                        List.map

--- a/lib/pipeline/pipeline_execution_resume.mli
+++ b/lib/pipeline/pipeline_execution_resume.mli
@@ -11,14 +11,15 @@
     [all_pre_tool_use_blocked] continues an exact checkpoint whose ToolUse and
     ToolResult identities match while the journal contains zero invocation
     nodes; that typed path never enters terminal recovery. [execute] receives
-    the durable turn identity ([turn]), owned by the journal rather than
-    reconstructed from mutable agent state. Fails closed on inconsistent
-    restored topology. *)
+    the durable turn identity ([turn]) and exact provider tool surface
+    ([tool_names]), both owned by the journal rather than reconstructed from
+    mutable agent state. Fails closed on inconsistent restored topology. *)
 val dispatch
   :  Agent_types.t
   -> execute:
        (turn:int
         -> response:Types.api_response
+        -> tool_names:string list
         -> Types.content_block Nonempty.t
         -> ('a, Error.sdk_error) result)
   -> tools_settled_before_checkpoint:

--- a/lib/pipeline/pipeline_execution_scope.ml
+++ b/lib/pipeline/pipeline_execution_scope.ml
@@ -93,16 +93,27 @@ let turn_ordinal t =
   | Durable turn -> Execution_agent_scope.turn_ordinal turn
 ;;
 
-let before_provider_attempt t binding =
+let before_provider_attempt t ~tool_names binding =
   match t.turn with
   | Transient _ -> Ok ()
   | Durable turn ->
-    Execution_agent_scope.open_provider_attempt turn ~ordinal:0 binding
+    Execution_agent_scope.open_provider_attempt turn ~ordinal:0 ~tool_names binding
     |> Result.map (fun provider -> t.provider <- Some provider)
     |> Result.map_error sdk_error
 ;;
 
 let provider (t : t) = t.provider
+
+let provider_tool_names (t : t) =
+  match t.provider with
+  | Some provider ->
+    Execution_agent_scope.provider_tool_names provider |> Result.map_error sdk_error
+  | None ->
+    Error
+      (sdk_error
+         (Execution_agent_scope.Resume_topology_mismatch
+            "active execution has no provider tool surface authority"))
+;;
 
 let record_provider_response (t : t) response =
   match t.turn, t.provider with

--- a/lib/pipeline/pipeline_execution_scope.mli
+++ b/lib/pipeline/pipeline_execution_scope.mli
@@ -29,8 +29,15 @@ val resume_current : Execution_agent_scope.t option -> (resumed, Error.sdk_error
 val finalize_settled : settled_boundary -> (unit, Error.sdk_error) result
 
 val turn_ordinal : t -> int
-val before_provider_attempt : t -> Binding_identity.t -> (unit, Error.sdk_error) result
+
+val before_provider_attempt
+  :  t
+  -> tool_names:string list
+  -> Binding_identity.t
+  -> (unit, Error.sdk_error) result
+
 val provider : t -> Execution_agent_scope.provider_attempt option
+val provider_tool_names : t -> (string list, Error.sdk_error) result
 
 val record_provider_response
   :  t

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -141,7 +141,7 @@ let%test "last_tool_results_from routes through canonical projection (with json)
 ;;
 
 let prepare_turn_for_agent agent ~turn_params =
-  let turn_params =
+  let effective_turn_params : Hooks.turn_params =
     { turn_params with
       tool_choice =
         (match turn_params.tool_choice with
@@ -152,7 +152,7 @@ let prepare_turn_for_agent agent ~turn_params =
   Agent_turn.prepare_turn
     ~tools:agent.tools
     ~messages:agent.state.messages
-    ~turn_params
+    ~turn_params:effective_turn_params
     ?model_input_projection:agent.model_input_projection
     ()
 ;;

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -141,6 +141,14 @@ let%test "last_tool_results_from routes through canonical projection (with json)
 ;;
 
 let prepare_turn_for_agent agent ~turn_params =
+  let turn_params =
+    { turn_params with
+      tool_choice =
+        (match turn_params.tool_choice with
+         | Some _ as choice -> choice
+         | None -> agent.state.config.tool_choice)
+    }
+  in
   Agent_turn.prepare_turn
     ~tools:agent.tools
     ~messages:agent.state.messages

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -140,7 +140,7 @@ let%test "last_tool_results_from routes through canonical projection (with json)
   | _ -> false
 ;;
 
-let prepare_turn_for_agent agent ~turn_params =
+let prepare_turn_for_agent agent ~(turn_params : Hooks.turn_params) =
   let effective_turn_params : Hooks.turn_params =
     { turn_params with
       tool_choice =

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -184,6 +184,13 @@ let preparation_error_to_sdk = function
          ; detail =
              Printf.sprintf "named tool %S is outside the selected tool surface" name
          })
+  | Agent_turn.Required_tool_choice_without_tools ->
+    Error.Config
+      (InvalidConfig
+         { field = "tool_choice"
+         ; detail =
+             "required tool choice cannot be used with an empty selected tool surface"
+         })
 ;;
 
 let stage_parse ?raw_trace_run ?clock ~turn agent =

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -149,15 +149,32 @@ let prepare_turn_for_agent agent ~turn_params =
     ()
 ;;
 
-let model_input_projection_error detail =
-  Error.Agent
-    (HookExecutionFailed
-       { hook_name = "model_input_projection"
-       ; stage = "turn:parse"
-       ; tool_name = None
-       ; tool_use_id = None
-       ; detail
-       })
+let preparation_error_to_sdk = function
+  | Agent_turn.Model_input_projection_failed detail ->
+    Error.Agent
+      (HookExecutionFailed
+         { hook_name = "model_input_projection"
+         ; stage = "turn:parse"
+         ; tool_name = None
+         ; tool_use_id = None
+         ; detail
+         })
+  | Agent_turn.Tool_selection_failed selection_error ->
+    let detail =
+      match selection_error with
+      | Tool_set.Duplicate_selection name ->
+        Printf.sprintf "duplicate selected tool name %S" name
+      | Tool_set.Unknown_selection name ->
+        Printf.sprintf "selected tool name %S is not registered" name
+    in
+    Error.Config (InvalidConfig { field = "tool_surface"; detail })
+  | Agent_turn.Tool_choice_not_visible name ->
+    Error.Config
+      (InvalidConfig
+         { field = "tool_choice"
+         ; detail =
+             Printf.sprintf "named tool %S is outside the selected tool surface" name
+         })
 ;;
 
 let stage_parse ?raw_trace_run ?clock ~turn agent =
@@ -249,8 +266,7 @@ let stage_parse ?raw_trace_run ?clock ~turn agent =
        (Turn_started { turn; timestamp = Pipeline_common.timestamp_now ?clock () })
    | None -> ());
   let* prep =
-    prepare_turn_for_agent agent ~turn_params
-    |> Result.map_error model_input_projection_error
+    prepare_turn_for_agent agent ~turn_params |> Result.map_error preparation_error_to_sdk
   in
   let ready_tool_names = prep.visible_tool_names in
   (* TurnReady reports the exact caller-supplied tool list the LLM will see

--- a/lib/pipeline/pipeline_stage_prepare.ml
+++ b/lib/pipeline/pipeline_stage_prepare.ml
@@ -162,6 +162,7 @@ let preparation_error_to_sdk = function
   | Agent_turn.Tool_selection_failed selection_error ->
     let detail =
       match selection_error with
+      | Tool_set.Blank_selection -> "selected tool name must not be blank"
       | Tool_set.Duplicate_selection name ->
         Printf.sprintf "duplicate selected tool name %S" name
       | Tool_set.Unknown_selection name ->
@@ -269,8 +270,8 @@ let stage_parse ?raw_trace_run ?clock ~turn agent =
     prepare_turn_for_agent agent ~turn_params |> Result.map_error preparation_error_to_sdk
   in
   let ready_tool_names = prep.visible_tool_names in
-  (* TurnReady reports the exact caller-supplied tool list the LLM will see
-     this turn. Downstream substrate observability subscribers use this
+  (* TurnReady reports the exact selected tool list the LLM will see and the
+     executor will accept this turn. Downstream substrate observability uses it
      to verify deterministically
      which tools the autonomous agent actually has access to, before
      making claims about LLM behaviour from a missing tool call.

--- a/lib/pipeline_stage_execute.ml
+++ b/lib/pipeline_stage_execute.ml
@@ -1,0 +1,96 @@
+open Types
+open Agent_types
+open Agent_trace
+open Result_syntax
+
+let run
+      ?raw_trace_run
+      ?before_tool_execution
+      ~turn
+      ~response
+      ~available_tools
+      agent
+      tools
+  =
+  let tool_uses = Nonempty.to_list tools in
+  Tracing.with_span
+    agent.options.tracer
+    { kind = Tool_exec
+    ; name = "turn:execute"
+    ; agent_name = agent.state.config.name
+    ; turn
+    ; extra = []
+    ; links = []
+    }
+    (fun _tracer ->
+       let results, completion, failure =
+         execute_tools_with_trace
+           agent
+           raw_trace_run
+           ~turn
+           ~tools:available_tools
+           ?before_tool_execution
+           tool_uses
+         |> Pipeline_terminal_tool.unpack_execution_result
+       in
+       let tool_results = Agent_turn.make_tool_results results in
+       let* () =
+         match tool_results with
+         | [] -> Ok ()
+         | _ ->
+           update_state agent (fun state ->
+             { state with
+               messages = Util.snoc state.messages (make_message ~role:Tool tool_results)
+             });
+           Pipeline_checkpoint.persist_for_state
+             agent
+             After_tool_results_appended
+             agent.state
+       in
+       match failure with
+       | Some
+           (Agent_tools.Hook_failure
+              (Agent_tools.Hook_execution_failed
+                 { hook_name; stage; tool_name; invocation; detail })) ->
+         Error
+           (Pipeline_common.hook_failed_sdk_error
+              ~hook_name
+              ~stage
+              ~tool_name:(Some tool_name)
+              ~tool_use_id:(Some (Tool_contract.Invocation.tool_use_id invocation))
+              ~detail)
+       | Some (Agent_tools.Observer_failure { exception_; backtrace; _ }) ->
+         Printexc.raise_with_backtrace exception_ backtrace
+       | Some (Agent_tools.Durability_failure { invocation; detail }) ->
+         Pipeline_terminal_tool.durability_failure ~invocation ~detail
+       | None ->
+         let finish = Pipeline_terminal_tool.outcome ~response completion in
+         (match agent.options.context_injector with
+          | None -> finish After_tool_results_appended
+          | Some injector ->
+            let* messages =
+              Agent_turn.apply_context_injection
+                ~context:agent.context
+                ~messages:agent.state.messages
+                ~injector
+                ~tool_uses
+                ~results
+              |> Result.map_error (fun error ->
+                Error.Internal
+                  (Printf.sprintf
+                     "context injector failed%s: %s"
+                     (match error.Agent_turn.tool_name with
+                      | Some name -> " for tool " ^ name
+                      | None -> "")
+                     error.detail))
+            in
+            let injected_state = { agent.state with messages } in
+            set_state agent injected_state;
+            let* () =
+              Pipeline_checkpoint.persist_for_state
+                agent
+                After_context_injection
+                injected_state
+            in
+            finish After_context_injection))
+;;

--- a/lib/pipeline_stage_execute.ml
+++ b/lib/pipeline_stage_execute.ml
@@ -3,14 +3,7 @@ open Agent_types
 open Agent_trace
 open Result_syntax
 
-let run
-      ?raw_trace_run
-      ?before_tool_execution
-      ~turn
-      ~response
-      ~available_tools
-      agent
-      tools
+let run ?raw_trace_run ?before_tool_execution ~turn ~response ~available_tools agent tools
   =
   let tool_uses = Nonempty.to_list tools in
   Tracing.with_span

--- a/lib/pipeline_tool_surface.ml
+++ b/lib/pipeline_tool_surface.ml
@@ -1,0 +1,45 @@
+open Types
+
+let validate_response ~visible_tools (response : api_response) =
+  let rec validate = function
+    | [] -> Ok ()
+    | ToolUse { name; _ } :: rest ->
+      if Tool_set.mem name visible_tools
+      then validate rest
+      else
+        Error
+          (Error.Config
+             (InvalidConfig
+                { field = "tool_surface"
+                ; detail =
+                    Printf.sprintf
+                      "provider called tool %S outside the selected turn surface"
+                      name
+                }))
+    | ( Text _
+      | Thinking _
+      | ReasoningDetails _
+      | RedactedThinking _
+      | ToolResult _
+      | Image _
+      | Document _
+      | Audio _ )
+      :: rest -> validate rest
+  in
+  validate response.content
+;;
+
+let select_durable ~tool_names tools =
+  match Tool_set.select_exact ~names:tool_names tools with
+  | Ok selected -> Ok selected
+  | Error selection_error ->
+    let detail =
+      match selection_error with
+      | Tool_set.Blank_selection -> "durable provider tool name is blank"
+      | Tool_set.Duplicate_selection name ->
+        Printf.sprintf "durable provider tool name %S is duplicated" name
+      | Tool_set.Unknown_selection name ->
+        Printf.sprintf "durable provider tool name %S is not registered" name
+    in
+    Error (Error.Config (InvalidConfig { field = "tool_surface"; detail }))
+;;

--- a/lib/tool_set.ml
+++ b/lib/tool_set.ml
@@ -14,6 +14,10 @@ type dep_error =
   | DuplicateName of string
   | EmptyName
 
+type selection_error =
+  | Duplicate_selection of string
+  | Unknown_selection of string
+
 let empty = { tools = []; by_name = Hashtbl.create 0 }
 
 let singleton tool =
@@ -54,6 +58,22 @@ let find name set = Hashtbl.find_opt set.by_name name
 let mem name set = Hashtbl.mem set.by_name name
 let size set = List.length set.tools
 let names set = List.map (fun (t : Tool.t) -> t.schema.Types.name) set.tools
+
+let select_exact ~names set =
+  let seen = Hashtbl.create (List.length names) in
+  let rec select selected_rev = function
+    | [] -> Ok (of_list (List.rev selected_rev))
+    | name :: rest ->
+      if Hashtbl.mem seen name
+      then Error (Duplicate_selection name)
+      else (
+        Hashtbl.add seen name ();
+        match find name set with
+        | None -> Error (Unknown_selection name)
+        | Some tool -> select (tool :: selected_rev) rest)
+  in
+  select [] names
+;;
 
 let validate set =
   let errors = ref [] in

--- a/lib/tool_set.ml
+++ b/lib/tool_set.ml
@@ -15,6 +15,7 @@ type dep_error =
   | EmptyName
 
 type selection_error =
+  | Blank_selection
   | Duplicate_selection of string
   | Unknown_selection of string
 
@@ -60,19 +61,18 @@ let size set = List.length set.tools
 let names set = List.map (fun (t : Tool.t) -> t.schema.Types.name) set.tools
 
 let select_exact ~names set =
-  let seen = Hashtbl.create (List.length names) in
-  let rec select selected_rev = function
-    | [] -> Ok (of_list (List.rev selected_rev))
-    | name :: rest ->
-      if Hashtbl.mem seen name
-      then Error (Duplicate_selection name)
-      else (
-        Hashtbl.add seen name ();
-        match find name set with
-        | None -> Error (Unknown_selection name)
-        | Some tool -> select (tool :: selected_rev) rest)
-  in
-  select [] names
+  match Tool_surface_names.validate names with
+  | Error Tool_surface_names.Blank_name -> Error Blank_selection
+  | Error (Tool_surface_names.Duplicate_name name) -> Error (Duplicate_selection name)
+  | Ok () ->
+    let rec select selected_rev = function
+      | [] -> Ok (of_list (List.rev selected_rev))
+      | name :: rest ->
+        (match find name set with
+         | None -> Error (Unknown_selection name)
+         | Some tool -> select (tool :: selected_rev) rest)
+    in
+    select [] names
 ;;
 
 let validate set =

--- a/lib/tool_set.mli
+++ b/lib/tool_set.mli
@@ -37,6 +37,14 @@ val mem : string -> t -> bool
 val size : t -> int
 val names : t -> string list
 
+type selection_error =
+  | Duplicate_selection of string
+  | Unknown_selection of string
+
+(** Select the exact named subset in caller-supplied order. Unknown and
+    duplicate names fail closed. *)
+val select_exact : names:string list -> t -> (t, selection_error) result
+
 (** {1 Validation} *)
 
 type dep_error =

--- a/lib/tool_set.mli
+++ b/lib/tool_set.mli
@@ -38,6 +38,7 @@ val size : t -> int
 val names : t -> string list
 
 type selection_error =
+  | Blank_selection
   | Duplicate_selection of string
   | Unknown_selection of string
 

--- a/lib/tool_surface_names.ml
+++ b/lib/tool_surface_names.ml
@@ -1,0 +1,29 @@
+type validation_error =
+  | Blank_name
+  | Duplicate_name of string
+
+let validate names =
+  let seen = Hashtbl.create (List.length names) in
+  let rec loop = function
+    | [] -> Ok ()
+    | name :: _ when String.equal (String.trim name) "" -> Error Blank_name
+    | name :: _ when Hashtbl.mem seen name -> Error (Duplicate_name name)
+    | name :: rest ->
+      Hashtbl.add seen name ();
+      loop rest
+  in
+  loop names
+;;
+
+let to_yojson names = `List (List.map (fun name -> `String name) names)
+
+let of_yojson = function
+  | `List names ->
+    let rec decode decoded_rev = function
+      | [] -> Ok (List.rev decoded_rev)
+      | `String name :: rest -> decode (name :: decoded_rev) rest
+      | _ :: _ -> Error "tool_names must contain only strings"
+    in
+    decode [] names
+  | _ -> Error "tool_names must be an array"
+;;

--- a/lib/tool_surface_names.ml
+++ b/lib/tool_surface_names.ml
@@ -25,5 +25,6 @@ let of_yojson = function
       | _ :: _ -> Error "tool_names must contain only strings"
     in
     decode [] names
-  | _ -> Error "tool_names must be an array"
+  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _ ->
+    Error "tool_names must be an array"
 ;;

--- a/lib/tool_surface_names.mli
+++ b/lib/tool_surface_names.mli
@@ -1,0 +1,7 @@
+type validation_error =
+  | Blank_name
+  | Duplicate_name of string
+
+val validate : string list -> (unit, validation_error) result
+val to_yojson : string list -> Yojson.Safe.t
+val of_yojson : Yojson.Safe.t -> (string list, string) result

--- a/scripts/check-terminal-tool-boundary.sh
+++ b/scripts/check-terminal-tool-boundary.sh
@@ -229,9 +229,9 @@ check_boundary() {
     "$EVENT" \
     "the common strict decoder whitelist must admit required completion"
   require_pattern \
-    'schema_version_current = 3' \
+    'schema_version_current = 4' \
     "$EVENT" \
-    "execution events must reject pre-completion schema versions"
+    "execution events must reject pre-tool-surface schema versions"
   require_pattern \
     'Provider_response_snapshot of Llm_provider\.Types\.api_response' \
     "$EVENT" \
@@ -319,7 +319,7 @@ self_test() {
   cp "$EVENT" "$fixture/lib/execution_event.ml"
 
   sed -i.bak \
-    's/schema_version_current = 3/schema_version_current = 2/' \
+    's/schema_version_current = 4/schema_version_current = 3/' \
     "$fixture/lib/execution_event.ml"
   rm -f "$fixture/lib/execution_event.ml.bak"
   if TERMINAL_BOUNDARY_SEARCH_BACKEND=perl \

--- a/test/test_agent_turn.ml
+++ b/test/test_agent_turn.ml
@@ -179,6 +179,23 @@ let test_prepare_turn_unknown_selected_tool_fails_closed () =
   | Ok _ -> Alcotest.fail "unknown selected tool was accepted"
 ;;
 
+let test_prepare_turn_blank_selected_tool_fails_closed () =
+  let blank =
+    Tool.create ~name:" " ~description:"invalid" ~parameters:[] (fun _ ->
+      Ok { Types.content = ""; _meta = None })
+  in
+  let turn_params =
+    { Hooks.default_turn_params with tool_surface = Hooks.Selected_tools [ " " ] }
+  in
+  match
+    Agent_turn.prepare_turn ~tools:(Tool_set.singleton blank) ~messages:[] ~turn_params ()
+  with
+  | Error (Agent_turn.Tool_selection_failed Tool_set.Blank_selection) -> ()
+  | Error error ->
+    Alcotest.failf "unexpected error: %s" (Agent_turn.preparation_error_to_string error)
+  | Ok _ -> Alcotest.fail "blank selected tool was accepted"
+;;
+
 let test_prepare_turn_duplicate_selected_tool_fails_closed () =
   let tool =
     Tool.create ~name:"search" ~description:"search" ~parameters:[] (fun _ ->
@@ -881,6 +898,10 @@ let () =
             "unknown selected tool fails closed"
             `Quick
             test_prepare_turn_unknown_selected_tool_fails_closed
+        ; Alcotest.test_case
+            "blank selected tool fails closed"
+            `Quick
+            test_prepare_turn_blank_selected_tool_fails_closed
         ; Alcotest.test_case
             "duplicate selected tool fails closed"
             `Quick

--- a/test/test_agent_turn.ml
+++ b/test/test_agent_turn.ml
@@ -24,7 +24,7 @@ let context_messages = function
 
 let prepared_turn = function
   | Ok prep -> prep
-  | Error detail -> Alcotest.fail detail
+  | Error error -> Alcotest.fail (Agent_turn.preparation_error_to_string error)
 ;;
 
 (* ── prepare_turn tests ────────────────────────────────────── *)
@@ -136,6 +136,90 @@ let test_prepare_turn_visible_tool_names_preserves_order () =
     "registry order preserved"
     [ "Bash"; "Read"; "Edit" ]
     prep.visible_tool_names
+;;
+
+let test_prepare_turn_selected_tools_are_exact_execution_surface () =
+  let make name =
+    Tool.create ~name ~description:name ~parameters:[] (fun _ ->
+      Ok { Types.content = name; _meta = None })
+  in
+  let tools = Tool_set.of_list [ make "search"; make "write"; make "publish" ] in
+  let turn_params =
+    { Hooks.default_turn_params with
+      tool_surface = Hooks.Selected_tools [ "search"; "publish" ]
+    }
+  in
+  let prep =
+    Agent_turn.prepare_turn ~tools ~messages:[] ~turn_params () |> prepared_turn
+  in
+  Alcotest.(check (list string))
+    "provider schemas"
+    [ "search"; "publish" ]
+    prep.visible_tool_names;
+  Alcotest.(check (list string))
+    "execution handlers"
+    [ "search"; "publish" ]
+    (Tool_set.names prep.visible_tools)
+;;
+
+let test_prepare_turn_unknown_selected_tool_fails_closed () =
+  let tool =
+    Tool.create ~name:"search" ~description:"search" ~parameters:[] (fun _ ->
+      Ok { Types.content = ""; _meta = None })
+  in
+  let turn_params =
+    { Hooks.default_turn_params with tool_surface = Hooks.Selected_tools [ "missing" ] }
+  in
+  match
+    Agent_turn.prepare_turn ~tools:(Tool_set.singleton tool) ~messages:[] ~turn_params ()
+  with
+  | Error (Agent_turn.Tool_selection_failed (Tool_set.Unknown_selection "missing")) -> ()
+  | Error error ->
+    Alcotest.failf "unexpected error: %s" (Agent_turn.preparation_error_to_string error)
+  | Ok _ -> Alcotest.fail "unknown selected tool was accepted"
+;;
+
+let test_prepare_turn_duplicate_selected_tool_fails_closed () =
+  let tool =
+    Tool.create ~name:"search" ~description:"search" ~parameters:[] (fun _ ->
+      Ok { Types.content = ""; _meta = None })
+  in
+  let turn_params =
+    { Hooks.default_turn_params with
+      tool_surface = Hooks.Selected_tools [ "search"; "search" ]
+    }
+  in
+  match
+    Agent_turn.prepare_turn ~tools:(Tool_set.singleton tool) ~messages:[] ~turn_params ()
+  with
+  | Error (Agent_turn.Tool_selection_failed (Tool_set.Duplicate_selection "search")) -> ()
+  | Error error ->
+    Alcotest.failf "unexpected error: %s" (Agent_turn.preparation_error_to_string error)
+  | Ok _ -> Alcotest.fail "duplicate selected tool was accepted"
+;;
+
+let test_prepare_turn_named_choice_must_be_visible () =
+  let make name =
+    Tool.create ~name ~description:name ~parameters:[] (fun _ ->
+      Ok { Types.content = ""; _meta = None })
+  in
+  let turn_params =
+    { Hooks.default_turn_params with
+      tool_choice = Some (Types.Tool "write")
+    ; tool_surface = Hooks.Selected_tools [ "search" ]
+    }
+  in
+  match
+    Agent_turn.prepare_turn
+      ~tools:(Tool_set.of_list [ make "search"; make "write" ])
+      ~messages:[]
+      ~turn_params
+      ()
+  with
+  | Error (Agent_turn.Tool_choice_not_visible "write") -> ()
+  | Error error ->
+    Alcotest.failf "unexpected error: %s" (Agent_turn.preparation_error_to_string error)
+  | Ok _ -> Alcotest.fail "hidden named tool_choice was accepted"
 ;;
 
 (* ── prepare_messages tests ────────────────────────────────── *)
@@ -789,6 +873,22 @@ let () =
             "visible_tool_names preserves order"
             `Quick
             test_prepare_turn_visible_tool_names_preserves_order
+        ; Alcotest.test_case
+            "selected tools define provider and execution surface"
+            `Quick
+            test_prepare_turn_selected_tools_are_exact_execution_surface
+        ; Alcotest.test_case
+            "unknown selected tool fails closed"
+            `Quick
+            test_prepare_turn_unknown_selected_tool_fails_closed
+        ; Alcotest.test_case
+            "duplicate selected tool fails closed"
+            `Quick
+            test_prepare_turn_duplicate_selected_tool_fails_closed
+        ; Alcotest.test_case
+            "named choice must be visible"
+            `Quick
+            test_prepare_turn_named_choice_must_be_visible
         ] )
     ; ( "prepare_messages"
       , [ Alcotest.test_case

--- a/test/test_agent_turn.ml
+++ b/test/test_agent_turn.ml
@@ -179,21 +179,22 @@ let test_prepare_turn_unknown_selected_tool_fails_closed () =
   | Ok _ -> Alcotest.fail "unknown selected tool was accepted"
 ;;
 
-let test_prepare_turn_blank_selected_tool_fails_closed () =
+let test_prepare_turn_blank_registered_tool_fails_closed () =
   let blank =
     Tool.create ~name:" " ~description:"invalid" ~parameters:[] (fun _ ->
       Ok { Types.content = ""; _meta = None })
   in
-  let turn_params =
-    { Hooks.default_turn_params with tool_surface = Hooks.Selected_tools [ " " ] }
-  in
   match
-    Agent_turn.prepare_turn ~tools:(Tool_set.singleton blank) ~messages:[] ~turn_params ()
+    Agent_turn.prepare_turn
+      ~tools:(Tool_set.singleton blank)
+      ~messages:[]
+      ~turn_params:Hooks.default_turn_params
+      ()
   with
   | Error (Agent_turn.Tool_selection_failed Tool_set.Blank_selection) -> ()
   | Error error ->
     Alcotest.failf "unexpected error: %s" (Agent_turn.preparation_error_to_string error)
-  | Ok _ -> Alcotest.fail "blank selected tool was accepted"
+  | Ok _ -> Alcotest.fail "blank registered tool was accepted"
 ;;
 
 let test_prepare_turn_duplicate_selected_tool_fails_closed () =
@@ -899,9 +900,9 @@ let () =
             `Quick
             test_prepare_turn_unknown_selected_tool_fails_closed
         ; Alcotest.test_case
-            "blank selected tool fails closed"
+            "blank registered tool fails closed"
             `Quick
-            test_prepare_turn_blank_selected_tool_fails_closed
+            test_prepare_turn_blank_registered_tool_fails_closed
         ; Alcotest.test_case
             "duplicate selected tool fails closed"
             `Quick

--- a/test/test_execution_event_store.ml
+++ b/test/test_execution_event_store.ml
@@ -266,6 +266,20 @@ let rewrite_event_seq event seq =
   | _ -> fail "event encoder did not return an object"
 ;;
 
+let test_previous_event_schema_is_explicitly_rejected () =
+  let event = List.hd (make_four_events "schema-hard-cut") in
+  let previous =
+    match Event.to_yojson event with
+    | `Assoc fields ->
+      `Assoc (("schema_version", `Int 3) :: List.remove_assoc "schema_version" fields)
+    | _ -> fail "event encoder did not return an object"
+  in
+  match Event.of_yojson previous with
+  | Error "unsupported execution event schema_version: 3" -> ()
+  | Error detail -> failf "unexpected previous-schema error: %s" detail
+  | Ok _ -> fail "previous execution event schema was accepted"
+;;
+
 let test_append_reopen_idempotency_and_paging () =
   Eio_main.run
   @@ fun env ->
@@ -1647,6 +1661,10 @@ let () =
             "old store format is explicitly rejected"
             `Quick
             test_old_store_format_is_explicitly_rejected
+        ; test_case
+            "previous event schema is explicitly rejected"
+            `Quick
+            test_previous_event_schema_is_explicitly_rejected
         ; test_case
             "torn tail is explicitly truncated"
             `Quick

--- a/test/test_execution_event_store.ml
+++ b/test/test_execution_event_store.ml
@@ -426,7 +426,7 @@ let test_old_store_format_is_explicitly_rejected () =
     let authority = Eio.Path.(dir / "events.v1.commit") in
     let wal_before = Eio.Path.load wal in
     let old_authority =
-      Eio.Path.load authority |> authority_with_format_version ~version:1
+      Eio.Path.load authority |> authority_with_format_version ~version:2
     in
     Eio.Path.with_open_out ~create:(`Or_truncate 0o600) authority (fun file ->
       Eio.Flow.copy_string old_authority file;
@@ -435,7 +435,7 @@ let test_old_store_format_is_explicitly_rejected () =
       match Journal.open_durable_writer ~sw ~codec ~dir with
       | Error
           (Journal.Persistence_failure
-             (Store.Unsupported_store_version { expected = 2; actual = 1 })) -> ()
+             (Store.Unsupported_store_version { expected = 3; actual = 2 })) -> ()
       | Error error ->
         fail ("unexpected journal failure: " ^ Journal.error_to_string error)
       | Ok _ -> fail "old recursive execution store was reopened");

--- a/test/test_execution_event_store.ml
+++ b/test/test_execution_event_store.ml
@@ -165,7 +165,9 @@ let legacy_recursive_events correlation_id =
       config
     |> require_event
   in
-  let provider_kind = require_event (Event.provider_attempt ~ordinal:0 binding) in
+  let provider_kind =
+    require_event (Event.provider_attempt ~ordinal:0 ~tool_names:[] binding)
+  in
   let provider, _ =
     require_journal
       (Journal.open_node journal ~run:parent_run ~parent:turn ~kind:provider_kind)

--- a/test/test_execution_event_store.ml
+++ b/test/test_execution_event_store.ml
@@ -267,6 +267,8 @@ let rewrite_event_seq event seq =
 ;;
 
 let test_previous_event_schema_is_explicitly_rejected () =
+  Eio_main.run
+  @@ fun _env ->
   let correlation_id = fresh Event.Correlation_id.fresh in
   let event = List.hd (make_four_events correlation_id) in
   let previous =

--- a/test/test_execution_event_store.ml
+++ b/test/test_execution_event_store.ml
@@ -267,7 +267,8 @@ let rewrite_event_seq event seq =
 ;;
 
 let test_previous_event_schema_is_explicitly_rejected () =
-  let event = List.hd (make_four_events "schema-hard-cut") in
+  let correlation_id = fresh Event.Correlation_id.fresh in
+  let event = List.hd (make_four_events correlation_id) in
   let previous =
     match Event.to_yojson event with
     | `Assoc fields ->

--- a/test/test_execution_journal.ml
+++ b/test/test_execution_journal.ml
@@ -57,7 +57,7 @@ let provider_attempt ?(model_id = "test-model") ordinal =
       config
     |> require_codec_ok
   in
-  require_codec_ok (Event.provider_attempt ~ordinal binding)
+  require_codec_ok (Event.provider_attempt ~ordinal ~tool_names:[] binding)
 ;;
 
 let tool_invocation ?(planned_index = 0) name =

--- a/test/test_execution_lane_writer.ml
+++ b/test/test_execution_lane_writer.ml
@@ -126,7 +126,8 @@ let binding_for ~provider_id =
 ;;
 
 let provider_attempt_for ~provider_id ordinal =
-  require_codec (Event.provider_attempt ~ordinal (binding_for ~provider_id))
+  require_codec
+    (Event.provider_attempt ~ordinal ~tool_names:[] (binding_for ~provider_id))
 ;;
 
 let provider_attempt ordinal =
@@ -693,6 +694,7 @@ let test_agent_scope_owns_effect_topology () =
           (Agent_scope.open_provider_attempt
              turn
              ~ordinal:0
+             ~tool_names:[ "effect" ]
              (binding_for ~provider_id:"scope-provider"))
       in
       let schedule : Tool_contract.schedule =
@@ -892,6 +894,7 @@ let test_agent_scope_executes_pending_after_restart () =
           (Agent_scope.open_provider_attempt
              turn
              ~ordinal:0
+             ~tool_names:[ "durable-tool" ]
              (binding_for ~provider_id:"pending-provider"))
       in
       let schedule : Tool_contract.schedule =

--- a/test/test_execution_projection.ml
+++ b/test/test_execution_projection.ml
@@ -196,7 +196,12 @@ let test_live_and_restart_projection () =
             in
             check int "frozen page excludes later commit" 0 (List.length frozen.events);
             let provider =
-              scope_value (Scope.open_provider_attempt turn ~ordinal:0 (binding ()))
+              scope_value
+                (Scope.open_provider_attempt
+                   turn
+                   ~ordinal:0
+                   ~tool_names:[ "recursive-tool" ]
+                   (binding ()))
             in
             let durable =
               scope_value

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -333,6 +333,7 @@ let test_selected_tool_surface_rejects_hidden_provider_call () =
   Eio.Switch.run
   @@ fun sw ->
   let executed = ref false in
+  let output_validated = ref false in
   let make_tool name =
     Tool.create ~name ~description:name ~parameters:[] (fun _ ->
       executed := true;
@@ -372,6 +373,17 @@ let test_selected_tool_surface_rejects_hidden_provider_call () =
   let options =
     { Agent.default_options with
       hooks
+    ; guardrails_async =
+        { Guardrails_async.empty with
+          output_validators =
+            [ { name = "hidden-tool-observer"
+              ; validate =
+                  (fun _response ->
+                    output_validated := true;
+                    Ok ())
+              }
+            ]
+        }
     ; transport = Some transport
     ; provider_config = Some (Provider_mock.to_provider_config ())
     }
@@ -395,6 +407,10 @@ let test_selected_tool_surface_rejects_hidden_provider_call () =
              })) -> ()
    | Error error -> Alcotest.failf "unexpected error: %s" (Error.to_string error)
    | Ok _ -> Alcotest.fail "hidden provider call was accepted");
+  Alcotest.(check bool)
+    "output validator does not observe hidden tool call"
+    false
+    !output_validated;
   Alcotest.(check bool) "handler not executed" false !executed;
   let captured_names =
     List.map Yojson.Safe.Util.(fun json -> json |> member "name" |> to_string) !captured

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -388,10 +388,11 @@ let test_selected_tool_surface_rejects_hidden_provider_call () =
   (match Agent.run ~sw agent "call hidden" with
    | Error
        (Error.Config
-         (InvalidConfig
-           { field = "tool_surface"
-           ; detail = "provider called tool \"hidden\" outside the selected turn surface"
-           })) -> ()
+          (InvalidConfig
+             { field = "tool_surface"
+             ; detail =
+                 "provider called tool \"hidden\" outside the selected turn surface"
+             })) -> ()
    | Error error -> Alcotest.failf "unexpected error: %s" (Error.to_string error)
    | Ok _ -> Alcotest.fail "hidden provider call was accepted");
   Alcotest.(check bool) "handler not executed" false !executed;

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -254,9 +254,7 @@ let test_base_named_tool_choice_must_be_visible () =
       ()
   in
   let turn_params =
-    { Hooks.default_turn_params with
-      tool_surface = Hooks.Selected_tools [ "visible" ]
-    }
+    { Hooks.default_turn_params with tool_surface = Hooks.Selected_tools [ "visible" ] }
   in
   match Internal_pipeline.prepare_turn_for_agent agent ~turn_params with
   | Error (Agent_turn.Tool_choice_not_visible "hidden") -> ()

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -327,6 +327,172 @@ let test_pipeline_sends_exact_supplied_tools () =
     (Option.equal (List.equal Yojson.Safe.equal) (Some expected) !captured)
 ;;
 
+let test_selected_tool_surface_rejects_hidden_provider_call () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let executed = ref false in
+  let make_tool name =
+    Tool.create ~name ~description:name ~parameters:[] (fun _ ->
+      executed := true;
+      Ok { Types.content = name; _meta = None })
+  in
+  let visible = make_tool "visible" in
+  let hidden = make_tool "hidden" in
+  let captured = ref [] in
+  let response : Types.api_response =
+    { id = "hidden-call"
+    ; model = "mock-model"
+    ; stop_reason = StopToolUse
+    ; content = [ ToolUse { id = "hidden-1"; name = "hidden"; input = `Assoc [] } ]
+    ; usage = None
+    ; telemetry = None
+    }
+  in
+  let transport : Llm_provider.Llm_transport.t =
+    { complete_sync =
+        (fun request ->
+          captured := request.tools;
+          { response = Ok response; latency_ms = Some 0 })
+    ; complete_stream = (fun ?on_telemetry:_ ~on_event:_ _request -> Ok response)
+    }
+  in
+  let hooks =
+    { Hooks.empty with
+      before_turn_params =
+        Some
+          (function
+            | Hooks.BeforeTurnParams { current_params; _ } ->
+              Hooks.AdjustParams
+                { current_params with tool_surface = Hooks.Selected_tools [ "visible" ] }
+            | _ -> Alcotest.fail "expected BeforeTurnParams")
+    }
+  in
+  let options =
+    { Agent.default_options with
+      hooks
+    ; transport = Some transport
+    ; provider_config = Some (Provider_mock.to_provider_config ())
+    }
+  in
+  let agent =
+    Agent.create
+      ~net:(Eio.Stdenv.net env)
+      ~tools:[ visible; hidden ]
+      ~config:
+        { (Types.default_config ~model:"test-model") with name = "selected-surface" }
+      ~options
+      ()
+  in
+  (match Agent.run ~sw agent "call hidden" with
+   | Error (Error.Config (InvalidConfig { field = "tool_surface"; _ })) -> ()
+   | Error error -> Alcotest.failf "unexpected error: %s" (Error.to_string error)
+   | Ok _ -> Alcotest.fail "hidden provider call was accepted");
+  Alcotest.(check bool) "handler not executed" false !executed;
+  let captured_names =
+    List.map Yojson.Safe.Util.(fun json -> json |> member "name" |> to_string) !captured
+  in
+  Alcotest.(check (list string))
+    "only visible schema serialized"
+    [ "visible" ]
+    captured_names
+;;
+
+let test_selected_tool_surface_expands_on_next_turn () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let activated = ref false in
+  let write_executions = ref 0 in
+  let search =
+    Tool.create ~name:"search" ~description:"search" ~parameters:[] (fun _ ->
+      activated := true;
+      Ok { Types.content = "activated write"; _meta = None })
+  in
+  let write =
+    Tool.create ~name:"write" ~description:"write" ~parameters:[] (fun _ ->
+      incr write_executions;
+      Ok { Types.content = "written"; _meta = None })
+  in
+  let provider_calls = ref 0 in
+  let next_response (request : Llm_provider.Llm_transport.completion_request) =
+    incr provider_calls;
+    let expected_names =
+      match !provider_calls with
+      | 1 -> [ "search" ]
+      | 2 | 3 -> [ "search"; "write" ]
+      | _ -> Alcotest.fail "unexpected provider call"
+    in
+    let actual_names =
+      List.map
+        Yojson.Safe.Util.(fun json -> json |> member "name" |> to_string)
+        request.tools
+    in
+    Alcotest.(check (list string)) "turn surface" expected_names actual_names;
+    match !provider_calls with
+    | 1 ->
+      { Types.id = "search-call"
+      ; model = "mock-model"
+      ; stop_reason = StopToolUse
+      ; content = [ ToolUse { id = "search-1"; name = "search"; input = `Assoc [] } ]
+      ; usage = None
+      ; telemetry = None
+      }
+    | 2 ->
+      { Types.id = "write-call"
+      ; model = "mock-model"
+      ; stop_reason = StopToolUse
+      ; content = [ ToolUse { id = "write-1"; name = "write"; input = `Assoc [] } ]
+      ; usage = None
+      ; telemetry = None
+      }
+    | 3 -> pipeline_response EndTurn
+    | _ -> assert false
+  in
+  let transport : Llm_provider.Llm_transport.t =
+    { complete_sync =
+        (fun request -> { response = Ok (next_response request); latency_ms = Some 0 })
+    ; complete_stream =
+        (fun ?on_telemetry:_ ~on_event:_ request -> Ok (next_response request))
+    }
+  in
+  let hooks =
+    { Hooks.empty with
+      before_turn_params =
+        Some
+          (function
+            | Hooks.BeforeTurnParams { current_params; _ } ->
+              let names = if !activated then [ "search"; "write" ] else [ "search" ] in
+              Hooks.AdjustParams
+                { current_params with tool_surface = Hooks.Selected_tools names }
+            | _ -> Alcotest.fail "expected BeforeTurnParams")
+    }
+  in
+  let options =
+    { Agent.default_options with
+      hooks
+    ; transport = Some transport
+    ; provider_config = Some (Provider_mock.to_provider_config ())
+    }
+  in
+  let agent =
+    Agent.create
+      ~net:(Eio.Stdenv.net env)
+      ~tools:[ search; write ]
+      ~config:
+        { (Types.default_config ~model:"test-model") with name = "expanding-surface" }
+      ~options
+      ()
+  in
+  (match Agent.run ~sw agent "discover then write" with
+   | Ok _ -> ()
+   | Error error -> Alcotest.failf "unexpected error: %s" (Error.to_string error));
+  Alcotest.(check int) "provider turns" 3 !provider_calls;
+  Alcotest.(check int) "write executed once" 1 !write_executions
+;;
+
 let test_effective_provider_config_drives_lifecycle_and_pricing () =
   Eio_main.run
   @@ fun env ->
@@ -1845,7 +2011,13 @@ let test_agent_run_resumes_tool_without_duplicate_effects
               | Error error -> Alcotest.fail (Internal_scope.error_to_string error)
             in
             let provider =
-              match Internal_scope.open_provider_attempt turn ~ordinal:0 binding with
+              match
+                Internal_scope.open_provider_attempt
+                  turn
+                  ~ordinal:0
+                  ~tool_names:[ "durable_tool" ]
+                  binding
+              with
               | Ok provider -> provider
               | Error error -> Alcotest.fail (Internal_scope.error_to_string error)
             in
@@ -2083,7 +2255,13 @@ let test_unattempted_legacy_invocation_requires_typed_readmission () =
              | Error detail -> Alcotest.fail detail
            in
            let provider =
-             match Internal_scope.open_provider_attempt turn ~ordinal:0 binding with
+             match
+               Internal_scope.open_provider_attempt
+                 turn
+                 ~ordinal:0
+                 ~tool_names:[ "durable_tool" ]
+                 binding
+             with
              | Ok provider -> provider
              | Error error -> Alcotest.fail (Internal_scope.error_to_string error)
            in
@@ -2369,7 +2547,13 @@ let test_agent_run_resumes_settled_closed_turn
               | Error error -> Alcotest.fail (Internal_scope.error_to_string error)
             in
             let provider =
-              match Internal_scope.open_provider_attempt turn ~ordinal:0 binding with
+              match
+                Internal_scope.open_provider_attempt
+                  turn
+                  ~ordinal:0
+                  ~tool_names:[ "durable_tool" ]
+                  binding
+              with
               | Ok provider -> provider
               | Error error -> Alcotest.fail (Internal_scope.error_to_string error)
             in
@@ -2786,8 +2970,19 @@ let test_settled_malformed_terminal_topology_does_not_finalize_turn () =
                | Ok turn -> turn
                | Error error -> Alcotest.fail (Internal_scope.error_to_string error)
              in
+             let tool_names =
+               match case with
+               | `Invalid_contract _ -> [ "terminal_tool" ]
+               | `Response_mismatch _ -> [ "zero_invocation_tool" ]
+               | `Resume (_, persisted, restored) ->
+                 List.map (fun (_, name, _, _, _) -> name) persisted
+                 @ List.map (fun (_, name, _) -> name) restored
+                 |> List.sort_uniq String.compare
+             in
              let provider =
-               match Internal_scope.open_provider_attempt turn ~ordinal:0 binding with
+               match
+                 Internal_scope.open_provider_attempt turn ~ordinal:0 ~tool_names binding
+               with
                | Ok provider -> provider
                | Error error -> Alcotest.fail (Internal_scope.error_to_string error)
              in
@@ -3381,7 +3576,13 @@ let test_agent_run_resumes_all_blocked_settled_turn () =
               | Ok turn -> turn
               | Error error -> Alcotest.fail (Internal_scope.error_to_string error)
             in
-            match Internal_scope.open_provider_attempt turn ~ordinal:0 binding with
+            match
+              Internal_scope.open_provider_attempt
+                turn
+                ~ordinal:0
+                ~tool_names:[ "durable_tool" ]
+                binding
+            with
             | Ok provider ->
               record_durable_provider_response
                 provider
@@ -3576,7 +3777,13 @@ let test_agent_run_resume_fires_on_yield () =
               | Ok turn -> turn
               | Error error -> Alcotest.fail (Internal_scope.error_to_string error)
             in
-            match Internal_scope.open_provider_attempt turn ~ordinal:0 binding with
+            match
+              Internal_scope.open_provider_attempt
+                turn
+                ~ordinal:0
+                ~tool_names:[ "durable_tool" ]
+                binding
+            with
             | Ok provider ->
               record_durable_provider_response
                 provider
@@ -3705,6 +3912,14 @@ let () =
             "provider receives exact supplied tools"
             `Quick
             test_pipeline_sends_exact_supplied_tools
+        ; Alcotest.test_case
+            "selected surface rejects hidden provider call"
+            `Quick
+            test_selected_tool_surface_rejects_hidden_provider_call
+        ; Alcotest.test_case
+            "selected surface expands next turn"
+            `Quick
+            test_selected_tool_surface_expands_on_next_turn
         ; Alcotest.test_case
             "effective provider config drives lifecycle and pricing"
             `Quick

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -290,7 +290,7 @@ let test_required_tool_choice_rejects_empty_selected_surface () =
     Tool.create ~name ~description:name ~parameters:[] (fun _ ->
       Ok { Types.content = name; _meta = None })
   in
-  let assert_rejected ~label ~base_tool_choice ~turn_tool_choice =
+  let assert_rejected ~label ~base_tool_choice ~turn_tool_choice_override =
     let hooks =
       { Hooks.empty with
         before_turn_params =
@@ -300,7 +300,9 @@ let test_required_tool_choice_rejects_empty_selected_surface () =
                 Hooks.AdjustParams
                   { current_params with
                     tool_choice =
-                      Option.value turn_tool_choice ~default:current_params.tool_choice
+                      (match turn_tool_choice_override with
+                       | `Preserve -> current_params.tool_choice
+                       | `Replace tool_choice -> tool_choice)
                   ; tool_surface = Hooks.Selected_tools []
                   }
               | _ -> Alcotest.fail "expected BeforeTurnParams")
@@ -333,11 +335,11 @@ let test_required_tool_choice_rejects_empty_selected_surface () =
   assert_rejected
     ~label:"base required choice"
     ~base_tool_choice:(Some Types.Any)
-    ~turn_tool_choice:None;
+    ~turn_tool_choice_override:`Preserve;
   assert_rejected
     ~label:"per-turn required choice"
     ~base_tool_choice:None
-    ~turn_tool_choice:(Some Types.Any)
+    ~turn_tool_choice_override:(`Replace (Some Types.Any))
 ;;
 
 let pipeline_response ?telemetry stop_reason : Types.api_response =

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -299,7 +299,8 @@ let test_required_tool_choice_rejects_empty_selected_surface () =
               | Hooks.BeforeTurnParams { current_params; _ } ->
                 Hooks.AdjustParams
                   { current_params with
-                    tool_choice = turn_tool_choice
+                    tool_choice =
+                      Option.value turn_tool_choice ~default:current_params.tool_choice
                   ; tool_surface = Hooks.Selected_tools []
                   }
               | _ -> Alcotest.fail "expected BeforeTurnParams")

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -237,6 +237,8 @@ let test_agent_turn_preparation () =
 let test_base_named_tool_choice_must_be_visible () =
   Eio_main.run
   @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
   let make_tool name =
     Tool.create ~name ~description:name ~parameters:[] (fun _ ->
       Ok { Types.content = name; _meta = None })
@@ -247,21 +249,35 @@ let test_base_named_tool_choice_must_be_visible () =
     }
   in
   let agent =
+    let hooks =
+      { Hooks.empty with
+        before_turn_params =
+          Some
+            (function
+              | Hooks.BeforeTurnParams { current_params; _ } ->
+                Hooks.AdjustParams
+                  { current_params with
+                    tool_surface = Hooks.Selected_tools [ "visible" ]
+                  }
+              | _ -> Alcotest.fail "expected BeforeTurnParams")
+      }
+    in
     Agent.create
       ~config
       ~net:(Eio.Stdenv.net env)
       ~tools:[ make_tool "visible"; make_tool "hidden" ]
+      ~options:{ Agent.default_options with hooks }
       ()
   in
-  let turn_params =
-    { Hooks.default_turn_params with tool_surface = Hooks.Selected_tools [ "visible" ] }
-  in
-  match Internal_pipeline.prepare_turn_for_agent agent ~turn_params with
-  | Error (Agent_turn.Tool_choice_not_visible "hidden") -> ()
+  match Agent.run ~sw agent "use the selected tool surface" with
+  | Error
+      (Error.Config
+         (InvalidConfig
+            { field = "tool_choice"
+            ; detail = "named tool \"hidden\" is outside the selected tool surface"
+            })) -> ()
   | Error error ->
-    Alcotest.failf
-      "unexpected preparation error: %s"
-      (Agent_turn.preparation_error_to_string error)
+    Alcotest.failf "unexpected preparation error: %s" (Error.to_string error)
   | Ok _ -> Alcotest.fail "base named tool choice escaped the selected turn surface"
 ;;
 

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -290,7 +290,7 @@ let test_required_tool_choice_rejects_empty_selected_surface () =
     Tool.create ~name ~description:name ~parameters:[] (fun _ ->
       Ok { Types.content = name; _meta = None })
   in
-  let assert_rejected ~label ~base_tool_choice ~turn_tool_choice_override =
+  let assert_rejected ~label ~base_tool_choice ~turn_tool_choice =
     let hooks =
       { Hooks.empty with
         before_turn_params =
@@ -299,10 +299,7 @@ let test_required_tool_choice_rejects_empty_selected_surface () =
               | Hooks.BeforeTurnParams { current_params; _ } ->
                 Hooks.AdjustParams
                   { current_params with
-                    tool_choice =
-                      (match turn_tool_choice_override with
-                       | `Preserve -> current_params.tool_choice
-                       | `Replace tool_choice -> tool_choice)
+                    tool_choice = turn_tool_choice
                   ; tool_surface = Hooks.Selected_tools []
                   }
               | _ -> Alcotest.fail "expected BeforeTurnParams")
@@ -335,11 +332,11 @@ let test_required_tool_choice_rejects_empty_selected_surface () =
   assert_rejected
     ~label:"base required choice"
     ~base_tool_choice:(Some Types.Any)
-    ~turn_tool_choice_override:`Preserve;
+    ~turn_tool_choice:None;
   assert_rejected
     ~label:"per-turn required choice"
     ~base_tool_choice:None
-    ~turn_tool_choice_override:(`Replace (Some Types.Any))
+    ~turn_tool_choice:(Some Types.Any)
 ;;
 
 let pipeline_response ?telemetry stop_reason : Types.api_response =

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -234,6 +234,39 @@ let test_agent_turn_preparation () =
     prep.visible_tool_names
 ;;
 
+let test_base_named_tool_choice_must_be_visible () =
+  Eio_main.run
+  @@ fun env ->
+  let make_tool name =
+    Tool.create ~name ~description:name ~parameters:[] (fun _ ->
+      Ok { Types.content = name; _meta = None })
+  in
+  let config =
+    { (Types.default_config ~model:"test-model") with
+      tool_choice = Some (Types.Tool "hidden")
+    }
+  in
+  let agent =
+    Agent.create
+      ~config
+      ~net:(Eio.Stdenv.net env)
+      ~tools:[ make_tool "visible"; make_tool "hidden" ]
+      ()
+  in
+  let turn_params =
+    { Hooks.default_turn_params with
+      tool_surface = Hooks.Selected_tools [ "visible" ]
+    }
+  in
+  match Internal_pipeline.prepare_turn_for_agent agent ~turn_params with
+  | Error (Agent_turn.Tool_choice_not_visible "hidden") -> ()
+  | Error error ->
+    Alcotest.failf
+      "unexpected preparation error: %s"
+      (Agent_turn.preparation_error_to_string error)
+  | Ok _ -> Alcotest.fail "base named tool choice escaped the selected turn surface"
+;;
+
 let pipeline_response ?telemetry stop_reason : Types.api_response =
   { id = "pipeline-reset-test"
   ; model = "mock-model"
@@ -3921,6 +3954,10 @@ let () =
         ] )
     ; ( "turn_mechanics"
       , [ Alcotest.test_case "turn preparation" `Quick test_agent_turn_preparation
+        ; Alcotest.test_case
+            "base named tool choice must be visible"
+            `Quick
+            test_base_named_tool_choice_must_be_visible
         ; Alcotest.test_case "no tools prep" `Quick test_prepare_turn_no_tools
         ; Alcotest.test_case
             "preserves messages"

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -386,7 +386,12 @@ let test_selected_tool_surface_rejects_hidden_provider_call () =
       ()
   in
   (match Agent.run ~sw agent "call hidden" with
-   | Error (Error.Config (InvalidConfig { field = "tool_surface"; _ })) -> ()
+   | Error
+       (Error.Config
+         (InvalidConfig
+           { field = "tool_surface"
+           ; detail = "provider called tool \"hidden\" outside the selected turn surface"
+           })) -> ()
    | Error error -> Alcotest.failf "unexpected error: %s" (Error.to_string error)
    | Ok _ -> Alcotest.fail "hidden provider call was accepted");
   Alcotest.(check bool) "handler not executed" false !executed;

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -455,7 +455,7 @@ let test_selected_tool_surface_expands_on_next_turn () =
       ; telemetry = None
       }
     | 3 -> pipeline_response EndTurn
-    | _ -> assert false
+    | _ -> Alcotest.fail "unexpected provider call"
   in
   let transport : Llm_provider.Llm_transport.t =
     { complete_sync =

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -281,6 +281,64 @@ let test_base_named_tool_choice_must_be_visible () =
   | Ok _ -> Alcotest.fail "base named tool choice escaped the selected turn surface"
 ;;
 
+let test_required_tool_choice_rejects_empty_selected_surface () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let make_tool name =
+    Tool.create ~name ~description:name ~parameters:[] (fun _ ->
+      Ok { Types.content = name; _meta = None })
+  in
+  let assert_rejected ~label ~base_tool_choice ~turn_tool_choice =
+    let hooks =
+      { Hooks.empty with
+        before_turn_params =
+          Some
+            (function
+              | Hooks.BeforeTurnParams { current_params; _ } ->
+                Hooks.AdjustParams
+                  { current_params with
+                    tool_choice = turn_tool_choice
+                  ; tool_surface = Hooks.Selected_tools []
+                  }
+              | _ -> Alcotest.fail "expected BeforeTurnParams")
+      }
+    in
+    let agent =
+      Agent.create
+        ~config:
+          { (Types.default_config ~model:"test-model") with
+            tool_choice = base_tool_choice
+          }
+        ~net:(Eio.Stdenv.net env)
+        ~tools:[ make_tool "hidden" ]
+        ~options:{ Agent.default_options with hooks }
+        ()
+    in
+    match Agent.run ~sw agent label with
+    | Error
+        (Error.Config
+           (InvalidConfig
+              { field = "tool_choice"
+              ; detail =
+                  "required tool choice cannot be used with an empty selected tool \
+                   surface"
+              })) -> ()
+    | Error error ->
+      Alcotest.failf "%s: unexpected preparation error: %s" label (Error.to_string error)
+    | Ok _ -> Alcotest.failf "%s: required tool choice reached provider dispatch" label
+  in
+  assert_rejected
+    ~label:"base required choice"
+    ~base_tool_choice:(Some Types.Any)
+    ~turn_tool_choice:None;
+  assert_rejected
+    ~label:"per-turn required choice"
+    ~base_tool_choice:None
+    ~turn_tool_choice:(Some Types.Any)
+;;
+
 let pipeline_response ?telemetry stop_reason : Types.api_response =
   { id = "pipeline-reset-test"
   ; model = "mock-model"
@@ -444,6 +502,29 @@ let test_selected_tool_surface_rejects_hidden_provider_call () =
       ~options
       ()
   in
+  let accepted_transport : Llm_provider.Llm_transport.t =
+    { complete_sync =
+        (fun _request ->
+          { response = Ok (pipeline_response EndTurn); latency_ms = Some 0 })
+    ; complete_stream =
+        (fun ?on_telemetry:_ ~on_event:_ _request -> Ok (pipeline_response EndTurn))
+    }
+  in
+  let accepted_agent =
+    Agent.create
+      ~net:(Eio.Stdenv.net env)
+      ~tools:[ visible; hidden ]
+      ~config:
+        { (Types.default_config ~model:"test-model") with name = "selected-surface" }
+      ~options:{ options with transport = Some accepted_transport }
+      ()
+  in
+  (match Agent.run ~sw accepted_agent "accept visible surface" with
+   | Ok _ -> ()
+   | Error error ->
+     Alcotest.failf "unexpected positive-control error: %s" (Error.to_string error));
+  Alcotest.(check bool) "output validator is wired" true !output_validated;
+  output_validated := false;
   (match Agent.run ~sw agent "call hidden" with
    | Error
        (Error.Config
@@ -3972,6 +4053,10 @@ let () =
             "base named tool choice must be visible"
             `Quick
             test_base_named_tool_choice_must_be_visible
+        ; Alcotest.test_case
+            "required tool choice rejects empty selected surface"
+            `Quick
+            test_required_tool_choice_rejects_empty_selected_surface
         ; Alcotest.test_case "no tools prep" `Quick test_prepare_turn_no_tools
         ; Alcotest.test_case
             "preserves messages"

--- a/test/test_pipeline_deep.ml
+++ b/test/test_pipeline_deep.ml
@@ -235,6 +235,7 @@ let test_resolve_params_adjust () =
     ; enable_thinking = None
     ; preserve_thinking = None
     ; tool_choice = None
+    ; tool_surface = Hooks.All_tools
     ; extra_system_context = Some "Debug mode"
     ; system_prompt_override = None
     }

--- a/test/test_turn_params.ml
+++ b/test/test_turn_params.ml
@@ -10,7 +10,10 @@ let test_default_turn_params () =
   Alcotest.(check (option int)) "no thinking_budget" None p.thinking_budget;
   Alcotest.(check (option bool)) "no enable_thinking" None p.enable_thinking;
   Alcotest.(check bool) "no extra context" true (p.extra_system_context = None);
-  Alcotest.(check bool) "no system prompt override" true (p.system_prompt_override = None)
+  Alcotest.(check bool) "no system prompt override" true (p.system_prompt_override = None);
+  match p.tool_surface with
+  | Hooks.All_tools -> ()
+  | Hooks.Selected_tools _ -> Alcotest.fail "default tool surface is not complete"
 ;;
 
 let test_enable_thinking_override () =


### PR DESCRIPTION
## 요약

- `BeforeTurnParams`에 typed per-turn tool surface를 추가했어용.
- provider 직렬화·실행·durable resume가 같은 exact `Tool_set` 권위를 사용해용.
- 선택되지 않은 provider `ToolUse`는 journaling/invocation 전에 거절해용.

## 계약

`Provider_attempt.tool_names`는 deliberate hard cut이에용. 누락·공백·중복·미등록 이름은 fail-closed하고, 레거시 decoder나 all-tools fallback은 두지 않았어용.

## hard-cut 전제 실측

2026-08-03에 masc 런타임 `~/me/.masc`, `~/.oas`, `~/me/.oas`를 제한 검색과 전수 스캔으로 확인했어용.

- persisted `"type":"provider_attempt"` 노드: **0건**
- `provider_attempt` 문자열 positive control: **33파일**, 전부 source/build 산출물
- masc의 `Execution_journal` / `Agent_sdk.Journal` 소비: **0파일**

따라서 컷으로 재개 불능이 되는 기존 in-flight 레코드는 이 워크스페이스 기준 0건이에용.

## 검증

- OCaml 5.4.1 / 5.5.0 CI
- Eio 1.3 / 1.4 compatibility CI
- focused pipeline·execution persistence tests
- OCaml format / code-smell ratchet / boundary lint

## 최종 검증

- exact head `60f6ea154f701a6bd3a01c653997399ff1dbbb8d`
- CI run `30853678054` attempt 2 성공: OCaml 5.4.1/5.5.0, Eio 1.3/1.4, lint, format, boundary
- P0 0 · P1 0 · P2 0이에용.
- P3 비차단 후속은 temp-path 계약 분류 jeong-sik/masc#27846, 테스트 실패 의미 jeong-sik/masc#27845, validated private type #2937에서 추적해용.
- unresolved thread 0, MERGEABLE이라 코드 기준 병합 가능해용. Draft 상태는 유지해용.