### PR TITLE
fix(tool): send the caller's JSON Schema to providers verbatim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,8 +59,8 @@ constructors return canonical `Tool.t` values directly, and the secondary
 typed runtime representation, erasure bridge, and unused agent-tool raw input
 field have been removed.
 
-* **checkpoint persistence:** accept only the exact current v9 checkpoint
-  schema. All earlier artifacts, including released v8, must be reset rather
+* **checkpoint persistence:** accept only the exact current v10 checkpoint
+  schema. All earlier artifacts, including released v9, must be reset rather
   than migrated at runtime.
 * **provider tools:** reject historical OpenAI `parameters` lists; current
   callers must supply `input_schema` or an already-provider-shaped JSON Schema

--- a/README.md
+++ b/README.md
@@ -205,14 +205,17 @@ let calc_tool =
 
 (* Context-aware handler *)
 let counter_tool =
-  Tool.create_with_context ~name:"counter"
-    ~description:"Increment and return counter"
-    ~parameters:[]
-    (fun ctx _input ->
+  Tool.of_schema
+    (Types.tool_schema_of_params
+      ~name:"counter"
+      ~description:"Increment and return counter"
+      ~parameters:[]
+      ())
+    (Tool.requiring_context (fun ctx _input ->
       let n = match Context.get ctx "count" with
         | Some (`Int n) -> n + 1 | _ -> 1 in
       Context.set ctx "count" (`Int n);
-      Ok { Types.content = string_of_int n; _meta = None })
+      Ok { Types.content = string_of_int n; _meta = None }))
 ```
 
 ## Hooks and HITL

--- a/examples/tool_use.ml
+++ b/examples/tool_use.ml
@@ -73,19 +73,21 @@ let weather_api_tool =
 (** A stateful tool whose context updates must retain call order. *)
 let counter_tool =
   let descriptor = Tool.ordinary_descriptor Serial in
-  Tool.create_with_context
+  Tool.of_schema
     ~descriptor
-    ~name:"counter"
-    ~description:"Increment and return a counter"
-    ~parameters:[]
-    (fun ctx _input ->
+    (Types.tool_schema_of_params
+       ~name:"counter"
+       ~description:"Increment and return a counter"
+       ~parameters:[]
+       ())
+    (Tool.requiring_context (fun ctx _input ->
        let n =
          match Context.get ctx "count" with
          | Some (`Int n) -> n + 1
          | _ -> 1
        in
        Context.set ctx "count" (`Int n);
-       Ok { Types.content = string_of_int n; _meta = None })
+       Ok { Types.content = string_of_int n; _meta = None }))
 ;;
 
 let () =

--- a/lib/base/tool.ml
+++ b/lib/base/tool.ml
@@ -46,14 +46,22 @@ type t =
   }
 
 (** Create a tool with a simple handler *)
-let create ?descriptor ?strict ~name ~description ~parameters handler =
-  let schema = { name; description; parameters; strict } in
+let create ?descriptor ?strict ?input_schema ~name ~description ~parameters handler =
+  let schema = { name; description; parameters; strict; input_schema } in
   { schema; descriptor; handler = (fun _execution_env input -> handler input) }
 ;;
 
 (** Create a tool with a context-aware handler *)
-let create_with_context ?descriptor ?strict ~name ~description ~parameters handler =
-  let schema = { name; description; parameters; strict } in
+let create_with_context
+      ?descriptor
+      ?strict
+      ?input_schema
+      ~name
+      ~description
+      ~parameters
+      handler
+  =
+  let schema = { name; description; parameters; strict; input_schema } in
   let handler execution_env input =
     match Execution_env.context execution_env with
     | Some context -> handler context input
@@ -67,8 +75,16 @@ let create_with_context ?descriptor ?strict ~name ~description ~parameters handl
   { schema; descriptor; handler }
 ;;
 
-let create_with_execution_env ?descriptor ?strict ~name ~description ~parameters handler =
-  let schema = { name; description; parameters; strict } in
+let create_with_execution_env
+      ?descriptor
+      ?strict
+      ?input_schema
+      ~name
+      ~description
+      ~parameters
+      handler
+  =
+  let schema = { name; description; parameters; strict; input_schema } in
   { schema; descriptor; handler }
 ;;
 
@@ -106,7 +122,13 @@ let schema_to_json tool =
   `Assoc
     ([ "name", `String tool.schema.name
      ; "description", `String tool.schema.description
-     ; "input_schema", Types.params_to_input_schema tool.schema.parameters
+       (* The authoritative schema goes to the provider verbatim. Deriving it
+          back from [parameters] would drop minimum/maximum/default/enum and
+          nested properties, which the model then never sees. *)
+     ; ( "input_schema"
+       , match tool.schema.input_schema with
+         | Some schema -> schema
+         | None -> Types.params_to_input_schema tool.schema.parameters )
      ]
      @
      match tool.schema.strict with

--- a/lib/base/tool.ml
+++ b/lib/base/tool.ml
@@ -45,41 +45,49 @@ type t =
   ; handler : execution_env_tool_handler
   }
 
-(** Create a tool with a simple handler *)
+(* ── Handler adapters ─────────────────────────────────────────────
+   Where the schema comes from and what the handler reads are independent
+   axes. Naming one constructor per (source, kind) pair makes this surface
+   their product, so every new handler kind owes one function per source and
+   every new source owes one per kind. That product is what left the
+   authoritative source reachable from only one of the three handler kinds.
+   The adapters below keep the axes separate: a handler is converted once, and
+   {!of_schema} is the single pairing function. *)
+
+(** Adapt a handler that does not read the execution environment. *)
+let ignoring_execution_env (handler : tool_handler) _execution_env input = handler input
+
+(** Adapt a context-aware handler. Without a context there is nothing to pass,
+    so the call fails rather than substituting an empty one. *)
+let requiring_context (handler : context_tool_handler) execution_env input =
+  match Execution_env.context execution_env with
+  | Some context -> handler context input
+  | None ->
+    Error
+      { message = "context-aware tool requires explicit context"
+      ; recoverable = false
+      ; error_class = Some Deterministic
+      }
+;;
+
+(** Pair a schema with a handler. [Types.tool_schema] is [private] and each of
+    its two constructors derives one argument view from the other, so a schema
+    whose views disagree cannot reach this function — the invariant is carried
+    by the type rather than re-encoded in a constructor's name. Every
+    (schema source, handler kind) combination is this function applied to the
+    schema constructor and the handler adapter for that combination. *)
+let of_schema ?descriptor (schema : tool_schema) (handler : execution_env_tool_handler) =
+  { schema; descriptor; handler }
+;;
+
+(** The (parameter view, plain handler) corner, which is most call sites.
+    Exactly [of_schema (Types.tool_schema_of_params ...)
+    (ignoring_execution_env handler)]. *)
 let create ?descriptor ?strict ~name ~description ~parameters handler =
-  let schema = Types.tool_schema_of_params ?strict ~name ~description ~parameters () in
-  { schema; descriptor; handler = (fun _execution_env input -> handler input) }
-;;
-
-(** Build a tool from one authoritative JSON Schema. The parameter view is
-    derived from that schema by {!Types.tool_schema_of_input_schema}, so the
-    two cannot disagree, and the schema reaches providers verbatim. *)
-let of_input_schema_result ?descriptor ?strict ~name ~description ~input_schema handler =
-  match Types.tool_schema_of_input_schema ?strict ~name ~description ~input_schema () with
-  | Error detail -> Error detail
-  | Ok schema ->
-    Ok { schema; descriptor; handler = (fun _execution_env input -> handler input) }
-;;
-
-(** Create a tool with a context-aware handler *)
-let create_with_context ?descriptor ?strict ~name ~description ~parameters handler =
-  let schema = Types.tool_schema_of_params ?strict ~name ~description ~parameters () in
-  let handler execution_env input =
-    match Execution_env.context execution_env with
-    | Some context -> handler context input
-    | None ->
-      Error
-        { message = "context-aware tool requires explicit context"
-        ; recoverable = false
-        ; error_class = Some Deterministic
-        }
-  in
-  { schema; descriptor; handler }
-;;
-
-let create_with_execution_env ?descriptor ?strict ~name ~description ~parameters handler =
-  let schema = Types.tool_schema_of_params ?strict ~name ~description ~parameters () in
-  { schema; descriptor; handler }
+  of_schema
+    ?descriptor
+    (Types.tool_schema_of_params ?strict ~name ~description ~parameters ())
+    (ignoring_execution_env handler)
 ;;
 
 (** Execute a tool with its explicit execution resources. *)

--- a/lib/base/tool.ml
+++ b/lib/base/tool.ml
@@ -46,22 +46,24 @@ type t =
   }
 
 (** Create a tool with a simple handler *)
-let create ?descriptor ?strict ?input_schema ~name ~description ~parameters handler =
-  let schema = { name; description; parameters; strict; input_schema } in
+let create ?descriptor ?strict ~name ~description ~parameters handler =
+  let schema = Types.tool_schema_of_params ?strict ~name ~description ~parameters () in
   { schema; descriptor; handler = (fun _execution_env input -> handler input) }
 ;;
 
+(** Build a tool from one authoritative JSON Schema. The parameter view is
+    derived from that schema by {!Types.tool_schema_of_input_schema}, so the
+    two cannot disagree, and the schema reaches providers verbatim. *)
+let of_input_schema_result ?descriptor ?strict ~name ~description ~input_schema handler =
+  match Types.tool_schema_of_input_schema ?strict ~name ~description ~input_schema () with
+  | Error detail -> Error detail
+  | Ok schema ->
+    Ok { schema; descriptor; handler = (fun _execution_env input -> handler input) }
+;;
+
 (** Create a tool with a context-aware handler *)
-let create_with_context
-      ?descriptor
-      ?strict
-      ?input_schema
-      ~name
-      ~description
-      ~parameters
-      handler
-  =
-  let schema = { name; description; parameters; strict; input_schema } in
+let create_with_context ?descriptor ?strict ~name ~description ~parameters handler =
+  let schema = Types.tool_schema_of_params ?strict ~name ~description ~parameters () in
   let handler execution_env input =
     match Execution_env.context execution_env with
     | Some context -> handler context input
@@ -75,16 +77,8 @@ let create_with_context
   { schema; descriptor; handler }
 ;;
 
-let create_with_execution_env
-      ?descriptor
-      ?strict
-      ?input_schema
-      ~name
-      ~description
-      ~parameters
-      handler
-  =
-  let schema = { name; description; parameters; strict; input_schema } in
+let create_with_execution_env ?descriptor ?strict ~name ~description ~parameters handler =
+  let schema = Types.tool_schema_of_params ?strict ~name ~description ~parameters () in
   { schema; descriptor; handler }
 ;;
 

--- a/lib/base/tool.mli
+++ b/lib/base/tool.mli
@@ -36,25 +36,37 @@ type t =
   ; handler : execution_env_tool_handler
   }
 
-(** [?input_schema] is the authoritative wire form sent to providers verbatim
-    by {!schema_to_json}; omitting it derives the wire form from [~parameters].
-    When supplied it must be the schema [~parameters] was derived from — see
-    [Types.tool_schema.input_schema]. [Mcp_schema.tool_of_input_schema_result]
-    derives both from one schema and is the preferred entry point. *)
+(** Build a tool from the parameter view. {!schema_to_json} then derives the
+    wire form with [Types.params_to_input_schema], which keeps only type,
+    description and required. Use {!of_input_schema_result} when the caller has
+    a JSON Schema — that is the only path an authoritative schema can take, and
+    it cannot be combined with [~parameters]. *)
 val create
   :  ?descriptor:descriptor
   -> ?strict:bool
-  -> ?input_schema:Yojson.Safe.t
   -> name:string
   -> description:string
   -> parameters:Types.tool_param list
   -> tool_handler
   -> t
 
+(** Build a tool from one authoritative JSON Schema, sent to providers verbatim
+    by {!schema_to_json}. The parameter view used for validation is derived
+    from that same schema by [Types.tool_schema_of_input_schema], so the two
+    cannot disagree. Fails when the value is not a tool argument schema or when
+    a property cannot be projected onto a [Types.tool_param]. *)
+val of_input_schema_result
+  :  ?descriptor:descriptor
+  -> ?strict:bool
+  -> name:string
+  -> description:string
+  -> input_schema:Yojson.Safe.t
+  -> tool_handler
+  -> (t, string) result
+
 val create_with_context
   :  ?descriptor:descriptor
   -> ?strict:bool
-  -> ?input_schema:Yojson.Safe.t
   -> name:string
   -> description:string
   -> parameters:Types.tool_param list
@@ -69,7 +81,6 @@ val create_with_context
 val create_with_execution_env
   :  ?descriptor:descriptor
   -> ?strict:bool
-  -> ?input_schema:Yojson.Safe.t
   -> name:string
   -> description:string
   -> parameters:Types.tool_param list

--- a/lib/base/tool.mli
+++ b/lib/base/tool.mli
@@ -36,9 +36,15 @@ type t =
   ; handler : execution_env_tool_handler
   }
 
+(** [?input_schema] is the authoritative wire form sent to providers verbatim
+    by {!schema_to_json}; omitting it derives the wire form from [~parameters].
+    When supplied it must be the schema [~parameters] was derived from — see
+    [Types.tool_schema.input_schema]. [Mcp_schema.tool_of_input_schema_result]
+    derives both from one schema and is the preferred entry point. *)
 val create
   :  ?descriptor:descriptor
   -> ?strict:bool
+  -> ?input_schema:Yojson.Safe.t
   -> name:string
   -> description:string
   -> parameters:Types.tool_param list
@@ -48,6 +54,7 @@ val create
 val create_with_context
   :  ?descriptor:descriptor
   -> ?strict:bool
+  -> ?input_schema:Yojson.Safe.t
   -> name:string
   -> description:string
   -> parameters:Types.tool_param list
@@ -62,6 +69,7 @@ val create_with_context
 val create_with_execution_env
   :  ?descriptor:descriptor
   -> ?strict:bool
+  -> ?input_schema:Yojson.Safe.t
   -> name:string
   -> description:string
   -> parameters:Types.tool_param list
@@ -85,6 +93,10 @@ val execution_mode : t -> Tool_contract.execution_mode
 val completion : t -> Tool_contract.completion
 
 val descriptor_to_yojson : descriptor option -> Yojson.Safe.t
+
+(** Provider-facing tool definition. ["input_schema"] is the authoritative
+    schema verbatim when the tool carries one, and
+    [Types.params_to_input_schema] of the parameters otherwise. *)
 val schema_to_json : t -> Yojson.Safe.t
 
 (** Wrap a tool to inject default arguments when not provided.

--- a/lib/base/tool.mli
+++ b/lib/base/tool.mli
@@ -36,11 +36,53 @@ type t =
   ; handler : execution_env_tool_handler
   }
 
-(** Build a tool from the parameter view. {!schema_to_json} then derives the
+(** Adapt a handler that does not read the execution environment. *)
+val ignoring_execution_env : tool_handler -> execution_env_tool_handler
+
+(** Adapt a context-aware handler. Executing it without a context returns a
+    non-recoverable [Deterministic] error rather than substituting one. *)
+val requiring_context : context_tool_handler -> execution_env_tool_handler
+
+(** Pair a schema with a handler.
+
+    Where the schema comes from and what the handler reads are independent
+    axes, and this is the only function that joins them. A [Types.tool_schema]
+    can only come from [Types.tool_schema_of_params] or
+    [Types.tool_schema_of_input_schema] — the type is [private] and each
+    constructor derives one argument view from the other — so the two views
+    cannot disagree here.
+
+    Combinations are expressed by composition, not by new constructors:
+
+    {[
+      (* authoritative schema, execution-environment handler *)
+      Result.map
+        (fun schema -> Tool.of_schema schema handler)
+        (Types.tool_schema_of_input_schema ~name ~description ~input_schema ())
+
+      (* parameter view, context handler *)
+      Tool.of_schema
+        (Types.tool_schema_of_params ~name ~description ~parameters ())
+        (Tool.requiring_context handler)
+    ]}
+
+    Do not add a [create_with_*] variant for a new combination: one function
+    per (source, kind) pair makes this surface their product, and that product
+    is how the authoritative source came to be reachable from only one of the
+    three handler kinds.
+
+    @since 0.232.0 *)
+val of_schema
+  :  ?descriptor:descriptor
+  -> Types.tool_schema
+  -> execution_env_tool_handler
+  -> t
+
+(** The (parameter view, plain handler) corner. {!schema_to_json} derives the
     wire form with [Types.params_to_input_schema], which keeps only type,
-    description and required. Use {!of_input_schema_result} when the caller has
-    a JSON Schema — that is the only path an authoritative schema can take, and
-    it cannot be combined with [~parameters]. *)
+    description and required; when the caller holds a JSON Schema, compose
+    {!of_schema} with [Types.tool_schema_of_input_schema] instead so it reaches
+    providers verbatim. *)
 val create
   :  ?descriptor:descriptor
   -> ?strict:bool
@@ -48,43 +90,6 @@ val create
   -> description:string
   -> parameters:Types.tool_param list
   -> tool_handler
-  -> t
-
-(** Build a tool from one authoritative JSON Schema, sent to providers verbatim
-    by {!schema_to_json}. The parameter view used for validation is derived
-    from that same schema by [Types.tool_schema_of_input_schema], so the two
-    cannot disagree. Fails when the value is not a tool argument schema or when
-    a property cannot be projected onto a [Types.tool_param]. *)
-val of_input_schema_result
-  :  ?descriptor:descriptor
-  -> ?strict:bool
-  -> name:string
-  -> description:string
-  -> input_schema:Yojson.Safe.t
-  -> tool_handler
-  -> (t, string) result
-
-val create_with_context
-  :  ?descriptor:descriptor
-  -> ?strict:bool
-  -> name:string
-  -> description:string
-  -> parameters:Types.tool_param list
-  -> context_tool_handler
-  -> t
-
-(** Creates a raw JSON tool whose handler receives the explicit execution
-    environment. The environment can contain both shared {!Context.t} and exact
-    {!Invocation.t} occurrence metadata.
-
-    @since 0.215.0 *)
-val create_with_execution_env
-  :  ?descriptor:descriptor
-  -> ?strict:bool
-  -> name:string
-  -> description:string
-  -> parameters:Types.tool_param list
-  -> execution_env_tool_handler
   -> t
 
 val execute

--- a/lib/checkpoint.mli
+++ b/lib/checkpoint.mli
@@ -98,10 +98,10 @@ type delta =
 (** {1 Serialization} *)
 
 (** Serialize an exact current checkpoint to JSON. Raises [Invalid_argument]
-    when a manually constructed value violates the v9 contract. *)
+    when a manually constructed value violates the v10 contract. *)
 val to_json : t -> Yojson.Safe.t
 
-(** Deserialize only the exact current v9 checkpoint schema. Every other
+(** Deserialize only the exact current v10 checkpoint schema. Every other
     version is rejected. *)
 val of_json : Yojson.Safe.t -> (t, Error.sdk_error) result
 
@@ -122,7 +122,7 @@ val delta_of_json : Yojson.Safe.t -> (delta, Error.sdk_error) result
 val compute_delta : t -> t -> delta
 
 (** Apply a delta to a base checkpoint. Both the base and resulting checkpoint
-    must satisfy the exact current v9 contract. *)
+    must satisfy the exact current v10 contract. *)
 val apply_delta : t -> delta -> (t, Error.sdk_error) result
 
 (** {1 Queries} *)

--- a/lib/checkpoint_codec.ml
+++ b/lib/checkpoint_codec.ml
@@ -495,12 +495,12 @@ let checkpoint_to_json cp =
 ;;
 
 let validate_checkpoint cp =
-  Checkpoint_v9_contract.validate_v9_json (checkpoint_to_json cp)
+  Checkpoint_v10_contract.validate_v10_json (checkpoint_to_json cp)
 ;;
 
 let validated_checkpoint_json_exn ~scope cp =
   let json = checkpoint_to_json cp in
-  match Checkpoint_v9_contract.validate_v9_json json with
+  match Checkpoint_v10_contract.validate_v10_json json with
   | Ok () -> json
   | Error error -> invalid_arg (scope ^ ": " ^ Error.to_string error)
 ;;
@@ -765,7 +765,7 @@ let to_json cp = validated_checkpoint_json_exn ~scope:"Checkpoint.to_json" cp
 let decode_current_json json =
   try
     let open Yojson.Safe.Util in
-    let* () = Checkpoint_v9_contract.validate_v9_json json in
+    let* () = Checkpoint_v10_contract.validate_v10_json json in
     let* tool_choice =
       match json |> member "tool_choice" with
       | `Null -> Ok None

--- a/lib/checkpoint_types.ml
+++ b/lib/checkpoint_types.ml
@@ -1,6 +1,6 @@
 open Types
 
-let checkpoint_version = 9
+let checkpoint_version = 10
 
 type t =
   { version : int

--- a/lib/checkpoint_v10_contract.ml
+++ b/lib/checkpoint_v10_contract.ml
@@ -1,4 +1,4 @@
-(** Exact validator for the current checkpoint-v9 persistence schema. *)
+(** Exact validator for the current checkpoint-v10 persistence schema. *)
 
 open Result_syntax
 
@@ -684,7 +684,7 @@ let validate_common_checkpoint_fields ~scope fields =
   validate_unique_object ~scope:(scope ^ ".context") context
 ;;
 
-let validate_v9_json json =
+let validate_v10_json json =
   let scope = checkpoint_scope in
   let* fields =
     validate_object_shape ~scope ~required:current_checkpoint_fields ~optional:[] json

--- a/lib/checkpoint_v9_contract.ml
+++ b/lib/checkpoint_v9_contract.ml
@@ -148,7 +148,7 @@ let validate_tool_schema ~scope json =
     validate_object_shape
       ~scope
       ~required:[ "name"; "description"; "parameters" ]
-      ~optional:[ "strict" ]
+      ~optional:[ "strict"; "input_schema" ]
       json
   in
   let* name = required_field ~scope "name" fields in
@@ -157,9 +157,17 @@ let validate_tool_schema ~scope json =
   let* () = validate_string ~scope:(scope ^ ".name") name in
   let* () = validate_string ~scope:(scope ^ ".description") description in
   let* () = validate_list ~scope:(scope ^ ".parameters") validate_tool_param parameters in
-  match List.assoc_opt "strict" fields with
+  let* () =
+    match List.assoc_opt "strict" fields with
+    | None -> Ok ()
+    | Some strict -> validate_bool ~scope:(scope ^ ".strict") strict
+  in
+  (* The authoritative tool argument schema is carried verbatim; only its
+     outer shape is contracted here, since its body is provider JSON Schema. *)
+  match List.assoc_opt "input_schema" fields with
   | None -> Ok ()
-  | Some strict -> validate_bool ~scope:(scope ^ ".strict") strict
+  | Some input_schema ->
+    validate_unique_object ~scope:(scope ^ ".input_schema") input_schema
 ;;
 
 let validate_tool_choice ~scope = function

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -565,7 +565,8 @@ let validate_tool_argument_root_schema schema =
      | Some (`String _) ->
        Error "tool input schema root type must describe object arguments"
      | Some _ -> Error "tool input schema root type must be a string or string array")
-  | _ -> Error "tool input schema must be a JSON object"
+  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ ->
+    Error "tool input schema must be a JSON object"
 ;;
 
 (* [Yojson.Safe.t] carries no derived converters, so the deriving attributes on

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -378,41 +378,58 @@ let property_type_from_union name values =
          | Error _, _ -> acc
          | Ok selected, `String type_name ->
            (match json_schema_type_member_to_param_type_option type_name with
-            | Ok (Some param_type) ->
-              (match selected with
-               | None -> Ok (Some param_type)
-               | Some selected_param_type when selected_param_type = param_type ->
-                 Ok selected
-               | Some _ ->
-                 Error
-                   (Printf.sprintf
-                      "property %S type array must contain exactly one non-null type"
-                      name))
+            | Ok (Some param_type) -> Ok (param_type :: selected)
             | Ok None -> Ok selected
             | Error _ as error -> error)
          | Ok _, _ ->
            Error (Printf.sprintf "property %S type array must contain only strings" name))
-      (Ok None)
+      (Ok [])
       values
   in
   match result with
-  | Ok (Some param_type) -> Ok param_type
-  | Ok None ->
-    Error
-      (Printf.sprintf
-         "property %S type array must include a supported non-null type"
-         name)
+  | Ok values ->
+    (match List.sort_uniq compare values with
+     | [ param_type ] -> Ok (Some param_type)
+     | [] | _ :: _ :: _ -> Ok None)
   | Error _ as error -> error
+;;
+
+let param_type_of_json_value = function
+  | `String _ -> Some String
+  | `Int _ | `Intlit _ -> Some Integer
+  | `Float _ -> Some Number
+  | `Bool _ -> Some Boolean
+  | `List _ -> Some Array
+  | `Assoc _ -> Some Object
+  | `Null -> None
+;;
+
+let infer_uniform_param_type values =
+  values
+  |> List.filter_map param_type_of_json_value
+  |> List.sort_uniq compare
+  |> function
+  | [ param_type ] -> Some param_type
+  | [] | _ :: _ :: _ -> None
 ;;
 
 let property_type name prop =
   match prop with
   | `Assoc fields ->
     (match List.assoc_opt "type" fields with
-     | Some (`String type_name) -> json_schema_type_to_param_type_result type_name
+     | Some (`String type_name) ->
+       (match json_schema_type_member_to_param_type_option type_name with
+        | Ok param_type -> Ok param_type
+        | Error _ as error -> error)
      | Some (`List values) -> property_type_from_union name values
-     | Some _ -> Error (Printf.sprintf "property %S type must be a string" name)
-     | None -> Error (Printf.sprintf "property %S is missing type" name))
+     | Some _ ->
+       Error (Printf.sprintf "property %S type must be a string or string array" name)
+     | None ->
+       (match List.assoc_opt "const" fields, List.assoc_opt "enum" fields with
+        | Some value, _ -> Ok (param_type_of_json_value value)
+        | None, Some (`List values) -> Ok (infer_uniform_param_type values)
+        | None, Some _ -> Error (Printf.sprintf "property %S enum must be an array" name)
+        | None, None -> Ok None))
   | _ -> Error (Printf.sprintf "property %S must be a JSON object" name)
 ;;
 
@@ -438,9 +455,12 @@ let json_schema_to_params_result schema =
          (fun (name, prop) acc ->
             let* params = acc in
             let* param_type = property_type name prop in
-            let* description = property_description prop in
-            let required = List.mem name required_list in
-            Ok ({ name; description; param_type; required } :: params))
+            match param_type with
+            | None -> Ok params
+            | Some param_type ->
+              let* description = property_description prop in
+              let required = List.mem name required_list in
+              Ok ({ name; description; param_type; required } :: params))
          pairs
          (Ok [])
      | Some _ -> Error "properties must be a JSON object")
@@ -522,6 +542,32 @@ let input_schema_of_json (json : Yojson.Safe.t)
     Error (Input_schema_not_an_object (json_shape_of_json other))
 ;;
 
+let validate_tool_argument_root_schema schema =
+  match schema with
+  | `Assoc fields ->
+    (match List.assoc_opt "type" fields with
+     | None | Some (`String "object") -> Ok ()
+     | Some (`List values) ->
+       let type_names =
+         List.fold_right
+           (fun value acc ->
+              match value, acc with
+              | `String type_name, Ok names -> Ok (type_name :: names)
+              | _, Ok _ -> Error "tool input schema root type must contain only strings"
+              | _, (Error _ as error) -> error)
+           values
+           (Ok [])
+       in
+       (match type_names with
+        | Ok names when List.sort_uniq String.compare names = [ "object" ] -> Ok ()
+        | Ok _ -> Error "tool input schema root type must describe object arguments"
+        | Error _ as error -> error)
+     | Some (`String _) ->
+       Error "tool input schema root type must describe object arguments"
+     | Some _ -> Error "tool input schema root type must be a string or string array")
+  | _ -> Error "tool input schema must be a JSON object"
+;;
+
 (* [Yojson.Safe.t] carries no derived converters, so the deriving attributes on
    [tool_schema.input_schema] name these three explicitly. [@default None]
    represents absence by omitting the field; a present field is decoded here
@@ -582,10 +628,13 @@ let tool_schema_of_input_schema ?strict ~name ~description ~input_schema ()
   match input_schema_of_json input_schema with
   | Error error -> Error (input_schema_error_to_string error)
   | Ok schema ->
-    (match json_schema_to_params_result schema with
-     | Error detail -> Error detail
-     | Ok parameters ->
-       Ok { name; description; parameters; strict; input_schema = Some schema })
+    (match validate_tool_argument_root_schema schema with
+     | Error _ as error -> error
+     | Ok () ->
+       (match json_schema_to_params_result schema with
+        | Error detail -> Error detail
+        | Ok parameters ->
+          Ok { name; description; parameters; strict; input_schema = Some schema }))
 ;;
 
 let tool_schema_of_input_schema_with_parameters
@@ -1032,15 +1081,7 @@ module Reasoning_source = struct
                 | Error _ -> None))
           | Some _ | None -> None)
        | _ -> None)
-    | `Null
-    | `Bool _
-    | `Int _
-    | `Intlit _
-    | `Float _
-    | `String _
-    | `List _
-    | `Tuple _
-    | `Variant _ -> None
+    | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ -> None
   ;;
 
   let entry source = key, to_json source

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -523,21 +523,18 @@ let input_schema_of_json (json : Yojson.Safe.t)
 ;;
 
 (* [Yojson.Safe.t] carries no derived converters, so the deriving attributes on
-   [tool_schema.input_schema] name these three explicitly. The encoding is the
-   identity on the carried schema; [`Null] stands for absence, which is
-   unambiguous because {!input_schema_of_json} refuses to store [`Null]. *)
+   [tool_schema.input_schema] name these three explicitly. [@default None]
+   represents absence by omitting the field; a present field is decoded here
+   and must contain an admissible schema object. *)
 let input_schema_to_yojson : Yojson.Safe.t option -> Yojson.Safe.t = function
   | None -> `Null
   | Some schema -> schema
 ;;
 
-let input_schema_of_yojson : Yojson.Safe.t -> (Yojson.Safe.t option, string) result =
-  function
-  | `Null -> Ok None
-  | json ->
-    (match input_schema_of_json json with
-     | Ok schema -> Ok (Some schema)
-     | Error error -> Error (input_schema_error_to_string error))
+let input_schema_of_yojson json =
+  match input_schema_of_json json with
+  | Ok schema -> Ok (Some schema)
+  | Error error -> Error (input_schema_error_to_string error)
 ;;
 
 let pp_input_schema fmt = function

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -179,6 +179,38 @@ let json_shape_to_string = function
   | Json_object -> "an object"
 ;;
 
+let duplicate_object_keys fields =
+  let rec collect acc = function
+    | first :: (second :: _ as rest) when String.equal first second ->
+      collect (first :: acc) rest
+    | _ :: rest -> collect acc rest
+    | [] -> acc
+  in
+  fields
+  |> List.map fst
+  |> List.sort String.compare
+  |> collect []
+  |> List.sort_uniq String.compare
+;;
+
+let exact_object_fields ~scope ~required ?(optional = []) fields =
+  let expected = List.sort_uniq String.compare (required @ optional) in
+  let actual = List.map fst fields |> List.sort_uniq String.compare in
+  let missing = List.filter (fun name -> not (List.mem name actual)) required in
+  let unknown = List.filter (fun name -> not (List.mem name expected)) actual in
+  let duplicates = duplicate_object_keys fields in
+  match missing, unknown, duplicates with
+  | [], [], [] -> Ok ()
+  | _ ->
+    Error
+      (Printf.sprintf
+         "%s fields mismatch (missing=[%s], unknown=[%s], duplicates=[%s])"
+         scope
+         (String.concat ", " missing)
+         (String.concat ", " unknown)
+         (String.concat ", " duplicates))
+;;
+
 (* Total field readers. [Yojson.Safe.Util.to_string] and friends raise
    [Type_error] on a shape mismatch, which would escape the [result] these
    decoders advertise; matching the constructor keeps the failure in the
@@ -209,11 +241,11 @@ let json_bool_field ~scope fields name =
   | None -> Error (Printf.sprintf "%s is missing field %s" scope name)
 ;;
 
-(* An absent key and an explicit [null] both mean "unset"; any other shape is a
-   caller mistake rather than an absent value. *)
+(* The manual encoder omits an unset optional field. An explicit [null] is not
+   that encoding and is rejected instead of being treated as an absent key. *)
 let json_optional_bool_field ~scope fields name =
   match List.assoc_opt name fields with
-  | None | Some `Null -> Ok None
+  | None -> Ok None
   | Some (`Bool value) -> Ok (Some value)
   | Some other ->
     Error
@@ -231,6 +263,12 @@ let tool_param_of_json (json : Yojson.Safe.t) : (tool_param, string) result =
   match json with
   | `Assoc fields ->
     let scope = tool_param_scope in
+    let* () =
+      exact_object_fields
+        ~scope
+        ~required:[ "name"; "description"; "param_type"; "required" ]
+        fields
+    in
     let* name = json_string_field ~scope fields "name" in
     let* description = json_string_field ~scope fields "description" in
     let* param_type_name = json_string_field ~scope fields "param_type" in
@@ -417,20 +455,6 @@ let input_schema_error_to_string = function
       (json_shape_to_string shape)
   | Input_schema_duplicate_keys { path; keys } ->
     Printf.sprintf "%s has duplicate keys: %s" path (String.concat ", " keys)
-;;
-
-let duplicate_object_keys fields =
-  let rec collect acc = function
-    | first :: (second :: _ as rest) when String.equal first second ->
-      collect (first :: acc) rest
-    | _ :: rest -> collect acc rest
-    | [] -> acc
-  in
-  fields
-  |> List.map fst
-  |> List.sort String.compare
-  |> collect []
-  |> List.sort_uniq String.compare
 ;;
 
 (* Yojson parses a duplicate key into a repeated assoc entry, so uniqueness is
@@ -630,6 +654,13 @@ let tool_schema_of_json (json : Yojson.Safe.t) : (tool_schema, string) result =
          (json_shape_to_string (json_shape_of_json other)))
   | `Assoc fields ->
     let scope = tool_schema_scope in
+    let* () =
+      exact_object_fields
+        ~scope
+        ~required:[ "name"; "description"; "parameters" ]
+        ~optional:[ "strict"; "input_schema" ]
+        fields
+    in
     let* name = json_string_field ~scope fields "name" in
     let* description = json_string_field ~scope fields "description" in
     let* strict = json_optional_bool_field ~scope fields "strict" in

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -179,6 +179,27 @@ let params_to_input_schema (params : tool_param list) : Yojson.Safe.t =
     ]
 ;;
 
+(* [Yojson.Safe.t] carries no derived converters, so the deriving attributes on
+   [tool_schema.input_schema] name these three explicitly. The encoding is the
+   identity on the carried schema; [`Null] stands for absence. A tool argument
+   schema is a JSON object, so [Some `Null] is not a value the deriving
+   constructors can produce. *)
+let input_schema_to_yojson : Yojson.Safe.t option -> Yojson.Safe.t = function
+  | None -> `Null
+  | Some schema -> schema
+;;
+
+let input_schema_of_yojson : Yojson.Safe.t -> (Yojson.Safe.t option, string) result =
+  function
+  | `Null -> Ok None
+  | schema -> Ok (Some schema)
+;;
+
+let pp_input_schema fmt = function
+  | None -> Format.pp_print_string fmt "None"
+  | Some schema -> Format.fprintf fmt "Some %s" (Yojson.Safe.to_string schema)
+;;
+
 (** Tool definition *)
 type tool_schema =
   { name : string
@@ -188,6 +209,19 @@ type tool_schema =
     (** Per-function JSON Schema strict validation. [Some true] opts the tool
         into strict mode (OpenAI, DeepSeek Beta, Kimi, MiMo); [None] omits the
         field so providers apply their default. *)
+  ; input_schema :
+      (Yojson.Safe.t option
+      [@to_yojson input_schema_to_yojson]
+      [@of_yojson input_schema_of_yojson]
+      [@printer pp_input_schema])
+    (** Authoritative wire form emitted to providers verbatim when [Some]; when
+        [None] the wire form is derived from [parameters] by
+        {!params_to_input_schema}. [parameters] stays the derived view used for
+        validation and introspection, so [Some schema] must always satisfy
+        [parameters = Mcp_schema.json_schema_to_params schema]. Build both
+        through {!Mcp_schema.tool_of_input_schema_result} or
+        {!Tool_middleware.tool_schema_of_json_result} rather than filling the
+        two fields independently. *)
   }
 [@@deriving yojson, show]
 
@@ -199,9 +233,15 @@ let tool_schema_to_json (s : tool_schema) : Yojson.Safe.t =
      ]
      (* Emit "strict" only when set so [None] round-trips to an absent field
         and providers keep their own default. *)
+     @ (match s.strict with
+        | Some b -> [ "strict", `Bool b ]
+        | None -> [])
+     (* Same absence encoding for the authoritative schema: an absent key means
+        the wire form is derived from [parameters]. Absence rather than [null]
+        keeps the round-trip lossless for every [Yojson.Safe.t]. *)
      @
-     match s.strict with
-     | Some b -> [ "strict", `Bool b ]
+     match s.input_schema with
+     | Some schema -> [ "input_schema", schema ]
      | None -> [])
 ;;
 
@@ -214,19 +254,35 @@ let result_all items =
   loop [] items
 ;;
 
+(* [Yojson.Safe.Util.member] answers [`Null] for an absent key, so it cannot
+   tell an omitted "input_schema" from a present one holding [null]. The assoc
+   lookup keeps those two distinct and makes the round-trip lossless. *)
+let tool_schema_input_schema_of_json (json : Yojson.Safe.t)
+  : (Yojson.Safe.t option, string) result
+  =
+  match json with
+  | `Assoc fields -> Ok (List.assoc_opt "input_schema" fields)
+  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ ->
+    Error "tool_schema must be a JSON object"
+;;
+
 let tool_schema_of_json (json : Yojson.Safe.t) : (tool_schema, string) result =
   let open Yojson.Safe.Util in
-  match
-    json |> member "parameters" |> to_list |> List.map tool_param_of_json |> result_all
-  with
+  match tool_schema_input_schema_of_json json with
   | Error e -> Error e
-  | Ok parameters ->
-    Ok
-      { name = json |> member "name" |> to_string
-      ; description = json |> member "description" |> to_string
-      ; parameters
-      ; strict = json |> member "strict" |> to_bool_option
-      }
+  | Ok input_schema ->
+    (match
+       json |> member "parameters" |> to_list |> List.map tool_param_of_json |> result_all
+     with
+     | Error e -> Error e
+     | Ok parameters ->
+       Ok
+         { name = json |> member "name" |> to_string
+         ; description = json |> member "description" |> to_string
+         ; parameters
+         ; strict = json |> member "strict" |> to_bool_option
+         ; input_schema
+         })
 ;;
 
 (** Tool choice mode *)

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -199,9 +199,9 @@ let exact_object_fields ~scope ~required ?(optional = []) fields =
   let missing = List.filter (fun name -> not (List.mem name actual)) required in
   let unknown = List.filter (fun name -> not (List.mem name expected)) actual in
   let duplicates = duplicate_object_keys fields in
-  match missing, unknown, duplicates with
-  | [], [], [] -> Ok ()
-  | _ ->
+  if List.is_empty missing && List.is_empty unknown && List.is_empty duplicates
+  then Ok ()
+  else
     Error
       (Printf.sprintf
          "%s fields mismatch (missing=[%s], unknown=[%s], duplicates=[%s])"

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -124,6 +124,11 @@ type tool_param =
   }
 [@@deriving yojson, show]
 
+(* Keep the generated decoder private behind an exact object-field boundary.
+   The generated record decoder is total, but it does not own this protocol's
+   duplicate/unknown-field contract. *)
+let tool_param_of_yojson_fields = tool_param_of_yojson
+
 let param_type_of_string = function
   | "string" -> Ok String
   | "integer" -> Ok Integer
@@ -257,6 +262,21 @@ let json_optional_bool_field ~scope fields name =
 ;;
 
 let tool_param_scope = "tool_param"
+
+let tool_param_of_yojson json =
+  match json with
+  | `Assoc fields ->
+    (match
+       exact_object_fields
+         ~scope:tool_param_scope
+         ~required:[ "name"; "description"; "param_type"; "required" ]
+         fields
+     with
+     | Error _ as error -> error
+     | Ok () -> tool_param_of_yojson_fields json)
+  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ ->
+    tool_param_of_yojson_fields json
+;;
 
 let tool_param_of_json (json : Yojson.Safe.t) : (tool_param, string) result =
   let ( let* ) = Result.bind in
@@ -592,19 +612,32 @@ let tool_schema_of_input_schema_with_parameters
 let tool_schema_of_yojson_fields = tool_schema_of_yojson
 
 let tool_schema_of_yojson json =
-  match tool_schema_of_yojson_fields json with
-  | Error _ as error -> error
-  | Ok { name; description; parameters; strict; input_schema } ->
-    (match input_schema with
-     | None -> Ok (tool_schema_of_params ?strict ~name ~description ~parameters ())
-     | Some input_schema ->
-       tool_schema_of_input_schema_with_parameters
-         ?strict
-         ~name
-         ~description
-         ~parameters
-         ~input_schema
-         ())
+  let decode () =
+    match tool_schema_of_yojson_fields json with
+    | Error _ as error -> error
+    | Ok { name; description; parameters; strict; input_schema } ->
+      (match input_schema with
+       | None -> Ok (tool_schema_of_params ?strict ~name ~description ~parameters ())
+       | Some input_schema ->
+         tool_schema_of_input_schema_with_parameters
+           ?strict
+           ~name
+           ~description
+           ~parameters
+           ~input_schema
+           ())
+  in
+  match json with
+  | `Assoc fields ->
+    (match
+       exact_object_fields
+         ~scope:"tool_schema"
+         ~required:[ "name"; "description"; "parameters"; "strict"; "input_schema" ]
+         fields
+     with
+     | Error _ as error -> error
+     | Ok () -> decode ())
+  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> decode ()
 ;;
 
 let tool_schema_to_json (s : tool_schema) : Yojson.Safe.t =

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -556,6 +556,7 @@ type tool_schema =
         field so providers apply their default. *)
   ; input_schema :
       (Yojson.Safe.t option
+      [@default None]
       [@to_yojson input_schema_to_yojson]
       [@of_yojson input_schema_of_yojson]
       [@printer pp_input_schema])
@@ -632,7 +633,13 @@ let tool_schema_of_yojson json =
     (match
        exact_object_fields
          ~scope:"tool_schema"
-         ~required:[ "name"; "description"; "parameters"; "strict"; "input_schema" ]
+         ~required:[ "name"; "description"; "parameters"; "strict" ]
+           (* Optional, not required: a payload written by a released version
+              carries no "input_schema" key at all, and [@default None] makes
+              this encoder omit it too. Requiring it would reject both. [strict]
+              stays required because every released encoder emits it, as
+              "strict": null when unset. *)
+         ~optional:[ "input_schema" ]
          fields
      with
      | Error _ as error -> error

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -143,17 +143,110 @@ let tool_param_to_json (p : tool_param) : Yojson.Safe.t =
     ]
 ;;
 
+(** Exact JSON shape of a value. Decoders report what arrived by naming this
+    variant instead of re-inspecting the value, so a new [Yojson.Safe.t]
+    constructor breaks the build rather than falling into a catch-all. *)
+type json_shape =
+  | Json_null
+  | Json_bool
+  | Json_int
+  | Json_intlit
+  | Json_float
+  | Json_string
+  | Json_list
+  | Json_object
+[@@deriving show, eq]
+
+let json_shape_of_json : Yojson.Safe.t -> json_shape = function
+  | `Null -> Json_null
+  | `Bool _ -> Json_bool
+  | `Int _ -> Json_int
+  | `Intlit _ -> Json_intlit
+  | `Float _ -> Json_float
+  | `String _ -> Json_string
+  | `List _ -> Json_list
+  | `Assoc _ -> Json_object
+;;
+
+let json_shape_to_string = function
+  | Json_null -> "null"
+  | Json_bool -> "a boolean"
+  | Json_int -> "an integer"
+  | Json_intlit -> "an integer literal"
+  | Json_float -> "a number"
+  | Json_string -> "a string"
+  | Json_list -> "an array"
+  | Json_object -> "an object"
+;;
+
+(* Total field readers. [Yojson.Safe.Util.to_string] and friends raise
+   [Type_error] on a shape mismatch, which would escape the [result] these
+   decoders advertise; matching the constructor keeps the failure in the
+   return type. *)
+let json_string_field ~scope fields name =
+  match List.assoc_opt name fields with
+  | Some (`String value) -> Ok value
+  | Some other ->
+    Error
+      (Printf.sprintf
+         "%s.%s must be a string, got %s"
+         scope
+         name
+         (json_shape_to_string (json_shape_of_json other)))
+  | None -> Error (Printf.sprintf "%s is missing field %s" scope name)
+;;
+
+let json_bool_field ~scope fields name =
+  match List.assoc_opt name fields with
+  | Some (`Bool value) -> Ok value
+  | Some other ->
+    Error
+      (Printf.sprintf
+         "%s.%s must be a boolean, got %s"
+         scope
+         name
+         (json_shape_to_string (json_shape_of_json other)))
+  | None -> Error (Printf.sprintf "%s is missing field %s" scope name)
+;;
+
+(* An absent key and an explicit [null] both mean "unset"; any other shape is a
+   caller mistake rather than an absent value. *)
+let json_optional_bool_field ~scope fields name =
+  match List.assoc_opt name fields with
+  | None | Some `Null -> Ok None
+  | Some (`Bool value) -> Ok (Some value)
+  | Some other ->
+    Error
+      (Printf.sprintf
+         "%s.%s must be a boolean, got %s"
+         scope
+         name
+         (json_shape_to_string (json_shape_of_json other)))
+;;
+
+let tool_param_scope = "tool_param"
+
 let tool_param_of_json (json : Yojson.Safe.t) : (tool_param, string) result =
-  let open Yojson.Safe.Util in
-  match param_type_of_string (json |> member "param_type" |> to_string) with
-  | Error s -> Error (Printf.sprintf "unknown param_type: %s" s)
-  | Ok param_type ->
-    Ok
-      { name = json |> member "name" |> to_string
-      ; description = json |> member "description" |> to_string
-      ; param_type
-      ; required = json |> member "required" |> to_bool
-      }
+  let ( let* ) = Result.bind in
+  match json with
+  | `Assoc fields ->
+    let scope = tool_param_scope in
+    let* name = json_string_field ~scope fields "name" in
+    let* description = json_string_field ~scope fields "description" in
+    let* param_type_name = json_string_field ~scope fields "param_type" in
+    let* param_type =
+      match param_type_of_string param_type_name with
+      | Ok param_type -> Ok param_type
+      | Error unknown -> Error (Printf.sprintf "unknown param_type: %s" unknown)
+    in
+    let* required = json_bool_field ~scope fields "required" in
+    Ok { name; description; param_type; required }
+  | (`Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _) as other ->
+    Error
+      (Printf.sprintf
+         "%s must be a JSON object, got %s"
+         tool_param_scope
+         (json_shape_to_string (json_shape_of_json other)))
 ;;
 
 let params_to_input_schema (params : tool_param list) : Yojson.Safe.t =
@@ -179,11 +272,216 @@ let params_to_input_schema (params : tool_param list) : Yojson.Safe.t =
     ]
 ;;
 
+(* ── JSON Schema -> parameter view ────────────────────────────────
+   The derivation lives here rather than in the MCP bridge because
+   {!tool_schema_of_input_schema} below is the only admissible way to store an
+   authoritative schema, and it has to derive the parameter view itself for the
+   two to stay in agreement. [Mcp_schema] re-exports these. *)
+
+let json_schema_type_to_param_type_result value =
+  match param_type_of_string value with
+  | Ok param_type -> Ok param_type
+  | Error unsupported ->
+    Error (Printf.sprintf "unsupported JSON Schema type %S" unsupported)
+;;
+
+let json_schema_type_member_to_param_type_option type_name =
+  match type_name with
+  | "null" -> Ok None
+  | value ->
+    (match json_schema_type_to_param_type_result value with
+     | Ok param_type -> Ok (Some param_type)
+     | Error _ as error -> error)
+;;
+
+let required_list_of_schema schema =
+  match schema with
+  | `Assoc fields ->
+    (match List.assoc_opt "required" fields with
+     | None | Some `Null -> Ok []
+     | Some (`List items) ->
+       List.fold_right
+         (fun item acc ->
+            match item, acc with
+            | `String value, Ok values -> Ok (value :: values)
+            | _, Ok _ -> Error "required must contain only strings"
+            | _, (Error _ as error) -> error)
+         items
+         (Ok [])
+     | Some _ -> Error "required must be an array of strings")
+  | _ -> Error "schema must be a JSON object"
+;;
+
+let property_type_from_union name values =
+  let result =
+    List.fold_left
+      (fun acc item ->
+         match acc, item with
+         | Error _, _ -> acc
+         | Ok selected, `String type_name ->
+           (match json_schema_type_member_to_param_type_option type_name with
+            | Ok (Some param_type) ->
+              (match selected with
+               | None -> Ok (Some param_type)
+               | Some selected_param_type when selected_param_type = param_type ->
+                 Ok selected
+               | Some _ ->
+                 Error
+                   (Printf.sprintf
+                      "property %S type array must contain exactly one non-null type"
+                      name))
+            | Ok None -> Ok selected
+            | Error _ as error -> error)
+         | Ok _, _ ->
+           Error (Printf.sprintf "property %S type array must contain only strings" name))
+      (Ok None)
+      values
+  in
+  match result with
+  | Ok (Some param_type) -> Ok param_type
+  | Ok None ->
+    Error
+      (Printf.sprintf
+         "property %S type array must include a supported non-null type"
+         name)
+  | Error _ as error -> error
+;;
+
+let property_type name prop =
+  match prop with
+  | `Assoc fields ->
+    (match List.assoc_opt "type" fields with
+     | Some (`String type_name) -> json_schema_type_to_param_type_result type_name
+     | Some (`List values) -> property_type_from_union name values
+     | Some _ -> Error (Printf.sprintf "property %S type must be a string" name)
+     | None -> Error (Printf.sprintf "property %S is missing type" name))
+  | _ -> Error (Printf.sprintf "property %S must be a JSON object" name)
+;;
+
+let property_description prop =
+  match prop with
+  | `Assoc fields ->
+    (match List.assoc_opt "description" fields with
+     | Some (`String value) -> Ok value
+     | None | Some `Null -> Ok ""
+     | Some _ -> Error "description must be a string")
+  | _ -> Error "property must be a JSON object"
+;;
+
+let json_schema_to_params_result schema =
+  let ( let* ) = Result.bind in
+  let* required_list = required_list_of_schema schema in
+  match schema with
+  | `Assoc fields ->
+    (match List.assoc_opt "properties" fields with
+     | None | Some `Null -> Ok []
+     | Some (`Assoc pairs) ->
+       List.fold_right
+         (fun (name, prop) acc ->
+            let* params = acc in
+            let* param_type = property_type name prop in
+            let* description = property_description prop in
+            let required = List.mem name required_list in
+            Ok ({ name; description; param_type; required } :: params))
+         pairs
+         (Ok [])
+     | Some _ -> Error "properties must be a JSON object")
+  | _ -> Error "schema must be a JSON object"
+;;
+
+(* ── Tool argument schema boundary ────────────────────────────────
+   A provider tool argument schema is a JSON object with unique keys. Anything
+   else — an explicit null, a scalar, an array, or an object Yojson parsed with
+   a repeated key — is a caller mistake, and is rejected here so it can never
+   be stored. Because non-objects cannot be stored, [Some `Null] is
+   unrepresentable and the [`Null]-means-absent encoding below is unambiguous. *)
+
+(** Why a JSON value was refused as a tool argument schema. *)
+type input_schema_error =
+  | Input_schema_not_an_object of json_shape
+  | Input_schema_duplicate_keys of
+      { path : string
+      ; keys : string list
+      }
+[@@deriving show, eq]
+
+(* Path shown for the schema root; nested paths extend it with ".key" and
+   "[index]" so a rejection names the offending object. *)
+let input_schema_root_path = "input_schema"
+
+let input_schema_error_to_string = function
+  | Input_schema_not_an_object shape ->
+    Printf.sprintf
+      "%s must be a JSON object, got %s"
+      input_schema_root_path
+      (json_shape_to_string shape)
+  | Input_schema_duplicate_keys { path; keys } ->
+    Printf.sprintf "%s has duplicate keys: %s" path (String.concat ", " keys)
+;;
+
+let duplicate_object_keys fields =
+  let rec collect acc = function
+    | first :: (second :: _ as rest) when String.equal first second ->
+      collect (first :: acc) rest
+    | _ :: rest -> collect acc rest
+    | [] -> acc
+  in
+  fields
+  |> List.map fst
+  |> List.sort String.compare
+  |> collect []
+  |> List.sort_uniq String.compare
+;;
+
+(* Yojson parses a duplicate key into a repeated assoc entry, so uniqueness is
+   not implied by the type and has to be checked. A duplicate nested inside
+   "properties" is as ambiguous as one at the root, hence the full walk. *)
+let rec check_unique_object_keys ~path (json : Yojson.Safe.t)
+  : (unit, input_schema_error) result
+  =
+  match json with
+  | `Assoc fields ->
+    (match duplicate_object_keys fields with
+     | _ :: _ as keys -> Error (Input_schema_duplicate_keys { path; keys })
+     | [] ->
+       List.fold_left
+         (fun acc (key, value) ->
+            match acc with
+            | Error _ -> acc
+            | Ok () -> check_unique_object_keys ~path:(path ^ "." ^ key) value)
+         (Ok ())
+         fields)
+  | `List items ->
+    List.fold_left
+      (fun (index, acc) value ->
+         ( index + 1
+         , match acc with
+           | Error _ -> acc
+           | Ok () ->
+             check_unique_object_keys ~path:(Printf.sprintf "%s[%d]" path index) value ))
+      (0, Ok ())
+      items
+    |> snd
+  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `Null | `String _ -> Ok ()
+;;
+
+(** Accept a value as a tool argument schema, or say exactly why not. *)
+let input_schema_of_json (json : Yojson.Safe.t)
+  : (Yojson.Safe.t, input_schema_error) result
+  =
+  match json with
+  | `Assoc _ ->
+    (match check_unique_object_keys ~path:input_schema_root_path json with
+     | Ok () -> Ok json
+     | Error _ as error -> error)
+  | (`Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _) as other ->
+    Error (Input_schema_not_an_object (json_shape_of_json other))
+;;
+
 (* [Yojson.Safe.t] carries no derived converters, so the deriving attributes on
    [tool_schema.input_schema] name these three explicitly. The encoding is the
-   identity on the carried schema; [`Null] stands for absence. A tool argument
-   schema is a JSON object, so [Some `Null] is not a value the deriving
-   constructors can produce. *)
+   identity on the carried schema; [`Null] stands for absence, which is
+   unambiguous because {!input_schema_of_json} refuses to store [`Null]. *)
 let input_schema_to_yojson : Yojson.Safe.t option -> Yojson.Safe.t = function
   | None -> `Null
   | Some schema -> schema
@@ -192,7 +490,10 @@ let input_schema_to_yojson : Yojson.Safe.t option -> Yojson.Safe.t = function
 let input_schema_of_yojson : Yojson.Safe.t -> (Yojson.Safe.t option, string) result =
   function
   | `Null -> Ok None
-  | schema -> Ok (Some schema)
+  | json ->
+    (match input_schema_of_json json with
+     | Ok schema -> Ok (Some schema)
+     | Error error -> Error (input_schema_error_to_string error))
 ;;
 
 let pp_input_schema fmt = function
@@ -216,14 +517,71 @@ type tool_schema =
       [@printer pp_input_schema])
     (** Authoritative wire form emitted to providers verbatim when [Some]; when
         [None] the wire form is derived from [parameters] by
-        {!params_to_input_schema}. [parameters] stays the derived view used for
-        validation and introspection, so [Some schema] must always satisfy
-        [parameters = Mcp_schema.json_schema_to_params schema]. Build both
-        through {!Mcp_schema.tool_of_input_schema_result} or
-        {!Tool_middleware.tool_schema_of_json_result} rather than filling the
-        two fields independently. *)
+        {!params_to_input_schema}. [parameters] is the derived view used for
+        validation and introspection. The pair is only ever built by
+        {!tool_schema_of_params} and {!tool_schema_of_input_schema}, so
+        [Some schema] always satisfies
+        [parameters = json_schema_to_params_result schema]. *)
   }
 [@@deriving yojson, show]
+
+(* ── Authoritative constructors ───────────────────────────────────
+   [tool_schema] is [private] in the signature, so these two functions are the
+   only way to obtain one. Each takes exactly one of the two views and derives
+   the other, which is what makes the pair unable to disagree. *)
+
+let tool_schema_of_params ?strict ~name ~description ~parameters () =
+  { name; description; parameters; strict; input_schema = None }
+;;
+
+let tool_schema_of_input_schema ?strict ~name ~description ~input_schema ()
+  : (tool_schema, string) result
+  =
+  match input_schema_of_json input_schema with
+  | Error error -> Error (input_schema_error_to_string error)
+  | Ok schema ->
+    (match json_schema_to_params_result schema with
+     | Error detail -> Error detail
+     | Ok parameters ->
+       Ok { name; description; parameters; strict; input_schema = Some schema })
+;;
+
+let tool_schema_of_input_schema_with_parameters
+      ?strict
+      ~name
+      ~description
+      ~parameters
+      ~input_schema
+      ()
+  =
+  match tool_schema_of_input_schema ?strict ~name ~description ~input_schema () with
+  | Error _ as error -> error
+  | Ok schema when schema.parameters = parameters -> Ok schema
+  | Ok _ ->
+    Error "tool_schema.parameters must equal the projection of tool_schema.input_schema"
+;;
+
+(* The derived decoder fills [parameters] and [input_schema] from independent
+   JSON fields, which is exactly the divergence the constructors prevent. Route
+   its output back through them and reject a pair the constructors could not
+   have produced. *)
+let tool_schema_of_yojson_fields = tool_schema_of_yojson
+
+let tool_schema_of_yojson json =
+  match tool_schema_of_yojson_fields json with
+  | Error _ as error -> error
+  | Ok { name; description; parameters; strict; input_schema } ->
+    (match input_schema with
+     | None -> Ok (tool_schema_of_params ?strict ~name ~description ~parameters ())
+     | Some input_schema ->
+       tool_schema_of_input_schema_with_parameters
+         ?strict
+         ~name
+         ~description
+         ~parameters
+         ~input_schema
+         ())
+;;
 
 let tool_schema_to_json (s : tool_schema) : Yojson.Safe.t =
   `Assoc
@@ -237,8 +595,10 @@ let tool_schema_to_json (s : tool_schema) : Yojson.Safe.t =
         | Some b -> [ "strict", `Bool b ]
         | None -> [])
      (* Same absence encoding for the authoritative schema: an absent key means
-        the wire form is derived from [parameters]. Absence rather than [null]
-        keeps the round-trip lossless for every [Yojson.Safe.t]. *)
+        the wire form is derived from [parameters]. Encoding absence as a
+        missing key rather than as [null] keeps the two distinct on the way
+        back, so every schema this field can hold — a JSON object with unique
+        keys, and nothing else — round-trips unchanged. *)
      @
      match s.input_schema with
      | Some schema -> [ "input_schema", schema ]
@@ -254,35 +614,50 @@ let result_all items =
   loop [] items
 ;;
 
-(* [Yojson.Safe.Util.member] answers [`Null] for an absent key, so it cannot
-   tell an omitted "input_schema" from a present one holding [null]. The assoc
-   lookup keeps those two distinct and makes the round-trip lossless. *)
-let tool_schema_input_schema_of_json (json : Yojson.Safe.t)
-  : (Yojson.Safe.t option, string) result
-  =
-  match json with
-  | `Assoc fields -> Ok (List.assoc_opt "input_schema" fields)
-  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ ->
-    Error "tool_schema must be a JSON object"
-;;
+let tool_schema_scope = "tool_schema"
 
+(* Total: every field is read by matching its JSON constructor, so a malformed
+   persisted payload lands in [Error] rather than raising [Type_error] out of
+   the advertised [result]. *)
 let tool_schema_of_json (json : Yojson.Safe.t) : (tool_schema, string) result =
-  let open Yojson.Safe.Util in
-  match tool_schema_input_schema_of_json json with
-  | Error e -> Error e
-  | Ok input_schema ->
-    (match
-       json |> member "parameters" |> to_list |> List.map tool_param_of_json |> result_all
-     with
-     | Error e -> Error e
-     | Ok parameters ->
-       Ok
-         { name = json |> member "name" |> to_string
-         ; description = json |> member "description" |> to_string
-         ; parameters
-         ; strict = json |> member "strict" |> to_bool_option
-         ; input_schema
-         })
+  let ( let* ) = Result.bind in
+  match json with
+  | (`Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _) as other ->
+    Error
+      (Printf.sprintf
+         "%s must be a JSON object, got %s"
+         tool_schema_scope
+         (json_shape_to_string (json_shape_of_json other)))
+  | `Assoc fields ->
+    let scope = tool_schema_scope in
+    let* name = json_string_field ~scope fields "name" in
+    let* description = json_string_field ~scope fields "description" in
+    let* strict = json_optional_bool_field ~scope fields "strict" in
+    let* parameter_items =
+      match List.assoc_opt "parameters" fields with
+      | Some (`List items) -> Ok items
+      | Some other ->
+        Error
+          (Printf.sprintf
+             "%s.parameters must be an array, got %s"
+             scope
+             (json_shape_to_string (json_shape_of_json other)))
+      | None -> Error (Printf.sprintf "%s is missing field parameters" scope)
+    in
+    let* parameters = parameter_items |> List.map tool_param_of_json |> result_all in
+    (* [Yojson.Safe.Util.member] answers [`Null] for an absent key, so it
+       cannot tell an omitted "input_schema" from a present one; the assoc
+       lookup keeps the two distinct. *)
+    (match List.assoc_opt "input_schema" fields with
+     | Some input_schema ->
+       tool_schema_of_input_schema_with_parameters
+         ?strict
+         ~name
+         ~description
+         ~parameters
+         ~input_schema
+         ()
+     | None -> Ok (tool_schema_of_params ?strict ~name ~description ~parameters ()))
 ;;
 
 (** Tool choice mode *)

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -370,6 +370,24 @@ let required_list_of_schema schema =
   | _ -> Error "schema must be a JSON object"
 ;;
 
+(* A property whose accepted values span several JSON types has no single
+   [param_type]. JSON Schema counts every integer as a number, so that one pair
+   narrows to [Number] instead of dropping the property — and with it the
+   property's name, description, and required flag — from the parameter view.
+   Every other combination stays unrepresentable. Both orderings of the pair are
+   listed because which one [List.sort_uniq] produces follows the constructor
+   order of {!param_type}, which this rule does not depend on.
+
+   Declared once and shared: a [type] array and an [enum] reach this decision by
+   different routes, and when only the array route carried the rule, mixed
+   numeric enums such as ["enum": [1, 2.5]] lost their property. *)
+let narrow_param_types types =
+  match List.sort_uniq compare types with
+  | [ param_type ] -> Some param_type
+  | [ Integer; Number ] | [ Number; Integer ] -> Some Number
+  | [] | _ :: _ :: _ -> None
+;;
+
 let property_type_from_union name values =
   let result =
     List.fold_left
@@ -387,11 +405,7 @@ let property_type_from_union name values =
       values
   in
   match result with
-  | Ok values ->
-    (match List.sort_uniq compare values with
-     | [ param_type ] -> Ok (Some param_type)
-     | [ Integer; Number ] | [ Number; Integer ] -> Ok (Some Number)
-     | [] | _ :: _ :: _ -> Ok None)
+  | Ok values -> Ok (narrow_param_types values)
   | Error _ as error -> error
 ;;
 
@@ -406,12 +420,7 @@ let param_type_of_json_value = function
 ;;
 
 let infer_uniform_param_type values =
-  values
-  |> List.filter_map param_type_of_json_value
-  |> List.sort_uniq compare
-  |> function
-  | [ param_type ] -> Some param_type
-  | [] | _ :: _ :: _ -> None
+  values |> List.filter_map param_type_of_json_value |> narrow_param_types
 ;;
 
 let property_type name prop =

--- a/lib/llm_provider/types.ml
+++ b/lib/llm_provider/types.ml
@@ -390,6 +390,7 @@ let property_type_from_union name values =
   | Ok values ->
     (match List.sort_uniq compare values with
      | [ param_type ] -> Ok (Some param_type)
+     | [ Integer; Number ] | [ Number; Integer ] -> Ok (Some Number)
      | [] | _ :: _ :: _ -> Ok None)
   | Error _ as error -> error
 ;;
@@ -415,6 +416,7 @@ let infer_uniform_param_type values =
 
 let property_type name prop =
   match prop with
+  | `Bool _ -> Ok None
   | `Assoc fields ->
     (match List.assoc_opt "type" fields with
      | Some (`String type_name) ->
@@ -430,7 +432,8 @@ let property_type name prop =
         | None, Some (`List values) -> Ok (infer_uniform_param_type values)
         | None, Some _ -> Error (Printf.sprintf "property %S enum must be an array" name)
         | None, None -> Ok None))
-  | _ -> Error (Printf.sprintf "property %S must be a JSON object" name)
+  | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ ->
+    Error (Printf.sprintf "property %S must be a JSON object or boolean schema" name)
 ;;
 
 let property_description prop =
@@ -542,29 +545,94 @@ let input_schema_of_json (json : Yojson.Safe.t)
     Error (Input_schema_not_an_object (json_shape_of_json other))
 ;;
 
+let rec schema_definitely_excludes_objects = function
+  | `Bool false -> true
+  | `Bool true -> false
+  | `Assoc fields ->
+    let type_excludes =
+      match List.assoc_opt "type" fields with
+      | Some (`String type_name) -> not (String.equal type_name "object")
+      | Some (`List values) ->
+        List.for_all
+          (function
+            | `String type_name -> not (String.equal type_name "object")
+            | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `Assoc _ | `List _ ->
+              false)
+          values
+      | None | Some (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `Assoc _) -> false
+    in
+    let const_excludes =
+      match List.assoc_opt "const" fields with
+      | Some (`Assoc _) | None -> false
+      | Some (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _) ->
+        true
+    in
+    let enum_excludes =
+      match List.assoc_opt "enum" fields with
+      | Some (`List values) ->
+        List.for_all
+          (function
+            | `Assoc _ -> false
+            | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ ->
+              true)
+          values
+      | None
+      | Some (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _) ->
+        false
+    in
+    let all_of_excludes =
+      match List.assoc_opt "allOf" fields with
+      | Some (`List schemas) -> List.exists schema_definitely_excludes_objects schemas
+      | None
+      | Some (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _) ->
+        false
+    in
+    let alternatives_exclude keyword =
+      match List.assoc_opt keyword fields with
+      | Some (`List schemas) -> List.for_all schema_definitely_excludes_objects schemas
+      | None
+      | Some (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _) ->
+        false
+    in
+    type_excludes
+    || const_excludes
+    || enum_excludes
+    || all_of_excludes
+    || alternatives_exclude "anyOf"
+    || alternatives_exclude "oneOf"
+  | `Null | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ -> false
+;;
+
 let validate_tool_argument_root_schema schema =
   match schema with
   | `Assoc fields ->
-    (match List.assoc_opt "type" fields with
-     | None | Some (`String "object") -> Ok ()
-     | Some (`List values) ->
-       let type_names =
-         List.fold_right
-           (fun value acc ->
-              match value, acc with
-              | `String type_name, Ok names -> Ok (type_name :: names)
-              | _, Ok _ -> Error "tool input schema root type must contain only strings"
-              | _, (Error _ as error) -> error)
-           values
-           (Ok [])
-       in
-       (match type_names with
-        | Ok names when List.sort_uniq String.compare names = [ "object" ] -> Ok ()
-        | Ok _ -> Error "tool input schema root type must describe object arguments"
-        | Error _ as error -> error)
-     | Some (`String _) ->
-       Error "tool input schema root type must describe object arguments"
-     | Some _ -> Error "tool input schema root type must be a string or string array")
+    let declared_type =
+      match List.assoc_opt "type" fields with
+      | None | Some (`String "object") -> Ok ()
+      | Some (`List values) ->
+        let type_names =
+          List.fold_right
+            (fun value acc ->
+               match value, acc with
+               | `String type_name, Ok names -> Ok (type_name :: names)
+               | _, Ok _ -> Error "tool input schema root type must contain only strings"
+               | _, (Error _ as error) -> error)
+            values
+            (Ok [])
+        in
+        (match type_names with
+         | Ok names when List.sort_uniq String.compare names = [ "object" ] -> Ok ()
+         | Ok _ -> Error "tool input schema root type must describe object arguments"
+         | Error _ as error -> error)
+      | Some (`String _) ->
+        Error "tool input schema root type must describe object arguments"
+      | Some _ -> Error "tool input schema root type must be a string or string array"
+    in
+    (match declared_type with
+     | Error _ as error -> error
+     | Ok () when schema_definitely_excludes_objects schema ->
+       Error "tool input schema constraints cannot describe object arguments"
+     | Ok () -> Ok ())
   | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ ->
     Error "tool input schema must be a JSON object"
 ;;

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -101,10 +101,56 @@ type tool_param =
 
 val param_type_of_string : string -> (param_type, string) result
 val tool_param_to_json : tool_param -> Yojson.Safe.t
+
+(** Total: a payload that is not an object, or whose fields have the wrong JSON
+    shape, is reported as [Error] rather than raising [Yojson.Safe.Util.Type_error]. *)
 val tool_param_of_json : Yojson.Safe.t -> (tool_param, string) result
+
 val params_to_input_schema : tool_param list -> Yojson.Safe.t
 
-type tool_schema =
+(** Exact JSON shape of a value, used to name what arrived when a decode is
+    refused. *)
+type json_shape =
+  | Json_null
+  | Json_bool
+  | Json_int
+  | Json_intlit
+  | Json_float
+  | Json_string
+  | Json_list
+  | Json_object
+[@@deriving show, eq]
+
+val json_shape_of_json : Yojson.Safe.t -> json_shape
+val json_shape_to_string : json_shape -> string
+val json_schema_type_to_param_type_result : string -> (param_type, string) result
+
+(** Derive the parameter view of a JSON Schema. Keeps only the parts a
+    {!tool_param} can carry — name, type, description, required — which is why
+    it is a projection of the schema and not a substitute for it. *)
+val json_schema_to_params_result : Yojson.Safe.t -> (tool_param list, string) result
+
+(** Why a JSON value was refused as a tool argument schema. *)
+type input_schema_error =
+  | Input_schema_not_an_object of json_shape
+  | Input_schema_duplicate_keys of
+      { path : string (** Path of the offending object, rooted at ["input_schema"]. *)
+      ; keys : string list (** The repeated keys, sorted and deduplicated. *)
+      }
+[@@deriving show, eq]
+
+val input_schema_error_to_string : input_schema_error -> string
+
+(** Accept a value as a tool argument schema. A provider tool argument schema
+    is a JSON object with unique keys, so an explicit [`Null], a scalar, an
+    array, or an object Yojson parsed with a repeated key (at any depth) is
+    refused instead of being stored. *)
+val input_schema_of_json : Yojson.Safe.t -> (Yojson.Safe.t, input_schema_error) result
+
+(** A tool definition. [private]: the two views of the arguments must agree, and
+    the only values that satisfy that are the ones {!tool_schema_of_params} and
+    {!tool_schema_of_input_schema} build. *)
+type tool_schema = private
   { name : string
   ; description : string
   ; parameters : tool_param list
@@ -115,12 +161,9 @@ type tool_schema =
   ; input_schema : Yojson.Safe.t option
     (** Authoritative wire form emitted to providers verbatim when [Some]; when
         [None] the wire form is derived from [parameters] by
-        {!params_to_input_schema}. [parameters] stays the derived view used for
-        validation and introspection, so [Some schema] must always satisfy
-        [parameters = Mcp_schema.json_schema_to_params schema]. Build both
-        through [Mcp_schema.tool_of_input_schema_result] or
-        [Tool_middleware.tool_schema_of_json_result] rather than filling the
-        two fields independently.
+        {!params_to_input_schema}. [parameters] is the derived view used for
+        validation and introspection, so [Some schema] always satisfies
+        [parameters = json_schema_to_params_result schema].
 
         {!params_to_input_schema} keeps only type, description and required,
         so a caller-supplied schema carrying [minimum], [maximum], [default],
@@ -129,11 +172,39 @@ type tool_schema =
   }
 [@@deriving yojson, show]
 
+(** Build a schema from the parameter view. [input_schema] is [None], so the
+    wire form is derived by {!params_to_input_schema}. *)
+val tool_schema_of_params
+  :  ?strict:bool
+  -> name:string
+  -> description:string
+  -> parameters:tool_param list
+  -> unit
+  -> tool_schema
+
+(** Build a schema from one authoritative JSON Schema — the only way
+    [input_schema] is ever [Some]. [parameters] is derived from [~input_schema]
+    here, so the two cannot disagree. Fails when the value is not a tool
+    argument schema ({!input_schema_of_json}) or when a property cannot be
+    projected onto a {!tool_param}. *)
+val tool_schema_of_input_schema
+  :  ?strict:bool
+  -> name:string
+  -> description:string
+  -> input_schema:Yojson.Safe.t
+  -> unit
+  -> (tool_schema, string) result
+
 val tool_schema_to_json : tool_schema -> Yojson.Safe.t
 
-(** Inverse of {!tool_schema_to_json}. [input_schema] is read by direct assoc
-    lookup, so an omitted key decodes to [None] and a present [null] decodes to
-    [Some `Null] — the round-trip is lossless for every [Yojson.Safe.t]. *)
+(** Inverse of {!tool_schema_to_json}, and total: malformed input is reported
+    as [Error] rather than raising. Absence of an authoritative schema is
+    encoded by omitting the ["input_schema"] key, so an omitted key decodes to
+    [None] and a present one must be a tool argument schema
+    ({!input_schema_of_json}). A payload whose ["parameters"] array disagrees
+    with the projection of its ["input_schema"] is refused, because no value of
+    this type could have carried that pair. A schema written by
+    {!tool_schema_to_json} therefore round-trips unchanged. *)
 val tool_schema_of_json : Yojson.Safe.t -> (tool_schema, string) result
 
 val result_all : ('a, 'e) result list -> ('a list, 'e) result

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -129,8 +129,11 @@ val json_shape_to_string : json_shape -> string
 val json_schema_type_to_param_type_result : string -> (param_type, string) result
 
 (** Derive the parameter view of a JSON Schema. Keeps only the parts a
-    {!tool_param} can carry — name, type, description, required — which is why
-    it is a projection of the schema and not a substitute for it. *)
+    {!tool_param} can carry — name, one representable type, description, and
+    required — which is why it is a projection of the schema and not a
+    substitute for it. Valid properties expressed only through [$ref],
+    [anyOf], [oneOf], or an unrepresentable union are omitted from this view;
+    they remain unchanged in the authoritative schema. *)
 val json_schema_to_params_result : Yojson.Safe.t -> (tool_param list, string) result
 
 (** Why a JSON value was refused as a tool argument schema. *)
@@ -187,9 +190,12 @@ val tool_schema_of_params
 
 (** Build a schema from one authoritative JSON Schema — the only way
     [input_schema] is ever [Some]. [parameters] is derived from [~input_schema]
-    here, so the two cannot disagree. Fails when the value is not a tool
-    argument schema ({!input_schema_of_json}) or when a property cannot be
-    projected onto a {!tool_param}. *)
+    here, so the two cannot disagree. Properties that cannot be represented by
+    the deliberately lossy {!tool_param} view (for example [$ref], [anyOf], or
+    multi-type unions) remain only in the authoritative schema instead of
+    making the tool unusable. Fails when the value is not a tool argument
+    schema ({!input_schema_of_json}), explicitly describes non-object tool
+    arguments, or contains a malformed projectable field. *)
 val tool_schema_of_input_schema
   :  ?strict:bool
   -> name:string

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -203,7 +203,8 @@ val tool_schema_to_json : tool_schema -> Yojson.Safe.t
     [None] and a present one must be a tool argument schema
     ({!input_schema_of_json}). A payload whose ["parameters"] array disagrees
     with the projection of its ["input_schema"] is refused, because no value of
-    this type could have carried that pair. A schema written by
+    this type could have carried that pair. Top-level and parameter objects must
+    contain exactly their declared fields with no duplicate keys. A schema written by
     {!tool_schema_to_json} therefore round-trips unchanged. *)
 val tool_schema_of_json : Yojson.Safe.t -> (tool_schema, string) result
 

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -102,8 +102,11 @@ type tool_param =
 val param_type_of_string : string -> (param_type, string) result
 val tool_param_to_json : tool_param -> Yojson.Safe.t
 
-(** Total: a payload that is not an object, or whose fields have the wrong JSON
-    shape, is reported as [Error] rather than raising [Yojson.Safe.Util.Type_error]. *)
+(** Total exact inverse for the manual JSON encoding. The derived
+    {!tool_param_of_yojson} boundary applies the same duplicate/unknown-field
+    rejection to its own encoding. A payload that is not an object, or whose
+    fields have the wrong JSON shape, is reported as [Error] rather than
+    raising [Yojson.Safe.Util.Type_error]. *)
 val tool_param_of_json : Yojson.Safe.t -> (tool_param, string) result
 
 val params_to_input_schema : tool_param list -> Yojson.Safe.t
@@ -204,8 +207,10 @@ val tool_schema_to_json : tool_schema -> Yojson.Safe.t
     ({!input_schema_of_json}). A payload whose ["parameters"] array disagrees
     with the projection of its ["input_schema"] is refused, because no value of
     this type could have carried that pair. Top-level and parameter objects must
-    contain exactly their declared fields with no duplicate keys. A schema written by
-    {!tool_schema_to_json} therefore round-trips unchanged. *)
+    contain exactly their declared fields with no duplicate keys. The derived
+    {!tool_schema_of_yojson} boundary enforces the same rule for its own
+    encoding. A schema written by {!tool_schema_to_json} therefore round-trips
+    unchanged. *)
 val tool_schema_of_json : Yojson.Safe.t -> (tool_schema, string) result
 
 val result_all : ('a, 'e) result list -> ('a list, 'e) result

--- a/lib/llm_provider/types.mli
+++ b/lib/llm_provider/types.mli
@@ -112,11 +112,30 @@ type tool_schema =
     (** Per-function JSON Schema strict validation. [Some true] opts the tool
         into strict mode (OpenAI, DeepSeek Beta, Kimi, MiMo); [None] omits the
         field so providers apply their default. *)
+  ; input_schema : Yojson.Safe.t option
+    (** Authoritative wire form emitted to providers verbatim when [Some]; when
+        [None] the wire form is derived from [parameters] by
+        {!params_to_input_schema}. [parameters] stays the derived view used for
+        validation and introspection, so [Some schema] must always satisfy
+        [parameters = Mcp_schema.json_schema_to_params schema]. Build both
+        through [Mcp_schema.tool_of_input_schema_result] or
+        [Tool_middleware.tool_schema_of_json_result] rather than filling the
+        two fields independently.
+
+        {!params_to_input_schema} keeps only type, description and required,
+        so a caller-supplied schema carrying [minimum], [maximum], [default],
+        [enum] or nested properties reaches the model only through this
+        field. *)
   }
 [@@deriving yojson, show]
 
 val tool_schema_to_json : tool_schema -> Yojson.Safe.t
+
+(** Inverse of {!tool_schema_to_json}. [input_schema] is read by direct assoc
+    lookup, so an omitted key decodes to [None] and a present [null] decodes to
+    [Some `Null] — the round-trip is lossless for every [Yojson.Safe.t]. *)
 val tool_schema_of_json : Yojson.Safe.t -> (tool_schema, string) result
+
 val result_all : ('a, 'e) result list -> ('a list, 'e) result
 
 type tool_choice =

--- a/lib/protocol/mcp.mli
+++ b/lib/protocol/mcp.mli
@@ -28,6 +28,18 @@ val json_schema_to_params : Yojson.Safe.t -> Types.tool_param list
 val json_schema_to_params_result : Yojson.Safe.t -> (Types.tool_param list, string) result
 val mcp_tool_of_sdk_tool : Mcp_schema.Sdk_types.tool -> mcp_tool
 
+(** Re-export of {!Mcp_schema.tool_of_input_schema_result}: derives the
+    parameter view from [~input_schema] and keeps that schema as the
+    authoritative wire form, so the two can never disagree. *)
+val tool_of_input_schema_result
+  :  ?descriptor:Tool.descriptor
+  -> ?strict:bool
+  -> name:string
+  -> description:string
+  -> input_schema:Yojson.Safe.t
+  -> (Yojson.Safe.t -> Types.tool_result)
+  -> (Tool.t, string) result
+
 val mcp_tool_to_sdk_tool
   :  call_fn:(Yojson.Safe.t -> Types.tool_result)
   -> mcp_tool

--- a/lib/protocol/mcp_schema.ml
+++ b/lib/protocol/mcp_schema.ml
@@ -151,18 +151,40 @@ let mcp_tool_of_sdk_tool (t : Sdk_types.tool) : mcp_tool =
   }
 ;;
 
-(** Convert {!mcp_tool} to SDK {!Tool.t} with the given call handler. *)
-let mcp_tool_to_sdk_tool_result ~call_fn mcp_tool =
-  match json_schema_to_params_result mcp_tool.input_schema with
-  | Error detail ->
-    Error (Printf.sprintf "tool %S schema invalid: %s" mcp_tool.name detail)
+(** Build a {!Tool.t} from one authoritative JSON Schema. The parameter view is
+    derived from that same schema, so [parameters] and [input_schema] cannot
+    disagree, and the schema reaches providers verbatim — keeping [minimum],
+    [maximum], [default], [enum] and nested properties that
+    {!Types.params_to_input_schema} would drop. *)
+let tool_of_input_schema_result
+      ?descriptor
+      ?strict
+      ~name
+      ~description
+      ~input_schema
+      call_fn
+  =
+  match json_schema_to_params_result input_schema with
+  | Error detail -> Error (Printf.sprintf "tool %S schema invalid: %s" name detail)
   | Ok params ->
     Ok
       (Tool.create
-         ~name:mcp_tool.name
-         ~description:mcp_tool.description
+         ?descriptor
+         ?strict
+         ~input_schema
+         ~name
+         ~description
          ~parameters:params
          call_fn)
+;;
+
+(** Convert {!mcp_tool} to SDK {!Tool.t} with the given call handler. *)
+let mcp_tool_to_sdk_tool_result ~call_fn mcp_tool =
+  tool_of_input_schema_result
+    ~name:mcp_tool.name
+    ~description:mcp_tool.description
+    ~input_schema:mcp_tool.input_schema
+    call_fn
 ;;
 
 let mcp_tool_to_sdk_tool ~call_fn mcp_tool =

--- a/lib/protocol/mcp_schema.ml
+++ b/lib/protocol/mcp_schema.ml
@@ -56,16 +56,9 @@ let tool_of_input_schema_result
       ~input_schema
       call_fn
   =
-  match
-    Tool.of_input_schema_result
-      ?descriptor
-      ?strict
-      ~name
-      ~description
-      ~input_schema
-      call_fn
-  with
-  | Ok tool_ -> Ok tool_
+  match Types.tool_schema_of_input_schema ?strict ~name ~description ~input_schema () with
+  | Ok schema ->
+    Ok (Tool.of_schema ?descriptor schema (Tool.ignoring_execution_env call_fn))
   | Error detail -> Error (Printf.sprintf "tool %S schema invalid: %s" name detail)
 ;;
 

--- a/lib/protocol/mcp_schema.ml
+++ b/lib/protocol/mcp_schema.ml
@@ -3,125 +3,17 @@ module Sdk_types = Mcp_protocol.Mcp_types
 
 (* ── JSON Schema -> SDK tool_param (oas-specific bridge) ─────────── *)
 
-let json_schema_type_to_param_type_result = function
-  | "string" -> Ok String
-  | "integer" -> Ok Integer
-  | "number" -> Ok Number
-  | "boolean" -> Ok Boolean
-  | "array" -> Ok Array
-  | "object" -> Ok Object
-  | value -> Error (Printf.sprintf "unsupported JSON Schema type %S" value)
-;;
+(* The conversion itself lives in {!Types}, next to the constructor that has to
+   apply it to keep [tool_schema.parameters] in agreement with
+   [tool_schema.input_schema]. These are re-exports for existing callers. *)
+
+let json_schema_type_to_param_type_result = Types.json_schema_type_to_param_type_result
+let json_schema_to_params_result = Types.json_schema_to_params_result
 
 let json_schema_type_to_param_type value =
   match json_schema_type_to_param_type_result value with
   | Ok param_type -> param_type
   | Error detail -> invalid_arg detail
-;;
-
-let json_schema_type_member_to_param_type_option type_name =
-  match type_name with
-  | "null" -> Ok None
-  | value ->
-    (match json_schema_type_to_param_type_result value with
-     | Ok param_type -> Ok (Some param_type)
-     | Error _ as error -> error)
-;;
-
-let required_list_of_schema schema =
-  match schema with
-  | `Assoc fields ->
-    (match List.assoc_opt "required" fields with
-     | None | Some `Null -> Ok []
-     | Some (`List items) ->
-       List.fold_right
-         (fun item acc ->
-            match item, acc with
-            | `String value, Ok values -> Ok (value :: values)
-            | _, Ok _ -> Error "required must contain only strings"
-            | _, (Error _ as error) -> error)
-         items
-         (Ok [])
-     | Some _ -> Error "required must be an array of strings")
-  | _ -> Error "schema must be a JSON object"
-;;
-
-let property_type_from_union name values =
-  let result =
-    List.fold_left
-      (fun acc item ->
-         match acc, item with
-         | Error _, _ -> acc
-         | Ok selected, `String type_name ->
-           (match json_schema_type_member_to_param_type_option type_name with
-            | Ok (Some param_type) ->
-              (match selected with
-               | None -> Ok (Some param_type)
-               | Some selected_param_type when selected_param_type = param_type ->
-                 Ok selected
-               | Some _ ->
-                 Error
-                   (Printf.sprintf
-                      "property %S type array must contain exactly one non-null type"
-                      name))
-            | Ok None -> Ok selected
-            | Error _ as error -> error)
-         | Ok _, _ ->
-           Error (Printf.sprintf "property %S type array must contain only strings" name))
-      (Ok None)
-      values
-  in
-  match result with
-  | Ok (Some param_type) -> Ok param_type
-  | Ok None ->
-    Error
-      (Printf.sprintf
-         "property %S type array must include a supported non-null type"
-         name)
-  | Error _ as error -> error
-;;
-
-let property_type name prop =
-  match prop with
-  | `Assoc fields ->
-    (match List.assoc_opt "type" fields with
-     | Some (`String type_name) -> json_schema_type_to_param_type_result type_name
-     | Some (`List values) -> property_type_from_union name values
-     | Some _ -> Error (Printf.sprintf "property %S type must be a string" name)
-     | None -> Error (Printf.sprintf "property %S is missing type" name))
-  | _ -> Error (Printf.sprintf "property %S must be a JSON object" name)
-;;
-
-let property_description prop =
-  match prop with
-  | `Assoc fields ->
-    (match List.assoc_opt "description" fields with
-     | Some (`String value) -> Ok value
-     | None | Some `Null -> Ok ""
-     | Some _ -> Error "description must be a string")
-  | _ -> Error "property must be a JSON object"
-;;
-
-let json_schema_to_params_result schema =
-  let ( let* ) = Result.bind in
-  let required_list = required_list_of_schema schema in
-  let* required_list = required_list in
-  match schema with
-  | `Assoc fields ->
-    (match List.assoc_opt "properties" fields with
-     | None | Some `Null -> Ok []
-     | Some (`Assoc pairs) ->
-       List.fold_right
-         (fun (name, prop) acc ->
-            let* params = acc in
-            let* param_type = property_type name prop in
-            let* description = property_description prop in
-            let required = List.mem name required_list in
-            Ok ({ name; description; param_type; required } :: params))
-         pairs
-         (Ok [])
-     | Some _ -> Error "properties must be a JSON object")
-  | _ -> Error "schema must be a JSON object"
 ;;
 
 let json_schema_to_params schema =
@@ -164,18 +56,17 @@ let tool_of_input_schema_result
       ~input_schema
       call_fn
   =
-  match json_schema_to_params_result input_schema with
+  match
+    Tool.of_input_schema_result
+      ?descriptor
+      ?strict
+      ~name
+      ~description
+      ~input_schema
+      call_fn
+  with
+  | Ok tool_ -> Ok tool_
   | Error detail -> Error (Printf.sprintf "tool %S schema invalid: %s" name detail)
-  | Ok params ->
-    Ok
-      (Tool.create
-         ?descriptor
-         ?strict
-         ~input_schema
-         ~name
-         ~description
-         ~parameters:params
-         call_fn)
 ;;
 
 (** Convert {!mcp_tool} to SDK {!Tool.t} with the given call handler. *)

--- a/lib/protocol/mcp_schema.mli
+++ b/lib/protocol/mcp_schema.mli
@@ -25,6 +25,22 @@ type mcp_resource_contents = Sdk_types.resource_contents
 type mcp_prompt = Sdk_types.prompt
 type mcp_prompt_result = Sdk_types.prompt_result
 
+(** {1 Tool construction} *)
+
+(** Build a tool from one authoritative JSON Schema: [parameters] are derived
+    from [~input_schema] here, so the two views cannot disagree, and the schema
+    reaches providers verbatim instead of being rebuilt from the lossy
+    parameter view. Fails with the offending property and reason when the
+    schema cannot be parsed. *)
+val tool_of_input_schema_result
+  :  ?descriptor:Tool.descriptor
+  -> ?strict:bool
+  -> name:string
+  -> description:string
+  -> input_schema:Yojson.Safe.t
+  -> Tool.tool_handler
+  -> (Tool.t, string) result
+
 val mcp_tool_of_sdk_tool : Sdk_types.tool -> mcp_tool
 val mcp_tool_to_sdk_tool : call_fn:Tool.tool_handler -> mcp_tool -> Tool.t
 

--- a/lib/protocol/mcp_schema.mli
+++ b/lib/protocol/mcp_schema.mli
@@ -30,8 +30,9 @@ type mcp_prompt_result = Sdk_types.prompt_result
 (** Build a tool from one authoritative JSON Schema: [parameters] are derived
     from [~input_schema] here, so the two views cannot disagree, and the schema
     reaches providers verbatim instead of being rebuilt from the lossy
-    parameter view. Fails with the offending property and reason when the
-    schema cannot be parsed. *)
+    parameter view. Valid properties that have no {!Types.tool_param}
+    representation remain only in that authoritative schema. Fails with the
+    offending field and reason when the schema boundary is malformed. *)
 val tool_of_input_schema_result
   :  ?descriptor:Tool.descriptor
   -> ?strict:bool

--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -77,6 +77,131 @@ let property_type_names = function
   | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ -> None
 ;;
 
+type canonical_number =
+  { negative : bool
+  ; significand : string
+  ; exponent : int
+  }
+
+let canonical_decimal value =
+  let decimal_digits value =
+    (not (String.equal value ""))
+    && String.for_all (fun char -> char >= '0' && char <= '9') value
+  in
+  let decimal_exponent value =
+    let digits =
+      if String.length value > 0 && (Char.equal value.[0] '+' || Char.equal value.[0] '-')
+      then String.sub value 1 (String.length value - 1)
+      else value
+    in
+    if decimal_digits digits then int_of_string_opt value else None
+  in
+  let length = String.length value in
+  let negative, unsigned =
+    if length > 0 && Char.equal value.[0] '-'
+    then true, String.sub value 1 (length - 1)
+    else false, value
+  in
+  let exponent_index =
+    match String.index_opt unsigned 'e', String.index_opt unsigned 'E' with
+    | None, None -> Some None
+    | Some index, None | None, Some index -> Some (Some index)
+    | Some _, Some _ -> None
+  in
+  match exponent_index with
+  | None -> None
+  | Some exponent_index ->
+    let mantissa, exponent =
+      match exponent_index with
+      | None -> Some unsigned, Some 0
+      | Some index ->
+        let mantissa = String.sub unsigned 0 index in
+        let raw_exponent =
+          String.sub unsigned (index + 1) (String.length unsigned - index - 1)
+        in
+        Some mantissa, decimal_exponent raw_exponent
+    in
+    (match mantissa, exponent with
+     | Some mantissa, Some exponent ->
+       let whole, fraction, has_decimal_point =
+         match String.index_opt mantissa '.' with
+         | None -> Some mantissa, Some "", false
+         | Some index ->
+           let whole = String.sub mantissa 0 index in
+           let fraction =
+             String.sub mantissa (index + 1) (String.length mantissa - index - 1)
+           in
+           if String.contains fraction '.'
+           then None, None, true
+           else Some whole, Some fraction, true
+       in
+       (match whole, fraction with
+        | Some whole, Some fraction
+          when (not (String.equal whole ""))
+               && ((not has_decimal_point) || not (String.equal fraction ""))
+               && decimal_digits whole
+               && (String.equal fraction "" || decimal_digits fraction)
+               && (String.length whole = 1 || not (Char.equal whole.[0] '0')) ->
+          let digits = whole ^ fraction in
+          let rec first_nonzero index =
+            if index = String.length digits
+            then None
+            else if Char.equal digits.[index] '0'
+            then first_nonzero (index + 1)
+            else Some index
+          in
+          (match first_nonzero 0 with
+           | None -> Some { negative = false; significand = "0"; exponent = 0 }
+           | Some first ->
+             let rec last_nonzero index =
+               if Char.equal digits.[index] '0' then last_nonzero (index - 1) else index
+             in
+             let last = last_nonzero (String.length digits - 1) in
+             let trailing_zeroes = String.length digits - last - 1 in
+             Some
+               { negative
+               ; significand = String.sub digits first (last - first + 1)
+               ; exponent = exponent - String.length fraction + trailing_zeroes
+               })
+        | Some _, Some _ | None, None | None, Some _ | Some _, None -> None)
+     | None, None | None, Some _ | Some _, None -> None)
+;;
+
+let canonical_number = function
+  | `Int value -> canonical_decimal (string_of_int value)
+  | `Intlit value -> canonical_decimal value
+  | `Float value when Float.is_finite value ->
+    canonical_decimal (Yojson.Safe.to_string (`Float value))
+  | `Float _ | `Null | `Bool _ | `String _ | `Assoc _ | `List _ -> None
+;;
+
+let numeric_equal left right =
+  match canonical_number left, canonical_number right with
+  | Some left, Some right -> left = right
+  | None, None | None, Some _ | Some _, None -> false
+;;
+
+let rec json_semantic_equal left right =
+  match left, right with
+  | (`Int _ | `Intlit _ | `Float _), (`Int _ | `Intlit _ | `Float _) ->
+    numeric_equal left right
+  | `Null, `Null -> true
+  | `Bool left, `Bool right -> Bool.equal left right
+  | `String left, `String right -> String.equal left right
+  | `List left, `List right -> List.equal json_semantic_equal left right
+  | `Assoc left, `Assoc right ->
+    List.length left = List.length right
+    && List.for_all
+         (fun (name, left_value) ->
+            match List.assoc_opt name right with
+            | Some right_value -> json_semantic_equal left_value right_value
+            | None -> false)
+         left
+  | ( (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _ | `List _)
+    , (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _ | `List _) )
+    -> false
+;;
+
 let property_matches property value =
   match property with
   | `Assoc fields ->
@@ -89,12 +214,12 @@ let property_matches property value =
     let const_matches =
       match List.assoc_opt "const" fields with
       | None -> true
-      | Some expected -> expected = value
+      | Some expected -> json_semantic_equal expected value
     in
     let enum_matches =
       match List.assoc_opt "enum" fields with
       | None -> true
-      | Some (`List values) -> List.exists (( = ) value) values
+      | Some (`List values) -> List.exists (json_semantic_equal value) values
       | Some _ -> false
     in
     type_matches && const_matches && enum_matches

--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -55,7 +55,11 @@ let matches_json_schema_type type_name = function
   | `String _ -> String.equal type_name "string"
   | `Int _ | `Intlit _ ->
     String.equal type_name "integer" || String.equal type_name "number"
-  | `Float _ -> String.equal type_name "number"
+  | `Float value ->
+    String.equal type_name "number"
+    || (String.equal type_name "integer"
+        && Float.is_finite value
+        && Float.is_integer value)
   | `Bool _ -> String.equal type_name "boolean"
   | `List _ -> String.equal type_name "array"
   | `Assoc _ -> String.equal type_name "object"
@@ -204,6 +208,7 @@ let rec json_semantic_equal left right =
 
 let property_matches property value =
   match property with
+  | `Bool allowed -> allowed
   | `Assoc fields ->
     let type_matches =
       match property_type_names property with
@@ -223,7 +228,7 @@ let property_matches property value =
       | Some _ -> false
     in
     type_matches && const_matches && enum_matches
-  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ -> true
+  | `Null | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ -> true
 ;;
 
 let expected_property_type property =

--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -50,16 +50,15 @@ let matches_type (expected : Types.param_type) (value : Yojson.Safe.t) : bool =
   | _ -> false
 ;;
 
-let matches_json_schema_type type_name value =
-  match type_name, value with
-  | "null", `Null -> true
-  | "string", `String _ -> true
-  | "integer", (`Int _ | `Intlit _) -> true
-  | "number", (`Float _ | `Int _ | `Intlit _) -> true
-  | "boolean", `Bool _ -> true
-  | "array", `List _ -> true
-  | "object", `Assoc _ -> true
-  | _ -> false
+let matches_json_schema_type type_name = function
+  | `Null -> String.equal type_name "null"
+  | `String _ -> String.equal type_name "string"
+  | `Int _ | `Intlit _ ->
+    String.equal type_name "integer" || String.equal type_name "number"
+  | `Float _ -> String.equal type_name "number"
+  | `Bool _ -> String.equal type_name "boolean"
+  | `List _ -> String.equal type_name "array"
+  | `Assoc _ -> String.equal type_name "object"
 ;;
 
 let property_type_names = function
@@ -71,10 +70,11 @@ let property_type_names = function
          (List.filter_map
             (function
               | `String value -> Some value
-              | _ -> None)
+              | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `Assoc _ | `List _ ->
+                None)
             values)
      | None | Some _ -> None)
-  | _ -> None
+  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ -> None
 ;;
 
 let property_matches property value =
@@ -98,7 +98,7 @@ let property_matches property value =
       | Some _ -> false
     in
     type_matches && const_matches && enum_matches
-  | _ -> true
+  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ -> true
 ;;
 
 let expected_property_type property =
@@ -115,7 +115,7 @@ let authoritative_schema_parts = function
         List.filter_map
           (function
             | `String value -> Some value
-            | _ -> None)
+            | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `Assoc _ | `List _ -> None)
           values
       | None | Some _ -> []
     in
@@ -125,7 +125,7 @@ let authoritative_schema_parts = function
       | None | Some _ -> []
     in
     required, properties
-  | _ -> [], []
+  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ -> [], []
 ;;
 
 let validate_authoritative input_schema input =

--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -30,8 +30,6 @@ let describe_json_value = function
   | `List _ -> "array"
   | `Assoc _ -> "object"
   | `Intlit s -> Printf.sprintf "integer(%s)" s
-  | `Tuple _ -> "tuple"
-  | `Variant _ -> "variant"
 ;;
 
 let string_of_param_type = Types.param_type_to_string
@@ -52,34 +50,157 @@ let matches_type (expected : Types.param_type) (value : Yojson.Safe.t) : bool =
   | _ -> false
 ;;
 
-(* ── Validation ──────────────────────────────────────────── *)
+let matches_json_schema_type type_name value =
+  match type_name, value with
+  | "null", `Null -> true
+  | "string", `String _ -> true
+  | "integer", (`Int _ | `Intlit _) -> true
+  | "number", (`Float _ | `Int _ | `Intlit _) -> true
+  | "boolean", `Bool _ -> true
+  | "array", `List _ -> true
+  | "object", `Assoc _ -> true
+  | _ -> false
+;;
 
-let validate (schema : Types.tool_schema) (input : Yojson.Safe.t) : validation_result =
-  let params = schema.parameters in
+let property_type_names = function
+  | `Assoc fields ->
+    (match List.assoc_opt "type" fields with
+     | Some (`String type_name) -> Some [ type_name ]
+     | Some (`List values) ->
+       Some
+         (List.filter_map
+            (function
+              | `String value -> Some value
+              | _ -> None)
+            values)
+     | None | Some _ -> None)
+  | _ -> None
+;;
+
+let property_matches property value =
+  match property with
+  | `Assoc fields ->
+    let type_matches =
+      match property_type_names property with
+      | None -> true
+      | Some type_names ->
+        List.exists (fun type_name -> matches_json_schema_type type_name value) type_names
+    in
+    let const_matches =
+      match List.assoc_opt "const" fields with
+      | None -> true
+      | Some expected -> expected = value
+    in
+    let enum_matches =
+      match List.assoc_opt "enum" fields with
+      | None -> true
+      | Some (`List values) -> List.exists (( = ) value) values
+      | Some _ -> false
+    in
+    type_matches && const_matches && enum_matches
+  | _ -> true
+;;
+
+let expected_property_type property =
+  match property_type_names property with
+  | Some (_ :: _ as type_names) -> String.concat " or " type_names
+  | Some [] | None -> "declared schema"
+;;
+
+let authoritative_schema_parts = function
+  | `Assoc fields ->
+    let required =
+      match List.assoc_opt "required" fields with
+      | Some (`List values) ->
+        List.filter_map
+          (function
+            | `String value -> Some value
+            | _ -> None)
+          values
+      | None | Some _ -> []
+    in
+    let properties =
+      match List.assoc_opt "properties" fields with
+      | Some (`Assoc values) -> values
+      | None | Some _ -> []
+    in
+    required, properties
+  | _ -> [], []
+;;
+
+let validate_authoritative input_schema input =
   match input with
   | `Assoc fields ->
+    let required, properties = authoritative_schema_parts input_schema in
+    let names =
+      List.map fst properties
+      @ List.filter (fun name -> not (List.mem_assoc name properties)) required
+    in
     let errors =
       List.filter_map
-        (fun (p : Types.tool_param) ->
-           let path = "/" ^ p.name in
-           match List.assoc_opt p.name fields with
-           | None when p.required ->
-             Some { path; expected = string_of_param_type p.param_type; actual = Missing }
-           | None -> None
-           | Some value when matches_type p.param_type value -> None
-           | Some value ->
+        (fun name ->
+           let path = "/" ^ name in
+           let property = List.assoc_opt name properties in
+           match List.assoc_opt name fields, property with
+           | None, _ when List.mem name required ->
              Some
                { path
-               ; expected = string_of_param_type p.param_type
+               ; expected =
+                   Option.fold ~none:"required" ~some:expected_property_type property
+               ; actual = Missing
+               }
+           | None, _ -> None
+           | Some value, Some property when not (property_matches property value) ->
+             Some
+               { path
+               ; expected = expected_property_type property
                ; actual = Received (describe_json_value value)
-               })
-        params
+               }
+           | Some _, _ -> None)
+        names
     in
     if errors = [] then Valid input else Invalid errors
   | other ->
     Invalid
       [ { path = "/"; expected = "object"; actual = Received (describe_json_value other) }
       ]
+;;
+
+(* ── Validation ──────────────────────────────────────────── *)
+
+let validate (schema : Types.tool_schema) (input : Yojson.Safe.t) : validation_result =
+  match schema.input_schema with
+  | Some input_schema -> validate_authoritative input_schema input
+  | None ->
+    let params = schema.parameters in
+    (match input with
+     | `Assoc fields ->
+       let errors =
+         List.filter_map
+           (fun (p : Types.tool_param) ->
+              let path = "/" ^ p.name in
+              match List.assoc_opt p.name fields with
+              | None when p.required ->
+                Some
+                  { path; expected = string_of_param_type p.param_type; actual = Missing }
+              | None -> None
+              | Some value when matches_type p.param_type value -> None
+              | Some value ->
+                Some
+                  { path
+                  ; expected = string_of_param_type p.param_type
+                  ; actual = Received (describe_json_value value)
+                  })
+           params
+       in
+       if errors = [] then Valid input else Invalid errors
+     | other ->
+       Invalid
+         [ { path = "/"
+           ; expected = "object"
+           ; actual = Received (describe_json_value other)
+           }
+         ])
 ;;
 
 (* ── Error formatting ────────────────────────────────────── *)

--- a/lib/tool_input_validation.mli
+++ b/lib/tool_input_validation.mli
@@ -23,10 +23,13 @@ type validation_result =
   | Valid of Yojson.Safe.t
   | Invalid of field_error list
 
-(** Validate [input] against the parameter schema of [tool]. Tool input is
-    always an object, including tools with no parameters. Missing required
-    fields and exact JSON type mismatches return [Invalid]. A successful result
-    contains the same value passed by the caller. *)
+(** Validate [input] against the authoritative schema's root [required] and
+    property [type]/[enum]/[const] constraints when [tool] carries one,
+    otherwise against its parameter view. Tool input is always an object,
+    including tools with no parameters. Missing required fields and exact JSON
+    type mismatches return [Invalid]. Nullable type arrays keep [null] valid
+    instead of being collapsed by the lossy parameter projection. A successful
+    result contains the same value passed by the caller. *)
 val validate : Types.tool_schema -> Yojson.Safe.t -> validation_result
 
 (** Format field errors as a structured, LLM-readable feedback string.

--- a/lib/tool_middleware.ml
+++ b/lib/tool_middleware.ml
@@ -25,7 +25,16 @@ let validate_input ~tool_name ~(schema : Types.tool_schema) args =
 
 let tool_schema_of_json_result ~name ?(description = "") json_schema =
   match Mcp_schema.json_schema_to_params_result json_schema with
-  | Ok parameters -> Ok { Types.name; description; parameters; strict = None }
+  | Ok parameters ->
+    (* [parameters] is the derived view; the caller's schema is kept as the
+       authoritative wire form so its constraints survive to the provider. *)
+    Ok
+      { Types.name
+      ; description
+      ; parameters
+      ; strict = None
+      ; input_schema = Some json_schema
+      }
   | Error detail -> Error detail
 ;;
 

--- a/lib/tool_middleware.ml
+++ b/lib/tool_middleware.ml
@@ -23,19 +23,11 @@ let validate_input ~tool_name ~(schema : Types.tool_schema) args =
 
 (* ── Schema conversion ────────────────────────────────────── *)
 
+(* The caller's schema is kept as the authoritative wire form so its
+   constraints survive to the provider; the constructor derives the parameter
+   view from it, so the two views cannot disagree. *)
 let tool_schema_of_json_result ~name ?(description = "") json_schema =
-  match Mcp_schema.json_schema_to_params_result json_schema with
-  | Ok parameters ->
-    (* [parameters] is the derived view; the caller's schema is kept as the
-       authoritative wire form so its constraints survive to the provider. *)
-    Ok
-      { Types.name
-      ; description
-      ; parameters
-      ; strict = None
-      ; input_schema = Some json_schema
-      }
-  | Error detail -> Error detail
+  Types.tool_schema_of_input_schema ~name ~description ~input_schema:json_schema ()
 ;;
 
 let tool_schema_of_json ~name ?(description = "") json_schema : Types.tool_schema =

--- a/lib/tool_middleware.mli
+++ b/lib/tool_middleware.mli
@@ -35,8 +35,9 @@ val validate_input
 
 (** Build a [Types.tool_schema] from a name and raw JSON Schema.
     Description defaults to [""].
-    Extracts parameters via {!Mcp_schema.json_schema_to_params}. Raises
-    [Invalid_argument] when the schema cannot be converted. *)
+    Extracts parameters via {!Mcp_schema.json_schema_to_params} and keeps the
+    supplied schema as [input_schema], so the two views are derived from one
+    source. Raises [Invalid_argument] when the schema cannot be converted. *)
 val tool_schema_of_json
   :  name:string
   -> ?description:string

--- a/lib/typed_tool.ml
+++ b/lib/typed_tool.ml
@@ -34,11 +34,9 @@ let create_with_context
       ?strict
       ()
   =
-  Tool.create_with_context
+  Tool.of_schema
     ?descriptor
-    ?strict
-    ~name
-    ~description
-    ~parameters:params
-    (fun context -> execute_typed ~parse ~handler:(handler context) ~encode)
+    (Types.tool_schema_of_params ?strict ~name ~description ~parameters:params ())
+    (Tool.requiring_context (fun context ->
+       execute_typed ~parse ~handler:(handler context) ~encode))
 ;;

--- a/test/dune
+++ b/test/dune
@@ -144,6 +144,7 @@
   test_structured_stream
   test_swiss_verdict_json
   test_tool
+  test_tool_input_schema_fidelity
   test_tool_input_validation
   test_tool_middleware
   test_tracing
@@ -282,6 +283,7 @@
   test_structured_stream
   test_swiss_verdict_json
   test_tool
+  test_tool_input_schema_fidelity
   test_tool_input_validation
   test_tool_middleware
   test_tracing

--- a/test/dune
+++ b/test/dune
@@ -147,6 +147,7 @@
   test_tool_input_schema_fidelity
   test_tool_input_validation
   test_tool_middleware
+  test_tool_schema_decode_boundary
   test_tracing
   test_trajectory
   test_trajectory_unit
@@ -286,6 +287,7 @@
   test_tool_input_schema_fidelity
   test_tool_input_validation
   test_tool_middleware
+  test_tool_schema_decode_boundary
   test_tracing
   test_trajectory
   test_trajectory_unit

--- a/test/test_agent_card.ml
+++ b/test/test_agent_card.ml
@@ -35,18 +35,17 @@ let base_info : Agent_card.agent_info =
       ; enable_thinking = Some true
       }
   ; tool_schemas =
-      [ { Types.name = "get_weather"
-        ; description = "Get weather"
-        ; parameters =
-            [ { name = "city"
+      [ Types.tool_schema_of_params
+          ~name:"get_weather"
+          ~description:"Get weather"
+          ~parameters:
+            [ { Types.name = "city"
               ; description = "City"
               ; param_type = String
               ; required = true
               }
             ]
-        ; strict = None
-        ; input_schema = None
-        }
+          ()
       ]
   ; supported_providers = []
   ; mcp_clients_count = 0

--- a/test/test_agent_card.ml
+++ b/test/test_agent_card.ml
@@ -45,6 +45,7 @@ let base_info : Agent_card.agent_info =
               }
             ]
         ; strict = None
+        ; input_schema = None
         }
       ]
   ; supported_providers = []

--- a/test/test_checkpoint.ml
+++ b/test/test_checkpoint.ml
@@ -156,6 +156,7 @@ let sample_tool_schema : Types.tool_schema =
         }
       ]
   ; strict = None
+  ; input_schema = None
   }
 ;;
 
@@ -757,7 +758,12 @@ let () =
                 ]
             in
             let tool : Types.tool_schema =
-              { name = "multi"; description = "test"; parameters = params; strict = None }
+              { name = "multi"
+              ; description = "test"
+              ; parameters = params
+              ; strict = None
+              ; input_schema = None
+              }
             in
             let cp = make_checkpoint ~tools:[ tool ] () in
             let cp2 = Result.get_ok (Checkpoint.of_json (Checkpoint.to_json cp)) in

--- a/test/test_checkpoint.ml
+++ b/test/test_checkpoint.ml
@@ -180,13 +180,13 @@ let () =
   run
     "Checkpoint"
     [ ( "version"
-      , [ test_case "checkpoint_version is 9" `Quick (fun () ->
-            check int "version" 9 Checkpoint.checkpoint_version)
+      , [ test_case "checkpoint_version is 10" `Quick (fun () ->
+            check int "version" 10 Checkpoint.checkpoint_version)
         ; test_case "version field in to_json" `Quick (fun () ->
             let cp = make_checkpoint () in
             let json = Checkpoint.to_json cp in
             let v = Yojson.Safe.Util.(json |> member "version" |> to_int) in
-            check int "version" 9 v)
+            check int "version" 10 v)
         ; test_case "wrong version returns Error" `Quick (fun () ->
             let cp = make_checkpoint () in
             let json = Checkpoint.to_json cp in
@@ -243,6 +243,17 @@ let () =
             | Error (Error.Serialization (Error.VersionMismatch { got = 8; _ })) -> ()
             | Error error -> fail ("unexpected error: " ^ Error.to_string error)
             | Ok _ -> fail "checkpoint v8 must be rejected")
+        ; test_case "released v9 is rejected" `Quick (fun () ->
+            let json =
+              match Checkpoint.to_json (make_checkpoint ()) with
+              | `Assoc fields ->
+                `Assoc (("version", `Int 9) :: List.remove_assoc "version" fields)
+              | _ -> fail "current checkpoint serializer must return an object"
+            in
+            match Checkpoint.of_json json with
+            | Error (Error.Serialization (Error.VersionMismatch { got = 9; _ })) -> ()
+            | Error error -> fail ("unexpected error: " ^ Error.to_string error)
+            | Ok _ -> fail "checkpoint v9 must be rejected")
         ; test_case "missing version is rejected explicitly" `Quick (fun () ->
             match Checkpoint.of_json (`Assoc []) with
             | Error (Error.Serialization (Error.JsonParseError { detail })) ->
@@ -739,6 +750,36 @@ let () =
             let p1 = List.hd t.parameters in
             check string "param name" "city" p1.name;
             check bool "required" true p1.required)
+        ; test_case "authoritative schema is a v10 wire" `Quick (fun () ->
+            let input_schema : Yojson.Safe.t =
+              `Assoc
+                [ "type", `String "object"
+                ; "properties", `Assoc [ "city", `Assoc [ "type", `String "string" ] ]
+                ]
+            in
+            let tool =
+              match
+                Types.tool_schema_of_input_schema
+                  ~name:"weather"
+                  ~description:"Weather"
+                  ~input_schema
+                  ()
+              with
+              | Ok schema -> schema
+              | Error detail -> fail detail
+            in
+            let json = Checkpoint.to_json (make_checkpoint ~tools:[ tool ] ()) in
+            let open Yojson.Safe.Util in
+            check int "new wire version" 10 (json |> member "version" |> to_int);
+            check
+              string
+              "authoritative schema persisted"
+              (Yojson.Safe.to_string input_schema)
+              (json
+               |> member "tools"
+               |> index 0
+               |> member "input_schema"
+               |> Yojson.Safe.to_string))
         ; test_case "empty tools roundtrip" `Quick (fun () ->
             let cp = make_checkpoint ~tools:[] () in
             let cp2 = Result.get_ok (Checkpoint.of_json (Checkpoint.to_json cp)) in
@@ -1348,7 +1389,7 @@ let () =
               | other -> other
             in
             check bool "error" true (Result.is_error (Checkpoint.of_json bad)))
-        ; test_case "current v9 rejects unknown nested message field" `Quick (fun () ->
+        ; test_case "current v10 rejects unknown nested message field" `Quick (fun () ->
             let message : Types.message =
               { role = Types.User
               ; content = [ Types.Text "hello" ]
@@ -1369,7 +1410,7 @@ let () =
               "unknown message field"
               true
               (Result.is_error (Checkpoint.of_json bad)))
-        ; test_case "current v9 rejects normalized empty metadata" `Quick (fun () ->
+        ; test_case "current v10 rejects normalized empty metadata" `Quick (fun () ->
             let message : Types.message =
               { role = Types.User
               ; content = [ Types.Text "hello" ]
@@ -1386,7 +1427,7 @@ let () =
                    (update_first_json (append_json_field "metadata" (`Assoc [])))
             in
             check bool "empty metadata" true (Result.is_error (Checkpoint.of_json bad)))
-        ; test_case "current v9 preserves blank reasoning content" `Quick (fun () ->
+        ; test_case "current v10 preserves blank reasoning content" `Quick (fun () ->
             let message : Types.message =
               { role = Types.Assistant
               ; content =
@@ -1433,7 +1474,7 @@ let () =
                |> index 0
                |> member "reasoning_content"
                |> to_string))
-        ; test_case "current v9 rejects duplicate nested content field" `Quick (fun () ->
+        ; test_case "current v10 rejects duplicate nested content field" `Quick (fun () ->
             let message : Types.message =
               { role = Types.User
               ; content = [ Types.Text "hello" ]
@@ -1459,7 +1500,7 @@ let () =
               "duplicate content field"
               true
               (Result.is_error (Checkpoint.of_json bad)))
-        ; test_case "current v9 rejects unknown nested tool field" `Quick (fun () ->
+        ; test_case "current v10 rejects unknown nested tool field" `Quick (fun () ->
             let bad =
               make_checkpoint ~tools:[ sample_tool_schema ] ()
               |> Checkpoint.to_json
@@ -1472,7 +1513,7 @@ let () =
               "unknown tool field"
               true
               (Result.is_error (Checkpoint.of_json bad)))
-        ; test_case "current v9 rejects noncanonical response format" `Quick (fun () ->
+        ; test_case "current v10 rejects noncanonical response format" `Quick (fun () ->
             let bad =
               make_checkpoint ()
               |> Checkpoint.to_json
@@ -1483,7 +1524,7 @@ let () =
               "legacy response format"
               true
               (Result.is_error (Checkpoint.of_json bad)))
-        ; test_case "current v9 rejects malformed nested MCP headers" `Quick (fun () ->
+        ; test_case "current v10 rejects malformed nested MCP headers" `Quick (fun () ->
             let session : Mcp_session.info =
               { server_name = "http-tools"
               ; command = "http"
@@ -1503,7 +1544,7 @@ let () =
                    (update_first_json (replace_json_field "http_headers" (`Assoc [])))
             in
             check bool "malformed headers" true (Result.is_error (Checkpoint.of_json bad)))
-        ; test_case "current v9 rejects duplicate context keys" `Quick (fun () ->
+        ; test_case "current v10 rejects duplicate context keys" `Quick (fun () ->
             let bad =
               make_checkpoint ()
               |> Checkpoint.to_json
@@ -1512,7 +1553,7 @@ let () =
                    (`Assoc [ "channel", `String "one"; "channel", `String "two" ])
             in
             check bool "duplicate context" true (Result.is_error (Checkpoint.of_json bad)))
-        ; test_case "current v9 rejects normalized reasoning effort" `Quick (fun () ->
+        ; test_case "current v10 rejects normalized reasoning effort" `Quick (fun () ->
             let bad =
               make_checkpoint ()
               |> Checkpoint.to_json

--- a/test/test_checkpoint.ml
+++ b/test/test_checkpoint.ml
@@ -141,23 +141,22 @@ let checkpoint_json_with_tool_result ?(extra_fields = []) outcome =
 
 (* Helper: a sample tool_schema *)
 let sample_tool_schema : Types.tool_schema =
-  { name = "get_weather"
-  ; description = "Get weather for a city"
-  ; parameters =
-      [ { name = "city"
+  Types.tool_schema_of_params
+    ~name:"get_weather"
+    ~description:"Get weather for a city"
+    ~parameters:
+      [ { Types.name = "city"
         ; description = "City name"
         ; param_type = Types.String
         ; required = true
         }
-      ; { name = "units"
+      ; { Types.name = "units"
         ; description = "Temperature units"
         ; param_type = Types.String
         ; required = false
         }
       ]
-  ; strict = None
-  ; input_schema = None
-  }
+    ()
 ;;
 
 let sample_echo_tool =
@@ -758,12 +757,11 @@ let () =
                 ]
             in
             let tool : Types.tool_schema =
-              { name = "multi"
-              ; description = "test"
-              ; parameters = params
-              ; strict = None
-              ; input_schema = None
-              }
+              Types.tool_schema_of_params
+                ~name:"multi"
+                ~description:"test"
+                ~parameters:params
+                ()
             in
             let cp = make_checkpoint ~tools:[ tool ] () in
             let cp2 = Result.get_ok (Checkpoint.of_json (Checkpoint.to_json cp)) in

--- a/test/test_checkpoint_delta.ml
+++ b/test/test_checkpoint_delta.ml
@@ -75,7 +75,8 @@ let tool_param_gen =
 let tool_schema_gen =
   let open QCheck.Gen in
   map3
-    (fun name description parameters -> { name; description; parameters; strict = None })
+    (fun name description parameters ->
+       { name; description; parameters; strict = None; input_schema = None })
     small_string_gen
     small_string_gen
     (list_size (int_range 0 2) tool_param_gen)
@@ -229,6 +230,7 @@ let sample_tool_schema =
   ; parameters =
       [ { name = "key"; description = "Key"; param_type = String; required = true } ]
   ; strict = None
+  ; input_schema = None
   }
 ;;
 

--- a/test/test_checkpoint_delta.ml
+++ b/test/test_checkpoint_delta.ml
@@ -76,7 +76,7 @@ let tool_schema_gen =
   let open QCheck.Gen in
   map3
     (fun name description parameters ->
-       { name; description; parameters; strict = None; input_schema = None })
+       Types.tool_schema_of_params ~name ~description ~parameters ())
     small_string_gen
     small_string_gen
     (list_size (int_range 0 2) tool_param_gen)
@@ -225,13 +225,13 @@ let make_unit_checkpoint
 ;;
 
 let sample_tool_schema =
-  { name = "lookup"
-  ; description = "Lookup a value"
-  ; parameters =
-      [ { name = "key"; description = "Key"; param_type = String; required = true } ]
-  ; strict = None
-  ; input_schema = None
-  }
+  Types.tool_schema_of_params
+    ~name:"lookup"
+    ~description:"Lookup a value"
+    ~parameters:
+      [ { Types.name = "key"; description = "Key"; param_type = String; required = true }
+      ]
+    ()
 ;;
 
 let sample_mcp_session =

--- a/test/test_checkpoint_store.ml
+++ b/test/test_checkpoint_store.ml
@@ -51,6 +51,7 @@ let sample_tool_schema : Types.tool_schema =
         }
       ]
   ; strict = None
+  ; input_schema = None
   }
 ;;
 

--- a/test/test_checkpoint_store.ml
+++ b/test/test_checkpoint_store.ml
@@ -41,18 +41,17 @@ let make_checkpoint ?(session_id = "test-session") ?(created_at = 1000.0) ()
 ;;
 
 let sample_tool_schema : Types.tool_schema =
-  { name = "get_weather"
-  ; description = "Get weather"
-  ; parameters =
-      [ { name = "city"
+  Types.tool_schema_of_params
+    ~name:"get_weather"
+    ~description:"Get weather"
+    ~parameters:
+      [ { Types.name = "city"
         ; description = "City name"
         ; param_type = Types.String
         ; required = true
         }
       ]
-  ; strict = None
-  ; input_schema = None
-  }
+    ()
 ;;
 
 let create_ok dir =

--- a/test/test_full_pipeline_cov.ml
+++ b/test/test_full_pipeline_cov.ml
@@ -641,17 +641,20 @@ let test_context_tool () =
     in
     let url = start_multi ~sw ~net:env#net ~port:21020 responses in
     let tool =
-      Tool.create_with_context
-        ~name:"ctx_tool"
-        ~description:"Context tool"
-        ~parameters:
-          [ { name = "key"
-            ; param_type = Types.String
-            ; description = "k"
-            ; required = true
-            }
-          ]
-        (fun _ctx _input -> Ok { Types.content = "ctx_result"; _meta = None })
+      Tool.of_schema
+        (Types.tool_schema_of_params
+           ~name:"ctx_tool"
+           ~description:"Context tool"
+           ~parameters:
+             [ { name = "key"
+               ; param_type = Types.String
+               ; description = "k"
+               ; required = true
+               }
+             ]
+           ())
+        (Tool.requiring_context (fun _ctx _input ->
+           Ok { Types.content = "ctx_result"; _meta = None }))
     in
     let agent = make_agent ~net:env#net ~tools:[ tool ] url in
     match Agent.run ~sw agent "ctx" with

--- a/test/test_mcp.ml
+++ b/test/test_mcp.ml
@@ -121,7 +121,7 @@ let test_json_schema_no_description () =
   Alcotest.check check_param_type "bool type" Types.Boolean (List.hd params).param_type
 ;;
 
-let test_json_schema_missing_property_type_fails () =
+let test_json_schema_missing_property_type_is_not_projected () =
   let schema =
     Yojson.Safe.from_string
       {|{
@@ -132,8 +132,9 @@ let test_json_schema_missing_property_type_fails () =
   }|}
   in
   match Mcp.json_schema_to_params_result schema with
-  | Error _ -> ()
-  | Ok _ -> Alcotest.fail "expected missing property type to fail"
+  | Error detail -> Alcotest.failf "valid untyped property rejected: %s" detail
+  | Ok params ->
+    Alcotest.(check int) "unprojectable property omitted" 0 (List.length params)
 ;;
 
 let test_json_schema_nullable_union_uses_concrete_type () =
@@ -167,7 +168,7 @@ let test_json_schema_union_unknown_type_fails () =
   | Ok _ -> Alcotest.fail "expected unknown union type to fail"
 ;;
 
-let test_json_schema_union_null_only_fails () =
+let test_json_schema_union_null_only_is_not_projected () =
   let schema =
     Yojson.Safe.from_string
       {|{
@@ -178,11 +179,11 @@ let test_json_schema_union_null_only_fails () =
   }|}
   in
   match Mcp.json_schema_to_params_result schema with
-  | Error _ -> ()
-  | Ok _ -> Alcotest.fail "expected null-only union type to fail"
+  | Error detail -> Alcotest.failf "valid null-only property rejected: %s" detail
+  | Ok params -> Alcotest.(check int) "null-only property omitted" 0 (List.length params)
 ;;
 
-let test_json_schema_union_multiple_concrete_types_fails () =
+let test_json_schema_union_multiple_concrete_types_is_not_projected () =
   let schema =
     Yojson.Safe.from_string
       {|{
@@ -193,8 +194,8 @@ let test_json_schema_union_multiple_concrete_types_fails () =
   }|}
   in
   match Mcp.json_schema_to_params_result schema with
-  | Error _ -> ()
-  | Ok _ -> Alcotest.fail "expected multi-concrete union type to fail"
+  | Error detail -> Alcotest.failf "valid multi-type property rejected: %s" detail
+  | Ok params -> Alcotest.(check int) "multi-type property omitted" 0 (List.length params)
 ;;
 
 (* ── Tool bridge ────────────────────────────────────────────────── *)
@@ -421,9 +422,9 @@ let () =
         ; test_case "no required" `Quick test_json_schema_no_required
         ; test_case "no description" `Quick test_json_schema_no_description
         ; test_case
-            "missing property type fails"
+            "missing property type is not projected"
             `Quick
-            test_json_schema_missing_property_type_fails
+            test_json_schema_missing_property_type_is_not_projected
         ; test_case
             "nullable union uses concrete type"
             `Quick
@@ -432,11 +433,14 @@ let () =
             "union unknown type fails"
             `Quick
             test_json_schema_union_unknown_type_fails
-        ; test_case "union null-only fails" `Quick test_json_schema_union_null_only_fails
         ; test_case
-            "union multiple concrete types fails"
+            "union null-only is not projected"
             `Quick
-            test_json_schema_union_multiple_concrete_types_fails
+            test_json_schema_union_null_only_is_not_projected
+        ; test_case
+            "union multiple concrete types is not projected"
+            `Quick
+            test_json_schema_union_multiple_concrete_types_is_not_projected
         ] )
     ; ( "tool_bridge"
       , [ test_case "mcp_tool_to_sdk_tool" `Quick test_mcp_tool_to_sdk_tool

--- a/test/test_mcp.ml
+++ b/test/test_mcp.ml
@@ -198,6 +198,23 @@ let test_json_schema_union_multiple_concrete_types_is_not_projected () =
   | Ok params -> Alcotest.(check int) "multi-type property omitted" 0 (List.length params)
 ;;
 
+let test_json_schema_integer_number_union_uses_number () =
+  let schema =
+    Yojson.Safe.from_string
+      {|{
+    "type": "object",
+    "properties": {"value": {"type": ["integer", "number"]}},
+    "required": ["value"]
+  }|}
+  in
+  match Mcp.json_schema_to_params_result schema with
+  | Error detail -> Alcotest.failf "representable numeric union rejected: %s" detail
+  | Ok [ param ] ->
+    Alcotest.check check_param_type "integer plus number" Types.Number param.param_type
+  | Ok params ->
+    Alcotest.failf "expected one projected parameter, got %d" (List.length params)
+;;
+
 (* ── Tool bridge ────────────────────────────────────────────────── *)
 
 let test_mcp_tool_to_sdk_tool () =
@@ -441,6 +458,10 @@ let () =
             "union multiple concrete types is not projected"
             `Quick
             test_json_schema_union_multiple_concrete_types_is_not_projected
+        ; test_case
+            "integer-number union uses number"
+            `Quick
+            test_json_schema_integer_number_union_uses_number
         ] )
     ; ( "tool_bridge"
       , [ test_case "mcp_tool_to_sdk_tool" `Quick test_mcp_tool_to_sdk_tool

--- a/test/test_mcp.ml
+++ b/test/test_mcp.ml
@@ -215,6 +215,47 @@ let test_json_schema_integer_number_union_uses_number () =
     Alcotest.failf "expected one projected parameter, got %d" (List.length params)
 ;;
 
+(* The [enum] route reaches the same decision as the [type] array above. It once
+   carried its own copy of the rule without the numeric pair, so a mixed numeric
+   enum dropped the property and took its description and required flag with
+   it — the parameter view lost a parameter the schema declares. *)
+let test_json_schema_mixed_numeric_enum_uses_number () =
+  let schema =
+    Yojson.Safe.from_string
+      {|{
+    "type": "object",
+    "properties": {
+      "ratio": {"enum": [1, 2.5], "description": "Sampling ratio"}
+    },
+    "required": ["ratio"]
+  }|}
+  in
+  match Mcp.json_schema_to_params_result schema with
+  | Error detail -> Alcotest.failf "representable numeric enum rejected: %s" detail
+  | Ok [ param ] ->
+    Alcotest.check check_param_type "integer plus number" Types.Number param.param_type;
+    Alcotest.(check string) "name kept" "ratio" param.name;
+    Alcotest.(check string) "description kept" "Sampling ratio" param.description;
+    Alcotest.(check bool) "required kept" true param.required
+  | Ok params ->
+    Alcotest.failf "expected one projected parameter, got %d" (List.length params)
+;;
+
+(* Boundary for the rule above: narrowing applies to the numeric pair only, so
+   an enum spanning unrelated JSON types stays unrepresentable. *)
+let test_json_schema_heterogeneous_enum_omits_property () =
+  let schema =
+    Yojson.Safe.from_string
+      {|{
+    "type": "object",
+    "properties": {"mixed": {"enum": [1, "a"]}}
+  }|}
+  in
+  match Mcp.json_schema_to_params_result schema with
+  | Error detail -> Alcotest.failf "heterogeneous enum rejected: %s" detail
+  | Ok params -> Alcotest.(check int) "heterogeneous enum omitted" 0 (List.length params)
+;;
+
 (* ── Tool bridge ────────────────────────────────────────────────── *)
 
 let test_mcp_tool_to_sdk_tool () =
@@ -462,6 +503,14 @@ let () =
             "integer-number union uses number"
             `Quick
             test_json_schema_integer_number_union_uses_number
+        ; test_case
+            "mixed numeric enum uses number"
+            `Quick
+            test_json_schema_mixed_numeric_enum_uses_number
+        ; test_case
+            "heterogeneous enum omits property"
+            `Quick
+            test_json_schema_heterogeneous_enum_omits_property
         ] )
     ; ( "tool_bridge"
       , [ test_case "mcp_tool_to_sdk_tool" `Quick test_mcp_tool_to_sdk_tool

--- a/test/test_mcp_session.ml
+++ b/test/test_mcp_session.ml
@@ -11,6 +11,7 @@ let sample_tool_schema : Types.tool_schema =
         }
       ]
   ; strict = None
+  ; input_schema = None
   }
 ;;
 
@@ -35,6 +36,7 @@ let multi_param_tool : Types.tool_schema =
         }
       ]
   ; strict = None
+  ; input_schema = None
   }
 ;;
 
@@ -346,6 +348,7 @@ let () =
                     }
                   ]
               ; strict = None
+              ; input_schema = None
               }
             in
             let info = make_info ~tool_schemas:[ all_types_tool ] () in

--- a/test/test_mcp_session.ml
+++ b/test/test_mcp_session.ml
@@ -1,43 +1,41 @@
 open Agent_sdk
 
 let sample_tool_schema : Types.tool_schema =
-  { name = "get_weather"
-  ; description = "Get weather for a city"
-  ; parameters =
-      [ { name = "city"
+  Types.tool_schema_of_params
+    ~name:"get_weather"
+    ~description:"Get weather for a city"
+    ~parameters:
+      [ { Types.name = "city"
         ; description = "City name"
         ; param_type = Types.String
         ; required = true
         }
       ]
-  ; strict = None
-  ; input_schema = None
-  }
+    ()
 ;;
 
 let multi_param_tool : Types.tool_schema =
-  { name = "search"
-  ; description = "Search documents"
-  ; parameters =
-      [ { name = "query"
+  Types.tool_schema_of_params
+    ~name:"search"
+    ~description:"Search documents"
+    ~parameters:
+      [ { Types.name = "query"
         ; description = "Search query"
         ; param_type = Types.String
         ; required = true
         }
-      ; { name = "limit"
+      ; { Types.name = "limit"
         ; description = "Max results"
         ; param_type = Types.Integer
         ; required = false
         }
-      ; { name = "filters"
+      ; { Types.name = "filters"
         ; description = "Filter object"
         ; param_type = Types.Object
         ; required = false
         }
       ]
-  ; strict = None
-  ; input_schema = None
-  }
+    ()
 ;;
 
 let make_info
@@ -313,10 +311,11 @@ let () =
               info2.env)
         ; test_case "all param types roundtrip" `Quick (fun () ->
             let all_types_tool : Types.tool_schema =
-              { name = "all_types"
-              ; description = "All param types"
-              ; parameters =
-                  [ { name = "s"
+              Types.tool_schema_of_params
+                ~name:"all_types"
+                ~description:"All param types"
+                ~parameters:
+                  [ { Types.name = "s"
                     ; description = ""
                     ; param_type = Types.String
                     ; required = true
@@ -341,15 +340,13 @@ let () =
                     ; param_type = Types.Array
                     ; required = false
                     }
-                  ; { name = "o"
+                  ; { Types.name = "o"
                     ; description = ""
                     ; param_type = Types.Object
                     ; required = false
                     }
                   ]
-              ; strict = None
-              ; input_schema = None
-              }
+                ()
             in
             let info = make_info ~tool_schemas:[ all_types_tool ] () in
             let json = Mcp_session.info_to_json info in

--- a/test/test_pipeline.ml
+++ b/test/test_pipeline.ml
@@ -438,10 +438,12 @@ let test_provider_turn_identity_is_shared_across_multiturn_tool_loop () =
     }
   in
   let tool =
-    Tool.create_with_execution_env
-      ~name:"identity_tool"
-      ~description:"observe the canonical provider turn"
-      ~parameters:[]
+    Tool.of_schema
+      (Types.tool_schema_of_params
+         ~name:"identity_tool"
+         ~description:"observe the canonical provider turn"
+         ~parameters:[]
+         ())
       (fun execution_env _input ->
          (match Tool.Execution_env.invocation execution_env with
           | None -> Alcotest.fail "tool handler received no invocation"

--- a/test/test_session_resume.ml
+++ b/test/test_session_resume.ml
@@ -89,18 +89,17 @@ let sample_usage : Types.usage_stats =
 ;;
 
 let sample_tool_schema : Types.tool_schema =
-  { name = "get_weather"
-  ; description = "Get weather for a location"
-  ; parameters =
+  Types.tool_schema_of_params
+    ~name:"get_weather"
+    ~description:"Get weather for a location"
+    ~parameters:
       [ { Types.name = "location"
         ; description = "City name"
         ; param_type = Types.String
         ; required = true
         }
       ]
-  ; strict = None
-  ; input_schema = None
-  }
+    ()
 ;;
 
 (* ── Session.resume_from tests ───────────────────────────────── *)

--- a/test/test_session_resume.ml
+++ b/test/test_session_resume.ml
@@ -99,6 +99,7 @@ let sample_tool_schema : Types.tool_schema =
         }
       ]
   ; strict = None
+  ; input_schema = None
   }
 ;;
 

--- a/test/test_tool.ml
+++ b/test/test_tool.ml
@@ -39,16 +39,18 @@ let test_simple_handler_error () =
 
 let test_context_handler_receives_context () =
   let tool =
-    Tool.create_with_context
-      ~name:"stateful"
-      ~description:"Read from context"
-      ~parameters:[]
-      (fun ctx _input ->
+    Tool.of_schema
+      (Types.tool_schema_of_params
+         ~name:"stateful"
+         ~description:"Read from context"
+         ~parameters:[]
+         ())
+      (Tool.requiring_context (fun ctx _input ->
          match Context.get ctx "key" with
          | Some (`String v) -> Ok { Types.content = v; _meta = None }
          | _ ->
            Error
-             { Types.message = "key not found"; recoverable = true; error_class = None })
+             { Types.message = "key not found"; recoverable = true; error_class = None }))
   in
   let ctx = Context.create_sync () in
   Context.set ctx "key" (`String "ctx_value");
@@ -60,13 +62,15 @@ let test_context_handler_receives_context () =
 
 let test_context_handler_writes_context () =
   let tool =
-    Tool.create_with_context
-      ~name:"writer"
-      ~description:"Write to context"
-      ~parameters:[]
-      (fun ctx _input ->
+    Tool.of_schema
+      (Types.tool_schema_of_params
+         ~name:"writer"
+         ~description:"Write to context"
+         ~parameters:[]
+         ())
+      (Tool.requiring_context (fun ctx _input ->
          Context.set ctx "written" (`Int 42);
-         Ok { Types.content = "done"; _meta = None })
+         Ok { Types.content = "done"; _meta = None }))
   in
   let ctx = Context.create_sync () in
   let _result = Tool.execute ~context:ctx tool `Null in
@@ -75,11 +79,14 @@ let test_context_handler_writes_context () =
 
 let test_context_handler_requires_context () =
   let tool =
-    Tool.create_with_context
-      ~name:"noctx"
-      ~description:"No explicit context"
-      ~parameters:[]
-      (fun _ctx _input -> Ok { Types.content = "works"; _meta = None })
+    Tool.of_schema
+      (Types.tool_schema_of_params
+         ~name:"noctx"
+         ~description:"No explicit context"
+         ~parameters:[]
+         ())
+      (Tool.requiring_context (fun _ctx _input ->
+         Ok { Types.content = "works"; _meta = None }))
   in
   let actual = Tool.execute tool `Null in
   match actual with
@@ -106,10 +113,12 @@ let missing_invocation_error () =
 
 let test_execution_env_handler_receives_context_and_invocation () =
   let tool =
-    Tool.create_with_execution_env
-      ~name:"execution_env"
-      ~description:"Read context and invocation"
-      ~parameters:[]
+    Tool.of_schema
+      (Types.tool_schema_of_params
+         ~name:"execution_env"
+         ~description:"Read context and invocation"
+         ~parameters:[]
+         ())
       (fun execution_env _input ->
          match
            ( Tool.Execution_env.context execution_env
@@ -161,10 +170,12 @@ let test_execution_env_handler_receives_context_and_invocation () =
 
 let test_execution_env_handler_observes_missing_invocation () =
   let tool =
-    Tool.create_with_execution_env
-      ~name:"execution_env"
-      ~description:"Read invocation"
-      ~parameters:[]
+    Tool.of_schema
+      (Types.tool_schema_of_params
+         ~name:"execution_env"
+         ~description:"Read invocation"
+         ~parameters:[]
+         ())
       (fun execution_env _input ->
          match Tool.Execution_env.invocation execution_env with
          | Some _ -> Ok { Types.content = "unexpected"; _meta = None }
@@ -449,16 +460,18 @@ let () =
             | Error _ -> fail "expected Ok")
         ; test_case "works with context handler" `Quick (fun () ->
             let tool =
-              Tool.create_with_context
-                ~name:"ctx_greet"
-                ~description:"Greet with context"
-                ~parameters:[]
-                (fun _ctx input ->
+              Tool.of_schema
+                (Types.tool_schema_of_params
+                   ~name:"ctx_greet"
+                   ~description:"Greet with context"
+                   ~parameters:[]
+                   ())
+                (Tool.requiring_context (fun _ctx input ->
                    let open Yojson.Safe.Util in
                    Ok
                      { Types.content = input |> member "agent" |> to_string
                      ; _meta = None
-                     })
+                     }))
             in
             let wrapped = Tool.with_defaults [ "agent", `String "worker-1" ] tool in
             let ctx = Context.create_sync () in
@@ -468,10 +481,12 @@ let () =
             | Error _ -> fail "expected Ok")
         ; test_case "works with execution environment handler" `Quick (fun () ->
             let tool =
-              Tool.create_with_execution_env
-                ~name:"execution_env_greet"
-                ~description:"Greet from execution environment"
-                ~parameters:[]
+              Tool.of_schema
+                (Types.tool_schema_of_params
+                   ~name:"execution_env_greet"
+                   ~description:"Greet from execution environment"
+                   ~parameters:[]
+                   ())
                 (fun execution_env input ->
                    let open Yojson.Safe.Util in
                    match Tool.Execution_env.invocation execution_env with

--- a/test/test_tool_execution.ml
+++ b/test/test_tool_execution.ml
@@ -1000,11 +1000,13 @@ let test_serial_barrier_splits_concurrent_batches () =
 
 let test_dispatch_passes_exact_tool_invocation () =
   let tool =
-    Tool.create_with_execution_env
+    Tool.of_schema
       ~descriptor:(descriptor_with Tool_contract.Concurrent)
-      ~name:"observe_invocation"
-      ~description:"Return exact invocation identity"
-      ~parameters:[]
+      (Types.tool_schema_of_params
+         ~name:"observe_invocation"
+         ~description:"Return exact invocation identity"
+         ~parameters:[]
+         ())
       (fun execution_env _ ->
          match Tool.Execution_env.invocation execution_env with
          | Some invocation ->
@@ -1108,10 +1110,8 @@ let test_lifecycle_surfaces_share_exact_tool_invocation () =
   in
   let subscription = Event_bus.subscribe ~config event_bus in
   let tool name result =
-    Tool.create_with_execution_env
-      ~name
-      ~description:""
-      ~parameters:[]
+    Tool.of_schema
+      (Types.tool_schema_of_params ~name ~description:"" ~parameters:[] ())
       (fun execution_env _ ->
          Option.iter
            (capture handler_invocations)

--- a/test/test_tool_input_schema_fidelity.ml
+++ b/test/test_tool_input_schema_fidelity.ml
@@ -160,20 +160,43 @@ let test_derived_schema_unchanged_without_input_schema () =
 
 (* ── parameters / input_schema invariant ──────────────────── *)
 
+let tool_param = testable Types.pp_tool_param ( = )
+
+(* Written out rather than computed as [Mcp.json_schema_to_params
+   rich_input_schema]. That projection is what the constructors run, so calling
+   it here would put it on both sides and cancel out any regression inside it —
+   a defect that drops every property description passes that way. These
+   literals are the projection of [rich_input_schema] read off by hand. *)
+let rich_schema_parameters =
+  [ { Types.name = "max_bytes"
+    ; description = "Maximum bytes to read"
+    ; param_type = Types.Integer
+    ; required = true
+    }
+  ; { Types.name = "cursor"
+    ; description = "Where to read from"
+    ; param_type = Types.String
+    ; required = false
+    }
+  ; { Types.name = "window"
+    ; description = "Nested window bounds"
+    ; param_type = Types.Object
+    ; required = false
+    }
+  ]
+;;
+
 let check_parameters_derived_from_schema label (schema : Types.tool_schema) =
   check
     (option json)
     (label ^ ": authoritative schema kept")
     (Some rich_input_schema)
     schema.input_schema;
-  match schema.input_schema with
-  | None -> failf "%s: expected an authoritative schema" label
-  | Some source ->
-    check
-      bool
-      (label ^ ": parameters equal json_schema_to_params input_schema")
-      true
-      (schema.parameters = Mcp.json_schema_to_params source)
+  check
+    (list tool_param)
+    (label ^ ": parameters are the projection of the schema")
+    rich_schema_parameters
+    schema.parameters
 ;;
 
 let test_tool_parameters_are_derived_from_the_schema () =
@@ -315,6 +338,123 @@ let test_tool_schema_json_roundtrip () =
   check_derived_roundtrip "derived with input_schema" with_schema
 ;;
 
+(* ── schema source × handler kind ─────────────────────────── *)
+
+(* The tool that produced the incident is built with an execution-environment
+   handler, and until [of_schema] existed the authoritative source was only
+   reachable from the plain-handler constructor. This pins the combination
+   itself: the schema must arrive verbatim AND the handler must still receive
+   its execution environment. *)
+let test_authoritative_schema_rides_an_execution_env_handler () =
+  let seen_invocation = ref None in
+  let handler execution_env _input =
+    seen_invocation := Tool.Execution_env.invocation execution_env;
+    Ok { Types.content = "ok"; _meta = None }
+  in
+  let tool =
+    match
+      Types.tool_schema_of_input_schema
+        ~name:"read_file"
+        ~description:"Read a file"
+        ~input_schema:rich_input_schema
+        ()
+    with
+    | Error detail -> failf "tool_schema_of_input_schema: %s" detail
+    | Ok schema -> Tool.of_schema schema handler
+  in
+  check
+    json
+    "authoritative schema survives the execution-env handler"
+    rich_input_schema
+    (Tool.schema_to_json tool |> member "input_schema");
+  check
+    (list tool_param)
+    "parameters still the projection"
+    rich_schema_parameters
+    tool.schema.parameters;
+  let invocation =
+    Tool_contract.Invocation.create
+      ~tool_use_id:"call-1"
+      ~turn:0
+      ~schedule:
+        { planned_index = 0
+        ; batch_index = 0
+        ; batch_size = 1
+        ; execution_mode = Tool_contract.Serial
+        }
+      ~completion:Tool_contract.Continue_after_success
+  in
+  let (_ : Types.tool_result) = Tool.execute ~invocation tool `Null in
+  check
+    (option string)
+    "handler received its execution environment"
+    (Some "call-1")
+    (Option.map Tool_contract.Invocation.tool_use_id !seen_invocation)
+;;
+
+let test_context_handler_still_refuses_a_missing_context () =
+  let tool =
+    Tool.of_schema
+      (Types.tool_schema_of_params
+         ~name:"ctx"
+         ~description:"Needs context"
+         ~parameters:[]
+         ())
+      (Tool.requiring_context (fun _context _input ->
+         Ok { Types.content = "unexpected"; _meta = None }))
+  in
+  match Tool.execute tool `Null with
+  | Ok _ -> fail "expected the missing context to be refused"
+  | Error { message; recoverable; _ } ->
+    check
+      string
+      "names the missing context"
+      "context-aware tool requires explicit context"
+      message;
+    check bool "not recoverable" false recoverable
+;;
+
+(* A tool_schema written by a released version carries no "input_schema" key at
+   all. ppx_deriving_yojson does not default an option field on its own, so
+   without [@default None] the derived decoder rejects every such payload and
+   Agent_card.of_json fails on any peer card that contains a tool. *)
+let test_released_payload_without_the_key_decodes () =
+  let legacy : Yojson.Safe.t =
+    `Assoc
+      [ "name", `String "read_file"
+      ; "description", `String "Read a file"
+      ; ( "parameters"
+        , `List
+            [ `Assoc
+                [ "name", `String "path"
+                ; "description", `String "Path"
+                ; "param_type", `List [ `String "String" ]
+                ; "required", `Bool true
+                ]
+            ] )
+      ; "strict", `Null
+      ]
+  in
+  match Types.tool_schema_of_yojson legacy with
+  | Error detail -> failf "released payload rejected: %s" detail
+  | Ok schema ->
+    check
+      (option json)
+      "absent key means no authoritative schema"
+      None
+      schema.input_schema;
+    check
+      (list tool_param)
+      "parameters decoded"
+      [ { Types.name = "path"
+        ; description = "Path"
+        ; param_type = Types.String
+        ; required = true
+        }
+      ]
+      schema.parameters
+;;
+
 let () =
   run
     "tool_input_schema_fidelity"
@@ -323,6 +463,18 @@ let () =
             "authoritative schema reaches the wire"
             `Quick
             test_authoritative_schema_reaches_the_wire
+        ; test_case
+            "authoritative schema rides an execution-env handler"
+            `Quick
+            test_authoritative_schema_rides_an_execution_env_handler
+        ; test_case
+            "context handler still refuses a missing context"
+            `Quick
+            test_context_handler_still_refuses_a_missing_context
+        ; test_case
+            "released payload without the input_schema key decodes"
+            `Quick
+            test_released_payload_without_the_key_decodes
         ; test_case
             "derived schema unchanged without input_schema"
             `Quick

--- a/test/test_tool_input_schema_fidelity.ml
+++ b/test/test_tool_input_schema_fidelity.ml
@@ -336,6 +336,54 @@ let test_nullable_property_validation_uses_authoritative_schema () =
   | Tool_input_validation.Valid _ -> fail "nullable string accepted an integer"
 ;;
 
+let test_const_and_enum_validation_use_json_semantics () =
+  let schema =
+    authoritative_schema_exn
+      (`Assoc
+          [ "type", `String "object"
+          ; ( "properties"
+            , `Assoc
+                [ ( "fixed"
+                  , `Assoc
+                      [ ( "const"
+                        , `Assoc
+                            [ "first", `Int 1
+                            ; "nested", `List [ `Float 2.0; `Intlit "300" ]
+                            ] )
+                      ] )
+                ; ( "choice"
+                  , `Assoc
+                      [ ( "enum"
+                        , `List [ `Assoc [ "enabled", `Bool true; "count", `Intlit "4" ] ]
+                        )
+                      ] )
+                ] )
+          ; "required", `List [ `String "fixed"; `String "choice" ]
+          ])
+  in
+  let reordered_equivalent =
+    `Assoc
+      [ "fixed", `Assoc [ "nested", `List [ `Int 2; `Float 300.0 ]; "first", `Float 1.0 ]
+      ; "choice", `Assoc [ "count", `Float 4.0; "enabled", `Bool true ]
+      ]
+  in
+  (match Tool_input_validation.validate schema reordered_equivalent with
+   | Tool_input_validation.Valid exact ->
+     check json "equivalent JSON accepted unchanged" reordered_equivalent exact
+   | Tool_input_validation.Invalid _ ->
+     fail "object key order or equivalent JSON numbers changed const/enum meaning");
+  match
+    Tool_input_validation.validate
+      schema
+      (`Assoc
+          [ "fixed", `Assoc [ "first", `Int 1; "nested", `List [ `Int 2; `Int 301 ] ]
+          ; "choice", `Assoc [ "enabled", `Bool true; "count", `Int 4 ]
+          ])
+  with
+  | Tool_input_validation.Invalid _ -> ()
+  | Tool_input_validation.Valid _ -> fail "a numerically different const was accepted"
+;;
+
 let test_explicit_non_object_root_schema_is_rejected () =
   let input_schema : Yojson.Safe.t =
     `Assoc [ "type", `String "array"; "items", `Assoc [ "type", `String "string" ] ]
@@ -613,6 +661,10 @@ let () =
             "nullable validation uses the authoritative schema"
             `Quick
             test_nullable_property_validation_uses_authoritative_schema
+        ; test_case
+            "const and enum use JSON semantic equality"
+            `Quick
+            test_const_and_enum_validation_use_json_semantics
         ; test_case
             "explicit non-object root schema is rejected"
             `Quick

--- a/test/test_tool_input_schema_fidelity.ml
+++ b/test/test_tool_input_schema_fidelity.ml
@@ -336,6 +336,46 @@ let test_nullable_property_validation_uses_authoritative_schema () =
   | Tool_input_validation.Valid _ -> fail "nullable string accepted an integer"
 ;;
 
+let test_integer_validation_accepts_integral_floats () =
+  let schema =
+    authoritative_schema_exn
+      (`Assoc
+          [ "type", `String "object"
+          ; "properties", `Assoc [ "count", `Assoc [ "type", `String "integer" ] ]
+          ; "required", `List [ `String "count" ]
+          ])
+  in
+  (match Tool_input_validation.validate schema (`Assoc [ "count", `Float 1.0 ]) with
+   | Tool_input_validation.Valid _ -> ()
+   | Tool_input_validation.Invalid _ -> fail "JSON Schema integer rejected 1.0");
+  match Tool_input_validation.validate schema (`Assoc [ "count", `Float 1.5 ]) with
+  | Tool_input_validation.Invalid _ -> ()
+  | Tool_input_validation.Valid _ -> fail "JSON Schema integer accepted 1.5"
+;;
+
+let test_boolean_property_schemas_are_preserved_and_enforced () =
+  let input_schema : Yojson.Safe.t =
+    `Assoc
+      [ "type", `String "object"
+      ; "properties", `Assoc [ "open_value", `Bool true; "closed_value", `Bool false ]
+      ; "required", `List [ `String "open_value" ]
+      ]
+  in
+  let schema = authoritative_schema_exn input_schema in
+  check (option json) "boolean schemas preserved" (Some input_schema) schema.input_schema;
+  check int "boolean schemas omitted from projection" 0 (List.length schema.parameters);
+  (match Tool_input_validation.validate schema (`Assoc [ "open_value", `List [] ]) with
+   | Tool_input_validation.Valid _ -> ()
+   | Tool_input_validation.Invalid _ -> fail "true property schema rejected a value");
+  match
+    Tool_input_validation.validate
+      schema
+      (`Assoc [ "open_value", `Null; "closed_value", `String "forbidden" ])
+  with
+  | Tool_input_validation.Invalid _ -> ()
+  | Tool_input_validation.Valid _ -> fail "false property schema accepted a value"
+;;
+
 let test_const_and_enum_validation_use_json_semantics () =
   let schema =
     authoritative_schema_exn
@@ -402,6 +442,40 @@ let test_explicit_non_object_root_schema_is_rejected () =
       true
       (Util.contains_substring_ci ~haystack:detail ~needle:"object")
   | Ok _ -> fail "an explicitly array-valued tool input schema was accepted"
+;;
+
+let test_non_object_only_root_constraints_are_rejected () =
+  let expect_rejected label input_schema =
+    match
+      Types.tool_schema_of_input_schema
+        ~name:"non_object_arguments"
+        ~description:label
+        ~input_schema
+        ()
+    with
+    | Error _ -> ()
+    | Ok _ -> failf "%s: non-object-only schema was accepted" label
+  in
+  expect_rejected "array const" (`Assoc [ "const", `List [] ]);
+  expect_rejected
+    "array-only anyOf"
+    (`Assoc [ "anyOf", `List [ `Assoc [ "type", `String "array" ] ] ]);
+  match
+    Types.tool_schema_of_input_schema
+      ~name:"object_or_array_arguments"
+      ~description:"Object remains possible"
+      ~input_schema:
+        (`Assoc
+            [ ( "anyOf"
+              , `List
+                  [ `Assoc [ "type", `String "array" ]
+                  ; `Assoc [ "type", `String "object" ]
+                  ] )
+            ])
+      ()
+  with
+  | Ok _ -> ()
+  | Error detail -> failf "mixed anyOf incorrectly excluded objects: %s" detail
 ;;
 
 (* [Types.tool_schema] is [private], so there is no expression that pairs a
@@ -662,6 +736,14 @@ let () =
             `Quick
             test_nullable_property_validation_uses_authoritative_schema
         ; test_case
+            "integer validation accepts integral floats"
+            `Quick
+            test_integer_validation_accepts_integral_floats
+        ; test_case
+            "boolean property schemas are preserved and enforced"
+            `Quick
+            test_boolean_property_schemas_are_preserved_and_enforced
+        ; test_case
             "const and enum use JSON semantic equality"
             `Quick
             test_const_and_enum_validation_use_json_semantics
@@ -669,6 +751,10 @@ let () =
             "explicit non-object root schema is rejected"
             `Quick
             test_explicit_non_object_root_schema_is_rejected
+        ; test_case
+            "non-object-only root constraints are rejected"
+            `Quick
+            test_non_object_only_root_constraints_are_rejected
         ; test_case
             "input_schema constructor derives its parameters"
             `Quick

--- a/test/test_tool_input_schema_fidelity.ml
+++ b/test/test_tool_input_schema_fidelity.ml
@@ -242,6 +242,120 @@ let test_invalid_schema_names_the_failing_property () =
        && Util.contains_substring_ci ~haystack:detail ~needle:"decimal")
 ;;
 
+let test_composed_properties_do_not_block_authoritative_schema () =
+  let input_schema : Yojson.Safe.t =
+    `Assoc
+      [ "type", `String "object"
+      ; ( "$defs"
+        , `Assoc
+            [ ( "location"
+              , `Assoc
+                  [ "type", `String "object"
+                  ; "properties", `Assoc [ "city", `Assoc [ "type", `String "string" ] ]
+                  ] )
+            ] )
+      ; ( "properties"
+        , `Assoc
+            [ "location", `Assoc [ "$ref", `String "#/$defs/location" ]
+            ; ( "label"
+              , `Assoc
+                  [ ( "anyOf"
+                    , `List
+                        [ `Assoc [ "type", `String "string" ]
+                        ; `Assoc [ "type", `String "null" ]
+                        ] )
+                  ] )
+            ; ( "choice"
+              , `Assoc
+                  [ ( "oneOf"
+                    , `List
+                        [ `Assoc [ "const", `String "left" ]
+                        ; `Assoc [ "const", `String "right" ]
+                        ] )
+                  ] )
+            ; "fixed", `Assoc [ "const", `String "current" ]
+            ; "mode", `Assoc [ "enum", `List [ `String "fast"; `String "safe" ] ]
+            ] )
+      ; "required", `List [ `String "location" ]
+      ]
+  in
+  match
+    Types.tool_schema_of_input_schema
+      ~name:"composed"
+      ~description:"Composed schema"
+      ~input_schema
+      ()
+  with
+  | Error detail -> failf "valid composed schema rejected: %s" detail
+  | Ok schema ->
+    check
+      (option json)
+      "authoritative schema preserved"
+      (Some input_schema)
+      schema.input_schema;
+    check
+      (list string)
+      "only inferable properties enter the lossy parameter view"
+      [ "fixed"; "mode" ]
+      (List.map (fun (param : Types.tool_param) -> param.name) schema.parameters)
+;;
+
+let authoritative_schema_exn input_schema =
+  match
+    Types.tool_schema_of_input_schema
+      ~name:"authoritative"
+      ~description:"Authoritative schema"
+      ~input_schema
+      ()
+  with
+  | Ok schema -> schema
+  | Error detail -> failf "authoritative schema rejected: %s" detail
+;;
+
+let test_nullable_property_validation_uses_authoritative_schema () =
+  let schema =
+    authoritative_schema_exn
+      (`Assoc
+          [ "type", `String "object"
+          ; ( "properties"
+            , `Assoc
+                [ "label", `Assoc [ "type", `List [ `String "string"; `String "null" ] ] ]
+            )
+          ; "required", `List [ `String "label" ]
+          ])
+  in
+  let expect_valid label input =
+    match Tool_input_validation.validate schema input with
+    | Tool_input_validation.Valid exact -> check json label input exact
+    | Tool_input_validation.Invalid _ -> failf "%s: expected valid" label
+  in
+  expect_valid "nullable accepts null" (`Assoc [ "label", `Null ]);
+  expect_valid "nullable accepts string" (`Assoc [ "label", `String "ready" ]);
+  match Tool_input_validation.validate schema (`Assoc [ "label", `Int 1 ]) with
+  | Tool_input_validation.Invalid _ -> ()
+  | Tool_input_validation.Valid _ -> fail "nullable string accepted an integer"
+;;
+
+let test_explicit_non_object_root_schema_is_rejected () =
+  let input_schema : Yojson.Safe.t =
+    `Assoc [ "type", `String "array"; "items", `Assoc [ "type", `String "string" ] ]
+  in
+  match
+    Types.tool_schema_of_input_schema
+      ~name:"array_arguments"
+      ~description:"Invalid tool argument root"
+      ~input_schema
+      ()
+  with
+  | Error detail ->
+    check
+      bool
+      "error names object root contract"
+      true
+      (Util.contains_substring_ci ~haystack:detail ~needle:"object")
+  | Ok _ -> fail "an explicitly array-valued tool input schema was accepted"
+;;
+
 (* [Types.tool_schema] is [private], so there is no expression that pairs a
    [Some schema] with a [parameters] list of the caller's choosing: the two
    constructors below are the only producers and each derives one view from
@@ -491,6 +605,18 @@ let () =
             "invalid schema names the failing property"
             `Quick
             test_invalid_schema_names_the_failing_property
+        ; test_case
+            "composed properties keep the authoritative schema"
+            `Quick
+            test_composed_properties_do_not_block_authoritative_schema
+        ; test_case
+            "nullable validation uses the authoritative schema"
+            `Quick
+            test_nullable_property_validation_uses_authoritative_schema
+        ; test_case
+            "explicit non-object root schema is rejected"
+            `Quick
+            test_explicit_non_object_root_schema_is_rejected
         ; test_case
             "input_schema constructor derives its parameters"
             `Quick

--- a/test/test_tool_input_schema_fidelity.ml
+++ b/test/test_tool_input_schema_fidelity.ml
@@ -414,12 +414,10 @@ let test_context_handler_still_refuses_a_missing_context () =
     check bool "not recoverable" false recoverable
 ;;
 
-(* A tool_schema written by a released version carries no "input_schema" key at
-   all. ppx_deriving_yojson does not default an option field on its own, so
-   without [@default None] the derived decoder rejects every such payload and
-   Agent_card.of_json fails on any peer card that contains a tool. *)
-let test_released_payload_without_the_key_decodes () =
-  let legacy : Yojson.Safe.t =
+(* [input_schema = None] is encoded by omitting the key. The derived decoder
+   must preserve that current parameter-derived schema representation. *)
+let test_payload_without_the_key_decodes () =
+  let payload : Yojson.Safe.t =
     `Assoc
       [ "name", `String "read_file"
       ; "description", `String "Read a file"
@@ -435,8 +433,8 @@ let test_released_payload_without_the_key_decodes () =
       ; "strict", `Null
       ]
   in
-  match Types.tool_schema_of_yojson legacy with
-  | Error detail -> failf "released payload rejected: %s" detail
+  match Types.tool_schema_of_yojson payload with
+  | Error detail -> failf "payload without input_schema rejected: %s" detail
   | Ok schema ->
     check
       (option json)
@@ -472,9 +470,9 @@ let () =
             `Quick
             test_context_handler_still_refuses_a_missing_context
         ; test_case
-            "released payload without the input_schema key decodes"
+            "payload without the input_schema key decodes"
             `Quick
-            test_released_payload_without_the_key_decodes
+            test_payload_without_the_key_decodes
         ; test_case
             "derived schema unchanged without input_schema"
             `Quick

--- a/test/test_tool_input_schema_fidelity.ml
+++ b/test/test_tool_input_schema_fidelity.ml
@@ -219,6 +219,42 @@ let test_invalid_schema_names_the_failing_property () =
        && Util.contains_substring_ci ~haystack:detail ~needle:"decimal")
 ;;
 
+(* [Types.tool_schema] is [private], so there is no expression that pairs a
+   [Some schema] with a [parameters] list of the caller's choosing: the two
+   constructors below are the only producers and each derives one view from
+   the other. That impossibility is enforced at compile time and cannot be
+   asserted at run time; what is asserted here is what the constructors
+   actually produce. *)
+
+let test_input_schema_constructor_derives_its_parameters () =
+  match
+    Types.tool_schema_of_input_schema
+      ~name:"read_file"
+      ~description:"Read a file"
+      ~input_schema:rich_input_schema
+      ()
+  with
+  | Error detail -> failf "tool_schema_of_input_schema: %s" detail
+  | Ok schema ->
+    check_parameters_derived_from_schema "Types.tool_schema_of_input_schema" schema
+;;
+
+let test_params_constructor_leaves_no_authoritative_schema () =
+  let parameters =
+    [ { Types.name = "expr"
+      ; description = "Expression"
+      ; param_type = Types.String
+      ; required = true
+      }
+    ]
+  in
+  let schema =
+    Types.tool_schema_of_params ~name:"calc" ~description:"Calculate" ~parameters ()
+  in
+  check (option json) "no authoritative schema" None schema.input_schema;
+  check bool "parameters kept verbatim" true (schema.parameters = parameters)
+;;
+
 (* ── tool_schema JSON round-trips ─────────────────────────── *)
 
 let sample_parameters =
@@ -244,14 +280,23 @@ let check_derived_roundtrip label (schema : Types.tool_schema) =
 
 let test_tool_schema_json_roundtrip () =
   let without =
-    { Types.name = "read_file"
-    ; description = "Read a file"
-    ; parameters = sample_parameters
-    ; strict = None
-    ; input_schema = None
-    }
+    Types.tool_schema_of_params
+      ~name:"read_file"
+      ~description:"Read a file"
+      ~parameters:sample_parameters
+      ()
   in
-  let with_schema = { without with Types.input_schema = Some rich_input_schema } in
+  let with_schema =
+    match
+      Types.tool_schema_of_input_schema
+        ~name:"read_file"
+        ~description:"Read a file"
+        ~input_schema:rich_input_schema
+        ()
+    with
+    | Ok schema -> schema
+    | Error detail -> failf "tool_schema_of_input_schema: %s" detail
+  in
   check
     bool
     "input_schema omitted when None"
@@ -268,13 +313,6 @@ let test_tool_schema_json_roundtrip () =
   check_manual_roundtrip "manual with input_schema" with_schema;
   check_derived_roundtrip "derived without input_schema" without;
   check_derived_roundtrip "derived with input_schema" with_schema
-;;
-
-let test_tool_schema_of_json_rejects_non_object () =
-  match Types.tool_schema_of_json (`List []) with
-  | Ok _ -> fail "expected a non-object tool_schema to be rejected"
-  | Error detail ->
-    check string "reports the shape" "tool_schema must be a JSON object" detail
 ;;
 
 let () =
@@ -303,13 +341,17 @@ let () =
             "invalid schema names the failing property"
             `Quick
             test_invalid_schema_names_the_failing_property
+        ; test_case
+            "input_schema constructor derives its parameters"
+            `Quick
+            test_input_schema_constructor_derives_its_parameters
+        ; test_case
+            "params constructor leaves no authoritative schema"
+            `Quick
+            test_params_constructor_leaves_no_authoritative_schema
         ] )
     ; ( "round-trip"
-      , [ test_case "tool_schema json round-trip" `Quick test_tool_schema_json_roundtrip
-        ; test_case
-            "tool_schema_of_json rejects non-object"
-            `Quick
-            test_tool_schema_of_json_rejects_non_object
-        ] )
+      , [ test_case "tool_schema json round-trip" `Quick test_tool_schema_json_roundtrip ]
+      )
     ]
 ;;

--- a/test/test_tool_input_schema_fidelity.ml
+++ b/test/test_tool_input_schema_fidelity.ml
@@ -1,0 +1,315 @@
+(** Regression tests for authoritative tool input schemas.
+
+    A caller-supplied JSON Schema used to be converted to [Types.tool_param
+    list] and then rebuilt by {!Types.params_to_input_schema}, which keeps only
+    type, description and required. Everything else — [minimum], [maximum],
+    [default], [enum], nested properties — was destroyed before the tool
+    definition reached the provider. These tests pin the authoritative schema
+    to the wire. *)
+
+open Alcotest
+open Agent_sdk
+
+(* The production case that surfaced the loss: a byte cap the model must stay
+   inside. Named so the expectations below cannot drift from the fixture. *)
+let max_bytes_minimum = 1
+let max_bytes_maximum = 65536
+let max_bytes_default = 65536
+let cursor_enum = [ "start"; "end" ]
+
+let rich_input_schema : Yojson.Safe.t =
+  `Assoc
+    [ "type", `String "object"
+    ; ( "properties"
+      , `Assoc
+          [ ( "max_bytes"
+            , `Assoc
+                [ "type", `String "integer"
+                ; "description", `String "Maximum bytes to read"
+                ; "minimum", `Int max_bytes_minimum
+                ; "maximum", `Int max_bytes_maximum
+                ; "default", `Int max_bytes_default
+                ] )
+          ; ( "cursor"
+            , `Assoc
+                [ "type", `String "string"
+                ; "description", `String "Where to read from"
+                ; "enum", `List (List.map (fun value -> `String value) cursor_enum)
+                ] )
+          ; ( "window"
+            , `Assoc
+                [ "type", `String "object"
+                ; "description", `String "Nested window bounds"
+                ; ( "properties"
+                  , `Assoc
+                      [ "offset", `Assoc [ "type", `String "integer" ]
+                      ; "length", `Assoc [ "type", `String "integer" ]
+                      ] )
+                ] )
+          ] )
+    ; "required", `List [ `String "max_bytes" ]
+    ]
+;;
+
+let noop_handler _input = Ok { Types.content = ""; _meta = None }
+
+let json =
+  testable
+    (fun formatter value ->
+       Format.pp_print_string formatter (Yojson.Safe.to_string value))
+    ( = )
+;;
+
+let tool_from_rich_schema () : Tool.t =
+  match
+    Mcp.tool_of_input_schema_result
+      ~name:"read_file"
+      ~description:"Read a file"
+      ~input_schema:rich_input_schema
+      noop_handler
+  with
+  | Ok tool -> tool
+  | Error detail -> failf "tool_of_input_schema_result: %s" detail
+;;
+
+let member name value = Yojson.Safe.Util.member name value
+
+(* ── Wire fidelity ────────────────────────────────────────── *)
+
+let test_authoritative_schema_reaches_the_wire () =
+  let tool = tool_from_rich_schema () in
+  let emitted = Tool.schema_to_json tool |> member "input_schema" in
+  check json "input_schema emitted verbatim" rich_input_schema emitted;
+  let properties = emitted |> member "properties" in
+  let max_bytes = properties |> member "max_bytes" in
+  check
+    int
+    "minimum survives"
+    max_bytes_minimum
+    (max_bytes |> member "minimum" |> Yojson.Safe.Util.to_int);
+  check
+    int
+    "maximum survives"
+    max_bytes_maximum
+    (max_bytes |> member "maximum" |> Yojson.Safe.Util.to_int);
+  check
+    int
+    "default survives"
+    max_bytes_default
+    (max_bytes |> member "default" |> Yojson.Safe.Util.to_int);
+  check
+    (list string)
+    "enum survives"
+    cursor_enum
+    (properties
+     |> member "cursor"
+     |> member "enum"
+     |> Yojson.Safe.Util.to_list
+     |> List.map Yojson.Safe.Util.to_string);
+  check
+    (list string)
+    "nested properties survive"
+    [ "length"; "offset" ]
+    (properties
+     |> member "window"
+     |> member "properties"
+     |> Yojson.Safe.Util.to_assoc
+     |> List.map fst
+     |> List.sort String.compare)
+;;
+
+let test_derived_schema_unchanged_without_input_schema () =
+  let parameters =
+    [ { Types.name = "expr"
+      ; description = "Expression"
+      ; param_type = Types.String
+      ; required = true
+      }
+    ; { Types.name = "precision"
+      ; description = "Decimal places"
+      ; param_type = Types.Integer
+      ; required = false
+      }
+    ]
+  in
+  let tool = Tool.create ~name:"calc" ~description:"Calculate" ~parameters noop_handler in
+  (* Pinned against a literal rather than against
+     [Types.params_to_input_schema parameters]. In the [None] branch
+     [schema_to_json] IS that function, so comparing the two puts the same
+     call on both sides of the check and any regression inside it cancels
+     out — dropping every parameter description passed that way. *)
+  check
+    json
+    "derived from parameters when no authoritative schema"
+    (`Assoc
+        [ "type", `String "object"
+        ; ( "properties"
+          , `Assoc
+              [ ( "expr"
+                , `Assoc [ "type", `String "string"; "description", `String "Expression" ]
+                )
+              ; ( "precision"
+                , `Assoc
+                    [ "type", `String "integer"; "description", `String "Decimal places" ]
+                )
+              ] )
+        ; "required", `List [ `String "expr" ]
+        ])
+    (Tool.schema_to_json tool |> member "input_schema")
+;;
+
+(* ── parameters / input_schema invariant ──────────────────── *)
+
+let check_parameters_derived_from_schema label (schema : Types.tool_schema) =
+  check
+    (option json)
+    (label ^ ": authoritative schema kept")
+    (Some rich_input_schema)
+    schema.input_schema;
+  match schema.input_schema with
+  | None -> failf "%s: expected an authoritative schema" label
+  | Some source ->
+    check
+      bool
+      (label ^ ": parameters equal json_schema_to_params input_schema")
+      true
+      (schema.parameters = Mcp.json_schema_to_params source)
+;;
+
+let test_tool_parameters_are_derived_from_the_schema () =
+  let tool = tool_from_rich_schema () in
+  check_parameters_derived_from_schema "Mcp.tool_of_input_schema_result" tool.schema
+;;
+
+let test_middleware_schema_keeps_its_source () =
+  match
+    Tool_middleware.tool_schema_of_json_result
+      ~name:"read_file"
+      ~description:"Read a file"
+      rich_input_schema
+  with
+  | Error detail -> failf "tool_schema_of_json_result: %s" detail
+  | Ok schema ->
+    check_parameters_derived_from_schema
+      "Tool_middleware.tool_schema_of_json_result"
+      schema
+;;
+
+let test_invalid_schema_names_the_failing_property () =
+  let unsupported_type_schema : Yojson.Safe.t =
+    `Assoc
+      [ "type", `String "object"
+      ; "properties", `Assoc [ "count", `Assoc [ "type", `String "decimal" ] ]
+      ]
+  in
+  match
+    Mcp.tool_of_input_schema_result
+      ~name:"broken"
+      ~description:"Broken"
+      ~input_schema:unsupported_type_schema
+      noop_handler
+  with
+  | Ok _ -> fail "expected the unsupported type to be rejected"
+  | Error detail ->
+    check
+      bool
+      "names the tool and the offending type"
+      true
+      (Util.contains_substring_ci ~haystack:detail ~needle:"broken"
+       && Util.contains_substring_ci ~haystack:detail ~needle:"decimal")
+;;
+
+(* ── tool_schema JSON round-trips ─────────────────────────── *)
+
+let sample_parameters =
+  [ { Types.name = "max_bytes"
+    ; description = "Maximum bytes to read"
+    ; param_type = Types.Integer
+    ; required = true
+    }
+  ]
+;;
+
+let check_manual_roundtrip label (schema : Types.tool_schema) =
+  match Types.tool_schema_of_json (Types.tool_schema_to_json schema) with
+  | Error detail -> failf "%s: tool_schema_of_json: %s" label detail
+  | Ok decoded -> check bool (label ^ ": record preserved") true (decoded = schema)
+;;
+
+let check_derived_roundtrip label (schema : Types.tool_schema) =
+  match Types.tool_schema_of_yojson (Types.tool_schema_to_yojson schema) with
+  | Error detail -> failf "%s: tool_schema_of_yojson: %s" label detail
+  | Ok decoded -> check bool (label ^ ": record preserved") true (decoded = schema)
+;;
+
+let test_tool_schema_json_roundtrip () =
+  let without =
+    { Types.name = "read_file"
+    ; description = "Read a file"
+    ; parameters = sample_parameters
+    ; strict = None
+    ; input_schema = None
+    }
+  in
+  let with_schema = { without with Types.input_schema = Some rich_input_schema } in
+  check
+    bool
+    "input_schema omitted when None"
+    false
+    (List.mem_assoc
+       "input_schema"
+       (Yojson.Safe.Util.to_assoc (Types.tool_schema_to_json without)));
+  check
+    json
+    "input_schema emitted verbatim when Some"
+    rich_input_schema
+    (Types.tool_schema_to_json with_schema |> member "input_schema");
+  check_manual_roundtrip "manual without input_schema" without;
+  check_manual_roundtrip "manual with input_schema" with_schema;
+  check_derived_roundtrip "derived without input_schema" without;
+  check_derived_roundtrip "derived with input_schema" with_schema
+;;
+
+let test_tool_schema_of_json_rejects_non_object () =
+  match Types.tool_schema_of_json (`List []) with
+  | Ok _ -> fail "expected a non-object tool_schema to be rejected"
+  | Error detail ->
+    check string "reports the shape" "tool_schema must be a JSON object" detail
+;;
+
+let () =
+  run
+    "tool_input_schema_fidelity"
+    [ ( "wire fidelity"
+      , [ test_case
+            "authoritative schema reaches the wire"
+            `Quick
+            test_authoritative_schema_reaches_the_wire
+        ; test_case
+            "derived schema unchanged without input_schema"
+            `Quick
+            test_derived_schema_unchanged_without_input_schema
+        ] )
+    ; ( "invariant"
+      , [ test_case
+            "tool parameters derived from the schema"
+            `Quick
+            test_tool_parameters_are_derived_from_the_schema
+        ; test_case
+            "middleware schema keeps its source"
+            `Quick
+            test_middleware_schema_keeps_its_source
+        ; test_case
+            "invalid schema names the failing property"
+            `Quick
+            test_invalid_schema_names_the_failing_property
+        ] )
+    ; ( "round-trip"
+      , [ test_case "tool_schema json round-trip" `Quick test_tool_schema_json_roundtrip
+        ; test_case
+            "tool_schema_of_json rejects non-object"
+            `Quick
+            test_tool_schema_of_json_rejects_non_object
+        ] )
+    ]
+;;

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -13,7 +13,12 @@ let make_param ?(required = true) ~param_type name =
 ;;
 
 let make_schema params =
-  { Types.name = "test_tool"; description = "test"; parameters = params; strict = None }
+  { Types.name = "test_tool"
+  ; description = "test"
+  ; parameters = params
+  ; strict = None
+  ; input_schema = None
+  }
 ;;
 
 (* ── Required field tests ──────────────────────────────── *)

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -12,13 +12,8 @@ let make_param ?(required = true) ~param_type name =
   { Types.name; description = ""; param_type; required }
 ;;
 
-let make_schema params =
-  { Types.name = "test_tool"
-  ; description = "test"
-  ; parameters = params
-  ; strict = None
-  ; input_schema = None
-  }
+let make_schema parameters =
+  Types.tool_schema_of_params ~name:"test_tool" ~description:"test" ~parameters ()
 ;;
 
 (* ── Required field tests ──────────────────────────────── *)

--- a/test/test_tool_middleware.ml
+++ b/test/test_tool_middleware.ml
@@ -23,7 +23,12 @@ let tool_schema name json_schema : Types.tool_schema =
 
 let test_pass_no_params () =
   let schema : Types.tool_schema =
-    { name = "noop"; description = ""; parameters = []; strict = None }
+    { name = "noop"
+    ; description = ""
+    ; parameters = []
+    ; strict = None
+    ; input_schema = None
+    }
   in
   match Tool_middleware.validate_input ~tool_name:"noop" ~schema (`Assoc []) with
   | Tool_middleware.Pass -> ()

--- a/test/test_tool_middleware.ml
+++ b/test/test_tool_middleware.ml
@@ -23,12 +23,7 @@ let tool_schema name json_schema : Types.tool_schema =
 
 let test_pass_no_params () =
   let schema : Types.tool_schema =
-    { name = "noop"
-    ; description = ""
-    ; parameters = []
-    ; strict = None
-    ; input_schema = None
-    }
+    Types.tool_schema_of_params ~name:"noop" ~description:"" ~parameters:[] ()
   in
   match Tool_middleware.validate_input ~tool_name:"noop" ~schema (`Assoc []) with
   | Tool_middleware.Pass -> ()

--- a/test/test_tool_schema_decode_boundary.ml
+++ b/test/test_tool_schema_decode_boundary.ml
@@ -412,6 +412,70 @@ let test_tool_param_decode_rejects_duplicate_and_unknown_fields () =
      | Error detail -> detail)
 ;;
 
+let derived_schema_error label json =
+  match Types.tool_schema_of_yojson json with
+  | Ok _ -> failf "%s: derived schema decoder accepted an ambiguous object" label
+  | Error detail -> detail
+;;
+
+let derived_param_error label json =
+  match Types.tool_param_of_yojson json with
+  | Ok _ -> failf "%s: derived param decoder accepted an ambiguous object" label
+  | Error detail -> detail
+;;
+
+let replace_assoc_field name value fields =
+  (name, value) :: List.filter (fun (key, _) -> not (String.equal key name)) fields
+;;
+
+let test_derived_decoders_reject_duplicate_and_unknown_fields () =
+  let parameter : Types.tool_param =
+    { name = "city"; description = ""; param_type = Types.String; required = true }
+  in
+  let parameter_fields =
+    match Types.tool_param_to_yojson parameter with
+    | `Assoc fields -> fields
+    | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ ->
+      fail "derived tool_param encoding must be an object"
+  in
+  check
+    string
+    "derived param duplicate is named"
+    "tool_param fields mismatch (missing=[], unknown=[], duplicates=[required])"
+    (derived_param_error
+       "duplicate derived param field"
+       (`Assoc (parameter_fields @ [ "required", `Bool false ])));
+  let schema =
+    Types.tool_schema_of_params
+      ~name:"weather"
+      ~description:"Read weather"
+      ~parameters:[ parameter ]
+      ()
+  in
+  let schema_fields =
+    match Types.tool_schema_to_yojson schema with
+    | `Assoc fields -> fields
+    | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ ->
+      fail "derived tool_schema encoding must be an object"
+  in
+  check
+    string
+    "derived schema unknown field is named"
+    "tool_schema fields mismatch (missing=[], unknown=[legacy_schema], duplicates=[])"
+    (derived_schema_error
+       "unknown derived schema field"
+       (`Assoc (("legacy_schema", `Assoc []) :: schema_fields)));
+  let unknown_parameter = `Assoc (("default", `String "Paris") :: parameter_fields) in
+  check
+    string
+    "nested derived param unknown field is named"
+    "tool_param fields mismatch (missing=[], unknown=[default], duplicates=[])"
+    (derived_schema_error
+       "unknown nested derived param field"
+       (`Assoc
+           (replace_assoc_field "parameters" (`List [ unknown_parameter ]) schema_fields)))
+;;
+
 let () =
   run
     "tool_schema_decode_boundary"
@@ -480,6 +544,12 @@ let () =
             "duplicate and unknown fields"
             `Quick
             test_tool_param_decode_rejects_duplicate_and_unknown_fields
+        ] )
+    ; ( "derived decoder exact fields"
+      , [ test_case
+            "duplicate and unknown fields"
+            `Quick
+            test_derived_decoders_reject_duplicate_and_unknown_fields
         ] )
     ]
 ;;

--- a/test/test_tool_schema_decode_boundary.ml
+++ b/test/test_tool_schema_decode_boundary.ml
@@ -220,6 +220,38 @@ let test_decode_rejects_a_missing_name () =
        (`Assoc [ "description", `String "Read a file"; "parameters", `List [] ]))
 ;;
 
+let test_decode_rejects_duplicate_and_unknown_top_level_fields () =
+  check
+    string
+    "duplicate is named"
+    "tool_schema fields mismatch (missing=[], unknown=[], duplicates=[name])"
+    (check_decode_error
+       "duplicate name"
+       (`Assoc
+           [ "name", `String "first"
+           ; "name", `String "second"
+           ; "description", `String "Read a file"
+           ; "parameters", `List []
+           ]));
+  check
+    string
+    "unknown is named"
+    "tool_schema fields mismatch (missing=[], unknown=[legacy_schema], duplicates=[])"
+    (check_decode_error
+       "unknown field"
+       (with_fields [ "parameters", `List []; "legacy_schema", `Assoc [] ]))
+;;
+
+let test_decode_rejects_explicit_null_strict () =
+  check
+    string
+    "manual absence is key omission"
+    "tool_schema.strict must be a boolean, got null"
+    (check_decode_error
+       "strict null"
+       (with_fields [ "parameters", `List []; "strict", `Null ]))
+;;
+
 (* [Some `Null] used to be representable and collapsed back to [None] on the
    derived round-trip. It is now unreachable, and a payload that spells it out
    is refused rather than silently reinterpreted as "no schema". *)
@@ -264,7 +296,6 @@ let test_decode_rejects_parameters_that_disagree_with_input_schema () =
                 ; "required", `Bool false
                 ]
             ] )
-      ; "strict", `Null
       ; "input_schema", input_schema
       ]
   in
@@ -355,6 +386,32 @@ let test_tool_param_decode_is_total () =
     cases
 ;;
 
+let test_tool_param_decode_rejects_duplicate_and_unknown_fields () =
+  let common =
+    [ "name", `String "city"
+    ; "description", `String ""
+    ; "param_type", `String "string"
+    ; "required", `Bool true
+    ]
+  in
+  check
+    string
+    "duplicate param field is named"
+    "tool_param fields mismatch (missing=[], unknown=[], duplicates=[required])"
+    (match Types.tool_param_of_json (`Assoc (common @ [ "required", `Bool false ])) with
+     | Ok _ -> fail "duplicate param field was accepted"
+     | Error detail -> detail);
+  check
+    string
+    "unknown param field is named"
+    "tool_param fields mismatch (missing=[], unknown=[default], duplicates=[])"
+    (match
+       Types.tool_param_of_json (`Assoc (common @ [ "default", `String "Paris" ]))
+     with
+     | Ok _ -> fail "unknown param field was accepted"
+     | Error detail -> detail)
+;;
+
 let () =
   run
     "tool_schema_decode_boundary"
@@ -400,6 +457,11 @@ let () =
             test_decode_rejects_a_name_that_is_not_a_string
         ; test_case "missing name" `Quick test_decode_rejects_a_missing_name
         ; test_case
+            "duplicate and unknown top-level fields"
+            `Quick
+            test_decode_rejects_duplicate_and_unknown_top_level_fields
+        ; test_case "strict null" `Quick test_decode_rejects_explicit_null_strict
+        ; test_case
             "input_schema not an object"
             `Quick
             test_decode_rejects_input_schema_that_is_not_an_object
@@ -413,6 +475,11 @@ let () =
             test_decode_validates_parameters_even_with_input_schema
         ] )
     ; ( "tool_param_of_json totality"
-      , [ test_case "malformed params" `Quick test_tool_param_decode_is_total ] )
+      , [ test_case "malformed params" `Quick test_tool_param_decode_is_total
+        ; test_case
+            "duplicate and unknown fields"
+            `Quick
+            test_tool_param_decode_rejects_duplicate_and_unknown_fields
+        ] )
     ]
 ;;

--- a/test/test_tool_schema_decode_boundary.ml
+++ b/test/test_tool_schema_decode_boundary.ml
@@ -214,7 +214,7 @@ let test_decode_rejects_a_missing_name () =
   check
     string
     "names the missing field"
-    "tool_schema is missing field name"
+    "tool_schema fields mismatch (missing=[name], unknown=[], duplicates=[])"
     (check_decode_error
        "missing name"
        (`Assoc [ "description", `String "Read a file"; "parameters", `List [] ]))

--- a/test/test_tool_schema_decode_boundary.ml
+++ b/test/test_tool_schema_decode_boundary.ml
@@ -1,0 +1,418 @@
+(** The two boundaries a tool schema crosses, pinned to their return types.
+
+    {!Types.input_schema_of_json} decides what may be stored as an
+    authoritative tool argument schema: a JSON object with unique keys, and
+    nothing else. Before this, any non-[`Null] value was accepted, so a bare
+    string or a list could be handed to a provider as an argument schema.
+
+    {!Types.tool_schema_of_json} decodes persisted checkpoints and session
+    payloads. Before this, it read its fields with [Yojson.Safe.Util.to_list],
+    [to_string] and [to_bool_option], which raise [Type_error] — so a malformed
+    payload escaped the [result] the signature advertises. Every case below
+    asserts an [Error] value {e and} that nothing was raised. *)
+
+open Alcotest
+open Agent_sdk
+
+let input_schema_error =
+  testable Types.pp_input_schema_error Types.equal_input_schema_error
+;;
+
+(* ── input_schema_of_json: only objects with unique keys ─── *)
+
+let check_rejected_shape name value shape =
+  check
+    (result
+       (of_pp (fun formatter _ -> Format.pp_print_string formatter "<schema>"))
+       input_schema_error)
+    (name ^ " is not a schema")
+    (Error (Types.Input_schema_not_an_object shape))
+    (Types.input_schema_of_json value)
+;;
+
+let test_explicit_null_is_not_a_schema () =
+  check_rejected_shape "explicit null" `Null Types.Json_null
+;;
+
+let test_string_is_not_a_schema () =
+  check_rejected_shape "a string" (`String "object") Types.Json_string
+;;
+
+let test_integer_is_not_a_schema () =
+  check_rejected_shape "an integer" (`Int 1) Types.Json_int
+;;
+
+let test_float_is_not_a_schema () =
+  check_rejected_shape "a number" (`Float 1.5) Types.Json_float
+;;
+
+let test_bool_is_not_a_schema () =
+  check_rejected_shape "a boolean" (`Bool true) Types.Json_bool
+;;
+
+let test_list_is_not_a_schema () =
+  check_rejected_shape "an array" (`List [ `String "object" ]) Types.Json_list
+;;
+
+let test_rejection_names_the_offending_shape () =
+  check
+    string
+    "message names the shape that arrived"
+    "input_schema must be a JSON object, got an array"
+    (Types.input_schema_error_to_string
+       (Types.Input_schema_not_an_object Types.Json_list))
+;;
+
+(* Yojson keeps both entries of a repeated key, so uniqueness is not implied by
+   the type and a duplicate would silently pick one meaning downstream. *)
+let test_duplicate_root_key_is_rejected () =
+  check
+    input_schema_error
+    "duplicate root key"
+    (Types.Input_schema_duplicate_keys { path = "input_schema"; keys = [ "type" ] })
+    (match
+       Types.input_schema_of_json
+         (`Assoc [ "type", `String "object"; "type", `String "string" ])
+     with
+     | Error error -> error
+     | Ok _ -> failf "expected a duplicate-key rejection")
+;;
+
+let test_duplicate_nested_key_is_rejected () =
+  let schema : Yojson.Safe.t =
+    `Assoc
+      [ "type", `String "object"
+      ; ( "properties"
+        , `Assoc
+            [ "city", `Assoc [ "type", `String "string" ]
+            ; "city", `Assoc [ "type", `String "integer" ]
+            ] )
+      ]
+  in
+  check
+    input_schema_error
+    "duplicate nested key, named by path"
+    (Types.Input_schema_duplicate_keys
+       { path = "input_schema.properties"; keys = [ "city" ] })
+    (match Types.input_schema_of_json schema with
+     | Error error -> error
+     | Ok _ -> failf "expected a duplicate-key rejection")
+;;
+
+(* The constructor is the only producer of an authoritative schema, so the gate
+   has to hold there too and not only on the raw predicate. *)
+let test_constructor_refuses_a_non_object_schema () =
+  match
+    Types.tool_schema_of_input_schema
+      ~name:"read_file"
+      ~description:"Read a file"
+      ~input_schema:(`String "object")
+      ()
+  with
+  | Ok _ -> fail "expected a non-object schema to be refused"
+  | Error detail ->
+    check
+      string
+      "names the shape"
+      "input_schema must be a JSON object, got a string"
+      detail
+;;
+
+(* ── tool_schema_of_json is total ─────────────────────────── *)
+
+let decode label json =
+  match Types.tool_schema_of_json json with
+  | result -> result
+  | exception exn -> failf "%s raised %s" label (Printexc.to_string exn)
+;;
+
+let check_decode_error label json =
+  match decode label json with
+  | Ok _ -> failf "%s: expected Error" label
+  | Error detail ->
+    check bool (label ^ ": error is not empty") true (String.length detail > 0);
+    detail
+;;
+
+let well_formed_fields =
+  [ "name", `String "read_file"; "description", `String "Read a file" ]
+;;
+
+let with_fields extra : Yojson.Safe.t = `Assoc (well_formed_fields @ extra)
+
+let test_decode_rejects_non_object_payload () =
+  check
+    string
+    "names the shape"
+    "tool_schema must be a JSON object, got an array"
+    (check_decode_error "non-object payload" (`List []))
+;;
+
+let test_decode_rejects_parameters_that_are_not_a_list () =
+  check
+    string
+    "names the field and the shape"
+    "tool_schema.parameters must be an array, got an object"
+    (check_decode_error "parameters not a list" (with_fields [ "parameters", `Assoc [] ]))
+;;
+
+let test_decode_rejects_a_param_name_that_is_not_a_string () =
+  check
+    string
+    "names the field and the shape"
+    "tool_param.name must be a string, got an integer"
+    (check_decode_error
+       "param name not a string"
+       (with_fields
+          [ ( "parameters"
+            , `List
+                [ `Assoc
+                    [ "name", `Int 1
+                    ; "description", `String ""
+                    ; "param_type", `String "string"
+                    ; "required", `Bool true
+                    ]
+                ] )
+          ]))
+;;
+
+let test_decode_rejects_a_param_that_is_not_an_object () =
+  check
+    string
+    "names the shape"
+    "tool_param must be a JSON object, got a string"
+    (check_decode_error
+       "param not an object"
+       (with_fields [ "parameters", `List [ `String "city" ] ]))
+;;
+
+let test_decode_rejects_strict_that_is_not_a_bool () =
+  check
+    string
+    "names the field and the shape"
+    "tool_schema.strict must be a boolean, got a string"
+    (check_decode_error
+       "strict not a bool"
+       (with_fields [ "parameters", `List []; "strict", `String "true" ]))
+;;
+
+let test_decode_rejects_a_name_that_is_not_a_string () =
+  check
+    string
+    "names the field and the shape"
+    "tool_schema.name must be a string, got a boolean"
+    (check_decode_error
+       "name not a string"
+       (`Assoc
+           [ "name", `Bool true
+           ; "description", `String "Read a file"
+           ; "parameters", `List []
+           ]))
+;;
+
+let test_decode_rejects_a_missing_name () =
+  check
+    string
+    "names the missing field"
+    "tool_schema is missing field name"
+    (check_decode_error
+       "missing name"
+       (`Assoc [ "description", `String "Read a file"; "parameters", `List [] ]))
+;;
+
+(* [Some `Null] used to be representable and collapsed back to [None] on the
+   derived round-trip. It is now unreachable, and a payload that spells it out
+   is refused rather than silently reinterpreted as "no schema". *)
+let test_decode_rejects_input_schema_that_is_not_an_object () =
+  check
+    string
+    "names the shape"
+    "input_schema must be a JSON object, got null"
+    (check_decode_error
+       "input_schema null"
+       (with_fields [ "parameters", `List []; "input_schema", `Null ]));
+  check
+    string
+    "names the shape"
+    "input_schema must be a JSON object, got an array"
+    (check_decode_error
+       "input_schema list"
+       (with_fields [ "parameters", `List []; "input_schema", `List [] ]))
+;;
+
+(* A persisted pair that disagrees is not a value the private constructors
+   could have produced. Reject it rather than silently discarding one side. *)
+let test_decode_rejects_parameters_that_disagree_with_input_schema () =
+  let input_schema : Yojson.Safe.t =
+    `Assoc
+      [ "type", `String "object"
+      ; ( "properties"
+        , `Assoc
+            [ "city", `Assoc [ "type", `String "string"; "description", `String "City" ] ]
+        )
+      ; "required", `List [ `String "city" ]
+      ]
+  in
+  let payload =
+    with_fields
+      [ ( "parameters"
+        , `List
+            [ `Assoc
+                [ "name", `String "stale"
+                ; "description", `String "no longer in the schema"
+                ; "param_type", `String "boolean"
+                ; "required", `Bool false
+                ]
+            ] )
+      ; "strict", `Null
+      ; "input_schema", input_schema
+      ]
+  in
+  let derived_payload =
+    let stale_parameters =
+      [ { Types.name = "stale"
+        ; description = "no longer in the schema"
+        ; param_type = Types.Boolean
+        ; required = false
+        }
+      ]
+    in
+    match
+      Types.tool_schema_of_params
+        ~name:"read_file"
+        ~description:"Read a file"
+        ~parameters:stale_parameters
+        ()
+      |> Types.tool_schema_to_yojson
+    with
+    | `Assoc fields ->
+      (* The derived encoder already writes ["input_schema": null] for the
+         absent case. Prepending a second entry would leave the key duplicated,
+         and the derived decoder reads only one of them — which is how a
+         divergent pair slipped through as accepted. Replace it instead. *)
+      `Assoc
+        (("input_schema", input_schema)
+         :: List.filter (fun (key, _) -> not (String.equal key "input_schema")) fields)
+    | _ -> fail "derived tool_schema encoding must be an object"
+  in
+  let expected =
+    "tool_schema.parameters must equal the projection of tool_schema.input_schema"
+  in
+  check
+    string
+    "manual decoder rejects the divergent pair"
+    expected
+    (check_decode_error "manual divergent pair" payload);
+  match Types.tool_schema_of_yojson derived_payload with
+  | Ok accepted ->
+    failf
+      "derived decoder accepted a divergent pair: %s"
+      (Types.show_tool_schema accepted)
+  | Error detail ->
+    check string "derived decoder rejects the divergent pair" expected detail
+;;
+
+let test_decode_validates_parameters_even_with_input_schema () =
+  let input_schema : Yojson.Safe.t = `Assoc [ "type", `String "object" ] in
+  check
+    string
+    "malformed derived view is still rejected"
+    "tool_schema.parameters must be an array, got an object"
+    (check_decode_error
+       "malformed parameters with input_schema"
+       (with_fields [ "parameters", `Assoc []; "input_schema", input_schema ]))
+;;
+
+(* ── tool_param_of_json is total ──────────────────────────── *)
+
+let test_tool_param_decode_is_total () =
+  let cases : (string * Yojson.Safe.t) list =
+    [ "not an object", `String "city"
+    ; "name not a string", `Assoc [ "name", `Int 1 ]
+    ; ( "required not a bool"
+      , `Assoc
+          [ "name", `String "city"
+          ; "description", `String ""
+          ; "param_type", `String "string"
+          ; "required", `String "yes"
+          ] )
+    ; ( "unknown param_type"
+      , `Assoc
+          [ "name", `String "city"
+          ; "description", `String ""
+          ; "param_type", `String "decimal"
+          ; "required", `Bool true
+          ] )
+    ]
+  in
+  List.iter
+    (fun (label, json) ->
+       match Types.tool_param_of_json json with
+       | exception exn -> failf "%s raised %s" label (Printexc.to_string exn)
+       | Ok _ -> failf "%s: expected Error" label
+       | Error detail ->
+         check bool (label ^ ": error is not empty") true (String.length detail > 0))
+    cases
+;;
+
+let () =
+  run
+    "tool_schema_decode_boundary"
+    [ ( "input_schema shape"
+      , [ test_case "explicit null" `Quick test_explicit_null_is_not_a_schema
+        ; test_case "string" `Quick test_string_is_not_a_schema
+        ; test_case "integer" `Quick test_integer_is_not_a_schema
+        ; test_case "float" `Quick test_float_is_not_a_schema
+        ; test_case "boolean" `Quick test_bool_is_not_a_schema
+        ; test_case "list" `Quick test_list_is_not_a_schema
+        ; test_case
+            "rejection names the shape"
+            `Quick
+            test_rejection_names_the_offending_shape
+        ; test_case "duplicate root key" `Quick test_duplicate_root_key_is_rejected
+        ; test_case "duplicate nested key" `Quick test_duplicate_nested_key_is_rejected
+        ; test_case
+            "constructor refuses a non-object schema"
+            `Quick
+            test_constructor_refuses_a_non_object_schema
+        ] )
+    ; ( "tool_schema_of_json totality"
+      , [ test_case "non-object payload" `Quick test_decode_rejects_non_object_payload
+        ; test_case
+            "parameters not a list"
+            `Quick
+            test_decode_rejects_parameters_that_are_not_a_list
+        ; test_case
+            "param name not a string"
+            `Quick
+            test_decode_rejects_a_param_name_that_is_not_a_string
+        ; test_case
+            "param not an object"
+            `Quick
+            test_decode_rejects_a_param_that_is_not_an_object
+        ; test_case
+            "strict not a bool"
+            `Quick
+            test_decode_rejects_strict_that_is_not_a_bool
+        ; test_case
+            "name not a string"
+            `Quick
+            test_decode_rejects_a_name_that_is_not_a_string
+        ; test_case "missing name" `Quick test_decode_rejects_a_missing_name
+        ; test_case
+            "input_schema not an object"
+            `Quick
+            test_decode_rejects_input_schema_that_is_not_an_object
+        ; test_case
+            "parameters disagree with input_schema"
+            `Quick
+            test_decode_rejects_parameters_that_disagree_with_input_schema
+        ; test_case
+            "parameters validated with input_schema"
+            `Quick
+            test_decode_validates_parameters_even_with_input_schema
+        ] )
+    ; ( "tool_param_of_json totality"
+      , [ test_case "malformed params" `Quick test_tool_param_decode_is_total ] )
+    ]
+;;

--- a/test/test_tool_schema_decode_boundary.ml
+++ b/test/test_tool_schema_decode_boundary.ml
@@ -317,10 +317,6 @@ let test_decode_rejects_parameters_that_disagree_with_input_schema () =
       |> Types.tool_schema_to_yojson
     with
     | `Assoc fields ->
-      (* The derived encoder already writes ["input_schema": null] for the
-         absent case. Prepending a second entry would leave the key duplicated,
-         and the derived decoder reads only one of them — which is how a
-         divergent pair slipped through as accepted. Replace it instead. *)
       `Assoc
         (("input_schema", input_schema)
          :: List.filter (fun (key, _) -> not (String.equal key "input_schema")) fields)
@@ -341,6 +337,29 @@ let test_decode_rejects_parameters_that_disagree_with_input_schema () =
       (Types.show_tool_schema accepted)
   | Error detail ->
     check string "derived decoder rejects the divergent pair" expected detail
+;;
+
+let test_derived_decoder_rejects_explicit_null_input_schema () =
+  let schema =
+    Types.tool_schema_of_params
+      ~name:"read_file"
+      ~description:"Read a file"
+      ~parameters:[]
+      ()
+  in
+  let payload =
+    match Types.tool_schema_to_yojson schema with
+    | `Assoc fields -> `Assoc (("input_schema", `Null) :: fields)
+    | _ -> fail "derived tool_schema encoding must be an object"
+  in
+  match Types.tool_schema_of_yojson payload with
+  | Ok _ -> fail "derived schema decoder accepted explicit null input_schema"
+  | Error detail ->
+    check
+      string
+      "present input_schema must be an object"
+      "input_schema must be a JSON object, got null"
+      detail
 ;;
 
 let test_decode_validates_parameters_even_with_input_schema () =
@@ -547,6 +566,10 @@ let () =
         ] )
     ; ( "derived decoder exact fields"
       , [ test_case
+            "explicit null input_schema"
+            `Quick
+            test_derived_decoder_rejects_explicit_null_input_schema
+        ; test_case
             "duplicate and unknown fields"
             `Quick
             test_derived_decoders_reject_duplicate_and_unknown_fields

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -421,12 +421,7 @@ let test_tool_param_manual_json_helpers () =
        (Agent_sdk.Util.contains_substring_ci ~haystack:msg ~needle:"param_type")
    | Ok _ -> Alcotest.fail "expected bad param type");
   let tool_schema =
-    { Types.name = "search"
-    ; description = "Search"
-    ; parameters = params
-    ; strict = None
-    ; input_schema = None
-    }
+    Types.tool_schema_of_params ~name:"search" ~description:"Search" ~parameters:params ()
   in
   let manual_json = Types.tool_schema_to_json tool_schema in
   (* strict = None must not emit the field, and must round-trip back to None. *)
@@ -440,7 +435,15 @@ let test_tool_param_manual_json_helpers () =
      Alcotest.(check bool) "strict stays None" true (decoded.strict = None)
    | Error msg -> Alcotest.fail msg);
   (* strict = Some true must emit "strict": true and round-trip to Some true. *)
-  let strict_json = Types.tool_schema_to_json { tool_schema with strict = Some true } in
+  let strict_json =
+    Types.tool_schema_to_json
+      (Types.tool_schema_of_params
+         ~strict:true
+         ~name:tool_schema.name
+         ~description:tool_schema.description
+         ~parameters:tool_schema.parameters
+         ())
+  in
   Alcotest.(check bool)
     "strict emitted when Some"
     true
@@ -1282,23 +1285,22 @@ let () =
     ; ( "tool_schema_yojson"
       , [ Alcotest.test_case "roundtrip" `Quick (fun () ->
             let schema : Types.tool_schema =
-              { name = "calc"
-              ; description = "Calculate"
-              ; parameters =
-                  [ { name = "expr"
+              Types.tool_schema_of_params
+                ~name:"calc"
+                ~description:"Calculate"
+                ~parameters:
+                  [ { Types.name = "expr"
                     ; description = "Expression"
                     ; param_type = Types.String
                     ; required = true
                     }
-                  ; { name = "precision"
+                  ; { Types.name = "precision"
                     ; description = "Decimal places"
                     ; param_type = Types.Integer
                     ; required = false
                     }
                   ]
-              ; strict = None
-              ; input_schema = None
-              }
+                ()
             in
             let json = Types.tool_schema_to_yojson schema in
             match Types.tool_schema_of_yojson json with

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -421,7 +421,12 @@ let test_tool_param_manual_json_helpers () =
        (Agent_sdk.Util.contains_substring_ci ~haystack:msg ~needle:"param_type")
    | Ok _ -> Alcotest.fail "expected bad param type");
   let tool_schema =
-    { Types.name = "search"; description = "Search"; parameters = params; strict = None }
+    { Types.name = "search"
+    ; description = "Search"
+    ; parameters = params
+    ; strict = None
+    ; input_schema = None
+    }
   in
   let manual_json = Types.tool_schema_to_json tool_schema in
   (* strict = None must not emit the field, and must round-trip back to None. *)
@@ -1292,6 +1297,7 @@ let () =
                     }
                   ]
               ; strict = None
+              ; input_schema = None
               }
             in
             let json = Types.tool_schema_to_yojson schema in


### PR DESCRIPTION
## 문제

호출자가 완전한 JSON Schema를 제공해도 기존 경로는 이를 `{name; description; param_type; required}`로 투영한 뒤 다시 wire schema로 조립했습니다. 그 과정에서 `minimum`, `maximum`, `default`, `enum`, 중첩 제약이 provider에 전달되지 않았습니다.

## 변경

- `Types.tool_schema`를 private record로 만들었습니다.
- `tool_schema_of_params`는 parameter view만 받고 wire schema를 파생합니다.
- `tool_schema_of_input_schema`는 authoritative JSON Schema 하나만 받고 validation용 `parameters`를 파생합니다.
- `Tool.of_schema`가 schema와 execution-environment handler를 결합하고, `ignoring_execution_env` / `requiring_context`가 handler 종류만 변환합니다. schema source와 handler kind의 생성자 행렬은 제거했습니다.
- MCP bridge와 middleware는 authoritative schema 생성자를 통과하므로 provider wire와 validation view가 갈라질 수 없습니다.

## Codec 계약

- `input_schema = None`: 키 생략
- `input_schema = Some schema`: unique-key JSON object를 그대로 기록
- 명시적 `null`, scalar, array, 중복 키 object: typed `Error`
- persisted `parameters`와 `input_schema` projection 불일치: `Error`
- 별도 migration, alias, compatibility facade는 없습니다.

## 검증

- exact head: `1ad83fc4120b2f68a18908f28c4dc1aa646a6633`
- negative control: derived decoder의 명시적 `input_schema: null` 수용 테스트가 수정 전 실패하고 수정 후 통과함을 확인
- local focused build: `test_tool_input_schema_fidelity.exe`, `test_tool_schema_decode_boundary.exe`, `test_tool.exe`, `test_tool_execution.exe`, `test_agent_card.exe`
- local execution: 11 + 26 + 19 + 26 + 42 tests 통과
- `ocamlformat --check`, `git diff --check` 통과
- exact-head GitHub CI: 진행 중

## 소비자

MASC #27020은 이 PR의 선행 차단 대상이 아닙니다. 현재 MASC는 범위를 벗어난 값을 조용히 clamp하고, #27020은 그 silent behavior를 명시적 validation error로 바꿉니다. 이 PR은 모델이 provider schema의 bound를 미리 보게 만드는 독립 개선이며, 이후 MASC OAS pin 갱신에서 새 constructor surface를 적용합니다.
