### PR TITLE
docs(changelog): 0.231.14 를 파괴적 릴리즈로 기록

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,44 @@ been removed. Binding identities are constructed only from canonical
 
 * **tool:** send the caller's JSON Schema to providers verbatim ([#2938](https://github.com/jeong-sik/oas/issues/2938)) ([8e3b616](https://github.com/jeong-sik/oas/commit/8e3b61669774e42edc5040e90887b5914c971d33))
 
+### Breaking Changes in a patch release
+
+The version number understates this release. The commit landed under a
+`fix(...)` subject, so the version was computed as a patch, but the change
+removes released public API and replaces the checkpoint contract. Upgrading
+from `0.231.13` is not source-compatible.
+
+`Tool.create_with_context` and `Tool.create_with_execution_env` are removed.
+Where a schema comes from and what a handler reads are independent, so one
+constructor per pair left combinations that no name covered — including an
+authoritative JSON Schema on an execution-environment handler. Callers now pair
+the two explicitly:
+
+```ocaml
+(* was: Tool.create_with_execution_env ~name ~description ~parameters handler *)
+Tool.of_schema (Types.tool_schema_of_params ~name ~description ~parameters ()) handler
+
+(* was: Tool.create_with_context ~name ~description ~parameters handler *)
+Tool.of_schema
+  (Types.tool_schema_of_params ~name ~description ~parameters ())
+  (Tool.requiring_context handler)
+```
+
+`Tool.ignoring_execution_env` adapts a handler that takes only the input, and
+`Types.tool_schema_of_input_schema` supplies the authoritative-schema half.
+`Tool.create` is unchanged.
+
+The checkpoint contract moved from v9 to v10 with no migration path. A stored
+v9 artifact decodes to
+`Error (Serialization (VersionMismatch { expected = 10; got = 9 }))`, so
+existing checkpoints must be reset rather than upgraded.
+
+Why the number was not corrected: `0.231.14` was already tagged and published
+when this was noticed. Releasing an otherwise empty `0.232.0` would have added
+a version boundary that no code change sits behind, so the release is recorded
+here as it is. See #2946 for the signal path that let a breaking change be
+numbered as a patch.
+
 ## [0.231.13](https://github.com/jeong-sik/oas/compare/v0.231.12...v0.231.13) (2026-08-04)
 
 


### PR DESCRIPTION
## 무엇

`v0.231.14` 는 **파괴적 릴리즈인데 patch 번호로 나갔습니다.** 이 PR 은 그 사실을 CHANGELOG 의 해당 릴리즈 섹션에 기록합니다.

| | v0.231.13 | v0.231.14 |
|---|---|---|
| `Tool.create_with_context` | `tool.mli:48` | 삭제 |
| `Tool.create_with_execution_env` | `tool.mli:62` | 삭제 |
| checkpoint 계약 | v9 | v10, 마이그레이션 없음 |

`0.231.14` 의 CHANGELOG 섹션은 지금 `### Bug Fixes` 한 줄뿐입니다. 기존 `Tool.t` 문단은 `## Unreleased` 에 있고 **심볼 이름이 없어서**, 업그레이드하다 빌드가 깨진 사람이 `grep` 할 대상이 없습니다.

## 변경

`## [0.231.14]` 섹션에 추가:

- "이 릴리즈는 patch 번호지만 `0.231.13` 에서 소스 호환이 아니다" 명시
- 삭제된 생성자 이름 + `Tool.of_schema` 로 가는 before/after 예제
- checkpoint v9 아티팩트가 `Error (Serialization (VersionMismatch { expected = 10; got = 9 }))` 로 거부된다는 사실
- 번호를 고치지 않은 이유

코드 변경 없음. CHANGELOG 만.

## 왜 `Release-As: 0.232.0` 이 아닌가

처음엔 그 방향이었습니다. 그런데 확인해 보니 릴리즈 PR #2944 가 이미 04:56 에 머지되고 `v0.231.14` 가 04:59 에 태깅된 뒤였습니다. `v0.231.14..origin/main` 은 0 커밋입니다.

즉 `Release-As` 는 이미 나간 릴리즈를 고치지 못하고, **코드 변경이 하나도 없는 0.232.0** 을 새로 찍게 됩니다. 아무 변경도 뒤에 없는 버전 경계를 만드는 대신, 릴리즈를 있는 그대로 기록하는 쪽을 택했습니다.

## 후속

이걸 허용한 신호 경로 — 손으로 쓰는 `## Unreleased` 섹션을 release-please 가 읽지 않는 구조 — 는 #2946 입니다. `## Unreleased` 에는 이미 출시된 항목 포함 12건이 쌓여 있고, 이 PR 은 그 1회성 정리를 하지 않습니다.

관련: #2938, #2944, #2946
