### PR TITLE
fix(glm): 1261 프롬프트 초과를 typed ContextOverflow 로 관통 (#2947)

### DIFF
--- a/lib/llm_provider/backend_glm.ml
+++ b/lib/llm_provider/backend_glm.ml
@@ -23,6 +23,7 @@ type glm_error_class =
   | Glm_auth_error
   | Glm_server_error
   | Glm_invalid_request
+  | Glm_context_overflow
 
 type glm_error_origin =
   | Provider_response
@@ -39,7 +40,8 @@ type glm_error =
 (** Classify Glm errors only by the provider's documented code field.
     Code mapping from docs.z.ai/api-reference/api-code:
     - 1000-1004,1100-1120: auth/account
-    - 1200-1261: parameter/request (terminal)
+    - 1200-1231: parameter/request (terminal)
+    - 1261: prompt exceeds max length (context overflow, oas#2947)
     - 1113: account arrears (quota)
     - 1300: policy block (terminal)
     - 1301: unsafe content (terminal)
@@ -73,8 +75,10 @@ let classify_glm_error ~code : glm_error_class * bool =
   | "1213"
   | "1214"
   | "1215"
-  | "1231"
-  | "1261" -> Glm_invalid_request, false
+  | "1231" -> Glm_invalid_request, false
+  (* oas#2947: 1261 is "Prompt exceeds max length" — a context-window
+     overflow, not a malformed request. Typed so consumers can shrink. *)
+  | "1261" -> Glm_context_overflow, false
   | _unknown_code -> Glm_invalid_request, false
 ;;
 
@@ -84,6 +88,7 @@ let http_code_of_glm_error_class = function
   | Glm_auth_error -> 401
   | Glm_server_error -> 500
   | Glm_invalid_request -> 400
+  | Glm_context_overflow -> 400
 ;;
 
 exception Glm_api_error of glm_error

--- a/lib/llm_provider/backend_glm.mli
+++ b/lib/llm_provider/backend_glm.mli
@@ -24,6 +24,10 @@ type glm_error_class =
   | Glm_auth_error
   | Glm_server_error
   | Glm_invalid_request
+  | Glm_context_overflow
+  (** oas#2947: code 1261 "Prompt exceeds max length" — the request
+        exceeded the model context window. Not retryable at the transport:
+        only the consumer's context recovery can make progress. *)
 
 type glm_error_origin =
   | Provider_response
@@ -52,6 +56,12 @@ val classify_glm_error : code:string -> glm_error_class * bool
     Used by complete.ml to normalize provider-specific codes
     into the shared HTTP error path. *)
 val http_code_of_glm_error_class : glm_error_class -> int
+
+(** Parse glm's structured error envelope from a raw response body.
+    [None] when the body is not JSON or carries no error object. Used by the
+    streaming path to classify a non-200 rejection by its documented [code]
+    field before provider identity is erased (oas#2947). *)
+val check_glm_error : string -> glm_error option
 
 (** Build a Glm chat completion request body.
     Delegates to {!Backend_openai.build_request} and injects

--- a/lib/llm_provider/complete_stream.ml
+++ b/lib/llm_provider/complete_stream.ml
@@ -917,6 +917,40 @@ let complete_stream_http
         publish_summary ~terminal:(Telemetry_event.Terminal_error "timeout_error") ();
         Error err
       | Ok (Error err) ->
+        (* oas#2947: a glm request rejection arrives as a non-200 whose body is
+           glm's structured error envelope. Promote a code-1261 context
+           overflow to the typed [ProviderFailure Context_overflow] here, while
+           the provider identity is still known — downstream classification
+           ([Retry.classify_error]) is provider-agnostic and would flatten it
+           into [InvalidRequest Unknown_invalid_request], cutting consumers off
+           from their compaction/shrink recovery. The promotion parses the
+           envelope's documented [code] field ([Backend_glm.check_glm_error]),
+           never message prose. *)
+        let err =
+          match http_codec with
+          | Provider_http_codec.Glm_chat ->
+            (match err with
+             | Http_client.HttpError { body; _ } ->
+               (match Backend_glm.check_glm_error body with
+                | Some
+                    { Backend_glm.error_class = Backend_glm.Glm_context_overflow
+                    ; message
+                    ; _
+                    } ->
+                  Http_client.ProviderFailure
+                    { kind = Http_client.Context_overflow { limit = None }; message }
+                | Some _ | None -> err)
+             | Http_client.NetworkError _
+             | Http_client.TimeoutError _
+             | Http_client.AcceptRejected _
+             | Http_client.ProviderTerminal _
+             | Http_client.ProviderFailure _ -> err)
+          | Provider_http_codec.Anthropic_messages
+          | Provider_http_codec.Openai_chat
+          | Provider_http_codec.Openai_responses
+          | Provider_http_codec.Gemini_generate_content
+          | Provider_http_codec.Ollama_chat -> err
+        in
         let terminal =
           match !terminal_state with
           | (Telemetry_event.Terminal_error _ | Telemetry_event.Terminal_cancelled) as

--- a/lib/llm_provider/complete_sync.ml
+++ b/lib/llm_provider/complete_sync.ml
@@ -98,14 +98,33 @@ let parse_sync_response ~http_codec ~provider_kind body =
     (match error.origin with
      | Backend_glm.Response_parse -> provider_parse_failure ~parser:"glm" error.message
      | Backend_glm.Provider_response ->
-       let semantic_code = Backend_glm.http_code_of_glm_error_class error.error_class in
-       let body =
-         match error.code with
-         | Some code -> Printf.sprintf "Glm error %s: %s" code error.message
-         | None -> Printf.sprintf "Glm error without code: %s" error.message
-       in
-       Error
-         (Http_client.HttpError { code = semantic_code; body; retry_after_header = None }))
+       (match error.error_class with
+        | Backend_glm.Glm_context_overflow ->
+          (* oas#2947: keep the provider-reported overflow typed instead of
+             flattening it into an HTTP 400 body string — consumers reach
+             their compaction/shrink path only on a typed overflow. glm's
+             envelope does not carry the token limit. *)
+          Error
+            (Http_client.ProviderFailure
+               { kind = Http_client.Context_overflow { limit = None }
+               ; message = error.message
+               })
+        | Backend_glm.Glm_quota_exceeded
+        | Backend_glm.Glm_rate_limited
+        | Backend_glm.Glm_auth_error
+        | Backend_glm.Glm_server_error
+        | Backend_glm.Glm_invalid_request ->
+          let semantic_code =
+            Backend_glm.http_code_of_glm_error_class error.error_class
+          in
+          let body =
+            match error.code with
+            | Some code -> Printf.sprintf "Glm error %s: %s" code error.message
+            | None -> Printf.sprintf "Glm error without code: %s" error.message
+          in
+          Error
+            (Http_client.HttpError
+               { code = semantic_code; body; retry_after_header = None })))
   | exn ->
     Reserved_exn.reraise_if_reserved exn;
     let message = Printexc.to_string exn in

--- a/lib/llm_provider/error.ml
+++ b/lib/llm_provider/error.ml
@@ -351,6 +351,16 @@ let of_provider_failure ?provider kind message =
                (Types.stop_reason_to_string stop_reason)
                message
          })
+  | Http_client.Context_overflow { limit } ->
+    (* oas#2947: same SDK-boundary flattening as the Empty_overflow arm above —
+       the typed overflow value is rendered via [Retry.error_message] into
+       [InvalidRequest] so the public surface stays source-compatible, while
+       the attribution path ([Provider_failure_attribution]) keeps the typed
+       [Retry.ContextOverflow] for consumers that branch on it. *)
+    InvalidRequest
+      { provider
+      ; reason = Retry.error_message (Retry.ContextOverflow { message; limit })
+      }
   | Http_client.Unknown_provider_failure { reason } ->
     let reason =
       match reason with

--- a/lib/llm_provider/http_client.ml
+++ b/lib/llm_provider/http_client.ml
@@ -125,6 +125,10 @@ type provider_failure_kind =
      thinking, text, or tool_calls). Distinct from a parse error. Preserve the
      typed stop reason so policy remains outside this transport fact. *)
   | Empty_completion of { stop_reason : Types.stop_reason }
+  (* oas#2947: provider-reported context-window overflow (e.g. glm 1261),
+     kept typed so consumers reach their compaction/shrink path instead of
+     seeing a generic invalid-request. *)
+  | Context_overflow of { limit : int option }
   | Unknown_provider_failure of { reason : string option }
 
 type http_error =
@@ -201,6 +205,9 @@ let provider_failure_kind_to_string = function
     Printf.sprintf "response_body_too_large:%d" limit_bytes
   | Empty_completion { stop_reason } ->
     Printf.sprintf "empty_completion:%s" (Types.stop_reason_to_string stop_reason)
+  | Context_overflow { limit = Some limit } ->
+    Printf.sprintf "context_overflow:limit_%d" limit
+  | Context_overflow { limit = None } -> "context_overflow"
   | Unknown_provider_failure { reason = Some reason } ->
     Printf.sprintf "unknown_provider_failure:%s" reason
   | Unknown_provider_failure { reason = None } -> "unknown_provider_failure"

--- a/lib/llm_provider/http_client.mli
+++ b/lib/llm_provider/http_client.mli
@@ -185,6 +185,16 @@ type provider_failure_kind =
   (** oas#2483: a 200 with no deliverable content (no thinking/text/tool_calls).
       The typed stop reason is preserved so downstream policy can distinguish,
       for example, [MaxTokens] from [EndTurn] without parsing diagnostics. *)
+  | Context_overflow of { limit : int option }
+  (** oas#2947: the provider reported in its error envelope that the request
+      exceeded the model context window (e.g. glm code 1261 "Prompt exceeds
+      max length"). Distinct from [Request_body_too_large] (a pre-dispatch
+      transport byte boundary) and from an empty completion whose
+      [stop_reason] is [ContextWindowExceeded] (the same condition reported
+      through a 200). Retrying or rotating replays the same oversized prompt;
+      only the consumer's context recovery (compaction/shrink) can make
+      progress. [limit] is the provider-reported token limit when the
+      envelope carries one. *)
   | Unknown_provider_failure of { reason : string option }
 
 (** Transport-level error. *)

--- a/lib/provider_failure_attribution.ml
+++ b/lib/provider_failure_attribution.ml
@@ -63,6 +63,13 @@ let sdk_error_of_http_error ?(accept_rejected = Api_invalid_request) err =
     Error.Api
       (Retry.InvalidRequest
          { message; reason = Retry.Request_body_too_large { actual_bytes; limit_bytes } })
+  | Http.ProviderFailure { kind = Http.Context_overflow { limit }; message } ->
+    (* oas#2947: a provider-reported context overflow (e.g. glm 1261) is the
+       same consumer contract as a ContextWindowExceeded empty turn — only the
+       consumer's context recovery (compaction/shrink) can make progress, so
+       it must surface as the typed [Api ContextOverflow] and never as a
+       generic invalid-request. *)
+    Error.Api (Retry.ContextOverflow { message; limit })
   | Http.ProviderFailure { kind = Http.Empty_completion { stop_reason }; message } ->
     (* The #2621 empty-completion overflow rule is centralised in
        [Retry.verdict_of_empty_completion]. A ContextWindowExceeded empty turn
@@ -213,7 +220,8 @@ let ownership_of_provider_failure ~binding = function
   | Http.Provider_wire_error _
   | Http.Request_body_too_large _
   | Http.Response_body_too_large _
-  | Http.Empty_completion _ -> Attempt_local
+  | Http.Empty_completion _
+  | Http.Context_overflow _ -> Attempt_local
   | Http.Cli_startup_failed { reason } -> ownership_of_cli_startup ~binding reason
   | Http.Provider_reported_error _ | Http.Unknown_provider_failure _ -> Unclassified
 ;;
@@ -374,6 +382,13 @@ let provider_failure_to_yojson = function
       ; ( "stop_reason"
         , `String (Llm_provider.Types.stop_reason_to_metric_label stop_reason) )
       ]
+  | Http.Context_overflow { limit } ->
+    `Assoc
+      ([ "kind", `String "context_overflow" ]
+       @
+       match limit with
+       | Some limit -> [ "limit", `Int limit ]
+       | None -> [])
   | Http.Unknown_provider_failure _ ->
     `Assoc [ "kind", `String "unknown_provider_failure" ]
 ;;

--- a/test/test_backend_glm_coverage.ml
+++ b/test/test_backend_glm_coverage.ml
@@ -74,7 +74,38 @@ let test_classification_matrix () =
   check_classification "quota" "1308" K.Glm_quota_exceeded false;
   check_classification "server" "1234" K.Glm_server_error true;
   check_classification "invalid" "1210" K.Glm_invalid_request false;
+  check_classification "context overflow (oas#2947)" "1261" K.Glm_context_overflow false;
   check_classification "unknown" "9999" K.Glm_invalid_request false
+;;
+
+(* oas#2947: the streaming path classifies a non-200 rejection by the
+   envelope's documented code field. 1261 must parse to the overflow class;
+   prose alone (no code) must not. *)
+let test_check_glm_error_1261_envelope () =
+  (match
+     K.check_glm_error {|{"error":{"code":"1261","message":"Prompt exceeds max length"}}|}
+   with
+   | Some err ->
+     check_class "envelope 1261 class" K.Glm_context_overflow err.K.error_class;
+     check
+       bool
+       "envelope 1261 message"
+       true
+       (String.equal err.K.message "Prompt exceeds max length")
+   | None -> fail "expected a parsed glm error envelope");
+  (match K.check_glm_error {|{"error":{"message":"Prompt exceeds max length"}}|} with
+   | Some err ->
+     check
+       bool
+       "codeless envelope is not overflow"
+       true
+       (err.K.error_class <> K.Glm_context_overflow)
+   | None -> fail "expected a parsed codeless glm error envelope");
+  check
+    bool
+    "non-json body parses to none"
+    true
+    (Option.is_none (K.check_glm_error "Prompt exceeds max length"))
 ;;
 
 let test_http_status_mapping () =
@@ -244,6 +275,10 @@ let () =
     "backend_glm_coverage"
     [ ( "classification"
       , [ test_case "error classification matrix" `Quick test_classification_matrix
+        ; test_case
+            "1261 envelope parses to context overflow (oas#2947)"
+            `Quick
+            test_check_glm_error_1261_envelope
         ; test_case "http status mapping" `Quick test_http_status_mapping
         ] )
     ; ( "request"

--- a/test/test_provider_failure_attribution.ml
+++ b/test/test_provider_failure_attribution.ml
@@ -558,6 +558,25 @@ let test_empty_completion_overflow_types_as_context_overflow () =
   | other -> Alcotest.failf "expected Api ContextOverflow, got %s" (Error.to_string other)
 ;;
 
+(* oas#2947: a provider-reported overflow (glm 1261) must reach the same
+   typed [Api ContextOverflow] as the empty-completion overflow above — the
+   consumer's compaction/shrink recovery branches on that constructor. *)
+let test_provider_reported_overflow_types_as_context_overflow () =
+  match
+    Attribution.sdk_error_of_http_error
+      (Http.ProviderFailure
+         { kind = Http.Context_overflow { limit = None }
+         ; message = "Prompt exceeds max length"
+         })
+  with
+  | Error.Api (Llm_provider.Retry.ContextOverflow { limit = None; _ } as api) ->
+    check_bool
+      "overflow is not transport-retryable"
+      false
+      (Llm_provider.Retry.is_retryable api)
+  | other -> Alcotest.failf "expected Api ContextOverflow, got %s" (Error.to_string other)
+;;
+
 let test_request_body_limit_preserves_typed_capacity_evidence () =
   match
     Attribution.sdk_error_of_http_error
@@ -750,6 +769,10 @@ let () =
             "ContextWindowExceeded types as Api ContextOverflow"
             `Quick
             test_empty_completion_overflow_types_as_context_overflow
+        ; Alcotest.test_case
+            "provider-reported overflow types as context overflow (oas#2947)"
+            `Quick
+            test_provider_reported_overflow_types_as_context_overflow
         ; Alcotest.test_case
             "EndTurn stays provider unavailable"
             `Quick


### PR DESCRIPTION
Closes #2947.

## 문제

glm code 1261("Prompt exceeds max length")이 typed `Retry.ContextOverflow` 로 도달하지 않고 `InvalidRequest { reason = Unknown_invalid_request }` 로 납작해진다. 소비자(masc keeper)의 overflow 자가회복(shrink/compaction)은 typed overflow 에만 발화하므로, glm 프롬프트 초과가 ~30초 주기 무한 실패 루프가 됐다 — 실사고 2건(2026-08-07 keeper 5/7 전멸, 08-08 code-reviewer 재발), masc#27427.

현재 `Retry.ContextOverflow` 의 유일한 생산자는 empty-completion 경로(#2621)뿐 — **에러 envelope 로 보고되는 overflow 는 생산자가 없었다.**

## 변경 (typed 관통 — prose/문자열 분류 없음)

1. `backend_glm.ml/.mli`: `glm_error_class` 에 `Glm_context_overflow` 추가, `"1261"` 을 invalid-request 블록에서 분리 매핑. `check_glm_error` 를 .mli 로 노출(스트리밍 경로용).
2. `http_client.ml/.mli`: `provider_failure_kind` 에 `Context_overflow of { limit : int option }` 추가 — `Request_body_too_large`(전송 전 바이트 경계)·empty-completion overflow(200 으로 보고되는 동일 조건)와 구분 문서화.
3. `complete_sync.ml`: Glm 분기에서 `Glm_context_overflow` 를 HttpError 400 으로 납작해지기 전에 `ProviderFailure Context_overflow` 로 분기 (glm error class 전수 명시 매치, catch-all 없음).
4. `complete_stream.ml`: **실사고 경로.** 비-200 스트림 거절을 codec=Glm_chat 일 때 `check_glm_error`(문서화된 code 필드 파싱)로 재분류 — provider identity 가 소거되기 전 승격. 타 codec 전수 명시 매치.
5. `provider_failure_attribution.ml`: `Context_overflow` → `Error.Api (Retry.ContextOverflow)` (masc 가 branch 하는 정확한 생성자), ownership 은 empty-completion 과 동일하게 `Attempt_local`, yojson evidence 직렬화 추가.
6. `error.ml` SDK 경계: empty-overflow arm 과 동일한 flatten 규칙 유지(공개 표면 source-compat).

closed type 이라 컴파일러가 폐포를 강제 — non-exhaustive 에러가 가리킨 4개 파일 전부 명시 arm 으로 닫음.

## 검증

- `dune build lib/` clean
- `test_backend_glm_coverage`: **10/10** (신규: 1261→Glm_context_overflow 분류 + envelope 파싱 3단 — code 있는 1261 은 overflow, code 없는 같은 문구는 non-overflow(prose 비의존 증명), 비-JSON 은 None)
- `test_provider_failure_attribution`: **17/17** (신규: `ProviderFailure Context_overflow` → `Api ContextOverflow` + not-retryable 단언)
- `ocamlformat` 10파일 PASS

## 소비자 경로 (후속)

masc 는 oas 를 핀으로 소비 — 머지 → release-please 릴리즈 → masc 핀 승격 후, masc E2E 기대: glm 800KB+ 프롬프트에서 "turn terminal (non-exhaustion error)" 대신 shrink manifest (`context_overflow_shrink_retry`) 발화.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
