### PR TITLE
fix(exact-output): 모델이 마크다운 펜스로 감싼 JSON 본문을 파싱한다

### DIFF
--- a/lib/llm_provider/exact_output.ml
+++ b/lib/llm_provider/exact_output.ml
@@ -1572,6 +1572,74 @@ let execution_error_cause = function
   | Exec.Output_normalization_failed (Exec.Invalid_json _) -> Invalid_json_output
 ;;
 
+(* A model asked for JSON without [response_format] answers in prose format
+   whenever it feels like it, and the most common deviation is a markdown
+   fence around an otherwise correct object. Measured 2026-08-08 against
+   glm-coding.glm-5-turbo on a 39,127-token structured-output prompt whose
+   instructions end with "Respond with ONLY the JSON object, no markdown":
+   two of five replies opened with ```json and the other three did not. The
+   run therefore failed at random on a body that parses once the fence is
+   removed, and the same prompt on kimi-for-coding fenced zero times out of
+   five — so this is per-model behaviour that no prompt wording has closed.
+
+   Only the fence is removed, and only when it wraps the whole body. Anything
+   else stays exactly as the provider sent it: this is not a repair pass over
+   malformed JSON, and [raw_response] keeps the original bytes either way so
+   the wire record still shows what arrived. *)
+let strip_enclosing_markdown_fence text =
+  let trimmed = String.trim text in
+  let starts_with prefix =
+    String.length trimmed >= String.length prefix
+    && String.equal (String.sub trimmed 0 (String.length prefix)) prefix
+  in
+  if not (starts_with "```")
+  then text
+  else (
+    match String.index_opt trimmed '\n' with
+    | None -> text
+    | Some first_newline ->
+      let opening = String.sub trimmed 0 first_newline in
+      (* The opening line is the fence plus at most a language tag, so a line
+         carrying anything else is not a fence this may touch. *)
+      let tag = String.trim (String.sub opening 3 (String.length opening - 3)) in
+      let tag_is_language =
+        String.for_all
+          (fun c ->
+             (c >= 'a' && c <= 'z')
+             || (c >= 'A' && c <= 'Z')
+             || (c >= '0' && c <= '9')
+             || Char.equal c '-'
+             || Char.equal c '_')
+          tag
+      in
+      if not tag_is_language
+      then text
+      else (
+        let body_start = first_newline + 1 in
+        let rest = String.sub trimmed body_start (String.length trimmed - body_start) in
+        let rest_trimmed = String.trim rest in
+        let closing = "```" in
+        let ends_with_fence =
+          String.length rest_trimmed >= String.length closing
+          && String.equal
+               (String.sub
+                  rest_trimmed
+                  (String.length rest_trimmed - String.length closing)
+                  (String.length closing))
+               closing
+        in
+        if not ends_with_fence
+        then text
+        else
+          (* The newline that separated the body from the closing fence is
+             part of the fence, not of the body. *)
+          String.trim
+            (String.sub
+               rest_trimmed
+               0
+               (String.length rest_trimmed - String.length closing))))
+;;
+
 let execute_once_with_publication ~publish ~net ?clock (attempt : attempt) =
   let ready = attempt.ready in
   let receipt = attempt.receipt in
@@ -1633,7 +1701,9 @@ let execute_once_with_publication ~publish ~net ?clock (attempt : attempt) =
          (match ready.provenance.actual_assurance, Plan.response_format ready.plan with
           | Json_syntax_only, Types.Off ->
             (try
-               let value = Yojson.Safe.from_string text in
+               let value =
+                 Yojson.Safe.from_string (strip_enclosing_markdown_fence text)
+               in
                Ok
                  { call_id = receipt_call_id receipt
                  ; receipt

--- a/lib/llm_provider/exact_output.mli
+++ b/lib/llm_provider/exact_output.mli
@@ -774,6 +774,16 @@ val flow_attempt_evidence : flow_attempt -> flow_evidence
     Every candidate performs at most one generation POST. A final semantic
     rejection returns a typed nonempty exhaustion trace. OAS performs no domain
     durable commit, recovery, retirement, or preference update. *)
+val strip_enclosing_markdown_fence : string -> string
+(** Remove a markdown code fence that wraps an entire response body, leaving
+    every other byte untouched. A model asked for JSON without
+    [response_format] fences the object at its own discretion — measured
+    2026-08-08 on glm-coding.glm-5-turbo, two of five replies to one
+    39,127-token structured-output prompt opened with a fence and three did
+    not — so the same request failed at random on a body that parses once the
+    fence is gone. Exposed for tests; the parse path applies it before
+    [Yojson.Safe.from_string] and the raw response keeps the original bytes. *)
+
 val execute_flow_once
   :  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> ?clock:_ Eio.Time.clock

--- a/test/dune
+++ b/test/dune
@@ -428,6 +428,11 @@
  (libraries agent_sdk llm_provider alcotest eio_main))
 
 (test
+ (name test_exact_output_markdown_fence)
+ (modules test_exact_output_markdown_fence)
+ (libraries agent_sdk alcotest))
+
+(test
  (name test_exact_output_validated_flow_evidence)
  (modules test_exact_output_validated_flow_evidence)
  (libraries agent_sdk llm_provider alcotest digestif eio_main))

--- a/test/test_exact_output_markdown_fence.ml
+++ b/test/test_exact_output_markdown_fence.ml
@@ -1,0 +1,84 @@
+(** [strip_enclosing_markdown_fence] on the structured-output parse path.
+
+    A model asked for JSON without [response_format] decides on its own
+    whether to fence the object. Measured 2026-08-08 against
+    glm-coding.glm-5-turbo on a 39,127-token prompt whose instructions end
+    with "Respond with ONLY the JSON object, no markdown": two of five replies
+    opened with a fence and three did not, so the same request failed at
+    random on a body that parses once the fence is removed. The same prompt on
+    kimi-for-coding fenced zero times out of five.
+
+    The risk in a change like this is that it stops being fence removal and
+    becomes a repair pass over malformed output. Half of these cases exist to
+    pin what must pass through untouched. *)
+
+module Exact_output = Agent_sdk.Exact_output
+
+let strip = Exact_output.strip_enclosing_markdown_fence
+let check name expected input = Alcotest.(check string) name expected (strip input)
+
+(* The shape actually observed on the wire. *)
+let test_fenced_object_is_unwrapped () =
+  check
+    "json tag"
+    {|{"retained_memory_ids": ["id:1"]}|}
+    "```json\n{\"retained_memory_ids\": [\"id:1\"]}\n```";
+  check "no tag" {|{"a":1}|} "```\n{\"a\":1}\n```";
+  check "surrounding whitespace" {|{"a":1}|} "\n  ```json\n{\"a\":1}\n```  \n"
+;;
+
+let test_unfenced_body_is_returned_verbatim () =
+  check "bare object" {|{"a":1}|} {|{"a":1}|};
+  (* Whitespace is part of the body when there is no fence: trimming here
+     would make the function do something other than what it says. *)
+  check "leading newline kept" "\n{\"a\":1}" "\n{\"a\":1}"
+;;
+
+(* A fence that does not enclose the whole body is prose that happens to
+   contain one. Removing the opening line would corrupt it. *)
+let test_partial_fence_is_left_alone () =
+  check
+    "no closing fence"
+    "```json\n{\"a\":1}"
+    "```json\n{\"a\":1}";
+  check
+    "text before the fence"
+    "here you go:\n```json\n{\"a\":1}\n```"
+    "here you go:\n```json\n{\"a\":1}\n```";
+  check "opening fence only" "```" "```"
+;;
+
+(* The opening line carries the fence and at most a language tag. A line with
+   anything else is not a fence this may touch. *)
+let test_opening_line_must_be_only_a_tag () =
+  check
+    "prose on the fence line"
+    "```json here is the object\n{\"a\":1}\n```"
+    "```json here is the object\n{\"a\":1}\n```"
+;;
+
+(* Not a repair pass: a fenced body that is still not JSON comes out as the
+   same non-JSON, and the caller reports it exactly as before. *)
+let test_fence_removal_does_not_repair_content () =
+  check "still invalid" "{not json" "```json\n{not json\n```"
+;;
+
+let () =
+  Alcotest.run
+    "exact output markdown fence"
+    [ ( "unwraps"
+      , [ Alcotest.test_case "fenced object is unwrapped" `Quick
+            test_fenced_object_is_unwrapped
+        ] )
+    ; ( "leaves alone"
+      , [ Alcotest.test_case "unfenced body is returned verbatim" `Quick
+            test_unfenced_body_is_returned_verbatim
+        ; Alcotest.test_case "partial fence is left alone" `Quick
+            test_partial_fence_is_left_alone
+        ; Alcotest.test_case "opening line must be only a tag" `Quick
+            test_opening_line_must_be_only_a_tag
+        ; Alcotest.test_case "fence removal does not repair content" `Quick
+            test_fence_removal_does_not_repair_content
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 문제

`response_format` 없이 보내는 구조화 출력 요청은 JSON 계약을 **프롬프트에만** 맡긴다. 모델은 그걸 지킬 수도, 안 지킬 수도 있다. 가장 흔한 이탈이 **정상 객체를 마크다운 펜스로 감싸는 것**이고, 파싱 경로는 원문 그대로 `Yojson.Safe.from_string` 을 부르므로 그 응답은 `Invalid_json_output` 이 되고 시도 전체가 실패한다.

## 실측 (2026-08-08)

`glm-coding.glm-5-turbo`, 39,127 토큰 프롬프트. 지시문 마지막 줄은 **`Respond with ONLY the JSON object, no markdown.`**

| provider | 5회 중 펜스 | 순수 JSON |
|---|---|---|
| glm-coding.glm-5-turbo | **2** | 3 |
| kimi-for-coding | 0 | 5 |

즉 **모델별이고, 비결정적이며, 프롬프트로 못 닫는다** — 지시문이 이미 그 행동을 명시적으로 금지하고 있다. 호출자 입장에서는 펜스만 벗기면 파싱되는 본문에 대해 요청이 **무작위로 실패**한다.

이 비결정성 때문에 원인 규명이 늦었다. 짧은 프롬프트로 한 번 찔러보면 깨끗한 JSON 이 나와서 "재현 안 됨" 으로 읽힌다. 실제 규모로 5 회 돌려야 보인다.

## 무엇을 하고 무엇을 안 하나

펜스가 **본문 전체를 감쌀 때만** 벗긴다:

- 여는 줄은 백틱 + 최대 언어 태그 하나여야 한다
- 닫는 펜스가 있어야 한다

그 외는 **바이트 단위로 그대로** 통과한다 — 펜스를 포함한 산문, 닫히지 않은 펜스, 다른 내용이 붙은 펜스 줄.

**수리 패스가 아니다.** 펜스 안이 여전히 JSON 이 아니면 같은 non-JSON 으로 나가고 호출자는 이전과 똑같이 `Invalid_json_output` 을 보고한다. `raw_response` 는 원문 바이트를 유지하므로 wire 기록은 실제로 도착한 것을 그대로 보여준다.

## 테스트

6 케이스 중 **4 개가 "건드리면 안 되는 것"** 이다. 이런 변경의 위험은 펜스 제거가 조용히 "깨진 프로바이더 출력 수리" 로 자라는 것이라서다.

작성 중에 실제 결함을 하나 잡았다 — 첫 구현이 닫는 펜스 앞 개행을 남겨서 벗긴 본문이 `{"a":1}\n` 으로 나왔다. 눈으로는 놓칠 한 글자다.

## 종단 확인

라이브 엔드포인트에 같은 프롬프트로 5 회:

```
1회  원문=parse_ok     펜스제거후=parse_ok
2회  원문=parse_FAIL   펜스제거후=parse_ok   ← 펜스
3회  원문=parse_ok     펜스제거후=parse_ok
4회  원문=parse_ok     펜스제거후=parse_ok
5회  원문=parse_ok     펜스제거후=parse_ok
```

```
dune build  OK
test_exact_output_markdown_fence  Test Successful, 5 tests run
```

## 소비자 영향

MASC 의 librarian 레인이 이 경로를 탄다 (`response_format` 미전송). 해당 레인은 1 순위 슬롯에서 사유 불명으로 반복 advance 하고 있었고, 그 사유가 이것이다. MASC 쪽 관련 작업: jeong-sik/masc#27432 (advance 가 버리던 cause 를 로그에 남김), jeong-sik/masc#27431 (같은 패턴 전수 스윕).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
